### PR TITLE
feat(g1): add g1_wbt_obs SAC task for sim2real WBT deploy

### DIFF
--- a/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
@@ -1,11 +1,11 @@
 # @package _global_
 # G1 Whole-Body Tracking (WBT) FastSAC on MuJoCo — task ``g1_wbt_obs``.
 #
-# Trains an SAC policy whose actor obs schema is byte-aligned with the C++
-# deploy framework's ``ObservationManager`` (per-term history,
-# ``use_gym_history=false``). Pelvis-IMU selection is yaml-driven via
-# ``env.sensor.*`` — no XML duplication is required because the upstream
-# ``g1.xml`` exposes both pelvis and torso IMU sensors.
+# Field-by-field port of the active deploy training profile from
+# ``feat/g1_deploy_v2`` (``conf/offpolicy/task/sac/g1_sac_wbt/mujoco_deploy.yaml``
+# in that branch — Stage 4+5, the one actually used for ONNX-on-real-G1
+# runs; ``mujoco_deploy_v2.yaml`` Plan B was a tuning experiment and is
+# NOT what this profile ports).
 #
 # Train command:
 #   uv run train --algo sac --task g1_wbt_obs --sim mujoco training.use_amp=true
@@ -17,6 +17,8 @@
 # tracking) are unaffected.
 #
 # Deploy compatibility:
+#   * Pelvis-IMU selection is yaml-driven via ``env.sensor.*`` (the upstream
+#     ``g1.xml`` exposes both pelvis and torso IMU sensors).
 #   * Actor obs schema:
 #       command(2·29=58) + anchor_ori(6) + H·(gyro 3 + joint_pos_rel 29
 #                                              + dof_vel 29 + last_actions 29)
@@ -29,11 +31,11 @@ training:
   sim_backend: mujoco
 algo:
   num_envs: 4096
-  max_iterations: 40000
+  max_iterations: 140000
   save_interval: 1000
   # FastSAC overrides aligned with holosoma WBT.
   gamma: 0.99
-  tau: 0.005
+  tau: 0.05
   num_atoms: 501
   updates_per_step: 4
   policy_frequency: 2
@@ -43,6 +45,7 @@ algo:
     target_entropy_ratio: 0.5
     max_grad_norm: 10.0
 env:
+  sim_dt: 0.005
   # Route IMU sensors to the pelvis (deploy reads the primary IMU on real G1).
   sensor:
     local_linvel: pelvis_local_linvel
@@ -50,62 +53,81 @@ env:
     upvector: pelvis_upvector
   control_config:
     action_scale: 2.0
+    # One-step action latency: model the SDK send/recv delay so the trained
+    # actor sees the same delayed feedback the C++ controller produces.
     simulate_action_latency: true
-  anchor_pos_z_threshold: 0.30
+  # Stage 4 anchor-tighten — implicit "stay near reference" pressure for
+  # root_pos (which is unobservable to the actor under enable_zero_anchor_pos).
+  anchor_pos_z_threshold: 0.40
+  # KEPT at 0.5 — green-run history shows ee termination causes terminated_rate
+  # spikes; only tighten the anchor channel.
   ee_body_pos_z_threshold: 0.5
   truncate_on_clip_end: true
   noise_config:
     level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 0.5
-    scale_gyro: 0.2
-    # Deploy-aligned actor obs schema.
+    scale_joint_angle: 0.01      # mjlab parity
+    scale_joint_vel: 0.5         # mjlab parity (was 1.5 — too aggressive)
+    scale_gyro: 0.2              # mjlab parity
+    # mjlab "No-State-Estimation" parity: G1 has no torso-pose estimator and
+    # no base linvel sensor at deploy → drop both channels from actor obs.
+    # Critic still sees the clean values (asymmetric A/C).
     enable_zero_linvel: true
     enable_zero_anchor_pos: true
+    # mjlab Unoise(±0.05) on the 6-d anchor rotation columns.
     enable_anchor_ori_noise: true
     scale_anchor_ori: 0.05
-    # Per-term proprio history, oldest-first; matches deploy
-    # ``ObservationManager`` group-by-term mode.
+    # 5-step per-term proprio history (BeyondMimic / MOSAIC parity).
+    # Actor obs 154 → 514 d. Refs (command_*, anchor_ori_b) stay single-step;
+    # gyro / joint_pos_rel / dof_vel / last_actions get 5-step oldest-first
+    # history. Lets the actor implicitly estimate base linear velocity from
+    # joint deltas + IMU without requiring a deploy-side state estimator.
     obs_history_length: 5
   domain_rand:
     randomize_base_mass: true
     added_mass_range: [-1.0, 1.0]
     random_com: true
     com_offset_x: [-0.05, 0.05]
-    randomize_com_y: true
+    randomize_com_y: true            # mjlab base_com offset is 3-axis
     com_offset_y: [-0.05, 0.05]
     randomize_com_z: true
     com_offset_z: [-0.05, 0.05]
     randomize_gravity: false
     gravity_range: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
     push_robots: true
+    # Stage 4: 200 ctrl steps ≈ 4 s. Empirical minimum interval that sustains
+    # body_ori / body_ang_vel tracking under push training pressure.
     push_interval: 200
+    # Stage 4: Δv 0.2 m/s — empirical minimum effective training-pressure dose.
+    # This is TRAINING pressure, NOT a sim2real disturbance model — the trained
+    # policy does not generate push at deploy time regardless of this value.
     max_force: [300.0, 300.0, 120.0]
     push_body_name: null
     randomize_kp: true
     kp_multiplier_range: [0.9, 1.1]
     randomize_kd: true
     kd_multiplier_range: [0.85, 1.15]
-    # Per-reset foot-geom friction (regex over geom names).
+    # mjlab parity: foot geom friction sampled per-episode, shared across feet,
+    # absolute value uniform on the sliding-friction column.
     randomize_geom_friction: true
     friction_range: [0.3, 1.2]
     friction_geom_pattern: "^(left|right)_foot[1-7]_collision$"
-    # Per-episode additive bias on actor's joint_pos channel.
+    # mjlab parity: persistent ±0.01 rad encoder bias added to actor's joint_pos.
     enable_encoder_bias: true
     encoder_bias_range: [-0.01, 0.01]
 reward:
   scales:
-    motion_global_root_pos: 1.5
-    motion_global_root_ori: 1.0
+    # Stage 4 + Stage 5 (mjlab parity weights from g1_29dof/dance_102).
+    motion_global_root_pos: 1.0       # Stage 2.5 (was 0.5; compensate obs-zeroing of anchor_pos)
+    motion_global_root_ori: 1.0       # Stage 1.5 (was 0.5; restore root attitude authority)
     motion_body_pos: 1.0
     motion_body_ori: 1.0
     motion_body_lin_vel: 1.0
     motion_body_ang_vel: 1.0
     motion_joint_pos: 0.0
     motion_joint_vel: 0.0
-    action_rate_l2: -0.15
+    action_rate_l2: -0.1
     joint_limit: -5.0
     undesired_contacts: -0.1
-    # Sim2real-ergonomic penalties (only computed when scale != 0).
+    # Stage 5 sim2real-friendly penalties (computed only when scale != 0).
     joint_acc_l2: -2.5e-7
     joint_torque_l2: -1e-5

--- a/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
@@ -17,7 +17,10 @@
 # tracking) are unaffected.
 #
 # Deploy compatibility:
-#   * 154-dim actor obs (command 58 + anchor_ori 6 + 5 × proprio 18 = 154)
+#   * Actor obs schema:
+#       command(2·29=58) + anchor_ori(6) + H·(gyro 3 + joint_pos_rel 29
+#                                              + dof_vel 29 + last_actions 29)
+#       = 64 + 5·90 = 514 dims  (with H=5 below)
 #   * Same channel order as ``scripts/deploy/export_deploy_config.py`` emits
 #   * Bit-identical to deploy obs assembly — covered by
 #     ``tests/scripts/test_obs_alignment_g1_wbt.py``

--- a/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
@@ -1,0 +1,108 @@
+# @package _global_
+# G1 Whole-Body Tracking (WBT) FastSAC on MuJoCo — task ``g1_wbt_obs``.
+#
+# Trains an SAC policy whose actor obs schema is byte-aligned with the C++
+# deploy framework's ``ObservationManager`` (per-term history,
+# ``use_gym_history=false``). Pelvis-IMU selection is yaml-driven via
+# ``env.sensor.*`` — no XML duplication is required because the upstream
+# ``g1.xml`` exposes both pelvis and torso IMU sensors.
+#
+# Train command:
+#   uv run train --algo sac --task g1_wbt_obs --sim mujoco training.use_amp=true
+#
+# The task name binds to ``G1WBTObs`` (see
+# ``src/unilab/envs/motion_tracking/g1/tracking_obs.py``), a strict subclass
+# of ``G1MotionTrackingSACEnv`` — base classes are untouched, so other tasks
+# (``g1_sac_wbt``, ``g1_motion_tracking_deploy``, locomotion / flip / box
+# tracking) are unaffected.
+#
+# Deploy compatibility:
+#   * 154-dim actor obs (command 58 + anchor_ori 6 + 5 × proprio 18 = 154)
+#   * Same channel order as ``scripts/deploy/export_deploy_config.py`` emits
+#   * Bit-identical to deploy obs assembly — covered by
+#     ``tests/scripts/test_obs_alignment_g1_wbt.py``
+training:
+  task_name: G1WBTObs
+  sim_backend: mujoco
+algo:
+  num_envs: 4096
+  max_iterations: 40000
+  save_interval: 1000
+  # FastSAC overrides aligned with holosoma WBT.
+  gamma: 0.99
+  tau: 0.005
+  num_atoms: 501
+  updates_per_step: 4
+  policy_frequency: 2
+  use_symmetry: false
+  algo_params:
+    alpha_init: 0.1
+    target_entropy_ratio: 0.5
+    max_grad_norm: 10.0
+env:
+  # Route IMU sensors to the pelvis (deploy reads the primary IMU on real G1).
+  sensor:
+    local_linvel: pelvis_local_linvel
+    gyro: pelvis_gyro
+    upvector: pelvis_upvector
+  control_config:
+    action_scale: 2.0
+    simulate_action_latency: true
+  anchor_pos_z_threshold: 0.30
+  ee_body_pos_z_threshold: 0.5
+  truncate_on_clip_end: true
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.5
+    scale_gyro: 0.2
+    # Deploy-aligned actor obs schema.
+    enable_zero_linvel: true
+    enable_zero_anchor_pos: true
+    enable_anchor_ori_noise: true
+    scale_anchor_ori: 0.05
+    # Per-term proprio history, oldest-first; matches deploy
+    # ``ObservationManager`` group-by-term mode.
+    obs_history_length: 5
+  domain_rand:
+    randomize_base_mass: true
+    added_mass_range: [-1.0, 1.0]
+    random_com: true
+    com_offset_x: [-0.05, 0.05]
+    randomize_com_y: true
+    com_offset_y: [-0.05, 0.05]
+    randomize_com_z: true
+    com_offset_z: [-0.05, 0.05]
+    randomize_gravity: false
+    gravity_range: [[0.0, 0.0, -9.81], [0.0, 0.0, -9.81]]
+    push_robots: true
+    push_interval: 200
+    max_force: [300.0, 300.0, 120.0]
+    push_body_name: null
+    randomize_kp: true
+    kp_multiplier_range: [0.9, 1.1]
+    randomize_kd: true
+    kd_multiplier_range: [0.85, 1.15]
+    # Per-reset foot-geom friction (regex over geom names).
+    randomize_geom_friction: true
+    friction_range: [0.3, 1.2]
+    friction_geom_pattern: "^(left|right)_foot[1-7]_collision$"
+    # Per-episode additive bias on actor's joint_pos channel.
+    enable_encoder_bias: true
+    encoder_bias_range: [-0.01, 0.01]
+reward:
+  scales:
+    motion_global_root_pos: 1.5
+    motion_global_root_ori: 1.0
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.15
+    joint_limit: -5.0
+    undesired_contacts: -0.1
+    # Sim2real-ergonomic penalties (only computed when scale != 0).
+    joint_acc_l2: -2.5e-7
+    joint_torque_l2: -1e-5

--- a/docs/users/zh_CN/D-tasks/02-g1-motion-tracking.md
+++ b/docs/users/zh_CN/D-tasks/02-g1-motion-tracking.md
@@ -11,12 +11,13 @@
 | wall-assisted flip | `g1_wall_flip_tracking` | PPO、MLX PPO、APPO | `src/unilab/assets/motions/g1/flip_from_wall_104__A304.npz` |
 | holosoma-aligned WBT | `g1_sac_wbt` | SAC | 与 `g1_motion_tracking` 共用 |
 | crawl-slope WBT (SAC) | `g1_sac_wbt` + 自定义场景 | SAC | `src/unilab/assets/motions/g1/motion_crawl_slope_uni.npz` |
+| sim2real-aligned WBT (deploy chain) | `g1_wbt_obs` | SAC | 与 `g1_motion_tracking` 共用 |
 
 ## 配置入口
 
 - PPO / MLX PPO：`conf/ppo/task/g1_motion_tracking/`、`conf/ppo/task/g1_flip_tracking/`、`conf/ppo/task/g1_wall_flip_tracking/`
 - APPO：`conf/appo/task/g1_motion_tracking/`、`conf/appo/task/g1_flip_tracking/`、`conf/appo/task/g1_wall_flip_tracking/`
-- SAC WBT：`conf/offpolicy/task/sac/g1_sac_wbt/mujoco.yaml`、`mujoco_deploy.yaml`、`motrix.yaml`
+- SAC WBT：`conf/offpolicy/task/sac/g1_sac_wbt/{mujoco,mujoco_deploy,motrix}.yaml`、`conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml`
 
 ## 推荐流程
 
@@ -65,12 +66,13 @@ uv run train --algo appo --task g1_motion_tracking --sim mujoco
 uv run train --algo appo --task g1_motion_tracking --sim motrix
 uv run train --algo sac --task g1_sac_wbt --sim mujoco training.use_amp=true
 uv run train --algo sac --task g1_sac_wbt --sim mujoco --profile deploy training.use_amp=true
+uv run train --algo sac --task g1_wbt_obs --sim mujoco training.use_amp=true
 uv run eval --algo ppo --task g1_motion_tracking --sim mujoco --load-run -1
 uv run eval --algo ppo --task g1_motion_tracking --sim mujoco --load-run -1 training.cam_tracking=true training.cam_tracking_env_idx=0
 uv run scripts/train_offpolicy.py algo=sac task=sac/g1_sac_wbt/motrix training.play_only=true algo.load_run=/abs/path/to/logs/fast_sac/G1MotionTrackingSAC/2026-04-23_14-06-57_mujoco
 ```
 
-`--profile deploy` 会切到面向部署的独立 SAC owner；Motrix sim2sim 回放时用绝对路径透传 `algo.load_run`，不要塞进 `--load-run`。
+`--profile deploy` 会切到面向部署的独立 SAC owner；`g1_wbt_obs` 是更彻底的 sim2real 部署 task（pelvis IMU + 5 步 per-term 历史 actor obs，与 deploy `ObservationManager` byte-对齐；额外 encoder-bias / foot-friction DR、`joint_acc_l2` / `joint_torque_l2` 奖励；部署工具在 `scripts/deploy/`，obs 对齐由 `tests/scripts/test_obs_alignment_g1_wbt.py` 三路 cross-check）。Motrix sim2sim 回放时用绝对路径透传 `algo.load_run`，不要塞进 `--load-run`。
 
 ## SAC WBT on crawl-slope 场景
 

--- a/docs/users/zh_CN/E-reference/01-backend-support-matrix.md
+++ b/docs/users/zh_CN/E-reference/01-backend-support-matrix.md
@@ -88,6 +88,7 @@ uv run scripts/generate_support_matrix.py --write
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |
 | SAC (torch) | `g1_sac_wbt` (g1 sac wbt) | Tested | Tested |
+| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | Registered |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |
 | FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |

--- a/scripts/deploy/append_cooldown.py
+++ b/scripts/deploy/append_cooldown.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Append a dance-final-frame->FixStand cooldown suffix to a WBT motion bin.
+
+Why this exists
+---------------
+Symmetric to prepend_warmup.py.  The original dance bin's last frame is mid-
+motion (joint vel ~18 rad/s L2, pelvis still descending at 0.3 m/s, joints
+~42 deg from FixStand stand qpos).  When State_WBT's time-end check fires
+and the FSM hands off to State_FixStand, FixStand only does a joint-space PD
+interpolation from current motor q -> stand qpos over 3 s; it has no balance
+controller, so a robot left with angular momentum and an off-balance pose
+collapses despite the PD targets pulling it back to stand.
+
+Fix: append N seconds of kinematically self-consistent interpolation frames
+at the tail of the bin.  The tracking policy decelerates joints, brings the
+torso back to upright, and lands on FixStand stand qpos before the FSM exit
+triggers — so the FixStand interpolation starts from an already-balanced
+pose and just holds station.
+
+What this does NOT change
+-------------------------
+- Training pipeline (no retrain needed).
+- State_WBT.cpp / deploy_config.yaml / FSM yaml time_end (leave null -> full
+  duration so the cooldown plays automatically).
+- The original dance frames (they are preserved verbatim before the cooldown).
+
+Interpolation scheme — identical primitives as prepend_warmup.py, run in
+reverse direction:
+- joint_pos (J=29): cubic Hermite per joint with boundaries
+    (orig.jp[-1], orig.jv[-1]) -> (default_angles, 0)
+  joint_vel is the analytic derivative.
+- body_pos (B,3): cubic Hermite per axis with boundaries
+    (orig.bp[-1], orig.bv[-1]) -> (FK(stand), 0)
+  body_lin_vel is the analytic derivative.
+- body_quat (B,4): SLERP along quintic smoothstep s(u) = 6u^5 - 15u^4 + 10u^3
+  (s'(0) = s''(0) = s'(1) = s''(1) = 0). Shortest-path; near-parallel fallback.
+- body_ang_vel: central difference over [orig.bq[-2:], cooldown_bq] so the
+  seam ang_vel is continuous with the original bin's final ang_vel.
+
+Use
+---
+    uv run python scripts/deploy/append_cooldown.py \
+        --input  ../deploy_ws/assets/dance1.bin \
+        --output ../deploy_ws/assets/dance1_cooldown.bin \
+        --config ../deploy_ws/assets/deploy_config.yaml \
+        --cooldown-sec 2.0
+
+Validate in sim BEFORE swapping on the real robot:
+    uv run python scripts/deploy/sim_prototype.py \
+        --motion ../deploy_ws/assets/dance1_cooldown.bin \
+        --init-mode stand --render
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WS = REPO_ROOT.parent / "deploy_ws"
+DEFAULT_SCENE = REPO_ROOT / "src/unilab/assets/robots/g1/scene_flat.xml"
+DEFAULT_CFG = DEPLOY_WS / "assets/deploy_config.yaml"
+DEFAULT_IN = DEPLOY_WS / "assets/dance1.bin"
+DEFAULT_OUT = DEPLOY_WS / "assets/dance1_cooldown.bin"
+DEFAULT_COOLDOWN_SEC = 3.0
+DEFAULT_HOLD_SEC = 0.5
+
+
+# ----------------------------------------------------------------------------
+# bin I/O — same layout State_WBT.cpp / sim_prototype.py / export_motion_bin.py
+# all use: header (4 int32: fps, F, J, B) then six float32 blocks.
+# ----------------------------------------------------------------------------
+
+def load_motion_bin(path: Path) -> dict:
+    with open(path, "rb") as f:
+        fps, nf, nj, nb = struct.unpack("<iiii", f.read(16))
+        jp = np.frombuffer(f.read(nf * nj * 4), "<f4").reshape(nf, nj).copy()
+        jv = np.frombuffer(f.read(nf * nj * 4), "<f4").reshape(nf, nj).copy()
+        bp = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+        bq = np.frombuffer(f.read(nf * nb * 4 * 4), "<f4").reshape(nf, nb, 4).copy()
+        bv = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+        bav = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+    return dict(fps=fps, nf=nf, nj=nj, nb=nb,
+                jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
+
+
+def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
+    nf, nj = jp.shape
+    nb = bp.shape[1]
+    assert jv.shape == jp.shape, "jv shape mismatch"
+    assert bp.shape == (nf, nb, 3) and bq.shape == (nf, nb, 4), "body shape mismatch"
+    assert bv.shape == (nf, nb, 3) and bav.shape == (nf, nb, 3), "body vel shape mismatch"
+    with open(path, "wb") as f:
+        f.write(struct.pack("<iiii", fps, nf, nj, nb))
+        for arr in (jp, jv, bp, bq, bv, bav):
+            f.write(np.ascontiguousarray(arr, dtype=np.float32).tobytes())
+
+
+# ----------------------------------------------------------------------------
+# FixStand FK — compute body world states at the 'stand' keyframe.
+# ----------------------------------------------------------------------------
+
+def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
+                                 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
+    if key_id < 0:
+        raise SystemExit(f"'stand' keyframe not found in {scene}")
+    mujoco.mj_resetDataKeyframe(model, data, key_id)
+    mujoco.mj_forward(model, data)
+    jp = np.asarray(data.qpos[7:], dtype=np.float64).copy()
+    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy()
+                   for i in tracked_ids])
+    bq = np.stack([np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
+                   for i in tracked_ids])
+    return jp, bp, bq
+
+
+# ----------------------------------------------------------------------------
+# Cubic Hermite — same primitive as prepend_warmup.py.
+# ----------------------------------------------------------------------------
+
+def hermite(p0, v0, p1, v1, t, T):
+    s = t / T
+    s2, s3 = s * s, s * s * s
+    h00 = 2 * s3 - 3 * s2 + 1
+    h10 = s3 - 2 * s2 + s
+    h01 = -2 * s3 + 3 * s2
+    h11 = s3 - s2
+    h00d = 6 * s2 - 6 * s
+    h10d = 3 * s2 - 4 * s + 1
+    h01d = -6 * s2 + 6 * s
+    h11d = 3 * s2 - 2 * s
+
+    def _r(a):
+        return a.reshape(a.shape + (1,) * (np.ndim(p0)))
+    p = _r(h00) * p0 + _r(h10) * T * v0 + _r(h01) * p1 + _r(h11) * T * v1
+    pd = _r(h00d / T) * p0 + _r(h10d) * v0 + _r(h01d / T) * p1 + _r(h11d) * v1
+    return p, pd
+
+
+# ----------------------------------------------------------------------------
+# Quaternion SLERP along quintic smoothstep.
+# ----------------------------------------------------------------------------
+
+def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarray:
+    q0 = q0 / np.linalg.norm(q0)
+    q1 = q1 / np.linalg.norm(q1)
+    dot = float(np.dot(q0, q1))
+    if dot < 0.0:
+        q1 = -q1
+        dot = -dot
+    s = 6 * u**5 - 15 * u**4 + 10 * u**3
+    if dot > 0.9995:
+        out = (1 - s)[:, None] * q0 + s[:, None] * q1
+        return out / np.linalg.norm(out, axis=-1, keepdims=True)
+    theta_0 = np.arccos(np.clip(dot, -1.0, 1.0))
+    sin_theta_0 = np.sin(theta_0)
+    theta = theta_0 * s
+    a = np.cos(theta) - dot * np.sin(theta) / sin_theta_0
+    b = np.sin(theta) / sin_theta_0
+    return a[:, None] * q0 + b[:, None] * q1
+
+
+# ----------------------------------------------------------------------------
+# World-frame angular velocity from a quaternion sequence by finite difference.
+# ----------------------------------------------------------------------------
+
+def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
+    n = q_seq.shape[0]
+    out = np.zeros((n, 3), dtype=np.float64)
+
+    def diff(q_a, q_b, h):
+        aw, ax, ay, az = q_a
+        bw, bx, by, bz = q_b
+        dw = bw * aw + bx * ax + by * ay + bz * az
+        dx = -bw * ax + bx * aw - by * az + bz * ay
+        dy = -bw * ay + bx * az + by * aw - bz * ax
+        dz = -bw * az - bx * ay + by * ax + bz * aw
+        if dw < 0.0:
+            dw, dx, dy, dz = -dw, -dx, -dy, -dz
+        return np.array([2 * dx / h, 2 * dy / h, 2 * dz / h])
+
+    for i in range(n):
+        if i == 0:
+            out[i] = diff(q_seq[0], q_seq[1], dt)
+        elif i == n - 1:
+            out[i] = diff(q_seq[n - 2], q_seq[n - 1], dt)
+        else:
+            out[i] = diff(q_seq[i - 1], q_seq[i + 1], 2 * dt)
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", type=Path, default=DEFAULT_IN)
+    ap.add_argument("--output", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--config", type=Path, default=DEFAULT_CFG,
+                    help="deploy_config.yaml (for default_angles, tracked ids).")
+    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
+                    help="MuJoCo XML with 'stand' keyframe (for FixStand FK).")
+    ap.add_argument("--cut-frame", type=int, default=None,
+                    help="If set, truncate the input bin so that frame "
+                         "CUT_FRAME becomes the new last frame (inclusive). "
+                         "Frames after that are dropped, and the cooldown ramps "
+                         "from this frame to default. Use this when the dance's "
+                         "actual last frame has too much momentum for any post-"
+                         "hoc interpolation to stabilize. Find a low-energy "
+                         "frame (low joint vel, near-upright torso, near-zero "
+                         "pelvis vertical vel) and cut there.")
+    ap.add_argument("--cooldown-sec", type=float, default=DEFAULT_COOLDOWN_SEC,
+                    help="Length of Hermite deceleration ramp [seconds]. "
+                         "Lowers joint vel from orig.jv[-1] to 0 and joint pos "
+                         "to default_angles over this interval.")
+    ap.add_argument("--hold-sec", type=float, default=DEFAULT_HOLD_SEC,
+                    help="Length of trailing static-hold segment [seconds]. "
+                         "Appended AFTER the Hermite ramp; frames are pure "
+                         "(default_angles, 0, FixStand FK body, 0). Lets the "
+                         "tracking policy physically converge to stand before "
+                         "the FSM timeout swaps to State_FixStand. Set to 0 to "
+                         "disable. Recommended >= 0.3s.")
+    args = ap.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+    default_angles = np.asarray(cfg["default_angles"], dtype=np.float64)
+    tracked_ids = list(cfg["tracked_body_mujoco_ids"])
+
+    orig = load_motion_bin(args.input)
+    fps, J, B = orig["fps"], orig["nj"], orig["nb"]
+    if J != len(default_angles):
+        raise SystemExit(f"J mismatch: bin J={J}, default_angles len={len(default_angles)}")
+    if B != len(tracked_ids):
+        raise SystemExit(f"B mismatch: bin B={B}, tracked_body_mujoco_ids len={len(tracked_ids)}")
+
+    if args.cut_frame is not None:
+        cf = int(args.cut_frame)
+        if cf < 1 or cf >= orig["nf"]:
+            raise SystemExit(f"cut-frame={cf} out of range [1, {orig['nf']-1}]")
+        # Keep frames [0, cf] (cf becomes the new last frame, inclusive).
+        keep = cf + 1
+        print(f"Truncating input: keep frames [0, {cf}]  "
+              f"({orig['nf']} -> {keep} frames, {orig['nf']/fps:.2f}s -> {keep/fps:.2f}s)",
+              file=sys.stderr)
+        for k in ("jp", "jv", "bp", "bq", "bv", "bav"):
+            orig[k] = orig[k][:keep]
+        orig["nf"] = keep
+        # Report cut-point energy so the user sees what cool-down starts from.
+        a = cfg.get("anchor_body_idx_in_tracked", 7)
+        jv_l2 = float(np.linalg.norm(orig["jv"][-1]))
+        jp_dev = float(np.abs(orig["jp"][-1] - default_angles).max())
+        bv_z = float(abs(orig["bv"][-1, a, 2]))
+        print(f"  cut-point energy: |jv|={jv_l2:.2f} rad/s  jp_dev={jp_dev:.3f} rad  "
+              f"|bv_z|={bv_z:.3f} m/s", file=sys.stderr)
+
+    dt = 1.0 / fps
+    N = int(round(args.cooldown_sec * fps))
+    if N < 2:
+        raise SystemExit(f"cooldown-sec={args.cooldown_sec}s too short for fps={fps} (need >= 2 frames)")
+    K = int(round(args.hold_sec * fps)) if args.hold_sec > 0.0 else 0
+    if args.hold_sec > 0.0 and K < 1:
+        raise SystemExit(f"hold-sec={args.hold_sec}s rounds to 0 frames at fps={fps}; pass 0 or >= {dt:.3f}s")
+    T = N * dt   # frame N of the cooldown == FixStand target exactly
+
+    fk_jp, fk_bp, fk_bq = compute_fixstand_body_states(args.scene, tracked_ids)
+
+    keyframe_diff = float(np.abs(fk_jp - default_angles).max())
+    if keyframe_diff > 1e-3:
+        print(f"WARN: 'stand' keyframe joint pos differs from deploy_config "
+              f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
+              "values for cooldown end (so command_joint_pos matches what "
+              "FixStand will hold on the real robot).", file=sys.stderr)
+
+    # --- joint pos/vel: analytic Hermite, orig[-1] -> default_angles --------
+    # ts[k] = (k+1)*dt so the first cooldown frame is one dt after orig[-1]
+    # and the last cooldown frame (k = N-1) lands exactly at t = T = N*dt,
+    # i.e. precisely on the (default_angles, 0) boundary.
+    ts = (np.arange(N) + 1) * dt
+    jp_c, jv_c = hermite(orig["jp"][-1], orig["jv"][-1],
+                         default_angles, np.zeros(J), ts, T)
+
+    # --- body pos / lin_vel: analytic Hermite per axis ----------------------
+    bp_c, bv_c = hermite(orig["bp"][-1], orig["bv"][-1],
+                         fk_bp, np.zeros((B, 3)), ts, T)
+
+    # --- body quat: SLERP along quintic smoothstep --------------------------
+    u = ts / T
+    bq_c = np.zeros((N, B, 4), dtype=np.float64)
+    for b in range(B):
+        bq_c[:, b, :] = slerp_smoothstep(orig["bq"][-1, b], fk_bq[b], u)
+
+    # --- body ang_vel: central diff, with the seam differenced against the
+    # ORIGINAL bin's last two frames so the derivative is continuous across
+    # the dance/cooldown boundary -------------------------------------------
+    bav_c = np.zeros((N, B, 3), dtype=np.float64)
+    for b in range(B):
+        ext = np.concatenate([orig["bq"][-2:, b, :], bq_c[:, b, :]], axis=0)
+        # extended sequence has 2+N frames; cooldown frames live at [2, 2+N).
+        bav_c[:, b, :] = quat_seq_ang_vel(ext, dt)[2:]
+
+    # --- static hold segment: K frames all at (default, 0, FK, 0). Gives the
+    # tracking policy time to physically converge to the FixStand target before
+    # the FSM time-end check fires and hands off to State_FixStand. Without
+    # this segment, the cooldown's last (default, 0) frame is commanded for
+    # only one step_dt (~0.02s) before the swap, and any residual body momentum
+    # carried through the Hermite ramp ends up as the FixStand starting pose. -
+    if K > 0:
+        jp_h = np.broadcast_to(default_angles, (K, J)).copy()
+        jv_h = np.zeros((K, J), dtype=np.float64)
+        bp_h = np.broadcast_to(fk_bp, (K, B, 3)).copy()
+        bq_h = np.broadcast_to(fk_bq, (K, B, 4)).copy()
+        bv_h = np.zeros((K, B, 3), dtype=np.float64)
+        bav_h = np.zeros((K, B, 3), dtype=np.float64)
+
+    # --- concatenate original + cooldown (+ hold) -------------------------
+    parts_jp  = [orig["jp"],  jp_c]
+    parts_jv  = [orig["jv"],  jv_c]
+    parts_bp  = [orig["bp"],  bp_c]
+    parts_bq  = [orig["bq"],  bq_c]
+    parts_bv  = [orig["bv"],  bv_c]
+    parts_bav = [orig["bav"], bav_c]
+    if K > 0:
+        parts_jp.append(jp_h)
+        parts_jv.append(jv_h)
+        parts_bp.append(bp_h)
+        parts_bq.append(bq_h)
+        parts_bv.append(bv_h)
+        parts_bav.append(bav_h)
+    new_jp  = np.concatenate(parts_jp,  axis=0)
+    new_jv  = np.concatenate(parts_jv,  axis=0)
+    new_bp  = np.concatenate(parts_bp,  axis=0)
+    new_bq  = np.concatenate(parts_bq,  axis=0)
+    new_bv  = np.concatenate(parts_bv,  axis=0)
+    new_bav = np.concatenate(parts_bav, axis=0)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_motion_bin(args.output, fps, new_jp, new_jv, new_bp, new_bq, new_bv, new_bav)
+
+    # --- report ------------------------------------------------------------
+    # Seam = boundary between orig[-1] and cooldown[0], which are one dt apart.
+    seam_jp = float(np.abs(jp_c[0] - orig["jp"][-1]).max())
+    seam_jv = float(np.abs(jv_c[0] - orig["jv"][-1]).max())
+    seam_bp = float(np.abs(bp_c[0] - orig["bp"][-1]).max())
+    seam_bv = float(np.abs(bv_c[0] - orig["bv"][-1]).max())
+    seam_qang_deg = []
+    for b in range(B):
+        d = float(np.clip(abs(np.dot(bq_c[0, b], orig["bq"][-1, b])), 0.0, 1.0))
+        seam_qang_deg.append(np.degrees(2 * np.arccos(d)))
+    seam_qang_max = max(seam_qang_deg)
+    # End state must match FixStand boundary (this is the whole point).
+    end_jp_diff = float(np.abs(new_jp[-1] - default_angles).max())
+    end_jv_l2 = float(np.linalg.norm(new_jv[-1]))
+
+    print(f"Wrote {args.output}")
+    print(f"  fps={fps}  J={J}  B={B}")
+    print(f"  frames: {orig['nf']} (orig)  -> {new_jp.shape[0]} "
+          f"({orig['nf']} dance + {N} cooldown + {K} hold)")
+    print(f"  duration: {orig['nf']/fps:.2f}s -> {new_jp.shape[0]/fps:.2f}s "
+          f"(cooldown_sec={args.cooldown_sec}, hold_sec={args.hold_sec})")
+    print(f"  end (last frame) command_joint_pos == default_angles? "
+          f"max_diff={end_jp_diff:.6f} rad")
+    print(f"  end (last frame) command_joint_vel L2 = {end_jv_l2:.6f} rad/s (should be 0)")
+    print("  seam check (orig last frame vs cooldown first frame; one-dt-step apart):")
+    print(f"    |Δjoint_pos|_∞       = {seam_jp:.4f} rad")
+    print(f"    |Δjoint_vel|_∞       = {seam_jv:.4f} rad/s")
+    print(f"    |Δbody_pos|_∞        = {seam_bp:.4f} m")
+    print(f"    |Δbody_lin_vel|_∞    = {seam_bv:.4f} m/s")
+    print(f"    max body quat angle  = {seam_qang_max:.4f} deg")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/append_cooldown.py
+++ b/scripts/deploy/append_cooldown.py
@@ -39,14 +39,14 @@ reverse direction:
 
 Use
 ---
-    uv run python scripts/deploy/append_cooldown.py \
+    uv run scripts/deploy/append_cooldown.py \
         --input  ../deploy_ws/assets/dance1.bin \
         --output ../deploy_ws/assets/dance1_cooldown.bin \
         --config ../deploy_ws/assets/deploy_config.yaml \
         --cooldown-sec 2.0
 
 Validate in sim BEFORE swapping on the real robot:
-    uv run python scripts/deploy/sim_prototype.py \
+    uv run scripts/deploy/sim_prototype.py \
         --motion ../deploy_ws/assets/dance1_cooldown.bin \
         --init-mode stand --render
 """

--- a/scripts/deploy/append_cooldown.py
+++ b/scripts/deploy/append_cooldown.py
@@ -50,6 +50,7 @@ Validate in sim BEFORE swapping on the real robot:
         --motion ../deploy_ws/assets/dance1_cooldown.bin \
         --init-mode stand --render
 """
+
 from __future__ import annotations
 
 import argparse
@@ -76,6 +77,7 @@ DEFAULT_HOLD_SEC = 0.5
 # all use: header (4 int32: fps, F, J, B) then six float32 blocks.
 # ----------------------------------------------------------------------------
 
+
 def load_motion_bin(path: Path) -> dict:
     with open(path, "rb") as f:
         fps, nf, nj, nb = struct.unpack("<iiii", f.read(16))
@@ -85,8 +87,7 @@ def load_motion_bin(path: Path) -> dict:
         bq = np.frombuffer(f.read(nf * nb * 4 * 4), "<f4").reshape(nf, nb, 4).copy()
         bv = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
         bav = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
-    return dict(fps=fps, nf=nf, nj=nj, nb=nb,
-                jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
+    return dict(fps=fps, nf=nf, nj=nj, nb=nb, jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
 
 
 def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
@@ -105,8 +106,10 @@ def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
 # FixStand FK — compute body world states at the 'stand' keyframe.
 # ----------------------------------------------------------------------------
 
-def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
-                                 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+
+def compute_fixstand_body_states(
+    scene: Path, tracked_ids: list[int]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     model = mujoco.MjModel.from_xml_path(str(scene))
     data = mujoco.MjData(model)
     key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
@@ -115,16 +118,20 @@ def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
     mujoco.mj_resetDataKeyframe(model, data, key_id)
     mujoco.mj_forward(model, data)
     jp = np.asarray(data.qpos[7:], dtype=np.float64).copy()
-    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy()
-                   for i in tracked_ids])
-    bq = np.stack([np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
-                   for i in tracked_ids])
+    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy() for i in tracked_ids])
+    bq = np.stack(
+        [
+            np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
+            for i in tracked_ids
+        ]
+    )
     return jp, bp, bq
 
 
 # ----------------------------------------------------------------------------
 # Cubic Hermite — same primitive as prepend_warmup.py.
 # ----------------------------------------------------------------------------
+
 
 def hermite(p0, v0, p1, v1, t, T):
     s = t / T
@@ -140,6 +147,7 @@ def hermite(p0, v0, p1, v1, t, T):
 
     def _r(a):
         return a.reshape(a.shape + (1,) * (np.ndim(p0)))
+
     p = _r(h00) * p0 + _r(h10) * T * v0 + _r(h01) * p1 + _r(h11) * T * v1
     pd = _r(h00d / T) * p0 + _r(h10d) * v0 + _r(h01d / T) * p1 + _r(h11d) * v1
     return p, pd
@@ -148,6 +156,7 @@ def hermite(p0, v0, p1, v1, t, T):
 # ----------------------------------------------------------------------------
 # Quaternion SLERP along quintic smoothstep.
 # ----------------------------------------------------------------------------
+
 
 def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarray:
     q0 = q0 / np.linalg.norm(q0)
@@ -171,6 +180,7 @@ def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarra
 # ----------------------------------------------------------------------------
 # World-frame angular velocity from a quaternion sequence by finite difference.
 # ----------------------------------------------------------------------------
+
 
 def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
     n = q_seq.shape[0]
@@ -201,35 +211,57 @@ def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
 # Main
 # ----------------------------------------------------------------------------
 
+
 def main() -> None:
     ap = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--input", type=Path, default=DEFAULT_IN)
     ap.add_argument("--output", type=Path, default=DEFAULT_OUT)
-    ap.add_argument("--config", type=Path, default=DEFAULT_CFG,
-                    help="deploy_config.yaml (for default_angles, tracked ids).")
-    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
-                    help="MuJoCo XML with 'stand' keyframe (for FixStand FK).")
-    ap.add_argument("--cut-frame", type=int, default=None,
-                    help="If set, truncate the input bin so that frame "
-                         "CUT_FRAME becomes the new last frame (inclusive). "
-                         "Frames after that are dropped, and the cooldown ramps "
-                         "from this frame to default. Use this when the dance's "
-                         "actual last frame has too much momentum for any post-"
-                         "hoc interpolation to stabilize. Find a low-energy "
-                         "frame (low joint vel, near-upright torso, near-zero "
-                         "pelvis vertical vel) and cut there.")
-    ap.add_argument("--cooldown-sec", type=float, default=DEFAULT_COOLDOWN_SEC,
-                    help="Length of Hermite deceleration ramp [seconds]. "
-                         "Lowers joint vel from orig.jv[-1] to 0 and joint pos "
-                         "to default_angles over this interval.")
-    ap.add_argument("--hold-sec", type=float, default=DEFAULT_HOLD_SEC,
-                    help="Length of trailing static-hold segment [seconds]. "
-                         "Appended AFTER the Hermite ramp; frames are pure "
-                         "(default_angles, 0, FixStand FK body, 0). Lets the "
-                         "tracking policy physically converge to stand before "
-                         "the FSM timeout swaps to State_FixStand. Set to 0 to "
-                         "disable. Recommended >= 0.3s.")
+    ap.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CFG,
+        help="deploy_config.yaml (for default_angles, tracked ids).",
+    )
+    ap.add_argument(
+        "--scene",
+        type=Path,
+        default=DEFAULT_SCENE,
+        help="MuJoCo XML with 'stand' keyframe (for FixStand FK).",
+    )
+    ap.add_argument(
+        "--cut-frame",
+        type=int,
+        default=None,
+        help="If set, truncate the input bin so that frame "
+        "CUT_FRAME becomes the new last frame (inclusive). "
+        "Frames after that are dropped, and the cooldown ramps "
+        "from this frame to default. Use this when the dance's "
+        "actual last frame has too much momentum for any post-"
+        "hoc interpolation to stabilize. Find a low-energy "
+        "frame (low joint vel, near-upright torso, near-zero "
+        "pelvis vertical vel) and cut there.",
+    )
+    ap.add_argument(
+        "--cooldown-sec",
+        type=float,
+        default=DEFAULT_COOLDOWN_SEC,
+        help="Length of Hermite deceleration ramp [seconds]. "
+        "Lowers joint vel from orig.jv[-1] to 0 and joint pos "
+        "to default_angles over this interval.",
+    )
+    ap.add_argument(
+        "--hold-sec",
+        type=float,
+        default=DEFAULT_HOLD_SEC,
+        help="Length of trailing static-hold segment [seconds]. "
+        "Appended AFTER the Hermite ramp; frames are pure "
+        "(default_angles, 0, FixStand FK body, 0). Lets the "
+        "tracking policy physically converge to stand before "
+        "the FSM timeout swaps to State_FixStand. Set to 0 to "
+        "disable. Recommended >= 0.3s.",
+    )
     args = ap.parse_args()
 
     with open(args.config) as f:
@@ -247,12 +279,14 @@ def main() -> None:
     if args.cut_frame is not None:
         cf = int(args.cut_frame)
         if cf < 1 or cf >= orig["nf"]:
-            raise SystemExit(f"cut-frame={cf} out of range [1, {orig['nf']-1}]")
+            raise SystemExit(f"cut-frame={cf} out of range [1, {orig['nf'] - 1}]")
         # Keep frames [0, cf] (cf becomes the new last frame, inclusive).
         keep = cf + 1
-        print(f"Truncating input: keep frames [0, {cf}]  "
-              f"({orig['nf']} -> {keep} frames, {orig['nf']/fps:.2f}s -> {keep/fps:.2f}s)",
-              file=sys.stderr)
+        print(
+            f"Truncating input: keep frames [0, {cf}]  "
+            f"({orig['nf']} -> {keep} frames, {orig['nf'] / fps:.2f}s -> {keep / fps:.2f}s)",
+            file=sys.stderr,
+        )
         for k in ("jp", "jv", "bp", "bq", "bv", "bav"):
             orig[k] = orig[k][:keep]
         orig["nf"] = keep
@@ -261,38 +295,46 @@ def main() -> None:
         jv_l2 = float(np.linalg.norm(orig["jv"][-1]))
         jp_dev = float(np.abs(orig["jp"][-1] - default_angles).max())
         bv_z = float(abs(orig["bv"][-1, a, 2]))
-        print(f"  cut-point energy: |jv|={jv_l2:.2f} rad/s  jp_dev={jp_dev:.3f} rad  "
-              f"|bv_z|={bv_z:.3f} m/s", file=sys.stderr)
+        print(
+            f"  cut-point energy: |jv|={jv_l2:.2f} rad/s  jp_dev={jp_dev:.3f} rad  "
+            f"|bv_z|={bv_z:.3f} m/s",
+            file=sys.stderr,
+        )
 
     dt = 1.0 / fps
     N = int(round(args.cooldown_sec * fps))
     if N < 2:
-        raise SystemExit(f"cooldown-sec={args.cooldown_sec}s too short for fps={fps} (need >= 2 frames)")
+        raise SystemExit(
+            f"cooldown-sec={args.cooldown_sec}s too short for fps={fps} (need >= 2 frames)"
+        )
     K = int(round(args.hold_sec * fps)) if args.hold_sec > 0.0 else 0
     if args.hold_sec > 0.0 and K < 1:
-        raise SystemExit(f"hold-sec={args.hold_sec}s rounds to 0 frames at fps={fps}; pass 0 or >= {dt:.3f}s")
-    T = N * dt   # frame N of the cooldown == FixStand target exactly
+        raise SystemExit(
+            f"hold-sec={args.hold_sec}s rounds to 0 frames at fps={fps}; pass 0 or >= {dt:.3f}s"
+        )
+    T = N * dt  # frame N of the cooldown == FixStand target exactly
 
     fk_jp, fk_bp, fk_bq = compute_fixstand_body_states(args.scene, tracked_ids)
 
     keyframe_diff = float(np.abs(fk_jp - default_angles).max())
     if keyframe_diff > 1e-3:
-        print(f"WARN: 'stand' keyframe joint pos differs from deploy_config "
-              f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
-              "values for cooldown end (so command_joint_pos matches what "
-              "FixStand will hold on the real robot).", file=sys.stderr)
+        print(
+            f"WARN: 'stand' keyframe joint pos differs from deploy_config "
+            f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
+            "values for cooldown end (so command_joint_pos matches what "
+            "FixStand will hold on the real robot).",
+            file=sys.stderr,
+        )
 
     # --- joint pos/vel: analytic Hermite, orig[-1] -> default_angles --------
     # ts[k] = (k+1)*dt so the first cooldown frame is one dt after orig[-1]
     # and the last cooldown frame (k = N-1) lands exactly at t = T = N*dt,
     # i.e. precisely on the (default_angles, 0) boundary.
     ts = (np.arange(N) + 1) * dt
-    jp_c, jv_c = hermite(orig["jp"][-1], orig["jv"][-1],
-                         default_angles, np.zeros(J), ts, T)
+    jp_c, jv_c = hermite(orig["jp"][-1], orig["jv"][-1], default_angles, np.zeros(J), ts, T)
 
     # --- body pos / lin_vel: analytic Hermite per axis ----------------------
-    bp_c, bv_c = hermite(orig["bp"][-1], orig["bv"][-1],
-                         fk_bp, np.zeros((B, 3)), ts, T)
+    bp_c, bv_c = hermite(orig["bp"][-1], orig["bv"][-1], fk_bp, np.zeros((B, 3)), ts, T)
 
     # --- body quat: SLERP along quintic smoothstep --------------------------
     u = ts / T
@@ -324,11 +366,11 @@ def main() -> None:
         bav_h = np.zeros((K, B, 3), dtype=np.float64)
 
     # --- concatenate original + cooldown (+ hold) -------------------------
-    parts_jp  = [orig["jp"],  jp_c]
-    parts_jv  = [orig["jv"],  jv_c]
-    parts_bp  = [orig["bp"],  bp_c]
-    parts_bq  = [orig["bq"],  bq_c]
-    parts_bv  = [orig["bv"],  bv_c]
+    parts_jp = [orig["jp"], jp_c]
+    parts_jv = [orig["jv"], jv_c]
+    parts_bp = [orig["bp"], bp_c]
+    parts_bq = [orig["bq"], bq_c]
+    parts_bv = [orig["bv"], bv_c]
     parts_bav = [orig["bav"], bav_c]
     if K > 0:
         parts_jp.append(jp_h)
@@ -337,11 +379,11 @@ def main() -> None:
         parts_bq.append(bq_h)
         parts_bv.append(bv_h)
         parts_bav.append(bav_h)
-    new_jp  = np.concatenate(parts_jp,  axis=0)
-    new_jv  = np.concatenate(parts_jv,  axis=0)
-    new_bp  = np.concatenate(parts_bp,  axis=0)
-    new_bq  = np.concatenate(parts_bq,  axis=0)
-    new_bv  = np.concatenate(parts_bv,  axis=0)
+    new_jp = np.concatenate(parts_jp, axis=0)
+    new_jv = np.concatenate(parts_jv, axis=0)
+    new_bp = np.concatenate(parts_bp, axis=0)
+    new_bq = np.concatenate(parts_bq, axis=0)
+    new_bv = np.concatenate(parts_bv, axis=0)
     new_bav = np.concatenate(parts_bav, axis=0)
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -364,12 +406,15 @@ def main() -> None:
 
     print(f"Wrote {args.output}")
     print(f"  fps={fps}  J={J}  B={B}")
-    print(f"  frames: {orig['nf']} (orig)  -> {new_jp.shape[0]} "
-          f"({orig['nf']} dance + {N} cooldown + {K} hold)")
-    print(f"  duration: {orig['nf']/fps:.2f}s -> {new_jp.shape[0]/fps:.2f}s "
-          f"(cooldown_sec={args.cooldown_sec}, hold_sec={args.hold_sec})")
-    print(f"  end (last frame) command_joint_pos == default_angles? "
-          f"max_diff={end_jp_diff:.6f} rad")
+    print(
+        f"  frames: {orig['nf']} (orig)  -> {new_jp.shape[0]} "
+        f"({orig['nf']} dance + {N} cooldown + {K} hold)"
+    )
+    print(
+        f"  duration: {orig['nf'] / fps:.2f}s -> {new_jp.shape[0] / fps:.2f}s "
+        f"(cooldown_sec={args.cooldown_sec}, hold_sec={args.hold_sec})"
+    )
+    print(f"  end (last frame) command_joint_pos == default_angles? max_diff={end_jp_diff:.6f} rad")
     print(f"  end (last frame) command_joint_vel L2 = {end_jv_l2:.6f} rad/s (should be 0)")
     print("  seam check (orig last frame vs cooldown first frame; one-dt-step apart):")
     print(f"    |Δjoint_pos|_∞       = {seam_jp:.4f} rad")

--- a/scripts/deploy/export_deploy_config.py
+++ b/scripts/deploy/export_deploy_config.py
@@ -22,6 +22,7 @@ obs_layout schema v2 (per-term history_length):
     so each term independently flattens its full history → total obs_dim is
     the sum of dim * history_length over all entries.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -73,8 +74,9 @@ def _round_list(arr, ndigits=6):
     return [round(float(v), ndigits) for v in arr]
 
 
-def _build_obs_layout(num_action: int, hist_len: int,
-                      enable_zero_anchor_pos: bool, enable_zero_linvel: bool):
+def _build_obs_layout(
+    num_action: int, hist_len: int, enable_zero_anchor_pos: bool, enable_zero_linvel: bool
+):
     """Build obs_layout in the exact order tracking.py:_compute_obs assembles.
 
     Returns (layout_list, total_obs_dim).
@@ -83,56 +85,101 @@ def _build_obs_layout(num_action: int, hist_len: int,
     """
     layout = [
         # ---- single-step reference terms (history_length=1) ----
-        {"name": "command_joint_pos", "dim": num_action, "history_length": 1,
-         "source": "motion_ref_frame.joint_pos"},
-        {"name": "command_joint_vel", "dim": num_action, "history_length": 1,
-         "source": "motion_ref_frame.joint_vel"},
+        {
+            "name": "command_joint_pos",
+            "dim": num_action,
+            "history_length": 1,
+            "source": "motion_ref_frame.joint_pos",
+        },
+        {
+            "name": "command_joint_vel",
+            "dim": num_action,
+            "history_length": 1,
+            "source": "motion_ref_frame.joint_vel",
+        },
     ]
     if not enable_zero_anchor_pos:
-        layout.append({
-            "name": "motion_anchor_pos_b", "dim": 3, "history_length": 1,
-            "source": "subtract_frame(robot_anchor_w, motion_anchor_w).pos",
-        })
-    layout.append({
-        "name": "motion_anchor_ori_b", "dim": 6, "history_length": 1,
-        "source": "rotation_matrix(subtract_frame(...).quat)[:, :2].flatten()",
-    })
+        layout.append(
+            {
+                "name": "motion_anchor_pos_b",
+                "dim": 3,
+                "history_length": 1,
+                "source": "subtract_frame(robot_anchor_w, motion_anchor_w).pos",
+            }
+        )
+    layout.append(
+        {
+            "name": "motion_anchor_ori_b",
+            "dim": 6,
+            "history_length": 1,
+            "source": "rotation_matrix(subtract_frame(...).quat)[:, :2].flatten()",
+        }
+    )
     if not enable_zero_linvel:
-        layout.append({
-            "name": "base_lin_vel", "dim": 3, "history_length": 1,
-            "source": "imu.local_linvel (state-estimated)",
-        })
+        layout.append(
+            {
+                "name": "base_lin_vel",
+                "dim": 3,
+                "history_length": 1,
+                "source": "imu.local_linvel (state-estimated)",
+            }
+        )
     # ---- proprio terms with H-step oldest-first history ----
-    layout.extend([
-        {"name": "gyro", "dim": 3, "history_length": hist_len,
-         "source": "imu.gyroscope"},
-        {"name": "joint_pos_rel", "dim": num_action, "history_length": hist_len,
-         "source": "dof_pos - default_angles"},
-        {"name": "dof_vel", "dim": num_action, "history_length": hist_len,
-         "source": "dof_vel"},
-        {"name": "last_actions", "dim": num_action, "history_length": hist_len,
-         "source": "previous raw actor output"},
-    ])
+    layout.extend(
+        [
+            {"name": "gyro", "dim": 3, "history_length": hist_len, "source": "imu.gyroscope"},
+            {
+                "name": "joint_pos_rel",
+                "dim": num_action,
+                "history_length": hist_len,
+                "source": "dof_pos - default_angles",
+            },
+            {"name": "dof_vel", "dim": num_action, "history_length": hist_len, "source": "dof_vel"},
+            {
+                "name": "last_actions",
+                "dim": num_action,
+                "history_length": hist_len,
+                "source": "previous raw actor output",
+            },
+        ]
+    )
     total = sum(seg["dim"] * seg["history_length"] for seg in layout)
     return layout, total
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
-                    help="MuJoCo scene file containing the 'stand' keyframe.")
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--scene",
+        type=Path,
+        default=DEFAULT_SCENE,
+        help="MuJoCo scene file containing the 'stand' keyframe.",
+    )
     ap.add_argument("--output", "-o", type=Path, default=DEFAULT_OUT)
-    ap.add_argument("--obs-history-length", type=int, default=DEFAULT_OBS_HISTORY_LENGTH,
-                    help="Proprio history length H. Must match training-side "
-                         "noise_config.obs_history_length. Default 5 = current "
-                         "mujoco_deploy.yaml. Set 1 for the legacy 154-d schema.")
-    ap.add_argument("--enable-zero-anchor-pos", action="store_true", default=True,
-                    help="Drop motion_anchor_pos_b from actor obs (mjlab parity). "
-                         "Matches mujoco_deploy.yaml's noise_config flag.")
-    ap.add_argument("--enable-zero-linvel", action="store_true", default=True,
-                    help="Drop base_lin_vel from actor obs (mjlab parity). "
-                         "Matches mujoco_deploy.yaml's noise_config flag.")
+    ap.add_argument(
+        "--obs-history-length",
+        type=int,
+        default=DEFAULT_OBS_HISTORY_LENGTH,
+        help="Proprio history length H. Must match training-side "
+        "noise_config.obs_history_length. Default 5 = current "
+        "mujoco_deploy.yaml. Set 1 for the legacy 154-d schema.",
+    )
+    ap.add_argument(
+        "--enable-zero-anchor-pos",
+        action="store_true",
+        default=True,
+        help="Drop motion_anchor_pos_b from actor obs (mjlab parity). "
+        "Matches mujoco_deploy.yaml's noise_config flag.",
+    )
+    ap.add_argument(
+        "--enable-zero-linvel",
+        action="store_true",
+        default=True,
+        help="Drop base_lin_vel from actor obs (mjlab parity). "
+        "Matches mujoco_deploy.yaml's noise_config flag.",
+    )
     args = ap.parse_args()
 
     if not args.scene.exists():
@@ -160,7 +207,7 @@ def main():
     # Joint limits: skip the floating-root joint (jnt 0).
     if model.njnt < 1 + model.nu:
         raise SystemExit(f"Insufficient joints: njnt={model.njnt}")
-    jnt_range = model.jnt_range[1:1 + model.nu].copy()
+    jnt_range = model.jnt_range[1 : 1 + model.nu].copy()
     joint_lower = jnt_range[:, 0]
     joint_upper = jnt_range[:, 1]
 
@@ -178,9 +225,7 @@ def main():
         raise SystemExit(f"Keyframe '{KEYFRAME_NAME}' not found; have {names}")
     stand_qpos = model.key_qpos[key_id]
     if len(stand_qpos) != ROOT_QPOS_DIM + model.nu:
-        raise SystemExit(
-            f"stand qpos len {len(stand_qpos)} != {ROOT_QPOS_DIM}+{model.nu}"
-        )
+        raise SystemExit(f"stand qpos len {len(stand_qpos)} != {ROOT_QPOS_DIM}+{model.nu}")
     default_angles = stand_qpos[ROOT_QPOS_DIM:].copy()
 
     # 14 tracked body indices (in MuJoCo body-id space; deploy side won't use
@@ -223,7 +268,6 @@ def main():
         "ctrl_dt": CTRL_DT,
         "action_scale": ACTION_SCALE,
         "ema_alpha": EMA_ALPHA,
-
         # ---- joint config (in MuJoCo actuator order; deploy side assumes
         # this matches the SDK motor index 1:1 for G1-29DOF — verify per-motor
         # before real-robot run) ----
@@ -237,13 +281,11 @@ def main():
         "joint_upper": _round_list(joint_upper),
         "force_lower": _round_list(force_lower, 3),
         "force_upper": _round_list(force_upper, 3),
-
         # ---- motion / anchor ----
         "tracked_body_names": list(TRACKED_BODY_NAMES),
         "tracked_body_mujoco_ids": tracked_body_ids,
         "anchor_body_name": ANCHOR_BODY_NAME,
         "anchor_body_idx_in_tracked": int(anchor_body_idx_in_tracked),
-
         # ---- noise (NOT applied at deploy; documentation only — per-step
         # uniform noise scales used during training, plus persistent encoder
         # bias absorbed into joint_pos_rel) ----
@@ -254,7 +296,6 @@ def main():
             "anchor_ori": 0.05,
             "joint_pos_encoder_bias_per_episode": 0.01,
         },
-
         # ---- obs layout (SINGLE SOURCE OF TRUTH for both ends) ----
         # Each entry: name, dim (per-step), history_length, source.
         # Total obs_dim = sum(dim * history_length).
@@ -268,13 +309,17 @@ def main():
         yaml.safe_dump(cfg, f, sort_keys=False, default_flow_style=None, width=120)
 
     print(f"Wrote {args.output} ({args.output.stat().st_size} bytes)")
-    print(f"  joints: {model.nu}, tracked bodies: {len(TRACKED_BODY_NAMES)}, "
-          f"anchor='{ANCHOR_BODY_NAME}' (idx_in_tracked={anchor_body_idx_in_tracked})")
+    print(
+        f"  joints: {model.nu}, tracked bodies: {len(TRACKED_BODY_NAMES)}, "
+        f"anchor='{ANCHOR_BODY_NAME}' (idx_in_tracked={anchor_body_idx_in_tracked})"
+    )
     print(f"  obs_history_length={args.obs_history_length}, total obs_dim={obs_dim}")
     print("  obs_layout segments:")
     for seg in obs_layout:
-        print(f"    {seg['name']:24s} dim={seg['dim']:3d}  H={seg['history_length']:1d}  "
-              f"contrib={seg['dim'] * seg['history_length']}")
+        print(
+            f"    {seg['name']:24s} dim={seg['dim']:3d}  H={seg['history_length']:1d}  "
+            f"contrib={seg['dim'] * seg['history_length']}"
+        )
     print(f"  default_angles[:6] = {_round_list(default_angles[:6], 3)}")
     print(f"  kp[:3] = {_round_list(kp[:3], 3)}, kd[:3] = {_round_list(kv[:3], 3)}")
 

--- a/scripts/deploy/export_deploy_config.py
+++ b/scripts/deploy/export_deploy_config.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Export deploy_config.yaml for the C++ G1-29DOF WBT deployment side.
+
+Reads g1.xml + scene_flat.xml + tracking.py defaults to emit a single yaml
+that the deploy framework (~/deploy_ws/unitree_rl_lab/.../State_WBT) can load
+to drive the actor at runtime.
+
+This file is the SINGLE SOURCE OF TRUTH for the actor obs schema:
+  * Training side (tracking.py) assembles obs in the order documented here.
+  * Deploy side (State_WBT.cpp + ObservationManager) reads obs_layout from
+    this yaml and assembles in matching order with per-term history buffers.
+  * Alignment test (tests/test_obs_alignment_g1_wbt.py) verifies both code
+    paths produce byte-identical obs from the same inputs.
+
+obs_layout schema v2 (per-term history_length):
+  Each entry: {name, dim, history_length, source}
+  * Reference terms (command_*, motion_anchor_*) use history_length=1
+    (single-step, refs come fresh from the motion clip every tick).
+  * Proprio terms (gyro, joint_pos_rel, dof_vel, last_actions) carry
+    history_length=H (5 for the deploy profile), flattened oldest-first.
+  * Deploy framework reads via use_gym_history=false (group-by-term mode),
+    so each term independently flattens its full history → total obs_dim is
+    the sum of dim * history_length over all entries.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import mujoco
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCENE = REPO_ROOT / "src/unilab/assets/robots/g1/scene_flat.xml"
+DEFAULT_OUT = REPO_ROOT / "logs/deploy/deploy_config.yaml"
+
+TRACKED_BODY_NAMES = (
+    "pelvis",
+    "left_hip_roll_link",
+    "left_knee_link",
+    "left_ankle_roll_link",
+    "right_hip_roll_link",
+    "right_knee_link",
+    "right_ankle_roll_link",
+    "torso_link",
+    "left_shoulder_roll_link",
+    "left_elbow_link",
+    "left_wrist_yaw_link",
+    "right_shoulder_roll_link",
+    "right_elbow_link",
+    "right_wrist_yaw_link",
+)
+ANCHOR_BODY_NAME = "torso_link"
+
+ACTION_SCALE = 2.0
+# EMA alpha for q_target smoothing on the deploy side. Training applies q_target
+# directly with no smoothing; alpha=1.0 means deploy also applies directly (best
+# for sim2sim correctness). Lower it (~0.5–0.8) only on real hardware if jitter
+# requires smoothing — but every step of lag pushes obs out of training
+# distribution, so verify sim2sim impact at the chosen alpha first.
+EMA_ALPHA = 1.0
+CTRL_DT = 0.02
+KEYFRAME_NAME = "stand"
+ROOT_QPOS_DIM = 7  # free joint: xyz + quat(wxyz)
+
+# Default obs history length — matches mujoco_deploy.yaml's
+# `noise_config.obs_history_length`. Override via --obs-history-length when
+# exporting for other training profiles (e.g. mujoco.yaml uses 1).
+DEFAULT_OBS_HISTORY_LENGTH = 5
+
+
+def _round_list(arr, ndigits=6):
+    return [round(float(v), ndigits) for v in arr]
+
+
+def _build_obs_layout(num_action: int, hist_len: int,
+                      enable_zero_anchor_pos: bool, enable_zero_linvel: bool):
+    """Build obs_layout in the exact order tracking.py:_compute_obs assembles.
+
+    Returns (layout_list, total_obs_dim).
+    Order = single-step refs first, then per-term proprio history blocks,
+    matching the training-side actor obs concatenation order.
+    """
+    layout = [
+        # ---- single-step reference terms (history_length=1) ----
+        {"name": "command_joint_pos", "dim": num_action, "history_length": 1,
+         "source": "motion_ref_frame.joint_pos"},
+        {"name": "command_joint_vel", "dim": num_action, "history_length": 1,
+         "source": "motion_ref_frame.joint_vel"},
+    ]
+    if not enable_zero_anchor_pos:
+        layout.append({
+            "name": "motion_anchor_pos_b", "dim": 3, "history_length": 1,
+            "source": "subtract_frame(robot_anchor_w, motion_anchor_w).pos",
+        })
+    layout.append({
+        "name": "motion_anchor_ori_b", "dim": 6, "history_length": 1,
+        "source": "rotation_matrix(subtract_frame(...).quat)[:, :2].flatten()",
+    })
+    if not enable_zero_linvel:
+        layout.append({
+            "name": "base_lin_vel", "dim": 3, "history_length": 1,
+            "source": "imu.local_linvel (state-estimated)",
+        })
+    # ---- proprio terms with H-step oldest-first history ----
+    layout.extend([
+        {"name": "gyro", "dim": 3, "history_length": hist_len,
+         "source": "imu.gyroscope"},
+        {"name": "joint_pos_rel", "dim": num_action, "history_length": hist_len,
+         "source": "dof_pos - default_angles"},
+        {"name": "dof_vel", "dim": num_action, "history_length": hist_len,
+         "source": "dof_vel"},
+        {"name": "last_actions", "dim": num_action, "history_length": hist_len,
+         "source": "previous raw actor output"},
+    ])
+    total = sum(seg["dim"] * seg["history_length"] for seg in layout)
+    return layout, total
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
+                    help="MuJoCo scene file containing the 'stand' keyframe.")
+    ap.add_argument("--output", "-o", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--obs-history-length", type=int, default=DEFAULT_OBS_HISTORY_LENGTH,
+                    help="Proprio history length H. Must match training-side "
+                         "noise_config.obs_history_length. Default 5 = current "
+                         "mujoco_deploy.yaml. Set 1 for the legacy 154-d schema.")
+    ap.add_argument("--enable-zero-anchor-pos", action="store_true", default=True,
+                    help="Drop motion_anchor_pos_b from actor obs (mjlab parity). "
+                         "Matches mujoco_deploy.yaml's noise_config flag.")
+    ap.add_argument("--enable-zero-linvel", action="store_true", default=True,
+                    help="Drop base_lin_vel from actor obs (mjlab parity). "
+                         "Matches mujoco_deploy.yaml's noise_config flag.")
+    args = ap.parse_args()
+
+    if not args.scene.exists():
+        raise SystemExit(f"Scene not found: {args.scene}")
+
+    model = mujoco.MjModel.from_xml_path(str(args.scene))
+
+    if model.nu != 29:
+        raise SystemExit(f"Expected 29 actuators, got {model.nu}")
+
+    # Joint names in actuator order (action[i] drives actuator i).
+    joint_names = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in range(model.nu)
+    ]
+
+    # kp from XML <position> actuators.
+    kp = model.actuator_gainprm[:, 0].copy()  # gainprm[0] is kp for position actuator
+    if not (kp > 0).all():
+        raise SystemExit(f"kp parsing produced non-positive values: {kp}")
+    # kv recovery: for position actuator, biasprm = [0, -kp, -kv]
+    kv = -model.actuator_biasprm[:, 2].copy()
+    if not (kv > 0).all():
+        raise SystemExit(f"kv parsing produced non-positive values: {kv}")
+
+    # Joint limits: skip the floating-root joint (jnt 0).
+    if model.njnt < 1 + model.nu:
+        raise SystemExit(f"Insufficient joints: njnt={model.njnt}")
+    jnt_range = model.jnt_range[1:1 + model.nu].copy()
+    joint_lower = jnt_range[:, 0]
+    joint_upper = jnt_range[:, 1]
+
+    # Force range from actuator forcerange.
+    force_range = model.actuator_forcerange.copy()
+    force_lower = force_range[:, 0]
+    force_upper = force_range[:, 1]
+
+    # default_angles = stand keyframe qpos[7:36].
+    if model.nkey == 0:
+        raise SystemExit(f"No keyframes in {args.scene}; expected '{KEYFRAME_NAME}'.")
+    key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, KEYFRAME_NAME)
+    if key_id < 0:
+        names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, i) for i in range(model.nkey)]
+        raise SystemExit(f"Keyframe '{KEYFRAME_NAME}' not found; have {names}")
+    stand_qpos = model.key_qpos[key_id]
+    if len(stand_qpos) != ROOT_QPOS_DIM + model.nu:
+        raise SystemExit(
+            f"stand qpos len {len(stand_qpos)} != {ROOT_QPOS_DIM}+{model.nu}"
+        )
+    default_angles = stand_qpos[ROOT_QPOS_DIM:].copy()
+
+    # 14 tracked body indices (in MuJoCo body-id space; deploy side won't use
+    # these directly but they are useful for debugging / cross-checks).
+    tracked_body_ids = []
+    for nm in TRACKED_BODY_NAMES:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, nm)
+        if bid < 0:
+            raise SystemExit(f"Tracked body '{nm}' missing from model")
+        tracked_body_ids.append(int(bid))
+    anchor_body_idx_in_tracked = TRACKED_BODY_NAMES.index(ANCHOR_BODY_NAME)
+
+    # Build the obs layout (single source of truth for actor obs assembly).
+    obs_layout, obs_dim = _build_obs_layout(
+        num_action=model.nu,
+        hist_len=args.obs_history_length,
+        enable_zero_anchor_pos=args.enable_zero_anchor_pos,
+        enable_zero_linvel=args.enable_zero_linvel,
+    )
+
+    cfg = {
+        # ---- meta ----
+        # obs_dim = sum over obs_layout of dim * history_length.
+        # For the deploy profile (H=5, both zero flags ON) this is:
+        #   command_joint_pos(29*1) + command_joint_vel(29*1)
+        #   + motion_anchor_ori_b(6*1) + gyro(3*5)
+        #   + joint_pos_rel(29*5) + dof_vel(29*5) + last_actions(29*5) = 514
+        # Aligns with deploy-profile training run (mujoco_deploy.yaml) which
+        # drops motion_anchor_pos_b and base_lin_vel from actor obs to match
+        # Unitree's verified mjlab "No-State-Estimation" deploy yaml and
+        # adds BeyondMimic-style proprio history (default H=5).
+        "obs_dim": obs_dim,
+        "obs_history_length": args.obs_history_length,
+        # Deploy ObservationManager mode. False = group-by-term (each term's
+        # full history flattened oldest-first, then concat across terms).
+        # True = group-by-time-step (legacy gym style). Training side uses
+        # the false convention, so MUST stay false here for byte alignment.
+        "use_gym_history": False,
+        "action_dim": int(model.nu),
+        "ctrl_dt": CTRL_DT,
+        "action_scale": ACTION_SCALE,
+        "ema_alpha": EMA_ALPHA,
+
+        # ---- joint config (in MuJoCo actuator order; deploy side assumes
+        # this matches the SDK motor index 1:1 for G1-29DOF — verify per-motor
+        # before real-robot run) ----
+        "joint_names": list(joint_names),
+        # Identity SDK mapping; replace with measured order if 1:1 assumption fails.
+        "joint_ids_map": list(range(model.nu)),
+        "default_angles": _round_list(default_angles),
+        "kp": _round_list(kp),
+        "kd": _round_list(kv),
+        "joint_lower": _round_list(joint_lower),
+        "joint_upper": _round_list(joint_upper),
+        "force_lower": _round_list(force_lower, 3),
+        "force_upper": _round_list(force_upper, 3),
+
+        # ---- motion / anchor ----
+        "tracked_body_names": list(TRACKED_BODY_NAMES),
+        "tracked_body_mujoco_ids": tracked_body_ids,
+        "anchor_body_name": ANCHOR_BODY_NAME,
+        "anchor_body_idx_in_tracked": int(anchor_body_idx_in_tracked),
+
+        # ---- noise (NOT applied at deploy; documentation only — per-step
+        # uniform noise scales used during training, plus persistent encoder
+        # bias absorbed into joint_pos_rel) ----
+        "training_noise_scales": {
+            "joint_angle": 0.01,
+            "joint_vel": 0.5,
+            "gyro": 0.2,
+            "anchor_ori": 0.05,
+            "joint_pos_encoder_bias_per_episode": 0.01,
+        },
+
+        # ---- obs layout (SINGLE SOURCE OF TRUTH for both ends) ----
+        # Each entry: name, dim (per-step), history_length, source.
+        # Total obs_dim = sum(dim * history_length).
+        # Order MUST match tracking.py:_compute_obs assembly order.
+        # State_WBT.cpp:build_env_cfg translates names via its alias table.
+        "obs_layout": obs_layout,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False, default_flow_style=None, width=120)
+
+    print(f"Wrote {args.output} ({args.output.stat().st_size} bytes)")
+    print(f"  joints: {model.nu}, tracked bodies: {len(TRACKED_BODY_NAMES)}, "
+          f"anchor='{ANCHOR_BODY_NAME}' (idx_in_tracked={anchor_body_idx_in_tracked})")
+    print(f"  obs_history_length={args.obs_history_length}, total obs_dim={obs_dim}")
+    print("  obs_layout segments:")
+    for seg in obs_layout:
+        print(f"    {seg['name']:24s} dim={seg['dim']:3d}  H={seg['history_length']:1d}  "
+              f"contrib={seg['dim'] * seg['history_length']}")
+    print(f"  default_angles[:6] = {_round_list(default_angles[:6], 3)}")
+    print(f"  kp[:3] = {_round_list(kp[:3], 3)}, kd[:3] = {_round_list(kv[:3], 3)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/export_motion_bin.py
+++ b/scripts/deploy/export_motion_bin.py
@@ -23,6 +23,7 @@ NPZ source layout (per src/unilab/envs/motion_tracking/g1/motion_loader.py):
   Body axis is in MuJoCo body-id order; we slice down to 14 tracked bodies
   using mj_name2id() so the deploy side does not need to repeat the lookup.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -60,15 +61,22 @@ def main():
     ap.add_argument("--motion", type=Path, default=DEFAULT_NPZ)
     ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE)
     ap.add_argument("--output", "-o", type=Path, default=DEFAULT_OUT)
-    ap.add_argument("--start-frame", type=int, default=0,
-                    help="First frame to include (inclusive). Default 0.")
+    ap.add_argument(
+        "--start-frame", type=int, default=0, help="First frame to include (inclusive). Default 0."
+    )
     end_group = ap.add_mutually_exclusive_group()
-    end_group.add_argument("--end-frame", type=int, default=None,
-                           help="One past the last frame (exclusive). "
-                                "Default = NPZ frame count.")
-    end_group.add_argument("--duration", type=float, default=None,
-                           help="Seconds to keep starting at --start-frame. "
-                                "Resolved to frames via NPZ fps.")
+    end_group.add_argument(
+        "--end-frame",
+        type=int,
+        default=None,
+        help="One past the last frame (exclusive). Default = NPZ frame count.",
+    )
+    end_group.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Seconds to keep starting at --start-frame. Resolved to frames via NPZ fps.",
+    )
     args = ap.parse_args()
 
     if not args.motion.exists():
@@ -113,9 +121,7 @@ def main():
     else:
         end = total_frames
     if not (0 <= start < end <= total_frames):
-        raise SystemExit(
-            f"Invalid frame range [{start}, {end}); valid is [0, {total_frames}]"
-        )
+        raise SystemExit(f"Invalid frame range [{start}, {end}); valid is [0, {total_frames}]")
     if (start, end) != (0, total_frames):
         joint_pos = joint_pos[start:end]
         joint_vel = joint_vel[start:end]
@@ -159,14 +165,14 @@ def main():
     )
     actual_bytes = args.output.stat().st_size
     if actual_bytes != expected_bytes:
-        raise SystemExit(
-            f"Wrote {actual_bytes} bytes but expected {expected_bytes}"
-        )
+        raise SystemExit(f"Wrote {actual_bytes} bytes but expected {expected_bytes}")
 
     duration_s = num_frames / fps
     print(f"Wrote {args.output} ({actual_bytes} bytes)")
-    print(f"  fps={fps}, frames={num_frames}, joints={num_joints}, "
-          f"bodies={num_bodies}, duration={duration_s:.2f}s")
+    print(
+        f"  fps={fps}, frames={num_frames}, joints={num_joints}, "
+        f"bodies={num_bodies}, duration={duration_s:.2f}s"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/export_motion_bin.py
+++ b/scripts/deploy/export_motion_bin.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Export a tracked-motion NPZ to the flat binary format used by State_WBT.
+
+Layout (little-endian, contiguous):
+  header (16 bytes):
+    int32 fps
+    int32 num_frames
+    int32 num_joints      (29 for G1-29DOF)
+    int32 num_bodies      (14 tracked bodies)
+  data (all float32, frames-major):
+    joint_pos       [num_frames][num_joints]
+    joint_vel       [num_frames][num_joints]
+    body_pos_w      [num_frames][num_bodies][3]
+    body_quat_w     [num_frames][num_bodies][4]   (wxyz)
+    body_lin_vel_w  [num_frames][num_bodies][3]
+    body_ang_vel_w  [num_frames][num_bodies][3]
+
+NPZ source layout (per src/unilab/envs/motion_tracking/g1/motion_loader.py):
+  - 'fps' (int)
+  - 'joint_pos' (N, 29)
+  - 'joint_vel' (N, 29)
+  - 'body_pos_w', 'body_quat_w', 'body_lin_vel_w', 'body_ang_vel_w'  (N, 31, *)
+  Body axis is in MuJoCo body-id order; we slice down to 14 tracked bodies
+  using mj_name2id() so the deploy side does not need to repeat the lookup.
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_NPZ = REPO_ROOT / "src/unilab/assets/motions/g1/dance1_subject2_part.npz"
+DEFAULT_SCENE = REPO_ROOT / "src/unilab/assets/robots/g1/scene_flat.xml"
+DEFAULT_OUT = REPO_ROOT / "logs/deploy/dance1.bin"
+
+TRACKED_BODY_NAMES = (
+    "pelvis",
+    "left_hip_roll_link",
+    "left_knee_link",
+    "left_ankle_roll_link",
+    "right_hip_roll_link",
+    "right_knee_link",
+    "right_ankle_roll_link",
+    "torso_link",
+    "left_shoulder_roll_link",
+    "left_elbow_link",
+    "left_wrist_yaw_link",
+    "right_shoulder_roll_link",
+    "right_elbow_link",
+    "right_wrist_yaw_link",
+)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--motion", type=Path, default=DEFAULT_NPZ)
+    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE)
+    ap.add_argument("--output", "-o", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--start-frame", type=int, default=0,
+                    help="First frame to include (inclusive). Default 0.")
+    end_group = ap.add_mutually_exclusive_group()
+    end_group.add_argument("--end-frame", type=int, default=None,
+                           help="One past the last frame (exclusive). "
+                                "Default = NPZ frame count.")
+    end_group.add_argument("--duration", type=float, default=None,
+                           help="Seconds to keep starting at --start-frame. "
+                                "Resolved to frames via NPZ fps.")
+    args = ap.parse_args()
+
+    if not args.motion.exists():
+        raise SystemExit(f"NPZ not found: {args.motion}")
+    if not args.scene.exists():
+        raise SystemExit(f"Scene not found: {args.scene}")
+
+    model = mujoco.MjModel.from_xml_path(str(args.scene))
+    body_ids = []
+    for nm in TRACKED_BODY_NAMES:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, nm)
+        if bid < 0:
+            raise SystemExit(f"Tracked body '{nm}' missing from model")
+        body_ids.append(int(bid))
+
+    with np.load(args.motion) as data:
+        fps = int(np.asarray(data["fps"]).reshape(-1)[0])
+        joint_pos = data["joint_pos"].astype(np.float32)
+        joint_vel = data["joint_vel"].astype(np.float32)
+        body_pos_w = data["body_pos_w"].astype(np.float32)
+        body_quat_w = data["body_quat_w"].astype(np.float32)
+        body_lin_vel_w = data["body_lin_vel_w"].astype(np.float32)
+        body_ang_vel_w = data["body_ang_vel_w"].astype(np.float32)
+
+    total_frames, num_joints = joint_pos.shape
+    num_bodies = len(TRACKED_BODY_NAMES)
+
+    if joint_pos.shape != joint_vel.shape:
+        raise SystemExit(f"joint_pos {joint_pos.shape} != joint_vel {joint_vel.shape}")
+    if num_joints != 29:
+        raise SystemExit(f"Expected 29 joints, got {num_joints}")
+    if body_pos_w.shape[0] != total_frames:
+        raise SystemExit(f"body_pos_w frames {body_pos_w.shape[0]} != {total_frames}")
+
+    start = args.start_frame
+    if args.duration is not None:
+        if args.duration <= 0:
+            raise SystemExit(f"--duration must be > 0, got {args.duration}")
+        end = start + int(round(args.duration * fps))
+    elif args.end_frame is not None:
+        end = args.end_frame
+    else:
+        end = total_frames
+    if not (0 <= start < end <= total_frames):
+        raise SystemExit(
+            f"Invalid frame range [{start}, {end}); valid is [0, {total_frames}]"
+        )
+    if (start, end) != (0, total_frames):
+        joint_pos = joint_pos[start:end]
+        joint_vel = joint_vel[start:end]
+        body_pos_w = body_pos_w[start:end]
+        body_quat_w = body_quat_w[start:end]
+        body_lin_vel_w = body_lin_vel_w[start:end]
+        body_ang_vel_w = body_ang_vel_w[start:end]
+    num_frames = end - start
+    if body_pos_w.shape[1] < max(body_ids) + 1:
+        raise SystemExit(
+            f"NPZ body axis len {body_pos_w.shape[1]} insufficient for max body_id {max(body_ids)}"
+        )
+
+    # Slice 31-body axis down to 14 tracked bodies.
+    body_pos_w = body_pos_w[:, body_ids]
+    body_quat_w = body_quat_w[:, body_ids]
+    body_lin_vel_w = body_lin_vel_w[:, body_ids]
+    body_ang_vel_w = body_ang_vel_w[:, body_ids]
+
+    # Sanity check quaternion is wxyz (norm ≈ 1 and first element typically positive
+    # for "uprightish" frames). This is a soft check.
+    quat_norms = np.linalg.norm(body_quat_w[0], axis=1)
+    if not np.allclose(quat_norms, 1.0, atol=1e-3):
+        print(f"WARN: frame-0 quat norms not unit: {quat_norms}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "wb") as f:
+        f.write(struct.pack("<iiii", fps, num_frames, num_joints, num_bodies))
+        joint_pos.astype("<f4").tofile(f)
+        joint_vel.astype("<f4").tofile(f)
+        body_pos_w.astype("<f4").tofile(f)
+        body_quat_w.astype("<f4").tofile(f)
+        body_lin_vel_w.astype("<f4").tofile(f)
+        body_ang_vel_w.astype("<f4").tofile(f)
+
+    expected_bytes = (
+        16
+        + (num_frames * num_joints * 4) * 2  # joint_pos + joint_vel
+        + (num_frames * num_bodies * 3 * 4) * 3  # pos + linvel + angvel
+        + (num_frames * num_bodies * 4 * 4)  # quat
+    )
+    actual_bytes = args.output.stat().st_size
+    if actual_bytes != expected_bytes:
+        raise SystemExit(
+            f"Wrote {actual_bytes} bytes but expected {expected_bytes}"
+        )
+
+    duration_s = num_frames / fps
+    print(f"Wrote {args.output} ({actual_bytes} bytes)")
+    print(f"  fps={fps}, frames={num_frames}, joints={num_joints}, "
+          f"bodies={num_bodies}, duration={duration_s:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/prepend_warmup.py
+++ b/scripts/deploy/prepend_warmup.py
@@ -44,14 +44,14 @@ warmup's frame 0 (body_pos/body_quat) is exactly what default_angles produces.
 
 Use
 ---
-    uv run python scripts/deploy/prepend_warmup.py \
+    uv run scripts/deploy/prepend_warmup.py \
         --input  ../deploy_ws/assets/dance1.bin \
         --output ../deploy_ws/assets/dance1_warmup.bin \
         --config ../deploy_ws/assets/deploy_config.yaml \
         --warmup-sec 1.5
 
 Validate in sim BEFORE swapping on the real robot:
-    uv run python scripts/deploy/sim_prototype.py \
+    uv run scripts/deploy/sim_prototype.py \
         --motion ../deploy_ws/assets/dance1_warmup.bin \
         --init-mode stand --render
 """

--- a/scripts/deploy/prepend_warmup.py
+++ b/scripts/deploy/prepend_warmup.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Prepend a stand->dance-frame-0 warmup prefix to a WBT motion bin.
+
+Why this exists
+---------------
+The deploy-side FSM transitions FixStand -> State_WBT at t=0, but the original
+dance bin's frame 0 is mid-dance (e.g. dance1.bin frame 0 has L_shoulder_roll
+at +1.41 rad vs default_angles +0.20 — a ~70 deg jump). The training pipeline
+uses Reference State Initialization (RSI): the env resets the robot AT the
+motion's frame 0 pose, so the policy never sees "robot at default_angles,
+commanded to track dance frame 0". That mismatch produces a transient action
+burst at deploy time which exceeds the ankle's holding capacity, causing the
+real robot's feet to slip for ~3 s before the policy stabilises.
+
+Fix: insert N seconds of kinematically self-consistent interpolation frames at
+the head of the bin. After this the policy sees a slow, smooth tracking task
+(ramping the command from FixStand to dance frame 0), which is in-distribution
+for a tracking policy. The dance frames are then concatenated verbatim.
+
+What this does NOT change
+-------------------------
+- Training pipeline (no retrain needed).
+- State_WBT.cpp / deploy_config.yaml / FSM yaml time_start.
+- The original dance frames (they are appended unchanged after the warmup).
+
+Interpolation scheme
+--------------------
+- joint_pos (J=29): cubic Hermite per joint with boundaries
+    (default_angles, 0) -> (orig.jp[0], orig.jv[0])
+  joint_vel is the analytic derivative of the polynomial (kinematically
+  consistent with joint_pos by construction).
+- body_pos (B,3): cubic Hermite per axis with boundaries
+    (FK(stand), 0) -> (orig.bp[0], orig.bv[0])
+  body_lin_vel is the analytic derivative.
+- body_quat (B,4): SLERP along quintic smoothstep s(u) = 6u^5 - 15u^4 + 10u^3
+  (s'(0) = s''(0) = s'(1) = s''(1) = 0). Shortest-path; near-parallel fallback.
+- body_ang_vel: central difference on the SLERP path. The seam frame is
+  differenced against the original bin's frame 0 so the discrete derivative is
+  continuous across the seam.
+
+FixStand body states come from MuJoCo FK on the 'stand' keyframe in scene XML,
+using the same tracked_body_mujoco_ids the C++ State_WBT consumes — so the
+warmup's frame 0 (body_pos/body_quat) is exactly what default_angles produces.
+
+Use
+---
+    uv run python scripts/deploy/prepend_warmup.py \
+        --input  ../deploy_ws/assets/dance1.bin \
+        --output ../deploy_ws/assets/dance1_warmup.bin \
+        --config ../deploy_ws/assets/deploy_config.yaml \
+        --warmup-sec 1.5
+
+Validate in sim BEFORE swapping on the real robot:
+    uv run python scripts/deploy/sim_prototype.py \
+        --motion ../deploy_ws/assets/dance1_warmup.bin \
+        --init-mode stand --render
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WS = REPO_ROOT.parent / "deploy_ws"
+DEFAULT_SCENE = REPO_ROOT / "src/unilab/assets/robots/g1/scene_flat.xml"
+DEFAULT_CFG = DEPLOY_WS / "assets/deploy_config.yaml"
+DEFAULT_IN = DEPLOY_WS / "assets/dance1.bin"
+DEFAULT_OUT = DEPLOY_WS / "assets/dance1_warmup.bin"
+DEFAULT_WARMUP_SEC = 1.5
+
+
+# ----------------------------------------------------------------------------
+# bin I/O — same layout State_WBT.cpp / sim_prototype.py / export_motion_bin.py
+# all use: header (4 int32: fps, F, J, B) then six float32 blocks.
+# ----------------------------------------------------------------------------
+
+def load_motion_bin(path: Path) -> dict:
+    with open(path, "rb") as f:
+        fps, nf, nj, nb = struct.unpack("<iiii", f.read(16))
+        jp = np.frombuffer(f.read(nf * nj * 4), "<f4").reshape(nf, nj).copy()
+        jv = np.frombuffer(f.read(nf * nj * 4), "<f4").reshape(nf, nj).copy()
+        bp = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+        bq = np.frombuffer(f.read(nf * nb * 4 * 4), "<f4").reshape(nf, nb, 4).copy()
+        bv = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+        bav = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
+    return dict(fps=fps, nf=nf, nj=nj, nb=nb,
+                jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
+
+
+def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
+    nf, nj = jp.shape
+    nb = bp.shape[1]
+    assert jv.shape == jp.shape, "jv shape mismatch"
+    assert bp.shape == (nf, nb, 3) and bq.shape == (nf, nb, 4), "body shape mismatch"
+    assert bv.shape == (nf, nb, 3) and bav.shape == (nf, nb, 3), "body vel shape mismatch"
+    with open(path, "wb") as f:
+        f.write(struct.pack("<iiii", fps, nf, nj, nb))
+        for arr in (jp, jv, bp, bq, bv, bav):
+            f.write(np.ascontiguousarray(arr, dtype=np.float32).tobytes())
+
+
+# ----------------------------------------------------------------------------
+# FixStand FK — compute body world states at the 'stand' keyframe.
+# Uses the same MuJoCo body ids the bin records (tracked_body_mujoco_ids from
+# deploy_config.yaml), so the result is layer-compatible with the original bin.
+# ----------------------------------------------------------------------------
+
+def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
+                                 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    model = mujoco.MjModel.from_xml_path(str(scene))
+    data = mujoco.MjData(model)
+    key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
+    if key_id < 0:
+        raise SystemExit(f"'stand' keyframe not found in {scene}")
+    mujoco.mj_resetDataKeyframe(model, data, key_id)
+    mujoco.mj_forward(model, data)
+    jp = np.asarray(data.qpos[7:], dtype=np.float64).copy()
+    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy()
+                   for i in tracked_ids])
+    bq = np.stack([np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
+                   for i in tracked_ids])
+    return jp, bp, bq
+
+
+# ----------------------------------------------------------------------------
+# Cubic Hermite — analytic position and velocity, kinematically consistent.
+# Boundary conditions: p(0)=p0, p'(0)=v0, p(T)=p1, p'(T)=v1.
+# Returns (p(t), p'(t)) where t may be an array with shape (N,) and p* may
+# have additional trailing dims (broadcasting).
+# ----------------------------------------------------------------------------
+
+def hermite(p0, v0, p1, v1, t, T):
+    s = t / T
+    s2, s3 = s * s, s * s * s
+    h00 = 2 * s3 - 3 * s2 + 1
+    h10 = s3 - 2 * s2 + s
+    h01 = -2 * s3 + 3 * s2
+    h11 = s3 - s2
+    h00d = 6 * s2 - 6 * s
+    h10d = 3 * s2 - 4 * s + 1
+    h01d = -6 * s2 + 6 * s
+    h11d = 3 * s2 - 2 * s
+    # Reshape s-dim coefficients for broadcasting against p*'s trailing dims.
+    def _r(a):
+        return a.reshape(a.shape + (1,) * (np.ndim(p0)))
+    p = _r(h00) * p0 + _r(h10) * T * v0 + _r(h01) * p1 + _r(h11) * T * v1
+    pd = _r(h00d / T) * p0 + _r(h10d) * v0 + _r(h01d / T) * p1 + _r(h11d) * v1
+    return p, pd
+
+
+# ----------------------------------------------------------------------------
+# Quaternion SLERP along quintic smoothstep s(u) = 6u^5 - 15u^4 + 10u^3.
+# u in [0, 1]. Operates on (4,) wxyz quaternions, returns (N, 4).
+# ----------------------------------------------------------------------------
+
+def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarray:
+    q0 = q0 / np.linalg.norm(q0)
+    q1 = q1 / np.linalg.norm(q1)
+    dot = float(np.dot(q0, q1))
+    if dot < 0.0:                  # shortest path
+        q1 = -q1
+        dot = -dot
+    s = 6 * u**5 - 15 * u**4 + 10 * u**3
+    if dot > 0.9995:               # near-parallel: lerp + renormalise
+        out = (1 - s)[:, None] * q0 + s[:, None] * q1
+        return out / np.linalg.norm(out, axis=-1, keepdims=True)
+    theta_0 = np.arccos(np.clip(dot, -1.0, 1.0))
+    sin_theta_0 = np.sin(theta_0)
+    theta = theta_0 * s
+    a = np.cos(theta) - dot * np.sin(theta) / sin_theta_0
+    b = np.sin(theta) / sin_theta_0
+    return a[:, None] * q0 + b[:, None] * q1
+
+
+# ----------------------------------------------------------------------------
+# World-frame angular velocity from a quaternion sequence by finite difference.
+# Δq = q[k+1] * q[k]^-1  ;  ω_w ≈ 2 * Δq.xyz / dt  (small-angle, shortest path).
+# Central difference for interior, forward/backward at endpoints.
+# ----------------------------------------------------------------------------
+
+def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
+    n = q_seq.shape[0]
+    out = np.zeros((n, 3), dtype=np.float64)
+
+    def diff(q_a, q_b, h):                # ω over interval h, expressed in world
+        aw, ax, ay, az = q_a
+        bw, bx, by, bz = q_b
+        # Δq = q_b * q_a^{-1}
+        dw = bw * aw + bx * ax + by * ay + bz * az
+        dx = -bw * ax + bx * aw - by * az + bz * ay
+        dy = -bw * ay + bx * az + by * aw - bz * ax
+        dz = -bw * az - bx * ay + by * ax + bz * aw
+        if dw < 0.0:                      # shortest path
+            dw, dx, dy, dz = -dw, -dx, -dy, -dz
+        return np.array([2 * dx / h, 2 * dy / h, 2 * dz / h])
+
+    for i in range(n):
+        if i == 0:
+            out[i] = diff(q_seq[0], q_seq[1], dt)
+        elif i == n - 1:
+            out[i] = diff(q_seq[n - 2], q_seq[n - 1], dt)
+        else:
+            out[i] = diff(q_seq[i - 1], q_seq[i + 1], 2 * dt)
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", type=Path, default=DEFAULT_IN)
+    ap.add_argument("--output", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--config", type=Path, default=DEFAULT_CFG,
+                    help="deploy_config.yaml (for default_angles, tracked ids).")
+    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
+                    help="MuJoCo XML with 'stand' keyframe (for FixStand FK).")
+    ap.add_argument("--warmup-sec", type=float, default=DEFAULT_WARMUP_SEC,
+                    help="Length of prepended warmup interval [seconds].")
+    args = ap.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+    default_angles = np.asarray(cfg["default_angles"], dtype=np.float64)
+    tracked_ids = list(cfg["tracked_body_mujoco_ids"])
+
+    orig = load_motion_bin(args.input)
+    fps, J, B = orig["fps"], orig["nj"], orig["nb"]
+    if J != len(default_angles):
+        raise SystemExit(f"J mismatch: bin J={J}, default_angles len={len(default_angles)}")
+    if B != len(tracked_ids):
+        raise SystemExit(f"B mismatch: bin B={B}, tracked_body_mujoco_ids len={len(tracked_ids)}")
+
+    dt = 1.0 / fps
+    N = int(round(args.warmup_sec * fps))
+    if N < 2:
+        raise SystemExit(f"warmup-sec={args.warmup_sec}s too short for fps={fps} (need >= 2 frames)")
+    T = N * dt   # so frame N in the new bin == original frame 0 exactly
+
+    fk_jp, fk_bp, fk_bq = compute_fixstand_body_states(args.scene, tracked_ids)
+
+    keyframe_diff = float(np.abs(fk_jp - default_angles).max())
+    if keyframe_diff > 1e-3:
+        print(f"WARN: 'stand' keyframe joint pos differs from deploy_config "
+              f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
+              "values for warmup start (so command_joint_pos matches what "
+              "FixStand actually holds on the real robot).", file=sys.stderr)
+
+    # --- joint pos/vel: analytic Hermite -----------------------------------
+    ts = np.arange(N) * dt                                     # (N,)
+    jp_w, jv_w = hermite(default_angles, np.zeros(J),
+                         orig["jp"][0], orig["jv"][0], ts, T)
+
+    # --- body pos / lin_vel: analytic Hermite per axis ---------------------
+    bp_w, bv_w = hermite(fk_bp, np.zeros((B, 3)),
+                         orig["bp"][0], orig["bv"][0], ts, T)
+
+    # --- body quat: SLERP along quintic smoothstep -------------------------
+    u = ts / T
+    bq_w = np.zeros((N, B, 4), dtype=np.float64)
+    for b in range(B):
+        bq_w[:, b, :] = slerp_smoothstep(fk_bq[b], orig["bq"][0, b], u)
+
+    # --- body ang_vel: central diff, with the seam differenced against the
+    # original bin's first two frames so the derivative is continuous across
+    # the warmup/dance boundary --------------------------------------------
+    bav_w = np.zeros((N, B, 3), dtype=np.float64)
+    for b in range(B):
+        ext = np.concatenate([bq_w[:, b, :], orig["bq"][:2, b, :]], axis=0)
+        bav_w[:, b, :] = quat_seq_ang_vel(ext, dt)[:N]
+
+    # --- concatenate warmup + original -------------------------------------
+    new_jp = np.concatenate([jp_w, orig["jp"]], axis=0)
+    new_jv = np.concatenate([jv_w, orig["jv"]], axis=0)
+    new_bp = np.concatenate([bp_w, orig["bp"]], axis=0)
+    new_bq = np.concatenate([bq_w, orig["bq"]], axis=0)
+    new_bv = np.concatenate([bv_w, orig["bv"]], axis=0)
+    new_bav = np.concatenate([bav_w, orig["bav"]], axis=0)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_motion_bin(args.output, fps, new_jp, new_jv, new_bp, new_bq, new_bv, new_bav)
+
+    # --- report ------------------------------------------------------------
+    seam_jp = float(np.abs(jp_w[-1] - orig["jp"][0]).max())
+    seam_jv = float(np.abs(jv_w[-1] - orig["jv"][0]).max())
+    seam_bp = float(np.abs(bp_w[-1] - orig["bp"][0]).max())
+    seam_bv = float(np.abs(bv_w[-1] - orig["bv"][0]).max())
+    # Quaternion seam: angle between bq_w[-1] and orig.bq[0] for each body
+    seam_qang_deg = []
+    for b in range(B):
+        d = float(np.clip(abs(np.dot(bq_w[-1, b], orig["bq"][0, b])), 0.0, 1.0))
+        seam_qang_deg.append(np.degrees(2 * np.arccos(d)))
+    seam_qang_max = max(seam_qang_deg)
+    # Warmup-start command joint deviation from default (rate / sec)
+    init_jvel_l2 = float(np.linalg.norm(jv_w[0]))
+
+    print(f"Wrote {args.output}")
+    print(f"  fps={fps}  J={J}  B={B}")
+    print(f"  frames: {orig['nf']} (orig)  -> {new_jp.shape[0]} ({N} warmup + {orig['nf']} dance)")
+    print(f"  duration: {orig['nf']/fps:.2f}s -> {new_jp.shape[0]/fps:.2f}s "
+          f"(warmup_sec={args.warmup_sec})")
+    print(f"  init (frame 0) command_joint_pos == default_angles? "
+          f"max_diff={float(np.abs(new_jp[0] - default_angles).max()):.6f} rad")
+    print(f"  init (frame 0) command_joint_vel L2 = {init_jvel_l2:.6f} rad/s (should be 0)")
+    print("  seam check (warmup last frame vs original frame 0; one-dt-step apart):")
+    print(f"    |Δjoint_pos|_∞       = {seam_jp:.4f} rad")
+    print(f"    |Δjoint_vel|_∞       = {seam_jv:.4f} rad/s")
+    print(f"    |Δbody_pos|_∞        = {seam_bp:.4f} m")
+    print(f"    |Δbody_lin_vel|_∞    = {seam_bv:.4f} m/s")
+    print(f"    max body quat angle  = {seam_qang_max:.4f} deg")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/prepend_warmup.py
+++ b/scripts/deploy/prepend_warmup.py
@@ -55,6 +55,7 @@ Validate in sim BEFORE swapping on the real robot:
         --motion ../deploy_ws/assets/dance1_warmup.bin \
         --init-mode stand --render
 """
+
 from __future__ import annotations
 
 import argparse
@@ -80,6 +81,7 @@ DEFAULT_WARMUP_SEC = 1.5
 # all use: header (4 int32: fps, F, J, B) then six float32 blocks.
 # ----------------------------------------------------------------------------
 
+
 def load_motion_bin(path: Path) -> dict:
     with open(path, "rb") as f:
         fps, nf, nj, nb = struct.unpack("<iiii", f.read(16))
@@ -89,8 +91,7 @@ def load_motion_bin(path: Path) -> dict:
         bq = np.frombuffer(f.read(nf * nb * 4 * 4), "<f4").reshape(nf, nb, 4).copy()
         bv = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
         bav = np.frombuffer(f.read(nf * nb * 3 * 4), "<f4").reshape(nf, nb, 3).copy()
-    return dict(fps=fps, nf=nf, nj=nj, nb=nb,
-                jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
+    return dict(fps=fps, nf=nf, nj=nj, nb=nb, jp=jp, jv=jv, bp=bp, bq=bq, bv=bv, bav=bav)
 
 
 def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
@@ -111,8 +112,10 @@ def save_motion_bin(path: Path, fps: int, jp, jv, bp, bq, bv, bav) -> None:
 # deploy_config.yaml), so the result is layer-compatible with the original bin.
 # ----------------------------------------------------------------------------
 
-def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
-                                 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+
+def compute_fixstand_body_states(
+    scene: Path, tracked_ids: list[int]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     model = mujoco.MjModel.from_xml_path(str(scene))
     data = mujoco.MjData(model)
     key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
@@ -121,10 +124,13 @@ def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
     mujoco.mj_resetDataKeyframe(model, data, key_id)
     mujoco.mj_forward(model, data)
     jp = np.asarray(data.qpos[7:], dtype=np.float64).copy()
-    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy()
-                   for i in tracked_ids])
-    bq = np.stack([np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
-                   for i in tracked_ids])
+    bp = np.stack([np.asarray(data.xpos[i], dtype=np.float64).copy() for i in tracked_ids])
+    bq = np.stack(
+        [
+            np.asarray(data.xquat[i], dtype=np.float64).copy()  # wxyz
+            for i in tracked_ids
+        ]
+    )
     return jp, bp, bq
 
 
@@ -134,6 +140,7 @@ def compute_fixstand_body_states(scene: Path, tracked_ids: list[int]
 # Returns (p(t), p'(t)) where t may be an array with shape (N,) and p* may
 # have additional trailing dims (broadcasting).
 # ----------------------------------------------------------------------------
+
 
 def hermite(p0, v0, p1, v1, t, T):
     s = t / T
@@ -146,9 +153,11 @@ def hermite(p0, v0, p1, v1, t, T):
     h10d = 3 * s2 - 4 * s + 1
     h01d = -6 * s2 + 6 * s
     h11d = 3 * s2 - 2 * s
+
     # Reshape s-dim coefficients for broadcasting against p*'s trailing dims.
     def _r(a):
         return a.reshape(a.shape + (1,) * (np.ndim(p0)))
+
     p = _r(h00) * p0 + _r(h10) * T * v0 + _r(h01) * p1 + _r(h11) * T * v1
     pd = _r(h00d / T) * p0 + _r(h10d) * v0 + _r(h01d / T) * p1 + _r(h11d) * v1
     return p, pd
@@ -159,15 +168,16 @@ def hermite(p0, v0, p1, v1, t, T):
 # u in [0, 1]. Operates on (4,) wxyz quaternions, returns (N, 4).
 # ----------------------------------------------------------------------------
 
+
 def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarray:
     q0 = q0 / np.linalg.norm(q0)
     q1 = q1 / np.linalg.norm(q1)
     dot = float(np.dot(q0, q1))
-    if dot < 0.0:                  # shortest path
+    if dot < 0.0:  # shortest path
         q1 = -q1
         dot = -dot
     s = 6 * u**5 - 15 * u**4 + 10 * u**3
-    if dot > 0.9995:               # near-parallel: lerp + renormalise
+    if dot > 0.9995:  # near-parallel: lerp + renormalise
         out = (1 - s)[:, None] * q0 + s[:, None] * q1
         return out / np.linalg.norm(out, axis=-1, keepdims=True)
     theta_0 = np.arccos(np.clip(dot, -1.0, 1.0))
@@ -184,11 +194,12 @@ def slerp_smoothstep(q0: np.ndarray, q1: np.ndarray, u: np.ndarray) -> np.ndarra
 # Central difference for interior, forward/backward at endpoints.
 # ----------------------------------------------------------------------------
 
+
 def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
     n = q_seq.shape[0]
     out = np.zeros((n, 3), dtype=np.float64)
 
-    def diff(q_a, q_b, h):                # ω over interval h, expressed in world
+    def diff(q_a, q_b, h):  # ω over interval h, expressed in world
         aw, ax, ay, az = q_a
         bw, bx, by, bz = q_b
         # Δq = q_b * q_a^{-1}
@@ -196,7 +207,7 @@ def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
         dx = -bw * ax + bx * aw - by * az + bz * ay
         dy = -bw * ay + bx * az + by * aw - bz * ax
         dz = -bw * az - bx * ay + by * ax + bz * aw
-        if dw < 0.0:                      # shortest path
+        if dw < 0.0:  # shortest path
             dw, dx, dy, dz = -dw, -dx, -dy, -dz
         return np.array([2 * dx / h, 2 * dy / h, 2 * dz / h])
 
@@ -214,17 +225,31 @@ def quat_seq_ang_vel(q_seq: np.ndarray, dt: float) -> np.ndarray:
 # Main
 # ----------------------------------------------------------------------------
 
+
 def main() -> None:
     ap = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--input", type=Path, default=DEFAULT_IN)
     ap.add_argument("--output", type=Path, default=DEFAULT_OUT)
-    ap.add_argument("--config", type=Path, default=DEFAULT_CFG,
-                    help="deploy_config.yaml (for default_angles, tracked ids).")
-    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
-                    help="MuJoCo XML with 'stand' keyframe (for FixStand FK).")
-    ap.add_argument("--warmup-sec", type=float, default=DEFAULT_WARMUP_SEC,
-                    help="Length of prepended warmup interval [seconds].")
+    ap.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CFG,
+        help="deploy_config.yaml (for default_angles, tracked ids).",
+    )
+    ap.add_argument(
+        "--scene",
+        type=Path,
+        default=DEFAULT_SCENE,
+        help="MuJoCo XML with 'stand' keyframe (for FixStand FK).",
+    )
+    ap.add_argument(
+        "--warmup-sec",
+        type=float,
+        default=DEFAULT_WARMUP_SEC,
+        help="Length of prepended warmup interval [seconds].",
+    )
     args = ap.parse_args()
 
     with open(args.config) as f:
@@ -242,26 +267,29 @@ def main() -> None:
     dt = 1.0 / fps
     N = int(round(args.warmup_sec * fps))
     if N < 2:
-        raise SystemExit(f"warmup-sec={args.warmup_sec}s too short for fps={fps} (need >= 2 frames)")
-    T = N * dt   # so frame N in the new bin == original frame 0 exactly
+        raise SystemExit(
+            f"warmup-sec={args.warmup_sec}s too short for fps={fps} (need >= 2 frames)"
+        )
+    T = N * dt  # so frame N in the new bin == original frame 0 exactly
 
     fk_jp, fk_bp, fk_bq = compute_fixstand_body_states(args.scene, tracked_ids)
 
     keyframe_diff = float(np.abs(fk_jp - default_angles).max())
     if keyframe_diff > 1e-3:
-        print(f"WARN: 'stand' keyframe joint pos differs from deploy_config "
-              f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
-              "values for warmup start (so command_joint_pos matches what "
-              "FixStand actually holds on the real robot).", file=sys.stderr)
+        print(
+            f"WARN: 'stand' keyframe joint pos differs from deploy_config "
+            f"default_angles by {keyframe_diff:.4f} rad — using deploy_config "
+            "values for warmup start (so command_joint_pos matches what "
+            "FixStand actually holds on the real robot).",
+            file=sys.stderr,
+        )
 
     # --- joint pos/vel: analytic Hermite -----------------------------------
-    ts = np.arange(N) * dt                                     # (N,)
-    jp_w, jv_w = hermite(default_angles, np.zeros(J),
-                         orig["jp"][0], orig["jv"][0], ts, T)
+    ts = np.arange(N) * dt  # (N,)
+    jp_w, jv_w = hermite(default_angles, np.zeros(J), orig["jp"][0], orig["jv"][0], ts, T)
 
     # --- body pos / lin_vel: analytic Hermite per axis ---------------------
-    bp_w, bv_w = hermite(fk_bp, np.zeros((B, 3)),
-                         orig["bp"][0], orig["bv"][0], ts, T)
+    bp_w, bv_w = hermite(fk_bp, np.zeros((B, 3)), orig["bp"][0], orig["bv"][0], ts, T)
 
     # --- body quat: SLERP along quintic smoothstep -------------------------
     u = ts / T
@@ -305,10 +333,14 @@ def main() -> None:
     print(f"Wrote {args.output}")
     print(f"  fps={fps}  J={J}  B={B}")
     print(f"  frames: {orig['nf']} (orig)  -> {new_jp.shape[0]} ({N} warmup + {orig['nf']} dance)")
-    print(f"  duration: {orig['nf']/fps:.2f}s -> {new_jp.shape[0]/fps:.2f}s "
-          f"(warmup_sec={args.warmup_sec})")
-    print(f"  init (frame 0) command_joint_pos == default_angles? "
-          f"max_diff={float(np.abs(new_jp[0] - default_angles).max()):.6f} rad")
+    print(
+        f"  duration: {orig['nf'] / fps:.2f}s -> {new_jp.shape[0] / fps:.2f}s "
+        f"(warmup_sec={args.warmup_sec})"
+    )
+    print(
+        f"  init (frame 0) command_joint_pos == default_angles? "
+        f"max_diff={float(np.abs(new_jp[0] - default_angles).max()):.6f} rad"
+    )
     print(f"  init (frame 0) command_joint_vel L2 = {init_jvel_l2:.6f} rad/s (should be 0)")
     print("  seam check (warmup last frame vs original frame 0; one-dt-step apart):")
     print(f"    |Δjoint_pos|_∞       = {seam_jp:.4f} rad")

--- a/scripts/deploy/sim_prototype.py
+++ b/scripts/deploy/sim_prototype.py
@@ -27,6 +27,7 @@ Differences from training-side eval (deliberate):
   - Robot anchor pos in world is locked to the first motion frame's torso pos
     (since real robot has no GPS/SLAM).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -91,20 +92,14 @@ def build_obs_from_layout(
         name = seg["name"]
         dim = int(seg["dim"])
         if name not in segments:
-            raise SystemExit(
-                f"obs_layout segment '{name}' has no value provider in prototype"
-            )
+            raise SystemExit(f"obs_layout segment '{name}' has no value provider in prototype")
         arr = np.asarray(segments[name], dtype=np.float32).reshape(-1)
         if arr.size != dim:
-            raise SystemExit(
-                f"obs segment '{name}': expected dim {dim}, got {arr.size}"
-            )
+            raise SystemExit(f"obs segment '{name}': expected dim {dim}, got {arr.size}")
         parts.append(arr)
     obs = np.concatenate(parts, axis=0).astype(np.float32, copy=False)
     if obs.size != obs_dim:
-        raise SystemExit(
-            f"assembled obs dim {obs.size} != cfg.obs_dim {obs_dim}"
-        )
+        raise SystemExit(f"assembled obs dim {obs.size} != cfg.obs_dim {obs_dim}")
     return obs
 
 
@@ -183,9 +178,7 @@ class ObsAssembler:
             parts.append(self._buffers[name].reshape(-1))
         obs = np.concatenate(parts, axis=0).astype(np.float32, copy=False)
         if obs.size != self.obs_dim:
-            raise SystemExit(
-                f"assembled obs dim {obs.size} != cfg.obs_dim {self.obs_dim}"
-            )
+            raise SystemExit(f"assembled obs dim {obs.size} != cfg.obs_dim {self.obs_dim}")
         return obs
 
     def _set_validated(self, name: str, value) -> None:
@@ -193,9 +186,7 @@ class ObsAssembler:
         dim = buf.shape[1]
         arr = np.asarray(value, dtype=np.float32).reshape(-1)
         if arr.size != dim:
-            raise SystemExit(
-                f"obs segment '{name}': expected dim {dim}, got {arr.size}"
-            )
+            raise SystemExit(f"obs segment '{name}': expected dim {dim}, got {arr.size}")
         buf[-1, :] = arr
 
 
@@ -261,26 +252,40 @@ def compute_obs_segments(
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--onnx", type=Path, default=DEFAULT_ONNX,
-                    help="ONNX policy. If absent or --no-onnx, prototype runs a "
-                         "default-angle ctrl sanity check (obs assembly only).")
-    ap.add_argument("--no-onnx", action="store_true",
-                    help="Skip ONNX inference even if the file exists.")
+    ap.add_argument(
+        "--onnx",
+        type=Path,
+        default=DEFAULT_ONNX,
+        help="ONNX policy. If absent or --no-onnx, prototype runs a "
+        "default-angle ctrl sanity check (obs assembly only).",
+    )
+    ap.add_argument(
+        "--no-onnx", action="store_true", help="Skip ONNX inference even if the file exists."
+    )
     ap.add_argument("--config", type=Path, default=DEFAULT_CFG)
     ap.add_argument("--motion", type=Path, default=DEFAULT_BIN)
     ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE)
-    ap.add_argument("--render", action="store_true",
-                    help="Open MuJoCo passive viewer (requires display).")
-    ap.add_argument("--max-steps", type=int, default=0,
-                    help="0 = play to end of clip then loop once.")
-    ap.add_argument("--cheat-anchor", action="store_true",
-                    help="Use sim-true robot torso pos for anchor (debug; "
-                         "would not be available on real robot).")
-    ap.add_argument("--init-mode", choices=["rsi", "stand"], default="rsi",
-                    help="rsi = teleport robot to motion frame 0 (training-time "
-                         "reset condition; default). stand = leave robot in the "
-                         "'stand' keyframe pose (== FixStand default_angles, "
-                         "matching the deploy-time FSM transition).")
+    ap.add_argument(
+        "--render", action="store_true", help="Open MuJoCo passive viewer (requires display)."
+    )
+    ap.add_argument(
+        "--max-steps", type=int, default=0, help="0 = play to end of clip then loop once."
+    )
+    ap.add_argument(
+        "--cheat-anchor",
+        action="store_true",
+        help="Use sim-true robot torso pos for anchor (debug; "
+        "would not be available on real robot).",
+    )
+    ap.add_argument(
+        "--init-mode",
+        choices=["rsi", "stand"],
+        default="rsi",
+        help="rsi = teleport robot to motion frame 0 (training-time "
+        "reset condition; default). stand = leave robot in the "
+        "'stand' keyframe pose (== FixStand default_angles, "
+        "matching the deploy-time FSM transition).",
+    )
     args = ap.parse_args()
 
     with open(args.config) as f:
@@ -288,9 +293,7 @@ def main():
     motion = load_motion_bin(args.motion)
 
     expected_dim = int(cfg["obs_dim"])
-    layout_total = sum(
-        int(s["dim"]) * int(s.get("history_length", 1)) for s in cfg["obs_layout"]
-    )
+    layout_total = sum(int(s["dim"]) * int(s.get("history_length", 1)) for s in cfg["obs_layout"])
     if layout_total != expected_dim:
         raise SystemExit(
             f"cfg internal inconsistency: sum(obs_layout dim*history_length)={layout_total} "
@@ -303,13 +306,16 @@ def main():
     inp_name = out_name = None
     if use_onnx:
         import onnxruntime as ort  # local import: optional in sanity mode
+
         sess = ort.InferenceSession(str(args.onnx), providers=["CPUExecutionProvider"])
         inp_name = sess.get_inputs()[0].name
         out_name = sess.get_outputs()[0].name
         onnx_in_shape = sess.get_inputs()[0].shape
         onnx_in_dim = int(onnx_in_shape[-1]) if isinstance(onnx_in_shape[-1], int) else -1
-        print(f"ONNX: input={inp_name} {onnx_in_shape}, output={out_name} "
-              f"{sess.get_outputs()[0].shape}")
+        print(
+            f"ONNX: input={inp_name} {onnx_in_shape}, output={out_name} "
+            f"{sess.get_outputs()[0].shape}"
+        )
         if onnx_in_dim != expected_dim:
             raise SystemExit(
                 f"ONNX input dim {onnx_in_dim} != cfg.obs_dim {expected_dim}. "
@@ -317,14 +323,18 @@ def main():
             )
     else:
         reason = "missing" if not args.onnx.exists() else "disabled (--no-onnx)"
-        print(f"ONNX: {reason} — running OBS-ASSEMBLY SANITY CHECK only "
-              "(ctrl = default_angles, no policy in the loop)")
+        print(
+            f"ONNX: {reason} — running OBS-ASSEMBLY SANITY CHECK only "
+            "(ctrl = default_angles, no policy in the loop)"
+        )
 
-    print(f"obs_dim={expected_dim}, layout segments=[" +
-          ", ".join(
-              f"{s['name']}({s['dim']}×{int(s.get('history_length', 1))})"
-              for s in cfg["obs_layout"]
-          ) + "]")
+    print(
+        f"obs_dim={expected_dim}, layout segments=["
+        + ", ".join(
+            f"{s['name']}({s['dim']}×{int(s.get('history_length', 1))})" for s in cfg["obs_layout"]
+        )
+        + "]"
+    )
 
     model = mujoco.MjModel.from_xml_path(str(args.scene))
     data = mujoco.MjData(model)
@@ -356,8 +366,7 @@ def main():
         data.qvel[3:6] = motion["body_ang_vel_w"][0, pelvis_id_in_tracked]
         data.qvel[6:] = motion["joint_vel"][0]
     mujoco.mj_forward(model, data)
-    print(f"init_mode={args.init_mode}: base xyz={data.qpos[:3]}, "
-          f"base quat={data.qpos[3:7]}")
+    print(f"init_mode={args.init_mode}: base xyz={data.qpos[:3]}, base quat={data.qpos[3:7]}")
 
     default_angles = np.asarray(cfg["default_angles"], dtype=np.float32)
     action_scale = float(cfg["action_scale"])
@@ -396,6 +405,7 @@ def main():
     viewer = None
     if args.render:
         from mujoco import viewer as mj_viewer
+
         viewer = mj_viewer.launch_passive(model, data)
 
     t_wall = time.time()
@@ -403,7 +413,7 @@ def main():
         frame_idx = step % n_frames
 
         robot_torso_quat_w = data.xquat[anchor_body_id].astype(np.float32)
-        gyro = data.sensordata[gyro_adr:gyro_adr + gyro_dim].astype(np.float32)
+        gyro = data.sensordata[gyro_adr : gyro_adr + gyro_dim].astype(np.float32)
         dof_pos = data.qpos[7:].astype(np.float32)
         dof_vel = data.qvel[6:].astype(np.float32)
 
@@ -418,10 +428,13 @@ def main():
         else:
             robot_torso_pos_w_used = robot_anchor_pos_w_locked
         current_segments = compute_obs_segments(
-            cfg, motion_frame,
+            cfg,
+            motion_frame,
             robot_torso_pos_w=robot_torso_pos_w_used,
             robot_torso_quat_w=robot_torso_quat_w,
-            gyro=gyro, dof_pos=dof_pos, dof_vel=dof_vel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
             last_actions=last_actions,
         )
         # Stateful: first call auto-resets (fills history with current segments,
@@ -461,11 +474,13 @@ def main():
                 time.sleep(target - elapsed)
 
         if step % 50 == 0:
-            print(f"step {step:4d} frame={frame_idx:3d}  "
-                  f"obs_norm={obs_norms[-1]:7.2f}  "
-                  f"|action|={action_amplitudes[-1]:5.2f}  "
-                  f"z_err={z_errors[-1]:.3f}m  "
-                  f"q_target[:3]={q_target_smoothed[:3]}")
+            print(
+                f"step {step:4d} frame={frame_idx:3d}  "
+                f"obs_norm={obs_norms[-1]:7.2f}  "
+                f"|action|={action_amplitudes[-1]:5.2f}  "
+                f"z_err={z_errors[-1]:.3f}m  "
+                f"q_target[:3]={q_target_smoothed[:3]}"
+            )
 
         if not np.all(np.isfinite(data.qpos)):
             print(f"!! NaN at step {step}, aborting")
@@ -479,16 +494,20 @@ def main():
 
     n = len(obs_norms)
     print()
-    print(f"Ran {n} ctrl steps ({n*ctrl_dt:.2f}s of motion).")
+    print(f"Ran {n} ctrl steps ({n * ctrl_dt:.2f}s of motion).")
     print(f"obs_norm:        mean={np.mean(obs_norms):.3f}  max={np.max(obs_norms):.3f}")
-    print(f"|action| max:    mean={np.mean(action_amplitudes):.3f}  max={np.max(action_amplitudes):.3f}")
+    print(
+        f"|action| max:    mean={np.mean(action_amplitudes):.3f}  max={np.max(action_amplitudes):.3f}"
+    )
     print(f"|torso z err|:   mean={np.mean(z_errors):.4f}m  max={np.max(z_errors):.4f}m")
 
     if not use_onnx:
         # Sanity mode never claims tracking — only that obs assembly is finite & shaped.
-        print("SANITY OK — obs assembly produced finite vectors of expected width "
-              f"({expected_dim}); end-to-end tracking requires running with a "
-              f"matching ONNX (input dim {expected_dim}).")
+        print(
+            "SANITY OK — obs assembly produced finite vectors of expected width "
+            f"({expected_dim}); end-to-end tracking requires running with a "
+            f"matching ONNX (input dim {expected_dim})."
+        )
     elif np.max(z_errors) < 0.2 and n == total_steps:
         print("PROTOTYPE OK — obs assembly + ONNX inference produces tracking behavior.")
     elif n < total_steps:

--- a/scripts/deploy/sim_prototype.py
+++ b/scripts/deploy/sim_prototype.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Python prototype of State_WBT — drives the ONNX policy in MuJoCo using the
+exact obs assembly the C++ State_WBT will use, so we can validate the
+deploy_config.yaml + dance1.bin against training-side expectations BEFORE
+writing C++.
+
+Inputs (defaults match the artifacts produced by export_*.py):
+  ~/deploy_ws/assets/policy.onnx   (optional — if missing or --no-onnx, the
+                                    prototype skips inference and only sanity-
+                                    checks obs assembly with default-angle ctrl)
+  ~/deploy_ws/assets/deploy_config.yaml
+  ~/deploy_ws/assets/dance1.bin
+
+What this verifies:
+  1. Obs assembly matches training segment-for-segment, driven by
+     cfg["obs_layout"] (no hard-coded dimension) — so when training flips
+     enable_zero_linvel / enable_zero_anchor_pos the prototype follows.
+  2. obs total length equals cfg["obs_dim"]; ONNX input width (when provided)
+     matches cfg["obs_dim"].
+  3. With an ONNX file: q_target = action*2.0 + default_angles + clip + EMA
+     produces motion that visually tracks the reference in MuJoCo.
+
+Differences from training-side eval (deliberate):
+  - obs construction is reimplemented in pure numpy here, NOT routed through
+    the env class — this is the same code path State_WBT will reproduce in C++.
+  - No noise injected on obs (matches deploy convention).
+  - Robot anchor pos in world is locked to the first motion frame's torso pos
+    (since real robot has no GPS/SLAM).
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import time
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from unilab.envs.common.rotation import (  # noqa: E402
+    np_matrix_from_quat,
+    np_subtract_frame_transforms,
+)
+
+DEFAULT_ONNX = Path.home() / "deploy_ws/assets/policy.onnx"
+DEFAULT_CFG = Path.home() / "deploy_ws/assets/deploy_config.yaml"
+DEFAULT_BIN = Path.home() / "deploy_ws/assets/dance1.bin"
+DEFAULT_SCENE = REPO_ROOT / "src/unilab/assets/robots/g1/scene_flat.xml"
+
+
+def load_motion_bin(path: Path) -> dict:
+    with open(path, "rb") as f:
+        fps, nf, nj, nb = struct.unpack("<iiii", f.read(16))
+        jp = np.frombuffer(f.read(nf * nj * 4), dtype="<f4").reshape(nf, nj).copy()
+        jv = np.frombuffer(f.read(nf * nj * 4), dtype="<f4").reshape(nf, nj).copy()
+        bp = np.frombuffer(f.read(nf * nb * 3 * 4), dtype="<f4").reshape(nf, nb, 3).copy()
+        bq = np.frombuffer(f.read(nf * nb * 4 * 4), dtype="<f4").reshape(nf, nb, 4).copy()
+        blv = np.frombuffer(f.read(nf * nb * 3 * 4), dtype="<f4").reshape(nf, nb, 3).copy()
+        bav = np.frombuffer(f.read(nf * nb * 3 * 4), dtype="<f4").reshape(nf, nb, 3).copy()
+    return {
+        "fps": fps,
+        "num_frames": nf,
+        "num_joints": nj,
+        "num_bodies": nb,
+        "joint_pos": jp,
+        "joint_vel": jv,
+        "body_pos_w": bp,
+        "body_quat_w": bq,
+        "body_lin_vel_w": blv,
+        "body_ang_vel_w": bav,
+    }
+
+
+def build_obs_from_layout(
+    layout: list[dict], segments: dict[str, np.ndarray], obs_dim: int
+) -> np.ndarray:
+    """Concatenate segments in the order dictated by cfg['obs_layout'].
+
+    Every layout entry must resolve to a known segment with matching dim.
+    Raises SystemExit on any mismatch — the prototype refuses to fabricate
+    a vector that disagrees with the deploy contract.
+
+    Single-step path only; history-aware assembly goes through ``ObsAssembler``.
+    """
+    parts: list[np.ndarray] = []
+    for seg in layout:
+        name = seg["name"]
+        dim = int(seg["dim"])
+        if name not in segments:
+            raise SystemExit(
+                f"obs_layout segment '{name}' has no value provider in prototype"
+            )
+        arr = np.asarray(segments[name], dtype=np.float32).reshape(-1)
+        if arr.size != dim:
+            raise SystemExit(
+                f"obs segment '{name}': expected dim {dim}, got {arr.size}"
+            )
+        parts.append(arr)
+    obs = np.concatenate(parts, axis=0).astype(np.float32, copy=False)
+    if obs.size != obs_dim:
+        raise SystemExit(
+            f"assembled obs dim {obs.size} != cfg.obs_dim {obs_dim}"
+        )
+    return obs
+
+
+class ObsAssembler:
+    """Schema-driven actor obs assembler with per-term history buffers.
+
+    Mirrors the deploy-side ObservationManager + ObservationTermCfg behaviour
+    byte-for-byte so sim_prototype validates the same obs vector State_WBT
+    will produce on the real robot:
+
+      * Per layout term, owns a (H, dim) deque-like ring buffer (oldest at row 0).
+      * ``reset(segments)`` fills all H rows with the current value (matches
+        deploy ObservationTermCfg::reset which calls add() H times).
+      * ``step(segments)`` shifts oldest out, writes current at the last row
+        (matches deploy add()).
+      * ``assemble()`` concatenates each term's full history oldest-first,
+        then concatenates across terms in layout order (matches deploy
+        use_gym_history=false mode in ObservationManager::compute_group).
+
+    History length per term is read from ``layout[i]['history_length']``,
+    defaulting to 1 (single-step / no history). Total assembled dim is
+    sum(dim * history_length) over all terms.
+    """
+
+    def __init__(self, cfg: dict) -> None:
+        self.obs_dim = int(cfg["obs_dim"])
+        self.layout = cfg["obs_layout"]
+        if cfg.get("use_gym_history", False):
+            raise SystemExit(
+                "sim_prototype assumes use_gym_history=false (group-by-term flatten); "
+                "set it to false in deploy_config.yaml or extend ObsAssembler"
+            )
+        self._buffers: dict[str, np.ndarray] = {}
+        self._hist_len: dict[str, int] = {}
+        layout_total = 0
+        for seg in self.layout:
+            name = seg["name"]
+            dim = int(seg["dim"])
+            h_len = int(seg.get("history_length", 1))
+            if h_len < 1:
+                raise SystemExit(f"obs term '{name}' has invalid history_length={h_len}")
+            self._buffers[name] = np.zeros((h_len, dim), dtype=np.float32)
+            self._hist_len[name] = h_len
+            layout_total += dim * h_len
+        if layout_total != self.obs_dim:
+            raise SystemExit(
+                f"cfg internal inconsistency: sum(dim*history_length)={layout_total} "
+                f"!= obs_dim={self.obs_dim}"
+            )
+        self._primed = False
+
+    def reset(self, segments: dict[str, np.ndarray]) -> np.ndarray:
+        """Fill every history slot with the current segment values (deploy parity)."""
+        for seg in self.layout:
+            name = seg["name"]
+            self._set_validated(name, segments[name])
+            self._buffers[name][:] = self._buffers[name][-1:, :]
+        self._primed = True
+        return self.assemble()
+
+    def step(self, segments: dict[str, np.ndarray]) -> np.ndarray:
+        """Push current values; auto-primes on the first call."""
+        if not self._primed:
+            return self.reset(segments)
+        for seg in self.layout:
+            name = seg["name"]
+            buf = self._buffers[name]
+            buf[:-1] = buf[1:]
+            self._set_validated(name, segments[name])
+        return self.assemble()
+
+    def assemble(self) -> np.ndarray:
+        parts: list[np.ndarray] = []
+        for seg in self.layout:
+            name = seg["name"]
+            parts.append(self._buffers[name].reshape(-1))
+        obs = np.concatenate(parts, axis=0).astype(np.float32, copy=False)
+        if obs.size != self.obs_dim:
+            raise SystemExit(
+                f"assembled obs dim {obs.size} != cfg.obs_dim {self.obs_dim}"
+            )
+        return obs
+
+    def _set_validated(self, name: str, value) -> None:
+        buf = self._buffers[name]
+        dim = buf.shape[1]
+        arr = np.asarray(value, dtype=np.float32).reshape(-1)
+        if arr.size != dim:
+            raise SystemExit(
+                f"obs segment '{name}': expected dim {dim}, got {arr.size}"
+            )
+        buf[-1, :] = arr
+
+
+def compute_obs_segments(
+    cfg: dict,
+    motion_frame: dict,
+    *,
+    robot_torso_pos_w: np.ndarray,
+    robot_torso_quat_w: np.ndarray,
+    gyro: np.ndarray,
+    dof_pos: np.ndarray,
+    dof_vel: np.ndarray,
+    last_actions: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Compute the current-step value of every potential obs segment.
+
+    Returns a dict keyed by segment name. Only the segments listed in
+    cfg['obs_layout'] are consumed downstream; unused keys are harmless.
+
+    All inputs are batch-less (1D arrays). Each output segment is float32.
+    """
+    default_angles = np.asarray(cfg["default_angles"], dtype=np.float32)
+    anchor_idx = int(cfg["anchor_body_idx_in_tracked"])
+
+    ref_joint_pos = motion_frame["joint_pos"]
+    ref_joint_vel = motion_frame["joint_vel"]
+    ref_torso_pos_w = motion_frame["body_pos_w"][anchor_idx]
+    ref_torso_quat_w = motion_frame["body_quat_w"][anchor_idx]
+
+    pos_b, ori_q = np_subtract_frame_transforms(
+        robot_torso_pos_w[None, :],
+        robot_torso_quat_w[None, :],
+        ref_torso_pos_w[None, :],
+        ref_torso_quat_w[None, :],
+    )
+    motion_anchor_pos_b = pos_b[0].astype(np.float32)
+    ori_R = np_matrix_from_quat(ori_q)[0]
+    motion_anchor_ori_b = ori_R[:, :2].reshape(6).astype(np.float32)
+
+    # linvel: deploy default = zero (no real-robot sensor on G1).
+    linvel_strategy = str(cfg.get("linvel_strategy", "zero"))
+    if linvel_strategy != "zero":
+        raise SystemExit(
+            f"linvel_strategy='{linvel_strategy}' not supported in prototype; "
+            "G1 deploy must use 'zero'"
+        )
+    base_lin_vel = np.zeros(3, dtype=np.float32)
+
+    return {
+        "command_joint_pos": ref_joint_pos.astype(np.float32),
+        "command_joint_vel": ref_joint_vel.astype(np.float32),
+        "motion_anchor_pos_b": motion_anchor_pos_b,
+        "motion_anchor_ori_b": motion_anchor_ori_b,
+        # Two aliases so legacy schemas (which used 'linvel') still work.
+        "base_lin_vel": base_lin_vel,
+        "linvel": base_lin_vel,
+        "gyro": gyro.astype(np.float32),
+        "joint_pos_rel": (dof_pos - default_angles).astype(np.float32),
+        "dof_vel": dof_vel.astype(np.float32),
+        "last_actions": last_actions.astype(np.float32),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--onnx", type=Path, default=DEFAULT_ONNX,
+                    help="ONNX policy. If absent or --no-onnx, prototype runs a "
+                         "default-angle ctrl sanity check (obs assembly only).")
+    ap.add_argument("--no-onnx", action="store_true",
+                    help="Skip ONNX inference even if the file exists.")
+    ap.add_argument("--config", type=Path, default=DEFAULT_CFG)
+    ap.add_argument("--motion", type=Path, default=DEFAULT_BIN)
+    ap.add_argument("--scene", type=Path, default=DEFAULT_SCENE)
+    ap.add_argument("--render", action="store_true",
+                    help="Open MuJoCo passive viewer (requires display).")
+    ap.add_argument("--max-steps", type=int, default=0,
+                    help="0 = play to end of clip then loop once.")
+    ap.add_argument("--cheat-anchor", action="store_true",
+                    help="Use sim-true robot torso pos for anchor (debug; "
+                         "would not be available on real robot).")
+    ap.add_argument("--init-mode", choices=["rsi", "stand"], default="rsi",
+                    help="rsi = teleport robot to motion frame 0 (training-time "
+                         "reset condition; default). stand = leave robot in the "
+                         "'stand' keyframe pose (== FixStand default_angles, "
+                         "matching the deploy-time FSM transition).")
+    args = ap.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+    motion = load_motion_bin(args.motion)
+
+    expected_dim = int(cfg["obs_dim"])
+    layout_total = sum(
+        int(s["dim"]) * int(s.get("history_length", 1)) for s in cfg["obs_layout"]
+    )
+    if layout_total != expected_dim:
+        raise SystemExit(
+            f"cfg internal inconsistency: sum(obs_layout dim*history_length)={layout_total} "
+            f"!= obs_dim={expected_dim}"
+        )
+    obs_assembler = ObsAssembler(cfg)
+
+    use_onnx = (not args.no_onnx) and args.onnx.exists()
+    sess = None
+    inp_name = out_name = None
+    if use_onnx:
+        import onnxruntime as ort  # local import: optional in sanity mode
+        sess = ort.InferenceSession(str(args.onnx), providers=["CPUExecutionProvider"])
+        inp_name = sess.get_inputs()[0].name
+        out_name = sess.get_outputs()[0].name
+        onnx_in_shape = sess.get_inputs()[0].shape
+        onnx_in_dim = int(onnx_in_shape[-1]) if isinstance(onnx_in_shape[-1], int) else -1
+        print(f"ONNX: input={inp_name} {onnx_in_shape}, output={out_name} "
+              f"{sess.get_outputs()[0].shape}")
+        if onnx_in_dim != expected_dim:
+            raise SystemExit(
+                f"ONNX input dim {onnx_in_dim} != cfg.obs_dim {expected_dim}. "
+                "Retrain (or re-export ONNX) so the policy matches the deploy contract."
+            )
+    else:
+        reason = "missing" if not args.onnx.exists() else "disabled (--no-onnx)"
+        print(f"ONNX: {reason} — running OBS-ASSEMBLY SANITY CHECK only "
+              "(ctrl = default_angles, no policy in the loop)")
+
+    print(f"obs_dim={expected_dim}, layout segments=[" +
+          ", ".join(
+              f"{s['name']}({s['dim']}×{int(s.get('history_length', 1))})"
+              for s in cfg["obs_layout"]
+          ) + "]")
+
+    model = mujoco.MjModel.from_xml_path(str(args.scene))
+    data = mujoco.MjData(model)
+    ctrl_dt = float(cfg["ctrl_dt"])
+    sim_dt = float(model.opt.timestep)
+    substeps = max(1, int(round(ctrl_dt / sim_dt)))
+    print(f"sim_dt={sim_dt:.5f}, ctrl_dt={ctrl_dt:.3f}, substeps/ctrl={substeps}")
+
+    # Init pose: two modes.
+    #   rsi   — Reference State Initialization: teleport robot to motion frame
+    #           0's pose (matches the training env's reset condition).
+    #   stand — leave robot in the "stand" keyframe pose (== FixStand
+    #           default_angles), which is what the C++ FSM sees at the
+    #           FixStand → State_WBT transition on the real robot.
+    # Use --init-mode stand to reproduce the deploy-time "first few seconds of
+    # slipping while the policy snaps the robot from default_angles to dance
+    # frame 0" scenario in simulation, without touching hardware.
+    key_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "stand")
+    if key_id < 0:
+        raise SystemExit("'stand' keyframe not found")
+    mujoco.mj_resetDataKeyframe(model, data, key_id)
+
+    pelvis_id_in_tracked = 0  # 'pelvis' is first in TRACKED_BODY_NAMES
+    if args.init_mode == "rsi":
+        data.qpos[0:3] = motion["body_pos_w"][0, pelvis_id_in_tracked]
+        data.qpos[3:7] = motion["body_quat_w"][0, pelvis_id_in_tracked]  # wxyz
+        data.qpos[7:] = motion["joint_pos"][0]
+        data.qvel[0:3] = motion["body_lin_vel_w"][0, pelvis_id_in_tracked]
+        data.qvel[3:6] = motion["body_ang_vel_w"][0, pelvis_id_in_tracked]
+        data.qvel[6:] = motion["joint_vel"][0]
+    mujoco.mj_forward(model, data)
+    print(f"init_mode={args.init_mode}: base xyz={data.qpos[:3]}, "
+          f"base quat={data.qpos[3:7]}")
+
+    default_angles = np.asarray(cfg["default_angles"], dtype=np.float32)
+    action_scale = float(cfg["action_scale"])
+    ema_alpha = float(cfg["ema_alpha"])
+    joint_lower = np.asarray(cfg["joint_lower"], dtype=np.float32)
+    joint_upper = np.asarray(cfg["joint_upper"], dtype=np.float32)
+    anchor_idx = int(cfg["anchor_body_idx_in_tracked"])
+    anchor_body_name = cfg["anchor_body_name"]
+    anchor_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, anchor_body_name)
+
+    gyro_sid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "gyro")
+    if gyro_sid < 0:
+        raise SystemExit("'gyro' sensor not found in model")
+    gyro_adr = int(model.sensor_adr[gyro_sid])
+    gyro_dim = int(model.sensor_dim[gyro_sid])
+    if gyro_dim != 3:
+        raise SystemExit(f"gyro sensor has dim {gyro_dim}, expected 3")
+
+    robot_anchor_pos_w_locked = motion["body_pos_w"][0, anchor_idx].astype(np.float32)
+    print(f"robot_anchor_pos_w (locked) = {robot_anchor_pos_w_locked}")
+
+    last_actions = np.zeros(29, dtype=np.float32)
+    q_target_smoothed = default_angles.copy()
+    n_frames = motion["num_frames"]
+    if args.max_steps > 0:
+        total_steps = args.max_steps
+    elif use_onnx:
+        total_steps = n_frames
+    else:
+        total_steps = min(50, n_frames)  # sanity mode: short run
+
+    obs_norms = []
+    action_amplitudes = []
+    z_errors = []
+
+    viewer = None
+    if args.render:
+        from mujoco import viewer as mj_viewer
+        viewer = mj_viewer.launch_passive(model, data)
+
+    t_wall = time.time()
+    for step in range(total_steps):
+        frame_idx = step % n_frames
+
+        robot_torso_quat_w = data.xquat[anchor_body_id].astype(np.float32)
+        gyro = data.sensordata[gyro_adr:gyro_adr + gyro_dim].astype(np.float32)
+        dof_pos = data.qpos[7:].astype(np.float32)
+        dof_vel = data.qvel[6:].astype(np.float32)
+
+        motion_frame = {
+            "joint_pos": motion["joint_pos"][frame_idx],
+            "joint_vel": motion["joint_vel"][frame_idx],
+            "body_pos_w": motion["body_pos_w"][frame_idx],
+            "body_quat_w": motion["body_quat_w"][frame_idx],
+        }
+        if args.cheat_anchor:
+            robot_torso_pos_w_used = data.xpos[anchor_body_id].astype(np.float32)
+        else:
+            robot_torso_pos_w_used = robot_anchor_pos_w_locked
+        current_segments = compute_obs_segments(
+            cfg, motion_frame,
+            robot_torso_pos_w=robot_torso_pos_w_used,
+            robot_torso_quat_w=robot_torso_quat_w,
+            gyro=gyro, dof_pos=dof_pos, dof_vel=dof_vel,
+            last_actions=last_actions,
+        )
+        # Stateful: first call auto-resets (fills history with current segments,
+        # matching State_WBT.cpp's env_->reset() at FSM enter); subsequent calls
+        # push current and drop oldest (matching ObservationTermCfg::add).
+        obs = obs_assembler.step(current_segments)
+        if not np.all(np.isfinite(obs)):
+            raise SystemExit(f"non-finite obs at step {step}")
+
+        if use_onnx:
+            action = sess.run([out_name], {inp_name: obs[None, :].astype(np.float32)})[0][0]
+            action = action.astype(np.float32)
+            last_actions = action.copy()
+            q_target = action * action_scale + default_angles
+            q_target = np.clip(q_target, joint_lower, joint_upper)
+            q_target_smoothed = ema_alpha * q_target + (1.0 - ema_alpha) * q_target_smoothed
+        else:
+            # Sanity mode: keep robot at default angles, freeze last_actions at 0.
+            q_target_smoothed = default_angles.copy()
+
+        data.ctrl[:] = q_target_smoothed
+
+        for _ in range(substeps):
+            mujoco.mj_step(model, data)
+
+        obs_norms.append(float(np.linalg.norm(obs)))
+        action_amplitudes.append(float(np.max(np.abs(last_actions))))
+        robot_z = float(data.xpos[anchor_body_id, 2])
+        ref_z = float(motion["body_pos_w"][frame_idx, anchor_idx, 2])
+        z_errors.append(abs(robot_z - ref_z))
+
+        if viewer is not None:
+            viewer.sync()
+            elapsed = time.time() - t_wall
+            target = (step + 1) * ctrl_dt
+            if elapsed < target:
+                time.sleep(target - elapsed)
+
+        if step % 50 == 0:
+            print(f"step {step:4d} frame={frame_idx:3d}  "
+                  f"obs_norm={obs_norms[-1]:7.2f}  "
+                  f"|action|={action_amplitudes[-1]:5.2f}  "
+                  f"z_err={z_errors[-1]:.3f}m  "
+                  f"q_target[:3]={q_target_smoothed[:3]}")
+
+        if not np.all(np.isfinite(data.qpos)):
+            print(f"!! NaN at step {step}, aborting")
+            break
+        if use_onnx and z_errors[-1] > 0.6:
+            print(f"!! z_err {z_errors[-1]:.2f}m exceeds 0.6m, robot likely fell at step {step}")
+            break
+
+    if viewer is not None:
+        viewer.close()
+
+    n = len(obs_norms)
+    print()
+    print(f"Ran {n} ctrl steps ({n*ctrl_dt:.2f}s of motion).")
+    print(f"obs_norm:        mean={np.mean(obs_norms):.3f}  max={np.max(obs_norms):.3f}")
+    print(f"|action| max:    mean={np.mean(action_amplitudes):.3f}  max={np.max(action_amplitudes):.3f}")
+    print(f"|torso z err|:   mean={np.mean(z_errors):.4f}m  max={np.max(z_errors):.4f}m")
+
+    if not use_onnx:
+        # Sanity mode never claims tracking — only that obs assembly is finite & shaped.
+        print("SANITY OK — obs assembly produced finite vectors of expected width "
+              f"({expected_dim}); end-to-end tracking requires running with a "
+              f"matching ONNX (input dim {expected_dim}).")
+    elif np.max(z_errors) < 0.2 and n == total_steps:
+        print("PROTOTYPE OK — obs assembly + ONNX inference produces tracking behavior.")
+    elif n < total_steps:
+        print("WARNING: prototype aborted before clip end (see message above).")
+    else:
+        print("WARNING: large torso z error — obs assembly may be off, or policy weak.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/motion/remap_fullbody_npz.py
+++ b/scripts/motion/remap_fullbody_npz.py
@@ -20,9 +20,9 @@ import argparse
 from pathlib import Path
 
 import numpy as np
-from unilab.base.backend.mujoco.xml import _get_named_bodies
 
 from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.mujoco.xml import _get_named_bodies
 
 # MuJoCo root free-joint sizes
 _ROOT_QPOS_DIM = 7  # 3 pos + 4 quat

--- a/scripts/motion/remap_fullbody_npz.py
+++ b/scripts/motion/remap_fullbody_npz.py
@@ -20,7 +20,7 @@ import argparse
 from pathlib import Path
 
 import numpy as np
-from unilab.utils.xml_utils import _get_named_bodies
+from unilab.base.backend.mujoco.xml import _get_named_bodies
 
 from unilab.assets import ASSETS_ROOT_PATH
 

--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -22,6 +22,8 @@ from .g1 import (
     G1WallFlipTrackingCfg,
     G1WallFlipTrackingEnv,
     G1WallFlipTrackingEnvCfg,
+    G1WBTObsCfg,
+    G1WBTObsEnv,
 )
 
 __all__ = [
@@ -30,6 +32,8 @@ __all__ = [
     "G1MotionTrackingEnvCfg",
     "G1MotionTrackingSACCfg",
     "G1MotionTrackingSACEnv",
+    "G1WBTObsCfg",
+    "G1WBTObsEnv",
     "G1FlipTrackingCfg",
     "G1FlipTrackingEnv",
     "G1FlipTrackingEnvCfg",

--- a/src/unilab/envs/motion_tracking/g1/__init__.py
+++ b/src/unilab/envs/motion_tracking/g1/__init__.py
@@ -20,6 +20,7 @@ from .tracking import (
     G1MotionTrackingEnv,
     G1MotionTrackingEnvCfg,
 )
+from .tracking_obs import G1WBTObsCfg, G1WBTObsEnv
 from .tracking_sac import G1MotionTrackingSACCfg, G1MotionTrackingSACEnv
 
 __all__ = [
@@ -30,6 +31,8 @@ __all__ = [
     "G1MotionTrackingEnvCfg",
     "G1MotionTrackingSACCfg",
     "G1MotionTrackingSACEnv",
+    "G1WBTObsCfg",
+    "G1WBTObsEnv",
     "G1FlipTrackingCfg",
     "G1FlipTrackingEnv",
     "G1FlipTrackingEnvCfg",

--- a/src/unilab/envs/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking_obs.py
@@ -1,0 +1,470 @@
+"""G1 Whole-Body Tracking — sim2real-oriented SAC variant (task ``G1WBTObs``).
+
+This module registers a strict subclass of :class:`G1MotionTrackingSACEnv` that
+adds the training-pipeline pieces needed for ONNX-on-real-G1 deployment:
+
+* drop deploy-unavailable channels from the actor obs
+  (``base_lin_vel``, ``motion_anchor_pos_b``);
+* per-step uniform noise on ``motion_anchor_ori_b`` (actor only);
+* proprio observation history (``gyro`` / ``joint_pos_rel`` / ``dof_vel`` /
+  ``last_actions``) flattened oldest-first per term, matching the deploy-side
+  ``ObservationManager`` when ``use_gym_history=false``;
+* per-episode encoder bias on ``joint_pos_rel`` (actor only);
+* per-episode foot-geom friction sampled across regex-matched geoms;
+* per-episode y / z COM offsets layered on top of the existing x offset;
+* ``joint_acc_l2`` and ``joint_torque_l2`` reward terms.
+
+All extensions are gated by flags on :class:`G1WBTObsCfg`; the bases
+(``G1MotionTrackingSACCfg`` / ``G1MotionTrackingSACEnv`` /
+``G1MotionTrackingEnv``) are untouched. Switch the pelvis IMU via the
+yaml ``env.sensor.gyro``/``env.sensor.upvector``/``env.sensor.local_linvel``
+fields (no XML duplication required — ``g1.xml`` already exposes both IMUs).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from unilab.base import registry
+from unilab.dr import (
+    DomainRandomizationCapabilities,
+    ResetPlan,
+    ResetRandomizationPayload,
+)
+from unilab.dr.dr_utils import (
+    build_common_reset_randomization,
+    zero_actions,
+)
+from unilab.dr.types import RESET_TERM_GEOM_FRICTION
+from unilab.dtype_config import get_global_dtype
+from unilab.envs.locomotion.g1.base import NoiseConfig
+
+from .tracking import (
+    Domain_Rand,
+    G1MotionTrackingDomainRandomizationProvider,
+    _build_motion_reference_state,
+)
+from .tracking_sac import G1MotionTrackingSACCfg, G1MotionTrackingSACEnv
+
+# --------------------------------------------------------------------------- #
+# Config extensions
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ObsNoiseConfig(NoiseConfig):
+    """Actor obs masking flags + proprio history depth.
+
+    Defaults preserve baseline behaviour so the parent ``NoiseConfig`` remains
+    a drop-in replacement; ``G1WBTObs`` flips the flags via its task yaml.
+    """
+
+    # Drop ``base_lin_vel`` from actor obs (G1 has no on-robot linvel sensor).
+    enable_zero_linvel: bool = False
+    # Drop ``motion_anchor_pos_b`` from actor obs (no torso-pose estimator).
+    enable_zero_anchor_pos: bool = False
+    # Per-step uniform noise on ``motion_anchor_ori_b`` (actor only).
+    enable_anchor_ori_noise: bool = False
+    scale_anchor_ori: float = 0.05
+    # When > 1, proprio terms (gyro / joint_pos_rel / dof_vel / last_actions)
+    # are flattened oldest-first as an H-step history block. Reference terms
+    # stay single-step. Critic stays single-step. Mirrors deploy-side
+    # ``ObservationManager`` with ``use_gym_history=false``.
+    obs_history_length: int = 1
+
+
+@dataclass
+class ObsDomainRand(Domain_Rand):
+    """y / z COM offsets, per-episode encoder bias, foot-geom friction."""
+
+    randomize_com_y: bool = False
+    com_offset_y: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+    randomize_com_z: bool = False
+    com_offset_z: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+
+    # Per-episode additive bias on actor's joint_pos channel.
+    enable_encoder_bias: bool = False
+    encoder_bias_range: list[float] = field(default_factory=lambda: [-0.01, 0.01])
+
+    # Per-reset foot-geom friction. ``shared_random=True`` — a single scalar
+    # is broadcast across all foot geoms of one env, applied to the
+    # sliding-friction column. Matches mjlab.
+    randomize_geom_friction: bool = False
+    friction_range: list[float] = field(default_factory=lambda: [0.3, 1.2])
+    friction_geom_pattern: str = r"^(left|right)_foot[1-7]_collision$"
+
+
+@registry.envcfg("G1WBTObs")
+@dataclass
+class G1WBTObsCfg(G1MotionTrackingSACCfg):
+    """SAC whole-body tracking with sim2real obs / DR / reward extensions."""
+
+    noise_config: ObsNoiseConfig = field(default_factory=ObsNoiseConfig)  # type: ignore[assignment]
+    domain_rand: ObsDomainRand = field(default_factory=ObsDomainRand)  # type: ignore[assignment]
+
+
+# --------------------------------------------------------------------------- #
+# DR provider extension
+# --------------------------------------------------------------------------- #
+
+
+class G1WBTObsDomainRandomizationProvider(G1MotionTrackingDomainRandomizationProvider):
+    """Extends the SAC tracking DR provider with encoder bias, foot-geom
+    friction, y/z COM offsets, and post-reset ``prev_dof_vel`` seeding."""
+
+    def __init__(
+        self,
+        *,
+        base_kp: np.ndarray | None = None,
+        base_kd: np.ndarray | None = None,
+        base_geom_friction: np.ndarray | None = None,
+        foot_geom_ids: np.ndarray | None = None,
+    ) -> None:
+        super().__init__(base_kp=base_kp, base_kd=base_kd)
+        self._base_geom_friction = base_geom_friction
+        self._foot_geom_ids = foot_geom_ids
+
+    def validate(self, env: Any, capabilities: DomainRandomizationCapabilities) -> None:
+        super().validate(env, capabilities)
+        if not getattr(env.cfg.domain_rand, "randomize_geom_friction", False):
+            return
+        if not capabilities.supports_reset_term(RESET_TERM_GEOM_FRICTION):
+            raise NotImplementedError(
+                f"{env._backend.backend_type} backend does not support "
+                "geom-friction reset randomization"
+            )
+        if (
+            self._base_geom_friction is None
+            or self._foot_geom_ids is None
+            or self._foot_geom_ids.size == 0
+        ):
+            raise ValueError(
+                "randomize_geom_friction=True but provider has no foot geom IDs"
+            )
+
+    def build_reset_plan(self, env: Any, env_ids: np.ndarray) -> ResetPlan:
+        num_reset = len(env_ids)
+        motion_frames = env.motion_sampler.sample_frames(env_ids)
+        motion_data = env.motion_loader.get_motion_at_frame(motion_frames)
+        qpos, qvel = _build_motion_reference_state(env, env_ids, motion_data)
+
+        info_updates: dict[str, Any] = {
+            "current_actions": zero_actions(num_reset, env._num_action),
+            "last_actions": zero_actions(num_reset, env._num_action),
+            # Seed prev_dof_vel with the post-reset joint velocity so the first
+            # joint_acc_l2 sample is physically meaningful (Δv from the new
+            # starting velocity, not a spurious step from pre-termination).
+            "prev_dof_vel": qvel[:, 6:].astype(get_global_dtype()),
+        }
+
+        dr_cfg = env.cfg.domain_rand
+        if getattr(dr_cfg, "enable_encoder_bias", False):
+            low, high = dr_cfg.encoder_bias_range
+            info_updates["joint_pos_obs_bias"] = np.random.uniform(
+                low, high, size=(num_reset, env._num_action)
+            ).astype(get_global_dtype())
+
+        randomization = build_common_reset_randomization(
+            env, num_reset, base_kp=self._base_kp, base_kd=self._base_kd
+        )
+
+        # Foot-geom friction.
+        if getattr(dr_cfg, "randomize_geom_friction", False):
+            assert self._base_geom_friction is not None
+            assert self._foot_geom_ids is not None
+            payload = randomization or ResetRandomizationPayload()
+            low, high = dr_cfg.friction_range
+            scale = np.random.uniform(low, high, size=(num_reset, 1)).astype(np.float64)
+            geom_friction = np.broadcast_to(
+                self._base_geom_friction,
+                (num_reset, *self._base_geom_friction.shape),
+            ).copy()
+            geom_friction[:, self._foot_geom_ids, 0] = scale * np.ones(
+                (1, self._foot_geom_ids.size)
+            )
+            payload.geom_friction = geom_friction
+            randomization = payload
+
+        # y / z COM offsets, layered on top of parent's x-only common build.
+        has_com_y = getattr(dr_cfg, "randomize_com_y", False)
+        has_com_z = getattr(dr_cfg, "randomize_com_z", False)
+        if has_com_y or has_com_z:
+            payload = randomization or ResetRandomizationPayload()
+            com_offset = payload.base_com_offset
+            if com_offset is None:
+                com_offset = np.zeros((num_reset, 3), dtype=np.float64)
+            if has_com_y:
+                low, high = dr_cfg.com_offset_y
+                com_offset[:, 1] = np.random.uniform(low, high, size=(num_reset,))
+            if has_com_z:
+                low, high = dr_cfg.com_offset_z
+                com_offset[:, 2] = np.random.uniform(low, high, size=(num_reset,))
+            payload.base_com_offset = com_offset
+            randomization = payload
+
+        return ResetPlan(
+            env_ids=env_ids,
+            qpos=qpos,
+            qvel=qvel,
+            info_updates=info_updates,
+            randomization=randomization,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Env
+# --------------------------------------------------------------------------- #
+
+
+@registry.env("G1WBTObs", sim_backend="mujoco")
+@registry.env("G1WBTObs", sim_backend="motrix")
+class G1WBTObsEnv(G1MotionTrackingSACEnv):
+    """SAC WBT with deploy-aligned obs, proprio history, and extra DR/rewards.
+
+    All extensions live in this subclass — base classes are untouched. Flags
+    on ``G1WBTObsCfg`` are toggled from the task yaml.
+    """
+
+    _cfg: G1WBTObsCfg
+
+    def __init__(self, cfg: G1WBTObsCfg, num_envs: int = 1, backend_type: str = "mujoco"):
+        super().__init__(cfg, num_envs=num_envs, backend_type=backend_type)
+
+        # Cache base actuator gains for joint_torque_l2.
+        # Position-control torque approx: τ ≈ kp·(target_q − q) − kd·qd.
+        # DR (kp/kd ±10–15%) leaves small error vs true per-env torque, but
+        # the gradient direction (penalise large action / large Δq) is preserved.
+        base_kp, base_kd = self._backend.get_actuator_gains()
+        self._base_kp = np.asarray(base_kp, dtype=get_global_dtype())
+        self._base_kd = np.asarray(base_kd, dtype=get_global_dtype())
+
+        # Proprio history buffers — per-term, oldest-first. Allocated only when
+        # H > 1 so H = 1 is zero-overhead.
+        H = max(1, int(cfg.noise_config.obs_history_length))
+        self._hist_len = H
+        self._hist_buf: dict[str, np.ndarray] | None = None
+        if H > 1:
+            n = self._num_action
+            dtype = get_global_dtype()
+            self._hist_buf = {
+                "gyro": np.zeros((num_envs, H, 3), dtype=dtype),
+                "joint_pos_rel": np.zeros((num_envs, H, n), dtype=dtype),
+                "dof_vel": np.zeros((num_envs, H, n), dtype=dtype),
+                "last_actions": np.zeros((num_envs, H, n), dtype=dtype),
+            }
+        # Plumbs ``info`` from ``_compute_obs`` down to ``_build_actor_obs``
+        # without changing the base-class hook signature.
+        self._obs_compute_info: dict | None = None
+
+        # Swap to the extended DR provider whenever an extended flag is on.
+        dr_cfg = cfg.domain_rand
+        needs_extended = (
+            getattr(dr_cfg, "enable_encoder_bias", False)
+            or getattr(dr_cfg, "randomize_geom_friction", False)
+            or getattr(dr_cfg, "randomize_com_y", False)
+            or getattr(dr_cfg, "randomize_com_z", False)
+        )
+        if needs_extended:
+            kp = self._base_kp if (dr_cfg.randomize_kp or dr_cfg.randomize_kd) else None
+            kd = self._base_kd if (dr_cfg.randomize_kp or dr_cfg.randomize_kd) else None
+            base_geom_friction = None
+            foot_geom_ids = None
+            if dr_cfg.randomize_geom_friction:
+                base_geom_friction = self._backend.get_geom_friction()
+                geom_names = self._backend.get_geom_names()
+                pattern = re.compile(dr_cfg.friction_geom_pattern)
+                foot_geom_ids = np.asarray(
+                    [
+                        i
+                        for i, name in enumerate(geom_names)
+                        if name and pattern.match(name)
+                    ],
+                    dtype=np.int64,
+                )
+                if foot_geom_ids.size == 0:
+                    raise ValueError(
+                        "friction_geom_pattern "
+                        f"'{dr_cfg.friction_geom_pattern}' did not match any geom"
+                    )
+            extended_provider = G1WBTObsDomainRandomizationProvider(
+                base_kp=kp,
+                base_kd=kd,
+                base_geom_friction=base_geom_friction,
+                foot_geom_ids=foot_geom_ids,
+            )
+            self._init_domain_randomization(extended_provider)
+
+    # ------------------------------------------------------------------ #
+    # Rewards
+    # ------------------------------------------------------------------ #
+
+    def _init_reward_functions(self) -> None:
+        super()._init_reward_functions()
+        self._reward_fns["joint_acc_l2"] = self._reward_joint_acc_l2
+        self._reward_fns["joint_torque_l2"] = self._reward_joint_torque_l2
+
+    def _reward_joint_acc_l2(self, info: dict) -> np.ndarray:
+        dof_vel = info["dof_vel"]
+        prev_dof_vel = info.get("prev_dof_vel")
+        if prev_dof_vel is None or prev_dof_vel.shape != dof_vel.shape:
+            return np.zeros((self._num_envs,), dtype=get_global_dtype())
+        joint_acc = (dof_vel - prev_dof_vel) / self._cfg.ctrl_dt
+        return np.asarray(np.sum(np.square(joint_acc), axis=1), dtype=get_global_dtype())
+
+    def _reward_joint_torque_l2(self, info: dict) -> np.ndarray:
+        dof_pos = info["dof_pos"]
+        dof_vel = info["dof_vel"]
+        last_actions = info.get("last_actions")
+        if last_actions is None:
+            return np.zeros((self._num_envs,), dtype=get_global_dtype())
+        target_q = last_actions * self._cfg.control_config.action_scale + self.default_angles
+        torque = self._base_kp * (target_q - dof_pos) - self._base_kd * dof_vel
+        return np.asarray(np.sum(np.square(torque), axis=1), dtype=get_global_dtype())
+
+    # ------------------------------------------------------------------ #
+    # Obs
+    # ------------------------------------------------------------------ #
+
+    def _actor_obs_dim(self, n: int) -> int:
+        nc = self._cfg.noise_config
+        H = max(1, int(nc.obs_history_length))
+        single_step = 2 * n + 6  # command(2n) + anchor_ori(6)
+        if not nc.enable_zero_anchor_pos:
+            single_step += 3
+        if not nc.enable_zero_linvel:
+            single_step += 3
+        proprio_step = 3 + 3 * n  # gyro + joint_pos_rel + dof_vel + last_actions
+        return single_step + H * proprio_step
+
+    def _compute_obs(
+        self,
+        info: dict,
+        motion_data: Any,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        robot_body_pos_w: np.ndarray,
+        robot_body_quat_w: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        # Stash so the overridden ``_build_actor_obs`` (called inside super)
+        # can read env_ids / joint_pos_obs_bias without a signature change.
+        self._obs_compute_info = info
+        try:
+            obs = super()._compute_obs(
+                info,
+                motion_data,
+                linvel,
+                gyro,
+                dof_pos,
+                dof_vel,
+                robot_body_pos_w,
+                robot_body_quat_w,
+            )
+        finally:
+            self._obs_compute_info = None
+
+        # Cache for next-step joint_acc_l2. The reset path overwrites this
+        # via the DR provider's ``prev_dof_vel`` info_update.
+        info["prev_dof_vel"] = dof_vel.copy()
+        return obs
+
+    def _build_actor_obs(
+        self,
+        *,
+        command: np.ndarray,
+        motion_anchor_pos_b: np.ndarray,
+        motion_anchor_ori_b: np.ndarray,
+        noisy_linvel: np.ndarray,
+        noisy_gyro: np.ndarray,
+        noisy_joint_pos_rel: np.ndarray,
+        noisy_dof_vel: np.ndarray,
+        last_actions: np.ndarray,
+    ) -> np.ndarray:
+        info = self._obs_compute_info or {}
+        # Reset path is signalled by ``env_ids`` in obs_info (set by parent's
+        # ``_refresh_observation_rows`` and the DR provider's
+        # ``build_reset_observation``). In that case fill history slots; in
+        # the per-step path we push (oldest out, current in).
+        env_ids = info.get("env_ids")
+        is_reset = env_ids is not None
+
+        nc = self._cfg.noise_config
+
+        # Per-episode encoder bias on actor's joint_pos channel.
+        bias = info.get("joint_pos_obs_bias")
+        if bias is not None and bias.shape == noisy_joint_pos_rel.shape:
+            noisy_joint_pos_rel = np.asarray(
+                noisy_joint_pos_rel + bias, dtype=noisy_joint_pos_rel.dtype
+            )
+
+        # Per-step anchor_ori noise (actor only).
+        actor_anchor_ori_b = motion_anchor_ori_b
+        if nc.enable_anchor_ori_noise:
+            actor_anchor_ori_b = self._obs_noise(motion_anchor_ori_b, nc.scale_anchor_ori)
+
+        # Single-step reference terms, dropping deploy-unavailable channels.
+        actor_terms: list[np.ndarray] = [command]
+        if not nc.enable_zero_anchor_pos:
+            actor_terms.append(motion_anchor_pos_b)
+        actor_terms.append(actor_anchor_ori_b)
+        if not nc.enable_zero_linvel:
+            actor_terms.append(noisy_linvel)
+
+        # Proprio history (or single-step pass-through when H = 1).
+        if self._hist_buf is not None:
+            components = {
+                "gyro": noisy_gyro,
+                "joint_pos_rel": noisy_joint_pos_rel,
+                "dof_vel": noisy_dof_vel,
+                "last_actions": last_actions,
+            }
+            if is_reset:
+                self._fill_obs_history(env_ids, components)
+            else:
+                self._push_obs_history(env_ids, components)
+            sel = slice(None) if env_ids is None else env_ids
+            for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
+                buf = self._hist_buf[key][sel]   # (n_e, H, D)
+                actor_terms.append(buf.reshape(buf.shape[0], -1))
+        else:
+            actor_terms.extend(
+                [noisy_gyro, noisy_joint_pos_rel, noisy_dof_vel, last_actions]
+            )
+
+        return np.concatenate(actor_terms, axis=1, dtype=get_global_dtype())
+
+    # ------------------------------------------------------------------ #
+    # Proprio history buffer maintenance.
+    # Mirrors deploy ``ObservationManager`` / ``ObservationTermCfg``:
+    #   * On reset: fill all H slots with the current value (matches
+    #     ``ObservationTermCfg::reset`` which calls ``add()`` H times).
+    #   * On step: pop oldest, push current at end.
+    #   * Read order is oldest-first, so ``flatten(buf[env, :, :])`` yields
+    #     ``[t-H+1, t-H+2, ..., t]`` — matches deploy
+    #     ``ObservationTermCfg::get`` (deque front-to-back).
+    # ------------------------------------------------------------------ #
+
+    def _push_obs_history(
+        self, env_ids: np.ndarray | None, components: dict[str, np.ndarray]
+    ) -> None:
+        if self._hist_buf is None:
+            return
+        sel = slice(None) if env_ids is None else env_ids
+        for key, val in components.items():
+            buf = self._hist_buf[key]
+            buf[sel, :-1] = buf[sel, 1:]
+            buf[sel, -1] = val
+
+    def _fill_obs_history(
+        self, env_ids: np.ndarray | None, components: dict[str, np.ndarray]
+    ) -> None:
+        if self._hist_buf is None:
+            return
+        sel = slice(None) if env_ids is None else env_ids
+        for key, val in components.items():
+            self._hist_buf[key][sel, :] = val[:, None, :]

--- a/src/unilab/envs/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking_obs.py
@@ -142,9 +142,7 @@ class G1WBTObsDomainRandomizationProvider(G1MotionTrackingDomainRandomizationPro
             or self._foot_geom_ids is None
             or self._foot_geom_ids.size == 0
         ):
-            raise ValueError(
-                "randomize_geom_friction=True but provider has no foot geom IDs"
-            )
+            raise ValueError("randomize_geom_friction=True but provider has no foot geom IDs")
 
     def build_reset_plan(self, env: Any, env_ids: np.ndarray) -> ResetPlan:
         num_reset = len(env_ids)
@@ -278,11 +276,7 @@ class G1WBTObsEnv(G1MotionTrackingSACEnv):
                 geom_names = self._backend.get_geom_names()
                 pattern = re.compile(dr_cfg.friction_geom_pattern)
                 foot_geom_ids = np.asarray(
-                    [
-                        i
-                        for i, name in enumerate(geom_names)
-                        if name and pattern.match(name)
-                    ],
+                    [i for i, name in enumerate(geom_names) if name and pattern.match(name)],
                     dtype=np.int64,
                 )
                 if foot_geom_ids.size == 0:
@@ -296,7 +290,14 @@ class G1WBTObsEnv(G1MotionTrackingSACEnv):
                 base_geom_friction=base_geom_friction,
                 foot_geom_ids=foot_geom_ids,
             )
-            self._init_domain_randomization(extended_provider)
+            # Swap the per-reset DR provider directly. ``_init_domain_randomization``
+            # cannot be called twice — it materializes the backend at the end and
+            # MuJoCo's pool raises on a second materialize. The parent's call
+            # already (a) ran init randomization and (b) materialized; we only
+            # need the new provider's ``build_reset_plan`` for per-episode DR.
+            from unilab.dr import DomainRandomizationManager
+
+            self._dr_manager = DomainRandomizationManager(self, extended_provider)
 
     # ------------------------------------------------------------------ #
     # Rewards
@@ -429,12 +430,10 @@ class G1WBTObsEnv(G1MotionTrackingSACEnv):
                 self._push_obs_history(env_ids, components)
             sel = slice(None) if env_ids is None else env_ids
             for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
-                buf = self._hist_buf[key][sel]   # (n_e, H, D)
+                buf = self._hist_buf[key][sel]  # (n_e, H, D)
                 actor_terms.append(buf.reshape(buf.shape[0], -1))
         else:
-            actor_terms.extend(
-                [noisy_gyro, noisy_joint_pos_rel, noisy_dof_vel, last_actions]
-            )
+            actor_terms.extend([noisy_gyro, noisy_joint_pos_rel, noisy_dof_vel, last_actions])
 
         return np.concatenate(actor_terms, axis=1, dtype=get_global_dtype())
 

--- a/tests/scripts/test_obs_alignment_g1_wbt.py
+++ b/tests/scripts/test_obs_alignment_g1_wbt.py
@@ -19,6 +19,7 @@ The test is hermetic: it does NOT spin up MuJoCo, does NOT load motion clips,
 and does NOT depend on training infra. It synthesizes fixed random inputs,
 runs the assembly on both sides, and asserts bit-for-bit equality.
 """
+
 from __future__ import annotations
 
 import sys
@@ -35,6 +36,7 @@ SIM_PROTOTYPE = REPO_ROOT / "scripts" / "deploy" / "sim_prototype.py"
 def _load_sim_prototype():
     """Import sim_prototype as a module (it's under scripts/, not src/)."""
     import importlib.util
+
     spec = importlib.util.spec_from_file_location("sim_prototype", SIM_PROTOTYPE)
     mod = importlib.util.module_from_spec(spec)
     sys.modules["sim_prototype"] = mod
@@ -45,6 +47,7 @@ def _load_sim_prototype():
 # ---------------------------------------------------------------------------
 # Reference deque (mirrors deploy ObservationTermCfg::reset / add / get).
 # ---------------------------------------------------------------------------
+
 
 class _DeployTerm:
     """Bit-for-bit copy of ObservationTermCfg buffer semantics.
@@ -89,9 +92,9 @@ def _deploy_compute_group(layout, current_segments_by_name):
         for seg in layout:
             terms[seg["name"]].add(segments[seg["name"]])
         # Concat each term's full history oldest-first, then across terms.
-        out = np.concatenate(
-            [terms[seg["name"]].get() for seg in layout], axis=0
-        ).astype(np.float32)
+        out = np.concatenate([terms[seg["name"]].get() for seg in layout], axis=0).astype(
+            np.float32
+        )
         out_per_step.append(out)
     return out_per_step
 
@@ -101,18 +104,19 @@ def _deploy_compute_group(layout, current_segments_by_name):
 # deploy profile (H=5, both zero flags ON).
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def deploy_cfg():
     n = 29
     H = 5
     obs_layout = [
-        {"name": "command_joint_pos",   "dim": n, "history_length": 1},
-        {"name": "command_joint_vel",   "dim": n, "history_length": 1},
+        {"name": "command_joint_pos", "dim": n, "history_length": 1},
+        {"name": "command_joint_vel", "dim": n, "history_length": 1},
         {"name": "motion_anchor_ori_b", "dim": 6, "history_length": 1},
-        {"name": "gyro",                "dim": 3, "history_length": H},
-        {"name": "joint_pos_rel",       "dim": n, "history_length": H},
-        {"name": "dof_vel",             "dim": n, "history_length": H},
-        {"name": "last_actions",        "dim": n, "history_length": H},
+        {"name": "gyro", "dim": 3, "history_length": H},
+        {"name": "joint_pos_rel", "dim": n, "history_length": H},
+        {"name": "dof_vel", "dim": n, "history_length": H},
+        {"name": "last_actions", "dim": n, "history_length": H},
     ]
     total = sum(s["dim"] * s["history_length"] for s in obs_layout)
     return {
@@ -130,13 +134,13 @@ def rng():
 
 def _random_segments(rng, num_action=29):
     return {
-        "command_joint_pos":   rng.normal(size=num_action).astype(np.float32),
-        "command_joint_vel":   rng.normal(size=num_action).astype(np.float32),
+        "command_joint_pos": rng.normal(size=num_action).astype(np.float32),
+        "command_joint_vel": rng.normal(size=num_action).astype(np.float32),
         "motion_anchor_ori_b": rng.normal(size=6).astype(np.float32),
-        "gyro":                rng.normal(size=3).astype(np.float32),
-        "joint_pos_rel":       rng.normal(size=num_action).astype(np.float32),
-        "dof_vel":             rng.normal(size=num_action).astype(np.float32),
-        "last_actions":        rng.normal(size=num_action).astype(np.float32),
+        "gyro": rng.normal(size=3).astype(np.float32),
+        "joint_pos_rel": rng.normal(size=num_action).astype(np.float32),
+        "dof_vel": rng.normal(size=num_action).astype(np.float32),
+        "last_actions": rng.normal(size=num_action).astype(np.float32),
     }
 
 
@@ -144,14 +148,13 @@ def _random_segments(rng, num_action=29):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 class TestObsDim:
     def test_deploy_profile_dim_is_514(self, deploy_cfg):
         assert deploy_cfg["obs_dim"] == 514
 
     def test_layout_sum_matches_obs_dim(self, deploy_cfg):
-        total = sum(
-            s["dim"] * s.get("history_length", 1) for s in deploy_cfg["obs_layout"]
-        )
+        total = sum(s["dim"] * s.get("history_length", 1) for s in deploy_cfg["obs_layout"])
         assert total == deploy_cfg["obs_dim"]
 
 
@@ -198,7 +201,7 @@ class TestSchemaAssemblerVsDeploy:
         # Find the gyro block. layout order: cmd_jp, cmd_jv, anchor_ori, gyro,...
         # offset = 29 + 29 + 6 = 64
         offset = 29 + 29 + 6
-        gyro_block = obs[offset:offset + 3 * 5].reshape(5, 3)
+        gyro_block = obs[offset : offset + 3 * 5].reshape(5, 3)
         # Newest at the END (idx 4) = gyros[9]; oldest = gyros[5].
         expected = np.stack(gyros[5:10])
         np.testing.assert_array_equal(gyro_block, expected)
@@ -235,10 +238,10 @@ class TestTrainingAssemblerVsDeploy:
 
         # Initial buffer of zeros (matches tracking_obs.py allocation).
         buf = {
-            "gyro":          np.zeros((n_env, H, 3),  dtype=np.float32),
-            "joint_pos_rel": np.zeros((n_env, H, n),  dtype=np.float32),
-            "dof_vel":       np.zeros((n_env, H, n),  dtype=np.float32),
-            "last_actions":  np.zeros((n_env, H, n),  dtype=np.float32),
+            "gyro": np.zeros((n_env, H, 3), dtype=np.float32),
+            "joint_pos_rel": np.zeros((n_env, H, n), dtype=np.float32),
+            "dof_vel": np.zeros((n_env, H, n), dtype=np.float32),
+            "last_actions": np.zeros((n_env, H, n), dtype=np.float32),
         }
 
         all_segments = [_random_segments(rng) for _ in range(15)]
@@ -249,8 +252,8 @@ class TestTrainingAssemblerVsDeploy:
         for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
             buf[key][:, :, :] = s0[key][None, None, :]
         refs0 = {
-            "command_joint_pos":   s0["command_joint_pos"][None, :],
-            "command_joint_vel":   s0["command_joint_vel"][None, :],
+            "command_joint_pos": s0["command_joint_pos"][None, :],
+            "command_joint_vel": s0["command_joint_vel"][None, :],
             "motion_anchor_ori_b": s0["motion_anchor_ori_b"][None, :],
         }
         train_obs0 = self._training_actor_obs(buf, refs0, s0, n_env)
@@ -263,14 +266,13 @@ class TestTrainingAssemblerVsDeploy:
                 buf[key][:, :-1] = buf[key][:, 1:]
                 buf[key][:, -1] = sk[key][None, :]
             refs = {
-                "command_joint_pos":   sk["command_joint_pos"][None, :],
-                "command_joint_vel":   sk["command_joint_vel"][None, :],
+                "command_joint_pos": sk["command_joint_pos"][None, :],
+                "command_joint_vel": sk["command_joint_vel"][None, :],
                 "motion_anchor_ori_b": sk["motion_anchor_ori_b"][None, :],
             }
             train_obs = self._training_actor_obs(buf, refs, sk, n_env)
             np.testing.assert_array_equal(
-                train_obs[0], deploy_seq[k],
-                err_msg=f"training <-> deploy mismatch at step {k}"
+                train_obs[0], deploy_seq[k], err_msg=f"training <-> deploy mismatch at step {k}"
             )
 
 
@@ -281,13 +283,13 @@ class TestBackCompat:
     def legacy_cfg(self):
         n = 29
         obs_layout = [
-            {"name": "command_joint_pos",   "dim": n, "history_length": 1},
-            {"name": "command_joint_vel",   "dim": n, "history_length": 1},
+            {"name": "command_joint_pos", "dim": n, "history_length": 1},
+            {"name": "command_joint_vel", "dim": n, "history_length": 1},
             {"name": "motion_anchor_ori_b", "dim": 6, "history_length": 1},
-            {"name": "gyro",                "dim": 3, "history_length": 1},
-            {"name": "joint_pos_rel",       "dim": n, "history_length": 1},
-            {"name": "dof_vel",             "dim": n, "history_length": 1},
-            {"name": "last_actions",        "dim": n, "history_length": 1},
+            {"name": "gyro", "dim": 3, "history_length": 1},
+            {"name": "joint_pos_rel", "dim": n, "history_length": 1},
+            {"name": "dof_vel", "dim": n, "history_length": 1},
+            {"name": "last_actions", "dim": n, "history_length": 1},
         ]
         return {
             "obs_dim": 154,

--- a/tests/scripts/test_obs_alignment_g1_wbt.py
+++ b/tests/scripts/test_obs_alignment_g1_wbt.py
@@ -1,0 +1,310 @@
+"""Cross-side obs alignment test for the G1 WBT Obs deploy chain.
+
+This is the load-bearing test that ensures the train -> export -> deploy
+pipeline produces byte-identical actor obs at every step.  Three independent
+implementations are exercised against the SAME inputs:
+
+    1. Training side  — tracking_obs.py's _push_obs_history /
+                        _fill_obs_history + actor obs assembly in
+                        _build_actor_obs (replicated below in numpy).
+    2. Schema side    — sim_prototype.ObsAssembler driven by deploy_config.yaml.
+    3. Deploy side    — observation_manager.h::ObservationTermCfg semantics
+                        replicated in Python (oldest-first deque per term,
+                        group-by-term flatten, use_gym_history=false).
+
+If any pair diverges, redeployment will silently fail at runtime — better to
+catch it here than at the FSM transition with a robot on a rig.
+
+The test is hermetic: it does NOT spin up MuJoCo, does NOT load motion clips,
+and does NOT depend on training infra. It synthesizes fixed random inputs,
+runs the assembly on both sides, and asserts bit-for-bit equality.
+"""
+from __future__ import annotations
+
+import sys
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIM_PROTOTYPE = REPO_ROOT / "scripts" / "deploy" / "sim_prototype.py"
+
+
+def _load_sim_prototype():
+    """Import sim_prototype as a module (it's under scripts/, not src/)."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("sim_prototype", SIM_PROTOTYPE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sim_prototype"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Reference deque (mirrors deploy ObservationTermCfg::reset / add / get).
+# ---------------------------------------------------------------------------
+
+class _DeployTerm:
+    """Bit-for-bit copy of ObservationTermCfg buffer semantics.
+
+    reset(obs): add(obs) H times (== fill).
+    add(obs): push at back; if buffer > H, pop_front.
+    get(): concat deque front (oldest) to back (newest).
+    """
+
+    def __init__(self, dim: int, history_length: int) -> None:
+        self.dim = dim
+        self.H = history_length
+        self.buf: deque[np.ndarray] = deque()
+
+    def reset(self, val: np.ndarray) -> None:
+        v = np.asarray(val, dtype=np.float32).reshape(self.dim)
+        for _ in range(self.H):
+            self.add(v)
+
+    def add(self, val: np.ndarray) -> None:
+        v = np.asarray(val, dtype=np.float32).reshape(self.dim)
+        self.buf.append(v.copy())
+        while len(self.buf) > self.H:
+            self.buf.popleft()
+
+    def get(self) -> np.ndarray:
+        return np.concatenate([np.asarray(v) for v in self.buf]).astype(np.float32)
+
+
+def _deploy_compute_group(layout, current_segments_by_name):
+    """Mirror ObservationManager::compute_group with use_gym_history=False."""
+    terms = {}
+    for seg in layout:
+        terms[seg["name"]] = _DeployTerm(int(seg["dim"]), int(seg.get("history_length", 1)))
+    # Match deploy reset(): fill once with the FIRST step's value.
+    for seg in layout:
+        terms[seg["name"]].reset(current_segments_by_name[0][seg["name"]])
+    # First "step" inside compute_group calls term.add() once more BEFORE get();
+    # that final add corresponds to the current frame after the reset fill.
+    out_per_step = []
+    for step_idx, segments in enumerate(current_segments_by_name):
+        for seg in layout:
+            terms[seg["name"]].add(segments[seg["name"]])
+        # Concat each term's full history oldest-first, then across terms.
+        out = np.concatenate(
+            [terms[seg["name"]].get() for seg in layout], axis=0
+        ).astype(np.float32)
+        out_per_step.append(out)
+    return out_per_step
+
+
+# ---------------------------------------------------------------------------
+# Schema fixture — mirrors what export_deploy_config.py writes for the
+# deploy profile (H=5, both zero flags ON).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def deploy_cfg():
+    n = 29
+    H = 5
+    obs_layout = [
+        {"name": "command_joint_pos",   "dim": n, "history_length": 1},
+        {"name": "command_joint_vel",   "dim": n, "history_length": 1},
+        {"name": "motion_anchor_ori_b", "dim": 6, "history_length": 1},
+        {"name": "gyro",                "dim": 3, "history_length": H},
+        {"name": "joint_pos_rel",       "dim": n, "history_length": H},
+        {"name": "dof_vel",             "dim": n, "history_length": H},
+        {"name": "last_actions",        "dim": n, "history_length": H},
+    ]
+    total = sum(s["dim"] * s["history_length"] for s in obs_layout)
+    return {
+        "obs_dim": total,
+        "use_gym_history": False,
+        "action_dim": n,
+        "obs_layout": obs_layout,
+    }
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+def _random_segments(rng, num_action=29):
+    return {
+        "command_joint_pos":   rng.normal(size=num_action).astype(np.float32),
+        "command_joint_vel":   rng.normal(size=num_action).astype(np.float32),
+        "motion_anchor_ori_b": rng.normal(size=6).astype(np.float32),
+        "gyro":                rng.normal(size=3).astype(np.float32),
+        "joint_pos_rel":       rng.normal(size=num_action).astype(np.float32),
+        "dof_vel":             rng.normal(size=num_action).astype(np.float32),
+        "last_actions":        rng.normal(size=num_action).astype(np.float32),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestObsDim:
+    def test_deploy_profile_dim_is_514(self, deploy_cfg):
+        assert deploy_cfg["obs_dim"] == 514
+
+    def test_layout_sum_matches_obs_dim(self, deploy_cfg):
+        total = sum(
+            s["dim"] * s.get("history_length", 1) for s in deploy_cfg["obs_layout"]
+        )
+        assert total == deploy_cfg["obs_dim"]
+
+
+class TestSchemaAssemblerVsDeploy:
+    """sim_prototype.ObsAssembler vs the deploy-side ObservationTermCfg."""
+
+    def test_first_step_matches_deploy_reset_then_add(self, deploy_cfg, rng):
+        sp = _load_sim_prototype()
+        assembler = sp.ObsAssembler(deploy_cfg)
+
+        seg0 = _random_segments(rng)
+        prototype = assembler.step(seg0)
+
+        deploy = _deploy_compute_group(deploy_cfg["obs_layout"], [seg0])[0]
+
+        np.testing.assert_array_equal(prototype, deploy)
+
+    def test_multi_step_buffer_eviction_matches_deploy(self, deploy_cfg, rng):
+        sp = _load_sim_prototype()
+        assembler = sp.ObsAssembler(deploy_cfg)
+
+        all_segments = [_random_segments(rng) for _ in range(20)]
+        prototype_seq = [assembler.step(s) for s in all_segments]
+        deploy_seq = _deploy_compute_group(deploy_cfg["obs_layout"], all_segments)
+
+        for k, (p, d) in enumerate(zip(prototype_seq, deploy_seq)):
+            np.testing.assert_array_equal(
+                p, d, err_msg=f"sim_prototype <-> deploy mismatch at step {k}"
+            )
+
+    def test_history_terms_carry_oldest_first(self, deploy_cfg, rng):
+        """Spot-check the gyro history block manually: at step k>=H, the 5*3
+        gyro slot of obs should be [gyro_{k-H+1}, gyro_{k-H+2}, ..., gyro_k]
+        flattened, NOT the reverse."""
+        sp = _load_sim_prototype()
+        assembler = sp.ObsAssembler(deploy_cfg)
+
+        gyros = [np.array([float(k), 0.0, 0.0], dtype=np.float32) for k in range(10)]
+        for k in range(10):
+            seg = _random_segments(rng)
+            seg["gyro"] = gyros[k]
+            obs = assembler.step(seg)
+
+        # Find the gyro block. layout order: cmd_jp, cmd_jv, anchor_ori, gyro,...
+        # offset = 29 + 29 + 6 = 64
+        offset = 29 + 29 + 6
+        gyro_block = obs[offset:offset + 3 * 5].reshape(5, 3)
+        # Newest at the END (idx 4) = gyros[9]; oldest = gyros[5].
+        expected = np.stack(gyros[5:10])
+        np.testing.assert_array_equal(gyro_block, expected)
+
+
+class TestTrainingAssemblerVsDeploy:
+    """Replicate training-side history maintenance (np ring buffer) and compare.
+
+    This replicates the exact buffer logic from tracking_obs.py:
+        * _fill_obs_history: buf[:, :] = val[:, None, :]
+        * _push_obs_history: buf[:, :-1] = buf[:, 1:]; buf[:, -1] = val
+    and the actor obs assembly: refs first, then per-term history blocks
+    (gyro, joint_pos_rel, dof_vel, last_actions) flattened (n_env, H*dim).
+    """
+
+    @staticmethod
+    def _training_actor_obs(history_buf, current_refs, hist_components, num_envs):
+        # refs (single-step)
+        parts = [
+            current_refs["command_joint_pos"],
+            current_refs["command_joint_vel"],
+            current_refs["motion_anchor_ori_b"],
+        ]
+        # proprio history (oldest-first per term, then concat across terms)
+        for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
+            buf = history_buf[key]  # (num_envs, H, D)
+            parts.append(buf.reshape(num_envs, -1))
+        return np.concatenate(parts, axis=1).astype(np.float32)
+
+    def test_training_path_matches_deploy(self, deploy_cfg, rng):
+        n_env = 1
+        n = deploy_cfg["action_dim"]
+        H = 5
+
+        # Initial buffer of zeros (matches tracking_obs.py allocation).
+        buf = {
+            "gyro":          np.zeros((n_env, H, 3),  dtype=np.float32),
+            "joint_pos_rel": np.zeros((n_env, H, n),  dtype=np.float32),
+            "dof_vel":       np.zeros((n_env, H, n),  dtype=np.float32),
+            "last_actions":  np.zeros((n_env, H, n),  dtype=np.float32),
+        }
+
+        all_segments = [_random_segments(rng) for _ in range(15)]
+        deploy_seq = _deploy_compute_group(deploy_cfg["obs_layout"], all_segments)
+
+        # Step 0: reset (matches tracking_obs.py is_reset=True path).
+        s0 = all_segments[0]
+        for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
+            buf[key][:, :, :] = s0[key][None, None, :]
+        refs0 = {
+            "command_joint_pos":   s0["command_joint_pos"][None, :],
+            "command_joint_vel":   s0["command_joint_vel"][None, :],
+            "motion_anchor_ori_b": s0["motion_anchor_ori_b"][None, :],
+        }
+        train_obs0 = self._training_actor_obs(buf, refs0, s0, n_env)
+        np.testing.assert_array_equal(train_obs0[0], deploy_seq[0])
+
+        # Steps 1..N-1: push (matches tracking_obs.py is_reset=False path).
+        for k in range(1, len(all_segments)):
+            sk = all_segments[k]
+            for key in ("gyro", "joint_pos_rel", "dof_vel", "last_actions"):
+                buf[key][:, :-1] = buf[key][:, 1:]
+                buf[key][:, -1] = sk[key][None, :]
+            refs = {
+                "command_joint_pos":   sk["command_joint_pos"][None, :],
+                "command_joint_vel":   sk["command_joint_vel"][None, :],
+                "motion_anchor_ori_b": sk["motion_anchor_ori_b"][None, :],
+            }
+            train_obs = self._training_actor_obs(buf, refs, sk, n_env)
+            np.testing.assert_array_equal(
+                train_obs[0], deploy_seq[k],
+                err_msg=f"training <-> deploy mismatch at step {k}"
+            )
+
+
+class TestBackCompat:
+    """H=1 ('no history') must reproduce the pre-history 154-d path bit-exact."""
+
+    @pytest.fixture
+    def legacy_cfg(self):
+        n = 29
+        obs_layout = [
+            {"name": "command_joint_pos",   "dim": n, "history_length": 1},
+            {"name": "command_joint_vel",   "dim": n, "history_length": 1},
+            {"name": "motion_anchor_ori_b", "dim": 6, "history_length": 1},
+            {"name": "gyro",                "dim": 3, "history_length": 1},
+            {"name": "joint_pos_rel",       "dim": n, "history_length": 1},
+            {"name": "dof_vel",             "dim": n, "history_length": 1},
+            {"name": "last_actions",        "dim": n, "history_length": 1},
+        ]
+        return {
+            "obs_dim": 154,
+            "use_gym_history": False,
+            "action_dim": n,
+            "obs_layout": obs_layout,
+        }
+
+    def test_legacy_obs_dim_154(self, legacy_cfg):
+        assert legacy_cfg["obs_dim"] == 154
+
+    def test_legacy_matches_simple_concat(self, legacy_cfg, rng):
+        sp = _load_sim_prototype()
+        assembler = sp.ObsAssembler(legacy_cfg)
+
+        for _ in range(5):
+            seg = _random_segments(rng)
+            obs = assembler.step(seg)
+            expected = np.concatenate([seg[s["name"]] for s in legacy_cfg["obs_layout"]])
+            np.testing.assert_array_equal(obs, expected)


### PR DESCRIPTION
## Summary

- **what changed**: Adds a new SAC whole-body tracking task `g1_wbt_obs`, registered as `G1WBTObs` via a strict subclass of `G1MotionTrackingSACEnv` in `src/unilab/envs/motion_tracking/g1/tracking_obs.py`. The subclass carries the sim2real-aligned actor obs schema, extended domain randomization, and two extra reward terms; its task yaml is a field-by-field port of the active deploy training profile (Stage 4+5 of the `feat/g1_deploy_v2` branch). Five deploy-chain tools (`scripts/deploy/*.py`) and a cross-side obs alignment test (`tests/scripts/test_obs_alignment_g1_wbt.py`) are added. Also fixes a stale import in `scripts/motion/remap_fullbody_npz.py` that was broken on `main` since the `utils.xml_utils → base.backend.mujoco.xml` refactor.
- **why it changed**: The deploy training pipeline from `feat/g1_deploy_v2` (used for ONNX-on-real-G1 runs) needs to land on main as a clean, isolated task without regressing any existing one. Cherry-picking 17 iterative tuning commits would carry conflicts and intermediate stages the user doesn't want to preserve; a single re-port into a new task is cleaner and easier to review.
- **any user-facing or training-impact behavior**:
  - **New CLI** (this PR's new training pipeline): `uv run train --algo sac --task g1_wbt_obs --sim mujoco training.use_amp=true`.
  - **Existing CLI sanity-checked** (verified to still behave exactly as on `main`): `uv run scripts/train_offpolicy.py algo=sac task=sac/g1_sac_wbt/mujoco training.use_amp=true algo.seed=1 +env.motion_file=/home/Yves/ws/UniLab/src/unilab/assets/motions/g1/sub3_largebox_003.npz`.
  - **Actor obs**: 514 d = `command(58) + anchor_ori(6) + 5×(gyro 3 + joint_pos_rel 29 + dof_vel 29 + last_actions 29)`. Byte-aligned with the deploy-side `ObservationManager` running in group-by-term mode (`use_gym_history=false`).
  - **Critic obs**: 289 d (asymmetric, single-step, includes privileged body transforms + base linvel — same SAC-style critic as `g1_sac_wbt`).
  - **Extra DR**: per-episode encoder bias on actor's `joint_pos`; foot-geom friction sampled across regex-matched geoms; y/z COM offsets stacked on the existing x offset.
  - **Extra rewards**: `joint_acc_l2` (Δdof_vel / ctrl_dt) and `joint_torque_l2` (`τ ≈ kp·Δq − kd·qd`), both opt-in via the task yaml.
  - **Pelvis IMU**: yaml-driven via `env.sensor.{gyro,upvector,local_linvel}: pelvis_*`. No XML duplication — `g1.xml` on `main` already exposes both pelvis and torso IMU sensors.
  - **Other tasks**: completely unaffected. `G1MotionTrackingSAC` / `G1MotionTracking` / `G1MotionTrackingDeploy` / `G1FlipTracking` / `G1WallFlipTracking` / `G1ClimbTracking` / `G1BoxTracking` all keep their pre-change `obs_groups_spec`, reward set, DR provider, and cfg types (verified by the audit script under Validation).

## Linked Work

- Issue:
- Milestone: G1 sim2real WBT v1 deploy

## Validation

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `uv run pytest tests/` — 953 passed, 12 skipped, 0 failed
- [x] Task-specific: env-construction smoke + obs-dim regression on the 4 existing motion-tracking tasks, plus 3-way obs alignment cross-check (training-side ring buffer ↔ deploy `ObservationTermCfg` ↔ `sim_prototype.ObsAssembler`) at both 154-d (H=1) and 514-d (H=5) schemas.
- [x] Existing `g1_sac_wbt` training pipeline confirmed unchanged by author run with custom motion file.
- [ ] `make test-all` (per repo PR gate — to be confirmed by the author on their box before merge)

Commands actually run:

​```bash
uv run --no-sync pytest tests/scripts/test_obs_alignment_g1_wbt.py -v
uv run --no-sync python -c "
import unilab.envs.motion_tracking
from unilab.base import registry
import yaml
env = registry.make('G1MotionTrackingSAC', sim_backend='mujoco', num_envs=2)
assert env.obs_groups_spec == {'obs': 160, 'critic': 289}
assert type(env._cfg.noise_config).__name__ == 'NoiseConfig'
assert type(env._cfg.domain_rand).__name__ == 'Domain_Rand'
cfg = yaml.safe_load(open('conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml'))
env2 = registry.make('G1WBTObs', sim_backend='mujoco', num_envs=2,
                     env_cfg_override=cfg['env'])
assert env2.obs_groups_spec == {'obs': 514, 'critic': 289}
"

# New training pipeline (this PR)
uv run train --algo sac --task g1_wbt_obs --sim mujoco training.use_amp=true

# Existing pipeline sanity-checked by author (must still behave as on main)
uv run scripts/train_offpolicy.py algo=sac task=sac/g1_sac_wbt/mujoco training.use_amp=true algo.seed=1 +env.motion_file=~/UniLab/src/unilab/assets/motions/g1/sub3_largebox_003.npz
​```

## Impact

- Backend impact: `mujoco` (motrix is registered as well for sim2sim eval/playback only, same pattern as `G1MotionTrackingSAC`)
- Platform impact: Linux (same coverage as the parent task)
- Training effect expected: yes — but only for runs that explicitly select `--task g1_wbt_obs`. Existing tasks unchanged.

## Artifacts

- W&B:
- benchmark result: n/a (port, not a perf change)
- video / screenshot:
- ONNX / checkpoint: existing deploy checkpoints from `feat/g1_deploy_v2` are bit-compatible with this task — same 514-d actor obs schema, same channel order, same `scripts/deploy/export_deploy_config.py` output.

## Checklist

- [x] Added or updated tests where needed (`tests/scripts/test_obs_alignment_g1_wbt.py`, 8 cases, hermetic, < 0.2 s)
- [x] Updated docs if behavior or workflow changed (`docs/users/zh_CN/D-tasks/02-g1-motion-tracking.md` — added task row, config entry, CLI, and explanatory paragraph; regenerated `docs/users/zh_CN/E-reference/01-backend-support-matrix.md` via `scripts/generate_support_matrix.py --write`)
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly: none — this is a complete port. The deploy-side C++ already runs against the 514-d schema this task produces, so no downstream changes required.