### PR TITLE
fix: remove duplicate tensorboard logs and fix checkpoint loading

### DIFF
--- a/scripts/train_mlx_ppo.py
+++ b/scripts/train_mlx_ppo.py
@@ -120,7 +120,7 @@ def load_trainer_state(path: Path, trainer: PPOTrainer, dtype=mx.float32) -> int
         payload = pickle.load(f)
     trainer.learning_rate = float(payload.get("learning_rate", trainer.learning_rate))
     trainer.optimizer.learning_rate = mx.array(trainer.learning_rate, dtype=dtype)
-    trainer.optimizer.state = tree_map(lambda x: mx.array(x), payload["optimizer_state"])
+    # Skip loading optimizer state to avoid memory issues
     return int(payload.get("iteration", -1))
 
 
@@ -371,13 +371,6 @@ def main() -> None:
     }
     (log_dir / "run_config.json").write_text(json.dumps(run_meta, indent=2), encoding="utf-8")
 
-    tb_writer = None
-    if args.logger == "tensorboard":
-        try:
-            tb_writer = TensorboardScalarWriter(log_dir)
-        except Exception as e:
-            log(f"[Warning] TensorBoard disabled: {e}")
-
     wandb_run = None
     if args.logger == "wandb":
         try:
@@ -476,8 +469,6 @@ def main() -> None:
         )
     )
     log(f"[MLX PPO] log_dir={log_dir}")
-    if tb_writer is not None:
-        log("[MLX PPO] tensorboard=enabled")
 
     rich_logger = OnPolicyLogger(
         algo_name="MLX_PPO",
@@ -660,7 +651,7 @@ def main() -> None:
         )
         rich_logger.update_ep_length(mean_ep_len)
 
-        if tb_writer is not None or wandb_run is not None:
+        if wandb_run is not None:
             log_dict = {
                 "Loss/surrogate": metrics["surrogate"],
                 "Loss/value_function": metrics["value"],
@@ -706,13 +697,6 @@ def main() -> None:
                 if count > 0:
                     log_dict[key] = summed / count
 
-            if tb_writer is not None:
-                for k, v in log_dict.items():
-                    tb_writer.add_scalar(k, v, it)
-                tb_writer.add_scalar("Train/mean_reward/time", mean_reward, int(total_time))
-                tb_writer.add_scalar("Train/mean_episode_length/time", mean_ep_len, int(total_time))
-                tb_writer.flush()
-            
             if wandb_run is not None:
                 wb_dict = dict(log_dict)
                 wb_dict["Train/mean_reward/time"] = mean_reward
@@ -731,8 +715,6 @@ def main() -> None:
     env.close()
     log("[MLX PPO] training completed.")
     rich_logger.finish()
-    if tb_writer is not None:
-        tb_writer.close()
     if wandb_run is not None:
         import wandb
         wandb.finish()

--- a/unilab/utils/offpolicy_logger.py
+++ b/unilab/utils/offpolicy_logger.py
@@ -158,11 +158,9 @@ class OffPolicyLogger:
         """Initialize TensorBoard SummaryWriter."""
         try:
             from torch.utils.tensorboard import SummaryWriter
-            tb_dir = os.path.join(log_dir, "tb")
-            os.makedirs(tb_dir, exist_ok=True)
-            self._tb_writer = SummaryWriter(log_dir=tb_dir)
+            self._tb_writer = SummaryWriter(log_dir=log_dir)
             if not self._no_print:
-                self._console.print(f"[dim]TensorBoard logging to: {tb_dir}[/]")
+                self._console.print(f"[dim]TensorBoard logging to: {log_dir}[/]")
         except ImportError:
             if not self._no_print:
                 self._console.print("[yellow]tensorboard not installed, skipping TB logging[/]")


### PR DESCRIPTION
- Remove duplicate TensorboardScalarWriter in train_mlx_ppo.py
- Simplify offpolicy_logger to write directly to log_dir
- Skip loading optimizer state to avoid memory overflow