### PR TITLE
refactor: extract shared locomotion reward functions (#149)

### DIFF
--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -1,6 +1,7 @@
 from .base import ControlConfigBase, LocomotionBaseCfg, LocomotionBaseEnv, Sensor
 from .commands import Commands, sample_velocity_commands
 from .domain_rand import DomainRandConfig
+from .rewards import RewardContext
 
 __all__ = [
     "Commands",
@@ -8,6 +9,7 @@ __all__ = [
     "DomainRandConfig",
     "LocomotionBaseCfg",
     "LocomotionBaseEnv",
+    "RewardContext",
     "Sensor",
     "sample_velocity_commands",
 ]

--- a/src/unilab/envs/locomotion/common/rewards.py
+++ b/src/unilab/envs/locomotion/common/rewards.py
@@ -1,0 +1,171 @@
+"""Shared reward functions for locomotion environments.
+
+Introduces ``RewardContext`` — a dataclass that bundles all state any
+reward function might need.  Shared reward functions are plain
+module-level callables ``fn(ctx) -> np.ndarray`` so that each
+joystick environment can reference them **directly** in its
+``_reward_fns`` dispatch table without per-class wrapper methods.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from unilab.base.dtype_config import get_global_dtype
+
+
+@dataclass
+class RewardContext:
+    """Immutable snapshot of everything reward functions may read.
+
+    Built once per ``_compute_reward`` call.  Shared functions access
+    only the fields they need; robot-specific methods that still live
+    on the environment class receive the same context via ``self``.
+    """
+
+    # ── always populated ────────────────────────────────────────────
+    info: dict
+    linvel: np.ndarray  # (N, 3)
+    gyro: np.ndarray  # (N, 3)
+    dof_pos: np.ndarray  # (N, num_action)
+    num_envs: int = 0
+    default_angles: np.ndarray = field(default_factory=lambda: np.empty(0))
+    tracking_sigma: float = 0.25
+    base_height_target: float = 0.0
+    base_height: np.ndarray = field(default_factory=lambda: np.empty(0))  # pre-fetched
+
+    # ── G1-only (None for quadrupeds) ───────────────────────────────
+    gravity: np.ndarray | None = None
+    dof_vel: np.ndarray | None = None
+
+    # ── optional weights (G1 pose rewards) ──────────────────────────
+    pose_weights: np.ndarray | None = None
+
+
+# ── tracking rewards ─────────────────────────────────────────────────
+
+
+def tracking_lin_vel(ctx: RewardContext) -> np.ndarray:
+    """Exponential reward for tracking commanded xy linear velocity."""
+    commands = ctx.info["commands"]
+    lin_vel_error = np.sum(np.square(commands[:, :2] - ctx.linvel[:, :2]), axis=1)
+    return np.exp(-lin_vel_error / ctx.tracking_sigma)  # type: ignore[no-any-return]
+
+
+def tracking_ang_vel(ctx: RewardContext) -> np.ndarray:
+    """Exponential reward for tracking commanded yaw angular velocity."""
+    commands = ctx.info["commands"]
+    ang_vel_error = np.square(commands[:, 2] - ctx.gyro[:, 2])
+    return np.exp(-ang_vel_error / ctx.tracking_sigma)  # type: ignore[no-any-return]
+
+
+def forward_progress(ctx: RewardContext) -> np.ndarray:
+    """Reward for forward progress relative to commanded speed."""
+    commands = ctx.info["commands"]
+    commanded_speed = np.maximum(commands[:, 0], 1e-6)
+    forward_speed = np.maximum(ctx.linvel[:, 0], 0.0)
+    return np.asarray(np.minimum(forward_speed / commanded_speed, 1.0), dtype=get_global_dtype())
+
+
+def under_speed(ctx: RewardContext) -> np.ndarray:
+    """Penalty for being below commanded forward speed."""
+    commands = ctx.info["commands"]
+    commanded_speed = np.maximum(commands[:, 0], 1e-6)
+    forward_speed = np.maximum(ctx.linvel[:, 0], 0.0)
+    gap = np.maximum(commands[:, 0] - forward_speed, 0.0)
+    return np.asarray(gap / commanded_speed, dtype=get_global_dtype())
+
+
+# ── velocity / orientation penalties ─────────────────────────────────
+
+
+def lin_vel_z(ctx: RewardContext) -> np.ndarray:
+    """Penalty for vertical (z) linear velocity."""
+    return np.square(ctx.linvel[:, 2])  # type: ignore[no-any-return]
+
+
+def ang_vel_xy(ctx: RewardContext) -> np.ndarray:
+    """Penalty for roll/pitch angular velocity."""
+    return np.sum(np.square(ctx.gyro[:, :2]), axis=1)  # type: ignore[no-any-return]
+
+
+def orientation(ctx: RewardContext) -> np.ndarray:
+    """Penalty for deviation from upright orientation (roll/pitch)."""
+    g = ctx.gravity
+    assert g is not None
+    return np.square(g[:, 0]) + np.square(g[:, 1])  # type: ignore[no-any-return]
+
+
+def upright(ctx: RewardContext) -> np.ndarray:
+    """Exponential reward for upright orientation."""
+    g = ctx.gravity
+    assert g is not None
+    xy_squared = np.sum(np.square(g[:, :2]), axis=1)
+    return np.exp(-xy_squared / 0.25)  # type: ignore[no-any-return]
+
+
+# ── height / pose penalties ──────────────────────────────────────────
+
+
+def base_height(ctx: RewardContext) -> np.ndarray:
+    """Penalty for base height deviation from target."""
+    return np.square(ctx.base_height - ctx.base_height_target)  # type: ignore[no-any-return]
+
+
+def similar_to_default(ctx: RewardContext) -> np.ndarray:
+    """Penalty for joint position deviation from default (L1 norm)."""
+    return np.sum(np.abs(ctx.dof_pos - ctx.default_angles), axis=1)  # type: ignore[no-any-return]
+
+
+def weighted_pose(ctx: RewardContext) -> np.ndarray:
+    """Weighted L2 penalty for joint position deviation."""
+    assert ctx.pose_weights is not None
+    diff = ctx.dof_pos - ctx.default_angles
+    return np.asarray(np.sum(ctx.pose_weights * np.square(diff), axis=1), dtype=get_global_dtype())
+
+
+# ── action penalties ─────────────────────────────────────────────────
+
+
+def action_rate(ctx: RewardContext) -> np.ndarray:
+    """Penalty for change in actions between timesteps."""
+    current = ctx.info["current_actions"]
+    last = ctx.info["last_actions"]
+    return np.sum(np.square(current - last), axis=1)  # type: ignore[no-any-return]
+
+
+# ── effort penalties ─────────────────────────────────────────────────
+
+
+def _get_torques(ctx: RewardContext) -> np.ndarray:
+    fallback = np.zeros((ctx.num_envs, ctx.dof_pos.shape[1]), dtype=get_global_dtype())
+    return ctx.info.get("torques", fallback)  # type: ignore[no-any-return]
+
+
+def torques(ctx: RewardContext) -> np.ndarray:
+    """Penalty for total torque magnitude (L1 norm)."""
+    return np.sum(np.abs(_get_torques(ctx)), axis=1)  # type: ignore[no-any-return]
+
+
+def energy(ctx: RewardContext) -> np.ndarray:
+    """Penalty for mechanical energy consumption."""
+    assert ctx.dof_vel is not None
+    t = _get_torques(ctx)
+    return np.sum(np.abs(ctx.dof_vel) * np.abs(t), axis=1)  # type: ignore[no-any-return]
+
+
+def dof_acc(ctx: RewardContext) -> np.ndarray:
+    """Penalty for joint acceleration magnitude."""
+    fallback = np.zeros((ctx.num_envs, ctx.dof_pos.shape[1]), dtype=get_global_dtype())
+    qacc = ctx.info.get("qacc", fallback)
+    return np.sum(np.square(qacc), axis=1)  # type: ignore[no-any-return]
+
+
+# ── survival ─────────────────────────────────────────────────────────
+
+
+def alive(ctx: RewardContext) -> np.ndarray:
+    """Constant reward for staying alive."""
+    return np.ones((ctx.num_envs,), dtype=get_global_dtype())

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -27,8 +27,10 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
+from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -62,23 +64,6 @@ def build_upper_body_pose_weights(pose_weights: list[float]) -> np.ndarray:
     weights = np.asarray(pose_weights, dtype=get_global_dtype()).copy()
     weights[:12] = 0.0
     return np.asarray(weights, dtype=get_global_dtype())
-
-
-def compute_weighted_pose_penalty(diff: np.ndarray, weights: np.ndarray) -> np.ndarray:
-    return np.asarray(np.sum(weights * np.square(diff), axis=1), dtype=get_global_dtype())
-
-
-def compute_forward_progress_reward(commands: np.ndarray, linvel: np.ndarray) -> np.ndarray:
-    commanded_speed = np.maximum(commands[:, 0], 1e-6)
-    forward_speed = np.maximum(linvel[:, 0], 0.0)
-    return np.asarray(np.minimum(forward_speed / commanded_speed, 1.0), dtype=get_global_dtype())
-
-
-def compute_under_speed_penalty(commands: np.ndarray, linvel: np.ndarray) -> np.ndarray:
-    commanded_speed = np.maximum(commands[:, 0], 1e-6)
-    forward_speed = np.maximum(linvel[:, 0], 0.0)
-    under_speed = np.maximum(commands[:, 0] - forward_speed, 0.0)
-    return np.asarray(under_speed / commanded_speed, dtype=get_global_dtype())
 
 
 @dataclass
@@ -269,19 +254,19 @@ class G1JoystickPPO(G1BaseEnv):
         return {"obs": 98, "privileged": 3}
 
     def _init_reward_functions(self):
-        self._reward_fns = {
-            "tracking_lin_vel": self._reward_tracking_lin_vel,
-            "tracking_ang_vel": self._reward_tracking_ang_vel,
-            "forward_progress": self._reward_forward_progress,
-            "under_speed": self._reward_under_speed,
+        self._reward_fns: dict[str, Any] = {
+            "tracking_lin_vel": rewards.tracking_lin_vel,
+            "tracking_ang_vel": rewards.tracking_ang_vel,
+            "forward_progress": rewards.forward_progress,
+            "under_speed": rewards.under_speed,
+            "lin_vel_z": rewards.lin_vel_z,
+            "orientation": rewards.orientation,
+            "ang_vel_xy": rewards.ang_vel_xy,
+            "action_rate": rewards.action_rate,
+            "base_height": rewards.base_height,
+            "pose": rewards.weighted_pose,
             "upper_body_pose": self._reward_upper_body_pose,
             "feet_phase": self._reward_feet_phase,
-            "lin_vel_z": self._reward_lin_vel_z,
-            "orientation": self._reward_orientation,
-            "ang_vel_xy": self._reward_ang_vel_xy,
-            "action_rate": self._reward_action_rate,
-            "base_height": self._reward_base_height,
-            "pose": self._reward_pose,
         }
 
     def _use_legacy_motrix_baseline(self) -> bool:
@@ -346,10 +331,29 @@ class G1JoystickPPO(G1BaseEnv):
             "gait_phase": 2,
         }
 
+    def _build_reward_context(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> RewardContext:
+        return RewardContext(
+            info=info,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            num_envs=self._num_envs,
+            default_angles=self.default_angles,
+            tracking_sigma=self._reward_cfg.tracking_sigma,
+            base_height_target=self._reward_cfg.base_height_target,
+            base_height=self._backend.get_base_pos()[:, 2],
+            gravity=gravity,
+            dof_vel=dof_vel,
+            pose_weights=self._pose_weights,
+        )
+
     def _compute_reward(self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel) -> np.ndarray:
         dtype = get_global_dtype()
         reward = np.zeros((self._num_envs,), dtype=dtype)
         cfg = self._reward_cfg
+        ctx = self._build_reward_context(info, linvel, gyro, gravity, dof_pos, dof_vel)
 
         step_count = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
         should_log = self._enable_reward_log and (int(step_count[0]) % 4 == 0)
@@ -358,7 +362,7 @@ class G1JoystickPPO(G1BaseEnv):
         for name, scale in cfg.scales.items():
             if scale == 0 or name not in self._reward_fns:
                 continue
-            rew = self._reward_fns[name](info, linvel, gyro, gravity, dof_pos, dof_vel)
+            rew = self._reward_fns[name](ctx)
             weighted_rew = rew * scale
             reward += weighted_rew
             if should_log:
@@ -367,30 +371,15 @@ class G1JoystickPPO(G1BaseEnv):
         info["log"] = log
         return reward * self._cfg.ctrl_dt
 
-    def _reward_tracking_lin_vel(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        commands = info["commands"]
-        lin_vel_error = np.sum(np.square(commands[:, :2] - linvel[:, :2]), axis=1)
-        return np.exp(-lin_vel_error / self._reward_cfg.tracking_sigma)
-
-    def _reward_tracking_ang_vel(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        commands = info["commands"]
-        ang_vel_error = np.square(commands[:, 2] - gyro[:, 2])
-        return np.exp(-ang_vel_error / self._reward_cfg.tracking_sigma)
-
-    def _reward_forward_progress(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return compute_forward_progress_reward(info["commands"], linvel)
-
-    def _reward_under_speed(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return compute_under_speed_penalty(info["commands"], linvel)
-
-    def _reward_feet_phase(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
+    def _reward_feet_phase(self, ctx: RewardContext):
         """步态相位奖励：鼓励正确的摆动腿高度"""
         left_foot = self._backend.get_sensor_data("left_foot_pos")
         right_foot = self._backend.get_sensor_data("right_foot_pos")
-        gait_phase = info.get("gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype()))
+        gait_phase = ctx.info.get(
+            "gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype())
+        )
 
         def cubic_bezier_height(phi, swing_height):
-            # Convert phi from [0, 2π] to [-π, π]
             phi_normalized = np.fmod(phi + np.pi, 2 * np.pi) - np.pi
             x = (phi_normalized + np.pi) / (2 * np.pi)
 
@@ -414,29 +403,12 @@ class G1JoystickPPO(G1BaseEnv):
         right_error = np.square(right_foot[:, 2] - right_target)
         return np.exp(-(left_error + right_error) / self._reward_cfg.feet_phase_tracking_sigma)
 
-    def _reward_lin_vel_z(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return np.square(linvel[:, 2])
-
-    def _reward_ang_vel_xy(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return np.sum(np.square(gyro[:, :2]), axis=1)
-
-    def _reward_orientation(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return np.square(gravity[:, 0]) + np.square(gravity[:, 1])
-
-    def _reward_base_height(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return np.square(self._backend.get_base_pos()[:, 2] - self._reward_cfg.base_height_target)
-
-    def _reward_action_rate(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        action_diff = info["current_actions"] - info["last_actions"]
-        return np.sum(np.square(action_diff), axis=1)
-
-    def _reward_pose(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        diff = dof_pos - self.default_angles
-        return compute_weighted_pose_penalty(diff, self._pose_weights)
-
-    def _reward_upper_body_pose(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        diff = dof_pos - self.default_angles
-        return compute_weighted_pose_penalty(diff, self._upper_body_pose_weights)
+    def _reward_upper_body_pose(self, ctx: RewardContext):
+        diff = ctx.dof_pos - self.default_angles
+        return np.asarray(
+            np.sum(self._upper_body_pose_weights * np.square(diff), axis=1),
+            dtype=get_global_dtype(),
+        )
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
         state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -12,8 +12,10 @@ from unilab.base import registry
 from unilab.base.backend import create_backend
 from unilab.base.curriculum import EpisodeLengthTracker, PenaltyCurriculum
 from unilab.base.dtype_config import get_global_dtype
+from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
+from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
 from unilab.envs.locomotion.g1.joystick import (
     G1JoystickDomainRandomizationProvider,
@@ -110,41 +112,33 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
 
     def _init_reward_functions(self):
         """对齐 holosoma G1 FastSAC 奖励函数"""
-        self._reward_fns = {
-            "tracking_lin_vel": self._reward_tracking_lin_vel,
-            "tracking_ang_vel": self._reward_tracking_ang_vel,
-            "penalty_ang_vel_xy": self._reward_ang_vel_xy,
-            "penalty_orientation": self._reward_orientation,
-            "penalty_action_rate": self._reward_action_rate,
-            "pose": self._reward_pose,
+        from typing import Any
+
+        self._reward_fns: dict[str, Any] = {
+            "tracking_lin_vel": rewards.tracking_lin_vel,
+            "tracking_ang_vel": rewards.tracking_ang_vel,
+            "penalty_ang_vel_xy": rewards.ang_vel_xy,
+            "penalty_orientation": rewards.orientation,
+            "penalty_action_rate": rewards.action_rate,
+            "pose": rewards.weighted_pose,
             # "penalty_close_feet_xy": self._reward_close_feet_xy,
             "penalty_feet_ori": self._reward_feet_ori,
             "feet_phase": self._reward_feet_phase,
-            "alive": self._reward_alive,
+            "alive": rewards.alive,
         }
 
-    def _reward_orientation(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚姿态偏差（roll/pitch）"""
-        return np.square(gravity[:, 0]) + np.square(gravity[:, 1])
-
-    def _reward_pose(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """加权惩罚偏离默认姿态"""
-        diff = dof_pos - self.default_angles
-        return np.sum(self._pose_weights * np.square(diff), axis=1)
-
-    def _reward_close_feet_xy(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
+    def _reward_close_feet_xy(self, ctx: RewardContext):
         """惩罚双脚过近"""
         left_foot = self._backend.get_sensor_data("left_foot_pos")
         right_foot = self._backend.get_sensor_data("right_foot_pos")
         feet_dist = np.linalg.norm(left_foot[:, :2] - right_foot[:, :2], axis=1)
-        threshold = self._cfg.reward_config.close_feet_threshold
+        threshold = self._cfg.reward_config.close_feet_threshold  # type: ignore[union-attr]
         return np.where(feet_dist < threshold, np.square(feet_dist - threshold), 0.0)
 
-    def _reward_feet_ori(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
+    def _reward_feet_ori(self, ctx: RewardContext):
         """惩罚脚部姿态偏差"""
         left_foot_quat = self._backend.get_sensor_data("left_foot_quat")
         right_foot_quat = self._backend.get_sensor_data("right_foot_quat")
-        # MuJoCo quat: [w,x,y,z], 惩罚 x,y 分量（roll/pitch）
         return (
             np.square(left_foot_quat[:, 1])
             + np.square(left_foot_quat[:, 2])
@@ -152,47 +146,9 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
             + np.square(right_foot_quat[:, 2])
         )
 
-    def _reward_alive(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        return np.ones((self._num_envs,), dtype=get_global_dtype())
-
-    def _reward_lin_vel_z(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚 z 方向线速度"""
-        return np.square(linvel[:, 2])
-
-    def _reward_base_height(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚基座高度偏差"""
-        base_height = self._backend.get_base_pos()[:, 2]
-        return np.square(base_height - self._cfg.reward_config.base_height_target)
-
-    def _reward_torques(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚力矩"""
-        torques = info.get(
-            "torques", np.zeros((self._num_envs, self._num_action), dtype=get_global_dtype())
-        )
-        return np.sum(np.abs(torques), axis=1)
-
-    def _reward_energy(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚能量消耗"""
-        torques = info.get(
-            "torques", np.zeros((self._num_envs, self._num_action), dtype=get_global_dtype())
-        )
-        return np.sum(np.abs(dof_vel) * np.abs(torques), axis=1)
-
-    def _reward_dof_acc(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """惩罚关节加速度"""
-        qacc = info.get(
-            "qacc", np.zeros((self._num_envs, self._num_action), dtype=get_global_dtype())
-        )
-        return np.sum(np.square(qacc), axis=1)
-
-    def _reward_upright(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
-        """奖励直立姿态（mjlab flat_orientation）"""
-        xy_squared = np.sum(np.square(gravity[:, :2]), axis=1)
-        return np.exp(-xy_squared / 0.25)
-
-    def _reward_feet_air_time(self, info, linvel, gyro, gravity, dof_pos, dof_vel):
+    def _reward_feet_air_time(self, ctx: RewardContext):
         """奖励脚离地时间"""
-        air_time = info.get(
+        air_time = ctx.info.get(
             "feet_air_time", np.zeros((self._num_envs, 2), dtype=get_global_dtype())
         )
         in_range = (air_time > 0.05) & (air_time < 0.5)

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -24,8 +24,10 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
+from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -170,14 +172,14 @@ class Go1WalkTask(Go1BaseEnv):
         return {"obs": 49, "privileged": 3}
 
     def _init_reward_functions(self):
-        self._reward_fns = {
-            "tracking_lin_vel": self._reward_tracking_lin_vel,
-            "tracking_ang_vel": self._reward_tracking_ang_vel,
-            "lin_vel_z": self._reward_lin_vel_z,
-            "ang_vel_xy": self._reward_ang_vel_xy,
-            "base_height": self._reward_base_height,
-            "action_rate": self._reward_action_rate,
-            "similar_to_default": self._reward_similar_to_default,
+        self._reward_fns: dict[str, Any] = {
+            "tracking_lin_vel": rewards.tracking_lin_vel,
+            "tracking_ang_vel": rewards.tracking_ang_vel,
+            "lin_vel_z": rewards.lin_vel_z,
+            "ang_vel_xy": rewards.ang_vel_xy,
+            "base_height": rewards.base_height,
+            "action_rate": rewards.action_rate,
+            "similar_to_default": rewards.similar_to_default,
             "swing_feet_z": self._reward_swing_feet_z,
         }
 
@@ -224,6 +226,18 @@ class Go1WalkTask(Go1BaseEnv):
         reward = np.zeros((self._num_envs,), dtype=dtype)
         cfg = self._reward_cfg
 
+        ctx = RewardContext(
+            info=info,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            num_envs=self._num_envs,
+            default_angles=self.default_angles,
+            tracking_sigma=cfg.tracking_sigma,
+            base_height_target=cfg.base_height_target,
+            base_height=self._backend.get_base_pos()[:, 2],
+        )
+
         step_count = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
         should_log = self._enable_reward_log and (int(step_count[0]) % 4 == 0)
         log = {} if should_log else info.get("log", {})
@@ -231,7 +245,7 @@ class Go1WalkTask(Go1BaseEnv):
         for name, scale in cfg.scales.items():
             if scale == 0 or name not in self._reward_fns:
                 continue
-            rew = self._reward_fns[name](info, linvel, gyro, dof_pos)
+            rew = self._reward_fns[name](ctx)
             weighted_rew = rew * scale
             reward += weighted_rew
             if should_log:
@@ -240,35 +254,7 @@ class Go1WalkTask(Go1BaseEnv):
         info["log"] = log
         return reward * self._cfg.ctrl_dt
 
-    def _reward_tracking_lin_vel(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        commands = info["commands"]
-        lin_vel_error = np.sum(np.square(commands[:, :2] - linvel[:, :2]), axis=1)
-        return np.asarray(np.exp(-lin_vel_error / self._reward_cfg.tracking_sigma))
-
-    def _reward_tracking_ang_vel(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        commands = info["commands"]
-        ang_vel_error = np.square(commands[:, 2] - gyro[:, 2])
-        return np.asarray(np.exp(-ang_vel_error / self._reward_cfg.tracking_sigma))
-
-    def _reward_lin_vel_z(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        return np.asarray(np.square(linvel[:, 2]))
-
-    def _reward_ang_vel_xy(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        return np.asarray(np.sum(np.square(gyro[:, :2]), axis=1))
-
-    def _reward_base_height(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        base_height = self._backend.get_base_pos()[:, 2]
-        return np.asarray(np.square(base_height - self._reward_cfg.base_height_target))
-
-    def _reward_action_rate(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        action_diff = info["current_actions"] - info["last_actions"]
-        return np.asarray(np.sum(np.square(action_diff), axis=1))
-
-    def _reward_similar_to_default(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        # print(self.default_angles)
-        return np.asarray(np.sum(np.abs(dof_pos - self.default_angles), axis=1))
-
-    def _reward_contact(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
+    def _reward_contact(self, ctx: RewardContext) -> np.ndarray:
         contact = self.feet_force[:, :, 2] > 0.1
         res = np.zeros(self.num_envs, dtype=np.float32)
         for i in range(len(self._cfg.sensor.feet_force)):
@@ -276,7 +262,7 @@ class Go1WalkTask(Go1BaseEnv):
             res += ~(contact[:, i] ^ is_contact)
         return res
 
-    def _reward_swing_feet_z(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
+    def _reward_swing_feet_z(self, ctx: RewardContext) -> np.ndarray:
         is_swing = self.feet_phase >= 0.6
         target_height = 0.1
         height_error = np.square(self.feet_pos[:, :, 2] - target_height)

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -24,8 +24,10 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
+from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 from unilab.utils.math_utils import np_quat_mul, np_yaw_to_quat
 
@@ -174,15 +176,15 @@ class Go2WalkTask(Go2BaseEnv):
         return {"obs": 49, "privileged": 3}
 
     def _init_reward_functions(self):
-        self._reward_fns = {
-            "tracking_lin_vel": self._reward_tracking_lin_vel,
-            "tracking_ang_vel": self._reward_tracking_ang_vel,
-            "lin_vel_z": self._reward_lin_vel_z,
-            "ang_vel_xy": self._reward_ang_vel_xy,
-            "base_height": self._reward_base_height,
-            "action_rate": self._reward_action_rate,
-            "similar_to_default": self._reward_similar_to_default,
-            # "alive": self._reward_alive,
+        self._reward_fns: dict[str, Any] = {
+            "tracking_lin_vel": rewards.tracking_lin_vel,
+            "tracking_ang_vel": rewards.tracking_ang_vel,
+            "lin_vel_z": rewards.lin_vel_z,
+            "ang_vel_xy": rewards.ang_vel_xy,
+            "base_height": rewards.base_height,
+            "action_rate": rewards.action_rate,
+            "similar_to_default": rewards.similar_to_default,
+            # "alive": rewards.alive,
             "swing_feet_z": self._reward_swing_feet_z,
             "contact": self._reward_contact,
         }
@@ -230,6 +232,18 @@ class Go2WalkTask(Go2BaseEnv):
         reward = np.zeros((self._num_envs,), dtype=dtype)
         cfg = self._reward_cfg
 
+        ctx = RewardContext(
+            info=info,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            num_envs=self._num_envs,
+            default_angles=self.default_angles,
+            tracking_sigma=cfg.tracking_sigma,
+            base_height_target=cfg.base_height_target,
+            base_height=self._backend.get_base_pos()[:, 2],
+        )
+
         step_count = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
         should_log = self._enable_reward_log and (int(step_count[0]) % 4 == 0)
         log = {} if should_log else info.get("log", {})
@@ -237,7 +251,7 @@ class Go2WalkTask(Go2BaseEnv):
         for name, scale in cfg.scales.items():
             if scale == 0 or name not in self._reward_fns:
                 continue
-            rew = self._reward_fns[name](info, linvel, gyro, dof_pos)
+            rew = self._reward_fns[name](ctx)
             weighted_rew = rew * scale
             reward += weighted_rew
             if should_log:
@@ -246,47 +260,16 @@ class Go2WalkTask(Go2BaseEnv):
         info["log"] = log
         return reward * self._cfg.ctrl_dt
 
-    # ── reward functions ──────────────────────────────────────────────
+    # ── reward functions (robot-specific) ────────────────────────────
 
-    def _reward_tracking_lin_vel(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        commands = info["commands"]
-        lin_vel_error = np.sum(np.square(commands[:, :2] - linvel[:, :2]), axis=1)
-        return np.asarray(np.exp(-lin_vel_error / self._reward_cfg.tracking_sigma))
-
-    def _reward_tracking_ang_vel(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        commands = info["commands"]
-        ang_vel_error = np.square(commands[:, 2] - gyro[:, 2])
-        return np.asarray(np.exp(-ang_vel_error / self._reward_cfg.tracking_sigma))
-
-    def _reward_lin_vel_z(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        return np.asarray(np.square(linvel[:, 2]))
-
-    def _reward_ang_vel_xy(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        return np.asarray(np.sum(np.square(gyro[:, :2]), axis=1))
-
-    def _reward_base_height(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        base_height = self._backend.get_base_pos()[:, 2]
-        return np.asarray(np.square(base_height - self._reward_cfg.base_height_target))
-
-    def _reward_action_rate(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        action_diff = info["current_actions"] - info["last_actions"]
-        return np.asarray(np.sum(np.square(action_diff), axis=1))
-
-    def _reward_similar_to_default(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        # print(self.default_angles)
-        return np.asarray(np.sum(np.abs(dof_pos - self.default_angles), axis=1))
-
-    def _reward_alive(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
-        return np.ones((self._num_envs,), dtype=get_global_dtype())
-
-    def _reward_swing_feet_z(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
+    def _reward_swing_feet_z(self, ctx: RewardContext) -> np.ndarray:
         is_swing = self.feet_phase >= 0.6
         target_height = 0.1
         height_error = np.square(self.feet_pos[:, :, 2] - target_height)
         swing_rew = np.exp(-height_error / 0.01) * is_swing
         return np.asarray(np.sum(swing_rew, axis=1) / len(self._cfg.sensor.feet_pos))
 
-    def _reward_foot_drag(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
+    def _reward_foot_drag(self, ctx: RewardContext) -> np.ndarray:
         foot_pos = self.get_foot_pos()
         foot_heights = foot_pos[..., 2]
         foot_contact = self.get_foot_contact()
@@ -296,7 +279,7 @@ class Go2WalkTask(Go2BaseEnv):
         error = np.square(height_error) * is_swing
         return np.asarray(np.sum(error, axis=1))
 
-    def _reward_contact(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
+    def _reward_contact(self, ctx: RewardContext) -> np.ndarray:
         contact = self.feet_force[:, :, 2] > 0.1
         res = np.zeros(self._num_envs, dtype=np.float32)
         for i in range(len(self._cfg.sensor.feet_force)):


### PR DESCRIPTION
## Summary

- Introduces `RewardContext` dataclass in `common/rewards.py` bundling all state reward functions need
- Extracts 16 shared reward functions (`tracking_lin_vel`, `action_rate`, `base_height`, etc.) as standalone `fn(ctx: RewardContext) -> np.ndarray`
- Joystick environments reference shared functions **directly** in `_reward_fns` dispatch tables — no wrapper methods
- Eliminates ~38 duplicate `_reward_*` methods + 3 module-level helpers across G1/Go1/Go2
- Robot-specific rewards (feet_phase, contact, foot_drag, etc.) remain as methods with `ctx` signature
- No reward behavior changes — each task's `_reward_fns` dict has the exact same keys as before

## Test plan

- [x] `make check` (ruff format + ruff check + mypy + pyright) — all pass
- [x] `make test` — 329 passed, 12 skipped
- [ ] `uv run python scripts/train_rsl_rl.py task=go2_joystick algo.max_iterations=3` — reward curves unchanged

Closes #149