### PR TITLE
feat(g1_sac_wbt): add Motrix sim2sim eval and isolated deploy DR profile

### DIFF
--- a/conf/offpolicy/task/sac/g1_sac_wbt/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_sac_wbt/motrix.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+# G1 Whole-Body Tracking (WBT) FastSAC — Motrix variant for sim2sim eval.
+# Inherits the mujoco training config in full and only switches the rendering
+# backend so checkpoints trained on mujoco can be replayed via motrix's native
+# renderer (`eval --sim motrix`). Training on motrix is not the intended path.
+defaults:
+  - /task/sac/g1_sac_wbt/mujoco
+  - _self_
+
+training:
+  task_name: G1MotionTrackingSAC
+  sim_backend: motrix
+env:
+  # motrix backend's kp/kd override path is broken on column slices, and DR
+  # is not desirable during deterministic sim2sim eval anyway. Match the
+  # `g1_walk_flat/motrix.yaml` convention by switching them off.
+  domain_rand:
+    randomize_kp: false
+    randomize_kd: false

--- a/conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml
+++ b/conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml
@@ -1,0 +1,59 @@
+# @package _global_
+# G1 Whole-Body Tracking (WBT) FastSAC on MuJoCo — `deploy` profile.
+# Self-contained variant intended for sim2real-oriented training: enables the
+# full domain-randomization stack and bumps env count / iteration budget.
+# Kept independent from `mujoco.yaml` (no Hydra `defaults` inheritance) so
+# tuning here cannot regress the baseline `--task g1_sac_wbt --sim mujoco` run.
+training:
+  task_name: G1MotionTrackingSAC
+  sim_backend: mujoco
+algo:
+  num_envs: 4096
+  max_iterations: 40000
+  save_interval: 1000
+  # --- holosoma WBT-specific overrides (vs sac.yaml defaults) ---
+  gamma: 0.99
+  tau: 0.05
+  num_atoms: 501
+  updates_per_step: 4
+  policy_frequency: 2
+  use_symmetry: false
+  algo_params:
+    alpha_init: 0.1
+    target_entropy_ratio: 0.5
+    max_grad_norm: 10.0
+env:
+  control_config:
+    action_scale: 2.0
+  anchor_pos_z_threshold: 0.5
+  ee_body_pos_z_threshold: 0.5
+  # Domain randomization switches — aligned with Domain_Rand fields available
+  # to G1MotionTrackingEnv (see src/unilab/envs/motion_tracking/g1/tracking.py).
+  domain_rand:
+    randomize_base_mass: true
+    added_mass_range: [-1.5, 1.5]
+    random_com: true
+    com_offset_x: [-0.05, 0.05]
+    randomize_gravity: true
+    gravity_range: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    push_robots: true
+    push_interval: 750
+    max_force: [1.0, 1.0, 0.5]
+    push_body_name: null
+    randomize_kp: true
+    kp_multiplier_range: [0.9, 1.1]
+    randomize_kd: true
+    kd_multiplier_range: [0.9, 1.1]
+reward:
+  scales:
+    motion_global_root_pos: 1.0
+    motion_global_root_ori: 0.5
+    motion_body_pos: 2.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -2.0
+    undesired_contacts: -0.1

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -77,7 +77,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Registered |
-| SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | - |
+| SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | Tested |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Tested |
 | FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |

--- a/docs/users/zh_CN/05-motion-tracking.md
+++ b/docs/users/zh_CN/05-motion-tracking.md
@@ -16,13 +16,13 @@ uv run eval --algo <algo> --task <task> --sim <backend> --load-run <run>
 | 通用 G1 whole-body motion tracking | `g1_motion_tracking` | `G1MotionTracking`    | PPO、MLX PPO、APPO   |
 | flip clip 专用 profile             | `g1_flip_tracking`   | `G1FlipTracking`      | PPO、MLX PPO、APPO   |
 | wall-assisted flip 专用 profile    | `g1_wall_flip_tracking` | `G1WallFlipTracking` | PPO、MLX PPO、APPO   |
-| holosoma-aligned FastSAC WBT       | `g1_sac_wbt`         | `G1MotionTrackingSAC` | FastSAC，MuJoCo only |
+| holosoma-aligned FastSAC WBT       | `g1_sac_wbt`         | `G1MotionTrackingSAC` | FastSAC（MuJoCo 训练；MuJoCo / Motrix 回放） |
 
 当前已提交的 owner YAML 位于：
 
 - PPO / MLX PPO：`conf/ppo/task/g1_motion_tracking/`、`conf/ppo/task/g1_flip_tracking/`、`conf/ppo/task/g1_wall_flip_tracking/`
 - APPO：`conf/appo/task/g1_motion_tracking/`、`conf/appo/task/g1_flip_tracking/`、`conf/appo/task/g1_wall_flip_tracking/`
-- FastSAC WBT：`conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml`
+- FastSAC WBT：`conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml`（baseline 训练）、`mujoco_deploy.yaml`（`--profile deploy`，开启 domain randomization 的 sim2real-oriented 训练变体，自包含、不继承 baseline）、`motrix.yaml`（sim2sim 回放，继承 `mujoco.yaml`）
 
 默认 motion：
 
@@ -234,6 +234,28 @@ uv run train --algo appo --task g1_motion_tracking --sim mujoco \
   algo.num_envs=128 algo.max_iterations=5 training.no_play=true
 ```
 
+### FastSAC
+
+`g1_sac_wbt` 默认走 holosoma-aligned 配置（`mujoco.yaml`），不开启 domain randomization：
+
+```bash
+uv run train --algo sac --task g1_sac_wbt --sim mujoco training.use_amp=true
+```
+
+如果需要面向 sim2real 部署的训练变体，使用 `--profile deploy` 切到 `mujoco_deploy.yaml`：
+
+```bash
+uv run train --algo sac --task g1_sac_wbt --sim mujoco --profile deploy training.use_amp=true
+```
+
+`mujoco_deploy.yaml` 是自包含配置（不通过 Hydra `defaults` 继承 `mujoco.yaml`），相对 baseline 的差异：
+
+- `algo.num_envs`：2048 → 4096
+- `algo.max_iterations`：25000 → 40000
+- 启用 `env.domain_rand`：base mass、CoM、gravity、push、kp/kd 乘子全开
+
+deploy 链路与 baseline 物理隔离，调整其中任一字段都不会回流到 `--task g1_sac_wbt --sim mujoco` 的训练。
+
 ## 回放 Checkpoint
 
 统一回放入口是 `uv run eval`。`--load-run -1` 表示加载该 task 日志目录下的最新 run。
@@ -267,6 +289,23 @@ uv run eval --algo ppo --task g1_motion_tracking --sim mujoco --load-run -1 \
   env.sampling_mode=start \
   env.joint_position_range=[0.0,0.0]
 ```
+
+### Motrix sim2sim 回放 FastSAC checkpoint
+
+`G1MotionTrackingSAC` 同时注册了 MuJoCo 和 Motrix 两个后端，mujoco 训练得到的 checkpoint 可以直接走 Motrix 原生 renderer 回放（配置走 `motrix.yaml`，继承 `mujoco.yaml`）。先安装 Motrix extra：
+
+```bash
+uv sync --extra motrix
+```
+
+加载任意路径下的 checkpoint —— `--load-run` 参数不接受绝对路径，改用 Hydra passthrough：
+
+```bash
+uv run eval --algo sac --task g1_sac_wbt --sim motrix \
+  algo.load_run=/abs/path/to/logs/<run>/model_<N>.pt
+```
+
+`motrix.yaml` 在继承基础上只关掉 `randomize_kp/kd`（motrix 后端的 kp/kd 列切片覆盖路径有缺陷，且确定性 sim2sim 回放也不需要 actuator gain 扰动）；其他 DR 字段是否生效由 `mujoco.yaml` 决定，baseline 默认全部关闭。
 
 ## 交互式调试
 

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -115,6 +115,12 @@ class Domain_Rand:
     max_force: list[float] = field(default_factory=lambda: [1.0, 1.0, 0.5])
     push_body_name: str | None = None
 
+    randomize_kp: bool = False
+    kp_multiplier_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
+
+    randomize_kd: bool = False
+    kd_multiplier_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
+
 
 @dataclass
 class G1MotionTrackingCfg(G1BaseCfg):
@@ -175,8 +181,16 @@ class G1MotionTrackingEnvCfg(G1MotionTrackingCfg):
 
 
 class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
+    def __init__(
+        self, *, base_kp: np.ndarray | None = None, base_kd: np.ndarray | None = None
+    ) -> None:
+        self._base_kp = base_kp
+        self._base_kd = base_kd
+
     def validate(self, env: Any, capabilities: DomainRandomizationCapabilities) -> None:
-        validate_common_reset_randomization(env, capabilities)
+        validate_common_reset_randomization(
+            env, capabilities, base_kp=self._base_kp, base_kd=self._base_kd
+        )
         validate_interval_push_support(env, capabilities)
 
     def build_interval_randomization_plan(
@@ -262,7 +276,9 @@ class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
             qpos=qpos,
             qvel=qvel,
             info_updates=info_updates,
-            randomization=build_common_reset_randomization(env, num_reset),
+            randomization=build_common_reset_randomization(
+                env, num_reset, base_kp=self._base_kp, base_kd=self._base_kd
+            ),
         )
 
     def build_reset_observation(
@@ -337,7 +353,14 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self.motion_sampler = MotionSampler(
             self.motion_loader, mode=cfg.sampling_mode, num_envs=num_envs
         )
-        self._init_domain_randomization(G1MotionTrackingDomainRandomizationProvider())
+        if cfg.domain_rand.randomize_kp or cfg.domain_rand.randomize_kd:
+            base_kp, base_kd = backend.get_actuator_gains()
+            dr_provider = G1MotionTrackingDomainRandomizationProvider(
+                base_kp=base_kp, base_kd=base_kd
+            )
+        else:
+            dr_provider = G1MotionTrackingDomainRandomizationProvider()
+        self._init_domain_randomization(dr_provider)
 
         # Buffers for relative body transforms
         self.body_pos_relative_w = np.zeros(

--- a/src/unilab/envs/motion_tracking/g1/tracking_sac.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking_sac.py
@@ -26,12 +26,17 @@ class G1MotionTrackingSACCfg(G1MotionTrackingCfg):
 
 
 @registry.env("G1MotionTrackingSAC", sim_backend="mujoco")
+@registry.env("G1MotionTrackingSAC", sim_backend="motrix")
 class G1MotionTrackingSACEnv(G1MotionTrackingEnv):
     """G1 Motion Tracking environment for FastSAC training.
 
     Extends the PPO motion-tracking environment with ``base_lin_vel``
     appended to the critic observation, matching holosoma's asymmetric
     actor-critic WBT design.
+
+    The motrix backend is registered for sim2sim eval/playback only — checkpoints
+    trained on mujoco can be replayed via motrix's native renderer through
+    ``eval --sim motrix``.
     """
 
     @property


### PR DESCRIPTION
## Summary

- Register the Motrix backend on `G1MotionTrackingSAC` and add `conf/offpolicy/task/sac/g1_sac_wbt/motrix.yaml`, so MuJoCo-trained FastSAC checkpoints can be replayed through Motrix's native renderer via `uv run eval --algo sac --task g1_sac_wbt --sim motrix ...`.
- Add `conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml` as a self-contained `--profile deploy` variant for sim2real-oriented training (full `env.domain_rand` stack, `algo.num_envs` 2048 → 4096, `algo.max_iterations` 25000 → 40000). It does NOT inherit from `mujoco.yaml` via Hydra defaults, so the deploy profile is fully isolated from the baseline training pipeline.
- Plumb optional kp/kd actuator-gain randomization through `G1MotionTrackingDomainRandomizationProvider`. New `Domain_Rand` fields default to `False`, so behavior is unchanged unless a YAML enables them — only `mujoco_deploy.yaml` does today.
- Why: we want to (1) iterate on a sim2real-oriented training recipe without disturbing the existing FastSAC WBT baseline, and (2) qualitatively review trained policies through the Motrix renderer, both starting from the same checkpoint format.
- User-facing impact: the existing `uv run train --algo sac --task g1_sac_wbt --sim mujoco` command is byte-for-byte unchanged (config and code paths untouched on that route); two new CLIs are introduced — `--profile deploy` for the isolated DR training variant, and `--sim motrix` (eval) for sim2sim playback. Documented in `docs/users/zh_CN/05-motion-tracking.md`.

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] `uv run eval --algo sac --task g1_sac_wbt --sim motrix algo.load_run=<abs>/model_35000.pt` loads a MuJoCo-trained checkpoint and renders through Motrix (verified locally).
- [x] `uv run train --algo sac --task g1_sac_wbt --sim mujoco --profile deploy training.use_amp=true` smoke run with DR enabled.

Commands actually run:

```bash
# CI-equivalent static checks (components of `make check`, run individually)
uv run ruff check .
uv run ruff format --check .
uv run mypy --config-file pyproject.toml \
  src/unilab/envs/motion_tracking/g1/tracking.py \
  src/unilab/envs/motion_tracking/g1/tracking_sac.py
uv run pyright \
  src/unilab/envs/motion_tracking/g1/tracking.py \
  src/unilab/envs/motion_tracking/g1/tracking_sac.py

# Functional smoke (verified by reporter)
uv run eval --algo sac --task g1_sac_wbt --sim motrix \
  algo.load_run=/abs/path/to/logs/<run>/model_xxx.pt
Impact
Backend impact: both — motrix gets a new registration on G1MotionTrackingSAC (eval-only path); mujoco gets a new mujoco_deploy.yaml profile (the existing mujoco.yaml baseline is untouched).
Platform impact: both — Linux for training; macOS Motrix renderer is auto-routed via mxpython by the existing CLI logic.
Training effect expected: mixed — baseline --task g1_sac_wbt --sim mujoco is unaffected; the new --profile deploy route is intentionally heavier (≈2× envs × 1.6× iterations + DR overhead).

Checklist
 Added or updated tests where needed — no new tests; the change is config-additive on the deploy/eval routes and existing CLI tests in tests/test_cli.py continue to cover routing.
 Updated docs if behavior or workflow changed — docs/users/zh_CN/05-motion-tracking.md covers both new CLIs.
 Linked the driving issue
 Noted any follow-up work explicitly — local working tree also contains an unrelated pyproject.toml / uv.lock change (onnxruntime constraint change + coloredlogs / humanfriendly lock entries); excluded from this PR.

