### PR TITLE
docs: fix broken links after removing en/ja/ko docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Always use `uv run`, not python**.
 
 UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructure 仓库。
-先看 [RL Infrastructure Development Standard](docs/en/00-development-architecture.md)。AGENTS 只保留 agent 必须记住的理念。
+先看 [RL Infrastructure Development Standard](docs/zh_CN/00-development-architecture.md)。AGENTS 只保留 agent 必须记住的理念。
 
 ## Core Principles
 
@@ -17,7 +17,7 @@ UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructu
 ## Read Order
 
 1. `AGENTS.md`
-2. `docs/en/00-development-architecture.md`
+2. `docs/zh_CN/00-development-architecture.md`
 3. `CONTRIBUTING.md`
 4. 当前任务相关代码与测试
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to UniLab
 
-Languages: English | [简体中文](docs/zh_CN/CONTRIBUTING.md) | [日本語](docs/ja/CONTRIBUTING.md) | [한국어](docs/ko/CONTRIBUTING.md)
+Languages: English | [简体中文](docs/zh_CN/CONTRIBUTING.md)
 
 ## Development Environment Setup
 
@@ -15,12 +15,12 @@ Languages: English | [简体中文](docs/zh_CN/CONTRIBUTING.md) | [日本語](do
 
 - Always use `uv run`; do not invoke `python` outside `uv run`
 - Run `make check` before code-related commits
-- For user-facing workflow changes, keep `README.md`, `CONTRIBUTING.md`, and the matching localized docs under `docs/{en,zh_CN,ja,ko}/` in sync
+- For user-facing workflow changes, keep `README.md`, `CONTRIBUTING.md`, and the matching localized docs under `docs/zh_CN/` in sync
 
 ## Read Before You Start
 
-- Before changing training entrypoints, runners, env contracts, or backend paths, read [RL Infrastructure Development Standard](docs/en/00-development-architecture.md)
-- Before changing collaboration flow or issue / milestone rules, read [docs/en/06-collaboration.md](docs/en/06-collaboration.md)
+- Before changing training entrypoints, runners, env contracts, or backend paths, read [RL Infrastructure Development Standard](docs/zh_CN/00-development-architecture.md)
+- Before changing collaboration flow or issue / milestone rules, read [docs/zh_CN/06-collaboration.md](docs/zh_CN/06-collaboration.md)
 
 ## Common Commands
 
@@ -123,7 +123,7 @@ Docs-only and collaboration-metadata changes such as `*.md`, `docs/**`, `CONTRIB
 - **PR**: must link the driving issue and list validation commands plus impact scope
 - **CODEOWNERS**: review ownership, not execution ownership
 
-More collaboration rules live in [docs/en/06-collaboration.md](docs/en/06-collaboration.md).
+More collaboration rules live in [docs/zh_CN/06-collaboration.md](docs/zh_CN/06-collaboration.md).
 
 ## Pull Request Workflow
 
@@ -147,4 +147,4 @@ UniLab uses Hydra + dataclass configuration:
 - **Change hyperparameters**: edit the matching YAML or use CLI overrides such as `algo.num_envs=2048`
 - **Add a new algorithm**: add the dataclass in `structured_configs.py` and create the matching `conf/` directory
 
-For more detail, see the Hydra section in [Training Guide](docs/en/03-training.md) and [Development Architecture](docs/en/00-development-architecture.md).
+For more detail, see the Hydra section in [Training Guide](docs/zh_CN/03-training.md) and [Development Architecture](docs/zh_CN/00-development-architecture.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # UniLab
 
-Languages: English | [简体中文](docs/zh_CN/README.md) | [日本語](docs/ja/README.md) | [한국어](docs/ko/README.md)
+Languages: English | [简体中文](docs/zh_CN/README.md)
 
 UniLab is built to test a simple hypothesis: **robot locomotion RL does not need a GPU simulation backend**.
 
@@ -60,17 +60,18 @@ Training scripts automatically enter playback after training unless you set `tra
 - `scripts/`: direct entrypoints for training, playback, motion preprocessing, and tooling
 - `src/unilab/`: environments, backends, algorithms, and shared utilities
 - `tests/`: unit tests, integration tests, and script configuration tests
-- `docs/`: language-specific documentation under `docs/en/`, `docs/zh_CN/`, `docs/ja/`, and `docs/ko/`
+- `docs/`: language-specific documentation under `docs/zh_CN/`
 
 ## Documentation
 
-- [00 RL Infrastructure Development Standard](docs/en/00-development-architecture.md): design principles, layering, contracts, and validation boundaries
-- [01 Getting Started](docs/en/01-getting-started.md): installation, dependency setup, mirrors, and first-run commands
-- [02 Simulation Backends](docs/en/02-simulation-backends.md): MuJoCo / Motrix support scope and backend selection
-- [03 Training Guide](docs/en/03-training.md): training, playback, resume flow, Hydra overrides, and W&B
-- [04 Algorithms](docs/en/04-algorithms.md): APPO, FastSAC, and FastTD3 usage and differences
-- [05 G1 Motion Tracking](docs/en/05-g1-motion-tracking.md): the G1 whole-body motion-tracking task
-- [06 Collaboration Workflow](docs/en/06-collaboration.md): GitHub issue / milestone / PR collaboration rules
+- [00 RL Infrastructure Development Standard](docs/zh_CN/00-development-architecture.md): design principles, layering, contracts, and validation boundaries
+- [01 Getting Started](docs/zh_CN/01-getting-started.md): installation, dependency setup, mirrors, and first-run commands
+- [02 Simulation Backends](docs/zh_CN/02-simulation-backends.md): MuJoCo / Motrix support scope and backend selection
+- [03 Training Guide](docs/zh_CN/03-training.md): training, playback, resume flow, Hydra overrides, and W&B
+- [04 Algorithms](docs/zh_CN/04-algorithms.md): APPO, FastSAC, and FastTD3 usage and differences
+- [05 G1 Motion Tracking](docs/zh_CN/05-g1-motion-tracking.md): the G1 whole-body motion-tracking task
+- [06 Collaboration Workflow](docs/zh_CN/06-collaboration.md): GitHub issue / milestone / PR collaboration rules
+- [07 Domain Randomization](docs/zh_CN/07-domain-randomization.md): domain randomization configuration and best practices
 - [Contributing](CONTRIBUTING.md): development workflow, testing, CI, and review expectations
 - [AGENTS](AGENTS.md): guidance for coding agents and automated editors working in this RL infra repo
 


### PR DESCRIPTION
## Summary

Fixes #130 - 修复删除 en/ja/ko 文档目录后的断链问题。

## Changes

- README.md: 将 \docs/en/\ 链接改为 \docs/zh_CN/\
- README.md: 移除不存在的 ja/ko 语言切换链接
- README.md: 文档索引添加 07-domain-randomization.md
- CONTRIBUTING.md: 将 \docs/en/\ 链接改为 \docs/zh_CN/\
- CONTRIBUTING.md: 移除不存在的 ja/ko 语言切换链接
- CONTRIBUTING.md: 第 18 行修改为仅要求维护 zh_CN
- AGENTS.md: 将 \docs/en/\ 链接改为 \docs/zh_CN/\

## Validation

- [x] README.md 零 404 链接
- [x] CONTRIBUTING.md 零 404 链接
- [x] AGENTS.md 零 404 链接
- [x] 07-domain-randomization.md 出现在 README 索引中

## Checklist

- [x] 仅修改文档，无代码变更
- [x] 所有链接已验证指向存在的文件