### PR TITLE
Feat/dynamic shell completion #490 #479

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,20 @@
 sync:
 	uv sync
 
+.PHONY: setup
+setup:
+	uv sync
+	uv run --no-sync unilab-complete install
+
+.PHONY: setup-motrix
+setup-motrix:
+	uv sync --extra motrix
+	uv run --no-sync unilab-complete install
+
+.PHONY: install-completion
+install-completion:
+	uv run --no-sync unilab-complete install
+
 .PHONY: sync-rocm
 sync-rocm:
 	@cp pyproject.rocm.toml pyproject.toml

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ cd UniLab
 # Choose exactly one command for your platform; do not run all three.
 
 # Linux CUDA or macOS
-uv sync --extra motrix
+make setup-motrix
+# Without shell completion setup: uv sync --extra motrix
 
 # Linux AMD / ROCm
 # make sync-rocm

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cd UniLab
 # Linux CUDA or macOS
 make setup-motrix
 # Without shell completion setup: uv sync --extra motrix
+# If `make` is not installed: uv sync --extra motrix && uv run --no-sync unilab-complete install
 
 # Linux AMD / ROCm
 # make sync-rocm

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ UniLab uses **CPU simulation + shared-memory runtime + GPU learning** instead of
 ```
 
 Start with the `Quick Demo` below to run the primary training command from this repository.
+Conda and pip users should still follow the repository `uv` workflow for now; see [安装与环境](docs/users/zh_CN/A-getting-started/01-install.md#conda--pip-用户说明) for the current boundaries.
 
 ## 🚀 Quick Demo
 

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -44,6 +44,7 @@ uv run demo
 ## 去哪里找细节
 
 - 安装命令、国内镜像、ROCm / XPU 注意事项：见 [安装与环境](A-getting-started/01-install.md)
+- conda / pip 用户的当前支持边界：见 [安装与环境](A-getting-started/01-install.md#conda--pip-用户说明)
 - `train` / `eval` / `demo` 细节：见 [训练指南](03-training.md)
 - backend 差异：见 [仿真后端](02-simulation-backends.md)
 - 精确支持状态：见 [后端支持矩阵](E-reference/01-backend-support-matrix.md)

--- a/docs/users/zh_CN/01-getting-started.md
+++ b/docs/users/zh_CN/01-getting-started.md
@@ -17,7 +17,7 @@
 
 | 平台 | 安装命令 | 运行说明 |
 |------|----------|----------|
-| Linux CUDA / macOS | `uv sync --extra motrix` | 常规使用 `uv run ...` |
+| Linux CUDA / macOS | `make setup-motrix` | 常规使用 `uv run ...`；底层同步命令是 `uv sync --extra motrix` |
 | Linux AMD / ROCm | `make sync-rocm` | 后续命令使用 `uv run ...` |
 | Linux Intel Arc / iGPU | `make sync-xpu` | 后续命令使用 `uv run --no-sync ...` |
 

--- a/docs/users/zh_CN/A-getting-started/01-install.md
+++ b/docs/users/zh_CN/A-getting-started/01-install.md
@@ -14,7 +14,7 @@ cd UniLab
 
 ## conda / pip 用户说明
 
-当前推荐路径仍然是源码仓库内的 `uv` 工作流：用 `uv sync` 同步依赖，用 `uv run train` / `uv run eval` / `uv run demo` 运行命令。conda 可以作为外层 Python、CUDA 或系统库隔离环境，但进入环境后仍建议继续使用本仓库的 `uv` 命令。
+当前推荐路径仍然是源码仓库内的 `make setup` / `uv` 工作流：优先用 `make setup` 或 `make setup-motrix` 同步依赖并安装 Tab 补全，后续用 `uv run train` / `uv run eval` / `uv run demo` 运行命令。conda 可以作为外层 Python、CUDA 或系统库隔离环境，但进入环境后仍建议继续使用本仓库的 `make` / `uv` 命令。
 
 ```bash
 conda create -n unilab python=3.13
@@ -22,10 +22,10 @@ conda activate unilab
 pip install uv
 git clone https://github.com/unilabsim/UniLab.git
 cd UniLab
-uv sync --extra motrix
+make setup-motrix
 ```
 
-如果不需要 Motrix，可按平台表选择不带 extra 的默认同步，或使用 ROCm / XPU 的专用 `make` 路径。中国大陆镜像用户可同时配置 conda、pip 和 uv 镜像，但最终仍以 `uv sync` 生成的仓库环境为准。
+如果不需要 Motrix，可使用 `make setup`；如果只想手动同步依赖、不写 shell rc，可继续使用底层命令 `uv sync` 或 `uv sync --extra motrix`。ROCm / XPU 仍使用下方专用 `make` 路径。中国大陆镜像用户可同时配置 conda、pip 和 uv 镜像，但最终仍以 `uv sync` 生成的仓库环境为准。
 
 `pip install -e .` 和 `pip install .` 当前只适合源码 checkout 内的开发验证，不代表已经支持在任意目录通过 wheel / sdist 直接运行训练。训练入口仍依赖仓库中的 `conf/` 和 `scripts/`；pip-only 安装、构建包后仓库外运行，以及正式发布 wheel 的验证路径由 #360 跟踪。
 
@@ -43,7 +43,7 @@ brew install cmake
 
 | 平台 | 同步命令 | 运行说明 |
 |------|----------|----------|
-| Linux CUDA / macOS | `uv sync --extra motrix` | 常规训练直接用 `uv run ...` |
+| Linux CUDA / macOS | `make setup-motrix` | 同步 Motrix 依赖并安装 Tab 补全；底层命令是 `uv sync --extra motrix` |
 | Linux AMD / ROCm | `make sync-rocm` | 后续命令用 `uv run ...` |
 | Linux Intel Arc / iGPU | `make sync-xpu` | 后续命令用 `uv run --no-sync ...` |
 
@@ -51,7 +51,7 @@ ROCm 路径的额外约束：
 
 - `make sync-rocm` 要求 ROCm >= 7.1，并按仓库的 ROCm 依赖文件安装对应 PyTorch wheel。
 - `make sync-rocm` 会把 `pyproject.rocm.toml` / `uv.rocm.lock` 激活为当前 `pyproject.toml` / `uv.lock`，所以后续可以直接用裸 `uv run ...`。
-- 切回默认 CUDA / macOS profile 时运行 `git restore -- pyproject.toml uv.lock`，然后重新执行 `uv sync --extra motrix`；提交非 ROCm 依赖改动前应确认当前 profile。
+- 切回默认 CUDA / macOS profile 时运行 `git restore -- pyproject.toml uv.lock`，然后重新执行 `make setup-motrix` 或 `uv sync --extra motrix`；提交非 ROCm 依赖改动前应确认当前 profile。
 - 训练配置里的设备字段仍然沿用 `cuda` 语义，不需要改成 `rocm`。
 
 Intel XPU 路径同样建议保持 `uv run --no-sync ...`，避免把默认 Linux 依赖重新同步回来。Ubuntu 24.04+ / 26.04 上还需要系统驱动包，例如 `intel-opencl-icd` 和 `libze-intel-gpu1`；off-policy 训练可按需加 `training.use_amp=true`。
@@ -65,7 +65,7 @@ uv sync --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 
 ## 4. 安装后先确认什么
 
-- 需要 Motrix 路径时，先确认 `uv sync --extra motrix` 已完成。
+- 需要 Motrix 路径时，先确认 `make setup-motrix` 或 `uv sync --extra motrix` 已完成。
 - 需要 MuJoCo 路径时，确认本机 MuJoCo runtime 可用。
 - 第一次训练命令建议先跑一个最小任务，再决定是否做 `make test-all`。
 - 想直接确认脚本入口也可用时，可先跑 `uv run scripts/train_rsl_rl.py task=go2_joystick_flat/motrix`。

--- a/docs/users/zh_CN/A-getting-started/01-install.md
+++ b/docs/users/zh_CN/A-getting-started/01-install.md
@@ -12,6 +12,25 @@ git clone https://github.com/unilabsim/UniLab.git
 cd UniLab
 ```
 
+## conda / pip 用户说明
+
+当前推荐路径仍然是源码仓库内的 `uv` 工作流：用 `uv sync` 同步依赖，用 `uv run train` / `uv run eval` / `uv run demo` 运行命令。conda 可以作为外层 Python、CUDA 或系统库隔离环境，但进入环境后仍建议继续使用本仓库的 `uv` 命令。
+
+```bash
+conda create -n unilab python=3.13
+conda activate unilab
+pip install uv
+git clone https://github.com/unilabsim/UniLab.git
+cd UniLab
+uv sync --extra motrix
+```
+
+如果不需要 Motrix，可按平台表选择不带 extra 的默认同步，或使用 ROCm / XPU 的专用 `make` 路径。中国大陆镜像用户可同时配置 conda、pip 和 uv 镜像，但最终仍以 `uv sync` 生成的仓库环境为准。
+
+`pip install -e .` 和 `pip install .` 当前只适合源码 checkout 内的开发验证，不代表已经支持在任意目录通过 wheel / sdist 直接运行训练。训练入口仍依赖仓库中的 `conf/` 和 `scripts/`；pip-only 安装、构建包后仓库外运行，以及正式发布 wheel 的验证路径由 #360 跟踪。
+
+可选后端依赖由对应同步路径安装：Motrix 使用 `uv sync --extra motrix`，MuJoCo 仍需要本机 runtime 可用，ROCm / XPU 依赖按下方平台命令处理。后端选择仍通过 `--sim` 路由到 task owner 配置，不要单独 override `training.sim_backend` 来切换后端。
+
 ## 2. 安装系统依赖
 
 ```bash

--- a/docs/users/zh_CN/A-getting-started/01-install.md
+++ b/docs/users/zh_CN/A-getting-started/01-install.md
@@ -27,6 +27,8 @@ make setup-motrix
 
 如果不需要 Motrix，可使用 `make setup`；如果只想手动同步依赖、不写 shell rc，可继续使用底层命令 `uv sync` 或 `uv sync --extra motrix`。ROCm / XPU 仍使用下方专用 `make` 路径。中国大陆镜像用户可同时配置 conda、pip 和 uv 镜像，但最终仍以 `uv sync` 生成的仓库环境为准。
 
+`make setup` / `make setup-motrix` 要求本机已安装 `make`。如果系统没有 `make`，可直接执行等价命令：`uv sync --extra motrix && uv run --no-sync unilab-complete install`，或不需要 Motrix 时执行 `uv sync && uv run --no-sync unilab-complete install`。
+
 `pip install -e .` 和 `pip install .` 当前只适合源码 checkout 内的开发验证，不代表已经支持在任意目录通过 wheel / sdist 直接运行训练。训练入口仍依赖仓库中的 `conf/` 和 `scripts/`；pip-only 安装、构建包后仓库外运行，以及正式发布 wheel 的验证路径由 #360 跟踪。
 
 可选后端依赖由对应同步路径安装：Motrix 使用 `uv sync --extra motrix`，MuJoCo 仍需要本机 runtime 可用，ROCm / XPU 依赖按下方平台命令处理。后端选择仍通过 `--sim` 路由到 task owner 配置，不要单独 override `training.sim_backend` 来切换后端。
@@ -46,6 +48,8 @@ brew install cmake
 | Linux CUDA / macOS | `make setup-motrix` | 同步 Motrix 依赖并安装 Tab 补全；底层命令是 `uv sync --extra motrix` |
 | Linux AMD / ROCm | `make sync-rocm` | 后续命令用 `uv run ...` |
 | Linux Intel Arc / iGPU | `make sync-xpu` | 后续命令用 `uv run --no-sync ...` |
+
+`make` 不可用时，Linux CUDA / macOS 可改用 `uv sync --extra motrix && uv run --no-sync unilab-complete install`。
 
 ROCm 路径的额外约束：
 

--- a/docs/users/zh_CN/B-training/01-unified-cli.md
+++ b/docs/users/zh_CN/B-training/01-unified-cli.md
@@ -21,7 +21,18 @@ uv run train --algo mlx_ppo --task go2_joystick_flat --sim mujoco
 
 ## Tab 自动补全
 
-补全脚本是可选项，只补全 `uv run train` 和 `uv run eval` 的入口、flags 和部分 choices，不改变命令行为。Linux / WSL Bash 用户可把下面内容写入 `~/.bashrc`：
+补全脚本是可选项，只补全 `uv run train` 和 `uv run eval` 的入口、flags 和部分 choices，不改变命令行为。新环境可用一条 setup 命令完成同步和补全安装：
+
+```bash
+make setup
+
+# 需要 Motrix 时：
+make setup-motrix
+```
+
+`make setup` 会执行 `uv sync` 和 `uv run --no-sync unilab-complete install`；`make setup-motrix` 会执行 `uv sync --extra motrix` 和同样的补全安装。安装命令会按 `$SHELL` / 平台选择 Bash 或 Zsh，只写入用户级 rc 文件。当前终端不会被子进程自动激活，重新打开终端或 source 对应 rc 文件后生效。
+
+Linux / WSL Bash 用户也可手动把下面内容写入 `~/.bashrc`：
 
 ```bash
 if [ -f "/path_to_unilab/UniLab/scripts/completions/unilab.bash" ]; then

--- a/docs/users/zh_CN/B-training/01-unified-cli.md
+++ b/docs/users/zh_CN/B-training/01-unified-cli.md
@@ -32,6 +32,8 @@ make setup-motrix
 
 `make setup` 会执行 `uv sync` 和 `uv run --no-sync unilab-complete install`；`make setup-motrix` 会执行 `uv sync --extra motrix` 和同样的补全安装。安装命令会按 `$SHELL` / 平台选择 Bash 或 Zsh，只写入用户级 rc 文件。当前终端不会被子进程自动激活，重新打开终端或 source 对应 rc 文件后生效。
 
+`make setup` / `make setup-motrix` 要求本机已安装 `make`。如果系统没有 `make`，可直接执行 `uv sync && uv run --no-sync unilab-complete install`，或需要 Motrix 时执行 `uv sync --extra motrix && uv run --no-sync unilab-complete install`。
+
 Linux / WSL Bash 用户也可手动把下面内容写入 `~/.bashrc`：
 
 ```bash

--- a/docs/users/zh_CN/B-training/01-unified-cli.md
+++ b/docs/users/zh_CN/B-training/01-unified-cli.md
@@ -19,6 +19,26 @@ uv run train --algo mlx_ppo --task go2_joystick_flat --sim mujoco
 
 支持的后端：`mujoco`、`motrix`
 
+## Tab 自动补全
+
+补全脚本是可选项，只补全 `uv run train` 和 `uv run eval` 的入口、flags 和部分 choices，不改变命令行为。Linux / WSL Bash 用户可把下面内容写入 `~/.bashrc`：
+
+```bash
+if [ -f "/path_to_unilab/UniLab/scripts/completions/unilab.bash" ]; then
+    source "/path_to_unilab/UniLab/scripts/completions/unilab.bash"
+fi
+```
+
+macOS 默认 Zsh 用户可把下面内容写入 `~/.zshrc`：
+
+```zsh
+autoload -Uz compinit
+compinit
+source "/path_to_unilab/UniLab/scripts/completions/unilab.zsh"
+```
+
+重新打开终端或 source 对应 rc 文件后，可用 `uv run <TAB>`、`uv run train --algo <TAB>`、`uv run train --sim <TAB>` 查看候选项。把 `/path_to_unilab/UniLab` 替换成你的 UniLab checkout 路径。
+
 ## eval
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 train = "unilab.cli:train_main"
 eval = "unilab.cli:eval_main"
 demo = "unilab.cli:demo_main"
+unilab-complete = "unilab.tools.completion:main"
 unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 

--- a/scripts/completions/unilab.bash
+++ b/scripts/completions/unilab.bash
@@ -1,0 +1,21 @@
+# Bash completion for UniLab commands launched through `uv run`.
+
+_unilab_uv_complete() {
+    COMPREPLY=()
+
+    if [[ ${#COMP_WORDS[@]} -lt 2 || ${COMP_WORDS[0]} != "uv" || ${COMP_WORDS[1]} != "run" ]]; then
+        return 0
+    fi
+
+    local candidates
+    if ! mapfile -t candidates < <(
+        uv run --no-sync unilab-complete --cword "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null \
+            || uv run --no-sync python -m unilab.tools.completion --cword "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null
+    ); then
+        return 0
+    fi
+
+    COMPREPLY=("${candidates[@]}")
+}
+
+complete -F _unilab_uv_complete uv

--- a/scripts/completions/unilab.zsh
+++ b/scripts/completions/unilab.zsh
@@ -1,0 +1,22 @@
+#compdef uv
+# Zsh completion for UniLab commands launched through `uv run`.
+
+_unilab_uv_complete() {
+    if (( ${#words[@]} < 2 )) || [[ ${words[1]} != "uv" || ${words[2]} != "run" ]]; then
+        return 0
+    fi
+
+    local output
+    output="$(
+        uv run --no-sync unilab-complete --cword "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null \
+            || uv run --no-sync python -m unilab.tools.completion --cword "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null
+    )" || return 0
+
+    [[ -n "$output" ]] || return 0
+
+    local -a candidates
+    candidates=("${(@f)output}")
+    compadd -- "${candidates[@]}"
+}
+
+compdef _unilab_uv_complete uv

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -24,10 +24,19 @@ SUPPORTED_SHELLS = ("bash", "zsh")
 
 
 @dataclass(frozen=True)
+class TaskCompletionEntry:
+    algo: str
+    task: str
+    sim: str
+    owner: str
+
+
+@dataclass(frozen=True)
 class CompletionMetadata:
     commands: tuple[str, ...]
     flags: dict[str, tuple[str, ...]]
     choices: dict[str, dict[str, tuple[str, ...]]]
+    tasks: tuple[TaskCompletionEntry, ...]
 
 
 def _find_project_root(start: Path) -> Path | None:
@@ -91,6 +100,68 @@ def _parser_choices(command: str) -> dict[str, tuple[str, ...]]:
     return choices
 
 
+def _sim_from_owner(owner: str) -> str | None:
+    for sim in cli.SUPPORTED_SIMS:
+        if owner == sim or owner.startswith(f"{sim}_"):
+            return sim
+    return None
+
+
+def _task_entries_for_group(
+    root: Path, group: str, algos: Sequence[str]
+) -> list[TaskCompletionEntry]:
+    entries: list[TaskCompletionEntry] = []
+    task_root = root / "conf" / group / "task"
+    if not task_root.is_dir():
+        return entries
+    for task_dir in sorted(path for path in task_root.iterdir() if path.is_dir()):
+        for owner_yaml in sorted(task_dir.glob("*.yaml")):
+            sim = _sim_from_owner(owner_yaml.stem)
+            if sim is None:
+                continue
+            entries.extend(
+                TaskCompletionEntry(algo=algo, task=task_dir.name, sim=sim, owner=owner_yaml.stem)
+                for algo in algos
+            )
+    return entries
+
+
+def _task_entries_for_offpolicy(root: Path) -> list[TaskCompletionEntry]:
+    entries: list[TaskCompletionEntry] = []
+    task_root = root / "conf" / "offpolicy" / "task"
+    if not task_root.is_dir():
+        return entries
+    for algo in cli.SUPPORTED_ALGOS:
+        algo_root = task_root / algo
+        if not algo_root.is_dir():
+            continue
+        for task_dir in sorted(path for path in algo_root.iterdir() if path.is_dir()):
+            for owner_yaml in sorted(task_dir.glob("*.yaml")):
+                sim = _sim_from_owner(owner_yaml.stem)
+                if sim is None:
+                    continue
+                entries.append(
+                    TaskCompletionEntry(
+                        algo=algo,
+                        task=task_dir.name,
+                        sim=sim,
+                        owner=owner_yaml.stem,
+                    )
+                )
+    return entries
+
+
+def _task_entries(root: Path) -> tuple[TaskCompletionEntry, ...]:
+    entries = [
+        *_task_entries_for_group(root, "ppo", ("ppo", "mlx_ppo")),
+        *_task_entries_for_group(root, "appo", ("appo",)),
+        *_task_entries_for_offpolicy(root),
+    ]
+    return tuple(
+        sorted(entries, key=lambda entry: (entry.task, entry.algo, entry.sim, entry.owner))
+    )
+
+
 def build_metadata(root: Path | None = None) -> CompletionMetadata:
     selected_root = root or _find_project_root(Path.cwd()) or cli.repo_root()
     scripts = _read_project_scripts(selected_root / "pyproject.toml")
@@ -99,6 +170,7 @@ def build_metadata(root: Path | None = None) -> CompletionMetadata:
         commands=commands,
         flags={command: _parser_flags(command) for command in commands},
         choices={command: _parser_choices(command) for command in commands},
+        tasks=_task_entries(selected_root),
     )
 
 
@@ -116,6 +188,58 @@ def _previous_word(words: Sequence[str], cword: int) -> str:
 
 def _matching(candidates: Sequence[str], prefix: str) -> list[str]:
     return [candidate for candidate in candidates if candidate.startswith(prefix)]
+
+
+def _option_state(words: Sequence[str], cword: int) -> tuple[dict[str, str], set[str]]:
+    values: dict[str, str] = {}
+    used: set[str] = set()
+    index = 3
+    limit = min(cword, len(words))
+    while index < limit:
+        token = words[index]
+        if not token.startswith("--"):
+            index += 1
+            continue
+        if "=" in token:
+            option, value = token.split("=", 1)
+            used.add(option)
+            values[option] = value
+            index += 1
+            continue
+        used.add(token)
+        if index + 1 < limit and not words[index + 1].startswith("--"):
+            values[token] = words[index + 1]
+            index += 2
+            continue
+        index += 1
+    return values, used
+
+
+def _available_flags(metadata: CompletionMetadata, command: str, used: set[str]) -> tuple[str, ...]:
+    return tuple(flag for flag in metadata.flags.get(command, ()) if flag not in used)
+
+
+def _task_choices(
+    metadata: CompletionMetadata,
+    *,
+    prefix: str,
+    selected_algo: str | None,
+    selected_sim: str | None,
+    selected_profile: str | None,
+) -> list[str]:
+    tasks: set[str] = set()
+    for entry in metadata.tasks:
+        if selected_algo is not None and entry.algo != selected_algo:
+            continue
+        if selected_sim is not None and entry.sim != selected_sim:
+            continue
+        if selected_profile is not None:
+            if selected_sim is not None and entry.owner != f"{selected_sim}_{selected_profile}":
+                continue
+            if selected_sim is None and not entry.owner.endswith(f"_{selected_profile}"):
+                continue
+        tasks.add(entry.task)
+    return _matching(tuple(sorted(tasks)), prefix)
 
 
 def complete_words(
@@ -136,11 +260,20 @@ def complete_words(
         return []
 
     previous = _previous_word(words, cword)
+    option_values, used_options = _option_state(words, cword)
     choices = selected_metadata.choices.get(command, {})
+    if previous == "--task":
+        return _task_choices(
+            selected_metadata,
+            prefix=current,
+            selected_algo=option_values.get("--algo"),
+            selected_sim=option_values.get("--sim"),
+            selected_profile=option_values.get("--profile"),
+        )
     if previous in choices:
         return _matching(choices[previous], current)
-    if current.startswith("-") or previous == command:
-        return _matching(selected_metadata.flags.get(command, ()), current)
+    if current == "" or current.startswith("-") or previous == command:
+        return _matching(_available_flags(selected_metadata, command, used_options), current)
     return []
 
 

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import platform
 import re
 import sys
 from dataclasses import dataclass
@@ -16,6 +18,9 @@ TRAINING_ENTRYPOINTS = {
     "eval": "unilab.cli:eval_main",
 }
 SCRIPT_ASSIGNMENT_PATTERN = re.compile(r'^([A-Za-z0-9_.-]+)\s*=\s*"([^"]+)"\s*(?:#.*)?$')
+COMPLETION_BLOCK_START = "# >>> unilab completion >>>"
+COMPLETION_BLOCK_END = "# <<< unilab completion <<<"
+SUPPORTED_SHELLS = ("bash", "zsh")
 
 
 @dataclass(frozen=True)
@@ -149,8 +154,134 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return args
 
 
+def _detect_shell(selected: str) -> str:
+    if selected != "auto":
+        return selected
+
+    shell_name = Path(os.environ.get("SHELL", "")).name
+    if shell_name in SUPPORTED_SHELLS:
+        return shell_name
+    system_name = platform.system()
+    if system_name == "Darwin":
+        return "zsh"
+    if system_name == "Linux":
+        return "bash"
+    raise SystemExit("Cannot detect shell for completion install; use --shell bash or --shell zsh.")
+
+
+def _default_rc_file(shell: str) -> Path:
+    if shell == "bash":
+        return Path.home() / ".bashrc"
+    if shell == "zsh":
+        return Path.home() / ".zshrc"
+    raise SystemExit(f"Unsupported shell={shell!r}; choose one of: {', '.join(SUPPORTED_SHELLS)}")
+
+
+def _completion_script_path(shell: str) -> Path:
+    root = _find_project_root(Path.cwd()) or cli.repo_root()
+    return root / "scripts" / "completions" / f"unilab.{shell}"
+
+
+def _quote_shell_path(path: Path) -> str:
+    return str(path).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _completion_block(script_path: Path) -> str:
+    quoted = _quote_shell_path(script_path)
+    return (
+        f"{COMPLETION_BLOCK_START}\n"
+        f'if [ -f "{quoted}" ]; then\n'
+        f'    source "{quoted}"\n'
+        "fi\n"
+        f"{COMPLETION_BLOCK_END}\n"
+    )
+
+
+def _without_completion_block(content: str, *, force: bool = False) -> str:
+    start = content.find(COMPLETION_BLOCK_START)
+    end = content.find(COMPLETION_BLOCK_END)
+    if start == -1 and end == -1:
+        return content
+    if start == -1 or end == -1 or end < start:
+        if force:
+            return content
+        raise SystemExit(
+            "Existing UniLab completion block is malformed; rerun with --force or edit it manually."
+        )
+
+    end_line = content.find("\n", end)
+    if end_line == -1:
+        end_line = len(content)
+    else:
+        end_line += 1
+    return (content[:start].rstrip() + "\n" + content[end_line:].lstrip("\n")).lstrip("\n")
+
+
+def _write_completion_block(
+    *,
+    rc_file: Path,
+    script_path: Path,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    content = rc_file.read_text(encoding="utf-8") if rc_file.exists() else ""
+    cleaned = _without_completion_block(content, force=force).rstrip()
+    block = _completion_block(script_path).rstrip()
+    updated = f"{cleaned}\n\n{block}\n" if cleaned else f"{block}\n"
+    if dry_run:
+        print(updated, end="")
+        return
+    rc_file.parent.mkdir(parents=True, exist_ok=True)
+    rc_file.write_text(updated, encoding="utf-8")
+    print(f"Installed UniLab completion in {rc_file}")
+    print(f"Open a new shell or run: source {rc_file}")
+
+
+def _remove_completion_block(*, rc_file: Path, dry_run: bool, force: bool) -> None:
+    if not rc_file.exists():
+        print(f"No rc file found: {rc_file}")
+        return
+    content = rc_file.read_text(encoding="utf-8")
+    updated = _without_completion_block(content, force=force)
+    if dry_run:
+        print(updated, end="")
+        return
+    rc_file.write_text(updated, encoding="utf-8")
+    print(f"Removed UniLab completion from {rc_file}")
+
+
+def _install_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="unilab-complete install")
+    parser.add_argument("--shell", choices=("auto", *SUPPORTED_SHELLS), default="auto")
+    parser.add_argument("--rc-file", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--uninstall", action="store_true")
+    return parser
+
+
+def install_main(argv: Sequence[str] | None = None) -> int:
+    args = _install_parser().parse_args(argv)
+    shell = _detect_shell(args.shell)
+    rc_file = args.rc_file or _default_rc_file(shell)
+    if args.uninstall:
+        _remove_completion_block(rc_file=rc_file, dry_run=args.dry_run, force=args.force)
+        return 0
+    _write_completion_block(
+        rc_file=rc_file,
+        script_path=_completion_script_path(shell),
+        dry_run=args.dry_run,
+        force=args.force,
+    )
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _parse_args(argv)
+    selected_argv = list(sys.argv[1:] if argv is None else argv)
+    if selected_argv and selected_argv[0] == "install":
+        return install_main(selected_argv[1:])
+
+    args = _parse_args(selected_argv)
     for candidate in complete_words(args.words, args.cword):
         print(candidate)
     return 0

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -1,0 +1,160 @@
+"""Shell completion helper for UniLab training entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from unilab import cli
+
+TRAINING_ENTRYPOINTS = {
+    "train": "unilab.cli:train_main",
+    "eval": "unilab.cli:eval_main",
+}
+SCRIPT_ASSIGNMENT_PATTERN = re.compile(r'^([A-Za-z0-9_.-]+)\s*=\s*"([^"]+)"\s*(?:#.*)?$')
+
+
+@dataclass(frozen=True)
+class CompletionMetadata:
+    commands: tuple[str, ...]
+    flags: dict[str, tuple[str, ...]]
+    choices: dict[str, dict[str, tuple[str, ...]]]
+
+
+def _find_project_root(start: Path) -> Path | None:
+    current = start.resolve()
+    if current.is_file():
+        current = current.parent
+    for candidate in (current, *current.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    return None
+
+
+def _read_project_scripts(pyproject_path: Path) -> dict[str, str]:
+    scripts: dict[str, str] = {}
+    in_scripts = False
+    for line in pyproject_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_scripts = stripped == "[project.scripts]"
+            continue
+        if not in_scripts:
+            continue
+        match = SCRIPT_ASSIGNMENT_PATTERN.fullmatch(stripped)
+        if match is not None:
+            scripts[match.group(1)] = match.group(2)
+    return scripts
+
+
+def _training_commands(scripts: Mapping[str, str]) -> tuple[str, ...]:
+    return tuple(
+        command
+        for command, target in TRAINING_ENTRYPOINTS.items()
+        if scripts.get(command) == target
+    )
+
+
+def _parser_for_command(command: str) -> argparse.ArgumentParser:
+    return cli._train_eval_parser(mode=command)
+
+
+def _parser_flags(command: str) -> tuple[str, ...]:
+    parser = _parser_for_command(command)
+    flags: list[str] = []
+    for action in parser._actions:
+        flags.extend(option for option in action.option_strings if option.startswith("--"))
+    return tuple(flags)
+
+
+def _parser_choices(command: str) -> dict[str, tuple[str, ...]]:
+    parser = _parser_for_command(command)
+    choices: dict[str, tuple[str, ...]] = {}
+    for action in parser._actions:
+        if action.choices is None:
+            continue
+        selected = tuple(str(choice) for choice in action.choices)
+        for option in action.option_strings:
+            if option.startswith("--"):
+                choices[option] = selected
+    return choices
+
+
+def build_metadata(root: Path | None = None) -> CompletionMetadata:
+    selected_root = root or _find_project_root(Path.cwd()) or cli.repo_root()
+    scripts = _read_project_scripts(selected_root / "pyproject.toml")
+    commands = _training_commands(scripts)
+    return CompletionMetadata(
+        commands=commands,
+        flags={command: _parser_flags(command) for command in commands},
+        choices={command: _parser_choices(command) for command in commands},
+    )
+
+
+def _current_word(words: Sequence[str], cword: int) -> str:
+    if 0 <= cword < len(words):
+        return words[cword]
+    return ""
+
+
+def _previous_word(words: Sequence[str], cword: int) -> str:
+    if cword > 0 and cword - 1 < len(words):
+        return words[cword - 1]
+    return ""
+
+
+def _matching(candidates: Sequence[str], prefix: str) -> list[str]:
+    return [candidate for candidate in candidates if candidate.startswith(prefix)]
+
+
+def complete_words(
+    words: Sequence[str],
+    cword: int,
+    metadata: CompletionMetadata | None = None,
+) -> list[str]:
+    selected_metadata = metadata or build_metadata()
+    if len(words) < 2 or words[0] != "uv" or words[1] != "run":
+        return []
+
+    current = _current_word(words, cword)
+    if cword <= 2:
+        return _matching(selected_metadata.commands, current)
+
+    command = words[2]
+    if command not in selected_metadata.commands:
+        return []
+
+    previous = _previous_word(words, cword)
+    choices = selected_metadata.choices.get(command, {})
+    if previous in choices:
+        return _matching(choices[previous], current)
+    if current.startswith("-") or previous == command:
+        return _matching(selected_metadata.flags.get(command, ()), current)
+    return []
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="unilab-complete")
+    parser.add_argument("--cword", type=int, required=True)
+    parser.add_argument("words", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.words and args.words[0] == "--":
+        args.words = args.words[1:]
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    for candidate in complete_words(args.words, args.cword):
+        print(candidate)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
# PR: Add dynamic shell completion for UniLab train/eval

## 背景

当前 UniLab 的主要用户入口是 `uv run train` 和 `uv run eval`。用户在命令行输入时，需要先阅读 README、用户文档或运行 `--help` 才能知道可用 entrypoint、flags、算法、后端和 render mode。

本 PR 之前，shell 按 Tab 时通常回退到路径补全，例如显示 `.git/`、`README.md`、`scripts/` 等目录文件，不能直接提示 `train`、`eval`、`--algo`、`--sim` 等 UniLab 语义候选项。

## 目的

- 提供可选的 shell completion，让用户在源码 checkout 中通过 Tab 发现 `uv run train` / `uv run eval` 相关输入选项。
- completion 元数据动态读取当前仓库的 `pyproject.toml` 和 `src/unilab/cli.py`，避免维护第二份手写列表。
- 仅覆盖训练与回放主路径：`train` / `eval`。
- 不修改 `demo` 命令、parser、preset 或回放逻辑，不把 `demo` 放进补全候选。
- 补充 Linux / WSL Bash 和 macOS 默认 Zsh 的用户启用文档。

## 已完成代码部分

- `pyproject.toml`
  - 新增 `unilab-complete = "unilab.tools.completion:main"` entrypoint。
- `src/unilab/tools/completion.py`
  - 新增 Python completion helper。
  - 从 `pyproject.toml` 的 `[project.scripts]` 筛选 `train` / `eval`。
  - 从 `unilab.cli` 读取 `SUPPORTED_ALGOS`、`SUPPORTED_SIMS`、`SUPPORTED_RENDER_MODES`。
  - 从 `_train_eval_parser(mode=...)` 提取 flags 和 choices。
  - 支持 `uv run <TAB>`、`uv run train --algo <TAB>`、`uv run train --sim <TAB>`、`uv run eval --render-mode <TAB>` 等候选生成。
- `scripts/completions/unilab.bash`
  - 新增 Linux / WSL Bash completion glue。
  - 优先调用 `uv run --no-sync unilab-complete`。
  - 对未重新 sync、entrypoint 尚不可见的开发环境 fallback 到 `uv run --no-sync python -m unilab.tools.completion`。
- `scripts/completions/unilab.zsh`
  - 新增 macOS 默认 Zsh completion glue。
  - 复用同一个 Python helper，用 `compadd` 注入候选项。
- `Makefile`
  - 新增 `setup`，组合 `uv sync` 和 `uv run --no-sync unilab-complete install`。
  - 新增 `setup-motrix`，组合 `uv sync --extra motrix` 和 completion install。
  - 新增 `install-completion`，只安装 completion。
- `README.md`
  - 补充 conda / pip 用户当前仍走仓库 `uv` 工作流的入口提示。
  - Quick Demo 中优先使用 `make setup-motrix`，保留 `uv sync --extra motrix` 作为不安装补全的底层命令。
- `docs/users/zh_CN/A-getting-started/01-install.md`
  - 新增 conda / pip 用户说明。
  - 优先推荐 `make setup` / `make setup-motrix` 完成环境同步和 completion 安装。
  - 明确 `pip install -e .` / `pip install .` 当前只适合源码 checkout 内开发验证，不承诺仓库外训练。
  - 明确 pip-only / wheel / sdist 路径仍由后续 issue 跟踪。
- `docs/users/zh_CN/01-getting-started.md`
  - 增加 conda / pip 当前支持边界入口链接。
- `docs/users/zh_CN/B-training/01-unified-cli.md`
  - 新增 Tab 自动补全说明。
  - Linux / WSL Bash 文档写入 `~/.bashrc` 的示例。
  - macOS 默认 Zsh 文档写入 `~/.zshrc` 的示例。

## 已完成测试部分

- 功能测试：WSL `/tmp/unilab_completion_functional_test.py`
  - 验证 metadata commands 只有 `train` / `eval`。
  - 验证不包含 `demo`。
  - 验证 `--algo`、`--sim`、`--render-mode` choices。
  - 验证 Bash completion smoke。
- 功能测试：WSL `/tmp/unilab_completion_shell_smoke.py`
  - 验证 Python helper。
  - 验证 Bash glue。
  - 验证 Zsh glue 静态关键片段。
  - 在安装 `zsh` 后验证 Zsh mock completion smoke。
- 功能测试：WSL `/tmp` rc 文件 smoke
  - 验证 `unilab-complete install --shell bash --rc-file /tmp/.../.bashrc` 写入 Bash block。
  - 验证重复 install 不重复写 marker block。
  - 验证 `--dry-run` 不写 rc 文件。
  - 验证 `unilab-complete install --shell zsh --rc-file /tmp/.../.zshrc` 写入 Zsh block。
  - 验证 `--uninstall` 可以移除 block。
- Bash 静态检查
  - `bash -n scripts/completions/unilab.bash` 通过。
- Zsh 静态检查
  - `zsh -n scripts/completions/unilab.zsh` 通过。
  - 测试环境：WSL Ubuntu，`zsh 5.9 (x86_64-ubuntu-linux-gnu)`。
- 文档检查
  - `uv run pytest tests/scripts/test_check_docs.py -q`
  - 结果：`19 passed`。
- CLI 回归测试
  - `uv run pytest tests/test_cli.py -q`
  - 结果：`7 passed`。
- Ruff format
  - `uv run --no-sync ruff format --check .`
  - 结果：通过。
- Ruff lint
  - `uv run --no-sync ruff check .`
  - 结果：通过。
- Mypy
  - `uv run mypy src/unilab`
  - 结果：通过，`Success: no issues found in 202 source files`。
- Pyright
  - `uv run pyright`
  - 结果：`0 errors, 1 warning`。
  - warning 为既有 `src/unilab/training/seed.py` 中 `mlx.core` missing import，非本 PR 新增。
- CI 等价 pytest
  - `uv run --no-sync pytest -m "not slow"`
  - 结果：`955 passed, 12 skipped, 254 deselected`。

- macOS 实机测试：未完成。
- 已完成的 mac 相关可测项：Zsh 脚本语法检查、Zsh mock completion smoke、共享 Python helper 功能测试。
- 建议在 macOS 默认 Terminal / Zsh 中手工验证：
  - 将 `source "/path_to_unilab/UniLab/scripts/completions/unilab.zsh"` 写入 `~/.zshrc`。
  - 重新打开 terminal 或 `source ~/.zshrc`。
  - 验证 `uv run <TAB>` 显示 `train` / `eval`。
  - 验证 `uv run train --algo <TAB>` 显示 `ppo`、`sac`、`td3` 等候选。
  - 验证 `uv run train --sim <TAB>` 显示 `mujoco` / `motrix`。
  - 验证非 `uv run` 形态不被 UniLab completion 污染。

