### PR TITLE
fix: lighten CI test dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,25 @@ jobs:
           # python-version: ${{ matrix.python-version }}
           python-version: '3.11'
       - name: Install dependencies
-        run: uv sync --extra motrix
+        run: |
+          uv sync --extra motrix \
+            --no-install-package torch \
+            --no-install-package torchvision \
+            --no-install-package nvidia-cublas-cu12 \
+            --no-install-package nvidia-cuda-cupti-cu12 \
+            --no-install-package nvidia-cuda-nvrtc-cu12 \
+            --no-install-package nvidia-cuda-runtime-cu12 \
+            --no-install-package nvidia-cudnn-cu12 \
+            --no-install-package nvidia-cufft-cu12 \
+            --no-install-package nvidia-cufile-cu12 \
+            --no-install-package nvidia-curand-cu12 \
+            --no-install-package nvidia-cusolver-cu12 \
+            --no-install-package nvidia-cusparse-cu12 \
+            --no-install-package nvidia-cusparselt-cu12 \
+            --no-install-package nvidia-nccl-cu12 \
+            --no-install-package nvidia-nvjitlink-cu12 \
+            --no-install-package nvidia-nvtx-cu12 \
+            --no-install-package triton
+          uv pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Test with coverage
-        run: uv run pytest -m "not slow" --cov=unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25
+        run: uv run --no-sync pytest -m "not slow" --cov=unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25

--- a/docs/developers/zh_CN/CONTRIBUTING.md
+++ b/docs/developers/zh_CN/CONTRIBUTING.md
@@ -107,7 +107,7 @@ uv run pytest -m "slow" -v
 | `ruff-format` | 在 `ubuntu-slim` 上执行 `uv sync --only-group dev` + `uv run --no-sync ruff format --check .` | ✅ |
 | `mypy` | 在 `ubuntu-slim` 上执行 `uv sync` + `uv run mypy src/unilab` | ✅ |
 | `pyright` | 在 `ubuntu-slim` 上执行 `uv sync` + `uv run pyright` | ✅ |
-| `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix` + `uv run pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25` | ✅ |
+| `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix`，跳过 CUDA torch / torchvision / nvidia wheel，安装 CPU torch / torchvision，并用 `uv run --no-sync pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25` | ✅ |
 
 只有协作元信息改动，例如 `LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，才会跳过 CI。文档改动会触发 CI，并由 `tests/scripts/test_check_docs.py` 校验。
 


### PR DESCRIPTION
Fixes #365

## Summary
- skip CUDA torch, torchvision, nvidia, and triton packages during the ubuntu-slim test dependency sync
- install CPU torch/torchvision for the test lane and run pytest with --no-sync
- update developer CI documentation to match the workflow

## Validation
- uv run pytest tests/scripts/test_check_docs.py tests/scripts/test_repo_hygiene.py -q
- git diff --check
- uv sync --frozen --dry-run --extra motrix --no-install-package torch --no-install-package torchvision --no-install-package nvidia-cublas-cu12 --no-install-package nvidia-cuda-cupti-cu12 --no-install-package nvidia-cuda-nvrtc-cu12 --no-install-package nvidia-cuda-runtime-cu12 --no-install-package nvidia-cudnn-cu12 --no-install-package nvidia-cufft-cu12 --no-install-package nvidia-cufile-cu12 --no-install-package nvidia-curand-cu12 --no-install-package nvidia-cusolver-cu12 --no-install-package nvidia-cusparse-cu12 --no-install-package nvidia-cusparselt-cu12 --no-install-package nvidia-nccl-cu12 --no-install-package nvidia-nvjitlink-cu12 --no-install-package nvidia-nvtx-cu12 --no-install-package triton --python-platform x86_64-manylinux_2_28
- uv pip install --dry-run torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cpu