### PR TITLE
fix: remove backend hot-path type shims

### DIFF
--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -85,9 +85,7 @@ class MotrixBackend(SimBackend):
             for floating_base in getattr(self._model, "floating_bases", [])
             if len(floating_base.dof_pos_indices) >= 7
         )
-        self._default_base_mass_override = np.array(
-            self._body_link.get_mass_override(self._data)
-        )
+        self._default_base_mass_override = np.array(self._body_link.get_mass_override(self._data))
         self._default_base_com_override = np.array(
             self._body_link.get_center_of_mass_override(self._data)
         )
@@ -232,8 +230,8 @@ class MotrixBackend(SimBackend):
 
     def get_base_pos(self) -> np.ndarray:
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_translation(self._data)
-        return self._body_link.get_pose(self._data)[:, :3]
+            return self._body_floatingbase.get_translation(self._data)  # type: ignore[no-any-return]
+        return self._body_link.get_pose(self._data)[:, :3]  # type: ignore[no-any-return]
 
     def get_base_quat(self) -> np.ndarray:
         if self._body_floatingbase is not None:
@@ -244,23 +242,23 @@ class MotrixBackend(SimBackend):
 
     def get_base_lin_vel(self) -> np.ndarray:
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_global_linear_velocity(self._data)
-        return self._body_link.get_linear_velocity(self._data)
+            return self._body_floatingbase.get_global_linear_velocity(self._data)  # type: ignore[no-any-return]
+        return self._body_link.get_linear_velocity(self._data)  # type: ignore[no-any-return]
 
     def get_base_ang_vel(self) -> np.ndarray:
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_global_angular_velocity(self._data)
-        return self._body_link.get_angular_velocity(self._data)
+            return self._body_floatingbase.get_global_angular_velocity(self._data)  # type: ignore[no-any-return]
+        return self._body_link.get_angular_velocity(self._data)  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------ #
     # DOF state                                                          #
     # ------------------------------------------------------------------ #
 
     def get_dof_pos(self) -> np.ndarray:
-        return self._body.get_joint_dof_pos(self._data)
+        return self._body.get_joint_dof_pos(self._data)  # type: ignore[no-any-return]
 
     def get_dof_vel(self) -> np.ndarray:
-        return self._body.get_joint_dof_vel(self._data)
+        return self._body.get_joint_dof_vel(self._data)  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------ #
     # Body kinematics — world frame                                      #
@@ -303,7 +301,7 @@ class MotrixBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def get_sensor_data(self, name: str) -> np.ndarray:
-        return self._model.get_sensor_value(name, self._data)
+        return self._model.get_sensor_value(name, self._data)  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------ #
     # MotrixSim-specific                                                 #

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -556,35 +556,35 @@ class MuJoCoBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def _get_mapped_indices(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._body_id_to_tracked_idx[body_ids])
+        return self._body_id_to_tracked_idx[body_ids]  # type: ignore[no-any-return]
 
     def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_pos_w_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_pos_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_quat_w_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_quat_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_linvel_w_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_linvel_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_angvel_w_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_angvel_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------ #
     # Body kinematics — baselink frame                                   #
     # ------------------------------------------------------------------ #
 
     def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_pos_b_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_pos_b_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_quat_b_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_quat_b_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_linvel_b_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_linvel_b_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
-        return np.asarray(self._tracked_angvel_b_all[:, self._get_mapped_indices(body_ids), :])
+        return self._tracked_angvel_b_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------ #
     # Sensors                                                            #


### PR DESCRIPTION
## Summary
- remove backend hot-path `np.asarray(...)` wrappers that were only serving static typing
- keep backend return contracts while avoiding extra runtime calls in MuJoCo and Motrix getters
- use local `# type: ignore[no-any-return]` only at third-party stub boundaries

## Validation
- pre-commit hooks on commit (`ruff`, `ruff format`, `pyright`, `mypy`)
- `UV_CACHE_DIR=.uv-cache uv run --no-sync ruff format --check .`
- `UV_CACHE_DIR=.uv-cache uv run --no-sync ruff check .`
- `UV_CACHE_DIR=.uv-cache uv run --no-sync mypy src/unilab`

## Notes
- stacked on top of #293 / `fix/motrix-remove-unnecessary-np-asarray`