### PR TITLE
fix: align logger compact headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,19 @@ git clone https://github.com/unilabsim/UniLab.git
 cd UniLab
 
 # 2. Install dependencies
+# Choose exactly one command for your platform; do not run all three.
+
+# Linux CUDA or macOS
 uv sync --extra motrix
-# Linux AMD / ROCm workstation:
+
+# Linux AMD / ROCm
 # make sync-rocm
-# Linux Intel Arc / iGPU workstation:
+
+# Linux Intel Arc / iGPU
 # make sync-xpu
 
 # 3. Run a first PPO training job
-# macOS: 73s on M5Max-128GB, 1min43s on M3Max-48GB, 2.5min on MacBookNeo-8GB
-# Linux: 31s on RTX 4090 + R9-9950x3d, 2min16s on Intel Arc iGPU + Core Ultra 9 185H
 uv run train --algo ppo --task go2_joystick_flat --sim motrix
-# Linux AMD / ROCm workstation after make sync-rocm:
-# uv run --no-sync train --algo ppo --task go2_joystick_flat --sim motrix
-# Linux Intel Arc / XPU workstation after make sync-xpu:
-# uv run --no-sync train --algo ppo --task go2_joystick_flat --sim motrix
 ```
 
 This is the first-level training entrypoint. It routes to the registered `go2_joystick_flat/motrix` task owner config and keeps backend selection in the CLI flags.
@@ -61,9 +60,9 @@ uv run demo
 
 On macOS / MacBook, the UniLab CLI routes Motrix interactive playback through `mxpython` when needed. Motrix defaults to interactive playback; use `--render-mode record` for headless video export or `--render-mode none` to skip playback. Detailed script-level commands are documented under `docs/users/zh_CN/`.
 
-On Linux AMD / ROCm workstations, `make sync-rocm` requires ROCm 7.1 or newer and installs the PyTorch ROCm 7.2 wheel (`torch==2.11.0+rocm7.2`). Use `uv run --no-sync ...` after that setup so `uv` does not resync the default Linux CUDA wheel.
+<!-- On Linux AMD / ROCm workstations, `make sync-rocm` requires ROCm 7.1 or newer and installs the PyTorch ROCm 7.2 wheel (`torch==2.11.0+rocm7.2`). Use `uv run --no-sync ...` after that setup so `uv` does not resync the default Linux CUDA wheel. -->
 
-On Linux Intel Arc / iGPU workstations, `make sync-xpu` installs the PyTorch XPU wheel (`torch==2.7.0+xpu`) which bundles the Intel oneAPI compiler/SYCL runtimes. The GPU userspace driver itself must come from the system package manager — on Ubuntu 24.04+ / 26.04 install `intel-opencl-icd` and `libze-intel-gpu1` (kernel 6.2+ ships the i915 driver). Use `uv run --no-sync ...` after the swap so `uv` does not resync the default Linux CUDA wheel. Off-policy training (`--algo sac` / `--algo flashsac`) supports bf16 mixed precision via `training.use_amp=true` on XPU; on-policy PPO does not need AMP.
+<!-- On Linux Intel Arc / iGPU workstations, `make sync-xpu` installs the PyTorch XPU wheel (`torch==2.7.0+xpu`) which bundles the Intel oneAPI compiler/SYCL runtimes. The GPU userspace driver itself must come from the system package manager — on Ubuntu 24.04+ / 26.04 install `intel-opencl-icd` and `libze-intel-gpu1` (kernel 6.2+ ships the i915 driver). Use `uv run --no-sync ...` after the swap so `uv` does not resync the default Linux CUDA wheel. Off-policy training (`--algo sac` / `--algo flashsac`) supports bf16 mixed precision via `training.use_amp=true` on XPU; on-policy PPO does not need AMP. -->
 
 ### Interactive Notebooks
 
@@ -84,13 +83,11 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco
 ```
 
 ```bash
-# Linux CUDA G1 motion tracking (27min on RTX 4090 and R9-9950x3d)
 # macOS users: omit training.use_amp=true
 uv run train --algo sac --task g1_sac_wbt --sim mujoco training.use_amp=true
 ```
 
 ```bash
-# Linux CUDA Sharpa in-hand HORA (36min on RTX 4090 D and Intel Xeon Platinum 8457C)
 uv run train --algo ppo --task sharpa_inhand --sim mujoco --profile hora
 ```
 

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -304,6 +304,36 @@ class BaseTrainingLogger:
 
         return Panel(header_text, style="dim", box=box.SIMPLE)
 
+    def _build_compact_header(
+        self,
+        *,
+        include_status: bool,
+        extra_fields: list[tuple[str, str]] | None = None,
+    ) -> Text:
+        elapsed = time.time() - self._start_time if self._start_time else 0
+        eta = self._estimate_eta()
+        fields: list[tuple[str, str]] = [
+            (f" {self.algo_name}", "bold cyan"),
+            (self.env_name, "bold white"),
+            (f"iter {self._iteration}/{self.max_iterations}", "yellow"),
+            (f"⏱ {_fmt_time(elapsed)}", "green"),
+        ]
+        if eta:
+            fields.append((f"ETA {eta}", "bold magenta"))
+        if self._mean_ep_length > 0:
+            fields.append((f"Ep Len {self._mean_ep_length:.1f}", "yellow"))
+        if extra_fields:
+            fields.extend(extra_fields)
+        if include_status and self._status:
+            fields.append((self._status, "dim italic"))
+
+        header_text = Text(no_wrap=True, overflow="ellipsis")
+        for index, (text, style) in enumerate(fields):
+            if index > 0:
+                header_text.append(" | ", style="dim")
+            header_text.append(text, style=style)
+        return header_text
+
     def _build_reward_table_common(
         self,
         *,

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from collections import deque
 from typing import Any
 
@@ -12,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from unilab.logging.common import BaseTrainingLogger, _fmt_number, _fmt_time, _load_wandb
+from unilab.logging.common import BaseTrainingLogger, _fmt_number, _load_wandb
 
 OFFPOLICY_COLLECTOR_TIMING_ORDER = {
     "weight_sync_ms": 0,
@@ -132,30 +131,14 @@ class OffPolicyLogger(BaseTrainingLogger):
         return self._learner_incremental_h2d_time + self._train_time + self._weight_sync_time
 
     def _build_compact_header(self, *, include_status: bool) -> Text:
-        elapsed = time.time() - self._start_time if self._start_time else 0
-        eta = self._estimate_eta()
         iter_steps_per_sec = self._get_iter_steps_per_sec()
-        fields: list[tuple[str, str]] = [
-            (f" {self.algo_name}", "bold cyan"),
-            (self.env_name, "bold white"),
-            (f"iter {self._iteration}/{self.max_iterations}", "yellow"),
-            (f"⏱ {_fmt_time(elapsed)}", "green"),
-        ]
-        if eta:
-            fields.append((f"ETA {eta}", "bold magenta"))
-        if self._mean_ep_length > 0:
-            fields.append((f"Ep Len {self._mean_ep_length:.1f}", "yellow"))
+        extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
-            fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
-        if include_status and self._status:
-            fields.append((self._status, "dim italic"))
-
-        header_text = Text(no_wrap=True, overflow="ellipsis")
-        for index, (text, style) in enumerate(fields):
-            if index > 0:
-                header_text.append(" | ", style="dim")
-            header_text.append(text, style=style)
-        return header_text
+            extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
+        return super()._build_compact_header(
+            include_status=include_status,
+            extra_fields=extra_fields,
+        )
 
     def update_collector_timing(self, timing_ms: dict[str, float]):
         self._collector_timing.update(timing_ms)

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -130,14 +130,21 @@ class OffPolicyLogger(BaseTrainingLogger):
     def _get_iter_pipeline_time(self) -> float:
         return self._learner_incremental_h2d_time + self._train_time + self._weight_sync_time
 
-    def _build_compact_header(self, *, include_status: bool) -> Text:
+    def _build_compact_header(
+        self,
+        *,
+        include_status: bool,
+        extra_fields: list[tuple[str, str]] | None = None,
+    ) -> Text:
         iter_steps_per_sec = self._get_iter_steps_per_sec()
-        extra_fields: list[tuple[str, str]] = []
+        header_extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
-            extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
+            header_extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
+        if extra_fields:
+            header_extra_fields.extend(extra_fields)
         return super()._build_compact_header(
             include_status=include_status,
-            extra_fields=extra_fields,
+            extra_fields=header_extra_fields,
         )
 
     def update_collector_timing(self, timing_ms: dict[str, float]):

--- a/src/unilab/logging/onpolicy.py
+++ b/src/unilab/logging/onpolicy.py
@@ -213,13 +213,20 @@ class OnPolicyLogger(BaseTrainingLogger):
 
         return table
 
-    def _build_compact_header(self, *, include_status: bool) -> Text:
+    def _build_compact_header(
+        self,
+        *,
+        include_status: bool,
+        extra_fields: list[tuple[str, str]] | None = None,
+    ) -> Text:
         iter_time = self._collect_time + self._train_time
-        extra_fields: list[tuple[str, str]] = []
+        header_extra_fields: list[tuple[str, str]] = []
         if iter_time > 0:
             steps_per_second = self.num_envs * self.num_steps / iter_time
-            extra_fields.append((f"Steps/s {steps_per_second:,.0f}", "bold green"))
+            header_extra_fields.append((f"Steps/s {steps_per_second:,.0f}", "bold green"))
+        if extra_fields:
+            header_extra_fields.extend(extra_fields)
         return super()._build_compact_header(
             include_status=include_status,
-            extra_fields=extra_fields,
+            extra_fields=header_extra_fields,
         )

--- a/src/unilab/logging/onpolicy.py
+++ b/src/unilab/logging/onpolicy.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import time
 from typing import Any
 
 from rich import box
 from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
-from unilab.logging.common import BaseTrainingLogger, _fmt_number, _fmt_time, _load_wandb
+from unilab.logging.common import BaseTrainingLogger, _fmt_number, _load_wandb
 
 
 class OnPolicyLogger(BaseTrainingLogger):
@@ -121,21 +121,17 @@ class OnPolicyLogger(BaseTrainingLogger):
             wandb.log(log_dict, step=iteration)
 
     def _build_display(self) -> Panel:
-        header_panel = self._build_header(include_status=False)
-
+        header = self._build_compact_header(include_status=True)
         left = self._build_metrics_table()
         right = self._build_reward_table()
         bottom = self._build_timing_table()
-
         grid = Table.grid(expand=True)
         grid.add_column(ratio=1)
+        grid.add_column(width=2)
         grid.add_column(ratio=1)
-        grid.add_row(left, right)
-
-        main_group = Group(header_panel, grid, bottom)
-
+        grid.add_row(left, "", right)
         return Panel(
-            main_group,
+            Group(header, Text(""), grid, Text(""), bottom),
             title="[bold] 🚀 UniLab On-Policy Training [/]",
             border_style="bright_blue",
             padding=(0, 1),
@@ -143,54 +139,87 @@ class OnPolicyLogger(BaseTrainingLogger):
 
     def _build_metrics_table(self) -> Table:
         table = Table(
-            title="[bold]Policy Metrics[/]",
             box=box.SIMPLE_HEAVY,
             show_header=True,
+            show_edge=False,
             header_style="bold cyan",
             expand=True,
             pad_edge=False,
         )
-        table.add_column("Metric", style="white", ratio=2)
+        table.add_column("Losses & Metrics", style="white", ratio=2)
         table.add_column("Value", style="yellow", justify="right", ratio=1)
 
         if not self._latest_metrics:
-            table.add_row("[dim]Waiting...[/]", "")
+            table.add_row("[dim]Waiting for data...[/]", "")
         else:
-            for k in sorted(self._latest_metrics.keys()):
-                v = self._latest_metrics[k]
-                name = k.replace("_", " ").title()
-                table.add_row(name, _fmt_number(v))
+            loss_keys = sorted([key for key in self._latest_metrics if "loss" in key.lower()])
+            other_keys = sorted([key for key in self._latest_metrics if "loss" not in key.lower()])
+            for key in loss_keys:
+                value = self._latest_metrics[key]
+                style = "red" if value > 10 else "yellow"
+                table.add_row(key.replace("_", " ").title(), f"[{style}]{_fmt_number(value)}[/]")
+            for key in other_keys:
+                value = self._latest_metrics[key]
+                table.add_row(f"  {key.replace('_', ' ').title()}", _fmt_number(value))
 
         return table
 
     def _build_reward_table(self) -> Table:
-        return self._build_reward_table_common(wait_message="[dim]Waiting...[/]")
+        return self._build_reward_table_common(
+            wait_message="[dim]Waiting for data...[/]",
+            include_ep_length=False,
+        )
 
     def _build_timing_table(self) -> Table:
         table = Table(
-            title="[bold]Timing[/]",
             box=box.SIMPLE_HEAVY,
             show_header=True,
+            show_edge=False,
             header_style="bold blue",
             expand=True,
             pad_edge=False,
         )
-        table.add_column("Item", style="white", ratio=1)
-        table.add_column("Value", style="yellow", justify="right", ratio=1)
-        table.add_column("Item", style="white", ratio=1)
-        table.add_column("Value", style="yellow", justify="right", ratio=1)
+        table.add_column("Learner", style="white", ratio=2, no_wrap=True)
+        table.add_column("Value", style="yellow", justify="right", ratio=1, no_wrap=True)
+        table.add_column("Collector", style="white", ratio=2, no_wrap=True)
+        table.add_column("Value", style="yellow", justify="right", ratio=1, no_wrap=True)
+        table.add_column("System", style="white", ratio=2, no_wrap=True)
+        table.add_column("Value", style="yellow", justify="right", ratio=1, no_wrap=True)
 
-        elapsed = time.time() - self._start_time if self._start_time else 0
         iter_time = self._collect_time + self._train_time
         fps = int(self.num_envs * self.num_steps / max(iter_time, 1e-8)) if iter_time > 0 else 0
 
-        table.add_row("Elapsed", _fmt_time(elapsed), "Envs", f"{self.num_envs:,}")
-        table.add_row(
-            "Collect",
-            f"{self._collect_time * 1000:.1f}ms",
-            "Train",
-            f"{self._train_time * 1000:.1f}ms",
-        )
-        table.add_row("Iter Time", f"{iter_time * 1000:.1f}ms", "Steps/s", f"{fps:,}")
+        learner_items = [
+            ("Train", f"{self._train_time * 1000:.1f}ms"),
+            ("Iter Time", f"{iter_time * 1000:.1f}ms"),
+        ]
+        collector_items = [
+            ("Collect", f"{self._collect_time * 1000:.1f}ms"),
+        ]
+        system_items = [
+            ("Envs", f"{self.num_envs:,}"),
+            ("Steps/s", f"{fps:,}"),
+        ]
+
+        row_count = max(len(learner_items), len(collector_items), len(system_items))
+        for index in range(row_count):
+            row: list[str] = []
+            for items in (learner_items, collector_items, system_items):
+                if index < len(items):
+                    row.extend(items[index])
+                else:
+                    row.extend(["", ""])
+            table.add_row(*row)
 
         return table
+
+    def _build_compact_header(self, *, include_status: bool) -> Text:
+        iter_time = self._collect_time + self._train_time
+        extra_fields: list[tuple[str, str]] = []
+        if iter_time > 0:
+            steps_per_second = self.num_envs * self.num_steps / iter_time
+            extra_fields.append((f"Steps/s {steps_per_second:,.0f}", "bold green"))
+        return super()._build_compact_header(
+            include_status=include_status,
+            extra_fields=extra_fields,
+        )

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from rich.console import Console
 
 import unilab.logging.common as common_module
-import unilab.logging.offpolicy as offpolicy_module
 from unilab.logging import OffPolicyLogger, OnPolicyLogger
 from unilab.training.experiment import ExperimentTracker, build_wandb_settings
 
@@ -132,6 +132,42 @@ def test_offpolicy_training_terminal_refresh_uses_single_low_frequency_trigger(m
 
     logger.log_status("[red]ERROR: Collector died[/]")
     assert update_refresh_values == [True, True, True]
+
+    logger.close()
+
+
+def test_onpolicy_logger_uses_offpolicy_terminal_layout():
+    logger = OnPolicyLogger(
+        algo_name="MLX_PPO",
+        env_name="Go2JoystickFlat",
+        max_iterations=10,
+        num_envs=4,
+        num_steps=8,
+        log_backend="no_print",
+    )
+    logger.start()
+    logger.log_step(
+        iteration=1,
+        metrics={"surrogate": 0.1, "value_loss": 0.2},
+        reward=3.0,
+        collect_time=0.02,
+        train_time=0.03,
+    )
+    logger.update_ep_length(12.0)
+
+    console = Console(record=True, width=120)
+    console.print(logger._build_display())
+    output = console.export_text()
+
+    assert "Losses & Metrics" in output
+    assert "Learner" in output
+    assert "Collector" in output
+    assert "Train" in output
+    assert "Collect" in output
+    assert "Steps/s" in output
+    assert "Rollout Steps" not in output
+    assert "Steps/Env" not in output
+    assert "Policy Metrics" not in output
 
     logger.close()
 
@@ -421,7 +457,7 @@ def test_offpolicy_logger_omits_iteration_extra_fields_when_not_supplied(monkeyp
         log_backend="wandb",
     )
     logger._start_time = 1.0
-    monkeypatch.setattr(offpolicy_module.time, "time", lambda: 2.0)
+    monkeypatch.setattr(common_module.time, "time", lambda: 2.0)
     logger.log_collector(total_steps=8, buffer_size=8)
     logger.log_step(
         iteration=1,


### PR DESCRIPTION
## Summary
- Clarify README quickstart install commands as mutually exclusive platform choices.
- Align on-policy and off-policy compact header overrides with the base logger signature.
- Preserve existing compact header throughput fields while forwarding extra fields.

## Validation
- make test-all