### PR TITLE
feat: add flashsac offpolicy integration

### DIFF
--- a/conf/offpolicy/algo/flashsac.yaml
+++ b/conf/offpolicy/algo/flashsac.yaml
@@ -1,0 +1,43 @@
+# @package algo
+algo: flashsac
+algo_log_name: flash_sac
+load_run: "-1"
+seed: 1
+num_envs: 2048
+batch_size: 2048
+replay_buffer_n: 512
+updates_per_step: 1
+warmup_steps: 10000
+policy_frequency: 2
+env_steps_per_sync: 1
+max_iterations: 5000
+save_interval: 1000
+gamma: 0.99
+tau: 0.01
+actor_lr: 3.0e-4
+critic_lr: 3.0e-4
+actor_hidden_dim: 128
+critic_hidden_dim: 256
+num_atoms: 101
+obs_normalization: false
+use_layer_norm: false
+algo_params:
+  normalize_reward: true
+  normalized_g_max: 5.0
+  actor_num_blocks: 2
+  critic_num_blocks: 2
+  actor_bc_alpha: 0.0
+  actor_noise_zeta_mu: 2.0
+  actor_noise_zeta_max: 16
+  critic_min_v: -5.0
+  critic_max_v: 5.0
+  temp_initial_value: 0.01
+  temp_target_sigma: 0.15
+  temp_target_entropy: null
+  learning_rate_init: 3.0e-4
+  learning_rate_peak: 3.0e-4
+  learning_rate_end: 1.5e-4
+  learning_rate_warmup_steps: 0
+  learning_rate_decay_steps: 500000
+  n_step: 1
+  use_compile: false

--- a/conf/offpolicy/task/flashsac/g1_sac/motrix.yaml
+++ b/conf/offpolicy/task/flashsac/g1_sac/motrix.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+training:
+  task_name: G1WalkTaskMjSAC
+  sim_backend: motrix
+algo:
+  num_envs: 2048
+  max_iterations: 5000
+  save_interval: 1000
+reward:
+  scales:
+    tracking_lin_vel: 2.2
+    tracking_ang_vel: 1.8
+    penalty_ang_vel_xy: -1.2
+    penalty_orientation: -12.0
+    penalty_action_rate: -2.5
+    pose: -0.6
+    penalty_feet_ori: -30.0
+    feet_phase: 6.0
+    alive: 12.0
+  tracking_sigma: 0.25
+  base_height_target: 0.754
+  min_base_height: 0.3
+  max_tilt_deg: 65.0
+  gait_frequency: 1.5
+  feet_phase_swing_height: 0.09
+  feet_phase_tracking_sigma: 0.008
+  close_feet_threshold: 0.15
+  pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/conf/offpolicy/task/flashsac/g1_sac/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/g1_sac/mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+training:
+  task_name: G1WalkTaskMjSAC
+  sim_backend: mujoco
+algo:
+  num_envs: 2048
+  max_iterations: 5000
+  save_interval: 1000
+reward:
+  scales:
+    tracking_lin_vel: 2.0
+    tracking_ang_vel: 1.5
+    penalty_ang_vel_xy: -1.0
+    penalty_orientation: -10.0
+    penalty_action_rate: -2.0
+    pose: -0.5
+    penalty_feet_ori: -25.0
+    feet_phase: 5.0
+    alive: 10.0
+  tracking_sigma: 0.25
+  base_height_target: 0.754
+  min_base_height: 0.3
+  max_tilt_deg: 65.0
+  gait_frequency: 1.5
+  feet_phase_swing_height: 0.09
+  feet_phase_tracking_sigma: 0.008
+  close_feet_threshold: 0.15
+  pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -86,6 +86,9 @@ def build_runner(algo_name: str, cfg: DictConfig):
     """Build algorithm runner from unified Hydra config."""
     env_cfg_override = build_offpolicy_env_cfg_override(algo_name, cfg)
 
+    if algo_name == "flashsac" and cfg.training.num_gpus > 1:
+        raise ValueError("FlashSAC does not support training.num_gpus > 1")
+
     if algo_name == "sac":
         from unilab.algos.torch.fast_sac.learner import FastSACLearner
         from unilab.algos.torch.fast_sac.runner import FastSACRunner
@@ -218,6 +221,52 @@ def build_runner(algo_name: str, cfg: DictConfig):
             sim_backend=cfg.training.sim_backend,
         )
 
+    if algo_name == "flashsac":
+        from unilab.algos.torch.flash_sac.runner import FlashSACRunner
+
+        return FlashSACRunner(
+            env_name=cfg.training.task_name,
+            env_cfg_override=env_cfg_override,
+            device=cfg.training.device,
+            num_envs=cfg.algo.num_envs,
+            replay_buffer_n=cfg.algo.replay_buffer_n,
+            batch_size=cfg.algo.batch_size,
+            warmup_steps=cfg.algo.warmup_steps,
+            updates_per_step=cfg.algo.updates_per_step,
+            policy_frequency=cfg.algo.policy_frequency,
+            gamma=cfg.algo.gamma,
+            tau=cfg.algo.tau,
+            actor_lr=cfg.algo.actor_lr,
+            critic_lr=cfg.algo.critic_lr,
+            obs_normalization=cfg.algo.obs_normalization,
+            actor_hidden_dim=cfg.algo.actor_hidden_dim,
+            critic_hidden_dim=cfg.algo.critic_hidden_dim,
+            num_atoms=cfg.algo.num_atoms,
+            use_amp=cfg.training.use_amp,
+            sync_collection=not cfg.training.no_sync_collection,
+            env_steps_per_sync=cfg.training.env_steps_per_sync,
+            sim_backend=cfg.training.sim_backend,
+            actor_num_blocks=cfg.algo.algo_params.actor_num_blocks,
+            critic_num_blocks=cfg.algo.algo_params.critic_num_blocks,
+            actor_bc_alpha=cfg.algo.algo_params.actor_bc_alpha,
+            actor_noise_zeta_mu=cfg.algo.algo_params.actor_noise_zeta_mu,
+            actor_noise_zeta_max=cfg.algo.algo_params.actor_noise_zeta_max,
+            critic_min_v=cfg.algo.algo_params.critic_min_v,
+            critic_max_v=cfg.algo.algo_params.critic_max_v,
+            target_sigma=cfg.algo.algo_params.temp_target_sigma,
+            target_entropy=cfg.algo.algo_params.temp_target_entropy,
+            temp_initial_value=cfg.algo.algo_params.temp_initial_value,
+            learning_rate_init=cfg.algo.algo_params.learning_rate_init,
+            learning_rate_peak=cfg.algo.algo_params.learning_rate_peak,
+            learning_rate_end=cfg.algo.algo_params.learning_rate_end,
+            learning_rate_warmup_steps=cfg.algo.algo_params.learning_rate_warmup_steps,
+            learning_rate_decay_steps=cfg.algo.algo_params.learning_rate_decay_steps,
+            normalize_reward=cfg.algo.algo_params.normalize_reward,
+            normalized_g_max=cfg.algo.algo_params.normalized_g_max,
+            n_step=cfg.algo.algo_params.n_step,
+            use_compile=cfg.algo.algo_params.use_compile,
+        )
+
     raise ValueError(f"Unsupported algo: {algo_name}")
 
 
@@ -274,6 +323,22 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
         )
         if cfg.algo.obs_normalization:
             normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
+    elif algo_name == "flashsac":
+        actor = build_actor(
+            "flashsac",
+            obs_dim,
+            action_dim,
+            cfg.algo.actor_hidden_dim,
+            cfg.algo.use_layer_norm,
+            device,
+            actor_num_blocks=cfg.algo.algo_params.actor_num_blocks,
+            actor_noise_zeta_mu=cfg.algo.algo_params.actor_noise_zeta_mu,
+            actor_noise_zeta_max=cfg.algo.algo_params.actor_noise_zeta_max,
+        )
+        if cfg.algo.obs_normalization:
+            from unilab.algos.torch.common.normalization import EmpiricalNormalization
+
+            normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
     else:
         raise ValueError(f"Unsupported algo: {algo_name}")
 
@@ -291,8 +356,11 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
 
     print(f"Loading model: {load_path}")
     checkpoint = torch.load(load_path, map_location=device, weights_only=True)
-    if algo_name == "sac":
+    if algo_name in ("sac", "flashsac"):
         actor.load_state_dict(checkpoint["actor"])
+        if normalizer and checkpoint.get("obs_normalizer"):
+            normalizer.load_state_dict(checkpoint["obs_normalizer"])
+            normalizer.eval()
     else:
         actor_state = {k: v for k, v in checkpoint["actor"].items() if k not in ("noise_scales",)}
         actor.load_state_dict(actor_state, strict=False)
@@ -309,7 +377,7 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
             obs_torch = normalizer(obs_torch, update=False)
         actions_np = (
             actor.explore(obs_torch, deterministic=True).cpu().numpy()
-            if algo_name == "sac"
+            if algo_name in ("sac", "flashsac")
             else actor(obs_torch).cpu().numpy()
         )
         state = env.step(actions_np)

--- a/src/unilab/algos/torch/flash_sac/__init__.py
+++ b/src/unilab/algos/torch/flash_sac/__init__.py
@@ -1,0 +1,12 @@
+"""FlashSAC algorithm package."""
+
+from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+from unilab.algos.torch.flash_sac.network import FlashSACActor, FlashSACDoubleCritic
+from unilab.algos.torch.flash_sac.runner import FlashSACRunner
+
+__all__ = [
+    "FlashSACActor",
+    "FlashSACDoubleCritic",
+    "FlashSACLearner",
+    "FlashSACRunner",
+]

--- a/src/unilab/algos/torch/flash_sac/layers.py
+++ b/src/unilab/algos/torch/flash_sac/layers.py
@@ -1,0 +1,277 @@
+"""FlashSAC layers and lightweight normalization helpers."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def safe_tanh_log_det_jacobian(x: torch.Tensor) -> torch.Tensor:
+    """Stable log|det J_tanh(x)| term."""
+    return cast(torch.Tensor, 2.0 * (math.log(2.0) - x - F.softplus(-2.0 * x)))
+
+
+class UnitLinear(nn.Module):
+    """Linear layer with post-step weight normalization."""
+
+    def __init__(self, input_dim: int, output_dim: int):
+        super().__init__()
+        self.w = nn.Linear(input_dim, output_dim, bias=False)
+        nn.init.orthogonal_(self.w.weight, gain=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, self.w(x))
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            self.w.weight.copy_(F.normalize(self.w.weight, dim=-1, eps=1e-8))
+
+
+class UnitBatchNorm(nn.Module):
+    """BatchNorm variant with normalized affine parameters."""
+
+    running_mean: torch.Tensor
+    running_var: torch.Tensor
+
+    def __init__(self, input_dim: int, momentum: float = 0.01, eps: float = 1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(input_dim))
+        self.bias = nn.Parameter(torch.zeros(input_dim))
+        self.register_buffer("running_mean", torch.zeros(input_dim))
+        self.register_buffer("running_var", torch.ones(input_dim))
+        self.momentum = momentum
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        return F.batch_norm(
+            x,
+            self.running_mean,
+            self.running_var,
+            self.weight,
+            self.bias,
+            training=training,
+            momentum=self.momentum,
+            eps=self.eps,
+        )
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            sqsum = torch.sum(self.weight * self.weight + self.bias * self.bias, dim=-1)
+            norm_factor = math.sqrt(float(self.weight.shape[-1])) * torch.rsqrt(sqsum + 1e-8)
+            self.weight.mul_(norm_factor)
+            self.bias.mul_(norm_factor)
+
+
+class UnitRMSNorm(nn.Module):
+    """RMSNorm with unit-length scale vector."""
+
+    def __init__(self, input_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(input_dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        rms = torch.sqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+        return (x / rms) * self.weight
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            sqsum = torch.sum(self.weight * self.weight, dim=-1)
+            norm_factor = math.sqrt(float(self.weight.shape[-1])) * torch.rsqrt(sqsum + 1e-8)
+            self.weight.mul_(norm_factor)
+
+
+class FlashSACEmbedder(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.norm = UnitBatchNorm(input_dim)
+        self.w = UnitLinear(input_dim, hidden_dim)
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        return cast(torch.Tensor, self.w(self.norm(x, training=training)))
+
+
+class FlashSACBlock(nn.Module):
+    def __init__(self, hidden_dim: int, expansion: int = 4):
+        super().__init__()
+        self.w1 = UnitLinear(hidden_dim, hidden_dim * expansion)
+        self.norm1 = UnitBatchNorm(hidden_dim * expansion)
+        self.w2 = UnitLinear(hidden_dim * expansion, hidden_dim)
+        self.norm2 = UnitBatchNorm(hidden_dim)
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        residual = x
+        x = self.w1(x)
+        x = self.norm1(x, training=training)
+        x = F.relu(x)
+        x = self.w2(x)
+        x = self.norm2(x, training=training)
+        x = F.relu(x)
+        return x + residual
+
+
+class NormalTanhPolicy(nn.Module):
+    def __init__(
+        self,
+        hidden_dim: int,
+        action_dim: int,
+        log_std_min: float = -10.0,
+        log_std_max: float = 2.0,
+    ):
+        super().__init__()
+        self.mean_w = UnitLinear(hidden_dim, action_dim)
+        self.mean_bias = nn.Parameter(torch.zeros(action_dim))
+        self.std_w = UnitLinear(hidden_dim, action_dim)
+        self.std_bias = nn.Parameter(torch.zeros(action_dim))
+        self.log_std_min = log_std_min
+        self.log_std_max = log_std_max
+
+    def get_mean_and_std(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mean = F.linear(x, self.mean_w.w.weight, self.mean_bias)
+        raw_log_std = F.linear(x, self.std_w.w.weight, self.std_bias)
+        log_std = self.log_std_min + (self.log_std_max - self.log_std_min) * 0.5 * (
+            1.0 + torch.tanh(raw_log_std)
+        )
+        std = torch.exp(log_std)
+        return mean, std
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        mean, std = self.get_mean_and_std(x)
+        dist = torch.distributions.Normal(mean, std)
+        raw_action = dist.rsample()
+        tanh_action = torch.tanh(raw_action)
+        log_prob = dist.log_prob(raw_action)
+        log_prob = log_prob - safe_tanh_log_det_jacobian(raw_action)
+        log_prob = log_prob.sum(dim=-1)
+        return tanh_action, {"log_prob": log_prob, "mean": mean, "std": std}
+
+
+class EnsembleUnitLinear(nn.Module):
+    def __init__(self, num_ensemble: int, input_dim: int, output_dim: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(num_ensemble, output_dim, input_dim))
+        for idx in range(num_ensemble):
+            nn.init.orthogonal_(self.weight[idx], gain=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.einsum("nbi,noi->nbo", x, self.weight)
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.copy_(F.normalize(self.weight, dim=-1, eps=1e-8))
+
+
+class EnsembleUnitBatchNorm(nn.Module):
+    running_mean: torch.Tensor
+    running_var: torch.Tensor
+
+    def __init__(
+        self, num_ensemble: int, input_dim: int, momentum: float = 0.01, eps: float = 1e-5
+    ):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_ensemble, input_dim))
+        self.bias = nn.Parameter(torch.zeros(num_ensemble, input_dim))
+        self.register_buffer("running_mean", torch.zeros(num_ensemble, input_dim))
+        self.register_buffer("running_var", torch.ones(num_ensemble, input_dim))
+        self.momentum = momentum
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        if training:
+            mean = x.mean(dim=1, keepdim=True)
+            var = x.var(dim=1, correction=0, keepdim=True)
+            with torch.no_grad():
+                batch_size = max(x.shape[1], 1)
+                correction = batch_size / max(batch_size - 1, 1)
+                self.running_mean.lerp_(mean.squeeze(1).float(), self.momentum)
+                self.running_var.lerp_((var.squeeze(1) * correction).float(), self.momentum)
+            normed = (x - mean) * torch.rsqrt(var + self.eps)
+        else:
+            normed = (x - self.running_mean.unsqueeze(1)) * torch.rsqrt(
+                self.running_var.unsqueeze(1) + self.eps
+            )
+        return normed * self.weight.unsqueeze(1) + self.bias.unsqueeze(1)
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            sqsum = torch.sum(
+                self.weight * self.weight + self.bias * self.bias, dim=-1, keepdim=True
+            )
+            norm_factor = math.sqrt(float(self.weight.shape[-1])) * torch.rsqrt(sqsum + 1e-8)
+            self.weight.mul_(norm_factor)
+            self.bias.mul_(norm_factor)
+
+
+class EnsembleUnitRMSNorm(nn.Module):
+    def __init__(self, num_ensemble: int, input_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_ensemble, input_dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        rms = torch.sqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+        return (x / rms) * self.weight.unsqueeze(1)
+
+    def normalize_parameters(self) -> None:
+        with torch.no_grad():
+            sqsum = torch.sum(self.weight * self.weight, dim=-1, keepdim=True)
+            norm_factor = math.sqrt(float(self.weight.shape[-1])) * torch.rsqrt(sqsum + 1e-8)
+            self.weight.mul_(norm_factor)
+
+
+class EnsembleFlashSACEmbedder(nn.Module):
+    def __init__(self, num_ensemble: int, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.norm = EnsembleUnitBatchNorm(num_ensemble, input_dim)
+        self.w = EnsembleUnitLinear(num_ensemble, input_dim, hidden_dim)
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        return cast(torch.Tensor, self.w(self.norm(x, training=training)))
+
+
+class EnsembleFlashSACBlock(nn.Module):
+    def __init__(self, num_ensemble: int, hidden_dim: int, expansion: int = 4):
+        super().__init__()
+        self.w1 = EnsembleUnitLinear(num_ensemble, hidden_dim, hidden_dim * expansion)
+        self.norm1 = EnsembleUnitBatchNorm(num_ensemble, hidden_dim * expansion)
+        self.w2 = EnsembleUnitLinear(num_ensemble, hidden_dim * expansion, hidden_dim)
+        self.norm2 = EnsembleUnitBatchNorm(num_ensemble, hidden_dim)
+
+    def forward(self, x: torch.Tensor, training: bool) -> torch.Tensor:
+        residual = x
+        x = self.w1(x)
+        x = self.norm1(x, training=training)
+        x = F.relu(x)
+        x = self.w2(x)
+        x = self.norm2(x, training=training)
+        x = F.relu(x)
+        return x + residual
+
+
+class EnsembleCategoricalValue(nn.Module):
+    support: torch.Tensor
+
+    def __init__(
+        self,
+        num_ensemble: int,
+        hidden_dim: int,
+        num_bins: int,
+        min_v: float,
+        max_v: float,
+    ):
+        super().__init__()
+        self.logit_w = EnsembleUnitLinear(num_ensemble, hidden_dim, num_bins)
+        self.logit_bias = nn.Parameter(torch.zeros(num_ensemble, num_bins))
+        self.register_buffer("support", torch.linspace(min_v, max_v, num_bins))
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        logits = self.logit_w(x) + self.logit_bias.unsqueeze(1)
+        log_probs = F.log_softmax(logits, dim=-1)
+        probs = log_probs.exp()
+        support = self.support.view(1, 1, -1)
+        values = cast(torch.Tensor, torch.sum(probs * support, dim=-1))
+        return values, {"log_prob": log_probs}

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -1,0 +1,407 @@
+"""FlashSAC learner adapted to UniLab's off-policy contract."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from unilab.algos.torch.common.normalization import EmpiricalNormalization
+from unilab.algos.torch.flash_sac.network import (
+    FlashSACActor,
+    FlashSACDoubleCritic,
+    FlashSACTemperature,
+)
+from unilab.algos.torch.flash_sac.update import (
+    build_lr_lambda,
+    compute_categorical_td_target,
+    resolve_target_entropy,
+    select_min_q_log_probs,
+)
+
+
+@dataclass
+class RunningMeanStd:
+    mean: torch.Tensor
+    var: torch.Tensor
+    count: torch.Tensor
+
+    @classmethod
+    def create(cls, device: torch.device) -> "RunningMeanStd":
+        return cls(
+            mean=torch.zeros(1, device=device, dtype=torch.float32),
+            var=torch.ones(1, device=device, dtype=torch.float32),
+            count=torch.tensor(1e-4, device=device, dtype=torch.float32),
+        )
+
+    def update(self, x: torch.Tensor) -> None:
+        x = x.reshape(-1).to(dtype=torch.float32)
+        if x.numel() == 0:
+            return
+        batch_mean = x.mean()
+        batch_var = x.var(unbiased=False)
+        batch_count = torch.tensor(float(x.numel()), device=x.device, dtype=torch.float32)
+
+        delta = batch_mean - self.mean
+        total_count = self.count + batch_count
+        new_mean = self.mean + delta * batch_count / total_count
+        m_a = self.var * self.count
+        m_b = batch_var * batch_count
+        correction = delta.pow(2) * self.count * batch_count / total_count
+        new_var = (m_a + m_b + correction) / total_count
+
+        self.mean = new_mean
+        self.var = new_var
+        self.count = total_count
+
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return {"mean": self.mean, "var": self.var, "count": self.count}
+
+    def load_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
+        self.mean = state_dict["mean"]
+        self.var = state_dict["var"]
+        self.count = state_dict["count"]
+
+
+class RewardNormalizer:
+    """Adaptive reward scaling with running reward statistics."""
+
+    def __init__(self, g_max: float, device: torch.device, eps: float = 1e-8):
+        self.g_max = g_max
+        self.eps = eps
+        self.device = device
+        self.rms = RunningMeanStd.create(device)
+        self.reward_abs_max = torch.tensor(0.0, device=device, dtype=torch.float32)
+
+    def update(self, rewards: torch.Tensor) -> None:
+        rewards = rewards.reshape(-1).to(device=self.device, dtype=torch.float32)
+        if rewards.numel() == 0:
+            return
+        self.rms.update(rewards)
+        self.reward_abs_max = torch.maximum(self.reward_abs_max, rewards.abs().max())
+
+    def normalize(self, rewards: torch.Tensor) -> torch.Tensor:
+        denominator = torch.maximum(
+            torch.sqrt(self.rms.var + self.eps),
+            self.reward_abs_max / max(self.g_max, self.eps),
+        )
+        return rewards / denominator
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "rms": self.rms.state_dict(),
+            "reward_abs_max": self.reward_abs_max,
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.rms.load_state_dict(state_dict["rms"])
+        self.reward_abs_max = state_dict["reward_abs_max"]
+
+
+class FlashSACLearner:
+    def __init__(
+        self,
+        obs_dim: int,
+        action_dim: int,
+        privileged_dim: int = 0,
+        device: str = "cpu",
+        gamma: float = 0.99,
+        tau: float = 0.01,
+        actor_lr: float = 3e-4,
+        critic_lr: float = 3e-4,
+        actor_hidden_dim: int = 128,
+        critic_hidden_dim: int = 256,
+        actor_num_blocks: int = 2,
+        critic_num_blocks: int = 2,
+        num_atoms: int = 101,
+        critic_min_v: float = -5.0,
+        critic_max_v: float = 5.0,
+        temp_initial_value: float = 0.01,
+        temp_target_sigma: float = 0.15,
+        temp_target_entropy: float | None = None,
+        actor_bc_alpha: float = 0.0,
+        actor_noise_zeta_mu: float = 2.0,
+        actor_noise_zeta_max: int = 16,
+        learning_rate_init: float = 3e-4,
+        learning_rate_peak: float = 3e-4,
+        learning_rate_end: float = 1.5e-4,
+        learning_rate_warmup_steps: int = 0,
+        learning_rate_decay_steps: int = 500000,
+        normalize_reward: bool = True,
+        normalized_g_max: float = 5.0,
+        n_step: int = 1,
+        obs_normalization: bool = False,
+        use_amp: bool = False,
+        use_compile: bool = False,
+    ):
+        self.device = torch.device(device)
+        self.gamma = gamma
+        self.tau = tau
+        self.n_step = n_step
+        self.actor_bc_alpha = actor_bc_alpha
+        self.obs_dim = obs_dim
+        self.critic_obs_dim = obs_dim + privileged_dim
+        self.action_dim = action_dim
+        self.privileged_dim = privileged_dim
+        self.update_count = 0
+        self.use_amp = bool(use_amp and self.device.type == "cuda")
+        self.use_compile = bool(
+            use_compile and hasattr(torch, "compile") and self.device.type == "cuda"
+        )
+
+        self.actor = FlashSACActor(
+            num_blocks=actor_num_blocks,
+            input_dim=obs_dim,
+            hidden_dim=actor_hidden_dim,
+            action_dim=action_dim,
+            noise_zeta_mu=actor_noise_zeta_mu,
+            noise_zeta_max=actor_noise_zeta_max,
+            device=self.device,
+        )
+        self.critic = FlashSACDoubleCritic(
+            num_blocks=critic_num_blocks,
+            input_dim=self.critic_obs_dim + action_dim,
+            hidden_dim=critic_hidden_dim,
+            num_bins=num_atoms,
+            min_v=critic_min_v,
+            max_v=critic_max_v,
+            device=self.device,
+        )
+        self.target_critic = copy.deepcopy(self.critic).to(self.device)
+        self.target_critic.eval()
+        self.temperature = FlashSACTemperature(temp_initial_value).to(self.device)
+
+        self.target_entropy = resolve_target_entropy(
+            action_dim=action_dim,
+            target_sigma=temp_target_sigma,
+            target_entropy=temp_target_entropy,
+        )
+
+        self.obs_normalizer: EmpiricalNormalization | nn.Identity
+        if obs_normalization:
+            self.obs_normalizer = EmpiricalNormalization(shape=obs_dim, device=self.device)
+        else:
+            self.obs_normalizer = nn.Identity()
+
+        self.reward_normalizer = (
+            RewardNormalizer(g_max=normalized_g_max, device=self.device)
+            if normalize_reward
+            else None
+        )
+
+        self.scaler: Any | None = getattr(torch.amp, "GradScaler")("cuda") if self.use_amp else None
+        lr_peak = learning_rate_peak if learning_rate_peak > 0 else actor_lr
+        fused = self.device.type == "cuda"
+        self.actor_optimizer = optim.Adam(self.actor.parameters(), lr=lr_peak, fused=fused)
+        self.critic_optimizer = optim.Adam(self.critic.parameters(), lr=lr_peak, fused=fused)
+        self.temperature_optimizer = optim.Adam(
+            self.temperature.parameters(), lr=lr_peak, fused=fused
+        )
+
+        scheduler_fn = build_lr_lambda(
+            init_lr=learning_rate_init,
+            peak_lr=lr_peak,
+            end_lr=learning_rate_end,
+            warmup_steps=learning_rate_warmup_steps,
+            decay_steps=learning_rate_decay_steps,
+        )
+        self.actor_scheduler = optim.lr_scheduler.LambdaLR(self.actor_optimizer, scheduler_fn)
+        self.critic_scheduler = optim.lr_scheduler.LambdaLR(self.critic_optimizer, scheduler_fn)
+        self.temperature_scheduler = optim.lr_scheduler.LambdaLR(
+            self.temperature_optimizer, scheduler_fn
+        )
+
+        if self.use_compile:
+            self.actor.get_mean_and_std = torch.compile(  # type: ignore[method-assign]
+                self.actor.get_mean_and_std, mode="reduce-overhead"
+            )
+
+    def _maybe_normalize_obs(self, obs: torch.Tensor, *, update: bool) -> torch.Tensor:
+        if isinstance(self.obs_normalizer, nn.Identity):
+            return obs
+        return cast(torch.Tensor, self.obs_normalizer(obs, update=update))
+
+    def _build_critic_obs(
+        self,
+        obs: torch.Tensor,
+        privileged: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if privileged is None:
+            return obs
+        return torch.cat([obs, privileged], dim=-1)
+
+    def _autocast(self):
+        return torch.autocast(device_type="cuda", dtype=torch.float16, enabled=self.use_amp)
+
+    @staticmethod
+    def _set_requires_grad(module: nn.Module, requires_grad: bool) -> None:
+        for param in module.parameters():
+            param.requires_grad_(requires_grad)
+
+    def update_critic(self, batch: dict[str, torch.Tensor]) -> dict[str, float]:
+        obs = batch["obs"].to(self.device)
+        actions = batch["actions"].to(self.device)
+        rewards = batch["rewards"].to(self.device)
+        next_obs = batch["next_obs"].to(self.device)
+        terminated = batch["dones"].to(self.device)
+        truncated = batch.get("truncated", torch.zeros_like(terminated)).to(self.device)
+        privileged = batch.get("privileged")
+        next_privileged = batch.get("next_privileged")
+        privileged = privileged.to(self.device) if privileged is not None else None
+        next_privileged = next_privileged.to(self.device) if next_privileged is not None else None
+
+        obs = self._maybe_normalize_obs(obs, update=True)
+        next_obs = self._maybe_normalize_obs(next_obs, update=False)
+        critic_obs = self._build_critic_obs(obs, privileged)
+        critic_next_obs = self._build_critic_obs(next_obs, next_privileged)
+
+        if self.reward_normalizer is not None:
+            self.reward_normalizer.update(rewards)
+            rewards = self.reward_normalizer.normalize(rewards)
+
+        gamma = self.gamma**self.n_step
+
+        with torch.no_grad():
+            with self._autocast():
+                next_actions, actor_info = self.actor(next_obs, training=False)
+                entropy_bonus = -self.temperature().detach() * actor_info["log_prob"]
+                next_q_values, next_q_info = self.target_critic(
+                    critic_next_obs, next_actions, training=False
+                )
+                next_q_log_probs = select_min_q_log_probs(next_q_values, next_q_info["log_prob"])
+                support = cast(torch.Tensor, self.target_critic.predictor.support)
+                target_probs = compute_categorical_td_target(
+                    support=support,
+                    target_log_probs=next_q_log_probs,
+                    reward=rewards,
+                    terminated=terminated,
+                    truncated=truncated,
+                    actor_entropy=entropy_bonus,
+                    gamma=gamma,
+                )
+
+        with self._autocast():
+            _, pred_info = self.critic(critic_obs, actions, training=True)
+            critic_loss = -(target_probs.unsqueeze(0) * pred_info["log_prob"]).sum(dim=-1).mean()
+
+        self.critic_optimizer.zero_grad(set_to_none=True)
+        if self.scaler is not None:
+            self.scaler.scale(critic_loss).backward()
+            self.scaler.step(self.critic_optimizer)
+            self.scaler.update()
+        else:
+            critic_loss.backward()
+            self.critic_optimizer.step()
+        self.critic_scheduler.step()
+        self.critic.normalize_parameters()
+
+        return {
+            "critic_loss": float(critic_loss.detach().cpu()),
+            "reward_scale_std": float(
+                torch.sqrt(self.reward_normalizer.rms.var).detach().cpu()
+                if self.reward_normalizer is not None
+                else torch.tensor(1.0)
+            ),
+        }
+
+    def update_actor(self, batch: dict[str, torch.Tensor]) -> dict[str, float]:
+        obs = batch["obs"].to(self.device)
+        expert_actions = batch["actions"].to(self.device)
+        privileged = batch.get("privileged")
+        privileged = privileged.to(self.device) if privileged is not None else None
+
+        obs = self._maybe_normalize_obs(obs, update=False)
+        critic_obs = self._build_critic_obs(obs, privileged)
+
+        with self._autocast():
+            actions, actor_info = self.actor(obs, training=True)
+            log_probs = actor_info["log_prob"]
+
+            self._set_requires_grad(self.critic, False)
+            q_values, _ = self.critic(critic_obs, actions, training=False)
+            self._set_requires_grad(self.critic, True)
+            min_q = torch.min(q_values[0], q_values[1])
+
+            actor_loss = (self.temperature().detach() * log_probs - min_q).mean()
+            if self.actor_bc_alpha > 0:
+                bc_loss = torch.mean((actions - expert_actions) ** 2)
+                actor_loss = (
+                    actor_loss + self.actor_bc_alpha * min_q.abs().mean().detach() * bc_loss
+                )
+
+        self.actor_optimizer.zero_grad(set_to_none=True)
+        if self.scaler is not None:
+            self.scaler.scale(actor_loss).backward()
+            self.scaler.step(self.actor_optimizer)
+            self.scaler.update()
+        else:
+            actor_loss.backward()
+            self.actor_optimizer.step()
+        self.actor_scheduler.step()
+        self.actor.normalize_parameters()
+
+        entropy = -log_probs.detach().mean()
+        temp_value = self.temperature()
+        temp_loss = temp_value * (entropy - self.target_entropy)
+        self.temperature_optimizer.zero_grad(set_to_none=True)
+        temp_loss.backward()
+        self.temperature_optimizer.step()
+        self.temperature_scheduler.step()
+
+        return {
+            "actor_loss": float(actor_loss.detach().cpu()),
+            "actor_entropy": float(entropy.detach().cpu()),
+            "temperature": float(temp_value.detach().cpu()),
+            "temperature_loss": float(temp_loss.detach().cpu()),
+        }
+
+    def soft_update_target(self) -> None:
+        with torch.no_grad():
+            for target_param, param in zip(
+                self.target_critic.parameters(), self.critic.parameters()
+            ):
+                target_param.data.mul_(1.0 - self.tau).add_(param.data, alpha=self.tau)
+
+    def get_state_dict(self) -> dict[str, Any]:
+        return {
+            "actor": self.actor.state_dict(),
+            "critic": self.critic.state_dict(),
+            "target_critic": self.target_critic.state_dict(),
+            "temperature": self.temperature.state_dict(),
+            "actor_optimizer": self.actor_optimizer.state_dict(),
+            "critic_optimizer": self.critic_optimizer.state_dict(),
+            "temperature_optimizer": self.temperature_optimizer.state_dict(),
+            "actor_scheduler": self.actor_scheduler.state_dict(),
+            "critic_scheduler": self.critic_scheduler.state_dict(),
+            "temperature_scheduler": self.temperature_scheduler.state_dict(),
+            "obs_normalizer": (
+                self.obs_normalizer.state_dict()
+                if hasattr(self.obs_normalizer, "state_dict")
+                else None
+            ),
+            "reward_normalizer": (
+                self.reward_normalizer.state_dict() if self.reward_normalizer is not None else None
+            ),
+            "update_count": self.update_count,
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        self.actor.load_state_dict(state_dict["actor"])
+        self.critic.load_state_dict(state_dict["critic"])
+        self.target_critic.load_state_dict(state_dict["target_critic"])
+        self.temperature.load_state_dict(state_dict["temperature"])
+        self.actor_optimizer.load_state_dict(state_dict["actor_optimizer"])
+        self.critic_optimizer.load_state_dict(state_dict["critic_optimizer"])
+        self.temperature_optimizer.load_state_dict(state_dict["temperature_optimizer"])
+        self.actor_scheduler.load_state_dict(state_dict["actor_scheduler"])
+        self.critic_scheduler.load_state_dict(state_dict["critic_scheduler"])
+        self.temperature_scheduler.load_state_dict(state_dict["temperature_scheduler"])
+        if state_dict.get("obs_normalizer") and hasattr(self.obs_normalizer, "load_state_dict"):
+            self.obs_normalizer.load_state_dict(state_dict["obs_normalizer"])
+        if self.reward_normalizer is not None and state_dict.get("reward_normalizer"):
+            self.reward_normalizer.load_state_dict(state_dict["reward_normalizer"])
+        self.update_count = int(state_dict.get("update_count", 0))

--- a/src/unilab/algos/torch/flash_sac/network.py
+++ b/src/unilab/algos/torch/flash_sac/network.py
@@ -1,0 +1,193 @@
+"""FlashSAC actor, critic, and temperature modules."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import torch
+import torch.nn as nn
+
+from unilab.algos.torch.flash_sac.layers import (
+    EnsembleCategoricalValue,
+    EnsembleFlashSACBlock,
+    EnsembleFlashSACEmbedder,
+    EnsembleUnitRMSNorm,
+    FlashSACBlock,
+    FlashSACEmbedder,
+    NormalTanhPolicy,
+    UnitRMSNorm,
+)
+
+
+def _normalize_module_tree(module: nn.Module) -> None:
+    with torch.no_grad():
+        for child in module.modules():
+            if child is module:
+                continue
+            normalize = getattr(child, "normalize_parameters", None)
+            if callable(normalize):
+                normalize()
+
+
+class FlashSACActor(nn.Module):
+    zeta_cdf: torch.Tensor
+    _noise: torch.Tensor
+    _repeat_count: torch.Tensor
+    _repeat_target: torch.Tensor
+
+    def __init__(
+        self,
+        num_blocks: int,
+        input_dim: int,
+        hidden_dim: int,
+        action_dim: int,
+        noise_zeta_mu: float = 2.0,
+        noise_zeta_max: int = 16,
+        device: str | torch.device = "cpu",
+    ):
+        super().__init__()
+        self.embedder = FlashSACEmbedder(input_dim=input_dim, hidden_dim=hidden_dim)
+        self.encoder = nn.ModuleList([FlashSACBlock(hidden_dim) for _ in range(num_blocks)])
+        self.post_norm = UnitRMSNorm(hidden_dim)
+        self.predictor = NormalTanhPolicy(hidden_dim=hidden_dim, action_dim=action_dim)
+        self.noise_zeta_mu = noise_zeta_mu
+        self.noise_zeta_max = noise_zeta_max
+        ns = torch.arange(1, noise_zeta_max + 1, dtype=torch.float32)
+        pmf = ns.pow(-noise_zeta_mu)
+        self.register_buffer("zeta_cdf", torch.cumsum(pmf / pmf.sum(), dim=0))
+        self.register_buffer("_noise", torch.zeros(0), persistent=False)
+        self.register_buffer("_repeat_count", torch.zeros(0, dtype=torch.int32), persistent=False)
+        self.register_buffer("_repeat_target", torch.zeros(0, dtype=torch.int32), persistent=False)
+        self.to(device)
+        self.normalize_parameters()
+
+    def normalize_parameters(self) -> None:
+        _normalize_module_tree(self)
+
+    def _encode(self, observations: torch.Tensor, training: bool) -> torch.Tensor:
+        x = self.embedder(observations, training=training)
+        for block in self.encoder:
+            x = block(x, training=training)
+        return cast(torch.Tensor, self.post_norm(x))
+
+    def get_mean_and_std(
+        self, observations: torch.Tensor, training: bool
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        encoded = self._encode(observations, training=training)
+        return self.predictor.get_mean_and_std(encoded)
+
+    def forward(
+        self, observations: torch.Tensor, training: bool
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        encoded = self._encode(observations, training=training)
+        return cast(tuple[torch.Tensor, dict[str, torch.Tensor]], self.predictor(encoded))
+
+    def _ensure_exploration_state(
+        self, batch_size: int, action_dim: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        if (
+            self._noise.numel() == batch_size * action_dim
+            and self._noise.device == device
+            and self._noise.dtype == dtype
+        ):
+            return
+        self._noise = torch.zeros(batch_size, action_dim, device=device, dtype=dtype)
+        self._repeat_count = torch.zeros(batch_size, device=device, dtype=torch.int32)
+        self._repeat_target = torch.zeros(batch_size, device=device, dtype=torch.int32)
+
+    def _sample_repeat_targets(self, batch_size: int, device: torch.device) -> torch.Tensor:
+        draws = torch.rand(batch_size, device=device)
+        cdf = self.zeta_cdf.to(device)
+        return cast(torch.Tensor, torch.searchsorted(cdf, draws).to(torch.int32) + 1)
+
+    @torch.no_grad()
+    def explore(
+        self,
+        obs: torch.Tensor,
+        dones: torch.Tensor | None = None,
+        deterministic: bool = False,
+    ) -> torch.Tensor:
+        if isinstance(dones, bool):
+            deterministic = dones
+            dones = None
+        mean, std = self.get_mean_and_std(obs, training=False)
+        if deterministic:
+            return torch.tanh(mean)
+
+        batch_size, action_dim = mean.shape
+        self._ensure_exploration_state(batch_size, action_dim, mean.device, mean.dtype)
+
+        if dones is None:
+            done_mask = torch.zeros(batch_size, device=mean.device, dtype=torch.bool)
+        else:
+            done_mask = dones.to(device=mean.device).reshape(-1) > 0.5
+
+        reinit = done_mask | (self._repeat_count <= 0) | (self._repeat_count >= self._repeat_target)
+        if torch.any(reinit):
+            new_noise = torch.randn_like(mean)
+            new_target = self._sample_repeat_targets(batch_size, mean.device)
+            self._noise = torch.where(reinit.unsqueeze(-1), new_noise, self._noise)
+            self._repeat_target = torch.where(reinit, new_target, self._repeat_target)
+            self._repeat_count = torch.where(
+                reinit, torch.zeros_like(self._repeat_count), self._repeat_count
+            )
+
+        actions = torch.tanh(mean + std * self._noise)
+        self._repeat_count = self._repeat_count + 1
+        return actions
+
+
+class FlashSACDoubleCritic(nn.Module):
+    def __init__(
+        self,
+        num_blocks: int,
+        input_dim: int,
+        hidden_dim: int,
+        num_bins: int,
+        min_v: float,
+        max_v: float,
+        num_qs: int = 2,
+        device: str | torch.device = "cpu",
+    ):
+        super().__init__()
+        self.embedder = EnsembleFlashSACEmbedder(num_qs, input_dim, hidden_dim)
+        self.encoder = nn.ModuleList(
+            [EnsembleFlashSACBlock(num_qs, hidden_dim) for _ in range(num_blocks)]
+        )
+        self.post_norm = EnsembleUnitRMSNorm(num_qs, hidden_dim)
+        self.predictor = EnsembleCategoricalValue(
+            num_ensemble=num_qs,
+            hidden_dim=hidden_dim,
+            num_bins=num_bins,
+            min_v=min_v,
+            max_v=max_v,
+        )
+        self.to(device)
+        self.normalize_parameters()
+
+    def normalize_parameters(self) -> None:
+        _normalize_module_tree(self)
+
+    def forward(
+        self,
+        observations: torch.Tensor,
+        actions: torch.Tensor,
+        training: bool,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        x = torch.cat((observations, actions), dim=-1)
+        x = x.unsqueeze(0).expand(self.predictor.logit_w.weight.shape[0], -1, -1)
+        x = self.embedder(x, training=training)
+        for block in self.encoder:
+            x = block(x, training=training)
+        x = self.post_norm(x)
+        return cast(tuple[torch.Tensor, dict[str, torch.Tensor]], self.predictor(x))
+
+
+class FlashSACTemperature(nn.Module):
+    def __init__(self, initial_value: float = 0.01):
+        super().__init__()
+        self.log_temp = nn.Parameter(torch.tensor([math.log(initial_value)], dtype=torch.float32))
+
+    def forward(self) -> torch.Tensor:
+        return torch.exp(self.log_temp)

--- a/src/unilab/algos/torch/flash_sac/runner.py
+++ b/src/unilab/algos/torch/flash_sac/runner.py
@@ -1,0 +1,129 @@
+"""FlashSAC runner using the shared off-policy runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+from unilab.algos.torch.offpolicy.runner import OffPolicyRunner
+from unilab.utils.device_utils import get_default_device
+
+
+class FlashSACRunner(OffPolicyRunner):
+    def __init__(
+        self,
+        env_name: str,
+        env_cfg_override: dict[str, Any] | None = None,
+        device: str | None = None,
+        num_envs: int = 2048,
+        replay_buffer_n: int = 512,
+        batch_size: int = 2048,
+        warmup_steps: int = 10000,
+        updates_per_step: int = 1,
+        policy_frequency: int = 2,
+        sync_collection: bool = True,
+        env_steps_per_sync: int = 1,
+        gamma: float = 0.99,
+        tau: float = 0.01,
+        actor_lr: float = 3e-4,
+        critic_lr: float = 3e-4,
+        obs_normalization: bool = False,
+        actor_hidden_dim: int = 128,
+        critic_hidden_dim: int = 256,
+        num_atoms: int = 101,
+        use_amp: bool = False,
+        sim_backend: str = "mujoco",
+        actor_num_blocks: int = 2,
+        critic_num_blocks: int = 2,
+        actor_bc_alpha: float = 0.0,
+        actor_noise_zeta_mu: float = 2.0,
+        actor_noise_zeta_max: int = 16,
+        critic_min_v: float = -5.0,
+        critic_max_v: float = 5.0,
+        target_sigma: float = 0.15,
+        target_entropy: float | None = None,
+        temp_initial_value: float = 0.01,
+        learning_rate_init: float = 3e-4,
+        learning_rate_peak: float = 3e-4,
+        learning_rate_end: float = 1.5e-4,
+        learning_rate_warmup_steps: int = 0,
+        learning_rate_decay_steps: int = 500000,
+        normalize_reward: bool = True,
+        normalized_g_max: float = 5.0,
+        n_step: int = 1,
+        use_compile: bool = False,
+    ):
+        from unilab.base import registry
+        from unilab.utils.algo_utils import ensure_registries
+        from unilab.utils.obs_utils import get_obs_dims
+
+        ensure_registries()
+        env: Any = registry.make(
+            env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
+        )
+        obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
+        action_shape = env.action_space.shape
+        assert action_shape is not None
+        action_dim = int(action_shape[0])
+        env.close()
+
+        runtime_device = device or get_default_device()
+        learner = FlashSACLearner(
+            obs_dim=obs_dim,
+            action_dim=action_dim,
+            privileged_dim=privileged_dim,
+            device=runtime_device,
+            gamma=gamma,
+            tau=tau,
+            actor_lr=actor_lr,
+            critic_lr=critic_lr,
+            actor_hidden_dim=actor_hidden_dim,
+            critic_hidden_dim=critic_hidden_dim,
+            actor_num_blocks=actor_num_blocks,
+            critic_num_blocks=critic_num_blocks,
+            num_atoms=num_atoms,
+            critic_min_v=critic_min_v,
+            critic_max_v=critic_max_v,
+            temp_initial_value=temp_initial_value,
+            temp_target_sigma=target_sigma,
+            temp_target_entropy=target_entropy,
+            actor_bc_alpha=actor_bc_alpha,
+            actor_noise_zeta_mu=actor_noise_zeta_mu,
+            actor_noise_zeta_max=actor_noise_zeta_max,
+            learning_rate_init=learning_rate_init,
+            learning_rate_peak=learning_rate_peak,
+            learning_rate_end=learning_rate_end,
+            learning_rate_warmup_steps=learning_rate_warmup_steps,
+            learning_rate_decay_steps=learning_rate_decay_steps,
+            normalize_reward=normalize_reward,
+            normalized_g_max=normalized_g_max,
+            n_step=n_step,
+            obs_normalization=obs_normalization,
+            use_amp=use_amp,
+            use_compile=use_compile,
+        )
+
+        super().__init__(
+            learner=learner,
+            env_name=env_name,
+            algo_type="flashsac",
+            num_envs=num_envs,
+            replay_buffer_n=replay_buffer_n,
+            batch_size=batch_size,
+            warmup_steps=warmup_steps,
+            updates_per_step=updates_per_step,
+            policy_frequency=policy_frequency,
+            sync_collection=sync_collection,
+            env_steps_per_sync=env_steps_per_sync,
+            device=runtime_device,
+            actor_hidden_dim=actor_hidden_dim,
+            use_layer_norm=False,
+            obs_normalization=obs_normalization,
+            sim_backend=sim_backend,
+            env_cfg_override=env_cfg_override,
+            actor_kwargs={
+                "actor_num_blocks": actor_num_blocks,
+                "actor_noise_zeta_mu": actor_noise_zeta_mu,
+                "actor_noise_zeta_max": actor_noise_zeta_max,
+            },
+        )

--- a/src/unilab/algos/torch/flash_sac/update.py
+++ b/src/unilab/algos/torch/flash_sac/update.py
@@ -1,0 +1,85 @@
+"""FlashSAC update helpers."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def build_lr_lambda(
+    init_lr: float,
+    peak_lr: float,
+    end_lr: float,
+    warmup_steps: int,
+    decay_steps: int,
+):
+    init_ratio = init_lr / peak_lr if peak_lr > 0 else 1.0
+    end_ratio = end_lr / peak_lr if peak_lr > 0 else 1.0
+    warmup_steps = max(int(warmup_steps), 0)
+    decay_steps = max(int(decay_steps), warmup_steps + 1)
+
+    def schedule(step: int) -> float:
+        if warmup_steps > 0 and step < warmup_steps:
+            progress = float(step) / float(max(warmup_steps, 1))
+            return init_ratio + (1.0 - init_ratio) * progress
+        progress = min(max((step - warmup_steps) / float(decay_steps - warmup_steps), 0.0), 1.0)
+        cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+        return end_ratio + (1.0 - end_ratio) * cosine
+
+    return schedule
+
+
+def select_min_q_log_probs(
+    next_q_values: torch.Tensor,
+    next_q_log_probs: torch.Tensor,
+) -> torch.Tensor:
+    num_bins = next_q_log_probs.shape[-1]
+    min_indices = next_q_values.argmin(dim=0)
+    gather_index = min_indices[None, :, None].expand(1, -1, num_bins)
+    return torch.gather(next_q_log_probs, dim=0, index=gather_index)[0]
+
+
+def compute_categorical_td_target(
+    support: torch.Tensor,
+    target_log_probs: torch.Tensor,
+    reward: torch.Tensor,
+    terminated: torch.Tensor,
+    truncated: torch.Tensor,
+    actor_entropy: torch.Tensor,
+    gamma: float,
+) -> torch.Tensor:
+    batch_size, num_bins = target_log_probs.shape
+    support = support.view(1, -1)
+    reward = reward.view(-1, 1)
+    terminated = terminated.view(-1, 1)
+    truncated = truncated.view(-1, 1)
+    actor_entropy = actor_entropy.view(-1, 1)
+
+    bootstrap = torch.clamp(1.0 - terminated + truncated, 0.0, 1.0)
+    target_bin_values = reward + bootstrap * gamma * (support - actor_entropy)
+    target_bin_values = torch.clamp(target_bin_values, float(support.min()), float(support.max()))
+
+    bin_width = float(support[0, 1] - support[0, 0])
+    offsets = (target_bin_values - float(support.min())) / max(bin_width, 1e-8)
+    lower = torch.floor(offsets).long().clamp(0, num_bins - 1)
+    upper = torch.ceil(offsets).long().clamp(0, num_bins - 1)
+    frac = offsets - lower.float()
+
+    probs = target_log_probs.exp()
+    target_probs = torch.zeros(batch_size, num_bins, dtype=probs.dtype, device=probs.device)
+    target_probs.scatter_add_(1, lower, probs * (1.0 - frac))
+    target_probs.scatter_add_(1, upper, probs * frac)
+    return target_probs
+
+
+def resolve_target_entropy(
+    action_dim: int,
+    target_sigma: float,
+    target_entropy: float | None,
+) -> float:
+    if target_entropy is not None:
+        return float(target_entropy)
+    sigma = max(float(target_sigma), 1e-6)
+    per_dim_entropy = 0.5 * math.log(2.0 * math.pi * math.e * sigma * sigma)
+    return float(action_dim) * per_dim_entropy

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -23,7 +23,7 @@ class OffPolicyRunner(AsyncRunner):
         self,
         learner,
         env_name: str,
-        algo_type: str,  # "sac" or "td3"
+        algo_type: str,  # "sac", "td3", or "flashsac"
         num_envs: int = 4096,
         replay_buffer_n: int = 1024,
         batch_size: int = 8192,
@@ -38,6 +38,7 @@ class OffPolicyRunner(AsyncRunner):
         obs_normalization: bool = False,
         sim_backend: str = "mujoco",
         env_cfg_override: dict | None = None,
+        actor_kwargs: dict | None = None,
     ):
         super().__init__(
             env_name=env_name,
@@ -62,6 +63,7 @@ class OffPolicyRunner(AsyncRunner):
         self.actor_hidden_dim = actor_hidden_dim
         self.use_layer_norm = use_layer_norm
         self.obs_normalization = obs_normalization
+        self.actor_kwargs = actor_kwargs or {}
 
         self.obs_dim, self.action_dim, self.privileged_dim = get_env_dims(
             self.env_name, sim_backend, env_cfg_override
@@ -145,6 +147,7 @@ class OffPolicyRunner(AsyncRunner):
             "env_cfg_override": self.env_cfg_override,
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
+            "actor_kwargs": self.actor_kwargs,
         }
         self._start_collector(
             target_fn=off_policy_collector_fn,
@@ -157,7 +160,9 @@ class OffPolicyRunner(AsyncRunner):
 
         # Setup logger
         logger = OffPolicyLogger(
-            algo_name=f"Fast{self.algo_type.upper()}",
+            algo_name=(
+                "FlashSAC" if self.algo_type == "flashsac" else f"Fast{self.algo_type.upper()}"
+            ),
             max_iterations=max_iterations,
             num_envs=self.num_envs,
             env_name=self.env_name,

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -61,6 +61,7 @@ def off_policy_collector_fn(
     env_cfg_override: dict | None = None,
     obs_dim: int | None = None,
     action_dim: int | None = None,
+    actor_kwargs: dict | None = None,
     **kwargs,
 ):
     """Entry point for the off-policy collector subprocess."""
@@ -92,6 +93,7 @@ def off_policy_collector_fn(
             env_cfg_override=env_cfg_override,
             obs_dim=obs_dim,
             action_dim=action_dim,
+            actor_kwargs=actor_kwargs,
         )
     except Exception as e:
         print(f"[Collector] Exception: {e}", file=sys.stderr, flush=True)
@@ -126,6 +128,7 @@ def _run_collector(
     env_cfg_override,
     obs_dim,
     action_dim,
+    actor_kwargs,
 ):
     from unilab.base import registry
     from unilab.ipc import SharedWeightSync
@@ -151,7 +154,14 @@ def _run_collector(
         action_dim=action_dim,
     )
     actor = build_actor(
-        algo_type, obs_dim, action_dim, actor_hidden_dim, use_layer_norm, "cpu", num_envs
+        algo_type,
+        obs_dim,
+        action_dim,
+        actor_hidden_dim,
+        use_layer_norm,
+        "cpu",
+        num_envs,
+        **(actor_kwargs or {}),
     )
     actor.eval()
 

--- a/src/unilab/config/structured_configs.py
+++ b/src/unilab/config/structured_configs.py
@@ -96,6 +96,58 @@ class TD3Config(BaseConfig):
     algo_params: TD3AlgoParams = field(default_factory=TD3AlgoParams)
 
 
+# ── Off-policy: FlashSAC ─────────────────────────────────────────────────────
+
+
+@dataclass
+class FlashSACAlgoParams:
+    normalize_reward: bool = True
+    normalized_g_max: float = 5.0
+    actor_num_blocks: int = 2
+    critic_num_blocks: int = 2
+    actor_bc_alpha: float = 0.0
+    actor_noise_zeta_mu: float = 2.0
+    actor_noise_zeta_max: int = 16
+    critic_min_v: float = -5.0
+    critic_max_v: float = 5.0
+    temp_initial_value: float = 0.01
+    temp_target_sigma: float = 0.15
+    temp_target_entropy: float | None = None
+    learning_rate_init: float = 3e-4
+    learning_rate_peak: float = 3e-4
+    learning_rate_end: float = 1.5e-4
+    learning_rate_warmup_steps: int = 0
+    learning_rate_decay_steps: int = 500000
+    n_step: int = 1
+    use_compile: bool = False
+
+
+@dataclass
+class FlashSACConfig(BaseConfig):
+    algo: str = "flashsac"
+    algo_log_name: str = "flash_sac"
+    seed: int = 1
+    num_envs: int = 2048
+    batch_size: int = 2048
+    replay_buffer_n: int = 512
+    updates_per_step: int = 1
+    warmup_steps: int = 10000
+    policy_frequency: int = 2
+    env_steps_per_sync: int = 1
+    max_iterations: int = 5000
+    save_interval: int = 1000
+    gamma: float = 0.99
+    tau: float = 0.01
+    actor_lr: float = 3e-4
+    critic_lr: float = 3e-4
+    actor_hidden_dim: int = 128
+    critic_hidden_dim: int = 256
+    num_atoms: int = 101
+    obs_normalization: bool = False
+    use_layer_norm: bool = False
+    algo_params: FlashSACAlgoParams = field(default_factory=FlashSACAlgoParams)
+
+
 # ── APPO ─────────────────────────────────────────────────────────────────────
 
 

--- a/src/unilab/ipc/async_runner.py
+++ b/src/unilab/ipc/async_runner.py
@@ -58,7 +58,10 @@ class AsyncRunner(ABC):
     ) -> None: ...
 
     def _start_collector(self, target_fn: Callable, kwargs: dict) -> None:
-        self._collector_process = _SPAWN_CTX.Process(target=target_fn, kwargs=kwargs, daemon=True)
+        collector_kwargs = {**self.extra_kwargs, **kwargs}
+        self._collector_process = _SPAWN_CTX.Process(
+            target=target_fn, kwargs=collector_kwargs, daemon=True
+        )
         self._collector_process.start()
 
     def close(self) -> None:

--- a/src/unilab/utils/algo_utils.py
+++ b/src/unilab/utils/algo_utils.py
@@ -84,7 +84,16 @@ def ensure_registries(
 
 
 def build_actor(
-    algo_type, obs_dim, action_dim, actor_hidden_dim, use_layer_norm, device, num_envs=1
+    algo_type,
+    obs_dim,
+    action_dim,
+    actor_hidden_dim,
+    use_layer_norm,
+    device,
+    num_envs=1,
+    actor_num_blocks: int = 2,
+    actor_noise_zeta_mu: float = 2.0,
+    actor_noise_zeta_max: int = 16,
 ):
     """Build the correct actor model based on algorithm type."""
     if algo_type == "sac":
@@ -108,6 +117,18 @@ def build_actor(
             init_scale=0.01,
             log_std_min=-0.9,
             log_std_max=0.0,
+            device=device,
+        )
+    elif algo_type == "flashsac":
+        from unilab.algos.torch.flash_sac.network import FlashSACActor
+
+        return FlashSACActor(
+            num_blocks=actor_num_blocks,
+            input_dim=obs_dim,
+            hidden_dim=actor_hidden_dim,
+            action_dim=action_dim,
+            noise_zeta_mu=actor_noise_zeta_mu,
+            noise_zeta_max=actor_noise_zeta_max,
             device=device,
         )
     else:

--- a/tests/algos/test_flash_sac_learner.py
+++ b/tests/algos/test_flash_sac_learner.py
@@ -1,0 +1,77 @@
+"""Unit tests for FlashSAC learner and actor interfaces."""
+
+from __future__ import annotations
+
+import torch
+
+from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+
+
+def _make_batch(batch_size: int = 32) -> dict[str, torch.Tensor]:
+    obs = torch.randn(batch_size, 98)
+    privileged = torch.randn(batch_size, 3)
+    actions = torch.tanh(torch.randn(batch_size, 29))
+    rewards = torch.randn(batch_size)
+    next_obs = torch.randn(batch_size, 98)
+    next_privileged = torch.randn(batch_size, 3)
+    dones = torch.zeros(batch_size)
+    truncated = torch.zeros(batch_size)
+    return {
+        "obs": obs,
+        "privileged": privileged,
+        "actions": actions,
+        "rewards": rewards,
+        "next_obs": next_obs,
+        "next_privileged": next_privileged,
+        "dones": dones,
+        "truncated": truncated,
+    }
+
+
+def test_flashsac_learner_exposes_expected_dims():
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+
+    assert learner.obs_dim == 98
+    assert learner.critic_obs_dim == 101
+    assert learner.action_dim == 29
+
+
+def test_flashsac_actor_explore_and_forward_shapes():
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    obs = torch.randn(4, 98)
+
+    actions = learner.actor.explore(obs, deterministic=False)
+    deterministic_actions = learner.actor.explore(obs, deterministic=True)
+    sampled_actions, info = learner.actor(obs, training=True)
+
+    assert actions.shape == (4, 29)
+    assert deterministic_actions.shape == (4, 29)
+    assert sampled_actions.shape == (4, 29)
+    assert info["log_prob"].shape == (4,)
+
+
+def test_flashsac_update_steps_run_on_cpu():
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    batch = _make_batch()
+
+    critic_metrics = learner.update_critic(batch)
+    actor_metrics = learner.update_actor(batch)
+    learner.soft_update_target()
+
+    assert "critic_loss" in critic_metrics
+    assert "reward_scale_std" in critic_metrics
+    assert "actor_loss" in actor_metrics
+    assert "temperature" in actor_metrics
+
+
+def test_flashsac_state_dict_round_trip():
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    batch = _make_batch()
+    learner.update_critic(batch)
+    learner.update_actor(batch)
+    state_dict = learner.get_state_dict()
+
+    restored = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    restored.load_state_dict(state_dict)
+
+    assert restored.get_state_dict()["update_count"] == learner.get_state_dict()["update_count"]

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -36,6 +36,17 @@ def test_td3_config_defaults():
     assert cfg.algo_params.weight_decay == 0.1
 
 
+def test_flashsac_config_defaults():
+    from unilab.config.structured_configs import FlashSACAlgoParams, FlashSACConfig
+
+    cfg = FlashSACConfig()
+    assert cfg.algo == "flashsac"
+    assert cfg.batch_size == 2048
+    assert cfg.obs_normalization is False
+    assert isinstance(cfg.algo_params, FlashSACAlgoParams)
+    assert cfg.algo_params.normalize_reward is True
+
+
 def test_ppo_config_defaults():
     from unilab.config.structured_configs import PPOConfig
 
@@ -121,6 +132,23 @@ def test_offpolicy_go2_task_overrides():
         cfg = compose("config", overrides=["algo=sac", "task=sac/go2_joystick/mujoco"])
     assert cfg.algo.num_envs == 1024
     assert cfg.training.task_name == "Go2JoystickFlatTerrain"
+
+
+def test_offpolicy_flashsac_g1_task_overrides():
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "offpolicy"), version_base="1.3"):
+        cfg = compose(
+            "config",
+            overrides=["algo=flashsac", "task=flashsac/g1_sac/mujoco"],
+        )
+    assert cfg.algo.algo == "flashsac"
+    assert cfg.training.task_name == "G1WalkTaskMjSAC"
+    assert cfg.training.sim_backend == "mujoco"
+    assert cfg.algo.algo_params.actor_num_blocks == 2
+    assert cfg.algo.algo_params.normalize_reward is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1025,6 +1025,25 @@ def test_offpolicy_td3_hydra_default_algo_log_name():
     assert cfg.algo.load_run == "-1"
 
 
+def test_offpolicy_flashsac_hydra_algo_log_name():
+    cfg = _offpolicy_cfg(["algo=flashsac", "task=flashsac/g1_sac/mujoco"])
+    assert cfg.algo.algo_log_name == "flash_sac"
+    assert cfg.algo.load_run == "-1"
+
+
+def test_offpolicy_flashsac_rejects_multi_gpu():
+    cfg = _offpolicy_cfg(
+        [
+            "algo=flashsac",
+            "task=flashsac/g1_sac/mujoco",
+            "training.num_gpus=2",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="FlashSAC does not support training.num_gpus > 1"):
+        _offpolicy().build_runner("flashsac", cfg)
+
+
 def test_train_rsl_rl_get_log_root_uses_algo_log_name(monkeypatch: pytest.MonkeyPatch):
     """Verify _get_log_root uses algo.algo_log_name (issue #168)."""
     mod = _train_rsl_rl(monkeypatch)

--- a/tests/utils/test_algo_utils.py
+++ b/tests/utils/test_algo_utils.py
@@ -186,6 +186,21 @@ class TestBuildActor:
         )
         assert hasattr(actor, "forward")
 
+    def test_builds_flashsac_actor(self) -> None:
+        actor = build_actor(
+            algo_type="flashsac",
+            obs_dim=98,
+            action_dim=29,
+            actor_hidden_dim=128,
+            use_layer_norm=False,
+            device="cpu",
+            actor_num_blocks=2,
+            actor_noise_zeta_mu=2.0,
+            actor_noise_zeta_max=16,
+        )
+        assert hasattr(actor, "forward")
+        assert hasattr(actor, "explore")
+
     def test_raises_for_unknown_algo_type(self) -> None:
         with pytest.raises(ValueError, match="Unknown algo_type"):
             build_actor(


### PR DESCRIPTION
## Summary

- add `algo=flashsac` to the unified off-policy training entrypoint
- add a dedicated `src/unilab/algos/torch/flash_sac/` package with runner, learner, network, layer, and update modules
- add Hydra config/schema coverage for `flashsac` and `task=flashsac/g1_sac/{mujoco,motrix}`
- extend actor/collector wiring and tests for FlashSAC compose and learner updates

## Validation

- `make check`
- `make test`

## Impact Scope

- offpolicy training entrypoint
- torch offpolicy runtime wiring
- Hydra structured configs and task owners
- FlashSAC algorithm implementation and unit coverage