### PR TITLE
refactor: unify slow and veryslow test marks into slow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,4 +179,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra motrix
       - name: Test with coverage
-        run: uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25
+        run: uv run pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ make check          # format + type (required before code-related commits)
 make test           # non-slow tests
 make test-cov       # non-slow tests + coverage report
 make test-slow      # slow integration tests (requires MuJoCo)
-make test-veryslow  # full training smoke tests (minutes)
+make test-slow  # full training smoke tests (minutes)
 make test-all       # make check && make test-cov
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,15 @@ check: format type
 
 .PHONY: test
 test:
-	uv run pytest -m "not slow and not veryslow"
+	uv run pytest -m "not slow"
 
 .PHONY: test-cov
 test-cov:
-	uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing
+	uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing
 
 .PHONY: test-slow
 test-slow:
-	uv run pytest -m "slow and not veryslow" -v
-
-.PHONY: test-veryslow
-test-veryslow:
-	uv run pytest -m "veryslow" -v
+	uv run pytest -m "slow" -v
 
 .PHONY: test-all
 test-all: check test-cov

--- a/docs/developers/zh_CN/CONTRIBUTING.md
+++ b/docs/developers/zh_CN/CONTRIBUTING.md
@@ -32,7 +32,7 @@ make check          # format + type（代码相关提交前必跑）
 make test           # 非 slow 测试
 make test-cov       # 非 slow 测试 + 覆盖率报告
 make test-slow      # slow 集成测试（需要 MuJoCo）
-make test-veryslow  # 完整训练冒烟测试（分钟级）
+make test-slow  # 完整训练冒烟测试（分钟级）
 make test-all       # make check && make test-cov
 ```
 
@@ -67,8 +67,7 @@ tests/
 ### Test Markers
 
 - 普通测试（无标记）: 不依赖 MuJoCo，使用 `make test`
-- `@pytest.mark.slow`: 需要 MuJoCo 环境，CI 会跳过，本地用 `make test-slow`
-- `@pytest.mark.veryslow`: 完整训练迭代或脚本冒烟测试，显式用 `make test-veryslow`
+- `@pytest.mark.slow`: 需要 MuJoCo 环境或完整训练迭代的测试，CI 会跳过，本地用 `make test-slow`
 - macOS only: `test_mlx_ppo.py` 使用 `pytest.importorskip("mlx")`，在非 macOS 平台自动跳过
 
 ### Test Writing Principles
@@ -83,16 +82,16 @@ tests/
 
 ```bash
 # 快速路径（与 CI 覆盖范围一致）
-uv run pytest -m "not slow and not veryslow"
+uv run pytest -m "not slow"
 
 # 带覆盖率
-uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report=term-missing
+uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing
 
 # 集成测试（需要 MuJoCo）
-uv run pytest -m "slow and not veryslow" -v
+uv run pytest -m "slow" -v
 
 # 完整训练冒烟测试
-uv run pytest -m veryslow -v
+uv run pytest -m "slow" -v
 ```
 
 ## CI Workflow
@@ -107,7 +106,7 @@ uv run pytest -m veryslow -v
 | `ruff-format` | 在 `ubuntu-slim` 上执行 `uv sync --only-group dev` + `uv run --no-sync ruff format --check .` | ✅ |
 | `mypy` | 在 `ubuntu-slim` 上执行 `uv sync` + `uv run mypy src/unilab` | ✅ |
 | `pyright` | 在 `ubuntu-slim` 上执行 `uv sync` + `uv run pyright` | ✅ |
-| `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix` + `uv run pytest -m "not slow and not veryslow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25` | ✅ |
+| `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix` + `uv run pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25` | ✅ |
 
 只有协作元信息改动，例如 `LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，才会跳过 CI。文档改动会触发 CI，并由 `tests/scripts/test_check_docs.py` 校验。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,8 @@ exclude = [
 testpaths = ["tests"]
 markers = [
     "slow: requires real env or long-running processes",
-    "veryslow: full training iteration tests (minutes per test)",
 ]
-addopts = "--tb=short -m 'not veryslow'"
+addopts = "--tb=short -m 'not slow'"
 
 [tool.coverage.run]
 source = ["unilab"]

--- a/tests/algos/test_appo_runner.py
+++ b/tests/algos/test_appo_runner.py
@@ -1,8 +1,7 @@
 """Slow integration tests for APPORunner.
 
 Requires MuJoCo to be installed. Run with:
-    uv run pytest -m slow -v           # init + close tests
-    uv run pytest -m veryslow -v       # full training iteration
+    uv run pytest -m slow -v           # init + close + full training iteration
 """
 
 from __future__ import annotations
@@ -34,7 +33,6 @@ def test_appo_runner_init_no_crash(mock_env_name):
 
 
 @pytest.mark.slow
-@pytest.mark.veryslow
 @pytest.mark.parametrize("env_name", ["Go2JoystickFlat"])
 def test_appo_runner_learn_two_iterations(env_name, default_go2_reward_config):
     """APPO learn test must use a real env — DummyFlatTest is not registered in

--- a/tests/algos/test_mlx_ppo.py
+++ b/tests/algos/test_mlx_ppo.py
@@ -318,12 +318,11 @@ def test_ppo_trainer_update_decreases_loss():
 
 
 # ---------------------------------------------------------------------------
-# Full training iteration on real env (veryslow)
+# Full training iteration on real env (slow)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.slow
-@pytest.mark.veryslow
 def test_mlx_ppo_one_iteration_real_env(default_go2_reward_config):
     """Run 1 full MLX PPO iteration (collect rollout + update) on a real env."""
     _mujoco = pytest.importorskip("mujoco")

--- a/tests/algos/test_offpolicy_runner.py
+++ b/tests/algos/test_offpolicy_runner.py
@@ -1,8 +1,7 @@
 """Slow integration tests for OffPolicyRunner (FastSAC/FastTD3).
 
 Requires MuJoCo to be installed. Run with:
-    uv run pytest -m slow -v           # init + close tests
-    uv run pytest -m veryslow -v       # full training iteration
+    uv run pytest -m slow -v           # init + close + full training iteration
 """
 
 from __future__ import annotations
@@ -55,7 +54,6 @@ def test_offpolicy_runner_sac_init_no_crash(mock_env_name):
 
 
 @pytest.mark.slow
-@pytest.mark.veryslow
 def test_offpolicy_runner_sac_learn_two_iterations(mock_env_name):
     runner = _make_sac_runner(mock_env_name)
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -113,7 +111,6 @@ def test_offpolicy_runner_td3_init_no_crash(mock_env_name):
 
 
 @pytest.mark.slow
-@pytest.mark.veryslow
 def test_offpolicy_runner_td3_learn_two_iterations(mock_env_name):
     runner = _make_td3_runner(mock_env_name)
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/algos/test_rsl_rl_runner.py
+++ b/tests/algos/test_rsl_rl_runner.py
@@ -1,7 +1,7 @@
 """Integration tests for RSL-RL PPO training.
 
 Requires MuJoCo and rsl_rl to be installed. Run with:
-    uv run pytest -m veryslow -v -k rsl_rl
+    uv run pytest -m slow -v -k rsl_rl
 """
 
 from __future__ import annotations
@@ -105,7 +105,6 @@ class _RslRlVecEnvWrapper:
 
 
 @pytest.mark.slow
-@pytest.mark.veryslow
 @pytest.mark.parametrize(
     "env_name",
     [

--- a/tests/scripts/test_train_script_configs.py
+++ b/tests/scripts/test_train_script_configs.py
@@ -26,7 +26,7 @@ def _mlx_runtime_usable() -> bool:
 _MLX_RUNTIME_USABLE = _mlx_runtime_usable()
 
 
-@pytest.mark.veryslow
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "task",
     [
@@ -56,7 +56,7 @@ def test_appo_task_configs_load(task):
     assert result.returncode == 0, f"APPO {task} failed:\n{result.stderr}"
 
 
-@pytest.mark.veryslow
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "task",
     ["sac/g1_walk_flat/mujoco", "sac/g1_walk_rough/mujoco", "td3/g1_walk_flat/mujoco"],


### PR DESCRIPTION
合并 `slow` 与 `veryslow` 两种 test mark 为单一的 `slow`，简化测试分类。

### 变更内容
- 所有 `@pytest.mark.veryslow` 替换为 `@pytest.mark.slow`
- `pyproject.toml` 移除 `veryslow` marker 定义，`addopts` 默认排除 `slow`
- `Makefile` 删除 `test-veryslow` target，统一使用 `test-slow`
- CI 与文档同步更新