### PR TITLE
test(batch_env): add jacobian parity tests for compute_site_jacobians

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     "torch==2.7.0",
-    "mujoco-uni==3.7.0rc0",
+    "mujoco-uni==3.8.0rc0",
     "gymnasium",
     "imageio",
     "etils",

--- a/tests/base/test_mujoco_batch_env_jacobian.py
+++ b/tests/base/test_mujoco_batch_env_jacobian.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco", reason="mujoco not installed")
+
+try:
+    import mujoco
+    from mujoco.batch_env import BatchEnvPool
+except Exception:
+    pytest.skip(
+        "mujoco.batch_env not available (platform/libstdc++ issue)", allow_module_level=True
+    )
+
+if not hasattr(BatchEnvPool, "compute_site_jacobians"):
+    pytest.skip(
+        "BatchEnvPool.compute_site_jacobians requires mujoco-uni>=3.8.0rc0",
+        allow_module_level=True,
+    )
+
+from unilab.assets import ASSETS_ROOT_PATH
+
+mj: Any = mujoco
+
+GO2_SITE_NAME = "imu"
+
+
+@dataclass
+class _PoolCtx:
+    model: Any
+    pool: BatchEnvPool
+    initial_state: np.ndarray
+    site_id: int
+
+
+def _xml(robot: str, scene: str = "scene_flat.xml") -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / robot / scene)
+
+
+def _make_initial_state(model: Any, nbatch: int, rng: np.random.Generator) -> np.ndarray:
+    nstate = mj.mj_stateSize(model, mj.mjtState.mjSTATE_FULLPHYSICS)
+    state0 = np.zeros((nbatch, nstate), dtype=np.float64)
+    state0[:, 1 : 1 + model.nq] = model.qpos0
+    # Perturb dof positions / velocities so each env produces a distinct Jacobian.
+    state0[:, 1 + 7 : 1 + model.nq] += 0.05 * rng.standard_normal((nbatch, model.nq - 7))
+    state0[:, 1 + model.nq + 6 : 1 + model.nq + model.nv] += 0.02 * rng.standard_normal(
+        (nbatch, model.nv - 6)
+    )
+    return state0
+
+
+def _reference_site_jacobian(
+    model: Any, state_row: np.ndarray, site_id: int, jacp: bool, jacr: bool
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    data = mj.MjData(model)
+    mj.mj_setState(model, data, state_row, int(mj.mjtState.mjSTATE_FULLPHYSICS))
+    mj.mj_kinematics(model, data)
+    mj.mj_comPos(model, data)
+    jp = np.zeros((3, model.nv), dtype=np.float64) if jacp else None
+    jr = np.zeros((3, model.nv), dtype=np.float64) if jacr else None
+    mj.mj_jacSite(model, data, jp, jr, site_id)
+    return jp, jr
+
+
+@pytest.fixture
+def pool_ctx() -> Iterator[_PoolCtx]:
+    rng = np.random.default_rng(0)
+    model = mj.MjModel.from_xml_path(_xml("go2"))
+    site_id = mj.mj_name2id(model, int(mj.mjtObj.mjOBJ_SITE), GO2_SITE_NAME)
+    assert site_id >= 0, f"go2 model is expected to expose site '{GO2_SITE_NAME}'"
+    nbatch = 3
+    pool = BatchEnvPool(model, nbatch=nbatch, nthread=2)
+    try:
+        yield _PoolCtx(
+            model=model,
+            pool=pool,
+            initial_state=_make_initial_state(model, nbatch, rng),
+            site_id=site_id,
+        )
+    finally:
+        pool.close()
+
+
+def test_compute_site_jacobians_matches_reference_jacp_only(pool_ctx: _PoolCtx) -> None:
+    jp, jr = pool_ctx.pool.compute_site_jacobians(
+        pool_ctx.initial_state, [pool_ctx.site_id], jacp=True, jacr=False
+    )
+    assert jr is None
+    assert jp.shape == (pool_ctx.initial_state.shape[0], 1, 3, pool_ctx.model.nv)
+    for i in range(pool_ctx.initial_state.shape[0]):
+        ref_jp, _ = _reference_site_jacobian(
+            pool_ctx.model, pool_ctx.initial_state[i], pool_ctx.site_id, True, False
+        )
+        np.testing.assert_allclose(jp[i, 0], ref_jp, atol=1e-12, rtol=0)
+
+
+def test_compute_site_jacobians_matches_reference_jacp_and_jacr(pool_ctx: _PoolCtx) -> None:
+    jp, jr = pool_ctx.pool.compute_site_jacobians(
+        pool_ctx.initial_state, [pool_ctx.site_id], jacp=True, jacr=True
+    )
+    assert jp.shape == (pool_ctx.initial_state.shape[0], 1, 3, pool_ctx.model.nv)
+    assert jr.shape == (pool_ctx.initial_state.shape[0], 1, 3, pool_ctx.model.nv)
+    for i in range(pool_ctx.initial_state.shape[0]):
+        ref_jp, ref_jr = _reference_site_jacobian(
+            pool_ctx.model, pool_ctx.initial_state[i], pool_ctx.site_id, True, True
+        )
+        np.testing.assert_allclose(jp[i, 0], ref_jp, atol=1e-12, rtol=0)
+        np.testing.assert_allclose(jr[i, 0], ref_jr, atol=1e-12, rtol=0)
+
+
+def test_compute_site_jacobians_scalar_site_squeezes_k_dim(pool_ctx: _PoolCtx) -> None:
+    jp, jr = pool_ctx.pool.compute_site_jacobians(
+        pool_ctx.initial_state, pool_ctx.site_id, jacp=True, jacr=True
+    )
+    assert jp.shape == (pool_ctx.initial_state.shape[0], 3, pool_ctx.model.nv)
+    assert jr.shape == (pool_ctx.initial_state.shape[0], 3, pool_ctx.model.nv)
+    for i in range(pool_ctx.initial_state.shape[0]):
+        ref_jp, ref_jr = _reference_site_jacobian(
+            pool_ctx.model, pool_ctx.initial_state[i], pool_ctx.site_id, True, True
+        )
+        np.testing.assert_allclose(jp[i], ref_jp, atol=1e-12, rtol=0)
+        np.testing.assert_allclose(jr[i], ref_jr, atol=1e-12, rtol=0)
+
+
+def test_compute_site_jacobians_requires_at_least_one_flag(pool_ctx: _PoolCtx) -> None:
+    with pytest.raises(ValueError):
+        pool_ctx.pool.compute_site_jacobians(
+            pool_ctx.initial_state, [pool_ctx.site_id], jacp=False, jacr=False
+        )
+
+
+def test_compute_site_jacobians_rejects_invalid_site_id(pool_ctx: _PoolCtx) -> None:
+    with pytest.raises(ValueError):
+        pool_ctx.pool.compute_site_jacobians(
+            pool_ctx.initial_state, [pool_ctx.model.nsite], jacp=True
+        )
+
+
+def test_compute_site_jacobians_rejects_wrong_state_shape(pool_ctx: _PoolCtx) -> None:
+    bad_state = pool_ctx.initial_state[:-1]
+    with pytest.raises(ValueError):
+        pool_ctx.pool.compute_site_jacobians(bad_state, [pool_ctx.site_id], jacp=True)

--- a/uv.lock
+++ b/uv.lock
@@ -2181,7 +2181,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-uni"
-version = "3.7.0rc0"
+version = "3.8.0rc0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2192,16 +2192,16 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/72/59/40f1a159a2161e9dce52760573c697aaf7d59e28e35504bb871311d109bf/mujoco_uni-3.7.0rc0.tar.gz", hash = "sha256:06aec65ccf581b4764644b49fc0643aa674cdb7020d1d41bbb5b9c8339a95f1c", size = 4764614, upload-time = "2026-04-26T04:06:34.757Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/7c/d8/f3a007e24138c720f93b62886982130d0c17d358cba61404887ccc8d10c5/mujoco_uni-3.8.0rc0.tar.gz", hash = "sha256:16a84253f158e59de018896499e085b89e60f5120151a39cfcb88f2c5102c1c6", size = 4816357, upload-time = "2026-05-06T15:44:00.103Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/46/ad/96cc59ed7219970a1dccb865bd0c0c76d7e508b8199dfe345e8262670056/mujoco_uni-3.7.0rc0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b29099826ed2d34b36a07303b2d35638752f81c3f1f6c791c9f68a289a2a400", size = 6968830, upload-time = "2026-04-26T04:06:11.385Z" },
-    { url = "https://test-files.pythonhosted.org/packages/e8/8c/d58d96a77a813cdf50ead2c31745745811e71ae88798340ce930689ee51c/mujoco_uni-3.7.0rc0-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:41823f3592b23eff8ac8f57e63c0c776bb6f2f0aba95c4d2ef1c06aef6a6a726", size = 10730028, upload-time = "2026-04-26T02:32:14.605Z" },
-    { url = "https://test-files.pythonhosted.org/packages/2b/bf/57f20b7faedd7bb491d93fc52b333066e4646361c6e1c9e0aa3a9cf8a5ee/mujoco_uni-3.7.0rc0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bf8010ec6c761fbb78e5dc9f23e8615ed5a3a4b846516aee5a47c3785f5d1", size = 6981334, upload-time = "2026-04-26T04:06:17.493Z" },
-    { url = "https://test-files.pythonhosted.org/packages/26/b8/142bdc59e6b5bf957c76da73de48c3d6031cf0f93781dcb9956e64ab2d3c/mujoco_uni-3.7.0rc0-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:0ad67ce5ccb3e7756bdcbeddadbb97a1a222115f31930bb8b2e01a4373f63a53", size = 10745168, upload-time = "2026-04-26T02:32:29.206Z" },
-    { url = "https://test-files.pythonhosted.org/packages/f6/40/be2b9b4e40ebb704abe9e4d759423c8d6c8b2f069a2b0aa1976905e0cd93/mujoco_uni-3.7.0rc0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:916907774fbadcf393ab588654e41085bb51176381d4d84c033f63943a973709", size = 6996772, upload-time = "2026-04-26T04:06:23.477Z" },
-    { url = "https://test-files.pythonhosted.org/packages/c9/92/66ed1f7b8a3e04e64f6fe2b33d45b43e616d12f6ac6a2d131224d30b9bef/mujoco_uni-3.7.0rc0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:9cfad2d20ac1212ae117ab62577b0bb1071161dd9b274cc3f6b2964fd407e16e", size = 10840883, upload-time = "2026-04-26T02:32:43.699Z" },
-    { url = "https://test-files.pythonhosted.org/packages/91/90/ef9705ca2c5bfff2bf25890a9a6a0643b96fd0522379af1cabc6d4a4a2a8/mujoco_uni-3.7.0rc0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee201a23236df4c48ef8ccd077b37a0c9a041c532ae851f11f12ec6aed4dff81", size = 6997212, upload-time = "2026-04-26T04:06:29.674Z" },
-    { url = "https://test-files.pythonhosted.org/packages/86/8f/84c78737b400a27e12762f07c422adae03d85cef13552a384a71f5231e94/mujoco_uni-3.7.0rc0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:43ab587bd1494f540822b1193f539c5190100c0f6dd209cbae6fcfe8068738c9", size = 10840745, upload-time = "2026-04-26T02:36:04.676Z" },
+    { url = "https://test-files.pythonhosted.org/packages/f3/ee/b761b8a88d8e1c658c25431e58017a7dc435777fc2d8236a2bce4b12145b/mujoco_uni-3.8.0rc0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b4babc44aa22341fbc8688f279708796d625323a2989239385dd89ef6168b2b6", size = 7054520, upload-time = "2026-05-06T15:43:32.04Z" },
+    { url = "https://test-files.pythonhosted.org/packages/7e/bd/796aa9b3a7fb1e0469f2a4cf05f1aadaa492d6ec6bf82227d4b65da42338/mujoco_uni-3.8.0rc0-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:7d347d9f0b6b3ea05f8769cb45cbd0ccced914a15b01e7a6430d6eed7e72eda7", size = 10765356, upload-time = "2026-05-06T15:31:30.457Z" },
+    { url = "https://test-files.pythonhosted.org/packages/c5/cb/63cc1fda007b017010cba8d7620b0afe34d5200abf8c0c5989588aeb4f16/mujoco_uni-3.8.0rc0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ecbe154013db33d594fe47161f3b63ffde44f6fee746b62a065e0449874fb99c", size = 7067679, upload-time = "2026-05-06T15:43:36.573Z" },
+    { url = "https://test-files.pythonhosted.org/packages/3b/29/0db135b57396fb93a7e246fc56e639b2a55fa06c2e0ec37c111b1d88a9a4/mujoco_uni-3.8.0rc0-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:dc44f9ca29c5ff6b4f924fd20ff701d4d3e68f8ca9c6286b90a897b2e4a2ab12", size = 10780147, upload-time = "2026-05-06T15:31:35.036Z" },
+    { url = "https://test-files.pythonhosted.org/packages/ff/13/ad75ec4625f0fdaad40662d89eb704c56320877fa77ec587e5362c24540a/mujoco_uni-3.8.0rc0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:32a102827803a3c12f36322385bbaf4e6065f5d757523b9c25e58ef432a1a1cd", size = 7092972, upload-time = "2026-05-06T15:43:48.928Z" },
+    { url = "https://test-files.pythonhosted.org/packages/cb/4b/6b622667d1eb207c9eb9b369f34089f457b57f0f64f3a06221127ca86afc/mujoco_uni-3.8.0rc0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:1a98517b8b2430312a9aa1066cde6e210c2edc7bb4730a4b9c795ef776ac25ef", size = 10874163, upload-time = "2026-05-06T15:31:39.4Z" },
+    { url = "https://test-files.pythonhosted.org/packages/c5/6b/981981bb30882bf05c807566bc299ac30ac8c52549bdebc907a329f88f07/mujoco_uni-3.8.0rc0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a7f6a7efd1fc4b6dbad5b3c18131c8f03ceae484d9b51b28be8cdd1f6bdb73b", size = 7093600, upload-time = "2026-05-06T15:43:55.635Z" },
+    { url = "https://test-files.pythonhosted.org/packages/d1/38/8328110dc8b96de748a38f97e5131b9aef63fca0c6f2aefa65be64ea35aa/mujoco_uni-3.8.0rc0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:fd465628f75a347c473423d9faaa2e931dfa78fca77c65bef27b44004375e5e6", size = 10873888, upload-time = "2026-05-06T15:31:43.666Z" },
 ]
 
 [[package]]
@@ -4475,7 +4475,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev96425", index = "https://pypi.motphys.com/simple/" },
-    { name = "mujoco-uni", specifier = "==3.7.0rc0", index = "https://test.pypi.org/simple/" },
+    { name = "mujoco-uni", specifier = "==3.8.0rc0", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },
     { name = "onnxruntime", specifier = ">=1.24.3" },


### PR DESCRIPTION
## Summary
- Add `tests/base/test_mujoco_batch_env_jacobian.py` covering parity vs `mj_jacSite`, scalar-site K-dim squeeze, and the three documented error paths (no flag, bad site id, bad state shape) for `BatchEnvPool.compute_site_jacobians`.
- Bump `mujoco-uni` to `3.8.0rc0` so the new API (introduced upstream in mujoco-uni 98f912d) is available; the test module gracefully skips on older builds.
- Tests use the existing `go2` asset and its `imu` site to stay consistent with `tests/base/test_mujoco_batch_env_randomization.py` conventions.

Refs #378.

## Test plan
- [x] `make test-all` (635 passed, 11 skipped)
- [x] Targeted run: `pytest tests/base/test_mujoco_batch_env_jacobian.py -v` → 6 passed