### PR TITLE
fix: reduce Motrix update_state hot-path reads

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -418,6 +418,15 @@ class SimBackend(abc.ABC):
             (num_envs, len(body_ids), 3)
         """
 
+    def get_body_pose_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return world-frame body position and quaternion through one owner call.
+
+        Backends may override this to share the same low-level pose read between
+        position and quaternion extraction. The default preserves the existing
+        backend contract by delegating to the individual getters.
+        """
+        return self.get_body_pos_w(body_ids), self.get_body_quat_w(body_ids)
+
     # ------------------------------------------------------------------ #
     # Body kinematics — baselink frame                                     #
     # ------------------------------------------------------------------ #
@@ -480,3 +489,12 @@ class SimBackend(abc.ABC):
         Returns:
             传感器数据数组
         """
+
+    def get_sensor_data_many(self, names: Sequence[str]) -> tuple[np.ndarray, ...]:
+        """Fetch multiple sensors through the backend owner contract.
+
+        The default implementation keeps behavior identical to repeated
+        ``get_sensor_data`` calls. Backends with batch sensor access can override
+        this without leaking backend-specific APIs into env code.
+        """
+        return tuple(self.get_sensor_data(name) for name in names)

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -143,6 +143,20 @@ class MotrixBackend(SimBackend):
         for link in self._model.links:
             if link.name:
                 self._link_cache[link.index] = link
+        self._sensor_dim_cache: dict[str, int] = {}
+        self._sensor_ndim_cache: dict[str, int] = {}
+        self._sensor_data_cache: dict[str, np.ndarray] = {}
+        self._dof_pos_cache: np.ndarray | None = None
+        self._dof_vel_cache: np.ndarray | None = None
+        self._base_pos_cache: np.ndarray | None = None
+        self._base_quat_cache: np.ndarray | None = None
+        self._base_lin_vel_cache: np.ndarray | None = None
+        self._base_ang_vel_cache: np.ndarray | None = None
+        self._link_velocities_cache: np.ndarray | None = None
+        self._body_sensor_cache: dict[tuple[str, tuple[int, ...]], np.ndarray] = {}
+        self._link_pose_slice_cache: dict[tuple[int, ...], np.ndarray] = {}
+        self._link_lin_vel_slice_cache: dict[tuple[int, ...], np.ndarray] = {}
+        self._link_ang_vel_slice_cache: dict[tuple[int, ...], np.ndarray] = {}
 
         # 运行一次正向运动学，确保初始 link 位置和传感器数据有效。
         self._model.forward_kinematic(self._data)
@@ -316,36 +330,59 @@ class MotrixBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def get_base_pos(self) -> np.ndarray:
+        if self._base_pos_cache is not None:
+            return self._base_pos_cache
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_translation(self._data)  # type: ignore[no-any-return]
-        return self._body_link.get_pose(self._data)[:, :3]  # type: ignore[no-any-return]
+            self._base_pos_cache = self._body_floatingbase.get_translation(self._data)
+        else:
+            self._base_pos_cache = self._body_link.get_pose(self._data)[:, :3]
+        return self._base_pos_cache  # type: ignore[return-value]
 
     def get_base_quat(self) -> np.ndarray:
+        if self._base_quat_cache is not None:
+            return self._base_quat_cache
         if self._body_floatingbase is not None:
             quat = self._body_floatingbase.get_rotation(self._data)
         else:
             quat = self._body_link.get_rotation(self._data)
-        return self._xyzw_to_wxyz(quat)
+        self._base_quat_cache = self._xyzw_to_wxyz(quat)
+        return self._base_quat_cache
 
     def get_base_lin_vel(self) -> np.ndarray:
+        if self._base_lin_vel_cache is not None:
+            return self._base_lin_vel_cache
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_global_linear_velocity(self._data)  # type: ignore[no-any-return]
-        return self._body_link.get_linear_velocity(self._data)  # type: ignore[no-any-return]
+            self._base_lin_vel_cache = self._body_floatingbase.get_global_linear_velocity(
+                self._data
+            )
+        else:
+            self._base_lin_vel_cache = self._body_link.get_linear_velocity(self._data)
+        return self._base_lin_vel_cache  # type: ignore[return-value]
 
     def get_base_ang_vel(self) -> np.ndarray:
+        if self._base_ang_vel_cache is not None:
+            return self._base_ang_vel_cache
         if self._body_floatingbase is not None:
-            return self._body_floatingbase.get_global_angular_velocity(self._data)  # type: ignore[no-any-return]
-        return self._body_link.get_angular_velocity(self._data)  # type: ignore[no-any-return]
+            self._base_ang_vel_cache = self._body_floatingbase.get_global_angular_velocity(
+                self._data
+            )
+        else:
+            self._base_ang_vel_cache = self._body_link.get_angular_velocity(self._data)
+        return self._base_ang_vel_cache  # type: ignore[return-value]
 
     # ------------------------------------------------------------------ #
     # DOF state                                                          #
     # ------------------------------------------------------------------ #
 
     def get_dof_pos(self) -> np.ndarray:
-        return self._body.get_joint_dof_pos(self._data)  # type: ignore[no-any-return]
+        if self._dof_pos_cache is None:
+            self._dof_pos_cache = self._body.get_joint_dof_pos(self._data)
+        return self._dof_pos_cache  # type: ignore[return-value]
 
     def get_dof_vel(self) -> np.ndarray:
-        return self._body.get_joint_dof_vel(self._data)  # type: ignore[no-any-return]
+        if self._dof_vel_cache is None:
+            self._dof_vel_cache = self._body.get_joint_dof_vel(self._data)
+        return self._dof_vel_cache  # type: ignore[return-value]
 
     # ------------------------------------------------------------------ #
     # Body kinematics — world frame                                      #
@@ -359,6 +396,10 @@ class MotrixBackend(SimBackend):
 
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._xyzw_to_wxyz(self._get_link_poses_w(body_ids)[:, :, 3:])
+
+    def get_body_pose_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        poses = self._get_link_poses_w(body_ids)
+        return poses[:, :, :3], self._xyzw_to_wxyz(poses[:, :, 3:])
 
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._get_link_lin_vel_w(body_ids)
@@ -388,7 +429,44 @@ class MotrixBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def get_sensor_data(self, name: str) -> np.ndarray:
-        return self._model.get_sensor_value(name, self._data)  # type: ignore[no-any-return]
+        cached = self._sensor_data_cache.get(name)
+        if cached is None:
+            cached = self._model.get_sensor_value(name, self._data)
+            self._sensor_data_cache[name] = cached
+            self._sensor_dim_cache.setdefault(name, self._sensor_width(cached))
+            self._sensor_ndim_cache.setdefault(name, int(np.asarray(cached).ndim))
+        return cached  # type: ignore[return-value]
+
+    def get_sensor_data_many(self, names: Sequence[str]) -> tuple[np.ndarray, ...]:
+        missing = [name for name in names if name not in self._sensor_data_cache]
+        if missing:
+            batch_names: list[str] = []
+            for name in missing:
+                if name in self._sensor_dim_cache:
+                    batch_names.append(name)
+                    continue
+                value = self._model.get_sensor_value(name, self._data)
+                self._sensor_dim_cache[name] = self._sensor_width(value)
+                self._sensor_ndim_cache[name] = int(np.asarray(value).ndim)
+                self._sensor_data_cache[name] = value
+
+            if batch_names:
+                packed = self._model.get_sensor_values(tuple(batch_names), self._data)
+                start = 0
+                for name in batch_names:
+                    width = self._sensor_dim_cache[name]
+                    if self._sensor_ndim_cache[name] == 1:
+                        self._sensor_data_cache[name] = packed[:, start]
+                    else:
+                        self._sensor_data_cache[name] = packed[:, start : start + width]
+                    start += width
+        return tuple(self._sensor_data_cache[name] for name in names)
+
+    def _sensor_width(self, value: np.ndarray) -> int:
+        arr = np.asarray(value)
+        if arr.ndim == 1:
+            return 1
+        return int(arr.shape[1])
 
     # ------------------------------------------------------------------ #
     # MotrixSim-specific                                                 #
@@ -399,30 +477,46 @@ class MotrixBackend(SimBackend):
 
     def _get_link_poses_w(self, body_ids: np.ndarray) -> np.ndarray:
         ids = self._as_body_ids(body_ids)
-        return np.ascontiguousarray(self._link_poses[:, ids, :])
+        cache_key = tuple(int(bid) for bid in ids)
+        cached = self._link_pose_slice_cache.get(cache_key)
+        if cached is None:
+            cached = np.ascontiguousarray(self._link_poses[:, ids, :])
+            self._link_pose_slice_cache[cache_key] = cached
+        return cached
 
     def _get_link_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         ids = self._as_body_ids(body_ids)
-        return np.stack(
-            [self._link_cache[int(bid)].get_linear_velocity(self._data) for bid in ids],
-            axis=1,
-        )
+        cache_key = tuple(int(bid) for bid in ids)
+        cached = self._link_lin_vel_slice_cache.get(cache_key)
+        if cached is None:
+            cached = np.ascontiguousarray(self._get_link_velocities()[:, ids, :3])
+            self._link_lin_vel_slice_cache[cache_key] = cached
+        return cached
 
     def _get_link_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         ids = self._as_body_ids(body_ids)
-        return np.stack(
-            [self._link_cache[int(bid)].get_angular_velocity(self._data) for bid in ids],
-            axis=1,
-        )
+        cache_key = tuple(int(bid) for bid in ids)
+        cached = self._link_ang_vel_slice_cache.get(cache_key)
+        if cached is None:
+            cached = np.ascontiguousarray(self._get_link_velocities()[:, ids, 3:])
+            self._link_ang_vel_slice_cache[cache_key] = cached
+        return cached
+
+    def _get_link_velocities(self) -> np.ndarray:
+        if self._link_velocities_cache is None:
+            self._link_velocities_cache = self._model.get_link_velocities(self._data)
+        return self._link_velocities_cache
 
     def _get_body_sensor_values(self, body_ids: np.ndarray, prefix: str) -> np.ndarray:
-        return np.stack(
-            [
-                self._model.get_sensor_value(f"{prefix}_{name}", self._data)
-                for name in self._get_body_names(body_ids)
-            ],
-            axis=1,
-        )
+        ids = self._as_body_ids(body_ids)
+        cache_key = (prefix, tuple(int(bid) for bid in ids))
+        cached = self._body_sensor_cache.get(cache_key)
+        if cached is None:
+            names = [f"{prefix}_{name}" for name in self._get_body_names(ids)]
+            values = self.get_sensor_data_many(names)
+            cached = np.stack(values, axis=1)
+            self._body_sensor_cache[cache_key] = cached
+        return cached
 
     def _xyzw_to_wxyz(self, q: np.ndarray) -> np.ndarray:
         """motrix xyzw → wxyz"""
@@ -436,12 +530,27 @@ class MotrixBackend(SimBackend):
         return qpos_motrix
 
     def _refresh_link_pose_cache(self, env_indices: np.ndarray | None = None) -> None:
+        self._clear_step_read_cache()
         if env_indices is None:
             self._link_poses = self._model.get_link_poses(self._data)
         else:
             mask = np.zeros(self._num_envs, dtype=bool)
             mask[env_indices] = True
             self._link_poses[env_indices] = self._model.get_link_poses(self._data[mask])
+
+    def _clear_step_read_cache(self) -> None:
+        self._sensor_data_cache.clear()
+        self._dof_pos_cache = None
+        self._dof_vel_cache = None
+        self._base_pos_cache = None
+        self._base_quat_cache = None
+        self._base_lin_vel_cache = None
+        self._base_ang_vel_cache = None
+        self._link_velocities_cache = None
+        self._body_sensor_cache.clear()
+        self._link_pose_slice_cache.clear()
+        self._link_lin_vel_slice_cache.clear()
+        self._link_ang_vel_slice_cache.clear()
 
     def push_robots(self, force_range):
         ex_force = np.random.rand(self.num_envs, 3) * 2 - 1  # [x_force, y_force, z_force]

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -798,6 +798,13 @@ class MuJoCoBackend(SimBackend):
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._tracked_quat_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
+    def get_body_pose_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        mapped = self._get_mapped_indices(body_ids)
+        return (
+            self._tracked_pos_w_all[:, mapped, :],
+            self._tracked_quat_w_all[:, mapped, :],
+        )
+
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._tracked_linvel_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
@@ -826,6 +833,9 @@ class MuJoCoBackend(SimBackend):
 
     def get_sensor_data(self, name: str) -> np.ndarray:
         return self._sensor_views[name]
+
+    def get_sensor_data_many(self, names: Sequence[str]) -> tuple[np.ndarray, ...]:
+        return tuple(self._sensor_views[name] for name in names)
 
     # ------------------------------------------------------------------ #
     # Mujoco-specific                                                 #

--- a/src/unilab/envs/locomotion/common/dr_provider.py
+++ b/src/unilab/envs/locomotion/common/dr_provider.py
@@ -127,9 +127,12 @@ class LocomotionDRProvider(DomainRandomizationProvider):
     def build_reset_observation(
         self, env: Any, env_ids: np.ndarray, info_updates: dict[str, Any]
     ) -> dict[str, np.ndarray]:
-        linvel = env.get_local_linvel()[env_ids]
-        gyro = env.get_gyro()[env_ids]
-        gravity = env._backend.get_sensor_data("upvector")[env_ids]
+        linvel, gyro, gravity = env._backend.get_sensor_data_many(
+            (env.cfg.sensor.local_linvel, env.cfg.sensor.gyro, "upvector")
+        )
+        linvel = linvel[env_ids]
+        gyro = gyro[env_ids]
+        gravity = gravity[env_ids]
         dof_pos = env.get_dof_pos()[env_ids]
         dof_vel = env.get_dof_vel()[env_ids]
         return cast(

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -103,8 +103,16 @@ def _scalarize_sensor_values(sensor_values: np.ndarray) -> np.ndarray:
 
 
 def compute_aggregated_foot_contact(backend: Any, sensor_names: list[str]) -> np.ndarray:
-    contacts = [_scalarize_sensor_values(backend.get_sensor_data(name)) for name in sensor_names]
+    sensor_values = _get_sensor_data_many(backend, sensor_names)
+    contacts = [_scalarize_sensor_values(value) for value in sensor_values]
     return np.asarray(np.any(np.stack(contacts, axis=1) > 0.5, axis=1), dtype=np.bool_)
+
+
+def _get_sensor_data_many(backend: Any, sensor_names: list[str] | tuple[str, ...]):
+    get_many = getattr(backend, "get_sensor_data_many", None)
+    if get_many is not None:
+        return get_many(sensor_names)
+    return tuple(backend.get_sensor_data(name) for name in sensor_names)
 
 
 def compute_feet_phase_contact_targets(
@@ -241,6 +249,10 @@ class G1WalkDomainRandomizationProvider(LocomotionDRProvider):
 class G1WalkEnv(G1BaseEnv):
     _cfg: G1WalkEnvCfg
     _reward_cfg: Any
+    _left_foot_pos_sensor = "left_foot_pos"
+    _right_foot_pos_sensor = "right_foot_pos"
+    _left_foot_quat_sensor = "left_foot_quat"
+    _right_foot_quat_sensor = "right_foot_quat"
 
     def __init__(self, cfg: G1WalkEnvCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:
@@ -320,9 +332,9 @@ class G1WalkEnv(G1BaseEnv):
         }
 
     def update_state(self, state: NpEnvState) -> NpEnvState:
-        linvel = self.get_local_linvel()
-        gyro = self.get_gyro()
-        gravity = self._backend.get_sensor_data("upvector")
+        linvel, gyro, gravity = self._backend.get_sensor_data_many(
+            (self._cfg.sensor.local_linvel, self._cfg.sensor.gyro, "upvector")
+        )
         dof_pos = self.get_dof_pos()
         dof_vel = self.get_dof_vel()
 
@@ -508,8 +520,7 @@ class G1WalkEnv(G1BaseEnv):
 
     def _reward_feet_phase(self, ctx: RewardContext):
         """步态相位奖励：鼓励正确的摆动腿高度"""
-        left_foot = self._backend.get_sensor_data("left_foot_pos")
-        right_foot = self._backend.get_sensor_data("right_foot_pos")
+        left_foot, right_foot = self._get_foot_pos_sensors()
         gait_phase = ctx.info.get(
             "gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype())
         )
@@ -525,8 +536,7 @@ class G1WalkEnv(G1BaseEnv):
         return compute_forward_speed_gate(linvel, min_forward_speed)
 
     def _reward_feet_phase_contrast(self, ctx: RewardContext):
-        left_foot = self._backend.get_sensor_data("left_foot_pos")
-        right_foot = self._backend.get_sensor_data("right_foot_pos")
+        left_foot, right_foot = self._get_foot_pos_sensors()
         gait_phase = ctx.info.get(
             "gait_phase", np.zeros((self._num_envs, 2), dtype=get_global_dtype())
         )
@@ -565,8 +575,9 @@ class G1WalkEnv(G1BaseEnv):
         )
 
     def _reward_feet_ori(self, ctx: RewardContext):
-        left_foot_quat = self._backend.get_sensor_data("left_foot_quat")
-        right_foot_quat = self._backend.get_sensor_data("right_foot_quat")
+        left_foot_quat, right_foot_quat = _get_sensor_data_many(
+            self._backend, (self._left_foot_quat_sensor, self._right_foot_quat_sensor)
+        )
         return (
             np.square(left_foot_quat[:, 1])
             + np.square(left_foot_quat[:, 2])
@@ -575,8 +586,7 @@ class G1WalkEnv(G1BaseEnv):
         )
 
     def _reward_close_feet_xy(self, ctx: RewardContext):
-        left_foot = self._backend.get_sensor_data("left_foot_pos")
-        right_foot = self._backend.get_sensor_data("right_foot_pos")
+        left_foot, right_foot = self._get_foot_pos_sensors()
         feet_dist = np.linalg.norm(left_foot[:, :2] - right_foot[:, :2], axis=1)
         return np.where(
             feet_dist < self._reward_cfg.close_feet_threshold,
@@ -597,6 +607,12 @@ class G1WalkEnv(G1BaseEnv):
             np.sum(self._upper_body_pose_weights * np.square(diff), axis=1),
             dtype=get_global_dtype(),
         )
+
+    def _get_foot_pos_sensors(self) -> tuple[np.ndarray, np.ndarray]:
+        left_foot, right_foot = _get_sensor_data_many(
+            self._backend, (self._left_foot_pos_sensor, self._right_foot_pos_sensor)
+        )
+        return left_foot, right_foot
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
         state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -129,16 +129,26 @@ class Go1WalkTask(Go1BaseEnv):
         self.feet_phase[:, 1] = (self.phase + 0.5) % 1
         self.feet_phase[:, 2] = (self.phase + 0.5) % 1
 
-        linvel = self.get_local_linvel()
-        gyro = self.get_gyro()
-        gravity = self._backend.get_sensor_data("upvector")
+        sensor_names = (
+            self._cfg.sensor.local_linvel,
+            self._cfg.sensor.gyro,
+            "upvector",
+            *self._cfg.sensor.feet_force,
+            *self._cfg.sensor.feet_pos,
+        )
+        sensor_values = self._backend.get_sensor_data_many(sensor_names)
+        linvel = sensor_values[0]
+        gyro = sensor_values[1]
+        gravity = sensor_values[2]
         dof_pos = self.get_dof_pos()
         dof_vel = self.get_dof_vel()
         self.feet_force[:, :, :] = 0
+        force_offset = 3
+        pos_offset = force_offset + len(self._cfg.sensor.feet_force)
         for i in range(len(self._cfg.sensor.feet_force)):
-            self.feet_force[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_force[i])
+            self.feet_force[:, i, :] = sensor_values[force_offset + i]
         for i in range(len(self._cfg.sensor.feet_pos)):
-            self.feet_pos[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_pos[i])
+            self.feet_pos[:, i, :] = sensor_values[pos_offset + i]
         terminated = gravity[:, 2] <= 0.5
         reward = self._compute_reward(state.info, linvel, gyro, dof_pos)
         obs = self._compute_obs(

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -134,16 +134,26 @@ class Go2WalkTask(Go2BaseEnv):
         self.feet_phase[:, 1] = (self.phase + 0.5) % 1
         self.feet_phase[:, 2] = (self.phase + 0.5) % 1
 
-        linvel = self.get_local_linvel()
-        gyro = self.get_gyro()
-        gravity = self._backend.get_sensor_data("upvector")
+        sensor_names = (
+            self._cfg.sensor.local_linvel,
+            self._cfg.sensor.gyro,
+            "upvector",
+            *self._cfg.sensor.feet_force,
+            *self._cfg.sensor.feet_pos,
+        )
+        sensor_values = self._backend.get_sensor_data_many(sensor_names)
+        linvel = sensor_values[0]
+        gyro = sensor_values[1]
+        gravity = sensor_values[2]
         dof_pos = self.get_dof_pos()
         dof_vel = self.get_dof_vel()
         self.feet_force[:, :, :] = 0
+        force_offset = 3
+        pos_offset = force_offset + len(self._cfg.sensor.feet_force)
         for i in range(len(self._cfg.sensor.feet_force)):
-            self.feet_force[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_force[i])
+            self.feet_force[:, i, :] = sensor_values[force_offset + i]
         for i in range(len(self._cfg.sensor.feet_pos)):
-            self.feet_pos[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_pos[i])
+            self.feet_pos[:, i, :] = sensor_values[pos_offset + i]
         terminated = gravity[:, 2] <= 0.5
         reward = self._compute_reward(state.info, linvel, gyro, dof_pos)
         obs = self._compute_obs(

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -353,6 +353,9 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self._clip_end_truncated = np.zeros((num_envs,), dtype=bool)
 
     def _get_body_pose_w(self) -> tuple[np.ndarray, np.ndarray]:
+        get_body_pose_w = getattr(self._backend, "get_body_pose_w", None)
+        if get_body_pose_w is not None:
+            return get_body_pose_w(self.body_ids)  # type: ignore[no-any-return]
         return self._backend.get_body_pos_w(self.body_ids), self._backend.get_body_quat_w(
             self.body_ids
         )


### PR DESCRIPTION
Fixes #338

## Summary
- Add backend owner APIs for batch sensor reads and combined world body pose reads.
- Cache Motrix single-step hot-path reads for sensors, DOF/base state, body sensor stacks, link pose slices, and lazy link velocity batches.
- Update Go1/Go2/G1 locomotion and G1 motion tracking env owner paths to reuse batch reads inside `update_state` / reward / reset observation.

## Benchmark
Command:

```bash
uv run benchmark/benchmark_env_step.py
```

Artifacts are generated locally under ignored `benchmark/outputs/env_step/`:
- before: `benchmark/outputs/env_step/issue338_before_full.json`
- after: `benchmark/outputs/env_step/results.json`
- after plots: `benchmark/outputs/env_step/env_step_summary.png`, `benchmark/outputs/env_step/env_step_breakdown.png`

Median `update_state_ms` before -> after:

| task/backend | before | after |
| --- | ---: | ---: |
| go1/motrix | 2.289 ms | 1.107 ms |
| go2/motrix | 2.326 ms | 1.114 ms |
| g1/motrix | 5.778 ms | 2.868 ms |
| g1_mt/motrix | 11.813 ms | 8.137 ms |

Remaining gap is concentrated in Motrix copy-return state access and env-side reward/observation computation. This patch removes repeated UniLab reads/stacks without moving backend-specific logic into scripts.

## Validation
- `uv run benchmark/benchmark_env_step.py`
- `make test-all`
