### PR TITLE
fix: remove unnecessary hot-path asarray shims

### DIFF
--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -25,7 +25,8 @@ class NpEnvState:
 
     @property
     def done(self) -> np.ndarray:
-        return np.asarray(np.logical_or(self.terminated, self.truncated))
+        done: np.ndarray = np.logical_or(self.terminated, self.truncated)
+        return done
 
     def replace(self, **updates: Any) -> "NpEnvState":
         return dataclasses.replace(self, **updates)

--- a/src/unilab/envs/locomotion/common/base.py
+++ b/src/unilab/envs/locomotion/common/base.py
@@ -73,18 +73,23 @@ class LocomotionBaseEnv(NpEnv):
             if self._cfg.control_config.simulate_action_latency
             else actions
         )
-        return np.asarray(
+        ctrl: np.ndarray = (
             exec_actions * self._cfg.control_config.action_scale + self.default_angles
         )
+        return ctrl
 
     def get_local_linvel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.local_linvel))
+        local_linvel: np.ndarray = self._backend.get_sensor_data(self._cfg.sensor.local_linvel)
+        return local_linvel
 
     def get_gyro(self) -> np.ndarray:
-        return np.asarray(self._backend.get_sensor_data(self._cfg.sensor.gyro))
+        gyro: np.ndarray = self._backend.get_sensor_data(self._cfg.sensor.gyro)
+        return gyro
 
     def get_dof_pos(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_pos())
+        dof_pos: np.ndarray = self._backend.get_dof_pos()
+        return dof_pos
 
     def get_dof_vel(self) -> np.ndarray:
-        return np.asarray(self._backend.get_dof_vel())
+        dof_vel: np.ndarray = self._backend.get_dof_vel()
+        return dof_vel

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -362,4 +362,5 @@ class G1JoystickPPO(G1BaseEnv):
         gait_phase[:, 1] = (gait_phase[:, 1] + self._gait_phase_delta) % (2 * np.pi)
         state.info["gait_phase"] = gait_phase
 
-        return np.asarray(actions * self._cfg.control_config.action_scale + self.default_angles)
+        ctrl: np.ndarray = actions * self._cfg.control_config.action_scale + self.default_angles
+        return ctrl

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -204,4 +204,5 @@ class Go1WalkTask(Go1BaseEnv):
         target_height = 0.1
         height_error = np.square(self.feet_pos[:, :, 2] - target_height)
         swing_rew = np.exp(-height_error / 0.01) * is_swing
-        return np.asarray(np.sum(swing_rew, axis=1) / len(self._cfg.sensor.feet_pos))
+        reward: np.ndarray = np.sum(swing_rew, axis=1) / len(self._cfg.sensor.feet_pos)
+        return reward

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -203,7 +203,8 @@ class Go2WalkTask(Go2BaseEnv):
         target_height = 0.1
         height_error = np.square(self.feet_pos[:, :, 2] - target_height)
         swing_rew = np.exp(-height_error / 0.01) * is_swing
-        return np.asarray(np.sum(swing_rew, axis=1) / len(self._cfg.sensor.feet_pos))
+        reward: np.ndarray = np.sum(swing_rew, axis=1) / len(self._cfg.sensor.feet_pos)
+        return reward
 
     def _reward_foot_drag(self, ctx: RewardContext) -> np.ndarray:
         foot_pos = self.get_foot_pos()
@@ -213,7 +214,8 @@ class Go2WalkTask(Go2BaseEnv):
         safe_height = self._reward_cfg.target_foot_height / 2.0
         height_error = np.clip(safe_height - foot_heights, 0.0, None)
         error = np.square(height_error) * is_swing
-        return np.asarray(np.sum(error, axis=1))
+        drag_penalty: np.ndarray = np.sum(error, axis=1)
+        return drag_penalty
 
     def _reward_contact(self, ctx: RewardContext) -> np.ndarray:
         contact = self.feet_force[:, :, 2] > 0.1

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/base.py
@@ -107,8 +107,9 @@ class AllegroBaseEnv(NpEnv):
         )
         new_ctrl = prev_ctrl + self._cfg.control_config.action_scale * clipped_actions
         new_ctrl = np.clip(new_ctrl, self._ctrl_lower, self._ctrl_upper)
-        state.info["prev_ctrl"] = np.asarray(new_ctrl, dtype=self._np_dtype)
-        return np.asarray(state.info["prev_ctrl"])
+        prev_ctrl = np.asarray(new_ctrl, dtype=self._np_dtype)
+        state.info["prev_ctrl"] = prev_ctrl
+        return prev_ctrl
 
     def get_hand_dof_pos(self) -> np.ndarray:
         return np.asarray(

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
@@ -293,9 +293,10 @@ class AllegroRotationPPO(AllegroBaseEnv):
     ) -> np.ndarray:
         del info, dof_pos, dof_vel, ball_pos, ball_linvel, torques, terminated
         vec_dot = ball_angvel @ self._rot_axis
-        return np.asarray(
-            np.clip(vec_dot, self._reward_cfg.angvel_clip_min, self._reward_cfg.angvel_clip_max)
+        reward: np.ndarray = np.clip(
+            vec_dot, self._reward_cfg.angvel_clip_min, self._reward_cfg.angvel_clip_max
         )
+        return reward
 
     def _reward_obj_linvel(
         self,
@@ -309,7 +310,8 @@ class AllegroRotationPPO(AllegroBaseEnv):
         terminated: np.ndarray,
     ) -> np.ndarray:
         del info, dof_pos, dof_vel, ball_pos, ball_angvel, torques, terminated
-        return np.asarray(np.sum(np.abs(ball_linvel), axis=1))
+        penalty: np.ndarray = np.sum(np.abs(ball_linvel), axis=1)
+        return penalty
 
     def _reward_pose_diff(
         self,
@@ -324,7 +326,8 @@ class AllegroRotationPPO(AllegroBaseEnv):
     ) -> np.ndarray:
         del dof_vel, ball_pos, ball_linvel, ball_angvel, torques, terminated
         diff = dof_pos - info["init_pose"]
-        return np.asarray(np.sum(np.square(diff), axis=1))
+        penalty: np.ndarray = np.sum(np.square(diff), axis=1)
+        return penalty
 
     def _reward_torque(
         self,
@@ -338,7 +341,8 @@ class AllegroRotationPPO(AllegroBaseEnv):
         terminated: np.ndarray,
     ) -> np.ndarray:
         del info, dof_pos, dof_vel, ball_pos, ball_linvel, ball_angvel, terminated
-        return np.asarray(np.sum(np.square(torques), axis=1))
+        penalty: np.ndarray = np.sum(np.square(torques), axis=1)
+        return penalty
 
     def _reward_work(
         self,
@@ -353,7 +357,8 @@ class AllegroRotationPPO(AllegroBaseEnv):
     ) -> np.ndarray:
         del info, dof_pos, ball_pos, ball_linvel, ball_angvel, terminated
         work = np.sum(torques * dof_vel, axis=1)
-        return np.asarray(np.square(work))
+        penalty: np.ndarray = np.square(work)
+        return penalty
 
     def _reward_drop(
         self,

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -386,8 +386,9 @@ class SharpaInhandBaseEnv(NpEnv):
         )
         targets = prev_targets + self._cfg.control_config.action_scale * clipped_actions
         targets = np.clip(targets, self._ctrl_lower, self._ctrl_upper)
-        state.info["prev_targets"] = np.asarray(targets, dtype=self._np_dtype)
-        return np.asarray(state.info["prev_targets"])
+        prev_targets = np.asarray(targets, dtype=self._np_dtype)
+        state.info["prev_targets"] = prev_targets
+        return prev_targets
 
     def get_hand_dof_pos(self) -> np.ndarray:
         return np.asarray(self._backend.get_dof_pos()[:, : self._num_action], dtype=self._np_dtype)
@@ -460,7 +461,7 @@ class SharpaInhandBaseEnv(NpEnv):
         else:
             self.last_contacts.fill(0.0)
 
-        return np.asarray(tactile, dtype=self._np_dtype)
+        return tactile
 
     def _compute_contact_positions(self, tactile: np.ndarray) -> np.ndarray:
         del tactile

--- a/src/unilab/utils/math_utils.py
+++ b/src/unilab/utils/math_utils.py
@@ -90,7 +90,8 @@ def np_quat_canonicalize(q: np.ndarray) -> np.ndarray:
 
     sign = np.where(q[:, 0:1] < 0.0, -1.0, 1.0)
     result = q * sign
-    return np.asarray(result[0] if q_was_1d else result)
+    canonical: np.ndarray = result[0] if q_was_1d else result
+    return canonical
 
 
 def np_quat_ensure_continuity(q: np.ndarray) -> np.ndarray:
@@ -124,7 +125,8 @@ def np_quat_to_axis_angle(q: np.ndarray) -> np.ndarray:
         0.5 - angle**2 / 48.0,
         np.sin(half_angle) / safe_angle,
     )
-    return np.asarray(xyz / sin_half_over_angle)  # type: ignore[no-any-return]
+    axis_angle: np.ndarray = xyz / sin_half_over_angle
+    return axis_angle
 
 
 def np_quat_angular_velocity(q: np.ndarray, dt: float) -> np.ndarray:
@@ -213,7 +215,8 @@ def np_quat_apply(q: np.ndarray, v: np.ndarray) -> np.ndarray:
         axis=1,
     )
 
-    return np.asarray(result[0] if q_was_1d and v_was_1d else result)
+    rotated: np.ndarray = result[0] if q_was_1d and v_was_1d else result
+    return rotated
 
 
 def np_quat_apply_inverse(q: np.ndarray, v: np.ndarray) -> np.ndarray:
@@ -244,7 +247,8 @@ def np_quat_error_magnitude(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
     xyz_norm = np.linalg.norm(q_rel[:, 1:], axis=1)
     w = np.clip(q_rel[:, 0], -1.0, 1.0)
     error = 2.0 * np.arctan2(xyz_norm, w)
-    return np.asarray(error[0] if q1_was_1d and q2_was_1d else error)
+    magnitude: np.ndarray = error[0] if q1_was_1d and q2_was_1d else error
+    return magnitude
 
 
 def np_quat_from_euler_xyz(roll: np.ndarray, pitch: np.ndarray, yaw: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- systemically remove hot-path np.asarray wrappers that were only serving return-type checking
- keep real dtype/contract normalization in place and avoid runtime shims in perf-sensitive env/reward/math paths
- preserve typing with local typed variables instead of extra array conversions

## Why
This repo is performance-sensitive infrastructure. Runtime wrappers added only to satisfy mypy are not acceptable on hot paths.

## Validation
- UV_CACHE_DIR=.uv-cache uv run --no-sync ruff format --check .
- UV_CACHE_DIR=.uv-cache uv run --no-sync ruff check .
- UV_CACHE_DIR=.uv-cache uv run --no-sync mypy src/unilab

Related to #293.