### PR TITLE
fix(backend): get_joint_range should skip all freejoints, not just index 0

### DIFF
--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -757,9 +757,9 @@ class MuJoCoBackend(SimBackend):
         return self.get_joint_dof_indices(names) - self._root_qvel_dim
 
     def get_joint_range(self) -> np.ndarray | None:
-        if self._root_qpos_dim > 0:
-            return np.array(self._model.jnt_range[1:], dtype=self._np_dtype)
-        return np.array(self._model.jnt_range, dtype=self._np_dtype)
+        jnt_range = self._model.jnt_range
+        mask = self._model.jnt_type != int(mujoco.mjtJoint.mjJNT_FREE)
+        return np.array(jnt_range[mask], dtype=self._np_dtype)
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                 #


### PR DESCRIPTION
## Summary

- `get_joint_range()` 改为按 `jnt_type` 过滤所有 `mjJNT_FREE` 类型的关节，而非 `jnt_range[1:]` 只跳 index 0
- 修复场景含多个 freejoint（如 G1 + largebox）时 `reward_joint_limit` 维度不匹配的 crash

Fixes #498

## Test plan

- [x] `uv run pytest tests/ -x -q` — 954 passed
- [x] `uv run python scripts/train_rsl_rl.py task=g1_box_tracking/mujoco +max_iterations=1` — 正常训练，无报错
- [x] 确认无 freejoint 的场景（如纯 locomotion）不受影响