### PR TITLE
fix: decouple MuJoCo import chain for optional Motrix paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ uv sync --extra motrix
 uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco
 ```
 
+Motrix registry bootstrap and Hydra config composition do not require importing MuJoCo anymore, but any MuJoCo task execution, playback, or MuJoCo-only tooling still requires a working MuJoCo runtime.
+
 ## Workflow Entrypoints
 
 | Goal | Entrypoint | Log root pattern |

--- a/docs/zh_CN/02-simulation-backends.md
+++ b/docs/zh_CN/02-simulation-backends.md
@@ -7,6 +7,13 @@ UniLab 当前支持两个仿真后端:
 - **MuJoCo**: 默认后端，能力最完整
 - **Motrix**: 可选后端，任务和算法支持仍在持续补齐
 
+## Runtime Prerequisites
+
+- `uv sync --extra motrix` 会安装 Motrix 依赖。
+- Motrix 路径的 registry bootstrap 和 Hydra 配置 compose 不再要求导入 MuJoCo。
+- 任何 `task=.../mujoco` 的实际运行、MuJoCo playback、以及 MuJoCo-only 调试工具，仍然要求可用的 MuJoCo runtime。
+- 某些任务目前仍然只有 MuJoCo owner 配置；例如 `AllegroInhandRotation` 只提供 `mujoco` task。
+
 ## Support Matrix
 
 ### MuJoCo

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -1,6 +1,13 @@
+from typing import Any, cast
+
 from .base import SimBackend
 from .motrix_backend import MOTRIX_AVAILABLE, MotrixBackend
-from .mujoco_backend import MuJoCoBackend
+
+
+def _load_mujoco_backend() -> Any:
+    from .mujoco_backend import MuJoCoBackend
+
+    return MuJoCoBackend
 
 
 def create_backend(
@@ -20,15 +27,22 @@ def create_backend(
     """
     position_actuator_gains = kwargs.pop("position_actuator_gains", None)
     if backend_type == "mujoco":
+        MuJoCoBackend = _load_mujoco_backend()
         if position_actuator_gains is not None:
             kwargs["position_actuator_gains"] = position_actuator_gains
-        return MuJoCoBackend(model_file, num_envs, sim_dt, **kwargs)
+        return cast(SimBackend, MuJoCoBackend(model_file, num_envs, sim_dt, **kwargs))
     elif backend_type == "motrix":
         if not MOTRIX_AVAILABLE:
             raise ImportError("MotrixSim not available, install motrixsim package")
         return MotrixBackend(model_file, num_envs, sim_dt, **kwargs)
     else:
         raise ValueError(f"Unknown backend: {backend_type}")
+
+
+def __getattr__(name: str):
+    if name == "MuJoCoBackend":
+        return _load_mujoco_backend()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import gymnasium as gym
-import mujoco
 import numpy as np
 
 from unilab.base.backend import SimBackend
@@ -104,6 +103,8 @@ class AllegroBaseMjEnv(NpEnv):
     # ── Buffers ─────────────────────────────────────────────────────
 
     def _init_buffer(self):
+        import mujoco
+
         key_id = mujoco.mj_name2id(self._backend.model, mujoco.mjtObj.mjOBJ_KEY, "home")
         if key_id < 0:
             raise ValueError("Keyframe 'home' not found in model.")

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
@@ -27,6 +27,10 @@ import numpy as np
 ROOT_DIR = Path(__file__).parents[4]
 sys.path.insert(0, str(ROOT_DIR))
 
+from unilab.training import ensure_registries
+
+ensure_registries()
+
 # ── Quality-check helpers ────────────────────────────────────────────────────
 
 _CONTACT_SENSORS = ["ff_contact", "mf_contact", "rf_contact", "th_contact"]
@@ -63,9 +67,7 @@ def collect_grasps(args) -> None:
 
     from unilab.base import registry
     from unilab.base.dtype_config import get_global_dtype
-    from unilab.training import ensure_registries
 
-    ensure_registries()
     env: Any = registry.make("AllegroInhandRotation", num_envs=args.num_envs, sim_backend="mujoco")
 
     # Override joint noise to the exploration value before init_state().

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py
@@ -20,24 +20,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-import mediapy as media
-import mujoco
-import mujoco.viewer
 import numpy as np
 
 # ── Path setup ──────────────────────────────────────────────────────────────
 # gen_grasp.py lives at: UniLab/unilab/envs/manipulation/inhand_rot_allegro/
 ROOT_DIR = Path(__file__).parents[4]
 sys.path.insert(0, str(ROOT_DIR))
-
-
-from unilab.training import ensure_registries
-
-ensure_registries()
-
-from unilab.base import registry  # noqa: E402  (after sys.path setup)
-from unilab.base.dtype_config import get_global_dtype  # noqa: E402
-from unilab.utils import render_many  # noqa: E402
 
 # ── Quality-check helpers ────────────────────────────────────────────────────
 
@@ -71,6 +59,13 @@ def check_grasp_quality(
 
 
 def collect_grasps(args) -> None:
+    import mujoco
+
+    from unilab.base import registry
+    from unilab.base.dtype_config import get_global_dtype
+    from unilab.training import ensure_registries
+
+    ensure_registries()
     env: Any = registry.make("AllegroInhandRotation", num_envs=args.num_envs, sim_backend="mujoco")
 
     # Override joint noise to the exploration value before init_state().
@@ -206,6 +201,10 @@ def collect_grasps(args) -> None:
 
     # ── Render video ──────────────────────────────────────────────────────
     if video_states:
+        import mediapy as media
+
+        from unilab.utils import render_many
+
         print(f"Rendering video to {video_path}...")
         frames = render_many.render_states_get_frames(
             video_states, env.cfg.model_file, width=1280, height=720, camera_id=-1

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
-import mujoco
 import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
@@ -38,6 +37,7 @@ from unilab.utils.math_utils import (
     np_subtract_frame_transforms,
     np_yaw_quat,
 )
+from unilab.utils.xml_utils import get_named_body_ids
 
 from .motion_loader import MotionLoader, MotionSampler
 
@@ -318,14 +318,9 @@ class G1MotionTrackingEnv(G1BaseEnv):
         if self._is_mujoco_backend():
             motion_body_ids = self.body_ids
         else:
-            # Motion data always uses MuJoCo body indexing.
-            mj_model = mujoco.MjModel.from_xml_path(cfg.model_file)
-            motion_body_ids = np.array(
-                [
-                    mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_BODY, name)
-                    for name in cfg.body_names
-                ],
-                dtype=np.int32,
+            # Motion data always uses MuJoCo-style body indexing, even on Motrix.
+            motion_body_ids = np.asarray(
+                get_named_body_ids(cfg.model_file, cfg.body_names), dtype=np.int32
             )
 
         self.anchor_body_idx = cfg.body_names.index(cfg.anchor_body_name)
@@ -397,6 +392,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         """Log action-scale diagnostics to help detect control-mapping issues."""
         if not self._cfg.log_action_scale or not self._is_mujoco_backend():
             return
+        import mujoco
 
         model = self._backend.model
         action_scale = self._cfg.control_config.action_scale

--- a/src/unilab/utils/xml_utils.py
+++ b/src/unilab/utils/xml_utils.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import os
 import tempfile
 import xml.etree.ElementTree as ET
+from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any, cast
-
-import mujoco
 
 
 def _enable_discardvisual(root: ET.Element) -> None:
@@ -23,16 +21,47 @@ def create_discardvisual_xml(model_file: str) -> str:
     return _write_temp_xml(tree, model_file)
 
 
+def _iter_expanded_children(
+    parent: ET.Element, base_dir: Path
+) -> Iterator[tuple[ET.Element, Path]]:
+    for child in parent:
+        if child.tag != "include":
+            yield child, base_dir
+            continue
+
+        include_file = child.get("file")
+        if not include_file:
+            raise ValueError(f"Invalid <include> without file attribute in {base_dir}")
+        include_path = (base_dir / include_file).resolve()
+        include_root = ET.parse(include_path).getroot()
+        yield from _iter_expanded_children(include_root, include_path.parent)
+
+
+def _iter_named_bodies(root: ET.Element, base_dir: Path) -> Iterator[str]:
+    for child, child_base_dir in _iter_expanded_children(root, base_dir):
+        if child.tag == "body":
+            body_name = child.get("name")
+            if body_name:
+                yield body_name
+        yield from _iter_named_bodies(child, child_base_dir)
+
+
 def _get_named_bodies(model_file: str) -> tuple[list[int], list[str]]:
-    mj = cast(Any, mujoco)
-    _m = mj.MjModel.from_xml_path(model_file)
-    ids, names = [], []
-    for i in range(1, _m.nbody):  # skip body 0 (world body)
-        name = mj.mj_id2name(_m, mj.mjtObj.mjOBJ_BODY, i)
-        if name:
-            ids.append(i)
-            names.append(name)
+    model_path = Path(model_file).resolve()
+    names = list(_iter_named_bodies(ET.parse(model_path).getroot(), model_path.parent))
+    ids = list(range(1, len(names) + 1))
     return ids, names
+
+
+def get_named_body_ids(model_file: str, names: Sequence[str]) -> list[int]:
+    """Resolve MuJoCo-style body ids from XML without importing mujoco."""
+    body_ids, body_names = _get_named_bodies(model_file)
+    body_id_by_name = dict(zip(body_names, body_ids, strict=True))
+    missing = [name for name in names if name not in body_id_by_name]
+    if missing:
+        missing_str = ", ".join(missing)
+        raise ValueError(f"Bodies not found in XML '{model_file}': {missing_str}")
+    return [body_id_by_name[name] for name in names]
 
 
 def _add_w_sensors(sensor_tag: ET.Element, valid_bnames: list[str]) -> None:

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -2,36 +2,76 @@
 
 Config-attribute tests (non-slow) verify that config dataclasses expose every
 attribute accessed by their paired env class, WITHOUT running a simulation.
-They still require MuJoCo to be importable because the config and env classes
-live in the same module file.
 
 Slow tests actually call registry.make() and run reset + step.
 """
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
-# The G1 env modules import create_backend → mujoco.batch_env at the top
-# level, so all tests in this file need a working MuJoCo installation.
-pytest.importorskip("mujoco", reason="mujoco not installed")
+from unilab.utils.algo_utils import ensure_registries
 
-# Some environments also use mujoco.batch_env (G1 backend). Guard against
-# partial MuJoCo installations where the base package installs but platform
-# extensions fail (e.g. wrong libstdc++ version).
-try:
-    from mujoco.batch_env import BatchEnvPool as _  # noqa: F401
-except Exception:
-    pytest.skip(
-        "mujoco.batch_env not available (platform/libstdc++ issue)", allow_module_level=True
-    )
 
-from unilab.utils.algo_utils import ensure_registries  # noqa: E402
+def _require_mujoco_runtime() -> None:
+    pytest.importorskip("mujoco", reason="mujoco not installed")
+    try:
+        from mujoco.batch_env import BatchEnvPool as _  # noqa: F401
+    except Exception:
+        pytest.skip("mujoco.batch_env not available (platform/libstdc++ issue)")
+
 
 # ---------------------------------------------------------------------------
 # Non-slow: config attribute completeness (no env.step(), no MuJoCo sim)
 # ---------------------------------------------------------------------------
+
+
+def test_registry_bootstrap_and_config_imports_do_not_require_mujoco():
+    repo_root = Path(__file__).parents[2]
+    script = textwrap.dedent(
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "mujoco" or name.startswith("mujoco."):
+                raise ImportError("mujoco blocked by test")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+
+        from unilab.base import registry
+        from unilab.base.backend import create_backend
+        from unilab.envs.manipulation.inhand_rot_allegro.rotation import AllegroRotationCfg
+        from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingCfg
+        from unilab.utils.algo_utils import ensure_registries
+
+        ensure_registries()
+        assert callable(create_backend)
+        assert registry.contains("G1MotionTracking")
+        assert registry.contains("AllegroInhandRotation")
+        G1MotionTrackingCfg()
+        AllegroRotationCfg()
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_g1_joystick_ppo_cfg_obs_groups_spec():
@@ -97,7 +137,7 @@ def test_g1_motion_tracking_uses_split_body_pose_queries():
             self.calls.append(("quat", body_ids.copy()))
             return np.ones((2, len(body_ids), 4))
 
-    env = object.__new__(G1MotionTrackingEnv)
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
     env._backend = FakeBackend()
     env.body_ids = np.array([1, 3], dtype=np.int32)
 
@@ -179,7 +219,7 @@ def test_g1_motion_tracking_clip_end_contributes_to_truncated():
         def step(self) -> np.ndarray:
             return np.array([1], dtype=np.int32)
 
-    env = object.__new__(G1MotionTrackingEnv)
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
     env._num_envs = 2
     env._cfg = type("Cfg", (), {"max_episode_steps": None})()
     env.body_ids = np.array([0], dtype=np.int32)
@@ -227,7 +267,7 @@ def test_g1_motion_tracking_clip_end_does_not_override_true_termination():
     from unilab.base.np_env import NpEnvState
     from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv
 
-    env = object.__new__(G1MotionTrackingEnv)
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
     env._num_envs = 2
     env._cfg = type("Cfg", (), {"max_episode_steps": None})()
     env._clip_end_truncated = np.array([False, True], dtype=bool)
@@ -276,6 +316,7 @@ def test_env_reset_and_step(
     - init_state + reset produces dict obs with correct keys and shapes
     - step with zero actions produces dict obs, scalar reward, bool done
     """
+    _require_mujoco_runtime()
     ensure_registries()
     from unilab.base import registry
 
@@ -292,8 +333,11 @@ def test_env_reset_and_step(
     elif "Allegro" in env_name:
         env_cfg_override = {"reward_config": default_allegro_reward_config}
 
-    env = registry.make(
-        env_name, num_envs=2, sim_backend="mujoco", env_cfg_override=env_cfg_override
+    env = cast(
+        Any,
+        registry.make(
+            env_name, num_envs=2, sim_backend="mujoco", env_cfg_override=env_cfg_override
+        ),
     )
     try:
         # 1. Spaces
@@ -328,7 +372,9 @@ def test_env_reset_and_step(
         env.close()
 
 
-def _assert_mujoco_position_gains(env, *, kp: float, kd: float, actuator_ids=slice(None)) -> None:
+def _assert_mujoco_position_gains(
+    env: Any, *, kp: float, kd: float, actuator_ids=slice(None)
+) -> None:
     model = env._backend.model
     np.testing.assert_allclose(model.actuator_gainprm[actuator_ids, 0], kp)
     np.testing.assert_allclose(model.actuator_biasprm[actuator_ids, 1], -kp)
@@ -339,17 +385,21 @@ def _assert_mujoco_position_gains(env, *, kp: float, kd: float, actuator_ids=sli
 
 @pytest.mark.slow
 def test_go1_env_initializes_kp_kd_into_pool(default_go1_reward_config):
+    _require_mujoco_runtime()
     ensure_registries()
     from unilab.base import registry
 
-    env = registry.make(
-        "Go1JoystickFlatTerrain",
-        num_envs=2,
-        sim_backend="mujoco",
-        env_cfg_override={
-            "reward_config": default_go1_reward_config,
-            "control_config": {"Kp": 12.0, "Kd": 0.7},
-        },
+    env = cast(
+        Any,
+        registry.make(
+            "Go1JoystickFlatTerrain",
+            num_envs=2,
+            sim_backend="mujoco",
+            env_cfg_override={
+                "reward_config": default_go1_reward_config,
+                "control_config": {"Kp": 12.0, "Kd": 0.7},
+            },
+        ),
     )
     try:
         _assert_mujoco_position_gains(env, kp=12.0, kd=0.7)
@@ -359,30 +409,34 @@ def test_go1_env_initializes_kp_kd_into_pool(default_go1_reward_config):
 
 @pytest.mark.slow
 def test_go2_env_initializes_kp_kd_into_pool():
+    _require_mujoco_runtime()
     ensure_registries()
     from unilab.base import registry
     from unilab.envs.locomotion.go2.joystick import RewardConfig
 
-    env = registry.make(
-        "Go2JoystickFlatTerrain",
-        num_envs=2,
-        sim_backend="mujoco",
-        env_cfg_override={
-            "reward_config": RewardConfig(
-                scales={
-                    "tracking_lin_vel": 1.0,
-                    "tracking_ang_vel": 0.2,
-                    "lin_vel_z": -5.0,
-                    "ang_vel_xy": -0.02,
-                    "base_height": -100.0,
-                    "action_rate": -0.005,
-                    "similar_to_default": -0.1,
-                },
-                tracking_sigma=0.25,
-                base_height_target=0.3,
-            ),
-            "control_config": {"Kp": 18.0, "Kd": 0.9},
-        },
+    env = cast(
+        Any,
+        registry.make(
+            "Go2JoystickFlatTerrain",
+            num_envs=2,
+            sim_backend="mujoco",
+            env_cfg_override={
+                "reward_config": RewardConfig(
+                    scales={
+                        "tracking_lin_vel": 1.0,
+                        "tracking_ang_vel": 0.2,
+                        "lin_vel_z": -5.0,
+                        "ang_vel_xy": -0.02,
+                        "base_height": -100.0,
+                        "action_rate": -0.005,
+                        "similar_to_default": -0.1,
+                    },
+                    tracking_sigma=0.25,
+                    base_height_target=0.3,
+                ),
+                "control_config": {"Kp": 18.0, "Kd": 0.9},
+            },
+        ),
     )
     try:
         _assert_mujoco_position_gains(env, kp=18.0, kd=0.9)
@@ -392,17 +446,21 @@ def test_go2_env_initializes_kp_kd_into_pool():
 
 @pytest.mark.slow
 def test_allegro_env_initializes_kp_kd_into_pool(default_allegro_reward_config):
+    _require_mujoco_runtime()
     ensure_registries()
     from unilab.base import registry
 
-    env = registry.make(
-        "AllegroInhandRotation",
-        num_envs=2,
-        sim_backend="mujoco",
-        env_cfg_override={
-            "reward_config": default_allegro_reward_config,
-            "control_config": {"kp": 2.5, "kd": 0.4},
-        },
+    env = cast(
+        Any,
+        registry.make(
+            "AllegroInhandRotation",
+            num_envs=2,
+            sim_backend="mujoco",
+            env_cfg_override={
+                "reward_config": default_allegro_reward_config,
+                "control_config": {"kp": 2.5, "kd": 0.4},
+            },
+        ),
     )
     try:
         _assert_mujoco_position_gains(env, kp=2.5, kd=0.4, actuator_ids=slice(0, 16))
@@ -415,11 +473,11 @@ def test_allegro_env_initializes_kp_kd_into_pool(default_allegro_reward_config):
 def test_g1_motion_tracking_reset_and_step(sim_backend: str):
     """G1MotionTracking needs a motion_file — skip if not available."""
     ensure_registries()
-    from pathlib import Path
-
     from unilab.base import registry
 
-    if sim_backend == "motrix":
+    if sim_backend == "mujoco":
+        _require_mujoco_runtime()
+    else:
         pytest.importorskip("motrixsim")
 
     # Look for any motion file in the expected location
@@ -432,11 +490,14 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
         pytest.skip(f"No .npz motion files in {motion_dir}")
 
     motion_file = str(npz_files[0])
-    env = registry.make(
-        "G1MotionTracking",
-        num_envs=2,
-        sim_backend=sim_backend,
-        env_cfg_override={"motion_file": motion_file},
+    env = cast(
+        Any,
+        registry.make(
+            "G1MotionTracking",
+            num_envs=2,
+            sim_backend=sim_backend,
+            env_cfg_override={"motion_file": motion_file},
+        ),
     )
     try:
         spec = env.obs_groups_spec
@@ -465,15 +526,19 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
 
 @pytest.mark.slow
 def test_go2_mujoco_reset_applies_kp_kd_domain_randomization(default_go2_reward_config):
+    _require_mujoco_runtime()
     ensure_registries()
 
     from unilab.base import registry
 
-    env = registry.make(
-        "Go2JoystickFlatTerrain",
-        num_envs=4,
-        sim_backend="mujoco",
-        env_cfg_override={"reward_config": default_go2_reward_config},
+    env = cast(
+        Any,
+        registry.make(
+            "Go2JoystickFlatTerrain",
+            num_envs=4,
+            sim_backend="mujoco",
+            env_cfg_override={"reward_config": default_go2_reward_config},
+        ),
     )
     try:
         env.init_state()


### PR DESCRIPTION
## Summary
- lazy-load the MuJoCo backend from the public backend package instead of importing it at package import time
- remove top-level MuJoCo imports from motion-tracking and Allegro env import/bootstrap paths, and resolve MuJoCo-style body ids from XML for Motrix
- split pure config/bootstrap checks from MuJoCo runtime tests and document backend-specific runtime prerequisites

Fixes #151

## Validation
- uv run pytest tests/envs/test_env_configs.py -q -m 'not slow and not veryslow'
- uv run pytest tests/envs/test_env_configs.py::test_registry_bootstrap_and_config_imports_do_not_require_mujoco -q
- uv run pytest 'tests/envs/test_env_configs.py::test_env_reset_and_step[Go1JoystickFlatTerrain]' -q -m slow
- uv run pytest 'tests/envs/test_env_configs.py::test_g1_motion_tracking_reset_and_step[mujoco]' -q -m slow
- uv run pytest tests/utils/test_algo_utils.py -q
- uv run pytest tests/scripts/test_check_docs.py -q
- uv run ruff check src/unilab/base/backend/__init__.py src/unilab/utils/xml_utils.py src/unilab/envs/motion_tracking/g1/tracking.py src/unilab/envs/manipulation/inhand_rot_allegro/base.py src/unilab/envs/manipulation/inhand_rot_allegro/gen_grasp.py tests/envs/test_env_configs.py
- uv run pyright src/unilab/base/backend/__init__.py tests/envs/test_env_configs.py
- uv run mypy src/unilab/base/backend/__init__.py