### PR TITLE
chore: bump mujoco-uni to 3.6.0.post5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     "torch==2.7.0",
-    "mujoco-uni==3.6.0.post4",
+    "mujoco-uni==3.6.0.post5",
     "gymnasium",
     "imageio",
     "etils",

--- a/uv.lock
+++ b/uv.lock
@@ -1933,7 +1933,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-uni"
-version = "3.6.0.post4"
+version = "3.6.0.post5"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -1944,16 +1944,16 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/a7/b1/9a5fec73e5e0e565b672dd0103380cb6a70be6280bbfb1be39f85745baf7/mujoco_uni-3.6.0.post4.tar.gz", hash = "sha256:1a3b214237d986e41378fd6b5e1d92928d351ebed6256114bcadeaec4a68cbff", size = 4725403, upload-time = "2026-04-08T09:13:00.092Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/0f/86/7b16f186b2e521f33d9fb153eb1076d5df1cfc1aaaf99baf7795f8d1cac6/mujoco_uni-3.6.0.post5.tar.gz", hash = "sha256:3f58758f8e2608fb79c031bc24b2f7520d63b593f8c2435802ed8da9fb6ac742", size = 4726211, upload-time = "2026-04-15T15:22:25.107Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/53/5b/cec67cd866e51e2e59e81675e658b1d6770f8e29a0e441a2a28c6223aa66/mujoco_uni-3.6.0.post4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1edd316810c5095b0c4b36ab02fe23f7c76ea8741ff220ce8f34a50714e4500d", size = 6787764, upload-time = "2026-04-08T09:12:32.086Z" },
-    { url = "https://test-files.pythonhosted.org/packages/5a/f1/1239737c8bacd16d31486755d269d6a904eaa990514035f0924bbd23d620/mujoco_uni-3.6.0.post4-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:9d874010fac4ad0a5a0a4afc1624186299fbc3538ec5e0dab162dbcc6cf62b7a", size = 6574675, upload-time = "2026-04-08T15:14:38.766Z" },
-    { url = "https://test-files.pythonhosted.org/packages/50/1c/b8c6725e1c6485e2c00d321955b1fa598b93943ea50d5ab2cc2f1a91a8f2/mujoco_uni-3.6.0.post4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d2cfa0b2179ac5652d05fe9739182fe8b735f94e78d9989d21ad8e3ba53ec45", size = 6801431, upload-time = "2026-04-08T09:12:40.304Z" },
-    { url = "https://test-files.pythonhosted.org/packages/71/30/a2bc02b6e23b8ae91eb2c73258cc9dbd9218c42e361f7003f2b174e2e7e0/mujoco_uni-3.6.0.post4-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:2cf5b81552ec0026109ef74e66b01a2bcab899dff37b6429d0eac004d495c259", size = 6586471, upload-time = "2026-04-08T15:15:09.983Z" },
-    { url = "https://test-files.pythonhosted.org/packages/43/4e/47fc3a8ae84f46ad8dfac92b1ba65523e3d16dca86cf5bd2b787ad211f93/mujoco_uni-3.6.0.post4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60749e11b0df089489a4d6feac564f06813361b8ec2b3b8e0480aa3c31bd80ee", size = 6823431, upload-time = "2026-04-08T09:12:44.741Z" },
-    { url = "https://test-files.pythonhosted.org/packages/f1/39/99d175d02b9a6752a7cffe26b2fab549468c49030cf4becb5bd05d1d556c/mujoco_uni-3.6.0.post4-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:30c5f36b269dd50f6f9a75774d22a1bb5b08b768f0b9e13cdc1bdd63b5b36cb2", size = 6614197, upload-time = "2026-04-08T15:15:31.981Z" },
-    { url = "https://test-files.pythonhosted.org/packages/e2/b8/e5a33429c8a686892eaf2ebe8d0f2c59c803e37712a7ccf079949bd2f22e/mujoco_uni-3.6.0.post4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1371af813b99f4ddba5f3722ebbc5254d256813df07d6a4b22866b9471d29656", size = 6823538, upload-time = "2026-04-08T09:12:54.108Z" },
-    { url = "https://test-files.pythonhosted.org/packages/79/e0/998a8da1b3cf380bff82f7db0c60621c0ab7c37c9ede55f4558f873e69af/mujoco_uni-3.6.0.post4-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:f181a3d594f8696da7fb4e0a4ed084b5ef41c54e539ad5e3e08b8711fc6d46e1", size = 6614958, upload-time = "2026-04-08T15:15:55.731Z" },
+    { url = "https://test-files.pythonhosted.org/packages/e3/26/9e9826e55986278b8e03bc7e6cca1041faaaf7c89555df962053b024af4f/mujoco_uni-3.6.0.post5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e334946a70ec7ea97025894414c6ca03faa50a2c22ac76761193ce29ae3f366", size = 6784165, upload-time = "2026-04-15T15:22:12.63Z" },
+    { url = "https://test-files.pythonhosted.org/packages/0e/95/284af99b4f5bb5682ab5a3281d03437bbc2eab028d26f89c5fcb46bf3644/mujoco_uni-3.6.0.post5-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:b6a42a2f366b414ce87dfa5b3c535eddf2794a1379684c8b23f169ea59713072", size = 6574675, upload-time = "2026-04-15T15:12:22.995Z" },
+    { url = "https://test-files.pythonhosted.org/packages/5c/df/466d463aa61830b8b77d8107aac83c03d440c74e604006bdd1bee6e60640/mujoco_uni-3.6.0.post5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db89fc261b01172db0b660ea4eb37549356a5c4385c195acebf0722bfc02a8e9", size = 6797900, upload-time = "2026-04-15T15:22:16.315Z" },
+    { url = "https://test-files.pythonhosted.org/packages/bf/1b/9e8b4b46333ef7e4b2cb55f4623be6849fdf0a8a298dbda5e569419caaeb/mujoco_uni-3.6.0.post5-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:db69c0fbef13ed48b03cd2e1997f9cc4552eed6065f32fe08f4eb058e342cc2b", size = 6586472, upload-time = "2026-04-15T15:12:26.227Z" },
+    { url = "https://test-files.pythonhosted.org/packages/22/dc/47556e958c64613b76e31ceb87ba1e6e16d12717f7acb3fa12dfca2035f2/mujoco_uni-3.6.0.post5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:739781b5ec12604d5d288bebf5b0d0356857d56056542e71049affbf4a472cbf", size = 6819489, upload-time = "2026-04-15T15:22:19.861Z" },
+    { url = "https://test-files.pythonhosted.org/packages/3e/b3/7d59f3a8d5a713c81ddddf47e036c60fb3cfc894c01a567462edb337e8c9/mujoco_uni-3.6.0.post5-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:1f7810d08cd7a2184f597b25505a691c6c69046b2ff30083272b29ef5f121e12", size = 6614198, upload-time = "2026-04-15T15:12:29.365Z" },
+    { url = "https://test-files.pythonhosted.org/packages/59/b7/ca402ae1a1d9ffa3f42f99b4bac3995982d4c3294df25ee42eff3b42536c/mujoco_uni-3.6.0.post5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db85b1c0b784ec86f77e2c527932912561bfa1b431aabf5b4565a68e83334511", size = 6819746, upload-time = "2026-04-15T15:22:21.687Z" },
+    { url = "https://test-files.pythonhosted.org/packages/3b/63/4bd237592b0f52bc2fbea27771642168217974663e64c7764950a5f093f5/mujoco_uni-3.6.0.post5-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:d2a597eb67e4c802cfcc7de6cfc5411f50d7f81cd732cc34becca26a66306b4c", size = 6614959, upload-time = "2026-04-15T15:12:32.339Z" },
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.0" },
-    { name = "mujoco-uni", specifier = "==3.6.0.post4", index = "https://test.pypi.org/simple/" },
+    { name = "mujoco-uni", specifier = "==3.6.0.post5", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },
     { name = "packaging" },


### PR DESCRIPTION
## Summary
- bump mujoco-uni from 3.6.0.post4 to 3.6.0.post5
- refresh uv.lock to match the new package release on TestPyPI

## Testing
- not run (dependency version bump only)