### PR TITLE
Extract shared interactive playback core

### DIFF
--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -112,6 +112,8 @@ interactive:
   camera_elevation: null
   camera_azimuth: null
   use_env_visual_model: true
+  speed: 1.0
+  start_paused: false
 
 viser:
   port: 8080

--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -53,6 +53,13 @@ from unilab.training.rsl_rl import (
     get_policy_obs_dims,
     normalize_ppo_train_cfg,
 )
+from unilab.visualization.interactive_playback import (
+    PlaybackControls,
+    RslRlPlaybackConfig,
+    create_rsl_rl_playback_session,
+    prepare_motion_overlay_selection,
+    select_torch_device,
+)
 
 ensure_registries()
 
@@ -61,6 +68,7 @@ from unilab.base.scene import SceneCfg
 from unilab.structured_configs import PPOConfig as _StructuredPPOConfig
 
 PPOConfig = _StructuredPPOConfig
+_PLAYBACK_ENV_UNAVAILABLE = "playback_env_unavailable"
 
 try:
     from rsl_rl.runners import OnPolicyRunner
@@ -101,6 +109,8 @@ class PlayInteractiveArgs:
     camera_elevation: float | None
     camera_azimuth: float | None
     use_env_visual_model: bool
+    speed: float
+    start_paused: bool
 
 
 def _infer_checkpoint_actor_input_dim(ckpt_path: str) -> int | None:
@@ -566,13 +576,23 @@ def _load_viewer_model(env: Any, *, use_env_visual_model: bool):
     return playback_model
 
 
+def _build_playback_config(args, *, num_envs: int = 1) -> RslRlPlaybackConfig:
+    return RslRlPlaybackConfig(
+        task=str(args.task),
+        load_run=str(args.load_run),
+        checkpoint=getattr(args, "checkpoint", None),
+        action_mode=str(args.action_mode),
+        policy_obs_mode=str(args.policy_obs_mode),
+        algo_log_name=str(getattr(args, "algo_log_name", "rsl_rl_ppo")),
+        log_root=getattr(args, "log_root", None),
+        num_envs=num_envs,
+        speed=float(getattr(args, "speed", 1.0)),
+        start_paused=bool(getattr(args, "start_paused", False)),
+    )
+
+
 def play_interactive(args, cfg: DictConfig | None = None):
-    if torch.cuda.is_available():
-        device = "cuda"
-    elif torch.backends.mps.is_available():
-        device = "mps"
-    else:
-        device = "cpu"
+    device = select_torch_device()
     print(f"[play_interactive] Device: {device}")
 
     # Always use a single env for interactive view
@@ -585,16 +605,16 @@ def play_interactive(args, cfg: DictConfig | None = None):
         )
         return
 
-    if cfg is None:
-        env = registry.make(args.task, num_envs=1, sim_backend="mujoco")
-    else:
+    def _create_env(num_envs: int):
+        if cfg is None:
+            return registry.make(args.task, num_envs=num_envs, sim_backend="mujoco")
         from unilab.training import create_env
 
         env_cfg_override = _backend_adapter(cfg).build_task_env_cfg_override()
         try:
-            env = create_env(
+            return create_env(
                 cfg,
-                num_envs=1,
+                num_envs=num_envs,
                 env_cfg_override=env_cfg_override,
                 sim_backend="mujoco",
                 task_name=args.task,
@@ -606,8 +626,31 @@ def play_interactive(args, cfg: DictConfig | None = None):
                     f"{args.task}. Available backends: {available_backends or ('<none>',)}. "
                     "This script only supports MuJoCo viewer mode."
                 )
-                return
+                raise RuntimeError(_PLAYBACK_ENV_UNAVAILABLE) from exc
             raise
+
+    try:
+        session = create_rsl_rl_playback_session(
+            playback_cfg=_build_playback_config(args, num_envs=1),
+            env_factory=_create_env,
+            algo_config=_algo_config_dict(cfg),
+            root_dir=ROOT_DIR,
+            device=device,
+            checkpoint_resolver=resolve_checkpoint,
+            checkpoint_input_dim_reader=_infer_checkpoint_actor_input_dim,
+            entrypoint_log_root=get_entrypoint_log_root,
+            wrapper_cls=RslRlVecEnvWrapper,
+            runner_cls=OnPolicyRunner,
+            policy_obs_dims_getter=get_policy_obs_dims,
+            train_cfg_normalizer=normalize_ppo_train_cfg,
+            log=lambda message: print(f"[play_interactive] {message}"),
+        )
+    except RuntimeError as exc:
+        if str(exc) == _PLAYBACK_ENV_UNAVAILABLE:
+            return
+        raise
+    playback_session = session[0]
+    env = playback_session.env
 
     if _uses_native_mujoco_viewer_launch() and not _can_launch_glfw_viewer():
         print(
@@ -615,112 +658,19 @@ def play_interactive(args, cfg: DictConfig | None = None):
             "Set DISPLAY correctly, or run this command in a desktop session."
         )
         return
-    actor_obs_dim, flat_obs_dim = get_policy_obs_dims(env.obs_groups_spec)
-
-    policy_obs_mode = args.policy_obs_mode
-    algo_log_name = getattr(args, "algo_log_name", "rsl_rl_ppo")
-    ckpt = None
-    if args.action_mode == "policy":
-        ckpt = resolve_checkpoint(
-            args.task,
-            args.load_run,
-            getattr(args, "checkpoint", None),
-            algo_log_name,
-            getattr(args, "log_root", None),
-        )
-        if policy_obs_mode == "auto" and ckpt is not None:
-            ckpt_dim = _infer_checkpoint_actor_input_dim(ckpt)
-            if ckpt_dim == actor_obs_dim:
-                policy_obs_mode = "actor"
-            elif ckpt_dim == flat_obs_dim:
-                policy_obs_mode = "flat"
-            elif ckpt_dim is not None:
-                raise RuntimeError(
-                    "Checkpoint actor input dim mismatch: "
-                    f"ckpt={ckpt_dim}, actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim}. "
-                    "Please pass --policy_obs_mode actor|flat explicitly if needed."
-                )
-            else:
-                # Default fallback keeps current behavior.
-                policy_obs_mode = "flat"
-
-    wrapped_env = RslRlVecEnvWrapper(env, device=device, policy_obs_mode=policy_obs_mode)
-    print(
-        "[play_interactive] Policy obs mode: "
-        f"{policy_obs_mode} (actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim})"
+    overlay = prepare_motion_overlay_selection(
+        env,
+        show_target_bodies=bool(args.show_target_bodies),
+        show_reward_debug=bool(args.show_reward_debug),
+        target_body_names=str(args.target_body_names),
+        target_max_bodies=int(args.target_max_bodies),
+        log=lambda message: print(f"[play_interactive] {message}"),
     )
 
-    train_cfg = normalize_ppo_train_cfg(_algo_config_dict(cfg))
-    if "runner" not in train_cfg:
-        train_cfg["runner"] = {}
-    train_cfg["runner"]["logger"] = "none"
-
-    policy = None
-    if args.action_mode == "policy":
-        if ckpt is None:
-            print("[play_interactive] WARNING: no checkpoint found — falling back to zero actions.")
-        else:
-            log_dir = str(
-                get_entrypoint_log_root(
-                    ROOT_DIR,
-                    algo_log_name=algo_log_name,
-                    log_root=getattr(args, "log_root", None),
-                )
-                / args.task
-                / "play_temp"
-            )
-            runner = OnPolicyRunner(wrapped_env, train_cfg, log_dir=log_dir, device=device)
-            runner.load(
-                ckpt,
-                load_cfg={
-                    "actor": True,
-                    "critic": False,
-                    "optimizer": False,
-                    "iteration": False,
-                    "rnd": False,
-                },
-            )
-            policy = runner.get_inference_policy(device=device)
-
-    print(f"[play_interactive] Action mode: {args.action_mode}")
-
-    target_vis_enabled = False
-    selected_indices = np.zeros((0,), dtype=np.int32)
-    if args.show_target_bodies or args.show_reward_debug:
-        if hasattr(env, "motion_loader") and hasattr(env, "motion_sampler"):
-            names = tuple(getattr(env.cfg, "body_names", ()))
-            if len(names) > 0:
-                name_to_idx = {name: i for i, name in enumerate(names)}
-                if args.target_body_names.strip():
-                    chosen = []
-                    for name in [n.strip() for n in args.target_body_names.split(",") if n.strip()]:
-                        if name in name_to_idx:
-                            chosen.append(name_to_idx[name])
-                        else:
-                            print(
-                                f"[play_interactive] WARNING: body name not found in task body list: {name}"
-                            )
-                    selected_indices = np.array(chosen, dtype=np.int32)
-                else:
-                    selected_indices = np.arange(len(names), dtype=np.int32)
-
-                if args.target_max_bodies > 0:
-                    selected_indices = selected_indices[: args.target_max_bodies]
-
-                target_vis_enabled = selected_indices.size > 0
-            else:
-                print(
-                    "[play_interactive] WARNING: task has no body_names; cannot visualize targets."
-                )
-        else:
-            print(
-                "[play_interactive] WARNING: target/reward visualization only works for motion-tracking tasks."
-            )
-
-    if target_vis_enabled:
+    if overlay.enabled:
         print(
             "[play_interactive] Target visualization enabled "
-            f"({selected_indices.size} bodies, axes={args.target_show_axes})."
+            f"({overlay.selected_indices.size} bodies, axes={args.target_show_axes})."
         )
     if args.show_reward_debug:
         print(
@@ -737,21 +687,32 @@ def play_interactive(args, cfg: DictConfig | None = None):
     state_spec = mujoco.mjtState.mjSTATE_FULLPHYSICS
     ctrl_dt = env.cfg.ctrl_dt
 
-    obs, _ = wrapped_env.reset()
-    paused_state = {"paused": False}
+    playback_session.reset()
+    controls = PlaybackControls(
+        paused=bool(getattr(args, "start_paused", False)),
+        speed=float(getattr(args, "speed", 1.0)),
+    )
 
     def _on_key(keycode: int) -> None:
         if keycode == ord(" "):
-            paused_state["paused"] = not paused_state["paused"]
-            status = "paused" if paused_state["paused"] else "resumed"
+            paused = controls.toggle_pause()
+            status = "paused" if paused else "resumed"
             print(f"[play_interactive] {status} (space)")
+        elif keycode in (ord("N"), ord("n")):
+            controls.request_single_step()
+            if not controls.paused:
+                controls.pause()
+                print("[play_interactive] paused for single-step mode (n)")
+            print("[play_interactive] single step requested (n)")
+        elif keycode in (ord("+"), ord("=")):
+            controls.set_speed(controls.speed * 1.25)
+            print(f"[play_interactive] speed={controls.speed:.2f}x")
+        elif keycode in (ord("-"), ord("_")):
+            controls.set_speed(controls.speed / 1.25)
+            print(f"[play_interactive] speed={controls.speed:.2f}x")
 
     print("[play_interactive] Opening viewer — close the window or press Esc to quit.")
-    print("[play_interactive] Controls: Space = pause/resume")
-
-    # Get action bounds for random mode
-    action_low = env.action_space.low
-    action_high = env.action_space.high
+    print("[play_interactive] Controls: Space=pause/resume, N=single-step, +/-=speed")
 
     with mujoco.viewer.launch_passive(mj_model, viz_data, key_callback=_on_key) as viewer:
         focus_body_id = _resolve_focus_body_id(
@@ -776,26 +737,10 @@ def play_interactive(args, cfg: DictConfig | None = None):
             while viewer.is_running():
                 t0 = time.perf_counter()
 
-                if not paused_state["paused"]:
-                    if args.action_mode == "policy" and policy is not None:
-                        actions = policy(obs)
-                    elif args.action_mode == "random":
-                        actions = (
-                            torch.from_numpy(
-                                np.random.uniform(
-                                    action_low, action_high, size=(1, env.action_space.shape[0])
-                                )
-                            )
-                            .to(device)
-                            .float()
-                        )
-                    else:  # zero
-                        actions = torch.zeros(1, env.action_space.shape[0], device=device)
-
-                    obs, _, _, _ = wrapped_env.step(actions)
+                playback_session.advance(controls)
 
                 # Push env state[0] into viz_data and refresh scene
-                phys = env.get_physics_state_snapshot()[0].astype(np.float64)
+                phys = playback_session.physics_state()[0].astype(np.float64)
                 mujoco.mj_setState(mj_model, viz_data, phys, state_spec)
                 mujoco.mj_forward(mj_model, viz_data)
 
@@ -807,12 +752,12 @@ def play_interactive(args, cfg: DictConfig | None = None):
                         base_pos[2] + float(getattr(args, "camera_height_offset", 0.15))
                     )
 
-                if target_vis_enabled:
+                if overlay.enabled:
                     if args.show_reward_debug:
                         _render_reward_debug_targets(
                             viewer,
-                            env.state.info,
-                            selected_indices,
+                            playback_session.info,
+                            overlay.selected_indices,
                             marker_radius=args.target_marker_radius,
                             marker_alpha=args.target_marker_alpha,
                             show_axes=args.target_show_axes,
@@ -828,7 +773,7 @@ def play_interactive(args, cfg: DictConfig | None = None):
                         _render_motion_targets(
                             viewer,
                             motion_data,
-                            selected_indices,
+                            overlay.selected_indices,
                             marker_radius=args.target_marker_radius,
                             marker_alpha=args.target_marker_alpha,
                             show_axes=args.target_show_axes,
@@ -841,8 +786,9 @@ def play_interactive(args, cfg: DictConfig | None = None):
 
                 # Real-time pacing
                 elapsed = time.perf_counter() - t0
-                if ctrl_dt - elapsed > 0:
-                    time.sleep(ctrl_dt - elapsed)
+                target_dt = controls.target_dt(ctrl_dt)
+                if target_dt - elapsed > 0:
+                    time.sleep(target_dt - elapsed)
 
     print("[play_interactive] Done.")
 
@@ -899,6 +845,8 @@ def _build_play_args(cfg: DictConfig) -> PlayInteractiveArgs:
             else None
         ),
         use_env_visual_model=bool(cfg.interactive.use_env_visual_model),
+        speed=float(OmegaConf.select(cfg, "interactive.speed", default=1.0)),
+        start_paused=bool(OmegaConf.select(cfg, "interactive.start_paused", default=False)),
     )
 
 

--- a/scripts/play_viser.py
+++ b/scripts/play_viser.py
@@ -55,6 +55,11 @@ from unilab.training.rsl_rl import (
     get_policy_obs_dims,
     normalize_ppo_train_cfg,
 )
+from unilab.visualization.interactive_playback import (
+    PlaybackControls,
+    create_rsl_rl_playback_session,
+    select_torch_device,
+)
 from unilab.visualization.render_many import get_grid_offsets
 from unilab.visualization.viser_scene import (
     VISER_AVAILABLE,
@@ -82,6 +87,7 @@ from play_interactive import (  # noqa: E402
     PlayInteractiveArgs,
     _available_backends_for_task,
     _backend_adapter,
+    _build_playback_config,
     _infer_checkpoint_actor_input_dim,
     resolve_checkpoint,
 )
@@ -208,11 +214,7 @@ def _close_scene_entries(entries: list[dict[str, Any]]) -> None:
 
 
 def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
-    device = (
-        "cuda"
-        if torch.cuda.is_available()
-        else ("mps" if torch.backends.mps.is_available() else "cpu")
-    )
+    device = select_torch_device()
     print(f"[play_viser] Device: {device}")
 
     # --- Validate backend ---------------------------------------------------
@@ -227,83 +229,36 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
     # --- Create environment --------------------------------------------------
     num_envs = int(OmegaConf.select(cfg, "viser.max_envs") or 1)
 
-    if cfg is None:
-        env = registry.make(args.task, num_envs=num_envs, sim_backend="mujoco")
-    else:
+    def _create_env(env_count: int):
+        if cfg is None:
+            return registry.make(args.task, num_envs=env_count, sim_backend="mujoco")
         from unilab.training import create_env
 
         env_cfg_override = _backend_adapter(cfg).build_task_env_cfg_override()
-        env = create_env(
+        return create_env(
             cfg,
-            num_envs=num_envs,
+            num_envs=env_count,
             env_cfg_override=env_cfg_override,
             sim_backend="mujoco",
             task_name=args.task,
         )
 
-    # --- Load policy ---------------------------------------------------------
-    actor_obs_dim, flat_obs_dim = get_policy_obs_dims(env.obs_groups_spec)
-
-    policy_obs_mode = args.policy_obs_mode
-    algo_log_name = getattr(args, "algo_log_name", "rsl_rl_ppo")
-    ckpt = None
-    if args.action_mode == "policy":
-        ckpt = resolve_checkpoint(
-            args.task,
-            args.load_run,
-            getattr(args, "checkpoint", None),
-            algo_log_name,
-            getattr(args, "log_root", None),
-        )
-        if policy_obs_mode == "auto" and ckpt is not None:
-            ckpt_dim = _infer_checkpoint_actor_input_dim(ckpt)
-            if ckpt_dim == actor_obs_dim:
-                policy_obs_mode = "actor"
-            elif ckpt_dim == flat_obs_dim:
-                policy_obs_mode = "flat"
-            elif ckpt_dim is not None:
-                raise RuntimeError(
-                    f"Checkpoint actor input dim mismatch: "
-                    f"ckpt={ckpt_dim}, actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim}."
-                )
-            else:
-                policy_obs_mode = "flat"
-
-    wrapped_env = RslRlVecEnvWrapper(env, device=device, policy_obs_mode=policy_obs_mode)
-
-    train_cfg = normalize_ppo_train_cfg(_algo_config_dict(cfg))
-    if "runner" not in train_cfg:
-        train_cfg["runner"] = {}
-    train_cfg["runner"]["logger"] = "none"
-
-    policy = None
-    if args.action_mode == "policy":
-        if ckpt is None:
-            print("[play_viser] WARNING: no checkpoint found — falling back to zero actions.")
-        else:
-            log_dir = str(
-                get_entrypoint_log_root(
-                    ROOT_DIR,
-                    algo_log_name=algo_log_name,
-                    log_root=getattr(args, "log_root", None),
-                )
-                / args.task
-                / "play_temp"
-            )
-            runner = OnPolicyRunner(wrapped_env, train_cfg, log_dir=log_dir, device=device)
-            runner.load(
-                ckpt,
-                load_cfg={
-                    "actor": True,
-                    "critic": False,
-                    "optimizer": False,
-                    "iteration": False,
-                    "rnd": False,
-                },
-            )
-            policy = runner.get_inference_policy(device=device)
-
-    print(f"[play_viser] Action mode: {args.action_mode}")
+    playback_session, _policy_obs_mode, _checkpoint_path = create_rsl_rl_playback_session(
+        playback_cfg=_build_playback_config(args, num_envs=num_envs),
+        env_factory=_create_env,
+        algo_config=_algo_config_dict(cfg),
+        root_dir=ROOT_DIR,
+        device=device,
+        checkpoint_resolver=resolve_checkpoint,
+        checkpoint_input_dim_reader=_infer_checkpoint_actor_input_dim,
+        entrypoint_log_root=get_entrypoint_log_root,
+        wrapper_cls=RslRlVecEnvWrapper,
+        runner_cls=OnPolicyRunner,
+        policy_obs_dims_getter=get_policy_obs_dims,
+        train_cfg_normalizer=normalize_ppo_train_cfg,
+        log=lambda message: print(f"[play_viser] {message}"),
+    )
+    env = playback_session.env
 
     # --- GUI controls --------------------------------------------------------
     max_visible_envs = min(int(OmegaConf.select(cfg, "viser.max_envs") or num_envs), num_envs)
@@ -343,6 +298,7 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
             initial_value=env_options[initial_env_idx],
         )
         pause_button = server.gui.add_button("Pause / Resume")
+        step_button = server.gui.add_button("Step")
         speed_slider = server.gui.add_slider(
             "Speed",
             min=0.1,
@@ -351,7 +307,11 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
             initial_value=1.0,
         )
 
-    paused = {"value": False}
+    controls = PlaybackControls(
+        paused=bool(getattr(args, "start_paused", False)),
+        speed=float(getattr(args, "speed", 1.0)),
+    )
+    speed_slider.value = controls.speed
     env_idx = {"value": initial_env_idx}
     display_mode = {"value": initial_mode}
     visible_envs = {"value": max_visible_envs}
@@ -389,9 +349,18 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
     @pause_button.on_click
     def _on_pause_click(event: Any) -> None:
         del event
-        paused["value"] = not paused["value"]
-        status = "paused" if paused["value"] else "resumed"
+        paused = controls.toggle_pause()
+        status = "paused" if paused else "resumed"
         print(f"[play_viser] {status}")
+
+    @step_button.on_click
+    def _on_step_click(event: Any) -> None:
+        del event
+        if not controls.paused:
+            controls.pause()
+            print("[play_viser] paused for single-step mode")
+        controls.request_single_step()
+        print("[play_viser] single step requested")
 
     @display_dropdown.on_update
     def _on_display_mode_update(event: Any) -> None:
@@ -413,9 +382,7 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
 
     env_dropdown.disabled = display_mode["value"] == "all"
 
-    obs, _info = wrapped_env.reset()
-    action_low = env.action_space.low
-    action_high = env.action_space.high
+    playback_session.reset()
 
     print(f"[play_viser] Server running at http://localhost:{port}")
     print(f"[play_viser] {num_envs} environment(s) loaded. Open browser to view.")
@@ -433,27 +400,10 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
             while True:
                 t0 = time.perf_counter()
 
-                if not paused["value"]:
-                    if args.action_mode == "policy" and policy is not None:
-                        actions = policy(obs)
-                    elif args.action_mode == "random":
-                        actions = (
-                            torch.from_numpy(
-                                np.random.uniform(
-                                    action_low,
-                                    action_high,
-                                    size=(num_envs, env.action_space.shape[0]),
-                                )
-                            )
-                            .to(device)
-                            .float()
-                        )
-                    else:  # zero
-                        actions = torch.zeros(num_envs, env.action_space.shape[0], device=device)
+                controls.set_speed(float(speed_slider.value))
+                playback_session.advance(controls)
 
-                    obs, _, _, _ = wrapped_env.step(actions)
-
-                physics_batch = env.get_physics_state_snapshot()
+                physics_batch = playback_session.physics_state()
                 for entry in scene_entries["value"]:
                     phys = physics_batch[int(entry["runtime_env_idx"])].astype(np.float64)
                     mujoco.mj_setState(entry["model"], entry["data"], phys, state_spec)
@@ -461,8 +411,7 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
                     entry["scene"].update(entry["data"])
 
                 # Real-time pacing
-                speed = speed_slider.value
-                target_dt = ctrl_dt / speed
+                target_dt = controls.target_dt(ctrl_dt)
                 elapsed = time.perf_counter() - t0
                 if target_dt - elapsed > 0:
                     time.sleep(target_dt - elapsed)
@@ -527,6 +476,8 @@ def _build_play_args(cfg: DictConfig) -> PlayInteractiveArgs:
             else None
         ),
         use_env_visual_model=bool(cfg.interactive.use_env_visual_model),
+        speed=float(OmegaConf.select(cfg, "interactive.speed", default=1.0)),
+        start_paused=bool(OmegaConf.select(cfg, "interactive.start_paused", default=False)),
     )
 
 

--- a/src/unilab/visualization/interactive_playback.py
+++ b/src/unilab/visualization/interactive_playback.py
@@ -1,0 +1,309 @@
+"""Shared core for interactive policy playback entrypoints."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+LogFn = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class RslRlPlaybackConfig:
+    """Configuration needed to bootstrap an RSL-RL interactive playback session."""
+
+    task: str
+    load_run: str
+    checkpoint: str | None
+    action_mode: str
+    policy_obs_mode: str
+    algo_log_name: str
+    log_root: str | None
+    num_envs: int = 1
+    speed: float = 1.0
+    start_paused: bool = False
+
+
+@dataclass
+class PlaybackControls:
+    """Viewer-independent playback control state."""
+
+    paused: bool = False
+    speed: float = 1.0
+    _single_step_requests: int = field(default=0, init=False, repr=False)
+
+    def pause(self) -> None:
+        self.paused = True
+
+    def resume(self) -> None:
+        self.paused = False
+
+    def toggle_pause(self) -> bool:
+        self.paused = not self.paused
+        return self.paused
+
+    def request_single_step(self, count: int = 1) -> None:
+        self._single_step_requests += max(int(count), 0)
+
+    def set_speed(self, value: float) -> None:
+        self.speed = max(float(value), 1e-6)
+
+    def consume_step_permission(self) -> bool:
+        if self.paused:
+            if self._single_step_requests <= 0:
+                return False
+            self._single_step_requests -= 1
+            return True
+        if self._single_step_requests > 0:
+            self._single_step_requests -= 1
+        return True
+
+    def target_dt(self, ctrl_dt: float) -> float:
+        return float(ctrl_dt) / max(float(self.speed), 1e-6)
+
+
+@dataclass(frozen=True)
+class MotionOverlaySelection:
+    """Cold-path selection of task bodies used by playback overlays."""
+
+    enabled: bool
+    selected_indices: np.ndarray
+
+
+class RslRlPlaybackSession:
+    """Policy/action stepping core shared by native and web viewers."""
+
+    def __init__(
+        self,
+        *,
+        env: Any,
+        wrapped_env: Any,
+        device: str,
+        action_mode: str,
+        policy: Callable[[Any], Any] | None,
+        num_envs: int,
+    ) -> None:
+        self.env = env
+        self.wrapped_env = wrapped_env
+        self.device = device
+        self.action_mode = action_mode
+        self.policy = policy
+        self.num_envs = int(num_envs)
+        self.obs: Any | None = None
+        self.step_count = 0
+
+    def reset(self) -> Any:
+        self.obs, _info = self.wrapped_env.reset()
+        self.step_count = 0
+        return self.obs
+
+    def step_once(self) -> Any:
+        actions = self._build_actions()
+        self.obs, _reward, _done, _info = self.wrapped_env.step(actions)
+        self.step_count += 1
+        return self.obs
+
+    def advance(self, controls: PlaybackControls) -> bool:
+        if not controls.consume_step_permission():
+            return False
+        self.step_once()
+        return True
+
+    def physics_state(self) -> np.ndarray:
+        return self.env.get_physics_state_snapshot()
+
+    @property
+    def info(self) -> dict[str, Any]:
+        state = getattr(self.env, "state", None)
+        info = getattr(state, "info", None)
+        return info if isinstance(info, dict) else {}
+
+    def _build_actions(self) -> torch.Tensor:
+        if self.obs is None:
+            raise RuntimeError("Playback session must be reset before stepping.")
+        action_space = self.env.action_space
+        action_dim = int(action_space.shape[0])
+        if self.action_mode == "policy" and self.policy is not None:
+            return self.policy(self.obs)
+        if self.action_mode == "random":
+            actions = np.random.uniform(
+                action_space.low,
+                action_space.high,
+                size=(self.num_envs, action_dim),
+            )
+            return torch.from_numpy(actions).to(self.device).float()
+        return torch.zeros(self.num_envs, action_dim, device=self.device)
+
+
+def select_torch_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def create_rsl_rl_playback_session(
+    *,
+    playback_cfg: RslRlPlaybackConfig,
+    env_factory: Callable[[int], Any],
+    algo_config: dict[str, Any],
+    root_dir: str | Path,
+    device: str | None,
+    checkpoint_resolver: Callable[[str, str, str | None, str, str | None], str | None],
+    checkpoint_input_dim_reader: Callable[[str], int | None],
+    entrypoint_log_root: Callable[..., Path],
+    wrapper_cls: Any,
+    runner_cls: Any,
+    policy_obs_dims_getter: Callable[[Any], tuple[int, int]],
+    train_cfg_normalizer: Callable[[dict[str, Any]], dict[str, Any]],
+    log: LogFn = print,
+) -> tuple[RslRlPlaybackSession, str, str | None]:
+    """Create a playback session and load the selected policy checkpoint."""
+
+    device_name = select_torch_device() if device is None else str(device)
+    env = env_factory(int(playback_cfg.num_envs))
+    if env is None:
+        raise RuntimeError("Playback env factory did not return an environment.")
+    actor_obs_dim, flat_obs_dim = policy_obs_dims_getter(env.obs_groups_spec)
+
+    policy_obs_mode = playback_cfg.policy_obs_mode
+    checkpoint_path: str | None = None
+    if playback_cfg.action_mode == "policy":
+        checkpoint_path = checkpoint_resolver(
+            playback_cfg.task,
+            playback_cfg.load_run,
+            playback_cfg.checkpoint,
+            playback_cfg.algo_log_name,
+            playback_cfg.log_root,
+        )
+        if policy_obs_mode == "auto" and checkpoint_path is not None:
+            ckpt_dim = checkpoint_input_dim_reader(checkpoint_path)
+            if ckpt_dim == actor_obs_dim:
+                policy_obs_mode = "actor"
+            elif ckpt_dim == flat_obs_dim:
+                policy_obs_mode = "flat"
+            elif ckpt_dim is not None:
+                raise RuntimeError(
+                    "Checkpoint actor input dim mismatch: "
+                    f"ckpt={ckpt_dim}, actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim}. "
+                    "Please pass --policy_obs_mode actor|flat explicitly if needed."
+                )
+            else:
+                policy_obs_mode = "flat"
+
+    wrapped_env = wrapper_cls(env, device=device_name, policy_obs_mode=policy_obs_mode)
+    log(f"Policy obs mode: {policy_obs_mode} (actor_obs={actor_obs_dim}, flat_obs={flat_obs_dim})")
+
+    train_cfg = train_cfg_normalizer(copy.deepcopy(algo_config))
+    if "runner" not in train_cfg:
+        train_cfg["runner"] = {}
+    train_cfg["runner"]["logger"] = "none"
+
+    policy = None
+    if playback_cfg.action_mode == "policy":
+        if checkpoint_path is None:
+            log("WARNING: no checkpoint found - falling back to zero actions.")
+        else:
+            log_dir = str(
+                entrypoint_log_root(
+                    Path(root_dir),
+                    algo_log_name=playback_cfg.algo_log_name,
+                    log_root=playback_cfg.log_root,
+                )
+                / playback_cfg.task
+                / "play_temp"
+            )
+            runner = runner_cls(wrapped_env, train_cfg, log_dir=log_dir, device=device_name)
+            runner.load(
+                checkpoint_path,
+                load_cfg={
+                    "actor": True,
+                    "critic": False,
+                    "optimizer": False,
+                    "iteration": False,
+                    "rnd": False,
+                },
+            )
+            policy = runner.get_inference_policy(device=device_name)
+
+    log(f"Action mode: {playback_cfg.action_mode}")
+    session = RslRlPlaybackSession(
+        env=env,
+        wrapped_env=wrapped_env,
+        device=device_name,
+        action_mode=playback_cfg.action_mode,
+        policy=policy,
+        num_envs=playback_cfg.num_envs,
+    )
+    return session, policy_obs_mode, checkpoint_path
+
+
+def prepare_motion_overlay_selection(
+    env: Any,
+    *,
+    show_target_bodies: bool,
+    show_reward_debug: bool,
+    target_body_names: str,
+    target_max_bodies: int,
+    log: LogFn = print,
+) -> MotionOverlaySelection:
+    """Resolve body indices used by motion-target and reward-debug overlays."""
+
+    if not (show_target_bodies or show_reward_debug):
+        return MotionOverlaySelection(
+            enabled=False,
+            selected_indices=np.zeros((0,), dtype=np.int32),
+        )
+
+    if not (hasattr(env, "motion_loader") and hasattr(env, "motion_sampler")):
+        log("WARNING: target/reward visualization only works for motion-tracking tasks.")
+        return MotionOverlaySelection(
+            enabled=False,
+            selected_indices=np.zeros((0,), dtype=np.int32),
+        )
+
+    names = tuple(getattr(env.cfg, "body_names", ()))
+    if len(names) == 0:
+        log("WARNING: task has no body_names; cannot visualize targets.")
+        return MotionOverlaySelection(
+            enabled=False,
+            selected_indices=np.zeros((0,), dtype=np.int32),
+        )
+
+    name_to_idx = {name: i for i, name in enumerate(names)}
+    if target_body_names.strip():
+        chosen = []
+        for name in [n.strip() for n in target_body_names.split(",") if n.strip()]:
+            if name in name_to_idx:
+                chosen.append(name_to_idx[name])
+            else:
+                log(f"WARNING: body name not found in task body list: {name}")
+        selected_indices = np.array(chosen, dtype=np.int32)
+    else:
+        selected_indices = np.arange(len(names), dtype=np.int32)
+
+    if target_max_bodies > 0:
+        selected_indices = selected_indices[:target_max_bodies]
+
+    return MotionOverlaySelection(
+        enabled=selected_indices.size > 0,
+        selected_indices=selected_indices,
+    )
+
+
+__all__ = [
+    "MotionOverlaySelection",
+    "PlaybackControls",
+    "RslRlPlaybackConfig",
+    "RslRlPlaybackSession",
+    "create_rsl_rl_playback_session",
+    "prepare_motion_overlay_selection",
+    "select_torch_device",
+]

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -2047,6 +2047,13 @@ def test_play_resolve_checkpoint_uses_algo_log_name(tmp_path):
         mod.ROOT_DIR = original_root
 
 
+def test_ppo_interactive_config_includes_playback_controls():
+    cfg = _ppo_cfg()
+
+    assert cfg.interactive.speed == pytest.approx(1.0)
+    assert cfg.interactive.start_paused is False
+
+
 def test_play_interactive_runner_log_dir_uses_algo_log_name(monkeypatch: pytest.MonkeyPatch):
     import types
 
@@ -2133,6 +2140,8 @@ def test_play_interactive_runner_log_dir_uses_algo_log_name(monkeypatch: pytest.
         reward_debug_ang_vel_scale=0.05,
         reward_debug_show_connectors=False,
         reward_debug_show_global_anchor=False,
+        speed=1.0,
+        start_paused=False,
     )
 
     mod.play_interactive(args)

--- a/tests/visualization/test_interactive_playback.py
+++ b/tests/visualization/test_interactive_playback.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from unilab.visualization.interactive_playback import (
+    PlaybackControls,
+    RslRlPlaybackConfig,
+    RslRlPlaybackSession,
+    create_rsl_rl_playback_session,
+    prepare_motion_overlay_selection,
+)
+
+
+class _FakeWrappedEnv:
+    def __init__(self, env: Any):
+        self.env = env
+        self.reset_calls = 0
+        self.step_calls = 0
+        self.last_actions = None
+
+    def reset(self):
+        self.reset_calls += 1
+        return "obs", {}
+
+    def step(self, actions):
+        self.step_calls += 1
+        self.last_actions = actions
+        return f"obs_{self.step_calls}", 0.0, False, {}
+
+
+def _fake_env(num_envs: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        action_space=SimpleNamespace(
+            shape=(2,),
+            low=np.full((2,), -1.0),
+            high=np.full((2,), 1.0),
+        ),
+        get_physics_state_snapshot=lambda: np.zeros((num_envs, 4), dtype=np.float32),
+        state=SimpleNamespace(info={"motion_data": object()}),
+    )
+
+
+def test_playback_controls_gate_single_step_and_speed() -> None:
+    controls = PlaybackControls(paused=True, speed=2.0)
+
+    assert controls.consume_step_permission() is False
+    controls.request_single_step()
+    assert controls.consume_step_permission() is True
+    assert controls.consume_step_permission() is False
+
+    controls.resume()
+    assert controls.consume_step_permission() is True
+
+    controls.set_speed(0.0)
+    assert controls.speed > 0.0
+    controls.set_speed(4.0)
+    assert controls.target_dt(0.02) == pytest.approx(0.005)
+
+
+def test_playback_session_advance_respects_pause_and_single_step() -> None:
+    env = _fake_env()
+    wrapped = _FakeWrappedEnv(env)
+    session = RslRlPlaybackSession(
+        env=env,
+        wrapped_env=wrapped,
+        device="cpu",
+        action_mode="zero",
+        policy=None,
+        num_envs=1,
+    )
+    controls = PlaybackControls(paused=True)
+
+    session.reset()
+    assert session.advance(controls) is False
+    assert wrapped.step_calls == 0
+
+    controls.request_single_step()
+    assert session.advance(controls) is True
+    assert wrapped.step_calls == 1
+    assert torch.equal(wrapped.last_actions, torch.zeros((1, 2)))
+    assert session.advance(controls) is False
+
+
+def test_create_rsl_rl_playback_session_loads_checkpoint_and_runner_log_dir() -> None:
+    env = SimpleNamespace(
+        obs_groups_spec={"obs": 5},
+        action_space=SimpleNamespace(
+            shape=(2,),
+            low=np.full((2,), -1.0),
+            high=np.full((2,), 1.0),
+        ),
+        get_physics_state_snapshot=lambda: np.zeros((1, 4), dtype=np.float32),
+    )
+    captured: dict[str, Any] = {}
+
+    class Wrapper:
+        def __init__(self, wrapped_env, *, device, policy_obs_mode):
+            captured["wrapper_env"] = wrapped_env
+            captured["device"] = device
+            captured["policy_obs_mode"] = policy_obs_mode
+
+        def reset(self):
+            return "obs", {}
+
+        def step(self, actions):
+            return "obs", 0.0, False, {}
+
+    class Runner:
+        def __init__(self, wrapped_env, train_cfg, log_dir, device):
+            captured["runner_log_dir"] = log_dir
+            captured["train_cfg"] = train_cfg
+            captured["runner_device"] = device
+
+        def load(self, checkpoint, load_cfg):
+            captured["checkpoint"] = checkpoint
+            captured["load_cfg"] = load_cfg
+
+        def get_inference_policy(self, *, device):
+            captured["policy_device"] = device
+            return lambda obs: torch.ones((1, 2))
+
+    session, policy_obs_mode, checkpoint = create_rsl_rl_playback_session(
+        playback_cfg=RslRlPlaybackConfig(
+            task="MyTask",
+            load_run="-1",
+            checkpoint=None,
+            action_mode="policy",
+            policy_obs_mode="auto",
+            algo_log_name="custom_ppo",
+            log_root=None,
+            num_envs=1,
+        ),
+        env_factory=lambda num_envs: env,
+        algo_config={"runner": {"logger": "tensorboard"}},
+        root_dir=Path("/repo"),
+        device="cpu",
+        checkpoint_resolver=lambda *args: "/tmp/model_10.pt",
+        checkpoint_input_dim_reader=lambda path: 5,
+        entrypoint_log_root=lambda root_dir, *, algo_log_name, log_root=None: (
+            Path("/tmp") / algo_log_name
+        ),
+        wrapper_cls=Wrapper,
+        runner_cls=Runner,
+        policy_obs_dims_getter=lambda spec: (5, 7),
+        train_cfg_normalizer=lambda cfg: cfg,
+        log=lambda message: None,
+    )
+
+    assert session.env is env
+    assert policy_obs_mode == "actor"
+    assert checkpoint == "/tmp/model_10.pt"
+    assert captured["runner_log_dir"] == "/tmp/custom_ppo/MyTask/play_temp"
+    assert captured["checkpoint"] == "/tmp/model_10.pt"
+    assert captured["train_cfg"]["runner"]["logger"] == "none"
+
+
+def test_create_rsl_rl_playback_session_rejects_missing_env() -> None:
+    with pytest.raises(RuntimeError, match="Playback env factory"):
+        create_rsl_rl_playback_session(
+            playback_cfg=RslRlPlaybackConfig(
+                task="MyTask",
+                load_run="-1",
+                checkpoint=None,
+                action_mode="zero",
+                policy_obs_mode="auto",
+                algo_log_name="custom_ppo",
+                log_root=None,
+                num_envs=1,
+            ),
+            env_factory=lambda num_envs: None,
+            algo_config={},
+            root_dir=Path("/repo"),
+            device="cpu",
+            checkpoint_resolver=lambda *args: None,
+            checkpoint_input_dim_reader=lambda path: None,
+            entrypoint_log_root=lambda root_dir, *, algo_log_name, log_root=None: Path("/tmp"),
+            wrapper_cls=object,
+            runner_cls=object,
+            policy_obs_dims_getter=lambda spec: (0, 0),
+            train_cfg_normalizer=lambda cfg: cfg,
+            log=lambda message: None,
+        )
+
+
+def test_prepare_motion_overlay_selection_filters_body_names() -> None:
+    env = SimpleNamespace(
+        motion_loader=object(),
+        motion_sampler=object(),
+        cfg=SimpleNamespace(body_names=("base", "left_foot", "right_foot")),
+    )
+    messages: list[str] = []
+
+    selection = prepare_motion_overlay_selection(
+        env,
+        show_target_bodies=True,
+        show_reward_debug=False,
+        target_body_names="right_foot,missing,base",
+        target_max_bodies=1,
+        log=messages.append,
+    )
+
+    assert selection.enabled is True
+    assert selection.selected_indices.tolist() == [2]
+    assert messages == ["WARNING: body name not found in task body list: missing"]


### PR DESCRIPTION
## Summary
- Add a shared interactive RSL-RL playback core for env creation, checkpoint/policy loading, action stepping, pause/resume, single-step, and speed control.
- Refactor native MuJoCo and viser playback scripts to use the shared core while keeping viewer-specific rendering and controls local.
- Add Hydra defaults and tests for playback controls, checkpoint loading, overlay body selection, and config composition.

Fixes #271

## Validation
- make test-all