### PR TITLE
docker files and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.history
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+__pycache__
+**/__pycache__
+logs
+benchmark/outputs
+dist
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python-is-python3 \
+    git \
+    curl \
+    ca-certificates \
+    build-essential \
+    cmake \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
+    libxrender1 \
+    libxext6 \
+    libsm6 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+WORKDIR /workspace/UniLab
+
+COPY . /workspace/UniLab
+
+# Use BuildKit cache mount so uv cache accelerates build but is not baked into image.
+# RUN --mount=type=cache,target=/root/.cache/uv \
+#     uv sync --dev --extra motrix
+
+RUN uv sync --dev --extra motrix \
+    && uv cache clean \
+    && rm -rf /root/.cache/uv
+
+RUN uv cache clean && rm -rf /root/.cache/uv
+
+CMD ["uv", "run", "unilab", "--help"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,35 @@
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python-is-python3 \
+    git \
+    curl \
+    ca-certificates \
+    build-essential \
+    cmake \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
+    libxrender1 \
+    libxext6 \
+    libsm6 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /workspace/UniLab
+
+COPY . /workspace/UniLab
+
+RUN uv sync
+
+CMD ["uv", "run", "unilab", "--help"]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,47 @@ unilab train --algo ppo --task go2_joystick_flat --sim mujoco training.max_itera
 
 > **For Developers**: Demo checkpoints currently require local training output. A checkpoint hosting solution (CDN / model registry) with automatic download is not yet in place.
 
+## Docker
+
+Use Docker when you want an isolated Linux runtime without changing your local Python environment. Local development still works best with `uv sync`; Docker is mainly for clean environment setup, image validation, and containerized runs.
+
+### Build images
+
+```bash
+# Base image: MuJoCo + UniLab runtime
+docker build -f Dockerfile.base -t unilab:base .
+
+# Dev image: base + Motrix + dev tools
+docker build -f Dockerfile -t unilab:dev .
+```
+
+### Run images
+
+```bash
+# Check the unified CLI entrypoint
+docker run --rm unilab:base
+docker run --rm unilab:dev
+
+# Interactive development with the repo mounted
+# Keep .venv in a named volume so the container does not overwrite the host venv
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+Using a named volume for `/workspace/UniLab/.venv` avoids mixing a container-created virtual environment with the host checkout. This prevents path mismatches such as `/workspace/UniLab/.venv` vs `.venv` and avoids permission problems when returning to local `uv` or `make test-all` workflows.
+
+### GPU containers
+
+On Linux hosts with the NVIDIA Container Toolkit configured, you can pass `--gpus all` to expose CUDA inside the container:
+
+```bash
+docker run --rm --gpus all unilab:base uv run python -c "import torch; print(torch.cuda.is_available())"
+docker run --rm --gpus all unilab:dev uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
 ## Repository Map
 
 - `conf/`: Hydra configuration, including task / reward / algorithm composition

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -100,6 +100,47 @@ unilab demo
 
 详细用法见 [训练指南](03-training.md)。
 
+## Docker
+
+当你希望在不改动本地 Python 环境的前提下获得隔离的 Linux 运行环境时，可以使用 Docker。本地开发仍然优先使用 `uv sync`；Docker 更适合做干净环境搭建、image 验证和容器化运行。
+
+### 构建 image
+
+```bash
+# 基础 image：MuJoCo + UniLab 运行时
+docker build -f Dockerfile.base -t unilab:base .
+
+# 开发 image：基础 image + Motrix + 开发工具
+docker build -f Dockerfile -t unilab:dev .
+```
+
+### 运行 image
+
+```bash
+# 检查统一 CLI 入口
+docker run --rm unilab:base
+docker run --rm unilab:dev
+
+# 挂载仓库进入交互式开发
+# 将 .venv 放在 named volume 中，避免容器覆盖宿主机虚拟环境
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+将 `/workspace/UniLab/.venv` 放到 named volume 中，可以避免把容器内创建的虚拟环境混入宿主机仓库目录，进而避免 `/workspace/UniLab/.venv` 与本地 `.venv` 的路径不一致，以及回到本地 `uv` 或 `make test-all` 工作流时出现权限问题。
+
+### GPU 容器
+
+在已经配置好 NVIDIA Container Toolkit 的 Linux 宿主机上，可以通过 `--gpus all` 将 CUDA 暴露给容器：
+
+```bash
+docker run --rm --gpus all unilab:base uv run python -c "import torch; print(torch.cuda.is_available())"
+docker run --rm --gpus all unilab:dev uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
 ## Navigation
 
 - Next: [Simulation Backends](02-simulation-backends.md)

--- a/docs/users/zh_CN/03-training.md
+++ b/docs/users/zh_CN/03-training.md
@@ -207,6 +207,57 @@ uv run scripts/train_offpolicy.py \
 
 自动记录的元数据包括 task、algorithm、backend、device、硬件信息、git 信息、完整配置、总运行时，以及可用时的最终回放视频。
 
+## Docker 中运行训练
+
+当你希望在隔离的 Linux 环境中运行训练时，可以直接在容器里执行统一 CLI 或脚本入口。推荐先在仓库根目录构建 image：
+
+```bash
+# 基础 image：MuJoCo + UniLab 运行时
+docker build -f Dockerfile.base -t unilab:base .
+
+# 开发 image：基础 image + Motrix + 开发工具
+docker build -f Dockerfile -t unilab:dev .
+```
+
+最简单的容器训练方式是挂载当前仓库，然后在容器内运行命令：
+
+```bash
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+这里延续 [快速开始](01-getting-started.md) 中的做法：将 `.venv` 单独放到 named volume，避免容器内创建的虚拟环境污染宿主机仓库目录。
+
+进入容器后，可以直接执行：
+
+```bash
+# 统一 CLI
+uv run unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# 直接脚本入口
+uv run scripts/train_rsl_rl.py task=go2_joystick_flat/mujoco
+uv run scripts/train_offpolicy.py algo=sac task=sac/g1_walk_flat/mujoco
+```
+
+如果宿主机已经配置好 NVIDIA Container Toolkit，可以使用 GPU 容器：
+
+```bash
+docker run --rm --gpus all -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+训练日志和产物仍会写入挂载后的仓库目录，例如 `logs/rsl_rl_ppo/<task>/`、`logs/fast_sac/<task>/`。如果只想快速验证 image 是否可用，可以直接运行：
+
+```bash
+docker run --rm unilab:base
+docker run --rm unilab:dev
+```
+
 ## Navigation
 
 - Previous: [Simulation Backends](02-simulation-backends.md)


### PR DESCRIPTION
## Summary

- Add Docker environment scaffolding on `main/UniLab` with three new files: `Dockerfile.base`, `Dockerfile`, and `.dockerignore`
- Use a two-image layout: a base MuJoCo runtime image and a dev image with Motrix + dev tooling
- Document Docker build/run workflows in `README.md` and `docs/users/zh_CN/01-getting-started.md`, keeping those two onboarding documents aligned
- Add Docker training guidance to `docs/users/zh_CN/03-training.md`
- Document and fix the recommended interactive container workflow by putting `.venv` on a named Docker volume to avoid polluting the host checkout with a container-created virtual environment
- Add a standalone Docker validation/cleanup runbook in `docker_test.md`

Why it changed:

- `infra_acceleration` already had Docker-related setup, but `main` did not
- The branch gap between `infra_acceleration` and `main` was too large, so Docker support needed to be recreated directly on `main`
- The previous bind-mount-only Docker workflow could leave a container-created `.venv` in the host repo, causing path mismatch and permission failures in local `uv` / `make test-all` workflows

User-facing / training-impact behavior:

- Users now have documented Docker build and run entrypoints on `main`
- The recommended interactive Docker command now mounts `.venv` via a named volume:
  - `docker run --rm -it -v "$(pwd):/workspace/UniLab" -v unilab-venv:/workspace/UniLab/.venv -w /workspace/UniLab unilab:dev bash`
- No training logic, Hydra routing contract, or algorithm behavior was changed

## Linked Work

- Issue: N/A
- Milestone: N/A

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Additional task-specific validation:

- [x] Reviewed `main/UniLab` project structure, `README.md`, `AGENTS.md`, `Makefile`, and `pyproject.toml` before porting Docker support
- [x] Reviewed Docker-related files from `infra_acceleration/UniLab` and ported the design with minimal changes
- [x] Verified that `README.md` and `docs/users/zh_CN/01-getting-started.md` remain aligned for Docker onboarding content
- [x] Added Docker usage, training, and cleanup documentation
- [x] Captured manual build/run/cleanup validation steps in `docker_test.md`
- [x] Identified and documented the host `.venv` pollution failure mode from bind-mount-only container workflows
- [ ] Successfully built Docker images locally
- [ ] Successfully ran Docker containers locally

Commands actually run:

```bash
# Docker build attempt on main
cd /home/fxl/unilab_workspace/main/UniLab
docker build -f Dockerfile.base -t unilab:base .

# Local check attempt after Docker workflow interaction
make test-all
```

Observed result:

- `docker build -f Dockerfile.base -t unilab:base .` failed before image build due to Docker Hub auth/network timeout when pulling `nvidia/cuda:12.8.0-cudnn-runtime-ubuntu22.04`
- `make test-all` later failed because the repo `.venv` had been polluted by a container-created environment rooted at `/workspace/UniLab/.venv`, causing a `VIRTUAL_ENV` mismatch and local permission failure
- The docs were updated to recommend a named volume for `/workspace/UniLab/.venv` to prevent this issue

## Impact

- Backend impact: both
- Platform impact: Linux
- Training effect expected: no

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [ ] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up work:

- Re-run Docker image build validation in an environment that can successfully pull from Docker Hub
- Validate both `unilab:base` and `unilab:dev` end to end with the commands listed in `docker_test.md`
- Optionally add README/docs notes for recovering from a polluted host `.venv` if users already ran the old bind-mount-only workflow
