### PR TITLE
fix: support go2 rough height scans on motrix

### DIFF
--- a/benchmark/benchmark_env_step.py
+++ b/benchmark/benchmark_env_step.py
@@ -252,6 +252,49 @@ def _go2_env_cls() -> type:
     return Go2WalkTask
 
 
+def _go2_rough_cfg(_: str) -> Any:
+    from unilab.envs.locomotion.go2.rough import Go2JoystickRoughCfg, RoughRewardConfig
+
+    cfg = Go2JoystickRoughCfg()
+    cfg.scene.terrain.generator.seed = 42
+    cfg.scene.terrain.generator.num_rows = 6
+    cfg.scene.terrain.generator.num_cols = 6
+    cfg.reward_config = RoughRewardConfig(
+        scales={
+            "lin_vel_z": -2.0,
+            "ang_vel_xy": -0.05,
+            "joint_torques_l2": -2.5e-5,
+            "joint_acc_l2": -2.5e-7,
+            "joint_pos_limits": -5.0,
+            "joint_power": -2.0e-5,
+            "stand_still": -2.0,
+            "joint_pos_penalty": -1.0,
+            "joint_mirror": -0.05,
+            "action_rate": -0.01,
+            "undesired_contacts": -1.0,
+            "contact_forces": -1.5e-4,
+            "tracking_lin_vel": 3.0,
+            "tracking_ang_vel": 1.5,
+            "feet_air_time": 0.5,
+            "feet_air_time_variance": -1.0,
+            "feet_contact_without_cmd": 0.1,
+            "feet_slide": -0.1,
+            "feet_height_body": -5.0,
+            "feet_gait": 0.5,
+            "upward": 1.0,
+        },
+        tracking_sigma=0.25,
+        base_height_target=0.33,
+    )
+    return cfg
+
+
+def _go2_rough_env_cls() -> type:
+    from unilab.envs.locomotion.go2.rough import Go2JoystickRoughEnv
+
+    return Go2JoystickRoughEnv
+
+
 def _go2w_cfg(_: str) -> Any:
     from unilab.envs.locomotion.go2w.joystick import Go2WJoystickCfg, RewardConfig
 
@@ -409,6 +452,12 @@ TASK_CONFIGS: dict[str, TaskConfig] = {
         cfg_factory=_go2_cfg,
         env_cls_factory=_go2_env_cls,
     ),
+    "go2_rough": TaskConfig(
+        task_id="go2_joystick_rough",
+        env_name="Go2JoystickRough",
+        cfg_factory=_go2_rough_cfg,
+        env_cls_factory=_go2_rough_env_cls,
+    ),
     "go2w": TaskConfig(
         task_id="go2w_joystick_flat",
         env_name="Go2WJoystickFlat",
@@ -458,6 +507,7 @@ DEFAULT_WARMUP_STEPS = 5
 TASK_COLORS = {
     "go1": "#4C78A8",
     "go2": "#54A24B",
+    "go2_rough": "#8CD17D",
     "g1": "#F58518",
     "g1_mt": "#B279A2",
     "g1_rough": "#E45756",

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -14,9 +14,9 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 1024
+  num_envs: 4096
   num_steps_per_env: 24
-  max_iterations: 500
+  max_iterations: 2000
   empirical_normalization: false
   obs_groups:
     actor:
@@ -31,6 +31,16 @@ algo:
 
 env:
   render_offset_mode: zero
+  control_config:
+    action_scale: 0.25
+    hip_action_scale: 0.125
+    non_hip_action_scale: 0.25
+    clip_actions: 100.0
+  commands:
+    vel_limit: [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]
+    resampling_time: 10.0
+    heading_command: true
+    heading_range: [-3.141592653589793, 3.141592653589793]
   terrain_curriculum:
     enabled: false
   scene:
@@ -44,22 +54,61 @@ env:
         seed: 42
         curriculum: false
         size: [8.0, 8.0]
-        num_rows: 1
-        num_cols: 1
+        num_rows: 6
+        num_cols: 6
         border_width: 1.0
   terrain_scan:
     enabled: true
     geom_name: floor
+  termination_config:
+    terrain_out_of_bounds: true
+    terrain_distance_buffer: 3.0
+  domain_rand:
+    randomize_base_mass: true
+    added_mass_range: [-1.0, 3.0]
+    random_com: true
+    randomize_kp: true
+    kp_multiplier_range: [0.5, 2.0]
+    randomize_kd: true
+    kd_multiplier_range: [0.5, 2.0]
+    push_robots: true
+    push_interval: 625
+    max_force: [1.0, 1.0, 0.5]
 reward:
   scales:
-    tracking_lin_vel: 1.0
-    tracking_ang_vel: 0.75
-    lin_vel_z: -1.0
+    lin_vel_z: -2.0
     ang_vel_xy: -0.05
-    base_height: -10.0
-    action_rate: -0.005
-    similar_to_default: -0.1
-    contact: 0.24
-    swing_feet_z: 4.0
+    joint_torques_l2: -2.5e-5
+    joint_acc_l2: -2.5e-7
+    joint_pos_limits: -5.0
+    joint_power: -2.0e-5
+    stand_still: -2.0
+    joint_pos_penalty: -1.0
+    joint_mirror: -0.05
+    action_rate: -0.01
+    undesired_contacts: -1.0
+    contact_forces: -1.5e-4
+    tracking_lin_vel: 3.0
+    tracking_ang_vel: 1.5
+    feet_air_time: 0.5
+    feet_air_time_variance: -1.0
+    feet_contact_without_cmd: 0.1
+    feet_slide: -0.1
+    feet_height_body: -5.0
+    feet_gait: 0.5
+    upward: 1.0
   tracking_sigma: 0.25
-  base_height_target: 0.3
+  base_height_target: 0.33
+  stand_still_command_threshold: 0.1
+  joint_pos_penalty_stand_still_scale: 5.0
+  joint_pos_penalty_velocity_threshold: 0.5
+  joint_pos_penalty_command_threshold: 0.1
+  contact_threshold: 1.0
+  contact_forces_threshold: 100.0
+  feet_air_time_threshold: 0.5
+  feet_height_body_target: -0.2
+  feet_height_body_tanh_mult: 2.0
+  feet_gait_std: 0.7071067811865476
+  feet_gait_max_err: 0.2
+  feet_gait_velocity_threshold: 0.5
+  feet_gait_command_threshold: 0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.7.1.dev100045"]
+motrix = ["motrixsim-core==0.7.1.dev100199"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -24,6 +24,14 @@ class BackendPlayCapabilities:
     supports_native_video_capture: bool = False
 
 
+class BackendHeightScanner(abc.ABC):
+    """Backend-owned height-field scanner created on the env init path."""
+
+    @abc.abstractmethod
+    def scan(self) -> np.ndarray:
+        """Return sampled values with shape ``(num_envs, num_points)``."""
+
+
 class SimBackend(abc.ABC):
     """仿真后端统一接口"""
 
@@ -115,7 +123,7 @@ class SimBackend(abc.ABC):
         """Return one geom size vector through the backend contract."""
         raise NotImplementedError(f"{self.__class__.__name__} does not expose geom sizes")
 
-    def sample_hfield_height(
+    def create_hfield_scanner(
         self,
         *,
         hfield_geom_id: int,
@@ -123,21 +131,13 @@ class SimBackend(abc.ABC):
         frame_body_id: int,
         alignment: str = "yaw",
         output: str = "height",
-    ) -> np.ndarray:
-        """Sample a height-field geom through a backend-native batched sensor path.
+    ) -> BackendHeightScanner:
+        """Create a reusable height-field scanner on the init/cold path.
 
-        Args:
-            hfield_geom_id: Backend geom id for a height-field geom.
-            offsets: Local XY offsets with shape ``(num_points, 2)``.
-            frame_body_id: Backend body id that anchors the local offsets.
-            alignment: Native alignment mode, e.g. ``"yaw"``.
-            output: Native output mode, e.g. ``"height"`` or ``"clearance"``.
-
-        Returns:
-            Array with shape ``(num_envs, num_points)``.
+        Backends that support height-field terrain scan must override this method.
         """
         raise NotImplementedError(
-            f"{self.__class__.__name__} does not support native height-field sampling"
+            f"{self.__class__.__name__} does not support native height-field scanners"
         )
 
     def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:

--- a/src/unilab/base/backend/motrix_backend.py
+++ b/src/unilab/base/backend/motrix_backend.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     MOTRIX_AVAILABLE = False
 
-from .base import BackendPlayCapabilities, SimBackend
+from .base import BackendHeightScanner, BackendPlayCapabilities, SimBackend
 from .motrix_camera import (
     MotrixTrackingCamera,
     render_offsets,
@@ -48,6 +48,22 @@ class _MotrixSceneContext:
     terrain_origins: np.ndarray | None = None
     terrain_surface_sampler: object | None = None
     cleanup_handle: object | None = None
+
+
+@dataclass
+class _MotrixTerrainScanner(BackendHeightScanner):
+    scanner: "mtx.TerrainScanner"
+    data: "mtx.SceneData"
+    out: np.ndarray
+
+    def scan(self) -> np.ndarray:
+        heights = np.asarray(self.scanner.scan(self.data, out=self.out))
+        if heights.shape != self.out.shape:
+            raise ValueError(
+                f"Motrix TerrainScanner.scan returned shape {heights.shape}, "
+                f"expected {self.out.shape}"
+            )
+        return heights
 
 
 def _build_motrix_scene_context(
@@ -258,6 +274,12 @@ class MotrixBackend(SimBackend):
                 raise ValueError(f"Body '{name}' not found in Motrix model")
             ids.append(int(bid))
         return np.array(ids, dtype=np.int32)
+
+    def get_geom_id(self, name: str) -> int:
+        geom_id = self._model.get_geom_index(name)
+        if geom_id is None or geom_id < 0:
+            raise ValueError(f"Geom '{name}' not found in Motrix model")
+        return int(geom_id)
 
     def get_joint_range(self) -> np.ndarray | None:
         return None
@@ -510,6 +532,51 @@ class MotrixBackend(SimBackend):
         ex_force[:, 1] *= force_range[1]
         ex_force[:, 2] *= force_range[2]
         self._push_body_link.add_external_force(self._data, ex_force, local=True)
+
+    def create_hfield_scanner(
+        self,
+        *,
+        hfield_geom_id: int,
+        offsets: np.ndarray,
+        frame_body_id: int,
+        alignment: str = "yaw",
+        output: str = "height",
+    ) -> BackendHeightScanner:
+        offsets_np = np.ascontiguousarray(np.asarray(offsets, dtype=np.float32))
+        if offsets_np.ndim != 2 or offsets_np.shape[1] != 2:
+            raise ValueError(f"offsets must have shape (num_points, 2), got {offsets_np.shape}")
+
+        if alignment != "yaw":
+            raise ValueError(f"MotrixBackend only supports alignment='yaw', got {alignment!r}")
+        if output not in {"height", "clearance"}:
+            raise ValueError(f"Unsupported hfield sampling output: {output!r}")
+
+        geom_id = int(hfield_geom_id)
+        if geom_id < 0 or geom_id >= int(self._model.num_geoms):
+            raise ValueError(f"hfield_geom_id out of range: {geom_id}")
+
+        body_id = int(frame_body_id)
+        if body_id < 0 or body_id >= int(self._model.num_links):
+            raise ValueError(f"frame_body_id out of range: {body_id}")
+
+        terrain = self._model.get_geom(geom_id)
+        if terrain is None:
+            raise ValueError(f"Geom id {geom_id} not found in Motrix model")
+        if not isinstance(terrain, mtx.GeomHField):
+            raise ValueError(f"Geom id {geom_id} is not backed by a Motrix hfield")
+        frame = self._link_cache[body_id]
+        scanner = mtx.TerrainScanner(
+            terrain,
+            frame,
+            offsets_np,
+            alignment=alignment,
+            output=output,
+        )
+        return _MotrixTerrainScanner(
+            scanner=scanner,
+            data=self._data,
+            out=np.empty((self._num_envs, offsets_np.shape[0]), dtype=self._np_dtype),
+        )
 
     def _update_tracking_camera_view(self) -> None:
         if (

--- a/src/unilab/base/backend/mujoco_backend.py
+++ b/src/unilab/base/backend/mujoco_backend.py
@@ -31,13 +31,38 @@ from unilab.dr.types import (
 )
 from unilab.dtype_config import get_global_dtype
 
-from .base import BackendPlayCapabilities, SimBackend
+from .base import BackendHeightScanner, BackendPlayCapabilities, SimBackend
 
 
 def _root_state_dims(model) -> tuple[int, int]:
     if model.njnt > 0 and int(model.jnt_type[0]) == int(mujoco.mjtJoint.mjJNT_FREE):
         return 7, 6
     return 0, 0
+
+
+@dataclass
+class _MuJoCoHeightScanner(BackendHeightScanner):
+    backend: "MuJoCoBackend"
+    hfield_geom_id: int
+    offsets: np.ndarray
+    frame_body_id: int
+    alignment: str
+    output: str
+
+    def scan(self) -> np.ndarray:
+        pool = self.backend._pool
+        if pool is None:
+            raise RuntimeError("MuJoCo backend pool must be materialized before hfield scanning")
+
+        heights = pool.sample_hfield_height(
+            self.backend._physics_state,
+            hfield_geom_id=self.hfield_geom_id,
+            offsets=self.offsets,
+            frame_body_id=self.frame_body_id,
+            alignment=self.alignment,
+            output=self.output,
+        )
+        return np.asarray(heights, dtype=self.backend._np_dtype)
 
 
 def _prepare_variant_model_xml(
@@ -618,7 +643,7 @@ class MuJoCoBackend(SimBackend):
     def get_geom_size(self, name: str) -> np.ndarray:
         return np.asarray(self._model.geom_size[self.get_geom_id(name)], dtype=np.float64).copy()
 
-    def sample_hfield_height(
+    def create_hfield_scanner(
         self,
         *,
         hfield_geom_id: int,
@@ -626,23 +651,19 @@ class MuJoCoBackend(SimBackend):
         frame_body_id: int,
         alignment: str = "yaw",
         output: str = "height",
-    ) -> np.ndarray:
-        if self._pool is None:
-            raise RuntimeError("MuJoCo backend pool must be materialized before hfield sampling")
-
+    ) -> BackendHeightScanner:
         offsets_np = np.ascontiguousarray(np.asarray(offsets, dtype=np.float64))
         if offsets_np.ndim != 2 or offsets_np.shape[1] != 2:
             raise ValueError(f"offsets must have shape (num_points, 2), got {offsets_np.shape}")
 
-        heights = self._pool.sample_hfield_height(
-            self._physics_state,
+        return _MuJoCoHeightScanner(
+            backend=self,
             hfield_geom_id=int(hfield_geom_id),
             offsets=offsets_np,
             frame_body_id=int(frame_body_id),
             alignment=alignment,
             output=output,
         )
-        return np.asarray(heights, dtype=self._np_dtype)
 
     def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
         subtree_ids = {int(root_body_id)}

--- a/src/unilab/envs/locomotion/go2/rough.py
+++ b/src/unilab/envs/locomotion/go2/rough.py
@@ -435,6 +435,7 @@ class Go2JoystickRoughEnv(Go2WalkTask):
         self._height_scan_hfield_geom_id: int | None = None
         self._height_scan_frame_body_id: int | None = None
         self._height_scan_offsets: np.ndarray | None = None
+        self._height_scan_sensor: Any | None = None
         if not scan_cfg.enabled:
             return
 
@@ -443,6 +444,13 @@ class Go2JoystickRoughEnv(Go2WalkTask):
         self._height_scan_offsets = _height_scan_offsets(
             scan_cfg.measured_points_x,
             scan_cfg.measured_points_y,
+        )
+        self._height_scan_sensor = self._backend.create_hfield_scanner(
+            hfield_geom_id=self._height_scan_hfield_geom_id,
+            offsets=self._height_scan_offsets,
+            frame_body_id=self._height_scan_frame_body_id,
+            alignment="yaw",
+            output="height",
         )
 
     def _compute_obs(
@@ -572,10 +580,12 @@ class Go2JoystickRoughEnv(Go2WalkTask):
         return np.asarray(np.mean(base_pos[:, 2:3] - raw_heights, axis=1), dtype=get_global_dtype())
 
     def _raw_height_scan_obs(self, num_obs: int) -> tuple[np.ndarray | None, np.ndarray | None]:
+        height_scan_sensor = getattr(self, "_height_scan_sensor", None)
         if (
             self._height_scan_hfield_geom_id is None
             or self._height_scan_frame_body_id is None
             or self._height_scan_offsets is None
+            or height_scan_sensor is None
         ):
             return None, None
 
@@ -583,13 +593,7 @@ class Go2JoystickRoughEnv(Go2WalkTask):
         if base_pos.shape[0] != num_obs:
             return None, None
 
-        raw_heights = self._backend.sample_hfield_height(
-            hfield_geom_id=self._height_scan_hfield_geom_id,
-            offsets=self._height_scan_offsets,
-            frame_body_id=self._height_scan_frame_body_id,
-            alignment="yaw",
-            output="height",
-        )
+        raw_heights = height_scan_sensor.scan()
         if raw_heights.shape != (num_obs, self._height_scan_dim):
             return None, None
         return np.asarray(raw_heights, dtype=get_global_dtype()), base_pos
@@ -1002,4 +1006,4 @@ def _yaw_from_quat(quat: np.ndarray) -> np.ndarray:
     return np.arctan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
 
 
-registry.register_env("Go2JoystickRough", Go2WalkTask, sim_backend="motrix")
+registry.register_env("Go2JoystickRough", Go2JoystickRoughEnv, sim_backend="motrix")

--- a/src/unilab/envs/locomotion/go2w/rough.py
+++ b/src/unilab/envs/locomotion/go2w/rough.py
@@ -95,6 +95,7 @@ class Go2WJoystickRoughTilesEnv(Go2WJoystickEnv):
         self._height_scan_hfield_geom_id: int | None = None
         self._height_scan_frame_body_id: int | None = None
         self._height_scan_offsets: np.ndarray | None = None
+        self._height_scan_sensor: object | None = None
         if not scan_cfg.enabled:
             return
 
@@ -103,6 +104,13 @@ class Go2WJoystickRoughTilesEnv(Go2WJoystickEnv):
         self._height_scan_offsets = _height_scan_offsets(
             scan_cfg.measured_points_x,
             scan_cfg.measured_points_y,
+        )
+        self._height_scan_sensor = self._backend.create_hfield_scanner(
+            hfield_geom_id=self._height_scan_hfield_geom_id,
+            offsets=self._height_scan_offsets,
+            frame_body_id=self._height_scan_frame_body_id,
+            alignment="yaw",
+            output="height",
         )
 
     def _compute_obs(
@@ -137,10 +145,12 @@ class Go2WJoystickRoughTilesEnv(Go2WJoystickEnv):
         return np.asarray(np.mean(base_pos[:, 2:3] - raw_heights, axis=1), dtype=get_global_dtype())
 
     def _raw_height_scan_obs(self, num_obs: int) -> tuple[np.ndarray | None, np.ndarray | None]:
+        height_scan_sensor = getattr(self, "_height_scan_sensor", None)
         if (
             self._height_scan_hfield_geom_id is None
             or self._height_scan_frame_body_id is None
             or self._height_scan_offsets is None
+            or height_scan_sensor is None
         ):
             return None, None
 
@@ -148,13 +158,10 @@ class Go2WJoystickRoughTilesEnv(Go2WJoystickEnv):
         if base_pos.shape[0] != num_obs:
             return None, None
 
-        raw_heights = self._backend.sample_hfield_height(
-            hfield_geom_id=self._height_scan_hfield_geom_id,
-            offsets=self._height_scan_offsets,
-            frame_body_id=self._height_scan_frame_body_id,
-            alignment="yaw",
-            output="height",
-        )
+        scan = getattr(height_scan_sensor, "scan", None)
+        if not callable(scan):
+            return None, None
+        raw_heights = scan()
         if raw_heights.shape != (num_obs, self._height_scan_dim):
             return None, None
         return np.asarray(raw_heights, dtype=get_global_dtype()), base_pos

--- a/tests/base/test_motrix_backend_options.py
+++ b/tests/base/test_motrix_backend_options.py
@@ -23,10 +23,20 @@ class _FakeMotrixBody:
     floatingbase = None
 
 
+class _FakeMotrixGeom:
+    def __init__(self, *, name: str = "floor", hfield: object | None = None) -> None:
+        self.name = name
+        self.index = 0
+        self.hfield = hfield
+
+
 class _FakeMotrixModel:
     def __init__(self) -> None:
         self.options = SimpleNamespace(timestep=None, max_iterations=None)
         self.links = [_FakeMotrixLink()]
+        self.num_links = 1
+        self.geoms = [_FakeMotrixGeom(hfield=object())]
+        self.num_geoms = len(self.geoms)
         self.actuators = []
         self.num_actuators = 0
         self.joint_dof_pos_indices = []
@@ -42,11 +52,70 @@ class _FakeMotrixModel:
     def get_link_index(self, name: str) -> int | None:
         return 0 if name == "base" else None
 
+    def get_geom_index(self, name: str) -> int | None:
+        return 0 if name == "floor" else None
+
+    def get_geom(self, arg: Any) -> _FakeMotrixGeom | None:
+        if isinstance(arg, int):
+            return self.geoms[arg] if 0 <= arg < len(self.geoms) else None
+        if isinstance(arg, str):
+            geom_id = self.get_geom_index(arg)
+            return self.get_geom(geom_id) if geom_id is not None else None
+        return None
+
     def forward_kinematic(self, data: Any) -> None:
         return None
 
     def get_link_poses(self, data: Any) -> np.ndarray:
-        return np.zeros((1, 1, 7), dtype=np.float64)
+        return np.asarray([[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]], dtype=np.float64)
+
+
+class _FakeNativeHFieldGeom(_FakeMotrixGeom):
+    def __init__(self) -> None:
+        super().__init__(hfield=object())
+        self.data: Any | None = None
+        self.xy: np.ndarray | None = None
+
+    def sample_height(self, data: Any, xy: np.ndarray) -> np.ndarray:
+        self.data = data
+        self.xy = np.asarray(xy)
+        return self.xy[..., 0] + 2.0 * self.xy[..., 1]
+
+
+class _FakeTerrainScanner:
+    instances: list["_FakeTerrainScanner"] = []
+
+    def __init__(
+        self,
+        terrain: Any,
+        frame: Any,
+        offsets: np.ndarray,
+        *,
+        alignment: str = "yaw",
+        output: str = "height",
+    ) -> None:
+        self.terrain = terrain
+        self.frame = frame
+        self.offsets = np.asarray(offsets)
+        self.alignment = alignment
+        self.output = output
+        self.scan_calls = 0
+        self.out: np.ndarray | None = None
+        _FakeTerrainScanner.instances.append(self)
+
+    def scan(self, data: Any, out: np.ndarray | None = None) -> np.ndarray:
+        del data
+        self.scan_calls += 1
+        self.out = out
+        num_envs = out.shape[0] if out is not None else 1
+        values = self.offsets[:, 0] + 2.0 * self.offsets[:, 1]
+        if self.output == "clearance":
+            values = 5.0 - values
+        result = np.broadcast_to(values, (num_envs, values.shape[0])).astype(np.float32)
+        if out is not None:
+            out[...] = result
+            return out
+        return result
 
 
 def _install_fake_motrix(monkeypatch, tmp_path):
@@ -54,6 +123,7 @@ def _install_fake_motrix(monkeypatch, tmp_path):
     import unilab.base.backend.motrix_scene as scene_mod
 
     fake_model = _FakeMotrixModel()
+    _FakeTerrainScanner.instances.clear()
 
     monkeypatch.setattr(mod, "MOTRIX_AVAILABLE", True)
     monkeypatch.setattr(
@@ -61,6 +131,8 @@ def _install_fake_motrix(monkeypatch, tmp_path):
         "mtx",
         SimpleNamespace(
             SceneData=lambda model, batch: SimpleNamespace(),
+            TerrainScanner=_FakeTerrainScanner,
+            GeomHField=_FakeNativeHFieldGeom,
         ),
     )
     monkeypatch.setattr(scene_mod, "materialize_motrix_scene", lambda **kwargs: fake_model)
@@ -100,6 +172,98 @@ def test_motrix_backend_motion_body_ids_read_scene_model(monkeypatch, tmp_path) 
     np.testing.assert_array_equal(
         backend.get_motion_body_ids(["base"]), np.array([1], dtype=np.int32)
     )
+
+
+def test_motrix_backend_resolves_geom_ids(monkeypatch, tmp_path) -> None:
+    mod, _ = _install_fake_motrix(monkeypatch, tmp_path)
+
+    backend = mod.MotrixBackend(
+        SceneCfg(model_file="source.xml"), num_envs=1, sim_dt=0.01, base_name="base"
+    )
+
+    assert backend.get_geom_id("floor") == 0
+
+
+def test_motrix_backend_creates_terrain_scanner(monkeypatch, tmp_path) -> None:
+    mod, fake_model = _install_fake_motrix(monkeypatch, tmp_path)
+    native_geom = _FakeNativeHFieldGeom()
+    fake_model.geoms = [native_geom]
+    backend = mod.MotrixBackend(
+        SceneCfg(model_file="source.xml"), num_envs=2, sim_dt=0.01, base_name="base"
+    )
+    backend._num_envs = 2
+    offsets = np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float64)
+
+    scanner = backend.create_hfield_scanner(
+        hfield_geom_id=0,
+        offsets=offsets,
+        frame_body_id=0,
+        alignment="yaw",
+        output="height",
+    )
+    heights = scanner.scan()
+    heights_again = scanner.scan()
+
+    assert len(_FakeTerrainScanner.instances) == 1
+    native_scanner = _FakeTerrainScanner.instances[0]
+    assert native_scanner.terrain is native_geom
+    assert native_scanner.frame is fake_model.links[0]
+    assert native_scanner.alignment == "yaw"
+    assert native_scanner.output == "height"
+    assert native_scanner.offsets.dtype == np.float32
+    np.testing.assert_allclose(native_scanner.offsets, offsets)
+    assert native_scanner.scan_calls == 2
+    assert native_scanner.out is not None
+    assert native_scanner.out.shape == (2, 2)
+    np.testing.assert_allclose(heights, [[1.0, 2.0], [1.0, 2.0]], atol=1e-6)
+    np.testing.assert_allclose(heights_again, heights, atol=1e-6)
+
+
+def test_motrix_backend_hfield_sampling_can_return_clearance(monkeypatch, tmp_path) -> None:
+    mod, fake_model = _install_fake_motrix(monkeypatch, tmp_path)
+    fake_model.geoms = [_FakeNativeHFieldGeom()]
+    backend = mod.MotrixBackend(
+        SceneCfg(model_file="source.xml"), num_envs=1, sim_dt=0.01, base_name="base"
+    )
+
+    scanner = backend.create_hfield_scanner(
+        hfield_geom_id=0,
+        offsets=np.asarray([[1.0, 0.0]], dtype=np.float64),
+        frame_body_id=0,
+        output="clearance",
+    )
+    clearance = scanner.scan()
+
+    np.testing.assert_allclose(clearance, [[4.0]], atol=1e-12)
+
+
+def test_motrix_backend_hfield_sampling_uses_terrain_scanner_output_contract(
+    monkeypatch, tmp_path
+) -> None:
+    mod, fake_model = _install_fake_motrix(monkeypatch, tmp_path)
+    native_geom = _FakeNativeHFieldGeom()
+    fake_model.geoms = [native_geom]
+    backend = mod.MotrixBackend(
+        SceneCfg(model_file="source.xml"), num_envs=1, sim_dt=0.01, base_name="base"
+    )
+    backend._link_poses = np.asarray(
+        [[[10.0, 20.0, 5.0, 0.0, 0.0, 0.0, 1.0]]],
+        dtype=np.float64,
+    )
+
+    scanner = backend.create_hfield_scanner(
+        hfield_geom_id=0,
+        offsets=np.asarray([[1.0, 0.0]], dtype=np.float64),
+        frame_body_id=0,
+        output="height",
+    )
+    heights = scanner.scan()
+
+    assert len(_FakeTerrainScanner.instances) == 1
+    scanner = _FakeTerrainScanner.instances[0]
+    assert scanner.out is not None
+    assert heights.dtype == np.float32
+    np.testing.assert_allclose(heights, [[1.0]], atol=1e-6)
 
 
 def test_create_backend_routes_motrix_max_iterations_override(monkeypatch) -> None:

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -294,9 +294,23 @@ def test_ppo_go2_joystick_rough_motrix_task_compose():
         cfg = compose("config", overrides=["task=go2_joystick_rough/motrix"])
     assert cfg.training.task_name == "Go2JoystickRough"
     assert cfg.training.sim_backend == "motrix"
-    assert cfg.algo.max_iterations == 500
+    assert cfg.algo.num_envs == 4096
+    assert cfg.algo.max_iterations == 2000
     assert cfg.env.render_offset_mode == "zero"
     assert cfg.env.scene.model_file.endswith("go2.xml")
+    assert cfg.env.scene.terrain.generator.num_rows == 6
+    assert cfg.env.scene.terrain.generator.num_cols == 6
+    assert cfg.env.terrain_scan.enabled is True
+    assert cfg.reward.scales.tracking_lin_vel == pytest.approx(3.0)
+    assert "base_height" not in cfg.reward.scales
+    assert "swing_feet_z" not in cfg.reward.scales
+
+
+def test_go2_joystick_rough_motrix_registers_rough_env():
+    from unilab.base import registry
+    from unilab.envs.locomotion.go2.rough import Go2JoystickRoughEnv
+
+    assert registry._envs["Go2JoystickRough"].env_cls_dict["motrix"] is Go2JoystickRoughEnv
 
 
 def test_offpolicy_g1_rough_terrain_task_overrides():

--- a/tests/envs/locomotion/go2w/test_go2w_height_scan.py
+++ b/tests/envs/locomotion/go2w/test_go2w_height_scan.py
@@ -196,31 +196,42 @@ def test_mujoco_backend_hfield_sampling_matches_python_reference(
         grid=grid,
     ).scan(backend.get_base_pos()[:, :2], backend.get_base_quat())
 
-    native = backend.sample_hfield_height(
+    scanner = backend.create_hfield_scanner(
         hfield_geom_id=backend.get_geom_id(scan_cfg.geom_name),
         offsets=_height_scan_offsets(scan_cfg.measured_points_x, scan_cfg.measured_points_y),
         frame_body_id=backend.get_body_id("base_link"),
         alignment="yaw",
         output="height",
     )
+    native = scanner.scan()
 
     assert native.shape == reference.shape
     np.testing.assert_allclose(native, reference, atol=1e-6, rtol=0)
 
 
 def test_go2w_rough_height_scan_uses_backend_native_sampling() -> None:
+    class FakeHeightScanner:
+        def __init__(self, heights: np.ndarray) -> None:
+            self.calls = 0
+            self.heights = heights
+
+        def scan(self) -> np.ndarray:
+            self.calls += 1
+            return self.heights
+
     class FakeBackend:
         def __init__(self) -> None:
-            self.calls: list[dict[str, Any]] = []
+            self.scanner_calls: list[dict[str, Any]] = []
             self.base_pos = np.asarray([[0.0, 0.0, 0.6], [1.0, 0.0, 0.7]], dtype=np.float32)
             self.heights = np.asarray([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+            self.scanner = FakeHeightScanner(self.heights)
 
         def get_base_pos(self) -> np.ndarray:
             return self.base_pos
 
-        def sample_hfield_height(self, **kwargs: Any) -> np.ndarray:
-            self.calls.append(kwargs)
-            return self.heights
+        def create_hfield_scanner(self, **kwargs: Any) -> FakeHeightScanner:
+            self.scanner_calls.append(kwargs)
+            return self.scanner
 
     env = object.__new__(Go2WJoystickRoughTilesEnv)
     fake_backend = FakeBackend()
@@ -229,13 +240,21 @@ def test_go2w_rough_height_scan_uses_backend_native_sampling() -> None:
     env._height_scan_hfield_geom_id = 7
     env._height_scan_frame_body_id = 3
     env._height_scan_offsets = np.asarray([[0.0, 0.0], [0.1, -0.1]], dtype=np.float64)
+    env._height_scan_sensor = fake_backend.create_hfield_scanner(
+        hfield_geom_id=env._height_scan_hfield_geom_id,
+        offsets=env._height_scan_offsets,
+        frame_body_id=env._height_scan_frame_body_id,
+        alignment="yaw",
+        output="height",
+    )
 
     raw_heights, base_pos = env._raw_height_scan_obs(num_obs=2)
 
     np.testing.assert_array_equal(raw_heights, fake_backend.heights)
     np.testing.assert_array_equal(base_pos, fake_backend.base_pos)
-    assert len(fake_backend.calls) == 1
-    call = fake_backend.calls[0]
+    assert fake_backend.scanner.calls == 1
+    assert len(fake_backend.scanner_calls) == 1
+    call = fake_backend.scanner_calls[0]
     assert call["hfield_geom_id"] == 7
     assert call["frame_body_id"] == 3
     assert call["alignment"] == "yaw"

--- a/tests/envs/locomotion/test_go2_rough_height_scan.py
+++ b/tests/envs/locomotion/test_go2_rough_height_scan.py
@@ -8,18 +8,28 @@ from unilab.envs.locomotion.go2.rough import Go2JoystickRoughEnv, _height_scan_o
 
 
 def test_go2_rough_height_scan_uses_backend_native_sampling() -> None:
+    class FakeHeightScanner:
+        def __init__(self, heights: np.ndarray) -> None:
+            self.calls = 0
+            self.heights = heights
+
+        def scan(self) -> np.ndarray:
+            self.calls += 1
+            return self.heights
+
     class FakeBackend:
         def __init__(self) -> None:
-            self.calls: list[dict[str, Any]] = []
+            self.scanner_calls: list[dict[str, Any]] = []
             self.base_pos = np.asarray([[0.0, 0.0, 0.6], [1.0, 0.0, 0.7]], dtype=np.float32)
             self.heights = np.asarray([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+            self.scanner = FakeHeightScanner(self.heights)
 
         def get_base_pos(self) -> np.ndarray:
             return self.base_pos
 
-        def sample_hfield_height(self, **kwargs: Any) -> np.ndarray:
-            self.calls.append(kwargs)
-            return self.heights
+        def create_hfield_scanner(self, **kwargs: Any) -> FakeHeightScanner:
+            self.scanner_calls.append(kwargs)
+            return self.scanner
 
     env = object.__new__(Go2JoystickRoughEnv)
     fake_backend = FakeBackend()
@@ -28,13 +38,21 @@ def test_go2_rough_height_scan_uses_backend_native_sampling() -> None:
     env._height_scan_hfield_geom_id = 7
     env._height_scan_frame_body_id = 3
     env._height_scan_offsets = np.asarray([[0.0, 0.0], [0.1, -0.1]], dtype=np.float64)
+    env._height_scan_sensor = fake_backend.create_hfield_scanner(
+        hfield_geom_id=env._height_scan_hfield_geom_id,
+        offsets=env._height_scan_offsets,
+        frame_body_id=env._height_scan_frame_body_id,
+        alignment="yaw",
+        output="height",
+    )
 
     raw_heights, base_pos = env._raw_height_scan_obs(num_obs=2)
 
     np.testing.assert_array_equal(raw_heights, fake_backend.heights)
     np.testing.assert_array_equal(base_pos, fake_backend.base_pos)
-    assert len(fake_backend.calls) == 1
-    call = fake_backend.calls[0]
+    assert fake_backend.scanner.calls == 1
+    assert len(fake_backend.scanner_calls) == 1
+    call = fake_backend.scanner_calls[0]
     assert call["hfield_geom_id"] == 7
     assert call["frame_body_id"] == 3
     assert call["alignment"] == "yaw"

--- a/uv.lock
+++ b/uv.lock
@@ -2111,7 +2111,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.7.1.dev100045"
+version = "0.7.1.dev100199"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2119,18 +2119,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63fafe0f4376e6cb8126b415716f60b61bfc276f1213d518cede250b7d3aa180" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530e9b446d60852ccc0ebb5f1f4b88bbedfa5f3e43090486b55bd6b69a5152ab" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp310-cp310-win_amd64.whl", hash = "sha256:b69fe0d4749ec960403675cdb1c092a5773db0284726e97941841b90f8ebc631" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa4e73332f8bb8d8f23fc2e36aa85f06a1bca1ac6441d19c17b6f379a5f06e6f" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be344aacd75379c4c4046676da576fa74b89de0783c41a17e4c1127ada3cd03e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp311-cp311-win_amd64.whl", hash = "sha256:b09132e505d4d9de47bb218cb2f2eb1ce2d278476a91635c8e3875cf31eab1cb" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8981b60915b0dff60f21acbb0cd99e2e3ea95ba6b178347740a55c9fef363c7c" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3f6ed40c4eca1c7bbf9dbffccb03bab7c7ec21684f256bbf4aed0e58801e28d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp312-cp312-win_amd64.whl", hash = "sha256:7e07b794f8317b052a5c79e3b772aaa77d56aa9b9bc575daf419be57e2776e18" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd88a4b758eac62353781e571c1a057ff10d385818e593b282182d5bec04689a" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45be548bcad7da56ff4134b58055a9f3ed24ad2a8ad3e18dc41462c16cc7e4c6" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100045-cp313-cp313-win_amd64.whl", hash = "sha256:ce3e4a757adb00cb1f94eea6d5c1b0e36d454fbfca51bf874cc474bfb78cbc6e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c98e17eeed35caae4caf58b4e7791e77509941a9ea65f210685b8621c4b2a904" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3de903976e42e18baf7a1db579b039f7ed5bb7f4c41df52e5b086db8fbab9485" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp310-cp310-win_amd64.whl", hash = "sha256:6efe710a8e93b272e6b458de634a1329f3a670d8b36f7c5e68db6e8b031b7605" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c9db39849bee5fcf5d1a68d148d0a86daf61970945d02ebcca4f929098bdd572" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:457892205631cab210d5b10d84e4a95c8ca7f74fd15c796fb07c1b25cc69d7a7" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp311-cp311-win_amd64.whl", hash = "sha256:583f92f1b03497259e0ee9e80b360e055765b963993451b41586c0c1d47af91e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aa30ea796fc1e51b3aa8ba782f9796211187bc8cb3149f93a178fa821d80fb26" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a5b1314ab6527e73c042a2868cd54678a708b6dab2a9a62aff21b211c7607ab" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp312-cp312-win_amd64.whl", hash = "sha256:4a78096315211aa77eb22e126fcbbd87200212a8eaee8cd256b87e00e83c3f3e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ce439cd82c386e32de16f56b82548e4f118181c504bfc091ecfa3887b4d0217" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52f6786018ce8b3ac17598bde188d80c9e5ea127564f5821b493793d0e7bdb89" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100199-cp313-cp313-win_amd64.whl", hash = "sha256:61fc56037ac0991d29f350c0308134ae67f84cb710767c4cab68436ce9b9b357" },
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev100045", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev100199", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- support Go2 rough terrain height scans on the Motrix backend
- add backend terrain scan hooks and regression coverage for Go2/Go2W rough tasks
- pin motrixsim-core==0.7.1.dev100199 from the motphys-pypi index

## Validation
- make test-all
- uv run pytest
- go2 rough env.step benchmark, 4096 envs, 20 timed steps, 5 warmup steps:
  - MuJoCo: median 25.233 ms, throughput 166,289 env-steps/s
  - Motrix: median 21.950 ms, throughput 193,946 env-steps/s
