### PR TITLE
refactor(offpolicy): drop Wall Steps/s, keep only iter Steps/s

### DIFF
--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -111,11 +111,6 @@ class OffPolicyLogger(BaseTrainingLogger):
     def _get_iter_pipeline_time(self) -> float:
         return max(self._collect_time, self._train_time)
 
-    def _get_wall_steps_per_sec(self, elapsed: float) -> float | None:
-        if elapsed <= 0 or self._total_steps <= 0:
-            return None
-        return self._total_steps / elapsed
-
     def update_collector_timing(self, timing_ms: dict[str, float]):
         self._collector_timing.update(timing_ms)
 
@@ -186,9 +181,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         train_time: float,
     ):
         global_step = self._total_steps if self._total_steps > 0 else iteration
-        elapsed = time.time() - self._start_time if self._start_time else 0
         iter_steps_per_sec = self._get_iter_steps_per_sec()
-        wall_steps_per_sec = self._get_wall_steps_per_sec(elapsed)
 
         if self._tb_writer:
             writer = self._tb_writer
@@ -215,11 +208,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 writer.add_scalar(f"timing/collector_{key}", value, global_step)
             if iter_steps_per_sec is not None:
                 writer.add_scalar("perf/steps_per_sec", iter_steps_per_sec, global_step)
-                writer.add_scalar("perf/steps_per_sec_iter", iter_steps_per_sec, global_step)
-            elif wall_steps_per_sec is not None:
-                writer.add_scalar("perf/steps_per_sec", wall_steps_per_sec, global_step)
-            if wall_steps_per_sec is not None:
-                writer.add_scalar("perf/steps_per_sec_wall", wall_steps_per_sec, global_step)
             writer.add_scalar("perf/iter_ms", self._get_iter_pipeline_time() * 1000, global_step)
             writer.add_scalar(
                 "perf/collect_train_ratio",
@@ -253,11 +241,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 log_dict[f"timing/collector_{key}"] = value
             if iter_steps_per_sec is not None:
                 log_dict["perf/steps_per_sec"] = iter_steps_per_sec
-                log_dict["perf/steps_per_sec_iter"] = iter_steps_per_sec
-            elif wall_steps_per_sec is not None:
-                log_dict["perf/steps_per_sec"] = wall_steps_per_sec
-            if wall_steps_per_sec is not None:
-                log_dict["perf/steps_per_sec_wall"] = wall_steps_per_sec
             log_dict["perf/iter_ms"] = self._get_iter_pipeline_time() * 1000
             log_dict["perf/collect_train_ratio"] = self._collect_time / max(self._train_time, 1e-6)
             wandb.log(log_dict, step=global_step)
@@ -391,11 +374,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 "",
             )
         iter_steps_per_sec = self._get_iter_steps_per_sec()
-        wall_steps_per_sec = self._get_wall_steps_per_sec(elapsed)
         if iter_steps_per_sec is not None:
             table.add_row("Steps/s", f"{iter_steps_per_sec:,.0f}", "", "")
-            if wall_steps_per_sec is not None:
-                table.add_row("Wall Steps/s", f"{wall_steps_per_sec:,.0f}", "", "")
-        elif wall_steps_per_sec is not None:
-            table.add_row("Steps/s", f"{wall_steps_per_sec:,.0f}", "", "")
         return table

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -236,7 +236,7 @@ def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeyp
     assert payload["timing/learner_collect_ms"] == 250.0
     assert payload["timing/learner_train_ms"] == 750.0
     assert payload["perf/iter_ms"] == 750.0
-    assert payload["perf/steps_per_sec_iter"] == pytest.approx(8.0 / 0.75)
+    assert payload["perf/steps_per_sec"] == pytest.approx(8.0 / 0.75)
 
     logger.finish()
 
@@ -263,7 +263,6 @@ def test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied(monkeyp
 
     payload, _ = fake_wandb.log_calls[-1]
     assert "timing/startup_wait_ms" not in payload
-    assert "perf/steps_per_sec_iter" not in payload
-    assert payload["perf/steps_per_sec_wall"] > 0
+    assert "perf/steps_per_sec" not in payload
 
     logger.finish()


### PR DESCRIPTION
## Summary

- Remove the `Wall Steps/s` row from the off-policy training terminal UI and the `perf/steps_per_sec_wall` scalar from TensorBoard/W&B.
- Drop the `perf/steps_per_sec_iter` alias — with only one variant remaining, the disambiguation introduced in #373 is no longer needed. Off-policy throughput is reported as a single `perf/steps_per_sec` (= `throughput_steps / max(collect_time, train_time)`).
- Drop the wall fallback path in `_backend_log_step`: when `extra_info` is missing, no `perf/steps_per_sec` is logged.

Context: #370 / #373 added `Wall Steps/s` as a ground-truth cross-check alongside the corrected pipeline `Steps/s`. Per request, the redundant wall display is removed to keep the logger focused on the pipeline metric.

## Behavior change

Runners that do not pass `extra_info={"throughput_steps": ...}` to `OffPolicyLogger.log_step` (currently HORA APPO, `src/unilab/algos/torch/hora/appo_runner.py`) will no longer show a Steps/s row. The other off-policy runners (`offpolicy/runner.py`, `appo/runner.py`, `offpolicy/multi_gpu_runner.py`) all supply `extra_info` and are unaffected.

## Test plan

- [x] `make test-all` (627 passed, 11 skipped)
- [x] Updated `test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput` to assert `perf/steps_per_sec`
- [x] Updated `test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied` to assert `perf/steps_per_sec` is absent (no fallback)