### PR TITLE
chore: add mailmap for author aliases

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+tatp-yf <jyf23@mails.tsinghua.edu.cn> tatp-yf <1305116641@qq.com>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> tatp-yf <jyf23@mails.tsinghua.edu.cn>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> jyf23 <jyf23@mails.tsinghua.edu.cn>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> YUFEI JIA <59379871+TATP-233@users.noreply.github.com>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> TATP-233 <jyf23@mails.tsinghua.edu.cn>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> yves <yves@Yvess-Mac-mini.local>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> yves <yves@yvesdeMac-mini.local>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> tatp <yves_jia@icloud.com>
+tatp-yf <jyf23@mails.tsinghua.edu.cn> robot <robot@robotdeMacBook.local>


### PR DESCRIPTION
## Summary
- add a repository .mailmap file
- unify historical author aliases under tatp-yf <jyf23@mails.tsinghua.edu.cn>
- keep commit history unchanged while improving author aggregation in git reports

## Validation
- git shortlog -sne --all
