### PR TITLE
fix: improve play-only checkpoint resolution diagnostics

### DIFF
--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -3,6 +3,7 @@ import statistics
 import sys
 import time
 from pathlib import Path
+from typing import Any, cast
 
 import hydra
 import torch
@@ -19,6 +20,8 @@ from unilab.training import (
     BackendAdapter,
     create_env,
     ensure_registries,
+    get_latest_checkpoint,
+    get_latest_run,
     get_log_root,
     parse_checkpoint_path,
     render_play_mode,
@@ -45,12 +48,12 @@ def _backend_adapter(cfg: DictConfig) -> BackendAdapter:
     )
 
 
-def build_ppo_env_cfg_override(cfg: DictConfig) -> dict:
-    return _backend_adapter(cfg).build_task_env_cfg_override()
+def build_ppo_env_cfg_override(cfg: DictConfig) -> dict[str, Any]:
+    return cast(dict[str, Any], _backend_adapter(cfg).build_task_env_cfg_override())
 
 
-def build_ppo_play_env_cfg_override(cfg: DictConfig) -> dict:
-    return _backend_adapter(cfg).build_play_env_cfg_override()
+def build_ppo_play_env_cfg_override(cfg: DictConfig) -> dict[str, Any]:
+    return cast(dict[str, Any], _backend_adapter(cfg).build_play_env_cfg_override())
 
 
 def run_motrix_rsl_play_loop(
@@ -77,27 +80,63 @@ def _get_log_root(cfg: DictConfig) -> str:
     return str(get_log_root(ROOT_DIR, cfg))
 
 
+def _algo_config_dict(cfg: DictConfig) -> dict[str, Any]:
+    train_cfg_raw = OmegaConf.to_container(cfg.algo, resolve=True)
+    if not isinstance(train_cfg_raw, dict):
+        raise TypeError("cfg.algo must resolve to a dict")
+    return cast(dict[str, Any], train_cfg_raw)
+
+
+def _format_play_checkpoint_error(
+    cfg: DictConfig,
+    *,
+    task_log_root: Path,
+    load_path: Path | None,
+    load_path_dir: Path | None,
+) -> str:
+    selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
+    checkpoint_hint = (
+        f" algo.checkpoint={selected_checkpoint!r}"
+        if selected_checkpoint not in (None, "", -1, "-1")
+        else ""
+    )
+
+    if load_path_dir is not None and load_path is None and checkpoint_hint:
+        reason = f"Requested checkpoint was not found under resolved_run={load_path_dir}."
+    elif not task_log_root.exists():
+        reason = "Task log root does not exist."
+    else:
+        latest_run = get_latest_run(task_log_root)
+        if latest_run is None:
+            reason = "No run directories were found under the task log root."
+        elif get_latest_checkpoint(latest_run) is None:
+            reason = f"Resolved latest run has no model_*.pt checkpoint files: {latest_run}."
+        else:
+            reason = "Requested run or checkpoint could not be resolved."
+
+    return (
+        "Could not resolve a checkpoint for play mode. "
+        f"{reason} task={cfg.training.task_name} task_log_root={task_log_root} "
+        f"algo.load_run={cfg.algo.load_run!r}{checkpoint_hint}."
+        " Use algo.load_run=<run-dir-or-checkpoint-path> "
+        "and optionally algo.checkpoint=<iteration-or-filename>."
+    )
+
+
 def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
     """Play mode for RSL-RL."""
 
-    env_cfg_override = build_ppo_play_env_cfg_override(cfg)
-
-    env = create_env(
-        cfg,
-        num_envs=cfg.training.play_env_num,
-        env_cfg_override=env_cfg_override,
-    )
-    wrapped_env = RslRlVecEnvWrapper(env, device=device)
-    train_cfg = OmegaConf.to_container(cfg.algo, resolve=True)
-    if "runner" not in train_cfg:
-        train_cfg["runner"] = {}
-    train_cfg["runner"]["logger"] = "none"
-    if is_rsl_rl_v5():
-        train_cfg = convert_config_v5(train_cfg)
-
+    task_log_root = get_log_root(ROOT_DIR, cfg) / str(cfg.training.task_name)
     load_path, load_path_dir = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
     if load_path is None or load_path_dir is None or not load_path.exists():
-        print(f"Could not find run to load at {load_path}")
+        print(
+            _format_play_checkpoint_error(
+                cfg,
+                task_log_root=task_log_root,
+                load_path=load_path,
+                load_path_dir=load_path_dir,
+            )
+        )
         return None
 
     print(f"Loading latest model: {load_path}")
@@ -109,12 +148,30 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
         )
         return None
 
-    runner = OnPolicyRunner(wrapped_env, train_cfg, log_dir=None, device=device)
+    env_cfg_override = build_ppo_play_env_cfg_override(cfg)
+
+    env = create_env(
+        cfg,
+        num_envs=cfg.training.play_env_num,
+        env_cfg_override=env_cfg_override,
+    )
+    wrapped_env = RslRlVecEnvWrapper(env, device=device)
+    train_cfg = _algo_config_dict(cfg)
+    if "runner" not in train_cfg:
+        train_cfg["runner"] = {}
+    train_cfg["runner"]["logger"] = "none"
+    if is_rsl_rl_v5():
+        train_cfg = cast(dict[str, Any], convert_config_v5(train_cfg))
+
+    runner = cast(
+        Any,
+        OnPolicyRunner(cast(Any, wrapped_env), train_cfg, log_dir=None, device=device),
+    )
     runner.load(str(load_path))
     policy = runner.get_inference_policy(device=device)
     if EXPORT_POLICY:
-        runner.export_policy_to_onnx(path=load_path_dir)
-        runner.export_policy_to_jit(path=load_path_dir)
+        runner.export_policy_to_onnx(path=str(load_path_dir))
+        runner.export_policy_to_jit(path=str(load_path_dir))
     if cfg.training.sim_backend == "motrix":
         print("Starting interactive visualization (motrix native renderer)...")
         print("Close the render window to exit.")
@@ -222,7 +279,7 @@ def main(cfg: DictConfig) -> None:
             )
             wrapped_env = RslRlVecEnvWrapper(env, device=device)
 
-            train_cfg = OmegaConf.to_container(cfg.algo, resolve=True)
+            train_cfg = _algo_config_dict(cfg)
             if "runner" not in train_cfg:
                 train_cfg["runner"] = {}
 
@@ -244,9 +301,12 @@ def main(cfg: DictConfig) -> None:
                 train_cfg["wandb_mode"] = wandb_settings["mode"]
 
             if is_rsl_rl_v5():
-                train_cfg = convert_config_v5(train_cfg)
+                train_cfg = cast(dict[str, Any], convert_config_v5(train_cfg))
 
-            runner = OnPolicyRunner(wrapped_env, train_cfg, log_dir=log_dir, device=device)
+            runner = cast(
+                Any,
+                OnPolicyRunner(cast(Any, wrapped_env), train_cfg, log_dir=log_dir, device=device),
+            )
 
             if cfg.algo.load_run != "-1":
                 resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
@@ -256,6 +316,7 @@ def main(cfg: DictConfig) -> None:
 
             train_start_wall = time.time()
             runner.learn(num_learning_iterations=max_iterations, init_at_random_ep_len=True)
+            assert log_dir is not None
             train_summary = {
                 "status": "completed",
                 "completed_iterations": int(runner.current_learning_iteration),

--- a/src/unilab/training/common.py
+++ b/src/unilab/training/common.py
@@ -156,13 +156,27 @@ def parse_checkpoint_path(
     root_dir: str | Path,
     load_run: str | None = None,
     task_name: str | None = None,
+    checkpoint: str | int | None = None,
     suffix: str = ".pt",
 ) -> tuple[Path | None, Path | None]:
     """Resolve a checkpoint path from Hydra config and repository root."""
     selected_task = task_name or str(OmegaConf.select(cfg, "training.task_name"))
     selected_run = load_run or str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
-    base_log_dir = get_log_root(root_dir, cfg) / selected_task
-    return resolve_checkpoint_path(base_log_dir, selected_run, suffix=suffix)
+    selected_checkpoint = checkpoint
+    if selected_checkpoint is None:
+        selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
+    if selected_checkpoint in (None, "", -1, "-1"):
+        selected_checkpoint = None
+
+    return resolve_task_checkpoint_path(
+        root_dir,
+        task_name=selected_task,
+        load_run=selected_run,
+        algo_log_name=str(OmegaConf.select(cfg, "algo.algo_log_name")),
+        checkpoint=str(selected_checkpoint) if selected_checkpoint is not None else None,
+        suffix=suffix,
+        log_root=OmegaConf.select(cfg, "training.log_root"),
+    )
 
 
 def resolve_task_checkpoint_path(

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1279,6 +1279,75 @@ def test_train_rsl_rl_get_log_root_uses_algo_log_name(monkeypatch: pytest.Monkey
     assert "logs/test_rsl_rl_ppo" in log_root
 
 
+def test_train_rsl_rl_play_missing_checkpoint_skips_env_creation_and_prints_context(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+):
+    mod = _train_rsl_rl(monkeypatch)
+    cfg = _ppo_cfg(["task=go1_joystick/mujoco", "training.play_only=true"])
+    cfg.algo.algo_log_name = "custom_ppo"
+
+    original_root = mod.ROOT_DIR
+    mod.ROOT_DIR = tmp_path
+    try:
+        monkeypatch.setattr(
+            mod,
+            "create_env",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("play_rsl_rl should not create an env before checkpoint resolution")
+            ),
+        )
+
+        result = mod.play_rsl_rl(cfg, device="cpu")
+    finally:
+        mod.ROOT_DIR = original_root
+
+    captured = capsys.readouterr().out
+    expected_task_log_root = tmp_path / "logs" / "custom_ppo" / cfg.training.task_name
+
+    assert result is None
+    assert "Could not resolve a checkpoint for play mode." in captured
+    assert "Task log root does not exist." in captured
+    assert f"task_log_root={expected_task_log_root}" in captured
+    assert "algo.load_run='-1'" in captured
+
+
+def test_train_rsl_rl_play_reports_missing_requested_checkpoint_in_resolved_run(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+):
+    mod = _train_rsl_rl(monkeypatch)
+    cfg = _ppo_cfg(["task=go1_joystick/mujoco", "training.play_only=true"])
+    cfg.algo.algo_log_name = "custom_ppo"
+    cfg.algo.checkpoint = 12
+
+    run_dir = (
+        tmp_path / "logs" / "custom_ppo" / cfg.training.task_name / "2024-01-01_00-00-00_mujoco"
+    )
+    run_dir.mkdir(parents=True)
+    (run_dir / "model_9.pt").write_bytes(b"")
+
+    original_root = mod.ROOT_DIR
+    mod.ROOT_DIR = tmp_path
+    try:
+        monkeypatch.setattr(
+            mod,
+            "create_env",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("play_rsl_rl should not create an env before checkpoint resolution")
+            ),
+        )
+
+        result = mod.play_rsl_rl(cfg, device="cpu")
+    finally:
+        mod.ROOT_DIR = original_root
+
+    captured = capsys.readouterr().out
+
+    assert result is None
+    assert "Could not resolve a checkpoint for play mode." in captured
+    assert f"resolved_run={run_dir}" in captured
+    assert "algo.checkpoint=12" in captured
+
+
 def test_train_appo_get_log_root_uses_algo_log_name():
     """Verify APPO _get_log_root uses algo.algo_log_name (issue #168)."""
     mod = _train_appo()

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -92,6 +92,42 @@ def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(tmp_path: Path):
     assert checkpoint_dir == run_dir
 
 
+def test_parse_checkpoint_path_supports_explicit_checkpoint_from_cfg(tmp_path: Path):
+    cfg = _ppo_cfg()
+    cfg.algo.algo_log_name = "custom_ppo"
+    cfg.algo.checkpoint = 12
+
+    run_dir = (
+        tmp_path / "logs" / "custom_ppo" / cfg.training.task_name / "2024-01-01_00-00-00_mujoco"
+    )
+    run_dir.mkdir(parents=True)
+    (run_dir / "model_9.pt").write_bytes(b"")
+    selected_model = run_dir / "model_12.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = parse_checkpoint_path(cfg, root_dir=tmp_path)
+
+    assert checkpoint_path == selected_model
+    assert checkpoint_dir == run_dir
+
+
+def test_parse_checkpoint_path_returns_run_dir_when_requested_checkpoint_is_missing(tmp_path: Path):
+    cfg = _ppo_cfg()
+    cfg.algo.algo_log_name = "custom_ppo"
+    cfg.algo.checkpoint = 12
+
+    run_dir = (
+        tmp_path / "logs" / "custom_ppo" / cfg.training.task_name / "2024-01-01_00-00-00_mujoco"
+    )
+    run_dir.mkdir(parents=True)
+    (run_dir / "model_9.pt").write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = parse_checkpoint_path(cfg, root_dir=tmp_path)
+
+    assert checkpoint_path is None
+    assert checkpoint_dir == run_dir
+
+
 def test_resolve_task_checkpoint_path_supports_explicit_checkpoint(tmp_path: Path):
     run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
     run_dir.mkdir(parents=True)


### PR DESCRIPTION
Fixes #300

## Summary
- resolve PPO play-mode checkpoints through the shared task-aware helper so algo.checkpoint works in train_rsl_rl.py
- fail fast in play_only mode before env construction and print actionable checkpoint-resolution context instead of `Could not find run to load at None`
- add regression tests for shared checkpoint parsing and RSL play-mode diagnostics

## Validation
- uv run pytest tests/training/test_training_helpers.py tests/scripts/test_train_scripts.py -q
- uv run ruff check scripts/train_rsl_rl.py src/unilab/training/common.py tests/training/test_training_helpers.py tests/scripts/test_train_scripts.py
- uv run ruff format --check scripts/train_rsl_rl.py src/unilab/training/common.py tests/training/test_training_helpers.py tests/scripts/test_train_scripts.py
