### PR TITLE
feat(dr): add reset gravity randomization

### DIFF
--- a/docs/users/zh_CN/06-domain-randomization.md
+++ b/docs/users/zh_CN/06-domain-randomization.md
@@ -11,15 +11,15 @@
 三条路径对应三类生命周期：
 
 - **init-lifecycle DR**：改变模型身份或模型几何的项，只能在 env/backend 初始化与 materialization 阶段生效，例如 Sharpa-hand 的 object `geom_size` 缩放。
-- **reset-lifecycle DR**：不改变模型身份、只改变同一个模型内参数或 reset 状态的项，例如 `base_mass_delta`、`base_com_offset`、`kp`、`kd`。
+- **reset-lifecycle DR**：不改变模型身份、只改变同一个模型内参数或 reset 状态的项，例如 `base_mass_delta`、`base_com_offset`、`gravity`、`kp`、`kd`。
 - **interval-lifecycle DR**：step 间的外部扰动，例如 push。
 
 ## 现状结论
 
 1. 当前已接入 DR provider 的任务全部使用统一 DR 入口，没有任务绕开 `DomainRandomizationManager` 直接在 `reset()` 里做另一套 DR 流程。
 2. 形式上基本都是结构化的：任务文件内定义 `domain_rand` 配置 dataclass、`DomainRandomizationProvider`、`ResetPlan`，`G1WalkFlat` 复用 `G1Walk` 的 provider。
-3. 现在“统一”的主要是入口和执行流程，不是所有随机项本身。公共 helper [`build_common_reset_randomization()`](../../../src/unilab/dr/dr_utils.py) 目前生成 `base_mass_delta`、`base_com_offset`、`kp`、`kd`；公共 interval helper 目前只生成 push。
-4. [`ResetRandomizationPayload`](../../../src/unilab/dr/types.py) 已经能表达 `body_iquat`、`body_inertia`、`kp`、`kd`，且 [`MuJoCoBackend`](../../../src/unilab/base/backend/mujoco_backend.py) 已声明支持。是否真正使用这些项，仍取决于任务 provider 是否采样并下发。
+3. 现在“统一”的主要是入口和执行流程，不是所有随机项本身。公共 helper [`build_common_reset_randomization()`](../../../src/unilab/dr/dr_utils.py) 目前生成 `base_mass_delta`、`base_com_offset`、`gravity`、`kp`、`kd`；公共 interval helper 目前只生成 push。
+4. [`ResetRandomizationPayload`](../../../src/unilab/dr/types.py) 已经能表达 `gravity`、`body_iquat`、`body_inertia`、`kp`、`kd`，且 [`MuJoCoBackend`](../../../src/unilab/base/backend/mujoco_backend.py) 已声明支持。是否真正使用这些项，仍取决于任务 provider 是否采样并下发。
 5. [`MotrixBackend`](../../../src/unilab/base/backend/motrix_backend.py) 当前支持 `base_mass_delta`、`base_com_offset`、`kp`、`kd` 和 interval push；并在初始化阶段要求模型 actuator 全部为 position actuator。
 6. `geom_size` 不属于 reset-lifecycle 字段；Sharpa-hand object geom scale 通过 init-lifecycle 的 model materialization 完成。
 
@@ -30,9 +30,9 @@
 | `Go1JoystickFlat` | 是 | 是：`Domain_Rand + Provider + ResetPlan` | 任务状态采样 + common payload | push | [`go1/joystick.py`](../../../src/unilab/envs/locomotion/go1/joystick.py) |
 | `Go2JoystickFlat` | 是 | 是：`Domain_Rand + Provider + ResetPlan` | 任务状态采样 + common payload | push | [`go2/joystick.py`](../../../src/unilab/envs/locomotion/go2/joystick.py) |
 | `G1WalkFlat` | 是 | 是：`Domain_Rand + Provider + ResetPlan` | 任务状态采样 + common payload | push | [`g1/joystick.py`](../../../src/unilab/envs/locomotion/g1/joystick.py) |
-| `G1WalkFlat` | 是 | 是：复用 [`G1WalkDomainRandomizationProvider`](../../../src/unilab/envs/locomotion/g1/joystick.py) | 任务状态采样 + common payload | push | [`g1/joystick.py`](../../../src/unilab/envs/locomotion/g1/joystick.py) |
+| `G1WalkRough` | 是 | 是：复用 [`G1WalkDomainRandomizationProvider`](../../../src/unilab/envs/locomotion/g1/joystick.py) | 任务状态采样 + common payload | push | [`g1/joystick.py`](../../../src/unilab/envs/locomotion/g1/joystick.py) |
 | `G1MotionTracking` | 是 | 是：`Domain_Rand + Provider + ResetPlan` | 大量任务特有 reset 采样 + common payload | push | [`motion_tracking/g1/tracking.py`](../../../src/unilab/envs/motion_tracking/g1/tracking.py) |
-| `AllegroInhandRotation` | 是 | 是：`DomainRandConfig + Provider + ResetPlan` | 纯任务特有 reset 采样，`randomization=None` | 无 | [`inhand_rot_allegro/rotation.py`](../../../src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py) |
+| `AllegroInhandRotation` | 是 | 是：`DomainRandConfig + Provider + ResetPlan` | 任务特有 reset 采样 + common payload | 无 | [`inhand_rot_allegro/rotation.py`](../../../src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py) |
 | `SharpaInhandRotation` | 是 | 是：`InitRandomizationPlan + ResetPlan` | grasp cache 采样 + common payload | 无 | [`sharpa_inhand/rotation.py`](../../../src/unilab/envs/manipulation/sharpa_inhand/rotation.py) |
 | `SharpaInhandRotationGrasp` | 是 | 是：复用 Sharpa rotation provider 并覆盖 reset 采样 | grasp collection reset + common payload | 无 | [`sharpa_inhand/grasp_gen.py`](../../../src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py) |
 
@@ -40,15 +40,14 @@
 
 | 任务 | 当前实现的 reset 域随机 | 当前实现的 interval 域随机 | 默认状态 |
 | --- | --- | --- | --- |
-| `Go1JoystickFlat` | base xy；base yaw；base qvel；command 采样；`current_actions/last_actions` 清零；可选 `base_mass_delta`；可选 `base_com_offset` | `push_robots` | 默认开启 `base_mass_delta`、`base_com_offset`、push |
-| `Go2JoystickFlat` | base xy；base yaw；base qvel；command 采样；`current_actions/last_actions` 清零；kp/kd 随机化（默认开启）；可选 `base_mass_delta`；可选 `base_com_offset` | `push_robots` | kp/kd 默认开启；common payload 和 push 默认关闭 |
-| `G1WalkFlat` | base xy；base yaw；按 `reset_base_qvel_limit` 采样 base qvel；command 采样；`gait_phase` 采样；`current_actions/last_actions` 清零；kp/kd 随机化（默认开启）；可选 `base_mass_delta`；可选 `base_com_offset` | `push_robots` | kp/kd 默认开启；common payload 和 push 默认关闭 |
+| `Go1JoystickFlat` | base xy；base yaw；base qvel；command 采样；`current_actions/last_actions` 清零；可选 `base_mass_delta`；可选 `base_com_offset`；可选 `gravity` | `push_robots` | 默认开启 `base_mass_delta`、`base_com_offset`、push；`gravity` 默认关闭 |
+| `Go2JoystickFlat` | base xy；base yaw；base qvel；command 采样；`current_actions/last_actions` 清零；kp/kd 随机化（默认开启）；可选 `base_mass_delta`；可选 `base_com_offset`；可选 `gravity` | `push_robots` | kp/kd 默认开启；common payload 和 push 默认关闭 |
+| `G1WalkFlat` | base xy；base yaw；按 `reset_base_qvel_limit` 采样 base qvel；command 采样；`gait_phase` 采样；`current_actions/last_actions` 清零；kp/kd 随机化（默认开启）；可选 `base_mass_delta`；可选 `base_com_offset`；可选 `gravity` | `push_robots` | kp/kd 默认开启；common payload 和 push 默认关闭 |
 | `G1WalkRough` | 与 `G1WalkFlat` 相同，直接复用同一个 provider | `push_robots` | kp/kd 默认开启；common payload 和 push 默认关闭 |
-| `G1MotionTracking` | motion frame 采样；root pose 扰动 `x/y/z/roll/pitch/yaw`；root velocity 扰动 `x/y/z/roll/pitch/yaw`；joint position noise；MuJoCo 下按 joint range clip；`current_actions/last_actions` 清零；可选 `base_mass_delta`；可选 `base_com_offset` | `push_robots` | `pose_randomization`、`velocity_randomization`、`joint_position_range` 默认有非零扰动；common payload 和 push 默认关闭 |
-| `AllegroInhandRotation` | 若有 grasp cache 则随机采样 grasp；否则对 hand joints 加 `joint_noise`、对球加 `ball_z_offset`；始终对球线速度加 `ball_vel_noise`；下发 common reset randomization payload | 无 | grasp cache 路径可用时默认会采样；`joint_noise`、`ball_vel_noise`、`ball_z_offset` 默认 0 |
-
-| `SharpaInhandRotation` | grasp cache 按 `scale_ids` 分桶采样；object pose / quat reset | 无 | `scale_range` 默认 `[0.5, 0.5, 1]`，MuJoCo 下会在 init 阶段 materialize object geom scale |
-| `SharpaInhandRotationGrasp` | hand pose reset；object pose / quat reset；采集成功 grasp 并按 `scale_ids` 分桶保存；可选 `base_mass_delta`；可选 `base_com_offset` | 无 | 默认用于生成 Sharpa grasp cache，cache 文件名包含 `scale_range` tag |
+| `G1MotionTracking` | motion frame 采样；root pose 扰动 `x/y/z/roll/pitch/yaw`；root velocity 扰动 `x/y/z/roll/pitch/yaw`；joint position noise；MuJoCo 下按 joint range clip；`current_actions/last_actions` 清零；可选 `base_mass_delta`；可选 `base_com_offset`；可选 `gravity` | `push_robots` | `pose_randomization`、`velocity_randomization`、`joint_position_range` 默认有非零扰动；common payload 和 push 默认关闭 |
+| `AllegroInhandRotation` | 若有 grasp cache 则随机采样 grasp；否则对 hand joints 加 `joint_noise`、对球加 `ball_z_offset`；始终对球线速度加 `ball_vel_noise`；可选 common reset randomization payload（含 `gravity`） | 无 | grasp cache 路径可用时默认会采样；`joint_noise`、`ball_vel_noise`、`ball_z_offset` 默认 0；common payload 默认关闭 |
+| `SharpaInhandRotation` | grasp cache 按 `scale_ids` 分桶采样；object pose / quat reset；可选 common reset randomization payload（含 `gravity`） | 无 | `scale_range` 默认 `[0.5, 0.5, 1]`，MuJoCo 下会在 init 阶段 materialize object geom scale；common payload 默认关闭 |
+| `SharpaInhandRotationGrasp` | hand pose reset；object pose / quat reset；采集成功 grasp 并按 `scale_ids` 分桶保存；可选 `base_mass_delta`；可选 `base_com_offset`；可选 `gravity` | 无 | 默认用于生成 Sharpa grasp cache，cache 文件名包含 `scale_range` tag；common payload 默认关闭 |
 
 ## 当前统一 DR 能力与边界
 
@@ -66,7 +65,7 @@
 
 [`dr_utils.py`](../../../src/unilab/dr/dr_utils.py) 当前只有两类公共 helper：
 
-- reset common payload：`base_mass_delta`、`base_com_offset`、`kp`、`kd`
+- reset common payload：`base_mass_delta`、`base_com_offset`、`gravity`、`kp`、`kd`
 - interval common payload：push
 
 这意味着：
@@ -84,6 +83,7 @@
 
 - `base_mass_delta`
 - `base_com_offset`
+- `gravity`
 - `body_iquat`
 - `body_inertia`
 - `kp`
@@ -91,10 +91,62 @@
 
 backend capability 当前是：
 
-- [`MuJoCoBackend`](../../../src/unilab/base/backend/mujoco_backend.py)：支持上面 6 个 reset term，且支持 interval push
+- [`MuJoCoBackend`](../../../src/unilab/base/backend/mujoco_backend.py)：支持上面 7 个 reset term，且支持 interval push
 - [`MotrixBackend`](../../../src/unilab/base/backend/motrix_backend.py)：支持 `base_mass_delta`、`base_com_offset`、`kp`、`kd`，且支持 interval push；初始化阶段要求 actuator 全为 position
 
 但任务侧当前实际情况是：并不是所有 provider 都构造这些字段。backend contract 是能力边界，任务配置和 provider 是否下发 payload 才决定该任务是否实际启用对应 DR 项。
+
+## Reset gravity 用法
+
+`gravity` 是 reset-lifecycle DR：每次 reset 时按 env 子集采样一个完整的 MuJoCo gravity 向量 `(gx, gy, gz)`，并通过 `ResetRandomizationPayload.gravity` 下发给 backend。该向量同时表达方向和大小：
+
+- 方向：由 `(gx, gy, gz)` 的方向决定。
+- 大小：由向量范数 `sqrt(gx^2 + gy^2 + gz^2)` 决定。
+- 生命周期：只在 reset 时采样和写入；同一个 env 会保持该 gravity，直到下一次 reset 重新采样。
+- backend：当前 UniLab 只声明 MuJoCo backend 支持该 reset term；Motrix backend 不支持，部分任务会按 capability 过滤跳过，部分任务会在 validate 阶段报错。
+
+配置入口在各任务的 `env.domain_rand`：
+
+```yaml
+env:
+  domain_rand:
+    randomize_gravity: true
+    gravity_range:
+      - [-0.2, -0.2, -10.5]
+      - [0.2, 0.2, -8.5]
+```
+
+字段语义：
+
+- `randomize_gravity`：是否启用 gravity reset DR，默认 `false`。
+- `gravity_range`：形状为 `(2, 3)` 的逐维采样区间；第一行和第二行分别给出每个分量的上下界。
+- 每次 reset 时会在 `[min(row0, row1), max(row0, row1)]` 内逐维均匀采样，不会自动归一化方向，也不会固定 gravity 模长。
+
+如果只想随机化大小、保持竖直向下方向，可以只放开 `z` 分量：
+
+```bash
+uv run python scripts/train_rsl_rl.py \
+  task=g1_walk_flat/mujoco \
+  env.domain_rand.randomize_gravity=true \
+  'env.domain_rand.gravity_range=[[0.0,0.0,-10.5],[0.0,0.0,-8.5]]'
+```
+
+如果想同时随机化方向和大小，可以放开 `x/y/z` 分量：
+
+```bash
+uv run python scripts/train_rsl_rl.py \
+  task=g1_walk_flat/mujoco \
+  env.domain_rand.randomize_gravity=true \
+  'env.domain_rand.gravity_range=[[-0.3,-0.3,-10.5],[0.3,0.3,-8.5]]'
+```
+
+注意：
+
+- `gravity_range` 必须能转成 `(2, 3)` 数组；否则 reset 构造 payload 时会报错。
+- 该项不调用 `mj_setConst`；MuJoCo step / forward 会直接读取 `mjModel.opt.gravity`。
+- 不要在 Motrix backend 下开启该项；当前 Motrix capability 不包含 `gravity`。
+- 如果当前环境仍安装不包含 `gravity` 字段的 `mujoco-uni` 包，MuJoCo reset 会报 unsupported field；需要使用包含该字段的 `mujoco-uni` 构建/发布版本。
+- 训练时建议从小范围倾斜开始，避免一开始采到过大水平重力导致任务退化为不可学习。
 
 ## Interval push 用法
 
@@ -253,11 +305,15 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 - `body_iquat`
 - `body_inertia`
 - `dof_armature`
+- `gravity`
 - `geom_friction`
 - `kp`
 - `kd`
 
-注意：即使使用 `mujoco-uni==3.6.0.post6`，`geom_size` 仍然不在 reset randomization 的 `SUPPORTED_FIELDS` 里；它在 UniLab 中通过 init-lifecycle model materialization 表达。
+注意：
+
+- `geom_size` 不在 reset randomization 的 `SUPPORTED_FIELDS` 里；它在 UniLab 中通过 init-lifecycle model materialization 表达。
+- 如果当前环境仍安装 `mujoco-uni==3.6.0.post6`，则 `gravity` 也不在发布包的 `SUPPORTED_FIELDS` 里；需要使用包含 gravity reset randomization 的本地构建或后续发布版本。
 
 ### 2. 当前整块替换方式
 
@@ -280,6 +336,7 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 - `body_iquat`: `4 * nbody`
 - `body_inertia`: `3 * nbody`
 - `dof_armature`: `nv`
+- `gravity`: `3`
 - `geom_friction`: `3 * ngeom`
 - `kp`: `nu`
 - `kd`: `nu`
@@ -291,6 +348,7 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 - `body_iquat`: `(len(env_ids), 4 * nbody)`
 - `body_inertia`: `(len(env_ids), 3 * nbody)`
 - `dof_armature`: `(len(env_ids), nv)`
+- `gravity`: `(len(env_ids), 3)`
 - `geom_friction`: `(len(env_ids), 3 * ngeom)`
 - `kp`: `(len(env_ids), nu)`
 - `kd`: `(len(env_ids), nu)`
@@ -311,7 +369,7 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 
 返回语义当前是稳定的：
 
-- `body_ipos` / `body_inertia` / `geom_friction`
+- `body_ipos` / `body_inertia` / `gravity` / `geom_friction`
   - 单索引返回 `(3,)`
   - 多索引返回 `(k, 3)`
 - `body_iquat`
@@ -320,6 +378,8 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 - `body_mass` / `dof_armature` / `kp` / `kd`
   - 单索引返回标量
   - 多索引返回 `(k,)`
+
+`gravity` 只有一个逻辑索引 `0`，因此索引读取通常只用于读取整条 gravity 向量。
 
 ### 4. 当前局部写入方式
 
@@ -336,7 +396,7 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 
 当前 setter 语义是：
 
-- `body_ipos` / `body_inertia` / `geom_friction`
+- `body_ipos` / `body_inertia` / `gravity` / `geom_friction`
   - 单索引写入要求 `value.shape == (3,)`
   - 多索引写入要求 `value.shape == (k, 3)`
 - `body_iquat`
@@ -345,6 +405,8 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 - `body_mass` / `dof_armature` / `kp` / `kd`
   - 单索引写入要求 `value` 为标量
   - 多索引写入要求 `value.shape == (k,)`
+
+`gravity` 的索引写入同样只应使用逻辑索引 `0`；常规 reset DR 更推荐通过整块 payload `gravity: (len(env_ids), 3)` 下发。
 
 因此现在有两种使用方式：
 
@@ -356,7 +418,7 @@ uv run python scripts/train_rsl_rl.py task=sharpa_inhand/mujoco 'env.scale_range
 另外，当前底层对 refresh 的处理也已经固定：
 
 - `body_mass`、`body_ipos`、`body_iquat`、`body_inertia`、`dof_armature` 会触发 `mj_setConst` refresh
-- `geom_friction`、`kp`、`kd` 不触发 refresh
+- `gravity`、`geom_friction`、`kp`、`kd` 不触发 refresh
 
 因此，当前 MuJoCo `BatchEnvPool` 的 reset-lifecycle randomization 接口可以概括为：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     "torch==2.7.0",
-    "mujoco-uni==3.6.0.post6",
+    "mujoco-uni==3.6.0.post8",
     "gymnasium",
     "imageio",
     "etils",

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -15,6 +15,7 @@ from unilab.dr.types import (
     RESET_TERM_BASE_MASS,
     RESET_TERM_BODY_INERTIA,
     RESET_TERM_BODY_IQUAT,
+    RESET_TERM_GRAVITY,
     RESET_TERM_KD,
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
@@ -527,6 +528,7 @@ class MuJoCoBackend(SimBackend):
                 {
                     RESET_TERM_BASE_MASS,
                     RESET_TERM_BASE_COM,
+                    RESET_TERM_GRAVITY,
                     RESET_TERM_BODY_IQUAT,
                     RESET_TERM_BODY_INERTIA,
                     RESET_TERM_KP,
@@ -698,6 +700,14 @@ class MuJoCoBackend(SimBackend):
             ).copy()
             body_ipos[:, self._base_body_id, :] += np.asarray(randomization.base_com_offset)
             translated["body_ipos"] = body_ipos.reshape(num_reset, -1)
+
+        if randomization.gravity is not None:
+            translated["gravity"] = self._coerce_reset_field(
+                randomization.gravity,
+                name="gravity",
+                num_reset=num_reset,
+                shaped_tail=(3,),
+            )
 
         if randomization.body_iquat is not None:
             translated["body_iquat"] = self._coerce_reset_field(

--- a/src/unilab/dr/dr_utils.py
+++ b/src/unilab/dr/dr_utils.py
@@ -38,6 +38,16 @@ def build_common_reset_randomization(
         base_com_offset[:, 0] = np.random.uniform(low, high, size=(num_reset,))
         payload.base_com_offset = base_com_offset
 
+    if getattr(domain_rand, "randomize_gravity", False):
+        gravity_range = np.asarray(domain_rand.gravity_range, dtype=np.float64)
+        if gravity_range.shape != (2, 3):
+            raise ValueError(
+                f"domain_rand.gravity_range must have shape (2, 3), got {gravity_range.shape}"
+            )
+        low = np.minimum(gravity_range[0], gravity_range[1])
+        high = np.maximum(gravity_range[0], gravity_range[1])
+        payload.gravity = np.random.uniform(low=low, high=high, size=(num_reset, 3))
+
     num_actuators = getattr(env, "_num_action", None)
     need_kp = num_actuators is not None and getattr(domain_rand, "randomize_kp", False)
     need_kd = num_actuators is not None and getattr(domain_rand, "randomize_kd", False)

--- a/src/unilab/dr/types.py
+++ b/src/unilab/dr/types.py
@@ -8,6 +8,7 @@ import numpy as np
 
 RESET_TERM_BASE_COM = "base_com_offset"
 RESET_TERM_BASE_MASS = "base_mass_delta"
+RESET_TERM_GRAVITY = "gravity"
 RESET_TERM_BODY_IQUAT = "body_iquat"
 RESET_TERM_BODY_INERTIA = "body_inertia"
 RESET_TERM_KP = "kp"
@@ -53,6 +54,7 @@ class DomainRandomizationCapabilities:
             base_com_offset=(
                 payload.base_com_offset if self.supports_reset_term(RESET_TERM_BASE_COM) else None
             ),
+            gravity=payload.gravity if self.supports_reset_term(RESET_TERM_GRAVITY) else None,
             body_iquat=(
                 payload.body_iquat if self.supports_reset_term(RESET_TERM_BODY_IQUAT) else None
             ),
@@ -69,6 +71,7 @@ class DomainRandomizationCapabilities:
 class ResetRandomizationPayload:
     base_mass_delta: np.ndarray | None = None
     base_com_offset: np.ndarray | None = None
+    gravity: np.ndarray | None = None
     body_iquat: np.ndarray | None = None
     body_inertia: np.ndarray | None = None
     kp: np.ndarray | None = None
@@ -80,6 +83,8 @@ class ResetRandomizationPayload:
             terms.add(RESET_TERM_BASE_MASS)
         if self.base_com_offset is not None:
             terms.add(RESET_TERM_BASE_COM)
+        if self.gravity is not None:
+            terms.add(RESET_TERM_GRAVITY)
         if self.body_iquat is not None:
             terms.add(RESET_TERM_BODY_IQUAT)
         if self.body_inertia is not None:

--- a/src/unilab/envs/locomotion/common/domain_rand.py
+++ b/src/unilab/envs/locomotion/common/domain_rand.py
@@ -11,6 +11,11 @@ class DomainRandConfig:
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
 
+    randomize_gravity: bool = False
+    gravity_range: list[list[float]] = field(
+        default_factory=lambda: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    )
+
     push_robots: bool = False
     push_interval: int = 750  # step
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/rotation.py
@@ -82,6 +82,10 @@ class DomainRandConfig:
     added_mass_range: list[float] = field(default_factory=lambda: [0.0, 0.0])
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    randomize_gravity: bool = False
+    gravity_range: list[list[float]] = field(
+        default_factory=lambda: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    )
     push_robots: bool = False
     push_interval: int = 750
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -93,6 +93,10 @@ class SharpaDomainRandConfig:
     added_mass_range: list[float] = field(default_factory=lambda: [0.0, 0.0])
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    randomize_gravity: bool = False
+    gravity_range: list[list[float]] = field(
+        default_factory=lambda: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    )
     push_body_name: str | None = None
 
 

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -105,6 +105,11 @@ class Domain_Rand:
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
 
+    randomize_gravity: bool = False
+    gravity_range: list[list[float]] = field(
+        default_factory=lambda: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    )
+
     push_robots: bool = False
     push_interval: int = 750
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])

--- a/tests/base/test_mujoco_batch_env_randomization.py
+++ b/tests/base/test_mujoco_batch_env_randomization.py
@@ -23,6 +23,7 @@ mj: Any = mujoco
 EXPECTED_SUPPORTED_FIELDS = {
     "body_mass",
     "body_ipos",
+    "gravity",
     "body_iquat",
     "body_inertia",
     "dof_armature",
@@ -96,6 +97,13 @@ def test_batch_env_reset_applies_body_ipos_randomization(pool_ctx: _PoolCtx) -> 
     updated = pool_ctx.pool.get_field(1, "body_ipos").reshape(pool_ctx.model.nbody, 3).copy()
     updated[1] += np.array([0.01, -0.02, 0.03], dtype=np.float64)
     _reset_and_assert_field_applied(pool_ctx, "body_ipos", updated.reshape(-1))
+
+
+@pytest.mark.slow
+def test_batch_env_reset_applies_gravity_randomization(pool_ctx: _PoolCtx) -> None:
+    updated = pool_ctx.pool.get_field(1, "gravity").copy()
+    updated += np.array([0.2, -0.1, 0.4], dtype=np.float64)
+    _reset_and_assert_field_applied(pool_ctx, "gravity", updated)
 
 
 @pytest.mark.slow

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -223,6 +223,7 @@ class TestMuJoCoBasic:
         assert {
             "base_mass_delta",
             "base_com_offset",
+            "gravity",
             "body_iquat",
             "body_inertia",
             "kp",
@@ -356,6 +357,24 @@ class TestMuJoCoBasic:
         np.testing.assert_allclose(
             pool.get_field(1, "body_iquat").reshape(bkd.model.nbody, 4), updated
         )
+
+    def test_set_state_gravity_randomization_only_affects_target_envs(self, bkd):
+        pool = bkd._pool
+        original = [pool.get_field(i, "gravity").copy() for i in range(NUM_ENVS)]
+        qpos = _identity_qpos_mujoco(bkd.model.nq)
+        qvel = np.zeros((1, bkd.model.nv))
+        updated = original[1].copy()
+        updated += np.array([0.2, -0.1, 0.4], dtype=np.float64)
+
+        bkd.set_state(
+            np.array([1]),
+            qpos,
+            qvel,
+            randomization=ResetRandomizationPayload(gravity=updated[None, :]),
+        )
+
+        np.testing.assert_array_equal(pool.get_field(0, "gravity"), original[0])
+        np.testing.assert_allclose(pool.get_field(1, "gravity"), updated)
 
     def test_set_state_body_inertia_randomization_only_affects_target_envs(self, bkd):
         pool = bkd._pool

--- a/tests/dr/test_manager.py
+++ b/tests/dr/test_manager.py
@@ -14,7 +14,8 @@ from unilab.dr import (
     ResetPlan,
     ResetRandomizationPayload,
 )
-from unilab.dr.types import RESET_TERM_BASE_MASS, RESET_TERM_KP
+from unilab.dr.dr_utils import build_common_reset_randomization
+from unilab.dr.types import RESET_TERM_BASE_MASS, RESET_TERM_GRAVITY, RESET_TERM_KP
 
 
 def test_capabilities_filter_reset_payload_drops_unsupported_terms():
@@ -23,16 +24,42 @@ def test_capabilities_filter_reset_payload_drops_unsupported_terms():
     )
     payload = ResetRandomizationPayload(
         base_mass_delta=np.array([0.25]),
+        gravity=np.array([[0.0, 0.0, -3.71]]),
         kp=np.array([[12.0, 12.0]]),
     )
 
     filtered, unsupported = capabilities.filter_reset_payload(payload)
 
-    assert unsupported == frozenset({RESET_TERM_KP})
+    assert unsupported == frozenset({RESET_TERM_GRAVITY, RESET_TERM_KP})
     assert filtered is not None
     assert filtered.base_mass_delta is not None
     np.testing.assert_allclose(filtered.base_mass_delta, np.array([0.25]))
+    assert filtered.gravity is None
     assert filtered.kp is None
+
+
+def test_build_common_reset_randomization_samples_gravity_vector():
+    env = SimpleNamespace(
+        cfg=SimpleNamespace(
+            domain_rand=SimpleNamespace(
+                randomize_gravity=True,
+                gravity_range=[[-1.0, -2.0, -10.5], [1.0, 2.0, -8.5]],
+            )
+        )
+    )
+
+    payload = build_common_reset_randomization(env, num_reset=8)
+
+    assert payload is not None
+    assert payload.gravity is not None
+    assert payload.gravity.shape == (8, 3)
+    assert payload.requested_terms() == frozenset({RESET_TERM_GRAVITY})
+    assert np.all(payload.gravity[:, 0] >= -1.0)
+    assert np.all(payload.gravity[:, 0] <= 1.0)
+    assert np.all(payload.gravity[:, 1] >= -2.0)
+    assert np.all(payload.gravity[:, 1] <= 2.0)
+    assert np.all(payload.gravity[:, 2] >= -10.5)
+    assert np.all(payload.gravity[:, 2] <= -8.5)
 
 
 @dataclass

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -114,6 +114,7 @@ def test_g1_walk_flat_cfg_has_domain_rand_for_motrix():
     assert hasattr(cfg, "reset_base_qvel_limit")
     assert cfg.domain_rand.randomize_base_mass is False
     assert cfg.domain_rand.random_com is False
+    assert cfg.domain_rand.randomize_gravity is False
     assert cfg.domain_rand.push_robots is False
 
 
@@ -371,6 +372,7 @@ def test_g1_motion_tracking_cfg_has_domain_rand_for_motrix():
     assert hasattr(cfg, "domain_rand")
     assert cfg.domain_rand.randomize_base_mass is False
     assert cfg.domain_rand.random_com is False
+    assert cfg.domain_rand.randomize_gravity is False
     assert cfg.domain_rand.push_robots is False
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2181,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-uni"
-version = "3.6.0.post6"
+version = "3.6.0.post8"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2192,16 +2192,16 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/9f/10/bf0713a791bc1df7855278645b20ae1ff95620383c263184cc7f4063eec9/mujoco_uni-3.6.0.post6.tar.gz", hash = "sha256:2fe8e11086a6c92d79dc22545447a98b339638fd5837199de8cc341e7fa0caf5", size = 3834700, upload-time = "2026-04-16T18:05:52.442Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/4d/d1/cc312dd6b19c2fe3851686bbdc680f328679d33354aea12b57aae93b872e/mujoco_uni-3.6.0.post8.tar.gz", hash = "sha256:6e5b047e500fcd9655444b12e91633737051d7875ec44812a929326e30e790f9", size = 3837378, upload-time = "2026-04-22T17:47:37.858195Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/4e/60/b098a8923da570436842f8cfab790f624f7ce9ae43e07ccd75f02ecfa254/mujoco_uni-3.6.0.post6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01fe4650398055c89adaab41cc2477d1495f8281302db51ce35c7bd75c90a277", size = 6794578, upload-time = "2026-04-16T18:18:33.648Z" },
-    { url = "https://test-files.pythonhosted.org/packages/1f/4b/f1e3f0158d2faef60b0c51bbc0a9e7b308069014f3d9ed8fc7864b0a4210/mujoco_uni-3.6.0.post6-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:b0d4cfaa5c6c7cc55a57d06553b12abafa8e8190a0f5ab042c40625e5960f47a", size = 6588523, upload-time = "2026-04-16T18:05:37.869Z" },
-    { url = "https://test-files.pythonhosted.org/packages/9b/0a/51c89a8e09dc74fe7525c9be4357b5bd021d6cf032dc1781fdeeb2ac8320/mujoco_uni-3.6.0.post6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:88031f06f75b6385f95d9841b8f06c6d99472f17007f65e40f921da768d9002f", size = 6808231, upload-time = "2026-04-16T18:18:37.216Z" },
-    { url = "https://test-files.pythonhosted.org/packages/93/90/20dcf3b3e167dba6b1c87193a4004ad8a089c4fb71bcd359e72b26c8cfd5/mujoco_uni-3.6.0.post6-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:e9e0443b1f36f83d20e51b057d4e0790b7455ea41c23e509d13bf9d635b15ff4", size = 6600041, upload-time = "2026-04-16T18:05:41.875Z" },
-    { url = "https://test-files.pythonhosted.org/packages/28/b9/c2df4eadc5e54a7f5be19d2e770669cf9e37a7fdd614c4c6bd0d71186300/mujoco_uni-3.6.0.post6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1d50c5997e1886d9ec008c1196ad6716bf77704af890d60f370c9803e21a0d3", size = 6829619, upload-time = "2026-04-16T18:18:40.191Z" },
-    { url = "https://test-files.pythonhosted.org/packages/b4/cd/6610a1bb839b3ca2981dc7fba77feb6b43de9a95b18751dc5fdbb149306a/mujoco_uni-3.6.0.post6-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe44d72de5f99ce9c14d2f292b039696b1aa418ac3bf2f4359e390f8b734d7ea", size = 6627167, upload-time = "2026-04-16T18:05:45.404Z" },
-    { url = "https://test-files.pythonhosted.org/packages/74/1d/49c882825369a63305f405c269a65538e81f5f76798627aa9792d75cf119/mujoco_uni-3.6.0.post6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e4b9b6de5c556fa5219e53bbc0f17816ae043e72ca0e26dbf5d0308eb85f36a", size = 6829999, upload-time = "2026-04-16T18:18:44.164Z" },
-    { url = "https://test-files.pythonhosted.org/packages/9d/26/e61ae9a0ef57830875f12510ed5ab5a4435fd8fdd125ca9a079d8c2d44d3/mujoco_uni-3.6.0.post6-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:ce7d31571d1d51843ff51afca496340af92e67e698446f998a50af70cb798c41", size = 6627741, upload-time = "2026-04-16T18:05:48.738Z" },
+    { url = "https://test-files.pythonhosted.org/packages/e3/26/8d9f8dfc215d06681a535fbd258332c93f99c30e480152f3a04ea8c79f5e/mujoco_uni-3.6.0.post8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3cfb2602f76717c17408a1f8ac0172d2b41dc440c135862bc961f5db83aa4648", size = 6889274, upload-time = "2026-04-22T17:47:27.683614Z" },
+    { url = "https://test-files.pythonhosted.org/packages/ba/e8/403f7b7dc7a9bf384e16c0b0f8188acdd79d8ff126a6c63ec02bd9adb7d8/mujoco_uni-3.6.0.post8-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:b36df7d96dbaa6583b680c5655d19c2be1c6a6520945543b7e39b1dc5c9a013c", size = 6740386, upload-time = "2026-04-22T17:47:12.854593Z" },
+    { url = "https://test-files.pythonhosted.org/packages/f3/dd/32d3845e4f0cbd41f11f85a64337406aa60d52691cd44731bcf79fc8e61d/mujoco_uni-3.6.0.post8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5dd35cf9343abd0b782d54ffda1ee5373f0f144f1fea01ff4959a554b0a9d06", size = 6903717, upload-time = "2026-04-22T17:47:35.836937Z" },
+    { url = "https://test-files.pythonhosted.org/packages/04/c2/aa39005111014c81de4317d775e687ce478bb49de61ba7638c0df8ef2f74/mujoco_uni-3.6.0.post8-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9f1e088a530c1021cd9201c706a553d4e6eecf27aa952888e0d91ab2ad0c4728", size = 6754879, upload-time = "2026-04-22T17:47:20.352342Z" },
+    { url = "https://test-files.pythonhosted.org/packages/b0/63/9e174f39f3c2e22bc079eba9411e8c84b3a0f75ca9ef9ded4b0d7f6cf894/mujoco_uni-3.6.0.post8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5aa988b48cd5b5e3ec330dd7d93b567c45530b0f6a05c1f06b83978d4842f785", size = 6919697, upload-time = "2026-04-22T17:47:43.574308Z" },
+    { url = "https://test-files.pythonhosted.org/packages/d5/22/8b7924c9fa85268a125b6ae58ecf3ee8668059db937fe25f9beddc35c2ee/mujoco_uni-3.6.0.post8-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:378b77ee387a40f1bd1849c2859f40b4ab5be7a36e1a530645d589582b10ba4d", size = 6771000, upload-time = "2026-04-22T17:47:27.063030Z" },
+    { url = "https://test-files.pythonhosted.org/packages/b6/0b/e09c3b5b481629f6c2c12c8bd08658d6c96f719b326c03d7f77380ab4a8c/mujoco_uni-3.6.0.post8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c81305588fd83d91e986ce0ce36db6c98f8903320e919d0e6d4a512ebe80f3de", size = 6920283, upload-time = "2026-04-22T17:47:51.332454Z" },
+    { url = "https://test-files.pythonhosted.org/packages/72/38/0912ccb75a8d5899e04ada5d975ad41e5d66c08b4fc918fc453f9ebabca6/mujoco_uni-3.6.0.post8-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:57e08fecb3850d64699b75bd7f5a61170977b984e58632cca326b93dc84a04c9", size = 6771859, upload-time = "2026-04-22T17:47:33.562718Z" },
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev96425", index = "https://pypi.motphys.com/simple/" },
-    { name = "mujoco-uni", specifier = "==3.6.0.post6", index = "https://test.pypi.org/simple/" },
+    { name = "mujoco-uni", specifier = "==3.6.0.post8", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },
     { name = "onnxruntime", specifier = ">=1.24.3" },


### PR DESCRIPTION
## Summary
- add reset-lifecycle gravity domain randomization to UniLab MuJoCo tasks
- upgrade `mujoco-uni` to `3.6.0.post8` and sync `uv.lock`
- document gravity DR usage and validate with targeted tests plus `make test-all`

Fixes #330