### PR TITLE
refactor: use MjSpec for tracking sensor injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These are example repository runs for documented commands and hardware setups. T
 
 ```bash
 # Linux SAC (5.5min on RTX 4090 and R9-9950x3d)
-uv run scripts/train_offpolicy.py algo=sac task=sac/g1_walk_flat/motrix
+uv run scripts/train_offpolicy.py algo=sac task=sac/g1_walk_flat/mujoco
 ```
 
 ```bash

--- a/docs/developers/zh_CN/CONTRIBUTING.md
+++ b/docs/developers/zh_CN/CONTRIBUTING.md
@@ -68,14 +68,14 @@ tests/
 
 ### Test Markers
 
-- 普通测试（无标记）: 不依赖 MuJoCo，使用 `make test`
-- `@pytest.mark.slow`: 需要 MuJoCo 环境或完整训练迭代的测试，CI 会跳过，本地用 `make test-slow`
+- 普通测试（无标记）: 快速 unit / contract / env smoke，使用 `make test`
+- `@pytest.mark.slow`: 完整训练/脚本冒烟，或累计耗时明显更高的 backend matrix，CI 会跳过，本地用 `make test-slow`
 - macOS only: `test_mlx_ppo.py` 使用 `pytest.importorskip("mlx")`，在非 macOS 平台自动跳过
 
 ### Test Writing Principles
 
-1. IPC 或纯计算逻辑: 放在 `tests/ipc/` 或对应模块测试目录，不加 `slow`
-2. 依赖 Runner 或真实 Env 的测试: 放在 `tests/algos/`，并加 `@pytest.mark.slow`
+1. IPC、纯计算逻辑、快速 env/backend contract: 放在对应目录，不加 `slow`
+2. 完整训练迭代、训练脚本启动、或累计成本高的 backend matrix: 加 `@pytest.mark.slow`
 3. 训练脚本冒烟测试: 放在 `tests/scripts/`，对可选依赖使用 `pytest.importorskip`
 4. 多进程测试使用 `_SPAWN_CTX = mp.get_context("spawn")`
 5. 单进程 `SharedObsNormStats` 测试使用 `_ThreadingCtx`，因为 `multiprocessing.Queue.empty()` 在同进程内不可靠

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     "torch==2.7.0",
-    "mujoco-uni==3.6.0.post8",
+    "mujoco-uni==3.7.0rc0",
     "gymnasium",
     "imageio",
     "etils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ exclude = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [
-    "slow: requires real env or long-running processes",
+    "slow: long-running training or script smoke tests, or cumulatively expensive backend matrices",
 ]
 addopts = "--tb=short -m 'not slow'"
 

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -5,6 +5,7 @@ from .motrix_backend import MOTRIX_AVAILABLE, MotrixBackend
 from .xml import (
     add_sensor,
     create_discardvisual_xml,
+    create_motrix_compatible_xml,
     get_named_body_ids,
     inject_motrix_tracking_sensors,
     inject_mujoco_tracking_sensors,
@@ -60,6 +61,7 @@ __all__ = [
     "MotrixBackend",
     "add_sensor",
     "create_discardvisual_xml",
+    "create_motrix_compatible_xml",
     "create_backend",
     "get_named_body_ids",
     "inject_motrix_tracking_sensors",

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -73,7 +73,13 @@ class MotrixBackend(SimBackend):
                 if (idx := self._model.get_link_index(name)) is not None
             }
         else:
-            self._model = mtx.load_model(model_file)  # pyright: ignore[reportPossiblyUnbound]
+            from unilab.base.backend.xml import create_motrix_compatible_xml
+
+            tmp_path = create_motrix_compatible_xml(model_file)
+            try:
+                self._model = mtx.load_model(tmp_path)  # pyright: ignore[reportPossiblyUnbound]
+            finally:
+                os.remove(tmp_path)
 
             # 枚举所有具名 link，用 link index 作 key
             self._body_id_to_name = {  # type: ignore[assignment]

--- a/src/unilab/base/backend/xml.py
+++ b/src/unilab/base/backend/xml.py
@@ -165,6 +165,25 @@ def _write_temp_xml(tree: ET.ElementTree[ET.Element], model_file: str) -> str:  
     return output_path
 
 
+def _normalize_motrix_texture_colorspaces(tree: ET.ElementTree[ET.Element]) -> None:  # type: ignore[type-arg]
+    """Rewrite MuJoCo's implicit/auto texture colorspaces to Motrix-supported values."""
+    root = tree.getroot()
+    for texture in root.findall(".//texture"):
+        colorspace = texture.get("colorspace")
+        if colorspace is None:
+            texture.set("colorspace", "sRGB")
+            continue
+        if colorspace != "auto":
+            continue
+        texture.set("colorspace", "sRGB")
+
+
+def create_motrix_compatible_xml(model_file: str) -> str:
+    tree = ET.parse(model_file)
+    _normalize_motrix_texture_colorspaces(tree)
+    return _write_temp_xml(tree, model_file)
+
+
 def _format_values(values: list[float] | tuple[float, ...]) -> str:
     return " ".join(str(float(value)) for value in values)
 
@@ -242,13 +261,52 @@ def inject_motrix_tracking_sensors(model_file: str, baselink_name: str) -> tuple
     Returns:
         (tmp_xml_path, tracked_body_ids, valid_bnames)
     """
-    mujoco = _mujoco_module()
     tracked_body_ids, valid_bnames = _get_named_bodies(model_file)
+    tree = ET.parse(model_file)
+    _normalize_motrix_texture_colorspaces(tree)
+    root = tree.getroot()
+    for bname in valid_bnames:
+        add_sensor(
+            root,
+            "framepos",
+            f"track_pos_b_{bname}",
+            objtype="xbody",
+            objname=bname,
+            reftype="xbody",
+            refname=baselink_name,
+        )
+    for bname in valid_bnames:
+        add_sensor(
+            root,
+            "framequat",
+            f"track_quat_b_{bname}",
+            objtype="xbody",
+            objname=bname,
+            reftype="xbody",
+            refname=baselink_name,
+        )
+    for bname in valid_bnames:
+        add_sensor(
+            root,
+            "framelinvel",
+            f"track_linvel_b_{bname}",
+            objtype="xbody",
+            objname=bname,
+            reftype="xbody",
+            refname=baselink_name,
+        )
+    for bname in valid_bnames:
+        add_sensor(
+            root,
+            "frameangvel",
+            f"track_angvel_b_{bname}",
+            objtype="xbody",
+            objname=bname,
+            reftype="xbody",
+            refname=baselink_name,
+        )
 
-    spec = mujoco.MjSpec.from_file(model_file)
-    _add_b_sensors(spec, valid_bnames, baselink_name)
-
-    return _materialize_spec_xml(spec, model_file), tracked_body_ids, valid_bnames
+    return _write_temp_xml(tree, model_file), tracked_body_ids, valid_bnames
 
 
 def processed_xml(xml_path):

--- a/src/unilab/base/backend/xml.py
+++ b/src/unilab/base/backend/xml.py
@@ -5,6 +5,7 @@ import tempfile
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import Any, cast
 
 
 def _enable_discardvisual(root: ET.Element) -> None:
@@ -64,72 +65,93 @@ def get_named_body_ids(model_file: str, names: Sequence[str]) -> list[int]:
     return [body_id_by_name[name] for name in names]
 
 
-def _add_w_sensors(sensor_tag: ET.Element, valid_bnames: list[str]) -> None:
+def _mujoco_module() -> Any:
+    import mujoco
+
+    return cast(Any, mujoco)
+
+
+def _materialize_spec_xml(spec, model_file: str) -> str:
+    fd, output_path = tempfile.mkstemp(
+        suffix=".xml", dir=os.path.dirname(os.path.abspath(model_file))
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(spec.to_xml())
+    except Exception:
+        os.close(fd)
+        raise
+    return output_path
+
+
+def _add_w_sensors(spec, valid_bnames: list[str]) -> None:
+    mujoco = _mujoco_module()
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag, "framepos", name=f"track_pos_w_{bname}", objtype="xbody", objname=bname
+        spec.add_sensor(
+            name=f"track_pos_w_{bname}",
+            type=mujoco.mjtSensor.mjSENS_FRAMEPOS,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
+            objname=bname,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag, "framequat", name=f"track_quat_w_{bname}", objtype="xbody", objname=bname
+        spec.add_sensor(
+            name=f"track_quat_w_{bname}",
+            type=mujoco.mjtSensor.mjSENS_FRAMEQUAT,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
+            objname=bname,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "framelinvel",
+        spec.add_sensor(
             name=f"track_linvel_w_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMELINVEL,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "frameangvel",
+        spec.add_sensor(
             name=f"track_angvel_w_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMEANGVEL,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
         )
 
 
-def _add_b_sensors(sensor_tag: ET.Element, valid_bnames: list[str], baselink_name: str) -> None:
+def _add_b_sensors(spec, valid_bnames: list[str], baselink_name: str) -> None:
+    mujoco = _mujoco_module()
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "framepos",
+        spec.add_sensor(
             name=f"track_pos_b_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMEPOS,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
-            reftype="xbody",
+            reftype=mujoco.mjtObj.mjOBJ_XBODY,
             refname=baselink_name,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "framequat",
+        spec.add_sensor(
             name=f"track_quat_b_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMEQUAT,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
-            reftype="xbody",
+            reftype=mujoco.mjtObj.mjOBJ_XBODY,
             refname=baselink_name,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "framelinvel",
+        spec.add_sensor(
             name=f"track_linvel_b_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMELINVEL,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
-            reftype="xbody",
+            reftype=mujoco.mjtObj.mjOBJ_XBODY,
             refname=baselink_name,
         )
     for bname in valid_bnames:
-        ET.SubElement(
-            sensor_tag,
-            "frameangvel",
+        spec.add_sensor(
             name=f"track_angvel_b_{bname}",
-            objtype="xbody",
+            type=mujoco.mjtSensor.mjSENS_FRAMEANGVEL,
+            objtype=mujoco.mjtObj.mjOBJ_XBODY,
             objname=bname,
-            reftype="xbody",
+            reftype=mujoco.mjtObj.mjOBJ_XBODY,
             refname=baselink_name,
         )
 
@@ -200,19 +222,15 @@ def inject_mujoco_tracking_sensors(
     Returns:
         (tmp_xml_path, tracked_body_ids, valid_bnames)
     """
+    mujoco = _mujoco_module()
     tracked_body_ids, valid_bnames = _get_named_bodies(model_file)
 
-    tree = ET.parse(model_file)
-    root = tree.getroot()
-    sensor_tag = root.find("sensor")
-    if sensor_tag is None:
-        sensor_tag = ET.SubElement(root, "sensor")
-
-    _add_w_sensors(sensor_tag, valid_bnames)
+    spec = mujoco.MjSpec.from_file(model_file)
+    _add_w_sensors(spec, valid_bnames)
     if baselink_name and baselink_name in valid_bnames:
-        _add_b_sensors(sensor_tag, valid_bnames, baselink_name)
+        _add_b_sensors(spec, valid_bnames, baselink_name)
 
-    return _write_temp_xml(tree, model_file), tracked_body_ids, valid_bnames
+    return _materialize_spec_xml(spec, model_file), tracked_body_ids, valid_bnames
 
 
 def inject_motrix_tracking_sensors(model_file: str, baselink_name: str) -> tuple[str, list, list]:
@@ -224,17 +242,13 @@ def inject_motrix_tracking_sensors(model_file: str, baselink_name: str) -> tuple
     Returns:
         (tmp_xml_path, tracked_body_ids, valid_bnames)
     """
+    mujoco = _mujoco_module()
     tracked_body_ids, valid_bnames = _get_named_bodies(model_file)
 
-    tree = ET.parse(model_file)
-    root = tree.getroot()
-    sensor_tag = root.find("sensor")
-    if sensor_tag is None:
-        sensor_tag = ET.SubElement(root, "sensor")
+    spec = mujoco.MjSpec.from_file(model_file)
+    _add_b_sensors(spec, valid_bnames, baselink_name)
 
-    _add_b_sensors(sensor_tag, valid_bnames, baselink_name)
-
-    return _write_temp_xml(tree, model_file), tracked_body_ids, valid_bnames
+    return _materialize_spec_xml(spec, model_file), tracked_body_ids, valid_bnames
 
 
 def processed_xml(xml_path):

--- a/tests/base/test_mujoco_batch_env_randomization.py
+++ b/tests/base/test_mujoco_batch_env_randomization.py
@@ -80,33 +80,28 @@ def _reset_and_assert_field_applied(
     np.testing.assert_allclose(pool_ctx.pool.get_field(1, field_name), updated)
 
 
-@pytest.mark.slow
 def test_batch_env_supported_fields_match_documented_reset_randomization_fields() -> None:
     assert set(SUPPORTED_FIELDS) == EXPECTED_SUPPORTED_FIELDS
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_body_mass_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "body_mass").copy()
     updated[1] += 0.25
     _reset_and_assert_field_applied(pool_ctx, "body_mass", updated)
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_body_ipos_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "body_ipos").reshape(pool_ctx.model.nbody, 3).copy()
     updated[1] += np.array([0.01, -0.02, 0.03], dtype=np.float64)
     _reset_and_assert_field_applied(pool_ctx, "body_ipos", updated.reshape(-1))
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_gravity_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "gravity").copy()
     updated += np.array([0.2, -0.1, 0.4], dtype=np.float64)
     _reset_and_assert_field_applied(pool_ctx, "gravity", updated)
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_body_iquat_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "body_iquat").reshape(pool_ctx.model.nbody, 4).copy()
     quat = np.array([0.92387953, 0.0, 0.38268343, 0.0], dtype=np.float64)
@@ -114,35 +109,30 @@ def test_batch_env_reset_applies_body_iquat_randomization(pool_ctx: _PoolCtx) ->
     _reset_and_assert_field_applied(pool_ctx, "body_iquat", updated.reshape(-1))
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_body_inertia_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "body_inertia").reshape(pool_ctx.model.nbody, 3).copy()
     updated[1] *= 1.25
     _reset_and_assert_field_applied(pool_ctx, "body_inertia", updated.reshape(-1))
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_dof_armature_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "dof_armature").copy()
     updated += np.linspace(0.01, 0.03, updated.size, dtype=np.float64)
     _reset_and_assert_field_applied(pool_ctx, "dof_armature", updated)
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_geom_friction_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "geom_friction").reshape(pool_ctx.model.ngeom, 3).copy()
     updated[0] += np.array([0.1, 0.002, 0.0002], dtype=np.float64)
     _reset_and_assert_field_applied(pool_ctx, "geom_friction", updated.reshape(-1))
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_kp_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "kp").copy()
     updated += 1.25
     _reset_and_assert_field_applied(pool_ctx, "kp", updated)
 
 
-@pytest.mark.slow
 def test_batch_env_reset_applies_kd_randomization(pool_ctx: _PoolCtx) -> None:
     updated = pool_ctx.pool.get_field(1, "kd").copy()
     updated += 0.25

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -1,7 +1,7 @@
-"""Tests for SimBackend implementations (MuJoCo and MotrixSim).
+"""Slow full-matrix tests for SimBackend implementations.
 
-All tests are @pytest.mark.slow — they require MuJoCo (and optionally
-motrixsim) to be installed, and are excluded from the default CI run.
+Fast representative backend smoke coverage lives in `test_sim_backend_smoke.py`.
+This file keeps the broader backend matrix outside the default CI lane.
 
 Run with:
     uv run pytest -m slow tests/base/test_sim_backend.py -v
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.xml import get_named_body_ids
 from unilab.dr import (
     GeomSizeOverride,
     InitRandomizationPlan,
@@ -114,12 +113,6 @@ class TestMuJoCoBasic:
     def test_num_envs(self, bkd):
         assert bkd.num_envs == NUM_ENVS
 
-    def test_model_not_none(self, bkd):
-        assert bkd.model is not None
-
-    def test_pool_materialized_by_lifecycle(self, bkd):
-        assert bkd._pool is not None
-
     def test_apply_init_randomization_sets_variants_before_materialization(self):
         from unilab.base.backend.mujoco_backend import MuJoCoBackend
 
@@ -184,16 +177,6 @@ class TestMuJoCoBasic:
 
     # simulation control
 
-    def test_step(self, bkd):
-        bkd.step(np.zeros((NUM_ENVS, bkd.model.nu)), nsteps=2)
-
-    def test_set_state_moves_base(self, bkd):
-        nq, nv = bkd.model.nq, bkd.model.nv
-        target = (1.0, 2.0, 0.8)
-        qpos = _identity_qpos_mujoco(nq, xyz=target)
-        bkd.set_state(np.array([0]), qpos, np.zeros((1, nv)))
-        np.testing.assert_allclose(bkd.get_base_pos()[0], target, atol=1e-5)
-
     def test_set_state_only_affects_target_envs(self, bkd):
         nq, nv = bkd.model.nq, bkd.model.nv
         pos_before = bkd.get_base_pos()[1].copy()
@@ -217,19 +200,6 @@ class TestMuJoCoBasic:
         np.testing.assert_allclose(updated[:base_body_id], original[1][:base_body_id])
         np.testing.assert_allclose(updated[base_body_id], original[1][base_body_id] + delta[0])
         np.testing.assert_allclose(updated[base_body_id + 1 :], original[1][base_body_id + 1 :])
-
-    def test_get_dr_capabilities_include_extended_reset_terms(self, bkd):
-        caps = bkd.get_dr_capabilities()
-        assert {
-            "base_mass_delta",
-            "base_com_offset",
-            "gravity",
-            "body_iquat",
-            "body_inertia",
-            "kp",
-            "kd",
-        }.issubset(caps.supported_reset_terms)
-        assert caps.supports_interval_push
 
     def test_apply_interval_randomization_calls_push_robots(self, bkd):
         called: dict[str, np.ndarray] = {}
@@ -466,37 +436,6 @@ def test_mujoco_backend_discards_visual_assets():
 
 
 @pytest.mark.slow
-def test_mujoco_backend_fixed_base_dof_views_do_not_skip_first_joint():
-    mujoco = _mujoco_module()
-
-    from unilab.base.backend.mujoco_backend import MuJoCoBackend
-
-    model_file = _xml("allegro_hand", "scene.xml")
-    bkd = MuJoCoBackend(model_file, NUM_ENVS, SIM_DT, base_name="palm")
-    assert int(bkd.model.jnt_type[0]) != int(mujoco.mjtJoint.mjJNT_FREE)
-    _shape(bkd.get_dof_pos(), NUM_ENVS, bkd.model.nq)
-    _shape(bkd.get_dof_vel(), NUM_ENVS, bkd.model.nv)
-    _shape(bkd.get_base_pos(), NUM_ENVS, 3)
-    _shape(bkd.get_base_quat(), NUM_ENVS, 4)
-    np.testing.assert_allclose(bkd.get_base_lin_vel(), 0.0, atol=1e-8)
-    np.testing.assert_allclose(bkd.get_base_ang_vel(), 0.0, atol=1e-8)
-    _unit_quat(bkd.get_base_quat(), "MuJoCo fixed-base quat")
-
-
-@pytest.mark.slow
-def test_motrix_backend_fixed_base_base_views_are_available():
-    from unilab.base.backend.motrix_backend import MotrixBackend
-
-    pytest.importorskip("motrixsim")
-    bkd = MotrixBackend(_ALLEGRO["model_file"], NUM_ENVS, SIM_DT, base_name=_ALLEGRO["base_name"])
-    _shape(bkd.get_base_pos(), NUM_ENVS, 3)
-    _shape(bkd.get_base_quat(), NUM_ENVS, 4)
-    np.testing.assert_allclose(bkd.get_base_lin_vel(), 0.0, atol=1e-8)
-    np.testing.assert_allclose(bkd.get_base_ang_vel(), 0.0, atol=1e-8)
-    _unit_quat(bkd.get_base_quat(), "Motrix fixed-base quat")
-
-
-@pytest.mark.slow
 def test_motrix_backend_fixed_base_set_state_matches_mujoco_for_hand_and_ball():
     from unilab.base.backend.motrix_backend import MotrixBackend
     from unilab.base.backend.mujoco_backend import MuJoCoBackend
@@ -688,27 +627,6 @@ class TestMotrixBasic:
     def test_num_envs(self, bkd):
         assert bkd.num_envs == NUM_ENVS
 
-    def test_model_not_none(self, bkd):
-        assert bkd.model is not None
-
-    def test_data_not_none(self, bkd):
-        assert bkd.data is not None
-
-    # simulation control
-
-    def test_step(self, bkd):
-        ctrl = np.zeros_like(bkd.data.actuator_ctrls)
-        bkd.step(ctrl, nsteps=2)
-
-    def test_set_state_moves_base(self, _ctx):
-        bkd, _ = _ctx
-        nq = bkd.get_dof_pos().shape[-1] + 7  # 7 base DOFs + joint DOFs
-        nv = bkd.get_dof_vel().shape[-1] + 6  # joint vels + base (3 lin + 3 ang)
-        target = (1.0, 2.0, 0.8)
-        qpos = _identity_qpos_mujoco(nq, xyz=target)
-        bkd.set_state(np.array([0]), qpos, np.zeros((1, nv)))
-        np.testing.assert_allclose(bkd.get_base_pos()[0], target, atol=1e-4)
-
     def test_set_state_randomization_only_affects_target_envs(self, _ctx):
         bkd, _ = _ctx
         nq = bkd.get_dof_pos().shape[-1] + 7
@@ -818,13 +736,6 @@ class TestMotrixBasic:
                 qvel,
                 randomization=ResetRandomizationPayload(body_inertia=np.zeros((1, 1, 3))),
             )
-
-    def test_get_dr_capabilities_include_expected_terms(self, bkd):
-        caps = bkd.get_dr_capabilities()
-        assert {"base_mass_delta", "base_com_offset", "kp", "kd"}.issubset(
-            caps.supported_reset_terms
-        )
-        assert caps.supports_interval_push
 
     def test_apply_interval_randomization_calls_push_robots(self, bkd):
         called: dict[str, np.ndarray] = {}
@@ -995,14 +906,6 @@ class TestCrossBackend:
         return mj, mx, p["base_name"]
 
     # --- base kinematics ---
-
-    def test_base_pos(self, synced):
-        mj, mx, _ = synced
-        np.testing.assert_allclose(mj.get_base_pos(), mx.get_base_pos(), atol=self.ATOL)
-
-    def test_base_quat(self, synced):
-        mj, mx, _ = synced
-        np.testing.assert_allclose(mj.get_base_quat(), mx.get_base_quat(), atol=self.ATOL)
 
     def test_base_lin_vel(self, synced):
         mj, mx, _ = synced
@@ -1310,10 +1213,6 @@ class TestCrossBackendModelProperties:
         mx = MotrixBackend(_G1["model_file"], NUM_ENVS, SIM_DT, base_name=_G1["base_name"])
         return mj, mx
 
-    def test_num_actuators_match(self, backends):
-        mj, mx = backends
-        assert mj.num_actuators == mx.num_actuators
-
     def test_num_dof_vel_match(self, backends):
         mj, mx = backends
         assert mj.num_dof_vel == mx.num_dof_vel
@@ -1321,10 +1220,3 @@ class TestCrossBackendModelProperties:
     def test_actuator_ctrl_range_shape_match(self, backends):
         mj, mx = backends
         assert mj.get_actuator_ctrl_range().shape == mx.get_actuator_ctrl_range().shape
-
-    def test_motion_body_ids_match_motion_xml(self, backends):
-        mj, mx = backends
-        body_names = ["pelvis", "torso_link"]
-        expected = np.asarray(get_named_body_ids(_G1["model_file"], body_names), dtype=np.int32)
-        np.testing.assert_array_equal(mj.get_motion_body_ids(body_names), expected)
-        np.testing.assert_array_equal(mx.get_motion_body_ids(body_names), expected)

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -1,0 +1,234 @@
+"""Fast smoke tests for representative SimBackend contracts.
+
+These tests stay in the default lane to cover the owner-layer backend
+contract without running the full backend matrix in `test_sim_backend.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.xml import get_named_body_ids
+
+pytest.importorskip("mujoco", reason="mujoco not installed")
+
+
+def _xml(robot: str, scene: str = "scene_flat.xml") -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / robot / scene)
+
+
+BASIC_ROBOTS = [
+    pytest.param(dict(model_file=_xml("g1"), base_name="pelvis"), id="g1"),
+    pytest.param(dict(model_file=_xml("go1"), base_name="trunk"), id="go1"),
+    pytest.param(dict(model_file=_xml("go2"), base_name="base"), id="go2"),
+]
+
+_G1 = dict(model_file=_xml("g1"), base_name="pelvis")
+_ALLEGRO = dict(model_file=_xml("allegro_hand", "scene.xml"), base_name="palm")
+
+NUM_ENVS = 2
+SIM_DT = 0.005
+_CROSS_BACKEND_ATOL = 2e-3
+
+
+def _shape(arr: np.ndarray, *expected: int) -> None:
+    assert arr.shape == expected, f"expected shape {expected}, got {arr.shape}"
+
+
+def _mujoco_module() -> Any:
+    import mujoco
+
+    return cast(Any, mujoco)
+
+
+def _unit_quat(q: np.ndarray, tag: str = "") -> None:
+    np.testing.assert_allclose(
+        np.linalg.norm(q, axis=-1),
+        1.0,
+        atol=1e-5,
+        err_msg=f"quaternion not unit — {tag}",
+    )
+
+
+def _identity_qpos_mujoco(nq: int, xyz=(0.0, 0.0, 0.8)) -> np.ndarray:
+    q = np.zeros((1, nq))
+    q[0, :3] = xyz
+    q[0, 3] = 1.0
+    return q
+
+
+def _mujoco_expected_dof_dims(model) -> tuple[int, int]:
+    mujoco = _mujoco_module()
+
+    if model.njnt > 0 and int(model.jnt_type[0]) == int(mujoco.mjtJoint.mjJNT_FREE):
+        return model.nq - 7, model.nv - 6
+    return model.nq, model.nv
+
+
+@pytest.mark.parametrize("robot", BASIC_ROBOTS)
+def test_mujoco_backend_smoke_contract(robot):
+    from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(robot["model_file"], NUM_ENVS, SIM_DT, base_name=robot["base_name"])
+    bkd.materialize()
+
+    assert bkd.num_envs == NUM_ENVS
+    assert bkd.model is not None
+    assert bkd._pool is not None
+
+    bkd.step(np.zeros((NUM_ENVS, bkd.model.nu)), nsteps=2)
+
+    qpos = _identity_qpos_mujoco(bkd.model.nq, xyz=(1.0, 2.0, 0.8))
+    bkd.set_state(np.array([0]), qpos, np.zeros((1, bkd.model.nv)))
+    np.testing.assert_allclose(bkd.get_base_pos()[0], (1.0, 2.0, 0.8), atol=1e-5)
+    _unit_quat(bkd.get_base_quat(), "MuJoCo smoke")
+
+    caps = bkd.get_dr_capabilities()
+    assert {
+        "base_mass_delta",
+        "base_com_offset",
+        "gravity",
+        "body_iquat",
+        "body_inertia",
+        "kp",
+        "kd",
+    }.issubset(caps.supported_reset_terms)
+    assert caps.supports_interval_push
+
+
+def test_mujoco_backend_fixed_base_dof_views_do_not_skip_first_joint():
+    mujoco = _mujoco_module()
+
+    from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(_ALLEGRO["model_file"], NUM_ENVS, SIM_DT, base_name=_ALLEGRO["base_name"])
+    assert int(bkd.model.jnt_type[0]) != int(mujoco.mjtJoint.mjJNT_FREE)
+    _shape(bkd.get_dof_pos(), NUM_ENVS, bkd.model.nq)
+    _shape(bkd.get_dof_vel(), NUM_ENVS, bkd.model.nv)
+    _shape(bkd.get_base_pos(), NUM_ENVS, 3)
+    _shape(bkd.get_base_quat(), NUM_ENVS, 4)
+    np.testing.assert_allclose(bkd.get_base_lin_vel(), 0.0, atol=1e-8)
+    np.testing.assert_allclose(bkd.get_base_ang_vel(), 0.0, atol=1e-8)
+    _unit_quat(bkd.get_base_quat(), "MuJoCo fixed-base smoke")
+
+
+@pytest.mark.parametrize("robot", BASIC_ROBOTS)
+def test_motrix_backend_smoke_contract(robot):
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix_backend import MotrixBackend
+
+    bkd = MotrixBackend(robot["model_file"], NUM_ENVS, SIM_DT, base_name=robot["base_name"])
+
+    assert bkd.num_envs == NUM_ENVS
+    assert bkd.model is not None
+    assert bkd.data is not None
+
+    ctrl = np.zeros_like(bkd.data.actuator_ctrls)
+    bkd.step(ctrl, nsteps=2)
+
+    nq = bkd.get_dof_pos().shape[-1] + 7
+    nv = bkd.get_dof_vel().shape[-1] + 6
+    qpos = _identity_qpos_mujoco(nq, xyz=(1.0, 2.0, 0.8))
+    bkd.set_state(np.array([0]), qpos, np.zeros((1, nv)))
+    np.testing.assert_allclose(bkd.get_base_pos()[0], (1.0, 2.0, 0.8), atol=1e-4)
+    _unit_quat(bkd.get_base_quat(), "Motrix smoke")
+
+    caps = bkd.get_dr_capabilities()
+    assert {"base_mass_delta", "base_com_offset", "kp", "kd"}.issubset(caps.supported_reset_terms)
+    assert caps.supports_interval_push
+
+
+def test_motrix_backend_fixed_base_base_views_are_available():
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix_backend import MotrixBackend
+
+    bkd = MotrixBackend(_ALLEGRO["model_file"], NUM_ENVS, SIM_DT, base_name=_ALLEGRO["base_name"])
+    _shape(bkd.get_base_pos(), NUM_ENVS, 3)
+    _shape(bkd.get_base_quat(), NUM_ENVS, 4)
+    np.testing.assert_allclose(bkd.get_base_lin_vel(), 0.0, atol=1e-8)
+    np.testing.assert_allclose(bkd.get_base_ang_vel(), 0.0, atol=1e-8)
+    _unit_quat(bkd.get_base_quat(), "Motrix fixed-base smoke")
+
+
+@pytest.mark.parametrize(
+    "robot",
+    [
+        pytest.param(dict(model_file=_xml("g1"), base_name="pelvis"), id="g1"),
+        pytest.param(dict(model_file=_xml("go2"), base_name="base"), id="go2"),
+    ],
+)
+def test_cross_backend_base_pose_smoke(robot):
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix_backend import MotrixBackend
+    from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+    mj = MuJoCoBackend(robot["model_file"], NUM_ENVS, SIM_DT, base_name=robot["base_name"])
+    mj.materialize()
+    mx = MotrixBackend(robot["model_file"], NUM_ENVS, SIM_DT, base_name=robot["base_name"])
+
+    nq, nv = mj.model.nq, mj.model.nv
+    qpos = np.tile(_identity_qpos_mujoco(nq), (NUM_ENVS, 1))
+    qvel = np.zeros((NUM_ENVS, nv))
+    env_idx = np.arange(NUM_ENVS)
+    mj.set_state(env_idx, qpos, qvel)
+    mx.set_state(env_idx, qpos, qvel)
+
+    np.testing.assert_allclose(mj.get_base_pos(), mx.get_base_pos(), atol=_CROSS_BACKEND_ATOL)
+    np.testing.assert_allclose(
+        np.abs(mj.get_base_quat()),
+        np.abs(mx.get_base_quat()),
+        atol=_CROSS_BACKEND_ATOL,
+    )
+
+
+def test_cross_backend_model_properties_smoke():
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix_backend import MotrixBackend
+    from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+    mj = MuJoCoBackend(_G1["model_file"], NUM_ENVS, SIM_DT, base_name=_G1["base_name"])
+    mx = MotrixBackend(_G1["model_file"], NUM_ENVS, SIM_DT, base_name=_G1["base_name"])
+
+    assert mj.num_actuators == mx.num_actuators
+    assert mj.num_dof_vel == mx.num_dof_vel
+    assert mj.get_actuator_ctrl_range().shape == mx.get_actuator_ctrl_range().shape
+
+    body_names = ["pelvis", "torso_link"]
+    expected = np.asarray(get_named_body_ids(_G1["model_file"], body_names), dtype=np.int32)
+    np.testing.assert_array_equal(mj.get_motion_body_ids(body_names), expected)
+    np.testing.assert_array_equal(mx.get_motion_body_ids(body_names), expected)
+
+
+def test_mujoco_model_properties_smoke():
+    from unilab.base.backend.mujoco_backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(_G1["model_file"], NUM_ENVS, SIM_DT, base_name=_G1["base_name"])
+    assert bkd.num_actuators == bkd.model.nu
+    assert bkd.num_actuators > 0
+    assert bkd.num_dof_vel > 0
+    assert bkd.num_dof_vel <= bkd.model.nv
+    ctrl_range = bkd.get_actuator_ctrl_range()
+    _shape(ctrl_range, bkd.num_actuators, 2)
+    _, expected_nv = _mujoco_expected_dof_dims(bkd.model)
+    assert expected_nv >= bkd.num_dof_vel
+
+
+def test_motrix_model_properties_smoke():
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix_backend import MotrixBackend
+
+    bkd = MotrixBackend(_G1["model_file"], NUM_ENVS, SIM_DT, base_name=_G1["base_name"])
+    assert bkd.num_actuators > 0
+    assert bkd.num_dof_vel > 0
+    ctrl_range = bkd.get_actuator_ctrl_range()
+    _shape(ctrl_range, bkd.num_actuators, 2)
+    assert bkd.get_joint_range() is None

--- a/tests/envs/test_allegro_domain_randomization.py
+++ b/tests/envs/test_allegro_domain_randomization.py
@@ -17,7 +17,6 @@ except Exception:
 from unilab.base.registry import ensure_registries
 
 
-@pytest.mark.slow
 def test_allegro_mujoco_reset_applies_base_mass_and_com_domain_randomization(
     default_allegro_reward_config: dict[str, Any],
 ) -> None:

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -601,7 +601,7 @@ def test_g1_motion_tracking_clip_end_does_not_override_true_termination():
 
 
 # ---------------------------------------------------------------------------
-# Slow: env instantiation + reset + step (runs MuJoCo physics)
+# Fast env/backend smoke tests
 # ---------------------------------------------------------------------------
 
 # Environments that don't need special config overrides
@@ -615,7 +615,6 @@ _STANDARD_ENVS = [
 ]
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("env_name", _STANDARD_ENVS)
 def test_env_reset_and_step(
     env_name: str,
@@ -700,7 +699,6 @@ def _assert_mujoco_position_gains(
     np.testing.assert_allclose(pool.get_field(0, "kd")[actuator_ids], kd)
 
 
-@pytest.mark.slow
 def test_go1_env_initializes_kp_kd_into_pool(default_go1_reward_config):
     _require_mujoco_runtime()
     ensure_registries()
@@ -724,7 +722,6 @@ def test_go1_env_initializes_kp_kd_into_pool(default_go1_reward_config):
         env.close()
 
 
-@pytest.mark.slow
 def test_go2_env_initializes_kp_kd_into_pool():
     _require_mujoco_runtime()
     ensure_registries()
@@ -761,7 +758,6 @@ def test_go2_env_initializes_kp_kd_into_pool():
         env.close()
 
 
-@pytest.mark.slow
 def test_allegro_env_initializes_kp_kd_into_pool(default_allegro_reward_config):
     _require_mujoco_runtime()
     ensure_registries()
@@ -785,7 +781,6 @@ def test_allegro_env_initializes_kp_kd_into_pool(default_allegro_reward_config):
         env.close()
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("sim_backend", ["mujoco", "motrix"])
 def test_g1_motion_tracking_reset_and_step(sim_backend: str):
     """G1MotionTracking needs a motion_file — skip if not available."""
@@ -841,7 +836,6 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
         env.close()
 
 
-@pytest.mark.slow
 def test_go2_mujoco_reset_applies_kp_kd_domain_randomization(default_go2_reward_config):
     _require_mujoco_runtime()
     ensure_registries()

--- a/tests/envs/test_go1_domain_randomization.py
+++ b/tests/envs/test_go1_domain_randomization.py
@@ -17,7 +17,6 @@ except Exception:
 from unilab.base.registry import ensure_registries
 
 
-@pytest.mark.slow
 def test_go1_mujoco_reset_applies_base_mass_and_com_domain_randomization(
     default_go1_reward_config: dict[str, Any],
 ) -> None:

--- a/tests/integration/test_reward_injection_integration.py
+++ b/tests/integration/test_reward_injection_integration.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.slow
 def test_reward_injection_in_training():
     """Test reward config is properly injected during training."""
     from hydra import compose, initialize

--- a/tests/ipc/test_async_runner.py
+++ b/tests/ipc/test_async_runner.py
@@ -211,7 +211,6 @@ def test_start_collector_spawns_process():
     r.close()
 
 
-@pytest.mark.slow
 def test_start_collector_does_not_merge_runner_runtime_fields():
     r = _make_runner(sim_backend="motrix")
     report_queue = _SPAWN_CTX.Queue()

--- a/tests/utils/test_mjspec_sensor_compile.py
+++ b/tests/utils/test_mjspec_sensor_compile.py
@@ -1,0 +1,28 @@
+"""Minimal regression test for MjSpec sensor compile failure.
+
+See: https://github.com/google-deepmind/mujoco/issues/XXX
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_mjspec_sensor_compile() -> None:
+    """Adding a frame sensor via MjSpec should not crash to_xml/compile."""
+    mujoco = pytest.importorskip("mujoco")
+
+    spec = mujoco.MjSpec.from_string(
+        '<mujoco><worldbody><body name="pelvis"/></worldbody></mujoco>'
+    )
+    spec.add_sensor(
+        name="track_pos_w_pelvis",
+        type=mujoco.mjtSensor.mjSENS_FRAMEPOS,
+        objtype=mujoco.mjtObj.mjOBJ_BODY,
+        objname="pelvis",
+    )
+    # This should succeed but currently raises UnicodeDecodeError / ValueError
+    # in mujoco 3.6.0 due to a bug in MjSpec sensor serialization.
+    xml = spec.to_xml()
+    assert isinstance(xml, str)
+    assert "track_pos_w_pelvis" in xml

--- a/tests/utils/test_mjspec_sensor_compile.py
+++ b/tests/utils/test_mjspec_sensor_compile.py
@@ -12,9 +12,10 @@ def test_mjspec_sensor_compile() -> None:
     """Adding a frame sensor via MjSpec should not crash to_xml/compile."""
     mujoco = pytest.importorskip("mujoco")
 
-    spec = mujoco.MjSpec.from_string(
-        '<mujoco><worldbody><body name="pelvis"/></worldbody></mujoco>'
-    )
+    from unilab.assets import ASSETS_ROOT_PATH
+
+    model_file = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+    spec = mujoco.MjSpec.from_file(model_file)
     spec.add_sensor(
         name="track_pos_w_pelvis",
         type=mujoco.mjtSensor.mjSENS_FRAMEPOS,

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import os
 
 import pytest
-from unilab.base.backend import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
 
 from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
 
 
 def _g1_scene() -> str:

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import os
 
 import pytest
+from unilab.utils.xml_utils import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.utils.xml_utils import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
 
 
 def _g1_scene() -> str:

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -7,7 +7,11 @@ import os
 import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
+from unilab.base.backend import (
+    create_motrix_compatible_xml,
+    inject_motrix_tracking_sensors,
+    inject_mujoco_tracking_sensors,
+)
 
 
 def _g1_scene() -> str:
@@ -52,5 +56,16 @@ def test_inject_motrix_tracking_sensors_only_adds_baselink_relative_sensors() ->
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_linvel_b_pelvis") >= 0
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_angvel_b_pelvis") >= 0
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_pos_w_pelvis") == -1
+    finally:
+        os.remove(tmp_xml)
+
+
+def test_motrix_xml_materialization_rewrites_auto_texture_colorspace() -> None:
+    tmp_xml = create_motrix_compatible_xml(_g1_scene())
+    try:
+        with open(tmp_xml, encoding="utf-8") as f:
+            xml_text = f.read()
+        assert 'colorspace="auto"' not in xml_text
+        assert 'colorspace="sRGB"' in xml_text
     finally:
         os.remove(tmp_xml)

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 import pytest
-from unilab.utils.xml_utils import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
+from unilab.base.backend import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
 
 from unilab.assets import ASSETS_ROOT_PATH
 

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -1,0 +1,56 @@
+"""Tests for MuJoCo-backed XML editing helpers."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.utils.xml_utils import inject_motrix_tracking_sensors, inject_mujoco_tracking_sensors
+
+
+def _g1_scene() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+
+
+def test_inject_mujoco_tracking_sensors_uses_mjspec_and_preserves_contract() -> None:
+    mujoco = pytest.importorskip("mujoco")
+
+    tmp_xml, tracked_body_ids, valid_bnames = inject_mujoco_tracking_sensors(
+        _g1_scene(),
+        baselink_name="pelvis",
+    )
+    try:
+        assert tracked_body_ids == list(range(1, len(valid_bnames) + 1))
+        assert valid_bnames[0] == "pelvis"
+
+        model = mujoco.MjModel.from_xml_path(tmp_xml)
+        for sensor_name in (
+            "track_pos_w_pelvis",
+            "track_quat_w_pelvis",
+            "track_linvel_w_pelvis",
+            "track_angvel_w_pelvis",
+            "track_pos_b_pelvis",
+            "track_quat_b_pelvis",
+            "track_linvel_b_pelvis",
+            "track_angvel_b_pelvis",
+        ):
+            assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_name) >= 0
+    finally:
+        os.remove(tmp_xml)
+
+
+def test_inject_motrix_tracking_sensors_only_adds_baselink_relative_sensors() -> None:
+    mujoco = pytest.importorskip("mujoco")
+
+    tmp_xml, _, _ = inject_motrix_tracking_sensors(_g1_scene(), baselink_name="pelvis")
+    try:
+        model = mujoco.MjModel.from_xml_path(tmp_xml)
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_pos_b_pelvis") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_quat_b_pelvis") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_linvel_b_pelvis") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_angvel_b_pelvis") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "track_pos_w_pelvis") == -1
+    finally:
+        os.remove(tmp_xml)

--- a/uv.lock
+++ b/uv.lock
@@ -2181,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-uni"
-version = "3.6.0.post8"
+version = "3.7.0rc0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2192,16 +2192,16 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/4d/d1/cc312dd6b19c2fe3851686bbdc680f328679d33354aea12b57aae93b872e/mujoco_uni-3.6.0.post8.tar.gz", hash = "sha256:6e5b047e500fcd9655444b12e91633737051d7875ec44812a929326e30e790f9", size = 3837378, upload-time = "2026-04-22T17:47:37.858195Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/72/59/40f1a159a2161e9dce52760573c697aaf7d59e28e35504bb871311d109bf/mujoco_uni-3.7.0rc0.tar.gz", hash = "sha256:06aec65ccf581b4764644b49fc0643aa674cdb7020d1d41bbb5b9c8339a95f1c", size = 4764614, upload-time = "2026-04-26T04:06:34.757Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/e3/26/8d9f8dfc215d06681a535fbd258332c93f99c30e480152f3a04ea8c79f5e/mujoco_uni-3.6.0.post8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3cfb2602f76717c17408a1f8ac0172d2b41dc440c135862bc961f5db83aa4648", size = 6889274, upload-time = "2026-04-22T17:47:27.683614Z" },
-    { url = "https://test-files.pythonhosted.org/packages/ba/e8/403f7b7dc7a9bf384e16c0b0f8188acdd79d8ff126a6c63ec02bd9adb7d8/mujoco_uni-3.6.0.post8-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:b36df7d96dbaa6583b680c5655d19c2be1c6a6520945543b7e39b1dc5c9a013c", size = 6740386, upload-time = "2026-04-22T17:47:12.854593Z" },
-    { url = "https://test-files.pythonhosted.org/packages/f3/dd/32d3845e4f0cbd41f11f85a64337406aa60d52691cd44731bcf79fc8e61d/mujoco_uni-3.6.0.post8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a5dd35cf9343abd0b782d54ffda1ee5373f0f144f1fea01ff4959a554b0a9d06", size = 6903717, upload-time = "2026-04-22T17:47:35.836937Z" },
-    { url = "https://test-files.pythonhosted.org/packages/04/c2/aa39005111014c81de4317d775e687ce478bb49de61ba7638c0df8ef2f74/mujoco_uni-3.6.0.post8-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9f1e088a530c1021cd9201c706a553d4e6eecf27aa952888e0d91ab2ad0c4728", size = 6754879, upload-time = "2026-04-22T17:47:20.352342Z" },
-    { url = "https://test-files.pythonhosted.org/packages/b0/63/9e174f39f3c2e22bc079eba9411e8c84b3a0f75ca9ef9ded4b0d7f6cf894/mujoco_uni-3.6.0.post8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5aa988b48cd5b5e3ec330dd7d93b567c45530b0f6a05c1f06b83978d4842f785", size = 6919697, upload-time = "2026-04-22T17:47:43.574308Z" },
-    { url = "https://test-files.pythonhosted.org/packages/d5/22/8b7924c9fa85268a125b6ae58ecf3ee8668059db937fe25f9beddc35c2ee/mujoco_uni-3.6.0.post8-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:378b77ee387a40f1bd1849c2859f40b4ab5be7a36e1a530645d589582b10ba4d", size = 6771000, upload-time = "2026-04-22T17:47:27.063030Z" },
-    { url = "https://test-files.pythonhosted.org/packages/b6/0b/e09c3b5b481629f6c2c12c8bd08658d6c96f719b326c03d7f77380ab4a8c/mujoco_uni-3.6.0.post8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c81305588fd83d91e986ce0ce36db6c98f8903320e919d0e6d4a512ebe80f3de", size = 6920283, upload-time = "2026-04-22T17:47:51.332454Z" },
-    { url = "https://test-files.pythonhosted.org/packages/72/38/0912ccb75a8d5899e04ada5d975ad41e5d66c08b4fc918fc453f9ebabca6/mujoco_uni-3.6.0.post8-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:57e08fecb3850d64699b75bd7f5a61170977b984e58632cca326b93dc84a04c9", size = 6771859, upload-time = "2026-04-22T17:47:33.562718Z" },
+    { url = "https://test-files.pythonhosted.org/packages/46/ad/96cc59ed7219970a1dccb865bd0c0c76d7e508b8199dfe345e8262670056/mujoco_uni-3.7.0rc0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b29099826ed2d34b36a07303b2d35638752f81c3f1f6c791c9f68a289a2a400", size = 6968830, upload-time = "2026-04-26T04:06:11.385Z" },
+    { url = "https://test-files.pythonhosted.org/packages/e8/8c/d58d96a77a813cdf50ead2c31745745811e71ae88798340ce930689ee51c/mujoco_uni-3.7.0rc0-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:41823f3592b23eff8ac8f57e63c0c776bb6f2f0aba95c4d2ef1c06aef6a6a726", size = 10730028, upload-time = "2026-04-26T02:32:14.605Z" },
+    { url = "https://test-files.pythonhosted.org/packages/2b/bf/57f20b7faedd7bb491d93fc52b333066e4646361c6e1c9e0aa3a9cf8a5ee/mujoco_uni-3.7.0rc0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bf8010ec6c761fbb78e5dc9f23e8615ed5a3a4b846516aee5a47c3785f5d1", size = 6981334, upload-time = "2026-04-26T04:06:17.493Z" },
+    { url = "https://test-files.pythonhosted.org/packages/26/b8/142bdc59e6b5bf957c76da73de48c3d6031cf0f93781dcb9956e64ab2d3c/mujoco_uni-3.7.0rc0-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:0ad67ce5ccb3e7756bdcbeddadbb97a1a222115f31930bb8b2e01a4373f63a53", size = 10745168, upload-time = "2026-04-26T02:32:29.206Z" },
+    { url = "https://test-files.pythonhosted.org/packages/f6/40/be2b9b4e40ebb704abe9e4d759423c8d6c8b2f069a2b0aa1976905e0cd93/mujoco_uni-3.7.0rc0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:916907774fbadcf393ab588654e41085bb51176381d4d84c033f63943a973709", size = 6996772, upload-time = "2026-04-26T04:06:23.477Z" },
+    { url = "https://test-files.pythonhosted.org/packages/c9/92/66ed1f7b8a3e04e64f6fe2b33d45b43e616d12f6ac6a2d131224d30b9bef/mujoco_uni-3.7.0rc0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:9cfad2d20ac1212ae117ab62577b0bb1071161dd9b274cc3f6b2964fd407e16e", size = 10840883, upload-time = "2026-04-26T02:32:43.699Z" },
+    { url = "https://test-files.pythonhosted.org/packages/91/90/ef9705ca2c5bfff2bf25890a9a6a0643b96fd0522379af1cabc6d4a4a2a8/mujoco_uni-3.7.0rc0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee201a23236df4c48ef8ccd077b37a0c9a041c532ae851f11f12ec6aed4dff81", size = 6997212, upload-time = "2026-04-26T04:06:29.674Z" },
+    { url = "https://test-files.pythonhosted.org/packages/86/8f/84c78737b400a27e12762f07c422adae03d85cef13552a384a71f5231e94/mujoco_uni-3.7.0rc0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:43ab587bd1494f540822b1193f539c5190100c0f6dd209cbae6fcfe8068738c9", size = 10840745, upload-time = "2026-04-26T02:36:04.676Z" },
 ]
 
 [[package]]
@@ -4250,16 +4250,16 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b1f0cdd0720ad60536deb5baa427b782fd920dd4fcf72e244d32974caafa3b9e" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ac1849553ee673dfafb44c610c60cb60a2890f0e117f43599a526cf777eb8b8c" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:47c895bcab508769d129d717a4b916b10225ae3855723aeec8dff8efe5346207" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c4bbc0b4be60319ba1cefc90be9557b317f0b3c261eeceb96ca6e0343eec56bf" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6bba7dca5d9a729f1e8e9befb98055498e551efaf5ed034824c168b560afc1ac" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7c0f08d1c44a02abad389373dddfce75904b969a410be2f4e5109483dd3dc0ce" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:633f35e8b1b1f640ef5f8a98dbd84f19b548222ce7ba8f017fe47ce6badc106a" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d2f69f909da5dc52113ec66a851d62079f3d52c83184cf64beebdf12ca2f705c" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fa05ac6ebed4777de7a5eff398c1f17b697c02422516748ce66a8151873e5a0e" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:78e13c26c38ae92d6841cf9ce760d7e9d52bca3e3183de371812e84274b054dc" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b1f0cdd0720ad60536deb5baa427b782fd920dd4fcf72e244d32974caafa3b9e", upload-time = "2025-05-14T03:33:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ac1849553ee673dfafb44c610c60cb60a2890f0e117f43599a526cf777eb8b8c", upload-time = "2025-04-22T18:19:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:47c895bcab508769d129d717a4b916b10225ae3855723aeec8dff8efe5346207", upload-time = "2025-05-14T03:35:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c4bbc0b4be60319ba1cefc90be9557b317f0b3c261eeceb96ca6e0343eec56bf", upload-time = "2025-04-22T18:20:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6bba7dca5d9a729f1e8e9befb98055498e551efaf5ed034824c168b560afc1ac", upload-time = "2025-05-14T03:37:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7c0f08d1c44a02abad389373dddfce75904b969a410be2f4e5109483dd3dc0ce", upload-time = "2025-04-22T18:20:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:633f35e8b1b1f640ef5f8a98dbd84f19b548222ce7ba8f017fe47ce6badc106a", upload-time = "2025-05-14T03:39:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d2f69f909da5dc52113ec66a851d62079f3d52c83184cf64beebdf12ca2f705c", upload-time = "2025-04-22T18:21:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fa05ac6ebed4777de7a5eff398c1f17b697c02422516748ce66a8151873e5a0e", upload-time = "2025-05-14T03:40:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:78e13c26c38ae92d6841cf9ce760d7e9d52bca3e3183de371812e84274b054dc", upload-time = "2025-04-22T18:21:58Z" },
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev96425", index = "https://pypi.motphys.com/simple/" },
-    { name = "mujoco-uni", specifier = "==3.6.0.post8", index = "https://test.pypi.org/simple/" },
+    { name = "mujoco-uni", specifier = "==3.7.0rc0", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },
     { name = "onnxruntime", specifier = ">=1.24.3" },


### PR DESCRIPTION
## Summary
- replace tracking sensor injection ET edits with MuJoCo MjSpec APIs
- preserve MuJoCo and Motrix tracking sensor contracts and temp XML workflow
- add focused regression coverage for tracking sensor injection

Fixes #255