### PR TITLE
fix: align docs validation with current training entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "CONTRIBUTING.md"
-      - "AGENTS.md"
       - "LICENSE"
       - ".github/CODEOWNERS"
       - ".github/ISSUE_TEMPLATE/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ uv run pytest -m veryslow -v
 
 ## CI Workflow
 
-PRs targeting `main` trigger five jobs automatically: `ruff-lint`, `ruff-format`, `mypy`, `pyright`, and `test`. The workflow also enables manual runs through `workflow_dispatch`, skips docs-only and collaboration-metadata changes, and cancels older in-progress runs for the same PR branch.
+PRs targeting `main` trigger five jobs automatically: `ruff-lint`, `ruff-format`, `mypy`, `pyright`, and `test`. The workflow also enables manual runs through `workflow_dispatch`, validates docs through the pytest suite on docs changes, and cancels older in-progress runs for the same PR branch.
 
 | Job | Content | Blocking on failure |
 |-----|---------|---------------------|
@@ -106,7 +106,7 @@ PRs targeting `main` trigger five jobs automatically: `ruff-lint`, `ruff-format`
 | `pyright` | `uv sync` + `uv run pyright` on `macos-26` | ✅ |
 | `test` | `uv sync --extra motrix` + `uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=10` on `ubuntu-slim` with Python 3.11 | ✅ |
 
-Docs-only and collaboration-metadata changes such as `*.md`, `docs/**`, `CONTRIBUTING.md`, `AGENTS.md`, `LICENSE`, issue templates, `CODEOWNERS`, and `.github/pull_request_template.md` do not trigger CI.
+Collaboration-metadata-only changes such as `LICENSE`, issue templates, `CODEOWNERS`, and `.github/pull_request_template.md` still skip CI. Docs changes do trigger CI and are validated by `tests/scripts/test_check_docs.py`.
 
 ## Documentation Expectations
 
@@ -130,7 +130,7 @@ More collaboration rules live in [docs/zh_CN/06-collaboration.md](docs/zh_CN/06-
 1. For code or config changes, run `make check` locally so lint, mypy, and pyright pass.
 2. For code changes, run `make test` locally so non-slow tests pass.
 3. If you touched IPC, Runner, or Config, add or update the matching tests.
-4. For docs-only changes, at minimum re-check Markdown links, file paths, script names, and command arguments.
+4. For docs-only changes, run `uv run pytest tests/scripts/test_check_docs.py -q` at minimum.
 5. Link the relevant GitHub issue and fill in validation plus impact scope in the PR template.
 6. Open the PR against `main` and wait for green CI.
 7. Wait for code review.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # UniLab
 
-Languages: English | [简体中文](docs/zh_CN/README.md)
+Languages: English | [简体中文](docs/zh_CN/01-getting-started.md)
 
 UniLab is built to test a simple hypothesis: **robot locomotion RL does not need a GPU simulation backend**.
 
@@ -40,17 +40,19 @@ uv sync
 uv sync --extra motrix
 
 # 3. Run a training job
-uv run python scripts/train_rsl_rl.py task=go1_joystick
+uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco
 ```
 
 ## Workflow Entrypoints
 
-| Goal | Entrypoint | Default log root |
+| Goal | Entrypoint | Log root pattern |
 |------|------------|------------------|
-| PPO (torch / RSL-RL) | `scripts/train_rsl_rl.py` | `logs/rsl_rl_train/<task>/` |
-| PPO (MLX, macOS) | `scripts/train_mlx_ppo.py` | `logs/mlx_rl_train/<task>/` |
-| APPO | `scripts/train_appo.py` | `logs/appo/<task>/` |
-| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/fast_sac/<task>/` / `logs/fast_td3/<task>/` |
+| PPO (torch / RSL-RL) | `scripts/train_rsl_rl.py` | `logs/<algo.algo_log_name>/<task>/` |
+| PPO (MLX, macOS) | `scripts/train_mlx_ppo.py` | `logs/<algo.algo_log_name>/<task>/` |
+| APPO | `scripts/train_appo.py` | `logs/<algo.algo_log_name>/<task>/` |
+| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/<algo.algo_log_name>/<task>/` |
+
+The concrete log directory comes from `algo.algo_log_name`. Current defaults are `rsl_rl_ppo`, `appo`, `fast_sac`, and `fast_td3`.
 
 Training scripts automatically enter playback after training unless you set `training.no_play=true`.
 

--- a/docs/zh_CN/00-development-architecture.md
+++ b/docs/zh_CN/00-development-architecture.md
@@ -120,7 +120,7 @@ Env **负责** MDP 语义、observation 结构、reward、reset，以及 backend
 | runner / IPC | `make test`；必要时补 `make test-slow` |
 | 训练主链路 | 相关测试 + 1 iteration smoke run |
 | backend 路径 | 对应 backend smoke run，必要时补 slow test |
-| docs-only | 手动核对命令、路径、配置名、CI 和 support claim |
+| docs-only | `uv run pytest tests/scripts/test_check_docs.py -q` + 手动核对 support claim |
 
 ---
 
@@ -147,5 +147,5 @@ Env **负责** MDP 语义、observation 结构、reward、reset，以及 backend
 
 ## Navigation
 
-- Previous: [README](README.md)
+- Previous: [README](../../README.md)
 - Next: [Getting Started](01-getting-started.md)

--- a/docs/zh_CN/03-training.md
+++ b/docs/zh_CN/03-training.md
@@ -6,12 +6,14 @@
 
 ## Pick An Entrypoint
 
-| 目标 | 入口脚本 | 默认日志根目录 |
+| 目标 | 入口脚本 | 日志根目录模式 |
 |------|----------|----------------|
-| PPO (RSL-RL / torch) | `scripts/train_rsl_rl.py` | `logs/rsl_rl_train/<task>/` |
-| PPO (MLX / macOS) | `scripts/train_mlx_ppo.py` | `logs/mlx_rl_train/<task>/` |
-| APPO | `scripts/train_appo.py` | `logs/appo/<task>/` |
-| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/fast_sac/<task>/` / `logs/fast_td3/<task>/` |
+| PPO (RSL-RL / torch) | `scripts/train_rsl_rl.py` | `logs/<algo.algo_log_name>/<task>/` |
+| PPO (MLX / macOS) | `scripts/train_mlx_ppo.py` | `logs/<algo.algo_log_name>/<task>/` |
+| APPO | `scripts/train_appo.py` | `logs/<algo.algo_log_name>/<task>/` |
+| SAC / TD3 | `scripts/train_offpolicy.py` | `logs/<algo.algo_log_name>/<task>/` |
+
+实际目录名由 `algo.algo_log_name` 决定；当前默认值分别是 `rsl_rl_ppo`、`appo`、`fast_sac` 和 `fast_td3`。
 
 ## Start Training
 
@@ -49,14 +51,14 @@ uv run python scripts/train_rsl_rl.py task=go2_joystick/mujoco training.play_onl
 uv run python scripts/train_offpolicy.py algo=sac task=sac/go2_joystick/mujoco training.play_only=true
 
 # 回放指定 run
-uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco training.play_only=true training.load_run="2024-02-04_12-00-00"
+uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco training.play_only=true algo.load_run="2024-02-04_12-00-00"
 ```
 
 ## Resume Training
 
 ```bash
-uv run python scripts/train_rsl_rl.py task=go2_joystick/mujoco training.load_run="2024-02-04_12-00-00"
-uv run python scripts/train_offpolicy.py algo=sac task=sac/go2_joystick/mujoco training.load_run="2024-02-04_12-00-00"
+uv run python scripts/train_rsl_rl.py task=go2_joystick/mujoco algo.load_run="2024-02-04_12-00-00"
+uv run python scripts/train_offpolicy.py algo=sac task=sac/go2_joystick/mujoco algo.load_run="2024-02-04_12-00-00"
 ```
 
 ## Hydra Overrides
@@ -72,7 +74,7 @@ task=go1_joystick/mujoco
 algo=sac
 training.play_only=true
 training.no_play=true
-training.load_run="-1"
+algo.load_run="-1"
 training.logger=tensorboard
 algo.num_envs=2048
 algo.max_iterations=1000

--- a/docs/zh_CN/04-algorithms.md
+++ b/docs/zh_CN/04-algorithms.md
@@ -16,7 +16,7 @@ APPO 是 UniLab 的异步 PPO 实现，带有 V-trace importance-sampling 修正
 | V-trace IS 修正 | 用 `pi_target / pi_behavior` 修正 off-policy 数据 |
 | 4 槽 ring buffer | 最多 4 条 rollout 可同时在飞 |
 | Replay queue | learner 侧缓存待消费 rollout 的队列 |
-| 日志目录 | `logs/appo/<task>/<timestamp>_mujoco/` |
+| 日志目录 | `logs/<algo.algo_log_name>/<task>/<timestamp>_<sim_backend>/` |
 
 ### Usage
 
@@ -38,7 +38,7 @@ uv run python scripts/train_appo.py task=go1_joystick/mujoco training.no_play=tr
 
 ```bash
 uv run python scripts/train_appo.py task=go1_joystick/mujoco training.play_only=true
-uv run python scripts/train_appo.py task=go1_joystick/mujoco training.play_only=true training.load_run="2026-03-16_01-35-12_mujoco"
+uv run python scripts/train_appo.py task=go1_joystick/mujoco training.play_only=true algo.load_run="2026-03-16_01-35-12_mujoco"
 ```
 
 ### Key Parameters
@@ -55,7 +55,7 @@ uv run python scripts/train_appo.py task=go1_joystick/mujoco training.play_only=
 | `training.logger` | `tensorboard` | 日志后端 |
 | `training.play_only` | false | 仅回放 |
 | `training.no_play` | false | 跳过自动回放 |
-| `training.load_run` | `-1` | run 目录名或 checkpoint 路径 |
+| `algo.load_run` | `-1` | run 目录名或 checkpoint 路径 |
 | `algo.save_interval` | 50 | checkpoint 保存间隔 |
 
 ### APPO vs PPO
@@ -98,7 +98,7 @@ uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco t
 
 ```bash
 uv run python scripts/train_offpolicy.py algo=sac task=sac/go2_joystick/mujoco training.play_only=true
-uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco training.play_only=true training.load_run="2024-02-04_12-00-00"
+uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco training.play_only=true algo.load_run="2024-02-04_12-00-00"
 ```
 
 ### Key Parameters

--- a/docs/zh_CN/06-collaboration.md
+++ b/docs/zh_CN/06-collaboration.md
@@ -4,7 +4,7 @@
 
 仓库文档只记录稳定标准。执行状态、owner 和阶段推进应放在 GitHub 协作对象中。
 
-如果你只是想安装或训练 UniLab，请先看 `docs/zh_CN/README.md`、`docs/zh_CN/01-getting-started.md` 和 `docs/zh_CN/03-training.md`。
+如果你只是想安装或训练 UniLab，请先看 `README.md`、`docs/zh_CN/01-getting-started.md` 和 `docs/zh_CN/03-training.md`。
 
 ## Work Item Granularity
 

--- a/docs/zh_CN/CONTRIBUTING.md
+++ b/docs/zh_CN/CONTRIBUTING.md
@@ -96,7 +96,7 @@ uv run pytest -m veryslow -v
 
 ## CI Workflow
 
-指向 `main` 的 PR 会自动触发五个 job: `ruff-lint`、`ruff-format`、`mypy`、`pyright` 和 `test`。workflow 也支持通过 `workflow_dispatch` 手动触发，会跳过纯文档和协作元信息改动，并且会自动取消同一 PR 分支上较早的进行中运行。
+指向 `main` 的 PR 会自动触发五个 job: `ruff-lint`、`ruff-format`、`mypy`、`pyright` 和 `test`。workflow 也支持通过 `workflow_dispatch` 手动触发；文档改动会通过 pytest 套件参与校验，并且会自动取消同一 PR 分支上较早的进行中运行。
 
 | Job | 内容 | 失败是否阻断 |
 |-----|------|--------------|
@@ -106,7 +106,7 @@ uv run pytest -m veryslow -v
 | `pyright` | 在 `macos-26` 上执行 `uv sync` + `uv run pyright` | ✅ |
 | `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix` + `uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=10` | ✅ |
 
-纯文档和协作元信息改动，例如 `*.md`、`docs/**`、`CONTRIBUTING.md`、`AGENTS.md`、`LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，不会触发 CI。
+只有协作元信息改动，例如 `LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，才会跳过 CI。文档改动会触发 CI，并由 `tests/scripts/test_check_docs.py` 校验。
 
 ## Documentation Expectations
 
@@ -130,7 +130,7 @@ uv run pytest -m veryslow -v
 1. 对代码或配置改动，先在本地运行 `make check`，确保 lint、mypy 和 pyright 通过。
 2. 对代码改动，再在本地运行 `make test`，确保非 slow 测试通过。
 3. 如果改到了 IPC、Runner 或 Config，补充或更新对应测试。
-4. 对 docs-only 改动，至少重新检查 Markdown 链接、文件路径、脚本名和命令参数。
+4. 对 docs-only 改动，至少运行 `uv run pytest tests/scripts/test_check_docs.py -q`。
 5. 链接对应 GitHub issue，并在 PR 模板中填写验证和影响范围。
 6. 向 `main` 分支发起 PR，并等待 CI 全绿。
 7. 等待 code review。

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/README.md
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/README.md
@@ -66,7 +66,7 @@ uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco algo.num_envs=8
 
 # Resume from a previous run
 uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco \
-    training.load_run=2026-03-10_22-50-13
+    algo.load_run=2026-03-10_22-50-13
 
 # Train without rendering a play video afterwards
 uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco training.no_play=true
@@ -77,7 +77,7 @@ uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco
 # Motrix preset is not configured for AllegroInhandRotation
 ```
 
-Training logs are saved to `logs/rsl_rl_train/AllegroInhandRotation/<timestamp>/`.
+Training logs are saved under `logs/<algo.algo_log_name>/AllegroInhandRotation/<timestamp>_mujoco/`.
 
 ---
 
@@ -92,7 +92,7 @@ uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco training.play_o
 
 # Load a specific run
 uv run python scripts/train_rsl_rl.py task=allegro_inhand/mujoco training.play_only=true \
-    training.load_run=2026-03-10_22-50-13
+    algo.load_run=2026-03-10_22-50-13
 ```
 
 The video is saved as `play_video.mp4` inside the loaded run directory.

--- a/tests/scripts/doc_checks.py
+++ b/tests/scripts/doc_checks.py
@@ -1,37 +1,13 @@
-#!/usr/bin/env python3
-"""Docs validation script for UniLab.
-
-Validates documentation for:
-- Script references (scripts/*.py must exist)
-- Hydra config keys (common keys must match expected patterns)
-- Relative links (markdown links must point to existing files)
-- File paths (paths mentioned in docs must exist)
-"""
-
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
-from typing import Any
 
-# Known valid scripts
-VALID_SCRIPTS = {
-    "scripts/train_rsl_rl.py",
-    "scripts/train_mlx_ppo.py",
-    "scripts/train_appo.py",
-    "scripts/train_offpolicy.py",
-    "scripts/play_interactive.py",
-    "scripts/visualization_env.py",
-}
-
-# Known valid Hydra config keys
 VALID_HYDRA_KEYS = {
     "task",
     "algo",
     "training",
     "reward",
-    # algo subkeys
     "num_envs",
     "max_iterations",
     "num_steps_per_env",
@@ -39,10 +15,8 @@ VALID_HYDRA_KEYS = {
     "entropy_coef",
     "desired_kl",
     "load_run",
-    # training subkeys
     "play_only",
     "no_play",
-    "load_run",
     "logger",
     "sim_backend",
     "play_env_num",
@@ -62,14 +36,12 @@ VALID_HYDRA_KEYS = {
     "wandb_mode",
 }
 
-# File patterns to check
 DOC_PATTERNS = [
     "*.md",
     "docs/**/*.md",
     "src/**/*.md",
 ]
 
-# Patterns to skip (generated, vendor, etc.)
 SKIP_PATTERNS = [
     r"\.git",
     r"\.venv",
@@ -78,52 +50,36 @@ SKIP_PATTERNS = [
 ]
 
 
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
 def should_skip(path: Path) -> bool:
-    """Check if path should be skipped."""
     path_str = str(path)
-    for pattern in SKIP_PATTERNS:
-        if re.search(pattern, path_str):
-            return True
-    return False
+    return any(re.search(pattern, path_str) for pattern in SKIP_PATTERNS)
 
 
 def find_docs(root: Path) -> list[Path]:
-    """Find all documentation files."""
     docs: list[Path] = []
     for pattern in DOC_PATTERNS:
-        if pattern.startswith("*/"):
-            # Handle recursive patterns
-            for path in root.rglob(pattern[3:]):
-                if not should_skip(path):
-                    docs.append(path)
-        else:
-            for path in root.glob(pattern):
-                if not should_skip(path):
-                    docs.append(path)
-    return docs
+        for path in root.glob(pattern):
+            if path.is_file() and not should_skip(path):
+                docs.append(path)
+    return sorted(set(docs))
 
 
 def check_script_references(content: str, doc_path: Path, root: Path) -> list[str]:
-    """Check that script references point to existing files."""
     errors: list[str] = []
-
-    # Pattern: scripts/xxx.py or uv run python scripts/xxx.py
-    script_pattern = r"(?:uv run python |python )?(scripts/\w+\.py)"
+    script_pattern = r"(?<![\w/.-])(scripts/[A-Za-z0-9_]+\.py)\b"
     for match in re.finditer(script_pattern, content):
         script_path = match.group(1)
-        full_path = root / script_path
-        if not full_path.exists():
+        if not (root / script_path).exists():
             errors.append(f"{doc_path}: Script not found: {script_path}")
-
     return errors
 
 
 def check_file_paths(content: str, doc_path: Path, root: Path) -> list[str]:
-    """Check that file paths in code blocks exist."""
     errors: list[str] = []
-
-    # Pattern: `path/to/file` or 'path/to/file' in code-like contexts
-    # Look for paths that look like source files
     path_patterns = [
         r"`(src/[^`]+)`",
         r"`(conf/[^`]+)`",
@@ -136,41 +92,30 @@ def check_file_paths(content: str, doc_path: Path, root: Path) -> list[str]:
     for pattern in path_patterns:
         for match in re.finditer(pattern, content):
             rel_path = match.group(1)
-            full_path = root / rel_path
-            # Skip if it looks like a pattern or has wildcards
-            if "*" in rel_path or "<" in rel_path:
+            if any(token in rel_path for token in ("*", "<", "{", "}", "...")):
                 continue
-            if not full_path.exists():
+            if not (root / rel_path).exists():
                 errors.append(f"{doc_path}: Path not found: {rel_path}")
 
     return errors
 
 
 def check_markdown_links(content: str, doc_path: Path, root: Path) -> list[str]:
-    """Check that markdown relative links point to existing files."""
     errors: list[str] = []
-
-    # Pattern: [text](path/to/file.md) or [text](../path/to/file.md)
     link_pattern = r"\[([^\]]+)\]\(([^)]+)\)"
 
     for match in re.finditer(link_pattern, content):
         link_text = match.group(1)
         link_target = match.group(2)
-
-        # Skip external links
         if link_target.startswith(("http://", "https://", "#", "mailto:")):
             continue
 
-        # Resolve relative to document
         if link_target.startswith("/"):
             full_path = root / link_target.lstrip("/")
         else:
             full_path = doc_path.parent / link_target
 
-        # Remove anchor
-        full_path_str = str(full_path).split("#")[0]
-        full_path = Path(full_path_str)
-
+        full_path = Path(str(full_path).split("#")[0])
         if not full_path.exists():
             errors.append(f"{doc_path}: Link not found: {link_target} (text: '{link_text}')")
 
@@ -178,44 +123,39 @@ def check_markdown_links(content: str, doc_path: Path, root: Path) -> list[str]:
 
 
 def check_hydra_keys(content: str, doc_path: Path, root: Path) -> list[str]:
-    """Check Hydra config keys for common patterns."""
+    del root
     errors: list[str] = []
-
-    # Pattern: key=value or key.nested=value
-    # Look for patterns like algo.num_envs=2048
     hydra_pattern = r"(?:^|\s)([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)="
+    for line in content.splitlines():
+        stripped = line.strip()
+        is_cli_line = "scripts/train_" in stripped or "scripts/play_interactive.py" in stripped
+        is_override_line = bool(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.-]*=", stripped))
+        if not (is_cli_line or is_override_line):
+            continue
 
-    for match in re.finditer(hydra_pattern, content):
-        full_key = match.group(1)
-        # Split by dots and check each component
-        parts = full_key.split(".")
-
-        # Skip if the first part is a known top-level key
-        if parts[0] not in VALID_HYDRA_KEYS and parts[0] not in {"python", "uv"}:
-            # Only warn for what look like config keys (lowercase with underscores)
-            if re.match(r"^[a-z_]+$", parts[0]):
-                errors.append(f"{doc_path}: Unknown config key: {full_key}")
+        for match in re.finditer(hydra_pattern, stripped):
+            full_key = match.group(1)
+            parts = full_key.split(".")
+            if parts[0] not in VALID_HYDRA_KEYS and parts[0] not in {"python", "uv"}:
+                if re.match(r"^[a-z_]+$", parts[0]):
+                    errors.append(f"{doc_path}: Unknown config key: {full_key}")
 
     return errors
 
 
 def check_argparse_vs_hydra(content: str, doc_path: Path, root: Path) -> list[str]:
-    """Check for outdated argparse style commands in Hydra scripts."""
+    del root
     errors: list[str] = []
-
-    # Pattern for old argparse style flags that should be Hydra style
     old_flags = [
         (r"--task\s+", "Use Hydra style: task=<value>"),
         (r"--env_num\s+", "Use Hydra style: algo.num_envs=<value>"),
         (r"--play_only\b", "Use Hydra style: training.play_only=true"),
         (r"--no_play\b", "Use Hydra style: training.no_play=true"),
-        (r"--load_run\s+", "Use Hydra style: training.load_run=<value>"),
+        (r"--load_run\s+", "Use Hydra style: algo.load_run=<value>"),
         (r"--cam_distance\s+", "Use Hydra style: training.cam_distance=<value>"),
         (r"--cam_elevation\s+", "Use Hydra style: training.cam_elevation=<value>"),
         (r"--cam_azimuth\s+", "Use Hydra style: training.cam_azimuth=<value>"),
     ]
-
-    # Scripts that use Hydra (not argparse)
     hydra_scripts = [
         "train_rsl_rl.py",
         "train_mlx_ppo.py",
@@ -228,9 +168,7 @@ def check_argparse_vs_hydra(content: str, doc_path: Path, root: Path) -> list[st
             start = max(0, match.start() - 100)
             end = min(len(content), match.end() + 50)
             context = content[start:end]
-            # Only flag if context contains a Hydra script
-            is_hydra_context = any(script in context for script in hydra_scripts)
-            if is_hydra_context:
+            if any(script in context for script in hydra_scripts):
                 errors.append(
                     f"{doc_path}: Outdated argparse flag '{match.group(0).strip()}': {message}"
                 )
@@ -238,46 +176,46 @@ def check_argparse_vs_hydra(content: str, doc_path: Path, root: Path) -> list[st
     return errors
 
 
-def check_document(doc_path: Path, root: Path) -> list[str]:
-    """Run all checks on a single document."""
+def check_training_entrypoint_semantics(content: str, doc_path: Path, root: Path) -> list[str]:
+    del root
     errors: list[str] = []
 
-    try:
-        content = doc_path.read_text(encoding="utf-8")
-    except Exception as e:
-        return [f"{doc_path}: Error reading file: {e}"]
+    for _match in re.finditer(r"\btraining\.load_run=", content):
+        errors.append(
+            f"{doc_path}: Deprecated Hydra key 'training.load_run': use algo.load_run=<value>"
+        )
 
+    for match in re.finditer(r"logs/(rsl_rl_train|mlx_rl_train)/", content):
+        errors.append(
+            f"{doc_path}: Stale log root '{match.group(0)}': describe logs via "
+            "logs/<algo.algo_log_name>/<task>/ or the current default algo.algo_log_name"
+        )
+
+    task_pattern = r"\btask=([A-Za-z0-9_-]+)(?=$|[\s\"'])"
+    for match in re.finditer(task_pattern, content):
+        errors.append(
+            f"{doc_path}: Task override '{match.group(0)}' is missing the backend segment; "
+            "use task=<task>/<backend> or task=<algo>/<task>/<backend>"
+        )
+
+    return errors
+
+
+def check_document(doc_path: Path, root: Path) -> list[str]:
+    content = doc_path.read_text(encoding="utf-8")
+    errors: list[str] = []
     errors.extend(check_script_references(content, doc_path, root))
     errors.extend(check_file_paths(content, doc_path, root))
     errors.extend(check_markdown_links(content, doc_path, root))
     errors.extend(check_hydra_keys(content, doc_path, root))
     errors.extend(check_argparse_vs_hydra(content, doc_path, root))
-
+    errors.extend(check_training_entrypoint_semantics(content, doc_path, root))
     return errors
 
 
-def main() -> int:
-    """Main entry point."""
-    root = Path(__file__).parent.parent
-    docs = find_docs(root)
-
-    all_errors: list[str] = []
-
-    print(f"Checking {len(docs)} documentation files...")
-
-    for doc_path in docs:
-        errors = check_document(doc_path, root)
-        all_errors.extend(errors)
-
-    if all_errors:
-        print(f"\nFound {len(all_errors)} issue(s):")
-        for error in all_errors:
-            print(f"  - {error}")
-        return 1
-    else:
-        print("\nAll documentation checks passed!")
-        return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+def collect_doc_errors(root: Path | None = None) -> list[str]:
+    resolved_root = root or repo_root()
+    errors: list[str] = []
+    for doc_path in find_docs(resolved_root):
+        errors.extend(check_document(doc_path, resolved_root))
+    return errors

--- a/tests/scripts/test_check_docs.py
+++ b/tests/scripts/test_check_docs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.scripts import doc_checks
+
+
+def test_documentation_files_match_current_repo_contracts():
+    root = Path(__file__).resolve().parents[2]
+    errors = doc_checks.collect_doc_errors(root)
+    assert errors == []
+
+
+def test_check_training_entrypoint_semantics_flags_issue_204_patterns():
+    root = Path(__file__).resolve().parents[2]
+    doc_path = root / "README.md"
+    content = """
+uv run python scripts/train_rsl_rl.py task=go1_joystick
+uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco training.load_run=2026-01-01
+Training logs are saved to logs/rsl_rl_train/MyTask/.
+"""
+
+    errors = doc_checks.check_training_entrypoint_semantics(content, doc_path, root)
+
+    assert any("training.load_run" in error for error in errors)
+    assert any("logs/rsl_rl_train/" in error for error in errors)
+    assert any("task=go1_joystick" in error for error in errors)
+
+
+def test_check_training_entrypoint_semantics_accepts_current_patterns():
+    root = Path(__file__).resolve().parents[2]
+    doc_path = root / "README.md"
+    content = """
+uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco algo.load_run=2026-01-01
+uv run python scripts/train_offpolicy.py algo=sac task=sac/go1_joystick/mujoco
+Logs live under logs/<algo.algo_log_name>/<task>/.
+"""
+
+    errors = doc_checks.check_training_entrypoint_semantics(content, doc_path, root)
+
+    assert errors == []
+
+
+def test_check_script_references_ignores_tests_paths():
+    root = Path(__file__).resolve().parents[2]
+    doc_path = root / "CONTRIBUTING.md"
+    content = "Run uv run pytest tests/scripts/test_check_docs.py -q"
+
+    errors = doc_checks.check_script_references(content, doc_path, root)
+
+    assert errors == []


### PR DESCRIPTION
## Summary
- update README and zh_CN docs to the current task=<task>/<backend>, algo.load_run, and algo.algo_log_name semantics
- move docs validation into the pytest suite by renaming scripts/check_docs.py into tests/scripts/doc_checks.py and adding tests/scripts/test_check_docs.py
- make CI run on docs changes so docs drift is checked in the normal test job

Fixes #204

## Validation
- uv run pytest tests/scripts/test_check_docs.py tests/scripts/test_train_scripts.py tests/training/test_training_helpers.py -q

## Impact Scope
- docs and docs validation only
- CI now runs for docs changes instead of skipping them