### PR TITLE
benchmark: improve env step memory metrics

### DIFF
--- a/benchmark/benchmark_env_step.py
+++ b/benchmark/benchmark_env_step.py
@@ -16,7 +16,10 @@ Usage:
 """
 
 import importlib.util
+import json
+import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,10 +58,16 @@ def _load_helper_module(module_name: str, relative_path: str):
 
 
 _DEVICE_INFO = _load_helper_module("bench_env_step_device_info", "device_info.py")
+_MEM_PROFILE = _load_helper_module("bench_env_step_mem_profile", "mem_profile.py")
 _OUTPUT = _load_helper_module("bench_env_step_output", "output.py")
 
 get_device_info_dict = _DEVICE_INFO.get_device_info_dict
 get_device_info_line = _DEVICE_INFO.get_device_info_line
+MEMORY_METRICS = _MEM_PROFILE.MEMORY_METRICS
+_build_memory_summary = _MEM_PROFILE.build_memory_summary
+_format_mb = _MEM_PROFILE.format_mb
+_mb = _MEM_PROFILE.mb
+_memory_snapshot = _MEM_PROFILE.memory_snapshot
 save_json = _OUTPUT.save_json
 
 BACKENDS = ["mujoco", "motrix"]
@@ -734,7 +743,9 @@ def _run_single(extra_args: list[str]) -> dict[str, Any]:
 
     env = None
     timing_records: dict[str, list[float]] = {}
+    memory_samples: dict[str, dict[str, Any]] = {}
     try:
+        memory_samples["before_env"] = _memory_snapshot("before_env")
         env_cls = task_config.env_cls_factory()
         env = env_cls(cfg, num_envs=num_envs, backend_type=sim_backend)
 
@@ -751,9 +762,11 @@ def _run_single(extra_args: list[str]) -> dict[str, Any]:
             timing = state.info.get("timing", {})
             for k, v in timing.items():
                 timing_records.setdefault(k, []).append(float(v))
+        memory_samples["after_benchmark"] = _memory_snapshot("after_benchmark")
     finally:
         if env is not None:
             env.close()
+            memory_samples["after_close"] = _memory_snapshot("after_close")
 
     return {
         "task_name": task_config.env_name,
@@ -762,6 +775,7 @@ def _run_single(extra_args: list[str]) -> dict[str, Any]:
         "num_steps": num_steps,
         "warmup_steps": warmup_steps,
         "timing_records": timing_records,
+        "memory": _build_memory_summary(memory_samples, num_envs),
     }
 
 
@@ -789,6 +803,7 @@ def _compute_result_summary(result: dict[str, Any]) -> dict[str, Any]:
         "throughput_env_steps_per_s": throughput,
         "timing_mean_ms": {},
         "timing_median_ms": {},
+        "memory": result.get("memory", {}),
     }
     for key, values in tr.items():
         arr = np.array(values, dtype=np.float64)
@@ -799,6 +814,8 @@ def _compute_result_summary(result: dict[str, Any]) -> dict[str, Any]:
 
 def _serialize_result(result: dict[str, Any]) -> dict[str, Any]:
     summary = _compute_result_summary(result)
+    memory = result.get("memory", {})
+    preferred_metric = str(memory.get("preferred_metric", "rss"))
     return {
         "task_name": result["task_name"],
         "task_key": result.get("task_key"),
@@ -806,10 +823,18 @@ def _serialize_result(result: dict[str, Any]) -> dict[str, Any]:
         "num_envs": result["num_envs"],
         "num_steps": result["num_steps"],
         "warmup_steps": result["warmup_steps"],
+        "memory": memory,
         "plot_data": {
             "label": summary["label"],
             "median_step_ms": summary["median_step_ms"],
             "throughput_env_steps_per_s": summary["throughput_env_steps_per_s"],
+            "total_rss_delta_mb": _mb(memory.get("total_rss_delta_bytes")),
+            "total_uss_delta_mb": _mb(memory.get("total_uss_delta_bytes")),
+            "preferred_memory_metric": preferred_metric,
+            "total_preferred_delta_mb": _mb(memory.get(f"total_{preferred_metric}_delta_bytes")),
+            "retained_preferred_delta_after_close_mb": _mb(
+                memory.get(f"retained_{preferred_metric}_delta_after_close_bytes")
+            ),
             "breakdown_median_ms": {
                 key: _median_timing_ms(result, key) for key, _, _ in BREAKDOWN_SEGMENTS
             },
@@ -834,6 +859,30 @@ def _print_single_report(result: dict[str, Any]) -> None:
     print(f"  Min step time:    {summary['min_step_ms']:.3f}ms")
     print(f"  Max step time:    {summary['max_step_ms']:.3f}ms")
     print(f"  Throughput:       {summary['throughput_env_steps_per_s']:.0f} env-steps/s")
+    memory = result.get("memory", {})
+    if memory:
+        preferred_metric = str(memory.get("preferred_metric", "rss"))
+        print(
+            "  Memory RSS:       "
+            f"total Δ={_format_mb(memory.get('total_rss_delta_bytes'))}, "
+            f"after step={_format_mb(memory.get('after_benchmark_rss_bytes'), signed=False)}"
+        )
+        if memory.get("total_uss_delta_bytes") is not None:
+            print(
+                "  Memory USS:       "
+                f"total Δ={_format_mb(memory.get('total_uss_delta_bytes'))}, "
+                f"after step={_format_mb(memory.get('after_benchmark_uss_bytes'), signed=False)}"
+            )
+        print(
+            "  Memory retained:  "
+            f"after close Δ={_format_mb(memory.get(f'retained_{preferred_metric}_delta_after_close_bytes'))} "
+            f"({preferred_metric.upper()})"
+        )
+        print(
+            "  Memory baseline:  "
+            f"before env={_format_mb(memory.get('before_env_rss_bytes'), signed=False)} "
+            f"(source: {memory.get('rss_source', 'unavailable')})"
+        )
     if tr:
         print(f"{'- ' * 30}")
         print("  Breakdown:")
@@ -877,6 +926,9 @@ def _print_comparison_table(results: list[dict[str, Any]]) -> None:
         ("  reset_done", "reset_done_ms"),
         ("  env_step_other", "env_step_other_ms"),
         ("throughput", "__throughput__"),
+        ("memory RSS Δ", "__total_rss_delta_mb__"),
+        ("memory USS Δ", "__total_uss_delta_mb__"),
+        ("close USS Δ", "__close_uss_delta_mb__"),
     ]
 
     # Build short column labels
@@ -898,7 +950,7 @@ def _print_comparison_table(results: list[dict[str, Any]]) -> None:
     header += "│".join(c.center(col_w) for c in col_labels) + "│"
     print(header)
 
-    unit_row = "│" + "(median ms)".center(metric_w) + "│"
+    unit_row = "│" + "(ms / MB)".center(metric_w) + "│"
     unit_row += "│".join(" " * col_w for _ in results) + "│"
     print(unit_row)
     print(hline("├", "┼", "┤"))
@@ -912,6 +964,17 @@ def _print_comparison_table(results: list[dict[str, Any]]) -> None:
                 total_s = total_arr.sum() / 1000.0
                 steps_per_env = r["num_steps"] * r["num_envs"]
                 cells.append(f"{steps_per_env / total_s:,.0f}" if total_s > 0 else "-")
+        elif key == "__total_rss_delta_mb__":
+            for r in results:
+                cells.append(_format_mb(r.get("memory", {}).get("total_rss_delta_bytes")))
+        elif key == "__total_uss_delta_mb__":
+            for r in results:
+                cells.append(_format_mb(r.get("memory", {}).get("total_uss_delta_bytes")))
+        elif key == "__close_uss_delta_mb__":
+            for r in results:
+                cells.append(
+                    _format_mb(r.get("memory", {}).get("retained_uss_delta_after_close_bytes"))
+                )
         else:
             for r in results:
                 arr = _timing_array(r, key)
@@ -1119,9 +1182,14 @@ def _save_summary_plot(results: list[dict[str, Any]], output_path: Path) -> bool
     labels = [summary["label"] for summary in summaries]
     width = 0.78
 
-    fig, axes = plt.subplots(1, 2, figsize=(max(10, len(labels) * 1.6), 5.5))
+    fig, axes = plt.subplots(1, 3, figsize=(max(13, len(labels) * 2.0), 5.5))
     median_ms = [summary["median_step_ms"] for summary in summaries]
     throughput = [summary["throughput_env_steps_per_s"] for summary in summaries]
+    memory_metric = [str(summary["memory"].get("preferred_metric", "rss")) for summary in summaries]
+    total_memory_delta_mb = [
+        _mb(summary["memory"].get(f"total_{memory_metric[idx]}_delta_bytes")) or 0.0
+        for idx, summary in enumerate(summaries)
+    ]
 
     for idx, result in enumerate(ordered):
         style = _backend_style(result["sim_backend"])
@@ -1144,6 +1212,15 @@ def _save_summary_plot(results: list[dict[str, Any]], output_path: Path) -> bool
             hatch=style["hatch"],
             alpha=0.92,
         )
+        axes[2].bar(
+            x[idx],
+            total_memory_delta_mb[idx],
+            width=width,
+            color=color,
+            edgecolor="#444444",
+            hatch=style["hatch"],
+            alpha=0.92,
+        )
 
     axes[0].set_ylabel("median env.step time (ms)")
     axes[0].set_title("Latency")
@@ -1153,14 +1230,19 @@ def _save_summary_plot(results: list[dict[str, Any]], output_path: Path) -> bool
     axes[1].set_title("Throughput")
     axes[1].grid(axis="y", alpha=0.3)
 
+    axes[2].axhline(0.0, color="#5F6368", linewidth=0.8)
+    axes[2].set_ylabel("memory delta (MB, USS preferred)")
+    axes[2].set_title("Memory")
+    axes[2].grid(axis="y", alpha=0.3)
+
     for ax in axes:
         _decorate_grouped_xaxis(ax, ordered, x, groups)
 
     fig.suptitle(f"Env step benchmark summary\n{get_device_info_line()}")
     handles = _backend_legend_handles()
     if handles:
-        axes[1].legend(handles=handles, title="backend", loc="upper right")
-    fig.subplots_adjust(bottom=0.24, top=0.82, wspace=0.22)
+        axes[2].legend(handles=handles, fontsize=8, loc="upper right")
+    fig.subplots_adjust(bottom=0.24, top=0.82, wspace=0.28)
     fig.savefig(output_path, dpi=160, bbox_inches="tight")
     plt.close(fig)
     print(f"Saved: {output_path.resolve()}")
@@ -1245,6 +1327,12 @@ def _persist_outputs(
         "device_info": get_device_info_dict(),
         "matplotlib_available": plt is not None,
         "plot_files": plot_files,
+        "memory_measurement": {
+            "single_case": "in_process",
+            "matrix": "case_subprocess_isolated",
+            "growth_range": "before_env_to_after_benchmark",
+            "metrics": list(MEMORY_METRICS),
+        },
     }
     if failures:
         meta["failures"] = failures
@@ -1252,11 +1340,70 @@ def _persist_outputs(
     save_json(out_json, [_serialize_result(result) for result in results], meta)
 
 
+def _case_runner_args(extra_args: list[str]) -> list[str]:
+    args: list[str] = []
+    i = 0
+    while i < len(extra_args):
+        arg = extra_args[i]
+        if arg in {"--out-json", "--plot-dir"}:
+            i += 2
+            continue
+        if arg.startswith("--out-json=") or arg.startswith("--plot-dir="):
+            i += 1
+            continue
+        if arg.startswith("out_json=") or arg.startswith("plot_dir="):
+            i += 1
+            continue
+        if arg == "--skip-plots" or arg.startswith("skip_plots="):
+            i += 1
+            continue
+        args.append(arg)
+        i += 1
+    return args
+
+
+def _tail_text(text: str, *, max_lines: int = 24) -> str:
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:])
+
+
+def _run_single_isolated(label: str, args: list[str]) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="unilab_env_step_case_") as tmpdir:
+        result_json = Path(tmpdir) / "result.json"
+        cmd = [
+            "uv",
+            "run",
+            "benchmark/benchmark_env_step.py",
+            *args,
+            "--emit-full-result-json",
+            str(result_json),
+        ]
+        completed = subprocess.run(
+            cmd,
+            cwd=ROOT_DIR,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            details = _tail_text(completed.stdout + "\n" + completed.stderr)
+            raise RuntimeError(details or f"case process exited with {completed.returncode}")
+
+        if not result_json.exists():
+            details = _tail_text(completed.stdout + "\n" + completed.stderr)
+            raise RuntimeError(f"{label} produced no result JSON\n{details}")
+
+        payload = json.loads(result_json.read_text(encoding="utf-8"))
+        record = payload.get("result")
+        if not isinstance(record, dict):
+            raise RuntimeError(f"{label} produced no raw result record")
+        return cast(dict[str, Any], record)
+
+
 def _run_matrix(
     extra_args: list[str], *, out_json: Path, plot_dir: Path | None, skip_plots: bool
 ) -> None:
     """Run all task x backend combinations and print comparison."""
-    from unilab.base.backend.motrix_backend import MOTRIX_AVAILABLE
+    from unilab.base.backend import MOTRIX_AVAILABLE
 
     backends = BACKENDS if MOTRIX_AVAILABLE else ["mujoco"]
     if not MOTRIX_AVAILABLE:
@@ -1273,8 +1420,8 @@ def _run_matrix(
             label = f"{task_key}/{backend}"
             print(f"Running {label} ...", flush=True)
             try:
-                args = [f"task={task_config.task_id}/{backend}"] + extra_args
-                result = _run_single(args)
+                args = [f"task={task_config.task_id}/{backend}"] + _case_runner_args(extra_args)
+                result = _run_single_isolated(label, args)
                 result["task_key"] = task_key
                 results.append(result)
                 _print_single_report(result)
@@ -1294,8 +1441,34 @@ def _run_matrix(
     )
 
 
+def _extract_emit_full_result_arg(argv: list[str]) -> tuple[Path | None, list[str]]:
+    emit_path: Path | None = None
+    remaining: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--emit-full-result-json":
+            i += 1
+            if i >= len(argv):
+                raise ValueError("--emit-full-result-json requires a path")
+            emit_path = Path(argv[i])
+        elif arg.startswith("--emit-full-result-json="):
+            emit_path = Path(arg.split("=", 1)[1])
+        else:
+            remaining.append(arg)
+        i += 1
+    return emit_path, remaining
+
+
 def main() -> None:
     argv = sys.argv[1:]
+    emit_full_result_json, argv = _extract_emit_full_result_arg(argv)
+    if emit_full_result_json is not None:
+        result = _run_single(argv)
+        emit_full_result_json.parent.mkdir(parents=True, exist_ok=True)
+        emit_full_result_json.write_text(json.dumps({"result": result}), encoding="utf-8")
+        return
+
     _, output_kwargs, _ = _parse_cli_args(argv)
     out_json = Path(output_kwargs["out_json"]) if output_kwargs["out_json"] else DEFAULT_OUTPUT_JSON
     plot_dir = Path(output_kwargs["plot_dir"]) if output_kwargs["plot_dir"] else None

--- a/benchmark/core/mem_profile.py
+++ b/benchmark/core/mem_profile.py
@@ -1,0 +1,155 @@
+"""Process memory profiling helpers for benchmark scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Any
+
+BYTES_PER_MB = 1024.0 * 1024.0
+MEMORY_METRICS = ("rss", "uss", "pss")
+
+
+def current_memory_bytes() -> dict[str, Any]:
+    try:
+        import psutil
+
+        process = psutil.Process()
+        info = process.memory_info()
+        result: dict[str, Any] = {
+            "rss_bytes": int(info.rss),
+            "memory_source": "psutil",
+        }
+        try:
+            full_info = process.memory_full_info()
+            uss = getattr(full_info, "uss", None)
+            pss = getattr(full_info, "pss", None)
+            if uss is not None:
+                result["uss_bytes"] = int(uss)
+            if pss is not None:
+                result["pss_bytes"] = int(pss)
+        except Exception:
+            pass
+        return result
+    except Exception:
+        pass
+
+    if sys.platform.startswith("linux"):
+        try:
+            page_size = int(os.sysconf("SC_PAGE_SIZE"))
+            with open("/proc/self/statm", encoding="utf-8") as f:
+                parts = f.read().split()
+            if len(parts) >= 2:
+                return {
+                    "rss_bytes": int(parts[1]) * page_size,
+                    "memory_source": "procfs",
+                }
+        except Exception:
+            pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(os.getpid())],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return {
+            "rss_bytes": int(result.stdout.strip()) * 1024,
+            "memory_source": "ps",
+        }
+    except Exception:
+        return {
+            "rss_bytes": None,
+            "memory_source": "unavailable",
+        }
+
+
+def peak_rss_bytes() -> int | None:
+    try:
+        import resource
+
+        usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform == "darwin":
+            return int(usage)
+        return int(usage) * 1024
+    except Exception:
+        return None
+
+
+def memory_snapshot(label: str) -> dict[str, Any]:
+    memory = current_memory_bytes()
+    source = memory.get("memory_source", "unavailable")
+    return {
+        "label": label,
+        **memory,
+        "rss_source": source,
+        "peak_rss_bytes": peak_rss_bytes(),
+    }
+
+
+def bytes_delta(after: int | None, before: int | None) -> int | None:
+    if after is None or before is None:
+        return None
+    return int(after) - int(before)
+
+
+def bytes_per_env(value_bytes: int | None, num_envs: int) -> float | None:
+    if value_bytes is None or num_envs <= 0:
+        return None
+    return float(value_bytes) / float(num_envs)
+
+
+def mb(value_bytes: int | float | None) -> float | None:
+    if value_bytes is None:
+        return None
+    return float(value_bytes) / BYTES_PER_MB
+
+
+def format_mb(value_bytes: int | float | None, *, signed: bool = True) -> str:
+    value_mb = mb(value_bytes)
+    if value_mb is None:
+        return "-"
+    sign = "+" if signed else ""
+    return f"{value_mb:{sign}.1f} MB"
+
+
+def first_available_metric(samples: dict[str, dict[str, Any]]) -> str:
+    for metric in ("uss", "pss", "rss"):
+        if any(sample.get(f"{metric}_bytes") is not None for sample in samples.values()):
+            return metric
+    return "rss"
+
+
+def build_memory_summary(
+    samples: dict[str, dict[str, Any]],
+    num_envs: int,
+) -> dict[str, Any]:
+    before_env = samples.get("before_env", {})
+    after_benchmark = samples.get("after_benchmark", {})
+    after_close = samples.get("after_close", {})
+    preferred_metric = first_available_metric(samples)
+
+    summary: dict[str, Any] = {
+        "rss_source": after_benchmark.get("rss_source", "unavailable"),
+        "memory_source": after_benchmark.get("memory_source", "unavailable"),
+        "preferred_metric": preferred_metric,
+        "before_env_rss_bytes": before_env.get("rss_bytes"),
+        "after_benchmark_rss_bytes": after_benchmark.get("rss_bytes"),
+        "after_close_rss_bytes": after_close.get("rss_bytes"),
+        "after_benchmark_peak_rss_bytes": after_benchmark.get("peak_rss_bytes"),
+        "samples": samples,
+    }
+    for metric in MEMORY_METRICS:
+        key = f"{metric}_bytes"
+        total_delta = bytes_delta(after_benchmark.get(key), before_env.get(key))
+        close_delta = bytes_delta(after_close.get(key), before_env.get(key))
+
+        summary[f"before_env_{metric}_bytes"] = before_env.get(key)
+        summary[f"after_benchmark_{metric}_bytes"] = after_benchmark.get(key)
+        summary[f"after_close_{metric}_bytes"] = after_close.get(key)
+        summary[f"total_{metric}_delta_bytes"] = total_delta
+        summary[f"retained_{metric}_delta_after_close_bytes"] = close_delta
+        summary[f"total_{metric}_delta_bytes_per_env"] = bytes_per_env(total_delta, num_envs)
+    return summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.7.1.dev100423"]
+motrix = ["motrixsim-core==0.7.1.dev101648"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -857,7 +857,9 @@ class MotrixBackend(SimBackend):
     def _set_position_actuator_kd_override(self, data_slice, kd: np.ndarray) -> None:
         for actuator in self._position_actuators:
             # TODO(motrixsim#1384): drop the copy once strided NumPy views are accepted.
-            actuator.set_kd_override(data_slice, np.ascontiguousarray(kd[:, int(actuator.index)]))
+            actuator.set_damping_override(
+                data_slice, np.ascontiguousarray(kd[:, int(actuator.index)])
+            )
 
     def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
         if not self._supports_position_actuator_gains:

--- a/tests/benchmark/test_mem_profile.py
+++ b/tests/benchmark/test_mem_profile.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import benchmark.core.mem_profile as mem_profile
+
+
+def test_build_memory_summary_keeps_env_step_schema() -> None:
+    samples = {
+        "before_env": {"rss_bytes": 1000, "uss_bytes": 800, "memory_source": "test"},
+        "after_benchmark": {
+            "rss_bytes": 2600,
+            "uss_bytes": 1900,
+            "memory_source": "test",
+            "rss_source": "test",
+            "peak_rss_bytes": 3000,
+        },
+        "after_close": {"rss_bytes": 2400, "uss_bytes": 1700, "memory_source": "test"},
+    }
+
+    summary = mem_profile.build_memory_summary(samples, num_envs=2)
+
+    assert summary["preferred_metric"] == "uss"
+    assert summary["total_rss_delta_bytes"] == 1600
+    assert summary["total_rss_delta_bytes_per_env"] == 800.0
+    assert summary["total_uss_delta_bytes"] == 1100
+    assert summary["total_uss_delta_bytes_per_env"] == 550.0
+    assert summary["retained_uss_delta_after_close_bytes"] == 900
+    assert summary["after_benchmark_peak_rss_bytes"] == 3000
+    assert summary["samples"] is samples
+
+
+def test_format_mb() -> None:
+    assert mem_profile.format_mb(None) == "-"
+    assert mem_profile.format_mb(1024 * 1024) == "+1.0 MB"
+    assert mem_profile.format_mb(1024 * 1024, signed=False) == "1.0 MB"

--- a/uv.lock
+++ b/uv.lock
@@ -2111,7 +2111,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.7.1.dev100423"
+version = "0.7.1.dev101648"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2119,18 +2119,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:13d32c5feb57da92a3dd1266555ad2e5b03e405872780a7181733b90a91d4c30" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50098db17f4b9c3ae5b4c54654b26c87b67827d70dcb3eb800f8b5407d46637c" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp310-cp310-win_amd64.whl", hash = "sha256:6c067b79858371452ded1a9cb05d2fb70a8565c7e45ac711e4f9c64561c1adfb" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4a103770e00b27ae85396e5ed127941067356a62c93b2883aef9e10bf3f4a383" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c03ae8b228b86835006b0bc500c76c70a81c5fc2852dd15363da627d027c06" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp311-cp311-win_amd64.whl", hash = "sha256:0362212f848698acdd315842a9780d265ec0ee13b862a693e9caa440f3f91f01" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f8713635a4848f10a16881e72436ccecf44cf2a3c8446f528f61764f2a15d083" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dace73521df41e43d97eb9dea08c28d18e6007a986990d410d44d8531ea7279f" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp312-cp312-win_amd64.whl", hash = "sha256:a508d06fb383b0d7d03515a405ebf8041eabc6563be1c51e4503db6f06dd7378" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c1a6d2416471960be8d1faa978bee18a10640d477c20fea69fedfb439b7f78a6" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b718fd2fa7e2c4b011ba26d5d58a8c85b09583cf764f41ff3ced43a5acc6ca5" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev100423-cp313-cp313-win_amd64.whl", hash = "sha256:3dcd56ff95ea545c8de7d6844ad943d1810bb4ebc51d096a47b421e48b589293" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e21af24a93184e5936df5c4ffbc5e9f0983c39eab90700d05edc80799fb6510d" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4ea3990b50aff909261325a78184b98bf2a36b9f00d6d16bb49568251796e1d" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp310-cp310-win_amd64.whl", hash = "sha256:d160092e98c5cdfefd268c48f44386a43604849cd1e0a7a4e028310e5bd80cba" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac1a8c76f117678aadab06bf676f539135b6d09ced6b02a5b1a6d9a1edcd6327" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15661851c47ba70091a61e1ba8d02e42579cbf5f1b6def08b3fd0bc550e62257" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp311-cp311-win_amd64.whl", hash = "sha256:5dd4c2e6e4047cb9785324a3bafc1c74ec8eebd9b837dccd626612b3641a852f" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b2f56685cd84be3bc59cccdc2c4b8ea9cb61fd7d48e72f934c6f03b728d71a6e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a37012bc1117bebcface37be7b37770caa8f9886678a3ad0ed1dcbd3bbe1701f" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp312-cp312-win_amd64.whl", hash = "sha256:6abdf3af3a06a0e8ab67afa6b2c84c5e99934eedfc0ba3bddaef3f61d455b10a" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d62389c4b05b37388232162da63b6fe0ef370d3fa9bbd4c46e75587e62c88da3" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0ef9ffbde733f6ac5c06fdba1e35fa50c83de0569333cd17a94d251fc8825c7" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev101648-cp313-cp313-win_amd64.whl", hash = "sha256:f68db9f0d12e3ff79226b01ac9b3e5bf0b6c508b482e56bc495a1c90277e81bc" },
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev100423", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev101648", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- isolate env-step benchmark matrix cases in subprocesses for cleaner memory accounting
- add RSS/USS/PSS memory snapshots and serialize memory deltas into benchmark outputs
- update Motrix dependency/API usage for damping override compatibility

## Validation
- make test-all