### PR TITLE
fix: restore G1 SAC locomotion training performance

### DIFF
--- a/conf/offpolicy/reward/g1_sac_mujoco.yaml
+++ b/conf/offpolicy/reward/g1_sac_mujoco.yaml
@@ -7,7 +7,7 @@ reward:
     penalty_orientation: -10.0
     penalty_action_rate: -2.0
     pose: -0.5
-    penalty_feet_ori: -25.0
+    penalty_feet_ori: -5.0
     feet_phase: 5.0
     alive: 10.0
   tracking_sigma: 0.25

--- a/conf/offpolicy/task/g1_sac.yaml
+++ b/conf/offpolicy/task/g1_sac.yaml
@@ -11,7 +11,7 @@ algo:
   updates_per_step: 8
   use_symmetry: true
   algo_params:
-    alpha_init: 0.01
+    alpha_init: 0.001
     target_entropy_ratio: 0.0
 motrix_legacy:
   enabled: true

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -84,15 +84,34 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
         self._penalty_curriculum = PenaltyCurriculum(
             self,
             enabled=True,
-            initial_scale=0.1,  # 从0.1开始，更容易
-            min_scale=0.1,  # 最小0.1
-            max_scale=1.0,  # 最大1.0
-            level_down_threshold=50.0,  # 低于50步降低难度
-            level_up_threshold=500.0,  # 高于500步增加难度
-            degree=0.002,  # 调整速度加快
+            initial_scale=0.5,
+            min_scale=0.5,
+            max_scale=1.0,
+            level_down_threshold=150.0,
+            level_up_threshold=750.0,
+            degree=0.001,
         )
 
         self._init_reward_functions()
+
+    def _compute_obs(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> dict[str, np.ndarray]:
+        diff = dof_pos - self.default_angles
+        command = info["commands"]
+        last_actions = info.get("current_actions", np.zeros_like(diff))
+        gait_phase = info.get(
+            "gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype())
+        )
+        actor = np.concatenate(
+            [gyro * 0.25, -gravity, diff, dof_vel * 0.05, last_actions, command, gait_phase],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
+        return {
+            "obs": actor,
+            "privileged": np.asarray(linvel * 2.0, dtype=get_global_dtype()),
+        }
 
     def _init_reward_functions(self):
         """对齐 holosoma G1 FastSAC 奖励函数"""


### PR DESCRIPTION
- Add _compute_obs override in G1WalkTaskMjSAC with obs scaling (gyro×0.25, dof_vel×0.05, linvel×2.0) for training stability
- Fix PenaltyCurriculum: initial_scale/min_scale 0.1→0.5, level_down_threshold 50→150, level_up_threshold 500→750, degree 0.002→0.001
- Fix penalty_feet_ori: -25.0→-5.0 to balance reward scales
- Fix alpha_init: 0.01→0.001 to align with zero target entropy setting
