### PR TITLE
perf: optimize g1 motion tracking state updates

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -533,6 +533,40 @@ class SimBackend(abc.ABC):
             (num_envs, len(body_ids), 3)
         """
 
+    def get_body_state_w(
+        self, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """获取指定 body 的世界系位置、四元数、线速度和角速度。"""
+        return (
+            self.get_body_pos_w(body_ids),
+            self.get_body_quat_w(body_ids),
+            self.get_body_lin_vel_w(body_ids),
+            self.get_body_ang_vel_w(body_ids),
+        )
+
+    def copy_body_state_w(
+        self,
+        body_ids: np.ndarray,
+        out_pos: np.ndarray,
+        out_quat: np.ndarray,
+        out_lin_vel: np.ndarray,
+        out_ang_vel: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Copy selected world-frame body state into caller-owned buffers."""
+        pos, quat, lin_vel, ang_vel = self.get_body_state_w(body_ids)
+        out_pos[...] = pos
+        out_quat[...] = quat
+        out_lin_vel[...] = lin_vel
+        out_ang_vel[...] = ang_vel
+        return out_pos, out_quat, out_lin_vel, out_ang_vel
+
+    def get_body_pose_w_rows(
+        self, env_ids: np.ndarray, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Get selected env rows of world-frame body position and quaternion."""
+        rows = np.asarray(env_ids, dtype=np.intp)
+        return self.get_body_pos_w(body_ids)[rows], self.get_body_quat_w(body_ids)[rows]
+
     # ------------------------------------------------------------------ #
     # Body kinematics — baselink frame                                     #
     # ------------------------------------------------------------------ #
@@ -665,6 +699,10 @@ class SimBackend(abc.ABC):
         Returns:
             传感器数据数组
         """
+
+    def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:
+        """Get selected env rows of a sensor array."""
+        return self.get_sensor_data(name)[np.asarray(env_ids, dtype=np.intp)]
 
     def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
         """Fetch multiple sensors and concatenate their flattened values.

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -536,7 +536,7 @@ class SimBackend(abc.ABC):
     def get_body_state_w(
         self, body_ids: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """获取指定 body 的世界系位置、四元数、线速度和角速度。"""
+        """Get selected body position, quaternion, linear velocity, and angular velocity."""
         return (
             self.get_body_pos_w(body_ids),
             self.get_body_quat_w(body_ids),

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -808,7 +808,9 @@ class MotrixBackend(SimBackend):
         rows = np.asarray(env_ids, dtype=np.intp)
         mask = np.zeros(self._num_envs, dtype=bool)
         mask[rows] = True
-        return self._model.get_sensor_value(name, self._data[mask])  # type: ignore[no-any-return]
+        selected_rows = np.flatnonzero(mask)
+        selected_values = self._model.get_sensor_value(name, self._data[mask])
+        return selected_values[np.searchsorted(selected_rows, rows)]  # type: ignore[no-any-return]
 
     def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
         sensor_names = tuple(names)

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -258,6 +258,7 @@ class MotrixBackend(SimBackend):
         self._render_offsets_np: np.ndarray | None = None
         self._render_tracking_camera: MotrixTrackingCamera | None = None
         self.backend_type = "motrix"
+        self._link_velocity_cache: np.ndarray | None = None
 
         # Pre-cache link objects to avoid repeated get_link() lookups.
         self._link_cache: dict[int, "mtx.Link"] = {}
@@ -719,11 +720,65 @@ class MotrixBackend(SimBackend):
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._xyzw_to_wxyz(self._get_link_poses_w(body_ids)[:, :, 3:])
 
+    def get_body_pose_w_rows(
+        self, env_ids: np.ndarray, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        rows = np.asarray(env_ids, dtype=np.intp)
+        poses_w = self._link_poses[rows[:, None], self._as_body_ids(body_ids), :]
+        return poses_w[:, :, :3], self._xyzw_to_wxyz(poses_w[:, :, 3:])
+
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._get_link_lin_vel_w(body_ids)
 
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._get_link_ang_vel_w(body_ids)
+
+    def get_body_state_w(
+        self, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        poses_w = self._get_link_poses_w(body_ids)
+        return (
+            poses_w[:, :, :3],
+            self._xyzw_to_wxyz(poses_w[:, :, 3:]),
+            self._get_link_lin_vel_w(body_ids),
+            self._get_link_ang_vel_w(body_ids),
+        )
+
+    def copy_body_state_w(
+        self,
+        body_ids: np.ndarray,
+        out_pos: np.ndarray,
+        out_quat: np.ndarray,
+        out_lin_vel: np.ndarray,
+        out_ang_vel: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        ids = self._as_body_ids(body_ids)
+        poses_w = self._get_link_poses_w(ids)
+        out_pos[..., 0] = poses_w[..., 0]
+        out_pos[..., 1] = poses_w[..., 1]
+        out_pos[..., 2] = poses_w[..., 2]
+        out_quat[..., 0] = poses_w[..., 6]
+        out_quat[..., 1] = poses_w[..., 3]
+        out_quat[..., 2] = poses_w[..., 4]
+        out_quat[..., 3] = poses_w[..., 5]
+
+        link_velocity_cache = self._model.get_link_velocities(self._data)
+        if self._link_velocity_cache is None or self._link_velocity_cache.shape != (
+            self._num_envs,
+            len(ids),
+            6,
+        ):
+            self._link_velocity_cache = np.empty(
+                (self._num_envs, len(ids), 6), dtype=self._np_dtype
+            )
+        np.take(link_velocity_cache, ids, axis=1, out=self._link_velocity_cache)
+        out_lin_vel[..., 0] = self._link_velocity_cache[..., 0]
+        out_lin_vel[..., 1] = self._link_velocity_cache[..., 1]
+        out_lin_vel[..., 2] = self._link_velocity_cache[..., 2]
+        out_ang_vel[..., 0] = self._link_velocity_cache[..., 3]
+        out_ang_vel[..., 1] = self._link_velocity_cache[..., 4]
+        out_ang_vel[..., 2] = self._link_velocity_cache[..., 5]
+        return out_pos, out_quat, out_lin_vel, out_ang_vel
 
     # ------------------------------------------------------------------ #
     # Body kinematics — baselink frame                                   #
@@ -748,6 +803,12 @@ class MotrixBackend(SimBackend):
 
     def get_sensor_data(self, name: str) -> np.ndarray:
         return self._model.get_sensor_value(name, self._data)  # type: ignore[no-any-return]
+
+    def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:
+        rows = np.asarray(env_ids, dtype=np.intp)
+        mask = np.zeros(self._num_envs, dtype=bool)
+        mask[rows] = True
+        return self._model.get_sensor_value(name, self._data[mask])  # type: ignore[no-any-return]
 
     def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
         sensor_names = tuple(names)

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -1066,11 +1066,46 @@ class MuJoCoBackend(SimBackend):
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._tracked_quat_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
+    def get_body_pose_w_rows(
+        self, env_ids: np.ndarray, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        rows = np.asarray(env_ids, dtype=np.intp)
+        mapped = self._get_mapped_indices(body_ids)
+        return self._tracked_pos_w_all[rows[:, None], mapped], self._tracked_quat_w_all[
+            rows[:, None], mapped
+        ]
+
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._tracked_linvel_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
 
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         return self._tracked_angvel_w_all[:, self._get_mapped_indices(body_ids), :]  # type: ignore[no-any-return]
+
+    def get_body_state_w(
+        self, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        mapped = self._get_mapped_indices(body_ids)
+        return (
+            self._tracked_pos_w_all[:, mapped, :],
+            self._tracked_quat_w_all[:, mapped, :],
+            self._tracked_linvel_w_all[:, mapped, :],
+            self._tracked_angvel_w_all[:, mapped, :],
+        )
+
+    def copy_body_state_w(
+        self,
+        body_ids: np.ndarray,
+        out_pos: np.ndarray,
+        out_quat: np.ndarray,
+        out_lin_vel: np.ndarray,
+        out_ang_vel: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        mapped = self._get_mapped_indices(body_ids)
+        np.take(self._tracked_pos_w_all, mapped, axis=1, out=out_pos)
+        np.take(self._tracked_quat_w_all, mapped, axis=1, out=out_quat)
+        np.take(self._tracked_linvel_w_all, mapped, axis=1, out=out_lin_vel)
+        np.take(self._tracked_angvel_w_all, mapped, axis=1, out=out_ang_vel)
+        return out_pos, out_quat, out_lin_vel, out_ang_vel
 
     # ------------------------------------------------------------------ #
     # Body kinematics — baselink frame                                   #
@@ -1094,6 +1129,9 @@ class MuJoCoBackend(SimBackend):
 
     def get_sensor_data(self, name: str) -> np.ndarray:
         return self._sensor_views[name]
+
+    def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:
+        return self._sensor_views[name][np.asarray(env_ids, dtype=np.intp)]
 
     def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
         sensor_names = tuple(names)

--- a/src/unilab/envs/common/rotation.py
+++ b/src/unilab/envs/common/rotation.py
@@ -32,6 +32,37 @@ def np_quat_mul(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
     return result[0] if q1_was_1d and q2_was_1d else result
 
 
+def np_quat_conjugate_batched(q: np.ndarray) -> np.ndarray:
+    """Conjugate quaternions with shape (..., 4), w-first."""
+    if q.shape[-1] != 4:
+        raise ValueError(f"Expected quaternion last dimension 4, got {q.shape}")
+    conj = np.array(q, copy=True)
+    conj[..., 1:] *= -1
+    return conj
+
+
+def np_quat_mul_batched(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """Multiply broadcast-compatible quaternion arrays with shape (..., 4)."""
+    if q1.shape[-1] != 4 or q2.shape[-1] != 4:
+        raise ValueError(f"Expected quaternion last dimension 4, got {q1.shape} and {q2.shape}")
+
+    lead_shape = np.broadcast_shapes(q1.shape[:-1], q2.shape[:-1])
+    q1 = np.broadcast_to(q1, (*lead_shape, 4))
+    q2 = np.broadcast_to(q2, (*lead_shape, 4))
+
+    w1, x1, y1, z1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    w2, x2, y2, z2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
+    return np.stack(
+        [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        ],
+        axis=-1,
+    )
+
+
 def np_quat_conjugate(q: np.ndarray) -> np.ndarray:
     """Conjugate of unit quaternions (N, 4) or (4,), w-first."""
     if q.ndim == 1:
@@ -192,6 +223,36 @@ def np_quat_apply(q: np.ndarray, v: np.ndarray) -> np.ndarray:
     return rotated
 
 
+def np_quat_apply_batched(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Rotate broadcast-compatible vector arrays by quaternions.
+
+    ``q`` has shape (..., 4), ``v`` has shape (..., 3), and leading dimensions
+    are broadcast. This avoids flattening/tile allocations in hot env paths.
+    """
+    if q.shape[-1] != 4 or v.shape[-1] != 3:
+        raise ValueError(f"Expected q (..., 4) and v (..., 3), got {q.shape} and {v.shape}")
+
+    lead_shape = np.broadcast_shapes(q.shape[:-1], v.shape[:-1])
+    q = np.broadcast_to(q, (*lead_shape, 4))
+    v = np.broadcast_to(v, (*lead_shape, 3))
+
+    w, x, y, z = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+    vx, vy, vz = v[..., 0], v[..., 1], v[..., 2]
+
+    tx = 2 * (y * vz - z * vy)
+    ty = 2 * (z * vx - x * vz)
+    tz = 2 * (x * vy - y * vx)
+
+    return v + np.stack(
+        [
+            w * tx + y * tz - z * ty,
+            w * ty + z * tx - x * tz,
+            w * tz + x * ty - y * tx,
+        ],
+        axis=-1,
+    )
+
+
 def np_quat_apply_inverse(q: np.ndarray, v: np.ndarray) -> np.ndarray:
     """Rotate vector(s) by inverse quaternion(s)."""
     return np_quat_apply(np_quat_inv(q), v)
@@ -222,6 +283,38 @@ def np_quat_error_magnitude(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
     error = 2.0 * np.arctan2(xyz_norm, w)
     magnitude: np.ndarray = error[0] if q1_was_1d and q2_was_1d else error
     return magnitude
+
+
+def np_quat_error_magnitude_batched(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """Angular error magnitude for broadcast-compatible quaternions (..., 4)."""
+    q_rel = np_quat_mul_batched(q2, np_quat_conjugate_batched(q1))
+    sign = np.where(q_rel[..., 0:1] < 0.0, -1.0, 1.0)
+    q_rel = q_rel * sign
+    xyz_norm = np.linalg.norm(q_rel[..., 1:], axis=-1)
+    w = np.clip(q_rel[..., 0], -1.0, 1.0)
+    return 2.0 * np.arctan2(xyz_norm, w)
+
+
+def np_quat_error_magnitude_squared_batched(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """Squared angular error for broadcast-compatible quaternions (..., 4)."""
+    if q1.shape[-1] != 4 or q2.shape[-1] != 4:
+        raise ValueError(f"Expected quaternion last dimension 4, got {q1.shape} and {q2.shape}")
+
+    lead_shape = np.broadcast_shapes(q1.shape[:-1], q2.shape[:-1])
+    q1 = np.broadcast_to(q1, (*lead_shape, 4))
+    q2 = np.broadcast_to(q2, (*lead_shape, 4))
+
+    w1, x1, y1, z1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    w2, x2, y2, z2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
+
+    # Relative rotation q2 * conj(q1), without materializing the full quaternion.
+    rel_w = np.abs(w2 * w1 + x2 * x1 + y2 * y1 + z2 * z1)
+    rel_x = -w2 * x1 + x2 * w1 - y2 * z1 + z2 * y1
+    rel_y = -w2 * y1 + x2 * z1 + y2 * w1 - z2 * x1
+    rel_z = -w2 * z1 - x2 * y1 + y2 * x1 + z2 * w1
+    xyz_norm = np.sqrt(rel_x * rel_x + rel_y * rel_y + rel_z * rel_z)
+    angle = 2.0 * np.arctan2(xyz_norm, np.clip(rel_w, -1.0, 1.0))
+    return angle * angle
 
 
 def np_quat_from_euler_xyz(roll: np.ndarray, pitch: np.ndarray, yaw: np.ndarray) -> np.ndarray:
@@ -300,10 +393,95 @@ def np_matrix_from_quat(q: np.ndarray) -> np.ndarray:
     return result[0] if q_was_1d else result
 
 
+def np_matrix_first_two_cols_from_quat(q: np.ndarray) -> np.ndarray:
+    """Return flattened first two rotation-matrix columns for quaternions (..., 4).
+
+    The output order matches ``np_matrix_from_quat(q)[:, :, :2].reshape(..., 6)``.
+    """
+    if q.shape[-1] != 4:
+        raise ValueError(f"Expected quaternion last dimension 4, got {q.shape}")
+
+    w, x, y, z = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+
+    xx = x * x
+    yy = y * y
+    zz = z * z
+    xy = x * y
+    xz = x * z
+    yz = y * z
+    wx = w * x
+    wy = w * y
+    wz = w * z
+
+    return np.stack(
+        [
+            1 - 2 * (yy + zz),
+            2 * (xy - wz),
+            2 * (xy + wz),
+            1 - 2 * (xx + zz),
+            2 * (xz - wy),
+            2 * (yz + wx),
+        ],
+        axis=-1,
+    )
+
+
 def np_subtract_frame_transforms(
     pos1: np.ndarray, quat1: np.ndarray, pos2: np.ndarray, quat2: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute relative transform from frame 1 to frame 2 in frame-1 coordinates."""
     rel_pos = np_quat_apply_inverse(quat1, pos2 - pos1)
     rel_quat = np_quat_mul(np_quat_inv(quat1), quat2)
+    return rel_pos, rel_quat
+
+
+def np_subtract_anchor_frame_transforms(
+    anchor_pos: np.ndarray,
+    anchor_quat: np.ndarray,
+    body_pos: np.ndarray,
+    body_quat: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute body transforms relative to per-env anchors.
+
+    ``anchor_pos``/``anchor_quat`` are shaped (N, 3)/(N, 4), while
+    ``body_pos``/``body_quat`` are shaped (N, B, 3)/(N, B, 4).
+    """
+    aw = anchor_quat[:, None, 0]
+    ax = anchor_quat[:, None, 1]
+    ay = anchor_quat[:, None, 2]
+    az = anchor_quat[:, None, 3]
+
+    vx = body_pos[..., 0] - anchor_pos[:, None, 0]
+    vy = body_pos[..., 1] - anchor_pos[:, None, 1]
+    vz = body_pos[..., 2] - anchor_pos[:, None, 2]
+
+    # Rotate by conj(anchor_quat) without materializing the conjugate quaternion.
+    qx = -ax
+    qy = -ay
+    qz = -az
+    tx = 2 * (qy * vz - qz * vy)
+    ty = 2 * (qz * vx - qx * vz)
+    tz = 2 * (qx * vy - qy * vx)
+    rel_pos = np.stack(
+        [
+            vx + aw * tx + qy * tz - qz * ty,
+            vy + aw * ty + qz * tx - qx * tz,
+            vz + aw * tz + qx * ty - qy * tx,
+        ],
+        axis=-1,
+    )
+
+    bw = body_quat[..., 0]
+    bx = body_quat[..., 1]
+    by = body_quat[..., 2]
+    bz = body_quat[..., 3]
+    rel_quat = np.stack(
+        [
+            aw * bw + ax * bx + ay * by + az * bz,
+            aw * bx - ax * bw - ay * bz + az * by,
+            aw * by + ax * bz - ay * bw - az * bx,
+            aw * bz - ax * by + ay * bx - az * bw,
+        ],
+        axis=-1,
+    )
     return rel_pos, rel_quat

--- a/src/unilab/envs/motion_tracking/g1/motion_box_loader.py
+++ b/src/unilab/envs/motion_tracking/g1/motion_box_loader.py
@@ -92,8 +92,10 @@ class BoxMotionLoader(MotionLoader):
             self.joint_pos = self.joint_pos[:, :n_robot_joints]
             self.joint_vel = self.joint_vel[:, :n_robot_joints]
 
-    def get_motion_at_frame(self, frame_idx: np.ndarray) -> BoxMotionData:
-        base = super().get_motion_at_frame(frame_idx)
+    def get_motion_at_frame(
+        self, frame_idx: np.ndarray, out: MotionData | None = None
+    ) -> BoxMotionData:
+        base = super().get_motion_at_frame(frame_idx, out=out)
         if not self.has_object:
             return BoxMotionData(
                 joint_pos=base.joint_pos,
@@ -103,6 +105,18 @@ class BoxMotionLoader(MotionLoader):
                 body_lin_vel_w=base.body_lin_vel_w,
                 body_ang_vel_w=base.body_ang_vel_w,
             )
+        if (
+            isinstance(out, BoxMotionData)
+            and out.object_pos_w is not None
+            and out.object_quat_w is not None
+            and out.object_lin_vel_w is not None
+            and out.object_ang_vel_w is not None
+        ):
+            np.take(self.object_pos_w, frame_idx, axis=0, out=out.object_pos_w)
+            np.take(self.object_quat_w, frame_idx, axis=0, out=out.object_quat_w)
+            np.take(self.object_lin_vel_w, frame_idx, axis=0, out=out.object_lin_vel_w)
+            np.take(self.object_ang_vel_w, frame_idx, axis=0, out=out.object_ang_vel_w)
+            return out
         return BoxMotionData(
             joint_pos=base.joint_pos,
             joint_vel=base.joint_vel,

--- a/src/unilab/envs/motion_tracking/g1/motion_loader.py
+++ b/src/unilab/envs/motion_tracking/g1/motion_loader.py
@@ -156,15 +156,46 @@ class MotionLoader:
         clip_indices = self.get_clip_indices(frame_idx)
         return np.asarray(self.clip_end_frames[clip_indices], dtype=np.int32)
 
-    def get_motion_at_frame(self, frame_idx: np.ndarray) -> MotionData:
+    def make_motion_data_buffer(self, num_frames: int) -> MotionData:
+        """Allocate a reusable ``MotionData`` buffer for frame-index gathers."""
+        return MotionData(
+            joint_pos=np.empty((num_frames, self.num_joints), dtype=self.joint_pos.dtype),
+            joint_vel=np.empty((num_frames, self.num_joints), dtype=self.joint_vel.dtype),
+            body_pos_w=np.empty(
+                (num_frames, self.num_bodies, 3), dtype=self.body_pos_w.dtype
+            ),
+            body_quat_w=np.empty(
+                (num_frames, self.num_bodies, 4), dtype=self.body_quat_w.dtype
+            ),
+            body_lin_vel_w=np.empty(
+                (num_frames, self.num_bodies, 3), dtype=self.body_lin_vel_w.dtype
+            ),
+            body_ang_vel_w=np.empty(
+                (num_frames, self.num_bodies, 3), dtype=self.body_ang_vel_w.dtype
+            ),
+        )
+
+    def get_motion_at_frame(
+        self, frame_idx: np.ndarray, out: MotionData | None = None
+    ) -> MotionData:
         """Get motion data at specified frame indices.
 
         Args:
             frame_idx: Frame indices (N,)
+            out: Optional reusable output buffer.
 
         Returns:
             MotionData at specified frames
         """
+        if out is not None:
+            np.take(self.joint_pos, frame_idx, axis=0, out=out.joint_pos)
+            np.take(self.joint_vel, frame_idx, axis=0, out=out.joint_vel)
+            np.take(self.body_pos_w, frame_idx, axis=0, out=out.body_pos_w)
+            np.take(self.body_quat_w, frame_idx, axis=0, out=out.body_quat_w)
+            np.take(self.body_lin_vel_w, frame_idx, axis=0, out=out.body_lin_vel_w)
+            np.take(self.body_ang_vel_w, frame_idx, axis=0, out=out.body_ang_vel_w)
+            return out
+
         return MotionData(
             joint_pos=self.joint_pos[frame_idx],
             joint_vel=self.joint_vel[frame_idx],
@@ -238,6 +269,7 @@ class MotionSampler:
         self.sampling_entropy = 0.0
         self.sampling_top1_prob = 0.0
         self.sampling_top1_bin = 0.0
+        self._done_mask = np.zeros(num_envs, dtype=bool)
 
     def sample_frames(self, env_ids: np.ndarray) -> np.ndarray:
         """Sample motion frames for specified environments.
@@ -373,9 +405,9 @@ class MotionSampler:
         self.current_frames += 1
 
         # Find environments that reached the end of their current clip.
-        done_mask = self.current_frames > self.current_clip_end_frames
-        return np.where(done_mask)[0]
+        np.greater(self.current_frames, self.current_clip_end_frames, out=self._done_mask)
+        return np.flatnonzero(self._done_mask)
 
-    def get_current_motion(self) -> MotionData:
+    def get_current_motion(self, out: MotionData | None = None) -> MotionData:
         """Get motion data at current frames for all environments."""
-        return self.motion_loader.get_motion_at_frame(self.current_frames)
+        return self.motion_loader.get_motion_at_frame(self.current_frames, out=out)

--- a/src/unilab/envs/motion_tracking/g1/motion_loader.py
+++ b/src/unilab/envs/motion_tracking/g1/motion_loader.py
@@ -161,12 +161,8 @@ class MotionLoader:
         return MotionData(
             joint_pos=np.empty((num_frames, self.num_joints), dtype=self.joint_pos.dtype),
             joint_vel=np.empty((num_frames, self.num_joints), dtype=self.joint_vel.dtype),
-            body_pos_w=np.empty(
-                (num_frames, self.num_bodies, 3), dtype=self.body_pos_w.dtype
-            ),
-            body_quat_w=np.empty(
-                (num_frames, self.num_bodies, 4), dtype=self.body_quat_w.dtype
-            ),
+            body_pos_w=np.empty((num_frames, self.num_bodies, 3), dtype=self.body_pos_w.dtype),
+            body_quat_w=np.empty((num_frames, self.num_bodies, 4), dtype=self.body_quat_w.dtype),
             body_lin_vel_w=np.empty(
                 (num_frames, self.num_bodies, 3), dtype=self.body_lin_vel_w.dtype
             ),

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -29,7 +29,6 @@ from unilab.dtype_config import get_global_dtype
 from unilab.envs.common.math import np_sample_uniform
 from unilab.envs.common.rotation import (
     np_quat_apply,
-    np_quat_error_magnitude_squared_batched,
     np_quat_from_euler_xyz,
     np_quat_inv,
     np_quat_mul,

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -28,14 +28,11 @@ from unilab.dr.dr_utils import (
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.common.math import np_sample_uniform
 from unilab.envs.common.rotation import (
-    np_matrix_from_quat,
     np_quat_apply,
-    np_quat_error_magnitude,
+    np_quat_error_magnitude_squared_batched,
     np_quat_from_euler_xyz,
     np_quat_inv,
     np_quat_mul,
-    np_subtract_frame_transforms,
-    np_yaw_quat,
 )
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
 
@@ -265,6 +262,64 @@ def _build_motion_reference_state(
     return qpos, qvel
 
 
+def _gravity_z_in_body_from_quat_w(quat_w: np.ndarray) -> np.ndarray:
+    """Z component of world gravity ``[0, 0, -1]`` expressed in body frame."""
+    return 2.0 * (quat_w[:, 1] * quat_w[:, 1] + quat_w[:, 2] * quat_w[:, 2]) - 1.0
+
+
+def _write_motion_anchor_transform(
+    robot_anchor_pos_w: np.ndarray,
+    robot_anchor_quat_w: np.ndarray,
+    anchor_pos_w: np.ndarray,
+    anchor_quat_w: np.ndarray,
+    out_pos: np.ndarray,
+    out_ori6: np.ndarray,
+) -> None:
+    aw = robot_anchor_quat_w[:, 0]
+    ax = robot_anchor_quat_w[:, 1]
+    ay = robot_anchor_quat_w[:, 2]
+    az = robot_anchor_quat_w[:, 3]
+
+    vx = anchor_pos_w[:, 0] - robot_anchor_pos_w[:, 0]
+    vy = anchor_pos_w[:, 1] - robot_anchor_pos_w[:, 1]
+    vz = anchor_pos_w[:, 2] - robot_anchor_pos_w[:, 2]
+
+    qx = -ax
+    qy = -ay
+    qz = -az
+    tx = 2 * (qy * vz - qz * vy)
+    ty = 2 * (qz * vx - qx * vz)
+    tz = 2 * (qx * vy - qy * vx)
+    out_pos[:, 0] = vx + aw * tx + qy * tz - qz * ty
+    out_pos[:, 1] = vy + aw * ty + qz * tx - qx * tz
+    out_pos[:, 2] = vz + aw * tz + qx * ty - qy * tx
+
+    bw = anchor_quat_w[:, 0]
+    bx = anchor_quat_w[:, 1]
+    by = anchor_quat_w[:, 2]
+    bz = anchor_quat_w[:, 3]
+    rw = aw * bw + ax * bx + ay * by + az * bz
+    rx = aw * bx - ax * bw - ay * bz + az * by
+    ry = aw * by + ax * bz - ay * bw - az * bx
+    rz = aw * bz - ax * by + ay * bx - az * bw
+
+    xx = rx * rx
+    yy = ry * ry
+    zz = rz * rz
+    xy = rx * ry
+    xz = rx * rz
+    yz = ry * rz
+    wx = rw * rx
+    wy = rw * ry
+    wz = rw * rz
+    out_ori6[:, 0] = 1 - 2 * (yy + zz)
+    out_ori6[:, 1] = 2 * (xy - wz)
+    out_ori6[:, 2] = 2 * (xy + wz)
+    out_ori6[:, 3] = 1 - 2 * (xx + zz)
+    out_ori6[:, 4] = 2 * (xz - wy)
+    out_ori6[:, 5] = 2 * (yz + wx)
+
+
 class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
     def __init__(
         self, *, base_kp: np.ndarray | None = None, base_kd: np.ndarray | None = None
@@ -364,6 +419,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self.ee_body_indices = np.array(
             [cfg.body_names.index(name) for name in cfg.ee_body_names], dtype=np.int32
         )
+        self._has_ee_body_indices = bool(self.ee_body_indices.size)
 
         # Get non-EE body indices for undesired contact penalty
         ee_set = set(cfg.ee_body_names)
@@ -371,6 +427,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
             [i for i, name in enumerate(cfg.body_names) if name not in ee_set],
             dtype=np.int32,
         )
+        self._has_undesired_contact_body_indices = bool(self.undesired_contact_body_indices.size)
 
         # Load motion data
         self.motion_loader = MotionLoader(cfg.motion_file, body_indices=motion_body_ids)
@@ -386,17 +443,67 @@ class G1MotionTrackingEnv(G1BaseEnv):
             dr_provider = G1MotionTrackingDomainRandomizationProvider()
         self._init_domain_randomization(dr_provider)
 
+        dtype = get_global_dtype()
+        n_body = len(cfg.body_names)
+        self._n_motion_bodies = n_body
+        self._actor_obs_width = self._actor_obs_dim(self._num_action)
+        self._critic_base_obs_width = self._critic_base_obs_dim(self._num_action)
+        self._critic_obs_width = self._critic_base_obs_width + n_body * 9
+        self._copy_body_state_w = self._backend.copy_body_state_w
+
         # Buffers for relative body transforms
-        self.body_pos_relative_w = np.zeros(
-            (num_envs, len(cfg.body_names), 3), dtype=get_global_dtype()
-        )
-        self.body_quat_relative_w = np.zeros(
-            (num_envs, len(cfg.body_names), 4), dtype=get_global_dtype()
-        )
+        self.body_pos_relative_w = np.zeros((num_envs, n_body, 3), dtype=dtype)
+        self.body_quat_relative_w = np.zeros((num_envs, n_body, 4), dtype=dtype)
         self.body_quat_relative_w[:, :, 0] = 1.0  # Initialize to identity quaternion
+        self._motion_data_buffer = (
+            self.motion_loader.make_motion_data_buffer(num_envs)
+            if hasattr(self.motion_loader, "make_motion_data_buffer")
+            else None
+        )
+        self._zero_actions = np.zeros((num_envs, self._num_action), dtype=dtype)
+        self._joint_range = self._backend.get_joint_range()
+        if self._joint_range is not None:
+            self._joint_range = np.asarray(self._joint_range, dtype=dtype)
+            self._joint_lower = self._joint_range[:, 0]
+            self._joint_upper = self._joint_range[:, 1]
+        else:
+            self._joint_lower = None
+            self._joint_upper = None
+        self._delta_pos_w = np.empty((num_envs, 3), dtype=dtype)
+        self._delta_ori_w = np.empty((num_envs, 4), dtype=dtype)
+        self._motion_anchor_pos_b = np.empty((num_envs, 3), dtype=dtype)
+        self._motion_anchor_ori_b = np.empty((num_envs, 6), dtype=dtype)
+        self._motion_command = np.empty((num_envs, self._num_action * 2), dtype=dtype)
+        self._joint_pos_rel = np.empty((num_envs, self._num_action), dtype=dtype)
+        self._robot_body_pos_w = np.empty((num_envs, n_body, 3), dtype=dtype)
+        self._robot_body_quat_w = np.empty((num_envs, n_body, 4), dtype=dtype)
+        self._robot_body_lin_vel_w = np.empty((num_envs, n_body, 3), dtype=dtype)
+        self._robot_body_ang_vel_w = np.empty((num_envs, n_body, 3), dtype=dtype)
+        self._quat_error_w = np.empty((num_envs, n_body), dtype=dtype)
+        self._quat_error_x = np.empty((num_envs, n_body), dtype=dtype)
+        self._body_vec_error = np.empty((num_envs, n_body, 3), dtype=dtype)
+        self._body_vec_tmp = np.empty((num_envs, n_body, 3), dtype=dtype)
+        self._joint_error = np.empty((num_envs, self._num_action), dtype=dtype)
+        self._joint_error_upper = np.empty((num_envs, self._num_action), dtype=dtype)
+        self._env_error = np.empty((num_envs,), dtype=dtype)
+        self._env_error2 = np.empty((num_envs,), dtype=dtype)
+        self._reward_term = np.empty((num_envs,), dtype=dtype)
+        self._weighted_reward = np.empty((num_envs,), dtype=dtype)
+        self._terminated = np.empty((num_envs,), dtype=bool)
+        self._env_bool = np.empty((num_envs,), dtype=bool)
+        self._ee_pos_error_z = np.empty((num_envs, self.ee_body_indices.size), dtype=dtype)
+        self._ee_terminated = np.empty((num_envs, self.ee_body_indices.size), dtype=bool)
+        self._undesired_contact_mask = np.empty(
+            (num_envs, self.undesired_contact_body_indices.size), dtype=bool
+        )
 
         self._enable_reward_log = True
         self._init_reward_functions()
+        self._active_reward_fns = {
+            name: reward_fn
+            for name, reward_fn in self._reward_fns.items()
+            if self._reward_term_is_active(name)
+        }
         self._clip_end_truncated = np.zeros((num_envs,), dtype=bool)
 
     def _resample_reference_state(self, env_ids: np.ndarray) -> None:
@@ -411,11 +518,14 @@ class G1MotionTrackingEnv(G1BaseEnv):
         motion_data = self.motion_loader.get_motion_at_frame(
             self.motion_sampler.current_frames[env_ids]
         )
-        linvel = self.get_local_linvel()[env_ids]
-        gyro = self.get_gyro()[env_ids]
-        dof_pos = self.get_dof_pos()[env_ids]
-        dof_vel = self.get_dof_vel()[env_ids]
-        robot_body_pos_w, robot_body_quat_w = self._get_body_pose_w()
+        row_ids = np.asarray(env_ids, dtype=np.intp)
+        linvel = self._backend.get_sensor_data_rows(self._cfg.sensor.local_linvel, row_ids)
+        gyro = self._backend.get_sensor_data_rows(self._cfg.sensor.gyro, row_ids)
+        dof_pos = self.get_dof_pos()[row_ids]
+        dof_vel = self.get_dof_vel()[row_ids]
+        robot_body_pos_w, robot_body_quat_w = self._backend.get_body_pose_w_rows(
+            row_ids, self.body_ids
+        )
 
         obs_info: dict[str, Any] = {}
         current_actions = info.get("current_actions")
@@ -430,8 +540,8 @@ class G1MotionTrackingEnv(G1BaseEnv):
             gyro,
             dof_pos,
             dof_vel,
-            robot_body_pos_w[env_ids],
-            robot_body_quat_w[env_ids],
+            robot_body_pos_w,
+            robot_body_quat_w,
         )
         for key, value in refreshed_obs.items():
             if value.shape[0] == len(env_ids):
@@ -444,8 +554,31 @@ class G1MotionTrackingEnv(G1BaseEnv):
             self.body_ids
         )
 
+    def _get_body_state_w(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        copy_body_state_w = self._copy_body_state_w
+        if copy_body_state_w is not None:
+            return copy_body_state_w(
+                self.body_ids,
+                self._robot_body_pos_w,
+                self._robot_body_quat_w,
+                self._robot_body_lin_vel_w,
+                self._robot_body_ang_vel_w,
+            )
+        robot_body_pos_w, robot_body_quat_w = self._get_body_pose_w()
+        return (
+            robot_body_pos_w,
+            robot_body_quat_w,
+            self._backend.get_body_lin_vel_w(self.body_ids),
+            self._backend.get_body_ang_vel_w(self.body_ids),
+        )
+
     def _get_joint_range(self) -> np.ndarray | None:
-        return self._backend.get_joint_range()  # type: ignore[no-any-return]
+        return self._joint_range
+
+    def _get_current_motion(self) -> MotionData:
+        if self._motion_data_buffer is None:
+            return self.motion_sampler.get_current_motion()
+        return self.motion_sampler.get_current_motion(self._motion_data_buffer)
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
@@ -454,11 +587,13 @@ class G1MotionTrackingEnv(G1BaseEnv):
         # Critic mirrors BeyondMimic physical terms without actor observation noise:
         #        command, motion anchor, robot body pos/ori, linvel, gyro, joints, actions.
         n = self._num_action
-        critic_extra_dim = len(self._cfg.body_names) * 9
-        return {
-            "obs": self._actor_obs_dim(n),
-            "critic": self._critic_base_obs_dim(n) + critic_extra_dim,
-        }
+        actor_width = getattr(self, "_actor_obs_width", self._actor_obs_dim(n))
+        critic_width = getattr(
+            self,
+            "_critic_obs_width",
+            self._critic_base_obs_dim(n) + len(self._cfg.body_names) * 9,
+        )
+        return {"obs": actor_width, "critic": critic_width}
 
     def _actor_obs_dim(self, n: int) -> int:
         return 3 + 6 + 3 + 3 + n * 5
@@ -478,20 +613,26 @@ class G1MotionTrackingEnv(G1BaseEnv):
         noisy_dof_vel: np.ndarray,
         last_actions: np.ndarray,
     ) -> np.ndarray:
-        return np.concatenate(
-            [
-                command,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                noisy_linvel,
-                noisy_gyro,
-                noisy_joint_pos_rel,
-                noisy_dof_vel,
-                last_actions,
-            ],
-            axis=1,
-            dtype=get_global_dtype(),
-        )
+        num_envs = command.shape[0]
+        n_action = noisy_joint_pos_rel.shape[1]
+        actor_obs = np.empty((num_envs, self._actor_obs_dim(n_action)), dtype=get_global_dtype())
+        offset = 0
+        actor_obs[:, offset : offset + command.shape[1]] = command
+        offset += command.shape[1]
+        actor_obs[:, offset : offset + 3] = motion_anchor_pos_b
+        offset += 3
+        actor_obs[:, offset : offset + 6] = motion_anchor_ori_b
+        offset += 6
+        actor_obs[:, offset : offset + 3] = noisy_linvel
+        offset += 3
+        actor_obs[:, offset : offset + 3] = noisy_gyro
+        offset += 3
+        actor_obs[:, offset : offset + n_action] = noisy_joint_pos_rel
+        offset += n_action
+        actor_obs[:, offset : offset + n_action] = noisy_dof_vel
+        offset += n_action
+        actor_obs[:, offset : offset + n_action] = last_actions
+        return actor_obs
 
     def _init_reward_functions(self):
         self._reward_fns = {
@@ -509,11 +650,20 @@ class G1MotionTrackingEnv(G1BaseEnv):
             "undesired_contacts": self._reward_undesired_contacts,
         }
 
+    def _reward_term_is_active(self, name: str) -> bool:
+        if name == "joint_limit":
+            return self._joint_lower is not None and self._joint_upper is not None
+        if name == "undesired_contacts":
+            return self._has_undesired_contact_body_indices
+        if name == "motion_ee_body_pos_z":
+            return self._has_ee_body_indices
+        return True
+
     def update_state(self, state: NpEnvState) -> NpEnvState:
         self._clip_end_truncated.fill(False)
 
         # Get current motion data
-        motion_data = self.motion_sampler.get_current_motion()
+        motion_data = self._get_current_motion()
 
         # Get robot state
         linvel = self.get_local_linvel()
@@ -522,9 +672,12 @@ class G1MotionTrackingEnv(G1BaseEnv):
         dof_vel = self.get_dof_vel()
 
         # Get body states
-        robot_body_pos_w, robot_body_quat_w = self._get_body_pose_w()
-        robot_body_lin_vel_w = self._backend.get_body_lin_vel_w(self.body_ids)
-        robot_body_ang_vel_w = self._backend.get_body_ang_vel_w(self.body_ids)
+        (
+            robot_body_pos_w,
+            robot_body_quat_w,
+            robot_body_lin_vel_w,
+            robot_body_ang_vel_w,
+        ) = self._get_body_state_w()
 
         # Compute relative body transforms (for observations and rewards)
         self._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
@@ -576,7 +729,12 @@ class G1MotionTrackingEnv(G1BaseEnv):
 
     def _compute_truncated(self, state: NpEnvState) -> np.ndarray:
         truncated = super()._compute_truncated(state)
-        clip_end_only = np.logical_and(self._clip_end_truncated, ~state.terminated)
+        clip_end_only = getattr(self, "_env_bool", None)
+        if clip_end_only is None or clip_end_only.shape != (self._num_envs,):
+            clip_end_only = np.empty((self._num_envs,), dtype=bool)
+            self._env_bool = clip_end_only
+        np.logical_not(state.terminated, out=clip_end_only)
+        np.logical_and(self._clip_end_truncated, clip_end_only, out=clip_end_only)
         np.logical_or(truncated, clip_end_only, out=truncated)
         return truncated
 
@@ -584,9 +742,6 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self, motion_data, robot_body_pos_w: np.ndarray, robot_body_quat_w: np.ndarray
     ):
         """Update relative body transforms for tracking."""
-        n_env = robot_body_pos_w.shape[0]
-        n_body = len(self._cfg.body_names)
-
         # Get anchor states
         anchor_pos_w = motion_data.body_pos_w[:, self.anchor_body_idx]
         anchor_quat_w = motion_data.body_quat_w[:, self.anchor_body_idx]
@@ -594,26 +749,81 @@ class G1MotionTrackingEnv(G1BaseEnv):
         robot_anchor_quat_w = robot_body_quat_w[:, self.anchor_body_idx]
 
         # Compute delta transform: keep robot's XY position, use motion's Z height
-        # and apply yaw-only rotation difference
-        delta_pos_w = robot_anchor_pos_w.copy()
+        # and apply yaw-only rotation difference.
+        delta_pos_w = self._delta_pos_w
+        delta_pos_w[:] = robot_anchor_pos_w
         delta_pos_w[:, 2] = anchor_pos_w[:, 2]
 
-        # Compute yaw-only rotation difference
-        quat_diff = np_quat_mul(robot_anchor_quat_w, np_quat_inv(anchor_quat_w))
-        delta_ori_w = np_yaw_quat(quat_diff)
-
-        # Vectorized: transform all bodies at once using reshape trick
-        # Flatten (N, B, 4) -> (N*B, 4) for quat ops, then reshape back
-        delta_ori_tiled = np.tile(delta_ori_w, (1, n_body)).reshape(n_env * n_body, 4)
-        motion_quat_flat = motion_data.body_quat_w.reshape(n_env * n_body, 4)
-        self.body_quat_relative_w[:] = np_quat_mul(delta_ori_tiled, motion_quat_flat).reshape(
-            n_env, n_body, 4
+        # Compute yaw-only rotation difference, equivalent to
+        # np_yaw_quat(np_quat_mul(robot_anchor_quat_w, np_quat_inv(anchor_quat_w))).
+        delta_ori_w = self._delta_ori_w
+        rw, rx, ry, rz = (
+            robot_anchor_quat_w[:, 0],
+            robot_anchor_quat_w[:, 1],
+            robot_anchor_quat_w[:, 2],
+            robot_anchor_quat_w[:, 3],
         )
+        aw, ax, ay, az = (
+            anchor_quat_w[:, 0],
+            anchor_quat_w[:, 1],
+            anchor_quat_w[:, 2],
+            anchor_quat_w[:, 3],
+        )
+        qw = rw * aw + rx * ax + ry * ay + rz * az
+        qx = -rw * ax + rx * aw - ry * az + rz * ay
+        qy = -rw * ay + rx * az + ry * aw - rz * ax
+        qz = -rw * az - rx * ay + ry * ax + rz * aw
+        half_yaw = 0.5 * np.arctan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz))
+        np.cos(half_yaw, out=delta_ori_w[:, 0])
+        delta_ori_w[:, 1:3] = 0.0
+        np.sin(half_yaw, out=delta_ori_w[:, 3])
 
-        rel_pos_all = motion_data.body_pos_w - anchor_pos_w[:, None, :]  # (N, B, 3)
-        rel_pos_flat = rel_pos_all.reshape(n_env * n_body, 3)
-        rotated = np_quat_apply(delta_ori_tiled, rel_pos_flat).reshape(n_env, n_body, 3)
-        self.body_pos_relative_w[:] = delta_pos_w[:, None, :] + rotated
+        dw1 = delta_ori_w[:, 0]
+        dz1 = delta_ori_w[:, 3]
+        dw = dw1[:, None]
+        dz = dz1[:, None]
+        mw = motion_data.body_quat_w[..., 0]
+        mx = motion_data.body_quat_w[..., 1]
+        my = motion_data.body_quat_w[..., 2]
+        mz = motion_data.body_quat_w[..., 3]
+        out_quat = self.body_quat_relative_w
+        out_quat[..., 0] = dw * mw
+        out_quat[..., 0] -= dz * mz
+        out_quat[..., 1] = dw * mx
+        out_quat[..., 1] -= dz * my
+        out_quat[..., 2] = dw * my
+        out_quat[..., 2] += dz * mx
+        out_quat[..., 3] = dw * mz
+        out_quat[..., 3] += dz * mw
+
+        rel_pos = self._body_vec_error
+        vx = rel_pos[..., 0]
+        vy = rel_pos[..., 1]
+        vz = rel_pos[..., 2]
+        np.subtract(motion_data.body_pos_w[..., 0], anchor_pos_w[:, None, 0], out=vx)
+        np.subtract(motion_data.body_pos_w[..., 1], anchor_pos_w[:, None, 1], out=vy)
+        np.subtract(motion_data.body_pos_w[..., 2], anchor_pos_w[:, None, 2], out=vz)
+
+        yaw_cross = self._env_error
+        yaw_z2 = self._reward_term
+        np.multiply(dw1, dz1, out=yaw_cross)
+        yaw_cross *= 2.0
+        np.square(dz1, out=yaw_z2)
+        yaw_z2 *= 2.0
+        yaw_cross_2d = yaw_cross[:, None]
+        yaw_z2_2d = yaw_z2[:, None]
+
+        out_pos = self.body_pos_relative_w
+        out_pos[..., 0] = vx
+        out_pos[..., 0] -= yaw_cross_2d * vy
+        out_pos[..., 0] -= yaw_z2_2d * vx
+        out_pos[..., 0] += delta_pos_w[:, None, 0]
+        out_pos[..., 1] = vy
+        out_pos[..., 1] += yaw_cross_2d * vx
+        out_pos[..., 1] -= yaw_z2_2d * vy
+        out_pos[..., 1] += delta_pos_w[:, None, 1]
+        out_pos[..., 2] = vz
+        out_pos[..., 2] += delta_pos_w[:, None, 2]
 
     def _compute_terminations(
         self,
@@ -622,41 +832,114 @@ class G1MotionTrackingEnv(G1BaseEnv):
         robot_body_quat_w: np.ndarray,
     ) -> np.ndarray:
         """Compute termination conditions."""
-        terminated = np.zeros(self._num_envs, dtype=bool)
+        terminated = self._terminated
+        terminated.fill(False)
 
         # Anchor position error (Z-axis only)
         anchor_pos_w = motion_data.body_pos_w[:, self.anchor_body_idx]
         robot_anchor_pos_w = robot_body_pos_w[:, self.anchor_body_idx]
-        anchor_pos_error_z = np.abs(anchor_pos_w[:, 2] - robot_anchor_pos_w[:, 2])
-        terminated |= anchor_pos_error_z > self._cfg.anchor_pos_z_threshold
+        np.subtract(anchor_pos_w[:, 2], robot_anchor_pos_w[:, 2], out=self._env_error)
+        np.abs(self._env_error, out=self._env_error)
+        np.greater(self._env_error, self._cfg.anchor_pos_z_threshold, out=self._env_bool)
+        terminated |= self._env_bool
 
-        # Anchor orientation error (gravity direction)
-        anchor_quat_w = motion_data.body_quat_w[:, self.anchor_body_idx]
-        robot_anchor_quat_w = robot_body_quat_w[:, self.anchor_body_idx]
-        gravity_vec = np.broadcast_to(
-            np.array([[0, 0, -1]], dtype=get_global_dtype()),
-            (anchor_quat_w.shape[0], 3),
-        ).copy()
-        motion_gravity_b = np_quat_apply(np_quat_inv(anchor_quat_w), gravity_vec)
-        robot_gravity_b = np_quat_apply(np_quat_inv(robot_anchor_quat_w), gravity_vec)
-        gravity_error = np.abs(motion_gravity_b[:, 2] - robot_gravity_b[:, 2])
-        terminated |= gravity_error > self._cfg.anchor_ori_threshold
+        # Anchor orientation error (gravity direction). The gravity-z difference
+        # is bounded by 2 for unit quaternions, so huge thresholds disable this
+        # termination without doing the per-step math.
+        if self._cfg.anchor_ori_threshold < 2.0:
+            anchor_quat_w = motion_data.body_quat_w[:, self.anchor_body_idx]
+            robot_anchor_quat_w = robot_body_quat_w[:, self.anchor_body_idx]
+            motion_gravity_z_b = _gravity_z_in_body_from_quat_w(anchor_quat_w)
+            robot_gravity_z_b = _gravity_z_in_body_from_quat_w(robot_anchor_quat_w)
+            np.subtract(motion_gravity_z_b, robot_gravity_z_b, out=self._env_error)
+            np.abs(self._env_error, out=self._env_error)
+            np.greater(self._env_error, self._cfg.anchor_ori_threshold, out=self._env_bool)
+            terminated |= self._env_bool
 
         # End-effector position error (Z-axis only)
-        for ee_idx in self.ee_body_indices:
-            ee_pos_error_z = np.abs(
-                self.body_pos_relative_w[:, ee_idx, 2] - robot_body_pos_w[:, ee_idx, 2]
+        if self._has_ee_body_indices:
+            np.subtract(
+                self.body_pos_relative_w[:, self.ee_body_indices, 2],
+                robot_body_pos_w[:, self.ee_body_indices, 2],
+                out=self._ee_pos_error_z,
             )
-            terminated |= ee_pos_error_z > self._cfg.ee_body_pos_z_threshold
+            np.abs(self._ee_pos_error_z, out=self._ee_pos_error_z)
+            np.greater(
+                self._ee_pos_error_z,
+                self._cfg.ee_body_pos_z_threshold,
+                out=self._ee_terminated,
+            )
+            np.logical_or.reduce(self._ee_terminated, axis=1, out=self._env_bool)
+            terminated |= self._env_bool
 
-        if (
-            self._cfg.terminate_on_undesired_contacts
-            and len(self.undesired_contact_body_indices) > 0
-        ):
+        if self._cfg.terminate_on_undesired_contacts and self._has_undesired_contact_body_indices:
             body_z = robot_body_pos_w[:, self.undesired_contact_body_indices, 2]
-            terminated |= np.any(body_z < self._cfg.undesired_contact_z_threshold, axis=-1)
+            np.less(
+                body_z,
+                self._cfg.undesired_contact_z_threshold,
+                out=self._undesired_contact_mask,
+            )
+            np.logical_or.reduce(self._undesired_contact_mask, axis=-1, out=self._env_bool)
+            terminated |= self._env_bool
 
         return terminated
+
+    def _write_body_pos_in_anchor_frame(
+        self,
+        anchor_pos: np.ndarray,
+        anchor_quat: np.ndarray,
+        body_pos: np.ndarray,
+        out: np.ndarray,
+    ) -> None:
+        aw = anchor_quat[:, None, 0]
+        ax = anchor_quat[:, None, 1]
+        ay = anchor_quat[:, None, 2]
+        az = anchor_quat[:, None, 3]
+
+        num_envs, n_body = body_pos.shape[:2]
+        rel_pos = self._body_vec_error[:num_envs, :n_body]
+
+        vx = rel_pos[..., 0]
+        vy = rel_pos[..., 1]
+        vz = rel_pos[..., 2]
+        np.subtract(body_pos[..., 0], anchor_pos[:, None, 0], out=vx)
+        np.subtract(body_pos[..., 1], anchor_pos[:, None, 1], out=vy)
+        np.subtract(body_pos[..., 2], anchor_pos[:, None, 2], out=vz)
+
+        tx = 2 * (az * vy - ay * vz)
+        ty = 2 * (ax * vz - az * vx)
+        tz = 2 * (ay * vx - ax * vy)
+
+        out[..., 0] = vx + aw * tx + az * ty - ay * tz
+        out[..., 1] = vy + aw * ty + ax * tz - az * tx
+        out[..., 2] = vz + aw * tz + ay * tx - ax * ty
+
+    def _write_body_ori6_in_anchor_frame(
+        self,
+        anchor_quat: np.ndarray,
+        body_quat: np.ndarray,
+        out: np.ndarray,
+    ) -> None:
+        aw = anchor_quat[:, None, 0]
+        ax = anchor_quat[:, None, 1]
+        ay = anchor_quat[:, None, 2]
+        az = anchor_quat[:, None, 3]
+        bw = body_quat[..., 0]
+        bx = body_quat[..., 1]
+        by = body_quat[..., 2]
+        bz = body_quat[..., 3]
+
+        rw = aw * bw + ax * bx + ay * by + az * bz
+        rx = aw * bx - ax * bw - ay * bz + az * by
+        ry = aw * by + ax * bz - ay * bw - az * bx
+        rz = aw * bz - ax * by + ay * bx - az * bw
+
+        out[..., 0] = 1 - 2 * (ry * ry + rz * rz)
+        out[..., 1] = 2 * (rx * ry - rw * rz)
+        out[..., 2] = 2 * (rx * ry + rw * rz)
+        out[..., 3] = 1 - 2 * (rx * rx + rz * rz)
+        out[..., 4] = 2 * (rx * rz - rw * ry)
+        out[..., 5] = 2 * (ry * rz + rw * rx)
 
     def _compute_obs(
         self,
@@ -671,11 +954,9 @@ class G1MotionTrackingEnv(G1BaseEnv):
     ) -> dict[str, np.ndarray]:
         """Compute observations as dict with actor and critic groups."""
         num_envs = linvel.shape[0]
-        command = np.concatenate(
-            [motion_data.joint_pos, motion_data.joint_vel],
-            axis=1,
-            dtype=get_global_dtype(),
-        )
+        dtype = get_global_dtype()
+        n_action = dof_pos.shape[1]
+        n_body = self._n_motion_bodies
 
         # Get anchor states
         anchor_pos_w = motion_data.body_pos_w[:, self.anchor_body_idx]
@@ -683,81 +964,93 @@ class G1MotionTrackingEnv(G1BaseEnv):
         robot_anchor_pos_w = robot_body_pos_w[:, self.anchor_body_idx]
         robot_anchor_quat_w = robot_body_quat_w[:, self.anchor_body_idx]
 
-        # Motion anchor position in robot frame
-        motion_anchor_pos_b, _ = np_subtract_frame_transforms(
-            robot_anchor_pos_w, robot_anchor_quat_w, anchor_pos_w, anchor_quat_w
+        # Motion anchor pose in robot frame
+        if num_envs == self._num_envs:
+            motion_anchor_pos_b = self._motion_anchor_pos_b
+            motion_anchor_ori_b = self._motion_anchor_ori_b
+            joint_pos_rel = self._joint_pos_rel
+            zero_actions = self._zero_actions
+        else:
+            motion_anchor_pos_b = np.empty((num_envs, 3), dtype=dtype)
+            motion_anchor_ori_b = np.empty((num_envs, 6), dtype=dtype)
+            joint_pos_rel = np.empty((num_envs, n_action), dtype=dtype)
+            zero_actions = np.zeros((num_envs, n_action), dtype=dtype)
+        _write_motion_anchor_transform(
+            robot_anchor_pos_w,
+            robot_anchor_quat_w,
+            anchor_pos_w,
+            anchor_quat_w,
+            motion_anchor_pos_b,
+            motion_anchor_ori_b,
         )
-
-        # Motion anchor orientation in robot frame (as rotation matrix first 2 columns)
-        _, motion_anchor_ori_rel = np_subtract_frame_transforms(
-            robot_anchor_pos_w, robot_anchor_quat_w, anchor_pos_w, anchor_quat_w
-        )
-        motion_anchor_ori_mat = np_matrix_from_quat(motion_anchor_ori_rel)
-        motion_anchor_ori_b = motion_anchor_ori_mat[:, :, :2].reshape(num_envs, 6)
 
         # Joint positions and velocities
-        joint_pos_rel = dof_pos - self.default_angles
-        last_actions = info.get("current_actions", np.zeros_like(joint_pos_rel))
+        np.subtract(dof_pos, self.default_angles, out=joint_pos_rel)
+        last_actions = info.get("current_actions")
+        if not isinstance(last_actions, np.ndarray):
+            last_actions = zero_actions
+
+        if num_envs == self._num_envs:
+            command = self._motion_command
+        else:
+            command = np.empty((num_envs, n_action * 2), dtype=dtype)
+        command[:, :n_action] = motion_data.joint_pos
+        command[:, n_action : n_action * 2] = motion_data.joint_vel
 
         # Per-step observation noise on sensor channels (actor only).
         # Critic uses the clean originals — asymmetric actor–critic contract.
         noise_cfg = self._cfg.noise_config
-        noisy_linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
-        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        noisy_joint_pos_rel = self._obs_noise(joint_pos_rel, noise_cfg.scale_joint_angle)
-        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        noise_enabled = noise_cfg.level > 0.0
+        if noise_enabled:
+            linvel_actor = self._obs_noise(linvel, noise_cfg.scale_linvel)
+            gyro_actor = self._obs_noise(gyro, noise_cfg.scale_gyro)
+            joint_pos_actor = self._obs_noise(joint_pos_rel, noise_cfg.scale_joint_angle)
+            dof_vel_actor = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        else:
+            linvel_actor = linvel
+            gyro_actor = gyro
+            joint_pos_actor = joint_pos_rel
+            dof_vel_actor = dof_vel
 
         # Actor observations (noisy proprioception)
         actor_obs = self._build_actor_obs(
             command=command,
             motion_anchor_pos_b=motion_anchor_pos_b,
             motion_anchor_ori_b=motion_anchor_ori_b,
-            noisy_linvel=noisy_linvel,
-            noisy_gyro=noisy_gyro,
-            noisy_joint_pos_rel=noisy_joint_pos_rel,
-            noisy_dof_vel=noisy_dof_vel,
+            noisy_linvel=linvel_actor,
+            noisy_gyro=gyro_actor,
+            noisy_joint_pos_rel=joint_pos_actor,
+            noisy_dof_vel=dof_vel_actor,
             last_actions=last_actions,
         )
 
-        # Robot body positions in robot anchor frame (critic-only privileged) — vectorized
-        n_body = len(self._cfg.body_names)
-        # Flatten (N, B, *) -> (N*B, *) for batched frame transform
-        anchor_pos_tiled = np.tile(robot_anchor_pos_w, (1, n_body)).reshape(num_envs * n_body, 3)
-        anchor_quat_tiled = np.tile(robot_anchor_quat_w, (1, n_body)).reshape(num_envs * n_body, 4)
-        body_pos_flat = robot_body_pos_w.reshape(num_envs * n_body, 3)
-        body_quat_flat = robot_body_quat_w.reshape(num_envs * n_body, 4)
-
-        pos_b_flat, ori_b_flat = np_subtract_frame_transforms(
-            anchor_pos_tiled, anchor_quat_tiled, body_pos_flat, body_quat_flat
-        )
-        robot_body_pos_b = pos_b_flat.reshape(num_envs, n_body, 3)
-        ori_mat = np_matrix_from_quat(ori_b_flat)  # (N*B, 3, 3)
-        robot_body_ori_b = ori_mat[:, :, :2].reshape(num_envs, n_body, 6)
-
-        critic_extra = np.concatenate(
-            [
-                robot_body_pos_b.reshape(num_envs, -1),
-                robot_body_ori_b.reshape(num_envs, -1),
-            ],
-            axis=1,
-            dtype=get_global_dtype(),
-        )
-
         # Critic observations (clean proprioception + privileged body transforms)
-        critic_obs = np.concatenate(
-            [
-                command,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                linvel,
-                gyro,
-                joint_pos_rel,
-                dof_vel,
-                last_actions,
-                critic_extra,
-            ],
-            axis=1,
-            dtype=get_global_dtype(),
+        critic_obs = np.empty((num_envs, self._critic_obs_width), dtype=dtype)
+        offset = 0
+        critic_obs[:, offset : offset + command.shape[1]] = command
+        offset += command.shape[1]
+        critic_obs[:, offset : offset + 3] = motion_anchor_pos_b
+        offset += 3
+        critic_obs[:, offset : offset + 6] = motion_anchor_ori_b
+        offset += 6
+        critic_obs[:, offset : offset + 3] = linvel
+        offset += 3
+        critic_obs[:, offset : offset + 3] = gyro
+        offset += 3
+        critic_obs[:, offset : offset + n_action] = joint_pos_rel
+        offset += n_action
+        critic_obs[:, offset : offset + n_action] = dof_vel
+        offset += n_action
+        critic_obs[:, offset : offset + n_action] = last_actions
+        offset += n_action
+        robot_body_pos_b = critic_obs[:, offset : offset + n_body * 3].reshape(num_envs, n_body, 3)
+        self._write_body_pos_in_anchor_frame(
+            robot_anchor_pos_w, robot_anchor_quat_w, robot_body_pos_w, robot_body_pos_b
+        )
+        offset += n_body * 3
+        robot_body_ori_b = critic_obs[:, offset : offset + n_body * 6].reshape(num_envs, n_body, 6)
+        self._write_body_ori6_in_anchor_frame(
+            robot_anchor_quat_w, robot_body_quat_w, robot_body_ori_b
         )
         return {"obs": actor_obs, "critic": critic_obs}
 
@@ -773,12 +1066,14 @@ class G1MotionTrackingEnv(G1BaseEnv):
         dof_vel: np.ndarray,
     ) -> np.ndarray:
         """Compute reward."""
-        dtype = get_global_dtype()
-        reward = np.zeros((self._num_envs,), dtype=dtype)
+        reward = self._env_error2
+        reward.fill(0.0)
         cfg = self._cfg.reward_config
 
-        step_count = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
-        should_log = self._enable_reward_log and (int(step_count[0]) % 4 == 0)
+        step_count = info.get("steps")
+        should_log = self._enable_reward_log and (
+            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
+        )
         log = {} if should_log else info.get("log", {})
 
         # Store motion and robot states in info for reward functions
@@ -794,16 +1089,66 @@ class G1MotionTrackingEnv(G1BaseEnv):
         info["dof_vel"] = dof_vel
 
         for name, scale in cfg.scales.items():
-            if scale == 0 or name not in self._reward_fns:
+            if scale == 0:
                 continue
-            rew = self._reward_fns[name](info)
-            weighted_rew = rew * scale
+            reward_fn = self._active_reward_fns.get(name)
+            if reward_fn is None:
+                if should_log and name in self._reward_fns:
+                    log[f"reward/{name}"] = 0.0
+                continue
+            rew = reward_fn(info)
+            weighted_rew = self._weighted_reward
+            np.multiply(rew, scale, out=weighted_rew)
             reward += weighted_rew
             if should_log:
-                log[f"reward/{name}"] = float(np.mean(weighted_rew))
+                log[f"reward/{name}"] = float(np.sum(weighted_rew) / weighted_rew.size)
 
         info["log"] = log
-        return reward * self._cfg.ctrl_dt
+        reward *= self._cfg.ctrl_dt
+        return reward
+
+    def _mean_body_xyz_squared_error(self, reference: np.ndarray, actual: np.ndarray) -> np.ndarray:
+        vec_error = self._body_vec_error
+        env_error = self._env_error
+        tmp_error = self._reward_term
+        np.subtract(reference[..., 0], actual[..., 0], out=vec_error[..., 0])
+        np.square(vec_error[..., 0], out=vec_error[..., 0])
+        np.sum(vec_error[..., 0], axis=1, out=env_error)
+        np.subtract(reference[..., 1], actual[..., 1], out=vec_error[..., 1])
+        np.square(vec_error[..., 1], out=vec_error[..., 1])
+        np.sum(vec_error[..., 1], axis=1, out=tmp_error)
+        env_error += tmp_error
+        np.subtract(reference[..., 2], actual[..., 2], out=vec_error[..., 2])
+        np.square(vec_error[..., 2], out=vec_error[..., 2])
+        np.sum(vec_error[..., 2], axis=1, out=tmp_error)
+        env_error += tmp_error
+        env_error /= reference.shape[1]
+        return env_error
+
+    def _quat_error_magnitude_squared_body(self, q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+        rel_w = self._quat_error_w
+        rel_x = self._quat_error_x
+        # Motion/backend quaternions are unit quaternions, so the relative
+        # rotation angle only needs abs(dot(q1, q2)).
+        np.multiply(q1[..., 0], q2[..., 0], out=rel_w)
+        np.multiply(q1[..., 1], q2[..., 1], out=rel_x)
+        rel_w += rel_x
+        np.multiply(q1[..., 2], q2[..., 2], out=rel_x)
+        rel_w += rel_x
+        np.multiply(q1[..., 3], q2[..., 3], out=rel_x)
+        rel_w += rel_x
+        np.abs(rel_w, out=rel_w)
+        np.clip(rel_w, 0.0, 1.0, out=rel_w)
+        np.arccos(rel_w, out=rel_x)
+        rel_x *= 2.0
+        np.square(rel_x, out=rel_x)
+        return rel_x
+
+    def _exp_reward_from_error(self, error: np.ndarray, std: float) -> np.ndarray:
+        out = self._reward_term
+        np.divide(error, -(std**2), out=out)
+        np.exp(out, out=out)
+        return out
 
     # Reward functions
     def _reward_motion_global_root_pos(self, info: dict) -> np.ndarray:
@@ -811,108 +1156,126 @@ class G1MotionTrackingEnv(G1BaseEnv):
         robot_body_pos_w = info["robot_body_pos_w"]
         anchor_pos_w = motion_data.body_pos_w[:, self.anchor_body_idx]
         robot_anchor_pos_w = robot_body_pos_w[:, self.anchor_body_idx]
-        error = np.sum(np.square(anchor_pos_w - robot_anchor_pos_w), axis=-1)
-        return np.asarray(
-            np.exp(-error / self._cfg.reward_config.std_root_pos**2), dtype=get_global_dtype()
-        )
+        error = self._env_error
+        np.subtract(anchor_pos_w[:, 0], robot_anchor_pos_w[:, 0], out=error)
+        np.square(error, out=error)
+        np.subtract(anchor_pos_w[:, 1], robot_anchor_pos_w[:, 1], out=self._reward_term)
+        np.square(self._reward_term, out=self._reward_term)
+        error += self._reward_term
+        np.subtract(anchor_pos_w[:, 2], robot_anchor_pos_w[:, 2], out=self._reward_term)
+        np.square(self._reward_term, out=self._reward_term)
+        error += self._reward_term
+        return self._exp_reward_from_error(error, self._cfg.reward_config.std_root_pos)
 
     def _reward_motion_global_root_ori(self, info: dict) -> np.ndarray:
         motion_data = info["motion_data"]
         robot_body_quat_w = info["robot_body_quat_w"]
         anchor_quat_w = motion_data.body_quat_w[:, self.anchor_body_idx]
         robot_anchor_quat_w = robot_body_quat_w[:, self.anchor_body_idx]
-        error = np_quat_error_magnitude(anchor_quat_w, robot_anchor_quat_w) ** 2
-        return np.exp(-error / self._cfg.reward_config.std_root_ori**2)
+        np.multiply(anchor_quat_w[:, 0], robot_anchor_quat_w[:, 0], out=self._env_error)
+        np.multiply(anchor_quat_w[:, 1], robot_anchor_quat_w[:, 1], out=self._reward_term)
+        self._env_error += self._reward_term
+        np.multiply(anchor_quat_w[:, 2], robot_anchor_quat_w[:, 2], out=self._reward_term)
+        self._env_error += self._reward_term
+        np.multiply(anchor_quat_w[:, 3], robot_anchor_quat_w[:, 3], out=self._reward_term)
+        self._env_error += self._reward_term
+        np.abs(self._env_error, out=self._env_error)
+        np.clip(self._env_error, 0.0, 1.0, out=self._env_error)
+        np.arccos(self._env_error, out=self._env_error)
+        self._env_error *= 2.0
+        np.square(self._env_error, out=self._env_error)
+        return self._exp_reward_from_error(self._env_error, self._cfg.reward_config.std_root_ori)
 
     def _reward_motion_body_pos(self, info: dict) -> np.ndarray:
         robot_body_pos_w = info["robot_body_pos_w"]
-        error = np.sum(np.square(self.body_pos_relative_w - robot_body_pos_w), axis=-1)
-        return np.asarray(
-            np.exp(-error.mean(-1) / self._cfg.reward_config.std_body_pos**2),
-            dtype=get_global_dtype(),
-        )
+        error = self._mean_body_xyz_squared_error(self.body_pos_relative_w, robot_body_pos_w)
+        return self._exp_reward_from_error(error, self._cfg.reward_config.std_body_pos)
 
     def _reward_motion_body_ori(self, info: dict) -> np.ndarray:
         robot_body_quat_w = info["robot_body_quat_w"]
-        # np_quat_error_magnitude only supports (N, 4) — flatten body dim first
-        n_env, n_body = robot_body_quat_w.shape[:2]
-        ref_flat = self.body_quat_relative_w.reshape(n_env * n_body, 4)
-        rob_flat = robot_body_quat_w.reshape(n_env * n_body, 4)
-        error = np_quat_error_magnitude(ref_flat, rob_flat) ** 2
-        error = error.reshape(n_env, n_body)
-        return np.asarray(
-            np.exp(-error.mean(-1) / self._cfg.reward_config.std_body_ori**2),
-            dtype=get_global_dtype(),
+        error = self._quat_error_magnitude_squared_body(
+            self.body_quat_relative_w, robot_body_quat_w
         )
+        np.sum(error, axis=-1, out=self._env_error)
+        self._env_error /= error.shape[1]
+        return self._exp_reward_from_error(self._env_error, self._cfg.reward_config.std_body_ori)
 
     def _reward_motion_body_lin_vel(self, info: dict) -> np.ndarray:
         motion_data = info["motion_data"]
         robot_body_lin_vel_w = info["robot_body_lin_vel_w"]
-        error = np.sum(np.square(motion_data.body_lin_vel_w - robot_body_lin_vel_w), axis=-1)
-        return np.asarray(
-            np.exp(-error.mean(-1) / self._cfg.reward_config.std_body_lin_vel**2),
-            dtype=get_global_dtype(),
-        )
+        error = self._mean_body_xyz_squared_error(motion_data.body_lin_vel_w, robot_body_lin_vel_w)
+        return self._exp_reward_from_error(error, self._cfg.reward_config.std_body_lin_vel)
 
     def _reward_motion_body_ang_vel(self, info: dict) -> np.ndarray:
         motion_data = info["motion_data"]
         robot_body_ang_vel_w = info["robot_body_ang_vel_w"]
-        error = np.sum(np.square(motion_data.body_ang_vel_w - robot_body_ang_vel_w), axis=-1)
-        return np.asarray(
-            np.exp(-error.mean(-1) / self._cfg.reward_config.std_body_ang_vel**2),
-            dtype=get_global_dtype(),
-        )
+        error = self._mean_body_xyz_squared_error(motion_data.body_ang_vel_w, robot_body_ang_vel_w)
+        return self._exp_reward_from_error(error, self._cfg.reward_config.std_body_ang_vel)
 
     def _reward_motion_ee_body_pos_z(self, info: dict) -> np.ndarray:
         robot_body_pos_w = info["robot_body_pos_w"]
-        error = np.square(
-            self.body_pos_relative_w[:, self.ee_body_indices, 2]
-            - robot_body_pos_w[:, self.ee_body_indices, 2]
+        np.subtract(
+            self.body_pos_relative_w[:, self.ee_body_indices, 2],
+            robot_body_pos_w[:, self.ee_body_indices, 2],
+            out=self._ee_pos_error_z,
         )
-        return np.asarray(
-            np.exp(-error.mean(-1) / self._cfg.reward_config.std_body_pos**2),
-            dtype=get_global_dtype(),
-        )
+        np.square(self._ee_pos_error_z, out=self._ee_pos_error_z)
+        np.sum(self._ee_pos_error_z, axis=-1, out=self._env_error)
+        self._env_error /= self._ee_pos_error_z.shape[1]
+        return self._exp_reward_from_error(self._env_error, self._cfg.reward_config.std_body_pos)
 
     def _reward_motion_joint_pos(self, info: dict) -> np.ndarray:
         motion_data = info["motion_data"]
         dof_pos = info["dof_pos"]
-        error = np.mean(np.square(motion_data.joint_pos - dof_pos), axis=-1)
-        return np.asarray(
-            np.exp(-error / self._cfg.reward_config.std_joint_pos**2), dtype=get_global_dtype()
-        )
+        np.subtract(motion_data.joint_pos, dof_pos, out=self._joint_error)
+        np.square(self._joint_error, out=self._joint_error)
+        np.sum(self._joint_error, axis=1, out=self._env_error)
+        self._env_error /= dof_pos.shape[1]
+        return self._exp_reward_from_error(self._env_error, self._cfg.reward_config.std_joint_pos)
 
     def _reward_motion_joint_vel(self, info: dict) -> np.ndarray:
         motion_data = info["motion_data"]
         dof_vel = info["dof_vel"]
-        error = np.mean(np.square(motion_data.joint_vel - dof_vel), axis=-1)
-        return np.asarray(
-            np.exp(-error / self._cfg.reward_config.std_joint_vel**2), dtype=get_global_dtype()
-        )
+        np.subtract(motion_data.joint_vel, dof_vel, out=self._joint_error)
+        np.square(self._joint_error, out=self._joint_error)
+        np.sum(self._joint_error, axis=1, out=self._env_error)
+        self._env_error /= dof_vel.shape[1]
+        return self._exp_reward_from_error(self._env_error, self._cfg.reward_config.std_joint_vel)
 
     def _reward_undesired_contacts(self, info: dict) -> np.ndarray:
         robot_body_pos_w = info["robot_body_pos_w"]
         body_z = robot_body_pos_w[:, self.undesired_contact_body_indices, 2]
-        is_contact = body_z < self._cfg.undesired_contact_z_threshold
-        return np.asarray(is_contact.sum(axis=-1), dtype=get_global_dtype())
+        np.less(
+            body_z,
+            self._cfg.undesired_contact_z_threshold,
+            out=self._undesired_contact_mask,
+        )
+        np.sum(self._undesired_contact_mask, axis=-1, out=self._env_error)
+        return self._env_error
 
     def _reward_action_rate_l2(self, info: dict) -> np.ndarray:
-        action_diff = info["current_actions"] - info["last_actions"]
-        return np.asarray(np.sum(np.square(action_diff), axis=1), dtype=get_global_dtype())
+        np.subtract(info["current_actions"], info["last_actions"], out=self._joint_error)
+        np.square(self._joint_error, out=self._joint_error)
+        np.sum(self._joint_error, axis=1, out=self._env_error)
+        return self._env_error
 
     def _reward_joint_limit(self, info: dict) -> np.ndarray:
         dof_pos = info["dof_pos"]
-        joint_range = self._get_joint_range()
-        if joint_range is None:
-            return np.zeros((self._num_envs,), dtype=get_global_dtype())
-        lower = joint_range[:, 0]
-        upper = joint_range[:, 1]
+        lower = self._joint_lower
+        upper = self._joint_upper
+        if lower is None or upper is None:
+            self._reward_term.fill(0.0)
+            return self._reward_term
 
         # Compute violation
-        lower_violation = np.maximum(0, lower - dof_pos)
-        upper_violation = np.maximum(0, dof_pos - upper)
-        violation = lower_violation + upper_violation
-        return np.asarray(np.sum(np.square(violation), axis=1), dtype=get_global_dtype())
+        np.subtract(lower, dof_pos, out=self._joint_error)
+        np.maximum(self._joint_error, 0, out=self._joint_error)
+        np.subtract(dof_pos, upper, out=self._joint_error_upper)
+        np.maximum(self._joint_error_upper, 0, out=self._joint_error_upper)
+        self._joint_error += self._joint_error_upper
+        np.square(self._joint_error, out=self._joint_error)
+        np.sum(self._joint_error, axis=1, out=self._reward_term)
+        return self._reward_term
 
 
 @registry.env("G1MotionTrackingDeploy", sim_backend="mujoco")

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -149,21 +149,22 @@ def test_motrix_backend_smoke_contract(robot):
     nq = bkd.get_dof_pos().shape[-1] + 7
     nv = bkd.get_dof_vel().shape[-1] + 6
     qpos = _identity_qpos_mujoco(nq, xyz=(1.0, 2.0, 0.8))
-    gravity = np.asarray([[1.0, 2.0, -3.0]], dtype=np.float64)
-    bkd.set_state(
-        np.array([0]),
-        qpos,
-        np.zeros((1, nv)),
-        randomization=ResetRandomizationPayload(gravity=gravity),
-    )
+    caps = bkd.get_dr_capabilities()
+    if "gravity" in caps.supported_reset_terms:
+        gravity = np.asarray([[1.0, 2.0, -3.0]], dtype=np.float64)
+        bkd.set_state(
+            np.array([0]),
+            qpos,
+            np.zeros((1, nv)),
+            randomization=ResetRandomizationPayload(gravity=gravity),
+        )
+        np.testing.assert_allclose(bkd.model.get_gravity_override(bkd.data)[0], gravity[0])
+    else:
+        bkd.set_state(np.array([0]), qpos, np.zeros((1, nv)))
     np.testing.assert_allclose(bkd.get_base_pos()[0], (1.0, 2.0, 0.8), atol=1e-4)
-    np.testing.assert_allclose(bkd.model.get_gravity_override(bkd.data)[0], gravity[0])
     _unit_quat(bkd.get_base_quat(), "Motrix smoke")
 
-    caps = bkd.get_dr_capabilities()
-    assert {"base_mass_delta", "base_com_offset", "gravity", "kp", "kd"}.issubset(
-        caps.supported_reset_terms
-    )
+    assert {"base_mass_delta", "base_com_offset", "kp", "kd"}.issubset(caps.supported_reset_terms)
     assert caps.supports_interval_push
     play_caps = bkd.get_play_capabilities()
     assert play_caps.supports_native_interactive_renderer
@@ -383,6 +384,39 @@ def test_motrix_model_properties_smoke():
     _shape(ctrl_range, bkd.num_actuators, 2)
     assert bkd.get_default_qpos().ndim == 1
     assert bkd.get_joint_range() is None
+
+
+def test_motrix_copy_body_state_matches_split_queries():
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix.backend import MotrixBackend
+
+    bkd = MotrixBackend(
+        SceneCfg(model_file=_G1["model_file"]),
+        NUM_ENVS,
+        SIM_DT,
+        base_name=_G1["base_name"],
+        add_body_sensors=True,
+    )
+    body_names = ["pelvis", "torso_link"]
+    body_ids = np.asarray([bkd.model.get_link_index(name) for name in body_names], dtype=np.int32)
+
+    expected_pos = bkd.get_body_pos_w(body_ids)
+    expected_quat = bkd.get_body_quat_w(body_ids)
+    expected_lin_vel = bkd.get_body_lin_vel_w(body_ids)
+    expected_ang_vel = bkd.get_body_ang_vel_w(body_ids)
+    out_pos = np.empty_like(expected_pos)
+    out_quat = np.empty_like(expected_quat)
+    out_lin_vel = np.empty_like(expected_lin_vel)
+    out_ang_vel = np.empty_like(expected_ang_vel)
+
+    result = bkd.copy_body_state_w(body_ids, out_pos, out_quat, out_lin_vel, out_ang_vel)
+
+    assert result == (out_pos, out_quat, out_lin_vel, out_ang_vel)
+    np.testing.assert_allclose(out_pos, expected_pos)
+    np.testing.assert_allclose(out_quat, expected_quat)
+    np.testing.assert_allclose(out_lin_vel, expected_lin_vel)
+    np.testing.assert_allclose(out_ang_vel, expected_ang_vel)
 
 
 def test_motrix_default_qpos_uses_mujoco_quaternion_convention():

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -149,22 +149,21 @@ def test_motrix_backend_smoke_contract(robot):
     nq = bkd.get_dof_pos().shape[-1] + 7
     nv = bkd.get_dof_vel().shape[-1] + 6
     qpos = _identity_qpos_mujoco(nq, xyz=(1.0, 2.0, 0.8))
-    caps = bkd.get_dr_capabilities()
-    if "gravity" in caps.supported_reset_terms:
-        gravity = np.asarray([[1.0, 2.0, -3.0]], dtype=np.float64)
-        bkd.set_state(
-            np.array([0]),
-            qpos,
-            np.zeros((1, nv)),
-            randomization=ResetRandomizationPayload(gravity=gravity),
-        )
-        np.testing.assert_allclose(bkd.model.get_gravity_override(bkd.data)[0], gravity[0])
-    else:
-        bkd.set_state(np.array([0]), qpos, np.zeros((1, nv)))
+    gravity = np.asarray([[1.0, 2.0, -3.0]], dtype=np.float64)
+    bkd.set_state(
+        np.array([0]),
+        qpos,
+        np.zeros((1, nv)),
+        randomization=ResetRandomizationPayload(gravity=gravity),
+    )
     np.testing.assert_allclose(bkd.get_base_pos()[0], (1.0, 2.0, 0.8), atol=1e-4)
+    np.testing.assert_allclose(bkd.model.get_gravity_override(bkd.data)[0], gravity[0])
     _unit_quat(bkd.get_base_quat(), "Motrix smoke")
 
-    assert {"base_mass_delta", "base_com_offset", "kp", "kd"}.issubset(caps.supported_reset_terms)
+    caps = bkd.get_dr_capabilities()
+    assert {"base_mass_delta", "base_com_offset", "gravity", "kp", "kd"}.issubset(
+        caps.supported_reset_terms
+    )
     assert caps.supports_interval_push
     play_caps = bkd.get_play_capabilities()
     assert play_caps.supports_native_interactive_renderer
@@ -370,6 +369,38 @@ def test_mujoco_metadata_getters_return_stable_copies():
     assert not np.isclose(dof_armature[-1], model.dof_armature[-1])
 
 
+def test_mujoco_copy_body_state_matches_split_queries():
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(
+        SceneCfg(model_file=_G1["model_file"]),
+        NUM_ENVS,
+        SIM_DT,
+        base_name=_G1["base_name"],
+        add_body_sensors=True,
+    )
+    bkd.materialize()
+    bkd.step(np.zeros((NUM_ENVS, bkd.model.nu)), nsteps=1)
+    body_ids = bkd.get_body_ids(["pelvis", "torso_link"])
+
+    expected_pos = bkd.get_body_pos_w(body_ids)
+    expected_quat = bkd.get_body_quat_w(body_ids)
+    expected_lin_vel = bkd.get_body_lin_vel_w(body_ids)
+    expected_ang_vel = bkd.get_body_ang_vel_w(body_ids)
+    out_pos = np.empty_like(expected_pos)
+    out_quat = np.empty_like(expected_quat)
+    out_lin_vel = np.empty_like(expected_lin_vel)
+    out_ang_vel = np.empty_like(expected_ang_vel)
+
+    result = bkd.copy_body_state_w(body_ids, out_pos, out_quat, out_lin_vel, out_ang_vel)
+
+    assert result == (out_pos, out_quat, out_lin_vel, out_ang_vel)
+    np.testing.assert_allclose(out_pos, expected_pos)
+    np.testing.assert_allclose(out_quat, expected_quat)
+    np.testing.assert_allclose(out_lin_vel, expected_lin_vel)
+    np.testing.assert_allclose(out_ang_vel, expected_ang_vel)
+
+
 def test_motrix_model_properties_smoke():
     pytest.importorskip("motrixsim")
 
@@ -417,6 +448,12 @@ def test_motrix_copy_body_state_matches_split_queries():
     np.testing.assert_allclose(out_quat, expected_quat)
     np.testing.assert_allclose(out_lin_vel, expected_lin_vel)
     np.testing.assert_allclose(out_ang_vel, expected_ang_vel)
+
+    row_ids = np.array([1, 0, 1], dtype=np.int32)
+    np.testing.assert_allclose(
+        bkd.get_sensor_data_rows("pelvis_local_linvel", row_ids),
+        bkd.get_sensor_data("pelvis_local_linvel")[row_ids],
+    )
 
 
 def test_motrix_default_qpos_uses_mujoco_quaternion_convention():

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -458,6 +458,8 @@ def _compute_g1_motion_tracking_obs_stub(env_cls: type):
     env = cast(Any, object.__new__(env_cls))
     env._num_envs = 1
     env._num_action = 2
+    env._n_motion_bodies = 2
+    env._critic_obs_width = env._critic_base_obs_dim(env._num_action) + env._n_motion_bodies * 9
     env._cfg = SimpleNamespace(
         noise_config=SimpleNamespace(
             level=1.0,
@@ -470,6 +472,15 @@ def _compute_g1_motion_tracking_obs_stub(env_cls: type):
     )
     env.default_angles = np.array([[0.5, -0.5]], dtype=np.float32)
     env.anchor_body_idx = 0
+    env._motion_anchor_pos_b = np.empty((1, 3), dtype=np.float32)
+    env._motion_anchor_ori_b = np.empty((1, 6), dtype=np.float32)
+    env._motion_command = np.empty((1, 4), dtype=np.float32)
+    env._joint_pos_rel = np.empty((1, 2), dtype=np.float32)
+    env._body_vec_error = np.empty((1, 2, 3), dtype=np.float32)
+    env._body_vec_tmp = np.empty((1, 2, 3), dtype=np.float32)
+    env._quat_error_w = np.empty((1, 2), dtype=np.float32)
+    env._quat_error_x = np.empty((1, 2), dtype=np.float32)
+    env._zero_actions = np.zeros((1, 2), dtype=np.float32)
     env._obs_noise = lambda data, scale: np.asarray(data + 100.0, dtype=np.float32)
 
     motion_data = MotionData(
@@ -538,6 +549,56 @@ def test_g1_motion_tracking_critic_uses_clean_beyondmimic_aligned_terms():
     )
 
 
+def test_g1_motion_tracking_anchor_frame_writers_match_reference():
+    from unilab.envs.common.rotation import (
+        np_matrix_from_quat,
+        np_quat_apply,
+        np_quat_inv,
+        np_quat_mul,
+    )
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv
+
+    rng = np.random.default_rng(123)
+    num_envs = 4
+    num_bodies = 5
+    dtype = np.float64
+
+    def random_quat(shape: tuple[int, ...]) -> np.ndarray:
+        quat = rng.normal(size=(*shape, 4)).astype(dtype)
+        quat /= np.linalg.norm(quat, axis=-1, keepdims=True)
+        return quat
+
+    anchor_pos = rng.normal(size=(num_envs, 3)).astype(dtype)
+    anchor_quat = random_quat((num_envs,))
+    body_pos = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    body_quat = random_quat((num_envs, num_bodies))
+
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
+    env._body_vec_error = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    env._body_vec_tmp = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    env._quat_error_w = np.empty((num_envs, num_bodies), dtype=dtype)
+    env._quat_error_x = np.empty((num_envs, num_bodies), dtype=dtype)
+
+    pos_out = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    ori_out = np.empty((num_envs, num_bodies, 6), dtype=dtype)
+
+    env._write_body_pos_in_anchor_frame(anchor_pos, anchor_quat, body_pos, pos_out)
+    env._write_body_ori6_in_anchor_frame(anchor_quat, body_quat, ori_out)
+
+    anchor_quat_inv = np_quat_inv(anchor_quat)
+    tiled_anchor_quat_inv = np.repeat(anchor_quat_inv, num_bodies, axis=0)
+    rel_pos_flat = (body_pos - anchor_pos[:, None, :]).reshape(num_envs * num_bodies, 3)
+    ref_pos = np_quat_apply(tiled_anchor_quat_inv, rel_pos_flat).reshape(num_envs, num_bodies, 3)
+    ref_quat = np_quat_mul(
+        tiled_anchor_quat_inv,
+        body_quat.reshape(num_envs * num_bodies, 4),
+    )
+    ref_ori = np_matrix_from_quat(ref_quat)[:, :, :2].reshape(num_envs, num_bodies, 6)
+
+    np.testing.assert_allclose(pos_out, ref_pos, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(ori_out, ref_ori, rtol=1e-12, atol=1e-12)
+
+
 def test_g1_motion_tracking_deploy_actor_matches_unitree_mimic_terms():
     from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingDeployEnv
 
@@ -600,6 +661,8 @@ def _compute_g1_box_tracking_obs_stub():
     env = cast(Any, object.__new__(G1BoxTrackingEnv))
     env._num_envs = 1
     env._num_action = 2
+    env._n_motion_bodies = 2
+    env._critic_obs_width = env._critic_base_obs_dim(env._num_action) + env._n_motion_bodies * 9
     env._cfg = SimpleNamespace(
         noise_config=SimpleNamespace(
             level=1.0,
@@ -613,6 +676,12 @@ def _compute_g1_box_tracking_obs_stub():
     env.default_angles = np.array([[0.5, -0.5]], dtype=np.float32)
     env.anchor_body_idx = 0
     env._object_body_ids = np.array([7], dtype=np.int32)
+    env._motion_anchor_pos_b = np.empty((1, 3), dtype=np.float32)
+    env._motion_anchor_ori_b = np.empty((1, 6), dtype=np.float32)
+    env._motion_command = np.empty((1, 4), dtype=np.float32)
+    env._joint_pos_rel = np.empty((1, 2), dtype=np.float32)
+    env._body_vec_error = np.empty((1, 2, 3), dtype=np.float32)
+    env._zero_actions = np.zeros((1, 2), dtype=np.float32)
     env._obs_noise = lambda data, scale: np.asarray(data + 100.0, dtype=np.float32)
 
     class FakeBackend:
@@ -685,6 +754,8 @@ def test_g1_box_tracking_critic_object_state_respects_subset_env_order():
     env = cast(Any, object.__new__(G1BoxTrackingEnv))
     env._num_envs = 4
     env._num_action = 2
+    env._n_motion_bodies = 2
+    env._critic_obs_width = env._critic_base_obs_dim(env._num_action) + env._n_motion_bodies * 9
     env.anchor_body_idx = 0
     env._object_body_ids = np.array([7], dtype=np.int32)
     env._cfg = SimpleNamespace(
@@ -698,6 +769,7 @@ def test_g1_box_tracking_critic_object_state_respects_subset_env_order():
         body_names=("pelvis", "torso_link"),
     )
     env.default_angles = np.zeros((2,), dtype=np.float32)
+    env._body_vec_error = np.empty((4, 2, 3), dtype=np.float32)
     env._obs_noise = lambda data, scale: np.asarray(data, dtype=np.float32)
 
     class FakeBackend:
@@ -784,7 +856,15 @@ def test_g1_motion_tracking_can_terminate_on_undesired_contacts():
     env._num_envs = 2
     env.anchor_body_idx = 0
     env.ee_body_indices = np.array([1], dtype=np.int32)
+    env._has_ee_body_indices = True
     env.undesired_contact_body_indices = np.array([2], dtype=np.int32)
+    env._has_undesired_contact_body_indices = True
+    env._terminated = np.empty((2,), dtype=bool)
+    env._env_bool = np.empty((2,), dtype=bool)
+    env._env_error = np.empty((2,), dtype=np.float32)
+    env._ee_pos_error_z = np.empty((2, 1), dtype=np.float32)
+    env._ee_terminated = np.empty((2, 1), dtype=bool)
+    env._undesired_contact_mask = np.empty((2, 1), dtype=bool)
     env.body_pos_relative_w = np.array(
         [
             [[0.0, 0.0, 1.0], [0.0, 0.0, 0.8], [0.0, 0.0, 0.8]],
@@ -854,6 +934,19 @@ def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatc
             calls["motion_body_ids_names"] = names
             return np.array([1, 2], dtype=np.int32)
 
+        def copy_body_state_w(
+            self,
+            body_ids: np.ndarray,
+            out_pos: np.ndarray,
+            out_quat: np.ndarray,
+            out_lin_vel: np.ndarray,
+            out_ang_vel: np.ndarray,
+        ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+            return out_pos, out_quat, out_lin_vel, out_ang_vel
+
+        def get_joint_range(self) -> None:
+            return None
+
     def fake_base_init(self, cfg, backend, num_envs):
         self._cfg = cfg
         self._backend = backend
@@ -883,7 +976,10 @@ def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatc
     monkeypatch.setattr(
         G1MotionTrackingEnv,
         "_init_reward_functions",
-        lambda self: calls.setdefault("reward_init", True),
+        lambda self: (
+            calls.setdefault("reward_init", True),
+            setattr(self, "_reward_fns", {}),
+        ),
     )
 
     cfg = G1MotionTrackingCfg(
@@ -1057,6 +1153,25 @@ def _make_g1_motion_tracking_clip_end_stub(
         def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
             return np.zeros((2, len(body_ids), 3), dtype=np.float32)
 
+        def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+            return np.zeros((2, len(body_ids), 3), dtype=np.float32)
+
+        def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+            return np.tile(
+                np.array([[[1.0, 0.0, 0.0, 0.0]]], dtype=np.float32),
+                (2, len(body_ids), 1),
+            )
+
+        def get_body_pose_w_rows(
+            self, env_ids: np.ndarray, body_ids: np.ndarray
+        ) -> tuple[np.ndarray, np.ndarray]:
+            rows = np.asarray(env_ids, dtype=np.intp)
+            return self.get_body_pos_w(body_ids)[rows], self.get_body_quat_w(body_ids)[rows]
+
+        def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:
+            del name
+            return np.zeros((len(env_ids), 3), dtype=np.float32)
+
         def set_state(self, env_ids: np.ndarray, qpos: np.ndarray, qvel: np.ndarray) -> None:
             self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
@@ -1122,6 +1237,7 @@ def _make_g1_motion_tracking_clip_end_stub(
     env._cfg = SimpleNamespace(
         max_episode_steps=None,
         truncate_on_clip_end=truncate_on_clip_end,
+        sensor=SimpleNamespace(local_linvel="local_linvel", gyro="gyro"),
         pose_randomization=zero_pose,
         velocity_randomization=zero_pose,
         joint_position_range=(0.0, 0.0),
@@ -1130,7 +1246,10 @@ def _make_g1_motion_tracking_clip_end_stub(
     env._backend = FakeBackend()
     env.motion_sampler = FakeSampler()
     env.motion_loader = FakeMotionLoader()
+    env._motion_data_buffer = None
+    env._copy_body_state_w = None
     env._clip_end_truncated = np.zeros((2,), dtype=bool)
+    env._env_bool = np.empty((2,), dtype=bool)
     env._init_qpos = np.zeros((9,), dtype=np.float32)
     env._init_qvel = np.zeros((8,), dtype=np.float32)
     env.get_local_linvel = lambda: np.zeros((2, 3), dtype=np.float32)

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -599,6 +599,232 @@ def test_g1_motion_tracking_anchor_frame_writers_match_reference():
     np.testing.assert_allclose(ori_out, ref_ori, rtol=1e-12, atol=1e-12)
 
 
+def test_g1_motion_tracking_relative_transform_fast_path_matches_reference():
+    from unilab.envs.common.rotation import np_quat_apply, np_quat_inv, np_quat_mul, np_yaw_quat
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv
+
+    rng = np.random.default_rng(321)
+    num_envs = 4
+    num_bodies = 5
+    anchor_idx = 2
+    dtype = np.float64
+
+    def random_quat(shape: tuple[int, ...]) -> np.ndarray:
+        quat = rng.normal(size=(*shape, 4)).astype(dtype)
+        quat /= np.linalg.norm(quat, axis=-1, keepdims=True)
+        return quat
+
+    motion_data = SimpleNamespace(
+        body_pos_w=rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype),
+        body_quat_w=random_quat((num_envs, num_bodies)),
+    )
+    robot_body_pos_w = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    robot_body_quat_w = random_quat((num_envs, num_bodies))
+
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
+    env.anchor_body_idx = anchor_idx
+    env.body_pos_relative_w = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    env.body_quat_relative_w = np.empty((num_envs, num_bodies, 4), dtype=dtype)
+    env._delta_pos_w = np.empty((num_envs, 3), dtype=dtype)
+    env._delta_ori_w = np.empty((num_envs, 4), dtype=dtype)
+    env._body_vec_error = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    env._env_error = np.empty((num_envs,), dtype=dtype)
+    env._reward_term = np.empty((num_envs,), dtype=dtype)
+
+    env._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
+
+    anchor_pos_w = motion_data.body_pos_w[:, anchor_idx]
+    anchor_quat_w = motion_data.body_quat_w[:, anchor_idx]
+    robot_anchor_pos_w = robot_body_pos_w[:, anchor_idx]
+    robot_anchor_quat_w = robot_body_quat_w[:, anchor_idx]
+    delta_pos_w = robot_anchor_pos_w.copy()
+    delta_pos_w[:, 2] = anchor_pos_w[:, 2]
+    delta_ori_w = np_yaw_quat(np_quat_mul(robot_anchor_quat_w, np_quat_inv(anchor_quat_w)))
+    delta_ori_tiled = np.tile(delta_ori_w, (1, num_bodies)).reshape(num_envs * num_bodies, 4)
+    expected_quat = np_quat_mul(
+        delta_ori_tiled,
+        motion_data.body_quat_w.reshape(num_envs * num_bodies, 4),
+    ).reshape(num_envs, num_bodies, 4)
+    rel_pos_flat = (motion_data.body_pos_w - anchor_pos_w[:, None, :]).reshape(
+        num_envs * num_bodies, 3
+    )
+    expected_pos = delta_pos_w[:, None, :] + np_quat_apply(delta_ori_tiled, rel_pos_flat).reshape(
+        num_envs, num_bodies, 3
+    )
+
+    np.testing.assert_allclose(env.body_pos_relative_w, expected_pos, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(env.body_quat_relative_w, expected_quat, rtol=1e-12, atol=1e-12)
+
+
+def test_g1_motion_tracking_reward_fast_path_matches_reference():
+    from unilab.envs.common.rotation import np_quat_error_magnitude
+    from unilab.envs.motion_tracking.g1.motion_loader import MotionData
+    from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingEnv, RewardConfig
+
+    rng = np.random.default_rng(456)
+    num_envs = 3
+    num_bodies = 4
+    num_actions = 2
+    anchor_idx = 1
+    ee_indices = np.array([2, 3], dtype=np.int32)
+    undesired_indices = np.array([0, 1], dtype=np.int32)
+    dtype = np.float64
+
+    def random_quat(shape: tuple[int, ...]) -> np.ndarray:
+        quat = rng.normal(size=(*shape, 4)).astype(dtype)
+        quat /= np.linalg.norm(quat, axis=-1, keepdims=True)
+        return quat
+
+    reward_config = RewardConfig()
+    reward_config.scales = {
+        "motion_global_root_pos": 0.5,
+        "motion_global_root_ori": 0.25,
+        "motion_body_pos": 1.0,
+        "motion_body_ori": 0.75,
+        "motion_body_lin_vel": 0.4,
+        "motion_body_ang_vel": 0.3,
+        "motion_ee_body_pos_z": 0.2,
+        "motion_joint_pos": 0.6,
+        "motion_joint_vel": 0.7,
+        "action_rate_l2": -0.1,
+        "joint_limit": -0.2,
+        "undesired_contacts": -0.3,
+    }
+    ctrl_dt = 0.02
+    contact_threshold = 0.05
+
+    motion_data = MotionData(
+        joint_pos=rng.normal(size=(num_envs, num_actions)).astype(dtype),
+        joint_vel=rng.normal(size=(num_envs, num_actions)).astype(dtype),
+        body_pos_w=rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype),
+        body_quat_w=random_quat((num_envs, num_bodies)),
+        body_lin_vel_w=rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype),
+        body_ang_vel_w=rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype),
+    )
+    robot_body_pos_w = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    robot_body_pos_w[:, undesired_indices, 2] = np.array(
+        [[0.01, 0.10], [0.20, 0.02], [0.07, 0.03]], dtype=dtype
+    )
+    robot_body_quat_w = random_quat((num_envs, num_bodies))
+    robot_body_lin_vel_w = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    robot_body_ang_vel_w = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    dof_pos = rng.normal(size=(num_envs, num_actions)).astype(dtype)
+    dof_vel = rng.normal(size=(num_envs, num_actions)).astype(dtype)
+    current_actions = rng.normal(size=(num_envs, num_actions)).astype(dtype)
+    last_actions = rng.normal(size=(num_envs, num_actions)).astype(dtype)
+    body_pos_relative_w = rng.normal(size=(num_envs, num_bodies, 3)).astype(dtype)
+    body_quat_relative_w = random_quat((num_envs, num_bodies))
+    joint_lower = np.array([-0.2, -0.1], dtype=dtype)
+    joint_upper = np.array([0.1, 0.2], dtype=dtype)
+
+    env = cast(Any, object.__new__(G1MotionTrackingEnv))
+    env._num_envs = num_envs
+    env.anchor_body_idx = anchor_idx
+    env.ee_body_indices = ee_indices
+    env.undesired_contact_body_indices = undesired_indices
+    env._has_ee_body_indices = True
+    env._has_undesired_contact_body_indices = True
+    env._cfg = SimpleNamespace(
+        reward_config=reward_config,
+        ctrl_dt=ctrl_dt,
+        undesired_contact_z_threshold=contact_threshold,
+    )
+    env.body_pos_relative_w = body_pos_relative_w.copy()
+    env.body_quat_relative_w = body_quat_relative_w.copy()
+    env._joint_lower = joint_lower
+    env._joint_upper = joint_upper
+    env._body_vec_error = np.empty((num_envs, num_bodies, 3), dtype=dtype)
+    env._joint_error = np.empty((num_envs, num_actions), dtype=dtype)
+    env._joint_error_upper = np.empty((num_envs, num_actions), dtype=dtype)
+    env._env_error = np.empty((num_envs,), dtype=dtype)
+    env._env_error2 = np.empty((num_envs,), dtype=dtype)
+    env._reward_term = np.empty((num_envs,), dtype=dtype)
+    env._weighted_reward = np.empty((num_envs,), dtype=dtype)
+    env._quat_error_w = np.empty((num_envs, num_bodies), dtype=dtype)
+    env._quat_error_x = np.empty((num_envs, num_bodies), dtype=dtype)
+    env._ee_pos_error_z = np.empty((num_envs, ee_indices.size), dtype=dtype)
+    env._undesired_contact_mask = np.empty((num_envs, undesired_indices.size), dtype=bool)
+    env._enable_reward_log = False
+    env._init_reward_functions()
+    env._active_reward_fns = {
+        name: fn for name, fn in env._reward_fns.items() if env._reward_term_is_active(name)
+    }
+
+    info = {
+        "current_actions": current_actions,
+        "last_actions": last_actions,
+        "steps": np.zeros((num_envs,), dtype=np.uint32),
+    }
+    actual = env._compute_reward(
+        info,
+        motion_data,
+        robot_body_pos_w,
+        robot_body_quat_w,
+        robot_body_lin_vel_w,
+        robot_body_ang_vel_w,
+        dof_pos,
+        dof_vel,
+    ).copy()
+
+    cfg = reward_config
+    expected = np.zeros((num_envs,), dtype=dtype)
+    root_pos_error = np.sum(
+        np.square(motion_data.body_pos_w[:, anchor_idx] - robot_body_pos_w[:, anchor_idx]),
+        axis=-1,
+    )
+    expected += cfg.scales["motion_global_root_pos"] * np.exp(-root_pos_error / cfg.std_root_pos**2)
+    root_ori_error = (
+        np_quat_error_magnitude(
+            motion_data.body_quat_w[:, anchor_idx],
+            robot_body_quat_w[:, anchor_idx],
+        )
+        ** 2
+    )
+    expected += cfg.scales["motion_global_root_ori"] * np.exp(-root_ori_error / cfg.std_root_ori**2)
+    body_pos_error = np.sum(np.square(body_pos_relative_w - robot_body_pos_w), axis=-1)
+    expected += cfg.scales["motion_body_pos"] * np.exp(
+        -body_pos_error.mean(-1) / cfg.std_body_pos**2
+    )
+    body_ori_error = np_quat_error_magnitude(
+        body_quat_relative_w.reshape(num_envs * num_bodies, 4),
+        robot_body_quat_w.reshape(num_envs * num_bodies, 4),
+    ).reshape(num_envs, num_bodies)
+    expected += cfg.scales["motion_body_ori"] * np.exp(
+        -np.square(body_ori_error).mean(-1) / cfg.std_body_ori**2
+    )
+    body_lin_error = np.sum(np.square(motion_data.body_lin_vel_w - robot_body_lin_vel_w), axis=-1)
+    expected += cfg.scales["motion_body_lin_vel"] * np.exp(
+        -body_lin_error.mean(-1) / cfg.std_body_lin_vel**2
+    )
+    body_ang_error = np.sum(np.square(motion_data.body_ang_vel_w - robot_body_ang_vel_w), axis=-1)
+    expected += cfg.scales["motion_body_ang_vel"] * np.exp(
+        -body_ang_error.mean(-1) / cfg.std_body_ang_vel**2
+    )
+    ee_error = np.square(body_pos_relative_w[:, ee_indices, 2] - robot_body_pos_w[:, ee_indices, 2])
+    expected += cfg.scales["motion_ee_body_pos_z"] * np.exp(
+        -ee_error.mean(-1) / cfg.std_body_pos**2
+    )
+    joint_pos_error = np.mean(np.square(motion_data.joint_pos - dof_pos), axis=-1)
+    expected += cfg.scales["motion_joint_pos"] * np.exp(-joint_pos_error / cfg.std_joint_pos**2)
+    joint_vel_error = np.mean(np.square(motion_data.joint_vel - dof_vel), axis=-1)
+    expected += cfg.scales["motion_joint_vel"] * np.exp(-joint_vel_error / cfg.std_joint_vel**2)
+    expected += cfg.scales["action_rate_l2"] * np.sum(
+        np.square(current_actions - last_actions), axis=1
+    )
+    lower_violation = np.maximum(0, joint_lower - dof_pos)
+    upper_violation = np.maximum(0, dof_pos - joint_upper)
+    expected += cfg.scales["joint_limit"] * np.sum(
+        np.square(lower_violation + upper_violation), axis=1
+    )
+    expected += cfg.scales["undesired_contacts"] * np.sum(
+        robot_body_pos_w[:, undesired_indices, 2] < contact_threshold,
+        axis=-1,
+    )
+    expected *= ctrl_dt
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
 def test_g1_motion_tracking_deploy_actor_matches_unitree_mimic_terms():
     from unilab.envs.motion_tracking.g1.tracking import G1MotionTrackingDeployEnv
 

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -117,22 +117,14 @@ def test_batched_quaternion_helpers_match_flattened_helpers() -> None:
         np.linspace(0.2, -0.15, num_envs * num_bodies),
         np.linspace(-0.5, 0.25, num_envs * num_bodies),
     ).reshape(num_envs, num_bodies, 4)
-    vectors = np.linspace(-0.6, 0.7, num_envs * num_bodies * 3).reshape(
-        num_envs, num_bodies, 3
-    )
+    vectors = np.linspace(-0.6, 0.7, num_envs * num_bodies * 3).reshape(num_envs, num_bodies, 3)
 
-    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(
-        num_envs * num_bodies, 4
-    )
+    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(num_envs * num_bodies, 4)
     body_quat_flat = body_quat.reshape(num_envs * num_bodies, 4)
     vectors_flat = vectors.reshape(num_envs * num_bodies, 3)
 
-    expected_mul = np_quat_mul(anchor_quat_tiled, body_quat_flat).reshape(
-        num_envs, num_bodies, 4
-    )
-    expected_apply = np_quat_apply(anchor_quat_tiled, vectors_flat).reshape(
-        num_envs, num_bodies, 3
-    )
+    expected_mul = np_quat_mul(anchor_quat_tiled, body_quat_flat).reshape(num_envs, num_bodies, 4)
+    expected_apply = np_quat_apply(anchor_quat_tiled, vectors_flat).reshape(num_envs, num_bodies, 3)
     expected_error = np_quat_error_magnitude(anchor_quat_tiled, body_quat_flat).reshape(
         num_envs, num_bodies
     )
@@ -172,9 +164,7 @@ def test_anchor_frame_transform_matches_flattened_path() -> None:
     num_bodies = 4
 
     anchor_pos = np.linspace(-0.2, 0.4, num_envs * 3).reshape(num_envs, 3)
-    body_pos = np.linspace(-0.5, 0.7, num_envs * num_bodies * 3).reshape(
-        num_envs, num_bodies, 3
-    )
+    body_pos = np.linspace(-0.5, 0.7, num_envs * num_bodies * 3).reshape(num_envs, num_bodies, 3)
     anchor_quat = np_quat_from_euler_xyz(
         np.linspace(0.0, 0.2, num_envs),
         np.linspace(-0.1, 0.1, num_envs),
@@ -186,12 +176,8 @@ def test_anchor_frame_transform_matches_flattened_path() -> None:
         np.linspace(-0.4, 0.3, num_envs * num_bodies),
     ).reshape(num_envs, num_bodies, 4)
 
-    anchor_pos_tiled = np.tile(anchor_pos, (1, num_bodies)).reshape(
-        num_envs * num_bodies, 3
-    )
-    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(
-        num_envs * num_bodies, 4
-    )
+    anchor_pos_tiled = np.tile(anchor_pos, (1, num_bodies)).reshape(num_envs * num_bodies, 3)
+    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(num_envs * num_bodies, 4)
     expected_pos, expected_quat = np_subtract_frame_transforms(
         anchor_pos_tiled,
         anchor_quat_tiled,

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 import numpy as np
 
 from unilab.envs.common.rotation import (
+    np_matrix_first_two_cols_from_quat,
+    np_matrix_from_quat,
     np_quat_angular_velocity,
+    np_quat_apply,
+    np_quat_apply_batched,
     np_quat_ensure_continuity,
     np_quat_error_magnitude,
+    np_quat_error_magnitude_batched,
+    np_quat_error_magnitude_squared_batched,
+    np_quat_from_euler_xyz,
+    np_quat_mul,
+    np_quat_mul_batched,
     np_quat_to_axis_angle,
+    np_subtract_anchor_frame_transforms,
+    np_subtract_frame_transforms,
 )
 
 
@@ -90,3 +101,110 @@ def test_quat_angular_velocity_ignores_sign_flip_spikes() -> None:
     expected = np.tile(np.array([0.0, 0.0, 1.0]), (q.shape[0], 1))
 
     np.testing.assert_allclose(angvel, expected, atol=1e-6)
+
+
+def test_batched_quaternion_helpers_match_flattened_helpers() -> None:
+    num_envs = 3
+    num_bodies = 4
+
+    anchor_quat = np_quat_from_euler_xyz(
+        np.linspace(-0.2, 0.3, num_envs),
+        np.linspace(0.1, -0.25, num_envs),
+        np.linspace(0.4, -0.1, num_envs),
+    )
+    body_quat = np_quat_from_euler_xyz(
+        np.linspace(-0.3, 0.4, num_envs * num_bodies),
+        np.linspace(0.2, -0.15, num_envs * num_bodies),
+        np.linspace(-0.5, 0.25, num_envs * num_bodies),
+    ).reshape(num_envs, num_bodies, 4)
+    vectors = np.linspace(-0.6, 0.7, num_envs * num_bodies * 3).reshape(
+        num_envs, num_bodies, 3
+    )
+
+    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(
+        num_envs * num_bodies, 4
+    )
+    body_quat_flat = body_quat.reshape(num_envs * num_bodies, 4)
+    vectors_flat = vectors.reshape(num_envs * num_bodies, 3)
+
+    expected_mul = np_quat_mul(anchor_quat_tiled, body_quat_flat).reshape(
+        num_envs, num_bodies, 4
+    )
+    expected_apply = np_quat_apply(anchor_quat_tiled, vectors_flat).reshape(
+        num_envs, num_bodies, 3
+    )
+    expected_error = np_quat_error_magnitude(anchor_quat_tiled, body_quat_flat).reshape(
+        num_envs, num_bodies
+    )
+    expected_matrix_cols = np_matrix_from_quat(body_quat_flat)[:, :, :2].reshape(
+        num_envs, num_bodies, 6
+    )
+
+    np.testing.assert_allclose(
+        np_quat_mul_batched(anchor_quat[:, None, :], body_quat),
+        expected_mul,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np_quat_apply_batched(anchor_quat[:, None, :], vectors),
+        expected_apply,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np_quat_error_magnitude_batched(anchor_quat[:, None, :], body_quat),
+        expected_error,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np_quat_error_magnitude_squared_batched(anchor_quat[:, None, :], body_quat),
+        expected_error * expected_error,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np_matrix_first_two_cols_from_quat(body_quat),
+        expected_matrix_cols,
+        atol=1e-12,
+    )
+
+
+def test_anchor_frame_transform_matches_flattened_path() -> None:
+    num_envs = 3
+    num_bodies = 4
+
+    anchor_pos = np.linspace(-0.2, 0.4, num_envs * 3).reshape(num_envs, 3)
+    body_pos = np.linspace(-0.5, 0.7, num_envs * num_bodies * 3).reshape(
+        num_envs, num_bodies, 3
+    )
+    anchor_quat = np_quat_from_euler_xyz(
+        np.linspace(0.0, 0.2, num_envs),
+        np.linspace(-0.1, 0.1, num_envs),
+        np.linspace(0.3, -0.2, num_envs),
+    )
+    body_quat = np_quat_from_euler_xyz(
+        np.linspace(-0.25, 0.35, num_envs * num_bodies),
+        np.linspace(0.15, -0.2, num_envs * num_bodies),
+        np.linspace(-0.4, 0.3, num_envs * num_bodies),
+    ).reshape(num_envs, num_bodies, 4)
+
+    anchor_pos_tiled = np.tile(anchor_pos, (1, num_bodies)).reshape(
+        num_envs * num_bodies, 3
+    )
+    anchor_quat_tiled = np.tile(anchor_quat, (1, num_bodies)).reshape(
+        num_envs * num_bodies, 4
+    )
+    expected_pos, expected_quat = np_subtract_frame_transforms(
+        anchor_pos_tiled,
+        anchor_quat_tiled,
+        body_pos.reshape(num_envs * num_bodies, 3),
+        body_quat.reshape(num_envs * num_bodies, 4),
+    )
+
+    actual_pos, actual_quat = np_subtract_anchor_frame_transforms(
+        anchor_pos,
+        anchor_quat,
+        body_pos,
+        body_quat,
+    )
+
+    np.testing.assert_allclose(actual_pos, expected_pos.reshape(num_envs, num_bodies, 3))
+    np.testing.assert_allclose(actual_quat, expected_quat.reshape(num_envs, num_bodies, 4))


### PR DESCRIPTION
## Summary

- Optimize G1 motion tracking hot-path state updates by reusing output buffers and avoiding repeated temporary allocations.
- Add backend body-state copy helpers and coverage to keep the optimized path contract-driven across MuJoCo and Motrix.
- Keep benchmarked behavior equivalent with reference tests for relative transforms and reward computation.

## Benchmark

Command shape:

```bash
uv run --active --no-sync benchmark/benchmark_env_step.py task=g1_motion_tracking/<backend> num_envs=2048 num_steps=50 warmup_steps=10 --skip-plots
```

Baseline: upstream/main 367d9c4f
Current:  optimize/g1-mt-update-state 455ecea3

```text
Backend  Metric        upstream/main        current        Improvement
-------  ------------  -------------------  -------------  -----------
mujoco   median_step     39.411 ms         34.463 ms      12.55% faster
mujoco   throughput       50881 eps         58340 eps     14.66% higher
mujoco   update_state     9.498 ms          4.540 ms      52.20% faster
motrix   median_step     48.766 ms         39.539 ms      18.92% faster
motrix   throughput       42118 eps         51168 eps     21.49% higher
motrix   update_state    11.457 ms          6.218 ms      45.72% faster
```

Raw benchmark outputs:

```text
/tmp/unilab_pr_bench_20260525/current_g1_mt_mujoco.json
/tmp/unilab_pr_bench_20260525/current_g1_mt_motrix.json
/tmp/unilab_pr_bench_20260525/upstream_main_g1_mt_mujoco.json
/tmp/unilab_pr_bench_20260525/upstream_main_g1_mt_motrix.json
```

## Validation

```text
make test-all
967 passed, 12 skipped, 254 deselected, 66 warnings
```

Additional run:

```text
CUDA PPO g1_flip_tracking/mujoco, algo.max_iterations=1000
Completed through model_999.pt, final_mean_reward=60.28, best_mean_reward=63.54
```
