### PR TITLE
fix: update slow test xml asset paths

### DIFF
--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -7,20 +7,15 @@ Run with:
     uv run pytest -m slow tests/base/test_sim_backend.py -v
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 
+from unilab.assets import ASSETS_ROOT_PATH
+
+
 # ---------------------------------------------------------------------------
-# Paths
-# ---------------------------------------------------------------------------
-
-_SRC = Path(__file__).parents[2] / "src"
-
-
 def _xml(robot: str, scene: str = "scene_flat.xml") -> str:
-    return str(_SRC / "unilab" / "envs" / "locomotion" / robot / "xml" / scene)
+    return str(ASSETS_ROOT_PATH / "robots" / robot / scene)
 
 
 BASIC_ROBOTS = [


### PR DESCRIPTION
## Summary

- update `tests/base/test_sim_backend.py` to resolve robot XMLs from `unilab.assets.ASSETS_ROOT_PATH`
- stop using the removed `src/unilab/envs/.../xml` paths in slow backend tests
- keep the test path helper aligned with the current asset layout under `src/unilab/assets`

## Validation

- `make check`
- `uv run pytest tests/base/test_sim_backend.py -m slow -q`
- `uv run pytest tests/scripts/test_train_script_configs.py -m veryslow -q`
- `uv run pytest tests/algos/test_appo_runner.py tests/algos/test_offpolicy_runner.py tests/algos/test_rsl_rl_runner.py -m "slow or veryslow" -q`
- `uv run pytest -m "slow or veryslow" -q`
