### PR TITLE
fix: clear stale final observation mask

### DIFF
--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -95,6 +95,9 @@ class NpEnv(ABEnv):
         if self._dr_manager is not None:
             self._dr_manager.apply_interval_randomization_if_due(self.step_counter)
         self._state.truncated.fill(False)
+        final_obs_mask = self._state.info.get("_final_observation")
+        if isinstance(final_obs_mask, np.ndarray):
+            final_obs_mask.fill(False)
 
         t0 = time.perf_counter()
         self._backend.step(ctrl, self._cfg.sim_substeps)

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -102,6 +102,24 @@ class _HookTruncatingStubEnv(_StubNpEnv):
         return truncated
 
 
+class _ToggleTerminatingStubEnv(_StubNpEnv):
+    """Terminates a configured env set on the next step only."""
+
+    def __init__(self, num_envs: int = 4):
+        super().__init__(num_envs)
+        self._terminate_indices: list[int] = []
+
+    def set_terminate_indices(self, terminate_indices: list[int]) -> None:
+        self._terminate_indices = terminate_indices
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        state = super().update_state(state)
+        terminated = np.zeros((self._num_envs,), dtype=bool)
+        if self._terminate_indices:
+            terminated[np.asarray(self._terminate_indices, dtype=np.int32)] = True
+        return state.replace(terminated=terminated)
+
+
 # ---------------------------------------------------------------------------
 # NpEnvState tests
 # ---------------------------------------------------------------------------
@@ -341,6 +359,34 @@ class TestResetDoneEnvs:
         env.step(np.zeros((3, 3)))
         mask = env.state.info["_final_observation"]
         np.testing.assert_array_equal(mask, [False, True, False])
+
+    def test_final_observation_mask_clears_on_first_non_terminal_step(self):
+        env = _StubNpEnv(num_envs=3)
+        env.init_state()
+        np.testing.assert_array_equal(env.state.info["_final_observation"], [True, True, True])
+
+        state = env.step(np.zeros((3, 3)))
+
+        np.testing.assert_array_equal(state.done, [False, False, False])
+        np.testing.assert_array_equal(state.info["_final_observation"], [False, False, False])
+
+    def test_final_observation_mask_clears_after_terminal_step(self):
+        env = _ToggleTerminatingStubEnv(num_envs=3)
+        env.init_state()
+        env.set_terminate_indices([1])
+
+        terminal_state = env.step(np.zeros((3, 3)))
+        np.testing.assert_array_equal(
+            terminal_state.info["_final_observation"], [False, True, False]
+        )
+
+        env.set_terminate_indices([])
+        non_terminal_state = env.step(np.zeros((3, 3)))
+
+        np.testing.assert_array_equal(non_terminal_state.done, [False, False, False])
+        np.testing.assert_array_equal(
+            non_terminal_state.info["_final_observation"], [False, False, False]
+        )
 
     def test_no_termination_skips_reset(self):
         env = _TerminatingStubEnv(num_envs=2, terminate_indices=[])


### PR DESCRIPTION
## Summary

- clear `state.info["_final_observation"]` at the start of each `NpEnv.step()` so it behaves as a per-step event mask
- keep terminal `final_observation` capture in `_reset_done_envs()` unchanged for envs that actually finish on the current step
- add regression tests for the stale-mask cases after `init_state()` and after a subsequent terminal step

## Linked Work

- Issue: Closes #126
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
UV_CACHE_DIR=.uv-cache uv run --no-sync pytest tests/base/test_np_env.py
UV_CACHE_DIR=.uv-cache uv run --no-sync ruff check src/unilab/base/np_env.py tests/base/test_np_env.py
UV_CACHE_DIR=.uv-cache uv run --no-sync ruff format --check src/unilab/base/np_env.py tests/base/test_np_env.py
```

## Impact

- Backend impact: both
- Platform impact: both
- Training effect expected: yes

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up work: none.
