### PR TITLE
fix: isolate G1 motion tracking backend hooks

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -22,6 +22,8 @@ class BackendPlayCapabilities:
 class SimBackend(abc.ABC):
     """仿真后端统一接口"""
 
+    _model_file: str
+
     # ------------------------------------------------------------------ #
     # Properties                                                           #
     # ------------------------------------------------------------------ #
@@ -90,6 +92,22 @@ class SimBackend(abc.ABC):
         Raises:
             ValueError: 若名称未找到
         """
+
+    def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        """Resolve MuJoCo-style body IDs used by motion datasets."""
+        from unilab.utils.xml_utils import get_named_body_ids
+
+        return np.asarray(get_named_body_ids(self._model_file, names), dtype=np.int32)
+
+    def resolve_action_scale(self, action_scale: float | np.ndarray) -> float | np.ndarray:
+        """Return the action scale after backend-specific control adaptation."""
+        return action_scale
+
+    def log_action_scale_diagnostics(
+        self, action_scale: float | np.ndarray, *, enabled: bool = False
+    ) -> None:
+        """Emit backend-owned diagnostics for action-scale configuration."""
+        return None
 
     @abc.abstractmethod
     def get_joint_range(self) -> np.ndarray | None:

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -99,16 +99,6 @@ class SimBackend(abc.ABC):
 
         return np.asarray(get_named_body_ids(self._model_file, names), dtype=np.int32)
 
-    def resolve_action_scale(self, action_scale: float | np.ndarray) -> float | np.ndarray:
-        """Return the action scale after backend-specific control adaptation."""
-        return action_scale
-
-    def log_action_scale_diagnostics(
-        self, action_scale: float | np.ndarray, *, enabled: bool = False
-    ) -> None:
-        """Emit backend-owned diagnostics for action-scale configuration."""
-        return None
-
     @abc.abstractmethod
     def get_joint_range(self) -> np.ndarray | None:
         """获取关节位置限制（不含浮动基座）

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -41,6 +41,7 @@ class MotrixBackend(SimBackend):
 
         self.add_body_sensors = add_body_sensors
         self._base_name = base_name
+        self._model_file = model_file
 
         if self.add_body_sensors:
             from unilab.utils.xml_utils import inject_motrix_tracking_sensors

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -46,6 +46,7 @@ class MuJoCoBackend(SimBackend):
     ):
         self.add_body_sensors = add_body_sensors
         self._base_name = base_name
+        self._model_file = model_file
         from unilab.utils.xml_utils import create_discardvisual_xml
 
         model_path = create_discardvisual_xml(model_file)
@@ -224,6 +225,52 @@ class MuJoCoBackend(SimBackend):
                 raise ValueError(f"Body '{name}' not found in MuJoCo model")
             ids.append(bid)
         return np.array(ids, dtype=np.int32)
+
+    def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_body_ids(names)
+
+    def resolve_action_scale(self, action_scale: float | np.ndarray) -> np.ndarray:
+        """Adapt position-control action scale to MuJoCo actuator normalization."""
+        nu = int(self._model.nu)
+        if isinstance(action_scale, np.ndarray):
+            resolved = action_scale.astype(get_global_dtype(), copy=True)
+        else:
+            resolved = np.full((nu,), float(action_scale), dtype=get_global_dtype())
+
+        effort_limit = np.max(np.abs(self._model.actuator_forcerange), axis=1)
+
+        # Fallback: derive actuator effort limits from joint force ranges when
+        # actuator forcerange is not explicitly defined in XML.
+        if np.all(effort_limit <= 0.0):
+            joint_ids = self._model.actuator_trnid[:, 0].astype(np.int32)
+            effort_limit = np.max(np.abs(self._model.jnt_actfrcrange[joint_ids]), axis=1)
+
+        stiffness = self._model.actuator_gainprm[:, 0]
+        valid = (effort_limit > 0.0) & (np.abs(stiffness) > 1e-6)
+        resolved[valid] = 0.25 * effort_limit[valid] / stiffness[valid]
+        return resolved
+
+    def log_action_scale_diagnostics(
+        self, action_scale: float | np.ndarray, *, enabled: bool = False
+    ) -> None:
+        """Log MuJoCo actuator/action-scale alignment for debugging."""
+        if not enabled:
+            return
+
+        if isinstance(action_scale, np.ndarray):
+            scale = action_scale.astype(get_global_dtype(), copy=False)
+        else:
+            scale = np.full((int(self._model.nu),), float(action_scale), dtype=get_global_dtype())
+
+        unique_scale = np.unique(np.round(scale, 6))
+        print(f"[G1MotionTracking] action_scale unique: {unique_scale.tolist()}")
+
+        preview_count = min(8, int(self._model.nu))
+        preview = []
+        for i in range(preview_count):
+            name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+            preview.append(f"{name}:{float(scale[i]):.6f}")
+        print("[G1MotionTracking] action_scale preview:", ", ".join(preview))
 
     def get_joint_range(self) -> np.ndarray | None:
         if self._root_qpos_dim > 0:

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -229,49 +229,6 @@ class MuJoCoBackend(SimBackend):
     def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
         return self.get_body_ids(names)
 
-    def resolve_action_scale(self, action_scale: float | np.ndarray) -> np.ndarray:
-        """Adapt position-control action scale to MuJoCo actuator normalization."""
-        nu = int(self._model.nu)
-        if isinstance(action_scale, np.ndarray):
-            resolved = action_scale.astype(get_global_dtype(), copy=True)
-        else:
-            resolved = np.full((nu,), float(action_scale), dtype=get_global_dtype())
-
-        effort_limit = np.max(np.abs(self._model.actuator_forcerange), axis=1)
-
-        # Fallback: derive actuator effort limits from joint force ranges when
-        # actuator forcerange is not explicitly defined in XML.
-        if np.all(effort_limit <= 0.0):
-            joint_ids = self._model.actuator_trnid[:, 0].astype(np.int32)
-            effort_limit = np.max(np.abs(self._model.jnt_actfrcrange[joint_ids]), axis=1)
-
-        stiffness = self._model.actuator_gainprm[:, 0]
-        valid = (effort_limit > 0.0) & (np.abs(stiffness) > 1e-6)
-        resolved[valid] = 0.25 * effort_limit[valid] / stiffness[valid]
-        return resolved
-
-    def log_action_scale_diagnostics(
-        self, action_scale: float | np.ndarray, *, enabled: bool = False
-    ) -> None:
-        """Log MuJoCo actuator/action-scale alignment for debugging."""
-        if not enabled:
-            return
-
-        if isinstance(action_scale, np.ndarray):
-            scale = action_scale.astype(get_global_dtype(), copy=False)
-        else:
-            scale = np.full((int(self._model.nu),), float(action_scale), dtype=get_global_dtype())
-
-        unique_scale = np.unique(np.round(scale, 6))
-        print(f"[G1MotionTracking] action_scale unique: {unique_scale.tolist()}")
-
-        preview_count = min(8, int(self._model.nu))
-        preview = []
-        for i in range(preview_count):
-            name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
-            preview.append(f"{name}:{float(scale[i]):.6f}")
-        print("[G1MotionTracking] action_scale preview:", ", ".join(preview))
-
     def get_joint_range(self) -> np.ndarray | None:
         if self._root_qpos_dim > 0:
             return np.array(self._model.jnt_range[1:], dtype=self._np_dtype)

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -140,7 +140,6 @@ class G1MotionTrackingCfg(G1BaseCfg):
         "right_wrist_yaw_link",
     )
     sampling_mode: Literal["start", "clip_start", "uniform", "adaptive"] = "adaptive"
-    log_action_scale: bool = False
     max_episode_seconds: float = 10.0
     reward_config: RewardConfig = field(default_factory=RewardConfig)
     pose_randomization: PoseRandomization = field(default_factory=PoseRandomization)
@@ -305,13 +304,6 @@ class G1MotionTrackingEnv(G1BaseEnv):
             iterations=cfg.iterations,
         )
         super().__init__(cfg, backend, num_envs)
-        self._cfg.control_config.action_scale = self._backend.resolve_action_scale(
-            self._cfg.control_config.action_scale
-        )
-        self._backend.log_action_scale_diagnostics(
-            self._cfg.control_config.action_scale,
-            enabled=self._cfg.log_action_scale,
-        )
 
         # Resolve body IDs for backend querying and motion-file indexing.
         self.body_ids = self._backend.get_body_ids(cfg.body_names)

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -37,7 +37,6 @@ from unilab.utils.math_utils import (
     np_subtract_frame_transforms,
     np_yaw_quat,
 )
-from unilab.utils.xml_utils import get_named_body_ids
 
 from .motion_loader import MotionLoader, MotionSampler
 
@@ -291,7 +290,6 @@ class G1MotionTrackingEnv(G1BaseEnv):
     """G1 Motion Tracking Environment."""
 
     _cfg: G1MotionTrackingCfg
-    _backend_type: Literal["mujoco", "motrix"]
 
     def __init__(self, cfg: G1MotionTrackingCfg, num_envs=1, backend_type="mujoco"):
         if not cfg.motion_file:
@@ -307,21 +305,17 @@ class G1MotionTrackingEnv(G1BaseEnv):
             iterations=cfg.iterations,
         )
         super().__init__(cfg, backend, num_envs)
-        if backend_type not in {"mujoco", "motrix"}:
-            raise ValueError(f"Unsupported backend type: {backend_type}")
-        self._backend_type = backend_type
-        self._apply_adaptive_g1_action_scale()
-        self._log_action_scale_diagnostics()
+        self._cfg.control_config.action_scale = self._backend.resolve_action_scale(
+            self._cfg.control_config.action_scale
+        )
+        self._backend.log_action_scale_diagnostics(
+            self._cfg.control_config.action_scale,
+            enabled=self._cfg.log_action_scale,
+        )
 
         # Resolve body IDs for backend querying and motion-file indexing.
         self.body_ids = self._backend.get_body_ids(cfg.body_names)
-        if self._is_mujoco_backend():
-            motion_body_ids = self.body_ids
-        else:
-            # Motion data always uses MuJoCo-style body indexing, even on Motrix.
-            motion_body_ids = np.asarray(
-                get_named_body_ids(cfg.model_file, cfg.body_names), dtype=np.int32
-            )
+        motion_body_ids = self._backend.get_motion_body_ids(cfg.body_names)
 
         self.anchor_body_idx = cfg.body_names.index(cfg.anchor_body_name)
 
@@ -350,9 +344,6 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self._init_reward_functions()
         self._clip_end_truncated = np.zeros((num_envs,), dtype=bool)
 
-    def _is_mujoco_backend(self) -> bool:
-        return self._backend_type == "mujoco"
-
     def _get_body_pose_w(self) -> tuple[np.ndarray, np.ndarray]:
         return self._backend.get_body_pos_w(self.body_ids), self._backend.get_body_quat_w(
             self.body_ids
@@ -360,54 +351,6 @@ class G1MotionTrackingEnv(G1BaseEnv):
 
     def _get_joint_range(self) -> np.ndarray | None:
         return self._backend.get_joint_range()  # type: ignore[no-any-return]
-
-    def _apply_adaptive_g1_action_scale(self) -> None:
-        """Set per-joint action scale to match adaptive's normalization."""
-        if not self._is_mujoco_backend():
-            return
-        model = self._backend.model
-        nu = int(model.nu)
-
-        base_scale = self._cfg.control_config.action_scale
-        if isinstance(base_scale, np.ndarray):
-            action_scale = base_scale.astype(get_global_dtype(), copy=True)
-        else:
-            action_scale = np.full((nu,), float(base_scale), dtype=get_global_dtype())
-
-        effort_limit = np.max(np.abs(model.actuator_forcerange), axis=1)
-
-        # Fallback: derive actuator effort limits from joint force ranges when
-        # actuator forcerange is not explicitly defined in XML.
-        if np.all(effort_limit <= 0.0):
-            joint_ids = model.actuator_trnid[:, 0].astype(np.int32)
-            effort_limit = np.max(np.abs(model.jnt_actfrcrange[joint_ids]), axis=1)
-
-        stiffness = model.actuator_gainprm[:, 0]
-        valid = (effort_limit > 0.0) & (np.abs(stiffness) > 1e-6)
-        action_scale[valid] = 0.25 * effort_limit[valid] / stiffness[valid]
-
-        self._cfg.control_config.action_scale = action_scale
-
-    def _log_action_scale_diagnostics(self) -> None:
-        """Log action-scale diagnostics to help detect control-mapping issues."""
-        if not self._cfg.log_action_scale or not self._is_mujoco_backend():
-            return
-        import mujoco
-
-        model = self._backend.model
-        action_scale = self._cfg.control_config.action_scale
-        if not isinstance(action_scale, np.ndarray):
-            action_scale = np.full((int(model.nu),), float(action_scale), dtype=get_global_dtype())
-
-        unique_scale = np.unique(np.round(action_scale, 6))
-        print(f"[G1MotionTracking] action_scale unique: {unique_scale.tolist()}")
-
-        preview_count = min(8, int(model.nu))
-        preview = []
-        for i in range(preview_count):
-            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
-            preview.append(f"{name}:{float(action_scale[i]):.6f}")
-        print("[G1MotionTracking] action_scale preview:", ", ".join(preview))
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -14,6 +14,7 @@ import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.dr import ResetRandomizationPayload
+from unilab.utils.xml_utils import get_named_body_ids
 
 
 # ---------------------------------------------------------------------------
@@ -1016,3 +1017,10 @@ class TestCrossBackendModelProperties:
     def test_actuator_ctrl_range_shape_match(self, backends):
         mj, mx = backends
         assert mj.get_actuator_ctrl_range().shape == mx.get_actuator_ctrl_range().shape
+
+    def test_motion_body_ids_match_motion_xml(self, backends):
+        mj, mx = backends
+        body_names = ["pelvis", "torso_link"]
+        expected = np.asarray(get_named_body_ids(_G1["model_file"], body_names), dtype=np.int32)
+        np.testing.assert_array_equal(mj.get_motion_body_ids(body_names), expected)
+        np.testing.assert_array_equal(mx.get_motion_body_ids(body_names), expected)

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -172,7 +172,7 @@ def test_g1_motion_tracking_cfg_preserves_legacy_defaults():
     assert cfg.anchor_ori_threshold == pytest.approx(0.8)
 
 
-def test_g1_motion_tracking_init_delegates_backend_specific_hooks(monkeypatch):
+def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatch):
     from unilab.envs.locomotion.g1.base import G1BaseEnv
     from unilab.envs.motion_tracking.g1 import tracking as tracking_module
     from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingCfg, G1MotionTrackingEnv
@@ -187,18 +187,6 @@ def test_g1_motion_tracking_init_delegates_backend_specific_hooks(monkeypatch):
         def get_motion_body_ids(self, names: tuple[str, ...]) -> np.ndarray:
             calls["motion_body_ids_names"] = names
             return np.array([1, 2], dtype=np.int32)
-
-        def resolve_action_scale(self, action_scale: float | np.ndarray) -> np.ndarray:
-            calls["resolved_action_scale_input"] = action_scale
-            return np.array([0.125, 0.25], dtype=np.float32)
-
-        def log_action_scale_diagnostics(
-            self, action_scale: float | np.ndarray, *, enabled: bool = False
-        ) -> None:
-            calls["log_action_scale"] = (
-                enabled,
-                np.array(action_scale, dtype=np.float32, copy=True),
-            )
 
     def fake_base_init(self, cfg, backend, num_envs):
         self._cfg = cfg
@@ -236,15 +224,10 @@ def test_g1_motion_tracking_init_delegates_backend_specific_hooks(monkeypatch):
         motion_file="dummy_motion.npz",
         body_names=("pelvis", "torso_link"),
         ee_body_names=("torso_link",),
-        log_action_scale=True,
     )
     env = cast(Any, G1MotionTrackingEnv)(cfg, num_envs=4, backend_type="motrix")
 
     np.testing.assert_array_equal(env.body_ids, np.array([10, 11], dtype=np.int32))
-    np.testing.assert_array_equal(
-        env._cfg.control_config.action_scale,
-        np.array([0.125, 0.25], dtype=np.float32),
-    )
     assert calls["body_ids_names"] == cfg.body_names
     assert calls["motion_body_ids_names"] == cfg.body_names
     assert calls["motion_loader"][0] == "dummy_motion.npz"
@@ -252,11 +235,6 @@ def test_g1_motion_tracking_init_delegates_backend_specific_hooks(monkeypatch):
     assert calls["motion_sampler"][1:] == ("adaptive", 4)
     assert calls["dr_provider"] == "G1MotionTrackingDomainRandomizationProvider"
     assert calls["reward_init"] is True
-    assert calls["log_action_scale"][0] is True
-    np.testing.assert_array_equal(
-        calls["log_action_scale"][1],
-        np.array([0.125, 0.25], dtype=np.float32),
-    )
 
 
 def test_g1_flip_tracking_cfg_uses_flip_profile():

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -172,6 +172,93 @@ def test_g1_motion_tracking_cfg_preserves_legacy_defaults():
     assert cfg.anchor_ori_threshold == pytest.approx(0.8)
 
 
+def test_g1_motion_tracking_init_delegates_backend_specific_hooks(monkeypatch):
+    from unilab.envs.locomotion.g1.base import G1BaseEnv
+    from unilab.envs.motion_tracking.g1 import tracking as tracking_module
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingCfg, G1MotionTrackingEnv
+
+    calls: dict[str, Any] = {}
+
+    class FakeBackend:
+        def get_body_ids(self, names: tuple[str, ...]) -> np.ndarray:
+            calls["body_ids_names"] = names
+            return np.array([10, 11], dtype=np.int32)
+
+        def get_motion_body_ids(self, names: tuple[str, ...]) -> np.ndarray:
+            calls["motion_body_ids_names"] = names
+            return np.array([1, 2], dtype=np.int32)
+
+        def resolve_action_scale(self, action_scale: float | np.ndarray) -> np.ndarray:
+            calls["resolved_action_scale_input"] = action_scale
+            return np.array([0.125, 0.25], dtype=np.float32)
+
+        def log_action_scale_diagnostics(
+            self, action_scale: float | np.ndarray, *, enabled: bool = False
+        ) -> None:
+            calls["log_action_scale"] = (
+                enabled,
+                np.array(action_scale, dtype=np.float32, copy=True),
+            )
+
+    def fake_base_init(self, cfg, backend, num_envs):
+        self._cfg = cfg
+        self._backend = backend
+        self._num_envs = num_envs
+        self._num_action = 2
+        self._init_qpos = np.zeros((9,), dtype=np.float32)
+        self._init_qvel = np.zeros((8,), dtype=np.float32)
+
+    class FakeMotionLoader:
+        def __init__(self, motion_file: str, body_indices: np.ndarray):
+            calls["motion_loader"] = (motion_file, body_indices.copy())
+
+    class FakeMotionSampler:
+        def __init__(self, motion_loader: Any, mode: str, num_envs: int):
+            calls["motion_sampler"] = (motion_loader, mode, num_envs)
+
+    fake_backend = FakeBackend()
+    monkeypatch.setattr(tracking_module, "create_backend", lambda *args, **kwargs: fake_backend)
+    monkeypatch.setattr(G1BaseEnv, "__init__", fake_base_init)
+    monkeypatch.setattr(tracking_module, "MotionLoader", FakeMotionLoader)
+    monkeypatch.setattr(tracking_module, "MotionSampler", FakeMotionSampler)
+    monkeypatch.setattr(
+        G1MotionTrackingEnv,
+        "_init_domain_randomization",
+        lambda self, provider: calls.setdefault("dr_provider", provider.__class__.__name__),
+    )
+    monkeypatch.setattr(
+        G1MotionTrackingEnv,
+        "_init_reward_functions",
+        lambda self: calls.setdefault("reward_init", True),
+    )
+
+    cfg = G1MotionTrackingCfg(
+        motion_file="dummy_motion.npz",
+        body_names=("pelvis", "torso_link"),
+        ee_body_names=("torso_link",),
+        log_action_scale=True,
+    )
+    env = cast(Any, G1MotionTrackingEnv)(cfg, num_envs=4, backend_type="motrix")
+
+    np.testing.assert_array_equal(env.body_ids, np.array([10, 11], dtype=np.int32))
+    np.testing.assert_array_equal(
+        env._cfg.control_config.action_scale,
+        np.array([0.125, 0.25], dtype=np.float32),
+    )
+    assert calls["body_ids_names"] == cfg.body_names
+    assert calls["motion_body_ids_names"] == cfg.body_names
+    assert calls["motion_loader"][0] == "dummy_motion.npz"
+    np.testing.assert_array_equal(calls["motion_loader"][1], np.array([1, 2], dtype=np.int32))
+    assert calls["motion_sampler"][1:] == ("adaptive", 4)
+    assert calls["dr_provider"] == "G1MotionTrackingDomainRandomizationProvider"
+    assert calls["reward_init"] is True
+    assert calls["log_action_scale"][0] is True
+    np.testing.assert_array_equal(
+        calls["log_action_scale"][1],
+        np.array([0.125, 0.25], dtype=np.float32),
+    )
+
+
 def test_g1_flip_tracking_cfg_uses_flip_profile():
     from unilab.envs.motion_tracking.g1.flip_tracking import G1FlipTrackingCfg
 


### PR DESCRIPTION
## Summary

- move G1 motion tracking motion body-id resolution out of tracking.py and into backend-owned get_motion_body_ids() hooks
- keep G1 motion tracking env backend-agnostic by removing explicit backend-name checks and leaving action-scale behavior unchanged
- add initialization and cross-backend coverage for motion body-id resolution, including G1 motion tracking reset/step smoke on both backends

## Linked Work

- Issue: Closes #217, Closes #228
- Milestone:

## Validation

- [x] make check
- [x] make test
- [x] Additional task-specific validation listed below

Commands actually run:

make check
make test
uv run pytest tests/envs/test_env_configs.py -q -k g1_motion_tracking
uv run pytest tests/base/test_sim_backend.py -q -m slow -k motion_body_ids_match_motion_xml

## Impact

- Backend impact: both
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
