### PR TITLE
refactor: unify observation dimension naming n_obs → obs_dim (Fixes #190)

### DIFF
--- a/src/unilab/algos/torch/common/networks.py
+++ b/src/unilab/algos/torch/common/networks.py
@@ -18,7 +18,7 @@ class DistributionalQNetwork(nn.Module):
 
     def __init__(
         self,
-        n_obs: int,
+        obs_dim: int,
         n_act: int,
         num_atoms: int,
         v_min: float,
@@ -28,7 +28,7 @@ class DistributionalQNetwork(nn.Module):
     ):
         super().__init__()
         self.net = nn.Sequential(
-            nn.Linear(n_obs + n_act, hidden_dim, device=device),
+            nn.Linear(obs_dim + n_act, hidden_dim, device=device),
             nn.ReLU(),
             nn.Linear(hidden_dim, hidden_dim // 2, device=device),
             nn.ReLU(),
@@ -96,7 +96,7 @@ class Critic(nn.Module):
 
     def __init__(
         self,
-        n_obs: int,
+        obs_dim: int,
         n_act: int,
         num_atoms: int,
         v_min: float,
@@ -106,7 +106,7 @@ class Critic(nn.Module):
     ):
         super().__init__()
         self.qnet1 = DistributionalQNetwork(
-            n_obs=n_obs,
+            obs_dim=obs_dim,
             n_act=n_act,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -115,7 +115,7 @@ class Critic(nn.Module):
             device=device,
         )
         self.qnet2 = DistributionalQNetwork(
-            n_obs=n_obs,
+            obs_dim=obs_dim,
             n_act=n_act,
             num_atoms=num_atoms,
             v_min=v_min,

--- a/src/unilab/algos/torch/fast_td3/learner.py
+++ b/src/unilab/algos/torch/fast_td3/learner.py
@@ -46,7 +46,7 @@ class TD3Actor(nn.Module):
 
     def __init__(
         self,
-        n_obs: int,
+        obs_dim: int,
         n_act: int,
         num_envs: int,
         init_scale: float,
@@ -58,7 +58,7 @@ class TD3Actor(nn.Module):
         super().__init__()
         self.n_act = n_act
         self.net = nn.Sequential(
-            nn.Linear(n_obs, hidden_dim, device=device),
+            nn.Linear(obs_dim, hidden_dim, device=device),
             nn.ReLU(),
             nn.Linear(hidden_dim, hidden_dim // 2, device=device),
             nn.ReLU(),
@@ -175,7 +175,7 @@ class FastTD3Learner:
 
         # Build actor
         self.actor = TD3Actor(
-            n_obs=obs_dim,
+            obs_dim=obs_dim,
             n_act=action_dim,
             num_envs=num_envs,
             init_scale=init_scale,
@@ -185,7 +185,7 @@ class FastTD3Learner:
             device=torch_device,
         )
         self.actor_target = TD3Actor(
-            n_obs=obs_dim,
+            obs_dim=obs_dim,
             n_act=action_dim,
             num_envs=num_envs,
             init_scale=init_scale,
@@ -198,7 +198,7 @@ class FastTD3Learner:
 
         # Build critic
         self.qnet = Critic(
-            n_obs=obs_dim,
+            obs_dim=obs_dim,
             n_act=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -207,7 +207,7 @@ class FastTD3Learner:
             device=torch_device,
         )
         self.qnet_target = Critic(
-            n_obs=obs_dim,
+            obs_dim=obs_dim,
             n_act=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,

--- a/src/unilab/utils/algo_utils.py
+++ b/src/unilab/utils/algo_utils.py
@@ -41,7 +41,7 @@ def build_actor(
         from unilab.algos.torch.fast_td3.learner import TD3Actor
 
         return TD3Actor(
-            n_obs=obs_dim,
+            obs_dim=obs_dim,
             n_act=action_dim,
             num_envs=num_envs,
             hidden_dim=actor_hidden_dim,


### PR DESCRIPTION
## Summary

Unified observation dimension naming from `n_obs` to `obs_dim` across the codebase to align with existing conventions (`fast_sac/learner.py` already uses `obs_dim`).

## Changes

### Modified Files

1. **`src/unilab/algos/torch/fast_td3/learner.py`**
   - `TD3Actor.__init__`: parameter `n_obs` → `obs_dim`
   - Updated all usages (lines 49, 61, 178, 188, 201, 210)

2. **`src/unilab/algos/torch/common/networks.py`**
   - `DistributionalQNetwork.__init__`: parameter `n_obs` → `obs_dim`
   - `Critic.__init__`: parameter `n_obs` → `obs_dim`
   - Updated all usages (lines 21, 31, 99, 109, 118)

3. **`src/unilab/utils/algo_utils.py`**
   - Updated `build_actor()` call site for TD3Actor (line 44)

## Verification

- ✅ All existing tests pass (`make test`)
- ✅ Code formatting verified (`ruff`)
- ✅ Type checking passes for modified files

Fixes #190