### PR TITLE
docs: add architecture adrs for runtime and backend contracts

### DIFF
--- a/docs/zh_CN/00-development-architecture.md
+++ b/docs/zh_CN/00-development-architecture.md
@@ -145,6 +145,20 @@ Env **负责** MDP 语义、observation 结构、reward、reset，以及 backend
 
 ---
 
+## 12. Architecture Decision Records (ADR)
+
+以下 ADR 记录了本页涉及的稳定 contract 以及 backend 能力边界:
+
+- [ADR Index](adr/README.md)
+- [ADR-0001 Runtime Model And Layer Boundaries](adr/ADR-0001-runtime-model-and-layer-boundaries.md)
+- [ADR-0002 Backend Capability Boundary For Play And Snapshot](adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
+- [ADR-0003 Task Owner And Config Compose Contract](adr/ADR-0003-task-owner-and-config-compose-contract.md)
+- [ADR-0004 Registry Bootstrap Contract](adr/ADR-0004-registry-bootstrap-contract.md)
+
+协作与交付流程要求见 [Collaboration](06-collaboration.md)。
+
+---
+
 ## Navigation
 
 - Previous: [README](../../README.md)

--- a/docs/zh_CN/02-simulation-backends.md
+++ b/docs/zh_CN/02-simulation-backends.md
@@ -110,6 +110,14 @@ uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco training.play_onl
 - backend 支持范围是阶段性的能力快照，不要把临时执行状态写成顶层 README 结论
 - 具体推进应通过 GitHub milestone 和 issue 跟踪，而不是维护仓库内的临时状态列表
 
+## Architecture Decision References
+
+- 总体架构标准: [RL Infrastructure 开发标准](00-development-architecture.md)
+- 后端能力边界 ADR: [ADR-0002 Backend Capability Boundary For Play And Snapshot](adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
+- task owner / compose contract ADR: [ADR-0003 Task Owner And Config Compose Contract](adr/ADR-0003-task-owner-and-config-compose-contract.md)
+- registry bootstrap ADR: [ADR-0004 Registry Bootstrap Contract](adr/ADR-0004-registry-bootstrap-contract.md)
+- ADR 索引: [ADR Index](adr/README.md)
+
 ## Navigation
 
 - Previous: [Getting Started](01-getting-started.md)

--- a/docs/zh_CN/06-collaboration.md
+++ b/docs/zh_CN/06-collaboration.md
@@ -50,6 +50,18 @@
 
 执行 owner 用 GitHub assignees 表达，review owner 用 `CODEOWNERS` 表达。如果暂时没有稳定的 GitHub handle，就让 issue 保持 unassigned，并在 issue body 里临时注明预期 owner。
 
+## ADR Governance
+
+当改动涉及 runtime / backend / config / registry contract 时，issue 或 PR 需要显式链接对应 ADR:
+
+- 架构标准入口: [RL Infrastructure 开发标准](00-development-architecture.md)
+- ADR 索引: [ADR Index](adr/README.md)
+- backend 能力边界: [ADR-0002](adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
+- task owner / compose: [ADR-0003](adr/ADR-0003-task-owner-and-config-compose-contract.md)
+- registry bootstrap: [ADR-0004](adr/ADR-0004-registry-bootstrap-contract.md)
+
+如果现有 ADR 无法覆盖新的结构性决策，在同一 PR 内新增 ADR，并把链接补回上述文档。
+
 ## Navigation
 
 - Previous: [G1 Motion Tracking](05-g1-motion-tracking.md)

--- a/docs/zh_CN/adr/ADR-0001-runtime-model-and-layer-boundaries.md
+++ b/docs/zh_CN/adr/ADR-0001-runtime-model-and-layer-boundaries.md
@@ -1,0 +1,46 @@
+# ADR-0001 Runtime Model And Layer Boundaries
+
+- Status: Accepted
+- Date: 2026-04-11
+- Owners: Infra / Training maintainers
+
+## Context
+
+UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtime 与分层边界时，问题容易在 `scripts/` 临时修补，导致 contract 漏洞与跨层耦合。
+
+## Decision
+
+采用并坚持以下稳定架构边界:
+
+1. Runtime 采用 `CPU Physics -> Collector/IPC -> GPU Learner` 的三段式零拷贝模型。
+2. 分层依赖单向: `backend -> env -> config/registry -> algo/ipc -> scripts`。
+3. `scripts/` 只做装配，不承载长期业务规则。
+4. 变更评审优先检查 contract 是否被破坏，而不是只看 smoke run 是否通过。
+
+## Stable Contracts
+
+- `registry.make(...)` 是 task 构造入口 contract。
+- `NpEnvState.obs` 必须是 `dict`，`reset()` 返回 `(obs_dict, info_dict)`。
+- `SimBackend` 是 backend 抽象边界；算法与脚本不应依赖后端私有实现。
+- 异步路径统一复用 `AsyncRunner` 生命周期与 shared resource cleanup。
+
+## Consequences
+
+- 跨层问题必须在 owner layer 修复。
+- 新功能必须先确定 contract 归属，再决定具体落点。
+- 文档和评审用语应区分“稳定 contract”与“阶段性能力”。
+
+## Evidence In Repo
+
+- 架构基线文档: `docs/zh_CN/00-development-architecture.md`
+- Backend 抽象: `src/unilab/base/backend/base.py`
+- Env contract: `src/unilab/base/np_env.py`
+- Registry 入口: `src/unilab/base/registry.py`
+- Async runner: `src/unilab/ipc/async_runner.py`
+
+## Related Documents
+
+- [ADR Index](README.md)
+- [RL Infrastructure 开发标准](../00-development-architecture.md)
+- [仿真后端](../02-simulation-backends.md)
+- [协作流程](../06-collaboration.md)

--- a/docs/zh_CN/adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md
+++ b/docs/zh_CN/adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md
@@ -1,0 +1,52 @@
+# ADR-0002 Backend Capability Boundary For Play And Snapshot
+
+- Status: Accepted
+- Date: 2026-04-11
+- Owners: Backend / Training maintainers
+
+## Context
+
+MuJoCo 与 Motrix 的渲染路径和输出形式不同。仓库当前存在两类事实:
+
+1. 一部分路径依赖 MuJoCo 的 physics snapshot + video 导出。
+2. 一部分路径依赖 Motrix 的交互式 renderer。
+
+这属于 backend capability 差异，不是“同功能不同实现”的简单替换关系。
+
+## Decision
+
+将 play/render/snapshot 视为 capability contract，而不是统一行为 contract:
+
+1. 允许 backend 在能力上不对等，不要求 feature parity。
+2. 脚本层只依赖正式 capability 或 env-facing contract，不直接假设具体 backend 私有行为。
+3. 文档和 support claim 明确区分:
+   - 稳定 contract: 能力边界和调用约束。
+   - backend-specific 差异: 输出形式、可用工具链、playback 体验。
+
+## Stable Contracts
+
+- 后端差异必须被显式建模为 capability，而不是散落在脚本判断里。
+- 对外行为承诺是“是否支持某能力”，而不是“所有后端行为一致”。
+
+## Backend-Specific Capability Differences
+
+- MuJoCo: 具备 physics snapshot 驱动的视频导出路径。
+- Motrix: 具备交互式 renderer 路径，常见 playback 体验是窗口渲染而非视频导出。
+
+## Consequences
+
+- 评审时不再以“是否与 MuJoCo 完全一致”作为 Motrix 路径验收标准。
+- 新增 play/debug 逻辑必须先声明 capability 归属，再决定 fallback 或拒绝策略。
+
+## Evidence In Repo
+
+- 后端文档与矩阵: `docs/zh_CN/02-simulation-backends.md`
+- Backend 抽象: `src/unilab/base/backend/base.py`
+- 训练入口与 play 边界: `scripts/train_rsl_rl.py`, `scripts/train_mlx_ppo.py`, `scripts/train_appo.py`, `scripts/train_offpolicy.py`
+
+## Related Documents
+
+- [ADR Index](README.md)
+- [RL Infrastructure 开发标准](../00-development-architecture.md)
+- [仿真后端](../02-simulation-backends.md)
+- [协作流程](../06-collaboration.md)

--- a/docs/zh_CN/adr/ADR-0003-task-owner-and-config-compose-contract.md
+++ b/docs/zh_CN/adr/ADR-0003-task-owner-and-config-compose-contract.md
@@ -1,0 +1,45 @@
+# ADR-0003 Task Owner And Config Compose Contract
+
+- Status: Accepted
+- Date: 2026-04-11
+- Owners: Config / Env maintainers
+
+## Context
+
+历史上 task、backend、reward、algo 组合可能分散在多个位置，导致:
+
+- 用户通过 `training.sim_backend=...` 误以为可以独立切后端。
+- 脚本层补丁掩盖 owner YAML 的真正身份语义。
+
+## Decision
+
+确立 `task owner YAML` 为后端与任务组合的唯一入口 contract:
+
+1. 组合入口是 `task=<task>/<backend>`（offpolicy 还包含 algo 维度）。
+2. owner YAML 直接持有 `training.task_name`、`training.sim_backend`、`reward`、`env` 及 task-specific `algo`。
+3. `training.sim_backend` 是 owner 身份字段，不是独立 backend switch。
+4. CLI override 允许参数覆盖，但不能破坏 task owner 的 backend identity。
+
+## Stable Contracts
+
+- PPO/APPO owner 路径: `conf/{ppo,appo}/task/<task>/<backend>.yaml`
+- Offpolicy owner 路径: `conf/offpolicy/task/<algo>/<task>/<backend>.yaml`
+- reward 注入与 backend 差异表达必须在 owner YAML 层显式存在。
+
+## Consequences
+
+- 文档示例和 issue 模板必须使用完整 `task=.../<backend>` 形式。
+- 配置行为变更应先改 owner YAML，再评估是否需要代码改动。
+
+## Evidence In Repo
+
+- 架构标准与配置语义: `docs/zh_CN/00-development-architecture.md`
+- 后端选择说明: `docs/zh_CN/02-simulation-backends.md`
+- 配置测试: `tests/config/test_config_system.py`
+
+## Related Documents
+
+- [ADR Index](README.md)
+- [RL Infrastructure 开发标准](../00-development-architecture.md)
+- [仿真后端](../02-simulation-backends.md)
+- [协作流程](../06-collaboration.md)

--- a/docs/zh_CN/adr/ADR-0004-registry-bootstrap-contract.md
+++ b/docs/zh_CN/adr/ADR-0004-registry-bootstrap-contract.md
@@ -2,43 +2,40 @@
 
 - Status: Accepted
 - Date: 2026-04-11
-- Owners: Infra / Registry maintainers
+- Owners: Env / Infra maintainers
 
 ## Context
 
-训练入口和工具脚本依赖 registry 中的 env 注册结果。若 bootstrap 规则不清晰，常见问题是:
+UniLab 的 env 注册依赖 `@registry.envcfg(...)` 与 `@registry.env(...)` decorator side effect。若 bootstrap 继续依赖目录扫描和隐式导入，问题会有三个:
 
-- 依赖隐式 import side effect，行为难以推断。
-- 文档只能描述“先跑某脚本再说”，缺少明确 contract。
+1. registry contract 由文件系统布局隐式决定，而不是由 package 明确声明。
+2. 导入失败边界不清晰，review 时很难区分“缺失 optional package”与“bootstrap contract 破坏”。
+3. support claim 与架构文档无法稳定引用 bootstrap 入口。
 
 ## Decision
 
-将 registry bootstrap 作为独立 contract 记录，并要求调用方显式遵守:
+将 env registry bootstrap 定义为显式 package contract:
 
-1. registry 以 `registry.make(...)` 作为实例化入口。
-2. bootstrap 过程由统一入口触发，保障 env decorators 已执行。
-3. support claim 与矩阵生成都以 bootstrap 后的 registry 事实为准。
+1. registry bootstrap 入口仍然是 `ensure_registries()`。
+2. package 若承担 bootstrap 责任，必须显式声明其 registry module 列表。
+3. `ensure_registries()` 只导入声明的 bootstrap modules，不再依赖目录扫描推断注册目标。
+4. optional package 与 required package 的失败策略继续分离: optional 记录 warning，required 直接失败。
 
 ## Stable Contracts
 
-- 构造 contract: `src/unilab/base/registry.py`
-- bootstrap 入口: `unilab.utils.algo_utils.ensure_registries()` 及其 training helper 包装
-- support claim 证据路径: registry 列表、owner YAML、测试清单
+- `ensure_registries()` 是 registry-based entrypoint 的统一 bootstrap 入口。
+- package-level bootstrap 清单必须是显式声明，而不是通过扫描推断。
+- bootstrap contract 破坏必须在导入阶段直接暴露。
 
 ## Consequences
 
-- 新增 env/task 时，需要同时更新注册入口和 owner YAML。
-- 文档和工具不得把“扫描目录是否恰好导入成功”当成 contract 本身。
+- 新增 env package 时，需要同步声明 bootstrap modules。
+- registry 相关回归可以在 `ensure_registries()` 边界直接测试，不必依赖顶层训练脚本间接发现。
+- 文档可以把 registry bootstrap 作为正式架构引用，而不是“当前实现细节”。
 
 ## Evidence In Repo
 
-- Registry 实现: `src/unilab/base/registry.py`
-- Bootstrap 使用面: `src/unilab/training/common.py`, `scripts/train_*.py`
-- 支持矩阵生成说明: `docs/zh_CN/02-simulation-backends.md`
-
-## Related Documents
-
-- [ADR Index](README.md)
-- [RL Infrastructure 开发标准](../00-development-architecture.md)
-- [仿真后端](../02-simulation-backends.md)
-- [协作流程](../06-collaboration.md)
+- Registry 入口: `src/unilab/base/registry.py`
+- Bootstrap helper: `src/unilab/utils/algo_utils.py`
+- Env package 入口: `src/unilab/envs/locomotion/__init__.py`, `src/unilab/envs/motion_tracking/__init__.py`, `src/unilab/envs/manipulation/inhand_rot_allegro/__init__.py`
+- Bootstrap tests: `tests/utils/test_algo_utils.py`, `tests/base/test_registry.py`

--- a/docs/zh_CN/adr/ADR-0004-registry-bootstrap-contract.md
+++ b/docs/zh_CN/adr/ADR-0004-registry-bootstrap-contract.md
@@ -1,0 +1,44 @@
+# ADR-0004 Registry Bootstrap Contract
+
+- Status: Accepted
+- Date: 2026-04-11
+- Owners: Infra / Registry maintainers
+
+## Context
+
+训练入口和工具脚本依赖 registry 中的 env 注册结果。若 bootstrap 规则不清晰，常见问题是:
+
+- 依赖隐式 import side effect，行为难以推断。
+- 文档只能描述“先跑某脚本再说”，缺少明确 contract。
+
+## Decision
+
+将 registry bootstrap 作为独立 contract 记录，并要求调用方显式遵守:
+
+1. registry 以 `registry.make(...)` 作为实例化入口。
+2. bootstrap 过程由统一入口触发，保障 env decorators 已执行。
+3. support claim 与矩阵生成都以 bootstrap 后的 registry 事实为准。
+
+## Stable Contracts
+
+- 构造 contract: `src/unilab/base/registry.py`
+- bootstrap 入口: `unilab.utils.algo_utils.ensure_registries()` 及其 training helper 包装
+- support claim 证据路径: registry 列表、owner YAML、测试清单
+
+## Consequences
+
+- 新增 env/task 时，需要同时更新注册入口和 owner YAML。
+- 文档和工具不得把“扫描目录是否恰好导入成功”当成 contract 本身。
+
+## Evidence In Repo
+
+- Registry 实现: `src/unilab/base/registry.py`
+- Bootstrap 使用面: `src/unilab/training/common.py`, `scripts/train_*.py`
+- 支持矩阵生成说明: `docs/zh_CN/02-simulation-backends.md`
+
+## Related Documents
+
+- [ADR Index](README.md)
+- [RL Infrastructure 开发标准](../00-development-architecture.md)
+- [仿真后端](../02-simulation-backends.md)
+- [协作流程](../06-collaboration.md)

--- a/docs/zh_CN/adr/README.md
+++ b/docs/zh_CN/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records (ADR)
+
+语言: 简体中文
+
+本目录记录 UniLab 的稳定架构决策。这里不跟踪阶段性执行状态，只记录已经落地并作为评审基线的 contract。
+
+## ADR 列表
+
+- [ADR-0001 Runtime Model And Layer Boundaries](ADR-0001-runtime-model-and-layer-boundaries.md)
+- [ADR-0002 Backend Capability Boundary For Play And Snapshot](ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
+- [ADR-0003 Task Owner And Config Compose Contract](ADR-0003-task-owner-and-config-compose-contract.md)
+- [ADR-0004 Registry Bootstrap Contract](ADR-0004-registry-bootstrap-contract.md)
+
+## 与主文档的关系
+
+- 架构总览: [RL Infrastructure 开发标准](../00-development-architecture.md)
+- 后端能力和支持矩阵: [仿真后端](../02-simulation-backends.md)
+- 协作流程与证据标准: [协作流程](../06-collaboration.md)


### PR DESCRIPTION
## Summary
- add ADR index and formal ADRs for runtime model, backend capability boundary, task/config compose, and registry bootstrap
- wire ADR references into the architecture, backend, and collaboration docs
- tighten registry bootstrap ADR evidence so docs checks reflect current repo state

## Validation
- uv run pytest tests/scripts/test_check_docs.py -q

Fixes #221