### PR TITLE
perf: batch Go2W joint sensor reads

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -665,3 +665,19 @@ class SimBackend(abc.ABC):
         Returns:
             传感器数据数组
         """
+
+    def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
+        """Fetch multiple sensors and concatenate their flattened values.
+
+        Args:
+            names: Sensor names in output order.
+
+        Returns:
+            Array with shape ``(num_envs, total_sensor_values)``.
+        """
+        sensor_names = tuple(names)
+        if not sensor_names:
+            return np.empty((self.num_envs, 0), dtype=np.float64)
+        values = [np.asarray(self.get_sensor_data(name)) for name in sensor_names]
+        flat_values = [value.reshape(value.shape[0], -1) for value in values]
+        return np.concatenate(flat_values, axis=1)

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -749,6 +749,13 @@ class MotrixBackend(SimBackend):
     def get_sensor_data(self, name: str) -> np.ndarray:
         return self._model.get_sensor_value(name, self._data)  # type: ignore[no-any-return]
 
+    def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
+        sensor_names = tuple(names)
+        if not sensor_names:
+            return np.empty((self._num_envs, 0), dtype=self._np_dtype)
+        values = self._model.get_sensor_values(sensor_names, self._data)
+        return np.asarray(values, dtype=self._np_dtype)
+
     # ------------------------------------------------------------------ #
     # MotrixSim-specific                                                 #
     # ------------------------------------------------------------------ #

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -1095,6 +1095,13 @@ class MuJoCoBackend(SimBackend):
     def get_sensor_data(self, name: str) -> np.ndarray:
         return self._sensor_views[name]
 
+    def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
+        sensor_names = tuple(names)
+        if not sensor_names:
+            return np.empty((self._num_envs, 0), dtype=self._np_dtype)
+        values = [self._sensor_views[name].reshape(self._num_envs, -1) for name in sensor_names]
+        return np.concatenate(values, axis=1)
+
     def get_site_jacobian_w(
         self,
         site_id: int,

--- a/src/unilab/envs/locomotion/go2w/base.py
+++ b/src/unilab/envs/locomotion/go2w/base.py
@@ -83,16 +83,10 @@ class Go2WBaseCfg(LocomotionBaseCfg):
     ctrl_dt: float = 0.02
 
 
-def _sensor_scalar(data: np.ndarray) -> np.ndarray:
-    return data.reshape(data.shape[0], -1)[:, 0]
-
-
 def stack_joint_sensors(backend, suffix: str, *, dtype: np.dtype | type) -> np.ndarray:
-    values = [
-        _sensor_scalar(backend.get_sensor_data(f"{prefix}_{suffix}"))
-        for prefix in JOINT_SENSOR_PREFIXES
-    ]
-    return np.asarray(np.stack(values, axis=1), dtype=dtype)
+    names = tuple(f"{prefix}_{suffix}" for prefix in JOINT_SENSOR_PREFIXES)
+    values = backend.get_sensor_data_batch(names)
+    return np.asarray(values.reshape(values.shape[0], -1)[:, :NUM_GO2W_ACTIONS], dtype=dtype)
 
 
 def compute_go2w_motor_ctrl(

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -247,6 +247,33 @@ def test_cross_backend_model_properties_smoke():
     np.testing.assert_array_equal(mx.get_motion_body_ids(body_names), expected)
 
 
+@pytest.mark.parametrize("backend_type", ["mujoco", "motrix"])
+def test_backend_batch_sensor_data_matches_individual_sensors(backend_type):
+    if backend_type == "motrix":
+        pytest.importorskip("motrixsim")
+
+    from unilab.base.backend import create_backend
+    from unilab.envs.locomotion.go2w.base import JOINT_SENSOR_PREFIXES
+
+    bkd = create_backend(
+        backend_type,
+        SceneCfg(model_file=_xml("go2w", "scene_flat.xml")),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="base_link",
+    )
+    bkd.materialize()
+
+    names = tuple(f"{prefix}_pos" for prefix in JOINT_SENSOR_PREFIXES[:4])
+    expected = np.concatenate(
+        [np.asarray(bkd.get_sensor_data(name)).reshape(NUM_ENVS, -1) for name in names],
+        axis=1,
+    )
+
+    np.testing.assert_allclose(bkd.get_sensor_data_batch(names), expected)
+    _shape(bkd.get_sensor_data_batch(()), NUM_ENVS, 0)
+
+
 def test_mujoco_model_properties_smoke():
     from unilab.base.backend.mujoco.backend import MuJoCoBackend
 

--- a/tests/envs/locomotion/go2w/test_go2w_motor_control.py
+++ b/tests/envs/locomotion/go2w/test_go2w_motor_control.py
@@ -72,6 +72,9 @@ def test_go2w_joint_state_reads_named_sensors() -> None:
             idx = len(calls)
             return np.array([[float(idx)], [float(idx + 100)]], dtype=np.float32)
 
+        def get_sensor_data_batch(self, names) -> np.ndarray:
+            return np.concatenate([self.get_sensor_data(name) for name in names], axis=1)
+
     env = cast(Any, object.__new__(_ConcreteGo2WBaseEnv))
     env._backend = FakeBackend()
     env.default_angles = DEFAULT_GO2W_ANGLES.astype(np.float32)
@@ -150,6 +153,9 @@ def test_go2w_init_does_not_pass_position_actuator_gains(monkeypatch: pytest.Mon
             if name.endswith("_pos") or name.endswith("_vel"):
                 return np.zeros((2, 1), dtype=np.float32)
             raise KeyError(name)
+
+        def get_sensor_data_batch(self, names) -> np.ndarray:
+            return np.concatenate([self.get_sensor_data(name) for name in names], axis=1)
 
         def set_pre_step_control(self, fn) -> None:
             captured["pre_step_control"] = fn
@@ -259,9 +265,15 @@ def test_go2w_pre_step_motor_control_reads_from_passed_backend() -> None:
                 return np.ones((1, 1), dtype=np.float32) * 0.1
             raise KeyError(name)
 
+        def get_sensor_data_batch(self, names) -> np.ndarray:
+            return np.concatenate([self.get_sensor_data(name) for name in names], axis=1)
+
     class PoisonBackend:
         def get_sensor_data(self, name: str) -> np.ndarray:
             raise AssertionError(f"unexpected env backend read: {name}")
+
+        def get_sensor_data_batch(self, names) -> np.ndarray:
+            raise AssertionError(f"unexpected env backend read: {names}")
 
     env = cast(Any, object.__new__(Go2WJoystickEnv))
     env._backend = PoisonBackend()


### PR DESCRIPTION
## Summary
- Add SimBackend.get_sensor_data_batch() contract for concatenating multiple sensor reads.
- Implement backend-specific batch sensor reads for MuJoCo cached sensor views and Motrix native get_sensor_values().
- Use batched joint position/velocity sensor reads in Go2W motor control and cover the contract in backend and Go2W tests.

## Performance
- Command: uv run python benchmark/benchmark_env_step.py task=go2w_joystick_flat/motrix num_envs=2048 num_steps=100 warmup_steps=20
- backend_set_ctrl_ms median: 4.360 ms -> 1.860 ms, about 57.3% reduction
- total step median: 26.976 ms -> 23.773 ms, about 11.9% reduction
- throughput: 76,152 -> 85,970 env-steps/s, about 12.9% increase

## Validation
- uv run pytest tests/envs/locomotion/go2w/test_go2w_motor_control.py tests/base/test_sim_backend_smoke.py -q: 26 passed
- make test-all: passed, 895 passed, 37 skipped, 254 deselected, 67 warnings

Note: pyright still reports the existing warning at src/unilab/training/seed.py:103 for unresolved optional mlx.core import.