### PR TITLE
refactor: extract LocomotionBaseEnv — eliminate G1/Go1/Go2 code duplication

### DIFF
--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -1,0 +1,13 @@
+from .base import ControlConfigBase, LocomotionBaseCfg, LocomotionBaseEnv, Sensor
+from .commands import Commands, sample_velocity_commands
+from .domain_rand import DomainRandConfig
+
+__all__ = [
+    "Commands",
+    "ControlConfigBase",
+    "DomainRandConfig",
+    "LocomotionBaseCfg",
+    "LocomotionBaseEnv",
+    "Sensor",
+    "sample_velocity_commands",
+]

--- a/src/unilab/envs/locomotion/common/base.py
+++ b/src/unilab/envs/locomotion/common/base.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+import gymnasium as gym
+import numpy as np
+
+from unilab.base.backend import SimBackend
+from unilab.base.base import EnvCfg
+from unilab.base.dtype_config import get_global_dtype
+from unilab.base.np_env import NpEnv, NpEnvState
+
+
+@dataclass
+class Sensor:
+    local_linvel = "local_linvel"
+    gyro = "gyro"
+
+
+@dataclass
+class ControlConfigBase:
+    action_scale: float = 0.25
+    simulate_action_latency: bool = False
+
+
+@dataclass
+class LocomotionBaseCfg(EnvCfg):
+    model_file: str = field(default=str(""))
+    control_config: ControlConfigBase = field(default_factory=ControlConfigBase)
+    sensor: Sensor = field(default_factory=Sensor)
+    sim_dt: float = 0.01
+    ctrl_dt: float = 0.02
+
+
+class LocomotionBaseEnv(NpEnv):
+    """Common base environment for locomotion tasks (G1, Go1, Go2, etc.)."""
+
+    _cfg: LocomotionBaseCfg
+
+    _keyframe_name: ClassVar[str] = "home"
+    _use_global_dtype: ClassVar[bool] = True
+
+    def __init__(self, cfg: LocomotionBaseCfg, backend: SimBackend, num_envs: int = 1):
+        super().__init__(cfg, backend, num_envs)
+        self._init_action_space()
+        self._num_action = self._action_space.shape[0]
+        self._init_buffers()
+
+    def _init_action_space(self) -> None:
+        ctrl_range = self._backend.get_actuator_ctrl_range()
+        nu = self._backend.num_actuators
+        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment, arg-type]
+
+    @property
+    def action_space(self) -> gym.spaces.Box:
+        return self._action_space  # type: ignore[no-any-return]
+
+    def _init_buffers(self) -> None:
+        dtype = get_global_dtype() if self._use_global_dtype else np.float32
+        self.default_angles = np.zeros((self._num_action,), dtype=dtype)
+        raw_qpos = self._backend.get_keyframe_qpos(self._keyframe_name)
+        self._init_qpos = np.array(raw_qpos, dtype=dtype) if self._use_global_dtype else raw_qpos
+        self.default_angles = self._init_qpos[-self._num_action :]
+        raw_qvel = self._backend.get_init_qvel()
+        self._init_qvel = raw_qvel.astype(dtype) if self._use_global_dtype else raw_qvel
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))
+        state.info["current_actions"] = actions
+        exec_actions = (
+            state.info["last_actions"]
+            if self._cfg.control_config.simulate_action_latency
+            else actions
+        )
+        return np.asarray(
+            exec_actions * self._cfg.control_config.action_scale + self.default_angles
+        )
+
+    def get_local_linvel(self) -> np.ndarray:
+        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.local_linvel))
+
+    def get_gyro(self) -> np.ndarray:
+        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.gyro))
+
+    def get_dof_pos(self) -> np.ndarray:
+        return np.asarray(self._backend.get_dof_pos())
+
+    def get_dof_vel(self) -> np.ndarray:
+        return np.asarray(self._backend.get_dof_vel())

--- a/src/unilab/envs/locomotion/common/commands.py
+++ b/src/unilab/envs/locomotion/common/commands.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from unilab.base.dtype_config import get_global_dtype
+
+
+@dataclass
+class Commands:
+    vel_limit = [
+        [-0.6, -0.4, -0.8],  # [vx_min, vy_min, vyaw_min]
+        [1.0, 0.4, 0.8],  # [vx_max, vy_max, vyaw_max]
+    ]
+
+
+def sample_velocity_commands(
+    rng: np.random.Generator, num_samples: int, low: np.ndarray, high: np.ndarray
+) -> np.ndarray:
+    return np.asarray(
+        rng.uniform(low=low, high=high, size=(num_samples, 3)), dtype=get_global_dtype()
+    )

--- a/src/unilab/envs/locomotion/common/domain_rand.py
+++ b/src/unilab/envs/locomotion/common/domain_rand.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DomainRandConfig:
+    randomize_base_mass: bool = False
+    added_mass_range: list[float] = field(default_factory=lambda: [-1.5, 1.5])
+
+    random_com: bool = False
+    com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+
+    push_robots: bool = False
+    push_interval: int = 750  # step
+    max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])

--- a/src/unilab/envs/locomotion/g1/base.py
+++ b/src/unilab/envs/locomotion/g1/base.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import gymnasium as gym
 import numpy as np
 
-from unilab.base.backend import SimBackend
-from unilab.base.base import EnvCfg
-from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.envs.locomotion.common.base import (
+    ControlConfigBase,
+    LocomotionBaseCfg,
+    LocomotionBaseEnv,
+)
 
 
 @dataclass
@@ -21,9 +22,8 @@ class NoiseConfig:
 
 
 @dataclass
-class ControlConfig:
-    action_scale: float | np.ndarray = 0.25
-    simulate_action_latency: bool = False
+class ControlConfig(ControlConfigBase):
+    action_scale: float | np.ndarray = 0.25  # type: ignore[assignment]
 
 
 @dataclass
@@ -34,66 +34,15 @@ class Asset:
 
 
 @dataclass
-class Sensor:
-    local_linvel = "local_linvel"
-    gyro = "gyro"
-
-
-@dataclass
-class G1BaseCfg(EnvCfg):
-    model_file: str = field(default=str(""))
+class G1BaseCfg(LocomotionBaseCfg):
     noise_config: NoiseConfig = field(default_factory=NoiseConfig)
-    control_config: ControlConfig = field(default_factory=ControlConfig)
+    control_config: ControlConfig = field(default_factory=ControlConfig)  # type: ignore[assignment]
     asset: Asset = field(default_factory=Asset)
-    sensor: Sensor = field(default_factory=Sensor)
     sim_dt: float = 0.02 / 3.0
     ctrl_dt: float = 0.02
 
 
-class G1BaseEnv(NpEnv):
+class G1BaseEnv(LocomotionBaseEnv):
     _cfg: G1BaseCfg
-
-    def __init__(self, cfg: G1BaseCfg, backend: SimBackend, num_envs=1):
-        super().__init__(cfg, backend, num_envs)
-        self._init_action_space()
-        self._num_action = self._action_space.shape[0]
-        self._init_buffers()
-
-    def _init_action_space(self):
-        ctrl_range = self._backend.get_actuator_ctrl_range()
-        nu = self._backend.num_actuators
-        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
-
-    @property
-    def action_space(self) -> gym.spaces.Box:
-        return self._action_space  # type: ignore[no-any-return]
-
-    def _init_buffers(self):
-        self.default_angles = np.zeros((self._num_action,), dtype=np.float32)
-        self._init_qpos = self._backend.get_keyframe_qpos("stand")
-        self.default_angles = self._init_qpos[-self._num_action :]
-        self._init_qvel = self._backend.get_init_qvel()
-
-    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
-        state.info["last_actions"] = state.info.get("current_actions", actions.copy())
-        state.info["current_actions"] = actions
-        exec_actions = (
-            state.info["last_actions"]
-            if self._cfg.control_config.simulate_action_latency
-            else actions
-        )
-        return np.asarray(
-            exec_actions * self._cfg.control_config.action_scale + self.default_angles
-        )
-
-    def get_local_linvel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.local_linvel))
-
-    def get_gyro(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.gyro))
-
-    def get_dof_pos(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_pos())
-
-    def get_dof_vel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_vel())
+    _keyframe_name = "stand"
+    _use_global_dtype = False

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -27,6 +27,8 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common.commands import Commands
+from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -34,35 +36,6 @@ from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 @dataclass
 class InitState:
     pos = [0.0, 0.0, 0.754]
-
-
-@dataclass
-class Commands:
-    vel_limit = [
-        [-0.6, -0.4, -0.8],  # [vx_min, vy_min, vyaw_min]
-        [1.0, 0.4, 0.8],  # [vx_max, vy_max, vyaw_max]
-    ]
-
-
-@dataclass
-class Domain_Rand:
-    randomize_base_mass: bool = False
-    added_mass_range: list[float] = field(default_factory=lambda: [-1.5, 1.5])
-
-    random_com: bool = False
-    com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
-
-    push_robots: bool = False
-    push_interval: int = 750
-    max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
-
-
-def sample_velocity_commands(
-    rng, num_samples: int, low: np.ndarray, high: np.ndarray
-) -> np.ndarray:
-    return np.asarray(
-        rng.uniform(low=low, high=high, size=(num_samples, 3)), dtype=get_global_dtype()
-    )
 
 
 def sample_gait_phase_pairs(rng, num_samples: int, mode: str) -> np.ndarray:
@@ -162,7 +135,7 @@ class G1JoystickPPOCfg(G1BaseCfg):
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     reward_config: RewardConfigPPO | None = None
-    domain_rand: Domain_Rand = field(default_factory=Domain_Rand)
+    domain_rand: DomainRandConfig = field(default_factory=DomainRandConfig)
     gait_phase_init_mode: str = "offset_phase"
     reset_base_qvel_limit: float = 0.5
     backend_overrides: dict | None = None

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -12,9 +12,10 @@ from unilab.base import registry
 from unilab.base.backend import create_backend
 from unilab.base.curriculum import EpisodeLengthTracker, PenaltyCurriculum
 from unilab.base.dtype_config import get_global_dtype
+from unilab.envs.locomotion.common.commands import Commands
+from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
 from unilab.envs.locomotion.g1.joystick import (
-    Domain_Rand,
     G1JoystickDomainRandomizationProvider,
     G1JoystickPPO,
     InitState,
@@ -25,16 +26,6 @@ from unilab.envs.locomotion.g1.joystick import (
 class ControlConfigSAC:
     action_scale: float = 1.0  # holosoma 0.25
     simulate_action_latency: bool = False
-
-
-@dataclass
-class Commands:
-    """对齐 holosoma: 多方向命令采样"""
-
-    vel_limit = [
-        [-0.6, -0.4, -0.8],  # [vx_min, vy_min, vyaw_min]
-        [1.0, 0.4, 0.8],  # [vx_max, vy_max, vyaw_max]
-    ]
 
 
 @dataclass
@@ -62,7 +53,7 @@ class G1JoystickSACCfg(G1BaseCfg):
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     control_config: ControlConfigSAC = field(default_factory=ControlConfigSAC)  # type: ignore[assignment]
-    domain_rand: Domain_Rand = field(default_factory=Domain_Rand)
+    domain_rand: DomainRandConfig = field(default_factory=DomainRandConfig)
     gait_phase_init_mode: str = "offset_phase"
     reset_base_qvel_limit: float = 0.5
 

--- a/src/unilab/envs/locomotion/go1/base.py
+++ b/src/unilab/envs/locomotion/go1/base.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import gymnasium as gym
-import numpy as np
-
-from unilab.base.backend import SimBackend
-from unilab.base.base import EnvCfg
-from unilab.base.dtype_config import get_global_dtype
-from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.envs.locomotion.common.base import (
+    ControlConfigBase,
+    LocomotionBaseCfg,
+    LocomotionBaseEnv,
+)
 
 
 @dataclass
@@ -22,11 +20,9 @@ class NoiseConfig:
 
 
 @dataclass
-class ControlConfig:
-    action_scale: float = 0.25
+class ControlConfig(ControlConfigBase):
     Kp: float = 35.0
     Kd: float = 0.5
-    simulate_action_latency: bool = False
 
 
 @dataclass
@@ -37,83 +33,13 @@ class Asset:
 
 
 @dataclass
-class Sensor:
-    local_linvel = "local_linvel"
-    gyro = "gyro"
-
-
-@dataclass
-class Domain_Rand:
-    # randomize_friction = True
-    # friction_range = [0.5, 1.25]
-    randomize_base_mass = False
-    added_mass_range = [-1.5, 1.5]
-
-    random_com = False
-    com_offset_x = [-0.05, 0.05]
-
-    push_robots = False
-    push_interval = 750  # step
-    max_force = [1, 1, 0.5]
-
-
-@dataclass
-class Go1BaseCfg(EnvCfg):
-    model_file: str = field(default=str(""))
+class Go1BaseCfg(LocomotionBaseCfg):
     noise_config: NoiseConfig = field(default_factory=NoiseConfig)
-    control_config: ControlConfig = field(default_factory=ControlConfig)
+    control_config: ControlConfig = field(default_factory=ControlConfig)  # type: ignore[assignment]
     asset: Asset = field(default_factory=Asset)
-    sensor: Sensor = field(default_factory=Sensor)
     sim_dt: float = 0.01
     ctrl_dt: float = 0.02
 
 
-class Go1BaseEnv(NpEnv):
+class Go1BaseEnv(LocomotionBaseEnv):
     _cfg: Go1BaseCfg
-
-    def __init__(self, cfg: Go1BaseCfg, backend: SimBackend, num_envs=1):
-        super().__init__(cfg, backend, num_envs)
-
-        self._init_action_space()
-        self._num_action = self._action_space.shape[0]
-        self._init_buffers()
-
-    def _init_action_space(self):
-        ctrl_range = self._backend.get_actuator_ctrl_range()
-        nu = self._backend.num_actuators
-        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
-
-    @property
-    def action_space(self) -> gym.spaces.Box:
-        return self._action_space  # type: ignore[no-any-return]
-
-    def _init_buffers(self):
-        dtype = get_global_dtype()
-        self.default_angles = np.zeros((self._num_action,), dtype=dtype)
-        self._init_qpos = np.array(self._backend.get_keyframe_qpos("home"), dtype=dtype)
-        self.default_angles = self._init_qpos[7:]
-        self._init_qvel = self._backend.get_init_qvel().astype(dtype)
-
-    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
-        state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))
-        state.info["current_actions"] = actions
-        exec_actions = (
-            state.info["last_actions"]
-            if self._cfg.control_config.simulate_action_latency
-            else actions
-        )
-        return np.asarray(
-            exec_actions * self._cfg.control_config.action_scale + self.default_angles
-        )
-
-    def get_local_linvel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.local_linvel))
-
-    def get_gyro(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.gyro))
-
-    def get_dof_pos(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_pos())
-
-    def get_dof_vel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_vel())

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -24,6 +24,8 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common.commands import Commands
+from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -31,14 +33,6 @@ from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 @dataclass
 class InitState:
     pos = [0.0, 0.0, 0.45]
-
-
-@dataclass
-class Commands:
-    vel_limit = [
-        [-0.6, -0.4, -0.8],  # [vx_min, vy_min, vyaw_min]
-        [1.0, 0.4, 0.8],  # [vx_max, vy_max, vyaw_max]
-    ]
 
 
 @dataclass
@@ -62,21 +56,6 @@ class JoystickSensor:
     feet_pos = ["FL_pos", "FR_pos", "RL_pos", "RR_pos"]
 
 
-@dataclass
-class Domain_Rand:
-    # randomize_friction = True
-    # friction_range = [0.5, 1.25]
-    randomize_base_mass = True
-    added_mass_range = [-1.5, 1.5]
-
-    random_com = True
-    com_offset_x = [-0.05, 0.05]
-
-    push_robots = True
-    push_interval = 750  # step
-    max_force = [1, 1, 0.5]
-
-
 @registry.envcfg("Go1JoystickFlatTerrain")
 @dataclass
 class Go1JoystickCfg(Go1BaseCfg):
@@ -87,7 +66,13 @@ class Go1JoystickCfg(Go1BaseCfg):
     reward_config: RewardConfig | None = None
     legacy_motrix_profile: LegacyMotrixProfile = field(default_factory=LegacyMotrixProfile)
     sensor: JoystickSensor = field(default_factory=JoystickSensor)  # type: ignore[assignment]
-    domain_rand: Domain_Rand = field(default_factory=Domain_Rand)
+    domain_rand: DomainRandConfig = field(
+        default_factory=lambda: DomainRandConfig(
+            randomize_base_mass=True,
+            random_com=True,
+            push_robots=True,
+        )
+    )
 
     def apply_legacy_motrix_profile(self) -> None:
         profile = self.legacy_motrix_profile

--- a/src/unilab/envs/locomotion/go2/base.py
+++ b/src/unilab/envs/locomotion/go2/base.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import gymnasium as gym
 import numpy as np
 
-from unilab.base.backend import SimBackend
-from unilab.base.base import EnvCfg
-from unilab.base.dtype_config import get_global_dtype
-from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.envs.locomotion.common.base import (
+    ControlConfigBase,
+    LocomotionBaseCfg,
+    LocomotionBaseEnv,
+)
 
 
 @dataclass
@@ -22,11 +22,9 @@ class NoiseConfig:
 
 
 @dataclass
-class ControlConfig:
-    action_scale: float = 0.25
+class ControlConfig(ControlConfigBase):
     Kp: float = 35.0
     Kd: float = 0.5
-    simulate_action_latency: bool = False
 
 
 @dataclass
@@ -37,72 +35,16 @@ class Asset:
 
 
 @dataclass
-class Sensor:
-    local_linvel = "local_linvel"
-    gyro = "gyro"
-
-
-@dataclass
-class Go2BaseCfg(EnvCfg):
-    model_file: str = field(default=str(""))
+class Go2BaseCfg(LocomotionBaseCfg):
     noise_config: NoiseConfig = field(default_factory=NoiseConfig)
-    control_config: ControlConfig = field(default_factory=ControlConfig)
+    control_config: ControlConfig = field(default_factory=ControlConfig)  # type: ignore[assignment]
     asset: Asset = field(default_factory=Asset)
-    sensor: Sensor = field(default_factory=Sensor)
     sim_dt: float = 0.01
     ctrl_dt: float = 0.02
 
 
-class Go2BaseEnv(NpEnv):
+class Go2BaseEnv(LocomotionBaseEnv):
     _cfg: Go2BaseCfg
-
-    def __init__(self, cfg: Go2BaseCfg, backend: SimBackend, num_envs=1):
-        super().__init__(cfg, backend, num_envs)
-
-        self._init_action_space()
-        self._num_action = self._action_space.shape[0]
-        self._init_buffers()
-
-    def _init_action_space(self):
-        ctrl_range = self._backend.get_actuator_ctrl_range()
-        nu = self._backend.num_actuators
-        self._action_space = gym.spaces.Box(ctrl_range[:, 0], ctrl_range[:, 1], (nu,), dtype=float)  # type: ignore[assignment]
-
-    @property
-    def action_space(self) -> gym.spaces.Box:
-        return self._action_space  # type: ignore[no-any-return]
-
-    def _init_buffers(self):
-        dtype = get_global_dtype()
-        self.default_angles = np.zeros((self._num_action,), dtype=np.float32)
-        self._init_qpos = np.array(self._backend.get_keyframe_qpos("home"), dtype=dtype)
-        self.default_angles = self._init_qpos[7:]
-        self._init_qvel = self._backend.get_init_qvel().astype(dtype)
-
-    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
-        state.info["last_actions"] = state.info.get("current_actions", actions.copy())
-        state.info["current_actions"] = actions
-
-        exec_actions = (
-            state.info["last_actions"]
-            if self._cfg.control_config.simulate_action_latency
-            else actions
-        )
-        return np.asarray(
-            exec_actions * self._cfg.control_config.action_scale + self.default_angles
-        )
-
-    def get_local_linvel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.local_linvel))
-
-    def get_gyro(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.gyro))
-
-    def get_dof_pos(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_pos())
-
-    def get_dof_vel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_vel())
 
     def get_foot_pos(self) -> np.ndarray:
         """Get foot positions. Returns shape (num_envs, 4, 3)"""

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -24,6 +24,8 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common.commands import Commands
+from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -34,32 +36,12 @@ class InitState:
 
 
 @dataclass
-class Commands:
-    vel_limit = [
-        [-0.6, -0.4, -0.8],  # [vx_min, vy_min, vyaw_min]
-        [1.0, 0.4, 0.8],  # [vx_max, vy_max, vyaw_max]
-    ]
-
-
-@dataclass
-class Domain_Rand:
-    # randomize_friction = True
-    # friction_range = [0.5, 1.25]
-    randomize_base_mass: bool = False
-    added_mass_range: list[float] = field(default_factory=lambda: [-1.5, 1.5])
-
-    random_com: bool = False
-    com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
-
+class Go2DomainRandConfig(DomainRandConfig):
     randomize_kp: bool = True
     kp_multiplier_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
 
     randomize_kd: bool = True
     kd_multiplier_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
-
-    push_robots: bool = False
-    push_interval: int = 750  # step
-    max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
 
 
 @dataclass
@@ -94,7 +76,7 @@ class Go2JoystickCfg(Go2BaseCfg):
     reward_config: RewardConfig | None = None
     legacy_motrix_profile: LegacyMotrixProfile = field(default_factory=LegacyMotrixProfile)
     sensor: JoystickSensor = field(default_factory=JoystickSensor)  # type: ignore[assignment]
-    domain_rand: Domain_Rand = field(default_factory=Domain_Rand)
+    domain_rand: Go2DomainRandConfig = field(default_factory=Go2DomainRandConfig)
 
     def apply_legacy_motrix_profile(self) -> None:
         profile = self.legacy_motrix_profile

--- a/src/unilab/utils/xml_utils.py
+++ b/src/unilab/utils/xml_utils.py
@@ -105,7 +105,7 @@ def _add_b_sensors(sensor_tag: ET.Element, valid_bnames: list[str], baselink_nam
         )
 
 
-def _write_temp_xml(tree: ET.ElementTree[ET.Element], model_file: str) -> str:
+def _write_temp_xml(tree: ET.ElementTree[ET.Element], model_file: str) -> str:  # type: ignore[type-arg]
     fd, output_path = tempfile.mkstemp(
         suffix=".xml", dir=os.path.dirname(os.path.abspath(model_file))
     )


### PR DESCRIPTION
## Summary

Closes #133

- Extract `LocomotionBaseEnv` base class into `locomotion/common/` module, consolidating 7 identical methods from G1/Go1/Go2 base environments
- Extract shared configs: `LocomotionBaseCfg`, `ControlConfigBase`, `Sensor`, `Commands`, `DomainRandConfig`
- Rename `Domain_Rand` → `DomainRandConfig` (PascalCase)
- Extract `sample_velocity_commands()` to common module
- Line count reductions: G1 52%, Go1 62%, Go2 50%

## Test plan

- [x] `make check` passes (ruff format + ruff check + mypy + pyright)
- [x] `make test` passes (329 tests, 0 failures)
- [x] All 222 backend tests pass
- [ ] `uv run python scripts/train_rsl_rl.py task=go1_joystick algo.max_iterations=3`
- [ ] `uv run python scripts/train_rsl_rl.py task=g1_joystick algo.max_iterations=3`