### PR TITLE
 优化 G1 SAC locomotion 步态自然性

### DIFF
--- a/conf/offpolicy/task/sac/g1_sac/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_sac/mujoco.yaml
@@ -11,15 +11,20 @@ algo:
   algo_params:
     alpha_init: 0.001
     target_entropy_ratio: 0.0
+env:
+  control_config:
+    action_scale: 1.0
+  gait_phase_init_mode: "offset_phase"
+  reset_base_qvel_limit: 0.5
 reward:
   scales:
     tracking_lin_vel: 2.0
     tracking_ang_vel: 1.5
     penalty_ang_vel_xy: -1.0
     penalty_orientation: -10.0
-    penalty_action_rate: -2.0
+    penalty_action_rate: -4.0
     pose: -0.5
-    penalty_feet_ori: -25.0
+    penalty_feet_ori: -20.0
     feet_phase: 5.0
     alive: 10.0
   tracking_sigma: 0.25
@@ -28,6 +33,6 @@ reward:
   max_tilt_deg: 65.0
   gait_frequency: 1.5
   feet_phase_swing_height: 0.09
-  feet_phase_tracking_sigma: 0.008
+  feet_phase_tracking_sigma: 0.04
   close_feet_threshold: 0.15
   pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -26,7 +26,7 @@ from unilab.envs.locomotion.g1.joystick import (
 
 @dataclass
 class ControlConfigSAC:
-    action_scale: float = 1.0  # holosoma 0.25
+    action_scale: float = 1.0
     simulate_action_latency: bool = False
 
 

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -111,6 +111,10 @@ def test_offpolicy_sac_g1_task_overrides():
     assert cfg.algo.algo_params.target_entropy_ratio == pytest.approx(0.0)
     assert cfg.training.task_name == "G1WalkTaskMjSAC"
 
+    assert cfg.env.control_config.action_scale == pytest.approx(1.0)
+    assert cfg.env.gait_phase_init_mode == "offset_phase"
+    assert cfg.env.reset_base_qvel_limit == pytest.approx(0.5)
+
 
 def test_offpolicy_td3_defaults():
     from hydra import compose, initialize_config_dir


### PR DESCRIPTION
## Summary

原因：G1WalkTaskMjSAC 的训练配置注释声称"对齐 holosoma"，但 UniLab 与 holosoma 使用了不同的 MuJoCo XML actuator 架构，导致直接对齐参数反而使步态变差

holosoma：<motor> actuator + 外部软件 PD（增益可在训练配置中自由调节，有效力矩远高于字面值）
UniLab：<position> actuator + MuJoCo 内置 PD（kp 固定烧死在 XML 里：髋 40.179、膝 99.098、踝 28.501 N·m/rad）
为什么 action_scale=0.25 在 UniLab 不可用：action_scale=0.25 将可用范围压缩至 1.0 时的 1/4，最大力矩贡献等比下降（kp=40.179，最大约 29 N·m；action_scale=1.0 时可充分利用 forcerange 上限 88 N·m）。训练初期策略在默认姿态附近探索时实际可用力矩远小于此，无法稳定产生单腿支撑所需的 ~30–40 N·m。

所以步态变差不是参数没有对齐holosoma，而是针对我们调整后的xml应该设置新的reward_scale

本次修改（owner layer，config first）：

conf/offpolicy/task/sac/g1_sac/mujoco.yaml：新增 env: 块，将 control_config.action_scale=1.0、gait_phase_init_mode、reset_base_qvel_limit 显式写入 owner preset，而非隐式依赖 Python dataclass 默认值；
调整 penalty_action_rate: -4.0（补偿 damping 减半）、feet_phase_tracking_sigma: 0.04（放宽相位精度以匹配 UniLab 机器人的实际力矩能力）

tests/config/test_locomotion_params.py：在 test_offpolicy_sac_g1_task_overrides 中增加assert，验证 env.control_config.action_scale==1.0、gait_phase_init_mode、reset_base_qvel_limit 通过 Hydra 正确注入，锁住架构级约束

## Linked Work

- Issue: https://github.com/unilabsim/UniLab/issues/244

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
# uv run pytest tests/config/test_locomotion_params.py tests/config/test_config_system.py -v
```

## Impact

- Backend impact：mujoco（motrix 后端暂不在本 PR 修改）
- Platform impact：Linux
- Training effect expected：yes（action_scale 和 penalty_action_rate 直接影响关节力矩与步态稳定性）

## Artifacts

- video / screenshot:

before：
https://github.com/user-attachments/assets/0a1bf074-9ac8-4416-8d2b-0788574ec6d7
after：
https://github.com/user-attachments/assets/6185fa2e-2f27-4c0b-80ce-e4519d09f0e1



## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
