### PR TITLE
fix: tune g1 wall flip motrix config

### DIFF
--- a/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_wall_flip_tracking/motrix.yaml
@@ -3,19 +3,62 @@ training:
   task_name: G1WallFlipTracking
   sim_backend: motrix
   play_env_num: 16
-  play_steps: 10000
+  play_steps: 1000
   render_spacing: 3.0
 algo:
   num_envs: 1024
-  max_iterations: 30000
+  max_iterations: 12000
   save_interval: 500
+  empirical_normalization: true
   obs_groups:
     actor:
       - actor
+    critic:
+      - critic
   algorithm:
     entropy_coef: 0.005
+    desired_kl: 0.01
 env:
   motrix_max_iterations: 3
+  sampling_mode: start
+  truncate_on_clip_end: false
+  sim_dt: 0.005
+  control_config:
+    action_scale:
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+  anchor_pos_z_threshold: 0.5
+  ee_body_pos_z_threshold: 0.5
+  terminate_on_undesired_contacts: true
+  noise_config:
+    level: 0.0
 play_profile:
   enabled: true
   env:
@@ -29,16 +72,18 @@ play_profile:
     ground_texrepeat: [0.25, 0.25]
 reward:
   scales:
-    motion_global_root_pos: 1.0
+    motion_global_root_pos: 0.5
     motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
+    motion_body_pos: 2.0
+    motion_body_ori: 1.5
     motion_body_lin_vel: 1.0
     motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.05
+    motion_ee_body_pos_z: 2.0
+    motion_joint_pos: 0.5
+    motion_joint_vel: 0.25
+    action_rate_l2: -0.005
     joint_limit: -10.0
+    undesired_contacts: -0.1
   std_root_pos: 0.3
   std_root_ori: 0.4
   std_body_pos: 0.3


### PR DESCRIPTION
## Summary

- Tune PPO Motrix owner config for G1 wall flip tracking.
- Update rollout length, training iterations, empirical normalization, actor/critic obs groups, Motrix env settings, and reward scales.
- Training behavior changes for Motrix only; MuJoCo owner config is unchanged in this PR.

## Linked Work

- Issue: Fixes #501
- Milestone:

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
make test-all
```

Result: failed in local environment after `make check` passed. `uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing` reported 23 failures in `tests/ipc/test_replay_pipeline_double_buffer.py`. The observed root cause is local CUDA header/toolchain availability while building `unilab_native_h2d`:

```text
fatal error: cuda_runtime_api.h: No such file or directory
RuntimeError: Error building extension 'unilab_native_h2d'
```

Maintainer/user override: PR is opened with this local environment failure recorded.

Task-specific validation:

```bash
uv run python - <<'PY'
from pathlib import Path
from hydra import compose, initialize_config_dir
from hydra.core.global_hydra import GlobalHydra

conf_dir = Path.cwd() / "conf" / "ppo"
GlobalHydra.instance().clear()
with initialize_config_dir(config_dir=str(conf_dir), version_base="1.3"):
    cfg = compose("config", overrides=["task=g1_wall_flip_tracking/motrix"])

assert cfg.training.task_name == "G1WallFlipTracking"
assert cfg.training.sim_backend == "motrix"
assert cfg.algo.max_iterations == 12000
assert cfg.algo.empirical_normalization is True
assert cfg.algo.obs_groups.critic == ["critic"]
assert cfg.env.sampling_mode == "start"
assert cfg.env.truncate_on_clip_end is False
assert len(cfg.env.control_config.action_scale) == 29
assert cfg.reward.scales.motion_ee_body_pos_z == 2.0
assert cfg.reward.scales.undesired_contacts == -0.1
print("g1_wall_flip_tracking/motrix config compose OK")
PY
```

Result: passed.

## Impact

- Backend impact: `motrix`
- Platform impact: both
- Training effect expected: yes

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [ ] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly