### PR TITLE
fix: avoid CI event concurrency collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

- Fix CI concurrency grouping so `pull_request` and `pull_request_target` runs for the same PR do not cancel each other.
- Keep the fork-`main` fallback lane added in `pull_request_target` while avoiding cross-event cancellation for normal in-repo PRs.
- Use `github.event_name` in the concurrency key so only newer runs of the same event replace older runs.

## Linked Work

- Issue: N/A
- Milestone: N/A
- Related PR: #288

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
/bin/zsh -lc 'UV_CACHE_DIR=.uv-cache uv run python -c "from pathlib import Path; import yaml; yaml.safe_load(Path(\".github/workflows/ci.yml\").read_text()); print(\"ci.yml ok\")"'
make check
make test
```

`make test` still fails on the existing local `render_many` issue present on current `main`:

```text
tests/utils/test_render_many.py::test_resolve_gl_backend_uses_egl_when_probe_succeeds
AssertionError: assert 'glfw' == 'egl'
```

That failure is unrelated to this CI workflow change and is already addressed by PR #288.

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly
