### PR TITLE
chore: set up github collaboration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "CONTRIBUTING.md"
-      - "AGENTS.md"
-      - "LICENSE"
-      - ".github/CODEOWNERS"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -23,6 +13,8 @@ on:
       - ".github/CODEOWNERS"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/pull_request_template.md"
+  workflow_dispatch:
+  workflow_dispatch:
 
 env:
   UV_FROZEN: "1"
@@ -83,4 +75,4 @@ jobs:
           sudo apt-get update && sudo apt-get install -y cmake
           uv sync --extra dev
       - name: Test with coverage
-        run: uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing --cov-fail-under=10
+        run: uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing --cov-fail-under=10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,13 @@ uv run pytest -m slow -v
 
 ## CI 流程
 
-Push / PR 到 `main` 时自动触发三个 job：
+PR 到 `main` 时自动触发三个 job；合并后不会在 `main` 上重复跑同一套 CI。
 
 | Job | 内容 | 失败即阻断 |
 |-----|------|-----------|
 | `lint` | `ruff check` + `ruff format --check` | ✅ |
 | `typecheck` | `mypy unilab` + `pyright` | ✅ |
-| `test` | `pytest -m "not slow" --cov --cov-fail-under=10` | ✅ |
+| `test` | `pytest -m "not slow and not veryslow" --cov --cov-fail-under=10` | ✅ |
 
 纯文档和协作元信息改动（如 `docs/**`、issue templates、`CODEOWNERS`）不触发 CI。
 


### PR DESCRIPTION
## Summary

- add collaboration workflow documentation and move dynamic task tracking out of repo docs
- add issue templates, PR template, and CODEOWNERS for clearer execution/review ownership
- reorganize docs into ordered guides with navigation links
- avoid duplicate CI runs after merge and explicitly exclude `veryslow` tests from the PR test job

## Linked Work

- Issue: #82
- Milestone: M1 - Motrix / G1 / ToReal Phase 1

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] GitHub milestone / issue / label structure created manually

Commands actually run:

```bash
make check
uv run pytest -m "not slow"
```

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: n/a
- benchmark result: n/a
- video / screenshot: n/a
- ONNX / checkpoint: n/a

## Checklist

- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted follow-up work in milestone issues
