### PR TITLE
fix: restore offpolicy terminal cursor on interrupt

### DIFF
--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -116,6 +116,8 @@ def _learner_worker(
         "nccl", rank=rank, world_size=world_size, timeout=timedelta(seconds=120)
     )
 
+    logger: Optional[OffPolicyLogger] = None
+    weight_sync: SharedWeightSync | None = None
     try:
         # 1. Initialise per-process GPU cache (host tensors already shared)
         replay_buffer.init_local_gpu_cache(device)
@@ -149,7 +151,6 @@ def _learner_worker(
         train_start_threshold = compute_train_start_threshold(batch_size, learning_starts, num_envs)
 
         # 6. Logger (rank 0 only)
-        logger: Optional[OffPolicyLogger] = None
         if rank == 0:
             os.makedirs(log_dir, exist_ok=True)
             logger = OffPolicyLogger(
@@ -304,8 +305,13 @@ def _learner_worker(
                 logger.finish()
 
         weight_sync.close()
+        weight_sync = None
 
     finally:
+        if logger is not None:
+            logger.close()
+        if weight_sync is not None:
+            weight_sync.close()
         dist.destroy_process_group()
 
 

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -91,6 +91,7 @@ class OffPolicyRunner(AsyncRunner):
         self.use_layer_norm = use_layer_norm
         self.obs_normalization = obs_normalization
         self.actor_kwargs = actor_kwargs or {}
+        self._active_logger: OffPolicyLogger | None = None
 
         self.obs_dim, self.action_dim, self.critic_obs_dim = get_env_dims(
             self.env_name, sim_backend, env_cfg_override
@@ -251,6 +252,7 @@ class OffPolicyRunner(AsyncRunner):
         logger.set_collection_sync(self.sync_collection, self.env_steps_per_sync)
         if hasattr(self.learner, "use_symmetry") and self.learner.use_symmetry:
             logger.log_status("Symmetry augmentation: enabled")
+        self._active_logger = logger
         logger.start()
 
         reward_history: deque = deque(maxlen=100)
@@ -454,6 +456,14 @@ class OffPolicyRunner(AsyncRunner):
             "training_wall_time_sec": time.time() - train_start_wall,
         }
         self.last_run_summary = summary
+        self._active_logger = None
+
+    def close(self) -> None:
+        active_logger = getattr(self, "_active_logger", None)
+        if active_logger is not None:
+            active_logger.close()
+            self._active_logger = None
+        super().close()
 
     def _check_collector_alive(self) -> bool:
         if self._collector_process is not None and not self._collector_process.is_alive():

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -96,6 +96,8 @@ class BaseTrainingLogger:
         self._tb_writer: Any | None = None
         self._wandb_run = None
         self._owns_wandb_run = False
+        self._finished = False
+        self._closed = False
 
         if self._log_backend == "tensorboard" and log_dir:
             self._init_tensorboard(log_dir, tensorboard_subdir)
@@ -196,11 +198,35 @@ class BaseTrainingLogger:
             )
             self._live.start()
 
-    def finish(self, *, title: str = "Training Summary", extra_summary: str = ""):
+    def _stop_live(self) -> None:
         if self._live is not None:
             self._live.update(self._build_display())
             self._live.stop()
             self._live = None
+
+    def _close_backends(self) -> None:
+        if self._tb_writer:
+            self._tb_writer.close()
+            self._tb_writer = None
+        if self._wandb_run and self._owns_wandb_run:
+            wandb = _load_wandb()
+            if wandb is not None:
+                wandb.finish()
+            self._wandb_run = None
+            self._owns_wandb_run = False
+
+    def close(self) -> None:
+        """Release live terminal state and backend handles without printing a summary."""
+        if self._closed:
+            return
+        self._stop_live()
+        self._close_backends()
+        self._closed = True
+
+    def finish(self, *, title: str = "Training Summary", extra_summary: str = ""):
+        if self._finished:
+            return
+        self._stop_live()
 
         elapsed = time.time() - self._start_time
         if not self._no_print:
@@ -218,12 +244,9 @@ class BaseTrainingLogger:
             self._console.print()
             self._console.print(Panel(summary, title=f"[bold]{title}[/]", border_style="green"))
 
-        if self._tb_writer:
-            self._tb_writer.close()
-        if self._wandb_run and self._owns_wandb_run:
-            wandb = _load_wandb()
-            if wandb is not None:
-                wandb.finish()
+        self._close_backends()
+        self._closed = True
+        self._finished = True
 
     def update_ep_length(self, length: float):
         self._mean_ep_length = length

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import queue
+from typing import cast
 
 import pytest
 import torch
@@ -12,6 +13,7 @@ from unilab.algos.torch.offpolicy.runner import (
     compute_train_start_threshold,
     replay_buffer_ready_for_learning,
 )
+from unilab.ipc.replay_buffer import ReplayBuffer
 
 
 class _FakeActor:
@@ -135,6 +137,8 @@ class _FakeLogger:
         del kwargs
         self.buffer_fill_calls: list[tuple[int, int]] = []
         self.step_calls: list[dict] = []
+        self.finish_calls = 0
+        self.close_calls = 0
         self._total_steps = 0
         self._mean_ep_length = 0.0
         _FakeLogger.last_instance = self
@@ -148,8 +152,12 @@ class _FakeLogger:
     def log_status(self, status: str) -> None:
         del status
 
-    def finish(self) -> None:
-        pass
+    def finish(self, *args, **kwargs) -> None:
+        del args, kwargs
+        self.finish_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
 
     def log_buffer_fill(self, current: int, target: int) -> None:
         self.buffer_fill_calls.append((current, target))
@@ -201,6 +209,12 @@ class _SyncReadyQueue:
         return 1
 
 
+class _InterruptingReadyQueue:
+    def get(self, timeout: float | None = None) -> int:
+        del timeout
+        raise KeyboardInterrupt
+
+
 class _RecordingQueue:
     def __init__(self) -> None:
         self.put_calls: list[int] = []
@@ -210,8 +224,18 @@ class _RecordingQueue:
 
 
 class _FakeProcess:
+    def __init__(self) -> None:
+        self._alive = True
+
     def is_alive(self) -> bool:
-        return True
+        return self._alive
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+        self._alive = False
+
+    def terminate(self) -> None:
+        self._alive = False
 
 
 class _FakeClock:
@@ -336,6 +360,42 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
     assert _FakeWeightSync.last_instance is not None
     assert _FakeWeightSync.last_instance.write_calls == 1
+
+
+def test_offpolicy_runner_close_releases_active_logger_after_interrupt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    runner = _make_runner(monkeypatch, sync_collection=True)
+    created_queues: list[object] = []
+
+    def queue_factory(maxsize: int = 0):
+        del maxsize
+        idx = len(created_queues)
+        if idx == 0:
+            queue_obj: object = _InterruptingReadyQueue()
+        elif idx == 1:
+            queue_obj = _RecordingQueue()
+        else:
+            queue_obj = queue.Queue()
+        created_queues.append(queue_obj)
+        return queue_obj
+
+    monkeypatch.setattr(runner_module._SPAWN_CTX, "Queue", queue_factory)
+    monkeypatch.setattr(runner_module.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(KeyboardInterrupt):
+        runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
+
+    logger = _FakeLogger.last_instance
+    assert logger is not None
+    assert runner._active_logger is logger
+    assert logger.finish_calls == 0
+    assert logger.close_calls == 0
+
+    runner.close()
+
+    assert runner._active_logger is None
+    assert logger.close_calls == 1
 
 
 def test_offpolicy_runner_async_waits_for_train_start_threshold(
@@ -501,7 +561,7 @@ def test_multi_gpu_worker_rank0_propagates_collect_time_and_extra_info(
         world_size=2,
         learner_kwargs={},
         runner_kwargs=runner_kwargs,
-        replay_buffer=replay_buffer,
+        replay_buffer=cast(ReplayBuffer, replay_buffer),
         weight_sync_name=weight_sync.name,
         weight_sync_lock=weight_sync._lock,
         weight_param_shapes={"weight": torch.Size([1])},

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -12,8 +13,9 @@ from unilab.training.experiment import ExperimentTracker, build_wandb_settings
 
 
 class _FakeConfig(dict):
-    def update(self, payload, allow_val_change=False):  # noqa: FBT002
-        super().update(payload)
+    def update(self, *args: Any, allow_val_change: bool = False, **kwargs: Any) -> None:  # noqa: FBT002
+        del allow_val_change
+        super().update(*args, **kwargs)
 
 
 class _FakeRun:
@@ -205,6 +207,23 @@ def test_offpolicy_logger_creates_and_finishes_owned_wandb_run(monkeypatch):
     assert init_call["config"]["obs_dim"] == 48
     assert init_call["config"]["action_dim"] == 12
     assert init_call["config"]["max_iterations"] == 321
+
+    logger.finish()
+    assert fake_wandb.finish_calls == 1
+
+
+def test_offpolicy_logger_close_releases_owned_wandb_run_once(monkeypatch):
+    fake_wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        env_name="Go2JoystickFlat",
+        log_backend="wandb",
+    )
+
+    logger.close()
+    assert fake_wandb.finish_calls == 1
 
     logger.finish()
     assert fake_wandb.finish_calls == 1


### PR DESCRIPTION
## Summary
- add idempotent logger close cleanup for Rich live terminal state and logging backends
- make offpolicy single-GPU and multi-GPU shutdown paths release active loggers on interrupts
- cover interrupt cleanup and logger close idempotency with unit tests

## Tests
- make test-all

Fixes #374