### PR TITLE
refactor: simplify collector timing metrics

### DIFF
--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -316,7 +316,6 @@ class APPORunner(AsyncRunner):
                 rollout_ring_buffer.advance_read()
 
             self._drain_metrics(metrics_queue, reward_history, latest_reward_components, logger)
-            startup_wait_time = wait_time if iteration == 1 else 0.0
 
             combined = staging_pool.batch()
 
@@ -354,7 +353,6 @@ class APPORunner(AsyncRunner):
                 learner_incremental_h2d_time=learner_incremental_h2d_time,
                 weight_sync_time=weight_sync_time,
                 extra_info={
-                    "startup_wait_time": startup_wait_time,
                     "throughput_steps": num_new * env_steps_per_sync,
                 },
             )

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -177,8 +177,6 @@ def _learner_worker(
         latest_reward_components: dict = {}
         write_read_ema = 0.0
         last_buf_log = 0
-        startup_wait_time = 0.0
-        have_startup_wait_time = False
 
         # 7. Training loop
         for it in range(1, max_iterations + 1):
@@ -224,9 +222,6 @@ def _learner_worker(
 
             dist.barrier()
             wait_time = time.time() - wait_start if rank == 0 else 0.0
-            if rank == 0 and not have_startup_wait_time:
-                startup_wait_time = wait_time
-                have_startup_wait_time = True
 
             # --- Training: each rank independently samples a different mini-batch ---
             iter_metrics: dict = defaultdict(list)
@@ -291,7 +286,6 @@ def _learner_worker(
                         learner_incremental_h2d_time=learner_incremental_h2d_time,
                         weight_sync_time=weight_sync_time,
                         extra_info={
-                            "startup_wait_time": startup_wait_time if it == 1 else 0.0,
                             "throughput_steps": num_envs * env_steps_per_sync,
                         },
                     )

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -288,8 +288,6 @@ class OffPolicyRunner(AsyncRunner):
         write_read_ema = 0.0
         reward_stats_ptr = 0
         train_start_threshold = self.train_start_threshold
-        startup_wait_time = 0.0
-        have_startup_wait_time = False
 
         training_e2e_start_ns = time.perf_counter_ns() if trace_recorder else 0
 
@@ -403,9 +401,6 @@ class OffPolicyRunner(AsyncRunner):
                 logger,
                 trace_recorder,
             )
-            if not have_startup_wait_time:
-                startup_wait_time = wait_time
-                have_startup_wait_time = True
             _reward_stats_ns = time.perf_counter_ns() if trace_recorder else 0
             reward_stats_ptr = self._update_reward_stats_from_replay(
                 replay_buffer,
@@ -559,7 +554,6 @@ class OffPolicyRunner(AsyncRunner):
                 learner_incremental_h2d_time=learner_incremental_h2d_time,
                 weight_sync_time=weight_sync_time,
                 extra_info={
-                    "startup_wait_time": startup_wait_time if iteration == 1 else 0.0,
                     "throughput_steps": self.num_envs * self.env_steps_per_sync,
                 },
             )

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -18,6 +18,17 @@ from unilab.base.observations import get_obs_dims, split_obs_dict
 from unilab.base.registry import ensure_registries
 from unilab.training.seed import apply_training_seed
 
+# Exclusive phases for one collector loop iteration (one vectorized env.step).
+# Every key is recorded once per iteration so the reported averages share one
+# denominator and can be summed without double counting.
+COLLECTOR_TIMING_KEYS = (
+    "weight_sync_ms",
+    "action_select_ms",
+    "env_step_ms",
+    "replay_ms",
+    "sync_coordination_ms",
+)
+
 
 def resolve_collector_actor_dims(
     env,
@@ -56,6 +67,17 @@ def sample_offpolicy_actions(
     raise ValueError(f"Unsupported off-policy algo_type for collector action sampling: {algo_type}")
 
 
+def _record_timing_ms(timing_accum_ms, timing_counts, key: str, value: float) -> None:
+    timing_accum_ms[key] += float(value)
+    timing_counts[key] += 1
+
+
+def _record_phase_ms(cycle_timing_ms: dict[str, float], key: str, start_ns: int) -> int:
+    end_ns = time.perf_counter_ns()
+    cycle_timing_ms[key] += (end_ns - start_ns) / 1e6
+    return end_ns
+
+
 def _collector_pack_shared_batch(replay_buffer, request: dict, shared_slots) -> dict:
     tick_id = int(request["tick_id"])
     snapshot_ptr = int(replay_buffer.ptr[0])
@@ -69,11 +91,11 @@ def _collector_pack_shared_batch(replay_buffer, request: dict, shared_slots) -> 
         raise RuntimeError(
             "collector_thread pack target_gpu_slot must differ from learner_hot_gpu_slot"
         )
+    pack_begin_ns = time.perf_counter_ns()
     gen = torch.Generator(device="cpu")
     gen.manual_seed(sample_seed)
     indices = torch.randint(0, snapshot_size, (sample_count,), generator=gen)
     dst = shared_slots[shared_slot]
-    pack_begin_ns = time.perf_counter_ns()
     torch.index_select(replay_buffer._storage, 0, indices, out=dst)
     pack_end_ns = time.perf_counter_ns()
     return {
@@ -314,7 +336,7 @@ def _run_collector(
 
     ep_reward_components = defaultdict(list)
     timing_accum_ms = defaultdict(float)
-    timing_count = 0
+    timing_counts = defaultdict(int)
     done_count_window = 0
     timeout_count_window = 0
     terminated_count_window = 0
@@ -336,6 +358,9 @@ def _run_collector(
 
     # Collection loop
     while not stop_event.is_set():
+        cycle_timing_ms: dict[str, float] = dict.fromkeys(COLLECTOR_TIMING_KEYS, 0.0)
+        phase_start_ns = _time.perf_counter_ns()
+
         # Check for weight updates
         if weight_sync.version > local_weight_version:
             _wt_ns = _time.perf_counter_ns()
@@ -356,6 +381,7 @@ def _run_collector(
                 if stats is not None:
                     # Apply stats to a local normalizer if needed, or directly to actor
                     pass  # Handled by EmpiricalNormalization in learner if actor possesses it. We need a local normalizer.
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "weight_sync_ms", phase_start_ns)
 
         # Normalize obs_np
         obs_np_input = obs_np
@@ -367,7 +393,6 @@ def _run_collector(
 
         # Select action
         with torch.no_grad():
-            _t_infer = _time.perf_counter()
             _t_infer_ns = _time.perf_counter_ns()
             obs_torch = torch.from_numpy(obs_np_input)
             dones_torch = torch.from_numpy(prev_dones_np)
@@ -378,7 +403,6 @@ def _run_collector(
                 prev_dones_torch=dones_torch,
             )
             actions_np = actions_torch.numpy()
-            timing_accum_ms["mlp_infer_ms"] += (_time.perf_counter() - _t_infer) * 1000
             if trace_recorder:
                 trace_recorder.add_slice(
                     "collector/actor_infer_cpu",
@@ -386,6 +410,7 @@ def _run_collector(
                     start_ns=_t_infer_ns,
                     end_ns=_time.perf_counter_ns(),
                 )
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "action_select_ms", phase_start_ns)
 
         # Step environment
         _env_ns = _time.perf_counter_ns()
@@ -398,13 +423,7 @@ def _run_collector(
                 end_ns=_time.perf_counter_ns(),
                 args={"num_envs": num_envs},
             )
-
-        timing_info = state.info.get("timing", {})
-        if timing_info:
-            for key in ("env_step_total_ms", "step_core_ms", "update_state_ms", "reset_done_ms"):
-                if key in timing_info:
-                    timing_accum_ms[key] += float(timing_info[key])
-            timing_count += 1
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "env_step_ms", phase_start_ns)
 
         # Extract data as numpy
         next_obs_np, next_critic_np = split_obs_dict(state.obs)
@@ -431,6 +450,7 @@ def _run_collector(
             info=state.info,
             truncated=truncated_np,
         )
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
 
         # ReplayBuffer `dones` follows the UniLab env lifecycle contract:
         # done = terminated | truncated. Learners use `truncated` to keep
@@ -464,6 +484,7 @@ def _run_collector(
                 start_ns=_rb_ns,
                 end_ns=_time.perf_counter_ns(),
             )
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
         _, pending_collector_pack_request = _service_collector_pack_requests(
             replay_buffer,
             collector_pack_request_queue,
@@ -473,6 +494,7 @@ def _run_collector(
             block_timeout=0.0,
             pending_request=pending_collector_pack_request,
         )
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
 
         # Track episode rewards - vectorized
         current_ep_rewards += rewards_np
@@ -489,6 +511,7 @@ def _run_collector(
         critic_np = next_critic_np
         total_steps += num_envs
         env_steps_since_sync += 1
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_coordination_ms", phase_start_ns)
 
         # Signal the learner once this collection chunk is ready.
         if (
@@ -506,6 +529,9 @@ def _run_collector(
                         start_ns=_sig_ns,
                         end_ns=_time.perf_counter_ns(),
                     )
+                phase_start_ns = _record_phase_ms(
+                    cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                )
                 _wait_ns = _time.perf_counter_ns()
                 while not stop_event.is_set():
                     _, pending_collector_pack_request = _service_collector_pack_requests(
@@ -517,8 +543,12 @@ def _run_collector(
                         block_timeout=0.0,
                         pending_request=pending_collector_pack_request,
                     )
+                    phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
                     try:
                         trainer_done_queue.get(timeout=0.001)
+                        phase_start_ns = _record_phase_ms(
+                            cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                        )
                         _, pending_collector_pack_request = _service_collector_pack_requests(
                             replay_buffer,
                             collector_pack_request_queue,
@@ -528,8 +558,14 @@ def _run_collector(
                             block_timeout=0.0,
                             pending_request=pending_collector_pack_request,
                         )
+                        phase_start_ns = _record_phase_ms(
+                            cycle_timing_ms, "replay_ms", phase_start_ns
+                        )
                         break
                     except queue.Empty:
+                        phase_start_ns = _record_phase_ms(
+                            cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                        )
                         continue
                 if trace_recorder:
                     trace_recorder.add_slice(
@@ -545,9 +581,13 @@ def _run_collector(
                             )
                         except Exception:
                             pass
+                    phase_start_ns = _record_phase_ms(
+                        cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                    )
                 env_steps_since_sync = 0
         elif env_steps_since_sync >= env_steps_per_sync:
             env_steps_since_sync = 0
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_coordination_ms", phase_start_ns)
 
         # Progress log every 2 seconds
         now = _time.time()
@@ -562,16 +602,19 @@ def _run_collector(
                     ep_reward_components[k].append(v)
 
         # Send metrics periodically
-        if metrics_queue is not None and total_steps % (num_envs * 10) == 0 and ep_rewards:
+        if metrics_queue is not None and total_steps % (num_envs * 10) == 0:
             import statistics
 
             try:
                 msg = {
                     "total_steps": total_steps,
-                    "mean_ep_reward": statistics.mean(ep_rewards[-100:]),
-                    "mean_ep_length": statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0,
                     "buffer_size": int(replay_buffer.size[0]),
                 }
+                if ep_rewards:
+                    msg["mean_ep_reward"] = statistics.mean(ep_rewards[-100:])
+                    msg["mean_ep_length"] = (
+                        statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
+                    )
                 # Add mean reward components
                 if ep_reward_components:
                     components_mean = {}
@@ -581,12 +624,12 @@ def _run_collector(
                     msg["reward_components"] = components_mean
                     ep_reward_components.clear()  # reset after sending
 
-                if timing_count > 0:
+                if timing_counts:
                     msg["collector_timing_ms"] = {
-                        k: (v / timing_count) for k, v in timing_accum_ms.items()
+                        k: (v / timing_counts[k])
+                        for k, v in timing_accum_ms.items()
+                        if timing_counts[k] > 0
                     }
-                    timing_accum_ms.clear()
-                    timing_count = 0
 
                 if done_count_window > 0:
                     msg["timeout_rate"] = timeout_count_window / done_count_window
@@ -599,8 +642,15 @@ def _run_collector(
                     msg["trace_events"] = trace_recorder.drain_events()
 
                 metrics_queue.put_nowait(msg)
+                if "collector_timing_ms" in msg:
+                    timing_accum_ms.clear()
+                    timing_counts.clear()
             except Exception as e:
                 print(f"[OffPolicyWorker] metrics enqueue error: {e}", file=sys.stderr)
+        phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_coordination_ms", phase_start_ns)
+
+        for key in COLLECTOR_TIMING_KEYS:
+            _record_timing_ms(timing_accum_ms, timing_counts, key, cycle_timing_ms[key])
 
     if metrics_queue is not None and trace_recorder:
         try:

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -14,6 +14,22 @@ from rich.text import Text
 
 from unilab.logging.common import BaseTrainingLogger, _fmt_number, _fmt_time, _load_wandb
 
+OFFPOLICY_COLLECTOR_TIMING_ORDER = {
+    "weight_sync_ms": 0,
+    "action_select_ms": 1,
+    "env_step_ms": 2,
+    "replay_ms": 3,
+    "sync_coordination_ms": 4,
+}
+
+OFFPOLICY_COLLECTOR_TIMING_LABELS = {
+    "weight_sync_ms": "Weight Sync",
+    "action_select_ms": "Action Select",
+    "env_step_ms": "Env Step",
+    "replay_ms": "Replay",
+    "sync_coordination_ms": "Sync Coordination",
+}
+
 
 class OffPolicyLogger(BaseTrainingLogger):
     """Rich logger for off-policy RL algorithms (SAC, TD3, etc)."""
@@ -65,7 +81,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_size: int = 0
         self._buffer_target: int = 0
         self._wait_time: float = 0.0
-        self._startup_wait_time: float = 0.0
         self._learner_incremental_h2d_time: float = 0.0
         self._weight_sync_time: float = 0.0
         self._throughput_steps: int = 0
@@ -188,10 +203,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._weight_sync_time = weight_sync_time
         self._has_iteration_extra_info = extra_info is not None
         if extra_info:
-            self._startup_wait_time = float(extra_info.get("startup_wait_time", 0.0))
             self._throughput_steps = int(extra_info.get("throughput_steps", 0))
         else:
-            self._startup_wait_time = 0.0
             self._throughput_steps = 0
         self._iter_times.append(self._get_iter_pipeline_time())
         if metrics:
@@ -231,10 +244,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             writer.add_scalar("episode/timeout_rate", self._timeout_rate, global_step)
             writer.add_scalar("episode/terminated_rate", self._terminated_rate, global_step)
             writer.add_scalar("timing/learner_wait_ms", self._wait_time * 1000, global_step)
-            if self._has_iteration_extra_info:
-                writer.add_scalar(
-                    "timing/startup_wait_ms", self._startup_wait_time * 1000, global_step
-                )
             writer.add_scalar(
                 "timing/learner_incremental_h2d_ms",
                 self._learner_incremental_h2d_time * 1000,
@@ -270,8 +279,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             log_dict["episode/timeout_rate"] = self._timeout_rate
             log_dict["episode/terminated_rate"] = self._terminated_rate
             log_dict["timing/learner_wait_ms"] = self._wait_time * 1000
-            if self._has_iteration_extra_info:
-                log_dict["timing/startup_wait_ms"] = self._startup_wait_time * 1000
             log_dict["timing/learner_incremental_h2d_ms"] = (
                 self._learner_incremental_h2d_time * 1000
             )
@@ -361,25 +368,21 @@ class OffPolicyLogger(BaseTrainingLogger):
             ("Train", f"{self._train_time * 1000:.1f}ms"),
             ("Weight Sync", f"{self._weight_sync_time * 1000:.1f}ms"),
         ]
-        collector_order = {
-            "env_step_total_ms": 0,
-            "step_core_ms": 1,
-            "update_state_ms": 2,
-            "reset_done_ms": 3,
-            "mlp_infer_ms": 4,
-        }
         collector_items = [
-            (key, f"{value:.1f}ms")
+            (OFFPOLICY_COLLECTOR_TIMING_LABELS.get(key, key), f"{value:.1f}ms")
             for key, value in sorted(
                 self._collector_timing.items(),
-                key=lambda item: (collector_order.get(item[0], len(collector_order)), item[0]),
+                key=lambda item: (
+                    OFFPOLICY_COLLECTOR_TIMING_ORDER.get(
+                        item[0], len(OFFPOLICY_COLLECTOR_TIMING_ORDER)
+                    ),
+                    item[0],
+                ),
             )
         ]
         system_items = [
             ("Buffer", f"{self._buffer_size:,}"),
         ]
-        if self._startup_wait_time > 0:
-            system_items.append(("Startup Wait", f"{self._startup_wait_time * 1000:.1f}ms"))
         system_items.extend(
             [
                 ("Timeout Rate", f"{self._timeout_rate * 100:.1f}%"),

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -280,7 +280,7 @@ def test_appo_runner_logs_learner_timing_for_fps_inputs(
     assert step["train_time"] == pytest.approx(0.5)
     assert step["learner_incremental_h2d_time"] >= 0.0
     assert step["weight_sync_time"] >= 0.0
-    assert step["extra_info"]["startup_wait_time"] == pytest.approx(10.0)
+    assert step["extra_info"] == {"throughput_steps": 8}
     assert step["extra_info"]["throughput_steps"] == 8
     assert step["metrics"]["rollouts_read"] == 1.0
     assert step["metrics"]["staging_pool_len"] == 1.0

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -372,7 +372,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     assert "collect_time" not in logger.step_calls[0]
     assert logger.step_calls[0]["learner_incremental_h2d_time"] == pytest.approx(0.004)
     assert logger.step_calls[0]["weight_sync_time"] >= 0.0
-    assert logger.step_calls[0]["extra_info"]["startup_wait_time"] == pytest.approx(10.0)
+    assert logger.step_calls[0]["extra_info"] == {"throughput_steps": 2}
     assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
     assert _FakeWeightSync.last_instance is not None
     assert _FakeWeightSync.last_instance.write_calls == 1
@@ -446,7 +446,7 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
     assert "collect_time" not in logger.step_calls[0]
     assert logger.step_calls[0]["learner_incremental_h2d_time"] == pytest.approx(0.004)
     assert logger.step_calls[0]["weight_sync_time"] >= 0.0
-    assert logger.step_calls[0]["extra_info"]["startup_wait_time"] == pytest.approx(10.0)
+    assert logger.step_calls[0]["extra_info"] == {"throughput_steps": 2}
     assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
 
 
@@ -922,5 +922,5 @@ def test_multi_gpu_worker_rank0_propagates_learner_timing_and_extra_info(
     assert "collect_time" not in step
     assert step["learner_incremental_h2d_time"] == pytest.approx(0.004)
     assert step["weight_sync_time"] >= 0.0
-    assert step["extra_info"]["startup_wait_time"] == pytest.approx(10.0)
+    assert step["extra_info"] == {"throughput_steps": 2}
     assert step["extra_info"]["throughput_steps"] == 2

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -55,6 +55,18 @@ class _FakeWandb:
         return _FakeVideo(path, format=format)
 
 
+class _FakeTensorBoardWriter:
+    def __init__(self) -> None:
+        self.scalars: list[tuple[str, float, int]] = []
+        self.close_calls = 0
+
+    def add_scalar(self, tag: str, value: float, step: int) -> None:
+        self.scalars.append((tag, value, step))
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 def test_training_logger_defers_initial_live_render(monkeypatch):
     start_refresh_values: list[bool] = []
 
@@ -309,7 +321,7 @@ def test_offpolicy_logger_close_releases_owned_wandb_run_once(monkeypatch):
     assert fake_wandb.finish_calls == 1
 
 
-def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeypatch):
+def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
     fake_wandb = _FakeWandb()
     monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
 
@@ -326,13 +338,12 @@ def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeyp
         wait_time=10.0,
         learner_incremental_h2d_time=0.02,
         weight_sync_time=0.05,
-        extra_info={"startup_wait_time": 9.75, "throughput_steps": 8},
+        extra_info={"throughput_steps": 8},
     )
 
     payload, step = fake_wandb.log_calls[-1]
     assert step == 1
     assert payload["timing/learner_wait_ms"] == 10_000.0
-    assert payload["timing/startup_wait_ms"] == 9_750.0
     assert "timing/learner_collect_ms" not in payload
     assert payload["timing/learner_incremental_h2d_ms"] == 20.0
     assert payload["timing/learner_train_ms"] == 750.0
@@ -342,6 +353,36 @@ def test_offpolicy_logger_logs_separate_startup_wait_and_iter_throughput(monkeyp
     assert "perf/collect_train_ratio" not in payload
 
     logger.finish()
+
+
+def test_offpolicy_logger_logs_collector_phase_timing_to_backends(monkeypatch):
+    fake_wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    wandb_logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        env_name="Go2JoystickFlat",
+        log_backend="wandb",
+    )
+    wandb_logger.update_collector_timing({"replay_ms": 1.25})
+    wandb_logger.log_step(iteration=3, metrics={}, train_time=0.1)
+
+    payload, _ = fake_wandb.log_calls[-1]
+    assert payload["timing/collector_replay_ms"] == pytest.approx(1.25)
+    wandb_logger.finish()
+
+    tb_writer = _FakeTensorBoardWriter()
+    tb_logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        env_name="Go2JoystickFlat",
+        log_backend="none",
+    )
+    tb_logger._tb_writer = tb_writer
+    tb_logger.update_collector_timing({"replay_ms": 2.5})
+    tb_logger.log_step(iteration=4, metrics={}, train_time=0.1)
+
+    assert ("timing/collector_replay_ms", 2.5, 4) in tb_writer.scalars
+    tb_logger.finish()
 
 
 def test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied(monkeypatch):
@@ -366,7 +407,6 @@ def test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied(monkeyp
     )
 
     payload, _ = fake_wandb.log_calls[-1]
-    assert "timing/startup_wait_ms" not in payload
     assert "timing/learner_collect_ms" not in payload
     assert "perf/steps_per_sec" not in payload
 


### PR DESCRIPTION
## Summary
- replace mixed offpolicy collector timing fields with exclusive collector process phases
- merge transition/replay add/replay pack into collector replay timing
- remove startup wait as a separate iteration timing field

## Validation
- make test-all