### PR TITLE
docs: note mxpython for Motrix visualization on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco
 
 Motrix registry bootstrap and Hydra config composition do not require importing MuJoCo anymore, but any MuJoCo task execution, playback, or MuJoCo-only tooling still requires a working MuJoCo runtime.
 
+On macOS / MacBook, commands that open the MotrixSim native renderer must be launched with `uv run mxpython` instead of `uv run python`. Plain non-rendering training can still use `uv run python ... training.no_play=true`.
+
 ## Workflow Entrypoints
 
 | Goal | Entrypoint | Log root pattern |
@@ -57,6 +59,12 @@ Motrix registry bootstrap and Hydra config composition do not require importing 
 The concrete log directory comes from `algo.algo_log_name`. Current defaults are `rsl_rl_ppo`, `appo`, `fast_sac`, and `fast_td3`.
 
 Training scripts automatically enter playback after training unless you set `training.no_play=true`.
+
+For MotrixSim visualization on macOS / MacBook, use `uv run mxpython`:
+
+```bash
+uv run mxpython scripts/train_rsl_rl.py task=go1_joystick/motrix training.play_only=true
+```
 
 ## Repository Map
 

--- a/docs/zh_CN/01-getting-started.md
+++ b/docs/zh_CN/01-getting-started.md
@@ -39,6 +39,8 @@ uv sync
 uv sync --extra motrix
 ```
 
+在 macOS / MacBook 上，只要命令会打开 MotrixSim 原生 renderer，就需要用 `uv run mxpython` 启动；不需要可视化的训练仍可使用 `uv run python ... training.no_play=true`。
+
 ## 中国大陆镜像
 
 ```bash

--- a/docs/zh_CN/02-simulation-backends.md
+++ b/docs/zh_CN/02-simulation-backends.md
@@ -11,6 +11,7 @@ UniLab 当前支持两个仿真后端:
 
 - `uv sync --extra motrix` 会安装 Motrix 依赖。
 - Motrix 路径的 registry bootstrap 和 Hydra 配置 compose 不再要求导入 MuJoCo。
+- 在 macOS / MacBook 上，只要命令会打开 MotrixSim 原生 renderer（训练后自动回放或 `training.play_only=true`），就需要用 `uv run mxpython` 启动；不需要可视化的训练仍可使用 `uv run python ... training.no_play=true`。
 - 任何 `task=.../mujoco` 的实际运行、MuJoCo playback、以及 MuJoCo-only 调试工具，仍然要求可用的 MuJoCo runtime。
 - 某些任务目前仍然只有 MuJoCo owner 配置；例如 `AllegroInhandRotation` 只提供 `mujoco` task。
 
@@ -102,12 +103,15 @@ uv run python scripts/train_rsl_rl.py task=go1_joystick/motrix
 ## Playback Differences
 
 - `mujoco`: 训练后的自动回放会导出 `play_video.mp4`
-- `motrix`: 回放通常打开交互式 renderer 窗口，而不是导出视频
+- `motrix`: 回放通常打开交互式 renderer 窗口，而不是导出视频；macOS / MacBook 上需要用 `uv run mxpython` 启动
 
 对 G1 motion tracking 来说，目前已验证的 Motrix 路径是 `PPO (torch) + motrix` 和 `APPO (torch) + motrix`。`scripts/play_interactive.py` 仍然沿用 MuJoCo 路径。
 
 ```bash
 uv run python scripts/train_rsl_rl.py task=go1_joystick/mujoco training.play_only=true
+
+# macOS / MacBook 上的 MotrixSim 原生 renderer
+uv run mxpython scripts/train_rsl_rl.py task=go1_joystick/motrix training.play_only=true
 ```
 
 ## Notes

--- a/docs/zh_CN/03-training.md
+++ b/docs/zh_CN/03-training.md
@@ -41,6 +41,8 @@ uv run python scripts/train_offpolicy.py algo=sac task=sac/g1_sac/mujoco algo.nu
 - `motrix` 会打开交互式窗口渲染
 - `training.no_play=true` 可以跳过自动回放
 
+在 macOS / MacBook 上，只要命令会打开 MotrixSim 原生 renderer（训练后自动回放或 `training.play_only=true`），就需要用 `uv run mxpython` 启动；不需要可视化的训练仍可使用 `uv run python ... training.no_play=true`。
+
 run 目录命名格式是 `YYYY-MM-DD_HH-MM-SS_<sim_backend>`，例如 `2026-03-09_18-30-00_mujoco`。
 
 ## Playback
@@ -49,6 +51,9 @@ run 目录命名格式是 `YYYY-MM-DD_HH-MM-SS_<sim_backend>`，例如 `2026-03-
 # 回放最新结果
 uv run python scripts/train_rsl_rl.py task=go2_joystick/mujoco training.play_only=true
 uv run python scripts/train_offpolicy.py algo=sac task=sac/go2_joystick/mujoco training.play_only=true
+
+# macOS / MacBook 上的 MotrixSim 原生 renderer
+uv run mxpython scripts/train_rsl_rl.py task=go2_joystick/motrix training.play_only=true
 
 # 回放指定 run
 uv run python scripts/train_offpolicy.py algo=td3 task=td3/go1_joystick/mujoco training.play_only=true algo.load_run="2024-02-04_12-00-00"

--- a/docs/zh_CN/05-g1-motion-tracking.md
+++ b/docs/zh_CN/05-g1-motion-tracking.md
@@ -38,19 +38,19 @@ uv run python scripts/train_appo.py task=g1_motion_tracking/motrix
 # 回放最新 checkpoint
 uv run python scripts/train_rsl_rl.py task=g1_motion_tracking/mujoco training.play_only=true
 
-# Motrix PPO 回放会打开原生 renderer
-uv run python scripts/train_rsl_rl.py task=g1_motion_tracking/motrix \
+# Motrix PPO 回放会打开原生 renderer；macOS / MacBook 用 mxpython
+uv run mxpython scripts/train_rsl_rl.py task=g1_motion_tracking/motrix \
   training.play_only=true
 
 # APPO MuJoCo 回放
 uv run python scripts/train_appo.py task=g1_motion_tracking/mujoco training.play_only=true
 
-# APPO Motrix 回放会打开原生 renderer
-uv run python scripts/train_appo.py task=g1_motion_tracking/motrix \
+# APPO Motrix 回放会打开原生 renderer；macOS / MacBook 用 mxpython
+uv run mxpython scripts/train_appo.py task=g1_motion_tracking/motrix \
   training.play_only=true
 ```
 
-对于 G1 motion tracking，Motrix 的训练和回放主路径应优先走 `scripts/train_rsl_rl.py` 和 `scripts/train_appo.py`。调试脚本 `scripts/play_interactive.py` 仍沿用 MuJoCo viewer 路径。
+对于 G1 motion tracking，Motrix 的训练和回放主路径应优先走 `scripts/train_rsl_rl.py` 和 `scripts/train_appo.py`。macOS / MacBook 上只要会打开 MotrixSim 原生 renderer，就用 `uv run mxpython` 启动；不需要可视化的训练仍可使用 `uv run python ... training.no_play=true`。调试脚本 `scripts/play_interactive.py` 仍沿用 MuJoCo viewer 路径。
 
 ## Interactive Debugging
 


### PR DESCRIPTION
## Summary

- Document that MotrixSim native renderer commands on macOS / MacBook must use `uv run mxpython` instead of `uv run python`.
- Add the guidance to `README.md` and the zh_CN getting-started, simulation-backends, training, and G1 motion-tracking docs.
- Clarify that non-rendering Motrix training can still use `uv run python ... training.no_play=true`.

## Linked Work

- Issue: N/A (direct docs update request)
- Milestone: N/A

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/scripts/test_check_docs.py -q
make check
make test
```

`make test` ran locally on macOS and failed on an existing render backend expectation unrelated to this docs-only change:

```text
tests/utils/test_render_many.py::test_resolve_gl_backend_uses_egl_when_probe_succeeds
AssertionError: assert 'glfw' == 'egl'
```

## Impact

- Backend impact: `motrix`
- Platform impact: macOS
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly
