### PR TITLE
feat: add g1 wall flip tracking env

### DIFF
--- a/conf/appo/task/g1_wall_flip_tracking/motrix.yaml
+++ b/conf/appo/task/g1_wall_flip_tracking/motrix.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+training:
+  task_name: G1WallFlipTracking
+  sim_backend: motrix
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 5000
+  save_interval: 500
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/conf/appo/task/g1_wall_flip_tracking/mujoco.yaml
+++ b/conf/appo/task/g1_wall_flip_tracking/mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+training:
+  task_name: G1WallFlipTracking
+  sim_backend: mujoco
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 5000
+  save_interval: 500
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+training:
+  task_name: G1WallFlipTracking
+  sim_backend: motrix
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 30000
+  save_interval: 500
+  obs_groups:
+    actor:
+      - actor
+  algorithm:
+    entropy_coef: 0.005
+reward:
+  scales:
+    motion_global_root_pos: 1.0
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.05
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_wall_flip_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_wall_flip_tracking/mujoco.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+training:
+  task_name: G1WallFlipTracking
+  sim_backend: mujoco
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 30000
+  save_interval: 500
+  obs_groups:
+    actor:
+      - actor
+  algorithm:
+    entropy_coef: 0.005
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -46,6 +46,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 | PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
 | PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
+| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
 | PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
@@ -58,6 +59,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 | PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | Configured |
 | PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | Configured |
+| PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
@@ -70,6 +72,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
 | APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
+| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
 | APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | APPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |

--- a/docs/users/zh_CN/05-motion-tracking.md
+++ b/docs/users/zh_CN/05-motion-tracking.md
@@ -15,23 +15,25 @@ uv run eval --algo <algo> --task <task> --sim <backend> --load-run <run>
 | ---------------------------------- | ---------------------- | ----------------------- | -------------------- |
 | 通用 G1 whole-body motion tracking | `g1_motion_tracking` | `G1MotionTracking`    | PPO、MLX PPO、APPO   |
 | flip clip 专用 profile             | `g1_flip_tracking`   | `G1FlipTracking`      | PPO、MLX PPO、APPO   |
+| wall-assisted flip 专用 profile    | `g1_wall_flip_tracking` | `G1WallFlipTracking` | PPO、MLX PPO、APPO   |
 | holosoma-aligned FastSAC WBT       | `g1_sac_wbt`         | `G1MotionTrackingSAC` | FastSAC，MuJoCo only |
 
 当前已提交的 owner YAML 位于：
 
-- PPO / MLX PPO：`conf/ppo/task/g1_motion_tracking/`、`conf/ppo/task/g1_flip_tracking/`
-- APPO：`conf/appo/task/g1_motion_tracking/`、`conf/appo/task/g1_flip_tracking/`
+- PPO / MLX PPO：`conf/ppo/task/g1_motion_tracking/`、`conf/ppo/task/g1_flip_tracking/`、`conf/ppo/task/g1_wall_flip_tracking/`
+- APPO：`conf/appo/task/g1_motion_tracking/`、`conf/appo/task/g1_flip_tracking/`、`conf/appo/task/g1_wall_flip_tracking/`
 - FastSAC WBT：`conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml`
 
 默认 motion：
 
 - `g1_motion_tracking`：`src/unilab/assets/motions/g1/dance1_subject2_part.npz`
 - `g1_flip_tracking`：`src/unilab/assets/motions/g1/flip_360_001__A304.npz`
+- `g1_wall_flip_tracking`：`src/unilab/assets/motions/g1/flip_from_wall_104__A304.npz`
 - `g1_sac_wbt`：与 `g1_motion_tracking` 相同
 
 ## 推荐流程
 
-1. 选择 task：普通动作先用 `g1_motion_tracking`，flip 数据先用 `g1_flip_tracking`。
+1. 选择 task：普通动作先用 `g1_motion_tracking`，flat flip 数据先用 `g1_flip_tracking`，带墙起跳/接触数据先用 `g1_wall_flip_tracking`。
 2. 准备或选择 `.npz` motion 文件。
 3. 用 MuJoCo replay 检查 `.npz` 的姿态、速度和 body layout。
 4. 用较小训练预算做 smoke run。
@@ -191,17 +193,22 @@ PPO owner YAML 默认训练预算：
 
 - `g1_motion_tracking`：`algo.max_iterations=15000`
 - `g1_flip_tracking`：`algo.max_iterations=30000`
+- `g1_wall_flip_tracking`：`algo.max_iterations=30000`
 
 ```bash
 uv run train --algo ppo --task g1_motion_tracking --sim mujoco
 uv run train --algo ppo --task g1_flip_tracking --sim mujoco
+uv run train --algo ppo --task g1_wall_flip_tracking --sim mujoco
 ```
+
+`g1_wall_flip_tracking` 是独立的 wall-assisted flip profile，使用带墙场景和 `flip_from_wall_104__A304.npz`，不改变 `g1_flip_tracking` 的 flat flip 默认配置。
 
 Motrix：
 
 ```bash
 uv run train --algo ppo --task g1_motion_tracking --sim motrix
 uv run train --algo ppo --task g1_flip_tracking --sim motrix
+uv run train --algo ppo --task g1_wall_flip_tracking --sim motrix
 ```
 
 smoke run 可以降低训练预算：

--- a/src/unilab/assets/robots/g1/scene_flat_with_wall.xml
+++ b/src/unilab/assets/robots/g1/scene_flat_with_wall.xml
@@ -35,7 +35,7 @@
       - `euler`: wall rotation in radians
       - `size`: half extents of the box (half_thickness half_length half_height)
     -->
-    <body name="wall" pos="0 1.5 1.0" euler="0.0 0.0 1.5708">
+    <body name="wall" pos="0 1.45 1.0" euler="0.0 0.0 1.5708">
       <geom
         name="wall_collision"
         type="box"

--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -11,6 +11,9 @@ from .g1 import (
     G1MotionTrackingEnvCfg,
     G1MotionTrackingSACCfg,
     G1MotionTrackingSACEnv,
+    G1WallFlipTrackingCfg,
+    G1WallFlipTrackingEnv,
+    G1WallFlipTrackingEnvCfg,
 )
 
 __all__ = [
@@ -22,4 +25,7 @@ __all__ = [
     "G1FlipTrackingCfg",
     "G1FlipTrackingEnv",
     "G1FlipTrackingEnvCfg",
+    "G1WallFlipTrackingCfg",
+    "G1WallFlipTrackingEnv",
+    "G1WallFlipTrackingEnvCfg",
 ]

--- a/src/unilab/envs/motion_tracking/g1/__init__.py
+++ b/src/unilab/envs/motion_tracking/g1/__init__.py
@@ -1,6 +1,13 @@
 """Motion tracking environments for Unitree G1."""
 
-from .flip_tracking import G1FlipTrackingCfg, G1FlipTrackingEnv, G1FlipTrackingEnvCfg
+from .flip_tracking import (
+    G1FlipTrackingCfg,
+    G1FlipTrackingEnv,
+    G1FlipTrackingEnvCfg,
+    G1WallFlipTrackingCfg,
+    G1WallFlipTrackingEnv,
+    G1WallFlipTrackingEnvCfg,
+)
 from .tracking import G1MotionTrackingCfg, G1MotionTrackingEnv, G1MotionTrackingEnvCfg
 from .tracking_sac import G1MotionTrackingSACCfg, G1MotionTrackingSACEnv
 
@@ -13,4 +20,7 @@ __all__ = [
     "G1FlipTrackingCfg",
     "G1FlipTrackingEnv",
     "G1FlipTrackingEnvCfg",
+    "G1WallFlipTrackingCfg",
+    "G1WallFlipTrackingEnv",
+    "G1WallFlipTrackingEnvCfg",
 ]

--- a/src/unilab/envs/motion_tracking/g1/flip_tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/flip_tracking.py
@@ -7,6 +7,7 @@ providing a dedicated registry task for flip-focused datasets/profiles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
@@ -72,3 +73,32 @@ class G1FlipTrackingEnv(G1MotionTrackingEnv):
     """G1 flip-tracking environment implementation."""
 
     _cfg: G1FlipTrackingCfg
+
+
+@dataclass
+class G1WallFlipTrackingCfg(G1FlipTrackingCfg):
+    """Config profile for wall-assisted G1 flip tracking clips."""
+
+    model_file: str = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat_with_wall.xml")
+    motion_file: str | list[str] = str(
+        ASSETS_ROOT_PATH / "motions" / "g1" / "flip_from_wall_104__A304.npz"
+    )
+    sampling_mode: Literal["start", "clip_start", "uniform", "adaptive"] = "start"
+    anchor_pos_z_threshold: float = 0.5
+    ee_body_pos_z_threshold: float = 0.5
+
+
+@registry.envcfg("G1WallFlipTracking")
+@dataclass
+class G1WallFlipTrackingEnvCfg(G1WallFlipTrackingCfg):
+    """Registered configuration for G1 wall flip tracking."""
+
+    pass
+
+
+@registry.env("G1WallFlipTracking", sim_backend="mujoco")
+@registry.env("G1WallFlipTracking", sim_backend="motrix")
+class G1WallFlipTrackingEnv(G1MotionTrackingEnv):
+    """G1 wall flip-tracking environment implementation."""
+
+    _cfg: G1WallFlipTrackingCfg

--- a/src/unilab/utils/support_matrix.py
+++ b/src/unilab/utils/support_matrix.py
@@ -24,6 +24,7 @@ _TASK_ORDER = {
     "g1_walk_rough": 3,
     "g1_motion_tracking": 4,
     "g1_flip_tracking": 5,
+    "g1_wall_flip_tracking": 6,
     "allegro_inhand": 7,
     "allegro_sac": 8,
 }
@@ -34,6 +35,7 @@ _TASK_LABELS = {
     "g1_walk_rough": "G1 walk rough",
     "g1_motion_tracking": "G1 motion tracking",
     "g1_flip_tracking": "G1 flip tracking",
+    "g1_wall_flip_tracking": "G1 wall flip tracking",
     "allegro_inhand": "Allegro in-hand",
     "allegro_sac": "Allegro SAC in-hand",
 }

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -449,6 +449,17 @@ def test_ppo_g1_flip_tracking():
     assert cfg.algo.max_iterations == 30000
 
 
+def test_ppo_g1_wall_flip_tracking():
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        cfg = compose("config", overrides=["task=g1_wall_flip_tracking/mujoco"])
+    assert cfg.training.task_name == "G1WallFlipTracking"
+    assert cfg.algo.max_iterations == 30000
+
+
 # ---------------------------------------------------------------------------
 # Issue #197 DoD: rough terrain profile params overridable via Hydra
 # ---------------------------------------------------------------------------

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -387,6 +387,7 @@ def test_g1_motion_tracking_cfg_preserves_legacy_defaults():
     assert cfg.velocity_randomization.x == (-0.5, 0.5)
     assert cfg.joint_position_range == (-0.1, 0.1)
     assert cfg.anchor_ori_threshold == pytest.approx(0.8)
+    assert cfg.sampling_mode == "adaptive"
 
 
 def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatch):
@@ -539,12 +540,29 @@ def test_g1_flip_tracking_cfg_uses_flip_profile():
 
     cfg = G1FlipTrackingCfg()
 
+    assert str(cfg.model_file).endswith("scene_flat.xml")
     assert str(cfg.motion_file).endswith("flip_360_001__A304.npz")
     assert cfg.pose_randomization.x == (0.0, 0.0)
     assert cfg.velocity_randomization.x == (0.0, 0.0)
     assert cfg.joint_position_range == (0.0, 0.0)
     assert cfg.anchor_ori_threshold == pytest.approx(1e9)
     assert cfg.sampling_mode in {"start", "clip_start", "uniform", "adaptive"}
+
+
+def test_g1_wall_flip_tracking_cfg_uses_wall_flip_profile():
+    from unilab.envs.motion_tracking.g1.flip_tracking import G1WallFlipTrackingCfg
+
+    cfg = G1WallFlipTrackingCfg()
+
+    assert str(cfg.model_file).endswith("scene_flat_with_wall.xml")
+    assert str(cfg.motion_file).endswith("flip_from_wall_104__A304.npz")
+    assert cfg.pose_randomization.x == (0.0, 0.0)
+    assert cfg.velocity_randomization.x == (0.0, 0.0)
+    assert cfg.joint_position_range == (0.0, 0.0)
+    assert cfg.anchor_ori_threshold == pytest.approx(1e9)
+    assert cfg.anchor_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.ee_body_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.sampling_mode == "start"
 
 
 def test_g1_motion_tracking_clip_end_contributes_to_truncated():

--- a/tests/scripts/test_train_script_configs.py
+++ b/tests/scripts/test_train_script_configs.py
@@ -35,6 +35,7 @@ _MLX_RUNTIME_USABLE = _mlx_runtime_usable()
         "g1_walk_flat/mujoco",
         "g1_motion_tracking/mujoco",
         "g1_flip_tracking/mujoco",
+        "g1_wall_flip_tracking/mujoco",
     ],
 )
 def test_appo_task_configs_load(task):


### PR DESCRIPTION
## Summary
- add separate `G1WallFlipTracking` env/config registration for wall-assisted flip tracking
- add PPO/APPO Hydra task owners for `g1_wall_flip_tracking` on MuJoCo and Motrix
- update docs/support matrix and tests for the new task owner

## Tests
- `uv run pytest tests/envs/test_env_configs.py::test_g1_motion_tracking_cfg_preserves_legacy_defaults tests/envs/test_env_configs.py::test_g1_flip_tracking_cfg_uses_flip_profile tests/envs/test_env_configs.py::test_g1_wall_flip_tracking_cfg_uses_wall_flip_profile tests/config/test_locomotion_params.py::test_ppo_g1_wall_flip_tracking tests/config/test_config_system.py::test_supported_task_composes tests/scripts/test_support_matrix.py -q`
- `uv run ruff check src/unilab/envs/motion_tracking/g1/flip_tracking.py src/unilab/envs/motion_tracking/g1/__init__.py src/unilab/envs/motion_tracking/__init__.py src/unilab/utils/support_matrix.py tests/envs/test_env_configs.py tests/config/test_locomotion_params.py tests/scripts/test_train_script_configs.py`
- `uv run ruff format --check src/unilab/envs/motion_tracking/g1/flip_tracking.py src/unilab/envs/motion_tracking/g1/__init__.py src/unilab/envs/motion_tracking/__init__.py src/unilab/utils/support_matrix.py tests/envs/test_env_configs.py tests/config/test_locomotion_params.py tests/scripts/test_train_script_configs.py`