### PR TITLE
feat: SimBackend unified model property API

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -1,4 +1,5 @@
 import abc
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -25,6 +26,69 @@ class SimBackend(abc.ABC):
     @abc.abstractmethod
     def model(self):
         """底层物理模型"""
+
+    # ------------------------------------------------------------------ #
+    # Model properties                                                     #
+    # ------------------------------------------------------------------ #
+
+    @property
+    @abc.abstractmethod
+    def num_actuators(self) -> int:
+        """执行器数量"""
+
+    @property
+    @abc.abstractmethod
+    def num_dof_vel(self) -> int:
+        """关节速度自由度数量（不含浮动基座）"""
+
+    @abc.abstractmethod
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        """获取执行器控制范围
+
+        Returns:
+            (num_actuators, 2) 数组，列为 [low, high]
+        """
+
+    @abc.abstractmethod
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        """获取指定关键帧的完整 qpos（含浮动基座）
+
+        Args:
+            name: 关键帧名称（如 "stand"、"home"）
+
+        Returns:
+            (nq,) 数组
+        """
+
+    @abc.abstractmethod
+    def get_init_qvel(self) -> np.ndarray:
+        """获取零初始化的 qvel 向量，维度与 set_state 期望一致
+
+        Returns:
+            全零数组
+        """
+
+    @abc.abstractmethod
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        """将 body/link 名称解析为后端整数 ID
+
+        Args:
+            names: body/link 名称序列
+
+        Returns:
+            (len(names),) int32 数组
+
+        Raises:
+            ValueError: 若名称未找到
+        """
+
+    @abc.abstractmethod
+    def get_joint_range(self) -> np.ndarray | None:
+        """获取关节位置限制（不含浮动基座）
+
+        Returns:
+            (num_dof, 2) 数组，列为 [low, high]；若后端不支持则返回 None
+        """
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                   #

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -122,7 +122,9 @@ class MotrixBackend(SimBackend):
         return int(self._model.num_dof_vel) - 6
 
     def get_actuator_ctrl_range(self) -> np.ndarray:
-        return np.asarray(self._model.actuator_ctrl_limits).T.copy()
+        arr: np.ndarray = np.array(self._model.actuator_ctrl_limits, dtype=self._np_dtype)
+        result: np.ndarray = arr.T.copy()
+        return result
 
     def get_keyframe_qpos(self, name: str) -> np.ndarray:
         if hasattr(self._model, "keyframes") and self._model.num_keyframes > 0:

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -105,6 +106,43 @@ class MotrixBackend(SimBackend):
     @property
     def data(self):
         return self._data
+
+    # ------------------------------------------------------------------ #
+    # Model properties                                                   #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def num_actuators(self) -> int:
+        return int(self._model.num_actuators)
+
+    @property
+    def num_dof_vel(self) -> int:
+        # model.num_dof_vel includes 6 floating-base DOFs; exclude them
+        # to match get_dof_vel() which returns joint velocities only.
+        return int(self._model.num_dof_vel) - 6
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return np.asarray(self._model.actuator_ctrl_limits).T.copy()
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        if hasattr(self._model, "keyframes") and self._model.num_keyframes > 0:
+            return np.array(self._model.keyframes[0].dof_pos, dtype=self._np_dtype)
+        return np.array(self._model.compute_init_dof_pos(), dtype=self._np_dtype)
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros((self._model.num_dof_vel,), dtype=self._np_dtype)
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        ids: list[int] = []
+        for name in names:
+            bid = self._model.get_link_index(name)
+            if bid is None or bid < 0:
+                raise ValueError(f"Body '{name}' not found in Motrix model")
+            ids.append(int(bid))
+        return np.array(ids, dtype=np.int32)
+
+    def get_joint_range(self) -> np.ndarray | None:
+        return None
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                 #

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Sequence
 from multiprocessing import cpu_count
 from typing import Optional, cast
 
@@ -186,6 +187,44 @@ class MuJoCoBackend(SimBackend):
     @property
     def model(self):
         return self._model
+
+    # ------------------------------------------------------------------ #
+    # Model properties                                                   #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def num_actuators(self) -> int:
+        return int(self._model.nu)
+
+    @property
+    def num_dof_vel(self) -> int:
+        return self._num_dof_vel
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return np.asarray(self._model.actuator_ctrlrange).copy()
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        key_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_KEY, name)
+        if key_id < 0:
+            raise ValueError(f"Keyframe '{name}' not found in MuJoCo model")
+        return np.array(self._model.key_qpos[key_id].copy(), dtype=self._np_dtype)
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros((self.nv,), dtype=self._np_dtype)
+
+    def get_body_ids(self, names: "Sequence[str]") -> np.ndarray:
+        ids: list[int] = []
+        for name in names:
+            bid = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, name)
+            if bid < 0:
+                raise ValueError(f"Body '{name}' not found in MuJoCo model")
+            ids.append(bid)
+        return np.array(ids, dtype=np.int32)
+
+    def get_joint_range(self) -> np.ndarray | None:
+        if self._root_qpos_dim > 0:
+            return np.asarray(self._model.jnt_range[1:]).copy()
+        return np.asarray(self._model.jnt_range).copy()
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                 #

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -198,10 +198,10 @@ class MuJoCoBackend(SimBackend):
 
     @property
     def num_dof_vel(self) -> int:
-        return self._num_dof_vel
+        return int(self._num_dof_vel)
 
     def get_actuator_ctrl_range(self) -> np.ndarray:
-        return np.asarray(self._model.actuator_ctrlrange).copy()
+        return np.array(self._model.actuator_ctrlrange, dtype=self._np_dtype)
 
     def get_keyframe_qpos(self, name: str) -> np.ndarray:
         key_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_KEY, name)
@@ -223,8 +223,8 @@ class MuJoCoBackend(SimBackend):
 
     def get_joint_range(self) -> np.ndarray | None:
         if self._root_qpos_dim > 0:
-            return np.asarray(self._model.jnt_range[1:]).copy()
-        return np.asarray(self._model.jnt_range).copy()
+            return np.array(self._model.jnt_range[1:], dtype=self._np_dtype)
+        return np.array(self._model.jnt_range, dtype=self._np_dtype)
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                 #

--- a/src/unilab/envs/locomotion/g1/base.py
+++ b/src/unilab/envs/locomotion/g1/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import gymnasium as gym
-import mujoco
 import numpy as np
 
 from unilab.base.backend import SimBackend
@@ -61,16 +60,9 @@ class G1BaseEnv(NpEnv):
         self._init_buffers()
 
     def _init_action_space(self):
-        model = self._backend.model
-        if hasattr(model, "actuator_ctrlrange"):
-            low = model.actuator_ctrlrange[:, 0].copy()
-            high = model.actuator_ctrlrange[:, 1].copy()
-            nu = model.nu
-        else:
-            low = model.actuator_ctrl_limits[0, :]
-            high = model.actuator_ctrl_limits[1, :]
-            nu = model.num_actuators
-        self._action_space = gym.spaces.Box(low, high, (nu,), dtype=float)  # type: ignore[assignment]
+        ctrl_range = self._backend.get_actuator_ctrl_range()
+        nu = self._backend.num_actuators
+        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
 
     @property
     def action_space(self) -> gym.spaces.Box:
@@ -78,19 +70,9 @@ class G1BaseEnv(NpEnv):
 
     def _init_buffers(self):
         self.default_angles = np.zeros((self._num_action,), dtype=np.float32)
-        model = self._backend.model
-        if hasattr(model, "key_qpos"):
-            key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
-            if key_id >= 0:
-                self._init_qpos = np.array(model.key_qpos[key_id].copy(), dtype=np.float32)
-                self.default_angles = self._init_qpos[7:]
-            else:
-                raise ValueError("Keyframe 'stand' not found")
-            self._init_qvel = np.zeros((model.nv,), dtype=np.float32)
-        else:
-            self._init_qpos = model.compute_init_dof_pos()
-            self.default_angles = self._init_qpos[-self._num_action :]
-            self._init_qvel = np.zeros((model.num_dof_vel,), dtype=np.float32)
+        self._init_qpos = self._backend.get_keyframe_qpos("stand")
+        self.default_angles = self._init_qpos[-self._num_action :]
+        self._init_qvel = self._backend.get_init_qvel()
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
         state.info["last_actions"] = state.info.get("current_actions", actions.copy())

--- a/src/unilab/envs/locomotion/go1/base.py
+++ b/src/unilab/envs/locomotion/go1/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import gymnasium as gym
-import mujoco
 import numpy as np
 
 from unilab.base.backend import SimBackend
@@ -80,16 +79,9 @@ class Go1BaseEnv(NpEnv):
         self._init_buffers()
 
     def _init_action_space(self):
-        model = self._backend.model
-        if hasattr(model, "actuator_ctrlrange"):
-            low = model.actuator_ctrlrange[:, 0].copy()
-            high = model.actuator_ctrlrange[:, 1].copy()
-            nu = model.nu
-        else:
-            low = model.actuator_ctrl_limits[0, :]
-            high = model.actuator_ctrl_limits[1, :]
-            nu = model.num_actuators
-        self._action_space = gym.spaces.Box(low, high, (nu,), dtype=float)  # type: ignore[assignment]
+        ctrl_range = self._backend.get_actuator_ctrl_range()
+        nu = self._backend.num_actuators
+        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
 
     @property
     def action_space(self) -> gym.spaces.Box:
@@ -98,26 +90,9 @@ class Go1BaseEnv(NpEnv):
     def _init_buffers(self):
         dtype = get_global_dtype()
         self.default_angles = np.zeros((self._num_action,), dtype=dtype)
-        model = self._backend.model
-        if hasattr(model, "key_qpos"):
-            # MuJoCo backend
-            key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
-            if key_id >= 0:
-                self._init_qpos = np.array(model.key_qpos[key_id].copy(), dtype=dtype)
-                self.default_angles = self._init_qpos[7:]
-            else:
-                raise ValueError("Keyframe 'home' not found in MuJoCo model")
-            self._init_qvel = np.zeros((model.nv,), dtype=dtype)
-        elif hasattr(model, "keyframes") and model.num_keyframes > 0:
-            # Motrix backend
-            kf = model.keyframes[0]  # Use first keyframe (should be "home")
-            self._init_qpos = np.array(kf.dof_pos, dtype=dtype)
-            self.default_angles = self._init_qpos[7:]
-            self._init_qvel = np.zeros((model.num_dof_vel,), dtype=dtype)
-        else:
-            raise ValueError(
-                "No keyframe found in model. Model must have either MuJoCo key_qpos or Motrix keyframes."
-            )
+        self._init_qpos = np.array(self._backend.get_keyframe_qpos("home"), dtype=dtype)
+        self.default_angles = self._init_qpos[7:]
+        self._init_qvel = self._backend.get_init_qvel().astype(dtype)
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
         state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))

--- a/src/unilab/envs/locomotion/go2/base.py
+++ b/src/unilab/envs/locomotion/go2/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import gymnasium as gym
-import mujoco
 import numpy as np
 
 from unilab.base.backend import SimBackend
@@ -65,17 +64,9 @@ class Go2BaseEnv(NpEnv):
         self._init_buffers()
 
     def _init_action_space(self):
-        model = self._backend.model
-        if hasattr(model, "actuator_ctrlrange"):
-            low = model.actuator_ctrlrange[:, 0].copy()
-            high = model.actuator_ctrlrange[:, 1].copy()
-            nu = model.nu
-        else:
-            low = model.actuator_ctrl_limits[0, :]
-            high = model.actuator_ctrl_limits[1, :]
-            nu = model.num_actuators
-
-        self._action_space = gym.spaces.Box(low, high, (nu,), dtype=float)  # type: ignore[assignment]
+        ctrl_range = self._backend.get_actuator_ctrl_range()
+        nu = self._backend.num_actuators
+        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
 
     @property
     def action_space(self) -> gym.spaces.Box:
@@ -84,35 +75,9 @@ class Go2BaseEnv(NpEnv):
     def _init_buffers(self):
         dtype = get_global_dtype()
         self.default_angles = np.zeros((self._num_action,), dtype=np.float32)
-
-        model = self._backend.model
-        if hasattr(model, "key_qpos"):
-            # MuJoCo backend
-            key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
-            if key_id >= 0:
-                self._init_qpos = np.array(model.key_qpos[key_id].copy(), dtype=dtype)
-                self.default_angles = self._init_qpos[7:]
-            else:
-                raise ValueError("Keyframe 'home' not found in MuJoCo model")
-            self._init_qvel = np.zeros((model.nv,), dtype=dtype)
-        elif hasattr(model, "keyframes") and model.num_keyframes > 0:
-            # Motrix backend
-            kf = model.keyframes[0]  # Use first keyframe (should be "home")
-            self._init_qpos = np.array(kf.dof_pos, dtype=dtype)
-            self.default_angles = self._init_qpos[7:]
-            self._init_qvel = np.zeros((model.num_dof_vel,), dtype=dtype)
-        # if hasattr(model, "key_qpos"):  # MuJoCo
-        #     key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home")
-        #     if key_id >= 0:
-        #         self._init_qpos = np.array(model.key_qpos[key_id].copy(), dtype=np.float32)
-        #         self.default_angles = self._init_qpos[7:]
-        #     else:
-        #         raise ValueError("Keyframe 'home' not found")
-        #     self._init_qvel = np.zeros((model.nv,), dtype=np.float32)
-        # else:  # MotrixSim
-        #     self._init_qpos = model.compute_init_dof_pos()
-        #     self.default_angles = self._init_qpos[-self._num_action :]
-        #     self._init_qvel = np.zeros((model.num_dof_vel,), dtype=np.float32)
+        self._init_qpos = np.array(self._backend.get_keyframe_qpos("home"), dtype=dtype)
+        self.default_angles = self._init_qpos[7:]
+        self._init_qvel = self._backend.get_init_qvel().astype(dtype)
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
         state.info["last_actions"] = state.info.get("current_actions", actions.copy())

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -313,24 +313,11 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self._log_action_scale_diagnostics()
 
         # Resolve body IDs for backend querying and motion-file indexing.
+        self.body_ids = self._backend.get_body_ids(cfg.body_names)
         if self._is_mujoco_backend():
-            self.body_ids = np.array(
-                [
-                    mujoco.mj_name2id(self._backend.model, mujoco.mjtObj.mjOBJ_BODY, name)
-                    for name in cfg.body_names
-                ],
-                dtype=np.int32,
-            )
             motion_body_ids = self.body_ids
         else:
-            backend_body_ids: list[int] = []
-            for name in cfg.body_names:
-                body_id = self._backend.model.get_link_index(name)
-                if body_id is None or body_id < 0:
-                    raise ValueError(f"Body '{name}' not found in motrix model")
-                backend_body_ids.append(int(body_id))
-            self.body_ids = np.array(backend_body_ids, dtype=np.int32)
-
+            # Motion data always uses MuJoCo body indexing.
             mj_model = mujoco.MjModel.from_xml_path(cfg.model_file)
             motion_body_ids = np.array(
                 [
@@ -376,9 +363,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         )
 
     def _get_joint_range(self) -> np.ndarray | None:
-        if not self._is_mujoco_backend():
-            return None
-        return np.asarray(self._backend.model.jnt_range[1:])  # Skip free joint
+        return self._backend.get_joint_range()
 
     def _apply_adaptive_g1_action_scale(self) -> None:
         """Set per-joint action scale to match adaptive's normalization."""

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -363,7 +363,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         )
 
     def _get_joint_range(self) -> np.ndarray | None:
-        return self._backend.get_joint_range()
+        return self._backend.get_joint_range()  # type: ignore[no-any-return]
 
     def _apply_adaptive_g1_action_scale(self) -> None:
         """Set per-joint action scale to match adaptive's normalization."""

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -779,3 +779,161 @@ class TestCrossBackendBodySensors:
             mx.get_body_ang_vel_b(mx_ids),
             atol=self.ATOL,
         )
+
+
+# ---------------------------------------------------------------------------
+# Unified model properties — MuJoCo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestMuJoCoModelProperties:
+    @pytest.fixture(params=BASIC_ROBOTS)
+    def bkd(self, request):
+        from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+        p = request.param
+        return MuJoCoBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
+
+    def test_num_actuators(self, bkd):
+        assert bkd.num_actuators == bkd.model.nu
+        assert bkd.num_actuators > 0
+
+    def test_num_dof_vel(self, bkd):
+        assert bkd.num_dof_vel > 0
+        assert bkd.num_dof_vel <= bkd.model.nv
+
+    def test_get_actuator_ctrl_range(self, bkd):
+        ctrl_range = bkd.get_actuator_ctrl_range()
+        _shape(ctrl_range, bkd.num_actuators, 2)
+        assert np.all(ctrl_range[:, 0] <= ctrl_range[:, 1])
+
+    def test_get_keyframe_qpos(self, bkd):
+        for name in ("stand", "home"):
+            try:
+                qpos = bkd.get_keyframe_qpos(name)
+                assert qpos.ndim == 1
+                assert len(qpos) == bkd.model.nq
+                return
+            except ValueError:
+                continue
+        pytest.skip("No 'stand' or 'home' keyframe in model")
+
+    def test_get_keyframe_qpos_missing(self, bkd):
+        with pytest.raises(ValueError, match="not found"):
+            bkd.get_keyframe_qpos("nonexistent_keyframe_xyz")
+
+    def test_get_init_qvel(self, bkd):
+        qvel = bkd.get_init_qvel()
+        assert qvel.ndim == 1
+        assert len(qvel) == bkd.model.nv
+        np.testing.assert_array_equal(qvel, 0.0)
+
+    def test_get_body_ids(self, bkd):
+        import mujoco
+
+        base_name = mujoco.mj_id2name(bkd.model, mujoco.mjtObj.mjOBJ_BODY, 1)
+        ids = bkd.get_body_ids([base_name])
+        assert ids.dtype == np.int32
+        assert ids[0] == 1
+
+    def test_get_body_ids_missing(self, bkd):
+        with pytest.raises(ValueError, match="not found"):
+            bkd.get_body_ids(["nonexistent_body_xyz"])
+
+    def test_get_joint_range(self, bkd):
+        jr = bkd.get_joint_range()
+        assert jr is not None
+        assert jr.ndim == 2
+        assert jr.shape[1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Unified model properties — Motrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestMotrixModelProperties:
+    @pytest.fixture(autouse=True)
+    def _require_motrix(self):
+        pytest.importorskip("motrixsim")
+
+    @pytest.fixture(params=BASIC_ROBOTS)
+    def _ctx(self, request):
+        from unilab.base.backend.motrix_backend import MotrixBackend
+
+        p = request.param
+        bkd = MotrixBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
+        return bkd, p["base_name"]
+
+    @pytest.fixture
+    def bkd(self, _ctx):
+        return _ctx[0]
+
+    def test_num_actuators(self, bkd):
+        assert bkd.num_actuators > 0
+
+    def test_num_dof_vel(self, bkd):
+        assert bkd.num_dof_vel > 0
+
+    def test_get_actuator_ctrl_range(self, bkd):
+        ctrl_range = bkd.get_actuator_ctrl_range()
+        _shape(ctrl_range, bkd.num_actuators, 2)
+
+    def test_get_keyframe_qpos(self, bkd):
+        # Motrix ignores the name but should not raise
+        qpos = bkd.get_keyframe_qpos("home")
+        assert qpos.ndim == 1
+        assert len(qpos) > 0
+
+    def test_get_init_qvel(self, bkd):
+        qvel = bkd.get_init_qvel()
+        assert qvel.ndim == 1
+        np.testing.assert_array_equal(qvel, 0.0)
+
+    def test_get_body_ids(self, _ctx):
+        bkd, base_name = _ctx
+        ids = bkd.get_body_ids([base_name])
+        assert ids.dtype == np.int32
+        assert len(ids) == 1
+
+    def test_get_body_ids_missing(self, bkd):
+        with pytest.raises(ValueError, match="not found"):
+            bkd.get_body_ids(["nonexistent_body_xyz"])
+
+    def test_get_joint_range(self, bkd):
+        assert bkd.get_joint_range() is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-backend model properties consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestCrossBackendModelProperties:
+    @pytest.fixture(autouse=True)
+    def _require_motrix(self):
+        pytest.importorskip("motrixsim")
+
+    @pytest.fixture
+    def backends(self):
+        from unilab.base.backend.motrix_backend import MotrixBackend
+        from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+        mj = MuJoCoBackend(**_G1, num_envs=NUM_ENVS, sim_dt=SIM_DT)
+        mx = MotrixBackend(**_G1, num_envs=NUM_ENVS, sim_dt=SIM_DT)
+        return mj, mx
+
+    def test_num_actuators_match(self, backends):
+        mj, mx = backends
+        assert mj.num_actuators == mx.num_actuators
+
+    def test_num_dof_vel_match(self, backends):
+        mj, mx = backends
+        assert mj.num_dof_vel == mx.num_dof_vel
+
+    def test_actuator_ctrl_range_shape_match(self, backends):
+        mj, mx = backends
+        assert mj.get_actuator_ctrl_range().shape == mx.get_actuator_ctrl_range().shape


### PR DESCRIPTION
## Summary

- Add 7 unified abstract methods to `SimBackend` base class: `num_actuators`, `num_dof_vel`, `get_actuator_ctrl_range()`, `get_keyframe_qpos()`, `get_init_qvel()`, `get_body_ids()`, `get_joint_range()`
- Implement in both `MuJoCoBackend` and `MotrixBackend`, normalizing API differences (e.g. ctrl range shape transposition, keyframe access patterns)
- Refactor G1/Go1/Go2 `base.py`: replace all `hasattr(model, ...)` branches with unified backend calls, remove `import mujoco` dependency
- Refactor `tracking.py`: use `get_body_ids()` for body ID resolution and `get_joint_range()` delegation
- Add 158 lines of tests covering both backends and cross-backend consistency

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `pyright` passes with 0 errors
- [x] `pytest` — 568 passed, 0 failures (includes new model property tests + cross-backend consistency)

Closes #131