### PR TITLE
fix: respect user GL override in render probe

### DIFF
--- a/src/unilab/utils/render_many.py
+++ b/src/unilab/utils/render_many.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import imageio
 
+_USER_MUJOCO_GL = os.environ.get("MUJOCO_GL")
+
 _EGL_PROBE_SCRIPT = textwrap.dedent(
     '''
     import mujoco
@@ -71,8 +73,8 @@ def _resolve_gl_backend() -> str:
         # macOS has no EGL support; glfw is the only off-screen option
         return current if current in safe_values else "glfw"
 
-    # Linux / other: honour explicit non-egl choices
-    if current in safe_values:
+    # Linux / other: honour explicit non-egl choices supplied before import.
+    if current in safe_values and current == _USER_MUJOCO_GL:
         return current
 
     # Probe EGL by creating a tiny MuJoCo renderer in a clean subprocess.


### PR DESCRIPTION
## Summary

- Fix `render_many` GL backend resolution so only user-provided `MUJOCO_GL` overrides are preserved on Linux.
- Avoid treating the module's own import-time fallback (`glfw` on macOS hosts probing Linux behavior in tests) as an explicit override.
- Restore the expected EGL probe behavior in the macOS unit test path.

## Linked Work

- Issue: N/A
- Milestone: N/A

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/utils/test_render_many.py -q
make check
make test
```

## Impact

- Backend impact: `mujoco`
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly
