### PR TITLE
fix: apply training seed contract across algorithms

### DIFF
--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -19,6 +19,7 @@ sys.path.append(str(ROOT_DIR))
 from unilab.algos.torch.appo.runtime import resolve_appo_runtime
 from unilab.training import (
     BackendAdapter,
+    apply_configured_training_seed,
     create_env,
     ensure_registries,
     get_log_root,
@@ -48,6 +49,7 @@ def build_appo_runner_kwargs(
         "num_envs": cfg.algo.num_envs,
         "steps_per_env": cfg.algo.steps_per_env,
         "sim_backend": cfg.training.sim_backend,
+        "seed": rl_cfg.get("seed"),
     }
     if cfg.training.replay_queue_size is not None:
         runner_kwargs["replay_queue_size"] = cfg.training.replay_queue_size
@@ -333,6 +335,7 @@ def play_appo(
 def main(cfg: DictConfig) -> None:
     ensure_registries()
 
+    seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     env_cfg_override = BackendAdapter(
         cfg, root_dir=ROOT_DIR, algo_name="appo"
     ).build_task_env_cfg_override()
@@ -379,6 +382,7 @@ def main(cfg: DictConfig) -> None:
             full_cfg=cfg,
             device=learner_device,
             collector_device=collector_device,
+            seed_info=seed_info,
         )
         tracker.start()
 

--- a/scripts/train_mlx_ppo.py
+++ b/scripts/train_mlx_ppo.py
@@ -31,6 +31,7 @@ from unilab.base.observations import flatten_obs_dict
 from unilab.logging import OnPolicyLogger
 from unilab.training import (
     BackendAdapter,
+    apply_configured_training_seed,
     create_env,
     ensure_registries,
     get_log_root,
@@ -369,7 +370,12 @@ def main(cfg: DictConfig) -> None:
     dtype = mx.float16 if use_fp16 else mx.float32
     model_dtype = mx.float32 if use_fp16 else dtype
 
-    mx.random.seed(cfg.training.seed)
+    seed_info = apply_configured_training_seed(
+        cfg,
+        torch_runtime=False,
+        cuda=False,
+        mlx_runtime=True,
+    )
 
     algo_cfg = cfg.algo.algorithm
     profile_collection = os.getenv("UNILAB_PROFILE_COLLECTION", "0") == "1"
@@ -403,6 +409,7 @@ def main(cfg: DictConfig) -> None:
         training_cfg=cfg.training,
         full_cfg=cfg,
         device="mps",
+        seed_info=seed_info,
     )
     tracker.start()
 

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -16,6 +16,7 @@ sys.path.append(str(ROOT_DIR))
 
 from unilab.training import (
     BackendAdapter,
+    apply_configured_training_seed,
     assert_offpolicy_task_choice_matches_algo,
     create_env,
     ensure_registries,
@@ -161,6 +162,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
                 obs_normalization=False,
                 sim_backend=cfg.training.sim_backend,
                 env_cfg_override=env_cfg_override,
+                seed=cfg.algo.seed,
             )
 
         return FastSACRunner(
@@ -191,6 +193,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             env_steps_per_sync=cfg.training.env_steps_per_sync,
             sim_backend=cfg.training.sim_backend,
             use_symmetry=cfg.algo.use_symmetry,
+            seed=cfg.algo.seed,
         )
 
     if algo_name == "td3":
@@ -226,6 +229,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             use_cdq=cfg.algo.algo_params.use_cdq,
             obs_normalization=cfg.algo.obs_normalization,
             sim_backend=cfg.training.sim_backend,
+            seed=cfg.algo.seed,
         )
 
     if algo_name == "flashsac":
@@ -272,6 +276,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             normalized_g_max=cfg.algo.algo_params.normalized_g_max,
             n_step=cfg.algo.algo_params.n_step,
             use_compile=cfg.algo.algo_params.use_compile,
+            seed=cfg.algo.seed,
         )
 
     raise ValueError(f"Unsupported algo: {algo_name}")
@@ -497,6 +502,7 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
 def main(cfg: DictConfig) -> None:
     ensure_registries()
 
+    seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     algo_name = cfg.algo.algo
     task_name = cfg.training.task_name
     assert_offpolicy_task_choice_matches_algo(cfg, algo_name=algo_name)
@@ -522,6 +528,7 @@ def main(cfg: DictConfig) -> None:
             training_cfg=cfg.training,
             full_cfg=cfg,
             device=default_device(torch, cfg.training.device),
+            seed_info=seed_info,
         )
         tracker.start()
 

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -20,6 +20,7 @@ from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 from unilab.base.backend.xml import materialize_scene_visual_override
 from unilab.training import (
     BackendAdapter,
+    apply_configured_training_seed,
     create_env,
     ensure_registries,
     get_latest_checkpoint,
@@ -242,6 +243,7 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
 def main(cfg: DictConfig) -> None:
     ensure_registries()
 
+    seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     env_cfg_override = build_ppo_env_cfg_override(cfg)
 
     if torch.cuda.is_available():
@@ -282,6 +284,7 @@ def main(cfg: DictConfig) -> None:
             training_cfg=cfg.training,
             full_cfg=cfg,
             device=device,
+            seed_info=seed_info,
         )
         tracker.start()
 

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -21,6 +21,7 @@ from unilab.algos.torch.appo.learner import APPOLearner
 from unilab.algos.torch.appo.worker import appo_collector_fn
 from unilab.ipc import AsyncRunner, RolloutRingBuffer, SharedWeightSync
 from unilab.logging import OffPolicyLogger
+from unilab.training.seed import apply_training_seed, derive_worker_seed
 
 
 class APPORunner(AsyncRunner):
@@ -38,6 +39,7 @@ class APPORunner(AsyncRunner):
         steps_per_env: int = 24,
         num_workers: int = 1,  # kept for API compat, but only 1 collector used
         replay_queue_size: int = 3,
+        seed: int | None = None,
     ):
         super().__init__(
             env_name=env_name,
@@ -51,6 +53,7 @@ class APPORunner(AsyncRunner):
 
         self.steps_per_env = steps_per_env
         self.replay_queue_size = replay_queue_size
+        self.seed = seed
 
         # Resolve dims
         self._resolve_dims()
@@ -91,6 +94,7 @@ class APPORunner(AsyncRunner):
 
         ensure_registries()
 
+        apply_training_seed(self.seed, torch_runtime=True, cuda=True)
         env = registry.make(
             self.env_name,
             num_envs=1,
@@ -112,6 +116,7 @@ class APPORunner(AsyncRunner):
         import torch
         from tensordict import TensorDict
 
+        apply_training_seed(self.seed, torch_runtime=True, cuda=True)
         obs_example = torch.zeros((self.num_envs, self.obs_dim), device=self.device)
         td_example = TensorDict({"policy": obs_example}, batch_size=self.num_envs)
 
@@ -231,6 +236,7 @@ class APPORunner(AsyncRunner):
             "collector_device": self.collector_device,
             "sim_backend": self.sim_backend,
             "env_cfg_override": self.env_cfg_overrides if self.env_cfg_overrides else None,
+            "seed": derive_worker_seed(self.seed, worker_index=0),
         }
         self._start_collector(
             target_fn=appo_collector_fn,

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -18,6 +18,7 @@ from rsl_rl.utils import resolve_callable
 from unilab.base.final_observation import resolve_terminal_observation_contract
 from unilab.base.observations import split_obs_dict
 from unilab.base.registry import ensure_registries
+from unilab.training.seed import apply_training_seed
 
 
 def compute_timeout_bootstrap_correction(
@@ -72,6 +73,7 @@ def appo_collector_fn(
     collector_device: str = "cpu",
     sim_backend: str = "mujoco",
     env_cfg_override: dict | None = None,
+    seed: int | None = None,
 ):
     """Entry point for the APPO collector subprocess.
 
@@ -85,6 +87,7 @@ def appo_collector_fn(
     from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 
     ensure_registries()
+    apply_training_seed(seed, torch_runtime=True, cuda=True)
 
     # Connect to shared memory
     ring_buffer = RolloutRingBuffer(

--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -41,11 +41,14 @@ class FastSACRunner(OffPolicyRunner):
         sim_backend: str = "mujoco",
         use_symmetry: bool = False,
         world_size: int = 1,
+        seed: int | None = None,
     ):
         from unilab.base import registry
         from unilab.base.registry import ensure_registries
+        from unilab.training.seed import apply_training_seed
 
         ensure_registries()
+        apply_training_seed(seed, torch_runtime=True, cuda=True)
         env: Any = registry.make(
             env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
         )
@@ -120,4 +123,5 @@ class FastSACRunner(OffPolicyRunner):
             obs_normalization=obs_normalization,
             sim_backend=sim_backend,
             env_cfg_override=env_cfg_override,
+            seed=seed,
         )

--- a/src/unilab/algos/torch/fast_td3/runner.py
+++ b/src/unilab/algos/torch/fast_td3/runner.py
@@ -42,7 +42,11 @@ class FastTD3Runner(OffPolicyRunner):
         use_cdq: bool = True,
         obs_normalization: bool = True,
         sim_backend: str = "mujoco",
+        seed: int | None = None,
     ):
+        from unilab.training.seed import apply_training_seed
+
+        apply_training_seed(seed, torch_runtime=True, cuda=True)
         obs_dim, action_dim, critic_obs_dim = get_env_dims(
             env_name, sim_backend, env_cfg_override=env_cfg_override
         )
@@ -91,4 +95,5 @@ class FastTD3Runner(OffPolicyRunner):
             obs_normalization=obs_normalization,
             sim_backend=sim_backend,
             env_cfg_override=env_cfg_override,
+            seed=seed,
         )

--- a/src/unilab/algos/torch/flash_sac/runner.py
+++ b/src/unilab/algos/torch/flash_sac/runner.py
@@ -52,12 +52,15 @@ class FlashSACRunner(OffPolicyRunner):
         normalized_g_max: float = 5.0,
         n_step: int = 1,
         use_compile: bool = False,
+        seed: int | None = None,
     ):
         from unilab.base import registry
         from unilab.base.observations import get_obs_dims
         from unilab.base.registry import ensure_registries
+        from unilab.training.seed import apply_training_seed
 
         ensure_registries()
+        apply_training_seed(seed, torch_runtime=True, cuda=True)
         env: Any = registry.make(
             env_name, num_envs=1, sim_backend=sim_backend, env_cfg_override=env_cfg_override
         )
@@ -118,6 +121,7 @@ class FlashSACRunner(OffPolicyRunner):
             device=runtime_device,
             actor_hidden_dim=actor_hidden_dim,
             use_layer_norm=False,
+            seed=seed,
             obs_normalization=obs_normalization,
             sim_backend=sim_backend,
             env_cfg_override=env_cfg_override,

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -25,6 +25,7 @@ from unilab.base.observations import get_critic_base_dim, get_obs_dims
 from unilab.base.registry import ensure_registries
 from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 from unilab.logging import OffPolicyLogger
+from unilab.training.seed import apply_training_seed, derive_worker_seed
 
 
 class HoraAPPORunner(APPORunner):
@@ -52,6 +53,7 @@ class HoraAPPORunner(APPORunner):
 
         ensure_registries()
 
+        apply_training_seed(self.seed, torch_runtime=True, cuda=True)
         env = registry.make(
             self.env_name,
             num_envs=self._detect_dim_probe_num_envs(),
@@ -90,6 +92,7 @@ class HoraAPPORunner(APPORunner):
         return 1
 
     def _build_learner(self):
+        apply_training_seed(self.seed, torch_runtime=True, cuda=True)
         cfg = dict(self.rl_cfg)
         if is_rsl_rl_v5():
             pass
@@ -210,6 +213,7 @@ class HoraAPPORunner(APPORunner):
             "collector_device": self.collector_device,
             "sim_backend": self.sim_backend,
             "env_cfg_override": self.env_cfg_overrides if self.env_cfg_overrides else None,
+            "seed": derive_worker_seed(self.seed, worker_index=0),
         }
         self._start_collector(
             target_fn=hora_appo_collector_fn,

--- a/src/unilab/algos/torch/hora/appo_worker.py
+++ b/src/unilab/algos/torch/hora/appo_worker.py
@@ -14,6 +14,7 @@ from rsl_rl.utils import resolve_callable
 
 from unilab.base.final_observation import resolve_terminal_observation_contract
 from unilab.base.registry import ensure_registries
+from unilab.training.seed import apply_training_seed
 
 from .observations import split_hora_obs_with_priv_info
 
@@ -76,6 +77,7 @@ def hora_appo_collector_fn(
     sim_backend: str = "mujoco",
     env_cfg_override: dict | None = None,
     priv_info_dim: int = 0,
+    seed: int | None = None,
 ):
     """Collect grouped HORA APPO rollouts into the shared IPC ring buffer."""
     from copy import deepcopy
@@ -91,6 +93,7 @@ def hora_appo_collector_fn(
     from unilab.ipc import RolloutRingBuffer, SharedWeightSync
 
     ensure_registries()
+    apply_training_seed(seed, torch_runtime=True, cuda=True)
 
     ring_buffer = RolloutRingBuffer(
         num_envs=num_envs,

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -34,6 +34,7 @@ from unilab.ipc import SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX
 from unilab.ipc.replay_buffer import ReplayBuffer
 from unilab.logging import OffPolicyLogger
+from unilab.training.seed import apply_training_seed, derive_worker_seed
 
 
 def _find_free_port() -> int:
@@ -119,6 +120,11 @@ def _learner_worker(
     logger: Optional[OffPolicyLogger] = None
     weight_sync: SharedWeightSync | None = None
     try:
+        apply_training_seed(
+            derive_worker_seed(runner_kwargs.get("seed"), worker_index=rank + 1000),
+            torch_runtime=True,
+            cuda=True,
+        )
         # 1. Initialise per-process GPU cache (host tensors already shared)
         replay_buffer.init_local_gpu_cache(device)
 
@@ -441,6 +447,7 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
             "shared_obs_normalizer_stats": None,
             "sim_backend": self.sim_backend,
             "env_cfg_override": self.env_cfg_override,
+            "seed": derive_worker_seed(self.seed, worker_index=0),
         }
         self._start_collector(
             target_fn=off_policy_collector_fn,
@@ -470,6 +477,7 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
             "logger_type": logger_type,
+            "seed": self.seed,
         }
 
         try:

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -15,6 +15,7 @@ from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX, AsyncRunner
 from unilab.ipc.replay_buffer import ReplayBuffer
 from unilab.logging import OffPolicyLogger
+from unilab.training.seed import apply_training_seed, derive_worker_seed
 from unilab.utils.device import get_default_device
 
 
@@ -61,6 +62,7 @@ class OffPolicyRunner(AsyncRunner):
         sim_backend: str = "mujoco",
         env_cfg_override: dict | None = None,
         actor_kwargs: dict | None = None,
+        seed: int | None = None,
     ):
         super().__init__(
             env_name=env_name,
@@ -91,8 +93,10 @@ class OffPolicyRunner(AsyncRunner):
         self.use_layer_norm = use_layer_norm
         self.obs_normalization = obs_normalization
         self.actor_kwargs = actor_kwargs or {}
+        self.seed = seed
         self._active_logger: OffPolicyLogger | None = None
 
+        apply_training_seed(self.seed, torch_runtime=True, cuda=True)
         self.obs_dim, self.action_dim, self.critic_obs_dim = get_env_dims(
             self.env_name, sim_backend, env_cfg_override
         )
@@ -226,6 +230,7 @@ class OffPolicyRunner(AsyncRunner):
             "obs_dim": self.obs_dim,
             "action_dim": self.action_dim,
             "actor_kwargs": self.actor_kwargs,
+            "seed": derive_worker_seed(self.seed, worker_index=0),
         }
         self._start_collector(
             target_fn=off_policy_collector_fn,

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -15,6 +15,7 @@ from unilab.algos.torch.common.actor_factory import build_actor
 from unilab.base.final_observation import resolve_terminal_observation_contract
 from unilab.base.observations import get_obs_dims, split_obs_dict
 from unilab.base.registry import ensure_registries
+from unilab.training.seed import apply_training_seed
 
 
 def resolve_collector_actor_dims(
@@ -78,6 +79,7 @@ def off_policy_collector_fn(
     obs_dim: int | None = None,
     action_dim: int | None = None,
     actor_kwargs: dict | None = None,
+    seed: int | None = None,
     **kwargs,
 ):
     """Entry point for the off-policy collector subprocess."""
@@ -110,6 +112,7 @@ def off_policy_collector_fn(
             obs_dim=obs_dim,
             action_dim=action_dim,
             actor_kwargs=actor_kwargs,
+            seed=seed,
         )
     except Exception as e:
         print(f"[Collector] Exception: {e}", file=sys.stderr, flush=True)
@@ -145,12 +148,14 @@ def _run_collector(
     obs_dim,
     action_dim,
     actor_kwargs,
+    seed,
 ):
     del learning_starts
     from unilab.base import registry
     from unilab.ipc import SharedWeightSync
 
     ensure_registries()
+    apply_training_seed(seed, torch_runtime=True, cuda=True)
 
     # Initialize environment
     env = registry.make(

--- a/src/unilab/training/__init__.py
+++ b/src/unilab/training/__init__.py
@@ -19,6 +19,13 @@ from unilab.training.run import (
     resolve_checkpoint_path,
     resolve_task_checkpoint_path,
 )
+from unilab.training.seed import (
+    TrainingSeedInfo,
+    apply_configured_training_seed,
+    apply_training_seed,
+    derive_worker_seed,
+    resolve_training_seed,
+)
 
 __all__ = [
     "BackendAdapter",
@@ -35,5 +42,10 @@ __all__ = [
     "parse_checkpoint_path",
     "resolve_checkpoint_path",
     "resolve_task_checkpoint_path",
+    "TrainingSeedInfo",
+    "apply_configured_training_seed",
+    "apply_training_seed",
+    "derive_worker_seed",
+    "resolve_training_seed",
     "setup_logger",
 ]

--- a/src/unilab/training/experiment.py
+++ b/src/unilab/training/experiment.py
@@ -161,6 +161,7 @@ class ExperimentTracker:
         full_cfg: Any,
         device: str | None = None,
         collector_device: str | None = None,
+        seed_info: Any | None = None,
     ):
         self.root_dir = Path(root_dir)
         self.log_dir = Path(log_dir)
@@ -171,6 +172,7 @@ class ExperimentTracker:
         self.full_cfg = full_cfg
         self.device = device
         self.collector_device = collector_device
+        self.seed_info = seed_info
         self.enabled = str(_cfg_get(training_cfg, "logger", "tensorboard")).lower() == "wandb"
 
         self.log_dir.mkdir(parents=True, exist_ok=True)
@@ -223,6 +225,14 @@ class ExperimentTracker:
             "hardware": get_device_info_dict(),
             "wandb": self.wandb_settings,
         }
+        if self.seed_info is not None:
+            if hasattr(self.seed_info, "to_dict"):
+                seed_payload = self.seed_info.to_dict()
+            elif isinstance(self.seed_info, dict):
+                seed_payload = dict(self.seed_info)
+            else:
+                seed_payload = {"effective_seed": self.seed_info}
+            metadata.update(seed_payload)
 
         payload = {
             "run": _json_safe(metadata),
@@ -285,6 +295,13 @@ class ExperimentTracker:
             "wall_time_sec": wall_time_sec,
             "wandb_run_url": self.run_url,
         }
+        if self.seed_info is not None:
+            if hasattr(self.seed_info, "to_dict"):
+                payload.update(self.seed_info.to_dict())
+            elif isinstance(self.seed_info, dict):
+                payload.update(self.seed_info)
+            else:
+                payload["effective_seed"] = self.seed_info
         self._write_json(self.log_dir / "run_summary.json", _json_safe(payload))
 
         if self._run is not None:

--- a/src/unilab/training/seed.py
+++ b/src/unilab/training/seed.py
@@ -1,0 +1,131 @@
+"""Shared training seed contract helpers."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from omegaconf import OmegaConf
+
+
+@dataclass(frozen=True)
+class TrainingSeedInfo:
+    """Configured and effective seed metadata for a training run."""
+
+    configured_seed: int | None
+    configured_seed_source: str | None
+    effective_seed: int | None
+
+    def to_dict(self) -> dict[str, int | str | None]:
+        return {
+            "configured_seed": self.configured_seed,
+            "configured_seed_source": self.configured_seed_source,
+            "effective_seed": self.effective_seed,
+        }
+
+
+def _select_seed(cfg: Any, path: str) -> Any:
+    if OmegaConf.is_config(cfg):
+        return OmegaConf.select(cfg, path, default=None)
+
+    current = cfg
+    for part in path.split("."):
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            current = getattr(current, part, None)
+    return current
+
+
+def resolve_training_seed(cfg: Any) -> TrainingSeedInfo:
+    """Resolve the configured seed, preferring the algorithm-level contract."""
+    candidates = (
+        ("algo.seed", _select_seed(cfg, "algo.seed")),
+        ("training.seed", _select_seed(cfg, "training.seed")),
+    )
+    for source, raw_seed in candidates:
+        if raw_seed is None:
+            continue
+        seed = int(raw_seed)
+        if seed < 0:
+            raise ValueError(f"{source} must be non-negative, got {seed}")
+        return TrainingSeedInfo(
+            configured_seed=seed,
+            configured_seed_source=source,
+            effective_seed=seed,
+        )
+    return TrainingSeedInfo(configured_seed=None, configured_seed_source=None, effective_seed=None)
+
+
+def derive_worker_seed(base_seed: int | None, worker_index: int = 0) -> int | None:
+    """Derive deterministic subprocess seeds from the effective run seed."""
+    if base_seed is None:
+        return None
+    if worker_index < 0:
+        raise ValueError(f"worker_index must be non-negative, got {worker_index}")
+    return int(base_seed) + int(worker_index) + 1
+
+
+def apply_training_seed(
+    seed: int | None,
+    *,
+    torch_runtime: bool = True,
+    cuda: bool = True,
+    mlx_runtime: bool = False,
+) -> int | None:
+    """Apply a seed to the runtimes used by training entrypoints."""
+    if seed is None:
+        return None
+
+    effective_seed = int(seed)
+    if effective_seed < 0:
+        raise ValueError(f"seed must be non-negative, got {effective_seed}")
+
+    random.seed(effective_seed)
+    np.random.seed(effective_seed)
+
+    if torch_runtime:
+        try:
+            import torch
+        except ImportError:
+            torch = None
+        if torch is not None:
+            torch.manual_seed(effective_seed)
+            if cuda and torch.cuda.is_available():
+                torch.cuda.manual_seed_all(effective_seed)
+
+    if mlx_runtime:
+        try:
+            import mlx.core as mx
+        except ImportError:
+            mx = None
+        if mx is not None:
+            mx.random.seed(effective_seed)
+
+    return effective_seed
+
+
+def apply_configured_training_seed(
+    cfg: Any,
+    *,
+    torch_runtime: bool = True,
+    cuda: bool = True,
+    mlx_runtime: bool = False,
+) -> TrainingSeedInfo:
+    """Resolve and apply the configured training seed before runtime construction."""
+    seed_info = resolve_training_seed(cfg)
+    effective_seed = apply_training_seed(
+        seed_info.effective_seed,
+        torch_runtime=torch_runtime,
+        cuda=cuda,
+        mlx_runtime=mlx_runtime,
+    )
+    return TrainingSeedInfo(
+        configured_seed=seed_info.configured_seed,
+        configured_seed_source=seed_info.configured_seed_source,
+        effective_seed=effective_seed,
+    )

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -164,6 +164,21 @@ def test_offpolicy_hydra_default_algo():
     assert cfg.algo.algo == "sac"
 
 
+def test_appo_runner_kwargs_forward_algorithm_seed():
+    mod = _train_appo()
+    cfg = _appo_cfg(["algo.seed=37"])
+    rl_cfg = OmegaConf.to_container(cfg.algo, resolve=True)
+
+    kwargs = mod.build_appo_runner_kwargs(
+        cfg,
+        env_cfg_override={"reward_config": {}},
+        collector_device="cpu",
+        rl_cfg=cast(dict[str, Any], rl_cfg),
+    )
+
+    assert kwargs["seed"] == 37
+
+
 def test_offpolicy_hydra_default_task():
     cfg = _offpolicy_cfg()
     assert cfg.training.task_name == "G1WalkFlat"

--- a/tests/training/test_seed_contract.py
+++ b/tests/training/test_seed_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
+
+from unilab.training.seed import (
+    apply_training_seed,
+    derive_worker_seed,
+    resolve_training_seed,
+)
+
+_ROOT_DIR = Path(__file__).resolve().parents[2]
+_CONF_DIR = _ROOT_DIR / "conf"
+
+
+def _compose(config_dir: str, overrides: list[str] | None = None):
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(_CONF_DIR / config_dir), version_base="1.3"):
+        return compose("config", overrides=overrides or [])
+
+
+def test_resolve_training_seed_prefers_algo_seed_over_legacy_training_seed():
+    cfg = OmegaConf.create({"algo": {"seed": 7}, "training": {"seed": 99}})
+
+    seed_info = resolve_training_seed(cfg)
+
+    assert seed_info.configured_seed == 7
+    assert seed_info.configured_seed_source == "algo.seed"
+    assert seed_info.effective_seed == 7
+
+
+def test_apply_training_seed_controls_python_numpy_and_torch_rng():
+    apply_training_seed(123, torch_runtime=True, cuda=True)
+    first = (random.random(), np.random.rand(), torch.rand(3))
+
+    apply_training_seed(123, torch_runtime=True, cuda=True)
+    second = (random.random(), np.random.rand(), torch.rand(3))
+
+    assert second[0] == first[0]
+    assert second[1] == first[1]
+    assert torch.equal(second[2], first[2])
+
+
+def test_apply_training_seed_rejects_negative_seed():
+    with pytest.raises(ValueError, match="non-negative"):
+        apply_training_seed(-1)
+
+
+def test_derive_worker_seed_is_deterministic_and_distinct_from_base_seed():
+    assert derive_worker_seed(10, worker_index=0) == 11
+    assert derive_worker_seed(10, worker_index=3) == 14
+    assert derive_worker_seed(None, worker_index=3) is None
+
+
+@pytest.mark.parametrize(
+    ("config_dir", "overrides"),
+    [
+        ("ppo", ["task=go1_joystick_flat/mujoco"]),
+        ("ppo", ["task=go1_joystick_flat/mujoco", "algo.seed=41"]),
+        ("ppo", ["task=sharpa_inhand/mujoco_hora"]),
+        ("appo", ["task=go1_joystick_flat/mujoco"]),
+        ("appo", ["task=sharpa_inhand/mujoco_hora"]),
+        ("offpolicy", ["algo=sac", "task=sac/g1_walk_flat/mujoco"]),
+        ("offpolicy", ["algo=td3", "task=td3/g1_walk_flat/mujoco"]),
+    ],
+)
+def test_owner_configs_resolve_algorithm_seed_contract(config_dir: str, overrides: list[str]):
+    cfg = _compose(config_dir, overrides)
+
+    seed_info = resolve_training_seed(cfg)
+
+    assert seed_info.configured_seed == int(cfg.algo.seed)
+    assert seed_info.configured_seed_source == "algo.seed"
+    assert seed_info.effective_seed == int(cfg.algo.seed)
+
+
+def test_mlx_config_keeps_training_seed_as_legacy_fallback_only():
+    mlx_cfg = OmegaConf.load(_CONF_DIR / "ppo" / "config_mlx.yaml")
+    mlx_cfg.algo.seed = 17
+    mlx_cfg.training.seed = 29
+
+    seed_info = resolve_training_seed(mlx_cfg)
+
+    assert seed_info.configured_seed == 17
+    assert seed_info.configured_seed_source == "algo.seed"

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -84,6 +84,11 @@ def test_experiment_tracker_writes_local_run_files(tmp_path):
         full_cfg={"training": {"logger": "tensorboard"}},
         device="cuda",
         collector_device="cpu",
+        seed_info={
+            "configured_seed": 5,
+            "configured_seed_source": "algo.seed",
+            "effective_seed": 5,
+        },
     )
 
     tracker.start()
@@ -95,8 +100,13 @@ def test_experiment_tracker_writes_local_run_files(tmp_path):
 
     assert run_config["run"]["algo"] == "appo"
     assert run_config["run"]["task"] == "G1MotionTracking"
+    assert run_config["run"]["configured_seed"] == 5
+    assert run_config["run"]["configured_seed_source"] == "algo.seed"
+    assert run_config["run"]["effective_seed"] == 5
     assert run_summary["final_mean_reward"] == 12.3
     assert run_summary["completed_iterations"] == 10
+    assert run_summary["configured_seed"] == 5
+    assert run_summary["effective_seed"] == 5
     assert run_summary["wall_time_sec"] >= 0.0
 
 


### PR DESCRIPTION
## Summary

- add a shared training seed helper that resolves `algo.seed`, applies Python/NumPy/Torch/CUDA/MLX seeds, and derives subprocess worker seeds
- apply the seed contract before env, wrapper, runner, learner, and model construction across RSL-RL PPO/HORA, MLX PPO, APPO/HORA APPO, SAC/TD3/FlashSAC, and async collectors
- record configured/effective seed metadata in run config and summary files
- add tests for owner config seed resolution, runtime RNG application, APPO seed forwarding, and experiment seed metadata

Fixes #379

## Tests

- `make test-all`
  - format / ruff / mypy / pyright passed
  - pytest coverage: 728 passed, 3 skipped, 242 deselected
