### PR TITLE
  fix:SAC stabilization and fix noise

### DIFF
--- a/conf/appo/task/g1_walk_flat/mujoco.yaml
+++ b/conf/appo/task/g1_walk_flat/mujoco.yaml
@@ -10,6 +10,11 @@ env:
     action_scale: 0.25
   curriculum:
     enabled: false
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
@@ -25,6 +25,7 @@ env:
     level_up_threshold: 750.0
     degree: 0.001
   noise_config:
+    level: 1.0
     scale_gyro: 0.0
     scale_gravity: 0.0
     scale_joint_angle: 0.01

--- a/conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml
@@ -24,6 +24,12 @@ env:
     action_scale: 2.0
   anchor_pos_z_threshold: 0.5
   ee_body_pos_z_threshold: 0.5
+  truncate_on_clip_end: true
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     motion_global_root_pos: 1.0

--- a/conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml
+++ b/conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml
@@ -27,6 +27,7 @@ env:
     action_scale: 2.0
   anchor_pos_z_threshold: 0.5
   ee_body_pos_z_threshold: 0.5
+  truncate_on_clip_end: true
   # Domain randomization switches — aligned with Domain_Rand fields available
   # to G1MotionTrackingEnv (see src/unilab/envs/motion_tracking/g1/tracking.py).
   domain_rand:
@@ -44,6 +45,11 @@ env:
     kp_multiplier_range: [0.9, 1.1]
     randomize_kd: true
     kd_multiplier_range: [0.9, 1.1]
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     motion_global_root_pos: 1.0

--- a/conf/offpolicy/task/sac/g1_walk_flat/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_flat/motrix.yaml
@@ -23,6 +23,11 @@ env:
     level_down_threshold: 150.0
     level_up_threshold: 750.0
     degree: 0.001
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     tracking_lin_vel: 2.2

--- a/conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml
@@ -26,6 +26,7 @@ env:
     level_up_threshold: 750.0
     degree: 0.001
   noise_config:
+    level: 1.0
     scale_gyro: 0.0
     scale_gravity: 0.0
     scale_joint_angle: 0.01

--- a/conf/offpolicy/task/sac/g1_walk_rough/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_rough/mujoco.yaml
@@ -26,6 +26,7 @@ env:
     level_up_threshold: 750.0
     degree: 0.001
   noise_config:
+    level: 1.0
     scale_gyro: 0.0
     scale_gravity: 0.0
     scale_joint_angle: 0.01

--- a/conf/offpolicy/task/td3/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/td3/g1_walk_flat/mujoco.yaml
@@ -18,6 +18,7 @@ env:
     level_up_threshold: 750.0
     degree: 0.001
   noise_config:
+    level: 1.0
     scale_gyro: 0.0
     scale_gravity: 0.0
     scale_joint_angle: 0.01

--- a/conf/ppo/task/g1_motion_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking/motrix.yaml
@@ -13,6 +13,11 @@ algo:
       - actor
   algorithm:
     entropy_coef: 0.005
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 play_profile:
   enabled: true
   env:

--- a/conf/ppo/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking/mujoco.yaml
@@ -24,7 +24,6 @@ reward:
     motion_joint_vel: 0.0
     action_rate_l2: -0.1
     joint_limit: -10.0
-    undesired_contacts: -0.1
   std_root_pos: 0.3
   std_root_ori: 0.4
   std_body_pos: 0.3

--- a/conf/ppo/task/g1_walk_flat/motrix.yaml
+++ b/conf/ppo/task/g1_walk_flat/motrix.yaml
@@ -28,6 +28,11 @@ env:
   reset_base_qvel_limit: 0.05
   curriculum:
     enabled: false
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/conf/ppo/task/g1_walk_flat/mujoco.yaml
+++ b/conf/ppo/task/g1_walk_flat/mujoco.yaml
@@ -13,6 +13,11 @@ env:
     action_scale: 0.25
   curriculum:
     enabled: false
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/src/unilab/envs/locomotion/g1/base.py
+++ b/src/unilab/envs/locomotion/g1/base.py
@@ -13,10 +13,10 @@ from unilab.envs.locomotion.common.base import (
 
 @dataclass
 class NoiseConfig:
-    level: float = 1.0
-    scale_joint_angle: float = 0.01
-    scale_joint_vel: float = 1.5
-    scale_gyro: float = 0.2
+    level: float = 0.0
+    scale_joint_angle: float = 0.02
+    scale_joint_vel: float = 0.3
+    scale_gyro: float = 0.1
     scale_gravity: float = 0.05
     scale_linvel: float = 0.1
 

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -58,7 +58,6 @@ class RewardConfig:
             "motion_joint_vel": 0.0,
             "action_rate_l2": -0.1,
             "joint_limit": -10.0,
-            "undesired_contacts": -0.1,
         }
     )
     # Standard deviations for exponential rewards
@@ -593,30 +592,31 @@ class G1MotionTrackingEnv(G1BaseEnv):
         joint_pos_rel = dof_pos - self.default_angles
         last_actions = info.get("current_actions", np.zeros_like(joint_pos_rel))
 
-        # Per-step observation noise on sensor channels
+        # Per-step observation noise on sensor channels (actor only).
+        # Critic uses the clean originals — asymmetric actor–critic contract.
         noise_cfg = self._cfg.noise_config
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        joint_pos_rel = self._obs_noise(joint_pos_rel, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        noisy_linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_joint_pos_rel = self._obs_noise(joint_pos_rel, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
 
-        # Actor observations
+        # Actor observations (noisy proprioception)
         actor_obs = np.concatenate(
             [
                 command,
                 motion_anchor_pos_b,
                 motion_anchor_ori_b,
-                linvel,
-                gyro,
-                joint_pos_rel,
-                dof_vel,
+                noisy_linvel,
+                noisy_gyro,
+                noisy_joint_pos_rel,
+                noisy_dof_vel,
                 last_actions,
             ],
             axis=1,
             dtype=get_global_dtype(),
         )
 
-        # Robot body positions in robot anchor frame (critic-only) — vectorized
+        # Robot body positions in robot anchor frame (critic-only privileged) — vectorized
         n_body = len(self._cfg.body_names)
         # Flatten (N, B, *) -> (N*B, *) for batched frame transform
         anchor_pos_tiled = np.tile(robot_anchor_pos_w, (1, n_body)).reshape(num_envs * n_body, 3)
@@ -640,7 +640,22 @@ class G1MotionTrackingEnv(G1BaseEnv):
             dtype=get_global_dtype(),
         )
 
-        critic_obs = np.concatenate([actor_obs, critic_extra], axis=1, dtype=get_global_dtype())
+        # Critic observations (clean proprioception + privileged body transforms)
+        critic_obs = np.concatenate(
+            [
+                command,
+                motion_anchor_pos_b,
+                motion_anchor_ori_b,
+                linvel,
+                gyro,
+                joint_pos_rel,
+                dof_vel,
+                last_actions,
+                critic_extra,
+            ],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
         return {"obs": actor_obs, "critic": critic_obs}
 
     def _compute_reward(


### PR DESCRIPTION
Summary

- Noise defaults reset to zero in NoiseConfig: in src/unilab/envs/locomotion/g1/base.py, level is now 0.0 by default with smaller per-channel scales — observation noise is now opt-in per task instead of always-on from code defaults.
- Per-task noise_config blocks added to PPO/APPO/SAC/TD3/FlashSAC configs for g1_walk_flat, g1_walk_rough, g1_sac_wbt, and g1_motion_tracking (mujoco + motrix), restoring level: 1.0 with the previous scales where training/eval expects noise.
- Asymmetric actor–critic split in motion tracking (src/unilab/envs/motion_tracking/g1/tracking.py): actor now consumes noisy proprioception; critic receives clean originals plus privileged body transforms.
- SAC WBT mujoco configs now set truncate_on_clip_end: true.
- Removed undesired_contacts: -0.1 reward from g1_motion_tracking (config + RewardConfig default).

Validation

- [x]  make check
- [x]  uv run pytest -m "not slow"
- [x]  SAC training run on g1_walk_flat / g1_sac_wbt verified
- [x]  Motion-tracking rollout verified with noise on actor only
- [x] Commands actually run:


# paste exact commands here
Impact
Backend impact: mujoco (plus motrix configs touched for parity)
Platform impact: both
Training effect expected: yes — noise is now opt-in per config, asymmetric obs in motion tracking changes critic input shape, and removing undesired_contacts changes the reward landscape
Checklist

- [ ] - Added or updated tests where needed
- [ ] -  Updated docs if behavior or workflow changed
- [ ] -  Linked the driving issue
- [x] -  Noted any follow-up work explicitly — callout: any downstream config that relied on the old non-zero NoiseConfig defaults must now declare noise_config explicitly, or it will train without observation noise.