### PR TITLE
chore: track CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,3 @@ cache/
 
 # Backend temp XML emitted next to robot.xml (motrix/mujoco scene materialization)
 src/unilab/assets/robots/**/tmp*.xml
-
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Stop ignoring CLAUDE.md.
- Track CLAUDE.md as a symlink to AGENTS.md.

## Validation
- uv run make test-all