### PR TITLE
tune go2 handstand motrix config

### DIFF
--- a/conf/ppo/task/go2_handstand/motrix.yaml
+++ b/conf/ppo/task/go2_handstand/motrix.yaml
@@ -3,7 +3,12 @@ training:
   task_name: Go2HandStand
   sim_backend: motrix
 algo:
-  max_iterations: 151
+  num_envs: 1024
+  max_iterations: 3000
+  policy:
+    init_noise_std: 0.5
+  algorithm:
+    entropy_coef: 0.005
   obs_groups:
     actor:
       - actor
@@ -11,11 +16,15 @@ algo:
       - critic
 reward:
   scales:
-    contact: -0.1
+    contact: -0.5
     height: 1.0
     oritentation: 1.0
-    pose: -0.1
+    pose: -0.3
     penalty_contact: -0.2
+    action_rate: -0.01
+    tar: 0.3
+    feet_air_time: 1.0
+    world_z_vel_penalty: -1.0
   tracking_sigma: 0.25
   base_height_target: 0.3
 env:


### PR DESCRIPTION
## Summary

Update Motrix config for Go2HandStand by increasing training iterations and tuning PPO exploration/reward scales.

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [ ] Additional task-specific validation listed below

Commands actually run:

```bash
# paste exact commands here
```

## Impact

- Backend impact: `mujoco` / `motrix` / both / none
- Platform impact: macOS / Linux / both / unknown
- Training effect expected: yes / no / unknown

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [ ] Noted any follow-up work explicitly
