### PR TITLE
fix(makefile): make sync-rocm uses pyproject.rocm.toml to avoid NVIDI…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,14 @@ sync:
 
 .PHONY: sync-rocm
 sync-rocm:
-	uv sync --extra motrix --no-install-package torch
-	uv pip install --no-deps torch==2.11.0 triton-rocm==3.6.0 --torch-backend rocm7.2
+	@cp pyproject.toml pyproject.toml.bak && cp uv.lock uv.lock.bak
+	@cp pyproject.rocm.toml pyproject.toml
+	@bash -c ' \
+		trap "mv pyproject.toml.bak pyproject.toml && mv uv.lock.bak uv.lock" EXIT INT TERM; \
+		if [ -f uv.rocm.lock ]; then cp uv.rocm.lock uv.lock; fi; \
+		uv sync --extra motrix; \
+		cp uv.lock uv.rocm.lock; \
+	'
 
 .PHONY: format
 format:

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -40,7 +40,7 @@ uv sync --extra motrix
 make sync-rocm
 ```
 
-`make sync-rocm` 会先按仓库 lock 同步非 torch 依赖，再从 PyTorch ROCm 源安装 `torch==2.11.0+rocm7.2` 和匹配的 `triton-rocm==3.6.0`。后续在该环境里运行训练命令时使用 `uv run --no-sync ...`，避免 `uv run` 自动把 Linux 默认 CUDA wheel 同步回来。PyTorch ROCm 运行时仍使用 `cuda` 设备类型，所以训练配置里的 `training.device=cuda` / 自动检测路径不需要改成 `rocm`。
+`make sync-rocm` 会基于 `pyproject.rocm.toml` 从 PyTorch ROCm 源同步并安装 `torch==2.11.0+rocm7.2`、`torchvision` 和 `triton-rocm==3.6.0`。后续在该环境里运行训练命令时使用 `uv run --no-sync ...`，避免 `uv run` 自动把 Linux 默认 CUDA wheel 同步回来。PyTorch ROCm 运行时仍使用 `cuda` 设备类型，所以训练配置里的 `training.device=cuda` / 自动检测路径不需要改成 `rocm`。
 
 ## 中国大陆镜像
 

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -1,0 +1,148 @@
+[build-system]
+requires = ["uv_build>=0.11.3,<0.12"]
+build-backend = "uv_build"
+
+[project]
+name = "unilab"
+version = "0.1.0"
+description = "Universal Lab for Robot Learning"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "numpy",
+    "torch==2.11.0",
+    "torchvision",
+    "triton-rocm==3.6.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "mujoco-uni==3.8.0rc2",
+    "gymnasium",
+    "imageio",
+    "etils",
+    "hydra-core>=1.3",
+    "tensordict",
+    "rsl-rl-lib>=5.0.0",
+    "packaging",
+    "mediapy",
+    "tensorboard",
+    "setuptools<70",
+    "rich",
+    "tqdm",
+    "typing-extensions",
+    "mlx ; sys_platform == 'darwin'",
+    "lark>=1.3.1",
+    "wandb",
+    "notebook>=7.5.5",
+    "onnxruntime>=1.24.3",
+]
+
+[project.scripts]
+train = "unilab.cli:train_main"
+eval = "unilab.cli:eval_main"
+demo = "unilab.cli:demo_main"
+unilab-viz-nan = "unilab.tools.viz_nan:main"
+unilab-export-scene = "unilab.tools.export_scene:main"
+
+[project.optional-dependencies]
+motrix = ["motrixsim-core==0.7.1.dev100199"]
+viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
+
+[dependency-groups]
+dev = ["pytest", "pytest-cov", "ruff", "mypy", "pyright>=1.1.408"]
+
+# ========== ROCm 索引配置 ==========
+[[tool.uv.index]]
+name = "pytorch-rocm72"
+url = "https://download.pytorch.org/whl/rocm7.2"
+explicit = true
+
+[[tool.uv.index]]
+name = "motphys-pypi"
+url = "https://pypi.motphys.com/simple/"
+explicit = true
+
+[[tool.uv.index]]
+name = "test-pypi"
+url = "https://test.pypi.org/simple/"
+explicit = true
+
+[tool.uv.sources]
+motrixsim-core = { index = "motphys-pypi" }
+mujoco-uni = { index = "test-pypi" }
+torch = [
+    { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+]
+torchvision = [
+    { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+]
+triton-rocm = [
+    { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+]
+
+[tool.uv]
+exclude-dependencies = ["nvidia-cublas-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12"]
+required-environments = [
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["src"]
+extend-exclude = [".history"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+ignore = [
+    "E501",
+    "N806",
+    "E402",
+    "F401",
+    "N801",
+    "F821",
+    "E741",
+    "N802",
+    "N803",
+    "N812",
+]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+no_site_packages = true
+exclude = [
+    "src/unilab/algos/torch/rsl_rl/",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "slow: long-running training or script smoke tests, or cumulatively expensive backend matrices",
+]
+addopts = "--tb=short -m 'not slow'"
+
+[tool.coverage.run]
+source = ["unilab"]
+omit = ["*/rsl_rl/*"]
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
+
+[tool.pyright]
+pythonVersion = "3.10"
+venvPath = "."
+venv = ".venv"
+include = ["src/unilab"]
+exclude = [
+    "src/unilab/algos/torch/rsl_rl/",
+    "src/unilab/algos/mlx/",
+    "src/unilab/algos/torch/common/ane_*",
+    "src/unilab/base/backend/",
+    "src/unilab/envs/",
+    "src/unilab/terrains/",
+    "src/unilab/training/monitoring.py",
+    "src/unilab/visualization/",
+]
+reportMissingImports = "warning"
+reportMissingModuleSource = "none"


### PR DESCRIPTION
…A deps

Add pyproject.rocm.toml for ROCm workstation setup and fix the Makefile sync-rocm target to actually use it.

Previously, sync-rocm ran uv sync against the default CUDA pyproject.toml with --no-install-package torch, which only skipped the top-level torch package while still installing all NVIDIA transitive dependencies (nvidia-cublas-cu12, nvidia-cuda-runtime-cu12, nvidia-cudnn-cu12, etc.).

Changes:
- Add pyproject.rocm.toml with pytorch-rocm72 index, torch==2.11.0, torchvision, and triton-rocm==3.6.0.
- Fix setuptools typo (setuptools<<70 -> setuptools<70).
- Update Makefile sync-rocm to temporarily swap in pyproject.rocm.toml for uv sync, then restore the original files.
- Cache uv.rocm.lock locally to speed up subsequent runs.

## Summary

- what changed
- why it changed
- any user-facing or training-impact behavior

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [ ] Additional task-specific validation listed below

Commands actually run:

```bash
# paste exact commands here
```

## Impact

- Backend impact: `mujoco` / `motrix` / both / none
- Platform impact: macOS / Linux / both / unknown
- Training effect expected: yes / no / unknown

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [ ] Noted any follow-up work explicitly
