### PR TITLE
fix: mark MuJoCo-only tooling explicitly

### DIFF
--- a/scripts/motion/bones_seed_csv_to_npz.py
+++ b/scripts/motion/bones_seed_csv_to_npz.py
@@ -1,4 +1,4 @@
-"""Convert G1 flip CSV motions to NPZ with forward kinematics.
+"""MuJoCo-only BONES-SEED CSV-to-NPZ conversion with forward kinematics.
 
 This script targets the CSV files under ``src/unilab/assets/motions/g1/flip``.
 Those files share one 36-column layout:
@@ -8,7 +8,11 @@ Those files share one 36-column layout:
 - ``root_rotateX/Y/Z``
 - 29 ``*_joint_dof`` columns using G1 MuJoCo joint names
 
-The exported NPZ format matches the motion tracking loader:
+The exported NPZ format matches the motion tracking loader. The export relies on
+MuJoCo model loading and tracking sensors, so it is not available for
+Motrix-only workflows.
+
+The exported NPZ format contains:
 - ``fps``
 - ``joint_pos``
 - ``joint_vel``
@@ -22,6 +26,8 @@ Usage:
     uv run python scripts/motion/bones_seed_csv_to_npz.py --dry-run
     uv run python scripts/motion/bones_seed_csv_to_npz.py --input src/unilab/assets/motions/g1/flip/flip_090_001__A304.csv
 """
+
+# pyright: reportAttributeAccessIssue=false
 
 from __future__ import annotations
 

--- a/scripts/motion/csv_to_npz.py
+++ b/scripts/motion/csv_to_npz.py
@@ -1,7 +1,8 @@
-"""Convert CSV motion files to NPZ format with forward kinematics.
+"""MuJoCo-only CSV-to-NPZ conversion with forward kinematics.
 
 This script converts motion data from CSV format (Unitree convention) to NPZ format
-with precomputed forward kinematics for all bodies.
+with precomputed forward kinematics for all bodies. It depends on MuJoCo model
+loading and sensor evaluation, so it is not available for Motrix-only workflows.
 
 Input CSV format:
 - Base position (3): x, y, z
@@ -17,6 +18,8 @@ Output NPZ format:
 - body_lin_vel_w: Body linear velocities (N_frames × N_bodies × 3)
 - body_ang_vel_w: Body angular velocities (N_frames × N_bodies × 3)
 """
+
+# pyright: reportAttributeAccessIssue=false
 
 import argparse
 from pathlib import Path
@@ -153,7 +156,7 @@ def run_simulation(
     joint_names: list[str],
     output_file: str,
 ):
-    """Run MuJoCo simulation to compute forward kinematics."""
+    """Run MuJoCo simulation to compute forward kinematics for the export."""
     # Inject track_* sensors so exported body_* fields match training-time semantics.
     tmp_model_path, _, _ = inject_mujoco_tracking_sensors(model_file)
     try:

--- a/scripts/motion/replay_bones_seed_csv.py
+++ b/scripts/motion/replay_bones_seed_csv.py
@@ -1,4 +1,4 @@
-"""Replay BONES-SEED G1 CSV motions in the MuJoCo viewer.
+"""MuJoCo-only replay of BONES-SEED G1 CSV motions in the MuJoCo viewer.
 
 This script targets the CSV files under ``src/unilab/assets/motions/g1/flip``.
 Those files share one 36-column layout:
@@ -14,12 +14,17 @@ Assumptions:
 - joint DOFs are stored in degrees
 - root Euler order defaults to ProtoMotions/Scipy-style extrinsic ``xyz``
 
+This replay path depends on the MuJoCo viewer/runtime and is not available for
+Motrix-only workflows.
+
 Usage:
     uv run python scripts/motion/replay_bones_seed_csv.py
     uv run python scripts/motion/replay_bones_seed_csv.py --input src/unilab/assets/motions/g1/flip
     uv run python scripts/motion/replay_bones_seed_csv.py --input src/unilab/assets/motions/g1/flip/flip_090_001__A304.csv
     uv run python scripts/motion/replay_bones_seed_csv.py --dry-run
 """
+
+# pyright: reportAttributeAccessIssue=false
 
 from __future__ import annotations
 

--- a/scripts/motion/replay_npz.py
+++ b/scripts/motion/replay_npz.py
@@ -1,7 +1,9 @@
-"""Replay NPZ motion data in MuJoCo viewer.
+"""MuJoCo-only NPZ motion replay in the MuJoCo viewer.
 
 Loads a preprocessed NPZ motion file and plays it back in the MuJoCo passive
 viewer, setting qpos/qvel each frame so you can visually inspect the motion.
+This replay path depends on the MuJoCo viewer/runtime and is not available for
+Motrix-only workflows.
 
 Usage:
     uv run python scripts/motion/replay_npz.py --npz_file path/to/motion.npz
@@ -15,6 +17,8 @@ Usage:
     # Slow-motion (0.5x speed)
     uv run python scripts/motion/replay_npz.py --npz_file motion.npz --speed 0.5
 """
+
+# pyright: reportAttributeAccessIssue=false, reportReturnType=false
 
 import argparse
 import time

--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -1,4 +1,7 @@
-"""Interactive play script: opens a live MuJoCo viewer for a trained RSL-RL policy.
+"""MuJoCo-only interactive play script for trained RSL-RL policies.
+
+This tool opens a live MuJoCo viewer for a trained RSL-RL policy. It is wired
+directly to MuJoCo viewer/runtime APIs and is not available for Motrix tasks.
 
 Usage:
     # Load the latest checkpoint for a task

--- a/src/unilab/envs/locomotion/g1/symmetry.py
+++ b/src/unilab/envs/locomotion/g1/symmetry.py
@@ -1,9 +1,15 @@
-"""G1 symmetry augmentation - vectorized operations."""
+"""MuJoCo-only G1 symmetry augmentation helpers.
+
+This module builds symmetry mappings from MuJoCo actuator names and therefore
+only applies to MuJoCo-backed G1 tooling.
+"""
 
 import torch
 
 
 class G1SymmetryAugmentation:
+    """MuJoCo-only symmetry helper derived from MuJoCo actuator ordering."""
+
     def __init__(self, model, obs_structure: dict, device: str = "cuda"):
         import mujoco
 

--- a/src/unilab/utils/render_many.py
+++ b/src/unilab/utils/render_many.py
@@ -1,3 +1,10 @@
+"""MuJoCo-only batched rendering helpers.
+
+This module renders many MuJoCo states into image frames by constructing
+MuJoCo model/data/renderer objects inside worker processes. It is not available
+for Motrix-only workflows.
+"""
+
 import math
 import os
 import sys
@@ -66,7 +73,7 @@ def _close_worker():
 
 
 def init_worker(model_path, shape):
-    """Initialize MuJoCo context for worker process."""
+    """Initialize MuJoCo-only rendering context for a worker process."""
     import atexit
 
     _worker_ctx["model"] = mujoco.MjModel.from_xml_path(model_path)

--- a/tests/scripts/test_mujoco_only_tooling_markers.py
+++ b/tests/scripts/test_mujoco_only_tooling_markers.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_mujoco_only_tooling_is_marked_explicitly():
+    root = Path(__file__).resolve().parents[2]
+    target_files = [
+        root / "scripts" / "play_interactive.py",
+        root / "scripts" / "motion" / "csv_to_npz.py",
+        root / "scripts" / "motion" / "replay_npz.py",
+        root / "scripts" / "motion" / "bones_seed_csv_to_npz.py",
+        root / "scripts" / "motion" / "replay_bones_seed_csv.py",
+        root / "src" / "unilab" / "utils" / "render_many.py",
+        root / "src" / "unilab" / "envs" / "locomotion" / "g1" / "symmetry.py",
+    ]
+
+    missing = [
+        str(path.relative_to(root))
+        for path in target_files
+        if "MuJoCo-only" not in path.read_text(encoding="utf-8")
+    ]
+
+    assert missing == []


### PR DESCRIPTION
## Summary

- mark MuJoCo-only boundaries in the affected debug and motion tooling entrypoints
- add a regression test that requires these files to keep an explicit `MuJoCo-only` marker
- keep the change at the tool/documentation layer without altering runtime behavior

## Linked Work

- Issue: Fixes #231
- Milestone: N/A

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
make check
make test
uv run pyright scripts/play_interactive.py scripts/motion/csv_to_npz.py scripts/motion/replay_npz.py scripts/motion/bones_seed_csv_to_npz.py scripts/motion/replay_bones_seed_csv.py src/unilab/utils/render_many.py src/unilab/envs/locomotion/g1/symmetry.py tests/scripts/test_mujoco_only_tooling_markers.py
uv run pytest tests/scripts/test_mujoco_only_tooling_markers.py tests/scripts/test_check_docs.py -q
```

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
