### PR TITLE
fix: materialize MuJoCo pool outside hot path

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -153,6 +153,9 @@ class SimBackend(abc.ABC):
             f"{self.__class__.__name__} does not support init-lifecycle randomization"
         )
 
+    def materialize(self) -> None:
+        """Finalize cold-path backend resources before reset/step."""
+
     @abc.abstractmethod
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         """Apply a scheduled interval randomization plan."""

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -339,18 +339,17 @@ class MuJoCoBackend(SimBackend):
             return self._model_variants[0]
         return [self._model_variants[int(idx)] for idx in self._model_assignments]
 
-    def _ensure_pool(self) -> BatchEnvPool:
-        if self._pool is None:
-            self._pool = BatchEnvPool(
-                self._current_model_sequence(),
-                nbatch=self._num_envs,
-                nthread=self._n_threads,
-            )
-            sensor_init = self._pool.forward(self._physics_state)
-            self._sensor_data[:] = sensor_init.astype(self._np_dtype)
-        return self._pool
+    def _build_pool(self) -> BatchEnvPool:
+        pool = BatchEnvPool(
+            self._current_model_sequence(),
+            nbatch=self._num_envs,
+            nthread=self._n_threads,
+        )
+        sensor_init = pool.forward(self._physics_state)
+        self._sensor_data[:] = sensor_init.astype(self._np_dtype)
+        return pool
 
-    def _rebuild_pool_from_assignments(
+    def _apply_model_assignments(
         self,
         model_variants: tuple[mujoco.MjModel, ...],
         model_assignments: np.ndarray,
@@ -377,9 +376,6 @@ class MuJoCoBackend(SimBackend):
         self._base_body_mass = np.asarray(self._model.body_mass).copy()
         self._base_body_ipos = np.asarray(self._model.body_ipos).copy()
         self._physics_state[:, self._idx_qpos : self._idx_qpos + self._model.nq] = self._model.qpos0
-        if self._pool is not None:
-            self._pool.close()
-            self._pool = None
 
     # ------------------------------------------------------------------ #
     # Properties                                                         #
@@ -444,7 +440,7 @@ class MuJoCoBackend(SimBackend):
         set_ctrl_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        state_np = self._ensure_pool().step(
+        state_np = self._pool.step(  # type: ignore[union-attr]
             self._physics_state,
             nstep=nsteps,
             control=control_traj,
@@ -454,7 +450,7 @@ class MuJoCoBackend(SimBackend):
         physics_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        sensor_np = self._ensure_pool().forward(self._physics_state)
+        sensor_np = self._pool.forward(self._physics_state)  # type: ignore[union-attr]
         self._sensor_data[:] = sensor_np.astype(self._np_dtype)
         refresh_cache_ms = (time.perf_counter() - t0) * 1000.0
 
@@ -481,7 +477,7 @@ class MuJoCoBackend(SimBackend):
         state_np[:, self._idx_qpos : self._idx_qpos + self.nq] = qpos
         state_np[:, self._idx_qvel : self._idx_qvel + self.nv] = qvel
 
-        state_out, sensor_np = self._ensure_pool().reset(
+        state_out, sensor_np = self._pool.reset(  # type: ignore[union-attr]
             env_ids=np.asarray(env_indices, dtype=np.int32),
             initial_state=state_np,
             randomization=self._translate_reset_randomization(randomization, num_reset),
@@ -508,9 +504,16 @@ class MuJoCoBackend(SimBackend):
     def apply_init_randomization(self, plan: InitRandomizationPlan) -> None:
         if plan.is_empty():
             return
+        if self._pool is not None:
+            raise RuntimeError("MuJoCo init randomization must run before pool materialization")
         model_assignments = np.asarray(plan.model_assignments, dtype=np.int32)
         model_variants = self._compile_model_variants(plan.model_variants)
-        self._rebuild_pool_from_assignments(model_variants, model_assignments)
+        self._apply_model_assignments(model_variants, model_assignments)
+
+    def materialize(self) -> None:
+        if self._pool is not None:
+            raise RuntimeError("MuJoCo backend pool is already materialized")
+        self._pool = self._build_pool()
 
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         if plan.push_perturbation_limit is None:

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -235,6 +235,7 @@ class NpEnv(ABEnv):
         self._dr_manager = DomainRandomizationManager(self, provider)
         if not self._init_randomization_applied:
             self._init_randomization_applied = self._dr_manager.apply_init_randomization()
+        self._backend.materialize()
 
     def reset(self, env_indices: np.ndarray) -> Tuple[dict[str, np.ndarray], dict]:
         if self._dr_manager is None:  # pragma: no cover - constructor integration error

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
@@ -37,6 +37,8 @@ class AllegroBaseEnv(NpEnv):
     _NUM_HAND_DOF: int = 16
     _FINGERTIP_BODY_NAMES: tuple[str, ...] = ("ff_tip", "mf_tip", "rf_tip", "th_tip")
     _cfg: AllegroBaseCfg
+    _init_qpos: np.ndarray
+    _init_qvel: np.ndarray
 
     def __init__(self, cfg: AllegroBaseCfg, backend: SimBackend, num_envs: int = 1):
         super().__init__(cfg, backend, num_envs)

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
@@ -122,7 +122,13 @@ class AllegroRotationDomainRandomizationProvider(DomainRandomizationProvider):
 
         cache_path = env.cfg.grasp_cache_path
         if not epath.Path(cache_path).exists():
-            raise FileNotFoundError(f"Grasp cache not found: {cache_path}")
+            print(
+                "[allegro_inhand] Grasp cache missing, falling back to procedural reset: "
+                f"{cache_path}"
+            )
+            env._grasp_cache = None
+            env._grasp_cache_loaded = True
+            return None
         env._grasp_cache = np.load(cache_path).astype(np.float64)
         env._grasp_cache_loaded = True
         print(

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -104,7 +104,9 @@ class TestMuJoCoBasic:
         from unilab.base.backend.mujoco_backend import MuJoCoBackend
 
         p = request.param
-        return MuJoCoBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
+        backend = MuJoCoBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
+        backend.materialize()
+        return backend
 
     # properties
 
@@ -114,7 +116,10 @@ class TestMuJoCoBasic:
     def test_model_not_none(self, bkd):
         assert bkd.model is not None
 
-    def test_apply_init_randomization_rebuilds_model_pool_from_variant_sequence(self):
+    def test_pool_materialized_by_lifecycle(self, bkd):
+        assert bkd._pool is not None
+
+    def test_apply_init_randomization_sets_variants_before_materialization(self):
         from unilab.base.backend.mujoco_backend import MuJoCoBackend
 
         bkd = MuJoCoBackend(_SHARPA["model_file"], 4, SIM_DT, base_name=_SHARPA["base_name"])
@@ -145,6 +150,9 @@ class TestMuJoCoBasic:
         np.testing.assert_allclose(bkd._model_variants[0].geom_size[geom_id], base_size * 0.5)
         np.testing.assert_allclose(bkd._model_variants[1].geom_size[geom_id], base_size * 0.75)
 
+        bkd.materialize()
+        assert bkd._pool is not None
+
     # simulation control
 
     def test_step(self, bkd):
@@ -165,7 +173,8 @@ class TestMuJoCoBasic:
         np.testing.assert_allclose(bkd.get_base_pos()[1], pos_before, atol=1e-5)
 
     def test_set_state_randomization_only_affects_target_envs(self, bkd):
-        original = [bkd._pool.get_field(i, "body_mass").copy() for i in range(NUM_ENVS)]
+        pool = bkd._pool
+        original = [pool.get_field(i, "body_mass").copy() for i in range(NUM_ENVS)]
         qpos = _identity_qpos_mujoco(bkd.model.nq)
         qvel = np.zeros((1, bkd.model.nv))
         base_body_id = bkd._base_body_id
@@ -174,8 +183,8 @@ class TestMuJoCoBasic:
 
         bkd.set_state(np.array([1]), qpos, qvel, randomization=randomization)
 
-        np.testing.assert_array_equal(bkd._pool.get_field(0, "body_mass"), original[0])
-        updated = bkd._pool.get_field(1, "body_mass")
+        np.testing.assert_array_equal(pool.get_field(0, "body_mass"), original[0])
+        updated = pool.get_field(1, "body_mass")
         np.testing.assert_allclose(updated[:base_body_id], original[1][:base_body_id])
         np.testing.assert_allclose(updated[base_body_id], original[1][base_body_id] + delta[0])
         np.testing.assert_allclose(updated[base_body_id + 1 :], original[1][base_body_id + 1 :])
@@ -193,7 +202,8 @@ class TestMuJoCoBasic:
         assert caps.supports_interval_push
 
     def test_set_state_body_iquat_randomization_only_affects_target_envs(self, bkd):
-        original = [bkd._pool.get_field(i, "body_iquat").copy() for i in range(NUM_ENVS)]
+        pool = bkd._pool
+        original = [pool.get_field(i, "body_iquat").copy() for i in range(NUM_ENVS)]
         qpos = _identity_qpos_mujoco(bkd.model.nq)
         qvel = np.zeros((1, bkd.model.nv))
         updated = original[1].reshape(bkd.model.nbody, 4).copy()
@@ -206,13 +216,14 @@ class TestMuJoCoBasic:
             randomization=ResetRandomizationPayload(body_iquat=updated[None, :, :]),
         )
 
-        np.testing.assert_array_equal(bkd._pool.get_field(0, "body_iquat"), original[0])
+        np.testing.assert_array_equal(pool.get_field(0, "body_iquat"), original[0])
         np.testing.assert_allclose(
-            bkd._pool.get_field(1, "body_iquat").reshape(bkd.model.nbody, 4), updated
+            pool.get_field(1, "body_iquat").reshape(bkd.model.nbody, 4), updated
         )
 
     def test_set_state_body_inertia_randomization_only_affects_target_envs(self, bkd):
-        original = [bkd._pool.get_field(i, "body_inertia").copy() for i in range(NUM_ENVS)]
+        pool = bkd._pool
+        original = [pool.get_field(i, "body_inertia").copy() for i in range(NUM_ENVS)]
         qpos = _identity_qpos_mujoco(bkd.model.nq)
         qvel = np.zeros((1, bkd.model.nv))
         updated = original[1].reshape(bkd.model.nbody, 3).copy()
@@ -225,14 +236,15 @@ class TestMuJoCoBasic:
             randomization=ResetRandomizationPayload(body_inertia=updated[None, :, :]),
         )
 
-        np.testing.assert_array_equal(bkd._pool.get_field(0, "body_inertia"), original[0])
+        np.testing.assert_array_equal(pool.get_field(0, "body_inertia"), original[0])
         np.testing.assert_allclose(
-            bkd._pool.get_field(1, "body_inertia").reshape(bkd.model.nbody, 3), updated
+            pool.get_field(1, "body_inertia").reshape(bkd.model.nbody, 3), updated
         )
 
     def test_set_state_kp_kd_randomization_only_affects_target_envs(self, bkd):
-        original_kp = [bkd._pool.get_field(i, "kp").copy() for i in range(NUM_ENVS)]
-        original_kd = [bkd._pool.get_field(i, "kd").copy() for i in range(NUM_ENVS)]
+        pool = bkd._pool
+        original_kp = [pool.get_field(i, "kp").copy() for i in range(NUM_ENVS)]
+        original_kd = [pool.get_field(i, "kd").copy() for i in range(NUM_ENVS)]
         qpos = _identity_qpos_mujoco(bkd.model.nq)
         qvel = np.zeros((1, bkd.model.nv))
         new_kp = original_kp[1] + 1.25
@@ -245,10 +257,10 @@ class TestMuJoCoBasic:
             randomization=ResetRandomizationPayload(kp=new_kp[None, :], kd=new_kd[None, :]),
         )
 
-        np.testing.assert_array_equal(bkd._pool.get_field(0, "kp"), original_kp[0])
-        np.testing.assert_array_equal(bkd._pool.get_field(0, "kd"), original_kd[0])
-        np.testing.assert_allclose(bkd._pool.get_field(1, "kp"), new_kp)
-        np.testing.assert_allclose(bkd._pool.get_field(1, "kd"), new_kd)
+        np.testing.assert_array_equal(pool.get_field(0, "kp"), original_kp[0])
+        np.testing.assert_array_equal(pool.get_field(0, "kd"), original_kd[0])
+        np.testing.assert_allclose(pool.get_field(1, "kp"), new_kp)
+        np.testing.assert_allclose(pool.get_field(1, "kd"), new_kd)
 
     # base kinematics
 
@@ -342,6 +354,7 @@ def test_motrix_backend_fixed_base_set_state_matches_mujoco_for_hand_and_ball():
         base_name=_ALLEGRO["base_name"],
         add_body_sensors=True,
     )
+    mj.materialize()
     mx = MotrixBackend(
         _ALLEGRO["model_file"],
         NUM_ENVS,
@@ -386,13 +399,15 @@ class TestMuJoCoBodySensors:
     def bkd(self):
         from unilab.base.backend.mujoco_backend import MuJoCoBackend
 
-        return MuJoCoBackend(
+        backend = MuJoCoBackend(
             _G1["model_file"],
             NUM_ENVS,
             SIM_DT,
             base_name=_G1["base_name"],
             add_body_sensors=True,
         )
+        backend.materialize()
+        return backend
 
     @pytest.fixture
     def body_ids(self, bkd):
@@ -719,6 +734,7 @@ class TestCrossBackend:
         pytest.importorskip("motrixsim")
         p = request.param
         mj = MuJoCoBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
+        mj.materialize()
         mx = MotrixBackend(p["model_file"], NUM_ENVS, SIM_DT, base_name=p["base_name"])
         nq, nv = mj.model.nq, mj.model.nv
         qpos = np.tile(_identity_qpos_mujoco(nq), (NUM_ENVS, 1))
@@ -792,6 +808,7 @@ class TestCrossBackendBodySensors:
             base_name=_G1["base_name"],
             add_body_sensors=True,
         )
+        mj.materialize()
         mx = MotrixBackend(
             _G1["model_file"],
             NUM_ENVS,

--- a/tests/envs/test_allegro_domain_randomization.py
+++ b/tests/envs/test_allegro_domain_randomization.py
@@ -43,13 +43,10 @@ def test_allegro_mujoco_reset_applies_base_mass_and_com_domain_randomization(
     try:
         env_obj.init_state()
         backend: Any = env_obj._backend
+        pool = backend._pool
         base_body_id = int(backend._base_body_id)
-        body_mass = np.stack(
-            [backend._pool.get_field(i, "body_mass") for i in range(env_obj.num_envs)]
-        )
-        body_ipos = np.stack(
-            [backend._pool.get_field(i, "body_ipos") for i in range(env_obj.num_envs)]
-        )
+        body_mass = np.stack([pool.get_field(i, "body_mass") for i in range(env_obj.num_envs)])
+        body_ipos = np.stack([pool.get_field(i, "body_ipos") for i in range(env_obj.num_envs)])
         body_ipos = body_ipos.reshape(env_obj.num_envs, -1, 3)
 
         base_mass = float(backend._base_body_mass[base_body_id])

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -461,11 +461,12 @@ def _assert_mujoco_position_gains(
     env: Any, *, kp: float, kd: float, actuator_ids=slice(None)
 ) -> None:
     model = env._backend.model
+    pool = env._backend._pool
     np.testing.assert_allclose(model.actuator_gainprm[actuator_ids, 0], kp)
     np.testing.assert_allclose(model.actuator_biasprm[actuator_ids, 1], -kp)
     np.testing.assert_allclose(model.actuator_biasprm[actuator_ids, 2], -kd)
-    np.testing.assert_allclose(env._backend._pool.get_field(0, "kp")[actuator_ids], kp)
-    np.testing.assert_allclose(env._backend._pool.get_field(0, "kd")[actuator_ids], kd)
+    np.testing.assert_allclose(pool.get_field(0, "kp")[actuator_ids], kp)
+    np.testing.assert_allclose(pool.get_field(0, "kd")[actuator_ids], kd)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- materialize MuJoCo BatchEnvPool explicitly after init domain randomization instead of lazy hot-path creation
- keep init randomization before pool materialization so model variants do not require duplicate pool builds
- make Allegro missing grasp cache fall back to procedural reset and update slow tests for the lifecycle contract

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -m "slow and not veryslow" tests/base/test_sim_backend.py::TestMuJoCoBasic tests/base/test_sim_backend.py::TestMuJoCoBodySensors tests/base/test_sim_backend.py::TestCrossBackend tests/base/test_sim_backend.py::TestCrossBackendBodySensors tests/base/test_sim_backend.py::test_motrix_backend_fixed_base_set_state_matches_mujoco_for_hand_and_ball tests/envs/test_allegro_domain_randomization.py::test_allegro_mujoco_reset_applies_base_mass_and_com_domain_randomization 'tests/envs/test_env_configs.py::test_env_reset_and_step[AllegroInhandRotation]' tests/envs/test_env_configs.py::test_go1_env_initializes_kp_kd_into_pool tests/envs/test_env_configs.py::test_go2_env_initializes_kp_kd_into_pool tests/envs/test_env_configs.py::test_allegro_env_initializes_kp_kd_into_pool -q
- UV_CACHE_DIR=/tmp/uv-cache make test-slow