### PR TITLE
fix: align Motrix hfield row direction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.7.1.dev99744"]
+motrix = ["motrixsim-core==0.7.1.dev100045"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/src/unilab/base/backend/motrix_scene.py
+++ b/src/unilab/base/backend/motrix_scene.py
@@ -152,8 +152,10 @@ def materialize_motrix_hfield_attached_scene(
     # MotrixSim's hfield source uses MuJoCo-style X/Y half extents.
     hfield.size = [float(generated.hfield_size[0]), float(generated.hfield_size[1])]
     hfield.height_scale = float(generated.height_extent)
+    # MotrixSim buffers use compiled hfield row order: row 0 is the -Y side.
+    hfield_data = np.ascontiguousarray(np.flipud(generated.heights_yx).astype(np.float32))
     hfield.source_type = msd.HFieldSourceType.buffer(
-        np.ascontiguousarray(generated.heights_yx.astype(np.float32).reshape(-1)),
+        hfield_data.reshape(-1),
         f"{hfield_name}_buffer",
     )
     world.assets.hfields[hfield_name] = hfield
@@ -181,6 +183,5 @@ def materialize_motrix_hfield_attached_scene(
         add_motrix_tracking_frame_sensors(world, base_name=base_name)
 
     if return_surface_sampler:
-        # TODO(motrixsim): remove flip_y once MotrixSim hfield Y convention aligns with MuJoCo.
-        return msd.build(world), generated.terrain_origins, generated.surface_sampler(flip_y=True)
+        return msd.build(world), generated.terrain_origins, generated.surface_sampler()
     return msd.build(world), generated.terrain_origins

--- a/src/unilab/terrains/terrain_generator.py
+++ b/src/unilab/terrains/terrain_generator.py
@@ -109,13 +109,12 @@ class GeneratedTerrain:
         normalized = (self.heights_yx - self.z_min) / span
         return np.rint(np.clip(normalized, 0.0, 1.0) * np.iinfo(np.uint16).max).astype(np.uint16)
 
-    def surface_sampler(self, *, flip_y: bool = False) -> "HeightfieldSurfaceSampler":
+    def surface_sampler(self) -> "HeightfieldSurfaceSampler":
         return HeightfieldSurfaceSampler(
             heights_uint16=self.to_uint16(),
             horizontal_scale=float(self.horizontal_scale),
             z_min=float(self.z_min),
             height_extent=float(self.height_extent),
-            flip_y=bool(flip_y),
         )
 
     def write_png(self, path: Path) -> None:
@@ -141,7 +140,6 @@ class HeightfieldSurfaceSampler:
     horizontal_scale: float
     z_min: float
     height_extent: float
-    flip_y: bool = False
 
     @property
     def size(self) -> tuple[float, float]:
@@ -157,8 +155,7 @@ class HeightfieldSurfaceSampler:
         size_x, size_y = self.size
         rows_y, cols_x = self.heights_uint16.shape
         cols = np.rint((flat[:, 0] + size_x * 0.5) / self.horizontal_scale).astype(np.intp)
-        y = flat[:, 1] if self.flip_y else -flat[:, 1]
-        rows = np.rint((y + size_y * 0.5) / self.horizontal_scale).astype(np.intp)
+        rows = np.rint((-flat[:, 1] + size_y * 0.5) / self.horizontal_scale).astype(np.intp)
         cols = np.clip(cols, 0, cols_x - 1)
         rows = np.clip(rows, 0, rows_y - 1)
 

--- a/tests/terrains/test_terrain_generator.py
+++ b/tests/terrains/test_terrain_generator.py
@@ -108,21 +108,6 @@ def test_generated_terrain_surface_sampler_uses_world_xy():
     assert sampled == pytest.approx(origin[2], abs=1e-4)
 
 
-def test_heightfield_surface_sampler_can_flip_world_y():
-    cfg = _small_rough_cfg()
-    cfg.border_width = 0.0
-    terrain = TerrainGenerator(cfg).generate()
-    sampler = terrain.surface_sampler(flip_y=True)
-    reference = terrain.surface_sampler()
-
-    xy = np.asarray([[1.25, -2.75], [-3.5, 4.25]], dtype=np.float64)
-
-    np.testing.assert_allclose(
-        sampler.sample_height(xy),
-        reference.sample_height(xy * np.asarray([1.0, -1.0])),
-    )
-
-
 @pytest.mark.parametrize("preset_name", sorted(EXPECTED_PRESETS))
 def test_each_preset_produces_heightfield(preset_name):
     rng = np.random.default_rng(42)

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -203,3 +203,40 @@ def test_materialize_motrix_hfield_attached_scene_composes_robot_and_task_fragme
     assert model.num_sensors >= 23
     assert model.get_body("base") is not None
     assert model.get_link("base") is not None
+
+
+def test_materialize_motrix_hfield_row_direction_uses_compiled_order() -> None:
+    pytest.importorskip("motrixsim")
+
+    import copy
+
+    import numpy as np
+
+    from unilab.terrains import ROUGH_TERRAINS_CFG, TerrainGenerator
+
+    cfg = copy.deepcopy(ROUGH_TERRAINS_CFG)
+    cfg.num_rows = 2
+    cfg.num_cols = 2
+    cfg.border_width = 0.0
+    cfg.add_lights = False
+    cfg.seed = 123
+
+    generated = TerrainGenerator(cfg).generate()
+    motrix_model, _, motrix_sampler = materialize_motrix_hfield_attached_scene(
+        model_file=_go2_robot(),
+        terrain_cfg=cfg,
+        fragment_files=[_go2_locomotion_task()],
+        return_surface_sampler=True,
+    )
+
+    motrix_heights = motrix_model.get_hfield("terrain_hfield").height_matrix
+
+    expected_hfield = np.flipud(generated.heights_yx - generated.z_min)
+    np.testing.assert_allclose(motrix_heights, expected_hfield, atol=1e-6)
+
+    xy = np.asarray([[0.0, -2.0], [0.0, 2.0], [2.0, -2.0], [-2.0, 2.0]], dtype=np.float64)
+    np.testing.assert_allclose(
+        motrix_sampler.sample_height(xy),
+        generated.surface_sampler().sample_height(xy),
+        atol=1e-6,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2111,7 +2111,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.7.1.dev99744"
+version = "0.7.1.dev100045"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2119,18 +2119,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3938f459c54278134555a948fe8c23e82b1652424b54e1eaaf67dbacd1f0a904" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd38be3e24c8eeffcd6abacefe8348ef1a5bfe514f3ff399b011ec17f607a38" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp310-cp310-win_amd64.whl", hash = "sha256:6ca46cbbf830dee36a853f06531d132f515d6179c8c4ad12ad347b8a28dd676e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1bd41d060b1ae7bcdd411ea0adb9ff1688cc1d6d5018eeddd4298e6edfe59776" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c632c9a32e3e7cd9a21e9545d08ac9efa81a2404d64474aeff5633319d149e52" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp311-cp311-win_amd64.whl", hash = "sha256:6484003d833b2da3c372bac66c7e0835bc00b9c84c6054ed02c0614185b494bd" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c45356bc07b7c3bf89554040811e5cb7f8da3ce6ea8ed16d09466449600184dc" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe93bc7f286b811fbd873f7749f630eb2ef0920a7e39e8dce55ac5db2c78f725" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp312-cp312-win_amd64.whl", hash = "sha256:2b50fdefa1feb49a8191e10fe5c0c57a34f04df781827978dbdac74d42511f78" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:218b0760ba117f7715338b9b3fbcd1845c27defe1f303c933459891c1ee99da1" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89231cf2933534eb076df588e185af23f61611a9c4d6d28c238cd7ec398e2d56" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev99744-cp313-cp313-win_amd64.whl", hash = "sha256:ef7ba14ada07b93a0e127ccfa1a5cceee695e31950866ef7c12e3fc49ce78d31" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63fafe0f4376e6cb8126b415716f60b61bfc276f1213d518cede250b7d3aa180" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530e9b446d60852ccc0ebb5f1f4b88bbedfa5f3e43090486b55bd6b69a5152ab" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-win_amd64.whl", hash = "sha256:b69fe0d4749ec960403675cdb1c092a5773db0284726e97941841b90f8ebc631" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa4e73332f8bb8d8f23fc2e36aa85f06a1bca1ac6441d19c17b6f379a5f06e6f" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be344aacd75379c4c4046676da576fa74b89de0783c41a17e4c1127ada3cd03e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-win_amd64.whl", hash = "sha256:b09132e505d4d9de47bb218cb2f2eb1ce2d278476a91635c8e3875cf31eab1cb" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8981b60915b0dff60f21acbb0cd99e2e3ea95ba6b178347740a55c9fef363c7c" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3f6ed40c4eca1c7bbf9dbffccb03bab7c7ec21684f256bbf4aed0e58801e28d" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-win_amd64.whl", hash = "sha256:7e07b794f8317b052a5c79e3b772aaa77d56aa9b9bc575daf419be57e2776e18" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd88a4b758eac62353781e571c1a057ff10d385818e593b282182d5bec04689a" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45be548bcad7da56ff4134b58055a9f3ed24ad2a8ad3e18dc41462c16cc7e4c6" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-win_amd64.whl", hash = "sha256:ce3e4a757adb00cb1f94eea6d5c1b0e36d454fbfca51bf874cc474bfb78cbc6e" },
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev99744", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev100045", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- Upgrade the Motrix extra to `motrixsim-core==0.7.1.dev100045`.
- Feed generated Motrix hfield buffers in compiled row order (`row 0 = -Y`) and remove the old Motrix-only `surface_sampler(flip_y=True)` shim.
- Remove the now-unused `flip_y` branch from `GeneratedTerrain.surface_sampler()` and add a Motrix hfield row-direction regression test.

Fixes #419

## Validation

- `make test-all`

Additional manual smoke test run before this PR:

```bash
uv run --extra motrix scripts/train_rsl_rl.py task=go2_joystick_rough/motrix training.play_only=true training.play_steps=10000 training.play_headless=false training.play_record_video=false
```
