### PR TITLE
fix: move offpolicy multi-gpu symmetry rule into runner

### DIFF
--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -100,11 +100,6 @@ def build_runner(algo_name: str, cfg: DictConfig):
         if cfg.training.num_gpus > 1:
             from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
 
-            if cfg.algo.use_symmetry:
-                raise ValueError(
-                    "Off-policy symmetry augmentation does not support training.num_gpus > 1"
-                )
-
             ensure_registries()
             device = cfg.training.device or get_default_device()
             env = create_env(
@@ -136,8 +131,13 @@ def build_runner(algo_name: str, cfg: DictConfig):
                 "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
                 "use_amp": cfg.training.use_amp,
                 "critic_obs_dim": critic_dim,
-                "use_symmetry": False,
+                "use_symmetry": cfg.algo.use_symmetry,
             }
+            MultiGPUOffPolicyRunner.validate_capabilities(
+                algo_type="sac",
+                learner_kwargs=learner_kwargs,
+                num_gpus=cfg.training.num_gpus,
+            )
             main_learner = FastSACLearner(device=device, **learner_kwargs)
 
             return MultiGPUOffPolicyRunner(

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -466,7 +466,11 @@ class FastSACLearner:
         self.scaler = torch.amp.GradScaler("cuda") if self.use_amp else None  # pyright: ignore[reportPrivateImportUsage]
 
         self.symmetry = symmetry_augmentation
-        self.use_symmetry = use_symmetry and symmetry_augmentation is not None
+        if use_symmetry and symmetry_augmentation is None:
+            raise ValueError(
+                "FastSACLearner use_symmetry=True requires a symmetry_augmentation contract"
+            )
+        self.use_symmetry = use_symmetry
 
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -306,6 +306,21 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
     Falls back transparently to single-GPU when ``num_gpus <= 1``.
     """
 
+    @staticmethod
+    def validate_capabilities(
+        *,
+        algo_type: str,
+        learner_kwargs: Dict[str, Any],
+        num_gpus: int,
+    ) -> None:
+        if num_gpus <= 1:
+            return
+        if algo_type == "sac" and bool(learner_kwargs.get("use_symmetry", False)):
+            raise ValueError(
+                "Off-policy symmetry augmentation does not support training.num_gpus > 1; "
+                "set training.num_gpus=1 or algo.use_symmetry=false"
+            )
+
     def __init__(
         self,
         learner: Any,
@@ -315,6 +330,11 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
         num_gpus: int = 1,
         **kwargs: Any,
     ) -> None:
+        self.validate_capabilities(
+            algo_type=algo_type,
+            learner_kwargs=learner_kwargs,
+            num_gpus=num_gpus,
+        )
         super().__init__(learner=learner, env_name=env_name, algo_type=algo_type, **kwargs)
         self.num_gpus = num_gpus
         self.world_size = num_gpus

--- a/tests/algos/test_fast_sac_symmetry_contract.py
+++ b/tests/algos/test_fast_sac_symmetry_contract.py
@@ -103,3 +103,54 @@ def test_fast_sac_runner_skips_symmetry_builder_when_disabled(monkeypatch: pytes
     assert fake_env.closed is True
     assert runner.batch_size == 8
     assert runner.learner.symmetry is None
+
+
+def test_fast_sac_learner_rejects_symmetry_without_augmentation():
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    with pytest.raises(
+        ValueError,
+        match="FastSACLearner use_symmetry=True requires a symmetry_augmentation contract",
+    ):
+        FastSACLearner(
+            obs_dim=4,
+            action_dim=2,
+            device="cpu",
+            use_symmetry=True,
+        )
+
+
+def test_multi_gpu_offpolicy_runner_rejects_sac_symmetry_capability():
+    from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
+
+    with pytest.raises(
+        ValueError,
+        match="Off-policy symmetry augmentation does not support training.num_gpus > 1",
+    ):
+        MultiGPUOffPolicyRunner.validate_capabilities(
+            algo_type="sac",
+            learner_kwargs={"use_symmetry": True},
+            num_gpus=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("algo_type", "learner_kwargs", "num_gpus"),
+    [
+        ("sac", {"use_symmetry": False}, 2),
+        ("sac", {"use_symmetry": True}, 1),
+        ("td3", {"use_symmetry": True}, 2),
+    ],
+)
+def test_multi_gpu_offpolicy_runner_allows_supported_capabilities(
+    algo_type: str,
+    learner_kwargs: dict[str, bool],
+    num_gpus: int,
+):
+    from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
+
+    MultiGPUOffPolicyRunner.validate_capabilities(
+        algo_type=algo_type,
+        learner_kwargs=learner_kwargs,
+        num_gpus=num_gpus,
+    )

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1273,6 +1273,76 @@ def test_offpolicy_flashsac_rejects_multi_gpu():
         _offpolicy().build_runner("flashsac", cfg)
 
 
+def test_offpolicy_sac_multi_gpu_rejects_symmetry():
+    cfg = _offpolicy_cfg(
+        [
+            "algo=sac",
+            "task=sac/g1_sac/mujoco",
+            "training.num_gpus=2",
+            "training.device=cpu",
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Off-policy symmetry augmentation does not support training.num_gpus > 1",
+    ):
+        _offpolicy().build_runner("sac", cfg)
+
+
+def test_offpolicy_sac_multi_gpu_allows_explicit_symmetry_disable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import gymnasium as gym
+
+    mod = _offpolicy()
+    cfg = _offpolicy_cfg(
+        [
+            "algo=sac",
+            "task=sac/g1_sac/mujoco",
+            "training.num_gpus=2",
+            "training.device=cpu",
+            "algo.use_symmetry=false",
+        ]
+    )
+
+    class _FakeEnv:
+        obs_groups_spec = {"obs": 4, "critic": 6}
+        action_space = gym.spaces.Box(-1.0, 1.0, shape=(2,))
+
+        def close(self) -> None:
+            return None
+
+    class _FakeLearner:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    class _FakeRunner:
+        @staticmethod
+        def validate_capabilities(*args, **kwargs) -> None:
+            return None
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(mod, "ensure_registries", lambda: None)
+    monkeypatch.setattr(mod, "create_env", lambda *args, **kwargs: _FakeEnv())
+
+    import unilab.algos.torch.fast_sac.learner as learner_mod
+    import unilab.algos.torch.offpolicy.multi_gpu_runner as multi_gpu_runner_mod
+
+    monkeypatch.setattr(learner_mod, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(multi_gpu_runner_mod, "MultiGPUOffPolicyRunner", _FakeRunner)
+
+    runner = mod.build_runner("sac", cfg)
+
+    assert isinstance(runner, _FakeRunner)
+    assert runner.kwargs["num_gpus"] == 2
+    assert runner.kwargs["learner_kwargs"]["use_symmetry"] is False
+
+
 @pytest.mark.parametrize(
     ("algo", "task"),
     [


### PR DESCRIPTION
## Summary

- move the multi-GPU SAC symmetry restriction out of `scripts/train_offpolicy.py` into `MultiGPUOffPolicyRunner.validate_capabilities()`
- preserve user intent by forwarding `algo.use_symmetry` into learner construction instead of silently forcing it off in the script
- harden `FastSACLearner` so `use_symmetry=True` now requires an explicit runtime symmetry augmentation contract
- add regression tests for runner capability allow/reject paths and the offpolicy script multi-GPU wiring

## Linked Work

- Issue: #239
- Milestone: -

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/algos/test_fast_sac_symmetry_contract.py tests/scripts/test_train_scripts.py -q
make check
make test
```

## Impact

- Backend impact: `mujoco`
- Platform impact: both
- Training effect expected: yes

## Artifacts

- W&B: -
- benchmark result: -
- video / screenshot: -
- ONNX / checkpoint: -

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up work: none identified.
