### PR TITLE
fix(offpolicy): use pipeline time for steps per second

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco
 ```
 
 ```bash
-# Linux CUDA G1 motion tracking (1h40min on RTX 4090 and R9-9950x3d)
+# Linux CUDA G1 motion tracking (27min on RTX 4090 and R9-9950x3d)
 # macOS users: omit training.use_amp=true
 uv run train --algo sac --task g1_sac_wbt --sim mujoco training.use_amp=true
 ```

--- a/conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml
@@ -6,7 +6,7 @@ training:
   sim_backend: mujoco
 algo:
   num_envs: 2048
-  max_iterations: 100000
+  max_iterations: 25000
   save_interval: 1000
   # --- holosoma WBT-specific overrides (vs sac.yaml defaults) ---
   gamma: 0.99

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -103,10 +103,13 @@ class OffPolicyLogger(BaseTrainingLogger):
     def _get_iter_steps_per_sec(self) -> float | None:
         if not self._has_iteration_extra_info or self._throughput_steps <= 0:
             return None
-        iter_time = self._collect_time + self._train_time
+        iter_time = self._get_iter_pipeline_time()
         if iter_time <= 0:
             return None
         return self._throughput_steps / iter_time
+
+    def _get_iter_pipeline_time(self) -> float:
+        return max(self._collect_time, self._train_time)
 
     def _get_wall_steps_per_sec(self, elapsed: float) -> float | None:
         if elapsed <= 0 or self._total_steps <= 0:
@@ -160,7 +163,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         else:
             self._startup_wait_time = 0.0
             self._throughput_steps = 0
-        self._iter_times.append(collect_time + train_time)
+        self._iter_times.append(self._get_iter_pipeline_time())
         if metrics:
             self._latest_metrics.update(metrics)
         if reward is not None:
@@ -217,9 +220,7 @@ class OffPolicyLogger(BaseTrainingLogger):
                 writer.add_scalar("perf/steps_per_sec", wall_steps_per_sec, global_step)
             if wall_steps_per_sec is not None:
                 writer.add_scalar("perf/steps_per_sec_wall", wall_steps_per_sec, global_step)
-            writer.add_scalar(
-                "perf/iter_ms", (self._collect_time + self._train_time) * 1000, global_step
-            )
+            writer.add_scalar("perf/iter_ms", self._get_iter_pipeline_time() * 1000, global_step)
             writer.add_scalar(
                 "perf/collect_train_ratio",
                 self._collect_time / max(self._train_time, 1e-6),
@@ -257,7 +258,7 @@ class OffPolicyLogger(BaseTrainingLogger):
                 log_dict["perf/steps_per_sec"] = wall_steps_per_sec
             if wall_steps_per_sec is not None:
                 log_dict["perf/steps_per_sec_wall"] = wall_steps_per_sec
-            log_dict["perf/iter_ms"] = (self._collect_time + self._train_time) * 1000
+            log_dict["perf/iter_ms"] = self._get_iter_pipeline_time() * 1000
             log_dict["perf/collect_train_ratio"] = self._collect_time / max(self._train_time, 1e-6)
             wandb.log(log_dict, step=global_step)
 

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 import unilab.logging.offpolicy as offpolicy_module
 from unilab.logging import OffPolicyLogger, OnPolicyLogger
 from unilab.training.experiment import ExperimentTracker, build_wandb_settings
@@ -232,7 +234,9 @@ def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeyp
     assert payload["timing/learner_wait_ms"] == 10_000.0
     assert payload["timing/startup_wait_ms"] == 9_750.0
     assert payload["timing/learner_collect_ms"] == 250.0
-    assert payload["perf/steps_per_sec_iter"] == 8.0
+    assert payload["timing/learner_train_ms"] == 750.0
+    assert payload["perf/iter_ms"] == 750.0
+    assert payload["perf/steps_per_sec_iter"] == pytest.approx(8.0 / 0.75)
 
     logger.finish()
 


### PR DESCRIPTION
## Summary

- compute offpolicy iteration Steps/s with pipeline time: `throughput_steps / max(collect_time, train_time)`
- log `perf/iter_ms` with the same pipeline-time semantics
- update experiment tracking coverage for the new throughput formula

Fixes #370

## Tests

- `make test-all`

