### PR TITLE
style: remove unused imports (Fixes #190)

### DIFF
--- a/src/unilab/__init__.py
+++ b/src/unilab/__init__.py
@@ -1,7 +1,5 @@
 """UniLab package initialization."""
 
-import os
-
 from etils import epath
 
 __version__ = "0.0.0"

--- a/src/unilab/algos/mlx/common/rollout_storage.py
+++ b/src/unilab/algos/mlx/common/rollout_storage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Generator, Union
 
 import mlx.core as mx


### PR DESCRIPTION
## Summary

Remove unused imports to clean up the codebase.

## Changes

- Remove unused `os` import from `src/unilab/__init__.py`
- Remove unused `field` import from `src/unilab/algos/mlx/common/rollout_storage.py`

## Checklist

- [x] Code follows the project style guidelines
- [x] Pre-commit checks pass
- [x] Related issue: Fixes #190