### PR TITLE
feat: add offline video rendering for Motrix backend

### DIFF
--- a/conf/appo/config.yaml
+++ b/conf/appo/config.yaml
@@ -66,6 +66,8 @@ training:
   play_only: false
   no_play: false
   play_env_num: 16
+  play_headless: true
+  play_record_video: true
   play_steps: 150
   cam_distance: 6.0
   cam_elevation: -20.0

--- a/conf/hora_distill/config.yaml
+++ b/conf/hora_distill/config.yaml
@@ -21,6 +21,8 @@ training:
   sim_backend: mujoco
   play_only: false
   play_env_num: 16
+  play_headless: true
+  play_record_video: true
   play_steps: 200
   render_spacing: 1.0
   cam_distance: 6.0

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -21,6 +21,8 @@ training:
   play_only: false
   no_play: false
   play_env_num: 16
+  play_headless: true
+  play_record_video: true
   play_steps: 800
   cam_distance: 6.0
   cam_elevation: -20.0

--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -75,6 +75,8 @@ training:
   play_only: false
   no_play: false
   play_env_num: 16
+  play_headless: true
+  play_record_video: true
   render_spacing: 1.0
   play_steps: 200
   cam_distance: 6.0

--- a/conf/ppo/config_mlx.yaml
+++ b/conf/ppo/config_mlx.yaml
@@ -58,6 +58,8 @@ training:
   play_only: false
   no_play: false
   play_env_num: 16
+  play_headless: true
+  play_record_video: true
   play_steps: 150
   logger: tensorboard
   wandb_project: unilab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim==0.7.1.dev96425"]
+motrix = ["motrixsim-core==0.7.1.dev99744"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]
@@ -62,7 +62,7 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.uv.sources]
-motrixsim = { index = "motphys-pypi" }
+motrixsim-core = { index = "motphys-pypi" }
 mujoco-uni = { index = "test-pypi" }
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform=='linux'" },

--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -260,7 +260,7 @@ def play_appo(
         else:
             print("ONNX export verified OK.")
 
-    if cfg.training.sim_backend == "motrix":
+    if cfg.training.sim_backend == "motrix" and load_path_dir is None:
         print("Starting interactive visualization (motrix native renderer)...")
         print("Close the render window to exit.")
         try:
@@ -281,14 +281,18 @@ def play_appo(
         print(f"Could not resolve checkpoint directory. load_path_dir={load_path_dir}")
         return None
 
-    output_video = os.path.join(load_path_dir, "play_video.mp4")
-    print(f"Rendering video to {output_video}...")
+    record_video = bool(getattr(cfg.training, "play_record_video", True))
+    output_video = os.path.join(load_path_dir, "play_video.mp4") if record_video else None
+    if record_video:
+        print(f"Rendering video to {output_video}...")
+    else:
+        print("Running playback without video recording...")
 
     if env.state is None:
         env.init_state()
     num_steps = int(getattr(cfg.training, "play_steps", 1000))
 
-    print("Collecting physics states...")
+    print("Rendering playback frames...")
     with torch.inference_mode():
         render_play_mode(
             env,
@@ -296,6 +300,8 @@ def play_appo(
             render_spacing=float(
                 getattr(cfg.training, "render_spacing", getattr(env.cfg, "render_spacing", 1.0))
             ),
+            headless=bool(getattr(cfg.training, "play_headless", True)),
+            record_video=record_video,
             num_steps=num_steps,
             output_video=output_video,
             initialize=lambda: np.asarray(
@@ -326,7 +332,8 @@ def play_appo(
                 "cam_tracking_extra_envs": getattr(cfg.training, "cam_tracking_extra_envs", 2),
             },
         )
-    print(f"Saving video to {output_video} with mediapy...")
+    if record_video:
+        print(f"Saving video to {output_video} with mediapy...")
     print("Done.")
     return output_video
 

--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -262,14 +262,13 @@ def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
     actor.eval()
     hist_normalizer.eval()
 
-    if cfg.training.sim_backend == "motrix":
-        raise NotImplementedError(
-            "HORA distillation play_only currently supports offline MuJoCo video rendering only."
-        )
-
-    output_video = Path(load_path_dir) / "play_video_stage2.mp4"
-    print(f"Rendering video to {output_video}...")
-    print("Collecting physics states...")
+    record_video = bool(getattr(cfg.training, "play_record_video", True))
+    output_video = Path(load_path_dir) / "play_video_stage2.mp4" if record_video else None
+    if record_video:
+        print(f"Rendering video to {output_video}...")
+    else:
+        print("Running playback without video recording...")
+    print("Rendering playback frames...")
     with torch.inference_mode():
         render_play_mode(
             env,
@@ -277,6 +276,8 @@ def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
             render_spacing=float(
                 getattr(cfg.training, "render_spacing", getattr(env.cfg, "render_spacing", 1.0))
             ),
+            headless=bool(getattr(cfg.training, "play_headless", True)),
+            record_video=record_video,
             num_steps=int(cfg.training.play_steps),
             output_video=output_video,
             initialize=lambda: wrapped_env.reset()[0],
@@ -286,7 +287,7 @@ def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
             camera_kwargs=_play_camera_kwargs(cfg),
         )
     print("Done.")
-    return str(output_video)
+    return str(output_video) if output_video is not None else None
 
 
 @hydra.main(version_base="1.3", config_path="../conf/hora_distill", config_name="config")

--- a/scripts/train_mlx_ppo.py
+++ b/scripts/train_mlx_ppo.py
@@ -311,46 +311,45 @@ def play_mlx_ppo(cfg: DictConfig, dtype, use_fp16: bool, resolved_sim_backend: s
         raw_obs = mx.array(flatten_obs_dict(state.obs))
         return mx.nan_to_num(raw_obs, nan=0.0, posinf=0.0, neginf=0.0)
 
-    if resolved_sim_backend == "motrix":
-        print("[MLX PPO] Starting interactive visualization (motrix native renderer)...")
-        print("[MLX PPO] Close the render window to exit.")
-
-        try:
-            render_play_mode(
-                env,
-                sim_backend="motrix",
-                num_steps=None,
-                initialize=lambda: obs,
-                step=_play_step,
-            )
-        except Exception as e:
-            if "RenderClosedError" in str(type(e).__name__):
-                print("[MLX PPO] Render window closed.")
-            else:
-                raise
-        env.close()
-        return None
-
+    record_video = bool(getattr(cfg.training, "play_record_video", True))
     output_dir = run_dir if run_dir is not None else task_log_root
-    output_video = output_dir / "play_video.mp4"
+    output_video = output_dir / "play_video.mp4" if record_video else None
 
-    print("[MLX PPO] Collecting physics states for play...")
+    if record_video:
+        print(f"[MLX PPO] Rendering video to {output_video}...")
+    else:
+        print("[MLX PPO] Running playback without video recording...")
+    print("[MLX PPO] Rendering playback frames...")
     try:
         render_play_mode(
             env,
             sim_backend=resolved_sim_backend,
+            headless=bool(getattr(cfg.training, "play_headless", True)),
+            record_video=record_video,
             num_steps=cfg.training.play_steps,
             output_video=output_video,
             initialize=lambda: obs,
             step=_play_step,
+            camera_kwargs={
+                "cam_distance": getattr(cfg.training, "cam_distance", 2.0),
+                "cam_elevation": getattr(cfg.training, "cam_elevation", -20.0),
+                "cam_azimuth": getattr(cfg.training, "cam_azimuth", 90.0),
+                "cam_lookat": getattr(cfg.training, "cam_lookat", None),
+                "cam_tracking": getattr(cfg.training, "cam_tracking", False),
+                "cam_tracking_env_idx": getattr(cfg.training, "cam_tracking_env_idx", 0),
+                "cam_tracking_extra_envs": getattr(cfg.training, "cam_tracking_extra_envs", 2),
+            },
         )
     except ImportError:
         print("mediapy is required for play video export. Install with `pip install mediapy`.")
         env.close()
         return None
-    print(f"[MLX PPO] Play video saved: {output_video}")
+    if record_video:
+        print(f"[MLX PPO] Play video saved: {output_video}")
+    else:
+        print("[MLX PPO] Playback done.")
     env.close()
-    return str(output_video)
+    return str(output_video) if output_video is not None else None
 
 
 @hydra.main(version_base="1.3", config_path="../conf/ppo", config_name="config_mlx")

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -438,8 +438,8 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
         state = env.step(actions_np)
         return np.asarray(extract_play_obs(state.obs), dtype=np.float32)
 
-    # Use Motrix native rendering
-    if cfg.training.sim_backend == "motrix":
+    # Use Motrix native rendering only when no video output directory is available.
+    if cfg.training.sim_backend == "motrix" and load_path_dir is None:
         print("Starting interactive visualization (motrix native renderer)...")
         print("Close the render window to exit.")
 
@@ -470,12 +470,19 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
         print(f"Could not resolve checkpoint directory. load_path_dir={load_path_dir}")
         return None
 
-    output_video = os.path.join(load_path_dir, "play_video.mp4")
-    print("Collecting physics states...")
+    record_video = bool(getattr(cfg.training, "play_record_video", True))
+    output_video = os.path.join(load_path_dir, "play_video.mp4") if record_video else None
+    if record_video:
+        print(f"Rendering video to {output_video}...")
+    else:
+        print("Running playback without video recording...")
+    print("Rendering playback frames...")
     with torch.inference_mode():
         render_play_mode(
             env,
             sim_backend=cfg.training.sim_backend,
+            headless=bool(getattr(cfg.training, "play_headless", True)),
+            record_video=record_video,
             num_steps=cfg.training.play_steps,
             output_video=output_video,
             initialize=lambda: np.asarray(
@@ -493,7 +500,8 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
                 "cam_azimuth": cfg.training.cam_azimuth,
             },
         )
-    print(f"Saving video to {output_video} ...")
+    if record_video:
+        print(f"Saving video to {output_video} ...")
     print("Done.")
     return output_video
 

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -188,7 +188,7 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
     if EXPORT_POLICY:
         runner.export_policy_to_onnx(path=str(load_path_dir))
         runner.export_policy_to_jit(path=str(load_path_dir))
-    if cfg.training.sim_backend == "motrix":
+    if cfg.training.sim_backend == "motrix" and load_path_dir is None:
         print("Starting interactive visualization (motrix native renderer)...")
         print("Close the render window to exit.")
         with torch.inference_mode():
@@ -208,10 +208,14 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
                 else:
                     raise
     else:
-        output_video = Path(load_path_dir) / "play_video.mp4"
-        print(f"Rendering video to {output_video}...")
+        record_video = bool(getattr(cfg.training, "play_record_video", True))
+        output_video = Path(load_path_dir) / "play_video.mp4" if record_video else None
+        if record_video:
+            print(f"Rendering video to {output_video}...")
+        else:
+            print("Running playback without video recording...")
 
-        print("Collecting physics states...")
+        print("Rendering playback frames...")
         with torch.inference_mode():
             render_play_mode(
                 env,
@@ -219,6 +223,8 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
                 render_spacing=float(
                     getattr(cfg.training, "render_spacing", getattr(env.cfg, "render_spacing", 1.0))
                 ),
+                headless=bool(getattr(cfg.training, "play_headless", True)),
+                record_video=record_video,
                 num_steps=cfg.training.play_steps,
                 output_video=output_video,
                 initialize=lambda: wrapped_env.reset()[0],
@@ -234,7 +240,7 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
                 },
             )
         print("Done.")
-        return str(output_video)
+        return str(output_video) if output_video is not None else None
 
     return None
 

--- a/src/unilab/algos/torch/hora/appo.py
+++ b/src/unilab/algos/torch/hora/appo.py
@@ -171,8 +171,12 @@ def play_hora_appo(
         print(f"Could not resolve checkpoint directory. load_path_dir={load_path_dir}")
         return None
 
-    output_video = os.path.join(load_path_dir, "play_video.mp4")
-    print(f"Rendering video to {output_video}...")
+    record_video = bool(getattr(cfg.training, "play_record_video", True))
+    output_video = os.path.join(load_path_dir, "play_video.mp4") if record_video else None
+    if record_video:
+        print(f"Rendering video to {output_video}...")
+    else:
+        print("Running playback without video recording...")
     num_steps = int(getattr(cfg.training, "play_steps", 1000))
     current_priv_info: np.ndarray | None = None
 
@@ -207,6 +211,8 @@ def play_hora_appo(
             render_spacing=float(
                 getattr(cfg.training, "render_spacing", getattr(env.cfg, "render_spacing", 1.0))
             ),
+            headless=bool(getattr(cfg.training, "play_headless", True)),
+            record_video=record_video,
             num_steps=num_steps,
             output_video=output_video,
             initialize=initialize_play_obs,
@@ -221,7 +227,8 @@ def play_hora_appo(
                 "cam_tracking_extra_envs": getattr(cfg.training, "cam_tracking_extra_envs", 2),
             },
         )
-    print(f"Saving video to {output_video} with mediapy...")
+    if record_video:
+        print(f"Saving video to {output_video} with mediapy...")
     print("Done.")
     return output_video
 

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -21,6 +21,7 @@ class BackendPlayCapabilities:
 
     supports_native_interactive_renderer: bool = False
     supports_physics_state_playback: bool = False
+    supports_native_video_capture: bool = False
 
 
 class SimBackend(abc.ABC):
@@ -297,16 +298,33 @@ class SimBackend(abc.ABC):
         """Return backend-native play/render capabilities."""
         return BackendPlayCapabilities()
 
-    def init_renderer(self, spacing: float = 1.0) -> None:
-        """Initialize a backend-native interactive renderer."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support native interactive rendering"
-        )
+    def init_renderer(
+        self,
+        spacing: float = 1.0,
+        *,
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a backend-native renderer.
+
+        ``headless`` controls whether a native window is opened. ``capture``
+        controls whether ``capture_video_frame`` is valid for the renderer.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support native rendering")
 
     def render(self) -> None:
         """Render one frame through a backend-native interactive renderer."""
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support native interactive rendering"
+        )
+
+    def capture_video_frame(self) -> np.ndarray:
+        """Capture one RGB frame through a backend-native renderer."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support native video capture"
         )
 
     def get_physics_state(self) -> np.ndarray:

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -1,7 +1,7 @@
 import os
 import time
 from collections.abc import Sequence
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import numpy as np
 
@@ -136,6 +136,8 @@ class MotrixBackend(SimBackend):
             self._body_link.get_center_of_mass_override(self._data)
         )
         self._render_app: "RenderApp | None" = None
+        self._render_headless: bool | None = None
+        self._render_capture_enabled = False
         self.backend_type = "motrix"
 
         # Pre-cache link objects to avoid repeated get_link() lookups.
@@ -309,7 +311,10 @@ class MotrixBackend(SimBackend):
         self.push_robots(plan.push_perturbation_limit)
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
-        return BackendPlayCapabilities(supports_native_interactive_renderer=True)
+        return BackendPlayCapabilities(
+            supports_native_interactive_renderer=True,
+            supports_native_video_capture=True,
+        )
 
     # ------------------------------------------------------------------ #
     # Base kinematics                                                    #
@@ -450,34 +455,133 @@ class MotrixBackend(SimBackend):
         ex_force[:, 2] *= force_range[2]
         self._push_body_link.add_external_force(self._data, ex_force, local=True)
 
-    def init_renderer(self, spacing: float = 1.0):
-        """Initialize interactive renderer for visualization"""
-        if self._render_app is not None:
-            return
-
+    def _render_offsets(self, spacing: float) -> list[list[float]]:
         cols = int(np.ceil(np.sqrt(self._num_envs)))
         offsets = []
         for i in range(self._num_envs):
             row = i // cols
             col = i % cols
             offsets.append([col * spacing, row * spacing, 0.0])
+        return offsets
 
-        self._render_app = RenderApp()
+    def _resolve_system_camera_view(
+        self,
+        offsets: Sequence[Sequence[float]],
+        camera_kwargs: dict[str, Any] | None,
+    ) -> tuple[list[float], float, float, float]:
+        cam_kw = dict(camera_kwargs or {})
+        if bool(cam_kw.get("cam_tracking", False)):
+            raise NotImplementedError("Motrix native video capture does not support cam_tracking")
+
+        lookat_raw = cam_kw.get("cam_lookat")
+        if lookat_raw is None:
+            offsets_np = np.asarray(offsets, dtype=np.float64)
+            lookat = [
+                float(np.mean(offsets_np[:, 0])),
+                float(np.mean(offsets_np[:, 1])),
+                0.75,
+            ]
+        else:
+            lookat_arr = np.asarray(lookat_raw, dtype=np.float64).reshape(-1)
+            if lookat_arr.shape != (3,):
+                raise ValueError(f"cam_lookat must contain 3 values, got {lookat_raw!r}")
+            lookat = [float(lookat_arr[0]), float(lookat_arr[1]), float(lookat_arr[2])]
+
+        return (
+            lookat,
+            float(cam_kw.get("cam_distance", 2.0)),
+            float(cam_kw.get("cam_elevation", -20.0)),
+            float(cam_kw.get("cam_azimuth", 90.0)),
+        )
+
+    def _assert_render_context_available(self, *, headless: bool, capture: bool) -> None:
+        if self._render_app is None:
+            return
+        if self._render_headless != headless:
+            raise RuntimeError(
+                "Motrix renderer is already initialized with "
+                f"headless={self._render_headless!r}; cannot reuse it with headless={headless!r}"
+            )
+        if capture and not self._render_capture_enabled:
+            raise RuntimeError(
+                "Motrix renderer is already initialized without video capture; "
+                "cannot enable capture on the existing renderer"
+            )
+        return
+
+    def init_renderer(
+        self,
+        spacing: float = 1.0,
+        *,
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a Motrix renderer, optionally enabling system-camera capture."""
+        headless = bool(headless)
+        capture = bool(capture)
+        self._assert_render_context_available(headless=headless, capture=capture)
+        if self._render_app is not None:
+            return
+
         settings = RenderSettings.performance()
         settings.enable_shadow = True
-        self._render_app.launch(
+        offsets = self._render_offsets(float(spacing))
+        if capture:
+            self._model.cameras.set_system_render_target("image", int(width), int(height))
+            lookat, distance, elevation, azimuth = self._resolve_system_camera_view(
+                offsets,
+                camera_kwargs,
+            )
+        render_app = RenderApp(headless=headless)
+        render_app.launch(
             self._model,
             batch=self._num_envs,
             render_offset=offsets,
             render_settings=settings,
         )
+        if capture:
+            render_app.system_camera.set_view(lookat, distance, elevation, azimuth)
+        self._render_app = render_app
+        self._render_headless = headless
+        self._render_capture_enabled = capture
 
     def render(self):
         """Render current state (interactive visualization)"""
         if self._render_app is None:
             self.init_renderer()
+        self._assert_render_context_available(headless=False, capture=False)
         assert self._render_app is not None
         self._render_app.sync(data=self._data)
+
+    def capture_video_frame(self) -> np.ndarray:
+        """Capture one RGB frame from Motrix's system camera."""
+        if self._render_app is None:
+            self.init_renderer(headless=True, capture=True)
+        if not self._render_capture_enabled:
+            raise RuntimeError("Motrix renderer is not initialized for video capture")
+        assert self._render_app is not None
+
+        task = self._render_app.system_camera.capture()
+        self._render_app.sync(data=self._data, wait=True)
+        image = task.take_image()
+        if image is None:
+            raise RuntimeError("Motrix system camera capture did not return an image")
+
+        pixels = np.asarray(image.pixels)
+        if pixels.ndim != 3:
+            raise RuntimeError(
+                f"Motrix system camera capture must return an HWC image, got shape {pixels.shape}"
+            )
+        if pixels.shape[-1] == 4:
+            pixels = pixels[..., :3]
+        if pixels.shape[-1] != 3:
+            raise RuntimeError(
+                f"Motrix system camera capture must return RGB/RGBA pixels, got shape {pixels.shape}"
+            )
+        return np.ascontiguousarray(pixels, dtype=np.uint8)
 
     def _apply_reset_randomization(
         self,

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -14,6 +14,7 @@ class EnvPlayCapabilities:
 
     supports_native_interactive_renderer: bool = False
     supports_physics_state_playback: bool = False
+    supports_native_video_capture: bool = False
 
 
 @dataclass
@@ -108,16 +109,31 @@ class ABEnv(abc.ABC):
     def close(self) -> None:
         """Clean up environment resources"""
 
-    def init_play_renderer(self, render_spacing: float | None = None) -> None:
-        """Initialize env-facing interactive playback when supported."""
+    def init_play_renderer(
+        self,
+        render_spacing: float | None = None,
+        *,
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize env-facing playback rendering when supported."""
         raise NotImplementedError(
-            f"{self.__class__.__name__} does not support native interactive playback"
+            f"{self.__class__.__name__} does not support native playback rendering"
         )
 
     def render_play_frame(self) -> None:
         """Render one frame through the env-facing interactive playback contract."""
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support native interactive playback"
+        )
+
+    def capture_play_video_frame(self) -> np.ndarray:
+        """Capture one RGB frame through the env-facing video contract."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support native video capture"
         )
 
     def get_physics_state_snapshot(self) -> np.ndarray:

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -283,19 +283,38 @@ class NpEnv(ABEnv):
             np.greater_equal(state.info["steps"], self._cfg.max_episode_steps, out=truncated)
         return truncated
 
-    def init_play_renderer(self, render_spacing: float | None = None) -> None:
-        """Initialize backend-native interactive playback when available."""
-        if not self.play_capabilities.supports_native_interactive_renderer:
+    def init_play_renderer(
+        self,
+        render_spacing: float | None = None,
+        *,
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize backend-native playback rendering when available."""
+        if capture:
+            if not self.play_capabilities.supports_native_video_capture:
+                raise NotImplementedError(
+                    f"{self._backend.__class__.__name__} does not support native video capture"
+                )
+        elif not self.play_capabilities.supports_native_interactive_renderer:
             raise NotImplementedError(
                 f"{self._backend.__class__.__name__} does not support native interactive playback"
             )
-        if render_spacing is None:
-            self._backend.init_renderer()
-            return
-        try:
-            self._backend.init_renderer(spacing=render_spacing)
-        except TypeError:
-            self._backend.init_renderer()
+
+        spacing = (
+            float(render_spacing) if render_spacing is not None else float(self._cfg.render_spacing)
+        )
+        self._backend.init_renderer(
+            spacing=spacing,
+            headless=bool(headless),
+            capture=bool(capture),
+            width=int(width),
+            height=int(height),
+            camera_kwargs=camera_kwargs,
+        )
 
     def render_play_frame(self) -> None:
         """Render one interactive playback frame through the env contract."""
@@ -304,6 +323,16 @@ class NpEnv(ABEnv):
                 f"{self._backend.__class__.__name__} does not support native interactive playback"
             )
         self._backend.render()
+
+    def capture_play_video_frame(self) -> np.ndarray:
+        """Capture one detached RGB video frame through the env contract."""
+        if not self.play_capabilities.supports_native_video_capture:
+            raise NotImplementedError(
+                f"{self._backend.__class__.__name__} does not support native video capture"
+            )
+        return cast(
+            np.ndarray, np.asarray(self._backend.capture_video_frame(), dtype=np.uint8).copy()
+        )
 
     def get_physics_state_snapshot(self) -> np.ndarray:
         """Return a detached physics snapshot for offline playback/video export."""
@@ -331,6 +360,7 @@ class NpEnv(ABEnv):
         return EnvPlayCapabilities(
             supports_native_interactive_renderer=capabilities.supports_native_interactive_renderer,
             supports_physics_state_playback=capabilities.supports_physics_state_playback,
+            supports_native_video_capture=capabilities.supports_native_video_capture,
         )
 
     def get_playback_model(self, env_index: int | None = None) -> Any:

--- a/src/unilab/visualization/playback.py
+++ b/src/unilab/visualization/playback.py
@@ -12,6 +12,26 @@ import numpy as np
 ObsT = TypeVar("ObsT")
 
 
+def _resolve_record_video(
+    *,
+    record_video: bool | None,
+    output_video: str | Path | None,
+) -> bool:
+    if record_video is not None:
+        return bool(record_video)
+    return output_video is not None
+
+
+def _resolve_headless(
+    *,
+    headless: bool | None,
+    record_video: bool,
+) -> bool:
+    if headless is not None:
+        return bool(headless)
+    return record_video
+
+
 def render_play_mode(
     env,
     *,
@@ -21,13 +41,62 @@ def render_play_mode(
     num_steps: int | None,
     output_video: str | Path | None = None,
     render_spacing: float | None = None,
+    headless: bool | None = None,
+    record_video: bool | None = None,
     frame_state_getter: Callable[[], np.ndarray] | None = None,
     camera_kwargs: dict[str, Any] | None = None,
 ) -> str | None:
-    """Render interactive Motrix play or MuJoCo video generation through shared callbacks."""
-    if sim_backend == "motrix":
-        env.init_play_renderer(render_spacing=render_spacing)
+    """Render play mode with explicit headless and video-recording controls."""
+    should_record_video = _resolve_record_video(
+        record_video=record_video,
+        output_video=output_video,
+    )
+    should_run_headless = _resolve_headless(
+        headless=headless,
+        record_video=should_record_video,
+    )
 
+    if sim_backend == "motrix":
+        if should_run_headless or should_record_video:
+            if num_steps is None:
+                raise ValueError("Motrix captured playback requires a finite num_steps value.")
+            if should_record_video and output_video is None:
+                raise ValueError("Motrix video recording requires an output_video path.")
+
+            cam_kw = dict(camera_kwargs or {})
+            effective_spacing = (
+                float(render_spacing)
+                if render_spacing is not None
+                else float(getattr(env.cfg, "render_spacing", 1.0))
+            )
+            env.init_play_renderer(
+                render_spacing=effective_spacing,
+                headless=should_run_headless,
+                capture=True,
+                width=1280,
+                height=720,
+                camera_kwargs=cam_kw,
+            )
+
+            obs = initialize()
+            frames: list[np.ndarray] | None = [] if should_record_video else None
+            for _ in range(num_steps):
+                obs = step(obs)
+                frame = np.asarray(env.capture_play_video_frame(), dtype=np.uint8)
+                if frames is not None:
+                    frames.append(frame.copy())
+
+            if not should_record_video:
+                return None
+
+            assert output_video is not None
+            assert frames is not None
+            import mediapy as media
+
+            media.write_video(str(output_video), frames, fps=int(1.0 / env.cfg.ctrl_dt))
+            return str(output_video)
+
+        env.init_play_renderer(render_spacing=render_spacing)
         obs = initialize()
         last_render_time = time.perf_counter()
         render_dt = 1.0 / 60.0
@@ -44,6 +113,10 @@ def render_play_mode(
             steps_run += 1
         return None
 
+    if not should_run_headless:
+        raise NotImplementedError("MuJoCo play mode does not support interactive rendering here.")
+    if not should_record_video:
+        raise ValueError("MuJoCo play rendering requires record_video=true.")
     if num_steps is None:
         raise ValueError("MuJoCo play rendering requires a finite num_steps value.")
     if output_video is None:

--- a/tests/base/test_backend_pre_step_control.py
+++ b/tests/base/test_backend_pre_step_control.py
@@ -184,3 +184,173 @@ def test_motrix_step_with_pre_step_control_uses_single_step_loop() -> None:
     assert backend._model.step_n_calls == []
     assert seen_sensors == [0.0, 1.0, 2.0]
     np.testing.assert_allclose(backend._data.actuator_ctrls, ctrl + 3)
+
+
+def test_motrix_native_video_capture_uses_headless_system_camera(monkeypatch) -> None:
+    import unilab.base.backend.motrix_backend as mod
+
+    captured: dict[str, object] = {}
+
+    class FakeCameras:
+        def set_system_render_target(self, target, width, height):
+            captured["render_target"] = (target, width, height)
+
+    class FakeModel:
+        cameras = FakeCameras()
+
+    class FakeSettings:
+        enable_shadow = False
+
+    class FakeRenderSettings:
+        @staticmethod
+        def performance():
+            captured["settings"] = True
+            return FakeSettings()
+
+    class FakeImage:
+        pixels = np.arange(2 * 3 * 4, dtype=np.uint8).reshape(2, 3, 4)
+
+    class FakeTask:
+        def take_image(self):
+            captured["take_image"] = True
+            return FakeImage()
+
+    class FakeSystemCamera:
+        def set_view(self, lookat, distance, elevation, azimuth):
+            captured["set_view"] = {
+                "lookat": lookat,
+                "distance": distance,
+                "elevation": elevation,
+                "azimuth": azimuth,
+            }
+
+        def capture(self):
+            captured["capture"] = True
+            return FakeTask()
+
+    class FakeRenderApp:
+        def __init__(self, **kwargs):
+            captured["render_app_kwargs"] = kwargs
+            self.system_camera = FakeSystemCamera()
+
+        def launch(self, model, *, batch, render_offset, render_settings):
+            captured["launch"] = {
+                "model": model,
+                "batch": batch,
+                "render_offset": render_offset,
+                "render_settings": render_settings,
+            }
+
+        def sync(self, *, data, wait=False):
+            captured["sync"] = {"data": data, "wait": wait}
+
+    monkeypatch.setattr(mod, "RenderApp", FakeRenderApp, raising=False)
+    monkeypatch.setattr(mod, "RenderSettings", FakeRenderSettings, raising=False)
+
+    backend = object.__new__(mod.MotrixBackend)
+    backend._model = FakeModel()
+    backend._data = object()
+    backend._num_envs = 3
+    backend._render_app = None
+    backend._render_headless = None
+    backend._render_capture_enabled = False
+
+    backend.init_renderer(
+        spacing=1.5,
+        headless=True,
+        capture=True,
+        width=3,
+        height=2,
+        camera_kwargs={
+            "cam_lookat": [1.0, 2.0, 3.0],
+            "cam_distance": 4.0,
+            "cam_elevation": -30.0,
+            "cam_azimuth": 45.0,
+        },
+    )
+    frame = backend.capture_video_frame()
+
+    assert captured["render_target"] == ("image", 3, 2)
+    assert captured["render_app_kwargs"] == {"headless": True}
+    assert captured["launch"]["model"] is backend._model
+    assert captured["launch"]["batch"] == 3
+    assert captured["launch"]["render_offset"] == [
+        [0.0, 0.0, 0.0],
+        [1.5, 0.0, 0.0],
+        [0.0, 1.5, 0.0],
+    ]
+    assert captured["set_view"] == {
+        "lookat": [1.0, 2.0, 3.0],
+        "distance": 4.0,
+        "elevation": -30.0,
+        "azimuth": 45.0,
+    }
+    assert captured["sync"] == {"data": backend._data, "wait": True}
+    assert captured["capture"] is True
+    assert captured["take_image"] is True
+    assert frame.shape == (2, 3, 3)
+    np.testing.assert_array_equal(frame, FakeImage.pixels[..., :3])
+
+
+def test_motrix_native_video_capture_defaults_camera_lookat_to_grid_center(monkeypatch) -> None:
+    import unilab.base.backend.motrix_backend as mod
+
+    captured: dict[str, object] = {}
+
+    class FakeCameras:
+        def set_system_render_target(self, target, width, height):
+            del target, width, height
+
+    class FakeModel:
+        cameras = FakeCameras()
+
+    class FakeSettings:
+        enable_shadow = False
+
+    class FakeRenderSettings:
+        @staticmethod
+        def performance():
+            return FakeSettings()
+
+    class FakeSystemCamera:
+        def set_view(self, lookat, distance, elevation, azimuth):
+            captured["set_view"] = {
+                "lookat": lookat,
+                "distance": distance,
+                "elevation": elevation,
+                "azimuth": azimuth,
+            }
+
+    class FakeRenderApp:
+        def __init__(self, **kwargs):
+            del kwargs
+            self.system_camera = FakeSystemCamera()
+
+        def launch(self, model, *, batch, render_offset, render_settings):
+            del model, batch, render_offset, render_settings
+
+    monkeypatch.setattr(mod, "RenderApp", FakeRenderApp, raising=False)
+    monkeypatch.setattr(mod, "RenderSettings", FakeRenderSettings, raising=False)
+
+    backend = object.__new__(mod.MotrixBackend)
+    backend._model = FakeModel()
+    backend._num_envs = 4
+    backend._render_app = None
+    backend._render_headless = None
+    backend._render_capture_enabled = False
+
+    backend.init_renderer(
+        spacing=2.0,
+        headless=True,
+        capture=True,
+        width=3,
+        height=2,
+        camera_kwargs=None,
+    )
+
+    assert captured["set_view"] == {
+        "lookat": [1.0, 1.0, 0.75],
+        "distance": 2.0,
+        "elevation": -20.0,
+        "azimuth": 90.0,
+    }

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -142,6 +142,9 @@ def test_motrix_backend_smoke_contract(robot):
     caps = bkd.get_dr_capabilities()
     assert {"base_mass_delta", "base_com_offset", "kp", "kd"}.issubset(caps.supported_reset_terms)
     assert caps.supports_interval_push
+    play_caps = bkd.get_play_capabilities()
+    assert play_caps.supports_native_interactive_renderer
+    assert play_caps.supports_native_video_capture
 
 
 def test_motrix_backend_fixed_base_base_views_are_available():

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -235,6 +235,118 @@ def test_render_play_mode_uses_env_interactive_contract():
     assert seen == [0, 1, 2]
 
 
+def test_render_play_mode_uses_motrix_native_video_capture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    captured: dict[str, object] = {}
+
+    class FakeEnv:
+        def __init__(self):
+            self.cfg = type("Cfg", (), {"ctrl_dt": 0.05, "model_file": "scene.xml"})()
+            self.init_calls: list[dict[str, object]] = []
+            self.capture_calls = 0
+
+        def init_play_renderer(self, **kwargs):
+            self.init_calls.append(kwargs)
+
+        def capture_play_video_frame(self) -> np.ndarray:
+            self.capture_calls += 1
+            return np.full((2, 3, 3), self.capture_calls, dtype=np.uint8)
+
+    fake_media = types.ModuleType("mediapy")
+    fake_media.write_video = lambda path, frames, fps: captured.update(  # type: ignore[attr-defined]
+        {"video_path": path, "frames": frames, "fps": fps}
+    )
+    monkeypatch.setitem(sys.modules, "mediapy", fake_media)
+
+    env = FakeEnv()
+    output_path = tmp_path / "motrix.mp4"
+    result = render_play_mode(
+        env,
+        sim_backend="motrix",
+        initialize=lambda: 0,
+        step=lambda obs: obs + 1,
+        num_steps=2,
+        output_video=output_path,
+        render_spacing=2.5,
+        camera_kwargs={"cam_distance": 3.0},
+    )
+
+    assert result == str(output_path)
+    assert env.init_calls == [
+        {
+            "render_spacing": 2.5,
+            "headless": True,
+            "capture": True,
+            "width": 1280,
+            "height": 720,
+            "camera_kwargs": {"cam_distance": 3.0},
+        }
+    ]
+    assert env.capture_calls == 2
+    assert captured["video_path"] == str(output_path)
+    assert captured["fps"] == 20
+    frames = captured["frames"]
+    assert isinstance(frames, list)
+    assert len(frames) == 2
+    np.testing.assert_array_equal(frames[0], np.full((2, 3, 3), 1, dtype=np.uint8))
+    np.testing.assert_array_equal(frames[1], np.full((2, 3, 3), 2, dtype=np.uint8))
+
+
+def test_render_play_mode_records_motrix_interactive_capture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    captured: dict[str, object] = {}
+
+    class FakeEnv:
+        def __init__(self):
+            self.cfg = type("Cfg", (), {"ctrl_dt": 0.05, "model_file": "scene.xml"})()
+            self.init_calls: list[dict[str, object]] = []
+            self.capture_calls = 0
+
+        def init_play_renderer(self, **kwargs):
+            self.init_calls.append(kwargs)
+
+        def capture_play_video_frame(self) -> np.ndarray:
+            self.capture_calls += 1
+            return np.full((2, 3, 3), self.capture_calls, dtype=np.uint8)
+
+    fake_media = types.ModuleType("mediapy")
+    fake_media.write_video = lambda path, frames, fps: captured.update(  # type: ignore[attr-defined]
+        {"video_path": path, "frames": frames, "fps": fps}
+    )
+    monkeypatch.setitem(sys.modules, "mediapy", fake_media)
+
+    env = FakeEnv()
+    output_path = tmp_path / "motrix_interactive.mp4"
+    result = render_play_mode(
+        env,
+        sim_backend="motrix",
+        initialize=lambda: 0,
+        step=lambda obs: obs + 1,
+        num_steps=2,
+        output_video=output_path,
+        headless=False,
+        record_video=True,
+        render_spacing=1.5,
+    )
+
+    assert result == str(output_path)
+    assert env.init_calls == [
+        {
+            "render_spacing": 1.5,
+            "headless": False,
+            "capture": True,
+            "width": 1280,
+            "height": 720,
+            "camera_kwargs": {},
+        }
+    ]
+    assert env.capture_calls == 2
+    assert captured["video_path"] == str(output_path)
+    assert captured["fps"] == 20
+
+
 def test_render_play_mode_defaults_to_env_physics_snapshot(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -2107,8 +2107,8 @@ wheels = [
 ]
 
 [[package]]
-name = "motrixsim"
-version = "0.7.1.dev96425"
+name = "motrixsim-core"
+version = "0.7.1.dev99744"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2116,18 +2116,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c713733a47a27e632ed39665f52ae3fa0eda5d08ed623ef1c134b24d1fda58d0" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b8add73bfd90913874c6dff283bb87b68d9714769661f2591740bbb5a6fe867" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp310-cp310-win_amd64.whl", hash = "sha256:67a3282f2b6b3e65aff776c80559e72422679d72023349e94ab572f74fb52765" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5c6d60a5e8178ee73451bfa59d04f3098cb75ddd349f4569dd559ed49df23cc6" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:285e81aebb576e61e17bbc8e2894df365b7be758eb99043fe90f4d43a44d1e19" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp311-cp311-win_amd64.whl", hash = "sha256:618f006011ed7bd44773ce7e3309218147fdc929a351d202938773b72e6b4930" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d40be7b9b5afc57e27ff75bfcb03755a5c5b9764e787b1355a1f7f6f96f8f52" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:219d720b8a41b32587eef2f67bf1eae262da3e44170737871424116e6ae0b7f1" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp312-cp312-win_amd64.whl", hash = "sha256:97baed34ed8c71b1f6c5f73e5cd40c141f751e1944500626605ac31368518267" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99669b580d23238c91410f6a21e1f0b2122c6280627f5ef9e60fef36be06db3b" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:616e138e93afd077a3b90229d44c44b33d4f3213b7d97f08155313c4c5accda7" },
-    { url = "https://pypi.motphys.com/packages/motrixsim-0.7.1.dev96425-cp313-cp313-win_amd64.whl", hash = "sha256:84358430ee89d5745f7b8d70ce1f8c72f467a6562b9c91ebdb6893d86c8722d6" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3938f459c54278134555a948fe8c23e82b1652424b54e1eaaf67dbacd1f0a904" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd38be3e24c8eeffcd6abacefe8348ef1a5bfe514f3ff399b011ec17f607a38" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-win_amd64.whl", hash = "sha256:6ca46cbbf830dee36a853f06531d132f515d6179c8c4ad12ad347b8a28dd676e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1bd41d060b1ae7bcdd411ea0adb9ff1688cc1d6d5018eeddd4298e6edfe59776" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c632c9a32e3e7cd9a21e9545d08ac9efa81a2404d64474aeff5633319d149e52" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-win_amd64.whl", hash = "sha256:6484003d833b2da3c372bac66c7e0835bc00b9c84c6054ed02c0614185b494bd" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c45356bc07b7c3bf89554040811e5cb7f8da3ce6ea8ed16d09466449600184dc" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe93bc7f286b811fbd873f7749f630eb2ef0920a7e39e8dce55ac5db2c78f725" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-win_amd64.whl", hash = "sha256:2b50fdefa1feb49a8191e10fe5c0c57a34f04df781827978dbdac74d42511f78" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:218b0760ba117f7715338b9b3fbcd1845c27defe1f303c933459891c1ee99da1" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89231cf2933534eb076df588e185af23f61611a9c4d6d28c238cd7ec398e2d56" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-win_amd64.whl", hash = "sha256:ef7ba14ada07b93a0e127ccfa1a5cceee695e31950866ef7c12e3fc49ce78d31" },
 ]
 
 [[package]]
@@ -2192,10 +2192,10 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/ca/1b/8a993e23223583c2f0f019291eab18452f5904393ab7d84027600ae76d1c/mujoco_uni-3.8.0rc2.tar.gz", hash = "sha256:207752265d5711a2adea2eb2091399d5e3b09efc943651b99e0da4fad2bbae96", size = 4817164, upload-time = "2026-05-08T11:49:45.230Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/ca/1b/8a993e23223583c2f0f019291eab18452f5904393ab7d84027600ae76d1c/mujoco_uni-3.8.0rc2.tar.gz", hash = "sha256:207752265d5711a2adea2eb2091399d5e3b09efc943651b99e0da4fad2bbae96", size = 4817164, upload-time = "2026-05-08T11:49:45.23Z" }
 wheels = [
     { url = "https://test-files.pythonhosted.org/packages/f2/27/23e419d67b0ce6215d341f36c43d13d1074db7cb63da86375677ff049235/mujoco_uni-3.8.0rc2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b7bfede16b2739dbd65959c9d01640f8c97fc4a3b2b08341a22f4b6ccfece72", size = 7063184, upload-time = "2026-05-08T11:49:20.173Z" },
-    { url = "https://test-files.pythonhosted.org/packages/f2/da/ad52769d4f5925bd871ca3c1809d79c6eeee823140f8f787b5d95afd11bb/mujoco_uni-3.8.0rc2-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:fd8f2972e806fedc177611fb438035e11fa24565949e07c0beea3e07960352b7", size = 10774427, upload-time = "2026-05-08T11:44:48.400Z" },
+    { url = "https://test-files.pythonhosted.org/packages/f2/da/ad52769d4f5925bd871ca3c1809d79c6eeee823140f8f787b5d95afd11bb/mujoco_uni-3.8.0rc2-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:fd8f2972e806fedc177611fb438035e11fa24565949e07c0beea3e07960352b7", size = 10774427, upload-time = "2026-05-08T11:44:48.4Z" },
     { url = "https://test-files.pythonhosted.org/packages/35/94/122781be2e2978c0625acfdb568a14df3f967a5167bf6a1c44d92e613283/mujoco_uni-3.8.0rc2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2654e4ae5e469020ef4c94c9a2ea5b97681ffa0042268220c5adcfb0d24ce509", size = 7076439, upload-time = "2026-05-08T11:49:28.708Z" },
     { url = "https://test-files.pythonhosted.org/packages/09/52/641fe3153eab87e701f4ff6b3ec373e1199e6b21bc9c22fa0d031dae3f70/mujoco_uni-3.8.0rc2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:a062794854124e666bddccd0bd61a0504afaf6c73de12b74d08436b534d54e35", size = 10788833, upload-time = "2026-05-08T11:44:59.398Z" },
     { url = "https://test-files.pythonhosted.org/packages/e3/c1/9affa3467899ee477169f33e9685e2fa9520c33ee708984e9e4c71c6024c/mujoco_uni-3.8.0rc2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:acde6afa7aa15c51015a587285cfbbee732284820c26f3472141693581b4a0eb", size = 7101749, upload-time = "2026-05-08T11:49:34.876Z" },
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [package.optional-dependencies]
 motrix = [
-    { name = "motrixsim" },
+    { name = "motrixsim-core" },
 ]
 viser = [
     { name = "trimesh" },
@@ -4474,7 +4474,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim", marker = "extra == 'motrix'", specifier = "==0.7.1.dev96425", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev99744", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- add native Motrix system-camera frame capture for both headless and interactive playback
- unify playback renderer initialization around `headless` and `capture`, with recording controlled separately by `training.play_record_video`
- add user-facing playback controls: `training.play_headless` and `training.play_record_video`
- route PPO/APPO/MLX/off-policy/HORA play paths through the explicit playback controls
- update Motrix extra to `motrixsim-core==0.7.1.dev99744`

Fixes #352

## Validation
- `uv run ruff format --check .`
- `uv run ruff check src/unilab/base/backend/base.py src/unilab/base/base.py src/unilab/base/np_env.py src/unilab/base/backend/motrix_backend.py src/unilab/visualization/playback.py tests/training/test_training_helpers.py tests/base/test_backend_pre_step_control.py`
- `uv run pytest tests/training/test_training_helpers.py tests/base/test_backend_pre_step_control.py -q`
- `uv run pytest tests/scripts/test_train_scripts.py -q`
- `uv run pytest tests/base/test_sim_backend_smoke.py::test_motrix_backend_smoke_contract -q`

Playback smoke matrix:
- Motrix `play_headless=true`, `play_record_video=true`: generated `play_video.mp4`
- Motrix `play_headless=false`, `play_record_video=true`: generated `play_video.mp4`
- Motrix `play_headless=true`, `play_record_video=false`: playback completed without writing video
- Motrix `play_headless=false`, `play_record_video=false`: playback completed without writing video
- MuJoCo `play_headless=true`, `play_record_video=true`: generated `play_video.mp4`
- MuJoCo `play_headless=true`, `play_record_video=false`: expected failure, `MuJoCo play rendering requires record_video=true.`
- MuJoCo `play_headless=false`, `play_record_video=true`: expected failure, `MuJoCo play mode does not support interactive rendering here.`
