### PR TITLE
Infra to main nan guard #273

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.history
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+__pycache__
+**/__pycache__
+logs
+benchmark/outputs
+dist
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python-is-python3 \
+    git \
+    curl \
+    ca-certificates \
+    build-essential \
+    cmake \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
+    libxrender1 \
+    libxext6 \
+    libsm6 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+WORKDIR /workspace/UniLab
+
+COPY . /workspace/UniLab
+
+# Use BuildKit cache mount so uv cache accelerates build but is not baked into image.
+# RUN --mount=type=cache,target=/root/.cache/uv \
+#     uv sync --dev --extra motrix
+
+RUN uv sync --dev --extra motrix \
+    && uv cache clean \
+    && rm -rf /root/.cache/uv
+
+RUN uv cache clean && rm -rf /root/.cache/uv
+
+CMD ["uv", "run", "unilab", "--help"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,35 @@
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python-is-python3 \
+    git \
+    curl \
+    ca-certificates \
+    build-essential \
+    cmake \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
+    libxrender1 \
+    libxext6 \
+    libsm6 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /workspace/UniLab
+
+COPY . /workspace/UniLab
+
+RUN uv sync
+
+CMD ["uv", "run", "unilab", "--help"]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,47 @@ unilab train --algo ppo --task go2_joystick_flat --sim mujoco training.max_itera
 
 > **For Developers**: Demo checkpoints currently require local training output. A checkpoint hosting solution (CDN / model registry) with automatic download is not yet in place.
 
+## Docker
+
+Use Docker when you want an isolated Linux runtime without changing your local Python environment. Local development still works best with `uv sync`; Docker is mainly for clean environment setup, image validation, and containerized runs.
+
+### Build images
+
+```bash
+# Base image: MuJoCo + UniLab runtime
+docker build -f Dockerfile.base -t unilab:base .
+
+# Dev image: base + Motrix + dev tools
+docker build -f Dockerfile -t unilab:dev .
+```
+
+### Run images
+
+```bash
+# Check the unified CLI entrypoint
+docker run --rm unilab:base
+docker run --rm unilab:dev
+
+# Interactive development with the repo mounted
+# Keep .venv in a named volume so the container does not overwrite the host venv
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+Using a named volume for `/workspace/UniLab/.venv` avoids mixing a container-created virtual environment with the host checkout. This prevents path mismatches such as `/workspace/UniLab/.venv` vs `.venv` and avoids permission problems when returning to local `uv` or `make test-all` workflows.
+
+### GPU containers
+
+On Linux hosts with the NVIDIA Container Toolkit configured, you can pass `--gpus all` to expose CUDA inside the container:
+
+```bash
+docker run --rm --gpus all unilab:base uv run python -c "import torch; print(torch.cuda.is_available())"
+docker run --rm --gpus all unilab:dev uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
 ## Repository Map
 
 - `conf/`: Hydra configuration, including task / reward / algorithm composition

--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -67,6 +67,11 @@ training:
   wandb_notes: null
   wandb_mode: null
   sim_backend: mujoco
+  nan_guard:
+    enabled: false
+    buffer_size: 100
+    max_envs_to_dump: 5
+    output_dir: null
   play_only: false
   no_play: false
   play_env_num: 16

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -100,6 +100,47 @@ unilab demo
 
 详细用法见 [训练指南](03-training.md)。
 
+## Docker
+
+当你希望在不改动本地 Python 环境的前提下获得隔离的 Linux 运行环境时，可以使用 Docker。本地开发仍然优先使用 `uv sync`；Docker 更适合做干净环境搭建、image 验证和容器化运行。
+
+### 构建 image
+
+```bash
+# 基础 image：MuJoCo + UniLab 运行时
+docker build -f Dockerfile.base -t unilab:base .
+
+# 开发 image：基础 image + Motrix + 开发工具
+docker build -f Dockerfile -t unilab:dev .
+```
+
+### 运行 image
+
+```bash
+# 检查统一 CLI 入口
+docker run --rm unilab:base
+docker run --rm unilab:dev
+
+# 挂载仓库进入交互式开发
+# 将 .venv 放在 named volume 中，避免容器覆盖宿主机虚拟环境
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+将 `/workspace/UniLab/.venv` 放到 named volume 中，可以避免把容器内创建的虚拟环境混入宿主机仓库目录，进而避免 `/workspace/UniLab/.venv` 与本地 `.venv` 的路径不一致，以及回到本地 `uv` 或 `make test-all` 工作流时出现权限问题。
+
+### GPU 容器
+
+在已经配置好 NVIDIA Container Toolkit 的 Linux 宿主机上，可以通过 `--gpus all` 将 CUDA 暴露给容器：
+
+```bash
+docker run --rm --gpus all unilab:base uv run python -c "import torch; print(torch.cuda.is_available())"
+docker run --rm --gpus all unilab:dev uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
 ## Navigation
 
 - Next: [Simulation Backends](02-simulation-backends.md)

--- a/docs/users/zh_CN/03-training.md
+++ b/docs/users/zh_CN/03-training.md
@@ -207,6 +207,57 @@ uv run scripts/train_offpolicy.py \
 
 自动记录的元数据包括 task、algorithm、backend、device、硬件信息、git 信息、完整配置、总运行时，以及可用时的最终回放视频。
 
+## Docker 中运行训练
+
+当你希望在隔离的 Linux 环境中运行训练时，可以直接在容器里执行统一 CLI 或脚本入口。推荐先在仓库根目录构建 image：
+
+```bash
+# 基础 image：MuJoCo + UniLab 运行时
+docker build -f Dockerfile.base -t unilab:base .
+
+# 开发 image：基础 image + Motrix + 开发工具
+docker build -f Dockerfile -t unilab:dev .
+```
+
+最简单的容器训练方式是挂载当前仓库，然后在容器内运行命令：
+
+```bash
+docker run --rm -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -v unilab-venv:/workspace/UniLab/.venv \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+这里延续 [快速开始](01-getting-started.md) 中的做法：将 `.venv` 单独放到 named volume，避免容器内创建的虚拟环境污染宿主机仓库目录。
+
+进入容器后，可以直接执行：
+
+```bash
+# 统一 CLI
+uv run unilab train --algo ppo --task go2_joystick_flat --sim mujoco
+
+# 直接脚本入口
+uv run scripts/train_rsl_rl.py task=go2_joystick_flat/mujoco
+uv run scripts/train_offpolicy.py algo=sac task=sac/g1_walk_flat/mujoco
+```
+
+如果宿主机已经配置好 NVIDIA Container Toolkit，可以使用 GPU 容器：
+
+```bash
+docker run --rm --gpus all -it \
+  -v "$(pwd):/workspace/UniLab" \
+  -w /workspace/UniLab \
+  unilab:dev bash
+```
+
+训练日志和产物仍会写入挂载后的仓库目录，例如 `logs/rsl_rl_ppo/<task>/`、`logs/fast_sac/<task>/`。如果只想快速验证 image 是否可用，可以直接运行：
+
+```bash
+docker run --rm unilab:base
+docker run --rm unilab:dev
+```
+
 ## Navigation
 
 - Previous: [Simulation Backends](02-simulation-backends.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
 
 [project.scripts]
 unilab = "unilab.cli:main"
+unilab-viz-nan = "unilab.tools.viz_nan:main"
+unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
 motrix = ["motrixsim==0.7.1.dev96425"]

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -273,6 +273,23 @@ def main(cfg: DictConfig) -> None:
                 num_envs=cfg.algo.num_envs,
                 env_cfg_override=env_cfg_override,
             )
+
+            nan_guard_cfg = getattr(cfg.training, "nan_guard", None)
+            if nan_guard_cfg is not None and getattr(nan_guard_cfg, "enabled", False):
+                from unilab.utils.nan_guard import NanGuard, NanGuardCfg
+
+                guard = NanGuard(
+                    NanGuardCfg(
+                        enabled=True,
+                        buffer_size=int(getattr(nan_guard_cfg, "buffer_size", 100)),
+                        max_envs_to_dump=int(getattr(nan_guard_cfg, "max_envs_to_dump", 5)),
+                        output_dir=getattr(nan_guard_cfg, "output_dir", None),
+                    ),
+                    num_envs=env.num_envs,
+                    supports_state_playback=env.play_capabilities.supports_physics_state_playback,
+                )
+                env.set_nan_guard(guard)
+
             wrapped_env = RslRlVecEnvWrapper(env, device=device)
 
             train_cfg = normalize_ppo_train_cfg(_algo_config_dict(cfg))

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -15,6 +15,7 @@ from unilab.dtype_config import get_global_dtype
 
 if TYPE_CHECKING:
     from unilab.base.augmentation import SymmetryAugmentation
+    from unilab.utils.nan_guard import NanGuard
 
 
 @dataclass
@@ -48,6 +49,7 @@ class NpEnv(ABEnv):
         self.step_counter = 0
         self._dr_manager: DomainRandomizationManager | None = None
         self._init_randomization_applied = False
+        self._nan_guard: NanGuard | None = None
 
     @property
     def cfg(self) -> EnvCfg:
@@ -148,6 +150,19 @@ class NpEnv(ABEnv):
             if backend_timing:
                 for k, v in backend_timing.items():
                     timing[f"backend_{k}"] = v
+
+        if self._nan_guard is not None:
+            self._nan_guard.capture(
+                self.get_physics_state_snapshot()
+                if self.play_capabilities.supports_physics_state_playback
+                else None
+            )
+            nan_ids = self._nan_guard.check(self._state.obs, self._state.reward)
+            if nan_ids is not None:
+                model_file = getattr(self._cfg, "model_file", "")
+                self._nan_guard.dump(nan_ids, str(model_file), self.step_counter)
+
+        np.nan_to_num(self._state.reward, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
 
         return self._state
 
@@ -333,6 +348,9 @@ class NpEnv(ABEnv):
             The backend-specific playback model.
         """
         return self._backend.get_playback_model(env_index)
+
+    def set_nan_guard(self, guard: "NanGuard") -> None:
+        self._nan_guard = guard
 
     def close(self) -> None:
         """关闭环境"""

--- a/src/unilab/tools/__init__.py
+++ b/src/unilab/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Debug and export tools for UniLab."""

--- a/src/unilab/tools/export_scene.py
+++ b/src/unilab/tools/export_scene.py
@@ -51,9 +51,7 @@ def main(argv: list[str] | None = None) -> int:
         description="Export a MuJoCo model to XML + mesh assets directory.",
     )
     parser.add_argument("model_file", help="Path to the MuJoCo XML or MJB model file")
-    parser.add_argument(
-        "-o", "--output-dir", default="exported_scene", help="Output directory"
-    )
+    parser.add_argument("-o", "--output-dir", default="exported_scene", help="Output directory")
     parser.add_argument("--zip", action="store_true", help="Also create a zip archive")
     args = parser.parse_args(argv)
 

--- a/src/unilab/tools/export_scene.py
+++ b/src/unilab/tools/export_scene.py
@@ -1,0 +1,66 @@
+"""Export a materialized MuJoCo scene to XML + mesh assets."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def export_scene(
+    model_file: str,
+    output_dir: str,
+    *,
+    as_zip: bool = False,
+) -> str:
+    import mujoco as _mujoco
+
+    mujoco: Any = _mujoco
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    spec = mujoco.MjSpec.from_file(model_file)
+
+    xml_content = spec.to_xml()
+    xml_path = output_path / "scene.xml"
+    xml_path.write_text(xml_content)
+
+    source_dir = Path(model_file).parent
+    meshdir = spec.meshdir if spec.meshdir else ""
+    mesh_source = source_dir / meshdir if meshdir else source_dir
+
+    assets_dst = output_path / "assets"
+    if mesh_source.is_dir():
+        for ext in ("*.stl", "*.obj", "*.msh", "*.ply"):
+            for f in mesh_source.glob(ext):
+                assets_dst.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(f, assets_dst / f.name)
+
+    if as_zip:
+        zip_path = shutil.make_archive(str(output_path), "zip", str(output_path))
+        return zip_path
+
+    return str(output_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="unilab-export-scene",
+        description="Export a MuJoCo model to XML + mesh assets directory.",
+    )
+    parser.add_argument("model_file", help="Path to the MuJoCo XML or MJB model file")
+    parser.add_argument(
+        "-o", "--output-dir", default="exported_scene", help="Output directory"
+    )
+    parser.add_argument("--zip", action="store_true", help="Also create a zip archive")
+    args = parser.parse_args(argv)
+
+    result = export_scene(args.model_file, args.output_dir, as_zip=args.zip)
+    print(f"Scene exported to: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/tools/viz_nan.py
+++ b/src/unilab/tools/viz_nan.py
@@ -50,9 +50,11 @@ def replay_dump(dump_path: str, env_index: int = 0) -> None:
         print(f"Cannot find model file. model_file in metadata: {model_file}")
         return
 
-    model = mujoco.MjModel.from_xml_path(model_path) if model_path.endswith(
-        ".xml"
-    ) else mujoco.MjModel.from_binary_path(model_path)
+    model = (
+        mujoco.MjModel.from_xml_path(model_path)
+        if model_path.endswith(".xml")
+        else mujoco.MjModel.from_binary_path(model_path)
+    )
     d = mujoco.MjData(model)
 
     num_steps = states.shape[0]
@@ -85,6 +87,7 @@ def replay_dump(dump_path: str, env_index: int = 0) -> None:
             viewer.sync()
 
             import time
+
             time.sleep(1.0 / 30.0)
             step_idx = (step_idx + 1) % num_steps
 
@@ -95,9 +98,7 @@ def main(argv: list[str] | None = None) -> int:
         description="Replay a NaN guard state dump in MuJoCo viewer.",
     )
     parser.add_argument("dump_path", help="Path to the .npz dump file")
-    parser.add_argument(
-        "--env-index", type=int, default=0, help="Environment index to visualize"
-    )
+    parser.add_argument("--env-index", type=int, default=0, help="Environment index to visualize")
     args = parser.parse_args(argv)
 
     replay_dump(args.dump_path, env_index=args.env_index)

--- a/src/unilab/tools/viz_nan.py
+++ b/src/unilab/tools/viz_nan.py
@@ -1,0 +1,108 @@
+"""Interactive viewer for NaN guard state dumps."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def load_dump(dump_path: str) -> dict:
+    data = np.load(dump_path, allow_pickle=True)
+    states = data["states"]
+    metadata = {}
+    for key in data.files:
+        if key.startswith("meta_"):
+            val = data[key]
+            metadata[key[5:]] = val.item() if val.ndim == 0 else val
+    return {"states": states, "metadata": metadata}
+
+
+def replay_dump(dump_path: str, env_index: int = 0) -> None:
+    import mujoco as _mujoco
+    import mujoco.viewer as _viewer  # noqa: F401
+
+    mujoco: Any = _mujoco
+
+    dump = load_dump(dump_path)
+    states = dump["states"]
+    meta = dump["metadata"]
+
+    if states.size == 0:
+        print("No physics states in dump (backend may not support state playback).")
+        print(f"Metadata: {meta}")
+        return
+
+    model_file = str(meta.get("model_file", ""))
+    dump_dir = Path(dump_path).parent
+    model_path = None
+    if model_file and Path(model_file).is_file():
+        model_path = model_file
+    else:
+        for f in sorted(dump_dir.glob("*_model.*")):
+            model_path = str(f)
+            break
+
+    if model_path is None:
+        print(f"Cannot find model file. model_file in metadata: {model_file}")
+        return
+
+    model = mujoco.MjModel.from_xml_path(model_path) if model_path.endswith(
+        ".xml"
+    ) else mujoco.MjModel.from_binary_path(model_path)
+    d = mujoco.MjData(model)
+
+    num_steps = states.shape[0]
+    num_envs = states.shape[1] if states.ndim >= 2 else 1
+    nan_env_ids = meta.get("nan_env_ids", np.array([]))
+    step_detected = meta.get("detection_step", "?")
+
+    print(f"Dump: {dump_path}")
+    print(f"Steps in buffer: {num_steps}, Envs: {num_envs}")
+    print(f"NaN detected at step {step_detected}, env ids: {nan_env_ids}")
+    print(f"Viewing env index: {env_index}")
+    print("Press Ctrl+C to exit.")
+
+    state_size = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_PHYSICS)
+
+    with mujoco.viewer.launch_passive(model, d) as viewer:
+        step_idx = 0
+        while viewer.is_running():
+            if states.ndim >= 3:
+                flat = states[step_idx, env_index]
+            elif states.ndim == 2:
+                flat = states[step_idx]
+            else:
+                break
+
+            if flat.shape[0] >= state_size:
+                mujoco.mj_setState(model, d, flat[:state_size], mujoco.mjtState.mjSTATE_PHYSICS)
+                mujoco.mj_forward(model, d)
+
+            viewer.sync()
+
+            import time
+            time.sleep(1.0 / 30.0)
+            step_idx = (step_idx + 1) % num_steps
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="unilab-viz-nan",
+        description="Replay a NaN guard state dump in MuJoCo viewer.",
+    )
+    parser.add_argument("dump_path", help="Path to the .npz dump file")
+    parser.add_argument(
+        "--env-index", type=int, default=0, help="Environment index to visualize"
+    )
+    args = parser.parse_args(argv)
+
+    replay_dump(args.dump_path, env_index=args.env_index)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/utils/nan_guard.py
+++ b/src/unilab/utils/nan_guard.py
@@ -1,0 +1,127 @@
+"""NaN/Inf guard for env-layer numerical anomaly detection and state dumping."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NanGuardCfg:
+    enabled: bool = False
+    buffer_size: int = 100
+    max_envs_to_dump: int = 5
+    output_dir: str | None = None
+
+
+class NanGuard:
+    def __init__(
+        self,
+        cfg: NanGuardCfg,
+        num_envs: int,
+        supports_state_playback: bool,
+    ) -> None:
+        self._cfg = cfg
+        self._num_envs = num_envs
+        self._supports_state_playback = supports_state_playback
+        self._buffer: list[np.ndarray] = []
+        self._buffer_idx: int = 0
+        self._buffer_full: bool = False
+        self._dumped: bool = False
+
+    def capture(self, physics_state: np.ndarray | None) -> None:
+        if physics_state is None:
+            return
+        if not self._buffer_full and len(self._buffer) < self._cfg.buffer_size:
+            self._buffer.append(physics_state)
+        else:
+            self._buffer_full = True
+            self._buffer[self._buffer_idx] = physics_state
+        self._buffer_idx = (self._buffer_idx + 1) % self._cfg.buffer_size
+
+    def check(
+        self, obs: dict[str, np.ndarray], reward: np.ndarray
+    ) -> np.ndarray | None:
+        if not self._cfg.enabled or self._dumped:
+            return None
+        bad_mask = np.zeros(self._num_envs, dtype=bool)
+        for v in obs.values():
+            bad_mask |= ~np.all(np.isfinite(v), axis=tuple(range(1, v.ndim)))
+        bad_mask |= ~np.isfinite(reward)
+        if not np.any(bad_mask):
+            return None
+        return np.flatnonzero(bad_mask).astype(np.int32)
+
+    def dump(
+        self,
+        nan_env_ids: np.ndarray,
+        model_file: str,
+        step: int,
+    ) -> str | None:
+        if self._dumped:
+            return None
+        self._dumped = True
+
+        output_dir = Path(self._cfg.output_dir or "/tmp/unilab/nan_dumps")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        dump_env_ids = nan_env_ids[: self._cfg.max_envs_to_dump]
+
+        if self._buffer_full:
+            ordered = (
+                self._buffer[self._buffer_idx :]
+                + self._buffer[: self._buffer_idx]
+            )
+        else:
+            ordered = list(self._buffer)
+
+        states = np.stack(ordered, axis=0) if ordered else np.array([])
+        if states.ndim >= 3 and dump_env_ids.size > 0:
+            states = states[:, dump_env_ids]
+
+        metadata = {
+            "num_envs_total": self._num_envs,
+            "nan_env_ids": nan_env_ids,
+            "dumped_env_ids": dump_env_ids,
+            "buffer_size": self._cfg.buffer_size,
+            "buffer_len": len(ordered),
+            "detection_step": step,
+            "timestamp": time.time(),
+            "model_file": model_file,
+            "supports_state_playback": self._supports_state_playback,
+        }
+
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        dump_name = f"nan_dump_{ts}_step{step}"
+        npz_path = output_dir / f"{dump_name}.npz"
+        np.savez(
+            str(npz_path),
+            states=states,
+            **{f"meta_{k}": v for k, v in metadata.items()},
+        )
+
+        if model_file and Path(model_file).is_file():
+            model_dst = output_dir / f"{dump_name}_model{Path(model_file).suffix}"
+            shutil.copy2(model_file, model_dst)
+
+        latest_link = output_dir / "nan_dump_latest.npz"
+        latest_link.unlink(missing_ok=True)
+        try:
+            latest_link.symlink_to(npz_path.name)
+        except OSError:
+            pass
+
+        logger.warning(
+            "NaN guard triggered at step %d for %d envs. Dump: %s",
+            step,
+            len(nan_env_ids),
+            npz_path,
+        )
+        return str(npz_path)

--- a/src/unilab/utils/nan_guard.py
+++ b/src/unilab/utils/nan_guard.py
@@ -46,9 +46,7 @@ class NanGuard:
             self._buffer[self._buffer_idx] = physics_state
         self._buffer_idx = (self._buffer_idx + 1) % self._cfg.buffer_size
 
-    def check(
-        self, obs: dict[str, np.ndarray], reward: np.ndarray
-    ) -> np.ndarray | None:
+    def check(self, obs: dict[str, np.ndarray], reward: np.ndarray) -> np.ndarray | None:
         if not self._cfg.enabled or self._dumped:
             return None
         bad_mask = np.zeros(self._num_envs, dtype=bool)
@@ -75,10 +73,7 @@ class NanGuard:
         dump_env_ids = nan_env_ids[: self._cfg.max_envs_to_dump]
 
         if self._buffer_full:
-            ordered = (
-                self._buffer[self._buffer_idx :]
-                + self._buffer[: self._buffer_idx]
-            )
+            ordered = self._buffer[self._buffer_idx :] + self._buffer[: self._buffer_idx]
         else:
             ordered = list(self._buffer)
 

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -516,3 +516,55 @@ class TestEdgeCases:
         state = env.step(np.zeros((1, 3)))
         assert set(state.obs.keys()) == {"obs", "critic", "history"}
         assert env.observation_space.shape == (18,)  # 4+6+8
+
+
+# ---------------------------------------------------------------------------
+# Reward sanitization (unconditional nan_to_num at end of step)
+# ---------------------------------------------------------------------------
+
+
+class _NanRewardStubEnv(_StubNpEnv):
+    """Produces NaN/Inf rewards for sanitization testing."""
+
+    def __init__(self, num_envs: int = 4, bad_rewards: np.ndarray | None = None):
+        super().__init__(num_envs)
+        self._bad_rewards = bad_rewards
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        state = super().update_state(state)
+        if self._bad_rewards is not None:
+            return state.replace(reward=self._bad_rewards.copy())
+        return state
+
+
+class TestRewardSanitization:
+    def test_step_sanitizes_nan_reward(self):
+        rewards = np.array([1.0, np.nan, 0.5, np.nan], dtype=np.float32)
+        env = _NanRewardStubEnv(num_envs=4, bad_rewards=rewards)
+        env.init_state()
+        state = env.step(np.zeros((4, 3)))
+        assert np.all(np.isfinite(state.reward))
+        np.testing.assert_array_equal(state.reward, [1.0, 0.0, 0.5, 0.0])
+
+    def test_step_sanitizes_inf_reward(self):
+        rewards = np.array([np.inf, -np.inf, 0.0, 1.0], dtype=np.float32)
+        env = _NanRewardStubEnv(num_envs=4, bad_rewards=rewards)
+        env.init_state()
+        state = env.step(np.zeros((4, 3)))
+        assert np.all(np.isfinite(state.reward))
+        np.testing.assert_array_equal(state.reward, [0.0, 0.0, 0.0, 1.0])
+
+    def test_guard_detects_nan_reward_before_sanitization(self):
+        from unilab.utils.nan_guard import NanGuard, NanGuardCfg
+
+        rewards = np.array([0.0, np.nan, 0.0, 0.0], dtype=np.float32)
+        env = _NanRewardStubEnv(num_envs=4, bad_rewards=rewards)
+        env.init_state()
+
+        cfg = NanGuardCfg(enabled=True, output_dir="/tmp/unilab_test_sanitize")
+        guard = NanGuard(cfg, num_envs=4, supports_state_playback=False)
+        env.set_nan_guard(guard)
+
+        state = env.step(np.zeros((4, 3)))
+        assert guard._dumped, "guard should have detected NaN before sanitization"
+        assert np.all(np.isfinite(state.reward)), "reward should be clean after step"

--- a/tests/test_export_scene.py
+++ b/tests/test_export_scene.py
@@ -1,0 +1,66 @@
+"""Tests for scene export tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from unilab.tools.export_scene import export_scene, main
+
+MINIMAL_XML = """\
+<mujoco>
+  <worldbody>
+    <body name="box" pos="0 0 0.5">
+      <geom type="box" size="0.1 0.1 0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture()
+def model_file(tmp_path: Path) -> str:
+    p = tmp_path / "test_model.xml"
+    p.write_text(MINIMAL_XML)
+    return str(p)
+
+
+def test_export_creates_xml(model_file: str, tmp_path: Path):
+    out = tmp_path / "export_out"
+    export_scene(model_file, str(out))
+    assert (out / "scene.xml").is_file()
+
+
+def test_export_directory_structure(model_file: str, tmp_path: Path):
+    out = tmp_path / "export_out2"
+    export_scene(model_file, str(out))
+    assert out.is_dir()
+    assert (out / "scene.xml").is_file()
+
+
+def test_exported_scene_reloadable(model_file: str, tmp_path: Path):
+    import mujoco
+
+    out = tmp_path / "export_out3"
+    export_scene(model_file, str(out))
+    model = mujoco.MjModel.from_xml_path(str(out / "scene.xml"))
+    assert model.ngeom > 0
+
+
+def test_export_scene_zip_contains_xml(model_file: str, tmp_path: Path):
+    out = tmp_path / "export_zip"
+    zip_path = Path(export_scene(model_file, str(out), as_zip=True))
+    assert zip_path.is_file()
+    assert zip_path.suffix == ".zip"
+    with ZipFile(zip_path) as zf:
+        assert "scene.xml" in zf.namelist()
+
+
+def test_export_scene_cli_creates_xml(model_file: str, tmp_path: Path):
+    out = tmp_path / "export_cli"
+    assert main([model_file, "-o", str(out)]) == 0
+    assert (out / "scene.xml").is_file()

--- a/tests/test_nan_guard.py
+++ b/tests/test_nan_guard.py
@@ -1,0 +1,207 @@
+"""Tests for NanGuard: env-layer NaN/Inf detection and state dumping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unilab.tools.viz_nan import load_dump
+from unilab.utils.nan_guard import NanGuard, NanGuardCfg
+
+NUM_ENVS = 4
+OBS_DIM = 10
+
+
+def _make_clean_obs() -> dict[str, np.ndarray]:
+    return {"policy": np.zeros((NUM_ENVS, OBS_DIM), dtype=np.float32)}
+
+
+def _make_clean_reward() -> np.ndarray:
+    return np.zeros(NUM_ENVS, dtype=np.float32)
+
+
+# ── 1. disabled guard ──────────────────────────────────────────────────────
+
+
+def test_disabled_guard_returns_none():
+    cfg = NanGuardCfg(enabled=False)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    obs = _make_clean_obs()
+    obs["policy"][0, 0] = np.nan
+    assert guard.check(obs, _make_clean_reward()) is None
+
+
+# ── 2. detect NaN in obs ──────────────────────────────────────────────────
+
+
+def test_detect_nan_in_obs():
+    cfg = NanGuardCfg(enabled=True)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    obs = _make_clean_obs()
+    obs["policy"][1, 3] = np.nan
+    obs["policy"][3, 7] = np.nan
+    result = guard.check(obs, _make_clean_reward())
+    assert result is not None
+    np.testing.assert_array_equal(result, [1, 3])
+
+
+# ── 3. detect Inf in obs ─────────────────────────────────────────────────
+
+
+def test_detect_inf_in_obs():
+    cfg = NanGuardCfg(enabled=True)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    obs = _make_clean_obs()
+    obs["policy"][2, 0] = np.inf
+    result = guard.check(obs, _make_clean_reward())
+    assert result is not None
+    np.testing.assert_array_equal(result, [2])
+
+
+def test_detect_nan_in_secondary_obs_group():
+    cfg = NanGuardCfg(enabled=True)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    obs = _make_clean_obs()
+    obs["critic"] = np.zeros((NUM_ENVS, 3), dtype=np.float32)
+    obs["critic"][2, 1] = np.nan
+    result = guard.check(obs, _make_clean_reward())
+    assert result is not None
+    np.testing.assert_array_equal(result, [2])
+
+
+# ── 4. detect NaN/Inf in reward ──────────────────────────────────────────
+
+
+def test_detect_nan_in_reward():
+    cfg = NanGuardCfg(enabled=True)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    reward = _make_clean_reward()
+    reward[0] = np.nan
+    reward[2] = -np.inf
+    result = guard.check(_make_clean_obs(), reward)
+    assert result is not None
+    np.testing.assert_array_equal(result, [0, 2])
+
+
+# ── 5. rolling buffer capacity ───────────────────────────────────────────
+
+
+def test_rolling_buffer_capacity():
+    buf_size = 5
+    cfg = NanGuardCfg(enabled=True, buffer_size=buf_size)
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    for i in range(buf_size + 3):
+        state = np.full((NUM_ENVS, 4), float(i), dtype=np.float32)
+        guard.capture(state)
+    assert len(guard._buffer) == buf_size
+
+
+def test_dump_preserves_rolling_buffer_order(tmp_path):
+    cfg = NanGuardCfg(enabled=True, buffer_size=3, output_dir=str(tmp_path))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    for i in range(5):
+        guard.capture(np.full((NUM_ENVS, 2), float(i), dtype=np.float32))
+    path = guard.dump(np.array([0], dtype=np.int32), model_file="", step=5)
+    assert path is not None
+    data = np.load(path, allow_pickle=True)
+    np.testing.assert_array_equal(data["states"][:, 0, 0], [2.0, 3.0, 4.0])
+
+
+# ── 6. dump output format ────────────────────────────────────────────────
+
+
+def test_dump_output_format(tmp_path):
+    cfg = NanGuardCfg(enabled=True, buffer_size=3, output_dir=str(tmp_path))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    for i in range(3):
+        guard.capture(np.ones((NUM_ENVS, 4), dtype=np.float32) * i)
+    nan_ids = np.array([0, 2], dtype=np.int32)
+    path = guard.dump(nan_ids, model_file="", step=42)
+    assert path is not None
+    data = np.load(path, allow_pickle=True)
+    assert "states" in data
+    assert data["states"].shape[0] == 3
+    assert int(data["meta_detection_step"]) == 42
+
+
+def test_dump_limits_state_envs_and_records_all_nan_ids(tmp_path):
+    cfg = NanGuardCfg(
+        enabled=True,
+        buffer_size=2,
+        max_envs_to_dump=2,
+        output_dir=str(tmp_path),
+    )
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    state = np.arange(NUM_ENVS * 3, dtype=np.float32).reshape(NUM_ENVS, 3)
+    guard.capture(state)
+    nan_ids = np.array([0, 1, 2, 3], dtype=np.int32)
+    path = guard.dump(nan_ids, model_file="", step=7)
+    assert path is not None
+    data = np.load(path, allow_pickle=True)
+    assert data["states"].shape == (1, 2, 3)
+    np.testing.assert_array_equal(data["states"][0], state[[0, 1]])
+    np.testing.assert_array_equal(data["meta_nan_env_ids"], nan_ids)
+    np.testing.assert_array_equal(data["meta_dumped_env_ids"], [0, 1])
+
+
+def test_dump_copies_model_file_and_updates_latest_link(tmp_path):
+    model_file = tmp_path / "model.xml"
+    model_file.write_text("<mujoco/>")
+    cfg = NanGuardCfg(enabled=True, output_dir=str(tmp_path / "dumps"))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    guard.capture(np.zeros((NUM_ENVS, 2), dtype=np.float32))
+    path = guard.dump(np.array([0], dtype=np.int32), model_file=str(model_file), step=3)
+    assert path is not None
+    dump_path = Path(path)
+    copied_models = list(dump_path.parent.glob("*_model.xml"))
+    assert len(copied_models) == 1
+    assert copied_models[0].read_text() == "<mujoco/>"
+    latest_link = dump_path.parent / "nan_dump_latest.npz"
+    if latest_link.exists():
+        assert latest_link.resolve() == dump_path
+
+
+def test_load_dump_round_trips_states_and_metadata(tmp_path):
+    cfg = NanGuardCfg(enabled=True, buffer_size=1, output_dir=str(tmp_path))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=True)
+    state = np.arange(NUM_ENVS * 2, dtype=np.float32).reshape(NUM_ENVS, 2)
+    guard.capture(state)
+    nan_ids = np.array([1, 3], dtype=np.int32)
+    path = guard.dump(nan_ids, model_file="", step=11)
+    assert path is not None
+    dump = load_dump(path)
+    np.testing.assert_array_equal(dump["states"], state[[1, 3]][None, ...])
+    assert dump["metadata"]["detection_step"] == 11
+    np.testing.assert_array_equal(dump["metadata"]["nan_env_ids"], nan_ids)
+
+
+# ── 7. dump only once ────────────────────────────────────────────────────
+
+
+def test_dump_only_once(tmp_path):
+    cfg = NanGuardCfg(enabled=True, output_dir=str(tmp_path))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    nan_ids = np.array([0], dtype=np.int32)
+    first = guard.dump(nan_ids, model_file="", step=1)
+    second = guard.dump(nan_ids, model_file="", step=2)
+    assert first is not None
+    assert second is None
+
+
+# ── 8. no physics state still detects ────────────────────────────────────
+
+
+def test_no_physics_state_still_detects(tmp_path):
+    cfg = NanGuardCfg(enabled=True, output_dir=str(tmp_path))
+    guard = NanGuard(cfg, NUM_ENVS, supports_state_playback=False)
+    guard.capture(None)
+    obs = _make_clean_obs()
+    obs["policy"][0, 0] = np.nan
+    result = guard.check(obs, _make_clean_reward())
+    assert result is not None
+    path = guard.dump(result, model_file="", step=10)
+    assert path is not None
+    data = np.load(path, allow_pickle=True)
+    assert data["states"].size == 0

--- a/tests/utils/test_utils_package_policy.py
+++ b/tests/utils/test_utils_package_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import unilab.utils
 
 ALLOWED_UTILS_API = {"get_default_device", "to_numpy", "to_torch"}
-ALLOWED_UTILS_MODULES = {"__init__", "device", "support_matrix", "tensor"}
+ALLOWED_UTILS_MODULES = {"__init__", "device", "nan_guard", "support_matrix", "tensor"}
 REMOVED_UTILS_SHIMS = {
     "algo_utils",
     "device_utils",


### PR DESCRIPTION
## Summary

- 为 UniLab 训练流程新增可选的 env 层 NaN/Inf guard。通过 Hydra 配置启用后，`NpEnv.step()` 会捕获最近的 physics state，检查所有 observation group 和 reward 中的非有限值，并在首次触发时写出 dump，便于复现和定位。
- 新增标准化调试工具：
  - `unilab-viz-nan`：加载并用 MuJoCo viewer 回放 NaN guard dump。
  - `unilab-export-scene`：将 materialized MuJoCo scene 导出为 `scene.xml` 和 mesh assets，可选导出 zip。
- 在 env 边界新增 reward 消毒：`step()` 返回前对 reward 执行 `np.nan_to_num(..., nan=0.0, posinf=0.0, neginf=0.0)`。该操作位于 guard check 之后，因此 guard 能看到原始异常值，而 learner 拿到的是 finite reward。
- 默认行为不变：NaN guard 默认关闭，配置为 `training.nan_guard.enabled=false`。

本 PR 实现 Issue #273 的调试工具链目标：可选 NaN guard、dump 回放工具、scene 导出工具，以及非交互部分的自动化测试覆盖。

## Linked Work

- Issue: #273
- Milestone: N/A

## 背景 / 动机

UniLab 之前只有 learner/algo 层的局部数值防护，但缺少标准化的 env 层检测能力。物理仿真、task 逻辑、obs/reward 计算中产生的 NaN/Inf 可能在没有足够上下文的情况下静默传播到 learner，后续定位困难。

本设计借鉴 mjlab 中对 UniLab 有价值的部分：

- 维护最近若干步 physics state 的 rolling buffer；
- 在最接近 env 边界的位置检测 NaN/Inf；
- 只 dump 一次，避免异常级联时反复写盘；
- 提供 replay/export 工具链，方便调试、复现和分享 scene。

本 PR 的范围刻意限定在 env/debug tooling 层，不替代已有的 loss/gradient 层 NaN 处理。

## 设计说明

### NaN guard 接入方式

- 配置入口：PPO config 下的 `training.nan_guard`。
- 启用方式：`training.nan_guard.enabled=true`。
- 注入点：`scripts/train_rsl_rl.py` 仅在启用时创建 `NanGuard`，并通过 `env.set_nan_guard(...)` 注入 env。
- 运行时检查点：`NpEnv.step()` 中 `update_state()`、truncation/reset 处理、timing 记录之后；reward 消毒和 return 之前。

这样保持了 `scripts/` 只负责流程装配，长期逻辑留在 env/utils 层。

### Contract 与分层约束

- `NpEnvState.obs` 仍然是 `dict[str, np.ndarray]`；guard 遍历所有 observation group，不假设只有 `policy` obs。
- `reset()` 和 `step()` 返回签名不变。
- backend-specific 逻辑不扩散到训练脚本。
- physics state 捕获通过 env/backend playback contract：`get_physics_state_snapshot()` 和 `play_capabilities.supports_physics_state_playback`。
- asset/XML/model 文件处理只发生在 dump/export/replay 等冷路径，不进入训练热路径。

### Dump 语义

- `capture()` 维护固定大小 rolling buffer。
- `dump()` 写出一个 `.npz` 文件后设置 `_dumped`，后续异常不再重复 dump。
- dump metadata 包含：
  - 总 env 数量；
  - 全部检测到异常的 env ids；
  - 实际写入 state 的 env ids；
  - buffer size 和 buffer len；
  - detection step；
  - timestamp；
  - model file path；
  - 是否支持 physics state playback。
- `max_envs_to_dump` 限制实际写入 `states` 的 env 维度，防止 dump 体积失控；metadata 仍保留全部异常 env ids。
- 如果 model file 存在，会复制到 dump 目录旁边。
- 尽力创建 `nan_dump_latest.npz` symlink，方便快速定位最新 dump。

### 工具链

- `unilab-viz-nan`：
  - `load_dump()` 可自动化测试，用于验证 dump round-trip；
  - `replay_dump()` 会打开 `mujoco.viewer`，用于人工调试；
  - 如果 dump 中没有 physics states，会打印 metadata，而不是直接失败。
- `unilab-export-scene`：
  - 将 MuJoCo model 导出为 `scene.xml`；
  - 复制常见 mesh asset 格式到 `assets/` 目录；
  - 支持生成 zip；
  - 测试中会用 MuJoCo 重新加载导出的 XML，验证可用性。

## 变更文件

### 新增文件

- `src/unilab/utils/nan_guard.py`
  - `NanGuardCfg`
  - `NanGuard.capture()`
  - `NanGuard.check()`
  - `NanGuard.dump()`
- `src/unilab/tools/__init__.py`
- `src/unilab/tools/viz_nan.py`
  - `load_dump()`
  - `replay_dump()`
  - `main()`，对应 `unilab-viz-nan`
- `src/unilab/tools/export_scene.py`
  - `export_scene()`
  - `main()`，对应 `unilab-export-scene`
- `tests/test_nan_guard.py`
- `tests/test_export_scene.py`

### 修改文件

- `src/unilab/base/np_env.py`
  - 新增 `_nan_guard` 字段；
  - 在 `step()` 中调用 guard capture/check/dump；
  - guard check 之后执行 reward 消毒；
  - 新增 `set_nan_guard()`。
- `conf/ppo/config.yaml`
  - 新增 `training.nan_guard` 配置块。
- `scripts/train_rsl_rl.py`
  - 启用配置打开时创建并注入 `NanGuard`。
- `pyproject.toml`
  - 注册 `unilab-viz-nan` 和 `unilab-export-scene` console scripts。

## Validation

- [x] `uv run pytest tests/test_nan_guard.py tests/test_export_scene.py tests/base/test_np_env.py -q`
- [x] `uv run pytest tests/ -q -k "not slow"`
- [x] `uv run ruff check src tests scripts`
- [x] `uv run pyright`
- [x] `uv run mypy src/unilab`
- [x] NaN guard 启用状态下的训练 smoke test

实际执行命令：

```bash
uv run pytest tests/test_nan_guard.py tests/test_export_scene.py tests/base/test_np_env.py -q
uv run pytest tests/ -q -k "not slow"
uv run ruff check src tests scripts
uv run pyright
uv run mypy src/unilab
uv run scripts/train_rsl_rl.py task=go2_joystick_flat/mujoco training.nan_guard.enabled=true algo.max_iterations=1 training.no_play=true
```

执行结果：

```text
targeted tests: 56 passed
full non-slow tests: 554 passed, 11 skipped, 235 deselected
ruff: All checks passed
pyright: 0 errors, 0 warnings, 0 informations
mypy: Success, no issues found in 137 source files
training smoke: completed 1 PPO iteration with NaN guard enabled
```

注意：当前 PPO 短训的正确 override 是 `algo.max_iterations=1`，不是 `training.max_iterations=1`。

## 测试覆盖详情

### NaN guard tests

覆盖行为包括：

- guard disabled 时返回 `None`，默认关闭不影响训练；
- policy obs 中 NaN 检测；
- policy obs 中 Inf 检测；
- secondary obs group（例如 critic obs）中的 NaN 检测；
- reward 中 NaN/Inf 检测；
- rolling buffer capacity；
- dump 顺序从旧到新；
- dump 输出格式和 metadata；
- `max_envs_to_dump` 限制实际 state dump，同时 metadata 保留全部异常 env ids；
- model file copy 和 latest symlink 行为；
- `load_dump()` round-trip；
- 只 dump 一次；
- 不支持 physics state 时仍然能检测并写出 metadata。

### Env integration tests

覆盖行为包括：

- `step()` 将 NaN reward 消毒为 `0.0`；
- `step()` 将正/负 Inf reward 消毒为 `0.0`；
- guard 在 reward 消毒前检测到原始 NaN reward。

### Scene export tests

覆盖行为包括：

- export 创建 `scene.xml`；
- export 输出目录结构正确；
- 导出的 XML 可以被 MuJoCo 重新加载；
- zip export 包含 `scene.xml`；
- CLI smoke test 能创建 `scene.xml`。

## Impact

- Backend impact: both
  - MuJoCo：支持完整检测 + physics state dump/replay 路径，前提是 backend 支持 playback。
  - Motrix：仍可检测 NaN/Inf；如果不支持 physics state playback，则 dump 中可能只有 metadata，没有可回放 physics states。
- Platform impact: 理论上覆盖 Linux 和 macOS；本次验证在当前 Linux/WSL 环境完成。
- Training effect expected: 默认无行为变化，因为 guard 默认关闭。启用后，env-step 增加 finite check 和可选 state snapshot copy 开销。reward 消毒是无条件执行，确保 learner-facing reward 为 finite。

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A
- Training smoke 本地生成日志路径：`logs/rsl_rl_ppo/Go2JoystickFlat/...`

## Reviewer Checklist

建议 reviewer 按以下风险边界审查：

- [ ] Env contract 是否保持：`NpEnvState.obs` 仍是 dict，`step()` 仍返回 `NpEnvState`，`reset()` contract 未改变。
- [ ] Guard check 是否发生在 reward 消毒之前。
- [ ] NaN guard 是否默认关闭。
- [ ] 启用方式是否通过 Hydra config，而不是 Python 层硬编码。
- [ ] Backend-specific 行为是否没有泄漏到训练脚本。
- [ ] 热路径是否没有解析 XML/assets，也没有探测 backend 私有能力。
- [ ] Dump 顺序是否从旧到新，且只 dump 一次是预期行为。
- [ ] `max_envs_to_dump` 是否限制 state tensor 大小，同时 metadata 保留全部异常 env ids。
- [ ] 自动化测试是否避免打开交互 viewer，仅测试 `load_dump()`。
- [ ] 静态检查是否通过，且没有扩大 type-ignore 范围。

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly

## Follow-up Work / Known Limits

- 真实训练中是否自然出现 NaN 不具备确定性。端到端触发验证建议使用临时 NaN 注入，验证后必须撤销，不能提交。
- `unilab-viz-nan` 是交互式工具，应作为人工验证工具，不放入 CI 自动化覆盖。
- Motrix 当前在不支持 physics state playback 时降级为检测 + metadata dump。
- 本 PR 不新增 gradient/parameter NaN dump 工具，范围聚焦在 env 层 obs/reward/state 调试。
- 如果用户文档中包含 PPO 短训命令，应使用 `algo.max_iterations=...`。
