### PR TITLE
refactor: enforce single critic observation contract

### DIFF
--- a/conf/offpolicy/task/sac/g1_sac/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_sac/mujoco.yaml
@@ -16,6 +16,12 @@ env:
     action_scale: 1.0
   gait_phase_init_mode: "offset_phase"
   reset_base_qvel_limit: 0.5
+  noise_config:
+    scale_gyro: 0.0
+    scale_gravity: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.1
+    scale_linvel: 0.0
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/conf/ppo/task/sharpa_inhand/motrix.yaml
+++ b/conf/ppo/task/sharpa_inhand/motrix.yaml
@@ -46,7 +46,7 @@ env:
   rot_axis: [0.0, 0.0, 1.0]
   grasp_cache_path: cache/sharpa_grasp_linspace
   joint_noise_scale: 0.0
-  privileged_obs_mode: merged
+  critic_obs_mode: merged
   observation_mode: simple
   sensor:
     tactile_force_sensor_names:

--- a/conf/ppo/task/sharpa_inhand/mujoco.yaml
+++ b/conf/ppo/task/sharpa_inhand/mujoco.yaml
@@ -51,7 +51,7 @@ env:
   rot_axis: [0.0, 0.0, 1.0]
   grasp_cache_path: cache/sharpa_grasp_linspace
   joint_noise_scale: 0.0
-  privileged_obs_mode: merged
+  critic_obs_mode: merged
   observation_mode: simple
   sensor:
     tactile_force_sensor_names:

--- a/conf/ppo/task/sharpa_inhand_grasp/motrix.yaml
+++ b/conf/ppo/task/sharpa_inhand_grasp/motrix.yaml
@@ -47,7 +47,7 @@ env:
   rot_axis: [0.0, 0.0, 1.0]
   grasp_cache_path: cache/sharpa_grasp_linspace
   joint_noise_scale: 0.02
-  privileged_obs_mode: merged
+  critic_obs_mode: merged
   sensor:
     tactile_force_sensor_names:
       - contact_right_thumb_elastomer_force

--- a/conf/ppo/task/sharpa_inhand_grasp/mujoco.yaml
+++ b/conf/ppo/task/sharpa_inhand_grasp/mujoco.yaml
@@ -47,7 +47,7 @@ env:
   rot_axis: [0.0, 0.0, 1.0]
   grasp_cache_path: cache/sharpa_grasp_linspace
   joint_noise_scale: 0.02
-  privileged_obs_mode: merged
+  critic_obs_mode: merged
   sensor:
     tactile_force_sensor_names:
       - contact_right_thumb_elastomer_force

--- a/docs/zh_CN/00-development-architecture.md
+++ b/docs/zh_CN/00-development-architecture.md
@@ -155,6 +155,7 @@ Env **负责** MDP 语义、observation 结构、reward、reset，以及 backend
 - [ADR-0002 Backend Capability Boundary For Play And Snapshot](adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
 - [ADR-0003 Task Owner And Config Compose Contract](adr/ADR-0003-task-owner-and-config-compose-contract.md)
 - [ADR-0004 Registry Bootstrap Contract](adr/ADR-0004-registry-bootstrap-contract.md)
+- [ADR-0005 Unified Obs Critic Env And IPC Contract](adr/ADR-0005-unified-obs-critic-env-and-ipc-contract.md)
 
 协作与交付流程要求见 [Collaboration](06-collaboration.md)。
 

--- a/docs/zh_CN/adr/ADR-0005-unified-obs-critic-env-and-ipc-contract.md
+++ b/docs/zh_CN/adr/ADR-0005-unified-obs-critic-env-and-ipc-contract.md
@@ -1,0 +1,67 @@
+# ADR-0005 Unified Obs Critic Env And IPC Contract
+
+语言: 简体中文
+
+## Status
+
+Accepted
+
+## Context
+
+UniLab 已经收敛到 `NpEnvState.obs: dict[str, np.ndarray]`，但历史实现里仍混杂过多种观测语义：
+
+- actor 路径消费 `obs`
+- 部分 env 额外暴露所谓 `privileged`
+- 部分 off-policy / asymmetric critic 路径又单独引入 `critic`
+
+这会直接破坏 contract-first：
+
+1. 同一个 env 在不同 learner / runner / IPC 路径里，critic 输入语义不一致。
+2. actor 路径可能意外吃到 critic-only 特征。
+3. 某些链路需要靠脚本层或 learner 层猜测如何把 actor obs、extra obs 重新拼成 critic 输入。
+
+这些都不是 owner layer 的职责，也不是可接受的顶层设计。
+
+## Decision
+
+UniLab 运行时 observation contract 统一为且仅为两层：
+
+1. Env observation dict
+   - `obs` 是唯一必选键，表示 actor observation。
+   - `critic` 是唯一可选额外键，表示 critic observation。
+   - 运行时不再承认 `privileged` 是 observation contract 的一部分。
+
+2. Actor contract
+   - actor 只消费 `obs`。
+   - 所谓 flat actor policy 也只等价于 `obs`；不能拼接 `critic`，更不能从别处推导 critic-only 信息。
+
+3. Critic contract
+   - critic 若存在 asymmetric 输入，则由 env owner layer 直接产出完整 `critic`。
+   - critic 若不存在单独输入，则显式回退到 `obs`。
+   - 不允许在 runner、learner、script、IPC 层做隐式拼接、补齐、猜测或兼容转换。
+
+4. IPC contract
+   - on-policy 与 off-policy 统一只传递：
+     - `obs`
+     - 可选 `critic`
+     - `next_obs`
+     - 可选 `next_critic`
+     - `last_obs`
+     - 可选 `last_critic`
+   - terminal patching / timeout bootstrap 若 env 提供 `critic`，必须原样保留并传到 critic 路径。
+
+5. Adapter boundary
+   - 某些第三方库若仍使用历史字段名，例如 RSL-RL 的 `num_privileged_obs` / `get_privileged_observations()`，只允许在 adapter boundary 做名字映射。
+   - 该映射不改变 UniLab 内部 contract；其语义必须仍然是 `critic`。
+
+## Consequences
+
+- asymmetric actor-critic 的职责被固定在 env owner layer，不再向 learner / script 扩散。
+- APPO、off-policy replay、terminal bootstrap、RSL wrapper 使用同一套 `obs` + optional `critic` 语义。
+- 新 env 若需要 critic-only 信息，必须在 `obs_groups_spec` 和 `_compute_obs()` 中直接声明 `critic`，而不是新增第三种历史键名。
+
+## Non-Goals
+
+- 不要求所有 env 都必须提供 `critic`。
+- 不要求第三方库同步改名；外部接口名兼容可以留在 adapter boundary。
+- 不把 `training.sim_backend`、脚本参数或 checkpoint 兼容逻辑混入 observation contract。

--- a/docs/zh_CN/adr/README.md
+++ b/docs/zh_CN/adr/README.md
@@ -10,6 +10,7 @@
 - [ADR-0002 Backend Capability Boundary For Play And Snapshot](ADR-0002-backend-capability-boundary-for-play-and-snapshot.md)
 - [ADR-0003 Task Owner And Config Compose Contract](ADR-0003-task-owner-and-config-compose-contract.md)
 - [ADR-0004 Registry Bootstrap Contract](ADR-0004-registry-bootstrap-contract.md)
+- [ADR-0005 Unified Obs Critic Env And IPC Contract](ADR-0005-unified-obs-critic-env-and-ipc-contract.md)
 
 ## 与主文档的关系
 

--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -138,7 +138,7 @@ def play_appo(cfg: DictConfig, rl_cfg: dict[str, Any]) -> str | None:
     )
     from unilab.utils.obs_utils import get_obs_dims
 
-    obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
+    obs_dim, critic_dim = get_obs_dims(env.obs_groups_spec)
     action_shape = env.action_space.shape
     if action_shape is None:
         raise ValueError("env.action_space.shape must be defined")
@@ -146,13 +146,23 @@ def play_appo(cfg: DictConfig, rl_cfg: dict[str, Any]) -> str | None:
 
     rl_cfg_dict = dict(rl_cfg)
     if "obs_groups" not in rl_cfg_dict:
-        rl_cfg_dict["obs_groups"] = {"actor": {"policy": obs_dim}}
+        rl_cfg_dict["obs_groups"] = {
+            "actor": {"policy": obs_dim},
+            "critic": {"policy": critic_dim if critic_dim > 0 else obs_dim},
+        }
     else:
         actor_group = rl_cfg_dict["obs_groups"].get(
             "actor", rl_cfg_dict["obs_groups"].get("policy", {})
         )
         if isinstance(actor_group, dict) and "policy" in actor_group:
             actor_group["policy"] = obs_dim
+        critic_group = rl_cfg_dict["obs_groups"].get("critic")
+        if critic_group is None:
+            rl_cfg_dict["obs_groups"]["critic"] = {
+                "policy": critic_dim if critic_dim > 0 else obs_dim
+            }
+        elif isinstance(critic_group, dict) and "policy" in critic_group:
+            critic_group["policy"] = critic_dim if critic_dim > 0 else obs_dim
 
     if is_rsl_rl_v5():
         pass

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -100,6 +100,11 @@ def build_runner(algo_name: str, cfg: DictConfig):
         if cfg.training.num_gpus > 1:
             from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
 
+            if cfg.algo.use_symmetry:
+                raise ValueError(
+                    "Off-policy symmetry augmentation does not support training.num_gpus > 1"
+                )
+
             ensure_registries()
             device = cfg.training.device or get_default_device()
             env = create_env(
@@ -131,7 +136,6 @@ def build_runner(algo_name: str, cfg: DictConfig):
                 "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
                 "use_amp": cfg.training.use_amp,
                 "critic_obs_dim": critic_dim,
-                # symmetry not supported in multi-GPU mode (mujoco_model not picklable)
                 "use_symmetry": False,
             }
             main_learner = FastSACLearner(device=device, **learner_kwargs)

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -110,7 +110,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             assert env.action_space.shape
             from unilab.utils.obs_utils import get_obs_dims
 
-            obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
+            obs_dim, critic_dim = get_obs_dims(env.obs_groups_spec)
             action_dim = env.action_space.shape[0]
             env.close()
 
@@ -130,7 +130,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
                 "use_layer_norm": cfg.algo.use_layer_norm,
                 "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
                 "use_amp": cfg.training.use_amp,
-                "privileged_dim": privileged_dim,
+                "critic_obs_dim": critic_dim,
                 # symmetry not supported in multi-GPU mode (mujoco_model not picklable)
                 "use_symmetry": False,
             }

--- a/src/unilab/algos/torch/appo/learner.py
+++ b/src/unilab/algos/torch/appo/learner.py
@@ -197,11 +197,11 @@ class APPOLearner:
         importance-sampling-corrected value targets and advantages.
         """
         obs = batch_dict["observations"]  # [T, N, D]
-        privileged = batch_dict.get("privileged", None)  # [T, N, P] or None
+        critic_base = batch_dict.get("critic", None)  # [T, N, C] or None
         rewards = batch_dict["rewards"]  # [T, N]
         dones = batch_dict["dones"].float()  # [T, N]
         last_obs = batch_dict["last_obs"]  # [N, D]
-        last_privileged = batch_dict.get("last_privileged", None)  # [N, P] or None
+        last_critic = batch_dict.get("last_critic", None)  # [N, C] or None
         behavior_log_probs = batch_dict["actions_log_prob"]  # [T, N]
         actions = batch_dict["actions"]  # [T, N, A]
 
@@ -212,13 +212,13 @@ class APPOLearner:
         obs_td = TensorDict({"policy": obs_flat}, batch_size=obs_flat.shape[0], device=self.device)
         last_obs_td = TensorDict({"policy": last_obs}, batch_size=N, device=self.device)
 
-        # Critic: obs + privileged
-        if privileged is not None:
-            critic_obs = torch.cat([obs, privileged], dim=-1)  # [T, N, D+P]
-            critic_last_obs = torch.cat([last_obs, last_privileged], dim=-1)  # [N, D+P]
-        else:
-            critic_obs = obs
-            critic_last_obs = last_obs
+        # Critic: explicit critic obs when available, else actor obs
+        if critic_base is None:
+            critic_base = obs
+        if last_critic is None:
+            last_critic = last_obs
+        critic_obs = critic_base
+        critic_last_obs = last_critic
         critic_obs_flat = critic_obs.flatten(0, 1)  # [T*N, D+P]
         critic_obs_td = TensorDict(
             {"policy": critic_obs_flat}, batch_size=critic_obs_flat.shape[0], device=self.device
@@ -305,16 +305,14 @@ class APPOLearner:
                 {"policy": obs_flat}, batch_size=obs_flat.shape[0], device=self.device
             )
 
-        # Critic uses obs+privileged
+        # Critic uses explicit critic obs when available
         critic_obs_flat = batch_dict.get("_critic_obs_flat")
         if critic_obs_flat is None:
-            # Fallback if not cached (shouldn't happen)
-            privileged_flat = batch_dict.get("privileged")
-            if privileged_flat is not None:
-                privileged_flat = privileged_flat.flatten(0, 1)
-                critic_obs_flat = torch.cat([obs_flat, privileged_flat], dim=-1)
-            else:
+            critic_base_flat = batch_dict.get("critic")
+            if critic_base_flat is None:
                 critic_obs_flat = obs_flat
+            else:
+                critic_obs_flat = critic_base_flat.flatten(0, 1)
         critic_obs_td = TensorDict(
             {"policy": critic_obs_flat}, batch_size=critic_obs_flat.shape[0], device=self.device
         )

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -68,19 +68,27 @@ class APPORunner(AsyncRunner):
 
         # Update rl_cfg so internal RSL-RL networks get correct observation dimension
         if "obs_groups" not in self.rl_cfg:
-            self.rl_cfg["obs_groups"] = {"actor": {"policy": self.obs_dim}}
+            self.rl_cfg["obs_groups"] = {
+                "actor": {"policy": self.obs_dim},
+                "critic": {"policy": self.critic_input_dim},
+            }
         else:
             actor_group = self.rl_cfg["obs_groups"].get(
                 "actor", self.rl_cfg["obs_groups"].get("policy", {})
             )
             if isinstance(actor_group, dict) and "policy" in actor_group:
                 actor_group["policy"] = self.obs_dim
+            critic_group = self.rl_cfg["obs_groups"].get("critic")
+            if critic_group is None:
+                self.rl_cfg["obs_groups"]["critic"] = {"policy": self.critic_input_dim}
+            elif isinstance(critic_group, dict) and "policy" in critic_group:
+                critic_group["policy"] = self.critic_input_dim
 
     def _detect_dims(self):
         """Create a tiny env to read obs/action dims, then close it."""
         from unilab.base import registry
         from unilab.utils.algo_utils import ensure_registries
-        from unilab.utils.obs_utils import get_obs_dims
+        from unilab.utils.obs_utils import get_critic_base_dim, get_obs_dims
 
         ensure_registries()
 
@@ -90,8 +98,9 @@ class APPORunner(AsyncRunner):
             sim_backend=self.extra_kwargs.get("sim_backend", "mujoco"),
             env_cfg_override=self.env_cfg_overrides if self.env_cfg_overrides else None,
         )
-        obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
-        self.privileged_dim = privileged_dim
+        obs_dim, critic_dim = get_obs_dims(env.obs_groups_spec)
+        self.critic_dim = critic_dim
+        self.critic_input_dim = get_critic_base_dim(env.obs_groups_spec)
         assert env.action_space.shape is not None
         action_dim = env.action_space.shape[0]
         env.close()
@@ -111,8 +120,7 @@ class APPORunner(AsyncRunner):
         obs_example = torch.zeros((self.num_envs, self.obs_dim), device=self.device)
         td_example = TensorDict({"policy": obs_example}, batch_size=self.num_envs)
 
-        # Critic input includes privileged obs
-        critic_obs_dim = self.obs_dim + self.privileged_dim
+        critic_obs_dim = self.critic_input_dim
         critic_obs_example = torch.zeros((self.num_envs, critic_obs_dim), device=self.device)
         critic_td_example = TensorDict({"policy": critic_obs_example}, batch_size=self.num_envs)
 
@@ -129,7 +137,7 @@ class APPORunner(AsyncRunner):
         critic_cls = resolve_callable(critic_cfg.pop("class_name", "rsl_rl.models.MLPModel"))
         critic_cfg.pop("num_actions", None)
         critic_cfg.pop("distribution_cfg", None)  # critic is deterministic
-        critic = critic_cls(critic_td_example, cfg["obs_groups"], "actor", 1, **critic_cfg)
+        critic = critic_cls(critic_td_example, cfg["obs_groups"], "critic", 1, **critic_cfg)
 
         # Extract algorithm hyperparams from rl_cfg["algorithm"] (or top-level)
         algo_cfg = cfg.get("algorithm", cfg)
@@ -182,7 +190,7 @@ class APPORunner(AsyncRunner):
             num_steps=self.steps_per_env,
             obs_dim=self.obs_dim,
             action_dim=self.action_dim,
-            privileged_dim=self.privileged_dim,
+            critic_dim=self.critic_dim,
             num_slots=4,
             create=True,
         )
@@ -219,7 +227,7 @@ class APPORunner(AsyncRunner):
             ),
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
-            "privileged_dim": self.privileged_dim,
+            "critic_dim": self.critic_dim,
             "actor_weight_sync_name": actor_weight_sync.name,
             "actor_weight_param_shapes": actor_weight_param_shapes,
             "critic_weight_sync_name": critic_weight_sync.name,
@@ -301,7 +309,7 @@ class APPORunner(AsyncRunner):
                 # Preprocess: storage is [N, T, *] (env-major); learner expects [T, N, *]
                 rollout: dict = {}
                 for k, v in raw.items():
-                    if k not in ("last_obs", "last_privileged") and v.ndim >= 2:
+                    if k not in ("last_obs", "last_critic") and v.ndim >= 2:
                         rollout[k] = v.transpose(0, 1)
                     else:
                         rollout[k] = v
@@ -319,8 +327,8 @@ class APPORunner(AsyncRunner):
             # computed independently per env-column — correct for any staleness level.
             combined: dict = {}
             for k in replay_queue[0]:
-                if k in ("last_obs", "last_privileged"):
-                    # last_obs and last_privileged are [N, D] - concat along dim 0
+                if k in ("last_obs", "last_critic"):
+                    # last_obs and last_critic are [N, D] - concat along dim 0
                     combined[k] = torch.cat([r[k] for r in replay_queue], dim=0)
                 else:
                     # All other tensors are [T, N, ...] - concat along dim 1 (env dimension)

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -26,7 +26,7 @@ def compute_timeout_bootstrap_correction(
     gamma: float,
     timeout_mask: np.ndarray,
     final_obs: np.ndarray,
-    final_privileged: np.ndarray | None,
+    final_critic: np.ndarray | None = None,
 ) -> np.ndarray:
     """Compute gamma * V(final_observation) for current timeout envs."""
     corrections = np.zeros(timeout_mask.shape, dtype=np.float32)
@@ -35,9 +35,7 @@ def compute_timeout_bootstrap_correction(
 
     from tensordict import TensorDict
 
-    critic_input_np = final_obs
-    if final_privileged is not None:
-        critic_input_np = np.concatenate([final_obs, final_privileged], axis=-1)
+    critic_input_np = final_critic if final_critic is not None else final_obs
     critic_input = torch.from_numpy(critic_input_np[timeout_mask]).to(collector_device)
     critic_td = TensorDict(
         {"policy": critic_input},
@@ -60,7 +58,7 @@ def appo_collector_fn(
     sync_primitives: tuple,
     obs_dim: int,
     action_dim: int,
-    privileged_dim: int,
+    critic_dim: int,
     actor_weight_sync_name: str,
     actor_weight_param_shapes: dict,
     critic_weight_sync_name: str,
@@ -90,7 +88,7 @@ def appo_collector_fn(
         num_steps=steps_per_env,
         obs_dim=obs_dim,
         action_dim=action_dim,
-        privileged_dim=privileged_dim,
+        critic_dim=critic_dim,
         create=False,
         shm_name_prefix=shm_storage_name,
     )
@@ -132,7 +130,7 @@ def appo_collector_fn(
     actor = actor.to(collector_device)
     actor.eval()
 
-    critic_obs_dim = obs_dim + privileged_dim
+    critic_obs_dim = critic_dim if critic_dim > 0 else obs_dim
     critic_obs_example = torch.zeros((num_envs, critic_obs_dim), device=collector_device)
     critic_td_example = TensorDict({"policy": critic_obs_example}, batch_size=num_envs)
     critic_cfg = deepcopy(cfg.get("critic") or cfg.get("actor") or {})
@@ -141,8 +139,8 @@ def appo_collector_fn(
     critic_cfg.pop("distribution_cfg", None)
     critic = critic_cls(
         critic_td_example,
-        cfg.get("obs_groups", {"actor": {"policy": critic_obs_dim}}),
-        "actor",
+        cfg.get("obs_groups", {"critic": {"policy": critic_obs_dim}}),
+        "critic",
         1,
         **critic_cfg,
     )
@@ -172,10 +170,10 @@ def appo_collector_fn(
             x = x.cpu().numpy()
         return np.asarray(x, dtype=np.float32)
 
-    obs_np, priv_np = split_obs_dict(obs_out)
+    obs_np, critic_np = split_obs_dict(obs_out)
     obs_np = to_float32_np(obs_np)
-    if priv_np is not None:
-        priv_np = to_float32_np(priv_np)
+    if critic_np is not None:
+        critic_np = to_float32_np(critic_np)
 
     # Pre-allocate obs TensorDict once; update in-place each step to avoid
     # repeated TensorDict construction overhead in the hot loop.
@@ -225,8 +223,8 @@ def appo_collector_fn(
                 )
 
                 write_buf["obs"][:, step, :] = obs_np
-                if priv_np is not None:
-                    write_buf["privileged"][:, step, :] = priv_np
+                if critic_np is not None:
+                    write_buf["critic"][:, step, :] = critic_np
                 write_buf["actions"][:, step, :] = actions_np
                 write_buf["log_probs"][:, step] = log_probs_torch.cpu().numpy().ravel()
 
@@ -243,10 +241,10 @@ def appo_collector_fn(
                 truncated_raw = np.asarray(state.truncated, dtype=np.float32).ravel()
                 combined_done_raw = np.clip(terminated_raw + truncated_raw, 0, 1)
 
-                next_actor_obs_np, next_actor_priv_np = split_obs_dict(next_obs_raw)
+                next_actor_obs_np, next_critic_np = split_obs_dict(next_obs_raw)
                 next_actor_obs_np = to_float32_np(next_actor_obs_np)
-                if next_actor_priv_np is not None:
-                    next_actor_priv_np = to_float32_np(next_actor_priv_np)
+                if next_critic_np is not None:
+                    next_critic_np = to_float32_np(next_critic_np)
                 terminal_contract = resolve_terminal_observation_contract(
                     next_obs_batch_size=next_actor_obs_np.shape[0],
                     final_observation=getattr(state, "final_observation", None),
@@ -265,10 +263,10 @@ def appo_collector_fn(
                         if terminal_contract.terminal_obs is not None
                         else next_actor_obs_np
                     ),
-                    final_privileged=(
-                        terminal_contract.terminal_privileged
-                        if terminal_contract.terminal_privileged is not None
-                        else next_actor_priv_np
+                    final_critic=(
+                        terminal_contract.terminal_critic
+                        if terminal_contract.terminal_critic is not None
+                        else next_critic_np
                     ),
                 )
 
@@ -326,11 +324,11 @@ def appo_collector_fn(
                         print(f"[APPOWorker] metrics enqueue error: {e}", file=sys.stderr)
 
                 obs_np = next_actor_obs_np
-                priv_np = next_actor_priv_np
+                critic_np = next_critic_np
 
             write_buf["last_obs"][:] = obs_np
-            if priv_np is not None:
-                write_buf["last_privileged"][:] = priv_np
+            if critic_np is not None:
+                write_buf["last_critic"][:] = critic_np
             storage.signal_write_done()  # atomic increment, non-blocking
 
     except Exception as e:

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -19,6 +19,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
+from unilab.base.augmentation import SymmetryAugmentation
+
 # ---------------------------------------------------------------------------
 # Actor Network (holosoma-style: SiLU + LayerNorm + Tanh squashing)
 # ---------------------------------------------------------------------------
@@ -375,8 +377,7 @@ class FastSACLearner:
         use_autotune: bool = True,
         use_symmetry: bool = False,
         use_amp: bool = False,
-        mujoco_model=None,
-        obs_structure: dict | None = None,
+        symmetry_augmentation: SymmetryAugmentation | None = None,
         world_size: int = 1,
         critic_obs_dim: int = 0,
     ):
@@ -464,18 +465,8 @@ class FastSACLearner:
         # AMP scaler for mixed precision
         self.scaler = torch.amp.GradScaler("cuda") if self.use_amp else None  # pyright: ignore[reportPrivateImportUsage]
 
-        # Symmetry augmentation (G1 only)
-        self.use_symmetry = (
-            use_symmetry
-            and (action_dim == 29)
-            and (mujoco_model is not None)
-            and (obs_structure is not None)
-        )
-        if self.use_symmetry:
-            from unilab.envs.locomotion.g1.symmetry import G1SymmetryAugmentation
-
-            assert obs_structure is not None
-            self.symmetry = G1SymmetryAugmentation(mujoco_model, obs_structure, device=device)
+        self.symmetry = symmetry_augmentation
+        self.use_symmetry = use_symmetry and symmetry_augmentation is not None
 
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.
@@ -516,15 +507,24 @@ class FastSACLearner:
         if self.use_symmetry:
             orig_actions = actions
 
-            # Augment actor observations and actions via proper symmetry
-            obs, actions = self.symmetry.augment(obs, actions)
-            next_obs, _ = self.symmetry.augment(next_obs, orig_actions)
+            assert self.symmetry is not None
+            obs, actions = self.symmetry.augment_obs_and_actions(obs, actions, obs_group="obs")
+            next_obs, _ = self.symmetry.augment_obs_and_actions(
+                next_obs, orig_actions, obs_group="obs"
+            )
 
-            # Augment critic trunk: use dedicated path when provided, else reuse actor-aug
             if critic is not None:
                 assert next_critic is not None
-                critic_base_aug, _ = self.symmetry.augment(critic, orig_actions)
-                critic_next_base_aug, _ = self.symmetry.augment(next_critic, orig_actions)
+                critic_base_aug, _ = self.symmetry.augment_obs_and_actions(
+                    critic,
+                    orig_actions,
+                    obs_group="critic",
+                )
+                critic_next_base_aug, _ = self.symmetry.augment_obs_and_actions(
+                    next_critic,
+                    orig_actions,
+                    obs_group="critic",
+                )
             else:
                 critic_base_aug = obs
                 critic_next_base_aug = next_obs
@@ -626,12 +626,14 @@ class FastSACLearner:
 
         # Apply symmetry augmentation
         if self.use_symmetry:
-            # Augment actor observations
-            obs = torch.cat([obs, self.symmetry.mirror_obs(obs)], dim=0)
+            assert self.symmetry is not None
+            obs = torch.cat([obs, self.symmetry.mirror_obs(obs, obs_group="obs")], dim=0)
 
-            # Augment critic trunk: dedicated path when critic key is provided
             if critic is not None:
-                critic_base_aug = torch.cat([critic, self.symmetry.mirror_obs(critic)], dim=0)
+                critic_base_aug = torch.cat(
+                    [critic, self.symmetry.mirror_obs(critic, obs_group="critic")],
+                    dim=0,
+                )
             else:
                 critic_base_aug = obs
 

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -379,6 +379,7 @@ class FastSACLearner:
         obs_structure: dict | None = None,
         world_size: int = 1,
         privileged_dim: int = 0,
+        critic_obs_dim: int = 0,
     ):
         self.device = device
         self.gamma = gamma
@@ -388,6 +389,7 @@ class FastSACLearner:
         self.use_amp = use_amp and device == "cuda"
         self.world_size = world_size
         self.privileged_dim = privileged_dim
+        self.critic_obs_dim = critic_obs_dim
 
         # Build actor (uses obs only)
         self.actor = SACActor(
@@ -401,10 +403,11 @@ class FastSACLearner:
             device=device,
         )
 
-        # Build critic ensemble (uses obs + privileged)
-        critic_obs_dim = obs_dim + privileged_dim
+        # Build critic ensemble: use dedicated critic trunk if provided, else fall back to actor obs
+        critic_trunk_dim = critic_obs_dim if critic_obs_dim > 0 else obs_dim
+        critic_net_obs_dim = critic_trunk_dim + privileged_dim
         self.qnet = SACCritic(
-            obs_dim=critic_obs_dim,
+            obs_dim=critic_net_obs_dim,
             action_dim=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -417,7 +420,7 @@ class FastSACLearner:
 
         # Target critic
         self.qnet_target = SACCritic(
-            obs_dim=critic_obs_dim,
+            obs_dim=critic_net_obs_dim,
             action_dim=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -478,6 +481,13 @@ class FastSACLearner:
             assert obs_structure is not None
             self.symmetry = G1SymmetryAugmentation(mujoco_model, obs_structure, device=device)
 
+    @staticmethod
+    def _build_critic_input(base: torch.Tensor, privileged: torch.Tensor | None) -> torch.Tensor:
+        """Concat critic trunk with privileged info (if any)."""
+        if privileged is None:
+            return base
+        return torch.cat([base, privileged], dim=-1)
+
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.
 
@@ -503,53 +513,53 @@ class FastSACLearner:
         """One critic update step."""
         obs = batch["obs"]
         privileged = batch.get("privileged", None)
+        critic = batch.get("critic", None)
         actions = batch["actions"]
         rewards = batch["rewards"]
         next_obs = batch["next_obs"]
         next_privileged = batch.get("next_privileged", None)
+        next_critic = batch.get("next_critic", None)
         dones = batch["dones"]
         truncated = batch.get("truncated")
 
-        # Critic input: obs + privileged
-        if privileged is not None:
-            assert next_privileged is not None
-            critic_obs = torch.cat([obs, privileged], dim=-1)
-            critic_next_obs = torch.cat([next_obs, next_privileged], dim=-1)
-        else:
-            critic_obs = obs
-            critic_next_obs = next_obs
+        # Critic trunk: use dedicated clean "critic" key if provided, else fall back to actor obs
+        critic_base = critic if critic is not None else obs
+        critic_next_base = next_critic if next_critic is not None else next_obs
+        critic_obs = self._build_critic_input(critic_base, privileged)
+        critic_next_obs = self._build_critic_input(critic_next_base, next_privileged)
 
         # Apply symmetry augmentation
         if self.use_symmetry:
-            # Save original actions before augmentation
             orig_actions = actions
 
-            # Handle privileged info separately
+            # Privileged mirror: flip y-axis for linvel [vx, vy, vz] -> [vx, -vy, vz]
             if privileged is not None:
                 assert next_privileged is not None
-                # Mirror privileged info: flip y-axis for linvel [vx, vy, vz] -> [vx, -vy, vz]
                 privileged_flip = torch.ones_like(privileged)
-                privileged_flip[..., 1] = -1.0  # Flip y component
-                mirrored_privileged = privileged * privileged_flip
-                mirrored_next_privileged = next_privileged * privileged_flip
-
-                # Concatenate original and mirrored privileged
-                privileged_aug = torch.cat([privileged, mirrored_privileged], dim=0)
-                next_privileged_aug = torch.cat([next_privileged, mirrored_next_privileged], dim=0)
-
-                # Augment actor observations and actions
-                obs, actions = self.symmetry.augment(obs, actions)
-                next_obs, _ = self.symmetry.augment(next_obs, orig_actions)
-
-                # Reconstruct critic observations: aug_obs + aug_privileged
-                critic_obs = torch.cat([obs, privileged_aug], dim=-1)
-                critic_next_obs = torch.cat([next_obs, next_privileged_aug], dim=-1)
+                privileged_flip[..., 1] = -1.0
+                privileged_aug = torch.cat([privileged, privileged * privileged_flip], dim=0)
+                next_privileged_aug = torch.cat(
+                    [next_privileged, next_privileged * privileged_flip], dim=0
+                )
             else:
-                # No privileged info, augment directly
-                obs, actions = self.symmetry.augment(obs, actions)
-                next_obs, _ = self.symmetry.augment(next_obs, orig_actions)
-                critic_obs = obs
-                critic_next_obs = next_obs
+                privileged_aug = None
+                next_privileged_aug = None
+
+            # Augment actor observations and actions via proper symmetry
+            obs, actions = self.symmetry.augment(obs, actions)
+            next_obs, _ = self.symmetry.augment(next_obs, orig_actions)
+
+            # Augment critic trunk: use dedicated path when provided, else reuse actor-aug
+            if critic is not None:
+                assert next_critic is not None
+                critic_base_aug, _ = self.symmetry.augment(critic, orig_actions)
+                critic_next_base_aug, _ = self.symmetry.augment(next_critic, orig_actions)
+            else:
+                critic_base_aug = obs
+                critic_next_base_aug = next_obs
+
+            critic_obs = self._build_critic_input(critic_base_aug, privileged_aug)
+            critic_next_obs = self._build_critic_input(critic_next_base_aug, next_privileged_aug)
 
             # Double the batch size for other tensors
             rewards = rewards.repeat(2)
@@ -640,34 +650,30 @@ class FastSACLearner:
         """One actor update step."""
         obs = batch["obs"]
         privileged = batch.get("privileged", None)
+        critic = batch.get("critic", None)
 
-        # Critic input: obs + privileged
-        if privileged is not None:
-            critic_obs = torch.cat([obs, privileged], dim=-1)
-        else:
-            critic_obs = obs
+        critic_base = critic if critic is not None else obs
+        critic_obs = self._build_critic_input(critic_base, privileged)
 
         # Apply symmetry augmentation
         if self.use_symmetry:
-            # Handle privileged info separately
             if privileged is not None:
-                # Mirror privileged info: flip y-axis for linvel [vx, vy, vz] -> [vx, -vy, vz]
                 privileged_flip = torch.ones_like(privileged)
-                privileged_flip[..., 1] = -1.0  # Flip y component
-                mirrored_privileged = privileged * privileged_flip
-
-                # Concatenate original and mirrored privileged
-                privileged_aug = torch.cat([privileged, mirrored_privileged], dim=0)
-
-                # Augment actor observations
-                obs = torch.cat([obs, self.symmetry.mirror_obs(obs)], dim=0)
-
-                # Reconstruct critic observations: aug_obs + aug_privileged
-                critic_obs = torch.cat([obs, privileged_aug], dim=-1)
+                privileged_flip[..., 1] = -1.0
+                privileged_aug = torch.cat([privileged, privileged * privileged_flip], dim=0)
             else:
-                # No privileged info, augment directly
-                obs = torch.cat([obs, self.symmetry.mirror_obs(obs)], dim=0)
-                critic_obs = obs
+                privileged_aug = None
+
+            # Augment actor observations
+            obs = torch.cat([obs, self.symmetry.mirror_obs(obs)], dim=0)
+
+            # Augment critic trunk: dedicated path when critic key is provided
+            if critic is not None:
+                critic_base_aug = torch.cat([critic, self.symmetry.mirror_obs(critic)], dim=0)
+            else:
+                critic_base_aug = obs
+
+            critic_obs = self._build_critic_input(critic_base_aug, privileged_aug)
 
         with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
             actions, log_probs, log_std = self.actor.get_actions_and_log_probs(obs)

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -378,7 +378,6 @@ class FastSACLearner:
         mujoco_model=None,
         obs_structure: dict | None = None,
         world_size: int = 1,
-        privileged_dim: int = 0,
         critic_obs_dim: int = 0,
     ):
         self.device = device
@@ -388,7 +387,6 @@ class FastSACLearner:
         self.use_autotune = use_autotune
         self.use_amp = use_amp and device == "cuda"
         self.world_size = world_size
-        self.privileged_dim = privileged_dim
         self.critic_obs_dim = critic_obs_dim
 
         # Build actor (uses obs only)
@@ -403,9 +401,7 @@ class FastSACLearner:
             device=device,
         )
 
-        # Build critic ensemble: use dedicated critic trunk if provided, else fall back to actor obs
-        critic_trunk_dim = critic_obs_dim if critic_obs_dim > 0 else obs_dim
-        critic_net_obs_dim = critic_trunk_dim + privileged_dim
+        critic_net_obs_dim = critic_obs_dim if critic_obs_dim > 0 else obs_dim
         self.qnet = SACCritic(
             obs_dim=critic_net_obs_dim,
             action_dim=action_dim,
@@ -481,13 +477,6 @@ class FastSACLearner:
             assert obs_structure is not None
             self.symmetry = G1SymmetryAugmentation(mujoco_model, obs_structure, device=device)
 
-    @staticmethod
-    def _build_critic_input(base: torch.Tensor, privileged: torch.Tensor | None) -> torch.Tensor:
-        """Concat critic trunk with privileged info (if any)."""
-        if privileged is None:
-            return base
-        return torch.cat([base, privileged], dim=-1)
-
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.
 
@@ -512,38 +501,20 @@ class FastSACLearner:
     def update_critic(self, batch: Dict[str, torch.Tensor]) -> Dict[str, float]:
         """One critic update step."""
         obs = batch["obs"]
-        privileged = batch.get("privileged", None)
         critic = batch.get("critic", None)
         actions = batch["actions"]
         rewards = batch["rewards"]
         next_obs = batch["next_obs"]
-        next_privileged = batch.get("next_privileged", None)
         next_critic = batch.get("next_critic", None)
         dones = batch["dones"]
         truncated = batch.get("truncated")
 
-        # Critic trunk: use dedicated clean "critic" key if provided, else fall back to actor obs
-        critic_base = critic if critic is not None else obs
-        critic_next_base = next_critic if next_critic is not None else next_obs
-        critic_obs = self._build_critic_input(critic_base, privileged)
-        critic_next_obs = self._build_critic_input(critic_next_base, next_privileged)
+        critic_obs = critic if critic is not None else obs
+        critic_next_obs = next_critic if next_critic is not None else next_obs
 
         # Apply symmetry augmentation
         if self.use_symmetry:
             orig_actions = actions
-
-            # Privileged mirror: flip y-axis for linvel [vx, vy, vz] -> [vx, -vy, vz]
-            if privileged is not None:
-                assert next_privileged is not None
-                privileged_flip = torch.ones_like(privileged)
-                privileged_flip[..., 1] = -1.0
-                privileged_aug = torch.cat([privileged, privileged * privileged_flip], dim=0)
-                next_privileged_aug = torch.cat(
-                    [next_privileged, next_privileged * privileged_flip], dim=0
-                )
-            else:
-                privileged_aug = None
-                next_privileged_aug = None
 
             # Augment actor observations and actions via proper symmetry
             obs, actions = self.symmetry.augment(obs, actions)
@@ -558,8 +529,8 @@ class FastSACLearner:
                 critic_base_aug = obs
                 critic_next_base_aug = next_obs
 
-            critic_obs = self._build_critic_input(critic_base_aug, privileged_aug)
-            critic_next_obs = self._build_critic_input(critic_next_base_aug, next_privileged_aug)
+            critic_obs = critic_base_aug
+            critic_next_obs = critic_next_base_aug
 
             # Double the batch size for other tensors
             rewards = rewards.repeat(2)
@@ -649,21 +620,12 @@ class FastSACLearner:
     def update_actor(self, batch: Dict[str, torch.Tensor]) -> Dict[str, float]:
         """One actor update step."""
         obs = batch["obs"]
-        privileged = batch.get("privileged", None)
         critic = batch.get("critic", None)
 
-        critic_base = critic if critic is not None else obs
-        critic_obs = self._build_critic_input(critic_base, privileged)
+        critic_obs = critic if critic is not None else obs
 
         # Apply symmetry augmentation
         if self.use_symmetry:
-            if privileged is not None:
-                privileged_flip = torch.ones_like(privileged)
-                privileged_flip[..., 1] = -1.0
-                privileged_aug = torch.cat([privileged, privileged * privileged_flip], dim=0)
-            else:
-                privileged_aug = None
-
             # Augment actor observations
             obs = torch.cat([obs, self.symmetry.mirror_obs(obs)], dim=0)
 
@@ -673,7 +635,7 @@ class FastSACLearner:
             else:
                 critic_base_aug = obs
 
-            critic_obs = self._build_critic_input(critic_base_aug, privileged_aug)
+            critic_obs = critic_base_aug
 
         with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
             actions, log_probs, log_std = self.actor.get_actions_and_log_probs(obs)

--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -48,9 +48,9 @@ class FastSACRunner(OffPolicyRunner):
         env: Any = registry.make(
             env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
         )
-        from unilab.utils.obs_utils import get_obs_dims_with_critic
+        from unilab.utils.obs_utils import get_obs_dims
 
-        obs_dim, privileged_dim, critic_obs_dim = get_obs_dims_with_critic(env.obs_groups_spec)
+        obs_dim, critic_obs_dim = get_obs_dims(env.obs_groups_spec)
         act_space_shape = env.action_space.shape
         assert act_space_shape is not None
         action_dim = act_space_shape[0]
@@ -83,7 +83,6 @@ class FastSACRunner(OffPolicyRunner):
             mujoco_model=mujoco_model,
             obs_structure=obs_structure,
             world_size=getattr(self, "world_size", world_size),
-            privileged_dim=privileged_dim,
             critic_obs_dim=critic_obs_dim,
         )
 

--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -54,13 +54,16 @@ class FastSACRunner(OffPolicyRunner):
         act_space_shape = env.action_space.shape
         assert act_space_shape is not None
         action_dim = act_space_shape[0]
-        mujoco_model = getattr(env, "_backend", None)
-        if mujoco_model is not None:
-            mujoco_model = getattr(mujoco_model, "model", None)
-        obs_structure = getattr(env, "get_obs_structure", lambda: None)()
-        env.close()
-
         device = device or get_default_device()
+        symmetry_augmentation = None
+        if use_symmetry:
+            symmetry_augmentation = env.build_symmetry_augmentation(device=device)
+            if symmetry_augmentation is None:
+                env.close()
+                raise ValueError(
+                    f"{env_name} with backend={sim_backend} does not provide symmetry augmentation"
+                )
+        env.close()
 
         learner = FastSACLearner(
             obs_dim=obs_dim,
@@ -80,17 +83,22 @@ class FastSACRunner(OffPolicyRunner):
             max_grad_norm=max_grad_norm,
             use_amp=use_amp,
             use_symmetry=use_symmetry,
-            mujoco_model=mujoco_model,
-            obs_structure=obs_structure,
+            symmetry_augmentation=symmetry_augmentation,
             world_size=getattr(self, "world_size", world_size),
             critic_obs_dim=critic_obs_dim,
         )
 
-        # Auto-adjust batch_size when symmetry is enabled
-        if use_symmetry:
-            batch_size = batch_size // 2
+        if symmetry_augmentation is not None:
+            if batch_size % symmetry_augmentation.batch_multiplier != 0:
+                raise ValueError(
+                    "Symmetry augmentation requires algo.batch_size to be divisible by "
+                    f"{symmetry_augmentation.batch_multiplier}, got {batch_size}"
+                )
+            batch_size = batch_size // symmetry_augmentation.batch_multiplier
             print(
-                f"[FastSAC] Symmetry enabled: batch_size adjusted to {batch_size} (effective: {batch_size * 2})"
+                "[FastSAC] Symmetry enabled: "
+                f"batch_size adjusted to {batch_size} "
+                f"(effective: {batch_size * symmetry_augmentation.batch_multiplier})"
             )
 
         super().__init__(

--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -48,9 +48,9 @@ class FastSACRunner(OffPolicyRunner):
         env: Any = registry.make(
             env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
         )
-        from unilab.utils.obs_utils import get_obs_dims
+        from unilab.utils.obs_utils import get_obs_dims_with_critic
 
-        obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
+        obs_dim, privileged_dim, critic_obs_dim = get_obs_dims_with_critic(env.obs_groups_spec)
         act_space_shape = env.action_space.shape
         assert act_space_shape is not None
         action_dim = act_space_shape[0]
@@ -84,6 +84,7 @@ class FastSACRunner(OffPolicyRunner):
             obs_structure=obs_structure,
             world_size=getattr(self, "world_size", world_size),
             privileged_dim=privileged_dim,
+            critic_obs_dim=critic_obs_dim,
         )
 
         # Auto-adjust batch_size when symmetry is enabled

--- a/src/unilab/algos/torch/fast_td3/learner.py
+++ b/src/unilab/algos/torch/fast_td3/learner.py
@@ -138,6 +138,7 @@ class FastTD3Learner:
         self,
         obs_dim: int,
         action_dim: int,
+        critic_obs_dim: int = 0,
         num_envs: int = 1024,
         device: str = "cpu",
         # Hyperparameters from reference
@@ -170,6 +171,7 @@ class FastTD3Learner:
         self.noise_clip = noise_clip
         self.policy_frequency = policy_frequency
         self.use_cdq = use_cdq
+        self.critic_obs_dim = critic_obs_dim if critic_obs_dim > 0 else obs_dim
 
         torch_device = torch.device(device)
 
@@ -198,7 +200,7 @@ class FastTD3Learner:
 
         # Build critic
         self.qnet = Critic(
-            obs_dim=obs_dim,
+            obs_dim=self.critic_obs_dim,
             n_act=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -207,7 +209,7 @@ class FastTD3Learner:
             device=torch_device,
         )
         self.qnet_target = Critic(
-            obs_dim=obs_dim,
+            obs_dim=self.critic_obs_dim,
             n_act=action_dim,
             num_atoms=num_atoms,
             v_min=v_min,
@@ -248,22 +250,16 @@ class FastTD3Learner:
     def update_critic(self, data: Dict[str, torch.Tensor]) -> Dict[str, float]:
         """One critic update step."""
         observations = self.normalize_obs(data["obs"], update=True)
-        privileged = data.get("privileged", None)
+        critic_obs = data.get("critic", None)
         actions = data["actions"]
         rewards = data["rewards"]
         next_observations = self.normalize_obs(data["next_obs"], update=False)
-        next_privileged = data.get("next_privileged", None)
+        next_critic_obs = data.get("next_critic", None)
         dones = data["dones"].bool()
         truncations = data["truncated"].bool()
 
-        # Critic input: obs + privileged
-        if privileged is not None:
-            assert next_privileged is not None
-            critic_obs = torch.cat([observations, privileged], dim=-1)
-            critic_next_obs = torch.cat([next_observations, next_privileged], dim=-1)
-        else:
-            critic_obs = observations
-            critic_next_obs = next_observations
+        critic_obs = critic_obs if critic_obs is not None else observations
+        critic_next_obs = next_critic_obs if next_critic_obs is not None else next_observations
 
         bootstrap = (truncations | ~dones).float()
         discount = torch.full_like(rewards, self.gamma)

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -141,7 +141,7 @@ class FlashSACLearner:
         self,
         obs_dim: int,
         action_dim: int,
-        privileged_dim: int = 0,
+        critic_obs_dim: int = 0,
         device: str = "cpu",
         gamma: float = 0.99,
         tau: float = 0.01,
@@ -178,9 +178,8 @@ class FlashSACLearner:
         self.n_step = n_step
         self.actor_bc_alpha = actor_bc_alpha
         self.obs_dim = obs_dim
-        self.critic_obs_dim = obs_dim + privileged_dim
+        self.critic_obs_dim = critic_obs_dim if critic_obs_dim > 0 else obs_dim
         self.action_dim = action_dim
-        self.privileged_dim = privileged_dim
         self.update_count = 0
         self.use_amp = bool(use_amp and self.device.type == "cuda")
         self.use_compile = bool(
@@ -259,15 +258,6 @@ class FlashSACLearner:
             return obs
         return cast(torch.Tensor, self.obs_normalizer(obs, update=update))
 
-    def _build_critic_obs(
-        self,
-        obs: torch.Tensor,
-        privileged: torch.Tensor | None,
-    ) -> torch.Tensor:
-        if privileged is None:
-            return obs
-        return torch.cat([obs, privileged], dim=-1)
-
     def _autocast(self):
         return torch.autocast(device_type="cuda", dtype=torch.float16, enabled=self.use_amp)
 
@@ -293,15 +283,15 @@ class FlashSACLearner:
         next_obs = batch["next_obs"].to(self.device)
         terminated = batch["dones"].to(self.device)
         truncated = batch.get("truncated", torch.zeros_like(terminated)).to(self.device)
-        privileged = batch.get("privileged")
-        next_privileged = batch.get("next_privileged")
-        privileged = privileged.to(self.device) if privileged is not None else None
-        next_privileged = next_privileged.to(self.device) if next_privileged is not None else None
+        critic_obs = batch.get("critic")
+        next_critic_obs = batch.get("next_critic")
+        critic_obs = critic_obs.to(self.device) if critic_obs is not None else None
+        next_critic_obs = next_critic_obs.to(self.device) if next_critic_obs is not None else None
 
         obs = self._maybe_normalize_obs(obs, update=True)
         next_obs = self._maybe_normalize_obs(next_obs, update=False)
-        critic_obs = self._build_critic_obs(obs, privileged)
-        critic_next_obs = self._build_critic_obs(next_obs, next_privileged)
+        critic_obs = critic_obs if critic_obs is not None else obs
+        critic_next_obs = next_critic_obs if next_critic_obs is not None else next_obs
 
         if self.reward_normalizer is not None:
             rewards = self.reward_normalizer.normalize(rewards)
@@ -354,11 +344,11 @@ class FlashSACLearner:
     def update_actor(self, batch: dict[str, torch.Tensor]) -> dict[str, float]:
         obs = batch["obs"].to(self.device)
         expert_actions = batch["actions"].to(self.device)
-        privileged = batch.get("privileged")
-        privileged = privileged.to(self.device) if privileged is not None else None
+        critic_obs = batch.get("critic")
+        critic_obs = critic_obs.to(self.device) if critic_obs is not None else None
 
         obs = self._maybe_normalize_obs(obs, update=False)
-        critic_obs = self._build_critic_obs(obs, privileged)
+        critic_obs = critic_obs if critic_obs is not None else obs
 
         with self._autocast():
             actions, actor_info = self.actor(obs, training=True)

--- a/src/unilab/algos/torch/flash_sac/runner.py
+++ b/src/unilab/algos/torch/flash_sac/runner.py
@@ -61,7 +61,7 @@ class FlashSACRunner(OffPolicyRunner):
         env: Any = registry.make(
             env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
         )
-        obs_dim, privileged_dim = get_obs_dims(env.obs_groups_spec)
+        obs_dim, critic_obs_dim = get_obs_dims(env.obs_groups_spec)
         action_shape = env.action_space.shape
         assert action_shape is not None
         action_dim = int(action_shape[0])
@@ -71,7 +71,7 @@ class FlashSACRunner(OffPolicyRunner):
         learner = FlashSACLearner(
             obs_dim=obs_dim,
             action_dim=action_dim,
-            privileged_dim=privileged_dim,
+            critic_obs_dim=critic_obs_dim,
             device=runtime_device,
             gamma=gamma,
             tau=tau,

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -13,7 +13,7 @@ from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
 from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX, AsyncRunner
 from unilab.ipc.replay_buffer import ReplayBuffer
-from unilab.utils.device_utils import get_default_device, get_env_dims
+from unilab.utils.device_utils import get_default_device, get_env_dims_with_critic
 from unilab.utils.offpolicy_logger import OffPolicyLogger
 
 
@@ -66,9 +66,12 @@ class OffPolicyRunner(AsyncRunner):
         self.obs_normalization = obs_normalization
         self.actor_kwargs = actor_kwargs or {}
 
-        self.obs_dim, self.action_dim, self.privileged_dim = get_env_dims(
-            self.env_name, sim_backend, env_cfg_override
-        )
+        (
+            self.obs_dim,
+            self.action_dim,
+            self.privileged_dim,
+            self.critic_dim,
+        ) = get_env_dims_with_critic(self.env_name, sim_backend, env_cfg_override)
 
     def _get_default_device(self) -> str:
         return get_default_device()
@@ -153,6 +156,7 @@ class OffPolicyRunner(AsyncRunner):
             action_dim=self.action_dim,
             device=self.device,
             privileged_dim=self.privileged_dim,
+            critic_dim=self.critic_dim,
         )
         self._shared_resources.append(replay_buffer)
 

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -13,7 +13,7 @@ from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
 from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX, AsyncRunner
 from unilab.ipc.replay_buffer import ReplayBuffer
-from unilab.utils.device_utils import get_default_device, get_env_dims_with_critic
+from unilab.utils.device_utils import get_default_device, get_env_dims
 from unilab.utils.offpolicy_logger import OffPolicyLogger
 
 
@@ -66,12 +66,9 @@ class OffPolicyRunner(AsyncRunner):
         self.obs_normalization = obs_normalization
         self.actor_kwargs = actor_kwargs or {}
 
-        (
-            self.obs_dim,
-            self.action_dim,
-            self.privileged_dim,
-            self.critic_dim,
-        ) = get_env_dims_with_critic(self.env_name, sim_backend, env_cfg_override)
+        self.obs_dim, self.action_dim, self.critic_dim = get_env_dims(
+            self.env_name, sim_backend, env_cfg_override
+        )
 
     def _get_default_device(self) -> str:
         return get_default_device()
@@ -155,7 +152,6 @@ class OffPolicyRunner(AsyncRunner):
             obs_dim=self.obs_dim,
             action_dim=self.action_dim,
             device=self.device,
-            privileged_dim=self.privileged_dim,
             critic_dim=self.critic_dim,
         )
         self._shared_resources.append(replay_buffer)

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -13,7 +13,7 @@ import torch
 
 from unilab.utils.algo_utils import build_actor, ensure_registries
 from unilab.utils.final_observation import resolve_terminal_observation_contract
-from unilab.utils.obs_utils import split_obs_dict_with_critic
+from unilab.utils.obs_utils import get_obs_dims, split_obs_dict
 
 
 def resolve_collector_actor_dims(
@@ -27,8 +27,6 @@ def resolve_collector_actor_dims(
     build identical actor shapes on override-heavy env paths.
     """
     if obs_dim is None:
-        from unilab.utils.obs_utils import get_obs_dims
-
         obs_dim, _ = get_obs_dims(env.obs_groups_spec)
 
     if action_dim is None:
@@ -205,10 +203,8 @@ def _run_collector(
     # Initial step to get first observation
     actions_np = np.zeros((num_envs, action_dim), dtype=np.float32)
     state = env.step(actions_np)
-    obs_np, priv_np, critic_np = split_obs_dict_with_critic(state.obs)
+    obs_np, critic_np = split_obs_dict(state.obs)
     obs_np = np.asarray(obs_np, dtype=np.float32)
-    if priv_np is not None:
-        priv_np = np.asarray(priv_np, dtype=np.float32)
     if critic_np is not None:
         critic_np = np.asarray(critic_np, dtype=np.float32)
     prev_dones_np = np.zeros(num_envs, dtype=np.float32)
@@ -284,10 +280,8 @@ def _run_collector(
             timing_count += 1
 
         # Extract data as numpy
-        next_obs_np, next_priv_np, next_critic_np = split_obs_dict_with_critic(state.obs)
+        next_obs_np, next_critic_np = split_obs_dict(state.obs)
         next_obs_np = np.asarray(next_obs_np, dtype=np.float32)
-        if next_priv_np is not None:
-            next_priv_np = np.asarray(next_priv_np, dtype=np.float32)
         if next_critic_np is not None:
             next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
         rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
@@ -328,17 +322,10 @@ def _run_collector(
             torch.from_numpy(next_obs_np),
             torch.from_numpy(terminated_np),
             torch.from_numpy(truncated_np),
-            torch.from_numpy(priv_np) if priv_np is not None else None,
-            torch.from_numpy(next_priv_np) if next_priv_np is not None else None,
             terminal_mask=torch.from_numpy(terminal_contract.terminal_mask),
             terminal_next_obs=(
                 torch.from_numpy(terminal_contract.terminal_obs)
                 if terminal_contract.terminal_obs is not None
-                else None
-            ),
-            terminal_next_privileged=(
-                torch.from_numpy(terminal_contract.terminal_privileged)
-                if terminal_contract.terminal_privileged is not None
                 else None
             ),
             critic=torch.from_numpy(critic_np) if critic_np is not None else None,
@@ -362,7 +349,6 @@ def _run_collector(
             current_ep_lengths[reset_indices] = 0
 
         obs_np = next_obs_np
-        priv_np = next_priv_np
         critic_np = next_critic_np
         total_steps += num_envs
         env_steps_since_sync += 1

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -13,7 +13,7 @@ import torch
 
 from unilab.utils.algo_utils import build_actor, ensure_registries
 from unilab.utils.final_observation import resolve_terminal_observation_contract
-from unilab.utils.obs_utils import split_obs_dict
+from unilab.utils.obs_utils import split_obs_dict_with_critic
 
 
 def resolve_collector_actor_dims(
@@ -205,10 +205,12 @@ def _run_collector(
     # Initial step to get first observation
     actions_np = np.zeros((num_envs, action_dim), dtype=np.float32)
     state = env.step(actions_np)
-    obs_np, priv_np = split_obs_dict(state.obs)
+    obs_np, priv_np, critic_np = split_obs_dict_with_critic(state.obs)
     obs_np = np.asarray(obs_np, dtype=np.float32)
     if priv_np is not None:
         priv_np = np.asarray(priv_np, dtype=np.float32)
+    if critic_np is not None:
+        critic_np = np.asarray(critic_np, dtype=np.float32)
     prev_dones_np = np.zeros(num_envs, dtype=np.float32)
     max_episode_steps = getattr(getattr(env, "cfg", None), "max_episode_steps", None)
     if max_episode_steps is not None and int(max_episode_steps) > 0:
@@ -282,10 +284,12 @@ def _run_collector(
             timing_count += 1
 
         # Extract data as numpy
-        next_obs_np, next_priv_np = split_obs_dict(state.obs)
+        next_obs_np, next_priv_np, next_critic_np = split_obs_dict_with_critic(state.obs)
         next_obs_np = np.asarray(next_obs_np, dtype=np.float32)
         if next_priv_np is not None:
             next_priv_np = np.asarray(next_priv_np, dtype=np.float32)
+        if next_critic_np is not None:
+            next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
         rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
 
         terminated_np = (
@@ -337,6 +341,13 @@ def _run_collector(
                 if terminal_contract.terminal_privileged is not None
                 else None
             ),
+            critic=torch.from_numpy(critic_np) if critic_np is not None else None,
+            next_critic=torch.from_numpy(next_critic_np) if next_critic_np is not None else None,
+            terminal_next_critic=(
+                torch.from_numpy(terminal_contract.terminal_critic)
+                if terminal_contract.terminal_critic is not None
+                else None
+            ),
         )
 
         # Track episode rewards - vectorized
@@ -352,6 +363,7 @@ def _run_collector(
 
         obs_np = next_obs_np
         priv_np = next_priv_np
+        critic_np = next_critic_np
         total_steps += num_envs
         env_steps_since_sync += 1
 

--- a/src/unilab/base/augmentation.py
+++ b/src/unilab/base/augmentation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import torch
+
+
+SymmetryObsLayout = tuple[tuple[str, int], ...]
+
+
+class SymmetryAugmentation(Protocol):
+    """Runtime symmetry augmentation contract owned by env/backend adapters."""
+
+    batch_multiplier: int
+
+    def augment_obs_and_actions(
+        self,
+        obs: torch.Tensor,
+        actions: torch.Tensor,
+        *,
+        obs_group: str = "obs",
+    ) -> tuple[torch.Tensor, torch.Tensor]: ...
+
+    def mirror_obs(
+        self,
+        obs: torch.Tensor,
+        *,
+        obs_group: str = "obs",
+    ) -> torch.Tensor: ...

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Optional, Tuple, cast
 
 import gymnasium as gym
 import numpy as np
@@ -12,6 +12,9 @@ from unilab.base.backend import SimBackend
 from unilab.base.base import ABEnv, EnvCfg, EnvPlayCapabilities
 from unilab.base.dtype_config import get_global_dtype
 from unilab.dr import DomainRandomizationManager, DomainRandomizationProvider
+
+if TYPE_CHECKING:
+    from unilab.base.augmentation import SymmetryAugmentation
 
 
 @dataclass
@@ -69,6 +72,10 @@ class NpEnv(ABEnv):
     def observation_space(self) -> gym.Space:
         total = sum(self.obs_groups_spec.values())
         return gym.spaces.Box(-np.inf, np.inf, shape=(total,), dtype=np.float64)
+
+    def build_symmetry_augmentation(self, *, device: str) -> "SymmetryAugmentation | None":
+        """Return an env-owned runtime symmetry adapter when the task/backend supports it."""
+        return None
 
     def init_state(self) -> NpEnvState:
         dtype = get_global_dtype()

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -59,7 +59,7 @@ class NpEnv(ABEnv):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
-        """Return observation group dimensions, e.g. {"actor": 98, "privileged": 3}.
+        """Return observation group dimensions, e.g. {"obs": 98, "critic": 101}.
 
         Subclasses MUST override this property.
         """

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -11,6 +11,7 @@ from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
+from unilab.base.augmentation import SymmetryObsLayout
 from unilab.base.backend import create_backend
 from unilab.base.dtype_config import get_global_dtype
 from unilab.base.np_env import NpEnvState
@@ -256,22 +257,30 @@ class G1JoystickPPO(G1BaseEnv):
         critic = np.concatenate([actor, linvel], axis=1, dtype=get_global_dtype())
         return {"obs": actor, "critic": critic}
 
-    def get_obs_structure(self) -> dict:
-        """Return observation structure for symmetry augmentation.
+    def _actor_symmetry_obs_layout(self) -> SymmetryObsLayout:
+        return (
+            ("gyro", 3),
+            ("gravity", 3),
+            ("dof_pos", self._num_action),
+            ("dof_vel", self._num_action),
+            ("actions", self._num_action),
+            ("command", 3),
+            ("gait_phase", 2),
+        )
 
-        Note: This only returns actor observation structure.
-        Critic-only channels are handled via the explicit "critic" obs group.
-        """
-        return {
-            # "linvel": 3,
-            "gyro": 3,
-            "gravity": 3,
-            "dof_pos": self._num_action,
-            "dof_vel": self._num_action,
-            "actions": self._num_action,
-            "command": 3,
-            "gait_phase": 2,
-        }
+    def get_symmetry_obs_layouts(self) -> dict[str, SymmetryObsLayout]:
+        return {"obs": self._actor_symmetry_obs_layout()}
+
+    def build_symmetry_augmentation(self, *, device: str):
+        if self._backend.backend_type != "mujoco":
+            return None
+        from unilab.envs.locomotion.g1.symmetry import G1SymmetryAugmentation
+
+        return G1SymmetryAugmentation(
+            self._backend.model,
+            self.get_symmetry_obs_layouts(),
+            device=device,
+        )
 
     def _build_reward_context(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -199,7 +199,7 @@ class G1JoystickPPO(G1BaseEnv):
     @property
     def obs_groups_spec(self) -> dict[str, int]:
         # gyro(3) + gravity(3) + diff(29) + dof_vel(29) + action(29) + cmd(3) + phase(2) = 98
-        return {"obs": 98, "privileged": 3}
+        return {"obs": 98, "critic": 101}
 
     def _init_reward_functions(self):
         self._reward_fns: dict[str, Any] = {
@@ -253,13 +253,14 @@ class G1JoystickPPO(G1BaseEnv):
             axis=1,
             dtype=get_global_dtype(),
         )
-        return {"obs": actor, "privileged": linvel}
+        critic = np.concatenate([actor, linvel], axis=1, dtype=get_global_dtype())
+        return {"obs": actor, "critic": critic}
 
     def get_obs_structure(self) -> dict:
         """Return observation structure for symmetry augmentation.
 
-        Note: This only returns actor observation structure (without privileged info like linvel).
-        Privileged information (linvel) is handled separately in the learner.
+        Note: This only returns actor observation structure.
+        Critic-only channels are handled via the explicit "critic" obs group.
         """
         return {
             # "linvel": 3,

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -105,8 +105,8 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
-        # obs / critic share the same 98-dim actor-trunk layout; privileged = linvel (3).
-        return {"obs": 98, "privileged": 3, "critic": 98}
+        # actor trunk = 98, critic path = clean 98-dim trunk + linvel (3).
+        return {"obs": 98, "critic": 101}
 
     def _compute_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
@@ -118,7 +118,7 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
         gait_phase = info.get("gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype()))
 
         # Clean critic trunk: same layout as actor but noise-free
-        critic = np.concatenate(
+        clean_critic = np.concatenate(
             [gyro * 0.25, -gravity, diff, dof_vel * 0.05, last_actions, command, gait_phase],
             axis=1,
             dtype=get_global_dtype(),
@@ -128,7 +128,6 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
         noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
         noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
         noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        noisy_linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
         actor = np.concatenate(
             [
                 noisy_gyro * 0.25,
@@ -145,8 +144,11 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
 
         return {
             "obs": actor,
-            "privileged": np.asarray(linvel * 2.0, dtype=get_global_dtype()),
-            "critic": critic,
+            "critic": np.concatenate(
+                [clean_critic, np.asarray(linvel * 2.0, dtype=get_global_dtype())],
+                axis=1,
+                dtype=get_global_dtype(),
+            ),
         }
 
     def _init_reward_functions(self):

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -9,6 +9,7 @@ from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
+from unilab.base.augmentation import SymmetryObsLayout
 from unilab.base.backend import create_backend
 from unilab.base.curriculum import EpisodeLengthTracker, PenaltyCurriculum
 from unilab.base.dtype_config import get_global_dtype
@@ -107,6 +108,13 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
     def obs_groups_spec(self) -> dict[str, int]:
         # actor trunk = 98, critic path = clean 98-dim trunk + linvel (3).
         return {"obs": 98, "critic": 101}
+
+    def get_symmetry_obs_layouts(self) -> dict[str, SymmetryObsLayout]:
+        actor_layout = self._actor_symmetry_obs_layout()
+        return {
+            "obs": actor_layout,
+            "critic": (*actor_layout, ("linvel", 3)),
+        }
 
     def _compute_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel

--- a/src/unilab/envs/locomotion/g1/joystick_sac.py
+++ b/src/unilab/envs/locomotion/g1/joystick_sac.py
@@ -103,27 +103,50 @@ class G1WalkTaskMjSAC(G1JoystickPPO):
             dr_provider = G1JoystickDomainRandomizationProvider()
         self._init_domain_randomization(dr_provider)
 
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        # obs / critic share the same 98-dim actor-trunk layout; privileged = linvel (3).
+        return {"obs": 98, "privileged": 3, "critic": 98}
+
     def _compute_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
         command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         gait_phase = info.get("gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype()))
-        actor = np.concatenate(
+
+        # Clean critic trunk: same layout as actor but noise-free
+        critic = np.concatenate(
             [gyro * 0.25, -gravity, diff, dof_vel * 0.05, last_actions, command, gait_phase],
             axis=1,
             dtype=get_global_dtype(),
         )
+
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        noisy_linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        actor = np.concatenate(
+            [
+                noisy_gyro * 0.25,
+                -noisy_gravity,
+                noisy_diff,
+                noisy_dof_vel * 0.05,
+                last_actions,
+                command,
+                gait_phase,
+            ],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
+
         return {
             "obs": actor,
             "privileged": np.asarray(linvel * 2.0, dtype=get_global_dtype()),
+            "critic": critic,
         }
 
     def _init_reward_functions(self):

--- a/src/unilab/envs/locomotion/g1/symmetry.py
+++ b/src/unilab/envs/locomotion/g1/symmetry.py
@@ -1,19 +1,36 @@
-"""MuJoCo-only G1 symmetry augmentation helpers.
+"""MuJoCo-only G1 symmetry augmentation owned by the task/backend layer."""
 
-This module builds symmetry mappings from MuJoCo actuator names and therefore
-only applies to MuJoCo-backed G1 tooling.
-"""
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 import torch
 
+from unilab.base.augmentation import SymmetryAugmentation, SymmetryObsLayout
 
-class G1SymmetryAugmentation:
-    """MuJoCo-only symmetry helper derived from MuJoCo actuator ordering."""
 
-    def __init__(self, model, obs_structure: dict, device: str = "cuda"):
+@dataclass(frozen=True)
+class _ObsGroupTransform:
+    dim: int
+    flip_mask: torch.Tensor
+    joint_map: torch.Tensor
+    joint_sign: torch.Tensor
+
+
+class G1SymmetryAugmentation(SymmetryAugmentation):
+    """Runtime symmetry adapter derived from the MuJoCo actuator ordering."""
+
+    batch_multiplier = 2
+
+    def __init__(
+        self,
+        model,
+        obs_layouts: dict[str, SymmetryObsLayout],
+        *,
+        device: str = "cuda",
+    ):
         import mujoco
 
-        # Build joint mapping
         actuator_names = [
             mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)
         ]
@@ -33,84 +50,107 @@ class G1SymmetryAugmentation:
             "left_wrist_yaw_joint": "right_wrist_yaw_joint",
         }
         name_to_idx = {name: i for i, name in enumerate(actuator_names)}
-        joint_map = {}
+        joint_map: dict[int, int] = {}
         for left, right in symmetry_pairs.items():
             if left in name_to_idx and right in name_to_idx:
                 joint_map[name_to_idx[left]] = name_to_idx[right]
                 joint_map[name_to_idx[right]] = name_to_idx[left]
         for i in range(len(actuator_names)):
-            if i not in joint_map:
-                joint_map[i] = i
-        self.joint_map = torch.tensor(
-            [joint_map[i] for i in range(len(actuator_names))], device=device, dtype=torch.long
+            joint_map.setdefault(i, i)
+
+        self._joint_map = torch.tensor(
+            [joint_map[i] for i in range(len(actuator_names))],
+            device=device,
+            dtype=torch.long,
         )
 
-        # Sign flip: which joints need negation after mirroring
         flip_names = {"roll", "yaw"}
         sign_mask = [1.0] * len(actuator_names)
         for i, name in enumerate(actuator_names):
             if any(flip in name for flip in flip_names):
                 sign_mask[i] = -1.0
-        self.sign_mask = torch.tensor(sign_mask, device=device)
+        self._sign_mask = torch.tensor(sign_mask, device=device)
+        self._obs_transforms = {
+            group_name: self._build_obs_group_transform(layout, device=device)
+            for group_name, layout in obs_layouts.items()
+        }
 
-        # Precompute obs flip mask and joint mapping indices
+    def _build_obs_group_transform(
+        self,
+        layout: SymmetryObsLayout,
+        *,
+        device: str,
+    ) -> _ObsGroupTransform:
+        obs_dim = sum(dim for _, dim in layout)
+        flip_mask = torch.ones(obs_dim, device=device)
+        joint_map = torch.arange(obs_dim, device=device, dtype=torch.long)
+        joint_sign = torch.ones(obs_dim, device=device)
         idx = 0
-        obs_dim = sum(
-            obs_structure.get(k, 0)
-            for k in [
-                "linvel",
-                "gyro",
-                "gravity",
-                "dof_pos",
-                "dof_vel",
-                "actions",
-                "command",
-                "gait_phase",
-            ]
-        )
-        self.obs_flip_mask = torch.ones(obs_dim, device=device)
-        self.obs_joint_map = torch.arange(obs_dim, device=device, dtype=torch.long)
-        self.obs_joint_sign = torch.ones(obs_dim, device=device)
 
-        for key in [
-            "linvel",
-            "gyro",
-            "gravity",
-            "dof_pos",
-            "dof_vel",
-            "actions",
-            "command",
-            "gait_phase",
-        ]:
-            if key not in obs_structure:
-                continue
-            dim = obs_structure[key]
+        for key, dim in layout:
+            if dim <= 0:
+                raise ValueError(
+                    f"Observation layout group {key!r} must have positive dim, got {dim}"
+                )
+
             if key == "linvel":
-                self.obs_flip_mask[idx + 1] = -1.0
+                self._require_dim(key, dim, 3)
+                flip_mask[idx + 1] = -1.0
             elif key == "gyro":
-                self.obs_flip_mask[idx] = -1.0
-                self.obs_flip_mask[idx + 2] = -1.0
+                self._require_dim(key, dim, 3)
+                flip_mask[idx] = -1.0
+                flip_mask[idx + 2] = -1.0
             elif key == "gravity":
-                self.obs_flip_mask[idx + 1] = -1.0
-            elif key in ["dof_pos", "dof_vel", "actions"]:
-                self.obs_joint_map[idx : idx + dim] = self.joint_map + idx
-                self.obs_joint_sign[idx : idx + dim] = self.sign_mask
+                self._require_dim(key, dim, 3)
+                flip_mask[idx + 1] = -1.0
+            elif key in {"dof_pos", "dof_vel", "actions"}:
+                self._require_dim(key, dim, int(self._joint_map.numel()))
+                joint_map[idx : idx + dim] = self._joint_map + idx
+                joint_sign[idx : idx + dim] = self._sign_mask
             elif key == "command":
-                self.obs_flip_mask[idx + 1] = -1.0
-                self.obs_flip_mask[idx + 2] = -1.0
+                self._require_dim(key, dim, 3)
+                flip_mask[idx + 1] = -1.0
+                flip_mask[idx + 2] = -1.0
             elif key == "gait_phase":
-                # Swap left and right gait phases
-                self.obs_joint_map[idx] = idx + 1
-                self.obs_joint_map[idx + 1] = idx
+                self._require_dim(key, dim, 2)
+                joint_map[idx] = idx + 1
+                joint_map[idx + 1] = idx
+
             idx += dim
 
+        return _ObsGroupTransform(
+            dim=obs_dim,
+            flip_mask=flip_mask,
+            joint_map=joint_map,
+            joint_sign=joint_sign,
+        )
+
+    @staticmethod
+    def _require_dim(group_name: str, actual: int, expected: int) -> None:
+        if actual != expected:
+            raise ValueError(
+                f"Symmetry group {group_name!r} must have dim {expected}, got {actual}"
+            )
+
     def mirror_action(self, action: torch.Tensor) -> torch.Tensor:
-        return action[..., self.joint_map] * self.sign_mask
+        return action[..., self._joint_map] * self._sign_mask
 
-    def mirror_obs(self, obs: torch.Tensor) -> torch.Tensor:
-        return obs[..., self.obs_joint_map] * self.obs_flip_mask * self.obs_joint_sign
+    def mirror_obs(self, obs: torch.Tensor, *, obs_group: str = "obs") -> torch.Tensor:
+        transform = self._obs_transforms[obs_group]
+        if obs.shape[-1] != transform.dim:
+            raise ValueError(
+                f"Symmetry obs group {obs_group!r} expects dim {transform.dim}, got {obs.shape[-1]}"
+            )
+        return obs[..., transform.joint_map] * transform.flip_mask * transform.joint_sign
 
-    def augment(self, obs: torch.Tensor, actions: torch.Tensor):
-        return torch.cat([obs, self.mirror_obs(obs)], dim=0), torch.cat(
-            [actions, self.mirror_action(actions)], dim=0
+    def augment_obs_and_actions(
+        self,
+        obs: torch.Tensor,
+        actions: torch.Tensor,
+        *,
+        obs_group: str = "obs",
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.cat([obs, self.mirror_obs(obs, obs_group=obs_group)], dim=0), torch.cat(
+            [actions, self.mirror_action(actions)],
+            dim=0,
         )

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -106,7 +106,7 @@ class Go1WalkTask(Go1BaseEnv):
     @property
     def obs_groups_spec(self) -> dict[str, int]:
         # gyro(3) + gravity(3) + diff(12) + dof_vel(12) + action(12) + cmd(3) + phase(4) = 49
-        return {"obs": 49, "privileged": 3}
+        return {"obs": 49, "critic": 52}
 
     def _init_reward_functions(self):
         self._reward_fns: dict[str, Any] = {
@@ -156,7 +156,8 @@ class Go1WalkTask(Go1BaseEnv):
             axis=1,
             dtype=get_global_dtype(),
         )
-        return {"obs": obs, "privileged": linvel}
+        critic = np.concatenate([obs, linvel], axis=1, dtype=get_global_dtype())
+        return {"obs": obs, "critic": critic}
 
     def _compute_reward(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
         dtype = get_global_dtype()

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -109,7 +109,7 @@ class Go2WalkTask(Go2BaseEnv):
     @property
     def obs_groups_spec(self) -> dict[str, int]:
         # gyro(3) + gravity(3) + diff(12) + dof_vel(12) + action(12) + cmd(3) + phase(4) = 49
-        return {"obs": 49, "privileged": 3}
+        return {"obs": 49, "critic": 52}
 
     def _init_reward_functions(self):
         self._reward_fns: dict[str, Any] = {
@@ -161,7 +161,8 @@ class Go2WalkTask(Go2BaseEnv):
             axis=1,
             dtype=get_global_dtype(),
         )
-        return {"obs": obs, "privileged": linvel}
+        critic = np.concatenate([obs, linvel], axis=1, dtype=get_global_dtype())
+        return {"obs": obs, "critic": critic}
 
     def _compute_reward(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:
         dtype = get_global_dtype()

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -105,10 +105,10 @@ class SharpaInhandBaseCfg(EnvCfg):
     action_space: int = 22
     observation_space: int = 192
     prop_hist_len: int = 30
-    priv_info_dim: int = 8
-    # "separate": keep privileged info in its own obs group.
-    # "merged": append privileged info into the main "obs" vector.
-    privileged_obs_mode: str = "separate"
+    critic_info_dim: int = 8
+    # "separate": keep critic-only info in its own obs group.
+    # "merged": append critic info into the main "obs" vector.
+    critic_obs_mode: str = "separate"
 
     clip_obs: float = 5.0
     clip_actions: float = 1.0
@@ -307,7 +307,7 @@ class SharpaInhandBaseEnv(NpEnv):
         self.proprio_hist_buf = np.zeros(
             (num_envs, cfg.prop_hist_len, cfg.frame_obs_dim), dtype=self._np_dtype
         )
-        self.priv_info_buf = np.zeros((num_envs, cfg.priv_info_dim), dtype=self._np_dtype)
+        self.critic_info_buf = np.zeros((num_envs, cfg.critic_info_dim), dtype=self._np_dtype)
 
         self.scale_ids, self._num_scales, self._bucket_env = self._build_scale_ids(
             num_envs, cfg.scale_range

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -50,7 +50,7 @@ class RewardConfig:
 class SharpaInhandRotationCfg(SharpaInhandBaseCfg):
     reward_config: RewardConfig | None = None
     zero_action_test_mode: bool = False
-    # "full": legacy Sharpa observation (proprio+tactile+contact-pos+privileged mode).
+    # "full": proprio+tactile+contact-pos plus critic-info channels.
     # "simple": only {joint_pos, target_joint_pos, object_pos} with history.
     observation_mode: str = "full"
 
@@ -139,21 +139,21 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             p_gain *= p_scale
             d_gain *= d_scale
 
-        priv_info = np.zeros((num_reset, env.cfg.priv_info_dim), dtype=dtype)
+        critic_info = np.zeros((num_reset, env.cfg.critic_info_dim), dtype=dtype)
         if env.cfg.randomize_friction:
-            priv_info[:, 3] = np.random.uniform(
+            critic_info[:, 3] = np.random.uniform(
                 env.cfg.randomize_friction_scale_lower,
                 env.cfg.randomize_friction_scale_upper,
                 size=(num_reset,),
             ).astype(dtype)
         if env.cfg.randomize_mass:
-            priv_info[:, 4] = np.random.uniform(
+            critic_info[:, 4] = np.random.uniform(
                 env.cfg.randomize_mass_lower,
                 env.cfg.randomize_mass_upper,
                 size=(num_reset,),
             ).astype(dtype)
         if env.cfg.randomize_com:
-            priv_info[:, 5:8] = np.random.uniform(
+            critic_info[:, 5:8] = np.random.uniform(
                 env.cfg.randomize_com_lower,
                 env.cfg.randomize_com_upper,
                 size=(num_reset, 3),
@@ -161,7 +161,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
 
         # NOTE: source task randomizes friction/mass/com in physics directly.
         # UniLab backend contract currently does not expose those object-level mutation hooks,
-        # so we preserve privileged channels but keep runtime physics mutation as TODO.
+        # so we preserve critic-info channels but keep runtime physics mutation as TODO.
 
         tactile = np.zeros((num_reset, env._num_tactile), dtype=dtype)
         contact_pos = np.zeros((num_reset, env._num_tactile * 3), dtype=dtype)
@@ -180,7 +180,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
         object_default_pose = np.concatenate(
             [object_pos_f, object_quat.astype(dtype)], axis=1
         ).astype(dtype)
-        priv_info[:, 0:3] = object_pos_f - object_default_pose[:, 0:3]
+        critic_info[:, 0:3] = object_pos_f - object_default_pose[:, 0:3]
 
         return {
             "current_actions": np.zeros((num_reset, env._num_action), dtype=dtype),
@@ -196,7 +196,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             "rot_axis": rot_axis.astype(dtype),
             "p_gain": p_gain,
             "d_gain": d_gain,
-            "priv_info": priv_info,
+            "critic_info": critic_info,
             "obs_lag_history": obs_lag_history,
             "proprio_hist": env._update_proprio_history(obs_lag_history),
         }
@@ -336,13 +336,13 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
                 "Set env.torque_control=false. Virtual torques are still computed explicitly for reward terms."
             )
 
-        mode = str(cfg.privileged_obs_mode).strip().lower()
+        mode = str(cfg.critic_obs_mode).strip().lower()
         if mode not in ("separate", "merged"):
             raise ValueError(
-                "privileged_obs_mode must be one of {'separate', 'merged'}, "
-                f"got {cfg.privileged_obs_mode!r}"
+                "critic_obs_mode must be one of {'separate', 'merged'}, "
+                f"got {cfg.critic_obs_mode!r}"
             )
-        self._privileged_obs_mode = "separate" if self._observation_mode == "simple" else mode
+        self._critic_obs_mode = "separate" if self._observation_mode == "simple" else mode
 
         self._reward_cfg = cfg.reward_config
         self._zero_action_test_mode = bool(cfg.zero_action_test_mode)
@@ -409,9 +409,9 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         base_obs_dim = self._cfg.obs_lag_steps * self._obs_frame_dim()
         if self._observation_mode == "simple":
             return {"obs": base_obs_dim}
-        if self._privileged_obs_mode == "merged":
-            return {"obs": base_obs_dim + self._cfg.priv_info_dim}
-        return {"obs": base_obs_dim, "privileged": self._cfg.priv_info_dim}
+        if self._critic_obs_mode == "merged":
+            return {"obs": base_obs_dim + self._cfg.critic_info_dim}
+        return {"obs": base_obs_dim, "critic": base_obs_dim + self._cfg.critic_info_dim}
 
     def _compute_obs_from_inputs(
         self,
@@ -449,10 +449,10 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         if self._observation_mode == "simple":
             return {"obs": obs}
 
-        priv_info = np.asarray(
+        critic_info = np.asarray(
             info.get(
-                "priv_info",
-                np.zeros((batch_size, self._cfg.priv_info_dim), dtype=self._np_dtype),
+                "critic_info",
+                np.zeros((batch_size, self._cfg.critic_info_dim), dtype=self._np_dtype),
             ),
             dtype=self._np_dtype,
         )
@@ -464,14 +464,15 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             ),
             dtype=self._np_dtype,
         )
-        if priv_info.shape[1] >= 3:
-            priv_info[:, 0:3] = object_pos - object_default_pose[:, 0:3]
+        if critic_info.shape[1] >= 3:
+            critic_info[:, 0:3] = object_pos - object_default_pose[:, 0:3]
 
-        info["priv_info"] = priv_info
-        if self._privileged_obs_mode == "merged":
-            merged_obs = np.concatenate([obs, priv_info], axis=1).astype(self._np_dtype)
+        info["critic_info"] = critic_info
+        if self._critic_obs_mode == "merged":
+            merged_obs = np.concatenate([obs, critic_info], axis=1).astype(self._np_dtype)
             return {"obs": merged_obs}
-        return {"obs": obs, "privileged": priv_info}
+        critic_obs = np.concatenate([obs, critic_info], axis=1).astype(self._np_dtype)
+        return {"obs": obs, "critic": critic_obs}
 
     def _compute_reward(
         self,

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -359,9 +359,8 @@ class G1MotionTrackingEnv(G1BaseEnv):
         #        + linvel(3) + gyro(3) + joint_pos(n) + joint_vel(n) + actions(n)
         n = self._num_action
         actor_dim = 3 + 6 + 3 + 3 + n * 5
-        # Privileged: body_pos_b(num_bodies*3) + body_ori_b(num_bodies*6)
-        privileged_dim = len(self._cfg.body_names) * 9
-        return {"obs": actor_dim, "privileged": privileged_dim}
+        critic_extra_dim = len(self._cfg.body_names) * 9
+        return {"obs": actor_dim, "critic": actor_dim + critic_extra_dim}
 
     def _init_reward_functions(self):
         self._reward_fns = {
@@ -523,7 +522,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         robot_body_pos_w: np.ndarray,
         robot_body_quat_w: np.ndarray,
     ) -> dict[str, np.ndarray]:
-        """Compute observations as dict with actor and privileged groups."""
+        """Compute observations as dict with actor and critic groups."""
         num_envs = linvel.shape[0]
         command = np.concatenate(
             [motion_data.joint_pos, motion_data.joint_vel],
@@ -576,7 +575,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
             dtype=get_global_dtype(),
         )
 
-        # Robot body positions in robot anchor frame (privileged) — vectorized
+        # Robot body positions in robot anchor frame (critic-only) — vectorized
         n_body = len(self._cfg.body_names)
         # Flatten (N, B, *) -> (N*B, *) for batched frame transform
         anchor_pos_tiled = np.tile(robot_anchor_pos_w, (1, n_body)).reshape(num_envs * n_body, 3)
@@ -591,7 +590,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         ori_mat = np_matrix_from_quat(ori_b_flat)  # (N*B, 3, 3)
         robot_body_ori_b = ori_mat[:, :, :2].reshape(num_envs, n_body, 6)
 
-        privileged_obs = np.concatenate(
+        critic_extra = np.concatenate(
             [
                 robot_body_pos_b.reshape(num_envs, -1),
                 robot_body_ori_b.reshape(num_envs, -1),
@@ -600,7 +599,8 @@ class G1MotionTrackingEnv(G1BaseEnv):
             dtype=get_global_dtype(),
         )
 
-        return {"obs": actor_obs, "privileged": privileged_obs}
+        critic_obs = np.concatenate([actor_obs, critic_extra], axis=1, dtype=get_global_dtype())
+        return {"obs": actor_obs, "critic": critic_obs}
 
     def _compute_reward(
         self,

--- a/src/unilab/ipc/replay_buffer.py
+++ b/src/unilab/ipc/replay_buffer.py
@@ -24,11 +24,13 @@ class ReplayBuffer(SharedBufferBase):
         device: str,
         privileged_dim: int = 0,
         defer_gpu: bool = False,
+        critic_dim: int = 0,
     ):
         super().__init__(capacity, device, defer_gpu=defer_gpu)
         self._obs_dim = obs_dim
         self._action_dim = action_dim
         self._privileged_dim = privileged_dim
+        self._critic_dim = critic_dim
 
         self.size = torch.zeros(1, dtype=torch.int64).share_memory_()
 
@@ -45,6 +47,10 @@ class ReplayBuffer(SharedBufferBase):
                 self.privileged_obs = torch.zeros(capacity, privileged_dim).share_memory_()
                 self.next_privileged_obs = torch.zeros(capacity, privileged_dim).share_memory_()
 
+            if critic_dim > 0:
+                self.critic_obs = torch.zeros(capacity, critic_dim).share_memory_()
+                self.next_critic_obs = torch.zeros(capacity, critic_dim).share_memory_()
+
             if not defer_gpu:
                 # GPU cache for zero-copy sampling
                 self.obs_gpu = torch.empty(capacity, obs_dim, device="cuda")
@@ -59,9 +65,14 @@ class ReplayBuffer(SharedBufferBase):
                     self.next_privileged_obs_gpu = torch.empty(
                         capacity, privileged_dim, device="cuda"
                     )
+
+                if critic_dim > 0:
+                    self.critic_obs_gpu = torch.empty(capacity, critic_dim, device="cuda")
+                    self.next_critic_obs_gpu = torch.empty(capacity, critic_dim, device="cuda")
         else:
-            # Single packed host tensor; layout: [obs | next_obs | actions | rew | done | trunc | priv | next_priv]
-            total_dim = 2 * obs_dim + action_dim + 3 + 2 * privileged_dim
+            # Single packed host tensor;
+            # layout: [obs | next_obs | actions | rew | done | trunc | priv | next_priv | critic | next_critic]
+            total_dim = 2 * obs_dim + action_dim + 3 + 2 * privileged_dim + 2 * critic_dim
             self._storage = torch.zeros(capacity, total_dim).share_memory_()
 
             c = 0
@@ -82,6 +93,13 @@ class ReplayBuffer(SharedBufferBase):
                 self._priv_sl = slice(c, c + privileged_dim)
                 c += privileged_dim
                 self._npriv_sl = slice(c, c + privileged_dim)
+                c += privileged_dim
+
+            if critic_dim > 0:
+                self._critic_sl = slice(c, c + critic_dim)
+                c += critic_dim
+                self._ncritic_sl = slice(c, c + critic_dim)
+                c += critic_dim
 
     def __getstate__(self) -> dict:
         """Custom pickle support.
@@ -103,6 +121,8 @@ class ReplayBuffer(SharedBufferBase):
             "truncated_gpu",
             "privileged_obs_gpu",
             "next_privileged_obs_gpu",
+            "critic_obs_gpu",
+            "next_critic_obs_gpu",
         ):
             state.pop(key, None)
         return state
@@ -130,6 +150,9 @@ class ReplayBuffer(SharedBufferBase):
             self.next_privileged_obs_gpu = torch.zeros(
                 self.capacity, self._privileged_dim, device=device
             )
+        if self._critic_dim > 0:
+            self.critic_obs_gpu = torch.zeros(self.capacity, self._critic_dim, device=device)
+            self.next_critic_obs_gpu = torch.zeros(self.capacity, self._critic_dim, device=device)
         self._gpu_synced_ptr = 0
         self._cuda_stream = torch.cuda.Stream(device=device)
 
@@ -146,10 +169,15 @@ class ReplayBuffer(SharedBufferBase):
         terminal_mask=None,
         terminal_next_obs=None,
         terminal_next_privileged=None,
+        critic=None,
+        next_critic=None,
+        terminal_next_critic=None,
     ):
         """Add batch (called by collector)."""
         n = obs.shape[0]
         idx = int(self.ptr[0]) % self.capacity
+        has_priv = self._privileged_dim > 0 and privileged is not None
+        has_critic = self._critic_dim > 0 and critic is not None
 
         if self.device == "cuda":
             if idx + n <= self.capacity:
@@ -159,18 +187,22 @@ class ReplayBuffer(SharedBufferBase):
                 self.rewards[idx : idx + n] = rewards
                 self.dones[idx : idx + n] = dones
                 self.truncated[idx : idx + n] = truncated
-                if self._privileged_dim > 0 and privileged is not None:
-                    assert next_privileged is not None
+                if has_priv:
+                    assert privileged is not None and next_privileged is not None
                     self.privileged_obs[idx : idx + n] = privileged
                     self.next_privileged_obs[idx : idx + n] = next_privileged
+                if has_critic:
+                    assert critic is not None and next_critic is not None
+                    self.critic_obs[idx : idx + n] = critic
+                    self.next_critic_obs[idx : idx + n] = next_critic
                 self._patch_terminal_next_observations(
                     self.next_obs[idx : idx + n],
                     terminal_mask,
                     terminal_next_obs,
-                    self.next_privileged_obs[idx : idx + n]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self.next_privileged_obs[idx : idx + n] if has_priv else None,
                     terminal_next_privileged,
+                    self.next_critic_obs[idx : idx + n] if has_critic else None,
+                    terminal_next_critic,
                 )
             else:
                 split = self.capacity - idx
@@ -186,33 +218,39 @@ class ReplayBuffer(SharedBufferBase):
                 self.dones[: n - split] = dones[split:]
                 self.truncated[idx:] = truncated[:split]
                 self.truncated[: n - split] = truncated[split:]
-                if self._privileged_dim > 0 and privileged is not None:
-                    assert next_privileged is not None
+                if has_priv:
+                    assert privileged is not None and next_privileged is not None
                     self.privileged_obs[idx:] = privileged[:split]
                     self.privileged_obs[: n - split] = privileged[split:]
                     self.next_privileged_obs[idx:] = next_privileged[:split]
                     self.next_privileged_obs[: n - split] = next_privileged[split:]
+                if has_critic:
+                    assert critic is not None and next_critic is not None
+                    self.critic_obs[idx:] = critic[:split]
+                    self.critic_obs[: n - split] = critic[split:]
+                    self.next_critic_obs[idx:] = next_critic[:split]
+                    self.next_critic_obs[: n - split] = next_critic[split:]
                 self._patch_terminal_next_observations(
                     self.next_obs[idx:],
                     terminal_mask[:split] if terminal_mask is not None else None,
                     terminal_next_obs[:split] if terminal_next_obs is not None else None,
-                    self.next_privileged_obs[idx:]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self.next_privileged_obs[idx:] if has_priv else None,
                     terminal_next_privileged[:split]
                     if terminal_next_privileged is not None
                     else None,
+                    self.next_critic_obs[idx:] if has_critic else None,
+                    terminal_next_critic[:split] if terminal_next_critic is not None else None,
                 )
                 self._patch_terminal_next_observations(
                     self.next_obs[: n - split],
                     terminal_mask[split:] if terminal_mask is not None else None,
                     terminal_next_obs[split:] if terminal_next_obs is not None else None,
-                    self.next_privileged_obs[: n - split]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self.next_privileged_obs[: n - split] if has_priv else None,
                     terminal_next_privileged[split:]
                     if terminal_next_privileged is not None
                     else None,
+                    self.next_critic_obs[: n - split] if has_critic else None,
+                    terminal_next_critic[split:] if terminal_next_critic is not None else None,
                 )
         else:
             parts = [
@@ -223,9 +261,12 @@ class ReplayBuffer(SharedBufferBase):
                 dones.unsqueeze(1),
                 truncated.unsqueeze(1),
             ]
-            if self._privileged_dim > 0 and privileged is not None:
+            if has_priv:
                 assert next_privileged is not None
                 parts.extend([privileged, next_privileged])
+            if has_critic:
+                assert next_critic is not None
+                parts.extend([critic, next_critic])
             row = torch.cat(parts, dim=1)
 
             if idx + n <= self.capacity:
@@ -234,10 +275,10 @@ class ReplayBuffer(SharedBufferBase):
                     self._storage[idx : idx + n, self._nobs_sl],
                     terminal_mask,
                     terminal_next_obs,
-                    self._storage[idx : idx + n, self._npriv_sl]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self._storage[idx : idx + n, self._npriv_sl] if has_priv else None,
                     terminal_next_privileged,
+                    self._storage[idx : idx + n, self._ncritic_sl] if has_critic else None,
+                    terminal_next_critic,
                 )
             else:
                 split = self.capacity - idx
@@ -247,23 +288,23 @@ class ReplayBuffer(SharedBufferBase):
                     self._storage[idx:, self._nobs_sl],
                     terminal_mask[:split] if terminal_mask is not None else None,
                     terminal_next_obs[:split] if terminal_next_obs is not None else None,
-                    self._storage[idx:, self._npriv_sl]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self._storage[idx:, self._npriv_sl] if has_priv else None,
                     terminal_next_privileged[:split]
                     if terminal_next_privileged is not None
                     else None,
+                    self._storage[idx:, self._ncritic_sl] if has_critic else None,
+                    terminal_next_critic[:split] if terminal_next_critic is not None else None,
                 )
                 self._patch_terminal_next_observations(
                     self._storage[: n - split, self._nobs_sl],
                     terminal_mask[split:] if terminal_mask is not None else None,
                     terminal_next_obs[split:] if terminal_next_obs is not None else None,
-                    self._storage[: n - split, self._npriv_sl]
-                    if self._privileged_dim > 0 and privileged is not None
-                    else None,
+                    self._storage[: n - split, self._npriv_sl] if has_priv else None,
                     terminal_next_privileged[split:]
                     if terminal_next_privileged is not None
                     else None,
+                    self._storage[: n - split, self._ncritic_sl] if has_critic else None,
+                    terminal_next_critic[split:] if terminal_next_critic is not None else None,
                 )
 
         self.ptr[0] += n
@@ -276,6 +317,8 @@ class ReplayBuffer(SharedBufferBase):
         terminal_next_obs,
         target_next_privileged=None,
         terminal_next_privileged=None,
+        target_next_critic=None,
+        terminal_next_critic=None,
     ) -> None:
         if terminal_mask is None or terminal_next_obs is None:
             return
@@ -286,9 +329,11 @@ class ReplayBuffer(SharedBufferBase):
 
         target_next_obs[terminal_mask] = terminal_next_obs[terminal_mask]
 
-        if target_next_privileged is None or terminal_next_privileged is None:
-            return
-        target_next_privileged[terminal_mask] = terminal_next_privileged[terminal_mask]
+        if target_next_privileged is not None and terminal_next_privileged is not None:
+            target_next_privileged[terminal_mask] = terminal_next_privileged[terminal_mask]
+
+        if target_next_critic is not None and terminal_next_critic is not None:
+            target_next_critic[terminal_mask] = terminal_next_critic[terminal_mask]
 
     def sample(self, batch_size: int) -> Dict[str, torch.Tensor]:
         """Sample batch (called by learner)."""
@@ -327,6 +372,13 @@ class ReplayBuffer(SharedBufferBase):
                         )
                         self.next_privileged_obs_gpu[idx : idx + delta].copy_(
                             self.next_privileged_obs[idx : idx + delta], non_blocking=True
+                        )
+                    if self._critic_dim > 0:
+                        self.critic_obs_gpu[idx : idx + delta].copy_(
+                            self.critic_obs[idx : idx + delta], non_blocking=True
+                        )
+                        self.next_critic_obs_gpu[idx : idx + delta].copy_(
+                            self.next_critic_obs[idx : idx + delta], non_blocking=True
                         )
                 else:
                     split = self.capacity - idx
@@ -367,6 +419,17 @@ class ReplayBuffer(SharedBufferBase):
                         self.next_privileged_obs_gpu[: delta - split].copy_(
                             self.next_privileged_obs[: delta - split], non_blocking=True
                         )
+                    if self._critic_dim > 0:
+                        self.critic_obs_gpu[idx:].copy_(self.critic_obs[idx:], non_blocking=True)
+                        self.critic_obs_gpu[: delta - split].copy_(
+                            self.critic_obs[: delta - split], non_blocking=True
+                        )
+                        self.next_critic_obs_gpu[idx:].copy_(
+                            self.next_critic_obs[idx:], non_blocking=True
+                        )
+                        self.next_critic_obs_gpu[: delta - split].copy_(
+                            self.next_critic_obs[: delta - split], non_blocking=True
+                        )
 
                 self._gpu_synced_ptr = ptr
 
@@ -382,6 +445,9 @@ class ReplayBuffer(SharedBufferBase):
             if self._privileged_dim > 0:
                 batch["privileged"] = self.privileged_obs_gpu[indices]
                 batch["next_privileged"] = self.next_privileged_obs_gpu[indices]
+            if self._critic_dim > 0:
+                batch["critic"] = self.critic_obs_gpu[indices]
+                batch["next_critic"] = self.next_critic_obs_gpu[indices]
             return batch
         else:
             chunk = self._storage[indices].to(self.device)
@@ -396,4 +462,7 @@ class ReplayBuffer(SharedBufferBase):
             if self._privileged_dim > 0:
                 batch["privileged"] = chunk[:, self._priv_sl]
                 batch["next_privileged"] = chunk[:, self._npriv_sl]
+            if self._critic_dim > 0:
+                batch["critic"] = chunk[:, self._critic_sl]
+                batch["next_critic"] = chunk[:, self._ncritic_sl]
             return batch

--- a/src/unilab/ipc/replay_buffer.py
+++ b/src/unilab/ipc/replay_buffer.py
@@ -22,14 +22,12 @@ class ReplayBuffer(SharedBufferBase):
         obs_dim: int,
         action_dim: int,
         device: str,
-        privileged_dim: int = 0,
         defer_gpu: bool = False,
         critic_dim: int = 0,
     ):
         super().__init__(capacity, device, defer_gpu=defer_gpu)
         self._obs_dim = obs_dim
         self._action_dim = action_dim
-        self._privileged_dim = privileged_dim
         self._critic_dim = critic_dim
 
         self.size = torch.zeros(1, dtype=torch.int64).share_memory_()
@@ -42,10 +40,6 @@ class ReplayBuffer(SharedBufferBase):
             self.rewards = torch.zeros(capacity).share_memory_()
             self.dones = torch.zeros(capacity).share_memory_()
             self.truncated = torch.zeros(capacity).share_memory_()
-
-            if privileged_dim > 0:
-                self.privileged_obs = torch.zeros(capacity, privileged_dim).share_memory_()
-                self.next_privileged_obs = torch.zeros(capacity, privileged_dim).share_memory_()
 
             if critic_dim > 0:
                 self.critic_obs = torch.zeros(capacity, critic_dim).share_memory_()
@@ -60,19 +54,13 @@ class ReplayBuffer(SharedBufferBase):
                 self.dones_gpu = torch.empty(capacity, device="cuda")
                 self.truncated_gpu = torch.empty(capacity, device="cuda")
 
-                if privileged_dim > 0:
-                    self.privileged_obs_gpu = torch.empty(capacity, privileged_dim, device="cuda")
-                    self.next_privileged_obs_gpu = torch.empty(
-                        capacity, privileged_dim, device="cuda"
-                    )
-
                 if critic_dim > 0:
                     self.critic_obs_gpu = torch.empty(capacity, critic_dim, device="cuda")
                     self.next_critic_obs_gpu = torch.empty(capacity, critic_dim, device="cuda")
         else:
             # Single packed host tensor;
-            # layout: [obs | next_obs | actions | rew | done | trunc | priv | next_priv | critic | next_critic]
-            total_dim = 2 * obs_dim + action_dim + 3 + 2 * privileged_dim + 2 * critic_dim
+            # layout: [obs | next_obs | actions | rew | done | trunc | critic | next_critic]
+            total_dim = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
             self._storage = torch.zeros(capacity, total_dim).share_memory_()
 
             c = 0
@@ -88,12 +76,6 @@ class ReplayBuffer(SharedBufferBase):
             c += 1
             self._trunc_col = c
             c += 1
-
-            if privileged_dim > 0:
-                self._priv_sl = slice(c, c + privileged_dim)
-                c += privileged_dim
-                self._npriv_sl = slice(c, c + privileged_dim)
-                c += privileged_dim
 
             if critic_dim > 0:
                 self._critic_sl = slice(c, c + critic_dim)
@@ -119,8 +101,6 @@ class ReplayBuffer(SharedBufferBase):
             "rewards_gpu",
             "dones_gpu",
             "truncated_gpu",
-            "privileged_obs_gpu",
-            "next_privileged_obs_gpu",
             "critic_obs_gpu",
             "next_critic_obs_gpu",
         ):
@@ -143,13 +123,6 @@ class ReplayBuffer(SharedBufferBase):
         self.rewards_gpu = torch.zeros(self.capacity, device=device)
         self.dones_gpu = torch.zeros(self.capacity, device=device)
         self.truncated_gpu = torch.zeros(self.capacity, device=device)
-        if self._privileged_dim > 0:
-            self.privileged_obs_gpu = torch.zeros(
-                self.capacity, self._privileged_dim, device=device
-            )
-            self.next_privileged_obs_gpu = torch.zeros(
-                self.capacity, self._privileged_dim, device=device
-            )
         if self._critic_dim > 0:
             self.critic_obs_gpu = torch.zeros(self.capacity, self._critic_dim, device=device)
             self.next_critic_obs_gpu = torch.zeros(self.capacity, self._critic_dim, device=device)
@@ -164,11 +137,8 @@ class ReplayBuffer(SharedBufferBase):
         next_obs,
         dones,
         truncated,
-        privileged=None,
-        next_privileged=None,
         terminal_mask=None,
         terminal_next_obs=None,
-        terminal_next_privileged=None,
         critic=None,
         next_critic=None,
         terminal_next_critic=None,
@@ -176,7 +146,6 @@ class ReplayBuffer(SharedBufferBase):
         """Add batch (called by collector)."""
         n = obs.shape[0]
         idx = int(self.ptr[0]) % self.capacity
-        has_priv = self._privileged_dim > 0 and privileged is not None
         has_critic = self._critic_dim > 0 and critic is not None
 
         if self.device == "cuda":
@@ -187,10 +156,6 @@ class ReplayBuffer(SharedBufferBase):
                 self.rewards[idx : idx + n] = rewards
                 self.dones[idx : idx + n] = dones
                 self.truncated[idx : idx + n] = truncated
-                if has_priv:
-                    assert privileged is not None and next_privileged is not None
-                    self.privileged_obs[idx : idx + n] = privileged
-                    self.next_privileged_obs[idx : idx + n] = next_privileged
                 if has_critic:
                     assert critic is not None and next_critic is not None
                     self.critic_obs[idx : idx + n] = critic
@@ -199,8 +164,6 @@ class ReplayBuffer(SharedBufferBase):
                     self.next_obs[idx : idx + n],
                     terminal_mask,
                     terminal_next_obs,
-                    self.next_privileged_obs[idx : idx + n] if has_priv else None,
-                    terminal_next_privileged,
                     self.next_critic_obs[idx : idx + n] if has_critic else None,
                     terminal_next_critic,
                 )
@@ -218,12 +181,6 @@ class ReplayBuffer(SharedBufferBase):
                 self.dones[: n - split] = dones[split:]
                 self.truncated[idx:] = truncated[:split]
                 self.truncated[: n - split] = truncated[split:]
-                if has_priv:
-                    assert privileged is not None and next_privileged is not None
-                    self.privileged_obs[idx:] = privileged[:split]
-                    self.privileged_obs[: n - split] = privileged[split:]
-                    self.next_privileged_obs[idx:] = next_privileged[:split]
-                    self.next_privileged_obs[: n - split] = next_privileged[split:]
                 if has_critic:
                     assert critic is not None and next_critic is not None
                     self.critic_obs[idx:] = critic[:split]
@@ -234,10 +191,6 @@ class ReplayBuffer(SharedBufferBase):
                     self.next_obs[idx:],
                     terminal_mask[:split] if terminal_mask is not None else None,
                     terminal_next_obs[:split] if terminal_next_obs is not None else None,
-                    self.next_privileged_obs[idx:] if has_priv else None,
-                    terminal_next_privileged[:split]
-                    if terminal_next_privileged is not None
-                    else None,
                     self.next_critic_obs[idx:] if has_critic else None,
                     terminal_next_critic[:split] if terminal_next_critic is not None else None,
                 )
@@ -245,10 +198,6 @@ class ReplayBuffer(SharedBufferBase):
                     self.next_obs[: n - split],
                     terminal_mask[split:] if terminal_mask is not None else None,
                     terminal_next_obs[split:] if terminal_next_obs is not None else None,
-                    self.next_privileged_obs[: n - split] if has_priv else None,
-                    terminal_next_privileged[split:]
-                    if terminal_next_privileged is not None
-                    else None,
                     self.next_critic_obs[: n - split] if has_critic else None,
                     terminal_next_critic[split:] if terminal_next_critic is not None else None,
                 )
@@ -261,9 +210,6 @@ class ReplayBuffer(SharedBufferBase):
                 dones.unsqueeze(1),
                 truncated.unsqueeze(1),
             ]
-            if has_priv:
-                assert next_privileged is not None
-                parts.extend([privileged, next_privileged])
             if has_critic:
                 assert next_critic is not None
                 parts.extend([critic, next_critic])
@@ -275,8 +221,6 @@ class ReplayBuffer(SharedBufferBase):
                     self._storage[idx : idx + n, self._nobs_sl],
                     terminal_mask,
                     terminal_next_obs,
-                    self._storage[idx : idx + n, self._npriv_sl] if has_priv else None,
-                    terminal_next_privileged,
                     self._storage[idx : idx + n, self._ncritic_sl] if has_critic else None,
                     terminal_next_critic,
                 )
@@ -288,10 +232,6 @@ class ReplayBuffer(SharedBufferBase):
                     self._storage[idx:, self._nobs_sl],
                     terminal_mask[:split] if terminal_mask is not None else None,
                     terminal_next_obs[:split] if terminal_next_obs is not None else None,
-                    self._storage[idx:, self._npriv_sl] if has_priv else None,
-                    terminal_next_privileged[:split]
-                    if terminal_next_privileged is not None
-                    else None,
                     self._storage[idx:, self._ncritic_sl] if has_critic else None,
                     terminal_next_critic[:split] if terminal_next_critic is not None else None,
                 )
@@ -299,10 +239,6 @@ class ReplayBuffer(SharedBufferBase):
                     self._storage[: n - split, self._nobs_sl],
                     terminal_mask[split:] if terminal_mask is not None else None,
                     terminal_next_obs[split:] if terminal_next_obs is not None else None,
-                    self._storage[: n - split, self._npriv_sl] if has_priv else None,
-                    terminal_next_privileged[split:]
-                    if terminal_next_privileged is not None
-                    else None,
                     self._storage[: n - split, self._ncritic_sl] if has_critic else None,
                     terminal_next_critic[split:] if terminal_next_critic is not None else None,
                 )
@@ -315,8 +251,6 @@ class ReplayBuffer(SharedBufferBase):
         target_next_obs,
         terminal_mask,
         terminal_next_obs,
-        target_next_privileged=None,
-        terminal_next_privileged=None,
         target_next_critic=None,
         terminal_next_critic=None,
     ) -> None:
@@ -328,9 +262,6 @@ class ReplayBuffer(SharedBufferBase):
             return
 
         target_next_obs[terminal_mask] = terminal_next_obs[terminal_mask]
-
-        if target_next_privileged is not None and terminal_next_privileged is not None:
-            target_next_privileged[terminal_mask] = terminal_next_privileged[terminal_mask]
 
         if target_next_critic is not None and terminal_next_critic is not None:
             target_next_critic[terminal_mask] = terminal_next_critic[terminal_mask]
@@ -366,13 +297,6 @@ class ReplayBuffer(SharedBufferBase):
                     self.truncated_gpu[idx : idx + delta].copy_(
                         self.truncated[idx : idx + delta], non_blocking=True
                     )
-                    if self._privileged_dim > 0:
-                        self.privileged_obs_gpu[idx : idx + delta].copy_(
-                            self.privileged_obs[idx : idx + delta], non_blocking=True
-                        )
-                        self.next_privileged_obs_gpu[idx : idx + delta].copy_(
-                            self.next_privileged_obs[idx : idx + delta], non_blocking=True
-                        )
                     if self._critic_dim > 0:
                         self.critic_obs_gpu[idx : idx + delta].copy_(
                             self.critic_obs[idx : idx + delta], non_blocking=True
@@ -406,19 +330,6 @@ class ReplayBuffer(SharedBufferBase):
                     self.truncated_gpu[: delta - split].copy_(
                         self.truncated[: delta - split], non_blocking=True
                     )
-                    if self._privileged_dim > 0:
-                        self.privileged_obs_gpu[idx:].copy_(
-                            self.privileged_obs[idx:], non_blocking=True
-                        )
-                        self.privileged_obs_gpu[: delta - split].copy_(
-                            self.privileged_obs[: delta - split], non_blocking=True
-                        )
-                        self.next_privileged_obs_gpu[idx:].copy_(
-                            self.next_privileged_obs[idx:], non_blocking=True
-                        )
-                        self.next_privileged_obs_gpu[: delta - split].copy_(
-                            self.next_privileged_obs[: delta - split], non_blocking=True
-                        )
                     if self._critic_dim > 0:
                         self.critic_obs_gpu[idx:].copy_(self.critic_obs[idx:], non_blocking=True)
                         self.critic_obs_gpu[: delta - split].copy_(
@@ -442,9 +353,6 @@ class ReplayBuffer(SharedBufferBase):
                 "dones": self.dones_gpu[indices],
                 "truncated": self.truncated_gpu[indices],
             }
-            if self._privileged_dim > 0:
-                batch["privileged"] = self.privileged_obs_gpu[indices]
-                batch["next_privileged"] = self.next_privileged_obs_gpu[indices]
             if self._critic_dim > 0:
                 batch["critic"] = self.critic_obs_gpu[indices]
                 batch["next_critic"] = self.next_critic_obs_gpu[indices]
@@ -459,9 +367,6 @@ class ReplayBuffer(SharedBufferBase):
                 "dones": chunk[:, self._done_col],
                 "truncated": chunk[:, self._trunc_col],
             }
-            if self._privileged_dim > 0:
-                batch["privileged"] = chunk[:, self._priv_sl]
-                batch["next_privileged"] = chunk[:, self._npriv_sl]
             if self._critic_dim > 0:
                 batch["critic"] = chunk[:, self._critic_sl]
                 batch["next_critic"] = chunk[:, self._ncritic_sl]

--- a/src/unilab/ipc/shared_onpolicy_storage.py
+++ b/src/unilab/ipc/shared_onpolicy_storage.py
@@ -10,36 +10,21 @@ import numpy as np
 
 _SPAWN_CTX = mp.get_context("spawn")
 
-# Fields stored per rollout and their shape constructors.
-# Shape: (num_slots, num_envs, num_steps, *trailing) for time-series fields,
-#        (num_slots, num_envs, obs_dim) for last_obs.
 _FIELD_SHAPES = {
-    "obs": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns, od),
-    "privileged": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns, pd),
-    "actions": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns, ad),
-    "log_probs": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns),
-    "rewards": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns),
-    "dones": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns),
-    "truncated": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, ns),
-    "last_obs": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, od),
-    "last_privileged": lambda ns_slots, ne, ns, od, ad, pd: (ns_slots, ne, pd),
+    "obs": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns, od),
+    "critic": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns, cd),
+    "actions": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns, ad),
+    "log_probs": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns),
+    "rewards": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns),
+    "dones": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns),
+    "truncated": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns),
+    "last_obs": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, od),
+    "last_critic": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, cd),
 }
 
 
 class SharedOnPolicyStorage:
-    """N-slot ring-buffer shared-memory store for on-policy rollouts.
-
-    The writer (collector subprocess) fills the current write slot and calls
-    ``signal_write_done()`` — this atomically advances ``_write_ptr`` and
-    returns immediately (no blocking).  The reader (learner) calls
-    ``wait_for_data()``, reads with ``read_torch()``, then calls
-    ``advance_read()`` to advance ``_read_ptr``.
-
-    When the collector is faster than the learner the buffer can fill up.
-    In that case the collector continues writing and the oldest unread slots
-    are silently overwritten (IMPALA/APPO overwrite semantics).  The learner
-    detects and skips overwritten slots inside ``advance_read()``.
-    """
+    """N-slot ring-buffer shared-memory store for on-policy rollouts."""
 
     def __init__(
         self,
@@ -48,7 +33,7 @@ class SharedOnPolicyStorage:
         obs_dim: int,
         action_dim: int,
         *,
-        privileged_dim: int = 0,
+        critic_dim: int = 0,
         num_slots: int = 4,
         create: bool = True,
         shm_name_prefix: Dict[str, str] | None = None,
@@ -57,20 +42,19 @@ class SharedOnPolicyStorage:
         self.num_steps = num_steps
         self.obs_dim = obs_dim
         self.action_dim = action_dim
-        self.privileged_dim = privileged_dim
+        self.critic_dim = critic_dim
         self.num_slots = num_slots
 
         self._shm_blocks: Dict[str, shared_memory.SharedMemory] = {}
         self._arrays: Dict[str, np.ndarray] = {}
 
-        # Only allocate privileged fields if privileged_dim > 0
         fields_to_allocate = {k: v for k, v in _FIELD_SHAPES.items()}
-        if privileged_dim == 0:
-            fields_to_allocate.pop("privileged", None)
-            fields_to_allocate.pop("last_privileged", None)
+        if critic_dim == 0:
+            fields_to_allocate.pop("critic", None)
+            fields_to_allocate.pop("last_critic", None)
 
         for field, shape_fn in fields_to_allocate.items():
-            shape = shape_fn(num_slots, num_envs, num_steps, obs_dim, action_dim, privileged_dim)
+            shape = shape_fn(num_slots, num_envs, num_steps, obs_dim, action_dim, critic_dim)
             nbytes = int(np.prod(shape)) * np.dtype(np.float32).itemsize
 
             if create:
@@ -83,32 +67,16 @@ class SharedOnPolicyStorage:
             self._arrays[field] = np.ndarray(shape, dtype=np.float32, buffer=shm.buf)
 
         if create:
-            # Monotonically increasing write / read pointers.
-            # slot index = ptr % num_slots
             self._write_ptr = _SPAWN_CTX.Value("l", 0)
             self._read_ptr = _SPAWN_CTX.Value("l", 0)
 
-    # ------------------------------------------------------------------
-    # Properties
-    # ------------------------------------------------------------------
-
     @property
     def name(self) -> Dict[str, str]:
-        """Return {field: shm_name} dict — pass as shm_name_prefix to attach."""
         return {field: shm.name for field, shm in self._shm_blocks.items()}
 
-    # ------------------------------------------------------------------
-    # Sync primitives (attached in worker subprocess)
-    # ------------------------------------------------------------------
-
     def attach_sync_primitives(self, write_ptr, read_ptr) -> None:
-        """Called in the worker to attach the sync primitives from the parent."""
         self._write_ptr = write_ptr
         self._read_ptr = read_ptr
-
-    # ------------------------------------------------------------------
-    # Writer API (collector subprocess)
-    # ------------------------------------------------------------------
 
     @property
     def write_slot(self) -> int:
@@ -116,25 +84,17 @@ class SharedOnPolicyStorage:
 
     @property
     def write_buffer(self) -> Dict[str, np.ndarray]:
-        """Return numpy arrays for the current write slot."""
         s = self.write_slot
         return {field: arr[s] for field, arr in self._arrays.items()}
 
     def signal_write_done(self) -> None:
-        """Atomically advance write pointer (non-blocking)."""
         with self._write_ptr.get_lock():
             self._write_ptr.value += 1
 
-    # ------------------------------------------------------------------
-    # Reader API (learner / main process)
-    # ------------------------------------------------------------------
-
     def available(self) -> int:
-        """Number of slots ready to consume."""
         return int(self._write_ptr.value) - int(self._read_ptr.value)
 
     def wait_for_data(self, timeout: float = 60.0) -> bool:
-        """Spin-wait (with sleep) until at least one slot is available."""
         import time
 
         deadline = time.monotonic() + timeout
@@ -149,7 +109,6 @@ class SharedOnPolicyStorage:
         return int(self._read_ptr.value) % self.num_slots
 
     def read_torch(self, device: str) -> dict:
-        """Copy current read slot into CPU tensors and move to *device*."""
         import torch
 
         s = self.read_slot
@@ -158,21 +117,14 @@ class SharedOnPolicyStorage:
         }
 
     def advance_read(self) -> None:
-        """Advance read pointer, skipping any slots overwritten by the collector."""
         with self._read_ptr.get_lock():
             rp = self._read_ptr.value + 1
             wp = self._write_ptr.value
-            # If the collector has run far ahead, fast-forward past overwritten slots.
             if wp - rp > self.num_slots:
                 rp = wp - self.num_slots + 1
             self._read_ptr.value = rp
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
     def cleanup(self) -> None:
-        """Close and unlink all shared memory (call from owner process)."""
         for shm in self._shm_blocks.values():
             try:
                 shm.close()
@@ -181,7 +133,6 @@ class SharedOnPolicyStorage:
                 pass
 
     def close(self) -> None:
-        """Close handles without unlinking (call from attached processes)."""
         for shm in self._shm_blocks.values():
             try:
                 shm.close()

--- a/src/unilab/utils/device_utils.py
+++ b/src/unilab/utils/device_utils.py
@@ -15,40 +15,15 @@ def get_default_device() -> str:
 def get_env_dims(
     env_name: str, sim_backend: str = "mujoco", env_cfg_override: dict | None = None
 ) -> tuple[int, int, int]:
-    """Get observation, action, and privileged dimensions from environment.
-
-    Returns:
-        (obs_dim, action_dim, privileged_dim)
-    """
+    """Get (actor_obs_dim, action_dim, critic_obs_dim) from environment."""
     from unilab.utils.obs_utils import get_obs_dims as get_obs_dims_from_spec
 
     env = registry.make(
         env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
     )
-    obs_dim, privileged_dim = get_obs_dims_from_spec(env.obs_groups_spec)
+    obs_dim, critic_dim = get_obs_dims_from_spec(env.obs_groups_spec)
     action_shape = env.action_space.shape
     assert action_shape is not None
     action_dim = action_shape[0]
     env.close()  # type: ignore[attr-defined]
-    return obs_dim, action_dim, privileged_dim
-
-
-def get_env_dims_with_critic(
-    env_name: str, sim_backend: str = "mujoco", env_cfg_override: dict | None = None
-) -> tuple[int, int, int, int]:
-    """Get (obs_dim, action_dim, privileged_dim, critic_dim) from environment.
-
-    Returns:
-        (obs_dim, action_dim, privileged_dim, critic_dim)
-    """
-    from unilab.utils.obs_utils import get_obs_dims_with_critic as get_obs_dims_from_spec
-
-    env = registry.make(
-        env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
-    )
-    obs_dim, privileged_dim, critic_dim = get_obs_dims_from_spec(env.obs_groups_spec)
-    action_shape = env.action_space.shape
-    assert action_shape is not None
-    action_dim = action_shape[0]
-    env.close()  # type: ignore[attr-defined]
-    return obs_dim, action_dim, privileged_dim, critic_dim
+    return obs_dim, action_dim, critic_dim

--- a/src/unilab/utils/device_utils.py
+++ b/src/unilab/utils/device_utils.py
@@ -31,3 +31,24 @@ def get_env_dims(
     action_dim = action_shape[0]
     env.close()  # type: ignore[attr-defined]
     return obs_dim, action_dim, privileged_dim
+
+
+def get_env_dims_with_critic(
+    env_name: str, sim_backend: str = "mujoco", env_cfg_override: dict | None = None
+) -> tuple[int, int, int, int]:
+    """Get (obs_dim, action_dim, privileged_dim, critic_dim) from environment.
+
+    Returns:
+        (obs_dim, action_dim, privileged_dim, critic_dim)
+    """
+    from unilab.utils.obs_utils import get_obs_dims_with_critic as get_obs_dims_from_spec
+
+    env = registry.make(
+        env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
+    )
+    obs_dim, privileged_dim, critic_dim = get_obs_dims_from_spec(env.obs_groups_spec)
+    action_shape = env.action_space.shape
+    assert action_shape is not None
+    action_dim = action_shape[0]
+    env.close()  # type: ignore[attr-defined]
+    return obs_dim, action_dim, privileged_dim, critic_dim

--- a/src/unilab/utils/final_observation.py
+++ b/src/unilab/utils/final_observation.py
@@ -5,15 +5,13 @@ from typing import Any
 
 import numpy as np
 
-from unilab.utils.obs_utils import split_obs_dict_with_critic
+from unilab.utils.obs_utils import split_obs_dict
 
 
 @dataclass(frozen=True)
 class TransitionBootstrapContract:
     actor_next_obs: np.ndarray
-    actor_next_privileged: np.ndarray | None
     transition_next_obs: np.ndarray
-    transition_next_privileged: np.ndarray | None
     terminal_mask: np.ndarray
     timeout_terminal_mask: np.ndarray
     actor_next_critic: np.ndarray | None = None
@@ -23,7 +21,6 @@ class TransitionBootstrapContract:
 @dataclass(frozen=True)
 class TerminalObservationContract:
     terminal_obs: np.ndarray | None
-    terminal_privileged: np.ndarray | None
     terminal_mask: np.ndarray
     timeout_terminal_mask: np.ndarray
     terminal_critic: np.ndarray | None = None
@@ -31,12 +28,11 @@ class TerminalObservationContract:
 
 def patch_transition_next_obs(
     next_obs: np.ndarray,
-    next_privileged: np.ndarray | None,
     final_observation: dict[str, Any] | None = None,
     done: np.ndarray | None = None,
     info: dict[str, Any] | None = None,
     next_critic: np.ndarray | None = None,
-) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
     """Patch transition next obs with final_observation without mutating actor inputs."""
     terminal_contract = resolve_terminal_observation_contract(
         next_obs_batch_size=next_obs.shape[0],
@@ -47,7 +43,6 @@ def patch_transition_next_obs(
     if not np.any(terminal_contract.terminal_mask) or terminal_contract.terminal_obs is None:
         return (
             next_obs,
-            next_privileged,
             next_critic,
             np.zeros((next_obs.shape[0],), dtype=bool),
         )
@@ -56,13 +51,6 @@ def patch_transition_next_obs(
     transition_next_obs[terminal_contract.terminal_mask] = np.asarray(
         terminal_contract.terminal_obs, dtype=next_obs.dtype
     )[terminal_contract.terminal_mask]
-
-    transition_next_privileged = next_privileged
-    if next_privileged is not None and terminal_contract.terminal_privileged is not None:
-        transition_next_privileged = next_privileged.copy()
-        transition_next_privileged[terminal_contract.terminal_mask] = np.asarray(
-            terminal_contract.terminal_privileged, dtype=next_privileged.dtype
-        )[terminal_contract.terminal_mask]
 
     transition_next_critic = next_critic
     if next_critic is not None and terminal_contract.terminal_critic is not None:
@@ -73,7 +61,6 @@ def patch_transition_next_obs(
 
     return (
         transition_next_obs,
-        transition_next_privileged,
         transition_next_critic,
         terminal_contract.terminal_mask,
     )
@@ -81,7 +68,6 @@ def patch_transition_next_obs(
 
 def resolve_transition_bootstrap_contract(
     next_obs: np.ndarray,
-    next_privileged: np.ndarray | None,
     info: dict[str, Any] | None = None,
     final_observation: dict[str, Any] | None = None,
     done: np.ndarray | None = None,
@@ -91,12 +77,10 @@ def resolve_transition_bootstrap_contract(
     """Resolve actor/storage observations and timeout bootstrap masks for a step."""
     (
         transition_next_obs,
-        transition_next_privileged,
         transition_next_critic,
         terminal_mask,
     ) = patch_transition_next_obs(
         next_obs,
-        next_privileged,
         final_observation=final_observation,
         done=done,
         info=info,
@@ -109,9 +93,7 @@ def resolve_transition_bootstrap_contract(
         )
     return TransitionBootstrapContract(
         actor_next_obs=next_obs,
-        actor_next_privileged=next_privileged,
         transition_next_obs=transition_next_obs,
-        transition_next_privileged=transition_next_privileged,
         terminal_mask=terminal_mask,
         timeout_terminal_mask=timeout_terminal_mask,
         actor_next_critic=next_critic,
@@ -131,12 +113,9 @@ def resolve_terminal_observation_contract(
     resolved_final_observation = _resolve_final_observation(final_observation, info)
 
     terminal_obs: np.ndarray | None = None
-    terminal_privileged: np.ndarray | None = None
     terminal_critic: np.ndarray | None = None
     if np.any(terminal_mask) and isinstance(resolved_final_observation, dict):
-        terminal_obs, terminal_privileged, terminal_critic = split_obs_dict_with_critic(
-            resolved_final_observation
-        )
+        terminal_obs, terminal_critic = split_obs_dict(resolved_final_observation)
 
     timeout_terminal_mask = terminal_mask
     if truncated is not None:
@@ -146,7 +125,6 @@ def resolve_terminal_observation_contract(
 
     return TerminalObservationContract(
         terminal_obs=terminal_obs,
-        terminal_privileged=terminal_privileged,
         terminal_mask=terminal_mask,
         timeout_terminal_mask=timeout_terminal_mask,
         terminal_critic=terminal_critic,

--- a/src/unilab/utils/final_observation.py
+++ b/src/unilab/utils/final_observation.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-from unilab.utils.obs_utils import split_obs_dict
+from unilab.utils.obs_utils import split_obs_dict_with_critic
 
 
 @dataclass(frozen=True)
@@ -16,6 +16,8 @@ class TransitionBootstrapContract:
     transition_next_privileged: np.ndarray | None
     terminal_mask: np.ndarray
     timeout_terminal_mask: np.ndarray
+    actor_next_critic: np.ndarray | None = None
+    transition_next_critic: np.ndarray | None = None
 
 
 @dataclass(frozen=True)
@@ -24,6 +26,7 @@ class TerminalObservationContract:
     terminal_privileged: np.ndarray | None
     terminal_mask: np.ndarray
     timeout_terminal_mask: np.ndarray
+    terminal_critic: np.ndarray | None = None
 
 
 def patch_transition_next_obs(
@@ -32,7 +35,8 @@ def patch_transition_next_obs(
     final_observation: dict[str, Any] | None = None,
     done: np.ndarray | None = None,
     info: dict[str, Any] | None = None,
-) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    next_critic: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray]:
     """Patch transition next obs with final_observation without mutating actor inputs."""
     terminal_contract = resolve_terminal_observation_contract(
         next_obs_batch_size=next_obs.shape[0],
@@ -41,7 +45,12 @@ def patch_transition_next_obs(
         info=info,
     )
     if not np.any(terminal_contract.terminal_mask) or terminal_contract.terminal_obs is None:
-        return next_obs, next_privileged, np.zeros((next_obs.shape[0],), dtype=bool)
+        return (
+            next_obs,
+            next_privileged,
+            next_critic,
+            np.zeros((next_obs.shape[0],), dtype=bool),
+        )
 
     transition_next_obs = next_obs.copy()
     transition_next_obs[terminal_contract.terminal_mask] = np.asarray(
@@ -55,7 +64,19 @@ def patch_transition_next_obs(
             terminal_contract.terminal_privileged, dtype=next_privileged.dtype
         )[terminal_contract.terminal_mask]
 
-    return transition_next_obs, transition_next_privileged, terminal_contract.terminal_mask
+    transition_next_critic = next_critic
+    if next_critic is not None and terminal_contract.terminal_critic is not None:
+        transition_next_critic = next_critic.copy()
+        transition_next_critic[terminal_contract.terminal_mask] = np.asarray(
+            terminal_contract.terminal_critic, dtype=next_critic.dtype
+        )[terminal_contract.terminal_mask]
+
+    return (
+        transition_next_obs,
+        transition_next_privileged,
+        transition_next_critic,
+        terminal_contract.terminal_mask,
+    )
 
 
 def resolve_transition_bootstrap_contract(
@@ -65,14 +86,21 @@ def resolve_transition_bootstrap_contract(
     final_observation: dict[str, Any] | None = None,
     done: np.ndarray | None = None,
     truncated: np.ndarray | None = None,
+    next_critic: np.ndarray | None = None,
 ) -> TransitionBootstrapContract:
     """Resolve actor/storage observations and timeout bootstrap masks for a step."""
-    transition_next_obs, transition_next_privileged, terminal_mask = patch_transition_next_obs(
+    (
+        transition_next_obs,
+        transition_next_privileged,
+        transition_next_critic,
+        terminal_mask,
+    ) = patch_transition_next_obs(
         next_obs,
         next_privileged,
         final_observation=final_observation,
         done=done,
         info=info,
+        next_critic=next_critic,
     )
     timeout_terminal_mask = terminal_mask
     if truncated is not None:
@@ -86,6 +114,8 @@ def resolve_transition_bootstrap_contract(
         transition_next_privileged=transition_next_privileged,
         terminal_mask=terminal_mask,
         timeout_terminal_mask=timeout_terminal_mask,
+        actor_next_critic=next_critic,
+        transition_next_critic=transition_next_critic,
     )
 
 
@@ -102,8 +132,11 @@ def resolve_terminal_observation_contract(
 
     terminal_obs: np.ndarray | None = None
     terminal_privileged: np.ndarray | None = None
+    terminal_critic: np.ndarray | None = None
     if np.any(terminal_mask) and isinstance(resolved_final_observation, dict):
-        terminal_obs, terminal_privileged = split_obs_dict(resolved_final_observation)
+        terminal_obs, terminal_privileged, terminal_critic = split_obs_dict_with_critic(
+            resolved_final_observation
+        )
 
     timeout_terminal_mask = terminal_mask
     if truncated is not None:
@@ -116,6 +149,7 @@ def resolve_terminal_observation_contract(
         terminal_privileged=terminal_privileged,
         terminal_mask=terminal_mask,
         timeout_terminal_mask=timeout_terminal_mask,
+        terminal_critic=terminal_critic,
     )
 
 

--- a/src/unilab/utils/obs_utils.py
+++ b/src/unilab/utils/obs_utils.py
@@ -23,6 +23,25 @@ def split_obs_dict(obs: dict[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray |
     return obs_arr, privileged_arr
 
 
+def split_obs_dict_with_critic(
+    obs: dict[str, np.ndarray],
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None]:
+    """Split obs dict into (obs, privileged, critic).
+
+    Args:
+        obs: Dict with "obs" key (required) and optional "privileged" / "critic" keys
+
+    Returns:
+        obs_arr: (N, obs_dim) array from "obs" key
+        privileged_arr: (N, priv_dim) array from "privileged" key, or None if missing
+        critic_arr: (N, critic_dim) array from "critic" key, or None if missing
+    """
+    obs_arr = obs["obs"]
+    privileged_arr = obs.get("privileged", None)
+    critic_arr = obs.get("critic", None)
+    return obs_arr, privileged_arr, critic_arr
+
+
 def get_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:
     """Extract obs_dim and privileged_dim from obs_groups_spec.
 
@@ -36,3 +55,20 @@ def get_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:
     obs_dim = obs_groups_spec.get("obs", 0)
     privileged_dim = obs_groups_spec.get("privileged", 0)
     return obs_dim, privileged_dim
+
+
+def get_obs_dims_with_critic(obs_groups_spec: dict[str, int]) -> tuple[int, int, int]:
+    """Extract (obs_dim, privileged_dim, critic_dim) from obs_groups_spec.
+
+    Args:
+        obs_groups_spec: Dict mapping group names to dimensions
+
+    Returns:
+        obs_dim: Dimension of "obs" group
+        privileged_dim: Dimension of "privileged" group (0 if missing)
+        critic_dim: Dimension of "critic" group (0 if missing)
+    """
+    obs_dim = obs_groups_spec.get("obs", 0)
+    privileged_dim = obs_groups_spec.get("privileged", 0)
+    critic_dim = obs_groups_spec.get("critic", 0)
+    return obs_dim, privileged_dim, critic_dim

--- a/src/unilab/utils/obs_utils.py
+++ b/src/unilab/utils/obs_utils.py
@@ -8,67 +8,22 @@ def flatten_obs_dict(obs: dict[str, np.ndarray]) -> np.ndarray:
     return np.concatenate(list(obs.values()), axis=1)
 
 
+def flatten_policy_obs_dict(obs: dict[str, np.ndarray]) -> np.ndarray:
+    """Build actor-policy inputs from the single actor observation group."""
+    return obs["obs"]
+
+
 def split_obs_dict(obs: dict[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray | None]:
-    """Split obs dict into (obs, privileged).
-
-    Args:
-        obs: Dict with "obs" key (required) and optional "privileged" key
-
-    Returns:
-        obs_arr: (N, obs_dim) array from "obs" key
-        privileged_arr: (N, priv_dim) array from "privileged" key, or None if missing
-    """
-    obs_arr = obs["obs"]
-    privileged_arr = obs.get("privileged", None)
-    return obs_arr, privileged_arr
-
-
-def split_obs_dict_with_critic(
-    obs: dict[str, np.ndarray],
-) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None]:
-    """Split obs dict into (obs, privileged, critic).
-
-    Args:
-        obs: Dict with "obs" key (required) and optional "privileged" / "critic" keys
-
-    Returns:
-        obs_arr: (N, obs_dim) array from "obs" key
-        privileged_arr: (N, priv_dim) array from "privileged" key, or None if missing
-        critic_arr: (N, critic_dim) array from "critic" key, or None if missing
-    """
-    obs_arr = obs["obs"]
-    privileged_arr = obs.get("privileged", None)
-    critic_arr = obs.get("critic", None)
-    return obs_arr, privileged_arr, critic_arr
+    """Split observation dict into (actor_obs, critic_obs)."""
+    return obs["obs"], obs.get("critic")
 
 
 def get_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:
-    """Extract obs_dim and privileged_dim from obs_groups_spec.
-
-    Args:
-        obs_groups_spec: Dict mapping group names to dimensions
-
-    Returns:
-        obs_dim: Dimension of "obs" group
-        privileged_dim: Dimension of "privileged" group (0 if missing)
-    """
-    obs_dim = obs_groups_spec.get("obs", 0)
-    privileged_dim = obs_groups_spec.get("privileged", 0)
-    return obs_dim, privileged_dim
+    """Extract (actor_obs_dim, critic_obs_dim) from obs_groups_spec."""
+    return obs_groups_spec.get("obs", 0), obs_groups_spec.get("critic", 0)
 
 
-def get_obs_dims_with_critic(obs_groups_spec: dict[str, int]) -> tuple[int, int, int]:
-    """Extract (obs_dim, privileged_dim, critic_dim) from obs_groups_spec.
-
-    Args:
-        obs_groups_spec: Dict mapping group names to dimensions
-
-    Returns:
-        obs_dim: Dimension of "obs" group
-        privileged_dim: Dimension of "privileged" group (0 if missing)
-        critic_dim: Dimension of "critic" group (0 if missing)
-    """
-    obs_dim = obs_groups_spec.get("obs", 0)
-    privileged_dim = obs_groups_spec.get("privileged", 0)
+def get_critic_base_dim(obs_groups_spec: dict[str, int]) -> int:
+    """Get critic observation dim, falling back to actor obs when absent."""
     critic_dim = obs_groups_spec.get("critic", 0)
-    return obs_dim, privileged_dim, critic_dim
+    return critic_dim if critic_dim > 0 else obs_groups_spec.get("obs", 0)

--- a/src/unilab/utils/rsl_rl_vec_env_wrapper.py
+++ b/src/unilab/utils/rsl_rl_vec_env_wrapper.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 from tensordict import TensorDict
 
-from unilab.utils.obs_utils import flatten_obs_dict
+from unilab.utils.obs_utils import flatten_policy_obs_dict
 from unilab.utils.torch_utils import to_torch
 
 
@@ -38,9 +38,11 @@ class RslRlVecEnvWrapper:
 
         # Compute observation dimensions
         self._actor_obs_dim = int(env.obs_groups_spec.get("obs", sum(env.obs_groups_spec.values())))
-        self._flat_obs_dim = int(sum(env.obs_groups_spec.values()))
+        self._critic_obs_dim = int(env.obs_groups_spec.get("critic", self._actor_obs_dim))
+        self._flat_obs_dim = self._actor_obs_dim
         self.num_obs = self._flat_obs_dim if policy_obs_mode == "flat" else self._actor_obs_dim
-        self.num_privileged_obs = self.num_obs
+        # Legacy RSL-RL field name; semantically this is the critic-path observation dim.
+        self.num_privileged_obs = self._critic_obs_dim
         self.num_actions = env.action_space.shape[0]
 
         # Episode tracking
@@ -56,22 +58,22 @@ class RslRlVecEnvWrapper:
         """Convert observation dict to TensorDict for RSL-RL.
 
         Args:
-            obs: Observation dictionary with "obs" key and optional "privileged" key.
+            obs: Observation dictionary with mandatory "obs" and optional "critic".
 
         Returns:
-            TensorDict with "policy" and "actor" keys (and optional "privileged").
+            TensorDict with "policy" and "actor" keys, plus optional "critic".
         """
         actor = to_torch(obs["obs"], self.device)
 
         if self.policy_obs_mode == "actor":
             policy = actor
         else:
-            policy = to_torch(flatten_obs_dict(obs), self.device)
+            policy = to_torch(flatten_policy_obs_dict(obs), self.device)
 
         td: dict[str, torch.Tensor] = {"policy": policy, "actor": actor}
 
-        if "privileged" in obs:
-            td["privileged"] = to_torch(obs["privileged"], self.device)
+        if "critic" in obs:
+            td["critic"] = to_torch(obs["critic"], self.device)
 
         return TensorDict(td, batch_size=self.num_envs, device=self.device)
 
@@ -154,11 +156,11 @@ class RslRlVecEnvWrapper:
         return self._obs_to_tensordict(self.env.state.obs)
 
     def get_privileged_observations(self):
-        """Get current privileged observations.
+        """Get current critic observations via the legacy RSL-RL hook name.
 
         Returns:
-            Torch tensor with privileged observations (or policy obs if unavailable).
+            Torch tensor with critic-path observations (or actor obs if unavailable).
         """
-        if self.policy_obs_mode == "actor":
-            return to_torch(self.env.state.obs["obs"], self.device)
-        return to_torch(flatten_obs_dict(self.env.state.obs), self.device)
+        obs = self.env.state.obs
+        critic_base = obs.get("critic", obs["obs"])
+        return to_torch(critic_base, self.device)

--- a/tests/algos/test_appo_worker.py
+++ b/tests/algos/test_appo_worker.py
@@ -19,7 +19,19 @@ def test_compute_timeout_bootstrap_correction_uses_final_observation_value():
         gamma=0.5,
         timeout_mask=np.array([True, False]),
         final_obs=np.array([[2.0, 3.0], [9.0, 9.0]], dtype=np.float32),
-        final_privileged=np.array([[5.0], [1.0]], dtype=np.float32),
     )
 
-    np.testing.assert_allclose(correction, np.array([5.0, 0.0], dtype=np.float32))
+    np.testing.assert_allclose(correction, np.array([2.5, 0.0], dtype=np.float32))
+
+
+def test_compute_timeout_bootstrap_correction_prefers_explicit_final_critic():
+    correction = compute_timeout_bootstrap_correction(
+        critic=_FakeCritic(),
+        collector_device="cpu",
+        gamma=0.5,
+        timeout_mask=np.array([True, False]),
+        final_obs=np.array([[2.0, 3.0], [9.0, 9.0]], dtype=np.float32),
+        final_critic=np.array([[11.0, 13.0], [0.0, 0.0]], dtype=np.float32),
+    )
+
+    np.testing.assert_allclose(correction, np.array([12.0, 0.0], dtype=np.float32))

--- a/tests/algos/test_fast_sac_symmetry_contract.py
+++ b/tests/algos/test_fast_sac_symmetry_contract.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium as gym
+import pytest
+
+
+class _FakeSymmetryAugmentation:
+    batch_multiplier = 2
+
+    def augment_obs_and_actions(self, obs, actions, *, obs_group: str = "obs"):
+        return obs, actions
+
+    def mirror_obs(self, obs, *, obs_group: str = "obs"):
+        return obs
+
+
+class _ForbiddenBackend:
+    @property
+    def model(self):
+        raise AssertionError("FastSAC runner should not read env._backend.model")
+
+
+class _FakeEnv:
+    def __init__(self, augmentation: Any | None):
+        self.obs_groups_spec = {"obs": 4, "critic": 6}
+        self.action_space = gym.spaces.Box(-1.0, 1.0, shape=(2,))
+        self._backend = _ForbiddenBackend()
+        self._augmentation = augmentation
+        self.closed = False
+        self.last_device: str | None = None
+
+    def get_obs_structure(self):
+        raise AssertionError("FastSAC runner should not call env.get_obs_structure()")
+
+    def build_symmetry_augmentation(self, *, device: str):
+        self.last_device = device
+        return self._augmentation
+
+    def close(self):
+        self.closed = True
+
+
+def test_fast_sac_runner_uses_env_owned_symmetry_contract(monkeypatch: pytest.MonkeyPatch):
+    from unilab.algos.torch.fast_sac.runner import FastSACRunner
+    from unilab.base import registry
+    from unilab.utils import algo_utils
+
+    augmentation = _FakeSymmetryAugmentation()
+    fake_env = _FakeEnv(augmentation)
+
+    monkeypatch.setattr(algo_utils, "ensure_registries", lambda: None)
+    monkeypatch.setattr(registry, "make", lambda *args, **kwargs: fake_env)
+
+    runner = FastSACRunner(
+        env_name="FakeEnv",
+        device="cpu",
+        num_envs=1,
+        replay_buffer_n=8,
+        batch_size=8,
+        warmup_steps=0,
+        updates_per_step=1,
+        policy_frequency=1,
+        use_symmetry=True,
+        obs_normalization=False,
+    )
+
+    assert fake_env.closed is True
+    assert fake_env.last_device == "cpu"
+    assert runner.batch_size == 4
+    assert runner.learner.symmetry is augmentation
+
+
+def test_fast_sac_runner_skips_symmetry_builder_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    from unilab.algos.torch.fast_sac.runner import FastSACRunner
+    from unilab.base import registry
+    from unilab.utils import algo_utils
+
+    fake_env = _FakeEnv(_FakeSymmetryAugmentation())
+
+    def _unexpected_builder(*args, **kwargs):
+        raise AssertionError("Symmetry builder should not be called when use_symmetry is false")
+
+    fake_env.build_symmetry_augmentation = _unexpected_builder  # type: ignore[method-assign]
+
+    monkeypatch.setattr(algo_utils, "ensure_registries", lambda: None)
+    monkeypatch.setattr(registry, "make", lambda *args, **kwargs: fake_env)
+
+    runner = FastSACRunner(
+        env_name="FakeEnv",
+        device="cpu",
+        num_envs=1,
+        replay_buffer_n=8,
+        batch_size=8,
+        warmup_steps=0,
+        updates_per_step=1,
+        policy_frequency=1,
+        use_symmetry=False,
+        obs_normalization=False,
+    )
+
+    assert fake_env.closed is True
+    assert runner.batch_size == 8
+    assert runner.learner.symmetry is None

--- a/tests/algos/test_flash_sac_learner.py
+++ b/tests/algos/test_flash_sac_learner.py
@@ -9,27 +9,27 @@ from unilab.algos.torch.flash_sac.learner import FlashSACLearner, RewardNormaliz
 
 def _make_batch(batch_size: int = 32) -> dict[str, torch.Tensor]:
     obs = torch.randn(batch_size, 98)
-    privileged = torch.randn(batch_size, 3)
+    critic = torch.randn(batch_size, 101)
     actions = torch.tanh(torch.randn(batch_size, 29))
     rewards = torch.randn(batch_size)
     next_obs = torch.randn(batch_size, 98)
-    next_privileged = torch.randn(batch_size, 3)
+    next_critic = torch.randn(batch_size, 101)
     dones = torch.zeros(batch_size)
     truncated = torch.zeros(batch_size)
     return {
         "obs": obs,
-        "privileged": privileged,
+        "critic": critic,
         "actions": actions,
         "rewards": rewards,
         "next_obs": next_obs,
-        "next_privileged": next_privileged,
+        "next_critic": next_critic,
         "dones": dones,
         "truncated": truncated,
     }
 
 
 def test_flashsac_learner_exposes_expected_dims():
-    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
 
     assert learner.obs_dim == 98
     assert learner.critic_obs_dim == 101
@@ -37,7 +37,7 @@ def test_flashsac_learner_exposes_expected_dims():
 
 
 def test_flashsac_actor_explore_and_forward_shapes():
-    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     obs = torch.randn(4, 98)
 
     actions = learner.actor.explore(obs, deterministic=False)
@@ -51,7 +51,7 @@ def test_flashsac_actor_explore_and_forward_shapes():
 
 
 def test_flashsac_update_steps_run_on_cpu():
-    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     batch = _make_batch()
 
     critic_metrics = learner.update_critic(batch)
@@ -65,13 +65,13 @@ def test_flashsac_update_steps_run_on_cpu():
 
 
 def test_flashsac_state_dict_round_trip():
-    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     batch = _make_batch()
     learner.update_critic(batch)
     learner.update_actor(batch)
     state_dict = learner.get_state_dict()
 
-    restored = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    restored = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     restored.load_state_dict(state_dict)
 
     assert restored.get_state_dict()["update_count"] == learner.get_state_dict()["update_count"]
@@ -91,7 +91,7 @@ def test_reward_normalizer_tracks_discounted_returns() -> None:
 
 
 def test_flashsac_critic_update_does_not_advance_reward_stats_from_sampled_batch() -> None:
-    learner = FlashSACLearner(obs_dim=98, action_dim=29, privileged_dim=3, device="cpu")
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     learner.update_reward_stats(
         rewards=torch.tensor([[1.0, 2.0]]),
         terminated=torch.zeros(1, 2),

--- a/tests/algos/test_rsl_rl_runner.py
+++ b/tests/algos/test_rsl_rl_runner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
+from typing import Any, cast
 
 import pytest
 
@@ -21,7 +22,6 @@ from tensordict import TensorDict
 from unilab.base import registry
 from unilab.config.structured_configs import PPOConfig
 from unilab.utils.algo_utils import ensure_registries
-from unilab.utils.obs_utils import flatten_obs_dict
 from unilab.utils.rsl_rl_compat import convert_config_v5, is_rsl_rl_v5
 from unilab.utils.torch_utils import to_torch
 
@@ -43,8 +43,8 @@ class _RslRlVecEnvWrapper:
         self.num_envs = env.num_envs
         self.observation_space = env.observation_space
         self.action_space = env.action_space
-        self.num_obs = sum(env.obs_groups_spec.values())
-        self.num_privileged_obs = self.num_obs
+        self.num_obs = int(env.obs_groups_spec["obs"])
+        self.num_privileged_obs = int(env.obs_groups_spec.get("critic", self.num_obs))
         self.num_actions = env.action_space.shape[0]
 
         self.episode_returns = torch.zeros(self.num_envs, device=device)
@@ -55,12 +55,9 @@ class _RslRlVecEnvWrapper:
 
     def _obs_to_tensordict(self, obs: dict[str, np.ndarray]) -> TensorDict:
         actor = to_torch(obs["obs"], self.device)
-        td = {"actor": actor}
-        if "privileged" in obs:
-            td["privileged"] = to_torch(obs["privileged"], self.device)
-            td["policy"] = to_torch(flatten_obs_dict(obs), self.device)
-        else:
-            td["policy"] = actor
+        td = {"actor": actor, "policy": actor}
+        if "critic" in obs:
+            td["critic"] = to_torch(obs["critic"], self.device)
         return TensorDict(td, batch_size=self.num_envs, device=self.device)
 
     def step(self, actions):
@@ -93,10 +90,13 @@ class _RslRlVecEnvWrapper:
         return self._obs_to_tensordict(obs_out), {}
 
     def get_observations(self):
+        assert self.env.state is not None
         return self._obs_to_tensordict(self.env.state.obs)
 
     def get_privileged_observations(self):
-        return to_torch(flatten_obs_dict(self.env.state.obs), self.device)
+        assert self.env.state is not None
+        obs = self.env.state.obs
+        return to_torch(obs.get("critic", obs["obs"]), self.device)
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +159,7 @@ def test_rsl_rl_ppo_one_iteration(
         train_cfg = convert_config_v5(train_cfg)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        runner = OnPolicyRunner(wrapped, train_cfg, log_dir=tmpdir, device="cpu")
+        runner = OnPolicyRunner(cast(Any, wrapped), train_cfg, log_dir=tmpdir, device="cpu")
         runner.learn(num_learning_iterations=1, init_at_random_ep_len=True)
 
     env.close()

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -6,7 +6,7 @@ These tests use a minimal concrete NpEnv stub — no MuJoCo required.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, cast
 from unittest.mock import MagicMock
 
 import gymnasium as gym
@@ -23,15 +23,20 @@ from unilab.base.np_env import NpEnv, NpEnvState
 
 @dataclass
 class _StubCfg(EnvCfg):
-    max_episode_seconds: float = 1.0
+    max_episode_seconds: float | None = 1.0
     ctrl_dt: float = 0.1
     sim_dt: float = 0.01
+
+
+def _require_state(env: NpEnv) -> NpEnvState:
+    assert env.state is not None
+    return env.state
 
 
 class _StubNpEnv(NpEnv):
     """Concrete NpEnv for testing — no physics, deterministic outputs."""
 
-    OBS_SPEC = {"obs": 5, "privileged": 2}
+    OBS_SPEC = {"obs": 5, "critic": 7}
 
     def __init__(self, num_envs: int = 4):
         cfg = _StubCfg()
@@ -55,7 +60,7 @@ class _StubNpEnv(NpEnv):
     def update_state(self, state: NpEnvState) -> NpEnvState:
         obs = {
             "obs": np.ones((self._num_envs, 5), dtype=np.float32),
-            "privileged": np.full((self._num_envs, 2), 0.5, dtype=np.float32),
+            "critic": np.full((self._num_envs, 7), 0.5, dtype=np.float32),
         }
         return state.replace(
             obs=obs,
@@ -69,7 +74,7 @@ class _StubNpEnv(NpEnv):
         n = len(env_indices)
         obs = {
             "obs": np.zeros((n, 5), dtype=np.float32),
-            "privileged": np.zeros((n, 2), dtype=np.float32),
+            "critic": np.zeros((n, 7), dtype=np.float32),
         }
         return obs, {}
 
@@ -127,7 +132,7 @@ class _ToggleTerminatingStubEnv(_StubNpEnv):
 
 class TestNpEnvState:
     def test_obs_is_dict(self):
-        obs = {"obs": np.zeros((2, 4)), "privileged": np.zeros((2, 1))}
+        obs = {"obs": np.zeros((2, 4)), "critic": np.zeros((2, 6))}
         state = NpEnvState(
             obs=obs,
             reward=np.zeros(2),
@@ -137,7 +142,7 @@ class TestNpEnvState:
         )
         assert isinstance(state.obs, dict)
         assert "obs" in state.obs
-        assert "privileged" in state.obs
+        assert "critic" in state.obs
 
     def test_done_combines_terminated_and_truncated(self):
         state = NpEnvState(
@@ -200,17 +205,17 @@ class TestNpEnvObsSpec:
         env = _StubNpEnv(num_envs=2)
         spec = env.obs_groups_spec
         assert isinstance(spec, dict)
-        assert spec == {"obs": 5, "privileged": 2}
+        assert spec == {"obs": 5, "critic": 7}
 
     def test_observation_space_total_dim(self):
         env = _StubNpEnv(num_envs=2)
         space = env.observation_space
         assert isinstance(space, gym.spaces.Box)
-        assert space.shape == (7,)  # 5 + 2
+        assert space.shape == (12,)  # 5 + 7
 
     def test_observation_space_bounds(self):
         env = _StubNpEnv(num_envs=1)
-        space = env.observation_space
+        space = cast(gym.spaces.Box, env.observation_space)
         assert np.all(space.low == -np.inf)
         assert np.all(space.high == np.inf)
 
@@ -235,18 +240,19 @@ class TestNpEnvInitState:
     def test_init_state_obs_is_dict(self):
         env = _StubNpEnv(num_envs=4)
         env.init_state()
-        assert isinstance(env.state.obs, dict)
+        assert isinstance(_require_state(env).obs, dict)
 
     def test_init_state_obs_keys_match_spec(self):
         env = _StubNpEnv(num_envs=4)
         env.init_state()
-        assert set(env.state.obs.keys()) == {"obs", "privileged"}
+        assert set(_require_state(env).obs.keys()) == {"obs", "critic"}
 
     def test_init_state_obs_shapes(self):
         env = _StubNpEnv(num_envs=4)
         env.init_state()
-        assert env.state.obs["obs"].shape == (4, 5)
-        assert env.state.obs["privileged"].shape == (4, 2)
+        state = _require_state(env)
+        assert state.obs["obs"].shape == (4, 5)
+        assert state.obs["critic"].shape == (4, 7)
 
     def test_init_state_obs_zeros(self):
         """Initial obs should be zeros (before reset fills them)."""
@@ -256,7 +262,7 @@ class TestNpEnvInitState:
         env.init_state()
         # After init_state, reset was called (terminated=True initially)
         # Our stub resets to zeros, so should be zeros
-        np.testing.assert_array_equal(env.state.obs["obs"], 0.0)
+        np.testing.assert_array_equal(_require_state(env).obs["obs"], 0.0)
 
     def test_init_state_triggers_reset(self):
         env = _StubNpEnv(num_envs=2)
@@ -267,13 +273,14 @@ class TestNpEnvInitState:
     def test_init_state_reward_shape(self):
         env = _StubNpEnv(num_envs=3)
         env.init_state()
-        assert env.state.reward.shape == (3,)
+        assert _require_state(env).reward.shape == (3,)
 
     def test_init_state_steps_initialized(self):
         env = _StubNpEnv(num_envs=2)
         env.init_state()
-        assert "steps" in env.state.info
-        np.testing.assert_array_equal(env.state.info["steps"], 0)
+        state = _require_state(env)
+        assert "steps" in state.info
+        np.testing.assert_array_equal(state.info["steps"], 0)
 
 
 # ---------------------------------------------------------------------------
@@ -289,15 +296,15 @@ class TestNpEnvStep:
         state = env.step(actions)
         assert isinstance(state.obs, dict)
         assert "obs" in state.obs
-        assert "privileged" in state.obs
+        assert "critic" in state.obs
 
     def test_step_obs_values_from_update_state(self):
         env = _StubNpEnv(num_envs=2)
         env.init_state()
         state = env.step(np.zeros((2, 3)))
-        # _StubNpEnv.update_state fills actor=1.0, privileged=0.5
+        # _StubNpEnv.update_state fills actor=1.0, critic=0.5
         np.testing.assert_array_equal(state.obs["obs"], 1.0)
-        np.testing.assert_array_equal(state.obs["privileged"], 0.5)
+        np.testing.assert_array_equal(state.obs["critic"], 0.5)
 
     def test_step_increments_counter(self):
         env = _StubNpEnv(num_envs=1)
@@ -311,7 +318,7 @@ class TestNpEnvStep:
         env = _StubNpEnv(num_envs=2)
         env.init_state()
         env.step(np.zeros((2, 3)))
-        np.testing.assert_array_equal(env.state.info["steps"], 1)
+        np.testing.assert_array_equal(_require_state(env).info["steps"], 1)
 
     def test_step_auto_inits_if_no_state(self):
         env = _StubNpEnv(num_envs=1)
@@ -341,12 +348,13 @@ class TestResetDoneEnvs:
         env = _TerminatingStubEnv(num_envs=2, terminate_indices=[0])
         env.init_state()
         env.step(np.zeros((2, 3)))
-        assert isinstance(env.state.final_observation, dict)
-        assert "obs" in env.state.final_observation
-        assert "privileged" in env.state.final_observation
-        assert isinstance(env.state.info["final_observation"], dict)
-        assert "obs" in env.state.info["final_observation"]
-        assert "privileged" in env.state.info["final_observation"]
+        state = _require_state(env)
+        assert isinstance(state.final_observation, dict)
+        assert "obs" in state.final_observation
+        assert "critic" in state.final_observation
+        assert isinstance(state.info["final_observation"], dict)
+        assert "obs" in state.info["final_observation"]
+        assert "critic" in state.info["final_observation"]
 
     def test_final_observation_captures_pre_reset_obs(self):
         env = _TerminatingStubEnv(num_envs=2, terminate_indices=[0])
@@ -354,21 +362,24 @@ class TestResetDoneEnvs:
         env.step(np.zeros((2, 3)))
         # update_state fills actor=1.0 before reset replaces it with 0.0
         # final_observation should capture the pre-reset obs (1.0)
-        np.testing.assert_array_equal(env.state.final_observation["obs"][0], 1.0)
-        np.testing.assert_array_equal(env.state.info["final_observation"]["obs"][0], 1.0)
+        state = _require_state(env)
+        assert state.final_observation is not None
+        np.testing.assert_array_equal(state.final_observation["obs"][0], 1.0)
+        np.testing.assert_array_equal(state.info["final_observation"]["obs"][0], 1.0)
 
     def test_final_observation_mask(self):
         env = _TerminatingStubEnv(num_envs=3, terminate_indices=[1])
         env.init_state()
         env.step(np.zeros((3, 3)))
-        mask = env.state.info["_final_observation"]
+        mask = _require_state(env).info["_final_observation"]
         np.testing.assert_array_equal(mask, [False, True, False])
 
     def test_final_observation_mask_clears_on_first_non_terminal_step(self):
         env = _StubNpEnv(num_envs=3)
         env.init_state()
-        assert env.state.final_observation is None
-        np.testing.assert_array_equal(env.state.info["_final_observation"], [False, False, False])
+        state = _require_state(env)
+        assert state.final_observation is None
+        np.testing.assert_array_equal(state.info["_final_observation"], [False, False, False])
 
         state = env.step(np.zeros((3, 3)))
 
@@ -411,9 +422,10 @@ class TestResetDoneEnvs:
         # After step, terminated envs had their steps reset to 0
         # then +1 from step, but _reset_done_envs is called AFTER info["steps"] += 1,
         # and it sets steps[env_indices] = 0
-        assert env.state.info["steps"][0] == 0
-        assert env.state.info["steps"][2] == 0
-        assert env.state.info["steps"][1] == 1
+        state = _require_state(env)
+        assert state.info["steps"][0] == 0
+        assert state.info["steps"][2] == 0
+        assert state.info["steps"][1] == 1
 
     def test_truncation_triggers_reset(self):
         """max_episode_steps triggers truncation → reset."""
@@ -423,7 +435,7 @@ class TestResetDoneEnvs:
         for _ in range(10):
             env.step(np.zeros((1, 3)))
         # After 10 steps, env should have been truncated and reset
-        assert env.state.info["steps"][0] == 0
+        assert _require_state(env).info["steps"][0] == 0
 
     def test_hook_truncation_triggers_reset(self):
         env = _HookTruncatingStubEnv(num_envs=3, truncate_indices=[1])
@@ -437,8 +449,9 @@ class TestResetDoneEnvs:
     def test_base_truncation_reuses_internal_buffer(self):
         env = _StubNpEnv(num_envs=2)
         env.init_state()
-        first = env._compute_truncated(env.state)
-        second = env._compute_truncated(env.state)
+        state = _require_state(env)
+        first = env._compute_truncated(state)
+        second = env._compute_truncated(state)
         assert first is second
 
 
@@ -449,7 +462,7 @@ class TestResetDoneEnvs:
 
 class TestEdgeCases:
     def test_single_obs_group_symmetric(self):
-        """Env with only "obs" (no privileged) works correctly."""
+        """Env with only "obs" (no critic) works correctly."""
 
         class _SymmetricEnv(_StubNpEnv):
             OBS_SPEC = {"obs": 10}
@@ -479,7 +492,7 @@ class TestEdgeCases:
         """Env with 3+ obs groups allocates correctly."""
 
         class _MultiGroupEnv(_StubNpEnv):
-            OBS_SPEC = {"obs": 4, "privileged": 2, "history": 8}
+            OBS_SPEC = {"obs": 4, "critic": 6, "history": 8}
 
             def update_state(self, state):
                 obs = {
@@ -501,5 +514,5 @@ class TestEdgeCases:
         env = _MultiGroupEnv(num_envs=1)
         env.init_state()
         state = env.step(np.zeros((1, 3)))
-        assert set(state.obs.keys()) == {"obs", "privileged", "history"}
-        assert env.observation_space.shape == (14,)  # 4+2+8
+        assert set(state.obs.keys()) == {"obs", "critic", "history"}
+        assert env.observation_space.shape == (18,)  # 4+6+8

--- a/tests/envs/locomotion/g1/test_symmetry_contract.py
+++ b/tests/envs/locomotion/g1/test_symmetry_contract.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+import torch
+
+from unilab.base import registry
+from unilab.envs.locomotion.g1.joystick_sac import RewardConfigSAC
+from unilab.utils.algo_utils import ensure_registries
+
+pytest.importorskip("mujoco", reason="mujoco is required for G1 symmetry contract tests")
+
+
+def _reward_config() -> RewardConfigSAC:
+    return RewardConfigSAC(
+        scales={"tracking_lin_vel": 2.0, "alive": 10.0},
+        tracking_sigma=0.25,
+        base_height_target=0.754,
+        min_base_height=0.3,
+        max_tilt_deg=65.0,
+        gait_frequency=1.5,
+        feet_phase_swing_height=0.09,
+        feet_phase_tracking_sigma=0.04,
+        close_feet_threshold=0.15,
+        pose_weights=[0.01] * 29,
+    )
+
+
+def test_g1_sac_symmetry_contract_matches_obs_groups():
+    ensure_registries()
+    env = cast(
+        Any,
+        registry.make(
+            "G1WalkTaskMjSAC",
+            num_envs=1,
+            sim_backend="mujoco",
+            env_cfg_override={"reward_config": _reward_config()},
+        ),
+    )
+
+    try:
+        layouts = env.get_symmetry_obs_layouts()
+        assert set(layouts) == {"obs", "critic"}
+        for group_name, layout in layouts.items():
+            assert sum(dim for _, dim in layout) == env.obs_groups_spec[group_name]
+    finally:
+        env.close()
+
+
+def test_g1_sac_symmetry_can_augment_critic_group():
+    ensure_registries()
+    env = cast(
+        Any,
+        registry.make(
+            "G1WalkTaskMjSAC",
+            num_envs=1,
+            sim_backend="mujoco",
+            env_cfg_override={"reward_config": _reward_config()},
+        ),
+    )
+
+    try:
+        augmentation = env.build_symmetry_augmentation(device="cpu")
+        assert augmentation is not None
+
+        action_dim = env.action_space.shape[0]
+        obs = torch.zeros((1, env.obs_groups_spec["obs"]))
+        critic = torch.zeros((1, env.obs_groups_spec["critic"]))
+        actions = torch.zeros((1, action_dim))
+
+        actor_aug, action_aug = augmentation.augment_obs_and_actions(obs, actions, obs_group="obs")
+        critic_aug, critic_action_aug = augmentation.augment_obs_and_actions(
+            critic,
+            actions,
+            obs_group="critic",
+        )
+
+        assert actor_aug.shape == (2, env.obs_groups_spec["obs"])
+        assert critic_aug.shape == (2, env.obs_groups_spec["critic"])
+        assert action_aug.shape == (2, action_dim)
+        assert critic_action_aug.shape == (2, action_dim)
+    finally:
+        env.close()

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -75,7 +75,7 @@ def test_registry_bootstrap_and_config_imports_do_not_require_mujoco():
 
 
 def test_g1_joystick_ppo_cfg_obs_groups_spec():
-    """G1JoystickPPO must declare obs_groups_spec with actor and privileged groups."""
+    """G1JoystickPPO must declare obs_groups_spec with actor and critic groups."""
     from unilab.envs.locomotion.g1.joystick import G1JoystickPPOCfg
 
     cfg = G1JoystickPPOCfg()
@@ -110,7 +110,7 @@ def test_g1_joystick_ppo_obs_groups_spec_dims():
     G1JoystickPPO._compute_obs outputs (G1 has 29 DoF):
         actor: gyro(3) + gravity(3) + diff(29) + dof_vel(29)
             + last_actions(29) + command(3) + gait_phase(2) = 98
-        privileged: linvel(3)
+        critic: actor(98) + linvel(3) = 101
     """
     from unilab.envs.locomotion.g1.joystick import G1JoystickPPO
 
@@ -118,7 +118,7 @@ def test_g1_joystick_ppo_obs_groups_spec_dims():
     spec = G1JoystickPPO.obs_groups_spec.fget(None)  # type: ignore[union-attr]
     assert spec is not None
     assert spec["obs"] == 98
-    assert spec["privileged"] == 3
+    assert spec["critic"] == 101
 
 
 def test_allegro_rotation_obs_groups_spec_dims():
@@ -324,13 +324,13 @@ def test_g1_motion_tracking_clip_end_contributes_to_truncated():
     env._compute_reward = lambda *args: np.zeros((2,), dtype=np.float32)
     env._compute_obs = lambda *args: {
         "obs": np.zeros((2, 1), dtype=np.float32),
-        "privileged": np.zeros((2, 1), dtype=np.float32),
+        "critic": np.zeros((2, 2), dtype=np.float32),
     }
 
     state = NpEnvState(
         obs={
             "obs": np.zeros((2, 1), dtype=np.float32),
-            "privileged": np.zeros((2, 1), dtype=np.float32),
+            "critic": np.zeros((2, 2), dtype=np.float32),
         },
         reward=np.zeros((2,), dtype=np.float32),
         terminated=np.zeros((2,), dtype=bool),
@@ -589,7 +589,7 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
         spec = env.obs_groups_spec
         assert isinstance(spec, dict)
         assert "obs" in spec
-        assert "privileged" in spec
+        assert "critic" in spec
         obs_shape = env.observation_space.shape
         assert obs_shape is not None
         assert sum(spec.values()) == obs_shape[0]

--- a/tests/ipc/test_shared_onpolicy_storage.py
+++ b/tests/ipc/test_shared_onpolicy_storage.py
@@ -12,6 +12,7 @@ _NUM_ENVS = 4
 _NUM_STEPS = 10
 _OBS_DIM = 8
 _ACTION_DIM = 3
+_CRITIC_DIM = 5
 _NUM_SLOTS = 2
 
 _EXPECTED_FIELDS = {"obs", "actions", "log_probs", "rewards", "dones", "truncated", "last_obs"}
@@ -24,6 +25,18 @@ def _make_storage(num_slots: int = _NUM_SLOTS) -> SharedOnPolicyStorage:
         obs_dim=_OBS_DIM,
         action_dim=_ACTION_DIM,
         num_slots=num_slots,
+        create=True,
+    )
+
+
+def _make_storage_with_critic() -> SharedOnPolicyStorage:
+    return SharedOnPolicyStorage(
+        num_envs=_NUM_ENVS,
+        num_steps=_NUM_STEPS,
+        obs_dim=_OBS_DIM,
+        action_dim=_ACTION_DIM,
+        critic_dim=_CRITIC_DIM,
+        num_slots=_NUM_SLOTS,
         create=True,
     )
 
@@ -165,3 +178,12 @@ def test_attach_sync_primitives():
 
     attached.close()
     owner.cleanup()
+
+
+def test_storage_allocates_optional_critic_fields():
+    storage = _make_storage_with_critic()
+
+    expected = _EXPECTED_FIELDS | {"critic", "last_critic"}
+    assert set(storage.write_buffer.keys()) == expected
+
+    storage.cleanup()

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -849,8 +849,8 @@ def test_offpolicy_extract_reset_obs_rejects_three_tuple():
         _offpolicy().extract_reset_obs(("ignored", obs, {"info": 1}))
 
 
-def test_offpolicy_resolve_play_obs_dim_ignores_privileged():
-    obs_dim = _offpolicy().resolve_play_obs_dim({"obs": 98, "privileged": 3})
+def test_offpolicy_resolve_play_obs_dim_ignores_critic():
+    obs_dim = _offpolicy().resolve_play_obs_dim({"obs": 98, "critic": 101})
 
     assert obs_dim == 98
 
@@ -860,7 +860,7 @@ def test_offpolicy_extract_play_obs_uses_obs_group_only():
 
     obs = {
         "obs": np.ones((2, 98), dtype=np.float32),
-        "privileged": np.full((2, 3), 2.0, dtype=np.float32),
+        "critic": np.full((2, 101), 2.0, dtype=np.float32),
     }
 
     play_obs = _offpolicy().extract_play_obs(obs)
@@ -1112,7 +1112,7 @@ def test_play_wrapper_policy_obs_mode_actor():
             self.cfg = type("Cfg", (), {"max_episode_seconds": 10.0, "ctrl_dt": 0.02})()
             self.observation_space = type("Space", (), {"shape": (3,)})()
             self.action_space = type("Space", (), {"shape": (2,)})()
-            self.obs_groups_spec = {"obs": 3, "privileged": 2}
+            self.obs_groups_spec = {"obs": 3, "critic": 5}
 
         def init_state(self):
             pass
@@ -1120,7 +1120,7 @@ def test_play_wrapper_policy_obs_mode_actor():
         def reset(self, env_indices):
             return {
                 "obs": np.ones((1, 3), dtype=np.float32),
-                "privileged": np.zeros((1, 2), dtype=np.float32),
+                "critic": np.zeros((1, 5), dtype=np.float32),
             }, {}
 
     env = FakeEnv()
@@ -1129,12 +1129,57 @@ def test_play_wrapper_policy_obs_mode_actor():
     wrapper_actor = RslRlVecEnvWrapper(env, device="cpu", policy_obs_mode="actor")
     assert wrapper_actor.num_obs == 3  # Only "obs" group
     assert wrapper_actor._actor_obs_dim == 3
-    assert wrapper_actor._flat_obs_dim == 5  # obs + privileged
+    assert wrapper_actor._flat_obs_dim == 3
 
     obs_td, _ = wrapper_actor.reset()
     # In actor mode, policy obs should equal actor obs
     assert obs_td["policy"].shape == (1, 3)
     assert obs_td["actor"].shape == (1, 3)
+    assert obs_td["critic"].shape == (1, 5)
+
+
+def test_play_wrapper_flat_policy_excludes_critic_only_group():
+    import numpy as np
+
+    from unilab.utils.rsl_rl_vec_env_wrapper import RslRlVecEnvWrapper
+
+    class FakeEnv:
+        def __init__(self):
+            self.num_envs = 1
+            self.state = type(
+                "State",
+                (),
+                {
+                    "obs": {
+                        "obs": np.array([[1.0, 2.0, 3.0]], dtype=np.float32),
+                        "critic": np.array([[9.0, 9.0, 9.0, 9.0]], dtype=np.float32),
+                    }
+                },
+            )()
+            self.cfg = type("Cfg", (), {"max_episode_seconds": 10.0, "ctrl_dt": 0.02})()
+            self.observation_space = type("Space", (), {"shape": (7,)})()
+            self.action_space = type("Space", (), {"shape": (2,)})()
+            self.obs_groups_spec = {"obs": 3, "critic": 4}
+
+        def init_state(self):
+            pass
+
+        def reset(self, env_indices):
+            return cast(dict[str, np.ndarray], getattr(self.state, "obs")), {}
+
+    wrapper = RslRlVecEnvWrapper(FakeEnv(), device="cpu", policy_obs_mode="flat")
+    obs_td, _ = wrapper.reset()
+
+    np.testing.assert_allclose(
+        obs_td["policy"].cpu().numpy(),
+        np.array([[1.0, 2.0, 3.0]], dtype=np.float32),
+    )
+    np.testing.assert_allclose(
+        obs_td["critic"].cpu().numpy(),
+        np.array([[9.0, 9.0, 9.0, 9.0]], dtype=np.float32),
+    )
+    assert wrapper.num_obs == 3
+    assert wrapper.num_privileged_obs == 4
 
 
 def test_play_wrapper_step_exports_timeout_bootstrap_obs():
@@ -1148,7 +1193,7 @@ def test_play_wrapper_step_exports_timeout_bootstrap_obs():
             self.cfg = type("Cfg", (), {"max_episode_seconds": 10.0, "ctrl_dt": 0.02})()
             self.observation_space = type("Space", (), {"shape": (3,)})()
             self.action_space = type("Space", (), {"shape": (2,)})()
-            self.obs_groups_spec = {"obs": 3}
+            self.obs_groups_spec = {"obs": 3, "critic": 2}
             self.state = type("State", (), {"obs": {"obs": np.zeros((1, 3), dtype=np.float32)}})()
 
         def init_state(self):
@@ -1168,9 +1213,13 @@ def test_play_wrapper_step_exports_timeout_bootstrap_obs():
                     "truncated": np.array([True]),
                     "final_observation": {
                         "obs": np.array([[7.0, 8.0, 9.0]], dtype=np.float32),
+                        "critic": np.array([[4.0, 5.0]], dtype=np.float32),
                     },
                     "info": {
-                        "final_observation": {"obs": np.array([[7.0, 8.0, 9.0]], dtype=np.float32)}
+                        "final_observation": {
+                            "obs": np.array([[7.0, 8.0, 9.0]], dtype=np.float32),
+                            "critic": np.array([[4.0, 5.0]], dtype=np.float32),
+                        }
                     },
                 },
             )()
@@ -1183,6 +1232,10 @@ def test_play_wrapper_step_exports_timeout_bootstrap_obs():
     np.testing.assert_allclose(
         infos["time_out_bootstrap_obs"]["policy"].cpu().numpy(),
         np.array([[7.0, 8.0, 9.0]], dtype=np.float32),
+    )
+    np.testing.assert_allclose(
+        infos["time_out_bootstrap_obs"]["critic"].cpu().numpy(),
+        np.array([[4.0, 5.0]], dtype=np.float32),
     )
 
 

--- a/tests/utils/test_final_observation.py
+++ b/tests/utils/test_final_observation.py
@@ -11,36 +11,34 @@ from unilab.utils.final_observation import (
 
 def test_patch_transition_next_obs_uses_final_observation_without_mutating_actor_obs():
     next_obs = np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32)
-    next_privileged = np.array([[10.0], [20.0]], dtype=np.float32)
+    next_critic = np.array([[10.0], [20.0]], dtype=np.float32)
     final_observation = {
         "obs": np.array([[7.0, 8.0], [9.0, 9.0]], dtype=np.float32),
-        "privileged": np.array([[70.0], [90.0]], dtype=np.float32),
+        "critic": np.array([[70.0], [90.0]], dtype=np.float32),
     }
 
     (
         transition_next_obs,
-        transition_next_privileged,
         transition_next_critic,
         terminal_mask,
     ) = patch_transition_next_obs(
         next_obs,
-        next_privileged,
         final_observation=final_observation,
         done=np.array([True, False]),
+        next_critic=next_critic,
     )
 
     np.testing.assert_array_equal(terminal_mask, np.array([True, False]))
     np.testing.assert_array_equal(transition_next_obs, np.array([[7.0, 8.0], [2.0, 2.0]]))
-    np.testing.assert_array_equal(transition_next_privileged, np.array([[70.0], [20.0]]))
-    assert transition_next_critic is None
+    np.testing.assert_array_equal(transition_next_critic, np.array([[70.0], [20.0]]))
     np.testing.assert_array_equal(next_obs, np.array([[1.0, 1.0], [2.0, 2.0]]))
-    np.testing.assert_array_equal(next_privileged, np.array([[10.0], [20.0]]))
+    np.testing.assert_array_equal(next_critic, np.array([[10.0], [20.0]]))
 
 
 def test_resolve_transition_bootstrap_contract_separates_actor_and_storage_paths():
     contract = resolve_transition_bootstrap_contract(
         next_obs=np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32),
-        next_privileged=None,
+        next_critic=np.array([[10.0], [20.0]], dtype=np.float32),
         final_observation={"obs": np.array([[5.0, 5.0], [8.0, 9.0]], dtype=np.float32)},
         done=np.array([False, True]),
         truncated=np.array([False, True]),
@@ -49,6 +47,12 @@ def test_resolve_transition_bootstrap_contract_separates_actor_and_storage_paths
     np.testing.assert_array_equal(contract.actor_next_obs, np.array([[1.0, 1.0], [2.0, 2.0]]))
     np.testing.assert_array_equal(
         contract.transition_next_obs, np.array([[1.0, 1.0], [8.0, 9.0]], dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        contract.actor_next_critic, np.array([[10.0], [20.0]], dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        contract.transition_next_critic, np.array([[10.0], [20.0]], dtype=np.float32)
     )
     np.testing.assert_array_equal(contract.terminal_mask, np.array([False, True]))
     np.testing.assert_array_equal(contract.timeout_terminal_mask, np.array([False, True]))
@@ -59,7 +63,7 @@ def test_resolve_terminal_observation_contract_returns_terminal_rows_without_cop
         next_obs_batch_size=2,
         final_observation={
             "obs": np.array([[5.0, 5.0], [8.0, 9.0]], dtype=np.float32),
-            "privileged": np.array([[1.0], [7.0]], dtype=np.float32),
+            "critic": np.array([[1.0], [7.0]], dtype=np.float32),
         },
         done=np.array([False, True]),
         truncated=np.array([False, True]),
@@ -72,6 +76,6 @@ def test_resolve_terminal_observation_contract_returns_terminal_rows_without_cop
         np.array([[5.0, 5.0], [8.0, 9.0]], dtype=np.float32),
     )
     np.testing.assert_array_equal(
-        terminal_contract.terminal_privileged,
+        terminal_contract.terminal_critic,
         np.array([[1.0], [7.0]], dtype=np.float32),
     )

--- a/tests/utils/test_final_observation.py
+++ b/tests/utils/test_final_observation.py
@@ -17,7 +17,12 @@ def test_patch_transition_next_obs_uses_final_observation_without_mutating_actor
         "privileged": np.array([[70.0], [90.0]], dtype=np.float32),
     }
 
-    transition_next_obs, transition_next_privileged, terminal_mask = patch_transition_next_obs(
+    (
+        transition_next_obs,
+        transition_next_privileged,
+        transition_next_critic,
+        terminal_mask,
+    ) = patch_transition_next_obs(
         next_obs,
         next_privileged,
         final_observation=final_observation,
@@ -27,6 +32,7 @@ def test_patch_transition_next_obs_uses_final_observation_without_mutating_actor
     np.testing.assert_array_equal(terminal_mask, np.array([True, False]))
     np.testing.assert_array_equal(transition_next_obs, np.array([[7.0, 8.0], [2.0, 2.0]]))
     np.testing.assert_array_equal(transition_next_privileged, np.array([[70.0], [20.0]]))
+    assert transition_next_critic is None
     np.testing.assert_array_equal(next_obs, np.array([[1.0, 1.0], [2.0, 2.0]]))
     np.testing.assert_array_equal(next_privileged, np.array([[10.0], [20.0]]))
 

--- a/tests/utils/test_obs_utils.py
+++ b/tests/utils/test_obs_utils.py
@@ -23,8 +23,8 @@ class TestFlattenObsDict:
 
     def test_two_groups_concatenated(self):
         obs = {
-            "actor": np.ones((2, 5)),
-            "privileged": np.full((2, 3), 2.0),
+            "obs": np.ones((2, 5)),
+            "critic": np.full((2, 3), 2.0),
         }
         flat = flatten_obs_dict(obs)
         assert flat.shape == (2, 8)
@@ -43,84 +43,85 @@ class TestFlattenObsDict:
 
     def test_three_groups(self):
         obs = {
-            "actor": np.zeros((3, 10)),
-            "privileged": np.ones((3, 4)),
+            "obs": np.zeros((3, 10)),
+            "critic": np.ones((3, 4)),
             "extra": np.full((3, 2), 9.0),
         }
         flat = flatten_obs_dict(obs)
         assert flat.shape == (3, 16)
 
     def test_dtype_preserved_float32(self):
-        obs = {"actor": np.zeros((1, 5), dtype=np.float32)}
+        obs = {"obs": np.zeros((1, 5), dtype=np.float32)}
         flat = flatten_obs_dict(obs)
         assert flat.dtype == np.float32
 
     def test_dtype_preserved_float64(self):
-        obs = {"actor": np.zeros((1, 5), dtype=np.float64)}
+        obs = {"obs": np.zeros((1, 5), dtype=np.float64)}
         flat = flatten_obs_dict(obs)
         assert flat.dtype == np.float64
 
     def test_mixed_dtype_upcasts(self):
         """NumPy concatenation rules apply — float64 wins over float32."""
         obs = {
-            "actor": np.zeros((2, 3), dtype=np.float32),
-            "privileged": np.zeros((2, 1), dtype=np.float64),
+            "obs": np.zeros((2, 3), dtype=np.float32),
+            "critic": np.zeros((2, 1), dtype=np.float64),
         }
         flat = flatten_obs_dict(obs)
         assert flat.dtype == np.float64
 
     def test_large_batch(self):
         n = 4096
-        obs = {"actor": np.random.randn(n, 98), "privileged": np.random.randn(n, 3)}
+        obs = {"obs": np.random.randn(n, 98), "critic": np.random.randn(n, 3)}
         flat = flatten_obs_dict(obs)
         assert flat.shape == (n, 101)
-        np.testing.assert_array_equal(flat[:, :98], obs["actor"])
-        np.testing.assert_array_equal(flat[:, 98:], obs["privileged"])
+        np.testing.assert_array_equal(flat[:, :98], obs["obs"])
+        np.testing.assert_array_equal(flat[:, 98:], obs["critic"])
 
     def test_single_env(self):
-        obs = {"actor": np.array([[1.0, 2.0, 3.0]])}
+        obs = {"obs": np.array([[1.0, 2.0, 3.0]])}
         flat = flatten_obs_dict(obs)
         assert flat.shape == (1, 3)
 
     def test_values_roundtrip(self):
         """Flatten then slice recovers original groups."""
         actor = np.random.randn(8, 45)
-        priv = np.random.randn(8, 3)
-        obs = {"actor": actor, "privileged": priv}
+        critic = np.random.randn(8, 3)
+        obs = {"obs": actor, "critic": critic}
         flat = flatten_obs_dict(obs)
         np.testing.assert_array_equal(flat[:, :45], actor)
-        np.testing.assert_array_equal(flat[:, 45:], priv)
+        np.testing.assert_array_equal(flat[:, 45:], critic)
 
 
 class TestSplitObsDict:
     """Unit tests for split_obs_dict."""
 
-    def test_with_privileged(self):
-        obs = {"obs": np.ones((4, 8)), "privileged": np.full((4, 3), 2.0)}
-        obs_arr, priv_arr = split_obs_dict(obs)
+    def test_with_critic(self):
+        obs = {"obs": np.ones((4, 8)), "critic": np.full((4, 3), 2.0)}
+        obs_arr, critic_arr = split_obs_dict(obs)
         assert obs_arr.shape == (4, 8)
-        assert priv_arr.shape == (4, 3)
+        assert critic_arr is not None
+        assert critic_arr.shape == (4, 3)
         np.testing.assert_array_equal(obs_arr, 1.0)
-        np.testing.assert_array_equal(priv_arr, 2.0)
+        np.testing.assert_array_equal(critic_arr, 2.0)
 
-    def test_no_privileged(self):
+    def test_no_critic(self):
         obs = {"obs": np.ones((4, 8))}
-        obs_arr, priv_arr = split_obs_dict(obs)
+        obs_arr, critic_arr = split_obs_dict(obs)
         assert obs_arr.shape == (4, 8)
-        assert priv_arr is None
+        assert critic_arr is None
 
 
 class TestGetObsDims:
     """Unit tests for get_obs_dims."""
 
-    def test_with_privileged(self):
-        spec = {"obs": 49, "privileged": 3}
-        obs_dim, priv_dim = get_obs_dims(spec)
+    def test_with_critic(self):
+        spec = {"obs": 49, "critic": 52}
+        obs_dim, critic_dim = get_obs_dims(spec)
         assert obs_dim == 49
-        assert priv_dim == 3
+        assert critic_dim == 52
 
-    def test_no_privileged(self):
+    def test_no_critic(self):
         spec = {"obs": 49}
-        obs_dim, priv_dim = get_obs_dims(spec)
+        obs_dim, critic_dim = get_obs_dims(spec)
         assert obs_dim == 49
-        assert priv_dim == 0
+        assert critic_dim == 0


### PR DESCRIPTION
## Summary
- replace the mixed obs/privileged/critic runtime semantics with a strict `obs` + optional `critic` contract
- update env owner layers, IPC storage, APPO and off-policy runners/learners, and Sharpa config naming to use the single critic contract
- rewrite ADR-0005 and refresh tests to lock the new contract in place

## Validation
- uv run python -m compileall src/unilab
- uv run ruff check src/unilab/base/np_env.py src/unilab/utils/obs_utils.py src/unilab/utils/final_observation.py src/unilab/utils/device_utils.py src/unilab/utils/rsl_rl_vec_env_wrapper.py src/unilab/ipc/replay_buffer.py src/unilab/ipc/shared_onpolicy_storage.py src/unilab/algos/torch/appo/worker.py src/unilab/algos/torch/appo/runner.py src/unilab/algos/torch/appo/learner.py src/unilab/algos/torch/offpolicy/worker.py src/unilab/algos/torch/offpolicy/runner.py src/unilab/algos/torch/fast_sac/learner.py src/unilab/algos/torch/flash_sac/learner.py src/unilab/algos/torch/fast_td3/learner.py src/unilab/envs/locomotion/go1/joystick.py src/unilab/envs/locomotion/go2/joystick.py src/unilab/envs/locomotion/g1/joystick.py src/unilab/envs/locomotion/g1/joystick_sac.py src/unilab/envs/motion_tracking/g1/tracking.py src/unilab/envs/manipulation/sharpa_inhand/base.py src/unilab/envs/manipulation/sharpa_inhand/rotation.py scripts/train_appo.py scripts/train_offpolicy.py tests/utils/test_obs_utils.py tests/utils/test_final_observation.py tests/ipc/test_shared_onpolicy_storage.py tests/algos/test_appo_worker.py tests/algos/test_flash_sac_learner.py tests/base/test_np_env.py tests/envs/test_env_configs.py tests/scripts/test_train_scripts.py
- uv run pytest tests/utils/test_obs_utils.py tests/utils/test_final_observation.py tests/ipc/test_shared_onpolicy_storage.py tests/ipc/test_replay_buffer.py tests/algos/test_appo_worker.py tests/algos/test_flash_sac_learner.py tests/base/test_np_env.py tests/envs/test_env_configs.py tests/scripts/test_train_scripts.py -q -k "not slow and not veryslow"
- uv run pytest -m "slow or veryslow"
