### PR TITLE
docs: restructure agent guide and add RL infra development standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,147 +1,50 @@
-# Development Standards
-
-## Package Management
+# UniLab Agent Principles
 
 **Always use `uv run`, not python**.
 
-```bash
-# ✅ Correct
-uv run python script.py
-uv run pytest
+UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructure 仓库。
+先看 [RL Infrastructure Development Standard](docs/00-development-architecture.md)。AGENTS 只保留 agent 必须记住的理念。
 
-# ❌ Incorrect
-python script.py
-pytest
-```
+## Core Principles
 
-## Installation
+1. Contract first: 不为了一次通过绕过 env / backend / runner contract。
+2. Fix at owner layer: `scripts/` 只组装流程，不承载长期业务规则。
+3. Config first: task / reward / backend 优先通过 Hydra + registry 表达。
+4. Backend isolation: MuJoCo / Motrix 差异留在 backend 适配层和配置层。
+5. Evidence only: support claim 只写仓库里已有的注册、配置、测试或 benchmark 事实。
+6. Validate near risk: 在最接近风险的边界补验证，不只跑顶层命令。
 
-```bash
-# macOS (MPS)
-uv sync --extra dev
+## Read Order
 
-# Linux (CUDA 12.4)
-uv sync --extra dev --extra cu124
-```
+1. `AGENTS.md`
+2. `docs/00-development-architecture.md`
+3. `CONTRIBUTING.md`
+4. 当前任务相关代码与测试
 
-## Development Workflow
+## High-Risk Areas
 
-### Quick Commands (Makefile)
+| 区域 | 不可破坏的不变量 |
+|------|----------------|
+| Env  | `NpEnvState.obs` 必须是 dict；`reset()` 返回 `(obs_dict, info_dict)`；`obs_groups_spec` 影响 wrapper 和 learner 维度。 |
+| Config / Reward | reward 通过 Hydra 注入；`training.sim_backend` 和 `motrix_legacy` 必须尊重显式 override。 |
+| Backend | backend-specific 逻辑留在 backend / env 适配层，不向训练脚本扩散。 |
+| Async | 不绕开 runner lifecycle，也不另起 collector / learner 同步协议。 |
 
-```bash
-make format     # Format and lint code (ruff format + ruff check --fix)
-make type       # Type check with mypy + pyright
-make check      # make format && make type
-make test       # Run all non-slow tests (default)
-make test-cov   # Run non-slow tests with coverage report
-make test-slow  # Run slow integration tests (requires MuJoCo)
-make test-veryslow  # Run full training iteration tests (minutes per test)
-make test-all   # make check && make test-cov
-```
+## Validation
 
-### Manual Commands
+- Hydra / task / reward：`make test`
+- env / obs / reset：`make test`
+- runner / IPC：`make test`，必要时 `make test-slow`
+- training path：相关测试 + 1-iteration smoke run
+- docs-only：核对命令、路径、配置名、CI 和 support claim
 
-```bash
-# Format
-uv run ruff format .
-uv run ruff check --fix
+## Pointers
 
-# Type check
-uv run mypy unilab
-uv run pyright
-
-# Test (non-slow)
-uv run pytest -m "not slow"
-
-# Test with coverage
-uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing
-
-# Slow integration tests (need MuJoCo installed)
-uv run pytest -m "slow and not veryslow" -v
-
-# Very slow: full training iteration tests (minutes per test)
-uv run pytest -m veryslow -v
-```
-
-## Test Structure
-
-```
-tests/
-├── conftest.py                    # shared fixtures + DummyFlatEnv stub
-├── ipc/                           # IPC primitives unit tests
-│   ├── test_replay_buffer.py
-│   ├── test_shared_onpolicy_storage.py
-│   ├── test_shared_weight_sync.py
-│   ├── test_shared_obs_stats.py
-│   └── test_async_runner.py
-├── base/
-│   ├── test_registry.py
-│   └── test_np_env.py             # NpEnvState + NpEnv dict-obs contract
-├── config/
-│   ├── test_locomotion_params.py
-│   └── test_manipulation_params.py
-├── envs/
-│   └── test_env_configs.py        # obs_groups_spec dims + env instantiation
-├── utils/
-│   └── test_obs_utils.py          # flatten_obs_dict
-├── scripts/
-│   └── test_train_scripts.py
-└── algos/
-    ├── test_appo_runner.py        # @pytest.mark.slow
-    ├── test_offpolicy_runner.py   # @pytest.mark.slow
-    └── test_mlx_ppo.py            # macOS only (MLX backend)
-```
-
-Tests marked `@pytest.mark.slow` require a real MuJoCo environment and are excluded from CI
-by default. Run them locally when working on runner/learner code.
-
-Tests marked `@pytest.mark.veryslow` run full training iterations (minutes per test). They are
-excluded by default even when running `make test-slow`. Run `make test-veryslow` explicitly.
-
-## Testing
-
-**New features must ship with tests.** When developing a new feature or refactoring, design and write comprehensive unit tests alongside the feature code — not as an afterthought. Tests should cover:
-
-- Normal behaviour and edge cases
-- Error paths and invalid inputs
-- Contract verification (e.g. interface shapes, types, key presence)
-- Integration with neighbouring modules when relevant (`@pytest.mark.slow` for MuJoCo-dependent tests)
-
-## Git Commits
-
-Use Conventional Commits:
-- `feat:` 新功能
-- `fix:` 修复 bug
-- `docs:` 文档
-- `style:` 格式化
-- `refactor:` 重构
-- `test:` 测试
-- `chore:` 构建/工具
-
-## Pre-commit
-
-```bash
-pre-commit install  # Optional
-```
-
-**Always run `make check` before committing.**
-
-## Configuration System
-
-UniLab uses **Hydra + dataclass** for type-safe, composable configs:
-
-- **Structured configs**: `src/unilab/config/structured_configs.py` (typed dataclasses)
-- **YAML configs**: `conf/` directory (offpolicy/appo/ppo)
-- **CLI overrides**: `algo.num_envs=2048 training.device=cuda`
-
-### Adding New Tasks
-
-1. Create YAML file: `conf/{algo}/task/my_task.yaml`
-2. Use `# @package _global_` directive
-3. Override only deltas from base config
-
-### Adding New Algorithms
-
-1. Add dataclass to `structured_configs.py`
-2. Create `conf/{algo}/config.yaml` with defaults
-3. Update training script with `@hydra.main()`
+- PPO: `scripts/train_rsl_rl.py`
+- MLX PPO: `scripts/train_mlx_ppo.py`
+- APPO: `scripts/train_appo.py`
+- SAC / TD3: `scripts/train_offpolicy.py`
+- env contract: `src/unilab/base/np_env.py`
+- backend contract: `src/unilab/base/backend/base.py`
+- config schema: `src/unilab/config/structured_configs.py`
+- async runner: `src/unilab/ipc/async_runner.py`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,24 +3,33 @@
 ## 开发环境设置
 
 1. Fork 并克隆仓库
-2. 安装依赖：`uv sync --extra dev`
-3. 创建功能分支：`git checkout -b feat/your-feature`
+2. 按平台安装依赖：
+   - macOS (MPS): `uv sync --extra dev`
+   - Linux (CUDA 12.4): `uv sync --extra dev --extra cu124`
+   - 需要 Motrix 时，在上面的命令后追加 `--extra motrix`
+3. 创建分支，例如：`git checkout -b docs/improve-readme`、`git checkout -b fix/backend-bug`
 
 ## 开发规范
 
 - **Always use `uv run`**，不要直接使用 `python`
-- 提交前必须通过 `make check`（ruff lint + mypy + pyright）
-- 动态任务状态不要写进 `README.md` 或临时 markdown，统一用 GitHub Issues / Milestones 跟踪
+- 代码相关提交前必须通过 `make check`（ruff lint + mypy + pyright）
+- 用户可见工作流改动时，同步更新 `README.md`、`docs/` 和 `CONTRIBUTING.md`
+
+## 开发前先看
+
+- 改训练入口、runner、env contract、backend 路径前，先看 [RL Infra Development Standard](docs/00-development-architecture.md)
+- 改协作流程、issue / milestone 规则时，再看 [docs/06-collaboration.md](docs/06-collaboration.md)
 
 ## 常用命令
 
 ```bash
 make format      # ruff format + ruff check --fix
-make type        # mypy unilab + pyright
+make type        # mypy src/unilab + pyright
 make check       # format + type（提交前必跑）
 make test        # 非 slow 单元测试
 make test-cov    # 非 slow 测试 + 覆盖率报告
 make test-slow   # slow 集成测试（需要 MuJoCo）
+make test-veryslow  # veryslow 训练冒烟测试（分钟级）
 make test-all    # make check && make test-cov
 ```
 
@@ -38,33 +47,25 @@ make test-all    # make check && make test-cov
 
 ## 测试
 
-### 测试结构
+### 测试目录
 
 ```
 tests/
-├── conftest.py                    # 共享 fixtures（含 DummyFlatEnv，无需 MuJoCo）
-├── ipc/                           # IPC 原语单元测试
-│   ├── test_replay_buffer.py
-│   ├── test_shared_onpolicy_storage.py
-│   ├── test_shared_weight_sync.py
-│   ├── test_shared_obs_stats.py
-│   └── test_async_runner.py
-├── base/
-│   └── test_registry.py
-├── config/
-│   └── test_locomotion_params.py
-├── scripts/
-│   └── test_train_scripts.py
-└── algos/
-    ├── test_appo_runner.py        # @pytest.mark.slow
-    ├── test_offpolicy_runner.py   # @pytest.mark.slow
-    └── test_mlx_ppo.py            # macOS only（MLX 后端）
+├── base/         # registry、backend 选择、env contract
+├── config/       # Hydra / dataclass / reward 注入
+├── envs/         # 环境配置与实例化
+├── ipc/          # shared-memory / async runner 原语
+├── scripts/      # 训练脚本配置与入口工具
+├── algos/        # runner 集成、RSL-RL PPO、MLX PPO
+├── integration/  # 跨模块 reward / config 集成
+└── utils/        # 工具函数与实验跟踪
 ```
 
 ### 测试标记
 
-- **普通测试**（无标记）：不依赖 MuJoCo，CI 中自动运行
+- **普通测试**（无标记）：不依赖 MuJoCo，默认 `make test`
 - **`@pytest.mark.slow`**：需要 MuJoCo 环境，CI 跳过，本地用 `make test-slow` 运行
+- **`@pytest.mark.veryslow`**：完整训练迭代或脚本冒烟测试，显式用 `make test-veryslow`
 - **macOS only**：`test_mlx_ppo.py` 用 `pytest.importorskip("mlx")` 在非 macOS 平台自动跳过
 
 ### 写测试的原则
@@ -79,30 +80,40 @@ tests/
 
 ```bash
 # 快速（CI 同款）
-uv run pytest -m "not slow"
+uv run pytest -m "not slow and not veryslow"
 
 # 带覆盖率
-uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing
+uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing
 
 # 集成测试（需 MuJoCo）
-uv run pytest -m slow -v
+uv run pytest -m "slow and not veryslow" -v
+
+# 完整训练冒烟
+uv run pytest -m veryslow -v
 ```
 
 ## CI 流程
 
-PR 到 `main` 时自动触发三个 job；合并后不会在 `main` 上重复跑同一套 CI。
+PR 到 `main` 时自动触发三个 job；当前 workflow 不在 `main` 合并后重复跑同一套 CI。
 
 | Job | 内容 | 失败即阻断 |
 |-----|------|-----------|
 | `lint` | `ruff check` + `ruff format --check` | ✅ |
-| `typecheck` | `mypy unilab` + `pyright` | ✅ |
+| `typecheck` | `mypy src/unilab` + `pyright` | ✅ |
 | `test` | `pytest -m "not slow and not veryslow" --cov --cov-fail-under=10` | ✅ |
 
-纯文档和协作元信息改动（如 `docs/**`、issue templates、`CODEOWNERS`）不触发 CI。
+纯文档和协作元信息改动（如 `*.md`、`docs/**`、issue templates、`CODEOWNERS`）不触发 CI。
+
+## 文档改动预期
+
+- 文档命令必须能在当前仓库结构中找到对应脚本、配置或 Makefile 目标
+- 如果文档描述了 backend 支持，请优先使用 `Registered` / `Configured` / `Benchmarked` / `Recommended` 语义
+- 使用相对链接，确保 GitHub 渲染可直接跳转
+- 如果文档描述了 CI、日志目录或支持矩阵，请对照 `.github/workflows/ci.yml`、`scripts/` 和 `conf/` 检查一次
 
 ## GitHub 协作方式
 
-- **Issue**：一个可执行工作项一个 Issue，不要把 milestone 任务堆在文档里
+- **Issue**：一个可执行工作项一个 Issue
 - **Milestone**：阶段目标，例如 `M1`
 - **PR**：必须链接驱动 Issue，写清验证命令和影响范围
 - **CODEOWNERS**：用于 review ownership，不等于执行 owner
@@ -111,16 +122,17 @@ PR 到 `main` 时自动触发三个 job；合并后不会在 `main` 上重复跑
 
 ## Pull Request 流程
 
-1. 本地运行 `make check` 确保 lint/mypy/pyright 通过
-2. 本地运行 `make test` 确保单元测试通过
+1. 对代码或配置改动，本地运行 `make check` 确保 lint/mypy/pyright 通过
+2. 对代码改动，本地运行 `make test` 确保非 slow 测试通过
 3. 若改动了 IPC / Runner / Config，补充或更新对应测试
-4. 链接对应 GitHub Issue，并按 PR 模板填写验证与影响范围
-5. 提交 PR 到 `main` 分支，等待 CI 全绿
-6. 等待 code review
+4. 若为 docs-only 变更，至少重新检查 Markdown 链接、文件路径、脚本名和命令参数
+5. 链接对应 GitHub Issue，并按 PR 模板填写验证与影响范围
+6. 提交 PR 到 `main` 分支，等待 CI 全绿
+7. 等待 code review
 
 ## 问题反馈
 
-使用 GitHub Issues 报告 bug 或提出功能建议；阶段计划请使用 GitHub Milestones，不要继续放在 `README` 或临时 markdown 中。
+使用 GitHub Issues 报告 bug 或提出功能建议。
 
 ## 配置系统
 
@@ -130,4 +142,4 @@ UniLab 使用 Hydra + dataclass 配置系统：
 - **修改超参数**：编辑对应 YAML 或使用 CLI 覆盖（`algo.num_envs=2048`）
 - **添加新算法**：在 `structured_configs.py` 添加 dataclass，创建对应 `conf/` 目录
 
-详见 `AGENTS.md` 配置系统章节。
+详见 [Training Guide](docs/03-training.md) 的 Hydra 说明，以及 [Development Architecture](docs/00-development-architecture.md)。

--- a/README.md
+++ b/README.md
@@ -35,10 +35,30 @@ uv sync --extra dev --extra cu124
 uv run python scripts/train_rsl_rl.py task=go1_joystick
 ```
 
+## Workflow Entrypoints
+
+| 目标 | 入口脚本 | 默认日志根目录 |
+|------|----------|---------------|
+| PPO (torch / RSL-RL) | `scripts/train_rsl_rl.py` | `logs/rsl_rl_train/<task>/` |
+| PPO (MLX, macOS) | `scripts/train_mlx_ppo.py` | `logs/mlx_rl_train/<task>/` |
+| APPO | `scripts/train_appo.py` | `logs/appo/<task>/` |
+| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/fast_sac/<task>/` / `logs/fast_td3/<task>/` |
+
+训练脚本默认会在训练结束后自动回放；用 `training.no_play=true` 可以跳过。
+
+## Repository Map
+
+- `conf/`: Hydra 配置与 task / reward / algo 组合
+- `scripts/`: 训练、回放、motion 预处理等直接入口
+- `src/unilab/`: 环境、后端、算法和通用工具
+- `tests/`: 单元测试、集成测试、脚本配置测试
+- `docs/`: 安装、后端、训练和协作文档
+
 更完整的安装、后端和训练说明已经拆到按顺序组织的 `docs/`：
 
 ## Documentation
 
+- [00 RL Infrastructure Development Standard](docs/00-development-architecture.md): RL infrastructure 开发标准、设计原则、分层责任与验证要求
 - [01 Getting Started](docs/01-getting-started.md): 安装、依赖、国内镜像、第一次运行
 - [02 Simulation Backends](docs/02-simulation-backends.md): MuJoCo / Motrix 支持范围与使用方式
 - [03 Training Guide](docs/03-training.md): 训练、回放、恢复训练、Hydra 参数、W&B
@@ -46,14 +66,7 @@ uv run python scripts/train_rsl_rl.py task=go1_joystick
 - [05 G1 Motion Tracking](docs/05-g1-motion-tracking.md): G1 whole-body motion tracking 任务说明
 - [06 Collaboration Workflow](docs/06-collaboration.md): GitHub issue / milestone / PR 协作方式
 - [Contributing](CONTRIBUTING.md): 开发规范、测试、CI、提交流程
-
-## Roadmap And Task Tracking
-
-UniLab 不再把阶段任务、owner 和执行状态直接维护在 `README.md`。
-
-- 用 GitHub Issues 跟踪 bug、feature、benchmark、docs 和 infra work
-- 用 GitHub Milestones 跟踪阶段目标，例如 `M1`
-- 用 [docs/06-collaboration.md](docs/06-collaboration.md) 统一说明协作规则
+- [AGENTS](AGENTS.md): coding agent / automated editor 的 RL infra 开发指南
 
 ## Related Projects
 

--- a/docs/00-development-architecture.md
+++ b/docs/00-development-architecture.md
@@ -1,0 +1,159 @@
+# RL Infrastructure Development Standard
+
+UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructure 仓库。
+本标准只回答一个问题：**什么样的改动是对的。**
+
+工程属性：高性能 · 结构化 · 系统性 · 模块化 · 可复用 · 可观测。
+
+---
+
+## 1. Runtime Model
+
+三段式零拷贝管线：
+
+```
+CPU Physics Sim ──shm──► Collector / IPC ──shm──► GPU Learner
+(MuJoCo/Motrix)          (AsyncRunner)            (torch/mlx)
+                                  ▲                   │
+                                  └── SharedWeightSync ┘
+```
+
+- Backend 通过 **contract + registry + 配置** 切换，不通过脚本分支。
+- Env 层是 numpy / vectorized；GPU 归 learner 独占。
+- Collector 与 learner 通过 IPC + shared memory 解耦，lifecycle 统一。
+
+---
+
+## 2. Layered Architecture
+
+依赖方向严格单向，**问题在哪一层产生，就在哪一层解决**。
+
+| Layer | 目录 | 职责 | 禁止承担 |
+|-------|------|------|---------|
+| L0 Backend | `base/backend/` | `SimBackend` 物理后端抽象 | 训练逻辑、reward |
+| L1 Env | `envs/`, `base/np_env.py` | MDP 语义、obs、reward、reset | 调度、日志策略 |
+| L2 Config & Registry | `config/`, `base/registry.py`, `conf/` | schema、task / reward 组合、注册 | 散落业务默认值 |
+| L3 Algo & IPC | `algos/`, `ipc/` | learner、runner、collector、shm 通路 | env/backend 细节 |
+| L4 Scripts | `scripts/` | **只做装配** | 核心业务规则 |
+
+---
+
+## 3. Design Principles
+
+1. **Contract-First** — 先保护 contract，再谈局部修补。承重墙：
+   `registry.make`、`NpEnvState.obs: dict`、`reset → (obs, info)`、
+   `obs_groups_spec`、`SimBackend`、collector/learner shm 协议。
+2. **Own your layer** — scripts 不修 env bug，env 不修 backend bug。
+3. **Config over branching** — 扩展优先级：
+   config schema → registry → env/backend 适配层 →（最后）脚本分支。
+4. **Backend isolation** — MuJoCo / Motrix 差异收敛在 backend 实现、
+   env 适配层、backend-specific profile；capability gap 必须显式写出。
+5. **Evidence-graded claims** — `Registered` / `Configured` /
+   `Benchmarked` / `Recommended`，无证据不写"稳定支持"。
+6. **Validate near risk** — 顶层 smoke 是补充，不是替代。
+7. **Reusable primitives** — 通用逻辑上浮到 `base/` / `utils/`，不复制粘贴。
+
+---
+
+## 4. Training Entrypoints
+
+| 路径 | 入口 | 主链路 |
+|------|------|--------|
+| PPO (torch) | `scripts/train_rsl_rl.py` | `registry.make` → `RslRlVecEnvWrapper` → `rsl_rl.OnPolicyRunner` |
+| PPO (MLX) | `scripts/train_mlx_ppo.py` | `registry.make` → MLX `RolloutBuffer` → `PPOTrainer` |
+| APPO | `scripts/train_appo.py` | `APPORunner` → collector → `SharedOnPolicyStorage` |
+| SAC / TD3 | `scripts/train_offpolicy.py` | `OffPolicyRunner` → collector → `ReplayBuffer` |
+
+动手前先定位自己在哪条链路上。
+
+---
+
+## 5. Configuration
+
+dataclass + Hydra。schema 在 `src/unilab/config/structured_configs.py`，
+运行时配置在 `conf/{ppo,appo,offpolicy}/`。
+
+合成顺序：`{algo}/config*.yaml` → `task=...` → `reward[_{backend}]` →
+CLI override →（必要时）`motrix_legacy`。
+
+- reward 必须显式注入。
+- backend 影响 reward/task 时必须通过配置表达。
+- 动态 override 必须尊重 CLI。
+
+---
+
+## 6. Env
+
+扩展流程：
+
+1. `@registry.envcfg("EnvName")` 注册 config dataclass
+2. `@registry.env("EnvName", sim_backend=...)` 注册实现类
+3. `registry.make(...)` 构造
+
+Env **承担**：MDP 语义、obs 结构、reward、reset、backend→训练语义映射。
+Env **不承担**：训练 orchestration、多进程调度、顶层日志。
+
+---
+
+## 7. Backend
+
+`SimBackend` (`src/unilab/base/backend/base.py`) 必须提供：
+base pose/vel、DOF state、body pose/vel（world & baselink）、named sensor。
+
+已知 backend 分支：`backend_type == "motrix"` 触发 `_process_rigid_body_props`；
+play/debug/video/symmetry 部分路径仍 MuJoCo-first。
+
+---
+
+## 8. Async & Runner
+
+所有异步算法共享 `src/unilab/ipc/async_runner.py` 的 `AsyncRunner`：
+统一 `spawn`、统一 collector lifecycle、统一 shared resource cleanup。
+
+- **APPO**：collector 写 `SharedOnPolicyStorage`，learner V-trace，
+  actor 权重经 `SharedWeightSync` 回传。
+- **Off-policy**：collector 写 `ReplayBuffer`，learner 采样，
+  `SharedWeightSync` 同步，支持 sync / async collection。
+
+禁止：外部复制并行协议、绕过 shared resource lifecycle、引入隐式耦合。
+
+---
+
+## 9. Validation
+
+| 改动 | 最少验证 |
+|------|---------|
+| Hydra / task / reward | `make test`（`tests/config/`, `tests/scripts/`） |
+| env contract / obs | `make test`（`tests/base/test_np_env.py` 等） |
+| runner / IPC | `make test`，必要时 `make test-slow` |
+| 训练主链路 | 相关测试 + 1-iteration smoke run |
+| backend path | 对应 backend smoke run，必要时 slow test |
+| docs-only | 手动核对命令、路径、配置名、CI、support claim |
+
+---
+
+## 10. Review Checklist
+
+1. 这次改动影响了哪个 contract？
+2. 是否应该在**更低层**解决？
+3. backend / task 行为通过**配置**表达还是被**脚本特判**掩盖？
+4. support 声明是否有 registry / config / test / benchmark 证据？
+5. 验证是否发生在**最接近风险**的边界？
+
+---
+
+## 11. High-Signal Files
+
+- `scripts/train_{rsl_rl,mlx_ppo,appo,offpolicy}.py`
+- `src/unilab/base/{registry,np_env}.py`
+- `src/unilab/base/backend/base.py`
+- `src/unilab/config/structured_configs.py`
+- `src/unilab/utils/{reward_utils,obs_utils}.py`
+- `src/unilab/ipc/async_runner.py`
+
+---
+
+## Navigation
+
+- Previous: [README](../README.md)
+- Next: [Getting Started](01-getting-started.md)

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -33,14 +33,15 @@ uv sync --extra dev
 uv sync --extra dev --extra cu124
 
 # 可选：Motrix 后端
-uv sync --extra motrix
+uv sync --extra dev --extra motrix
+uv sync --extra dev --extra cu124 --extra motrix
 ```
 
 ## 国内镜像
 
 ```bash
 export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+uv sync --extra dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ## First Run
@@ -51,20 +52,28 @@ uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 uv run python scripts/train_rsl_rl.py task=go1_joystick
 ```
 
-### 只做回放
+### 常用入口脚本
 
 ```bash
-uv run python scripts/train_rsl_rl.py task=go1_joystick training.play_only=true
+# PPO (RSL-RL)
+uv run python scripts/train_rsl_rl.py task=go1_joystick
+
+# APPO
+uv run python scripts/train_appo.py task=go1_joystick
+
+# SAC / TD3
+uv run python scripts/train_offpolicy.py algo=sac task=go1_joystick
+uv run python scripts/train_offpolicy.py algo=td3 task=go1_joystick
 ```
 
-### 运行检查
+### 验证环境
 
 ```bash
 make check
-uv run pytest -m "not slow"
+uv run pytest -m "not slow and not veryslow"
 ```
 
 ## Navigation
 
-- Previous: [README](../README.md)
+- Previous: [Development Architecture](00-development-architecture.md)
 - Next: [Simulation Backends](02-simulation-backends.md)

--- a/docs/03-training.md
+++ b/docs/03-training.md
@@ -2,6 +2,15 @@
 
 本页覆盖训练、回放、恢复训练、Hydra 覆盖参数和 W&B。
 
+## Pick An Entrypoint
+
+| 目标 | 入口脚本 | 默认日志根目录 |
+|------|----------|---------------|
+| PPO (RSL-RL / torch) | `scripts/train_rsl_rl.py` | `logs/rsl_rl_train/<task>/` |
+| PPO (MLX / macOS) | `scripts/train_mlx_ppo.py` | `logs/mlx_rl_train/<task>/` |
+| APPO | `scripts/train_appo.py` | `logs/appo/<task>/` |
+| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/fast_sac/<task>/` / `logs/fast_td3/<task>/` |
+
 ## Start Training
 
 ```bash

--- a/docs/05-g1-motion-tracking.md
+++ b/docs/05-g1-motion-tracking.md
@@ -4,7 +4,8 @@ UniLab 当前提供一个 G1 的 whole-body motion tracking 任务。
 
 - Hydra task：`g1_motion_tracking`
 - 注册环境名：`G1MotionTracking`
-- 当前后端：`mujoco`，以及已验证的 `motrix` PPO / APPO 路径
+- 后端注册：`mujoco` 和 `motrix`
+- 已提交的 Motrix 特化配置：PPO 和 APPO 的 motion-tracking reward
 - 默认 motion 文件：`src/unilab/assets/motions/g1/dance1_subject2_part.npz`
 
 ## Environment Entrypoints
@@ -39,8 +40,8 @@ uv run python scripts/train_appo.py task=g1_motion_tracking \
   training.play_only=true
 ```
 
-目前已验证的 Motrix 训练/回放主链路包括 `scripts/train_rsl_rl.py` 和
-`scripts/train_appo.py`。`scripts/play_interactive.py` 仍按 MuJoCo 路径使用。
+G1 motion tracking 的 Motrix 训练 / 回放主链路优先走 `scripts/train_rsl_rl.py` 和
+`scripts/train_appo.py`。调试脚本 `scripts/play_interactive.py` 仍按 MuJoCo viewer 路径使用。
 
 ## Interactive Debugging
 
@@ -113,10 +114,11 @@ uv run python scripts/motion/replay_npz.py \
 
 `task=g1_motion_tracking` 默认读取环境配置里的 `motion_file`。如果要切换到自定义 motion，先生成 `.npz`，再更新环境配置里的默认 `motion_file`。
 
-如果要验证 Motrix 路径，优先使用：
+如果要验证 Motrix 路径，优先使用训练脚本内置 play mode，而不是 MuJoCo-only 的调试脚本：
 
 ```bash
 uv run python scripts/train_rsl_rl.py task=g1_motion_tracking training.sim_backend=motrix
+uv run python scripts/train_appo.py task=g1_motion_tracking training.sim_backend=motrix
 ```
 
 ## Navigation

--- a/docs/06-collaboration.md
+++ b/docs/06-collaboration.md
@@ -1,77 +1,53 @@
 # Collaboration Workflow
 
-This document defines where different kinds of information should live in UniLab.
+仓库文档写稳定标准；执行状态、owner 和阶段推进放在 GitHub 协作对象里。
 
-## Source of Truth
+如果你只是想安装或训练 UniLab，请先看 `README.md`、`docs/01-getting-started.md` 和 `docs/03-training.md`。
 
-- `README.md`
-  Use for stable project-facing information: architecture, installation, training entrypoints, and supported workflows.
-- `CONTRIBUTING.md`
-  Use for developer workflow: branching, validation, review expectations, and CI policy.
-- GitHub Issues
-  Use for actionable work items, bugs, benchmarks, docs tasks, and infra work.
-- GitHub Milestones
-  Use for phase-level planning such as `M1`.
-- GitHub Projects
-  Use for status tracking across issues and PRs when project scopes are available.
+## Work Item Granularity
 
-## What Not To Track In Docs
+每个 issue 至少回答以下问题：
 
-Do not keep the following in `README.md` or temporary markdown notes:
+1. 我们在解决什么问题？
+2. 预期交付物是什么？
+3. 完成标准是什么？
+4. 谁负责执行？
+5. 有哪些上游阻塞？
 
-- ownership assignments
-- sprint / milestone task lists
-- execution status like "in progress", "blocked", or "done"
-- review checklists for individual deliverables
-- benchmark rollout plans
-
-These belong in GitHub Issues, Milestones, and Projects.
-
-## Issue Structure
-
-Each issue should answer the following:
-
-1. What problem are we solving?
-2. What is the expected deliverable?
-3. How do we know it is done?
-4. Who owns it?
-5. What other work blocks it?
-
-Recommended issue types:
+推荐 issue 类型：
 
 - `bug`
-- `work item` for feature / infra / benchmark / test / sim work
+- `work item`：feature / infra / benchmark / test / sim / docs work
 
 ## Milestone Structure
 
-For each milestone:
+每个 milestone 应该：
 
-- create one milestone object on GitHub
-- create one tracking issue that links all child issues
-- put execution details in child issues, not in the milestone description
-- define completion by artifacts, not just merged code
+- 在 GitHub 上创建一个 milestone 对象
+- 创建一个 tracking issue 汇总子 issue
+- 把执行细节写在子 issue，不写在 milestone 描述里
+- 以产物定义完成，而不只是“代码已 merge”
 
-Typical required artifacts:
+典型完成产物：
 
 - green CI
-- benchmark result or W&B run link when applicable
-- demo video / ONNX export / checkpoint path when applicable
-- docs update if user-facing behavior changed
+- benchmark 结果或 W&B run link
+- demo video / ONNX export / checkpoint path
+- 若用户可见行为变化，则附带 docs update
 
-## PR Expectations
+## PR Evidence Standard
 
-Every PR should:
+每个 PR 应该：
 
-- link the driving issue
-- describe user-facing and training-impact changes
-- list validation commands actually run
-- state whether behavior changes across `mujoco`, `motrix`, macOS, or Linux
+- link 对应 driving issue
+- 描述 user-facing change 和 training-impact
+- 列出实际执行过的 validation commands
+- 说明行为是否在 `mujoco`、`motrix`、macOS、Linux 间发生变化
 
-## Ownership
+## Ownership Model
 
-Use GitHub assignees for execution ownership and `CODEOWNERS` for review ownership.
-If the responsible engineer is not yet mapped to a GitHub handle, keep the issue unassigned and
-record the expected owner in the issue body until the handle mapping is confirmed.
+使用 GitHub assignees 表达执行 owner，使用 `CODEOWNERS` 表达 review owner。
+如果负责人暂时还没有稳定的 GitHub handle，就先保持 issue unassigned，并在 issue body 中临时记录预期 owner。
 
 ## Navigation
 


### PR DESCRIPTION
## Summary
- Add `docs/00-development-architecture.md` as the canonical RL infrastructure standard: runtime model (CPU sim → shm collector → GPU learner), layered architecture with ownership rules, design principles, training entrypoints, and review checklist.
- Tighten `AGENTS.md` to principles-only with an infra positioning line and a High-Risk Areas table keyed on contract invariants.
- Refresh `README.md`, `CONTRIBUTING.md`, and surrounding docs to point at the new architecture doc and align with the current test layout, CI matrix, and workflow entrypoints.

## Test plan
- [ ] Render all touched markdown files on GitHub and verify relative links resolve
- [ ] Cross-check commands, script paths, and config names in CONTRIBUTING/README against the current repo
- [ ] Confirm `make check` / `make test` examples match the Makefile