### PR TITLE
chore: remove duplicated dev extra and rely on default uv dependency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
       - name: mypy
         run: uv run mypy src/unilab
       - name: pyright
@@ -63,15 +63,15 @@ jobs:
       #   if: runner.os == 'Linux'
       #   run: |
       #     sudo apt-get update && sudo apt-get install -y cmake
-      #     uv sync --extra dev
+      #     uv sync
       # - name: Install dependencies (macOS)
       #   if: runner.os == 'macOS'
       #   run: |
       #     brew install cmake
-      #     uv sync --extra dev
+      #     uv sync
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y cmake
-          uv sync --extra dev
+          uv sync
       - name: Test with coverage
         run: uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing --cov-fail-under=10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Languages: English | [简体中文](docs/zh_CN/CONTRIBUTING.md) | [日本語](do
 
 1. Fork and clone the repository.
 2. Install dependencies for your platform:
-   - macOS (MPS): `uv sync --extra dev`
-   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra dev --extra cu124`
+   - macOS (MPS): `uv sync`
+   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra cu124`
    - When you need Motrix, append `--extra motrix`
 3. Create a branch such as `git checkout -b docs/improve-readme` or `git checkout -b fix/backend-bug`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: sync
 sync:
-	uv sync --extra dev
+	uv sync
 
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ cd UniLab
 
 # 2. Install dependencies
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (choose one CUDA extra such as cu124)
-uv sync --extra dev --extra cu124
+uv sync --extra cu124
 
 # Optional: Motrix backend
-uv sync --extra dev --extra motrix
+uv sync --extra motrix
 
 # 3. Run a training job
 uv run python scripts/train_rsl_rl.py task=go1_joystick

--- a/docs/en/01-getting-started.md
+++ b/docs/en/01-getting-started.md
@@ -29,24 +29,24 @@ brew install cmake  # macOS
 
 ```bash
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8)
-uv sync --extra dev --extra cu118
-uv sync --extra dev --extra cu124
-uv sync --extra dev --extra cu126
-uv sync --extra dev --extra cu128
+uv sync --extra cu118
+uv sync --extra cu124
+uv sync --extra cu126
+uv sync --extra cu128
 
 # Optional: Motrix backend
-uv sync --extra dev --extra motrix
-uv sync --extra dev --extra cu124 --extra motrix
+uv sync --extra motrix
+uv sync --extra cu124 --extra motrix
 ```
 
 ## Mainland China Mirror
 
 ```bash
 export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-uv sync --extra dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ## First Run

--- a/docs/ja/01-getting-started.md
+++ b/docs/ja/01-getting-started.md
@@ -29,24 +29,24 @@ brew install cmake  # macOS
 
 ```bash
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8)
-uv sync --extra dev --extra cu118
-uv sync --extra dev --extra cu124
-uv sync --extra dev --extra cu126
-uv sync --extra dev --extra cu128
+uv sync --extra cu118
+uv sync --extra cu124
+uv sync --extra cu126
+uv sync --extra cu128
 
 # オプション: Motrix backend
-uv sync --extra dev --extra motrix
-uv sync --extra dev --extra cu124 --extra motrix
+uv sync --extra motrix
+uv sync --extra cu124 --extra motrix
 ```
 
 ## 中国本土向けミラー
 
 ```bash
 export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-uv sync --extra dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ## First Run

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -6,8 +6,8 @@
 
 1. リポジトリを fork して clone します。
 2. 利用するプラットフォームに応じて依存関係を入れます:
-   - macOS (MPS): `uv sync --extra dev`
-   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra dev --extra cu124`
+   - macOS (MPS): `uv sync`
+   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra cu124`
    - Motrix が必要な場合は `--extra motrix` を追加します
 3. `git checkout -b docs/improve-readme` や `git checkout -b fix/backend-bug` のように branch を切ります。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -30,13 +30,13 @@ cd UniLab
 
 # 2. 依存関係をインストール
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (CUDA extra を 1 つ選択。例: cu124)
-uv sync --extra dev --extra cu124
+uv sync --extra cu124
 
 # オプション: Motrix バックエンド
-uv sync --extra dev --extra motrix
+uv sync --extra motrix
 
 # 3. 学習ジョブを実行
 uv run python scripts/train_rsl_rl.py task=go1_joystick

--- a/docs/ko/01-getting-started.md
+++ b/docs/ko/01-getting-started.md
@@ -29,24 +29,24 @@ brew install cmake  # macOS
 
 ```bash
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8)
-uv sync --extra dev --extra cu118
-uv sync --extra dev --extra cu124
-uv sync --extra dev --extra cu126
-uv sync --extra dev --extra cu128
+uv sync --extra cu118
+uv sync --extra cu124
+uv sync --extra cu126
+uv sync --extra cu128
 
 # 선택 사항: Motrix 백엔드
-uv sync --extra dev --extra motrix
-uv sync --extra dev --extra cu124 --extra motrix
+uv sync --extra motrix
+uv sync --extra cu124 --extra motrix
 ```
 
 ## 중국 본토 미러
 
 ```bash
 export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-uv sync --extra dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ## First Run

--- a/docs/ko/CONTRIBUTING.md
+++ b/docs/ko/CONTRIBUTING.md
@@ -6,8 +6,8 @@
 
 1. 저장소를 fork한 뒤 clone합니다.
 2. 사용하는 플랫폼에 맞게 의존성을 설치합니다:
-   - macOS (MPS): `uv sync --extra dev`
-   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra dev --extra cu124`
+   - macOS (MPS): `uv sync`
+   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra cu124`
    - Motrix가 필요하면 `--extra motrix`를 추가합니다
 3. `git checkout -b docs/improve-readme` 또는 `git checkout -b fix/backend-bug` 같은 branch를 만듭니다.
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -30,13 +30,13 @@ cd UniLab
 
 # 2. 의존성 설치
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (예: cu124 같은 CUDA extra 하나 선택)
-uv sync --extra dev --extra cu124
+uv sync --extra cu124
 
 # 선택 사항: Motrix 백엔드
-uv sync --extra dev --extra motrix
+uv sync --extra motrix
 
 # 3. 학습 실행
 uv run python scripts/train_rsl_rl.py task=go1_joystick

--- a/docs/zh_CN/01-getting-started.md
+++ b/docs/zh_CN/01-getting-started.md
@@ -29,24 +29,24 @@ brew install cmake  # macOS
 
 ```bash
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8)
-uv sync --extra dev --extra cu118
-uv sync --extra dev --extra cu124
-uv sync --extra dev --extra cu126
-uv sync --extra dev --extra cu128
+uv sync --extra cu118
+uv sync --extra cu124
+uv sync --extra cu126
+uv sync --extra cu128
 
 # 可选: Motrix 后端
-uv sync --extra dev --extra motrix
-uv sync --extra dev --extra cu124 --extra motrix
+uv sync --extra motrix
+uv sync --extra cu124 --extra motrix
 ```
 
 ## 中国大陆镜像
 
 ```bash
 export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-uv sync --extra dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ## First Run

--- a/docs/zh_CN/CONTRIBUTING.md
+++ b/docs/zh_CN/CONTRIBUTING.md
@@ -6,8 +6,8 @@
 
 1. Fork 并克隆仓库。
 2. 按平台安装依赖:
-   - macOS (MPS): `uv sync --extra dev`
-   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra dev --extra cu124`
+   - macOS (MPS): `uv sync`
+   - Linux (CUDA 11.8 / 12.4 / 12.6 / 12.8): `uv sync --extra cu124`
    - 需要 Motrix 时，在命令后追加 `--extra motrix`
 3. 创建分支，例如 `git checkout -b docs/improve-readme` 或 `git checkout -b fix/backend-bug`。
 

--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -30,13 +30,13 @@ cd UniLab
 
 # 2. 安装依赖
 # macOS (MPS)
-uv sync --extra dev
+uv sync
 
 # Linux (任选一个 CUDA extra，例如 cu124)
-uv sync --extra dev --extra cu124
+uv sync --extra cu124
 
 # 可选: Motrix 后端
-uv sync --extra dev --extra motrix
+uv sync --extra motrix
 
 # 3. 运行一个训练任务
 uv run python scripts/train_rsl_rl.py task=go1_joystick

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "mypy", "pyright>=1.1.408"]
 cu118 = []
 cu124 = []
 cu126 = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'linux'",
@@ -3759,13 +3759,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
 motrix = [
     { name = "motrixsim" },
 ]
@@ -3790,16 +3783,11 @@ requires-dist = [
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.0" },
     { name = "mujoco-uni", specifier = "==3.6.0.post2", index = "https://test.pypi.org/simple/" },
-    { name = "mypy", marker = "extra == 'dev'" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "rich" },
     { name = "rsl-rl-lib", specifier = ">=5.0.0" },
-    { name = "ruff", marker = "extra == 'dev'" },
     { name = "setuptools", specifier = "<70" },
     { name = "tensorboard" },
     { name = "tensordict" },
@@ -3808,7 +3796,7 @@ requires-dist = [
     { name = "typing-extensions" },
     { name = "wandb" },
 ]
-provides-extras = ["dev", "cu118", "cu124", "cu126", "cu128", "motrix"]
+provides-extras = ["cu118", "cu124", "cu126", "cu128", "motrix"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
  ## Summary

  - remove the duplicated `dev` entry from `[project.optional-dependencies]` in `pyproject.toml`
  - keep `dev` only in `[dependency-groups]`, so development dependencies continue to install via default `uv sync`
  - update CI, `README.md`, `CONTRIBUTING.md`, and all localized docs under `docs/` to remove obsolete `--extra dev` usage
  - no training logic, backend contract, or runtime behavior changed; this is dependency/configuration and docs cleanup only

  ## Linked Work

  - Issue: https://github.com/unilabsim/UniLab/issues/115
  - Milestone: 

  ## Validation

  - [ ] `make check`
  - [ ] `uv run pytest -m "not slow"`
  - [x] Additional task-specific validation listed below

  Commands actually run:

  ```bash
  rg -n "uv sync --extra dev|\[project.optional-dependencies\]|\[dependency-groups\]" pyproject.toml README.md CONTRIBUTING.md docs .github -S
  git diff -- pyproject.toml README.md CONTRIBUTING.md docs .github/workflows/ci.yml
  ```

  ## Impact

  - Backend impact: none
  - Platform impact: both
  - Training effect expected: no

  ## Artifacts

  - W&B:
  - benchmark result:
  - video / screenshot:
  - ONNX / checkpoint:

  ## Checklist

  - [ ] Added or updated tests where needed
  - [x] Updated docs if behavior or workflow changed
  - [ ] Linked the driving issue
  - [x] Noted any follow-up work explicitly