### PR TITLE
feat: add per-step observation noise for Go1 & Go2 locomotion envs

### DIFF
--- a/src/unilab/envs/locomotion/go1/base.py
+++ b/src/unilab/envs/locomotion/go1/base.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import numpy as np
+
 from unilab.envs.locomotion.common.base import (
     ControlConfigBase,
     LocomotionBaseCfg,
@@ -43,3 +45,14 @@ class Go1BaseCfg(LocomotionBaseCfg):
 
 class Go1BaseEnv(LocomotionBaseEnv):
     _cfg: Go1BaseCfg
+
+    def _obs_noise(self, data: np.ndarray, scale: float) -> np.ndarray:
+        """Apply per-step uniform observation noise scaled by ``noise_config.level``."""
+        noise_cfg = self._cfg.noise_config
+        if noise_cfg.level > 0.0:
+            return data + (
+                np.random.uniform(-1.0, 1.0, data.shape).astype(data.dtype)
+                * noise_cfg.level
+                * scale
+            )
+        return data

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -148,7 +148,13 @@ class Go1WalkTask(Go1BaseEnv):
     def _compute_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel, feet_phase
     ) -> dict[str, np.ndarray]:
+        noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
+        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
         command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         obs = np.concatenate(

--- a/src/unilab/envs/locomotion/go2/base.py
+++ b/src/unilab/envs/locomotion/go2/base.py
@@ -46,6 +46,17 @@ class Go2BaseCfg(LocomotionBaseCfg):
 class Go2BaseEnv(LocomotionBaseEnv):
     _cfg: Go2BaseCfg
 
+    def _obs_noise(self, data: np.ndarray, scale: float) -> np.ndarray:
+        """Apply per-step uniform observation noise scaled by ``noise_config.level``."""
+        noise_cfg = self._cfg.noise_config
+        if noise_cfg.level > 0.0:
+            return data + (
+                np.random.uniform(-1.0, 1.0, data.shape).astype(data.dtype)
+                * noise_cfg.level
+                * scale
+            )
+        return data
+
     def get_foot_pos(self) -> np.ndarray:
         """Get foot positions. Returns shape (num_envs, 4, 3)"""
         foot_names = ["FL_pos", "FR_pos", "RL_pos", "RR_pos"]

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -153,7 +153,13 @@ class Go2WalkTask(Go2BaseEnv):
     def _compute_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel, feet_phase
     ) -> dict[str, np.ndarray]:
+        noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
+        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
         command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         obs = np.concatenate(

--- a/tests/envs/test_go1_obs_noise.py
+++ b/tests/envs/test_go1_obs_noise.py
@@ -1,0 +1,77 @@
+"""Tests for Go1 per-step observation noise."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv, NoiseConfig
+
+
+class _ConcreteGo1Env(Go1BaseEnv):
+    """Minimal concrete subclass — only needed to satisfy the ABC."""
+
+    def update_state(self, state):
+        raise NotImplementedError
+
+
+def _make_env(level: float) -> Go1BaseEnv:
+    cfg = Go1BaseCfg(noise_config=NoiseConfig(level=level))
+    env = object.__new__(_ConcreteGo1Env)
+    env._cfg = cfg
+    return env
+
+
+class TestObsNoise:
+    def test_noise_applied_when_level_positive(self):
+        env = _make_env(level=1.0)
+        data = np.ones((4, 10), dtype=np.float32)
+        cfg = env._cfg.noise_config
+
+        results = [env._obs_noise(data.copy(), cfg.scale_joint_angle) for _ in range(5)]
+        # At least one result should differ from the original
+        assert any(not np.allclose(r, data) for r in results)
+
+    def test_no_noise_when_level_zero(self):
+        env = _make_env(level=0.0)
+        data = np.ones((4, 10), dtype=np.float32)
+        cfg = env._cfg.noise_config
+
+        result = env._obs_noise(data.copy(), cfg.scale_joint_angle)
+        np.testing.assert_array_equal(result, data)
+
+    def test_noise_bounded_by_level_times_scale(self):
+        env = _make_env(level=1.0)
+        data = np.zeros((128, 29), dtype=np.float32)
+        scale = 0.2
+        result = env._obs_noise(data.copy(), scale)
+        # uniform[-1,1] * 1.0 * 0.2 => bounded by [-0.2, 0.2]
+        assert np.all(result >= -scale)
+        assert np.all(result <= scale)
+
+    def test_noise_scales_with_level(self):
+        env_half = _make_env(level=0.5)
+        env_full = _make_env(level=1.0)
+        data = np.zeros((1024, 10), dtype=np.float32)
+        scale = 1.0
+
+        np.random.seed(0)
+        r_half = env_half._obs_noise(data.copy(), scale)
+        np.random.seed(0)
+        r_full = env_full._obs_noise(data.copy(), scale)
+
+        # Same random seed: full-level noise should be exactly 2x half-level noise
+        np.testing.assert_allclose(r_full, r_half * 2.0)
+
+    def test_noise_preserves_dtype(self):
+        for dt in [np.float32, np.float64]:
+            env = _make_env(level=1.0)
+            data = np.ones((4, 5), dtype=dt)
+            result = env._obs_noise(data, 0.1)
+            assert result.dtype == dt
+
+    def test_noise_preserves_shape(self):
+        env = _make_env(level=1.0)
+        for shape in [(1, 3), (64, 29), (1024, 10)]:
+            data = np.zeros(shape, dtype=np.float32)
+            result = env._obs_noise(data, 0.1)
+            assert result.shape == shape

--- a/tests/envs/test_go2_obs_noise.py
+++ b/tests/envs/test_go2_obs_noise.py
@@ -1,0 +1,74 @@
+"""Tests for Go2 per-step observation noise."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from unilab.envs.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv, NoiseConfig
+
+
+class _ConcreteGo2Env(Go2BaseEnv):
+    """Minimal concrete subclass — only needed to satisfy the ABC."""
+
+    def update_state(self, state):
+        raise NotImplementedError
+
+
+def _make_env(level: float) -> Go2BaseEnv:
+    cfg = Go2BaseCfg(noise_config=NoiseConfig(level=level))
+    env = object.__new__(_ConcreteGo2Env)
+    env._cfg = cfg
+    return env
+
+
+class TestObsNoise:
+    def test_noise_applied_when_level_positive(self):
+        env = _make_env(level=1.0)
+        data = np.ones((4, 10), dtype=np.float32)
+        cfg = env._cfg.noise_config
+
+        results = [env._obs_noise(data.copy(), cfg.scale_joint_angle) for _ in range(5)]
+        assert any(not np.allclose(r, data) for r in results)
+
+    def test_no_noise_when_level_zero(self):
+        env = _make_env(level=0.0)
+        data = np.ones((4, 10), dtype=np.float32)
+        cfg = env._cfg.noise_config
+
+        result = env._obs_noise(data.copy(), cfg.scale_joint_angle)
+        np.testing.assert_array_equal(result, data)
+
+    def test_noise_bounded_by_level_times_scale(self):
+        env = _make_env(level=1.0)
+        data = np.zeros((128, 29), dtype=np.float32)
+        scale = 0.2
+        result = env._obs_noise(data.copy(), scale)
+        assert np.all(result >= -scale)
+        assert np.all(result <= scale)
+
+    def test_noise_scales_with_level(self):
+        env_half = _make_env(level=0.5)
+        env_full = _make_env(level=1.0)
+        data = np.zeros((1024, 10), dtype=np.float32)
+        scale = 1.0
+
+        np.random.seed(0)
+        r_half = env_half._obs_noise(data.copy(), scale)
+        np.random.seed(0)
+        r_full = env_full._obs_noise(data.copy(), scale)
+
+        np.testing.assert_allclose(r_full, r_half * 2.0)
+
+    def test_noise_preserves_dtype(self):
+        for dt in [np.float32, np.float64]:
+            env = _make_env(level=1.0)
+            data = np.ones((4, 5), dtype=dt)
+            result = env._obs_noise(data, 0.1)
+            assert result.dtype == dt
+
+    def test_noise_preserves_shape(self):
+        env = _make_env(level=1.0)
+        for shape in [(1, 3), (64, 29), (1024, 10)]:
+            data = np.zeros(shape, dtype=np.float32)
+            result = env._obs_noise(data, 0.1)
+            assert result.shape == shape


### PR DESCRIPTION
## Summary
- Add `_obs_noise()` method to `Go1BaseEnv` and `Go2BaseEnv`, following the same pattern as G1
- Apply per-step uniform noise to sensor observations (`gyro`, `gravity`, `joint angle`, `joint vel`, `linvel`) in both `Go1WalkTask._compute_obs()` and `Go2WalkTask._compute_obs()`
- Go2 noise parameters aligned with Go1 (`level=0.0, scale_joint_angle=0.03, scale_joint_vel=0.5, scale_gyro=0.2, scale_gravity=0.05, scale_linvel=0.1`)
- Add 6 unit tests each for Go1 and Go2 (12 total)

Closes #307
Closes #308
Refs #125

## Validation
```bash
uv run pytest tests/envs/test_go1_obs_noise.py tests/envs/test_go2_obs_noise.py -v
```

## Test plan
- [x] `_obs_noise()` applies noise when `level > 0`
- [x] `_obs_noise()` returns data unchanged when `level == 0`
- [x] Noise is bounded by `level * scale`
- [x] Noise magnitude scales linearly with level
- [x] dtype and shape are preserved
- [x] All 12 tests pass (6 Go1 + 6 Go2)