### PR TITLE
feat: add Motrix task yaml configs

### DIFF
--- a/conf/offpolicy/task/sac/g1_walk_rough/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_rough/motrix.yaml
@@ -4,7 +4,7 @@ training:
   sim_backend: motrix
 algo:
   num_envs: 2048
-  learning_starts: 10
+  learning_starts: 1
   max_iterations: 5000
   save_interval: 1000
   updates_per_step: 8
@@ -28,29 +28,23 @@ env:
     level_down_threshold: 150.0
     level_up_threshold: 750.0
     degree: 0.001
-  noise_config:
-    scale_gyro: 0.0
-    scale_gravity: 0.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 0.1
-    scale_linvel: 0.0
 reward:
   scales:
-    tracking_lin_vel: 2.0
-    tracking_ang_vel: 1.5
-    penalty_ang_vel_xy: -1.0
-    penalty_orientation: -10.0
-    penalty_action_rate: -4.0
-    pose: -0.5
-    penalty_feet_ori: -20.0
-    feet_phase: 5.0
-    alive: 10.0
+    tracking_lin_vel: 2.2
+    tracking_ang_vel: 1.8
+    penalty_ang_vel_xy: -1.2
+    penalty_orientation: -12.0
+    penalty_action_rate: -2.5
+    pose: -0.6
+    penalty_feet_ori: -5.0
+    feet_phase: 6.0
+    alive: 12.0
   tracking_sigma: 0.25
   base_height_target: 0.754
   min_base_height: 0.3
   max_tilt_deg: 65.0
   gait_frequency: 1.5
   feet_phase_swing_height: 0.09
-  feet_phase_tracking_sigma: 0.04
+  feet_phase_tracking_sigma: 0.008
   close_feet_threshold: 0.15
   pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/conf/offpolicy/task/sac/g1_walk_rough/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_rough/motrix.yaml
@@ -1,10 +1,10 @@
 # @package _global_
 training:
-  task_name: G1WalkFlat
+  task_name: G1WalkRough
   sim_backend: motrix
 algo:
   num_envs: 2048
-  learning_starts: 1
+  learning_starts: 10
   max_iterations: 5000
   save_interval: 1000
   updates_per_step: 8
@@ -28,23 +28,29 @@ env:
     level_down_threshold: 150.0
     level_up_threshold: 750.0
     degree: 0.001
+  noise_config:
+    scale_gyro: 0.0
+    scale_gravity: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.1
+    scale_linvel: 0.0
 reward:
   scales:
-    tracking_lin_vel: 2.2
-    tracking_ang_vel: 1.8
-    penalty_ang_vel_xy: -1.2
-    penalty_orientation: -12.0
-    penalty_action_rate: -2.5
-    pose: -0.6
-    penalty_feet_ori: -5.0
-    feet_phase: 6.0
-    alive: 12.0
+    tracking_lin_vel: 2.0
+    tracking_ang_vel: 1.5
+    penalty_ang_vel_xy: -1.0
+    penalty_orientation: -10.0
+    penalty_action_rate: -4.0
+    pose: -0.5
+    penalty_feet_ori: -20.0
+    feet_phase: 5.0
+    alive: 10.0
   tracking_sigma: 0.25
   base_height_target: 0.754
   min_base_height: 0.3
   max_tilt_deg: 65.0
   gait_frequency: 1.5
   feet_phase_swing_height: 0.09
-  feet_phase_tracking_sigma: 0.008
+  feet_phase_tracking_sigma: 0.04
   close_feet_threshold: 0.15
   pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/conf/ppo/task/g1_walk_flat/motrix.yaml
+++ b/conf/ppo/task/g1_walk_flat/motrix.yaml
@@ -4,11 +4,13 @@ training:
   sim_backend: motrix
 algo:
   num_envs: 2048
-  max_iterations: 220
+  max_iterations: 2200
   empirical_normalization: true
   obs_groups:
     actor:
       - policy
+    critic:
+      - critic
   policy:
     init_noise_std: 0.5
   algorithm:

--- a/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
@@ -2,7 +2,9 @@
 training:
   task_name: G1WallFlipTracking
   sim_backend: motrix
-  play_steps: 1000
+  play_env_num: 16
+  play_steps: 10000
+  render_spacing: 3.0
 algo:
   num_envs: 1024
   max_iterations: 30000
@@ -12,6 +14,19 @@ algo:
       - actor
   algorithm:
     entropy_coef: 0.005
+env:
+  motrix_max_iterations: 3
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 4.0
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/g1/scene_flat_with_wall.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
 reward:
   scales:
     motion_global_root_pos: 1.0

--- a/conf/ppo/task/go2w_joystick_rough_tiles/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_rough_tiles/motrix.yaml
@@ -1,0 +1,76 @@
+# @package _global_
+training:
+  task_name: Go2WJoystickRoughTiles
+  sim_backend: motrix
+algo:
+  num_envs: 1024
+  num_steps_per_env: 48
+  max_iterations: 5000
+  empirical_normalization: false
+  obs_groups:
+    actor:
+      - actor
+    critic:
+      - critic
+  policy:
+    init_noise_std: 0.5
+    actor_hidden_dims: [512, 256, 128]
+    critic_hidden_dims: [512, 256, 128]
+  algorithm:
+    learning_rate: 1.0e-3
+    entropy_coef: 1.0e-3
+env:
+  render_offset_mode: zero
+  scene:
+  model_file: src/unilab/assets/robots/go2w/scene_rough_tiles_motrix.xml
+  commands:
+    vel_limit:
+      - [-1.0, -0.6, -1.0]
+      - [1.0, 0.6, 1.0]
+    resampling_time: 10.0
+    heading_command: true
+    heading_range: [-3.14, 3.14]
+  control_config:
+    action_scale: 0.25
+    wheel_action_scale: 10.0
+    Kp: 40.0
+    Kd: 1.0
+    wheel_Kd: 0.5
+    simulate_action_latency: false
+  terrain_scan:
+    enabled: false
+    hfield_name: go2w_tile_stairs_5x5
+    geom_name: terrain_scan_probe
+  domain_rand:
+    randomize_base_mass: true
+    added_mass_range: [-1.0, 2.0]
+    random_com: true
+    com_offset_x: [-0.05, 0.05]
+    randomize_kp: true
+    kp_multiplier_range: [0.9, 1.1]
+    randomize_kd: true
+    kd_multiplier_range: [0.9, 1.1]
+    randomize_init_yaw: false
+    init_yaw_range: [0.0, 0.0]
+    push_robots: false
+    push_body_name: base_link
+reward:
+  scales:
+    tracking_lin_vel: 1.5
+    tracking_ang_vel: 0.75
+    lin_vel_z: -1.0
+    ang_vel_xy: -0.05
+    orientation: -0.5
+    base_height: -10.0
+    torques: -5.0e-4
+    dof_acc: -1.0e-7
+    dof_vel: -1.0e-7
+    wheel_acc: -1.0e-7
+    action_rate: -0.01
+    stand_still: -0.5
+    hip_pos: -0.5
+    dof_error: -0.05
+    alive: 0.0
+  tracking_sigma: 0.25
+  base_height_target: 0.4
+  only_positive_rewards: true

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -78,7 +78,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | APPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Registered |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |
 | SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | Tested |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -52,7 +52,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - |
-| PPO (torch) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Tested | - |
+| PPO (torch) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | PPO (torch) | `sharpa_inhand_grasp` (sharpa inhand grasp) | Tested | - |
 | PPO (mlx) | `go1_joystick_flat` (Go1 joystick) | Tested | Tested |
@@ -66,7 +66,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | - |
-| PPO (mlx) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Configured | - |
+| PPO (mlx) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand` (sharpa inhand) | Configured | - |
 | PPO (mlx) | `sharpa_inhand_grasp` (sharpa inhand grasp) | Configured | - |
 | APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | Registered |
@@ -78,7 +78,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | APPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Registered |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |
 | SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | Tested |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -52,7 +52,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - |
-| PPO (torch) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Tested | Tested |
+| PPO (torch) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Tested | - |
 | PPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | PPO (torch) | `sharpa_inhand_grasp` (sharpa inhand grasp) | Tested | - |
 | PPO (mlx) | `go1_joystick_flat` (Go1 joystick) | Tested | Tested |
@@ -66,7 +66,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | - |
-| PPO (mlx) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Configured | Configured |
+| PPO (mlx) | `go2w_joystick_rough_tiles` (go2w joystick rough tiles) | Configured | - |
 | PPO (mlx) | `sharpa_inhand` (sharpa inhand) | Configured | - |
 | PPO (mlx) | `sharpa_inhand_grasp` (sharpa inhand grasp) | Configured | - |
 | APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | Registered |
@@ -78,7 +78,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | APPO (torch) | `sharpa_inhand` (sharpa inhand) | Tested | - |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Registered |
 | SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | Tested |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -228,7 +228,7 @@ def test_ppo_g1_backend_specific_hyperparams_remain_separate():
     assert mujoco_cfg.algo.empirical_normalization is False
     assert mujoco_cfg.algo.obs_groups.actor == ["actor"]
 
-    assert motrix_cfg.algo.max_iterations == 220
+    assert motrix_cfg.algo.max_iterations == 2200
     assert motrix_cfg.algo.empirical_normalization is True
     assert motrix_cfg.algo.obs_groups.actor == ["policy"]
     assert OmegaConf.select(motrix_cfg, "env.motrix_max_iterations") is None

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -332,14 +332,14 @@ def test_ppo_go1_resolved_algo_matches_old_motrix_behavior():
     assert cfg.algo.algorithm.entropy_coef == pytest.approx(1.0e-3)
 
 
-def test_ppo_g1_resolved_algo_matches_old_motrix_behavior():
-    """Equivalence: PPO G1 algo hyperparams match pre-refactor motrix values.
+def test_ppo_g1_resolved_algo_matches_motrix_owner():
+    """Equivalence: PPO G1 algo hyperparams match the Motrix owner values.
 
     For this migration we align with the final UniLab1 Motrix runtime.
     """
     cfg = _ppo_cfg(["task=g1_walk_flat/motrix"])
 
-    assert cfg.algo.max_iterations == 220
+    assert cfg.algo.max_iterations == 2200
     assert cfg.algo.empirical_normalization is True
     assert cfg.algo.obs_groups.actor == ["policy"]
     assert cfg.algo.policy.init_noise_std == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Add Motrix YAML config for SAC G1 walk flat.
- Add Motrix YAML config for PPO G1 walk flat.
- Add and tune Motrix YAML config for SAC G1 walk rough (`conf/offpolicy/task/sac/g1_walk_rough/motrix.yaml`).
- Add Motrix YAML config for PPO Go2W joystick rough tiles.
- Add Motrix YAML config for PPO G1 wall flip tracking (`conf/ppo/task/g1_wall_flip_tracking/motrix.yaml`).
- Update config/script tests and generated support matrix for the Motrix owner configs.

## Linked Work
- Issue: N/A

## Validation
- [x] `uv run pytest tests/config/test_config_system.py::test_ppo_g1_backend_specific_hyperparams_remain_separate tests/scripts/test_train_scripts.py::test_ppo_g1_resolved_algo_matches_motrix_owner -q`
- [x] `uv run pytest tests/scripts/test_check_docs.py::test_documentation_files_match_current_repo_contracts -q`

## Impact
- Config and test update for Motrix task owner YAMLs.
- Keeps backend-specific behavior expressed through owner YAMLs and matching config tests.
