### PR TITLE
fix: apply MuJoCo push via external force

### DIFF
--- a/docs/users/zh_CN/06-domain-randomization.md
+++ b/docs/users/zh_CN/06-domain-randomization.md
@@ -96,7 +96,41 @@ backend capability 当前是：
 
 但任务侧当前实际情况是：并不是所有 provider 都构造这些字段。backend contract 是能力边界，任务配置和 provider 是否下发 payload 才决定该任务是否实际启用对应 DR 项。
 
-### 4. `geom_size` 的生命周期边界
+## Interval push 用法
+
+支持 interval push 的任务在 `env.domain_rand` 下配置：
+
+```yaml
+env:
+  domain_rand:
+    push_robots: true
+    push_interval: 750
+    max_force: [1.0, 1.0, 0.5]
+    push_body_name: null
+```
+
+- `push_robots`：是否启用 push。
+- `push_interval`：每隔多少个 env step 触发一次。
+- `max_force`：长度为 3 的外力上限；每次在 `[-max_force, max_force]` 内逐维采样。
+- `push_body_name`：外力施加目标 body / link。默认 `null`，表示使用 backend 的 `base_name`。
+
+```bash
+uv run python scripts/train_rsl_rl.py \
+  task=g1_walk_flat/mujoco \
+  env.domain_rand.push_robots=true \
+  env.domain_rand.push_interval=500 \
+  'env.domain_rand.max_force=[20.0,20.0,5.0]' \
+  env.domain_rand.push_body_name=torso_link
+```
+
+注意：
+
+- MuJoCo 按 body 名解析，Motrix 按 link 名解析；名称不存在会在 env/backend 初始化阶段报错。
+- `push_body_name` 是 init 配置，env 创建后再改不会改变已解析的目标。
+- 热路径只采样并施加外力，不解析 XML / asset，不做 backend 私有能力探测。
+- MuJoCo push 通过 `xfrc_applied` 外力实现，不直接改写 base velocity。
+
+## `geom_size` 的生命周期边界
 
 `geom_size` 明确不属于 [`ResetRandomizationPayload`](../../../src/unilab/dr/types.py)，也不应通过 `BatchEnvPool.reset(..., randomization=...)` 在热路径中修改。
 

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -46,6 +46,7 @@ class MotrixBackend(SimBackend):
         np_dtype=np.float32,
         add_body_sensors: bool = False,
         iterations: int | None = None,
+        push_body_name: str | None = None,
     ):
         if not MOTRIX_AVAILABLE:
             raise ImportError("motrixsim not available")
@@ -91,6 +92,10 @@ class MotrixBackend(SimBackend):
         )
         self._body_link: "mtx.Link" = _require_not_none(
             self._model.get_link(base_name), f"Link '{base_name}' not found in Motrix model"
+        )
+        push_body = push_body_name if push_body_name is not None else base_name
+        self._push_body_link: "mtx.Link" = _require_not_none(
+            self._model.get_link(push_body), f"Push link '{push_body}' not found in Motrix model"
         )
         self._body_floatingbase = self._body.floatingbase
         self._joint_dof_pos_indices = np.asarray(self._model.joint_dof_pos_indices, dtype=np.intp)
@@ -399,7 +404,7 @@ class MotrixBackend(SimBackend):
         ex_force[:, 0] *= force_range[0]
         ex_force[:, 1] *= force_range[1]
         ex_force[:, 2] *= force_range[2]
-        self._body_link.add_external_force(self._data, ex_force, local=True)
+        self._push_body_link.add_external_force(self._data, ex_force, local=True)
 
     def init_renderer(self, spacing: float = 1.0):
         """Initialize interactive renderer for visualization"""

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -113,9 +113,11 @@ class MuJoCoBackend(SimBackend):
         add_body_sensors: bool = False,
         position_actuator_gains: dict | None = None,
         iterations: int | None = None,
+        push_body_name: Optional[str] = None,
     ):
         self.add_body_sensors = add_body_sensors
         self._base_name = base_name
+        self._push_body_name = push_body_name
         self._model_file = model_file
         self._sim_dt = float(sim_dt)
         self._iterations = None if iterations is None else int(iterations)
@@ -128,11 +130,14 @@ class MuJoCoBackend(SimBackend):
             if base_name is not None
             else -1
         )
+        self._push_body_id = self._resolve_push_body_id(self._model)
+        self._push_body_force_slice = self._resolve_push_body_force_slice(self._push_body_id)
         self._base_body_mass = np.asarray(self._model.body_mass).copy()
         self._base_body_ipos = np.asarray(self._model.body_ipos).copy()
         self._num_envs = num_envs
         self._np_dtype = np_dtype if np_dtype is not None else get_global_dtype()
         self.backend_type = "mujoco"
+        self._pending_xfrc_applied = np.zeros((num_envs, 6 * self._model.nbody), dtype=np.float64)
 
         # 线程配置
         self._n_threads = min(num_envs, cpu_count() * 2)
@@ -263,6 +268,21 @@ class MuJoCoBackend(SimBackend):
         if self._position_actuator_gains is not None:
             self._apply_position_actuator_gains_to_model(model, **self._position_actuator_gains)
 
+    def _resolve_push_body_id(self, model: mujoco.MjModel) -> int:
+        body_name = self._push_body_name if self._push_body_name is not None else self._base_name
+        if body_name is None:
+            return -1
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if body_id < 0:
+            raise ValueError(f"Push body '{body_name}' not found in MuJoCo model")
+        return int(body_id)
+
+    def _resolve_push_body_force_slice(self, body_id: int) -> slice:
+        if body_id < 0:
+            return slice(0, 0)
+        start = 6 * body_id
+        return slice(start, start + 3)
+
     def _compile_model_variants(
         self,
         variant_specs: Sequence[ModelVariantSpec],
@@ -373,8 +393,13 @@ class MuJoCoBackend(SimBackend):
             if self._base_name is not None
             else -1
         )
+        self._push_body_id = self._resolve_push_body_id(self._model)
+        self._push_body_force_slice = self._resolve_push_body_force_slice(self._push_body_id)
         self._base_body_mass = np.asarray(self._model.body_mass).copy()
         self._base_body_ipos = np.asarray(self._model.body_ipos).copy()
+        self._pending_xfrc_applied = np.zeros(
+            (self._num_envs, 6 * self._model.nbody), dtype=np.float64
+        )
         self._physics_state[:, self._idx_qpos : self._idx_qpos + self._model.nq] = self._model.qpos0
 
     # ------------------------------------------------------------------ #
@@ -437,6 +462,14 @@ class MuJoCoBackend(SimBackend):
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict | None:
         t0 = time.perf_counter()
         control_traj = np.broadcast_to(ctrl[:, None, :], (self._num_envs, nsteps, ctrl.shape[-1]))
+        control_spec = int(mujoco.mjtState.mjSTATE_CTRL)
+        if np.any(self._pending_xfrc_applied):
+            control_spec |= int(mujoco.mjtState.mjSTATE_XFRC_APPLIED)
+            xfrc_traj = np.broadcast_to(
+                self._pending_xfrc_applied[:, None, :],
+                (self._num_envs, nsteps, self._pending_xfrc_applied.shape[-1]),
+            )
+            control_traj = np.concatenate((control_traj, xfrc_traj), axis=-1)
         set_ctrl_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
@@ -444,8 +477,10 @@ class MuJoCoBackend(SimBackend):
             self._physics_state,
             nstep=nsteps,
             control=control_traj,
-            control_spec=int(mujoco.mjtState.mjSTATE_CTRL),
+            control_spec=control_spec,
         )
+        if control_spec & int(mujoco.mjtState.mjSTATE_XFRC_APPLIED):
+            self._pending_xfrc_applied.fill(0.0)
         self._physics_state[:] = state_np.astype(self._np_dtype)
         physics_ms = (time.perf_counter() - t0) * 1000.0
 
@@ -498,7 +533,7 @@ class MuJoCoBackend(SimBackend):
                     RESET_TERM_KD,
                 }
             ),
-            supports_interval_push=True,
+            supports_interval_push=self._push_body_id >= 0,
         )
 
     def apply_init_randomization(self, plan: InitRandomizationPlan) -> None:
@@ -518,9 +553,13 @@ class MuJoCoBackend(SimBackend):
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         if plan.push_perturbation_limit is None:
             return
-        velocity_delta = np.random.uniform(-1.0, 1.0, size=(self._num_envs, 3))
-        velocity_delta *= np.asarray(plan.push_perturbation_limit, dtype=np.float64)
-        self._base_lin_vel_view[:] += velocity_delta.astype(self._np_dtype)
+        self.push_robots(plan.push_perturbation_limit)
+
+    def push_robots(self, force_range: Sequence[float] | np.ndarray) -> None:
+        ex_force = np.random.uniform(-1.0, 1.0, size=(self._num_envs, 3))
+        ex_force *= force_range
+        self._pending_xfrc_applied.fill(0.0)
+        self._pending_xfrc_applied[:, self._push_body_force_slice] = ex_force
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
         return BackendPlayCapabilities(supports_physics_state_playback=True)

--- a/src/unilab/dr/dr_utils.py
+++ b/src/unilab/dr/dr_utils.py
@@ -85,9 +85,7 @@ def build_interval_push_plan(env: Any, step_counter: int) -> IntervalRandomizati
         return None
     if step_counter % domain_rand.push_interval != 0:
         return None
-    return IntervalRandomizationPlan(
-        push_perturbation_limit=np.asarray(domain_rand.max_force, dtype=np.float64)
-    )
+    return IntervalRandomizationPlan(push_perturbation_limit=domain_rand.max_force)
 
 
 def validate_interval_push_support(env: Any, capabilities: DomainRandomizationCapabilities) -> None:
@@ -98,3 +96,6 @@ def validate_interval_push_support(env: Any, capabilities: DomainRandomizationCa
         raise NotImplementedError(
             f"{env._backend.backend_type} backend does not support interval push"
         )
+    force_limit = np.asarray(domain_rand.max_force, dtype=np.float64)
+    if force_limit.shape != (3,):
+        raise ValueError(f"domain_rand.max_force must have shape (3,), got {force_limit.shape}")

--- a/src/unilab/dr/types.py
+++ b/src/unilab/dr/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -95,7 +96,7 @@ class ResetRandomizationPayload:
 
 @dataclass
 class IntervalRandomizationPlan:
-    push_perturbation_limit: np.ndarray | None = None
+    push_perturbation_limit: Sequence[float] | np.ndarray | None = None
 
     def is_empty(self) -> bool:
         return self.push_perturbation_limit is None

--- a/src/unilab/envs/locomotion/common/domain_rand.py
+++ b/src/unilab/envs/locomotion/common/domain_rand.py
@@ -14,3 +14,4 @@ class DomainRandConfig:
     push_robots: bool = False
     push_interval: int = 750  # step
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
+    push_body_name: str | None = None

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -251,6 +251,7 @@ class G1WalkEnv(G1BaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             iterations=cfg.iterations,
         )
         super().__init__(cfg, backend, num_envs)

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -89,6 +89,7 @@ class Go1WalkTask(Go1BaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
             iterations=cfg.iterations,
         )

--- a/src/unilab/envs/locomotion/go2/handstand.py
+++ b/src/unilab/envs/locomotion/go2/handstand.py
@@ -117,6 +117,7 @@ class Go2HandStandTask(Go2BaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
             iterations=cfg.iterations,
         )

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -92,6 +92,7 @@ class Go2WalkTask(Go2BaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
             iterations=cfg.iterations,
         )

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
@@ -85,6 +85,7 @@ class DomainRandConfig:
     push_robots: bool = False
     push_interval: int = 750
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
+    push_body_name: str | None = None
     joint_noise: float = 0.0
     ball_vel_noise: float = 0.0
     ball_z_offset: float = 0.0
@@ -245,6 +246,7 @@ class AllegroRotationPPO(AllegroBaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name="palm",
+            push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
             position_actuator_gains={
                 "kp": cfg.control_config.kp,

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -93,6 +93,7 @@ class SharpaDomainRandConfig:
     added_mass_range: list[float] = field(default_factory=lambda: [0.0, 0.0])
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    push_body_name: str | None = None
 
 
 @dataclass

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -310,6 +310,7 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
             iterations=cfg.iterations,
         )

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -108,6 +108,7 @@ class Domain_Rand:
     push_robots: bool = False
     push_interval: int = 750
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
+    push_body_name: str | None = None
 
 
 @dataclass
@@ -302,6 +303,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
             num_envs,
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
+            push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
             iterations=cfg.iterations,
         )

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -230,6 +230,113 @@ class TestMuJoCoBasic:
         }.issubset(caps.supported_reset_terms)
         assert caps.supports_interval_push
 
+    def test_apply_interval_randomization_calls_push_robots(self, bkd):
+        called: dict[str, np.ndarray] = {}
+
+        def _fake_push_robots(force_range):
+            called["force_range"] = np.asarray(force_range, dtype=np.float64)
+
+        bkd.push_robots = _fake_push_robots  # type: ignore[method-assign]
+        limit = np.array([0.7, 0.3, 0.2], dtype=np.float64)
+
+        bkd.apply_interval_randomization(IntervalRandomizationPlan(push_perturbation_limit=limit))
+
+        np.testing.assert_allclose(called["force_range"], limit)
+
+    def test_step_uses_xfrc_applied_for_interval_push(self, bkd, monkeypatch: pytest.MonkeyPatch):
+        mujoco = _mujoco_module()
+        sampled = np.array([[0.5, -0.25, 0.1], [-0.1, 0.8, -0.4]], dtype=np.float64)
+        limit = np.array([0.7, 0.3, 0.2], dtype=np.float64)
+        calls: list[dict[str, Any]] = []
+
+        monkeypatch.setattr(np.random, "uniform", lambda low, high, size: sampled.copy())
+
+        def _fake_step(initial_state, *, nstep, control_spec=0, control=None, **kwargs):
+            calls.append(
+                {
+                    "nstep": nstep,
+                    "control_spec": control_spec,
+                    "control": None if control is None else np.array(control, copy=True),
+                }
+            )
+            return np.array(initial_state, copy=True)
+
+        monkeypatch.setattr(bkd._pool, "step", _fake_step)
+        monkeypatch.setattr(
+            bkd._pool,
+            "forward",
+            lambda state: np.array(bkd._sensor_data, copy=True),
+        )
+
+        bkd.apply_interval_randomization(IntervalRandomizationPlan(push_perturbation_limit=limit))
+
+        ctrl = np.zeros((NUM_ENVS, bkd.model.nu), dtype=np.float64)
+        bkd.step(ctrl, nsteps=2)
+        bkd.step(ctrl, nsteps=1)
+
+        expected_xfrc = np.zeros((NUM_ENVS, 6 * bkd.model.nbody), dtype=np.float64)
+        start = 6 * bkd._base_body_id
+        expected_xfrc[:, start : start + 3] = sampled * limit[None, :]
+        expected_xfrc_traj = np.broadcast_to(
+            expected_xfrc[:, None, :],
+            (NUM_ENVS, 2, 6 * bkd.model.nbody),
+        )
+        expected_ctrl_traj = np.broadcast_to(ctrl[:, None, :], (NUM_ENVS, 2, bkd.model.nu))
+
+        assert len(calls) == 2
+        assert calls[0]["nstep"] == 2
+        assert calls[0]["control_spec"] & int(mujoco.mjtState.mjSTATE_CTRL)
+        assert calls[0]["control_spec"] & int(mujoco.mjtState.mjSTATE_XFRC_APPLIED)
+        np.testing.assert_allclose(calls[0]["control"][:, :, : bkd.model.nu], expected_ctrl_traj)
+        np.testing.assert_allclose(calls[0]["control"][:, :, bkd.model.nu :], expected_xfrc_traj)
+
+        assert calls[1]["nstep"] == 1
+        assert calls[1]["control_spec"] == int(mujoco.mjtState.mjSTATE_CTRL)
+        assert calls[1]["control"].shape == (NUM_ENVS, 1, bkd.model.nu)
+
+    def test_interval_push_uses_configured_body(self, monkeypatch: pytest.MonkeyPatch):
+        from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+        mujoco = _mujoco_module()
+        bkd = MuJoCoBackend(
+            _G1["model_file"],
+            NUM_ENVS,
+            SIM_DT,
+            base_name=_G1["base_name"],
+            push_body_name="torso_link",
+        )
+        bkd.materialize()
+        sampled = np.array([[0.5, -0.25, 0.1], [-0.1, 0.8, -0.4]], dtype=np.float64)
+        limit = np.array([0.7, 0.3, 0.2], dtype=np.float64)
+        calls: list[dict[str, Any]] = []
+
+        monkeypatch.setattr(np.random, "uniform", lambda low, high, size: sampled.copy())
+
+        def _fake_step(initial_state, *, nstep, control_spec=0, control=None, **kwargs):
+            calls.append(
+                {
+                    "control_spec": control_spec,
+                    "control": None if control is None else np.array(control, copy=True),
+                }
+            )
+            return np.array(initial_state, copy=True)
+
+        monkeypatch.setattr(bkd._pool, "step", _fake_step)
+        monkeypatch.setattr(
+            bkd._pool,
+            "forward",
+            lambda state: np.array(bkd._sensor_data, copy=True),
+        )
+
+        bkd.apply_interval_randomization(IntervalRandomizationPlan(push_perturbation_limit=limit))
+        bkd.step(np.zeros((NUM_ENVS, bkd.model.nu), dtype=np.float64))
+
+        base_start = 6 * bkd._base_body_id
+        push_start = 6 * mujoco.mj_name2id(bkd.model, mujoco.mjtObj.mjOBJ_BODY, "torso_link")
+        xfrc = calls[0]["control"][:, 0, bkd.model.nu :]
+        np.testing.assert_allclose(xfrc[:, push_start : push_start + 3], sampled * limit[None, :])
+        np.testing.assert_allclose(xfrc[:, base_start : base_start + 3], 0.0)
+
     def test_set_state_body_iquat_randomization_only_affects_target_envs(self, bkd):
         pool = bkd._pool
         original = [pool.get_field(i, "body_iquat").copy() for i in range(NUM_ENVS)]


### PR DESCRIPTION
## Summary
- apply MuJoCo interval push through xfrc_applied instead of velocity injection
- add configurable push_body_name for selecting the target body/link at backend init
- document interval push configuration and cold-path constraints

## Tests
- make test-all
- uv run pytest tests/scripts/test_check_docs.py -q

Fixes #329