### PR TITLE
refactor(appo): add bounded rollout staging

### DIFF
--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -18,6 +18,7 @@ import torch
 from rsl_rl.utils import resolve_callable
 
 from unilab.algos.torch.appo.learner import APPOLearner
+from unilab.algos.torch.appo.staging import RolloutStagingPool
 from unilab.algos.torch.appo.worker import appo_collector_fn
 from unilab.ipc import AsyncRunner, RolloutRingBuffer, SharedWeightSync
 from unilab.logging import OffPolicyLogger
@@ -53,7 +54,10 @@ class APPORunner(AsyncRunner):
 
         self.steps_per_env = steps_per_env
         self.replay_queue_size = replay_queue_size
+        self.staging_pool_size = replay_queue_size
         self.seed = seed
+        if self.staging_pool_size < 1:
+            raise ValueError("APPO staging pool size must be >= 1")
 
         # Resolve dims
         self._resolve_dims()
@@ -184,7 +188,8 @@ class APPORunner(AsyncRunner):
 
         learner = self._build_learner()
 
-        # Create shared rollout IPC ring buffer; replay queue lives in learner.
+        # Create shared rollout IPC ring buffer; learner-side tensor lifetime is
+        # owned by the bounded staging pool below.
         rollout_ring_buffer = RolloutRingBuffer(
             num_envs=self.num_envs,
             num_steps=self.steps_per_env,
@@ -259,17 +264,19 @@ class APPORunner(AsyncRunner):
         logger.start()
         logger.log_status(
             f"Waiting for first rollout... "
-            f"(replay_queue={self.replay_queue_size}, "
+            f"(staging_pool={self.staging_pool_size}, "
             f"epochs={learner.num_learning_epochs})"
         )
 
         reward_history: deque = deque(maxlen=200)
         latest_reward_components: dict = {}
 
-        # Replay queue: stores the last replay_queue_size preprocessed rollouts in
-        # learner-process memory.  Each entry is a dict of GPU tensors with shape
-        # [T, N, *] (time-major) ready for process_batch / update.
-        replay_queue: deque[dict] = deque(maxlen=self.replay_queue_size)
+        staging_pool = RolloutStagingPool(
+            capacity=self.staging_pool_size,
+            num_envs=self.num_envs,
+            slot_shapes=rollout_ring_buffer.slot_shapes,
+            device=self.device,
+        )
 
         for iteration in range(1, max_iterations + 1):
             # Drain collector metrics while waiting for next rollout
@@ -296,7 +303,7 @@ class APPORunner(AsyncRunner):
             available_on_arrive = rollout_ring_buffer.available()
             wait_time = time.time() - wait_start
 
-            # Drain ALL available slots into the replay queue in one pass.
+            # Drain ALL available slots into the staging pool in one pass.
             # This keeps the GPU busy: if the collector produced 3 rollouts while
             # the learner was training, we consume all 3 immediately rather than
             # processing them one-per-iteration.
@@ -304,37 +311,14 @@ class APPORunner(AsyncRunner):
             learner_incremental_h2d_time = 0.0
             for _ in range(num_new):
                 h2d_start = time.perf_counter()
-                raw = rollout_ring_buffer.read_torch(self.device)
+                staging_pool.stage_numpy_views(rollout_ring_buffer.read_numpy_views())
                 learner_incremental_h2d_time += time.perf_counter() - h2d_start
                 rollout_ring_buffer.advance_read()
-
-                # Preprocess: payload is [N, T, *] (env-major); learner expects [T, N, *]
-                rollout: dict = {}
-                for k, v in raw.items():
-                    if k not in ("last_obs", "last_critic") and v.ndim >= 2:
-                        rollout[k] = v.transpose(0, 1)
-                    else:
-                        rollout[k] = v
-                if "obs" in rollout:
-                    rollout["observations"] = rollout.pop("obs")
-                if "log_probs" in rollout:
-                    rollout["actions_log_prob"] = rollout.pop("log_probs")
-                replay_queue.append(rollout)
 
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
             startup_wait_time = wait_time if iteration == 1 else 0.0
 
-            # Concatenate all rollouts in the replay queue along the env dimension.
-            # Each rollout keeps its own behavior_log_probs so V-trace IS ratios are
-            # computed independently per env-column — correct for any staleness level.
-            combined: dict = {}
-            for k in replay_queue[0]:
-                if k in ("last_obs", "last_critic"):
-                    # last_obs and last_critic are [N, D] - concat along dim 0
-                    combined[k] = torch.cat([r[k] for r in replay_queue], dim=0)
-                else:
-                    # All other tensors are [T, N, ...] - concat along dim 1 (env dimension)
-                    combined[k] = torch.cat([r[k] for r in replay_queue], dim=1)
+            combined = staging_pool.batch()
 
             train_start = time.time()
             learner.process_batch(combined)
@@ -345,11 +329,12 @@ class APPORunner(AsyncRunner):
             critic_weight_sync.write_weights(learner.critic.state_dict())
             weight_sync_time = time.perf_counter() - weight_sync_start
 
-            metrics["replay_queue_len"] = float(len(replay_queue))
+            metrics["staging_pool_len"] = float(staging_pool.active_count)
+            metrics["staging_pool_capacity"] = float(staging_pool.capacity)
             metrics["available_on_arrive"] = float(available_on_arrive)
             metrics["rollouts_read"] = float(num_new)
 
-            logger.update_replay_queue(len(replay_queue), self.replay_queue_size)
+            logger.update_staging_pool(staging_pool.active_count, staging_pool.capacity)
 
             mean_reward = (
                 sum(list(reward_history)[-50:]) / max(len(list(reward_history)[-50:]), 1)

--- a/src/unilab/algos/torch/appo/staging.py
+++ b/src/unilab/algos/torch/appo/staging.py
@@ -1,0 +1,137 @@
+"""Bounded rollout staging for APPO learners."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+import torch
+
+_LAST_FIELDS = frozenset({"last_obs", "last_critic"})
+_FIELD_ALIASES = {
+    "obs": "observations",
+    "log_probs": "actions_log_prob",
+}
+
+
+class RolloutStagingPool:
+    """Preallocated learner-device storage for a bounded set of rollouts.
+
+    Raw IPC rollout slots are env-major: [N, T, ...].  Learners consume
+    time-major combined batches: [T, K*N, ...].  The pool owns the destination
+    tensors and exposes active views without rebuilding them via torch.cat.
+    """
+
+    def __init__(
+        self,
+        *,
+        capacity: int,
+        num_envs: int,
+        slot_shapes: Mapping[str, tuple[int, ...]],
+        device: str | torch.device,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("RolloutStagingPool capacity must be >= 1")
+        if num_envs < 1:
+            raise ValueError("RolloutStagingPool num_envs must be >= 1")
+
+        self.capacity = int(capacity)
+        self.num_envs = int(num_envs)
+        self.device = torch.device(device)
+        self._next_slot = 0
+        self._active_count = 0
+        self._writes = 0
+        self._slot_versions = [-1] * self.capacity
+        self._raw_to_batch_field: dict[str, str] = {}
+        self._buffers: dict[str, torch.Tensor] = {}
+
+        for raw_field, slot_shape in slot_shapes.items():
+            self._allocate_field(raw_field, tuple(slot_shape))
+
+    @property
+    def active_count(self) -> int:
+        return self._active_count
+
+    @property
+    def slot_versions(self) -> tuple[int, ...]:
+        return tuple(self._slot_versions)
+
+    def _allocate_field(self, raw_field: str, slot_shape: tuple[int, ...]) -> None:
+        if not slot_shape or slot_shape[0] != self.num_envs:
+            raise ValueError(
+                f"rollout field {raw_field!r} must start with num_envs={self.num_envs}; "
+                f"got shape {slot_shape}"
+            )
+
+        batch_field = _FIELD_ALIASES.get(raw_field, raw_field)
+        self._raw_to_batch_field[raw_field] = batch_field
+
+        if raw_field in _LAST_FIELDS:
+            combined_shape = (self.capacity * self.num_envs, *slot_shape[1:])
+        else:
+            if len(slot_shape) < 2:
+                raise ValueError(f"rollout field {raw_field!r} must include a time dimension")
+            combined_shape = (
+                slot_shape[1],
+                self.capacity * self.num_envs,
+                *slot_shape[2:],
+            )
+        self._buffers[batch_field] = torch.empty(
+            combined_shape,
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+    def _slot_view(self, raw_field: str, slot: int) -> torch.Tensor:
+        batch_field = self._raw_to_batch_field[raw_field]
+        storage = self._buffers[batch_field]
+        start = slot * self.num_envs
+        end = start + self.num_envs
+        if raw_field in _LAST_FIELDS:
+            return storage[start:end]
+        return storage[:, start:end, ...]
+
+    def stage_numpy_views(self, raw_views: Mapping[str, np.ndarray]) -> int:
+        """Copy one raw shared-memory rollout into the next staging slot."""
+        missing = self._raw_to_batch_field.keys() - raw_views.keys()
+        if missing:
+            raise KeyError(f"missing rollout fields for staging: {sorted(missing)}")
+
+        slot = self._next_slot
+        for raw_field, raw_view in raw_views.items():
+            if raw_field not in self._raw_to_batch_field:
+                raise KeyError(f"unexpected rollout field {raw_field!r}")
+            if raw_view.dtype != np.float32:
+                raise TypeError(f"rollout field {raw_field!r} must be float32")
+
+            src = torch.from_numpy(raw_view)
+            if raw_field not in _LAST_FIELDS:
+                src = src.transpose(0, 1)
+
+            dst = self._slot_view(raw_field, slot)
+            if tuple(src.shape) != tuple(dst.shape):
+                raise ValueError(
+                    f"rollout field {raw_field!r} shape mismatch: "
+                    f"expected {tuple(dst.shape)}, got {tuple(src.shape)}"
+                )
+            dst.copy_(src, non_blocking=False)
+
+        self._slot_versions[slot] = self._writes
+        self._writes += 1
+        self._active_count = min(self._active_count + 1, self.capacity)
+        self._next_slot = (slot + 1) % self.capacity
+        return slot
+
+    def batch(self) -> dict[str, torch.Tensor]:
+        """Return active learner-ready views backed by the staging pool."""
+        if self._active_count == 0:
+            raise RuntimeError("RolloutStagingPool has no active rollouts")
+
+        active_envs = self._active_count * self.num_envs
+        out: dict[str, torch.Tensor] = {}
+        for field, storage in self._buffers.items():
+            if field in _LAST_FIELDS:
+                out[field] = storage[:active_envs]
+            else:
+                out[field] = storage[:, :active_envs, ...]
+        return out

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -14,6 +14,7 @@ import torch
 from rsl_rl.utils import resolve_callable
 
 from unilab.algos.torch.appo.runner import APPORunner
+from unilab.algos.torch.appo.staging import RolloutStagingPool
 from unilab.algos.torch.hora.appo_learner import HoraAPPOLearner
 from unilab.algos.torch.hora.appo_worker import hora_appo_collector_fn
 from unilab.algos.torch.hora.rsl_rl_compat import (
@@ -235,13 +236,18 @@ class HoraAPPORunner(APPORunner):
         logger.start()
         logger.log_status(
             f"Waiting for first rollout... "
-            f"(replay_queue={self.replay_queue_size}, "
+            f"(staging_pool={self.staging_pool_size}, "
             f"epochs={learner.num_learning_epochs})"
         )
 
         reward_history: deque = deque(maxlen=200)
         latest_reward_components: dict = {}
-        replay_queue: deque[dict] = deque(maxlen=self.replay_queue_size)
+        staging_pool = RolloutStagingPool(
+            capacity=self.staging_pool_size,
+            num_envs=self.num_envs,
+            slot_shapes=rollout_ring_buffer.slot_shapes,
+            device=self.device,
+        )
 
         for iteration in range(1, max_iterations + 1):
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
@@ -272,30 +278,13 @@ class HoraAPPORunner(APPORunner):
             learner_incremental_h2d_time = 0.0
             for _ in range(num_new):
                 h2d_start = time.perf_counter()
-                raw = rollout_ring_buffer.read_torch(self.device)
+                staging_pool.stage_numpy_views(rollout_ring_buffer.read_numpy_views())
                 learner_incremental_h2d_time += time.perf_counter() - h2d_start
                 rollout_ring_buffer.advance_read()
 
-                rollout: dict = {}
-                for k, v in raw.items():
-                    if k not in ("last_obs", "last_critic") and v.ndim >= 2:
-                        rollout[k] = v.transpose(0, 1)
-                    else:
-                        rollout[k] = v
-                if "obs" in rollout:
-                    rollout["observations"] = rollout.pop("obs")
-                if "log_probs" in rollout:
-                    rollout["actions_log_prob"] = rollout.pop("log_probs")
-                replay_queue.append(rollout)
-
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
 
-            combined: dict = {}
-            for k in replay_queue[0]:
-                if k in ("last_obs", "last_critic"):
-                    combined[k] = torch.cat([r[k] for r in replay_queue], dim=0)
-                else:
-                    combined[k] = torch.cat([r[k] for r in replay_queue], dim=1)
+            combined = staging_pool.batch()
 
             train_start = time.time()
             learner.process_batch(combined)
@@ -306,9 +295,10 @@ class HoraAPPORunner(APPORunner):
             critic_weight_sync.write_weights(learner.critic.state_dict())
             weight_sync_time = time.perf_counter() - weight_sync_start
 
-            metrics["replay_queue_len"] = float(len(replay_queue))
+            metrics["staging_pool_len"] = float(staging_pool.active_count)
+            metrics["staging_pool_capacity"] = float(staging_pool.capacity)
             metrics["available_on_arrive"] = float(available_on_arrive)
-            logger.update_replay_queue(len(replay_queue), self.replay_queue_size)
+            logger.update_staging_pool(staging_pool.active_count, staging_pool.capacity)
 
             mean_reward = (
                 sum(list(reward_history)[-50:]) / max(len(list(reward_history)[-50:]), 1)

--- a/src/unilab/ipc/rollout_ring_buffer.py
+++ b/src/unilab/ipc/rollout_ring_buffer.py
@@ -81,9 +81,22 @@ class RolloutRingBuffer:
     def name(self) -> Dict[str, str]:
         return {field: shm.name for field, shm in self._shm_blocks.items()}
 
+    @property
+    def slot_shapes(self) -> Dict[str, tuple[int, ...]]:
+        return {field: tuple(arr.shape[1:]) for field, arr in self._arrays.items()}
+
     def attach_sync_primitives(self, write_ptr, read_ptr) -> None:
         self._write_ptr = write_ptr
         self._read_ptr = read_ptr
+
+    def _clamp_read_ptr_to_valid_window(self) -> None:
+        wp = int(self._write_ptr.value)
+        oldest_available = max(0, wp - self.num_slots)
+        if int(self._read_ptr.value) >= oldest_available:
+            return
+        with self._read_ptr.get_lock():
+            if int(self._read_ptr.value) < oldest_available:
+                self._read_ptr.value = oldest_available
 
     @property
     def write_slot(self) -> int:
@@ -99,7 +112,8 @@ class RolloutRingBuffer:
             self._write_ptr.value += 1
 
     def available(self) -> int:
-        return int(self._write_ptr.value) - int(self._read_ptr.value)
+        self._clamp_read_ptr_to_valid_window()
+        return min(max(0, int(self._write_ptr.value) - int(self._read_ptr.value)), self.num_slots)
 
     def wait_for_data(self, timeout: float = 60.0) -> bool:
         import time
@@ -113,23 +127,52 @@ class RolloutRingBuffer:
 
     @property
     def read_slot(self) -> int:
+        self._clamp_read_ptr_to_valid_window()
         return int(self._read_ptr.value) % self.num_slots
+
+    def read_numpy_views(self) -> dict[str, np.ndarray]:
+        """Return shared-memory views for the current read slot.
+
+        The returned arrays are borrowed views. Consumers must copy them into
+        owned storage before calling advance_read().
+        """
+        s = self.read_slot
+        return {field: arr[s] for field, arr in self._arrays.items()}
+
+    def copy_read_slot_to_torch(self, destination: dict) -> None:
+        import torch
+
+        s = self.read_slot
+        for field, arr in self._arrays.items():
+            if field not in destination:
+                raise KeyError(f"missing destination tensor for rollout field {field!r}")
+            dst = destination[field]
+            src_view = arr[s]
+            if tuple(dst.shape) != tuple(src_view.shape):
+                raise ValueError(
+                    f"destination shape mismatch for {field!r}: "
+                    f"expected {tuple(src_view.shape)}, got {tuple(dst.shape)}"
+                )
+            if dst.dtype != torch.float32:
+                raise TypeError(f"destination tensor for {field!r} must be torch.float32")
+            dst.copy_(torch.from_numpy(src_view), non_blocking=False)
 
     def read_torch(self, device: str) -> dict:
         import torch
 
-        s = self.read_slot
-        return {
-            field: torch.from_numpy(arr[s].copy()).to(device) for field, arr in self._arrays.items()
+        result = {
+            field: torch.empty(tuple(arr.shape[1:]), dtype=torch.float32, device=device)
+            for field, arr in self._arrays.items()
         }
+        self.copy_read_slot_to_torch(result)
+        return result
 
     def advance_read(self) -> None:
         with self._read_ptr.get_lock():
-            rp = self._read_ptr.value + 1
-            wp = self._write_ptr.value
-            if wp - rp > self.num_slots:
-                rp = wp - self.num_slots + 1
-            self._read_ptr.value = rp
+            wp = int(self._write_ptr.value)
+            rp = min(int(self._read_ptr.value) + 1, wp)
+            oldest_available = max(0, wp - self.num_slots)
+            self._read_ptr.value = max(rp, oldest_available)
 
     def cleanup(self) -> None:
         for shm in self._shm_blocks.values():

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -77,8 +77,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_utilization: float = 0.0
         self._sync_collection: bool = False
         self._env_steps_per_sync: int = 0
-        self._replay_queue_len: int = 0
-        self._replay_queue_max: int = 0
+        self._staging_pool_len: int = 0
+        self._staging_pool_max: int = 0
         self._status: str = "Initializing..."
         self._terminal_refresh_started: bool = False
 
@@ -153,8 +153,11 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_utilization = float(utilization)
 
     def update_replay_queue(self, current_len: int, max_size: int):
-        self._replay_queue_len = current_len
-        self._replay_queue_max = max_size
+        self.update_staging_pool(current_len, max_size)
+
+    def update_staging_pool(self, current_len: int, max_size: int):
+        self._staging_pool_len = current_len
+        self._staging_pool_max = max_size
 
     def set_collection_sync(self, enabled: bool, env_steps_per_sync: int = 0):
         self._sync_collection = enabled
@@ -390,12 +393,12 @@ class OffPolicyLogger(BaseTrainingLogger):
             else "✗"
         )
         system_items.append(("Sync Collect", sync_collect))
-        if self._replay_queue_max > 0:
-            replay_color = "green" if self._replay_queue_len < self._replay_queue_max else "yellow"
+        if self._staging_pool_max > 0:
+            staging_color = "green" if self._staging_pool_len < self._staging_pool_max else "yellow"
             system_items.append(
                 (
-                    "Replay Queue",
-                    f"[{replay_color}]{self._replay_queue_len}/{self._replay_queue_max}[/]",
+                    "Staging Pool",
+                    f"[{staging_color}]{self._staging_pool_len}/{self._staging_pool_max}[/]",
                 )
             )
         row_count = max(len(learner_items), len(collector_items), len(system_items))

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import queue
 
+import numpy as np
 import pytest
 import torch
 
@@ -11,6 +12,7 @@ from unilab.algos.torch.appo.runner import APPORunner
 
 @pytest.fixture(autouse=True)
 def _reset_fakes() -> None:
+    _FakeLearner.last_instance = None
     _FakeRolloutRingBuffer.last_instance = None
     _FakeRolloutRingBuffer.available_rollouts = 1
     _FakeLogger.last_instance = None
@@ -22,10 +24,14 @@ class _FakeModule:
 
 
 class _FakeLearner:
+    last_instance: "_FakeLearner | None" = None
+
     def __init__(self) -> None:
         self.actor = _FakeModule()
         self.critic = _FakeModule()
         self.num_learning_epochs = 1
+        self.last_batch: dict[str, torch.Tensor] | None = None
+        _FakeLearner.last_instance = self
 
     def get_state_dict(self) -> dict[str, int]:
         return {"iteration": 0}
@@ -61,6 +67,20 @@ class _FakeRolloutRingBuffer:
         self.advance_calls = 0
         _FakeRolloutRingBuffer.last_instance = self
 
+    @property
+    def slot_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {
+            "obs": (2, 4, 4),
+            "critic": (2, 4, 7),
+            "actions": (2, 4, 2),
+            "log_probs": (2, 4),
+            "rewards": (2, 4),
+            "dones": (2, 4),
+            "truncated": (2, 4),
+            "last_obs": (2, 4),
+            "last_critic": (2, 7),
+        }
+
     def wait_for_data(self, timeout: float = 60.0) -> bool:
         del timeout
         self.wait_calls += 1
@@ -80,6 +100,13 @@ class _FakeRolloutRingBuffer:
             "truncated": torch.zeros(2, 4, device=device),
             "last_obs": torch.zeros(2, 4, device=device),
             "last_critic": torch.zeros(2, 7, device=device),
+        }
+
+    def read_numpy_views(self) -> dict[str, np.ndarray]:
+        value = float(self.advance_calls + 1)
+        return {
+            field: np.full(shape, value, dtype=np.float32)
+            for field, shape in self.slot_shapes.items()
         }
 
     def advance_read(self) -> None:
@@ -133,6 +160,9 @@ class _FakeLogger:
         pass
 
     def update_replay_queue(self, current_len: int, max_size: int) -> None:
+        del current_len, max_size
+
+    def update_staging_pool(self, current_len: int, max_size: int) -> None:
         del current_len, max_size
 
     def log_collector(self, total_steps: int, buffer_size: int, mean_reward: float = 0.0) -> None:
@@ -253,3 +283,63 @@ def test_appo_runner_logs_learner_timing_for_fps_inputs(
     assert step["extra_info"]["startup_wait_time"] == pytest.approx(10.0)
     assert step["extra_info"]["throughput_steps"] == 8
     assert step["metrics"]["rollouts_read"] == 1.0
+    assert step["metrics"]["staging_pool_len"] == 1.0
+
+
+def test_appo_runner_stages_multiple_rollouts_without_runner_cat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    def fake_detect_dims(self: APPORunner) -> tuple[int, int]:
+        self.critic_dim = 7
+        self.critic_input_dim = 5
+        return (4, 2)
+
+    def fail_cat(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("runner must not rebuild APPO batches with torch.cat")
+
+    _FakeRolloutRingBuffer.available_rollouts = 2
+    monkeypatch.setattr(APPORunner, "_detect_dims", fake_detect_dims)
+    monkeypatch.setattr(APPORunner, "_build_learner", lambda self: _FakeLearner())
+    monkeypatch.setattr(APPORunner, "_check_collector_alive", lambda self: True)
+    monkeypatch.setattr(appo_runner_module, "RolloutRingBuffer", _FakeRolloutRingBuffer)
+    monkeypatch.setattr(appo_runner_module, "SharedWeightSync", _FakeWeightSync)
+    monkeypatch.setattr(appo_runner_module, "OffPolicyLogger", _FakeLogger)
+    monkeypatch.setattr(appo_runner_module.mp, "get_context", lambda method: queue)
+    monkeypatch.setattr(appo_runner_module.torch, "save", lambda *args, **kwargs: None)
+    monkeypatch.setattr(appo_runner_module.torch, "cat", fail_cat)
+
+    fake_clock = _FakeClock([100.0, 100.0, 110.0, 120.0, 120.5, 121.0])
+    monkeypatch.setattr(appo_runner_module.time, "time", fake_clock.time)
+
+    runner = APPORunner(
+        env_name="DummyEnv",
+        env_cfg_overrides={},
+        rl_cfg={"actor": {}, "critic": {}, "algorithm": {}},
+        device="cpu",
+        collector_device="cpu",
+        sim_backend="mujoco",
+        num_envs=2,
+        steps_per_env=4,
+    )
+    monkeypatch.setattr(runner, "_start_collector", lambda *args, **kwargs: None)
+
+    runner.learn(max_iterations=1, save_interval=0, log_dir=str(tmp_path))
+
+    storage = _FakeRolloutRingBuffer.last_instance
+    learner = _FakeLearner.last_instance
+    logger = _FakeLogger.last_instance
+    assert storage is not None
+    assert learner is not None
+    assert learner.last_batch is not None
+    assert logger is not None
+    assert storage.advance_calls == 2
+
+    batch = learner.last_batch
+    assert batch["observations"].shape == (4, 4, 4)
+    assert batch["actions"].shape == (4, 4, 2)
+    assert batch["actions_log_prob"].shape == (4, 4)
+    assert batch["last_obs"].shape == (4, 4)
+    assert torch.equal(torch.unique(batch["observations"]), torch.tensor([1.0, 2.0]))
+    assert logger.step_calls[0]["metrics"]["staging_pool_len"] == 2.0
+    assert logger.step_calls[0]["metrics"]["rollouts_read"] == 2.0

--- a/tests/algos/test_appo_staging.py
+++ b/tests/algos/test_appo_staging.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from unilab.algos.torch.appo.staging import RolloutStagingPool
+
+_NUM_ENVS = 2
+_NUM_STEPS = 3
+_OBS_DIM = 4
+_ACTION_DIM = 2
+_CRITIC_DIM = 5
+
+_SLOT_SHAPES = {
+    "obs": (_NUM_ENVS, _NUM_STEPS, _OBS_DIM),
+    "critic": (_NUM_ENVS, _NUM_STEPS, _CRITIC_DIM),
+    "actions": (_NUM_ENVS, _NUM_STEPS, _ACTION_DIM),
+    "log_probs": (_NUM_ENVS, _NUM_STEPS),
+    "rewards": (_NUM_ENVS, _NUM_STEPS),
+    "dones": (_NUM_ENVS, _NUM_STEPS),
+    "truncated": (_NUM_ENVS, _NUM_STEPS),
+    "last_obs": (_NUM_ENVS, _OBS_DIM),
+    "last_critic": (_NUM_ENVS, _CRITIC_DIM),
+}
+
+
+def _raw_rollout(value: float) -> dict[str, np.ndarray]:
+    return {field: np.full(shape, value, dtype=np.float32) for field, shape in _SLOT_SHAPES.items()}
+
+
+def test_staging_pool_exposes_learner_ready_combined_batch() -> None:
+    pool = RolloutStagingPool(
+        capacity=2,
+        num_envs=_NUM_ENVS,
+        slot_shapes=_SLOT_SHAPES,
+        device="cpu",
+    )
+    first = _raw_rollout(1.0)
+    second = _raw_rollout(2.0)
+
+    pool.stage_numpy_views(first)
+    pool.stage_numpy_views(second)
+
+    batch = pool.batch()
+    expected_obs = torch.cat(
+        [
+            torch.from_numpy(first["obs"]).transpose(0, 1),
+            torch.from_numpy(second["obs"]).transpose(0, 1),
+        ],
+        dim=1,
+    )
+    expected_last_obs = torch.cat(
+        [torch.from_numpy(first["last_obs"]), torch.from_numpy(second["last_obs"])],
+        dim=0,
+    )
+
+    assert batch["observations"].shape == (_NUM_STEPS, 2 * _NUM_ENVS, _OBS_DIM)
+    assert batch["critic"].shape == (_NUM_STEPS, 2 * _NUM_ENVS, _CRITIC_DIM)
+    assert batch["actions_log_prob"].shape == (_NUM_STEPS, 2 * _NUM_ENVS)
+    assert batch["last_obs"].shape == (2 * _NUM_ENVS, _OBS_DIM)
+    assert torch.equal(batch["observations"], expected_obs)
+    assert torch.equal(batch["last_obs"], expected_last_obs)
+
+
+def test_staging_pool_reuses_slots_and_drops_overwritten_rollouts() -> None:
+    pool = RolloutStagingPool(
+        capacity=2,
+        num_envs=_NUM_ENVS,
+        slot_shapes=_SLOT_SHAPES,
+        device="cpu",
+    )
+
+    pool.stage_numpy_views(_raw_rollout(1.0))
+    pool.stage_numpy_views(_raw_rollout(2.0))
+    pool.stage_numpy_views(_raw_rollout(3.0))
+
+    batch = pool.batch()
+    assert pool.active_count == 2
+    assert pool.slot_versions == (2, 1)
+    assert torch.equal(torch.unique(batch["observations"]), torch.tensor([2.0, 3.0]))
+    assert not torch.any(batch["observations"] == 1.0)
+
+
+def test_staging_pool_batch_dict_does_not_retain_learner_mutations() -> None:
+    pool = RolloutStagingPool(
+        capacity=2,
+        num_envs=_NUM_ENVS,
+        slot_shapes=_SLOT_SHAPES,
+        device="cpu",
+    )
+    pool.stage_numpy_views(_raw_rollout(1.0))
+
+    batch = pool.batch()
+    batch["values"] = torch.zeros(_NUM_STEPS, _NUM_ENVS)
+
+    assert "values" not in pool.batch()
+
+
+def test_staging_pool_rejects_empty_capacity() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        RolloutStagingPool(
+            capacity=0,
+            num_envs=_NUM_ENVS,
+            slot_shapes=_SLOT_SHAPES,
+            device="cpu",
+        )

--- a/tests/ipc/test_rollout_ring_buffer.py
+++ b/tests/ipc/test_rollout_ring_buffer.py
@@ -81,11 +81,28 @@ def test_advance_read_skips_overwritten_slots():
     # Writer produces 4 rollouts (2x more than num_slots)
     for _ in range(4):
         s.signal_write_done()
-    # wp = 4, rp = 0 → available = 4 > num_slots
     s.advance_read()
     # After advance, rp should have jumped past overwritten slots
     # wp - rp should be <= num_slots
     assert int(s._write_ptr.value) - int(s._read_ptr.value) <= s.num_slots
+    s.cleanup()
+
+
+def test_reader_clamps_to_oldest_non_overwritten_slot_before_read():
+    s = _make_ring_buffer(num_slots=2)
+    for value in (1.0, 2.0, 3.0):
+        wb = s.write_buffer
+        for arr in wb.values():
+            arr[:] = value
+        s.signal_write_done()
+
+    assert s.available() == 2
+    first = s.read_torch("cpu")
+    assert torch.all(first["obs"] == 2.0)
+
+    s.advance_read()
+    second = s.read_torch("cpu")
+    assert torch.all(second["obs"] == 3.0)
     s.cleanup()
 
 
@@ -102,6 +119,26 @@ def test_read_torch_returns_all_fields():
     assert set(result.keys()) == _EXPECTED_FIELDS
     for k, v in result.items():
         assert isinstance(v, torch.Tensor), f"{k} is not a tensor"
+    s.cleanup()
+
+
+def test_copy_read_slot_to_torch_reuses_destination_tensors():
+    s = _make_ring_buffer()
+    wb = s.write_buffer
+    for arr in wb.values():
+        arr[:] = 7.0
+    s.signal_write_done()
+
+    destination = {
+        field: torch.empty(shape, dtype=torch.float32) for field, shape in s.slot_shapes.items()
+    }
+    pointers = {field: tensor.data_ptr() for field, tensor in destination.items()}
+
+    s.copy_read_slot_to_torch(destination)
+
+    assert {field: tensor.data_ptr() for field, tensor in destination.items()} == pointers
+    for tensor in destination.values():
+        assert torch.all(tensor == 7.0)
     s.cleanup()
 
 


### PR DESCRIPTION
## Summary
- replace APPO runner replay_queue rollout duplication with a bounded learner-device staging pool
- stage raw shared-memory rollout views directly into preallocated tensors and expose learner-ready active views without runner-side torch.cat
- update HORA APPO to use the same staging path and align logger display with staging pool capacity
- clamp RolloutRingBuffer reads to non-overwritten slots and add targeted staging/overwrite tests

Fixes #432

## Validation
- make test-all