### PR TITLE
fix: formalize registry discovery bootstrap

### DIFF
--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -1,0 +1,7 @@
+"""Locomotion env registry bootstrap contract."""
+
+__unilab_registry_modules__ = (
+    "unilab.envs.locomotion.go1",
+    "unilab.envs.locomotion.go2",
+    "unilab.envs.locomotion.g1",
+)

--- a/src/unilab/envs/manipulation/__init__.py
+++ b/src/unilab/envs/manipulation/__init__.py
@@ -1,0 +1,3 @@
+"""Manipulation env registry bootstrap contract."""
+
+__unilab_registry_modules__ = ("unilab.envs.manipulation.inhand_rot_allegro",)

--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -1,5 +1,7 @@
 """Motion tracking environments."""
 
+__unilab_registry_modules__ = ("unilab.envs.motion_tracking.g1",)
+
 from .g1 import (
     G1FlipTrackingCfg,
     G1FlipTrackingEnv,

--- a/src/unilab/utils/algo_utils.py
+++ b/src/unilab/utils/algo_utils.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import importlib
 import logging
-import pkgutil
 from typing import Sequence
 
 logger = logging.getLogger(__name__)
 
-# Default packages to scan for env registration
+# Attribute name for package-level registry bootstrap contracts.
+_REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"
+
+# Default packages to import for env registration bootstrap.
 _DEFAULT_REGISTRY_PACKAGES = (
     "unilab.envs.locomotion",
     "unilab.envs.manipulation",
@@ -23,11 +25,13 @@ def ensure_registries(
     optional_packages: Sequence[str] | None = None,
     fail_on_error: bool = True,
 ) -> None:
-    """Import all env modules so they are registered.
+    """Import env registry bootstrap modules.
 
     Args:
-        packages: List of package names to scan for env modules.
-                  Defaults to standard unilab env packages.
+        packages: Package or module names to import for env registration.
+                  Package-level registry modules should declare
+                  ``__unilab_registry_modules__`` as explicit bootstrap targets.
+                  Defaults to standard unilab env registry packages.
         optional_packages: List of optional package names that may not be present.
                           Import failures for these are logged as warnings, not raised.
         fail_on_error: If True (default), raise exceptions for non-optional packages.
@@ -35,7 +39,8 @@ def ensure_registries(
 
     Raises:
         ImportError: If a non-optional package fails to import and fail_on_error is True.
-        Exception: If a module within a package fails to import and fail_on_error is True.
+        RuntimeError: If a declared registry module fails to import and fail_on_error is True.
+        TypeError: If ``__unilab_registry_modules__`` has an invalid format.
     """
     pkgs = list(packages) if packages is not None else list(_DEFAULT_REGISTRY_PACKAGES)
     optional = set(optional_packages) if optional_packages else set()
@@ -56,19 +61,26 @@ def ensure_registries(
                 logger.warning("Registry package not found: %s (%s)", pkg_name, e)
             continue
 
-        if not hasattr(package, "__path__"):
-            continue
+        modules = getattr(package, _REGISTRY_MODULES_ATTR, ())
+        if isinstance(modules, str) or not isinstance(modules, Sequence):
+            raise TypeError(
+                f"'{pkg_name}.{_REGISTRY_MODULES_ATTR}' must be a sequence of module names."
+            )
 
-        for _, name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+        for name in modules:
+            if not isinstance(name, str) or not name:
+                raise TypeError(
+                    f"'{pkg_name}.{_REGISTRY_MODULES_ATTR}' entries must be non-empty strings."
+                )
             try:
                 importlib.import_module(name)
             except Exception as e:
                 if fail_on_error and not is_optional:
                     raise RuntimeError(
-                        f"Failed to import env module '{name}'. "
+                        f"Failed to import declared registry module '{name}' from '{pkg_name}'. "
                         f"Fix the import error or add '{pkg_name}' to optional_packages."
                     ) from e
-                logger.warning("Failed to import env module '%s': %s", name, e)
+                logger.warning("Failed to import declared registry module '%s': %s", name, e)
 
 
 def build_actor(

--- a/tests/utils/test_algo_utils.py
+++ b/tests/utils/test_algo_utils.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
+
 import pytest
 
 from unilab.utils.algo_utils import build_actor, ensure_registries
@@ -64,6 +67,57 @@ class TestEnsureRegistries:
     def test_empty_packages_list(self) -> None:
         """Empty packages list should be a no-op."""
         ensure_registries([])
+
+    def test_non_package_module_import_is_supported(self) -> None:
+        """A plain module path should be accepted without package scanning."""
+        ensure_registries(["unilab.utils.algo_utils"])
+
+    def test_declared_registry_module_failure_raises(self, tmp_path, monkeypatch) -> None:
+        """Required packages should fail fast when declared registry modules fail to import."""
+        pkg_dir = tmp_path / "registry_fail_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "__unilab_registry_modules__ = ('registry_fail_pkg.broken',)\n",
+            encoding="utf-8",
+        )
+        (pkg_dir / "broken.py").write_text(
+            "raise RuntimeError('bootstrap failure')\n",
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        importlib.invalidate_caches()
+        sys.modules.pop("registry_fail_pkg", None)
+        sys.modules.pop("registry_fail_pkg.broken", None)
+
+        with pytest.raises(RuntimeError, match="registry_fail_pkg.broken"):
+            ensure_registries(["registry_fail_pkg"])
+
+    def test_optional_package_registry_module_failure_logs_warning(
+        self, tmp_path, monkeypatch, caplog
+    ) -> None:
+        """Optional package declared-module failures should log warnings and continue."""
+        import logging
+
+        pkg_dir = tmp_path / "registry_optional_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "__unilab_registry_modules__ = ('registry_optional_pkg.broken',)\n",
+            encoding="utf-8",
+        )
+        (pkg_dir / "broken.py").write_text("raise RuntimeError('optional failure')\n", encoding="utf-8")
+        monkeypatch.syspath_prepend(str(tmp_path))
+        importlib.invalidate_caches()
+        sys.modules.pop("registry_optional_pkg", None)
+        sys.modules.pop("registry_optional_pkg.broken", None)
+
+        with caplog.at_level(logging.WARNING):
+            ensure_registries(
+                ["registry_optional_pkg"],
+                optional_packages=["registry_optional_pkg"],
+            )
+
+        assert "registry_optional_pkg.broken" in caplog.text
+        assert "Failed to import declared registry module" in caplog.text
 
 
 class TestBuildActor:

--- a/tests/utils/test_algo_utils.py
+++ b/tests/utils/test_algo_utils.py
@@ -104,7 +104,9 @@ class TestEnsureRegistries:
             "__unilab_registry_modules__ = ('registry_optional_pkg.broken',)\n",
             encoding="utf-8",
         )
-        (pkg_dir / "broken.py").write_text("raise RuntimeError('optional failure')\n", encoding="utf-8")
+        (pkg_dir / "broken.py").write_text(
+            "raise RuntimeError('optional failure')\n", encoding="utf-8"
+        )
         monkeypatch.syspath_prepend(str(tmp_path))
         importlib.invalidate_caches()
         sys.modules.pop("registry_optional_pkg", None)

--- a/tests/utils/test_algo_utils.py
+++ b/tests/utils/test_algo_utils.py
@@ -119,6 +119,21 @@ class TestEnsureRegistries:
         assert "registry_optional_pkg.broken" in caplog.text
         assert "Failed to import declared registry module" in caplog.text
 
+    def test_invalid_registry_modules_contract_raises(self, tmp_path, monkeypatch) -> None:
+        """Package bootstrap contract must be a sequence of module names."""
+        pkg_dir = tmp_path / "registry_invalid_contract_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "__unilab_registry_modules__ = 'registry_invalid_contract_pkg.child'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        importlib.invalidate_caches()
+        sys.modules.pop("registry_invalid_contract_pkg", None)
+
+        with pytest.raises(TypeError, match="__unilab_registry_modules__"):
+            ensure_registries(["registry_invalid_contract_pkg"])
+
 
 class TestBuildActor:
     """Tests for build_actor."""


### PR DESCRIPTION
## Summary
- replace scan/import-based registry bootstrap with explicit package-level bootstrap contracts
- add registry bootstrap manifests for env package entrypoints and keep ensure_registries() call sites compatible
- extend tests to cover declared bootstrap contracts, optional-package failures, and invalid contract formats

## Validation
- uv run pytest tests/utils/test_algo_utils.py tests/base/test_registry.py tests/config/test_reward_injection.py tests/base/test_reward_override.py -q

Fixes #220