### PR TITLE
fix: normalize checkpoint load_run values

### DIFF
--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -46,7 +46,7 @@ def default_device(torch_module, preferred: str | None = None) -> str:
 
 
 def resolve_checkpoint_path(
-    root_dir: Path, algo_log_name: str, task: str, load_run: str
+    root_dir: Path, algo_log_name: str, task: str, load_run: str | int
 ) -> tuple[str | None, str | None]:
     checkpoint_path, checkpoint_dir = resolve_checkpoint_path_common(
         Path(root_dir) / "logs" / algo_log_name / task,

--- a/src/unilab/training/run.py
+++ b/src/unilab/training/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from os import PathLike
 from pathlib import Path
 
 from omegaconf import DictConfig, OmegaConf
@@ -89,24 +90,29 @@ def get_latest_checkpoint(run_dir: str | Path, *, suffix: str = ".pt") -> Path |
     return max(model_files, key=_iteration)
 
 
+def _normalize_load_run(load_run: str | int | PathLike[str]) -> str:
+    return str(load_run)
+
+
 def resolve_checkpoint_path(
     base_log_dir: str | Path,
-    load_run: str,
+    load_run: str | int | PathLike[str],
     *,
     suffix: str = ".pt",
 ) -> tuple[Path | None, Path | None]:
     """Resolve a latest or explicit checkpoint path from a task log root."""
     base_dir = Path(base_log_dir)
-    if load_run == "-1":
+    selected_run = _normalize_load_run(load_run)
+    if selected_run == "-1":
         run_dir = get_latest_run(base_dir)
         if run_dir is None:
             return None, None
         checkpoint = get_latest_checkpoint(run_dir, suffix=suffix)
         return (checkpoint, run_dir) if checkpoint is not None else (None, None)
 
-    candidate = Path(load_run)
+    candidate = Path(selected_run)
     if not candidate.exists():
-        candidate = base_dir / load_run
+        candidate = base_dir / selected_run
     if candidate.is_file():
         return candidate, candidate.parent
     if candidate.is_dir():
@@ -119,14 +125,18 @@ def parse_checkpoint_path(
     cfg: DictConfig,
     *,
     root_dir: str | Path,
-    load_run: str | None = None,
+    load_run: str | int | PathLike[str] | None = None,
     task_name: str | None = None,
     checkpoint: str | int | None = None,
     suffix: str = ".pt",
 ) -> tuple[Path | None, Path | None]:
     """Resolve a checkpoint path from Hydra config and repository root."""
     selected_task = task_name or str(OmegaConf.select(cfg, "training.task_name"))
-    selected_run = load_run or str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
+    selected_run = (
+        _normalize_load_run(load_run)
+        if load_run is not None
+        else str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
+    )
     selected_checkpoint = checkpoint
     if selected_checkpoint is None:
         selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
@@ -148,7 +158,7 @@ def resolve_task_checkpoint_path(
     root_dir: str | Path,
     *,
     task_name: str,
-    load_run: str,
+    load_run: str | int | PathLike[str],
     algo_log_name: str,
     checkpoint: str | None = None,
     suffix: str = ".pt",
@@ -165,12 +175,13 @@ def resolve_task_checkpoint_path(
     )
 
     run_dir: Path | None
-    if load_run == "-1":
+    selected_run = _normalize_load_run(load_run)
+    if selected_run == "-1":
         run_dir = get_latest_run(task_log_root)
     else:
-        candidate = Path(load_run)
+        candidate = Path(selected_run)
         if not candidate.exists():
-            candidate = task_log_root / load_run
+            candidate = task_log_root / selected_run
         if candidate.is_file():
             return candidate, candidate.parent
         run_dir = candidate if candidate.is_dir() else None

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1081,6 +1081,20 @@ def test_resolve_checkpoint_latest_picks_highest_iter(tmp_path):
     assert "model_100.pt" in path
 
 
+def test_resolve_checkpoint_accepts_integer_latest_run(tmp_path):
+    """load_run=-1 from Hydra CLI picks the latest model."""
+    task_dir = tmp_path / "logs" / "sac" / "MyTask" / "run1"
+    task_dir.mkdir(parents=True)
+    (task_dir / "model_10.pt").write_bytes(b"")
+    (task_dir / "model_50.pt").write_bytes(b"")
+
+    path, path_dir = _offpolicy().resolve_checkpoint_path(tmp_path, "sac", "MyTask", -1)
+
+    assert path is not None
+    assert "model_50.pt" in path
+    assert path_dir == str(task_dir)
+
+
 def test_resolve_checkpoint_explicit_run_name(tmp_path):
     """load_run = run-directory name under the log root."""
     task_dir = tmp_path / "logs" / "sac" / "MyTask" / "myrun"

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -19,6 +19,7 @@ from unilab.training import (
     get_latest_checkpoint,
     get_latest_run,
     parse_checkpoint_path,
+    resolve_checkpoint_path,
     resolve_task_checkpoint_path,
 )
 from unilab.visualization.playback import render_play_mode
@@ -91,6 +92,19 @@ def test_get_latest_run_and_checkpoint_support_shared_checkpoint_resolution(tmp_
 
     assert latest_run == newer_run
     assert latest_checkpoint == newer_run / "model_9.pt"
+
+
+def test_resolve_checkpoint_path_accepts_integer_latest_run(tmp_path: Path):
+    task_dir = tmp_path / "logs" / "sac" / "MyTask"
+    run_dir = task_dir / "2024-02-01_00-00-00_motrix"
+    run_dir.mkdir(parents=True)
+    selected_model = run_dir / "model_9.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_checkpoint_path(task_dir, -1)
+
+    assert checkpoint_path == selected_model
+    assert checkpoint_dir == run_dir
 
 
 def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(tmp_path: Path):
@@ -178,6 +192,23 @@ def test_resolve_task_checkpoint_path_returns_run_dir_when_checkpoint_missing(tm
     )
 
     assert checkpoint_path is None
+    assert checkpoint_dir == run_dir
+
+
+def test_resolve_task_checkpoint_path_accepts_integer_latest_run(tmp_path: Path):
+    run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    selected_model = run_dir / "model_12.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_task_checkpoint_path(
+        tmp_path,
+        task_name="MyTask",
+        load_run=-1,
+        algo_log_name="custom_ppo",
+    )
+
+    assert checkpoint_path == selected_model
     assert checkpoint_dir == run_dir
 
 


### PR DESCRIPTION
Fixes #473

## Summary

- Normalize `load_run` values at the shared checkpoint resolver boundary before comparing with `"-1"` or constructing `Path` objects.
- Allow shared checkpoint helpers and the offpolicy eval wrapper to handle Hydra/OmegaConf integer `-1` values.
- Add regression coverage for integer `load_run=-1` in shared training helpers and offpolicy checkpoint resolution.

## Validation

- `uv run pytest tests/training/test_training_helpers.py::test_resolve_checkpoint_path_accepts_integer_latest_run tests/training/test_training_helpers.py::test_resolve_task_checkpoint_path_accepts_integer_latest_run tests/scripts/test_train_scripts.py::test_resolve_checkpoint_accepts_integer_latest_run`
- `uv run pytest tests/training/test_training_helpers.py tests/scripts/test_train_scripts.py`
- `uv run eval --algo sac --task g1_walk_flat --sim motrix --load-run -1 training.play_steps=1`
- `make test-all`
