### PR TITLE
train: record hardware info in run configs

### DIFF
--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -48,6 +48,7 @@ from unilab.training import (
     setup_logger,
     should_run_playback,
 )
+from unilab.training.experiment import get_device_info_dict
 
 
 def _write_distill_run_config(
@@ -72,6 +73,7 @@ def _write_distill_run_config(
             "task": str(OmegaConf.select(cfg, "training.task_name")),
             "sim_backend": str(OmegaConf.select(cfg, "training.sim_backend")),
             "log_dir": str(log_dir),
+            "hardware": get_device_info_dict(),
             "teacher": teacher_metadata,
         },
         "config": OmegaConf.to_container(cfg, resolve=True),

--- a/src/unilab/training/experiment.py
+++ b/src/unilab/training/experiment.py
@@ -8,6 +8,7 @@ import importlib
 import importlib.util
 import json
 import os
+import platform
 import socket
 import subprocess
 import time
@@ -57,9 +58,29 @@ def _json_safe(value: Any) -> Any:
         return str(value)
 
 
+def _fallback_device_info_dict() -> dict[str, str]:
+    return {
+        "platform": platform.platform(),
+        "chip": platform.processor() or "unknown",
+        "cpu_total_cores": str(os.cpu_count() or "unknown"),
+        "gpu_name": "unknown",
+        "memory": "unknown",
+    }
+
+
+def _benchmark_device_info_path() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "benchmark" / "core" / "device_info.py"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def get_device_info_dict() -> dict[str, str]:
     try:
-        module_path = Path(__file__).resolve().parents[4] / "benchmark" / "core" / "device_info.py"
+        module_path = _benchmark_device_info_path()
+        if module_path is None:
+            return _fallback_device_info_dict()
         spec = importlib.util.spec_from_file_location(
             "unilab_benchmark_device_info",
             module_path,
@@ -71,7 +92,7 @@ def get_device_info_dict() -> dict[str, str]:
         getter = getattr(module, "get_device_info_dict")
         return dict(getter())
     except Exception:
-        return {"platform": os.uname().sysname if hasattr(os, "uname") else "unknown"}
+        return _fallback_device_info_dict()
 
 
 def get_git_info(root_dir: str | Path) -> dict[str, Any]:

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -275,6 +275,28 @@ def test_offpolicy_hydra_algo_td3():
     assert cfg.algo.algo == "td3"
 
 
+def test_hora_distill_run_config_records_hardware(tmp_path, monkeypatch):
+    mod = _train_hora_distill()
+    hardware = {
+        "platform": "test-platform",
+        "chip": "test-cpu",
+        "cpu_total_cores": "8",
+        "gpu_name": "test-gpu",
+        "memory": "32 GB",
+    }
+    monkeypatch.setattr(mod, "get_device_info_dict", lambda: hardware)
+    cfg = OmegaConf.create({"training": {"task_name": "Task", "sim_backend": "mujoco"}})
+
+    mod._write_distill_run_config(
+        tmp_path,
+        cfg=cfg,
+        teacher_metadata={"checkpoint_path": "teacher.pt"},
+    )
+
+    payload = json.loads((tmp_path / "distill_run_config.json").read_text(encoding="utf-8"))
+    assert payload["run"]["hardware"] == hardware
+
+
 def test_hora_distill_task_owner_overrides_root_config_defaults():
     mod = _train_hora_distill()
     root_cfg = OmegaConf.load(_CONF_DIR / "hora_distill" / "config.yaml")

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -9,6 +9,7 @@ import pytest
 from rich.console import Console
 
 import unilab.logging.common as common_module
+import unilab.training.experiment as experiment_module
 from unilab.logging import OffPolicyLogger, OnPolicyLogger
 from unilab.training.experiment import ExperimentTracker, build_wandb_settings
 
@@ -190,7 +191,28 @@ def test_build_wandb_settings_defaults_for_shared_workspace():
     assert "mujoco" in settings["tags"]
 
 
-def test_experiment_tracker_writes_local_run_files(tmp_path):
+def test_experiment_device_info_uses_benchmark_helper():
+    helper_path = experiment_module._benchmark_device_info_path()
+    assert helper_path is not None
+    assert helper_path.name == "device_info.py"
+
+    info = experiment_module.get_device_info_dict()
+    assert info["platform"]
+    assert "chip" in info
+    assert "cpu_total_cores" in info
+    assert "memory" in info
+    assert "gpu_name" in info or "gpu_cores" in info
+
+
+def test_experiment_tracker_writes_local_run_files(tmp_path, monkeypatch):
+    hardware = {
+        "platform": "test-platform",
+        "chip": "test-cpu",
+        "cpu_total_cores": "16",
+        "gpu_name": "test-gpu",
+        "memory": "64 GB",
+    }
+    monkeypatch.setattr(experiment_module, "get_device_info_dict", lambda: hardware)
     log_dir = tmp_path / "logs" / "run1"
     tracker = ExperimentTracker(
         root_dir=tmp_path,
@@ -221,6 +243,7 @@ def test_experiment_tracker_writes_local_run_files(tmp_path):
     assert run_config["run"]["configured_seed"] == 5
     assert run_config["run"]["configured_seed_source"] == "algo.seed"
     assert run_config["run"]["effective_seed"] == 5
+    assert run_config["run"]["hardware"] == hardware
     assert run_summary["final_mean_reward"] == 12.3
     assert run_summary["completed_iterations"] == 10
     assert run_summary["configured_seed"] == 5


### PR DESCRIPTION
## Summary

- what changed
- why it changed
- any user-facing or training-impact behavior

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [ ] Additional task-specific validation listed below

Commands actually run:

```bash
# paste exact commands here
```

## Impact

- Backend impact: `mujoco` / `motrix` / both / none
- Platform impact: macOS / Linux / both / unknown
- Training effect expected: yes / no / unknown

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [ ] Noted any follow-up work explicitly
