### PR TITLE
tune flashsac g1_walk_flat training hyperparameters and fix flashsac …

### DIFF
--- a/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
@@ -3,13 +3,14 @@ training:
   task_name: G1WalkFlat
   sim_backend: mujoco
 algo:
-  num_envs: 2048
+  num_envs: 3072
   learning_starts: 49
-  max_iterations: 6000
+  max_iterations: 5000
   save_interval: 1000
   updates_per_step: 8
   #use_symmetry: true
-  replay_buffer_n: 1024
+  replay_buffer_n: 1366
+  tau: 0.05
 env:
   control_config:
     action_scale: 1.0
@@ -37,8 +38,8 @@ reward:
     penalty_orientation: -10.0
     penalty_action_rate: -4.0
     pose: -0.8
-    penalty_feet_ori: -20.0
-    feet_phase: 5.0
+    penalty_feet_ori: -25.0
+    feet_phase: 6.0
     alive: 10.0
   tracking_sigma: 0.25
   base_height_target: 0.754
@@ -46,6 +47,6 @@ reward:
   max_tilt_deg: 65.0
   gait_frequency: 1.5
   feet_phase_swing_height: 0.09
-  feet_phase_tracking_sigma: 0.025
+  feet_phase_tracking_sigma: 0.02
   close_feet_threshold: 0.15
-  pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
+  pose_weights: [0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -376,27 +376,13 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
 
     # Export actor to ONNX
     if load_path_dir is not None:
-        import torch.nn as nn
-
         onnx_path = os.path.join(load_path_dir, "policy.onnx")
         dummy_input = torch.randn(1, obs_dim, device=device)
         with torch.inference_mode():
             if normalizer:
                 dummy_input = normalizer(dummy_input, update=False)
             if algo_name in ("sac", "flashsac"):
-                # SACActor.forward returns (action, mean, log_std); wrap to output deterministic action only
-                _sac_actor = actor
-
-                class _DeterministicWrapper(nn.Module):
-                    def __init__(self, base: nn.Module):
-                        super().__init__()
-                        self.base = base
-
-                    def forward(self, obs: torch.Tensor) -> torch.Tensor:
-                        action, _, _ = self.base(obs)
-                        return action
-
-                export_module = _DeterministicWrapper(_sac_actor)
+                export_module = actor.as_export_module()
                 output_names = ["action"]
             else:
                 export_module = actor

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -11,7 +11,7 @@ Hyperparameters aligned with holosoma FastSACConfig defaults.
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, cast
 
 import torch
 import torch.distributed as dist
@@ -109,6 +109,21 @@ class SACActor(nn.Module):
             action = mean
 
         return action, mean, log_std
+
+    def as_export_module(self) -> "nn.Module":
+        """Return a single-input/single-output wrapper suitable for torch.onnx.export."""
+        actor = self
+
+        class _Wrapper(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.base = actor
+
+            def forward(self, obs: torch.Tensor) -> torch.Tensor:
+                action, _, _ = self.base(obs)
+                return cast(torch.Tensor, action)
+
+        return _Wrapper()
 
     def get_actions_and_log_probs(
         self, obs: torch.Tensor

--- a/src/unilab/algos/torch/flash_sac/network.py
+++ b/src/unilab/algos/torch/flash_sac/network.py
@@ -83,6 +83,21 @@ class FlashSACActor(nn.Module):
         encoded = self._encode(observations, training=training)
         return cast(tuple[torch.Tensor, dict[str, torch.Tensor]], self.predictor(encoded))
 
+    def as_export_module(self) -> "nn.Module":
+        """Return a single-input/single-output wrapper suitable for torch.onnx.export."""
+        actor = self
+
+        class _Wrapper(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.base = actor
+
+            def forward(self, obs: torch.Tensor) -> torch.Tensor:
+                action, _ = self.base(obs, training=False)
+                return cast(torch.Tensor, action)
+
+        return _Wrapper()
+
     def _ensure_exploration_state(
         self, batch_size: int, action_dim: int, device: torch.device, dtype: torch.dtype
     ) -> None:


### PR DESCRIPTION
…play bug

## Summary

- `FlashSACActor.forward(obs, training)` 与 `SACActor.forward(obs)` 接口不同：
  前者因内部 BatchNorm 需要显式传入 `training` 标志，且返回
  `(action, info_dict)` 而非 `(action, mean, log_std)`。原始脚本用共享
  的 `_DeterministicWrapper` 调用 `self.base(obs)` 时缺少 `training` 参数，
  导致 FlashSAC `play_only=true` 模式下 ONNX 导出必然崩溃。
- 将导出包装逻辑下沉到各 actor 类（`as_export_module()`），
  脚本层不再感知各 actor 的内部签名差异。SACActor 同步修复以保持一致性。
- 调整 flashsac/g1_walk_flat 训练超参（num_envs、tau、reward weights）

## Linked Work

- Issue:  #262 


## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run python scripts/train_offpolicy.py \
  algo=flashsac task=flashsac/g1_walk_flat/mujoco \
  training.play_only=true algo.load_run="2026-04-23_14-06-57_mujoco"
# 修复前：TypeError: FlashSACActor.forward() missing 1 required positional argument: 'training'
# 修复后：成功导出 policy.onnx 并通过 onnxruntime 验证
```

## Impact

- Backend impact: `mujoco`
- Platform impact:  both 
- Training effect expected: yes 

## Artifacts

- tensorboard:
<img width="999" height="335" alt="image" src="https://github.com/user-attachments/assets/b5cf389c-43b4-412d-90a3-2c63146b19e2" />
<img width="1298" height="631" alt="image" src="https://github.com/user-attachments/assets/5387abbe-c10c-4846-87c5-56b728c9fffc" />

- video / screenshot:

https://github.com/user-attachments/assets/3909488b-c1ad-4e7c-b4a4-05002bb1d04d


## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [ ] Noted any follow-up work explicitly
