### PR TITLE
fix: make benchmark smoke checks reliable

### DIFF
--- a/benchmark/benchmark_ane_inference.py
+++ b/benchmark/benchmark_ane_inference.py
@@ -31,9 +31,15 @@ import tempfile
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-import coremltools as ct
+try:
+    import coremltools as ct
+except Exception as exc:
+    ct = None
+    _COREMLTOOLS_IMPORT_ERROR = exc
+else:
+    _COREMLTOOLS_IMPORT_ERROR = None
 import numpy as np
 import torch
 
@@ -75,9 +81,11 @@ def _build_and_convert_coreml_ane(
     env_nums: List[int],
     mlmodel_path: str,
     seed: int = 42,
-    precision: ct.precision = ct.precision.FLOAT32,
+    precision: Any = None,
 ) -> bool:
     """Convert to Core ML with EnumeratedShapes so model can run on ANE (no flexible batch)."""
+    if ct is None:
+        raise RuntimeError("coremltools is unavailable")
     dims = [obs_dim] + hidden_dims + [action_dim]
     layers = []
     torch.manual_seed(seed)
@@ -274,6 +282,12 @@ def main() -> None:
         help="Plot directory (default: same as --out parent)",
     )
     args = parser.parse_args()
+
+    if ct is None:
+        raise RuntimeError(
+            "coremltools is required (failed to import coremltools: "
+            f"{_COREMLTOOLS_IMPORT_ERROR})"
+        )
 
     env_nums = [int(x.strip()) for x in args.sizes.split(",") if x.strip()]
     hidden_dims = [int(x.strip()) for x in args.hidden_dims.split(",") if x.strip()]

--- a/benchmark/benchmark_ane_inference.py
+++ b/benchmark/benchmark_ane_inference.py
@@ -285,8 +285,7 @@ def main() -> None:
 
     if ct is None:
         raise RuntimeError(
-            "coremltools is required (failed to import coremltools: "
-            f"{_COREMLTOOLS_IMPORT_ERROR})"
+            f"coremltools is required (failed to import coremltools: {_COREMLTOOLS_IMPORT_ERROR})"
         )
 
     env_nums = [int(x.strip()) for x in args.sizes.split(",") if x.strip()]

--- a/benchmark/benchmark_fast_sac_backends.py
+++ b/benchmark/benchmark_fast_sac_backends.py
@@ -39,12 +39,15 @@ def run_backend(task, max_iterations, backend, num_envs):
 
     cfg = SACConfig()
 
-    # Set collector device based on backend
-    device = "mps"
-    if backend == "torch_mps":
-        pass
-    elif backend in ("torch_cpu", "numpy"):
-        pass
+    device_map = {
+        "torch_mps": "mps",
+        "torch_cpu": "cpu",
+    }
+    if backend not in device_map:
+        raise ValueError(
+            f"Unsupported backend '{backend}'. Expected one of {sorted(device_map)}."
+        )
+    device = device_map[backend]
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     log_dir = os.path.join(ROOT_DIR, "logs", "benchmark", f"{backend}_{timestamp}")
@@ -119,7 +122,7 @@ def main():
     parser.add_argument("--task", type=str, default="go1_joystick_flat")
     parser.add_argument("--max_iterations", type=int, default=100)
     parser.add_argument("--num_envs", type=int, default=4096)
-    parser.add_argument("--backends", type=str, default="torch_mps,torch_cpu,ane")
+    parser.add_argument("--backends", type=str, default="torch_mps,torch_cpu")
     parser.add_argument("--output", type=str, default="benchmark/outputs/fast_sac_backends.json")
     args = parser.parse_args()
     task_id = normalize_locomotion_task_id(args.task)

--- a/benchmark/benchmark_fast_sac_backends.py
+++ b/benchmark/benchmark_fast_sac_backends.py
@@ -44,9 +44,7 @@ def run_backend(task, max_iterations, backend, num_envs):
         "torch_cpu": "cpu",
     }
     if backend not in device_map:
-        raise ValueError(
-            f"Unsupported backend '{backend}'. Expected one of {sorted(device_map)}."
-        )
+        raise ValueError(f"Unsupported backend '{backend}'. Expected one of {sorted(device_map)}.")
     device = device_map[backend]
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/benchmark/smoke_test.py
+++ b/benchmark/smoke_test.py
@@ -1,47 +1,49 @@
 #!/usr/bin/env python3
-"""Smoke test all benchmark files."""
+"""Lightweight smoke test for benchmark entrypoints.
 
+This checks that benchmark modules import, without requiring every optional
+dependency or full benchmark run.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-tests = [
-    "benchmark_backends",
-    "benchmark_conversions",
-    "benchmark_ane_inference",
-    "benchmark_mlp_inference",
-    "benchmark_forward_reset_methods",
-    "benchmark_physics_step_genesis",
-    "benchmark_physics_step_isaacgym",
-    "benchmark_physics_step_mj_step",
-    "benchmark_physics_step_mujoco_warp",
-    "benchmark_mlx_compile",
-    "benchmark_postprocess",
-    "benchmark_reset_batch_vs_loop",
-    "benchmark_sim",
-]
+BENCHMARK_DIR = Path(__file__).resolve().parent
+MODULES = sorted(
+    name
+    for _, name, is_pkg in pkgutil.iter_modules([str(BENCHMARK_DIR)])
+    if not is_pkg and name.startswith("benchmark_")
+)
 
-print("Testing benchmark files...\n")
-passed = []
-failed = []
+passed: list[str] = []
+failed: list[tuple[str, str]] = []
 
-for name in tests:
+print("Testing benchmark modules...\n")
+for name in MODULES:
     print(f"Testing {name}...")
     try:
-        mod = __import__(f"benchmark.{name}", fromlist=[name])
+        importlib.import_module(f"benchmark.{name}")
+    except Exception as exc:
+        print(f"  ✗ Import failed: {exc}")
+        failed.append((name, str(exc)))
+    else:
         print("  ✓ Import OK")
         passed.append(name)
-    except Exception as e:
-        print(f"  ✗ Import failed: {e}")
-        failed.append((name, str(e)))
 
 print(f"\n{'=' * 50}")
-print(f"Passed: {len(passed)}/{len(tests)}")
-print(f"Failed: {len(failed)}/{len(tests)}")
+print(f"Passed: {len(passed)}/{len(MODULES)}")
+print(f"Failed: {len(failed)}/{len(MODULES)}")
 
 if failed:
     print("\nFailed tests:")
     for name, err in failed:
-        print(f"  - {name}: {err[:80]}")
+        print(f"  - {name}: {err[:120]}")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- make ANE inference benchmark importable without requiring coremltools at smoke-test time
- restrict Fast SAC backend benchmark defaults to real torch backends
- update benchmark smoke test to auto-discover benchmark modules and only perform lightweight import checks

## Validation
- uv run ruff check benchmark/benchmark_ane_inference.py benchmark/benchmark_fast_sac_backends.py benchmark/smoke_test.py
- uv run benchmark/smoke_test.py

Audit notes were saved locally under agent/ and intentionally excluded from the commit.