### PR TITLE
fix: stabilize registry default backend resolution

### DIFF
--- a/docs/zh_CN/02-simulation-backends.md
+++ b/docs/zh_CN/02-simulation-backends.md
@@ -43,7 +43,7 @@ UniLab 当前支持两个仿真后端:
 
 ## Select A Backend
 
-默认后端是 `mujoco`。通过 `task=<task>/<backend>` 切换到 `motrix`，不要用 `training.sim_backend=motrix` 单独切换后端。
+训练 owner config 的默认后端通常是 `mujoco`。通过 `task=<task>/<backend>` 切换到 `motrix`，不要用 `training.sim_backend=motrix` 单独切换后端。底层 `registry.make(..., sim_backend=None)` 也会显式按 `mujoco`、`motrix` 的顺序解析默认 backend，而不是依赖 decorator 注册顺序。
 
 实际要改参数时，不再去拆着找 `reward` / `backend preset` / `algo preset`。直接改对应的 `task` 文件：
 

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Optional, Type, TypeVar
 from .base import ABEnv, EnvCfg
 
 TEnvCfg = TypeVar("TEnvCfg", bound=EnvCfg)
+_DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 
 
 @dataclass
@@ -12,7 +13,10 @@ class EnvMeta:
     env_cls_dict: Dict[str, Type[ABEnv]] = field(default_factory=dict)
 
     def available_sim_backend(self) -> Optional[str]:
-        """Return the first available simulation backend."""
+        """Return the explicit default simulation backend for this environment."""
+        for backend in _DEFAULT_SIM_BACKEND_ORDER:
+            if backend in self.env_cls_dict:
+                return backend
         return next(iter(self.env_cls_dict), None)
 
     def support_sim_backend(self, sim_backend: str) -> bool:
@@ -91,7 +95,7 @@ def env(name: str, sim_backend: str) -> Callable[[Type[ABEnv]], Type[ABEnv]]:
 
 
 def find_available_sim_backend(env_name: str) -> str:
-    """Find the first available simulation backend for an environment."""
+    """Find the explicit default simulation backend for an environment."""
     if env_name not in _envs:
         raise ValueError(f"Environment '{env_name}' is not registered.")
 
@@ -113,7 +117,8 @@ def make(
 
     Args:
         name: Environment name
-        sim_backend: Simulation backend ("mujoco" or "motrix"). If None, uses first available.
+        sim_backend: Simulation backend ("mujoco" or "motrix"). If None, uses the
+            explicit default backend order: "mujoco", then "motrix".
         env_cfg_override: Dictionary of config overrides
         num_envs: Number of environments to create
 

--- a/tests/base/test_registry.py
+++ b/tests/base/test_registry.py
@@ -17,6 +17,7 @@ from unilab.base.base import ABEnv, EnvCfg
 # ---------------------------------------------------------------------------
 _TEST_ENV_A = "_TestRegistryEnvA"
 _TEST_ENV_B = "_TestRegistryEnvB_Dup"
+_TEST_ENV_C = "_TestRegistryEnvC_DefaultOrder"
 
 
 @dataclass
@@ -68,6 +69,10 @@ class _TestEnvA(ABEnv):
         pass
 
 
+class _TestEnvMotrix(_TestEnvA):
+    pass
+
+
 # Register once at module level (idempotent guard)
 if not registry_mod.contains(_TEST_ENV_A):
     registry_mod.register_env_config(_TEST_ENV_A, _TestCfgA)
@@ -75,6 +80,11 @@ if not registry_mod.contains(_TEST_ENV_A):
 
 if not registry_mod.contains(_TEST_ENV_B):
     registry_mod.register_env_config(_TEST_ENV_B, _TestCfgB)
+
+if not registry_mod.contains(_TEST_ENV_C):
+    registry_mod.register_env_config(_TEST_ENV_C, _TestCfgA)
+    registry_mod.register_env(_TEST_ENV_C, _TestEnvMotrix, "motrix")
+    registry_mod.register_env(_TEST_ENV_C, _TestEnvA, "mujoco")
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +133,11 @@ def test_duplicate_env_config_raises():
 
 def test_find_available_sim_backend():
     backend = registry_mod.find_available_sim_backend(_TEST_ENV_A)
+    assert backend == "mujoco"
+
+
+def test_find_available_sim_backend_prefers_explicit_default_order():
+    backend = registry_mod.find_available_sim_backend(_TEST_ENV_C)
     assert backend == "mujoco"
 
 
@@ -187,8 +202,13 @@ def test_find_available_sim_backend_no_env_cls_raises():
 
 
 def test_make_auto_selects_backend():
-    """make() with sim_backend=None selects the first available backend."""
+    """make() with sim_backend=None selects the explicit default backend."""
     env = registry_mod.make(_TEST_ENV_A, sim_backend=None)
+    assert isinstance(env, _TestEnvA)
+
+
+def test_make_auto_selects_default_backend_independent_of_registration_order():
+    env = registry_mod.make(_TEST_ENV_C, sim_backend=None)
     assert isinstance(env, _TestEnvA)
 
 


### PR DESCRIPTION
## Summary

- stabilize `registry.make(..., sim_backend=None)` so it resolves defaults by an explicit backend order instead of decorator registration order
- add registry tests proving the default backend stays stable even when `motrix` is registered before `mujoco`
- update backend-selection docs to match the implemented registry default semantics

## Linked Work

- Issue: Fixes #160
- Milestone: none

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/base/test_registry.py -q
make check
make test
```

## Impact

- Backend impact: both
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: none
- benchmark result: none
- video / screenshot: none
- ONNX / checkpoint: none

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
