### PR TITLE
fix: upgrade motrixsim to 0.7.1.dev96425 and fix mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-motrix = ["motrixsim==0.7.1.dev95684"]
+motrix = ["motrixsim==0.7.1.dev96425"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -1,6 +1,7 @@
 import os
 import time
 from collections.abc import Sequence
+from typing import TypeVar
 
 import numpy as np
 
@@ -21,6 +22,14 @@ except ImportError:
     MOTRIX_AVAILABLE = False
 
 from .base import BackendPlayCapabilities, SimBackend
+
+T = TypeVar("T")
+
+
+def _require_not_none(value: T | None, error_message: str) -> T:
+    if value is None:
+        raise ValueError(error_message)
+    return value
 
 
 class MotrixBackend(SimBackend):
@@ -75,8 +84,12 @@ class MotrixBackend(SimBackend):
         self._np_dtype = np_dtype
 
         self._data = mtx.SceneData(self._model, batch=[num_envs])  # pyright: ignore[reportPossiblyUnbound]
-        self._body = self._model.get_body(base_name)
-        self._body_link = self._model.get_link(base_name)
+        self._body: "mtx.Body" = _require_not_none(
+            self._model.get_body(base_name), f"Body '{base_name}' not found in Motrix model"
+        )
+        self._body_link: "mtx.Link" = _require_not_none(
+            self._model.get_link(base_name), f"Link '{base_name}' not found in Motrix model"
+        )
         self._body_floatingbase = self._body.floatingbase
         self._joint_dof_pos_indices = np.asarray(self._model.joint_dof_pos_indices, dtype=np.intp)
         self._joint_dof_vel_indices = np.asarray(self._model.joint_dof_vel_indices, dtype=np.intp)

--- a/uv.lock
+++ b/uv.lock
@@ -2100,7 +2100,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim"
-version = "0.7.1.dev95684"
+version = "0.7.1.dev96425"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2108,18 +2108,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fb6f17f5f297e826b52ecebbc31cef7240bba8adcf66dba875aeb7008a15b859" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516913266a572d7d051c183e173113393c9ae144b95b316e5a46349066d99f81" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp310-cp310-win_amd64.whl", hash = "sha256:8686aec95b5e9f1046160a412499fafa7f3848b68a362af6b1c3e9c469ee134a" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c8b92c0e357b7f57c9de87d0de19e7e4ebfe1244e4f56ecacae2c4063b2b4b34" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee7330e690ef3593441f22f8a0b510a5dd87bf57c2b07a5e29f36f8a24cc78a9" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp311-cp311-win_amd64.whl", hash = "sha256:c2bb459119e1844c59c9fcb893d9b2810c16799ca96ba19a07f8355702825f75" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66f61a255648b0859ef63d25054d82bfa1eddcb4c9f22dd15348bdac992d344d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47aa0d7e8ff085f4d9848c4efdd27d4b18132173400f9bb635f6af5ebf0aefe0" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp312-cp312-win_amd64.whl", hash = "sha256:373fd7a8e721e70389c71174e945d22b4fda62c8bf77f54f371ea945471609cf" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4c816b4ea632bd46d5af6fb3daa10feb8ebdf1518e59a939e07dcb0cf52eedd9" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2c984c10250d7cbd188fa65aa619ec2ef4a3aed9a22e83d93c81bb5d49122e5" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev95684-cp313-cp313-win_amd64.whl", hash = "sha256:a52ac414d4029d3529aafbe88350df919841a9802f1d967c7d0ca85bd08eb25b" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c713733a47a27e632ed39665f52ae3fa0eda5d08ed623ef1c134b24d1fda58d0" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b8add73bfd90913874c6dff283bb87b68d9714769661f2591740bbb5a6fe867" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-win_amd64.whl", hash = "sha256:67a3282f2b6b3e65aff776c80559e72422679d72023349e94ab572f74fb52765" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5c6d60a5e8178ee73451bfa59d04f3098cb75ddd349f4569dd559ed49df23cc6" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:285e81aebb576e61e17bbc8e2894df365b7be758eb99043fe90f4d43a44d1e19" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-win_amd64.whl", hash = "sha256:618f006011ed7bd44773ce7e3309218147fdc929a351d202938773b72e6b4930" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d40be7b9b5afc57e27ff75bfcb03755a5c5b9764e787b1355a1f7f6f96f8f52" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:219d720b8a41b32587eef2f67bf1eae262da3e44170737871424116e6ae0b7f1" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-win_amd64.whl", hash = "sha256:97baed34ed8c71b1f6c5f73e5cd40c141f751e1944500626605ac31368518267" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99669b580d23238c91410f6a21e1f0b2122c6280627f5ef9e60fef36be06db3b" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:616e138e93afd077a3b90229d44c44b33d4f3213b7d97f08155313c4c5accda7" },
+    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-win_amd64.whl", hash = "sha256:84358430ee89d5745f7b8d70ce1f8c72f467a6562b9c91ebdb6893d86c8722d6" },
 ]
 
 [[package]]
@@ -4369,7 +4369,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev95684", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev96425", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.6.0.post6", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- upgrade optional dependency motrixsim from 0.7.1.dev95684 to 0.7.1.dev96425
- refresh uv.lock to pin new motrixsim wheels/hashes
- fix mypy union-attr errors in MotrixBackend by centralizing non-null checks for base body/link

## Validation
- uv run mypy src