### PR TITLE
fix: derive backend support matrix from repo facts

### DIFF
--- a/docs/zh_CN/02-simulation-backends.md
+++ b/docs/zh_CN/02-simulation-backends.md
@@ -16,30 +16,63 @@ UniLab 当前支持两个仿真后端:
 
 ## Support Matrix
 
-### MuJoCo
+下面的矩阵由 registry、owner YAML 和测试清单自动汇总；不要手工编辑表格内容。需要刷新时运行：
 
-| 算法 | Go1 | Go2 | G1 |
-|------|-----|-----|----|
-| PPO (torch) | ✅ |  | ✅ |
-| PPO (mlx) | ✅ |  | ✅ |
-| SAC (torch) | ✅ | ⚠️ | ✅ |
-| TD3 (torch) | ⚠️ | ⚠️ | ⚠️ |
-| APPO (torch) | ✅ | ✅ | ✅ |
+```bash
+uv run python scripts/generate_support_matrix.py --write
+```
 
-### Motrix
+<!-- BEGIN GENERATED SUPPORT MATRIX -->
+### Evidence Grades
 
-| 算法 | Go1 | Go2 | G1 |
-|------|-----|-----|----|
-| PPO (torch) | ⚠️ |  | ✅ |
-| PPO (mlx) | ⚠️ |  |  |
-| SAC (torch) | ⚠️ |  |  |
-| TD3 (torch) |  |  |  |
-| APPO (torch) |  |  | ✅ |
+| 等级 | 仓库事实来源 |
+|------|--------------|
+| `Registered` | `ensure_registries()` 导入后的 `registry.list_registered_envs()` 中存在该 env/backend。 |
+| `Configured` | 存在对应的 owner YAML：`conf/{ppo,appo,offpolicy}/task/...`。 |
+| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合。这里的 `Tested` 包含 config compose 与脚本/运行时测试，不等同于默认推荐路径。 |
+| `Benchmarked` | 存在与该组合绑定的已提交 benchmark manifest。 |
+| `Recommended` | 仓库中存在显式 recommendation 元数据。 |
 
-图例:
+未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
+仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
 
-- `✅` 已支持
-- `⚠️` 开发中
+### Entrypoint x Task Owner
+
+| Entrypoint | Task owner | MuJoCo | Motrix |
+|------------|------------|--------|--------|
+| PPO (torch) | `go1_joystick` (Go1 joystick) | Tested | Tested |
+| PPO (torch) | `go2_joystick` (Go2 joystick) | Tested | Tested |
+| PPO (torch) | `g1_joystick` (G1 joystick) | Tested | Tested |
+| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
+| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
+| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - |
+| PPO (mlx) | `go1_joystick` (Go1 joystick) | Tested | Tested |
+| PPO (mlx) | `go2_joystick` (Go2 joystick) | Tested | Tested |
+| PPO (mlx) | `g1_joystick` (G1 joystick) | Tested | Tested |
+| PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | Configured |
+| PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | Configured |
+| PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | - |
+| APPO (torch) | `go1_joystick` (Go1 joystick) | Tested | Registered |
+| APPO (torch) | `go2_joystick` (Go2 joystick) | Tested | Registered |
+| APPO (torch) | `g1_joystick` (G1 joystick) | Tested | Registered |
+| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
+| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
+| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - |
+| SAC (torch) | `go1_joystick` (Go1 joystick) | Tested | Tested |
+| SAC (torch) | `go2_joystick` (Go2 joystick) | Tested | Tested |
+| SAC (torch) | `g1_sac` (G1 SAC locomotion) | Tested | Tested |
+| SAC (torch) | `allegro_sac` (Allegro SAC in-hand) | Tested | - |
+| TD3 (torch) | `go1_joystick` (Go1 joystick) | Tested | Tested |
+| TD3 (torch) | `go2_joystick` (Go2 joystick) | Tested | Tested |
+
+### Source Index
+
+- Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.utils.algo_utils.ensure_registries()`.
+- Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/offpolicy/task/**`.
+- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.
+- MLX-specific compose coverage only upgrades task owners listed in `tests/config/test_config_system.py::_PPO_MLX_TASKS`: `go1_joystick`, `go2_joystick`, `g1_joystick`.
+- MLX runtime smoke: `tests/algos/test_mlx_ppo.py::test_mlx_ppo_one_iteration_real_env` currently exercises `go2_joystick/mujoco`.
+<!-- END GENERATED SUPPORT MATRIX -->
 
 ## Select A Backend
 

--- a/scripts/generate_support_matrix.py
+++ b/scripts/generate_support_matrix.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+"""Refresh the generated support matrix section in docs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from unilab.docs.support_matrix import (
+    render_generated_block,
+    render_support_matrix,
+    replace_generated_block,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Update docs/zh_CN/02-simulation-backends.md in place.",
+    )
+    args = parser.parse_args()
+
+    root = _repo_root()
+    if not args.write:
+        print(render_support_matrix(root))
+        return 0
+
+    doc_path = root / "docs" / "zh_CN" / "02-simulation-backends.md"
+    content = doc_path.read_text(encoding="utf-8")
+    updated = replace_generated_block(content, render_generated_block(root))
+    doc_path.write_text(updated, encoding="utf-8")
+    print(f"Updated {doc_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/docs/__init__.py
+++ b/src/unilab/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation helpers derived from repository facts."""

--- a/src/unilab/docs/support_matrix.py
+++ b/src/unilab/docs/support_matrix.py
@@ -1,0 +1,328 @@
+"""Generate backend support matrix content from registry, configs, and tests."""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+from unilab.base import registry
+from unilab.utils.algo_utils import ensure_registries
+
+BEGIN_MARKER = "<!-- BEGIN GENERATED SUPPORT MATRIX -->"
+END_MARKER = "<!-- END GENERATED SUPPORT MATRIX -->"
+BACKENDS: tuple[str, str] = ("mujoco", "motrix")
+
+_TASK_ORDER = {
+    "go1_joystick": 0,
+    "go2_joystick": 1,
+    "g1_joystick": 2,
+    "g1_motion_tracking": 3,
+    "g1_flip_tracking": 4,
+    "g1_sac": 5,
+    "allegro_inhand": 6,
+    "allegro_sac": 7,
+}
+_TASK_LABELS = {
+    "go1_joystick": "Go1 joystick",
+    "go2_joystick": "Go2 joystick",
+    "g1_joystick": "G1 joystick",
+    "g1_motion_tracking": "G1 motion tracking",
+    "g1_flip_tracking": "G1 flip tracking",
+    "g1_sac": "G1 SAC locomotion",
+    "allegro_inhand": "Allegro in-hand",
+    "allegro_sac": "Allegro SAC in-hand",
+}
+
+
+class EvidenceLevel(IntEnum):
+    MISSING = 0
+    REGISTERED = 1
+    CONFIGURED = 2
+    TESTED = 3
+    BENCHMARKED = 4
+    RECOMMENDED = 5
+
+    @property
+    def label(self) -> str:
+        return {
+            EvidenceLevel.MISSING: "-",
+            EvidenceLevel.REGISTERED: "Registered",
+            EvidenceLevel.CONFIGURED: "Configured",
+            EvidenceLevel.TESTED: "Tested",
+            EvidenceLevel.BENCHMARKED: "Benchmarked",
+            EvidenceLevel.RECOMMENDED: "Recommended",
+        }[self]
+
+
+@dataclass(frozen=True)
+class EntrypointSpec:
+    entrypoint_id: str
+    label: str
+    config_dir: str
+    task_glob: str
+    generic_tested: bool = False
+
+
+@dataclass(frozen=True)
+class SupportCell:
+    env_name: str
+    level: EvidenceLevel
+
+
+@dataclass(frozen=True)
+class SupportRow:
+    entrypoint_label: str
+    task_slug: str
+    task_label: str
+    cells: dict[str, SupportCell]
+
+
+ENTRYPOINT_SPECS: tuple[EntrypointSpec, ...] = (
+    EntrypointSpec(
+        entrypoint_id="ppo_torch",
+        label="PPO (torch)",
+        config_dir="conf/ppo/task",
+        task_glob="*/*.yaml",
+        generic_tested=True,
+    ),
+    EntrypointSpec(
+        entrypoint_id="ppo_mlx",
+        label="PPO (mlx)",
+        config_dir="conf/ppo/task",
+        task_glob="*/*.yaml",
+        generic_tested=False,
+    ),
+    EntrypointSpec(
+        entrypoint_id="appo_torch",
+        label="APPO (torch)",
+        config_dir="conf/appo/task",
+        task_glob="*/*.yaml",
+        generic_tested=True,
+    ),
+    EntrypointSpec(
+        entrypoint_id="sac_torch",
+        label="SAC (torch)",
+        config_dir="conf/offpolicy/task/sac",
+        task_glob="*/*.yaml",
+        generic_tested=True,
+    ),
+    EntrypointSpec(
+        entrypoint_id="td3_torch",
+        label="TD3 (torch)",
+        config_dir="conf/offpolicy/task/td3",
+        task_glob="*/*.yaml",
+        generic_tested=True,
+    ),
+)
+
+
+def repo_root(root: Path | None = None) -> Path:
+    return root or Path(__file__).resolve().parents[3]
+
+
+def _task_sort_key(task_slug: str) -> tuple[int, str]:
+    return (_TASK_ORDER.get(task_slug, 999), task_slug)
+
+
+def _task_label(task_slug: str) -> str:
+    return _TASK_LABELS.get(task_slug, task_slug.replace("_", " "))
+
+
+def _load_task_name(task_path: Path) -> str:
+    raw = OmegaConf.to_container(OmegaConf.load(task_path), resolve=True) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"Expected mapping config in {task_path}")
+    training = raw.get("training")
+    if not isinstance(training, dict) or "task_name" not in training:
+        raise ValueError(f"Missing training.task_name in {task_path}")
+    task_name = training["task_name"]
+    if not isinstance(task_name, str):
+        raise ValueError(f"training.task_name must be a string in {task_path}")
+    return task_name
+
+
+def _load_registry_backends() -> dict[str, set[str]]:
+    ensure_registries()
+    registered = registry.list_registered_envs()
+    return {
+        env_name: set(meta["available_backends"])
+        for env_name, meta in registered.items()
+        if isinstance(meta.get("available_backends"), list)
+    }
+
+
+def _mlx_tested_task_slugs(root: Path) -> set[str]:
+    config_test_path = root / "tests" / "config" / "test_config_system.py"
+    content = config_test_path.read_text(encoding="utf-8")
+    match = re.search(r"_PPO_MLX_TASKS\s*=\s*(\{[^\n]+\})", content)
+    if match is None:
+        return set()
+    parsed = ast.literal_eval(match.group(1))
+    if not isinstance(parsed, set):
+        return set()
+    return {item for item in parsed if isinstance(item, str)}
+
+
+def _has_checked_in_benchmark_manifest(root: Path) -> bool:
+    del root
+    return False
+
+
+def _has_recommendation_metadata(root: Path) -> bool:
+    del root
+    return False
+
+
+def _configured_entries(root: Path, spec: EntrypointSpec) -> dict[str, dict[str, str]]:
+    task_root = root / spec.config_dir
+    entries: dict[str, dict[str, str]] = {}
+    for task_path in sorted(task_root.glob(spec.task_glob)):
+        task_slug = task_path.parent.name
+        backend = task_path.stem
+        entries.setdefault(task_slug, {})[backend] = _load_task_name(task_path)
+    return entries
+
+
+def _is_tested(spec: EntrypointSpec, task_slug: str, root: Path) -> bool:
+    if spec.entrypoint_id == "ppo_mlx":
+        return task_slug in _mlx_tested_task_slugs(root)
+    return spec.generic_tested
+
+
+def _cell_level(
+    *,
+    backend: str,
+    env_name: str,
+    configured_backends: dict[str, str],
+    registry_backends: dict[str, set[str]],
+    tested: bool,
+    benchmarked: bool,
+    recommended: bool,
+) -> EvidenceLevel:
+    available_backends = registry_backends.get(env_name, set())
+    if backend not in available_backends:
+        return EvidenceLevel.MISSING
+
+    level = EvidenceLevel.REGISTERED
+    if backend in configured_backends:
+        level = EvidenceLevel.CONFIGURED
+    if backend in configured_backends and tested:
+        level = EvidenceLevel.TESTED
+    if backend in configured_backends and tested and benchmarked:
+        level = EvidenceLevel.BENCHMARKED
+    if backend in configured_backends and tested and benchmarked and recommended:
+        level = EvidenceLevel.RECOMMENDED
+    return level
+
+
+def build_support_rows(root: Path | None = None) -> list[SupportRow]:
+    resolved_root = repo_root(root)
+    registry_backends = _load_registry_backends()
+    benchmarked = _has_checked_in_benchmark_manifest(resolved_root)
+    recommended = _has_recommendation_metadata(resolved_root)
+    rows: list[SupportRow] = []
+
+    for spec in ENTRYPOINT_SPECS:
+        for task_slug, configured_backends in sorted(
+            _configured_entries(resolved_root, spec).items(),
+            key=lambda item: _task_sort_key(item[0]),
+        ):
+            env_name = next(iter(configured_backends.values()))
+            tested = _is_tested(spec, task_slug, resolved_root)
+            cells = {
+                backend: SupportCell(
+                    env_name=env_name,
+                    level=_cell_level(
+                        backend=backend,
+                        env_name=env_name,
+                        configured_backends=configured_backends,
+                        registry_backends=registry_backends,
+                        tested=tested,
+                        benchmarked=benchmarked,
+                        recommended=recommended,
+                    ),
+                )
+                for backend in BACKENDS
+            }
+            rows.append(
+                SupportRow(
+                    entrypoint_label=spec.label,
+                    task_slug=task_slug,
+                    task_label=_task_label(task_slug),
+                    cells=cells,
+                )
+            )
+
+    return rows
+
+
+def render_support_matrix(root: Path | None = None) -> str:
+    resolved_root = repo_root(root)
+    mlx_tested_tasks = sorted(_mlx_tested_task_slugs(resolved_root), key=_task_sort_key)
+    benchmark_note = (
+        "未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。"
+    )
+    recommendation_note = (
+        "仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。"
+    )
+
+    lines = [
+        "### Evidence Grades",
+        "",
+        "| 等级 | 仓库事实来源 |",
+        "|------|--------------|",
+        "| `Registered` | `ensure_registries()` 导入后的 `registry.list_registered_envs()` 中存在该 env/backend。 |",
+        "| `Configured` | 存在对应的 owner YAML：`conf/{ppo,appo,offpolicy}/task/...`。 |",
+        "| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合。这里的 `Tested` 包含 config compose 与脚本/运行时测试，不等同于默认推荐路径。 |",
+        "| `Benchmarked` | 存在与该组合绑定的已提交 benchmark manifest。 |",
+        "| `Recommended` | 仓库中存在显式 recommendation 元数据。 |",
+        "",
+        benchmark_note,
+        recommendation_note,
+        "",
+        "### Entrypoint x Task Owner",
+        "",
+        "| Entrypoint | Task owner | MuJoCo | Motrix |",
+        "|------------|------------|--------|--------|",
+    ]
+
+    for row in build_support_rows(resolved_root):
+        lines.append(
+            f"| {row.entrypoint_label} | `{row.task_slug}` ({row.task_label}) | "
+            f"{row.cells['mujoco'].level.label} | {row.cells['motrix'].level.label} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "### Source Index",
+            "",
+            "- Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.utils.algo_utils.ensure_registries()`.",
+            "- Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/offpolicy/task/**`.",
+            "- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.",
+            "- MLX-specific compose coverage only upgrades task owners listed in `tests/config/test_config_system.py::_PPO_MLX_TASKS`: "
+            + ", ".join(f"`{task}`" for task in mlx_tested_tasks)
+            + ".",
+            "- MLX runtime smoke: `tests/algos/test_mlx_ppo.py::test_mlx_ppo_one_iteration_real_env` currently exercises `go2_joystick/mujoco`.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_generated_block(root: Path | None = None) -> str:
+    return "\n".join([BEGIN_MARKER, render_support_matrix(root), END_MARKER])
+
+
+def replace_generated_block(content: str, rendered_block: str) -> str:
+    pattern = re.compile(
+        rf"{re.escape(BEGIN_MARKER)}.*?{re.escape(END_MARKER)}",
+        flags=re.DOTALL,
+    )
+    if pattern.search(content) is None:
+        raise ValueError("Generated support matrix markers not found")
+    return pattern.sub(rendered_block, content)

--- a/tests/scripts/doc_checks.py
+++ b/tests/scripts/doc_checks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from unilab.docs.support_matrix import render_generated_block, replace_generated_block
+
 VALID_HYDRA_KEYS = {
     "task",
     "algo",
@@ -94,6 +96,8 @@ def check_file_paths(content: str, doc_path: Path, root: Path) -> list[str]:
             rel_path = match.group(1)
             if any(token in rel_path for token in ("*", "<", "{", "}", "...")):
                 continue
+            if "::" in rel_path:
+                rel_path = rel_path.split("::", 1)[0]
             if not (root / rel_path).exists():
                 errors.append(f"{doc_path}: Path not found: {rel_path}")
 
@@ -201,6 +205,20 @@ def check_training_entrypoint_semantics(content: str, doc_path: Path, root: Path
     return errors
 
 
+def check_generated_support_matrix(content: str, doc_path: Path, root: Path) -> list[str]:
+    errors: list[str] = []
+    if doc_path != root / "docs" / "zh_CN" / "02-simulation-backends.md":
+        return errors
+
+    expected = replace_generated_block(content, render_generated_block(root))
+    if expected != content:
+        errors.append(
+            f"{doc_path}: Generated support matrix is stale; run "
+            "`uv run python scripts/generate_support_matrix.py --write`"
+        )
+    return errors
+
+
 def check_document(doc_path: Path, root: Path) -> list[str]:
     content = doc_path.read_text(encoding="utf-8")
     errors: list[str] = []
@@ -210,6 +228,7 @@ def check_document(doc_path: Path, root: Path) -> list[str]:
     errors.extend(check_hydra_keys(content, doc_path, root))
     errors.extend(check_argparse_vs_hydra(content, doc_path, root))
     errors.extend(check_training_entrypoint_semantics(content, doc_path, root))
+    errors.extend(check_generated_support_matrix(content, doc_path, root))
     return errors
 
 

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from unilab.docs.support_matrix import EvidenceLevel, build_support_rows
+
+
+def _row(entrypoint_label: str, task_slug: str):
+    root = Path(__file__).resolve().parents[2]
+    for row in build_support_rows(root):
+        if row.entrypoint_label == entrypoint_label and row.task_slug == task_slug:
+            return row
+    raise AssertionError(f"Missing support row: {entrypoint_label} / {task_slug}")
+
+
+def test_support_matrix_marks_go2_ppo_backends_as_tested():
+    row = _row("PPO (torch)", "go2_joystick")
+
+    assert row.cells["mujoco"].level == EvidenceLevel.TESTED
+    assert row.cells["motrix"].level == EvidenceLevel.TESTED
+
+
+def test_support_matrix_marks_appo_go1_motrix_as_registered_only():
+    row = _row("APPO (torch)", "go1_joystick")
+
+    assert row.cells["mujoco"].level == EvidenceLevel.TESTED
+    assert row.cells["motrix"].level == EvidenceLevel.REGISTERED
+
+
+def test_support_matrix_keeps_uncovered_mlx_tasks_at_configured():
+    row = _row("PPO (mlx)", "g1_motion_tracking")
+
+    assert row.cells["mujoco"].level == EvidenceLevel.CONFIGURED
+    assert row.cells["motrix"].level == EvidenceLevel.CONFIGURED


### PR DESCRIPTION
## Summary

- replace the hand-maintained backend support table with a generated matrix derived from registry facts, owner YAMLs, and test coverage
- add a reusable support-matrix generator plus a thin refresh script for docs
- add docs guardrails and regression tests so the matrix cannot drift silently again

## Linked Work

- Issue: Fixes #164
- Milestone: none

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
UV_CACHE_DIR=.uv-cache uv run python scripts/generate_support_matrix.py --write
UV_CACHE_DIR=.uv-cache uv run pytest tests/scripts/test_support_matrix.py tests/scripts/test_check_docs.py -q
UV_CACHE_DIR=.uv-cache make check
UV_CACHE_DIR=.uv-cache make test
UV_CACHE_DIR=.uv-cache uv run pytest -m "not slow and not veryslow" --ignore=tests/algos/test_mlx_ppo.py
```

`make test` aborts during collection because `tests/algos/test_mlx_ppo.py` triggers a host-level `mlx.core` import abort instead of reaching `pytest.importorskip(...)`.
The broader non-slow run excluding that file still hits pre-existing IPC failures and later another `train_mlx_ppo.py` import abort inside `tests/scripts/test_train_scripts.py`.
The support-matrix-specific tests added in this PR pass.

## Impact

- Backend impact: both
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: none
- benchmark result: none
- video / screenshot: none
- ONNX / checkpoint: none

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
