### PR TITLE
fix: separate APPO startup time from rollout fps

### DIFF
--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -266,8 +266,6 @@ class APPORunner(AsyncRunner):
         replay_queue: deque[dict] = deque(maxlen=self.replay_queue_size)
 
         for iteration in range(1, max_iterations + 1):
-            iter_start = time.time()
-
             # Drain collector metrics while waiting for next rollout
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
             wait_start = time.time()
@@ -297,9 +295,14 @@ class APPORunner(AsyncRunner):
             # the learner was training, we consume all 3 immediately rather than
             # processing them one-per-iteration.
             num_new = shared_storage.available()
+            rollout_collect_time = 0.0
             for _ in range(num_new):
                 raw = shared_storage.read_torch(self.device)
                 shared_storage.advance_read()
+
+                raw_collect_time = raw.pop("rollout_collect_time_s", None)
+                if raw_collect_time is not None:
+                    rollout_collect_time += float(raw_collect_time.reshape(-1)[0].item())
 
                 # Preprocess: storage is [N, T, *] (env-major); learner expects [T, N, *]
                 rollout: dict = {}
@@ -315,7 +318,8 @@ class APPORunner(AsyncRunner):
                 replay_queue.append(rollout)
 
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
-            collect_time = time.time() - iter_start
+            collect_time = rollout_collect_time
+            startup_wait_time = max(wait_time - collect_time, 0.0) if iteration == 1 else 0.0
 
             # Concatenate all rollouts in the replay queue along the env dimension.
             # Each rollout keeps its own behavior_log_probs so V-trace IS ratios are
@@ -338,6 +342,7 @@ class APPORunner(AsyncRunner):
 
             metrics["replay_queue_len"] = float(len(replay_queue))
             metrics["available_on_arrive"] = float(available_on_arrive)
+            metrics["rollouts_read"] = float(num_new)
 
             logger.update_replay_queue(len(replay_queue), self.replay_queue_size)
 
@@ -357,6 +362,10 @@ class APPORunner(AsyncRunner):
                 collect_time=collect_time,
                 train_time=train_time,
                 wait_time=wait_time,
+                extra_info={
+                    "startup_wait_time": startup_wait_time,
+                    "throughput_steps": num_new * env_steps_per_sync,
+                },
             )
 
             if save_interval > 0 and iteration % save_interval == 0:

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -48,6 +48,11 @@ def compute_timeout_bootstrap_correction(
     return corrections
 
 
+def record_rollout_collect_time(write_buf: dict[str, np.ndarray], collect_time_s: float) -> None:
+    """Write collector-measured rollout wall time into shared rollout metadata."""
+    write_buf["rollout_collect_time_s"][:] = float(collect_time_s)
+
+
 def appo_collector_fn(
     stop_event: Any,
     env_name: str,
@@ -204,6 +209,7 @@ def appo_collector_fn(
 
             # Collect one rollout of length steps_per_env
             write_buf = storage.write_buffer
+            rollout_start = time.perf_counter()
             for step in range(steps_per_env):
                 # --- MLP inference (timed) ---
                 t_mlp = time.perf_counter()
@@ -322,6 +328,7 @@ def appo_collector_fn(
             write_buf["last_obs"][:] = obs_np
             if critic_np is not None:
                 write_buf["last_critic"][:] = critic_np
+            record_rollout_collect_time(write_buf, time.perf_counter() - rollout_start)
             storage.signal_write_done()  # atomic increment, non-blocking
 
     except Exception as e:

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -169,6 +169,8 @@ def _learner_worker(
         latest_reward_components: dict = {}
         write_read_ema = 0.0
         last_buf_log = 0
+        startup_wait_time = 0.0
+        have_startup_wait_time = False
 
         # 7. Training loop
         for it in range(1, max_iterations + 1):
@@ -216,7 +218,16 @@ def _learner_worker(
 
             dist.barrier()
             wait_time = time.time() - wait_start if rank == 0 else 0.0
-            collect_time = time.time() - iter_start if rank == 0 else 0.0
+            collect_time = (
+                float(getattr(replay_buffer, "collect_time_s", torch.zeros(1))[0])
+                if rank == 0
+                else 0.0
+            )
+            if rank == 0 and collect_time <= 0:
+                collect_time = time.time() - iter_start
+            if rank == 0 and not have_startup_wait_time and wait_time > collect_time:
+                startup_wait_time = max(wait_time - collect_time, 0.0)
+                have_startup_wait_time = True
 
             # --- Training: each rank independently samples a different mini-batch ---
             train_start = time.time()
@@ -272,6 +283,10 @@ def _learner_worker(
                         collect_time=collect_time,
                         train_time=train_time,
                         wait_time=wait_time,
+                        extra_info={
+                            "startup_wait_time": startup_wait_time if it == 1 else 0.0,
+                            "throughput_steps": num_envs * env_steps_per_sync,
+                        },
                     )
 
                 if save_interval > 0 and it % save_interval == 0:

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -261,6 +261,8 @@ class OffPolicyRunner(AsyncRunner):
         write_read_ema = 0.0
         reward_stats_ptr = 0
         train_start_threshold = self.train_start_threshold
+        startup_wait_time = 0.0
+        have_startup_wait_time = False
 
         # Training loop
         for iteration in range(1, max_iterations + 1):
@@ -347,7 +349,13 @@ class OffPolicyRunner(AsyncRunner):
 
             wait_time = time.time() - wait_start
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
-            collect_time = time.time() - iter_start
+            collect_time = float(getattr(replay_buffer, "collect_time_s", torch.zeros(1))[0])
+            if collect_time <= 0:
+                collect_time = time.time() - iter_start - wait_time
+            collect_time = max(float(collect_time), 0.0)
+            if not have_startup_wait_time and wait_time > collect_time:
+                startup_wait_time = max(wait_time - collect_time, 0.0)
+                have_startup_wait_time = True
             reward_stats_ptr = self._update_reward_stats_from_replay(
                 replay_buffer,
                 reward_stats_ptr,
@@ -422,6 +430,10 @@ class OffPolicyRunner(AsyncRunner):
                 collect_time=collect_time,
                 train_time=train_time,
                 wait_time=wait_time,
+                extra_info={
+                    "startup_wait_time": startup_wait_time if iteration == 1 else 0.0,
+                    "throughput_steps": self.num_envs * self.env_steps_per_sync,
+                },
             )
 
             if save_interval > 0 and iteration % save_interval == 0:

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -212,6 +212,7 @@ def _run_collector(
     import time as _time
 
     _last_log_time = _time.time()
+    chunk_start = _time.perf_counter()
 
     # Track env.step calls collected since the last learner phase.
     env_steps_since_sync = 0
@@ -343,6 +344,8 @@ def _run_collector(
             and trainer_done_queue is not None
         ):
             if env_steps_since_sync >= env_steps_per_sync:
+                collect_time_s = _time.perf_counter() - chunk_start
+                replay_buffer.collect_time_s[0] = float(collect_time_s)
                 collection_ready_queue.put(1)
                 while not stop_event.is_set():
                     try:
@@ -351,6 +354,12 @@ def _run_collector(
                     except queue.Empty:
                         continue
                 env_steps_since_sync = 0
+                chunk_start = _time.perf_counter()
+        elif env_steps_since_sync >= env_steps_per_sync:
+            collect_time_s = _time.perf_counter() - chunk_start
+            replay_buffer.collect_time_s[0] = float(collect_time_s)
+            env_steps_since_sync = 0
+            chunk_start = _time.perf_counter()
 
         # Progress log every 2 seconds
         now = _time.time()

--- a/src/unilab/ipc/replay_buffer.py
+++ b/src/unilab/ipc/replay_buffer.py
@@ -29,6 +29,7 @@ class ReplayBuffer(SharedBufferBase):
         self._obs_dim = obs_dim
         self._action_dim = action_dim
         self._critic_dim = critic_dim
+        self.collect_time_s = torch.zeros(1, dtype=torch.float32).share_memory_()
 
         self.size = torch.zeros(1, dtype=torch.int64).share_memory_()
 

--- a/src/unilab/ipc/shared_onpolicy_storage.py
+++ b/src/unilab/ipc/shared_onpolicy_storage.py
@@ -20,6 +20,7 @@ _FIELD_SHAPES = {
     "truncated": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, ns),
     "last_obs": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, od),
     "last_critic": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, ne, cd),
+    "rollout_collect_time_s": lambda ns_slots, ne, ns, od, ad, cd: (ns_slots, 1),
 }
 
 

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -66,6 +66,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._wait_time: float = 0.0
         self._startup_wait_time: float = 0.0
         self._throughput_steps: int = 0
+        self._has_iteration_extra_info: bool = False
         self._iter_times: deque = deque(maxlen=50)
         self._collector_timing: dict[str, float] = {}
         self._timeout_rate: float = 0.0
@@ -100,7 +101,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._refresh()
 
     def _get_iter_steps_per_sec(self) -> float | None:
-        if self._throughput_steps <= 0:
+        if not self._has_iteration_extra_info or self._throughput_steps <= 0:
             return None
         iter_time = self._collect_time + self._train_time
         if iter_time <= 0:
@@ -152,10 +153,13 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._collect_time = collect_time
         self._train_time = train_time
         self._wait_time = wait_time
-        self._startup_wait_time = (
-            float(extra_info.get("startup_wait_time", 0.0)) if extra_info else 0.0
-        )
-        self._throughput_steps = int(extra_info.get("throughput_steps", 0)) if extra_info else 0
+        self._has_iteration_extra_info = extra_info is not None
+        if extra_info:
+            self._startup_wait_time = float(extra_info.get("startup_wait_time", 0.0))
+            self._throughput_steps = int(extra_info.get("throughput_steps", 0))
+        else:
+            self._startup_wait_time = 0.0
+            self._throughput_steps = 0
         self._iter_times.append(collect_time + train_time)
         if metrics:
             self._latest_metrics.update(metrics)
@@ -198,7 +202,10 @@ class OffPolicyLogger(BaseTrainingLogger):
             writer.add_scalar("episode/timeout_rate", self._timeout_rate, global_step)
             writer.add_scalar("episode/terminated_rate", self._terminated_rate, global_step)
             writer.add_scalar("timing/learner_wait_ms", self._wait_time * 1000, global_step)
-            writer.add_scalar("timing/startup_wait_ms", self._startup_wait_time * 1000, global_step)
+            if self._has_iteration_extra_info:
+                writer.add_scalar(
+                    "timing/startup_wait_ms", self._startup_wait_time * 1000, global_step
+                )
             writer.add_scalar("timing/learner_collect_ms", collect_time * 1000, global_step)
             writer.add_scalar("timing/learner_train_ms", train_time * 1000, global_step)
             for key, value in self._collector_timing.items():
@@ -206,10 +213,10 @@ class OffPolicyLogger(BaseTrainingLogger):
             if iter_steps_per_sec is not None:
                 writer.add_scalar("perf/steps_per_sec", iter_steps_per_sec, global_step)
                 writer.add_scalar("perf/steps_per_sec_iter", iter_steps_per_sec, global_step)
-                if wall_steps_per_sec is not None:
-                    writer.add_scalar("perf/steps_per_sec_wall", wall_steps_per_sec, global_step)
             elif wall_steps_per_sec is not None:
                 writer.add_scalar("perf/steps_per_sec", wall_steps_per_sec, global_step)
+            if wall_steps_per_sec is not None:
+                writer.add_scalar("perf/steps_per_sec_wall", wall_steps_per_sec, global_step)
             writer.add_scalar(
                 "perf/iter_ms", (self._collect_time + self._train_time) * 1000, global_step
             )
@@ -237,7 +244,8 @@ class OffPolicyLogger(BaseTrainingLogger):
             log_dict["episode/timeout_rate"] = self._timeout_rate
             log_dict["episode/terminated_rate"] = self._terminated_rate
             log_dict["timing/learner_wait_ms"] = self._wait_time * 1000
-            log_dict["timing/startup_wait_ms"] = self._startup_wait_time * 1000
+            if self._has_iteration_extra_info:
+                log_dict["timing/startup_wait_ms"] = self._startup_wait_time * 1000
             log_dict["timing/learner_collect_ms"] = collect_time * 1000
             log_dict["timing/learner_train_ms"] = train_time * 1000
             for key, value in self._collector_timing.items():
@@ -245,10 +253,10 @@ class OffPolicyLogger(BaseTrainingLogger):
             if iter_steps_per_sec is not None:
                 log_dict["perf/steps_per_sec"] = iter_steps_per_sec
                 log_dict["perf/steps_per_sec_iter"] = iter_steps_per_sec
-                if wall_steps_per_sec is not None:
-                    log_dict["perf/steps_per_sec_wall"] = wall_steps_per_sec
             elif wall_steps_per_sec is not None:
                 log_dict["perf/steps_per_sec"] = wall_steps_per_sec
+            if wall_steps_per_sec is not None:
+                log_dict["perf/steps_per_sec_wall"] = wall_steps_per_sec
             log_dict["perf/iter_ms"] = (self._collect_time + self._train_time) * 1000
             log_dict["perf/collect_train_ratio"] = self._collect_time / max(self._train_time, 1e-6)
             wandb.log(log_dict, step=global_step)

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -64,6 +64,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_size: int = 0
         self._buffer_target: int = 0
         self._wait_time: float = 0.0
+        self._startup_wait_time: float = 0.0
+        self._throughput_steps: int = 0
         self._iter_times: deque = deque(maxlen=50)
         self._collector_timing: dict[str, float] = {}
         self._timeout_rate: float = 0.0
@@ -96,6 +98,19 @@ class OffPolicyLogger(BaseTrainingLogger):
         pct = current / max(target, 1) * 100
         self._status = f"Buffer fill: {current:,}/{target:,} ({pct:.0f}%)"
         self._refresh()
+
+    def _get_iter_steps_per_sec(self) -> float | None:
+        if self._throughput_steps <= 0:
+            return None
+        iter_time = self._collect_time + self._train_time
+        if iter_time <= 0:
+            return None
+        return self._throughput_steps / iter_time
+
+    def _get_wall_steps_per_sec(self, elapsed: float) -> float | None:
+        if elapsed <= 0 or self._total_steps <= 0:
+            return None
+        return self._total_steps / elapsed
 
     def update_collector_timing(self, timing_ms: dict[str, float]):
         self._collector_timing.update(timing_ms)
@@ -133,11 +148,14 @@ class OffPolicyLogger(BaseTrainingLogger):
         wait_time: float = 0.0,
         extra_info: dict | None = None,
     ):
-        del extra_info
         self._iteration = iteration
         self._collect_time = collect_time
         self._train_time = train_time
         self._wait_time = wait_time
+        self._startup_wait_time = (
+            float(extra_info.get("startup_wait_time", 0.0)) if extra_info else 0.0
+        )
+        self._throughput_steps = int(extra_info.get("throughput_steps", 0)) if extra_info else 0
         self._iter_times.append(collect_time + train_time)
         if metrics:
             self._latest_metrics.update(metrics)
@@ -162,6 +180,8 @@ class OffPolicyLogger(BaseTrainingLogger):
     ):
         global_step = self._total_steps if self._total_steps > 0 else iteration
         elapsed = time.time() - self._start_time if self._start_time else 0
+        iter_steps_per_sec = self._get_iter_steps_per_sec()
+        wall_steps_per_sec = self._get_wall_steps_per_sec(elapsed)
 
         if self._tb_writer:
             writer = self._tb_writer
@@ -178,12 +198,18 @@ class OffPolicyLogger(BaseTrainingLogger):
             writer.add_scalar("episode/timeout_rate", self._timeout_rate, global_step)
             writer.add_scalar("episode/terminated_rate", self._terminated_rate, global_step)
             writer.add_scalar("timing/learner_wait_ms", self._wait_time * 1000, global_step)
+            writer.add_scalar("timing/startup_wait_ms", self._startup_wait_time * 1000, global_step)
             writer.add_scalar("timing/learner_collect_ms", collect_time * 1000, global_step)
             writer.add_scalar("timing/learner_train_ms", train_time * 1000, global_step)
             for key, value in self._collector_timing.items():
                 writer.add_scalar(f"timing/collector_{key}", value, global_step)
-            if elapsed > 0 and self._total_steps > 0:
-                writer.add_scalar("perf/steps_per_sec", self._total_steps / elapsed, global_step)
+            if iter_steps_per_sec is not None:
+                writer.add_scalar("perf/steps_per_sec", iter_steps_per_sec, global_step)
+                writer.add_scalar("perf/steps_per_sec_iter", iter_steps_per_sec, global_step)
+                if wall_steps_per_sec is not None:
+                    writer.add_scalar("perf/steps_per_sec_wall", wall_steps_per_sec, global_step)
+            elif wall_steps_per_sec is not None:
+                writer.add_scalar("perf/steps_per_sec", wall_steps_per_sec, global_step)
             writer.add_scalar(
                 "perf/iter_ms", (self._collect_time + self._train_time) * 1000, global_step
             )
@@ -211,12 +237,18 @@ class OffPolicyLogger(BaseTrainingLogger):
             log_dict["episode/timeout_rate"] = self._timeout_rate
             log_dict["episode/terminated_rate"] = self._terminated_rate
             log_dict["timing/learner_wait_ms"] = self._wait_time * 1000
+            log_dict["timing/startup_wait_ms"] = self._startup_wait_time * 1000
             log_dict["timing/learner_collect_ms"] = collect_time * 1000
             log_dict["timing/learner_train_ms"] = train_time * 1000
             for key, value in self._collector_timing.items():
                 log_dict[f"timing/collector_{key}"] = value
-            if elapsed > 0 and self._total_steps > 0:
-                log_dict["perf/steps_per_sec"] = self._total_steps / elapsed
+            if iter_steps_per_sec is not None:
+                log_dict["perf/steps_per_sec"] = iter_steps_per_sec
+                log_dict["perf/steps_per_sec_iter"] = iter_steps_per_sec
+                if wall_steps_per_sec is not None:
+                    log_dict["perf/steps_per_sec_wall"] = wall_steps_per_sec
+            elif wall_steps_per_sec is not None:
+                log_dict["perf/steps_per_sec"] = wall_steps_per_sec
             log_dict["perf/iter_ms"] = (self._collect_time + self._train_time) * 1000
             log_dict["perf/collect_train_ratio"] = self._collect_time / max(self._train_time, 1e-6)
             wandb.log(log_dict, step=global_step)
@@ -299,6 +331,13 @@ class OffPolicyLogger(BaseTrainingLogger):
             "",
             "",
         )
+        if self._startup_wait_time > 0:
+            table.add_row(
+                "[dim]startup[/] Wait",
+                f"{self._startup_wait_time * 1000:.1f}ms",
+                "",
+                "",
+            )
         timing_items = list(self._collector_timing.items())
         for index in range(0, len(timing_items), 2):
             left_key, left_value = timing_items[index]
@@ -342,6 +381,12 @@ class OffPolicyLogger(BaseTrainingLogger):
                 "",
                 "",
             )
-        if elapsed > 0 and self._total_steps > 0:
-            table.add_row("Steps/s", f"{self._total_steps / elapsed:,.0f}", "", "")
+        iter_steps_per_sec = self._get_iter_steps_per_sec()
+        wall_steps_per_sec = self._get_wall_steps_per_sec(elapsed)
+        if iter_steps_per_sec is not None:
+            table.add_row("Steps/s", f"{iter_steps_per_sec:,.0f}", "", "")
+            if wall_steps_per_sec is not None:
+                table.add_row("Wall Steps/s", f"{wall_steps_per_sec:,.0f}", "", "")
+        elif wall_steps_per_sec is not None:
+            table.add_row("Steps/s", f"{wall_steps_per_sec:,.0f}", "", "")
         return table

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import queue
+
 import pytest
 import torch
 
 import unilab.algos.torch.appo.runner as appo_runner_module
 from unilab.algos.torch.appo.runner import APPORunner
+
+
+@pytest.fixture(autouse=True)
+def _reset_fakes() -> None:
+    _FakeSharedOnPolicyStorage.last_instance = None
+    _FakeSharedOnPolicyStorage.rollout_collect_times = [0.25]
+    _FakeLogger.last_instance = None
 
 
 class _FakeModule:
@@ -21,8 +30,18 @@ class _FakeLearner:
     def get_state_dict(self) -> dict[str, int]:
         return {"iteration": 0}
 
+    def process_batch(self, batch: dict[str, torch.Tensor]) -> None:
+        self.last_batch = batch
+
+    def update(self, batch: dict[str, torch.Tensor]) -> dict[str, float]:
+        del batch
+        return {"loss": 0.5}
+
 
 class _FakeSharedOnPolicyStorage:
+    last_instance: "_FakeSharedOnPolicyStorage | None" = None
+    rollout_collect_times: list[float] = [0.25]
+
     def __init__(
         self,
         *,
@@ -38,6 +57,35 @@ class _FakeSharedOnPolicyStorage:
         self.name = "fake-storage"
         self._write_ptr = object()
         self._read_ptr = object()
+        self.wait_calls = 0
+        self.advance_calls = 0
+        _FakeSharedOnPolicyStorage.last_instance = self
+
+    def wait_for_data(self, timeout: float = 60.0) -> bool:
+        del timeout
+        self.wait_calls += 1
+        return True
+
+    def available(self) -> int:
+        return max(len(self.rollout_collect_times) - self.advance_calls, 0)
+
+    def read_torch(self, device: str) -> dict[str, torch.Tensor]:
+        collect_time = self.rollout_collect_times[self.advance_calls]
+        return {
+            "obs": torch.zeros(2, 4, 4, device=device),
+            "critic": torch.zeros(2, 4, 7, device=device),
+            "actions": torch.zeros(2, 4, 2, device=device),
+            "log_probs": torch.zeros(2, 4, device=device),
+            "rewards": torch.zeros(2, 4, device=device),
+            "dones": torch.zeros(2, 4, device=device),
+            "truncated": torch.zeros(2, 4, device=device),
+            "last_obs": torch.zeros(2, 4, device=device),
+            "last_critic": torch.zeros(2, 7, device=device),
+            "rollout_collect_time_s": torch.tensor([collect_time], device=device),
+        }
+
+    def advance_read(self) -> None:
+        self.advance_calls += 1
 
     def cleanup(self) -> None:
         pass
@@ -57,12 +105,19 @@ class _FakeWeightSync:
     def cleanup(self) -> None:
         pass
 
+    def write_weights(self, state_dict: dict[str, torch.Tensor]) -> None:
+        del state_dict
+
 
 class _FakeLogger:
+    last_instance: "_FakeLogger | None" = None
+
     def __init__(self, **kwargs) -> None:
         del kwargs
         self._total_steps = 0
         self._mean_ep_length = 0.0
+        self.step_calls: list[dict] = []
+        _FakeLogger.last_instance = self
 
     def set_collection_sync(self, enabled: bool, env_steps_per_sync: int) -> None:
         del enabled, env_steps_per_sync
@@ -78,6 +133,33 @@ class _FakeLogger:
 
     def finish(self) -> None:
         pass
+
+    def update_replay_queue(self, current_len: int, max_size: int) -> None:
+        del current_len, max_size
+
+    def log_collector(self, total_steps: int, buffer_size: int, mean_reward: float = 0.0) -> None:
+        del buffer_size, mean_reward
+        self._total_steps = total_steps
+
+    def update_ep_length(self, mean_ep_length: float) -> None:
+        self._mean_ep_length = mean_ep_length
+
+    def update_collector_timing(self, timing_ms: dict[str, float]) -> None:
+        del timing_ms
+
+    def update_done_rates(self, timeout_rate: float, terminated_rate: float) -> None:
+        del timeout_rate, terminated_rate
+
+    def log_step(self, **kwargs) -> None:
+        self.step_calls.append(kwargs)
+
+
+class _FakeClock:
+    def __init__(self, values: list[float]) -> None:
+        self._values = iter(values)
+
+    def time(self) -> float:
+        return next(self._values)
 
 
 def test_appo_runner_uses_explicit_runtime_context(
@@ -120,3 +202,54 @@ def test_appo_runner_uses_explicit_runtime_context(
     assert captured_detect["sim_backend"] == "motrix"
     assert captured_collector["sim_backend"] == "motrix"
     assert captured_collector["env_cfg_override"] == {"reward_config": {"scales": {"alive": 1.0}}}
+
+
+def test_appo_runner_uses_collector_rollout_time_for_fps_inputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    def fake_detect_dims(self: APPORunner) -> tuple[int, int]:
+        self.critic_dim = 7
+        self.critic_input_dim = 5
+        return (4, 2)
+
+    monkeypatch.setattr(APPORunner, "_detect_dims", fake_detect_dims)
+    monkeypatch.setattr(APPORunner, "_build_learner", lambda self: _FakeLearner())
+    monkeypatch.setattr(APPORunner, "_check_collector_alive", lambda self: True)
+    monkeypatch.setattr(appo_runner_module, "SharedOnPolicyStorage", _FakeSharedOnPolicyStorage)
+    monkeypatch.setattr(appo_runner_module, "SharedWeightSync", _FakeWeightSync)
+    monkeypatch.setattr(appo_runner_module, "OffPolicyLogger", _FakeLogger)
+    monkeypatch.setattr(appo_runner_module.mp, "get_context", lambda method: queue)
+    monkeypatch.setattr(appo_runner_module.torch, "save", lambda *args, **kwargs: None)
+
+    fake_clock = _FakeClock([100.0, 100.0, 110.0, 120.0, 120.5, 121.0])
+    monkeypatch.setattr(appo_runner_module.time, "time", fake_clock.time)
+
+    runner = APPORunner(
+        env_name="DummyEnv",
+        env_cfg_overrides={},
+        rl_cfg={"actor": {}, "critic": {}, "algorithm": {}},
+        device="cpu",
+        collector_device="cpu",
+        sim_backend="mujoco",
+        num_envs=2,
+        steps_per_env=4,
+    )
+    monkeypatch.setattr(runner, "_start_collector", lambda *args, **kwargs: None)
+
+    runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
+
+    logger = _FakeLogger.last_instance
+    storage = _FakeSharedOnPolicyStorage.last_instance
+    assert logger is not None
+    assert storage is not None
+    assert storage.wait_calls == 1
+    assert storage.advance_calls == 1
+    assert logger.step_calls
+
+    step = logger.step_calls[0]
+    assert step["collect_time"] == pytest.approx(0.25)
+    assert step["wait_time"] == pytest.approx(10.0)
+    assert step["train_time"] == pytest.approx(0.5)
+    assert step["extra_info"]["startup_wait_time"] == pytest.approx(9.75)
+    assert step["extra_info"]["throughput_steps"] == 8
+    assert step["metrics"]["rollouts_read"] == 1.0

--- a/tests/algos/test_appo_worker.py
+++ b/tests/algos/test_appo_worker.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import numpy as np
 import torch
 
-from unilab.algos.torch.appo.worker import compute_timeout_bootstrap_correction
+from unilab.algos.torch.appo.worker import (
+    compute_timeout_bootstrap_correction,
+    record_rollout_collect_time,
+)
 
 
 class _FakeCritic:
@@ -36,3 +39,11 @@ def test_compute_timeout_bootstrap_correction_prefers_explicit_final_critic():
     )
 
     np.testing.assert_allclose(correction, np.array([12.0, 0.0], dtype=np.float32))
+
+
+def test_record_rollout_collect_time_writes_storage_metadata():
+    write_buf = {"rollout_collect_time_s": np.zeros((1,), dtype=np.float32)}
+
+    record_rollout_collect_time(write_buf, 1.25)
+
+    np.testing.assert_allclose(write_buf["rollout_collect_time_s"], np.array([1.25]))

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -16,15 +16,22 @@ from unilab.algos.torch.offpolicy.runner import (
 
 class _FakeActor:
     def __init__(self) -> None:
+        self._param = torch.nn.Parameter(torch.zeros(1))
         self._state = {"weight": torch.zeros(1)}
 
     def state_dict(self) -> dict[str, torch.Tensor]:
         return {key: value.clone() for key, value in self._state.items()}
 
+    def parameters(self):
+        return [self._param]
+
 
 class _FakeLearner:
-    def __init__(self) -> None:
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
         self.actor = _FakeActor()
+        self.qnet = _FakeActor()
+        self.log_alpha = torch.zeros(1)
         self.reward_normalizer = None
         self.update_count = 0
         self.critic_updates = 0
@@ -61,10 +68,14 @@ class _FakeReplayBuffer:
         del capacity, obs_dim, action_dim, device, critic_dim, defer_gpu
         self.size = torch.zeros(1, dtype=torch.int64)
         self.ptr = torch.zeros(1, dtype=torch.int64)
+        self.collect_time_s = torch.zeros(1, dtype=torch.float32)
         self.sample_calls = 0
         self.sample_request_sizes: list[int] = []
         self.sample_sizes_at_call: list[int] = []
         _FakeReplayBuffer.last_instance = self
+
+    def init_local_gpu_cache(self, device: str) -> None:
+        del device
 
     def sample(self, batch_size: int) -> dict[str, torch.Tensor]:
         self.sample_calls += 1
@@ -86,11 +97,13 @@ class _FakeReplayBuffer:
 class _FakeWeightSync:
     last_instance: "_FakeWeightSync | None" = None
 
-    def __init__(self) -> None:
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
         self.name = "fake-weight-sync"
         self._lock = None
         self.version = 0
         self.write_calls = 0
+        self.read_calls = 0
 
     @classmethod
     def from_state_dict(
@@ -104,6 +117,12 @@ class _FakeWeightSync:
     def write_weights(self, state_dict: dict[str, torch.Tensor]) -> None:
         del state_dict
         self.write_calls += 1
+        self.version += 1
+
+    def read_weights_into(self, state_dict: dict[str, torch.Tensor]) -> int:
+        del state_dict
+        self.read_calls += 1
+        return self.version
 
     def close(self) -> None:
         pass
@@ -159,17 +178,25 @@ class _FakeLogger:
 
 
 class _SyncReadyQueue:
-    def __init__(self, replay_buffer: _FakeReplayBuffer, sizes: list[int]) -> None:
+    def __init__(
+        self,
+        replay_buffer: _FakeReplayBuffer,
+        sizes: list[int],
+        collect_times: list[float] | None = None,
+    ) -> None:
         self._replay_buffer = replay_buffer
         self._sizes = list(sizes)
+        self._collect_times = list(collect_times or [0.25] * len(sizes))
         self.get_calls = 0
 
     def get(self, timeout: float | None = None) -> int:
         del timeout
         assert self._sizes, "collection_ready_queue exhausted before learner started"
         size = self._sizes.pop(0)
+        collect_time = self._collect_times.pop(0) if self._collect_times else 0.0
         self._replay_buffer.size[0] = size
         self._replay_buffer.ptr[0] = size
+        self._replay_buffer.collect_time_s[0] = collect_time
         self.get_calls += 1
         return 1
 
@@ -185,6 +212,19 @@ class _RecordingQueue:
 class _FakeProcess:
     def is_alive(self) -> bool:
         return True
+
+
+class _FakeClock:
+    def __init__(self, values: list[float]) -> None:
+        self._values = list(values)
+        self._index = 0
+
+    def time(self) -> float:
+        if self._index < len(self._values):
+            value = self._values[self._index]
+            self._index += 1
+            return value
+        return self._values[-1]
 
 
 @pytest.fixture(autouse=True)
@@ -255,6 +295,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     runner = _make_runner(monkeypatch, sync_collection=True)
     threshold = runner.train_start_threshold
     created_queues: list[object] = []
+    fake_clock = _FakeClock([100.0, 100.1, 100.2, 110.2, 110.3, 110.8, 111.0, 111.1])
 
     def queue_factory(maxsize: int = 0):
         del maxsize
@@ -263,7 +304,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
         if idx == 0:
             replay_buffer = _FakeReplayBuffer.last_instance
             assert replay_buffer is not None
-            queue_obj = _SyncReadyQueue(replay_buffer, [4, 8, threshold])
+            queue_obj = _SyncReadyQueue(replay_buffer, [4, 8, threshold], [0.1, 0.2, 0.25])
         elif idx == 1:
             queue_obj = _RecordingQueue()
         else:
@@ -273,6 +314,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
 
     monkeypatch.setattr(runner_module._SPAWN_CTX, "Queue", queue_factory)
     monkeypatch.setattr(runner_module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(runner_module.time, "time", fake_clock.time)
 
     runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
 
@@ -289,6 +331,9 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     assert replay_buffer.sample_sizes_at_call == [threshold]
     assert trainer_done_queue.put_calls == [1, 1, 1, 1]
     assert logger.step_calls and logger.step_calls[0]["iteration"] == 1
+    assert logger.step_calls[0]["collect_time"] == pytest.approx(0.25)
+    assert logger.step_calls[0]["extra_info"]["startup_wait_time"] == pytest.approx(9.75)
+    assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
     assert _FakeWeightSync.last_instance is not None
     assert _FakeWeightSync.last_instance.write_calls == 1
 
@@ -299,6 +344,7 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
     runner = _make_runner(monkeypatch, sync_collection=False)
     threshold = runner.train_start_threshold
     sleep_sizes = iter([4, 8, threshold])
+    fake_clock = _FakeClock([200.0, 200.1, 200.2, 210.2, 210.3, 210.8, 211.0, 211.1])
 
     def fake_sleep(seconds: float) -> None:
         if seconds < 0.5:
@@ -307,9 +353,11 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
             assert replay_buffer is not None
             replay_buffer.size[0] = next_size
             replay_buffer.ptr[0] = next_size
+            replay_buffer.collect_time_s[0] = 0.25
 
     monkeypatch.setattr(runner_module._SPAWN_CTX, "Queue", lambda maxsize=0: queue.Queue())
     monkeypatch.setattr(runner_module.time, "sleep", fake_sleep)
+    monkeypatch.setattr(runner_module.time, "time", fake_clock.time)
 
     runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
 
@@ -320,6 +368,9 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
     assert replay_buffer.sample_calls == 1
     assert replay_buffer.sample_sizes_at_call == [threshold]
     assert logger.step_calls and logger.step_calls[0]["iteration"] == 1
+    assert logger.step_calls[0]["collect_time"] == pytest.approx(0.25)
+    assert logger.step_calls[0]["extra_info"]["startup_wait_time"] == pytest.approx(9.75)
+    assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
 
 
 def test_offpolicy_runner_passes_explicit_runtime_context_to_collector(
@@ -387,3 +438,80 @@ def test_multi_gpu_runner_passes_explicit_runtime_context_to_collector(
 
     assert captured["sim_backend"] == "motrix"
     assert captured["env_cfg_override"] == {"reward_config": {"scales": {"alive": 1.0}}}
+
+
+def test_multi_gpu_worker_rank0_propagates_collect_time_and_extra_info(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(multi_gpu_runner_module, "ReplayBuffer", _FakeReplayBuffer)
+    monkeypatch.setattr(multi_gpu_runner_module, "SharedWeightSync", _FakeWeightSync)
+    monkeypatch.setattr(multi_gpu_runner_module, "OffPolicyLogger", _FakeLogger)
+    monkeypatch.setattr(multi_gpu_runner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(multi_gpu_runner_module.torch.cuda, "set_device", lambda rank: None)
+    monkeypatch.setattr(multi_gpu_runner_module.dist, "init_process_group", lambda *args, **kwargs: None)
+    monkeypatch.setattr(multi_gpu_runner_module.dist, "broadcast", lambda *args, **kwargs: None)
+    monkeypatch.setattr(multi_gpu_runner_module.dist, "barrier", lambda *args, **kwargs: None)
+    monkeypatch.setattr(multi_gpu_runner_module.dist, "destroy_process_group", lambda *args, **kwargs: None)
+    monkeypatch.setattr(multi_gpu_runner_module.torch, "save", lambda *args, **kwargs: None)
+
+    fake_clock = _FakeClock([300.0, 300.1, 310.1, 310.2, 310.7])
+    monkeypatch.setattr(multi_gpu_runner_module.time, "time", fake_clock.time)
+
+    sleep_sizes = iter([4, 8, 12])
+
+    def fake_sleep(seconds: float) -> None:
+        if seconds < 0.5:
+            next_size = next(sleep_sizes, 12)
+            replay_buffer = _FakeReplayBuffer.last_instance
+            assert replay_buffer is not None
+            replay_buffer.size[0] = next_size
+            replay_buffer.ptr[0] = next_size
+            replay_buffer.collect_time_s[0] = 0.25
+
+    monkeypatch.setattr(multi_gpu_runner_module.time, "sleep", fake_sleep)
+
+    replay_buffer = _FakeReplayBuffer(capacity=64, obs_dim=4, action_dim=2, device="cpu")
+    weight_sync = _FakeWeightSync()
+    metrics_queue = queue.Queue()
+    stop_event = type("_Stop", (), {"is_set": staticmethod(lambda: False)})()
+
+    runner_kwargs = {
+        "max_iterations": 1,
+        "save_interval": 0,
+        "log_dir": str(tmp_path),
+        "batch_size": 8,
+        "learning_starts": 6,
+        "updates_per_step": 1,
+        "policy_frequency": 1,
+        "sync_collection": False,
+        "env_steps_per_sync": 1,
+        "env_name": "DummyEnv",
+        "num_envs": 2,
+        "obs_dim": 4,
+        "action_dim": 2,
+        "logger_type": "wandb",
+    }
+
+    multi_gpu_runner_module._learner_worker(
+        rank=0,
+        world_size=2,
+        learner_kwargs={},
+        runner_kwargs=runner_kwargs,
+        replay_buffer=replay_buffer,
+        weight_sync_name=weight_sync.name,
+        weight_sync_lock=weight_sync._lock,
+        weight_param_shapes={"weight": torch.Size([1])},
+        stop_event=stop_event,
+        collection_ready_queue=None,
+        trainer_done_queue=None,
+        metrics_queue=metrics_queue,
+        master_port=12345,
+    )
+
+    logger = _FakeLogger.last_instance
+    assert logger is not None
+    assert logger.step_calls
+    step = logger.step_calls[0]
+    assert step["collect_time"] == pytest.approx(0.25)
+    assert step["extra_info"]["startup_wait_time"] == pytest.approx(9.75)
+    assert step["extra_info"]["throughput_steps"] == 2

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -448,10 +448,14 @@ def test_multi_gpu_worker_rank0_propagates_collect_time_and_extra_info(
     monkeypatch.setattr(multi_gpu_runner_module, "OffPolicyLogger", _FakeLogger)
     monkeypatch.setattr(multi_gpu_runner_module, "FastSACLearner", _FakeLearner)
     monkeypatch.setattr(multi_gpu_runner_module.torch.cuda, "set_device", lambda rank: None)
-    monkeypatch.setattr(multi_gpu_runner_module.dist, "init_process_group", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        multi_gpu_runner_module.dist, "init_process_group", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(multi_gpu_runner_module.dist, "broadcast", lambda *args, **kwargs: None)
     monkeypatch.setattr(multi_gpu_runner_module.dist, "barrier", lambda *args, **kwargs: None)
-    monkeypatch.setattr(multi_gpu_runner_module.dist, "destroy_process_group", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        multi_gpu_runner_module.dist, "destroy_process_group", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(multi_gpu_runner_module.torch, "save", lambda *args, **kwargs: None)
 
     fake_clock = _FakeClock([300.0, 300.1, 310.1, 310.2, 310.7])

--- a/tests/ipc/test_replay_buffer.py
+++ b/tests/ipc/test_replay_buffer.py
@@ -48,6 +48,13 @@ def test_add_single_batch_increases_size():
     assert int(buf.size[0]) == 16
 
 
+def test_collect_time_metadata_is_shared():
+    buf = _make_buf()
+    assert hasattr(buf, "collect_time_s")
+    buf.collect_time_s[0] = 1.25
+    assert float(buf.collect_time_s[0]) == pytest.approx(1.25)
+
+
 def test_add_beyond_capacity_wraps_ptr():
     """Adding more than capacity should wrap ptr but cap size at capacity."""
     buf = _make_buf(capacity=32)

--- a/tests/ipc/test_shared_onpolicy_storage.py
+++ b/tests/ipc/test_shared_onpolicy_storage.py
@@ -15,7 +15,16 @@ _ACTION_DIM = 3
 _CRITIC_DIM = 5
 _NUM_SLOTS = 2
 
-_EXPECTED_FIELDS = {"obs", "actions", "log_probs", "rewards", "dones", "truncated", "last_obs"}
+_EXPECTED_FIELDS = {
+    "obs",
+    "actions",
+    "log_probs",
+    "rewards",
+    "dones",
+    "truncated",
+    "last_obs",
+    "rollout_collect_time_s",
+}
 
 
 def _make_storage(num_slots: int = _NUM_SLOTS) -> SharedOnPolicyStorage:

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -205,3 +205,32 @@ def test_offpolicy_logger_creates_and_finishes_owned_wandb_run(monkeypatch):
 
     logger.finish()
     assert fake_wandb.finish_calls == 1
+
+
+def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeypatch):
+    fake_wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    logger = OffPolicyLogger(
+        algo_name="APPO",
+        env_name="Go2JoystickFlat",
+        num_envs=2,
+        log_backend="wandb",
+    )
+    logger.log_step(
+        iteration=1,
+        metrics={},
+        collect_time=0.25,
+        train_time=0.75,
+        wait_time=10.0,
+        extra_info={"startup_wait_time": 9.75, "throughput_steps": 8},
+    )
+
+    payload, step = fake_wandb.log_calls[-1]
+    assert step == 1
+    assert payload["timing/learner_wait_ms"] == 10_000.0
+    assert payload["timing/startup_wait_ms"] == 9_750.0
+    assert payload["timing/learner_collect_ms"] == 250.0
+    assert payload["perf/steps_per_sec_iter"] == 8.0
+
+    logger.finish()

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -4,6 +4,7 @@ import json
 import sys
 from pathlib import Path
 
+import unilab.logging.offpolicy as offpolicy_module
 from unilab.logging import OffPolicyLogger, OnPolicyLogger
 from unilab.training.experiment import ExperimentTracker, build_wandb_settings
 
@@ -232,5 +233,33 @@ def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeyp
     assert payload["timing/startup_wait_ms"] == 9_750.0
     assert payload["timing/learner_collect_ms"] == 250.0
     assert payload["perf/steps_per_sec_iter"] == 8.0
+
+    logger.finish()
+
+
+def test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied(monkeypatch):
+    fake_wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        env_name="Go2JoystickFlat",
+        log_backend="wandb",
+    )
+    logger._start_time = 1.0
+    monkeypatch.setattr(offpolicy_module.time, "time", lambda: 2.0)
+    logger.log_collector(total_steps=8, buffer_size=8)
+    logger.log_step(
+        iteration=1,
+        metrics={},
+        collect_time=0.25,
+        train_time=0.75,
+        wait_time=1.0,
+    )
+
+    payload, _ = fake_wandb.log_calls[-1]
+    assert "timing/startup_wait_ms" not in payload
+    assert "perf/steps_per_sec_iter" not in payload
+    assert payload["perf/steps_per_sec_wall"] > 0
 
     logger.finish()


### PR DESCRIPTION
## Summary
- move APPO rollout timing to the collector payload so learner FPS excludes startup and env init
- log separate startup wait and wall-clock throughput diagnostics
- add focused tests for storage metadata, runner timing, and logger output

Fixes #353
Fixes #361