### PR TITLE
ci: optimize CI strategy and align pre-commit with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   mypy:
     timeout-minutes: 10
-    runs-on: macos-26 # Mac platform requires fewer dependencies to install
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -70,7 +70,7 @@ jobs:
 
   pyright:
     timeout-minutes: 10
-    runs-on: macos-26 # Mac platform requires fewer dependencies to install
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
     rev: v1.1.408
     hooks:
       - id: pyright
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-PyYAML]
+        args: [--config-file=pyproject.toml]

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ test:
 test-cov:
 	uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing
 
-.PHONY: test-fast
-test-fast:
-	uv run pytest -m "not slow and not veryslow"
-
 .PHONY: test-slow
 test-slow:
 	uv run pytest -m "slow and not veryslow" -v


### PR DESCRIPTION
## Summary

This PR addresses issue #134 by optimizing CI strategy and aligning pre-commit hooks with CI checks.

## Changes

1. **Migrate type check jobs to Linux**
   - Changed `mypy` job runner from `macos-26` to `ubuntu-slim`
   - Changed `pyright` job runner from `macos-26` to `ubuntu-slim`
   - Reduces CI costs (Linux runners are cheaper than macOS)

2. **Align pre-commit with CI**
   - Added `mypy` hook to pre-commit configuration
   - Ensures local pre-commit checks match CI checks

3. **Remove redundant Makefile target**
   - Removed `make test-fast` (was identical to `make test`)

## Verification

- [x] All existing tests pass (353 passed, 5 skipped)
- [x] mypy type check passes
- [x] pre-commit configuration is valid

Fixes #134