### PR TITLE
refactor(ipc): rename rollout ring buffer contract

### DIFF
--- a/docs/developers/zh_CN/development-standard.md
+++ b/docs/developers/zh_CN/development-standard.md
@@ -61,7 +61,7 @@ CPU Physics Sim ──shm──► Collector / IPC ──shm──► GPU Learne
 |------|------|--------|
 | PPO (torch) | `scripts/train_rsl_rl.py` | `registry.make` -> `RslRlVecEnvWrapper` -> `rsl_rl.OnPolicyRunner` |
 | PPO (MLX) | `scripts/train_mlx_ppo.py` | `registry.make` -> MLX `RolloutBuffer` -> `PPOTrainer` |
-| APPO | `scripts/train_appo.py` | `APPORunner` -> collector -> `SharedOnPolicyStorage` |
+| APPO | `scripts/train_appo.py` | `APPORunner` -> collector -> `RolloutRingBuffer` |
 | SAC / TD3 | `scripts/train_offpolicy.py` | `OffPolicyRunner` -> collector -> `ReplayBuffer` |
 
 动手前，先定位自己正在修改哪条链路。
@@ -108,7 +108,7 @@ Env **负责** MDP 语义、observation 结构、reward、reset，以及 backend
 
 所有异步算法共享 `src/unilab/ipc/async_runner.py` 中的 `AsyncRunner`: 统一的 spawn 模型、统一的 collector lifecycle、统一的 shared-resource cleanup。
 
-- **APPO**: collector 写入 `SharedOnPolicyStorage`；learner 使用 V-trace；actor 权重通过 `SharedWeightSync` 回传
+- **APPO**: collector 写入 `RolloutRingBuffer`；learner 使用 V-trace；actor 权重通过 `SharedWeightSync` 回传
 - **Off-policy**: collector 写入 `ReplayBuffer`；learner 从中采样；`SharedWeightSync` 同步权重；同时支持同步和异步采集
 
 不要在 shared runner 之外复制并行协议、绕过 shared-resource lifecycle，或引入隐式耦合。

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -1,7 +1,7 @@
 """APPO Runner — Asynchronous PPO with native multiprocessing.
 
 Pipeline:
-  1. Collector subprocess collects on-policy rollouts → SharedOnPolicyStorage
+  1. Collector subprocess publishes rollout payloads → RolloutRingBuffer
   2. Learner reads rollouts, computes V-trace corrected updates
   3. Weights synced back to collector via SharedWeightSync
 """
@@ -19,7 +19,7 @@ from rsl_rl.utils import resolve_callable
 
 from unilab.algos.torch.appo.learner import APPOLearner
 from unilab.algos.torch.appo.worker import appo_collector_fn
-from unilab.ipc import AsyncRunner, SharedOnPolicyStorage, SharedWeightSync
+from unilab.ipc import AsyncRunner, RolloutRingBuffer, SharedWeightSync
 from unilab.logging import OffPolicyLogger
 
 
@@ -179,8 +179,8 @@ class APPORunner(AsyncRunner):
 
         learner = self._build_learner()
 
-        # Create shared storage (4-slot ring buffer for IPC; replay queue lives in learner)
-        shared_storage = SharedOnPolicyStorage(
+        # Create shared rollout IPC ring buffer; replay queue lives in learner.
+        rollout_ring_buffer = RolloutRingBuffer(
             num_envs=self.num_envs,
             num_steps=self.steps_per_env,
             obs_dim=self.obs_dim,
@@ -189,7 +189,7 @@ class APPORunner(AsyncRunner):
             num_slots=4,
             create=True,
         )
-        self._shared_resources.append(shared_storage)
+        self._shared_resources.append(rollout_ring_buffer)
 
         # Create weight sync for collector-side actor and critic bootstrap values.
         actor_weight_sync = SharedWeightSync.from_state_dict(
@@ -215,10 +215,10 @@ class APPORunner(AsyncRunner):
             "rl_cfg": self.rl_cfg,
             "num_envs": self.num_envs,
             "steps_per_env": self.steps_per_env,
-            "shm_storage_name": shared_storage.name,
+            "shm_rollout_ring_buffer_name": rollout_ring_buffer.name,
             "sync_primitives": (
-                shared_storage._write_ptr,
-                shared_storage._read_ptr,
+                rollout_ring_buffer._write_ptr,
+                rollout_ring_buffer._read_ptr,
             ),
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
@@ -270,7 +270,7 @@ class APPORunner(AsyncRunner):
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
             wait_start = time.time()
 
-            data_ready = shared_storage.wait_for_data(timeout=60.0)
+            data_ready = rollout_ring_buffer.wait_for_data(timeout=60.0)
             if not data_ready:
                 # Check if the collector subprocess died — fail fast instead of
                 # burning through remaining iterations with 60s timeouts each.
@@ -287,24 +287,24 @@ class APPORunner(AsyncRunner):
                 )
                 continue
 
-            available_on_arrive = shared_storage.available()
+            available_on_arrive = rollout_ring_buffer.available()
             wait_time = time.time() - wait_start
 
             # Drain ALL available slots into the replay queue in one pass.
             # This keeps the GPU busy: if the collector produced 3 rollouts while
             # the learner was training, we consume all 3 immediately rather than
             # processing them one-per-iteration.
-            num_new = shared_storage.available()
+            num_new = rollout_ring_buffer.available()
             rollout_collect_time = 0.0
             for _ in range(num_new):
-                raw = shared_storage.read_torch(self.device)
-                shared_storage.advance_read()
+                raw = rollout_ring_buffer.read_torch(self.device)
+                rollout_ring_buffer.advance_read()
 
                 raw_collect_time = raw.pop("rollout_collect_time_s", None)
                 if raw_collect_time is not None:
                     rollout_collect_time += float(raw_collect_time.reshape(-1)[0].item())
 
-                # Preprocess: storage is [N, T, *] (env-major); learner expects [T, N, *]
+                # Preprocess: payload is [N, T, *] (env-major); learner expects [T, N, *]
                 rollout: dict = {}
                 for k, v in raw.items():
                     if k not in ("last_obs", "last_critic") and v.ndim >= 2:

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -1,6 +1,6 @@
 """APPO Rollout Worker — runs in a subprocess.
 
-Collects on-policy rollouts and writes to SharedOnPolicyStorage.
+Collects rollout payloads and writes them to RolloutRingBuffer.
 """
 
 from __future__ import annotations
@@ -59,7 +59,7 @@ def appo_collector_fn(
     rl_cfg: dict,
     num_envs: int,
     steps_per_env: int,
-    shm_storage_name: Dict[str, str],
+    shm_rollout_ring_buffer_name: Dict[str, str],
     sync_primitives: tuple,
     obs_dim: int,
     action_dim: int,
@@ -75,28 +75,28 @@ def appo_collector_fn(
 ):
     """Entry point for the APPO collector subprocess.
 
-    Creates environment + policy, collects rollouts, writes to SharedOnPolicyStorage.
+    Creates environment + policy, collects rollouts, writes raw payloads to the IPC ring buffer.
     """
     from copy import deepcopy
 
     from tensordict import TensorDict
 
     from unilab.base import registry
-    from unilab.ipc import SharedOnPolicyStorage, SharedWeightSync
+    from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 
     ensure_registries()
 
     # Connect to shared memory
-    storage = SharedOnPolicyStorage(
+    ring_buffer = RolloutRingBuffer(
         num_envs=num_envs,
         num_steps=steps_per_env,
         obs_dim=obs_dim,
         action_dim=action_dim,
         critic_dim=critic_dim,
         create=False,
-        shm_name_prefix=shm_storage_name,
+        shm_name_prefix=shm_rollout_ring_buffer_name,
     )
-    storage.attach_sync_primitives(*sync_primitives)  # (write_ptr, read_ptr)
+    ring_buffer.attach_sync_primitives(*sync_primitives)  # (write_ptr, read_ptr)
     actor_weight_sync = SharedWeightSync(
         actor_weight_param_shapes, create=False, shm_name=actor_weight_sync_name
     )
@@ -208,7 +208,7 @@ def appo_collector_fn(
                 critic.load_state_dict(critic_sd)
 
             # Collect one rollout of length steps_per_env
-            write_buf = storage.write_buffer
+            write_buf = ring_buffer.write_buffer
             rollout_start = time.perf_counter()
             for step in range(steps_per_env):
                 # --- MLP inference (timed) ---
@@ -330,7 +330,7 @@ def appo_collector_fn(
             if critic_np is not None:
                 write_buf["last_critic"][:] = critic_np
             record_rollout_collect_time(write_buf, time.perf_counter() - rollout_start)
-            storage.signal_write_done()  # atomic increment, non-blocking
+            ring_buffer.signal_write_done()  # atomic increment, non-blocking
 
     except Exception as e:
         import traceback
@@ -345,7 +345,7 @@ def appo_collector_fn(
         stop_event.set()
         raise
 
-    storage.close()
+    ring_buffer.close()
     actor_weight_sync.close()
     critic_weight_sync.close()
     env.close()

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -23,7 +23,7 @@ from unilab.algos.torch.hora.rsl_rl_compat import (
 )
 from unilab.base.observations import get_critic_base_dim, get_obs_dims
 from unilab.base.registry import ensure_registries
-from unilab.ipc import SharedOnPolicyStorage, SharedWeightSync
+from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 from unilab.logging import OffPolicyLogger
 
 
@@ -160,7 +160,7 @@ class HoraAPPORunner(APPORunner):
 
         learner = self._build_learner()
 
-        shared_storage = SharedOnPolicyStorage(
+        rollout_ring_buffer = RolloutRingBuffer(
             num_envs=self.num_envs,
             num_steps=self.steps_per_env,
             obs_dim=self.obs_dim,
@@ -169,7 +169,7 @@ class HoraAPPORunner(APPORunner):
             num_slots=4,
             create=True,
         )
-        self._shared_resources.append(shared_storage)
+        self._shared_resources.append(rollout_ring_buffer)
 
         actor_weight_sync = SharedWeightSync.from_state_dict(
             learner.actor.state_dict(), create=True
@@ -193,10 +193,10 @@ class HoraAPPORunner(APPORunner):
             "rl_cfg": self.rl_cfg,
             "num_envs": self.num_envs,
             "steps_per_env": self.steps_per_env,
-            "shm_storage_name": shared_storage.name,
+            "shm_rollout_ring_buffer_name": rollout_ring_buffer.name,
             "sync_primitives": (
-                shared_storage._write_ptr,
-                shared_storage._read_ptr,
+                rollout_ring_buffer._write_ptr,
+                rollout_ring_buffer._read_ptr,
             ),
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
@@ -244,7 +244,7 @@ class HoraAPPORunner(APPORunner):
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
             wait_start = time.time()
 
-            data_ready = shared_storage.wait_for_data(timeout=60.0)
+            data_ready = rollout_ring_buffer.wait_for_data(timeout=60.0)
             if not data_ready:
                 if not self._check_collector_alive():
                     self._drain_metrics(
@@ -262,13 +262,13 @@ class HoraAPPORunner(APPORunner):
                 )
                 continue
 
-            available_on_arrive = shared_storage.available()
+            available_on_arrive = rollout_ring_buffer.available()
             wait_time = time.time() - wait_start
 
-            num_new = shared_storage.available()
+            num_new = rollout_ring_buffer.available()
             for _ in range(num_new):
-                raw = shared_storage.read_torch(self.device)
-                shared_storage.advance_read()
+                raw = rollout_ring_buffer.read_torch(self.device)
+                rollout_ring_buffer.advance_read()
 
                 rollout: dict = {}
                 for k, v in raw.items():

--- a/src/unilab/algos/torch/hora/appo_worker.py
+++ b/src/unilab/algos/torch/hora/appo_worker.py
@@ -62,7 +62,7 @@ def hora_appo_collector_fn(
     rl_cfg: dict,
     num_envs: int,
     steps_per_env: int,
-    shm_storage_name: Dict[str, str],
+    shm_rollout_ring_buffer_name: Dict[str, str],
     sync_primitives: tuple,
     obs_dim: int,
     action_dim: int,
@@ -77,7 +77,7 @@ def hora_appo_collector_fn(
     env_cfg_override: dict | None = None,
     priv_info_dim: int = 0,
 ):
-    """Collect grouped HORA APPO rollouts into shared storage."""
+    """Collect grouped HORA APPO rollouts into the shared IPC ring buffer."""
     from copy import deepcopy
 
     from tensordict import TensorDict
@@ -88,20 +88,20 @@ def hora_appo_collector_fn(
         is_rsl_rl_v5,
     )
     from unilab.base import registry
-    from unilab.ipc import SharedOnPolicyStorage, SharedWeightSync
+    from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 
     ensure_registries()
 
-    storage = SharedOnPolicyStorage(
+    ring_buffer = RolloutRingBuffer(
         num_envs=num_envs,
         num_steps=steps_per_env,
         obs_dim=obs_dim,
         action_dim=action_dim,
         critic_dim=critic_dim,
         create=False,
-        shm_name_prefix=shm_storage_name,
+        shm_name_prefix=shm_rollout_ring_buffer_name,
     )
-    storage.attach_sync_primitives(*sync_primitives)
+    ring_buffer.attach_sync_primitives(*sync_primitives)
     actor_weight_sync = SharedWeightSync(
         actor_weight_param_shapes,
         create=False,
@@ -218,7 +218,7 @@ def hora_appo_collector_fn(
                 local_critic_weight_version = critic_weight_sync.read_weights_into(critic_sd)
                 critic.load_state_dict(critic_sd)
 
-            write_buf = storage.write_buffer
+            write_buf = ring_buffer.write_buffer
             for step in range(steps_per_env):
                 t_mlp = time.perf_counter()
                 with torch.no_grad():
@@ -361,7 +361,7 @@ def hora_appo_collector_fn(
             write_buf["last_obs"][:] = obs_np
             if critic_np is not None:
                 write_buf["last_critic"][:] = critic_np
-            storage.signal_write_done()
+            ring_buffer.signal_write_done()
 
     except Exception as e:
         import traceback
@@ -376,7 +376,7 @@ def hora_appo_collector_fn(
         stop_event.set()
         raise
 
-    storage.close()
+    ring_buffer.close()
     actor_weight_sync.close()
     critic_weight_sync.close()
     env.close()

--- a/src/unilab/ipc/__init__.py
+++ b/src/unilab/ipc/__init__.py
@@ -2,13 +2,13 @@
 
 from unilab.ipc.async_runner import AsyncRunner
 from unilab.ipc.replay_buffer import ReplayBuffer
+from unilab.ipc.rollout_ring_buffer import RolloutRingBuffer
 from unilab.ipc.shared_obs_stats import SharedObsNormStats
-from unilab.ipc.shared_onpolicy_storage import SharedOnPolicyStorage
 from unilab.ipc.weight_sync import SharedWeightSync
 
 __all__ = [
     "SharedWeightSync",
-    "SharedOnPolicyStorage",
+    "RolloutRingBuffer",
     "AsyncRunner",
     "SharedObsNormStats",
     "ReplayBuffer",

--- a/src/unilab/ipc/rollout_ring_buffer.py
+++ b/src/unilab/ipc/rollout_ring_buffer.py
@@ -1,4 +1,4 @@
-"""Shared on-policy rollout storage for APPO / async PPO."""
+"""Shared rollout IPC ring buffer for APPO / async PPO."""
 
 from __future__ import annotations
 
@@ -24,8 +24,8 @@ _FIELD_SHAPES = {
 }
 
 
-class SharedOnPolicyStorage:
-    """N-slot ring-buffer shared-memory store for on-policy rollouts."""
+class RolloutRingBuffer:
+    """N-slot shared-memory ring buffer for raw rollout payloads."""
 
     def __init__(
         self,

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -11,8 +11,8 @@ from unilab.algos.torch.appo.runner import APPORunner
 
 @pytest.fixture(autouse=True)
 def _reset_fakes() -> None:
-    _FakeSharedOnPolicyStorage.last_instance = None
-    _FakeSharedOnPolicyStorage.rollout_collect_times = [0.25]
+    _FakeRolloutRingBuffer.last_instance = None
+    _FakeRolloutRingBuffer.rollout_collect_times = [0.25]
     _FakeLogger.last_instance = None
 
 
@@ -38,8 +38,8 @@ class _FakeLearner:
         return {"loss": 0.5}
 
 
-class _FakeSharedOnPolicyStorage:
-    last_instance: "_FakeSharedOnPolicyStorage | None" = None
+class _FakeRolloutRingBuffer:
+    last_instance: "_FakeRolloutRingBuffer | None" = None
     rollout_collect_times: list[float] = [0.25]
 
     def __init__(
@@ -59,7 +59,7 @@ class _FakeSharedOnPolicyStorage:
         self._read_ptr = object()
         self.wait_calls = 0
         self.advance_calls = 0
-        _FakeSharedOnPolicyStorage.last_instance = self
+        _FakeRolloutRingBuffer.last_instance = self
 
     def wait_for_data(self, timeout: float = 60.0) -> bool:
         del timeout
@@ -180,7 +180,7 @@ def test_appo_runner_uses_explicit_runtime_context(
 
     monkeypatch.setattr(APPORunner, "_detect_dims", fake_detect_dims)
     monkeypatch.setattr(APPORunner, "_build_learner", lambda self: _FakeLearner())
-    monkeypatch.setattr(appo_runner_module, "SharedOnPolicyStorage", _FakeSharedOnPolicyStorage)
+    monkeypatch.setattr(appo_runner_module, "RolloutRingBuffer", _FakeRolloutRingBuffer)
     monkeypatch.setattr(appo_runner_module, "SharedWeightSync", _FakeWeightSync)
     monkeypatch.setattr(appo_runner_module, "OffPolicyLogger", _FakeLogger)
     monkeypatch.setattr(appo_runner_module.torch, "save", lambda *args, **kwargs: None)
@@ -215,7 +215,7 @@ def test_appo_runner_uses_collector_rollout_time_for_fps_inputs(
     monkeypatch.setattr(APPORunner, "_detect_dims", fake_detect_dims)
     monkeypatch.setattr(APPORunner, "_build_learner", lambda self: _FakeLearner())
     monkeypatch.setattr(APPORunner, "_check_collector_alive", lambda self: True)
-    monkeypatch.setattr(appo_runner_module, "SharedOnPolicyStorage", _FakeSharedOnPolicyStorage)
+    monkeypatch.setattr(appo_runner_module, "RolloutRingBuffer", _FakeRolloutRingBuffer)
     monkeypatch.setattr(appo_runner_module, "SharedWeightSync", _FakeWeightSync)
     monkeypatch.setattr(appo_runner_module, "OffPolicyLogger", _FakeLogger)
     monkeypatch.setattr(appo_runner_module.mp, "get_context", lambda method: queue)
@@ -239,7 +239,7 @@ def test_appo_runner_uses_collector_rollout_time_for_fps_inputs(
     runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
 
     logger = _FakeLogger.last_instance
-    storage = _FakeSharedOnPolicyStorage.last_instance
+    storage = _FakeRolloutRingBuffer.last_instance
     assert logger is not None
     assert storage is not None
     assert storage.wait_calls == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import torch
 from unilab.base import registry
 from unilab.base.base import ABEnv, EnvCfg
 from unilab.ipc.replay_buffer import ReplayBuffer
-from unilab.ipc.shared_onpolicy_storage import SharedOnPolicyStorage
+from unilab.ipc.rollout_ring_buffer import RolloutRingBuffer
 from unilab.ipc.weight_sync import SharedWeightSync
 
 # ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ def tiny_replay_buffer():
 
 @pytest.fixture
 def tiny_storage():
-    storage = SharedOnPolicyStorage(
+    storage = RolloutRingBuffer(
         num_envs=4,
         num_steps=10,
         obs_dim=_DUMMY_OBS_DIM,

--- a/tests/ipc/test_rollout_ring_buffer.py
+++ b/tests/ipc/test_rollout_ring_buffer.py
@@ -1,4 +1,4 @@
-"""Tests for SharedOnPolicyStorage IPC primitive."""
+"""Tests for RolloutRingBuffer IPC primitive."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 
-from unilab.ipc.shared_onpolicy_storage import SharedOnPolicyStorage
+from unilab.ipc.rollout_ring_buffer import RolloutRingBuffer
 
 _NUM_ENVS = 4
 _NUM_STEPS = 10
@@ -27,8 +27,8 @@ _EXPECTED_FIELDS = {
 }
 
 
-def _make_storage(num_slots: int = _NUM_SLOTS) -> SharedOnPolicyStorage:
-    return SharedOnPolicyStorage(
+def _make_ring_buffer(num_slots: int = _NUM_SLOTS) -> RolloutRingBuffer:
+    return RolloutRingBuffer(
         num_envs=_NUM_ENVS,
         num_steps=_NUM_STEPS,
         obs_dim=_OBS_DIM,
@@ -38,8 +38,8 @@ def _make_storage(num_slots: int = _NUM_SLOTS) -> SharedOnPolicyStorage:
     )
 
 
-def _make_storage_with_critic() -> SharedOnPolicyStorage:
-    return SharedOnPolicyStorage(
+def _make_ring_buffer_with_critic() -> RolloutRingBuffer:
+    return RolloutRingBuffer(
         num_envs=_NUM_ENVS,
         num_steps=_NUM_STEPS,
         obs_dim=_OBS_DIM,
@@ -51,7 +51,7 @@ def _make_storage_with_critic() -> SharedOnPolicyStorage:
 
 
 def test_pointers_start_at_zero():
-    s = _make_storage()
+    s = _make_ring_buffer()
     assert int(s._write_ptr.value) == 0
     assert int(s._read_ptr.value) == 0
     s.cleanup()
@@ -59,7 +59,7 @@ def test_pointers_start_at_zero():
 
 def test_signal_write_done_and_wait_for_data():
     """signal_write_done() advances write_ptr; wait_for_data() returns True."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     assert s.available() == 0
     s.signal_write_done()
     assert s.available() == 1
@@ -68,7 +68,7 @@ def test_signal_write_done_and_wait_for_data():
 
 
 def test_available_returns_correct_count():
-    s = _make_storage(num_slots=4)
+    s = _make_ring_buffer(num_slots=4)
     assert s.available() == 0
     for i in range(3):
         s.signal_write_done()
@@ -78,7 +78,7 @@ def test_available_returns_correct_count():
 
 def test_advance_read_skips_overwritten_slots():
     """If writer ran far ahead (wp - rp > num_slots), advance_read fast-forwards."""
-    s = _make_storage(num_slots=2)
+    s = _make_ring_buffer(num_slots=2)
     # Writer produces 4 rollouts (2x more than num_slots)
     for _ in range(4):
         s.signal_write_done()
@@ -92,7 +92,7 @@ def test_advance_read_skips_overwritten_slots():
 
 def test_read_torch_returns_all_fields():
     """read_torch() must return a dict with all expected field keys."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     # Fill write slot with non-zero data
     wb = s.write_buffer
     for arr in wb.values():
@@ -108,14 +108,14 @@ def test_read_torch_returns_all_fields():
 
 def test_cleanup_is_idempotent():
     """cleanup() called twice must not raise."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     s.cleanup()
     s.cleanup()
 
 
 def test_wait_for_data_timeout_returns_false():
     """wait_for_data() with a short timeout returns False when no data is available."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     result = s.wait_for_data(timeout=0.05)
     assert result is False
     s.cleanup()
@@ -123,7 +123,7 @@ def test_wait_for_data_timeout_returns_false():
 
 def test_write_buffer_returns_dict_of_arrays():
     """write_buffer property returns a dict of numpy arrays for the current write slot."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     wb = s.write_buffer
     assert set(wb.keys()) == _EXPECTED_FIELDS
     for k, arr in wb.items():
@@ -133,13 +133,13 @@ def test_write_buffer_returns_dict_of_arrays():
 
 def test_close_does_not_raise():
     """close() (attach-mode teardown, no unlink) must not raise."""
-    s = _make_storage()
+    s = _make_ring_buffer()
     s.close()
 
 
 def test_attach_create_false_reads_same_data():
     """Attaching to existing shm (create=False) exposes the same data as the owner."""
-    owner = _make_storage()
+    owner = _make_ring_buffer()
     # Write known data into write slot 0
     wb = owner.write_buffer
     for arr in wb.values():
@@ -147,7 +147,7 @@ def test_attach_create_false_reads_same_data():
     owner.signal_write_done()
 
     # Attach
-    attached = SharedOnPolicyStorage(
+    attached = RolloutRingBuffer(
         num_envs=_NUM_ENVS,
         num_steps=_NUM_STEPS,
         obs_dim=_OBS_DIM,
@@ -170,8 +170,8 @@ def test_attach_create_false_reads_same_data():
 
 def test_attach_sync_primitives():
     """attach_sync_primitives() replaces internal pointers in the attached instance."""
-    owner = _make_storage()
-    attached = SharedOnPolicyStorage(
+    owner = _make_ring_buffer()
+    attached = RolloutRingBuffer(
         num_envs=_NUM_ENVS,
         num_steps=_NUM_STEPS,
         obs_dim=_OBS_DIM,
@@ -189,17 +189,17 @@ def test_attach_sync_primitives():
     owner.cleanup()
 
 
-def test_storage_allocates_optional_critic_fields():
-    storage = _make_storage_with_critic()
+def test_ring_buffer_allocates_optional_critic_fields():
+    ring_buffer = _make_ring_buffer_with_critic()
 
     expected = _EXPECTED_FIELDS | {"critic", "last_critic"}
-    assert set(storage.write_buffer.keys()) == expected
+    assert set(ring_buffer.write_buffer.keys()) == expected
 
-    storage.cleanup()
+    ring_buffer.cleanup()
 
 
-def test_storage_ipc_contract_has_no_privileged_fields():
-    from unilab.ipc.shared_onpolicy_storage import _FIELD_SHAPES
+def test_ring_buffer_ipc_contract_has_no_privileged_fields():
+    from unilab.ipc.rollout_ring_buffer import _FIELD_SHAPES
 
     assert "priv_info" not in _FIELD_SHAPES
     assert "last_priv_info" not in _FIELD_SHAPES


### PR DESCRIPTION
Fixes #371

## Summary
- rename SharedOnPolicyStorage to RolloutRingBuffer and move the IPC primitive to rollout_ring_buffer.py
- update APPO/HORA runner-worker call sites, tests, and developer docs to use the strict contract name
- remove the old on-policy storage import path instead of keeping a compatibility alias

## Validation
- make test-all