### PR TITLE
fix: silence motrix profiler import on mujoco paths

### DIFF
--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -1,7 +1,6 @@
 from typing import Any, cast
 
 from .base import SimBackend
-from .motrix_backend import MOTRIX_AVAILABLE, MotrixBackend
 from .xml import (
     add_sensor,
     create_discardvisual_xml,
@@ -19,6 +18,12 @@ def _load_mujoco_backend() -> Any:
     from .mujoco_backend import MuJoCoBackend
 
     return MuJoCoBackend
+
+
+def _load_motrix_backend() -> tuple[Any, bool]:
+    from .motrix_backend import MOTRIX_AVAILABLE, MotrixBackend
+
+    return MotrixBackend, bool(MOTRIX_AVAILABLE)
 
 
 def create_backend(
@@ -43,9 +48,10 @@ def create_backend(
             kwargs["position_actuator_gains"] = position_actuator_gains
         return cast(SimBackend, MuJoCoBackend(model_file, num_envs, sim_dt, **kwargs))
     elif backend_type == "motrix":
-        if not MOTRIX_AVAILABLE:
+        MotrixBackend, motrix_available = _load_motrix_backend()
+        if not motrix_available:
             raise ImportError("MotrixSim not available, install motrixsim package")
-        return MotrixBackend(model_file, num_envs, sim_dt, **kwargs)
+        return cast(SimBackend, MotrixBackend(model_file, num_envs, sim_dt, **kwargs))
     else:
         raise ValueError(f"Unknown backend: {backend_type}")
 
@@ -53,6 +59,10 @@ def create_backend(
 def __getattr__(name: str):
     if name == "MuJoCoBackend":
         return _load_mujoco_backend()
+    if name == "MotrixBackend":
+        return _load_motrix_backend()[0]
+    if name == "MOTRIX_AVAILABLE":
+        return _load_motrix_backend()[1]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/tests/base/test_backend_imports.py
+++ b/tests/base/test_backend_imports.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_mujoco_backend_import_path_does_not_eagerly_import_motrix() -> None:
+    code = textwrap.dedent(
+        """
+        import importlib.util
+        import sys
+
+        from unilab.base.backend import create_backend, materialize_scene_visual_override
+        from unilab.base.backend.xml import create_discardvisual_xml
+
+        assert create_backend is not None
+        assert materialize_scene_visual_override is not None
+        assert create_discardvisual_xml is not None
+
+        if importlib.util.find_spec("mujoco") is not None:
+            import unilab.base.backend.mujoco_backend
+            print("mujoco_backend imported")
+        else:
+            print("mujoco_backend skipped")
+
+        print("motrix_backend", "unilab.base.backend.motrix_backend" in sys.modules)
+        print("motrixsim", "motrixsim" in sys.modules)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Motphys profiler initialized" not in result.stdout + result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] in {"mujoco_backend imported", "mujoco_backend skipped"}
+    assert lines[1:] == ["motrix_backend False", "motrixsim False"]


### PR DESCRIPTION
Fixes #399

Summary:
- Lazy-load Motrix backend from unilab.base.backend so MuJoCo/XML imports no longer import motrixsim.
- Keep Motrix backend access available through create_backend("motrix") and module getattr.
- Add a subprocess regression test for the MuJoCo backend import path.

Validation:
- uv run scripts/train_rsl_rl.py task=go2_joystick_flat/mujoco training.play_only=true training.play_steps=1 training.play_env_num=1 algo.load_run=2026-05-02_21-57-36_mujoco algo.checkpoint=150
- make test-all