### PR TITLE
feat: support Motrix camera tracking

### DIFF
--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -25,6 +25,12 @@ except ImportError:
     MOTRIX_AVAILABLE = False
 
 from .base import BackendPlayCapabilities, SimBackend
+from .motrix_camera import (
+    MotrixTrackingCamera,
+    render_offsets,
+    resolve_system_camera_view,
+    tracking_camera_lookat,
+)
 
 T = TypeVar("T")
 DEFAULT_MOTRIX_MAX_ITERATIONS = 3
@@ -176,6 +182,8 @@ class MotrixBackend(SimBackend):
         self._render_app: "RenderApp | None" = None
         self._render_headless: bool | None = None
         self._render_capture_enabled = False
+        self._render_offsets_np: np.ndarray | None = None
+        self._render_tracking_camera: MotrixTrackingCamera | None = None
         self.backend_type = "motrix"
 
         # Pre-cache link objects to avoid repeated get_link() lookups.
@@ -503,47 +511,23 @@ class MotrixBackend(SimBackend):
         ex_force[:, 2] *= force_range[2]
         self._push_body_link.add_external_force(self._data, ex_force, local=True)
 
-    def _render_offsets(self, spacing: float, offset_mode: str = "grid") -> list[list[float]]:
-        if offset_mode == "zero":
-            return [[0.0, 0.0, 0.0] for _ in range(self._num_envs)]
-        if offset_mode != "grid":
-            raise ValueError(f"Unsupported Motrix render_offset_mode: {offset_mode!r}")
-        cols = int(np.ceil(np.sqrt(self._num_envs)))
-        offsets = []
-        for i in range(self._num_envs):
-            row = i // cols
-            col = i % cols
-            offsets.append([col * spacing, row * spacing, 0.0])
-        return offsets
-
-    def _resolve_system_camera_view(
-        self,
-        offsets: Sequence[Sequence[float]],
-        camera_kwargs: dict[str, Any] | None,
-    ) -> tuple[list[float], float, float, float]:
-        cam_kw = dict(camera_kwargs or {})
-        if bool(cam_kw.get("cam_tracking", False)):
-            raise NotImplementedError("Motrix native video capture does not support cam_tracking")
-
-        lookat_raw = cam_kw.get("cam_lookat")
-        if lookat_raw is None:
-            offsets_np = np.asarray(offsets, dtype=np.float64)
-            lookat = [
-                float(np.mean(offsets_np[:, 0])),
-                float(np.mean(offsets_np[:, 1])),
-                0.75,
-            ]
-        else:
-            lookat_arr = np.asarray(lookat_raw, dtype=np.float64).reshape(-1)
-            if lookat_arr.shape != (3,):
-                raise ValueError(f"cam_lookat must contain 3 values, got {lookat_raw!r}")
-            lookat = [float(lookat_arr[0]), float(lookat_arr[1]), float(lookat_arr[2])]
-
-        return (
+    def _update_tracking_camera_view(self) -> None:
+        if (
+            self._render_app is None
+            or self._render_tracking_camera is None
+            or self._render_offsets_np is None
+        ):
+            return
+        lookat = tracking_camera_lookat(
+            self.get_base_pos(),
+            self._render_tracking_camera,
+            self._render_offsets_np,
+        )
+        self._render_app.system_camera.set_view(
             lookat,
-            float(cam_kw.get("cam_distance", 2.0)),
-            float(cam_kw.get("cam_elevation", -20.0)),
-            float(cam_kw.get("cam_azimuth", 90.0)),
+            self._render_tracking_camera.distance,
+            self._render_tracking_camera.elevation,
+            self._render_tracking_camera.azimuth,
         )
 
     def _assert_render_context_available(self, *, headless: bool, capture: bool) -> None:
@@ -581,13 +565,29 @@ class MotrixBackend(SimBackend):
 
         settings = RenderSettings.performance()
         settings.enable_shadow = True
-        offsets = self._render_offsets(float(spacing), offset_mode=str(offset_mode))
+        offsets = render_offsets(
+            self._num_envs,
+            float(spacing),
+            offset_mode=str(offset_mode),
+        )
+        offsets_np = np.asarray(offsets, dtype=np.float64)
+        self._render_offsets_np = offsets_np
         use_configured_camera = capture or camera_kwargs is not None
         if use_configured_camera:
-            lookat, distance, elevation, azimuth = self._resolve_system_camera_view(
+            base_positions = (
+                self.get_base_pos()
+                if bool(dict(camera_kwargs or {}).get("cam_tracking", False))
+                else None
+            )
+            camera_view = resolve_system_camera_view(
+                self._num_envs,
+                base_positions,
                 offsets,
                 camera_kwargs,
             )
+            tracking_camera = camera_view.tracking
+        else:
+            tracking_camera = None
         if capture:
             self._model.cameras.set_system_render_target("image", int(width), int(height))
         render_app = RenderApp(headless=headless)
@@ -598,12 +598,18 @@ class MotrixBackend(SimBackend):
             render_settings=settings,
         )
         if use_configured_camera:
-            render_app.system_camera.set_view(lookat, distance, elevation, azimuth)
+            render_app.system_camera.set_view(
+                camera_view.lookat,
+                camera_view.distance,
+                camera_view.elevation,
+                camera_view.azimuth,
+            )
             if not capture:
                 render_app.set_main_camera(None)
         self._render_app = render_app
         self._render_headless = headless
         self._render_capture_enabled = capture
+        self._render_tracking_camera = tracking_camera
 
     def render(self):
         """Render current state (interactive visualization)"""
@@ -611,6 +617,7 @@ class MotrixBackend(SimBackend):
             self.init_renderer()
         self._assert_render_context_available(headless=False, capture=False)
         assert self._render_app is not None
+        self._update_tracking_camera_view()
         self._render_app.sync(data=self._data)
 
     def capture_video_frame(self) -> np.ndarray:
@@ -621,6 +628,7 @@ class MotrixBackend(SimBackend):
             raise RuntimeError("Motrix renderer is not initialized for video capture")
         assert self._render_app is not None
 
+        self._update_tracking_camera_view()
         task = self._render_app.system_camera.capture()
         self._render_app.sync(data=self._data, wait=True)
         image = task.take_image()

--- a/src/unilab/base/backend/motrix_camera.py
+++ b/src/unilab/base/backend/motrix_camera.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MotrixTrackingCamera:
+    env_idx: int
+    distance: float
+    elevation: float
+    azimuth: float
+
+
+@dataclass(frozen=True)
+class MotrixCameraView:
+    lookat: list[float]
+    distance: float
+    elevation: float
+    azimuth: float
+    tracking: MotrixTrackingCamera | None = None
+
+
+def render_offsets(num_envs: int, spacing: float, offset_mode: str = "grid") -> list[list[float]]:
+    if offset_mode == "zero":
+        return [[0.0, 0.0, 0.0] for _ in range(num_envs)]
+    if offset_mode != "grid":
+        raise ValueError(f"Unsupported Motrix render_offset_mode: {offset_mode!r}")
+    cols = int(np.ceil(np.sqrt(num_envs)))
+    offsets = []
+    for i in range(num_envs):
+        row = i // cols
+        col = i % cols
+        offsets.append([col * spacing, row * spacing, 0.0])
+    return offsets
+
+
+def tracking_camera_lookat(
+    base_positions: np.ndarray,
+    tracking_camera: MotrixTrackingCamera,
+    offsets: np.ndarray,
+) -> list[float]:
+    base_pos = np.asarray(base_positions[tracking_camera.env_idx], dtype=np.float64)
+    render_offset = np.asarray(offsets[tracking_camera.env_idx], dtype=np.float64)
+    lookat = base_pos + render_offset
+    return [float(lookat[0]), float(lookat[1]), float(lookat[2])]
+
+
+def resolve_system_camera_view(
+    num_envs: int,
+    base_positions: np.ndarray | None,
+    offsets: Sequence[Sequence[float]],
+    camera_kwargs: dict[str, Any] | None,
+) -> MotrixCameraView:
+    cam_kw = dict(camera_kwargs or {})
+    if bool(cam_kw.get("cam_tracking", False)):
+        if base_positions is None:
+            raise ValueError("base_positions is required when cam_tracking=true")
+        env_idx = int(cam_kw.get("cam_tracking_env_idx", 0))
+        env_idx = max(0, min(env_idx, num_envs - 1))
+        tracking_camera = MotrixTrackingCamera(
+            env_idx=env_idx,
+            distance=float(cam_kw.get("cam_distance", 2.0)),
+            elevation=float(cam_kw.get("cam_elevation", -20.0)),
+            azimuth=float(cam_kw.get("cam_azimuth", 90.0)),
+        )
+        lookat = tracking_camera_lookat(
+            base_positions,
+            tracking_camera,
+            np.asarray(offsets, dtype=np.float64),
+        )
+        return MotrixCameraView(
+            lookat=lookat,
+            distance=tracking_camera.distance,
+            elevation=tracking_camera.elevation,
+            azimuth=tracking_camera.azimuth,
+            tracking=tracking_camera,
+        )
+
+    lookat_raw = cam_kw.get("cam_lookat")
+    if lookat_raw is None:
+        offsets_np = np.asarray(offsets, dtype=np.float64)
+        lookat = [
+            float(np.mean(offsets_np[:, 0])),
+            float(np.mean(offsets_np[:, 1])),
+            0.75,
+        ]
+    else:
+        lookat_arr = np.asarray(lookat_raw, dtype=np.float64).reshape(-1)
+        if lookat_arr.shape != (3,):
+            raise ValueError(f"cam_lookat must contain 3 values, got {lookat_raw!r}")
+        lookat = [float(lookat_arr[0]), float(lookat_arr[1]), float(lookat_arr[2])]
+
+    return MotrixCameraView(
+        lookat=lookat,
+        distance=float(cam_kw.get("cam_distance", 2.0)),
+        elevation=float(cam_kw.get("cam_elevation", -20.0)),
+        azimuth=float(cam_kw.get("cam_azimuth", 90.0)),
+    )

--- a/tests/base/test_backend_pre_step_control.py
+++ b/tests/base/test_backend_pre_step_control.py
@@ -356,6 +356,122 @@ def test_motrix_native_video_capture_defaults_camera_lookat_to_grid_center(monke
     }
 
 
+def test_motrix_native_video_capture_tracks_primary_env_base(monkeypatch) -> None:
+    import unilab.base.backend.motrix_backend as mod
+
+    captured: dict[str, object] = {"set_views": []}
+    base_positions = np.array(
+        [
+            [0.0, 0.0, 0.5],
+            [2.0, 3.0, 0.75],
+            [4.0, 5.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+
+    class FakeImage:
+        pixels = np.zeros((2, 3, 3), dtype=np.uint8)
+
+    class FakeCaptureTask:
+        def take_image(self):
+            return FakeImage()
+
+    class FakeCameras:
+        def set_system_render_target(self, target, width, height):
+            captured["render_target"] = (target, width, height)
+
+    class FakeModel:
+        cameras = FakeCameras()
+
+    class FakeSettings:
+        enable_shadow = False
+
+    class FakeRenderSettings:
+        @staticmethod
+        def performance():
+            return FakeSettings()
+
+    class FakeSystemCamera:
+        def set_view(self, lookat, distance, elevation, azimuth):
+            captured["set_views"].append(
+                {
+                    "lookat": lookat,
+                    "distance": distance,
+                    "elevation": elevation,
+                    "azimuth": azimuth,
+                }
+            )
+
+        def capture(self):
+            captured["capture"] = True
+            return FakeCaptureTask()
+
+    class FakeRenderApp:
+        def __init__(self, **kwargs):
+            captured["render_app_kwargs"] = kwargs
+            self.system_camera = FakeSystemCamera()
+
+        def launch(self, model, *, batch, render_offset, render_settings):
+            captured["launch"] = {
+                "model": model,
+                "batch": batch,
+                "render_offset": render_offset,
+                "render_settings": render_settings,
+            }
+
+        def sync(self, *, data, wait=False):
+            captured["sync"] = {"data": data, "wait": wait}
+
+    monkeypatch.setattr(mod, "RenderApp", FakeRenderApp, raising=False)
+    monkeypatch.setattr(mod, "RenderSettings", FakeRenderSettings, raising=False)
+
+    backend = object.__new__(mod.MotrixBackend)
+    backend._model = FakeModel()
+    backend._data = object()
+    backend._num_envs = 3
+    backend._render_app = None
+    backend._render_headless = None
+    backend._render_capture_enabled = False
+    backend.get_base_pos = lambda: base_positions
+
+    backend.init_renderer(
+        spacing=1.5,
+        headless=True,
+        capture=True,
+        width=3,
+        height=2,
+        camera_kwargs={
+            "cam_tracking": True,
+            "cam_tracking_env_idx": 1,
+            "cam_distance": 6.0,
+            "cam_elevation": -30.0,
+            "cam_azimuth": 45.0,
+        },
+    )
+
+    assert captured["set_views"] == [
+        {
+            "lookat": [3.5, 3.0, 0.75],
+            "distance": 6.0,
+            "elevation": -30.0,
+            "azimuth": 45.0,
+        }
+    ]
+
+    base_positions[1] = [10.0, 20.0, 1.25]
+    frame = backend.capture_video_frame()
+
+    assert captured["set_views"][-1] == {
+        "lookat": [11.5, 20.0, 1.25],
+        "distance": 6.0,
+        "elevation": -30.0,
+        "azimuth": 45.0,
+    }
+    assert captured["sync"] == {"data": backend._data, "wait": True}
+    assert captured["capture"] is True
+    assert frame.shape == (2, 3, 3)
+
+
 def test_motrix_interactive_renderer_applies_camera_kwargs(monkeypatch) -> None:
     import unilab.base.backend.motrix_backend as mod
 


### PR DESCRIPTION
## Summary
- Add Motrix camera helpers for render offsets, configured camera view, and tracked lookat resolution.
- Update Motrix native render/video capture to follow a selected env base when cam_tracking is enabled.
- Add coverage for Motrix native video capture tracking behavior.

## Validation
- make test-all