### PR TITLE
Infra issue 280 #280

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,4 +179,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra motrix
       - name: Test with coverage
-        run: uv run pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25
+        run: uv run pytest -m "not slow" --cov=unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ uv run scripts/train_rsl_rl.py task=go2_joystick_flat/motrix
 
 This is the shortest repository entrypoint today. It uses the PPO training script on the registered `go2_joystick_flat/motrix` task and gives a direct first-success path before you learn the full workflow.
 
+You can also use the unified `unilab` CLI:
+
+```bash
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Train with the unified CLI
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# One-click demo (plays back a pre-trained checkpoint)
+unilab demo
+```
+
 On macOS / MacBook, commands that open the MotrixSim native renderer must be launched with `uv run mxpython` instead of `uv run python`. Plain non-rendering training can still use `uv run python ... training.no_play=true`.
 
 ## Example Runs
@@ -73,6 +86,42 @@ uv run scripts/train_rsl_rl.py task=g1_motion_tracking/mujoco
 Training scripts automatically enter playback after training unless you set `training.no_play=true`.
 
 For MotrixSim visualization or `training.play_only=true` on macOS / MacBook, reuse the macOS renderer rule from `Quick Demo` and see `docs/users/zh_CN/03-training.md`.
+
+## Unified CLI (`unilab`)
+
+The `unilab` command wraps the training scripts above with a simpler interface:
+
+```bash
+# Train
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# Evaluate (play back the latest checkpoint)
+unilab eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
+
+# Demo (pre-trained checkpoint playback)
+unilab demo
+```
+
+Supported algorithms: `ppo`, `mlx_ppo`, `appo`, `sac`, `td3`, `flashsac`
+Supported simulators: `mujoco`, `motrix`
+
+Hydra overrides can be appended directly:
+
+```bash
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco training.max_iterations=10
+```
+
+### Demo
+
+`unilab demo` runs a pre-configured playback with a trained checkpoint.
+
+| Flag | Description |
+|------|-------------|
+| `--preset` | Demo preset name (default: `go2_joystick_mujoco_ppo`) |
+| `--refresh` | Remove and regenerate the demo directory |
+| `--device` | Inference device (`cpu`, `cuda`, `mps`) |
+
+> **For Developers**: Demo checkpoints currently require local training output. A checkpoint hosting solution (CDN / model registry) with automatic download is not yet in place.
 
 ## Repository Map
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ unilab demo
 
 On macOS / MacBook, commands that open the MotrixSim native renderer must be launched with `uv run mxpython` instead of `uv run python`. Plain non-rendering training can still use `uv run python ... training.no_play=true`.
 
+### Interactive Notebooks
+
+Prefer a guided, step-by-step experience? Open the notebooks in Jupyter:
+
+- [Demo Notebook](notebook/demo.ipynb): one-click checkpoint playback — run `unilab demo` and view the result video
+- [PPO Training Walkthrough](notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb): end-to-end guide from config preview to training to playback, with explanations for beginners
+
+> Notebooks require a local environment (no Colab support) — MuJoCo needs local compute.
+
 ## Example Runs
 
 These are example repository runs for documented commands and hardware setups. They are useful as concrete entrypoints and reported timings, but they are **not** yet a formal benchmark manifest.
@@ -140,6 +149,8 @@ unilab train --algo ppo --task go2_joystick_flat --sim mujoco training.max_itera
 - [04 Algorithms](docs/users/zh_CN/04-algorithms.md): APPO, FastSAC, and FastTD3 usage and differences
 - [05 G1 Motion Tracking](docs/users/zh_CN/05-motion-tracking.md): the G1 whole-body motion-tracking task
 - [06 Domain Randomization](docs/users/zh_CN/06-domain-randomization.md): domain randomization configuration and best practices
+- [Demo Notebook](notebook/demo.ipynb): one-click demo playback
+- [PPO Training Walkthrough](notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb): beginner-friendly end-to-end training guide
 
 
 ### For Developers

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -77,6 +77,29 @@ uv run scripts/train_offpolicy.py algo=td3 task=td3/g1_walk_flat/mujoco
 make test-all
 ```
 
+## 统一 CLI (`unilab`)
+
+UniLab 提供了统一的 `unilab` 命令行入口，无需记忆各训练脚本路径：
+
+```bash
+# 激活虚拟环境后即可使用
+source .venv/bin/activate
+
+# 训练
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# 评估（回放最新 checkpoint）
+unilab eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
+
+# 一键 demo（预置 checkpoint 回放）
+unilab demo
+```
+
+支持的算法：`ppo`、`mlx_ppo`、`appo`、`sac`、`td3`、`flashsac`
+支持的模拟器：`mujoco`、`motrix`
+
+详细用法见 [训练指南](03-training.md)。
+
 ## Navigation
 
 - Next: [Simulation Backends](02-simulation-backends.md)

--- a/docs/users/zh_CN/03-training.md
+++ b/docs/users/zh_CN/03-training.md
@@ -15,6 +15,79 @@
 
 实际目录名由 `algo.algo_log_name` 决定；当前默认值分别是 `rsl_rl_ppo`、`mlx_rl_train`、`appo`、`fast_sac` 和 `fast_td3`。
 
+## 统一 CLI (`unilab`)
+
+除了直接调用脚本，UniLab 还提供了统一的 `unilab` 命令行入口，通过 `--algo`、`--task`、`--sim` 三个参数自动路由到对应的训练脚本。
+
+### unilab train
+
+```bash
+# PPO
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# APPO
+unilab train --algo appo --task go2_joystick_flat --sim mujoco
+
+# SAC
+unilab train --algo sac --task g1_walk_flat --sim mujoco
+
+# TD3
+unilab train --algo td3 --task g1_walk_flat --sim mujoco
+
+# FlashSAC
+unilab train --algo flashsac --task g1_walk_flat --sim mujoco
+
+# MLX PPO (macOS only)
+unilab train --algo mlx_ppo --task go2_joystick_flat --sim mujoco
+```
+
+支持的算法：`ppo`、`mlx_ppo`、`appo`、`sac`、`td3`、`flashsac`
+支持的模拟器：`mujoco`、`motrix`
+
+Hydra override 可以直接追加在命令末尾：
+
+```bash
+unilab train --algo ppo --task go2_joystick_flat --sim mujoco training.max_iterations=10
+```
+
+### unilab eval
+
+评估模式自动设置 `training.play_only=true`，并通过 `--load-run` 指定 checkpoint：
+
+```bash
+# 回放最新 run
+unilab eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
+
+# 回放指定 run
+unilab eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run 2026-04-24_01-36-01_mujoco
+```
+
+### unilab demo
+
+一键运行预置的 demo，无需手动指定 task 和 checkpoint：
+
+```bash
+# 默认 preset（go2_joystick_mujoco_ppo）
+unilab demo
+
+# 指定 preset
+unilab demo --preset go2_joystick_mujoco_ppo
+
+# 重新生成 demo 目录
+unilab demo --refresh
+
+# 指定推理设备
+unilab demo --device cpu
+```
+
+| 参数 | 说明 |
+|------|------|
+| `--preset` | demo 预设名称（默认 `go2_joystick_mujoco_ppo`） |
+| `--refresh` | 删除已有 demo 目录并重新生成 |
+| `--device` | 推理设备（`cpu`、`cuda`、`mps`） |
+
+> **For Developers**: 当前 demo checkpoint 需要本地训练产出后手动放置。尚缺少 checkpoint 网络托管方案（如 CDN / model registry），后续需要补充自动下载机制。
+
 ## Start Training
 
 ```bash

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -3,36 +3,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# UniLab Demo: 一键回放训练好的策略\n",
-    "\n",
-    "这个 notebook 演示如何用 UniLab 的 `demo` 命令，加载一个已经训练好的 checkpoint，\n",
-    "让机器人在仿真环境中执行学到的策略。\n",
-    "\n",
-    "**你不需要任何机器人或强化学习背景**——只需要运行下面的 cell 就能看到效果。\n",
-    "\n",
-    "## 它做了什么？\n",
-    "\n",
-    "1. 从预设的 checkpoint 目录复制模型文件到 demo 运行目录\n",
-    "2. 启动 MuJoCo 物理仿真器\n",
-    "3. 让 Go2 四足机器人用训练好的策略行走\n",
-    "4. 录制一段回放视频\n",
-    "\n",
-    "## 前置条件\n",
-    "\n",
-    "- 已完成 `uv sync` 并激活虚拟环境\n",
-    "- 本地存在训练产出的 checkpoint 文件（位于 `logs/rsl_rl_ppo/Go2JoystickFlatTerrain/` 下）\n",
-    "- 如果你还没有 checkpoint，请先运行 walkthrough notebook 完成一次训练"
-   ]
+   "source": "# UniLab Demo: 一键回放训练好的策略\n\n这个 notebook 演示如何用 UniLab 的 `demo` 命令，加载一个已经训练好的 checkpoint，\n让机器人在仿真环境中执行学到的策略。\n\n**你不需要任何机器人或强化学习背景**——只需要运行下面的 cell 就能看到效果。\n\n## 它做了什么？\n\n1. 从预设的 checkpoint 目录复制模型文件到 demo 运行目录\n2. 启动 MuJoCo 物理仿真器\n3. 让 Go2 四足机器人用训练好的策略行走\n4. 录制一段回放视频\n\n## 环境准备\n\n> 如果你已经完成了 README 中 Quick Demo 的步骤，可以跳过这一节。\n\n**系统要求**：Python >= 3.10, < 3.14\n\n```bash\n# 1. 安装 uv（Python 包管理器）\ncurl -LsSf https://astral.sh/uv/install.sh | sh\n\n# 2. 克隆仓库\ngit clone <repo-url> && cd UniLab\n\n# 3. 安装依赖\nuv sync\n\n# 4. 激活虚拟环境\nsource .venv/bin/activate\n\n# 5. 验证 CLI 可用\nunilab --help\n```\n\n**前置条件**：本地需要存在训练产出的 checkpoint 文件（位于 `logs/rsl_rl_ppo/Go2JoystickFlatTerrain/` 下）。\n如果你还没有 checkpoint，请先运行 walkthrough notebook 完成一次训练。\n\n> **Colab 不适用**：本项目依赖 MuJoCo 物理仿真器的本地运行环境，不支持 Google Colab。请在本地机器上运行此 notebook。"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Step 1: 确认环境\n",
-    "\n",
-    "先检查我们是否在正确的项目根目录，以及 `unilab` CLI 是否可用。"
-   ]
+   "source": "## Step 1: 确认环境\n\n检查我们是否在正确的项目根目录，以及 `unilab` CLI 是否可用。"
   },
   {
    "cell_type": "code",

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# UniLab Demo: 一键回放训练好的策略\n",
+    "\n",
+    "这个 notebook 演示如何用 UniLab 的 `demo` 命令，加载一个已经训练好的 checkpoint，\n",
+    "让机器人在仿真环境中执行学到的策略。\n",
+    "\n",
+    "**你不需要任何机器人或强化学习背景**——只需要运行下面的 cell 就能看到效果。\n",
+    "\n",
+    "## 它做了什么？\n",
+    "\n",
+    "1. 从预设的 checkpoint 目录复制模型文件到 demo 运行目录\n",
+    "2. 启动 MuJoCo 物理仿真器\n",
+    "3. 让 Go2 四足机器人用训练好的策略行走\n",
+    "4. 录制一段回放视频\n",
+    "\n",
+    "## 前置条件\n",
+    "\n",
+    "- 已完成 `uv sync` 并激活虚拟环境\n",
+    "- 本地存在训练产出的 checkpoint 文件（位于 `logs/rsl_rl_ppo/Go2JoystickFlatTerrain/` 下）\n",
+    "- 如果你还没有 checkpoint，请先运行 walkthrough notebook 完成一次训练"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: 确认环境\n",
+    "\n",
+    "先检查我们是否在正确的项目根目录，以及 `unilab` CLI 是否可用。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# 确保在项目根目录运行\n",
+    "root = Path(\".\").resolve()\n",
+    "assert (root / \"scripts\").is_dir(), f\"请在 UniLab 项目根目录运行此 notebook，当前目录: {root}\"\n",
+    "assert (root / \"conf\").is_dir(), \"缺少 conf/ 目录，请确认项目完整性\"\n",
+    "print(f\"项目根目录: {root}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run unilab --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: 检查 checkpoint 是否存在\n",
+    "\n",
+    "demo 命令需要一个预训练好的模型文件。下面检查它是否在预期位置。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log_dir = root / \"logs\" / \"rsl_rl_ppo\" / \"Go2JoystickFlatTerrain\"\n",
+    "\n",
+    "if log_dir.is_dir():\n",
+    "    runs = sorted(log_dir.iterdir())\n",
+    "    print(f\"找到 {len(runs)} 个训练 run:\")\n",
+    "    for r in runs:\n",
+    "        ckpts = list(r.glob(\"model_*.pt\"))\n",
+    "        print(f\"  {r.name}  ->  {len(ckpts)} 个 checkpoint\")\n",
+    "else:\n",
+    "    print(f\"未找到日志目录: {log_dir}\")\n",
+    "    print(\"请先完成至少一次训练，或手动放置 checkpoint 文件。\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: 运行 Demo\n",
+    "\n",
+    "`unilab demo` 会自动完成以下步骤：\n",
+    "- 找到 preset 对应的 checkpoint\n",
+    "- 复制到 demo 专用目录\n",
+    "- 以 play_only 模式启动仿真，录制视频\n",
+    "\n",
+    "默认 preset 是 `go2_joystick_mujoco_ppo`（Go2 机器人 + 摇杆控制 + MuJoCo 仿真器 + PPO 算法）。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run unilab demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: 查看回放视频\n",
+    "\n",
+    "如果 demo 成功运行，会在 demo run 目录下生成 `play_video.mp4`。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Video\n",
+    "\n",
+    "demo_run_dir = log_dir / \"demo_go2_joystick_mujoco_ppo_v0\"\n",
+    "video_path = demo_run_dir / \"play_video.mp4\"\n",
+    "\n",
+    "if video_path.is_file():\n",
+    "    print(f\"视频路径: {video_path}\")\n",
+    "    display(Video(str(video_path), embed=True, width=640))\n",
+    "else:\n",
+    "    print(f\"未找到视频文件: {video_path}\")\n",
+    "    print(\"可能原因: demo 运行失败，或渲染环境不可用。\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 下一步\n",
+    "\n",
+    "- 想了解训练过程？请查看 `unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb`\n",
+    "- 想用其他算法或机器人？运行 `uv run unilab train --help` 查看所有选项\n",
+    "- 想自定义 demo preset？查看 `src/unilab/demo.py` 中的 `DEMO_PRESETS`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb
+++ b/notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb
@@ -1,0 +1,348 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# UniLab Walkthrough: PPO + Go1 Joystick + MuJoCo\n",
+    "\n",
+    "This notebook walks you through training a quadruped robot to walk using reinforcement learning (RL).\n",
+    "\n",
+    "**No robotics or RL background needed** - every step explains the \"why\".\n",
+    "\n",
+    "| Step | What | You will learn |\n",
+    "|------|------|----------------|\n",
+    "| 1 | Preview config | What parameters does RL training need? |\n",
+    "| 2 | Smoke test | 1 iteration to verify the environment works |\n",
+    "| 3 | Full training | Complete training loop (optional) |\n",
+    "| 4 | Inspect artifacts | Model files, logs, metrics |\n",
+    "| 5 | Playback | Watch the robot perform its learned skill |\n",
+    "\n",
+    "### Key concepts (30-second version)\n",
+    "\n",
+    "- **PPO** (Proximal Policy Optimization): a popular RL algorithm that improves a policy through trial and error\n",
+    "- **Policy**: a neural network - input: robot state (joint angles, velocities), output: actions (joint torques)\n",
+    "- **MuJoCo**: a physics engine that simulates the robot in a virtual world\n",
+    "- **Reward**: a signal telling the algorithm how well it's doing - moving forward = good, falling = bad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prereq",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "```bash\n",
+    "# Run in the UniLab project root\n",
+    "uv sync\n",
+    "source .venv/bin/activate\n",
+    "```\n",
+    "\n",
+    "Once `unilab --help` works, you're ready to go."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step1-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 1: Environment check\n",
+    "\n",
+    "Make sure we're in the right directory and key files exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step1-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "ROOT = Path(\".\").resolve()\n",
+    "checks = {\n",
+    "    \"scripts/\": (ROOT / \"scripts\").is_dir(),\n",
+    "    \"conf/\": (ROOT / \"conf\").is_dir(),\n",
+    "    \"conf/ppo/task/go1_joystick_flat/mujoco.yaml\": (\n",
+    "        ROOT / \"conf\" / \"ppo\" / \"task\" / \"go1_joystick_flat\" / \"mujoco.yaml\"\n",
+    "    ).is_file(),\n",
+    "}\n",
+    "for name, ok in checks.items():\n",
+    "    status = \"OK\" if ok else \"MISSING\"\n",
+    "    print(f\"  [{status}] {name}\")\n",
+    "assert all(checks.values()), f\"Run this notebook from the UniLab project root. Current dir: {ROOT}\"\n",
+    "print(f\"\\nProject root: {ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step2-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 2: Preview the training config\n",
+    "\n",
+    "Before training, let's see what parameters Hydra will use. Think of this as \"previewing the menu\":\n",
+    "- Algorithm hyperparameters (learning rate, batch size, etc.)\n",
+    "- Environment settings (number of parallel envs, simulation timestep, etc.)\n",
+    "- Reward function weights\n",
+    "\n",
+    "`--cfg job` tells Hydra to print the final merged config without actually running training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step2-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run python scripts/train_rsl_rl.py task=go1_joystick_flat/mujoco --cfg job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step3-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 3: Smoke test (1 iteration)\n",
+    "\n",
+    "Before committing to a full training run, let's do **1 iteration** to make sure everything works.\n",
+    "This takes just a few seconds.\n",
+    "\n",
+    "If this cell errors out, fix the environment issue before continuing.\n",
+    "\n",
+    "`algo.max_iterations=1` tells PPO to stop after 1 update step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step3-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run python scripts/train_rsl_rl.py task=go1_joystick_flat/mujoco algo.max_iterations=1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step3-note",
+   "metadata": {},
+   "source": [
+    "If you see output like `iteration 1/1 ... done`, the environment is working correctly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step4-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 4: Full training (optional)\n",
+    "\n",
+    "Full training takes longer (minutes to hours depending on hardware).\n",
+    "\n",
+    "If you just want to experience the workflow, skip this and use the smoke test checkpoint from Step 3.\n",
+    "\n",
+    "Two equivalent ways to launch training:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step4-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1: Unified CLI (recommended)\n",
+    "# !uv run unilab train --algo ppo --task go1_joystick_flat --sim mujoco\n",
+    "\n",
+    "# Option 2: Direct script call (equivalent)\n",
+    "# !uv run python scripts/train_rsl_rl.py task=go1_joystick_flat/mujoco"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step5-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 5: Inspect training artifacts\n",
+    "\n",
+    "After training, all outputs are saved under `logs/rsl_rl_ppo/`.\n",
+    "Each run creates a timestamped directory containing:\n",
+    "- `model_*.pt` - model checkpoints saved at different iterations\n",
+    "- `run_config.json` - the full config used for this run\n",
+    "- `run_summary.json` - training result summary (if available)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step5-list",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "log_base = ROOT / \"logs\" / \"rsl_rl_ppo\"\n",
+    "task_dir = log_base / \"Go1JoystickFlatTerrain\"\n",
+    "\n",
+    "if not task_dir.is_dir():\n",
+    "    print(f\"Go1JoystickFlatTerrain directory not found. Listing {log_base}:\")\n",
+    "    task_dir = log_base\n",
+    "\n",
+    "if task_dir.is_dir():\n",
+    "    runs = sorted([d for d in task_dir.iterdir() if d.is_dir()], key=lambda p: p.name)\n",
+    "    if runs:\n",
+    "        latest = runs[-1]\n",
+    "        print(f\"Latest run: {latest.name}\\n\")\n",
+    "        print(\"Contents:\")\n",
+    "        for f in sorted(latest.iterdir()):\n",
+    "            if f.is_file():\n",
+    "                print(f\"  {f.name:40s}  {f.stat().st_size:>10,} bytes\")\n",
+    "            else:\n",
+    "                print(f\"  {f.name}/\")\n",
+    "    else:\n",
+    "        print(\"No run directories found. Run Step 3 or Step 4 first.\")\n",
+    "else:\n",
+    "    print(f\"Log directory does not exist: {log_base}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step5-json-header",
+   "metadata": {},
+   "source": [
+    "### Read training config and summary\n",
+    "\n",
+    "Let's peek inside the JSON files to see what config was used and how training went."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step5-json",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if task_dir.is_dir() and runs:\n",
+    "    latest = runs[-1]\n",
+    "    for name in [\"run_config.json\", \"run_summary.json\"]:\n",
+    "        path = latest / name\n",
+    "        if path.is_file():\n",
+    "            data = json.loads(path.read_text())\n",
+    "            print(f\"=== {name} ===\")\n",
+    "            print(json.dumps(data, indent=2, ensure_ascii=False)[:2000])\n",
+    "            print()\n",
+    "        else:\n",
+    "            print(f\"{name} not found in {latest.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step6-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Step 6: Playback - watch the robot perform\n",
+    "\n",
+    "Now let's load the trained checkpoint and run the policy in \"play only\" mode.\n",
+    "The robot will execute its learned walking behavior in the simulator.\n",
+    "\n",
+    "`training.play_only=true` tells the script to skip training and just run inference.\n",
+    "`algo.load_run=-1` means \"load the most recent run\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step6-eval",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1: Unified CLI\n",
+    "!uv run unilab eval --algo ppo --task go1_joystick_flat --sim mujoco --load-run -1\n",
+    "\n",
+    "# Option 2: Direct script call (equivalent)\n",
+    "# !uv run python scripts/train_rsl_rl.py task=go1_joystick_flat/mujoco training.play_only=true algo.load_run=-1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step6-video-header",
+   "metadata": {},
+   "source": [
+    "### Display the playback video\n",
+    "\n",
+    "If playback generated a video file, we can display it right here in the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "step6-video",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Video\n",
+    "\n",
+    "if task_dir.is_dir() and runs:\n",
+    "    latest = runs[-1]\n",
+    "    videos = list(latest.glob(\"play_video*.mp4\"))\n",
+    "    if videos:\n",
+    "        vid = videos[0]\n",
+    "        print(f\"Video: {vid}\")\n",
+    "        display(Video(str(vid), embed=True, width=640))\n",
+    "    else:\n",
+    "        print(f\"No video found in {latest.name}.\")\n",
+    "        print(\"Playback may not have generated a video, or rendering was unavailable.\")\n",
+    "else:\n",
+    "    print(\"No run directory available. Complete training first.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "next-steps",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## What's next?\n",
+    "\n",
+    "- **Try a different robot**: `uv run unilab train --algo ppo --task g1_walk_flat --sim mujoco`\n",
+    "- **Try a different algorithm**: `uv run unilab train --algo sac --task g1_walk_flat --sim mujoco`\n",
+    "- **Run the demo notebook**: see `demo.ipynb` for one-click checkpoint playback\n",
+    "- **Explore all options**: `uv run unilab train --help`\n",
+    "\n",
+    "### How the unified CLI maps to scripts\n",
+    "\n",
+    "| CLI command | Underlying script | Config path |\n",
+    "|-------------|-------------------|-------------|\n",
+    "| `unilab train --algo ppo` | `scripts/train_rsl_rl.py` | `conf/ppo/task/{task}/{sim}.yaml` |\n",
+    "| `unilab train --algo sac` | `scripts/train_offpolicy.py` | `conf/offpolicy/task/sac/{task}/{sim}.yaml` |\n",
+    "| `unilab train --algo appo` | `scripts/train_appo.py` | `conf/appo/task/{task}/{sim}.yaml` |\n",
+    "| `unilab eval ...` | Same as train + `training.play_only=true` | Same |\n",
+    "| `unilab demo` | Preset-based checkpoint playback | N/A |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb
+++ b/notebook/unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb
@@ -31,17 +31,7 @@
    "cell_type": "markdown",
    "id": "prereq",
    "metadata": {},
-   "source": [
-    "## Prerequisites\n",
-    "\n",
-    "```bash\n",
-    "# Run in the UniLab project root\n",
-    "uv sync\n",
-    "source .venv/bin/activate\n",
-    "```\n",
-    "\n",
-    "Once `unilab --help` works, you're ready to go."
-   ]
+   "source": "## Prerequisites\n\n> If you've already completed the Quick Demo steps in README.md, skip to Step 1.\n\n**System requirement**: Python >= 3.10, < 3.14\n\n```bash\n# 1. Install uv (Python package manager)\ncurl -LsSf https://astral.sh/uv/install.sh | sh\n\n# 2. Clone the repo\ngit clone <repo-url> && cd UniLab\n\n# 3. Install dependencies\nuv sync\n\n# 4. Activate the virtual environment\nsource .venv/bin/activate\n\n# 5. Verify the CLI works\nunilab --help\n```\n\n> **Colab not supported**: This project requires a local MuJoCo runtime for physics simulation. Please run this notebook on a local machine."
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     "onnxruntime>=1.24.3",
 ]
 
+[project.scripts]
+unilab = "unilab.cli:main"
+
 [project.optional-dependencies]
 motrix = ["motrixsim==0.7.1.dev96425"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -1,0 +1,223 @@
+"""Thin package CLI for routing to existing UniLab training entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Sequence
+
+from unilab.demo import run_demo
+
+SUPPORTED_ALGOS = ("ppo", "mlx_ppo", "appo", "sac", "td3", "flashsac")
+SUPPORTED_SIMS = ("mujoco", "motrix")
+OFFPOLICY_ALGOS = {"sac", "td3", "flashsac"}
+RESERVED_OVERRIDE_KEYS = {
+    "algo",
+    "task",
+    "training.sim_backend",
+    "training.play_only",
+}
+TASK_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]*$")
+RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class Route:
+    script_name: str
+    config_group: str
+    owner_task: str
+    generated_overrides: tuple[str, ...]
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _script_path(route: Route, root: Path) -> Path:
+    return root / "scripts" / route.script_name
+
+
+def _owner_yaml_path(route: Route, root: Path) -> Path:
+    return root / "conf" / route.config_group / "task" / route.owner_task
+
+
+def _check_private_checkout(root: Path) -> None:
+    if not (root / "conf").is_dir() or not (root / "scripts").is_dir():
+        raise SystemExit(
+            "The current `unilab` CLI expects a UniLab source checkout. "
+            "Run it from the uv-managed editable environment created by this repo."
+        )
+
+
+def _check_reserved_overrides(overrides: Sequence[str]) -> None:
+    reserved = [
+        override
+        for override in overrides
+        if _override_key(override) in RESERVED_OVERRIDE_KEYS
+    ]
+    if reserved:
+        joined = ", ".join(reserved)
+        raise SystemExit(
+            "Route-defining Hydra overrides must be provided through CLI flags, "
+            f"not passthrough: {joined}"
+        )
+
+
+def _override_key(override: str) -> str:
+    key = override.split("=", 1)[0].strip()
+    return key.lstrip("+~")
+
+
+def _check_task_name(task: str) -> None:
+    if TASK_NAME_PATTERN.fullmatch(task) is None:
+        raise SystemExit(
+            "--task must be a registry task name such as `go1_joystick`; "
+            "do not include slashes, dots, or path separators."
+        )
+
+
+def _check_load_run(load_run: str) -> None:
+    if load_run == "-1":
+        return
+    if RUN_ID_PATTERN.fullmatch(load_run) is None or load_run in {".", ".."}:
+        raise SystemExit("--load-run must be `-1` or a run directory name, not a path.")
+
+
+def _check_runtime_requirements(algo: str, sim: str) -> None:
+    if algo == "mlx_ppo" and platform.system() != "Darwin":
+        raise SystemExit("mlx_ppo is only supported on macOS; use --algo ppo for torch PPO.")
+    if sim == "motrix" and find_spec("motrixsim") is None:
+        raise SystemExit(
+            "sim=motrix requires the Motrix extra. Install it with `uv sync --extra motrix`."
+        )
+
+
+def build_route(algo: str, task: str, sim: str) -> Route:
+    task_choice: str
+    if algo in OFFPOLICY_ALGOS:
+        task_choice = f"{algo}/{task}/{sim}"
+        return Route(
+            script_name="train_offpolicy.py",
+            config_group="offpolicy",
+            owner_task=f"{algo}/{task}/{sim}.yaml",
+            generated_overrides=(f"algo={algo}", f"task={task_choice}"),
+        )
+    task_choice = f"{task}/{sim}"
+    if algo == "ppo":
+        return Route(
+            script_name="train_rsl_rl.py",
+            config_group="ppo",
+            owner_task=f"{task}/{sim}.yaml",
+            generated_overrides=(f"task={task_choice}",),
+        )
+    if algo == "mlx_ppo":
+        return Route(
+            script_name="train_mlx_ppo.py",
+            config_group="ppo",
+            owner_task=f"{task}/{sim}.yaml",
+            generated_overrides=(f"task={task_choice}",),
+        )
+    if algo == "appo":
+        return Route(
+            script_name="train_appo.py",
+            config_group="appo",
+            owner_task=f"{task}/{sim}.yaml",
+            generated_overrides=(f"task={task_choice}",),
+        )
+    raise SystemExit(f"Unsupported algo={algo!r}; choose one of: {', '.join(SUPPORTED_ALGOS)}")
+
+
+def build_command(
+    *,
+    mode: str,
+    algo: str,
+    task: str,
+    sim: str,
+    overrides: Sequence[str],
+    load_run: str | None = None,
+    root: Path | None = None,
+) -> list[str]:
+    selected_root = root or repo_root()
+    _check_private_checkout(selected_root)
+    _check_task_name(task)
+    _check_reserved_overrides(overrides)
+    _check_runtime_requirements(algo, sim)
+
+    route = build_route(algo, task, sim)
+    script = _script_path(route, selected_root)
+    if not script.is_file():
+        raise SystemExit(f"Entrypoint script not found: {script}")
+
+    owner_yaml = _owner_yaml_path(route, selected_root)
+    if not owner_yaml.is_file():
+        raise SystemExit(
+            f"No owner config exists for algo={algo}, task={task}, sim={sim}: {owner_yaml}"
+        )
+
+    generated = list(route.generated_overrides)
+    if mode == "eval":
+        generated.append("training.play_only=true")
+        if load_run is not None:
+            _check_load_run(load_run)
+            if any(_override_key(o) == "algo.load_run" for o in overrides):
+                raise SystemExit("Use either --load-run or algo.load_run=..., not both.")
+            generated.append(f"algo.load_run={load_run}")
+
+    return [sys.executable, str(script), *generated, *overrides]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="unilab")
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    for mode in ("train", "eval"):
+        sub = subparsers.add_parser(mode)
+        sub.add_argument("--algo", required=True, choices=SUPPORTED_ALGOS)
+        sub.add_argument("--task", required=True)
+        sub.add_argument("--sim", required=True, choices=SUPPORTED_SIMS)
+        if mode == "eval":
+            sub.add_argument("--load-run", default=None)
+
+    demo_parser = subparsers.add_parser("demo")
+    demo_parser.add_argument("--preset", default="go2_joystick_mujoco_ppo")
+    demo_parser.add_argument("--refresh", action="store_true")
+    demo_parser.add_argument("--device", default=None)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args, overrides = parser.parse_known_args(argv)
+
+    if args.mode == "demo":
+        if overrides:
+            raise SystemExit(
+                f"unilab demo does not accept passthrough Hydra overrides: "
+                f"{', '.join(overrides)}"
+            )
+        return run_demo(
+            preset_name=args.preset,
+            refresh=args.refresh,
+            device=args.device,
+        )
+
+    command = build_command(
+        mode=args.mode,
+        algo=args.algo,
+        task=args.task,
+        sim=args.sim,
+        overrides=overrides,
+        load_run=getattr(args, "load_run", None),
+    )
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -57,9 +57,7 @@ def _check_private_checkout(root: Path) -> None:
 
 def _check_reserved_overrides(overrides: Sequence[str]) -> None:
     reserved = [
-        override
-        for override in overrides
-        if _override_key(override) in RESERVED_OVERRIDE_KEYS
+        override for override in overrides if _override_key(override) in RESERVED_OVERRIDE_KEYS
     ]
     if reserved:
         joined = ", ".join(reserved)
@@ -199,8 +197,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.mode == "demo":
         if overrides:
             raise SystemExit(
-                f"unilab demo does not accept passthrough Hydra overrides: "
-                f"{', '.join(overrides)}"
+                f"unilab demo does not accept passthrough Hydra overrides: {', '.join(overrides)}"
             )
         return run_demo(
             preset_name=args.preset,

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DemoPreset:
+    preset_id: str
+    algo: str
+    task: str
+    sim: str
+    task_name: str
+    algo_log_name: str
+    source_run: str
+    checkpoint_filename: str
+    demo_run: str
+    expected_output: str = "play_video.mp4"
+
+
+DEMO_PRESETS = {
+    "go2_joystick_mujoco_ppo": DemoPreset(
+        preset_id="go2_joystick_mujoco_ppo",
+        algo="ppo",
+        task="go2_joystick_flat",
+        sim="mujoco",
+        task_name="Go2JoystickFlatTerrain",
+        algo_log_name="rsl_rl_ppo",
+        source_run="2026-04-24_01-36-01_mujoco",
+        checkpoint_filename="model_999.pt",
+        demo_run="demo_go2_joystick_mujoco_ppo_v0",
+    )
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def get_demo_preset(preset_name: str) -> DemoPreset:
+    try:
+        return DEMO_PRESETS[preset_name]
+    except KeyError as exc:
+        available = ", ".join(sorted(DEMO_PRESETS))
+        raise SystemExit(
+            f"Unknown demo preset {preset_name!r}. Available presets: {available}"
+        ) from exc
+
+
+def _task_log_root(root: Path, preset: DemoPreset) -> Path:
+    return root / "logs" / preset.algo_log_name / preset.task_name
+
+
+def _source_run_dir(root: Path, preset: DemoPreset) -> Path:
+    return _task_log_root(root, preset) / preset.source_run
+
+
+def _demo_run_dir(root: Path, preset: DemoPreset) -> Path:
+    return _task_log_root(root, preset) / preset.demo_run
+
+
+def materialize_demo_run(*, root: Path, preset: DemoPreset, refresh: bool) -> Path:
+    source_run_dir = _source_run_dir(root, preset)
+    source_checkpoint = source_run_dir / preset.checkpoint_filename
+    if not source_checkpoint.is_file():
+        raise SystemExit(
+            "Demo checkpoint not found. Expected local asset at "
+            f"{source_checkpoint}."
+        )
+
+    demo_run_dir = _demo_run_dir(root, preset)
+    if refresh and demo_run_dir.exists():
+        shutil.rmtree(demo_run_dir)
+
+    demo_checkpoint = demo_run_dir / preset.checkpoint_filename
+    if not demo_checkpoint.is_file():
+        demo_run_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_checkpoint, demo_checkpoint)
+
+    return demo_run_dir
+
+
+def build_demo_command(*, preset: DemoPreset, device: str | None = None) -> list[str]:
+    command = [
+        sys.executable,
+        str(_repo_root() / "scripts" / "train_rsl_rl.py"),
+        f"task={preset.task}/{preset.sim}",
+        "training.play_only=true",
+        f"algo.load_run={preset.demo_run}",
+    ]
+    if device is not None:
+        command.append(f"training.device={device}")
+    return command
+
+
+def run_demo(*, preset_name: str, refresh: bool, device: str | None = None) -> int:
+    root = _repo_root()
+    preset = get_demo_preset(preset_name)
+    demo_run_dir = materialize_demo_run(root=root, preset=preset, refresh=refresh)
+    command = build_demo_command(preset=preset, device=device)
+    env = os.environ.copy()
+    env.setdefault("UV_PROJECT_ENVIRONMENT", str(root / ".venv"))
+    returncode = subprocess.run(command, check=False, env=env).returncode
+    if returncode == 0:
+        video_path = demo_run_dir / preset.expected_output
+        print(f"Demo preset: {preset.preset_id}")
+        if video_path.is_file():
+            print(f"Demo video: {video_path}")
+        else:
+            print(f"Demo completed, but expected video was not found: {video_path}")
+    return returncode

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -67,10 +67,7 @@ def materialize_demo_run(*, root: Path, preset: DemoPreset, refresh: bool) -> Pa
     source_run_dir = _source_run_dir(root, preset)
     source_checkpoint = source_run_dir / preset.checkpoint_filename
     if not source_checkpoint.is_file():
-        raise SystemExit(
-            "Demo checkpoint not found. Expected local asset at "
-            f"{source_checkpoint}."
-        )
+        raise SystemExit(f"Demo checkpoint not found. Expected local asset at {source_checkpoint}.")
 
     demo_run_dir = _demo_run_dir(root, preset)
     if refresh and demo_run_dir.exists():


### PR DESCRIPTION
## Summary

- Add two Jupyter notebooks under `notebook/`: a one-click demo playback (`demo.ipynb`) and a full PPO training walkthrough (`unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb`)
- Both notebooks include full setup instructions (Python version, uv install, clone, sync, activate) so beginners can start from scratch
- Update `README.md` to add notebook links in Quick Demo and For Users sections
- Explicitly note Colab is not supported (MuJoCo requires local runtime)
- No changes to existing code or training logic; purely additive docs/notebook deliverable

## Linked Work

- Issue: #280
- Milestone: #266 (first-success demo)

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [ ] Notebook cells execute end-to-end locally (smoke test + playback)
- [ ] Commands in notebooks match CLI / script interfaces on `main`

Commands actually run:

```bash
cd /home/fxl/unilab_workspace/main/UniLab

# format check (CI-equivalent)
uv run --no-sync ruff format --check .

# test suite
uv run pytest -m "not slow"

# notebook smoke validation
uv run python scripts/train_rsl_rl.py task=go1_joystick_flat/mujoco algo.max_iterations=1
uv run unilab demo
```

## Impact

- Backend impact: none
- Platform impact: both (notebooks are platform-agnostic)
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: generated by `unilab demo` and playback cells in notebooks
- ONNX / checkpoint: N/A

## Checklist

- [ ] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly
  - demo checkpoint public hosting (CDN / model registry) not yet available — notebooks depend on local training output
