### PR TITLE
feat: add Intel Arc / XPU device routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ sync-rocm:
 	uv sync --extra motrix --no-install-package torch
 	uv pip install --no-deps torch==2.11.0 triton-rocm==3.6.0 --torch-backend rocm7.2
 
+.PHONY: sync-xpu
+sync-xpu:
+	uv sync --extra motrix --no-install-package torch
+	uv pip install torch==2.7.0 --torch-backend xpu
+
 .PHONY: format
 format:
 	uv run ruff format

--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ cd UniLab
 uv sync --extra motrix
 # Linux AMD / ROCm workstation:
 # make sync-rocm
+# Linux Intel Arc / iGPU workstation:
+# make sync-xpu
 
 # 3. Run a first PPO training job
 # macOS: 73s on M5Max-128GB, 1min43s on M3Max-48GB, 2.5min on MacBookNeo-8GB
-# Linux: 31s on RTX 4090 and R9-9950x3d
+# Linux: 31s on RTX 4090 + R9-9950x3d, 2min16s on Intel Arc iGPU + Core Ultra 9 185H
 uv run train --algo ppo --task go2_joystick_flat --sim motrix
 # Linux AMD / ROCm workstation after make sync-rocm:
+# uv run --no-sync train --algo ppo --task go2_joystick_flat --sim motrix
+# Linux Intel Arc / XPU workstation after make sync-xpu:
 # uv run --no-sync train --algo ppo --task go2_joystick_flat --sim motrix
 ```
 
@@ -55,6 +59,8 @@ uv run demo
 On macOS / MacBook, the UniLab CLI routes Motrix renderer playback through `mxpython` when needed. Detailed script-level commands are documented under `docs/users/zh_CN/`.
 
 On Linux AMD / ROCm workstations, `make sync-rocm` requires ROCm 7.1 or newer and installs the PyTorch ROCm 7.2 wheel (`torch==2.11.0+rocm7.2`). Use `uv run --no-sync ...` after that setup so `uv` does not resync the default Linux CUDA wheel.
+
+On Linux Intel Arc / iGPU workstations, `make sync-xpu` installs the PyTorch XPU wheel (`torch==2.7.0+xpu`) which bundles the Intel oneAPI compiler/SYCL runtimes. The GPU userspace driver itself must come from the system package manager — on Ubuntu 24.04+ / 26.04 install `intel-opencl-icd` and `libze-intel-gpu1` (kernel 6.2+ ships the i915 driver). Use `uv run --no-sync ...` after the swap so `uv` does not resync the default Linux CUDA wheel. Off-policy training (`--algo sac` / `--algo flashsac`) supports bf16 mixed precision via `training.use_amp=true` on XPU; on-policy PPO does not need AMP.
 
 ### Interactive Notebooks
 

--- a/benchmark/core/device_info.py
+++ b/benchmark/core/device_info.py
@@ -162,7 +162,7 @@ def _get_device_info_linux() -> Dict[str, str]:
             info["gpu_gtt_memory"] = f"{int(gtt_match.group(1))} MB"
     except Exception:
         pass
-    # Fallback GPU via lspci (AMD/ATI and others)
+    # Fallback GPU via lspci (AMD/ATI, Intel iGPU/Arc, and others)
     if info["gpu_name"] == "unknown":
         try:
             lspci_out = subprocess.check_output(["lspci"], text=True, stderr=subprocess.DEVNULL)
@@ -174,6 +174,12 @@ def _get_device_info_linux() -> Dict[str, str]:
                             name = match.group(1).strip()
                             name = re.sub(r"\s*\(rev.*\)", "", name)
                             info["gpu_name"] = name
+                            break
+                    elif "Intel" in line:
+                        # e.g. "Intel Corporation Meteor Lake-P [Intel Arc Graphics] (rev 08)"
+                        match = re.search(r"\[([^\]]+)\]", line)
+                        if match:
+                            info["gpu_name"] = match.group(1).strip()
                             break
         except Exception:
             pass

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -30,6 +30,7 @@ from unilab.training import (
 )
 from unilab.training.experiment import ExperimentTracker, patch_rsl_rl_wandb_writer
 from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
+from unilab.utils.device import get_default_device
 from unilab.visualization import render_play_mode
 
 try:
@@ -255,12 +256,7 @@ def main(cfg: DictConfig) -> None:
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     env_cfg_override = build_ppo_env_cfg_override(cfg)
 
-    if torch.cuda.is_available():
-        device = "cuda"
-    elif torch.backends.mps.is_available():
-        device = "mps"
-    else:
-        device = "cpu"
+    device = get_default_device()
     print(f"Using device: {device}")
 
     # Compute effective max_iterations (supports num_timesteps override)

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -401,7 +401,9 @@ class FastSACLearner:
         self.tau = tau
         self.max_grad_norm = max_grad_norm
         self.use_autotune = use_autotune
-        self.use_amp = use_amp and device == "cuda"
+        self.use_amp = use_amp and device in ("cuda", "xpu")
+        # CUDA uses fp16 + GradScaler; XPU uses bf16 (fp32 range, no scaler needed).
+        self._amp_dtype = torch.bfloat16 if device == "xpu" else torch.float16
         self.world_size = world_size
         self.critic_obs_dim = critic_obs_dim
 
@@ -476,8 +478,12 @@ class FastSACLearner:
         # Step counter
         self.update_count = 0
 
-        # AMP scaler for mixed precision
-        self.scaler = torch.amp.GradScaler("cuda") if self.use_amp else None  # pyright: ignore[reportPrivateImportUsage]
+        # AMP scaler for mixed precision (fp16 only; bf16 has fp32 range and skips scaler)
+        self.scaler = (
+            torch.amp.GradScaler("cuda")  # pyright: ignore[reportPrivateImportUsage]
+            if self.use_amp and device == "cuda"
+            else None
+        )
 
         self.symmetry = symmetry_augmentation
         if use_symmetry and symmetry_augmentation is None:
@@ -485,6 +491,11 @@ class FastSACLearner:
                 "FastSACLearner use_symmetry=True requires a symmetry_augmentation contract"
             )
         self.use_symmetry = use_symmetry
+
+    def _autocast(self):
+        return torch.amp.autocast(  # pyright: ignore[reportPrivateImportUsage]
+            self.device, dtype=self._amp_dtype, enabled=self.use_amp
+        )
 
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.
@@ -548,20 +559,20 @@ class FastSACLearner:
         discount = torch.full_like(dones, self.gamma)
 
         with torch.no_grad():
-            with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
+            with self._autocast():
                 next_actions, next_log_probs, _ = self.actor.get_actions_and_log_probs(next_obs)
             adjusted_rewards = (
                 rewards - discount * bootstrap * self.log_alpha.exp() * next_log_probs
             )
 
-            with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
+            with self._autocast():
                 target_distributions = self.qnet_target.projection(
                     critic_next_obs, next_actions, adjusted_rewards, bootstrap, discount
                 )
                 target_values = self.qnet_target.get_value(target_distributions)
 
         # Critic loss: cross-entropy with projected distributions
-        with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
+        with self._autocast():
             q_outputs = self.qnet(critic_obs, actions)
             critic_log_probs = F.log_softmax(q_outputs, dim=-1).clamp(min=-30.0)
             critic_losses = -torch.sum(target_distributions * critic_log_probs, dim=-1)
@@ -634,14 +645,14 @@ class FastSACLearner:
                 dim=0,
             )
 
-        with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
+        with self._autocast():
             actions, log_probs, log_std = self.actor.get_actions_and_log_probs(obs)
 
         with torch.no_grad():
             action_std = log_std.exp().mean()
             policy_entropy = -log_probs.mean()
 
-        with torch.amp.autocast("cuda", enabled=self.use_amp):  # pyright: ignore[reportPrivateImportUsage]
+        with self._autocast():
             q_outputs = self.qnet(critic_obs, actions)
             q_probs = F.softmax(q_outputs, dim=-1)
             q_values = self.qnet.get_value(q_probs)

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -178,7 +178,9 @@ class FlashSACLearner:
         self.critic_obs_dim = critic_obs_dim
         self.action_dim = action_dim
         self.update_count = 0
-        self.use_amp = bool(use_amp and self.device.type == "cuda")
+        self.use_amp = bool(use_amp and self.device.type in ("cuda", "xpu"))
+        # CUDA uses fp16 + GradScaler; XPU uses bf16 (fp32 range, no scaler needed).
+        self._amp_dtype = torch.bfloat16 if self.device.type == "xpu" else torch.float16
         self.use_compile = bool(
             use_compile and hasattr(torch, "compile") and self.device.type == "cuda"
         )
@@ -223,7 +225,12 @@ class FlashSACLearner:
             else None
         )
 
-        self.scaler: Any | None = getattr(torch.amp, "GradScaler")("cuda") if self.use_amp else None
+        # GradScaler is only needed for fp16 (cuda); bf16 on xpu doesn't need it.
+        self.scaler: Any | None = (
+            getattr(torch.amp, "GradScaler")("cuda")
+            if self.use_amp and self.device.type == "cuda"
+            else None
+        )
         lr_peak = learning_rate_peak if learning_rate_peak > 0 else actor_lr
         fused = self.device.type == "cuda"
         self.actor_optimizer = optim.Adam(self.actor.parameters(), lr=lr_peak, fused=fused)
@@ -256,7 +263,9 @@ class FlashSACLearner:
         return cast(torch.Tensor, self.obs_normalizer(obs, update=update))
 
     def _autocast(self):
-        return torch.autocast(device_type="cuda", dtype=torch.float16, enabled=self.use_amp)
+        return torch.autocast(
+            device_type=self.device.type, dtype=self._amp_dtype, enabled=self.use_amp
+        )
 
     def update_reward_stats(
         self,

--- a/tests/benchmark/test_device_info.py
+++ b/tests/benchmark/test_device_info.py
@@ -51,3 +51,38 @@ GPU: 0
     assert info["gpu_memory"] == "98304 MB"
     assert info["gpu_gtt_memory"] == "15862 MB"
     assert info["memory"] == "31.0 GB"
+
+
+def test_linux_device_info_reads_intel_igpu_from_lspci(monkeypatch):
+    cpuinfo = "model name\t: Intel(R) Core(TM) Ultra 9 185H\nprocessor\t: 0\n"
+    meminfo = "MemTotal:       31692928 kB\n"
+    lspci_out = (
+        "00:02.0 VGA compatible controller: "
+        "Intel Corporation Meteor Lake-P [Intel Arc Graphics] (rev 08)\n"
+    )
+
+    def fake_open(path, *args, **kwargs):
+        del args, kwargs
+        from io import StringIO
+
+        if path == "/proc/cpuinfo":
+            return StringIO(cpuinfo)
+        if path == "/proc/meminfo":
+            return StringIO(meminfo)
+        raise FileNotFoundError(path)
+
+    def fake_check_output(cmd, *args, **kwargs):
+        del args, kwargs
+        if cmd[0] == "lspci":
+            return lspci_out
+        # No nvidia-smi, rocm-smi, or amd-smi on Intel iGPU systems
+        raise FileNotFoundError(cmd[0])
+
+    monkeypatch.setattr(device_info, "open", fake_open, raising=False)
+    monkeypatch.setattr(device_info.subprocess, "check_output", fake_check_output)
+
+    info = device_info._get_device_info_linux()
+
+    assert info["gpu_name"] == "Intel Arc Graphics"
+    assert info["chip"] == "Intel(R) Core(TM) Ultra 9 185H"
+    assert info["memory"] == "30.2 GB"


### PR DESCRIPTION
Adds support for Intel iGPU (Xe-LPG / Arc) training on Linux via the PyTorch XPU wheel. CUDA / ROCm / MPS users are unaffected (changes are purely additive).

- utils/device: detect torch.xpu.is_available() after cuda/mps
- Makefile: sync-xpu target installs torch==2.7.0+xpu via uv
- scripts/train_rsl_rl, scripts/train_offpolicy: route PPO and off-policy playback through get_default_device() so they pick up xpu
- ipc/shared_buffer, ipc/replay_buffer: generalize the CUDA GPU-cache path to cover xpu; pre-allocate the GPU mirror on the active device
- algos/torch/fast_sac, algos/torch/flash_sac: enable training.use_amp on xpu via bf16 autocast (no GradScaler since bf16 has fp32 range)
- benchmark/device_info: read Intel iGPU name from lspci fallback so benchmark plots no longer label the GPU as "unknown"
- tests/benchmark: parallel Intel iGPU test alongside the AMD one
- README: install + first-run instructions for the XPU wheel, system package requirements (intel-opencl-icd, libze-intel-gpu1), and the uv run --no-sync discipline

Validated on Intel Core Ultra 9 185H + Arc Graphics (Meteor Lake-P):
  - PPO go2_joystick_flat/motrix: 151 iters / 2m16s, reward converged
  - FastSAC g1_walk_flat/mujoco: 1180ms/iter steady, reward climbing

## Summary

- what changed
- why it changed
- any user-facing or training-impact behavior

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [ ] Additional task-specific validation listed below

Commands actually run:

```bash
# paste exact commands here
```

## Impact

- Backend impact: `mujoco` / `motrix` / both / none
- Platform impact: macOS / Linux / both / unknown
- Training effect expected: yes / no / unknown

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [ ] Noted any follow-up work explicitly
