### PR TITLE
fix(env): collapse done/terminated/truncated to two-signal contract

### DIFF
--- a/scripts/train_mlx_ppo.py
+++ b/scripts/train_mlx_ppo.py
@@ -173,16 +173,12 @@ def get_time_limit_bootstrap_values(state: Any, model: Any, model_dtype: Any = N
     mx_mod = _require_mlx_runtime().mx if use_mlx_runtime else mx
     if model_dtype is None:
         model_dtype = mx_mod.float32
-    if not hasattr(state, "truncated"):
-        return None
     timeout_mask = np.asarray(state.truncated, dtype=bool)
     if not np.any(timeout_mask):
         return None
-    final_observation = getattr(state, "final_observation", None)
-    info = getattr(state, "info", None)
-    if final_observation is None:
-        if isinstance(info, dict):
-            final_observation = info.get("final_observation")
+    final_observation = state.final_observation
+    if final_observation is None and isinstance(state.info, dict):
+        final_observation = state.info.get("final_observation")
     if not isinstance(final_observation, dict):
         return None
     final_obs = mx_mod.array(flatten_obs_dict(final_observation))
@@ -591,32 +587,24 @@ def main(cfg: DictConfig) -> None:
                     )
 
             raw_rewards = mx.array(state.reward)
-            raw_dones = mx.array(state.done)
+            raw_dones = mx.array(state.terminated | state.truncated)
             raw_obs = mx.array(flatten_obs_dict(state.obs))
             rewards = mx.nan_to_num(raw_rewards, nan=0.0, posinf=0.0, neginf=0.0)
             dones = mx.where(mx.isfinite(raw_dones), raw_dones, mx.ones_like(raw_dones)).astype(
                 dtype
             )
             next_obs = mx.nan_to_num(raw_obs, nan=0.0, posinf=0.0, neginf=0.0)
-            if hasattr(state, "truncated"):
-                timeouts = mx.array(state.truncated, dtype=dtype)
-                timeout_bootstrap_values = get_time_limit_bootstrap_values(
-                    state, model, model_dtype
-                )
-                if timeout_bootstrap_values is None:
-                    timeout_bootstrap_values = values_mx
-                rewards = (
-                    rewards
-                    + ppo_cfg.gamma * timeout_bootstrap_values.astype(rewards.dtype) * timeouts
-                )
+            timeouts = mx.array(state.truncated, dtype=dtype)
+            timeout_bootstrap_values = get_time_limit_bootstrap_values(state, model, model_dtype)
+            if timeout_bootstrap_values is None:
+                timeout_bootstrap_values = values_mx
+            rewards = (
+                rewards + ppo_cfg.gamma * timeout_bootstrap_values.astype(rewards.dtype) * timeouts
+            )
             if rewards.dtype != dtype:
                 rewards = rewards.astype(dtype)
 
-            if (
-                collect_reward_components
-                and hasattr(state, "info")
-                and isinstance(state.info, dict)
-            ):
+            if collect_reward_components and isinstance(state.info, dict):
                 step_log = state.info.get("log", {})
                 if isinstance(step_log, dict):
                     for key, value in step_log.items():

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -231,16 +231,17 @@ def appo_collector_fn(
 
                 next_obs_raw = state.obs
                 reward_raw = np.asarray(state.reward, dtype=np.float32).ravel()
-                terminated_raw = np.asarray(state.terminated, dtype=np.float32).ravel()
-                truncated_raw = np.asarray(state.truncated, dtype=np.float32).ravel()
-                combined_done_raw = np.clip(terminated_raw + truncated_raw, 0, 1)
+                truncated_raw = state.truncated.astype(np.float32, copy=False).ravel()
+                combined_done_raw = (
+                    (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
+                )
 
                 next_actor_obs_np, next_critic_np = split_obs_dict(next_obs_raw)
                 next_actor_obs_np = to_float32_np(next_actor_obs_np)
                 next_critic_np = to_float32_np(next_critic_np)
                 terminal_contract = resolve_terminal_observation_contract(
                     next_obs_batch_size=next_actor_obs_np.shape[0],
-                    final_observation=getattr(state, "final_observation", None),
+                    final_observation=state.final_observation,
                     done=combined_done_raw > 0.5,
                     info=state.info,
                     truncated=truncated_raw,

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -516,7 +516,7 @@ class FastSACLearner:
         next_obs = batch["next_obs"]
         critic_next_obs = batch["next_critic"]
         dones = batch["dones"]
-        truncated = batch.get("truncated")
+        truncated = batch["truncated"]
 
         # Apply symmetry augmentation
         if self.use_symmetry:
@@ -542,13 +542,9 @@ class FastSACLearner:
             # Double the batch size for other tensors
             rewards = rewards.repeat(2)
             dones = dones.repeat(2)
-            if truncated is not None:
-                truncated = truncated.repeat(2)
+            truncated = truncated.repeat(2)
 
-        if truncated is None:
-            bootstrap = (1.0 - dones).float()
-        else:
-            bootstrap = torch.clamp(1.0 - dones.float() + truncated.float(), 0.0, 1.0)
+        bootstrap = torch.clamp(1.0 - dones.float() + truncated.float(), 0.0, 1.0)
         discount = torch.full_like(dones, self.gamma)
 
         with torch.no_grad():

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -93,23 +93,20 @@ class RewardNormalizer:
     def update_from_transitions(
         self,
         rewards: torch.Tensor,
-        terminated: torch.Tensor,
-        truncated: torch.Tensor,
+        dones: torch.Tensor,
     ) -> None:
         rewards = rewards.to(device=self.device, dtype=torch.float32)
-        terminated = terminated.to(device=self.device, dtype=torch.float32)
-        truncated = truncated.to(device=self.device, dtype=torch.float32)
+        dones = dones.to(device=self.device, dtype=torch.float32)
 
         if rewards.ndim == 1:
             rewards = rewards.unsqueeze(0)
-            terminated = terminated.unsqueeze(0)
-            truncated = truncated.unsqueeze(0)
+            dones = dones.unsqueeze(0)
         if rewards.numel() == 0:
             return
 
         num_envs = int(rewards.shape[-1])
         self._ensure_g_r_shape(num_envs)
-        done = torch.clamp(terminated + truncated, min=0.0, max=1.0)
+        done = torch.clamp(dones, min=0.0, max=1.0)
 
         for step in range(rewards.shape[0]):
             self.g_r = self.gamma * (1.0 - done[step]) * self.g_r + rewards[step]
@@ -264,12 +261,11 @@ class FlashSACLearner:
     def update_reward_stats(
         self,
         rewards: torch.Tensor,
-        terminated: torch.Tensor,
-        truncated: torch.Tensor,
+        dones: torch.Tensor,
     ) -> None:
         if self.reward_normalizer is None:
             return
-        self.reward_normalizer.update_from_transitions(rewards, terminated, truncated)
+        self.reward_normalizer.update_from_transitions(rewards, dones)
 
     @staticmethod
     def _set_requires_grad(module: nn.Module, requires_grad: bool) -> None:
@@ -281,8 +277,8 @@ class FlashSACLearner:
         actions = batch["actions"].to(self.device)
         rewards = batch["rewards"].to(self.device)
         next_obs = batch["next_obs"].to(self.device)
-        terminated = batch["dones"].to(self.device)
-        truncated = batch.get("truncated", torch.zeros_like(terminated)).to(self.device)
+        dones = batch["dones"].to(self.device)
+        truncated = batch["truncated"].to(self.device)
         critic_obs = batch["critic"].to(self.device)
         critic_next_obs = batch["next_critic"].to(self.device)
 
@@ -310,7 +306,7 @@ class FlashSACLearner:
                     support=support,
                     target_log_probs=next_q_log_probs,
                     reward=rewards,
-                    terminated=terminated,
+                    dones=dones,
                     truncated=truncated,
                     actor_entropy=actor_entropy,
                     gamma=gamma,

--- a/src/unilab/algos/torch/flash_sac/update.py
+++ b/src/unilab/algos/torch/flash_sac/update.py
@@ -44,7 +44,7 @@ def compute_categorical_td_target(
     support: torch.Tensor,
     target_log_probs: torch.Tensor,
     reward: torch.Tensor,
-    terminated: torch.Tensor,
+    dones: torch.Tensor,
     truncated: torch.Tensor,
     actor_entropy: torch.Tensor,
     gamma: float,
@@ -52,11 +52,11 @@ def compute_categorical_td_target(
     batch_size, num_bins = target_log_probs.shape
     support = support.view(1, -1)
     reward = reward.view(-1, 1)
-    terminated = terminated.view(-1, 1)
+    dones = dones.view(-1, 1)
     truncated = truncated.view(-1, 1)
     actor_entropy = actor_entropy.view(-1, 1)
 
-    bootstrap = torch.clamp(1.0 - terminated + truncated, 0.0, 1.0)
+    bootstrap = torch.clamp(1.0 - dones + truncated, 0.0, 1.0)
     target_bin_values = reward + bootstrap * gamma * (support - actor_entropy)
     target_bin_values = torch.clamp(target_bin_values, float(support.min()), float(support.max()))
 

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -147,12 +147,10 @@ class OffPolicyRunner(AsyncRunner):
 
         rewards = self._read_recent_replay_field(replay_buffer, "rewards", start_ptr, count)
         dones = self._read_recent_replay_field(replay_buffer, "dones", start_ptr, count)
-        truncated = self._read_recent_replay_field(replay_buffer, "truncated", start_ptr, count)
         num_steps = count // self.num_envs
         self.learner.update_reward_stats(
             rewards.view(num_steps, self.num_envs),
             dones.view(num_steps, self.num_envs),
-            truncated.view(num_steps, self.num_envs),
         )
         return end_ptr
 

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -256,7 +256,7 @@ def _run_collector(
         # Step environment
         state = env.step(actions_np)
 
-        timing_info = state.info.get("timing", {}) if hasattr(state, "info") else {}
+        timing_info = state.info.get("timing", {})
         if timing_info:
             for key in ("env_step_total_ms", "step_core_ms", "update_state_ms", "reset_done_ms"):
                 if key in timing_info:
@@ -269,18 +269,10 @@ def _run_collector(
         next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
         rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
 
-        terminated_np = (
-            np.asarray(state.terminated, dtype=np.float32).ravel()
-            if state.terminated is not None
-            else np.zeros(num_envs, dtype=np.float32)
-        )
-        truncated_np = (
-            np.asarray(state.truncated, dtype=np.float32).ravel()
-            if state.truncated is not None
-            else np.zeros(num_envs, dtype=np.float32)
-        )
-        combined_dones = np.clip(terminated_np + truncated_np, 0, 1)
-        prev_dones_np = combined_dones.astype(np.float32, copy=False)
+        terminated_np = state.terminated.astype(np.float32, copy=False).ravel()
+        truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
+        combined_dones = (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
+        prev_dones_np = combined_dones
         done_mask_np = combined_dones > 0.5
         timeout_mask_np = truncated_np > 0.5
         terminated_mask_np = np.logical_and(terminated_np > 0.5, ~timeout_mask_np)
@@ -291,19 +283,21 @@ def _run_collector(
 
         terminal_contract = resolve_terminal_observation_contract(
             next_obs_batch_size=next_obs_np.shape[0],
-            final_observation=getattr(state, "final_observation", None),
+            final_observation=state.final_observation,
             done=done_mask_np,
             info=state.info,
             truncated=truncated_np,
         )
 
-        # Write to replay buffer
+        # ReplayBuffer `dones` follows the UniLab env lifecycle contract:
+        # done = terminated | truncated. Learners use `truncated` to keep
+        # bootstrap enabled for timeout/truncation rows.
         replay_buffer.add(
             torch.from_numpy(obs_np),
             torch.from_numpy(actions_np),
             torch.from_numpy(rewards_np),
             torch.from_numpy(next_obs_np),
-            torch.from_numpy(terminated_np),
+            torch.from_numpy(combined_dones),
             torch.from_numpy(truncated_np),
             terminal_mask=torch.from_numpy(terminal_contract.terminal_mask),
             terminal_next_obs=(

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -27,11 +27,6 @@ class NpEnvState:
     info: dict[str, Any]
     final_observation: dict[str, np.ndarray] | None = None
 
-    @property
-    def done(self) -> np.ndarray:
-        done: np.ndarray = np.logical_or(self.terminated, self.truncated)
-        return done
-
     def replace(self, **updates: Any) -> "NpEnvState":
         return dataclasses.replace(self, **updates)
 
@@ -133,7 +128,7 @@ class NpEnv(ABEnv):
         truncated = self._compute_truncated(self._state)
         np.logical_or(self._state.truncated, truncated, out=self._state.truncated)
 
-        done = self._state.done
+        done = self._state.terminated | self._state.truncated
         t0 = time.perf_counter()
         if np.any(done):
             self._reset_done_envs()
@@ -168,7 +163,7 @@ class NpEnv(ABEnv):
 
     def _reset_done_envs(self) -> None:
         assert self._state is not None
-        done = self._state.done
+        done = self._state.terminated | self._state.truncated
         if not np.any(done):
             return
 

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -337,14 +337,11 @@ class G1WalkEnv(G1BaseEnv):
         obs = self._compute_obs(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
         state = state.replace(obs=obs, reward=reward, terminated=terminated)
 
-        if (
-            self._episode_tracker is None
-            or self._penalty_curriculum is None
-            or not np.any(state.done)
-        ):
+        done = state.terminated | state.truncated
+        if self._episode_tracker is None or self._penalty_curriculum is None or not np.any(done):
             return state
 
-        done_indices = np.where(state.done)[0]
+        done_indices = np.where(done)[0]
         episode_lengths = state.info["steps"][done_indices] + 1
         self._episode_tracker.update(episode_lengths)
         self._penalty_curriculum.update(self._episode_tracker.average_length)

--- a/src/unilab/envs/manipulation/inhand_rot_allegro/grasp_gen.py
+++ b/src/unilab/envs/manipulation/inhand_rot_allegro/grasp_gen.py
@@ -217,7 +217,7 @@ class AllegroRotationGrasp(AllegroRotationPPO):
 
     def _reset_done_envs(self) -> None:
         if self.state is not None:
-            done = self.state.done
+            done = self.state.terminated | self.state.truncated
             if np.any(done):
                 env_ids = np.flatnonzero(done).astype(np.int32)
                 self._collect_successful_grasps(env_ids)

--- a/src/unilab/ipc/replay_buffer.py
+++ b/src/unilab/ipc/replay_buffer.py
@@ -143,7 +143,12 @@ class ReplayBuffer(SharedBufferBase):
         next_critic=None,
         terminal_next_critic=None,
     ):
-        """Add batch (called by collector)."""
+        """Add batch (called by collector).
+
+        `dones` follows the UniLab env lifecycle contract:
+        done = terminated | truncated. Learners must pair it with
+        `truncated` when computing bootstrap masks.
+        """
         n = obs.shape[0]
         idx = int(self.ptr[0]) % self.capacity
         has_critic = self._critic_dim > 0 and critic is not None

--- a/src/unilab/training/rsl_rl.py
+++ b/src/unilab/training/rsl_rl.py
@@ -10,6 +10,7 @@ import torch
 from tensordict import TensorDict
 
 from unilab.base.final_observation import resolve_terminal_observation_contract
+from unilab.base.np_env import NpEnvState
 from unilab.utils.tensor import to_numpy, to_torch
 
 
@@ -143,20 +144,11 @@ class RslRlVecEnvWrapper:
             td_dict["critic"] = to_torch(obs["critic"], self.device)
         return TensorDict(td_dict, batch_size=self.num_envs, device=self.device)
 
-    def _resolve_done(self, state: Any) -> torch.Tensor:
-        if hasattr(state, "done"):
-            return to_torch(state.done, self.device).bool()
-        terminated = np.asarray(getattr(state, "terminated"), dtype=bool).ravel()
-        truncated = np.asarray(getattr(state, "truncated"), dtype=bool).ravel()
-        return to_torch(np.logical_or(terminated, truncated), self.device).bool()
-
-    def _resolve_final_observation(self, state: Any) -> dict[str, Any] | None:
-        final_observation = getattr(state, "final_observation", None)
-        if isinstance(final_observation, dict):
-            return final_observation
-        info = getattr(state, "info", None)
-        if isinstance(info, dict):
-            final_observation = info.get("final_observation")
+    def _resolve_final_observation(self, state: NpEnvState) -> dict[str, Any] | None:
+        if isinstance(state.final_observation, dict):
+            return state.final_observation
+        if isinstance(state.info, dict):
+            final_observation = state.info.get("final_observation")
             if isinstance(final_observation, dict):
                 return final_observation
         return None
@@ -167,7 +159,7 @@ class RslRlVecEnvWrapper:
         actions_np = to_numpy(actions)
         state = self.env.step(actions_np)
         rewards = to_torch(state.reward, self.device)
-        dones = self._resolve_done(state)
+        dones = to_torch(state.terminated | state.truncated, self.device).bool()
 
         self.episode_returns += rewards
         self.episode_lengths += 1
@@ -175,17 +167,15 @@ class RslRlVecEnvWrapper:
         infos: dict[str, torch.Tensor | TensorDict | dict[str, Any]] = {}
         done_idx = torch.nonzero(dones).flatten()
         if len(done_idx) > 0:
-            truncated = getattr(state, "truncated", None)
-            if truncated is not None:
-                infos["time_outs"] = to_torch(truncated, self.device).bool()
+            infos["time_outs"] = to_torch(state.truncated, self.device).bool()
 
             final_observation = self._resolve_final_observation(state)
             terminal_contract = resolve_terminal_observation_contract(
                 next_obs_batch_size=self.num_envs,
                 final_observation=final_observation,
                 done=to_numpy(dones),
-                info=getattr(state, "info", None),
-                truncated=to_numpy(infos["time_outs"]) if "time_outs" in infos else None,
+                info=state.info,
+                truncated=to_numpy(infos["time_outs"]),
             )
             if np.any(terminal_contract.timeout_terminal_mask) and final_observation is not None:
                 infos["time_out_bootstrap_obs"] = self._obs_to_tensordict(final_observation)
@@ -193,7 +183,7 @@ class RslRlVecEnvWrapper:
             self.episode_returns[done_idx] = 0
             self.episode_lengths[done_idx] = 0
 
-        if hasattr(state, "info") and "log" in state.info:
+        if "log" in state.info:
             infos["log"] = state.info["log"]
 
         return self._obs_to_tensordict(state.obs), rewards, dones, infos

--- a/tests/algos/test_flash_sac_learner.py
+++ b/tests/algos/test_flash_sac_learner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import torch
 
 from unilab.algos.torch.flash_sac.learner import FlashSACLearner, RewardNormalizer
+from unilab.algos.torch.flash_sac.update import compute_categorical_td_target
 
 
 def _make_batch(batch_size: int = 32) -> dict[str, torch.Tensor]:
@@ -82,8 +83,7 @@ def test_reward_normalizer_tracks_discounted_returns() -> None:
 
     normalizer.update_from_transitions(
         rewards=torch.tensor([[2.0, 1.0], [4.0, 3.0]]),
-        terminated=torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
-        truncated=torch.zeros(2, 2),
+        dones=torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
     )
 
     torch.testing.assert_close(normalizer.g_r, torch.tensor([5.0, 3.5]))
@@ -94,8 +94,7 @@ def test_flashsac_critic_update_does_not_advance_reward_stats_from_sampled_batch
     learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
     learner.update_reward_stats(
         rewards=torch.tensor([[1.0, 2.0]]),
-        terminated=torch.zeros(1, 2),
-        truncated=torch.zeros(1, 2),
+        dones=torch.zeros(1, 2),
     )
     assert learner.reward_normalizer is not None
     before = learner.reward_normalizer.g_r.clone()
@@ -103,3 +102,45 @@ def test_flashsac_critic_update_does_not_advance_reward_stats_from_sampled_batch
     learner.update_critic(_make_batch())
 
     torch.testing.assert_close(learner.reward_normalizer.g_r, before)
+
+
+def test_flashsac_critic_requires_truncated_field() -> None:
+    learner = FlashSACLearner(obs_dim=98, action_dim=29, critic_obs_dim=101, device="cpu")
+    batch = _make_batch()
+    batch.pop("truncated")
+
+    try:
+        learner.update_critic(batch)
+    except KeyError as exc:
+        assert exc.args == ("truncated",)
+    else:  # pragma: no cover - explicit failure path
+        raise AssertionError("FlashSAC learner must require replay 'truncated'")
+
+
+def test_flashsac_td_target_treats_dones_as_combined_done_with_truncation_bootstrap() -> None:
+    support = torch.tensor([0.0, 1.0, 2.0])
+    target_log_probs = torch.log(
+        torch.tensor(
+            [
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ).clamp_min(1e-8)
+    )
+
+    targets = compute_categorical_td_target(
+        support=support,
+        target_log_probs=target_log_probs,
+        reward=torch.zeros(3),
+        dones=torch.tensor([0.0, 1.0, 1.0]),
+        truncated=torch.tensor([0.0, 1.0, 0.0]),
+        actor_entropy=torch.zeros(3),
+        gamma=1.0,
+    )
+
+    # Continuing rows and truncated rows bootstrap to support value 2.0.
+    torch.testing.assert_close(targets[0], torch.tensor([0.0, 0.0, 1.0]))
+    torch.testing.assert_close(targets[1], torch.tensor([0.0, 0.0, 1.0]))
+    # True terminal rows do not bootstrap and project to reward-only value 0.0.
+    torch.testing.assert_close(targets[2], torch.tensor([1.0, 0.0, 0.0]))

--- a/tests/algos/test_mlx_ppo.py
+++ b/tests/algos/test_mlx_ppo.py
@@ -390,7 +390,7 @@ def test_mlx_ppo_one_iteration_real_env(default_go2_reward_config):
         state = env.step(env_actions)
         raw_obs = flatten_obs_dict(state.obs)
         rewards = mx.array(state.reward)
-        dones = mx.array(state.done.astype(np.float32))
+        dones = mx.array((state.terminated | state.truncated).astype(np.float32))
 
         buffer.add(
             obs=obs,

--- a/tests/algos/test_offpolicy_bootstrap_contract.py
+++ b/tests/algos/test_offpolicy_bootstrap_contract.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import torch
+
+from unilab.algos.torch.fast_sac.learner import FastSACLearner
+from unilab.algos.torch.fast_td3.learner import FastTD3Learner
+
+
+class _CaptureSacTargetCritic(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_parameter("anchor", torch.nn.Parameter(torch.zeros(())))
+        self.bootstrap: torch.Tensor | None = None
+
+    def projection(self, obs, actions, rewards, bootstrap, discount):
+        del obs, actions, rewards, discount
+        self.bootstrap = bootstrap.detach().clone()
+        batch_size = bootstrap.shape[0]
+        probs = torch.zeros(2, batch_size, 3, dtype=bootstrap.dtype)
+        probs[:, :, 0] = 1.0
+        return probs
+
+    def get_value(self, probs):
+        return probs[:, :, 0]
+
+
+class _CaptureTd3TargetCritic(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.bootstrap: torch.Tensor | None = None
+
+    def projection(self, obs, actions, rewards, bootstrap, discount):
+        del obs, actions, rewards, discount
+        self.bootstrap = bootstrap.detach().clone()
+        batch_size = bootstrap.shape[0]
+        probs = torch.zeros(batch_size, 3, dtype=bootstrap.dtype)
+        probs[:, 0] = 1.0
+        return probs, probs.clone()
+
+    def get_value(self, probs):
+        return probs[:, 0]
+
+
+def _offpolicy_batch(batch_size: int = 3) -> dict[str, torch.Tensor]:
+    return {
+        "obs": torch.zeros(batch_size, 4),
+        "critic": torch.zeros(batch_size, 5),
+        "actions": torch.zeros(batch_size, 2),
+        "rewards": torch.zeros(batch_size),
+        "next_obs": torch.zeros(batch_size, 4),
+        "next_critic": torch.zeros(batch_size, 5),
+        "dones": torch.tensor([0.0, 1.0, 1.0]),
+        "truncated": torch.tensor([0.0, 1.0, 0.0]),
+    }
+
+
+def test_fast_sac_critic_bootstrap_uses_combined_dones_and_truncated() -> None:
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+    )
+    target_critic = _CaptureSacTargetCritic()
+    learner.qnet_target = target_critic
+
+    learner.update_critic(_offpolicy_batch())
+
+    assert target_critic.bootstrap is not None
+    torch.testing.assert_close(target_critic.bootstrap, torch.tensor([1.0, 1.0, 0.0]))
+
+
+def test_fast_sac_critic_requires_truncated_field() -> None:
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+    )
+    batch = _offpolicy_batch()
+    batch.pop("truncated")
+
+    try:
+        learner.update_critic(batch)
+    except KeyError as exc:
+        assert exc.args == ("truncated",)
+    else:  # pragma: no cover - explicit failure path
+        raise AssertionError("FastSAC learner must require replay 'truncated'")
+
+
+def test_fast_td3_critic_bootstrap_uses_combined_dones_and_truncated() -> None:
+    learner = FastTD3Learner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        num_envs=3,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        obs_normalization=False,
+    )
+    target_critic = _CaptureTd3TargetCritic()
+    learner.qnet_target = target_critic
+
+    learner.update_critic(_offpolicy_batch())
+
+    assert target_critic.bootstrap is not None
+    torch.testing.assert_close(target_critic.bootstrap, torch.tensor([1.0, 1.0, 0.0]))

--- a/tests/algos/test_rsl_rl_ppo.py
+++ b/tests/algos/test_rsl_rl_ppo.py
@@ -4,6 +4,7 @@ import torch
 from tensordict import TensorDict
 
 from unilab.algos.torch.rsl_rl_ppo import FinalObservationAwarePPO
+from unilab.training.rsl_rl import RslRlVecEnvWrapper
 
 
 class _FakeActor:
@@ -75,3 +76,43 @@ def test_final_observation_aware_ppo_bootstraps_from_final_observation():
 
     assert torch.allclose(algo.storage.saved_rewards, torch.tensor([1.0 + 0.99 * 3.0, 2.0]))
     assert torch.equal(algo.critic.last_obs["policy"], final_obs["policy"])
+
+
+def test_rsl_rl_adapter_outputs_combined_dones_and_time_outs_alias():
+    class FakeEnv:
+        def __init__(self):
+            self.num_envs = 3
+            self.cfg = type("Cfg", (), {"max_episode_seconds": 10.0, "ctrl_dt": 0.02})()
+            self.observation_space = type("Space", (), {"shape": (2,)})()
+            self.action_space = type("Space", (), {"shape": (1,)})()
+            self.obs_groups_spec = {"obs": 2}
+            self.state = type("State", (), {"obs": {"obs": torch.zeros(3, 2).numpy()}})()
+
+        def init_state(self):
+            pass
+
+        def reset(self, env_indices):
+            del env_indices
+            return {"obs": torch.zeros(3, 2).numpy()}, {}
+
+        def step(self, actions):
+            del actions
+            return type(
+                "StepState",
+                (),
+                {
+                    "obs": {"obs": torch.zeros(3, 2).numpy()},
+                    "reward": torch.zeros(3).numpy(),
+                    "terminated": torch.tensor([True, False, False]).numpy(),
+                    "truncated": torch.tensor([False, True, False]).numpy(),
+                    "info": {},
+                    "final_observation": None,
+                },
+            )()
+
+    wrapper = RslRlVecEnvWrapper(FakeEnv(), device="cpu", policy_obs_mode="actor")
+
+    _, _, dones, infos = wrapper.step(torch.zeros(3, 1))
+
+    assert torch.equal(dones, torch.tensor([True, True, False]))
+    assert torch.equal(infos["time_outs"], torch.tensor([False, True, False]))

--- a/tests/algos/test_rsl_rl_runner.py
+++ b/tests/algos/test_rsl_rl_runner.py
@@ -66,17 +66,16 @@ class _RslRlVecEnvWrapper:
         )
         state = self.env.step(actions_np)
         rewards = to_torch(state.reward, self.device)
-        dones = to_torch(state.done, self.device).bool()
+        dones = to_torch(state.terminated | state.truncated, self.device).bool()
         self.episode_returns += rewards
         self.episode_lengths += 1
         infos = {}
         done_idx = torch.nonzero(dones).flatten()
         if len(done_idx) > 0:
-            if hasattr(state, "truncated"):
-                infos["time_outs"] = to_torch(state.truncated, self.device).bool()
+            infos["time_outs"] = to_torch(state.truncated, self.device).bool()
             self.episode_returns[done_idx] = 0
             self.episode_lengths[done_idx] = 0
-        if hasattr(state, "info") and "log" in state.info:
+        if "log" in state.info:
             infos["log"] = state.info["log"]
         return self._obs_to_tensordict(state.obs), rewards, dones, infos
 

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -144,7 +144,7 @@ class TestNpEnvState:
         assert "obs" in state.obs
         assert "critic" in state.obs
 
-    def test_done_combines_terminated_and_truncated(self):
+    def test_terminated_and_truncated_are_separate_signals(self):
         state = NpEnvState(
             obs={"a": np.zeros((3, 1))},
             reward=np.zeros(3),
@@ -152,10 +152,11 @@ class TestNpEnvState:
             truncated=np.array([False, False, True]),
             info={},
         )
-        done = state.done
-        np.testing.assert_array_equal(done, [True, False, True])
+        np.testing.assert_array_equal(state.terminated, [True, False, False])
+        np.testing.assert_array_equal(state.truncated, [False, False, True])
+        np.testing.assert_array_equal(state.terminated | state.truncated, [True, False, True])
 
-    def test_done_both_true(self):
+    def test_terminated_and_truncated_can_both_be_true(self):
         state = NpEnvState(
             obs={"a": np.zeros((1, 1))},
             reward=np.zeros(1),
@@ -163,7 +164,7 @@ class TestNpEnvState:
             truncated=np.array([True]),
             info={},
         )
-        assert state.done[0] is np.True_
+        assert (state.terminated | state.truncated)[0] is np.True_
 
     def test_replace_preserves_type(self):
         obs = {"obs": np.zeros((2, 3))}
@@ -383,7 +384,7 @@ class TestResetDoneEnvs:
 
         state = env.step(np.zeros((3, 3)))
 
-        np.testing.assert_array_equal(state.done, [False, False, False])
+        np.testing.assert_array_equal(state.terminated | state.truncated, [False, False, False])
         assert state.final_observation is None
         np.testing.assert_array_equal(state.info["_final_observation"], [False, False, False])
 
@@ -400,7 +401,9 @@ class TestResetDoneEnvs:
         env.set_terminate_indices([])
         non_terminal_state = env.step(np.zeros((3, 3)))
 
-        np.testing.assert_array_equal(non_terminal_state.done, [False, False, False])
+        np.testing.assert_array_equal(
+            non_terminal_state.terminated | non_terminal_state.truncated, [False, False, False]
+        )
         assert non_terminal_state.final_observation is None
         np.testing.assert_array_equal(
             non_terminal_state.info["_final_observation"], [False, False, False]

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -682,7 +682,8 @@ def test_env_reset_and_step(
         for key, dim in spec.items():
             assert state.obs[key].shape == (2, dim)
         assert state.reward.shape == (2,)
-        assert state.done.shape == (2,)
+        assert state.terminated.shape == (2,)
+        assert state.truncated.shape == (2,)
     finally:
         env.close()
 
@@ -831,7 +832,8 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
         state = env.step(actions)
         assert isinstance(state.obs, dict)
         assert state.reward.shape == (2,)
-        assert state.done.shape == (2,)
+        assert state.terminated.shape == (2,)
+        assert state.truncated.shape == (2,)
     finally:
         env.close()
 

--- a/tests/ipc/test_replay_buffer.py
+++ b/tests/ipc/test_replay_buffer.py
@@ -172,6 +172,25 @@ def test_add_patches_terminal_next_obs_without_prebuilding_full_transition_copy(
     assert torch.allclose(stored_next_obs, expected)
 
 
+def test_add_stores_combined_dones_and_truncated_contract():
+    buf = _make_buf(capacity=8)
+    terminated = torch.tensor([1.0, 0.0, 0.0])
+    truncated = torch.tensor([0.0, 1.0, 0.0])
+    dones = (terminated.bool() | truncated.bool()).float()
+
+    buf.add(
+        torch.zeros(3, _OBS_DIM),
+        torch.zeros(3, _ACTION_DIM),
+        torch.zeros(3),
+        torch.zeros(3, _OBS_DIM),
+        dones,
+        truncated,
+    )
+
+    torch.testing.assert_close(buf._storage[:3, buf._done_col], torch.tensor([1.0, 1.0, 0.0]))
+    torch.testing.assert_close(buf._storage[:3, buf._trunc_col], torch.tensor([0.0, 1.0, 0.0]))
+
+
 # ---------------------------------------------------------------------------
 # Multiprocess test
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1196,7 +1196,7 @@ def test_play_wrapper_step_exports_timeout_bootstrap_obs():
                 {
                     "obs": {"obs": np.array([[1.0, 2.0, 3.0]], dtype=np.float32)},
                     "reward": np.array([1.0], dtype=np.float32),
-                    "done": np.array([True]),
+                    "terminated": np.array([False]),
                     "truncated": np.array([True]),
                     "final_observation": {
                         "obs": np.array([[7.0, 8.0, 9.0]], dtype=np.float32),


### PR DESCRIPTION
## Summary

- Drop `NpEnvState.done` property; the dataclass now owns just `terminated` + `truncated` as two atomic signals. Consumers compute `terminated | truncated` inline when they need combined-done.
- Remove the `unilab.base.termination` patch module (`combine_done_signals`, `storage_done_signals_from_state`) and every `hasattr/getattr(state, ...)` probe on contract fields across APPO worker, off-policy worker, RSL-RL adapter, MLX PPO script, and tests.
- Tighten off-policy buffer contract: FastSAC drops the silent `if truncated is None: bootstrap = 1 - dones` footgun and now requires `batch[\"truncated\"]`; FlashSAC drops the dead `truncated` arg from `update_reward_stats`; off-policy worker writes `terminated | truncated` (combined dones) to replay so learners can pair with `truncated` for bootstrap masks.
- Add real contract tests: `tests/algos/test_offpolicy_bootstrap_contract.py` (FastSAC + FastTD3 mixed terminated/truncated), `test_flashsac_critic_requires_truncated_field`, `test_flashsac_td_target_treats_dones_as_combined_done_with_truncation_bootstrap`, and a real RSL-RL adapter step test.

Closes #347.

## Test plan

- [x] `make test` (601 passed, 3 skipped, 0 failed)
- [x] `uv run pytest tests/utils/test_final_observation.py tests/ipc/test_replay_buffer.py tests/base/test_np_env.py -k final_observation`
- [x] `uv run pytest tests/algos/test_offpolicy_bootstrap_contract.py tests/algos/test_flash_sac_learner.py tests/algos/test_appo_worker.py tests/algos/test_rsl_rl_ppo.py`
- [ ] Smoke check on a real off-policy training run (FastSAC / FastTD3 / FlashSAC) before merge
- [ ] Smoke check on APPO + MLX PPO collectors before merge