### PR TITLE
feat: add PPO motion-tracking play camera tracking and Viser web viewer (MuJoCo)

### DIFF
--- a/conf/appo/config.yaml
+++ b/conf/appo/config.yaml
@@ -69,6 +69,9 @@ training:
   cam_distance: 6.0
   cam_elevation: -20.0
   cam_azimuth: 90.0
+  cam_tracking: false
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 2
   replay_queue_size: null
 
 hydra:

--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -76,6 +76,9 @@ training:
   cam_elevation: -20.0
   cam_azimuth: 90.0
   cam_lookat: null
+  cam_tracking: false
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 2
   num_timesteps: null
   log_dir: null
 
@@ -102,6 +105,10 @@ interactive:
   camera_elevation: null
   camera_azimuth: null
   use_env_visual_model: true
+
+viser:
+  port: 8080
+  env_idx: 0
 
 hydra:
   run:

--- a/docs/zh_CN/05-g1-motion-tracking.md
+++ b/docs/zh_CN/05-g1-motion-tracking.md
@@ -145,7 +145,39 @@ uv run python scripts/train_rsl_rl.py task=g1_motion_tracking/motrix
 uv run python scripts/train_appo.py task=g1_motion_tracking/motrix
 ```
 
-## Navigation
+## PPO Motion Tracking：Play Tracking + Viser
 
-- Previous: [Algorithms](04-algorithms.md)
-- Next: [Collaboration Workflow](06-collaboration.md)
+本次在 `task=g1_motion_tracking/mujoco` 的 PPO 路径新增两项能力：
+
+- Play 回放支持跟随镜头：`training.cam_tracking=true`
+- 浏览器可视化脚本：`scripts/play_viser.py`（仅 MuJoCo）
+
+新增配置（`training`）：
+
+- `cam_tracking`（默认 `false`）
+- `cam_tracking_env_idx`（默认 `0`）
+- `cam_tracking_extra_envs`（默认 `2`）
+
+仅 Viser 功能需要额外依赖：
+
+```bash
+uv sync --extra viser
+```
+
+必要命令运行示例：
+
+```bash
+# 1) PPO Play 回放（启用 tracking，亦可选择默认配置，即非跟随镜头）
+uv run python scripts/train_rsl_rl.py task=g1_motion_tracking/mujoco training.play_only=true training.cam_tracking=true algo.load_run=xxx algo.checkpoint=xxx
+```
+
+```bash
+# 2) Viser 可视化（零动作）
+uv run python scripts/play_viser.py task=g1_motion_tracking/mujoco interactive.action_mode=zero algo.num_envs=8 viser.port=8080
+```
+
+```bash
+# 3) Viser 可视化（策略）
+uv run python scripts/play_viser.py task=g1_motion_tracking/mujoco interactive.action_mode=policy algo.load_run=xxx algo.checkpoint=xxx algo.num_envs=4 viser.port=8080
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 motrix = ["motrixsim==0.7.0"]
+viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pyright>=1.1.408"]
@@ -119,6 +120,7 @@ exclude = [
     "src/unilab/base/backend/",             # mujoco-uni stubs mismatch; optional backends
     "src/unilab/envs/",                     # mujoco-uni internal API, stubs mismatch
     "src/unilab/utils/render_many.py",      # direct mujoco C bindings
+    "src/unilab/utils/viser_scene.py",     # optional viser dependency
     "src/unilab/utils/hardware_monitor.py", # optional pynvml/psutil deps
 ]
 reportMissingImports = "warning"

--- a/scripts/play_viser.py
+++ b/scripts/play_viser.py
@@ -1,0 +1,366 @@
+# pyright: reportMissingImports=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false
+"""Viser-based interactive viewer for trained MuJoCo policies.
+
+Opens a web-based 3D viewer (powered by *viser*) so you can inspect a trained
+policy from any browser — no local display or GLFW required.  Supports multiple
+environments with an in-browser dropdown to switch between them.
+
+Prerequisites::
+
+    uv sync --extra viser
+
+Usage::
+
+    # Zero-action mode (no checkpoint needed)
+    uv run python scripts/play_viser.py task=go2_joystick/mujoco interactive.action_mode=zero
+
+    # With a trained policy
+    uv run python scripts/play_viser.py task=go2_joystick/mujoco interactive.action_mode=policy
+
+    # Multiple environments with env switching
+    uv run python scripts/play_viser.py task=go2_joystick/mujoco algo.num_envs=4 viser.port=8080
+
+    # Motion tracking task
+    uv run python scripts/play_viser.py task=g1_motion_tracking/mujoco interactive.action_mode=policy
+
+Camera controls (browser):
+    Left-drag    - rotate
+    Scroll       - zoom
+    Right-drag   - pan
+"""
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import hydra
+import mujoco
+import numpy as np
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+ROOT_DIR = Path(__file__).parent.parent
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from unilab.training import (
+    ensure_registries,
+    get_entrypoint_log_root,
+)
+
+ensure_registries()
+
+from unilab.base import registry
+from unilab.config.structured_configs import PPOConfig
+from unilab.utils.rsl_rl_compat import convert_config_v3_to_v4, is_rsl_rl_v4
+from unilab.utils.rsl_rl_vec_env_wrapper import RslRlVecEnvWrapper
+from unilab.utils.viser_scene import VISER_AVAILABLE, MujocoViserScene
+
+try:
+    from rsl_rl.runners import OnPolicyRunner
+except ImportError:
+    print("Could not import rsl_rl. Please ensure it is installed.")
+    sys.exit(1)
+
+if not VISER_AVAILABLE:
+    print("[play_viser] viser is not installed. Install with: uv sync --extra viser")
+    sys.exit(1)
+
+import viser  # noqa: E402
+from play_interactive import (  # noqa: E402
+    PlayInteractiveArgs,
+    _available_backends_for_task,
+    _backend_adapter,
+    _infer_checkpoint_actor_input_dim,
+    resolve_checkpoint,
+)
+
+# --------------------------------------------------------------------------- #
+# Core viewer                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
+    device = (
+        "cuda"
+        if torch.cuda.is_available()
+        else ("mps" if torch.backends.mps.is_available() else "cpu")
+    )
+    print(f"[play_viser] Device: {device}")
+
+    # --- Validate backend ---------------------------------------------------
+    available_backends = _available_backends_for_task(args.task)
+    if available_backends and "mujoco" not in available_backends:
+        print(
+            f"[play_viser] Task {args.task} does not support MuJoCo backend. "
+            f"Available: {available_backends or ('<none>',)}"
+        )
+        return
+
+    # --- Create environment --------------------------------------------------
+    num_envs = int(cfg.algo.num_envs) if OmegaConf.select(cfg, "algo.num_envs") else 1
+    # Clamp to a reasonable number for interactive viewing
+    num_envs = min(num_envs, 64)
+
+    if cfg is None:
+        env = registry.make(args.task, num_envs=num_envs, sim_backend="mujoco")
+    else:
+        from unilab.training import create_env
+
+        env_cfg_override = _backend_adapter(cfg).build_task_env_cfg_override()
+        env = create_env(
+            cfg,
+            num_envs=num_envs,
+            env_cfg_override=env_cfg_override,
+            sim_backend="mujoco",
+            task_name=args.task,
+        )
+
+    # --- Load policy ---------------------------------------------------------
+    actor_obs_dim = int(env.obs_groups_spec.get("obs", sum(env.obs_groups_spec.values())))
+    flat_obs_dim = int(sum(env.obs_groups_spec.values()))
+
+    policy_obs_mode = args.policy_obs_mode
+    algo_log_name = getattr(args, "algo_log_name", "rsl_rl_ppo")
+    ckpt = None
+    if args.action_mode == "policy":
+        ckpt = resolve_checkpoint(
+            args.task,
+            args.load_run,
+            getattr(args, "checkpoint", None),
+            algo_log_name,
+            getattr(args, "log_root", None),
+        )
+        if policy_obs_mode == "auto" and ckpt is not None:
+            ckpt_dim = _infer_checkpoint_actor_input_dim(ckpt)
+            if ckpt_dim == actor_obs_dim:
+                policy_obs_mode = "actor"
+            elif ckpt_dim == flat_obs_dim:
+                policy_obs_mode = "flat"
+            elif ckpt_dim is not None:
+                raise RuntimeError(
+                    f"Checkpoint actor input dim mismatch: "
+                    f"ckpt={ckpt_dim}, actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim}."
+                )
+            else:
+                policy_obs_mode = "flat"
+
+    wrapped_env = RslRlVecEnvWrapper(env, device=device, policy_obs_mode=policy_obs_mode)
+
+    ppo_cfg = PPOConfig()
+    train_cfg = ppo_cfg.to_dict()
+    if is_rsl_rl_v4():
+        train_cfg = convert_config_v3_to_v4(train_cfg)
+
+    policy = None
+    if args.action_mode == "policy":
+        if ckpt is None:
+            print("[play_viser] WARNING: no checkpoint found — falling back to zero actions.")
+        else:
+            log_dir = str(
+                get_entrypoint_log_root(
+                    ROOT_DIR,
+                    algo_log_name=algo_log_name,
+                    log_root=getattr(args, "log_root", None),
+                )
+                / args.task
+                / "play_temp"
+            )
+            runner = OnPolicyRunner(wrapped_env, train_cfg, log_dir=log_dir, device=device)
+            runner.load(
+                ckpt,
+                load_cfg={
+                    "actor": True,
+                    "critic": False,
+                    "optimizer": False,
+                    "iteration": False,
+                    "rnd": False,
+                },
+            )
+            policy = runner.get_inference_policy(device=device)
+
+    print(f"[play_viser] Action mode: {args.action_mode}")
+
+    # --- Load MuJoCo model for visualization ---------------------------------
+    use_env_visual_model = bool(getattr(args, "use_env_visual_model", True))
+    mj_model = None
+    if use_env_visual_model:
+        model_file = getattr(getattr(env, "cfg", None), "model_file", None)
+        if model_file:
+            try:
+                mj_model = mujoco.MjModel.from_xml_path(str(model_file))
+                print(f"[play_viser] Using visual model: {model_file}")
+            except Exception as exc:
+                print(f"[play_viser] WARNING: failed to load visual model ({exc}).")
+                mj_model = None
+    if mj_model is None:
+        mj_model = env.get_playback_model()
+
+    viz_data = mujoco.MjData(mj_model)
+    state_spec = mujoco.mjtState.mjSTATE_FULLPHYSICS
+    ctrl_dt = env.cfg.ctrl_dt
+
+    # --- Setup viser server --------------------------------------------------
+    port = int(OmegaConf.select(cfg, "viser.port") or 8080)
+    server = viser.ViserServer(port=port)
+    scene = MujocoViserScene(server, mj_model)
+
+    # --- GUI controls --------------------------------------------------------
+    env_options = tuple(f"env_{i}" for i in range(num_envs))
+    initial_env_idx = int(OmegaConf.select(cfg, "viser.env_idx") or 0)
+    initial_env_idx = min(initial_env_idx, num_envs - 1)
+
+    with server.gui.add_folder("Controls"):
+        env_dropdown = server.gui.add_dropdown(
+            "Environment",
+            options=env_options,
+            initial_value=env_options[initial_env_idx],
+        )
+        pause_button = server.gui.add_button("Pause / Resume")
+        speed_slider = server.gui.add_slider(
+            "Speed",
+            min=0.1,
+            max=5.0,
+            step=0.1,
+            initial_value=1.0,
+        )
+
+    paused = {"value": False}
+    env_idx = {"value": initial_env_idx}
+
+    @pause_button.on_click
+    def _on_pause_click(event: Any) -> None:
+        paused["value"] = not paused["value"]
+        status = "paused" if paused["value"] else "resumed"
+        print(f"[play_viser] {status}")
+
+    @env_dropdown.on_update
+    def _on_env_switch(event: Any) -> None:
+        selected = env_dropdown.value
+        idx = int(selected.split("_")[1])
+        env_idx["value"] = idx
+        print(f"[play_viser] Switched to env {idx}")
+
+    obs, _info = wrapped_env.reset()
+    action_low = env.action_space.low
+    action_high = env.action_space.high
+
+    print(f"[play_viser] Server running at http://localhost:{port}")
+    print(f"[play_viser] {num_envs} environment(s) loaded. Open browser to view.")
+    print("[play_viser] Press Ctrl+C to quit.")
+
+    # --- Main loop -----------------------------------------------------------
+    try:
+        with torch.inference_mode():
+            while True:
+                t0 = time.perf_counter()
+
+                if not paused["value"]:
+                    if args.action_mode == "policy" and policy is not None:
+                        actions = policy(obs)
+                    elif args.action_mode == "random":
+                        actions = (
+                            torch.from_numpy(
+                                np.random.uniform(
+                                    action_low,
+                                    action_high,
+                                    size=(num_envs, env.action_space.shape[0]),
+                                )
+                            )
+                            .to(device)
+                            .float()
+                        )
+                    else:  # zero
+                        actions = torch.zeros(num_envs, env.action_space.shape[0], device=device)
+
+                    obs, _, _, _ = wrapped_env.step(actions)
+
+                # Push selected env state into viz_data
+                idx = env_idx["value"]
+                phys = env.get_physics_state_snapshot()[idx].astype(np.float64)
+                mujoco.mj_setState(mj_model, viz_data, phys, state_spec)
+                mujoco.mj_forward(mj_model, viz_data)
+
+                scene.update(viz_data)
+
+                # Real-time pacing
+                speed = speed_slider.value
+                target_dt = ctrl_dt / speed
+                elapsed = time.perf_counter() - t0
+                if target_dt - elapsed > 0:
+                    time.sleep(target_dt - elapsed)
+
+    except KeyboardInterrupt:
+        print("\n[play_viser] Shutting down.")
+
+
+# --------------------------------------------------------------------------- #
+# Hydra entry point                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _build_play_args(cfg: DictConfig) -> PlayInteractiveArgs:
+    return PlayInteractiveArgs(
+        task=str(cfg.training.task_name),
+        load_run=str(cfg.algo.load_run),
+        checkpoint=(
+            str(OmegaConf.select(cfg, "algo.checkpoint"))
+            if OmegaConf.select(cfg, "algo.checkpoint") not in (None, -1, "-1")
+            else None
+        ),
+        action_mode=str(cfg.interactive.action_mode),
+        policy_obs_mode=str(cfg.interactive.policy_obs_mode),
+        algo_log_name=str(cfg.algo.algo_log_name),
+        log_root=(
+            str(cfg.training.log_root)
+            if OmegaConf.select(cfg, "training.log_root") is not None
+            else None
+        ),
+        show_target_bodies=bool(cfg.interactive.show_target_bodies),
+        show_reward_debug=bool(cfg.interactive.show_reward_debug),
+        target_show_axes=bool(cfg.interactive.target_show_axes),
+        target_body_names=str(cfg.interactive.target_body_names),
+        target_max_bodies=int(cfg.interactive.target_max_bodies),
+        target_marker_radius=float(cfg.interactive.target_marker_radius),
+        target_axis_length=float(cfg.interactive.target_axis_length),
+        target_marker_alpha=float(cfg.interactive.target_marker_alpha),
+        reward_debug_show_velocity=bool(cfg.interactive.reward_debug_show_velocity),
+        reward_debug_lin_vel_scale=float(cfg.interactive.reward_debug_lin_vel_scale),
+        reward_debug_ang_vel_scale=float(cfg.interactive.reward_debug_ang_vel_scale),
+        reward_debug_show_connectors=bool(cfg.interactive.reward_debug_show_connectors),
+        reward_debug_show_global_anchor=bool(cfg.interactive.reward_debug_show_global_anchor),
+        camera_follow_body=bool(cfg.interactive.camera_follow_body),
+        camera_focus_body_name=str(cfg.interactive.camera_focus_body_name),
+        camera_height_offset=float(cfg.interactive.camera_height_offset),
+        camera_distance=(
+            float(cfg.interactive.camera_distance)
+            if OmegaConf.select(cfg, "interactive.camera_distance") is not None
+            else None
+        ),
+        camera_elevation=(
+            float(cfg.interactive.camera_elevation)
+            if OmegaConf.select(cfg, "interactive.camera_elevation") is not None
+            else None
+        ),
+        camera_azimuth=(
+            float(cfg.interactive.camera_azimuth)
+            if OmegaConf.select(cfg, "interactive.camera_azimuth") is not None
+            else None
+        ),
+        use_env_visual_model=bool(cfg.interactive.use_env_visual_model),
+    )
+
+
+@hydra.main(version_base="1.3", config_path="../conf/ppo", config_name="config")
+def main(cfg: DictConfig) -> None:
+    if str(cfg.training.sim_backend) != "mujoco":
+        raise ValueError("play_viser.py only supports MuJoCo backend; use task=<task>/mujoco.")
+    play_viser(_build_play_args(cfg), cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -240,6 +240,9 @@ def play_appo(cfg: DictConfig, rl_cfg: dict[str, Any]) -> str | None:
                 "cam_distance": cfg.training.cam_distance,
                 "cam_elevation": cfg.training.cam_elevation,
                 "cam_azimuth": cfg.training.cam_azimuth,
+                "cam_tracking": getattr(cfg.training, "cam_tracking", False),
+                "cam_tracking_env_idx": getattr(cfg.training, "cam_tracking_env_idx", 0),
+                "cam_tracking_extra_envs": getattr(cfg.training, "cam_tracking_extra_envs", 2),
             },
         )
     print(f"Saving video to {output_video} with mediapy...")

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -155,6 +155,9 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
                     "cam_elevation": cfg.training.cam_elevation,
                     "cam_azimuth": cfg.training.cam_azimuth,
                     "cam_lookat": getattr(cfg.training, "cam_lookat", None),
+                    "cam_tracking": getattr(cfg.training, "cam_tracking", False),
+                    "cam_tracking_env_idx": getattr(cfg.training, "cam_tracking_env_idx", 0),
+                    "cam_tracking_extra_envs": getattr(cfg.training, "cam_tracking_extra_envs", 2),
                 },
             )
         print("Done.")

--- a/src/unilab/training/common.py
+++ b/src/unilab/training/common.py
@@ -312,19 +312,39 @@ def render_play_mode(
 
     from unilab.utils import render_many
 
-    frames = render_many.render_states_get_frames(
-        state_list,
-        env.cfg.model_file,
-        width=1280,
-        height=720,
-        camera_id=-1,
-        render_spacing=(
-            float(render_spacing)
-            if render_spacing is not None
-            else float(getattr(env.cfg, "render_spacing", 1.0))
-        ),
-        **(camera_kwargs or {}),
+    cam_kw = dict(camera_kwargs or {})
+    use_tracking = bool(cam_kw.pop("cam_tracking", False))
+    tracking_env_idx = int(cam_kw.pop("cam_tracking_env_idx", 0))
+    tracking_extra_envs = int(cam_kw.pop("cam_tracking_extra_envs", 2))
+    effective_spacing = (
+        float(render_spacing)
+        if render_spacing is not None
+        else float(getattr(env.cfg, "render_spacing", 1.0))
     )
+
+    if use_tracking:
+        frames = render_many.render_states_get_frames_tracking(
+            state_list,
+            env.cfg.model_file,
+            width=1280,
+            height=720,
+            tracking_env_idx=tracking_env_idx,
+            max_extra_envs=tracking_extra_envs,
+            cam_distance=cam_kw.get("cam_distance", 2.0),
+            cam_elevation=cam_kw.get("cam_elevation", -20),
+            cam_azimuth=cam_kw.get("cam_azimuth", 90),
+            render_spacing=effective_spacing,
+        )
+    else:
+        frames = render_many.render_states_get_frames(
+            state_list,
+            env.cfg.model_file,
+            width=1280,
+            height=720,
+            camera_id=-1,
+            render_spacing=effective_spacing,
+            **cam_kw,
+        )
 
     import mediapy as media
 

--- a/src/unilab/utils/render_many.py
+++ b/src/unilab/utils/render_many.py
@@ -353,6 +353,193 @@ def render_states_get_frames(
     return frames
 
 
+def _get_nearest_env_indices(offsets, primary_idx, max_extra):
+    """Return indices of the *max_extra* environments closest to *primary_idx*."""
+    if len(offsets) <= 1 + max_extra:
+        return [i for i in range(len(offsets)) if i != primary_idx]
+    primary = offsets[primary_idx]
+    dists = np.linalg.norm(offsets - primary, axis=1)
+    dists[primary_idx] = np.inf  # exclude self
+    return list(np.argsort(dists)[:max_extra])
+
+
+def render_frame_tracking_job(args):
+    """Render a single frame with camera tracking on the primary env's root body.
+
+    The camera uses ``mjCAMERA_TRACKING`` so it follows the robot each frame.
+    Only the primary env + nearest neighbours are rendered.
+    """
+    (
+        state_batch,
+        offsets,
+        env_indices,
+        primary_local_idx,
+        cam_distance,
+        cam_elevation,
+        cam_azimuth,
+    ) = args
+
+    model = _worker_ctx["model"]
+    data = _worker_ctx["data"]
+    renderer = _worker_ctx["renderer"]
+
+    vopt = mujoco.MjvOption()
+    pert = mujoco.MjvPerturb()
+    catmask_dynamic = mujoco.mjtCatBit.mjCAT_DYNAMIC
+    catmask_static = mujoco.mjtCatBit.mjCAT_STATIC
+
+    def set_state(d, s, offset=None):
+        d.time = s[0]
+        d.qpos[:] = s[1 : 1 + model.nq]
+        d.qvel[:] = s[1 + model.nq : 1 + model.nq + model.nv]
+
+        apply_root_offset = False
+
+        if offset is not None:
+            robot_moved = False
+            first_body_jnt = model.body_jntadr[1] if model.nbody > 1 else -1
+            if first_body_jnt >= 0:
+                jnt_type = model.jnt_type[first_body_jnt]
+                if jnt_type == 0:  # mjJNT_FREE
+                    d.qpos[0] += offset[0]
+                    d.qpos[1] += offset[1]
+                    robot_moved = True
+
+            if not robot_moved:
+                apply_root_offset = True
+
+            box_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "box")
+            if box_id >= 0:
+                jnt_adr = model.body_jntadr[box_id]
+                if jnt_adr >= 0:
+                    qpos_adr = model.jnt_qposadr[jnt_adr]
+                    d.qpos[qpos_adr] += offset[0]
+                    d.qpos[qpos_adr + 1] += offset[1]
+
+            target_x = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_x")
+            if target_x >= 0:
+                d.qpos[model.jnt_qposadr[target_x]] += offset[0]
+
+            target_y = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_y")
+            if target_y >= 0:
+                d.qpos[model.jnt_qposadr[target_y]] += offset[1]
+
+        mujoco.mj_forward(model, d)
+
+        if apply_root_offset and offset is not None:
+            box_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "box")
+            target_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "mocap_target")
+
+            for i in range(model.ngeom):
+                body_id = model.geom_bodyid[i]
+                is_box_or_target = (body_id == box_body_id) or (body_id == target_body_id)
+                is_plane = model.geom_type[i] == mujoco.mjtGeom.mjGEOM_PLANE
+
+                if not is_box_or_target and not is_plane:
+                    d.geom_xpos[i, 0] += offset[0]
+                    d.geom_xpos[i, 1] += offset[1]
+
+            for i in range(model.nsite):
+                body_id = model.site_bodyid[i]
+                is_box_or_target = (body_id == box_body_id) or (body_id == target_body_id)
+                if not is_box_or_target:
+                    d.site_xpos[i, 0] += offset[0]
+                    d.site_xpos[i, 1] += offset[1]
+
+    # Primary env first — camera tracks body 1 of this env
+    primary_global = env_indices[primary_local_idx]
+    set_state(
+        data, state_batch[primary_global], offsets[primary_global] if offsets is not None else None
+    )
+
+    cam = mujoco.MjvCamera()
+    cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+    cam.trackbodyid = 1  # robot root body
+    cam.distance = cam_distance
+    cam.elevation = cam_elevation
+    cam.azimuth = cam_azimuth
+
+    renderer.update_scene(data, camera=cam, scene_option=vopt)
+
+    # Add neighbour envs as background context
+    for local_i, global_i in enumerate(env_indices):
+        if local_i == primary_local_idx:
+            continue
+        set_state(data, state_batch[global_i], offsets[global_i] if offsets is not None else None)
+        mujoco.mjv_addGeoms(model, data, vopt, pert, catmask_dynamic, renderer.scene)
+
+        geomgroup0 = int(vopt.geomgroup[0])
+        vopt.geomgroup[0] = 0
+        mujoco.mjv_addGeoms(model, data, vopt, pert, catmask_static, renderer.scene)
+        vopt.geomgroup[0] = geomgroup0
+
+    return renderer.render()
+
+
+def render_states_get_frames_tracking(
+    state_list,
+    model_path,
+    width=1280,
+    height=720,
+    tracking_env_idx=0,
+    max_extra_envs=2,
+    cam_distance=2.0,
+    cam_elevation=-20,
+    cam_azimuth=90,
+    render_spacing=1.0,
+):
+    """Render with camera tracking on a single primary environment.
+
+    Only the primary env and its nearest neighbours are shown. The camera
+    follows the root body of the primary env each frame (``mjCAMERA_TRACKING``).
+
+    Args:
+        state_list: List of numpy arrays, each shape (num_envs, state_dim).
+        model_path: Path to the mujoco XML model file.
+        tracking_env_idx: Index of the primary environment to track.
+        max_extra_envs: Number of nearest-neighbour envs to render alongside.
+        cam_distance: Camera distance from the tracked body.
+        cam_elevation: Camera elevation angle in degrees.
+        cam_azimuth: Camera azimuth angle in degrees.
+        render_spacing: Grid spacing for env layout.
+    """
+    if not state_list:
+        print("No states to render.")
+        return []
+
+    num_envs = state_list[0].shape[0]
+    offsets = get_grid_offsets(num_envs, spacing=render_spacing)
+    shape = (width, height)
+
+    tracking_env_idx = min(tracking_env_idx, num_envs - 1)
+    neighbour_indices = _get_nearest_env_indices(offsets, tracking_env_idx, max_extra_envs)
+    env_indices = [tracking_env_idx] + neighbour_indices
+    primary_local_idx = 0  # primary is always first in env_indices
+
+    total_shown = len(env_indices)
+    print(
+        f"Rendering {len(state_list)} frames (tracking env {tracking_env_idx} "
+        f"+ {total_shown - 1} neighbours) ..."
+    )
+
+    tasks = [
+        (s, offsets, env_indices, primary_local_idx, cam_distance, cam_elevation, cam_azimuth)
+        for s in state_list
+    ]
+
+    # Camera tracking changes each frame so multiprocessing gives inconsistent
+    # results when workers don't share state. Default to serial.
+    frames = []
+    init_worker(model_path, shape)
+    try:
+        for task in tasks:
+            frames.append(render_frame_tracking_job(task))
+    finally:
+        _close_worker()
+
+    return frames
+
+
 def render_states_to_video(
     state_list,
     model_path,

--- a/src/unilab/utils/viser_scene.py
+++ b/src/unilab/utils/viser_scene.py
@@ -1,0 +1,220 @@
+# pyright: reportMissingImports=false
+"""MuJoCo-to-viser scene adapter for interactive web-based 3D visualization.
+
+This module renders MuJoCo scenes via a viser web server, providing browser-based
+interactive 3D viewing without requiring a local display or GLFW.  It is gated
+behind the ``viser`` optional-dependency group and is **not** imported by default.
+
+Usage (from ``scripts/play_viser.py``)::
+
+    from unilab.utils.viser_scene import MujocoViserScene, VISER_AVAILABLE
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import mujoco
+import numpy as np
+
+try:
+    import trimesh
+    import viser
+
+    VISER_AVAILABLE = True
+except ImportError:
+    VISER_AVAILABLE = False
+
+
+# --------------------------------------------------------------------------- #
+# Rotation helpers (pure numpy, no scipy dependency)                          #
+# --------------------------------------------------------------------------- #
+
+
+def _rotmat_to_wxyz(mat: np.ndarray) -> tuple[float, float, float, float]:
+    """Convert a 3x3 rotation matrix to a (w, x, y, z) quaternion."""
+    m = np.asarray(mat, dtype=np.float64).reshape(3, 3)
+    trace = m[0, 0] + m[1, 1] + m[2, 2]
+
+    if trace > 0:
+        s = 0.5 / math.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (m[2, 1] - m[1, 2]) * s
+        y = (m[0, 2] - m[2, 0]) * s
+        z = (m[1, 0] - m[0, 1]) * s
+    elif m[0, 0] > m[1, 1] and m[0, 0] > m[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + m[0, 0] - m[1, 1] - m[2, 2])
+        w = (m[2, 1] - m[1, 2]) / s
+        x = 0.25 * s
+        y = (m[0, 1] + m[1, 0]) / s
+        z = (m[0, 2] + m[2, 0]) / s
+    elif m[1, 1] > m[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + m[1, 1] - m[0, 0] - m[2, 2])
+        w = (m[0, 2] - m[2, 0]) / s
+        x = (m[0, 1] + m[1, 0]) / s
+        y = 0.25 * s
+        z = (m[1, 2] + m[2, 1]) / s
+    else:
+        s = 2.0 * math.sqrt(1.0 + m[2, 2] - m[0, 0] - m[1, 1])
+        w = (m[1, 0] - m[0, 1]) / s
+        x = (m[0, 2] + m[2, 0]) / s
+        y = (m[1, 2] + m[2, 1]) / s
+        z = 0.25 * s
+
+    return (float(w), float(x), float(y), float(z))
+
+
+# --------------------------------------------------------------------------- #
+# Geometry extraction helpers                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _rgba_to_color(rgba: np.ndarray) -> tuple[int, int, int]:
+    """Convert MuJoCo float RGBA [0,1] to viser int RGB [0,255]."""
+    return (
+        int(np.clip(rgba[0] * 255, 0, 255)),
+        int(np.clip(rgba[1] * 255, 0, 255)),
+        int(np.clip(rgba[2] * 255, 0, 255)),
+    )
+
+
+def _rgba_to_opacity(rgba: np.ndarray) -> float:
+    return float(np.clip(rgba[3], 0.0, 1.0))
+
+
+def _extract_mesh(model: mujoco.MjModel, geom_dataid: int) -> tuple[np.ndarray, np.ndarray]:
+    """Extract vertices and faces for a MuJoCo mesh geom."""
+    vert_adr = model.mesh_vertadr[geom_dataid]
+    vert_num = model.mesh_vertnum[geom_dataid]
+    face_adr = model.mesh_faceadr[geom_dataid]
+    face_num = model.mesh_facenum[geom_dataid]
+
+    vertices = model.mesh_vert[vert_adr : vert_adr + vert_num].copy()
+    faces = model.mesh_face[face_adr : face_adr + face_num].copy()
+    return vertices, faces
+
+
+# --------------------------------------------------------------------------- #
+# MujocoViserScene                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class MujocoViserScene:
+    """Bridges a ``mujoco.MjModel`` to a ``viser.ViserServer`` scene graph.
+
+    Call :meth:`build` once to populate the scene with geometry handles, then
+    call :meth:`update` each frame to sync body transforms from ``MjData``.
+    """
+
+    def __init__(self, server: Any, model: mujoco.MjModel) -> None:
+        if not VISER_AVAILABLE:
+            raise ImportError("viser is not installed. Install with: uv sync --extra viser")
+        self._server: viser.ViserServer = server
+        self._model = model
+        self._handles: dict[int, Any] = {}
+        self._build()
+
+    # ------------------------------------------------------------------ #
+    # Scene construction                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _build(self) -> None:
+        """Create viser scene nodes for every MuJoCo geom."""
+        model = self._model
+        server = self._server
+
+        server.scene.set_up_direction("+z")
+
+        for i in range(model.ngeom):
+            geom_type = model.geom_type[i]
+            size = model.geom_size[i]
+            rgba = model.geom_rgba[i]
+            color = _rgba_to_color(rgba)
+            opacity = _rgba_to_opacity(rgba)
+            name = f"/mujoco/geom/{i}"
+
+            handle = None
+
+            if geom_type == mujoco.mjtGeom.mjGEOM_PLANE:
+                # Render ground plane as a grid
+                plane_size = float(size[0]) if size[0] > 0 else 10.0
+                handle = server.scene.add_grid(
+                    name,
+                    width=plane_size * 2,
+                    height=plane_size * 2,
+                    cell_size=0.5,
+                )
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_SPHERE:
+                handle = server.scene.add_icosphere(
+                    name,
+                    radius=float(size[0]),
+                    color=color,
+                    opacity=opacity,
+                )
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_CAPSULE:
+                half_len = float(size[1])
+                radius = float(size[0])
+                mesh = trimesh.creation.capsule(height=half_len * 2, radius=radius)
+                handle = server.scene.add_mesh_trimesh(name, mesh=mesh)
+                # Manually set color since trimesh mesh may not carry it
+                if hasattr(handle, "color"):
+                    handle.color = color
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_ELLIPSOID:
+                # Use a unit sphere mesh scaled non-uniformly
+                mesh = trimesh.creation.icosphere(subdivisions=3, radius=1.0)
+                mesh.vertices *= np.array([float(size[0]), float(size[1]), float(size[2])])
+                handle = server.scene.add_mesh_trimesh(name, mesh=mesh)
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_CYLINDER:
+                handle = server.scene.add_cylinder(
+                    name,
+                    radius=float(size[0]),
+                    height=float(size[1]) * 2,
+                    color=color,
+                    opacity=opacity,
+                )
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_BOX:
+                handle = server.scene.add_box(
+                    name,
+                    dimensions=(
+                        float(size[0]) * 2,
+                        float(size[1]) * 2,
+                        float(size[2]) * 2,
+                    ),
+                    color=color,
+                    opacity=opacity,
+                )
+
+            elif geom_type == mujoco.mjtGeom.mjGEOM_MESH:
+                dataid = model.geom_dataid[i]
+                if dataid >= 0:
+                    vertices, faces = _extract_mesh(model, dataid)
+                    handle = server.scene.add_mesh_simple(
+                        name,
+                        vertices=vertices.astype(np.float32),
+                        faces=faces.astype(np.int32),
+                        color=color,
+                        opacity=opacity,
+                    )
+
+            if handle is not None:
+                self._handles[i] = handle
+
+    # ------------------------------------------------------------------ #
+    # Per-frame update                                                    #
+    # ------------------------------------------------------------------ #
+
+    def update(self, data: mujoco.MjData) -> None:
+        """Sync all geom transforms from *data* into the viser scene."""
+        with self._server.atomic():
+            for i, handle in self._handles.items():
+                xpos = data.geom_xpos[i]
+                xmat = data.geom_xmat[i]
+
+                handle.position = (float(xpos[0]), float(xpos[1]), float(xpos[2]))
+                handle.wxyz = _rotmat_to_wxyz(xmat)


### PR DESCRIPTION
## Summary

This PR adds two visualization improvements for `task=g1_motion_tracking/mujoco` on the PPO path:

1. Play-mode camera tracking for MuJoCo replay.
2. A browser-based viewer via `scripts/play_viser.py` (Viser), without local GLFW window dependency.

## What Changed

- Config
  - Added `training.cam_tracking`
  - Added `training.cam_tracking_env_idx`
  - Added `training.cam_tracking_extra_envs`
  - Added `viser.port` and `viser.env_idx` in PPO config

- Play rendering path
  - Wired tracking camera args from:
    - `scripts/train_rsl_rl.py`
    - `scripts/train_appo.py`
  - Updated `src/unilab/training/common.py` to switch between normal render and tracking render path.
  - Added tracking render implementation in `src/unilab/utils/render_many.py`:
    - Track primary env root body with MuJoCo tracking camera
    - Render primary env + nearest neighbor envs for context

- New browser visualization
  - Added `scripts/play_viser.py`
  - Added `src/unilab/utils/viser_scene.py`
  - Supports env switching, pause/resume, and speed control in browser UI
  - MuJoCo-only path

- Dependencies
  - Added optional extra in `pyproject.toml`:
    - `viser>=1.0.26`
    - `trimesh>=3.21.7`

- Docs
  - Updated `docs/zh_CN/05-g1-motion-tracking.md` with a short “PPO Motion Tracking: Play Tracking + Viser” section and minimal CLI examples.

## Validation Commands

```bash
# install viser deps (only needed for viser viewer)
uv sync --extra viser

# PPO play replay with tracking
uv run python scripts/train_rsl_rl.py \
  task=g1_motion_tracking/mujoco \
  training.play_only=true \
  training.cam_tracking=true \
  algo.load_run=xxx \
  algo.checkpoint=xxx

# viser viewer (zero action)
uv run python scripts/play_viser.py \
  task=g1_motion_tracking/mujoco \
  interactive.action_mode=zero \
  algo.num_envs=4 \
  viser.port=8080

# viser viewer (policy)
uv run python scripts/play_viser.py \
  task=g1_motion_tracking/mujoco \
  interactive.action_mode=policy \
  algo.load_run=xxx \
  algo.checkpoint=xxx \
  algo.num_envs=4 \
  viser.port=8080
