### PR TITLE
enable AMP+compile by default for fastsac/flashsac with safe platform…

### DIFF
--- a/conf/offpolicy/algo/flashsac.yaml
+++ b/conf/offpolicy/algo/flashsac.yaml
@@ -41,4 +41,4 @@ algo_params:
   learning_rate_decay_steps: 500000
   n_step: 1
   amp_dtype: auto
-  use_compile: false
+  use_compile: true

--- a/conf/offpolicy/algo/sac.yaml
+++ b/conf/offpolicy/algo/sac.yaml
@@ -28,4 +28,4 @@ algo_params:
   target_entropy_ratio: 0.0
   max_grad_norm: 0.0
   amp_dtype: auto
-  use_compile: false
+  use_compile: true

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -17,7 +17,7 @@ training:
   wandb_mode: null
   sim_backend: mujoco
   num_gpus: 1
-  use_amp: false
+  use_amp: true
   play_only: false
   no_play: false
   play_render_mode: auto

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -405,7 +405,9 @@ class FastSACLearner:
         self.max_grad_norm = max_grad_norm
         self.use_autotune = use_autotune
         self.use_amp = bool(use_amp) and self._device_type in ("cuda", "xpu")
-        self.use_compile = bool(use_compile)
+        self.use_compile = (
+            bool(use_compile) and self._device_type == "cuda" and hasattr(torch, "compile")
+        )
         self.amp_dtype = amp_dtype
         self._amp_dtype = self._resolve_amp_dtype(amp_dtype, self._device_type)
         self.world_size = world_size
@@ -502,7 +504,7 @@ class FastSACLearner:
     def _resolve_amp_dtype(amp_dtype: str, device_type: str) -> torch.dtype:
         normalized = amp_dtype.lower()
         if normalized == "auto":
-            return torch.bfloat16 if device_type == "xpu" else torch.float16
+            return torch.bfloat16
         if normalized == "fp16":
             return torch.float16
         if normalized == "bf16":
@@ -519,10 +521,8 @@ class FastSACLearner:
 
     def _compile_training_methods(self) -> None:
         compile_fn = getattr(torch, "compile", None)
-        if compile_fn is None:
-            raise ValueError("FastSAC compile requires torch.compile support")
-        if torch.device(self.device).type != "cuda":
-            raise ValueError("FastSAC compile currently requires a CUDA device")
+        if compile_fn is None or torch.device(self.device).type != "cuda":
+            return
 
         compile_kwargs = {"options": {"triton.cudagraphs": False}}
         self._critic_loss_tensors = compile_fn(  # type: ignore[method-assign]

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -275,7 +275,7 @@ class FlashSACLearner:
     def _resolve_amp_dtype(amp_dtype: str, device_type: str) -> torch.dtype:
         normalized = amp_dtype.lower()
         if normalized == "auto":
-            return torch.bfloat16 if device_type == "xpu" else torch.float16
+            return torch.bfloat16
         if normalized == "fp16":
             return torch.float16
         if normalized == "bf16":

--- a/src/unilab/structured_configs.py
+++ b/src/unilab/structured_configs.py
@@ -26,7 +26,7 @@ class SACAlgoParams:
     target_entropy_ratio: float = 0.0
     max_grad_norm: float = 0.0
     amp_dtype: str = "auto"
-    use_compile: bool = False
+    use_compile: bool = True
 
 
 @dataclass
@@ -122,7 +122,7 @@ class FlashSACAlgoParams:
     learning_rate_decay_steps: int = 500000
     n_step: int = 1
     amp_dtype: str = "auto"
-    use_compile: bool = False
+    use_compile: bool = True
 
 
 @dataclass

--- a/tests/algos/test_fast_sac_compile.py
+++ b/tests/algos/test_fast_sac_compile.py
@@ -46,7 +46,7 @@ def test_fast_sac_compile_targets_training_hot_paths(monkeypatch) -> None:
 
 
 def test_fast_sac_amp_dtype_resolution_and_scaler_rules() -> None:
-    assert FastSACLearner._resolve_amp_dtype("auto", "cuda") is torch.float16
+    assert FastSACLearner._resolve_amp_dtype("auto", "cuda") is torch.bfloat16
     assert FastSACLearner._resolve_amp_dtype("auto", "xpu") is torch.bfloat16
     assert FastSACLearner._resolve_amp_dtype("fp16", "cuda") is torch.float16
     assert FastSACLearner._resolve_amp_dtype("bf16", "cuda") is torch.bfloat16

--- a/tests/algos/test_flash_sac_learner.py
+++ b/tests/algos/test_flash_sac_learner.py
@@ -71,7 +71,7 @@ def test_flashsac_compile_targets_training_hot_paths(monkeypatch) -> None:
 
 
 def test_flashsac_amp_dtype_resolution_and_scaler_rules() -> None:
-    assert FlashSACLearner._resolve_amp_dtype("auto", "cuda") is torch.float16
+    assert FlashSACLearner._resolve_amp_dtype("auto", "cuda") is torch.bfloat16
     assert FlashSACLearner._resolve_amp_dtype("auto", "xpu") is torch.bfloat16
     assert FlashSACLearner._resolve_amp_dtype("fp16", "cuda") is torch.float16
     assert FlashSACLearner._resolve_amp_dtype("bf16", "cuda") is torch.bfloat16

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -181,7 +181,7 @@ def test_sac_portable_devices_allow_cpu_pinned_double_buffer(
     assert isinstance(runner, _FakeRunner)
     assert runner.kwargs["device"] == device
     assert runner.kwargs["replay_prefetch_mode"] == "one_tick"
-    assert runner.kwargs["learner"].kwargs["use_compile"] is False
+    assert runner.kwargs["learner"].kwargs["use_compile"] is True
 
 
 def test_sac_compile_override_is_passed_to_learner(monkeypatch: pytest.MonkeyPatch):

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -57,7 +57,7 @@ def test_sac_config_defaults():
     assert cfg.use_symmetry is False
     assert isinstance(cfg.algo_params, SACAlgoParams)
     assert cfg.algo_params.alpha_init == 0.01
-    assert cfg.algo_params.use_compile is False
+    assert cfg.algo_params.use_compile is True
 
 
 def test_td3_config_defaults():
@@ -83,7 +83,7 @@ def test_flashsac_config_defaults():
     assert isinstance(cfg.algo_params, FlashSACAlgoParams)
     assert cfg.algo_params.normalize_reward is True
     assert cfg.algo_params.amp_dtype == "auto"
-    assert cfg.algo_params.use_compile is False
+    assert cfg.algo_params.use_compile is True
 
 
 def test_ppo_config_defaults():
@@ -144,7 +144,7 @@ def test_offpolicy_sac_g1_task_overrides():
     assert cfg.algo.max_iterations == 5000
     assert cfg.algo.use_symmetry is True
     assert cfg.algo.algo_params.target_entropy_ratio == pytest.approx(0.0)
-    assert cfg.algo.algo_params.use_compile is False
+    assert cfg.algo.algo_params.use_compile is True
     assert cfg.training.task_name == "G1WalkFlat"
 
     assert cfg.env.control_config.action_scale == pytest.approx(1.0)


### PR DESCRIPTION
… fallback

## Summary

将所有flashsac和fastsac任务的AMP和compile设为默认开启且使用bf16



## Validation


<!--StartFragment-->
平台 | AMP | compile
-- | -- | --
CUDA | ✅ bf16（auto） | ✅
ROCm | ✅ bf16（torch 把 ROCm 视为 cuda） | ✅
XPU | ✅ bf16 | ❌ 静默跳过
MPS（Mac） | ❌ 静默跳过（白名单只含 cuda/xpu） | ❌ 静默跳过

<!--EndFragment-->

