### PR TITLE
refactor: remove unused g1 policy obs override

### DIFF
--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -228,11 +228,6 @@ class G1JoystickPPO(G1BaseEnv):
         )
         return {"obs": actor, "privileged": linvel}
 
-    def get_policy_obs(self, obs: dict[str, np.ndarray]) -> np.ndarray:
-        if getattr(self._backend, "backend_type", None) == "motrix" and "privileged" in obs:
-            return np.concatenate([obs["privileged"], obs["obs"]], axis=1)
-        return np.concatenate(list(obs.values()), axis=1)
-
     def get_obs_structure(self) -> dict:
         """Return observation structure for symmetry augmentation.
 


### PR DESCRIPTION
## Summary
- remove the unused `G1JoystickPPO.get_policy_obs()` override from `src/unilab/envs/locomotion/g1/joystick.py`
- keep the observation dict contract unchanged as `{"obs": actor, "privileged": linvel}`
- rely on the shared obs-group consumption path used by current training code

## Issue
- Refs #214

## Validation
- `make check`
- `make test`

## Impact Scope
- G1 locomotion env implementation only
- no config, runner, or backend contract changes