### PR TITLE
fix: add step staggering to prevent synchronized mass resets

### DIFF
--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -209,20 +209,6 @@ def _run_collector(
     if critic_np is not None:
         critic_np = np.asarray(critic_np, dtype=np.float32)
     prev_dones_np = np.zeros(num_envs, dtype=np.float32)
-    max_episode_steps = getattr(getattr(env, "cfg", None), "max_episode_steps", None)
-    if max_episode_steps is not None and int(max_episode_steps) > 0:
-        step_offsets = np.random.randint(
-            0, int(max_episode_steps), size=(num_envs,), dtype=np.uint32
-        )
-        if (
-            hasattr(env, "state")
-            and env.state is not None
-            and isinstance(getattr(env.state, "info", None), dict)
-        ):
-            if "steps" in env.state.info:
-                env.state.info["steps"][:] = step_offsets
-        if isinstance(getattr(state, "info", None), dict) and "steps" in state.info:
-            state.info["steps"][:] = step_offsets
     import time as _time
 
     _last_log_time = _time.time()

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -86,7 +86,13 @@ class NpEnv(ABEnv):
         reward = np.zeros((self._num_envs,), dtype=dtype)
         terminated = np.ones((self._num_envs,), dtype=bool)
         truncated = np.zeros((self._num_envs,), dtype=bool)
-        info: dict = {"steps": np.zeros((self._num_envs,), dtype=np.uint32)}
+        if self._cfg.max_episode_steps:
+            steps = np.random.randint(
+                0, self._cfg.max_episode_steps, size=(self._num_envs,), dtype=np.uint32
+            )
+        else:
+            steps = np.zeros((self._num_envs,), dtype=np.uint32)
+        info: dict = {"steps": steps}
 
         self._state = NpEnvState(obs, reward, terminated, truncated, info)
         self._reset_done_envs()


### PR DESCRIPTION
## Summary

- Move random step offset initialization from the off-policy worker into `NpEnv.init_state()`, so **all algorithms** (PPO, RSL-RL, APPO, off-policy) automatically get step staggering
- Remove the now-redundant staggering logic from `offpolicy/worker.py`
- When `max_episode_steps` is configured, each env starts at a random step in `[0, max_episode_steps)`, preventing synchronized truncation resets that cause training instability

Fixes #315

## Test plan

- [x] `make test` — 473 passed, 3 skipped