### PR TITLE
fix: unify auxiliary entrypoint bootstrap helpers

### DIFF
--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -2,10 +2,10 @@
 
 Usage:
     # Load the latest checkpoint for a task
-    python scripts/play_interactive.py --task Go2JoystickFlatTerrain
+    uv run python scripts/play_interactive.py --task Go2JoystickFlatTerrain
 
     # Load a specific run
-    python scripts/play_interactive.py --task Go2JoystickFlatTerrain --load_run 2024-02-04_12-00-00
+    uv run python scripts/play_interactive.py --task Go2JoystickFlatTerrain --load_run 2024-02-04_12-00-00
 
 Camera controls (MuJoCo viewer):
     Mouse drag     - rotate
@@ -13,8 +13,9 @@ Camera controls (MuJoCo viewer):
     Right-drag     - pan
 """
 
+# pyright: reportAttributeAccessIssue=false, reportArgumentType=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false
+
 import argparse
-import os
 import sys
 import time
 from pathlib import Path
@@ -27,7 +28,7 @@ import torch
 ROOT_DIR = Path(__file__).parent.parent
 sys.path.append(str(ROOT_DIR))
 
-from unilab.training import ensure_registries
+from unilab.training import ensure_registries, resolve_task_checkpoint_path
 
 ensure_registries()
 
@@ -35,7 +36,6 @@ from unilab.base import registry
 from unilab.config.structured_configs import PPOConfig
 from unilab.utils.rsl_rl_compat import convert_config_v3_to_v4, is_rsl_rl_v4
 from unilab.utils.rsl_rl_vec_env_wrapper import RslRlVecEnvWrapper
-from unilab.utils.run_utils import get_latest_run
 
 try:
     from rsl_rl.runners import OnPolicyRunner
@@ -72,42 +72,27 @@ def _infer_checkpoint_actor_input_dim(ckpt_path: str) -> int | None:
 def resolve_checkpoint(
     task: str, load_run: str, checkpoint: str | None = None, algo_log_name: str = "rsl_rl_ppo"
 ) -> str | None:
-    base = ROOT_DIR / "logs" / algo_log_name / task
-    if load_run == "-1":
-        path = get_latest_run(str(base))
-    elif os.path.exists(load_run):
-        path = load_run
-    else:
-        path = str(base / load_run)
-
-    if not path or not os.path.exists(path):
-        print(f"[play_interactive] Run not found: {path}")
+    checkpoint_path, checkpoint_dir = resolve_task_checkpoint_path(
+        ROOT_DIR,
+        task_name=task,
+        load_run=load_run,
+        algo_log_name=algo_log_name,
+        checkpoint=checkpoint,
+    )
+    if checkpoint_path is None:
+        if checkpoint is not None and checkpoint_dir is not None:
+            checkpoint_name = (
+                f"model_{checkpoint}.pt" if str(checkpoint).isdigit() else str(checkpoint)
+            )
+            print(f"[play_interactive] Checkpoint not found: {checkpoint_dir / checkpoint_name}")
+        elif checkpoint_dir is not None:
+            print(f"[play_interactive] No model_*.pt files in {checkpoint_dir}")
+        else:
+            print(f"[play_interactive] Run not found for load_run={load_run}")
         return None
 
-    if os.path.isdir(path):
-        if checkpoint is not None:
-            if str(checkpoint).isdigit():
-                model_name = f"model_{checkpoint}.pt"
-            else:
-                model_name = checkpoint
-            model_path = os.path.join(path, model_name)
-            if os.path.exists(model_path):
-                path = model_path
-            else:
-                print(f"[play_interactive] Checkpoint not found: {model_path}")
-                return None
-        else:
-            model_files = sorted(
-                [f for f in os.listdir(path) if f.startswith("model_") and f.endswith(".pt")],
-                key=lambda f: int(f.split("_")[1].split(".")[0]),
-            )
-            if not model_files:
-                print(f"[play_interactive] No model_*.pt files in {path}")
-                return None
-            path = os.path.join(path, model_files[-1])
-
-    print(f"[play_interactive] Loading checkpoint: {path}")
-    return path
+    print(f"[play_interactive] Loading checkpoint: {checkpoint_path}")
+    return str(checkpoint_path)
 
 
 # ---------------------------------------------------------------------------

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import importlib
-import pkgutil
 import sys
 import time
 from pathlib import Path
@@ -33,35 +31,13 @@ ROOT_DIR = Path(__file__).parents[4]
 sys.path.insert(0, str(ROOT_DIR))
 
 
-# ── Registry discovery ───────────────────────────────────────────────────────
-
-
-def ensure_registries():
-    for pkg_name in ("unilab.envs.locomotion", "unilab.envs.manipulation"):
-        try:
-            package = importlib.import_module(pkg_name)
-            if hasattr(package, "__path__"):
-                for _, name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
-                    try:
-                        importlib.import_module(name)
-                    except Exception:
-                        pass
-        except ImportError:
-            pass
-
+from unilab.training import ensure_registries
 
 ensure_registries()
 
 from unilab.base import registry  # noqa: E402  (after sys.path setup)
 from unilab.base.dtype_config import get_global_dtype  # noqa: E402
-
-# Explicit import to guarantee the @registry.env decorator runs,
-# since ensure_registries() silently swallows import errors.
-from unilab.envs.manipulation.inhand_rot_allegro import rotation as _rotation_register
 from unilab.utils import render_many  # noqa: E402
-
-_ = _rotation_register  # side-effect import: triggers @registry.env decorator
-
 
 # ── Quality-check helpers ────────────────────────────────────────────────────
 

--- a/src/unilab/training/__init__.py
+++ b/src/unilab/training/__init__.py
@@ -4,12 +4,14 @@ from unilab.training.backend_adapter import BackendAdapter
 from unilab.training.common import (
     create_env,
     ensure_registries,
+    get_entrypoint_log_root,
     get_latest_checkpoint,
     get_latest_run,
     get_log_root,
     parse_checkpoint_path,
     render_play_mode,
     resolve_checkpoint_path,
+    resolve_task_checkpoint_path,
     setup_logger,
 )
 
@@ -17,11 +19,13 @@ __all__ = [
     "BackendAdapter",
     "create_env",
     "ensure_registries",
+    "get_entrypoint_log_root",
     "get_latest_checkpoint",
     "get_latest_run",
     "get_log_root",
     "parse_checkpoint_path",
     "render_play_mode",
     "resolve_checkpoint_path",
+    "resolve_task_checkpoint_path",
     "setup_logger",
 ]

--- a/src/unilab/training/common.py
+++ b/src/unilab/training/common.py
@@ -29,6 +29,21 @@ def get_log_root(root_dir: str | Path, cfg: DictConfig) -> Path:
     return Path(root_dir) / "logs" / str(OmegaConf.select(cfg, "algo.algo_log_name"))
 
 
+def get_entrypoint_log_root(
+    root_dir: str | Path,
+    *,
+    algo_log_name: str,
+    log_root: str | Path | None = None,
+) -> Path:
+    """Resolve the log root for non-Hydra entrypoints using training helper semantics."""
+    if log_root is not None:
+        configured_root = Path(log_root)
+        return (
+            configured_root if configured_root.is_absolute() else Path(root_dir) / configured_root
+        )
+    return Path(root_dir) / "logs" / algo_log_name
+
+
 def get_latest_run(log_dir: str | Path) -> Path | None:
     """Return the lexicographically latest run directory under a task log root."""
     base_dir = Path(log_dir)
@@ -102,6 +117,52 @@ def parse_checkpoint_path(
     selected_run = load_run or str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
     base_log_dir = get_log_root(root_dir, cfg) / selected_task
     return resolve_checkpoint_path(base_log_dir, selected_run, suffix=suffix)
+
+
+def resolve_task_checkpoint_path(
+    root_dir: str | Path,
+    *,
+    task_name: str,
+    load_run: str,
+    algo_log_name: str,
+    checkpoint: str | None = None,
+    suffix: str = ".pt",
+    log_root: str | Path | None = None,
+) -> tuple[Path | None, Path | None]:
+    """Resolve checkpoint paths for auxiliary entrypoints through shared training semantics."""
+    task_log_root = (
+        get_entrypoint_log_root(
+            root_dir,
+            algo_log_name=algo_log_name,
+            log_root=log_root,
+        )
+        / task_name
+    )
+
+    run_dir: Path | None
+    if load_run == "-1":
+        run_dir = get_latest_run(task_log_root)
+    else:
+        candidate = Path(load_run)
+        if not candidate.exists():
+            candidate = task_log_root / load_run
+        if candidate.is_file():
+            return candidate, candidate.parent
+        run_dir = candidate if candidate.is_dir() else None
+
+    if run_dir is None:
+        return None, None
+
+    checkpoint_path: Path | None
+    if checkpoint is not None:
+        checkpoint_name = (
+            f"model_{checkpoint}{suffix}" if str(checkpoint).isdigit() else str(checkpoint)
+        )
+        checkpoint_path = run_dir / checkpoint_name
+        return (checkpoint_path, run_dir) if checkpoint_path.exists() else (None, run_dir)
+
+    checkpoint_path = get_latest_checkpoint(run_dir, suffix=suffix)
+    return (checkpoint_path, run_dir) if checkpoint_path is not None else (None, run_dir)
 
 
 def setup_logger(

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -20,6 +20,7 @@ from hydra.core.global_hydra import GlobalHydra
 
 _SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
 _CONF_DIR = Path(__file__).parent.parent.parent / "conf"
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
 
 
 def _normalize_overrides(overrides: list[str] | None, *, offpolicy: bool = False) -> list[str]:
@@ -845,6 +846,33 @@ def test_play_resolve_checkpoint_empty_dir(tmp_path):
     assert result is None
 
 
+@pytest.mark.skipif(not _HAS_MUJOCO, reason="mujoco not installed")
+def test_play_resolve_checkpoint_delegates_to_shared_helper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    mod = _load_script("play_interactive")
+    model_path = tmp_path / "resolved" / "model_12.pt"
+    model_path.parent.mkdir(parents=True)
+    model_path.write_bytes(b"")
+    captured: dict[str, object] = {}
+
+    def _fake_resolver(root_dir, **kwargs):
+        captured["root_dir"] = root_dir
+        captured.update(kwargs)
+        return model_path, model_path.parent
+
+    monkeypatch.setattr(mod, "resolve_task_checkpoint_path", _fake_resolver)
+
+    result = mod.resolve_checkpoint("MyTask", "-1", checkpoint="12", algo_log_name="custom_ppo")
+
+    assert result == str(model_path)
+    assert captured["root_dir"] == mod.ROOT_DIR
+    assert captured["task_name"] == "MyTask"
+    assert captured["load_run"] == "-1"
+    assert captured["algo_log_name"] == "custom_ppo"
+    assert captured["checkpoint"] == "12"
+
+
 # ---------------------------------------------------------------------------
 # play_interactive.py — RslRlVecEnvWrapper contract behavior
 # ---------------------------------------------------------------------------
@@ -1021,3 +1049,32 @@ def test_play_resolve_checkpoint_uses_algo_log_name(tmp_path):
         assert "model_50.pt" in result
     finally:
         mod.ROOT_DIR = original_root
+
+
+def test_gen_grasp_import_does_not_swallow_registry_bootstrap_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import types
+
+    gen_grasp_path = (
+        _SRC_DIR / "unilab" / "envs" / "manipulation" / "inhand_rot_allegro" / "gen_grasp.py"
+    )
+    training_mod = cast(Any, types.ModuleType("unilab.training"))
+
+    def _fail_bootstrap() -> None:
+        raise RuntimeError("bootstrap failed")
+
+    training_mod.ensure_registries = _fail_bootstrap
+    monkeypatch.setitem(sys.modules, "unilab.training", training_mod)
+    monkeypatch.setitem(sys.modules, "mediapy", cast(Any, types.ModuleType("mediapy")))
+
+    mujoco_mod = cast(Any, types.ModuleType("mujoco"))
+    mujoco_mod.viewer = cast(Any, types.ModuleType("mujoco.viewer"))
+    monkeypatch.setitem(sys.modules, "mujoco", mujoco_mod)
+    monkeypatch.setitem(sys.modules, "mujoco.viewer", mujoco_mod.viewer)
+
+    spec = importlib.util.spec_from_file_location("gen_grasp_test_module", gen_grasp_path)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="bootstrap failed"):
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -11,6 +11,7 @@ from unilab.training import (
     get_latest_checkpoint,
     get_latest_run,
     parse_checkpoint_path,
+    resolve_task_checkpoint_path,
 )
 
 _ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -84,6 +85,41 @@ def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(tmp_path: Path):
     checkpoint_path, checkpoint_dir = parse_checkpoint_path(cfg, root_dir=tmp_path)
 
     assert checkpoint_path == model_path
+    assert checkpoint_dir == run_dir
+
+
+def test_resolve_task_checkpoint_path_supports_explicit_checkpoint(tmp_path: Path):
+    run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    (run_dir / "model_9.pt").write_bytes(b"")
+    selected_model = run_dir / "model_12.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_task_checkpoint_path(
+        tmp_path,
+        task_name="MyTask",
+        load_run="-1",
+        algo_log_name="custom_ppo",
+        checkpoint="12",
+    )
+
+    assert checkpoint_path == selected_model
+    assert checkpoint_dir == run_dir
+
+
+def test_resolve_task_checkpoint_path_returns_run_dir_when_checkpoint_missing(tmp_path: Path):
+    run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+
+    checkpoint_path, checkpoint_dir = resolve_task_checkpoint_path(
+        tmp_path,
+        task_name="MyTask",
+        load_run="-1",
+        algo_log_name="custom_ppo",
+        checkpoint="12",
+    )
+
+    assert checkpoint_path is None
     assert checkpoint_dir == run_dir
 
 


### PR DESCRIPTION
## Summary

- Route `scripts/play_interactive.py` checkpoint resolution through shared training helpers instead of maintaining local log-root and latest-checkpoint rules.
- Replace `gen_grasp.py` local registry bootstrap with `unilab.training.ensure_registries()` so import failures are no longer swallowed.
- Add focused regression coverage for auxiliary entrypoint checkpoint resolution and registry bootstrap failure propagation.

## Linked Work

- Issue: Fixes #205
- Milestone: n/a

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
make check
uv run pytest tests/scripts/test_train_scripts.py -q
uv run pytest tests/training/test_training_helpers.py -q
uv run pytest tests/scripts/test_train_scripts.py tests/training/test_training_helpers.py -q
```

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: n/a
- benchmark result: n/a
- video / screenshot: n/a
- ONNX / checkpoint: n/a

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up work:

- None.
