### PR TITLE
feat: add deploy G1 motion tracking env

### DIFF
--- a/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+training:
+  task_name: G1MotionTrackingDeploy
+  sim_backend: motrix
+  play_env_num: 128
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 15000
+  save_interval: 500
+  obs_groups:
+    actor:
+      - actor
+  algorithm:
+    entropy_coef: 0.005
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 2.5
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/g1/scene_flat.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
+reward:
+  scales:
+    motion_global_root_pos: 1.0
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.05
+    joint_limit: -10.0
+    undesired_contacts: -0.1
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+training:
+  task_name: G1MotionTrackingDeploy
+  sim_backend: mujoco
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 15000
+  save_interval: 500
+  obs_groups:
+    actor:
+      - actor
+  algorithm:
+    entropy_coef: 0.005
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/docs/users/zh_CN/02-simulation-backends.md
+++ b/docs/users/zh_CN/02-simulation-backends.md
@@ -50,6 +50,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
 | PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
+| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
 | PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - |
@@ -65,6 +66,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
+| PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
 | PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | - |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | - |

--- a/src/unilab/envs/motion_tracking/g1/__init__.py
+++ b/src/unilab/envs/motion_tracking/g1/__init__.py
@@ -8,11 +8,19 @@ from .flip_tracking import (
     G1WallFlipTrackingEnv,
     G1WallFlipTrackingEnvCfg,
 )
-from .tracking import G1MotionTrackingCfg, G1MotionTrackingEnv, G1MotionTrackingEnvCfg
+from .tracking import (
+    G1MotionTrackingCfg,
+    G1MotionTrackingDeployEnv,
+    G1MotionTrackingDeployEnvCfg,
+    G1MotionTrackingEnv,
+    G1MotionTrackingEnvCfg,
+)
 from .tracking_sac import G1MotionTrackingSACCfg, G1MotionTrackingSACEnv
 
 __all__ = [
     "G1MotionTrackingCfg",
+    "G1MotionTrackingDeployEnv",
+    "G1MotionTrackingDeployEnvCfg",
     "G1MotionTrackingEnv",
     "G1MotionTrackingEnvCfg",
     "G1MotionTrackingSACCfg",

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -187,6 +187,14 @@ class G1MotionTrackingEnvCfg(G1MotionTrackingCfg):
     pass
 
 
+@registry.envcfg("G1MotionTrackingDeploy")
+@dataclass
+class G1MotionTrackingDeployEnvCfg(G1MotionTrackingCfg):
+    """Registered deploy configuration for G1 motion tracking."""
+
+    pass
+
+
 def _build_motion_reference_state(
     env: Any, env_ids: np.ndarray, motion_data: MotionData
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -443,9 +451,44 @@ class G1MotionTrackingEnv(G1BaseEnv):
         # Critic mirrors MJLab physical terms without actor observation noise:
         #        command, motion anchor, robot body pos/ori, linvel, gyro, joints, actions.
         n = self._num_action
-        actor_dim = 3 + 6 + 3 + 3 + n * 5
         critic_extra_dim = len(self._cfg.body_names) * 9
-        return {"obs": actor_dim, "critic": actor_dim + critic_extra_dim}
+        return {
+            "obs": self._actor_obs_dim(n),
+            "critic": self._critic_base_obs_dim(n) + critic_extra_dim,
+        }
+
+    def _actor_obs_dim(self, n: int) -> int:
+        return 3 + 6 + 3 + 3 + n * 5
+
+    def _critic_base_obs_dim(self, n: int) -> int:
+        return 3 + 6 + 3 + 3 + n * 5
+
+    def _build_actor_obs(
+        self,
+        *,
+        command: np.ndarray,
+        motion_anchor_pos_b: np.ndarray,
+        motion_anchor_ori_b: np.ndarray,
+        noisy_linvel: np.ndarray,
+        noisy_gyro: np.ndarray,
+        noisy_joint_pos_rel: np.ndarray,
+        noisy_dof_vel: np.ndarray,
+        last_actions: np.ndarray,
+    ) -> np.ndarray:
+        return np.concatenate(
+            [
+                command,
+                motion_anchor_pos_b,
+                motion_anchor_ori_b,
+                noisy_linvel,
+                noisy_gyro,
+                noisy_joint_pos_rel,
+                noisy_dof_vel,
+                last_actions,
+            ],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
 
     def _init_reward_functions(self):
         self._reward_fns = {
@@ -662,19 +705,15 @@ class G1MotionTrackingEnv(G1BaseEnv):
         noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
 
         # Actor observations (noisy proprioception)
-        actor_obs = np.concatenate(
-            [
-                command,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                noisy_linvel,
-                noisy_gyro,
-                noisy_joint_pos_rel,
-                noisy_dof_vel,
-                last_actions,
-            ],
-            axis=1,
-            dtype=get_global_dtype(),
+        actor_obs = self._build_actor_obs(
+            command=command,
+            motion_anchor_pos_b=motion_anchor_pos_b,
+            motion_anchor_ori_b=motion_anchor_ori_b,
+            noisy_linvel=noisy_linvel,
+            noisy_gyro=noisy_gyro,
+            noisy_joint_pos_rel=noisy_joint_pos_rel,
+            noisy_dof_vel=noisy_dof_vel,
+            last_actions=last_actions,
         )
 
         # Robot body positions in robot anchor frame (critic-only privileged) — vectorized
@@ -871,3 +910,41 @@ class G1MotionTrackingEnv(G1BaseEnv):
         upper_violation = np.maximum(0, dof_pos - upper)
         violation = lower_violation + upper_violation
         return np.asarray(np.sum(np.square(violation), axis=1), dtype=get_global_dtype())
+
+
+@registry.env("G1MotionTrackingDeploy", sim_backend="mujoco")
+@registry.env("G1MotionTrackingDeploy", sim_backend="motrix")
+class G1MotionTrackingDeployEnv(G1MotionTrackingEnv):
+    """Deploy-oriented G1 motion tracking env with unitree_rl_lab mimic actor inputs."""
+
+    _cfg: G1MotionTrackingDeployEnvCfg
+
+    def _actor_obs_dim(self, n: int) -> int:
+        # unitree_rl_lab mimic deploy actor input:
+        # motion_command(2n), motion_anchor_ori_b(6), gyro(3), joints, actions.
+        return 6 + 3 + n * 5
+
+    def _build_actor_obs(
+        self,
+        *,
+        command: np.ndarray,
+        motion_anchor_pos_b: np.ndarray,
+        motion_anchor_ori_b: np.ndarray,
+        noisy_linvel: np.ndarray,
+        noisy_gyro: np.ndarray,
+        noisy_joint_pos_rel: np.ndarray,
+        noisy_dof_vel: np.ndarray,
+        last_actions: np.ndarray,
+    ) -> np.ndarray:
+        return np.concatenate(
+            [
+                command,
+                motion_anchor_ori_b,
+                noisy_gyro,
+                noisy_joint_pos_rel,
+                noisy_dof_vel,
+                last_actions,
+            ],
+            axis=1,
+            dtype=get_global_dtype(),
+        )

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -473,6 +473,18 @@ def test_ppo_g1_motion_tracking():
     assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
 
 
+def test_ppo_g1_motion_tracking_deploy():
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        cfg = compose("config", overrides=["task=g1_motion_tracking_deploy/mujoco"])
+    assert cfg.training.task_name == "G1MotionTrackingDeploy"
+    assert cfg.algo.max_iterations == 15000
+    assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
+
+
 def test_ppo_g1_flip_tracking():
     from hydra import compose, initialize_config_dir
     from hydra.core.global_hydra import GlobalHydra

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -52,14 +52,19 @@ def test_registry_bootstrap_and_config_imports_do_not_require_mujoco():
         from unilab.base import registry
         from unilab.base.backend import create_backend
         from unilab.envs.manipulation.allegro_inhand.rotation import AllegroRotationCfg
-        from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingCfg
+        from unilab.envs.motion_tracking.g1.tracking import (
+            G1MotionTrackingCfg,
+            G1MotionTrackingDeployEnvCfg,
+        )
         from unilab.base.registry import ensure_registries
 
         ensure_registries()
         assert callable(create_backend)
         assert registry.contains("G1MotionTracking")
+        assert registry.contains("G1MotionTrackingDeploy")
         assert registry.contains("AllegroInhandRotation")
         G1MotionTrackingCfg()
+        G1MotionTrackingDeployEnvCfg()
         AllegroRotationCfg()
         """
     )
@@ -366,11 +371,10 @@ def test_g1_motion_tracking_uses_split_body_pose_queries():
     np.testing.assert_array_equal(env._backend.calls[1][1], np.array([1, 3], dtype=np.int32))
 
 
-def test_g1_motion_tracking_critic_uses_clean_mjlab_aligned_terms():
+def _compute_g1_motion_tracking_obs_stub(env_cls: type):
     from unilab.envs.motion_tracking.g1.motion_loader import MotionData
-    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv
 
-    env = cast(Any, object.__new__(G1MotionTrackingEnv))
+    env = cast(Any, object.__new__(env_cls))
     env._num_envs = 1
     env._num_action = 2
     env._cfg = SimpleNamespace(
@@ -413,11 +417,23 @@ def test_g1_motion_tracking_critic_uses_clean_mjlab_aligned_terms():
         robot_body_pos_w,
         robot_body_quat_w,
     )
+    return env, obs, motion_data, linvel, gyro, dof_pos, dof_vel, info
 
+
+def test_g1_motion_tracking_critic_uses_clean_mjlab_aligned_terms():
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv
+
+    env, obs, motion_data, linvel, gyro, dof_pos, dof_vel, info = (
+        _compute_g1_motion_tracking_obs_stub(G1MotionTrackingEnv)
+    )
+
+    assert env.obs_groups_spec == {"obs": 25, "critic": 43}
+    assert obs["obs"].shape == (1, 25)
     np.testing.assert_allclose(obs["obs"][:, 13:16], linvel + 100.0)
     np.testing.assert_allclose(obs["obs"][:, 16:19], gyro + 100.0)
     np.testing.assert_allclose(obs["obs"][:, 19:21], dof_pos - env.default_angles + 100.0)
     np.testing.assert_allclose(obs["obs"][:, 21:23], dof_vel + 100.0)
+    np.testing.assert_allclose(obs["obs"][:, 23:25], info["current_actions"])
 
     command_dim = motion_data.joint_pos.shape[1] + motion_data.joint_vel.shape[1]
     anchor_dim = 3 + 6
@@ -439,6 +455,21 @@ def test_g1_motion_tracking_critic_uses_clean_mjlab_aligned_terms():
         obs["critic"][:, clean_proprio_start + 10 : clean_proprio_start + 12],
         info["current_actions"],
     )
+
+
+def test_g1_motion_tracking_deploy_actor_matches_unitree_mimic_terms():
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingDeployEnv
+
+    env, obs, _motion_data, _linvel, gyro, dof_pos, dof_vel, info = (
+        _compute_g1_motion_tracking_obs_stub(G1MotionTrackingDeployEnv)
+    )
+
+    assert env.obs_groups_spec == {"obs": 19, "critic": 43}
+    assert obs["obs"].shape == (1, 19)
+    np.testing.assert_allclose(obs["obs"][:, 10:13], gyro + 100.0)
+    np.testing.assert_allclose(obs["obs"][:, 13:15], dof_pos - env.default_angles + 100.0)
+    np.testing.assert_allclose(obs["obs"][:, 15:17], dof_vel + 100.0)
+    np.testing.assert_allclose(obs["obs"][:, 17:19], info["current_actions"])
 
 
 def test_g1_motion_tracking_can_terminate_on_undesired_contacts():
@@ -1157,6 +1188,44 @@ def test_g1_motion_tracking_reset_and_step(sim_backend: str):
         assert state.reward.shape == (2,)
         assert state.terminated.shape == (2,)
         assert state.truncated.shape == (2,)
+    finally:
+        env.close()
+
+
+def test_g1_motion_tracking_deploy_reset_and_step_mujoco():
+    """Deploy env keeps motion-tracking behavior but exposes unitree mimic actor inputs."""
+    ensure_registries()
+    _require_mujoco_runtime()
+    from unilab.base import registry
+
+    motion_dir = Path(__file__).parents[2] / "src" / "unilab" / "assets" / "motions" / "g1"
+    if not motion_dir.exists():
+        pytest.skip(f"Motion data directory not found: {motion_dir}")
+
+    npz_files = list(motion_dir.glob("*.npz"))
+    if not npz_files:
+        pytest.skip(f"No .npz motion files in {motion_dir}")
+
+    env = cast(
+        Any,
+        registry.make(
+            "G1MotionTrackingDeploy",
+            num_envs=2,
+            sim_backend="mujoco",
+            env_cfg_override={"motion_file": str(npz_files[0])},
+        ),
+    )
+    try:
+        assert env.obs_groups_spec == {"obs": 154, "critic": 286}
+        state = env.init_state()
+        assert state.obs["obs"].shape == (2, 154)
+        assert state.obs["critic"].shape == (2, 286)
+
+        action_shape = env.action_space.shape
+        assert action_shape is not None
+        state = env.step(np.zeros((2, action_shape[0])))
+        assert state.obs["obs"].shape == (2, 154)
+        assert state.obs["critic"].shape == (2, 286)
     finally:
         env.close()
 


### PR DESCRIPTION
Summary:
- add G1MotionTrackingDeploy with unitree_rl_lab mimic actor inputs while preserving G1MotionTracking actor inputs
- add PPO owner configs for g1_motion_tracking_deploy on MuJoCo and Motrix
- cover deploy registration, obs dimensions, Hydra config, and support matrix docs

Validation:
- make check
- make test
- make test-all