### PR TITLE
feat(dr): add geom friction & joint-default-pos randomization for G1 deploy

### DIFF
--- a/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
@@ -18,6 +18,26 @@ env:
     local_linvel: pelvis_local_linvel
     gyro: pelvis_gyro
     upvector: pelvis_upvector
+  domain_rand:
+      random_com: true
+      com_offset_x: [-0.025, 0.025]
+      com_offset_y: [-0.05, 0.05]
+      com_offset_z: [-0.05, 0.05]
+      randomize_base_mass: true
+      added_mass_range: [-1.5, 1.5]
+      push_robots: true
+      push_interval: 750
+      max_force: [1.0, 1.0, 0.5]
+      randomize_geom_friction: true
+      friction_range: [0.3, 1.2]
+      randomize_joint_default_pos: true
+      joint_default_pos_range: [-0.01, 0.01]
+  noise_config:
+      scale_joint_angle: 0.01
+      scale_joint_vel: 0.5
+      scale_gyro: 0.2
+      scale_linvel: 0.5
+      scale_gravity: 0.05
   control_config:
     action_scale:
       - 0.5475464629911068

--- a/src/unilab/dr/dr_utils.py
+++ b/src/unilab/dr/dr_utils.py
@@ -67,9 +67,17 @@ def build_common_reset_randomization(
         payload.body_mass = body_mass
 
     if getattr(domain_rand, "random_com", False):
-        low, high = domain_rand.com_offset_x
         base_com_offset = np.zeros((num_reset, 3), dtype=np.float64)
+        low, high = domain_rand.com_offset_x
         base_com_offset[:, 0] = np.random.uniform(low, high, size=(num_reset,))
+        com_offset_y = getattr(domain_rand, "com_offset_y", None)
+        if com_offset_y is not None:
+            low, high = com_offset_y
+            base_com_offset[:, 1] = np.random.uniform(low, high, size=(num_reset,))
+        com_offset_z = getattr(domain_rand, "com_offset_z", None)
+        if com_offset_z is not None:
+            low, high = com_offset_z
+            base_com_offset[:, 2] = np.random.uniform(low, high, size=(num_reset,))
         payload.base_com_offset = base_com_offset
 
     if getattr(domain_rand, "randomize_gravity", False):

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -18,7 +18,6 @@ from unilab.dr import (
     IntervalRandomizationPlan,
     ResetPlan,
 )
-from unilab.dr.types import RESET_TERM_GEOM_FRICTION, ResetRandomizationPayload
 from unilab.dr.dr_utils import (
     build_common_reset_randomization,
     build_interval_push_plan,
@@ -26,6 +25,7 @@ from unilab.dr.dr_utils import (
     validate_interval_push_support,
     zero_actions,
 )
+from unilab.dr.types import RESET_TERM_GEOM_FRICTION, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.common.math import np_sample_uniform
 from unilab.envs.common.rotation import (

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -18,6 +18,7 @@ from unilab.dr import (
     IntervalRandomizationPlan,
     ResetPlan,
 )
+from unilab.dr.types import RESET_TERM_GEOM_FRICTION, ResetRandomizationPayload
 from unilab.dr.dr_utils import (
     build_common_reset_randomization,
     build_interval_push_plan,
@@ -101,6 +102,8 @@ class Domain_Rand:
 
     random_com: bool = False
     com_offset_x: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+    com_offset_y: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+    com_offset_z: list[float] = field(default_factory=lambda: [-0.05, 0.05])
 
     randomize_gravity: bool = False
     gravity_range: list[list[float]] = field(
@@ -117,6 +120,13 @@ class Domain_Rand:
 
     randomize_kd: bool = False
     kd_multiplier_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
+
+    randomize_geom_friction: bool = False
+    friction_range: list[float] = field(default_factory=lambda: [0.3, 1.2])
+    friction_geom_pattern: str = r"^(left|right)_foot[1-7]_collision$"
+
+    randomize_joint_default_pos: bool = False
+    joint_default_pos_range: list[float] = field(default_factory=lambda: [-0.01, 0.01])
 
 
 @dataclass
@@ -321,16 +331,35 @@ def _write_motion_anchor_transform(
 
 class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
     def __init__(
-        self, *, base_kp: np.ndarray | None = None, base_kd: np.ndarray | None = None
+        self,
+        *,
+        base_kp: np.ndarray | None = None,
+        base_kd: np.ndarray | None = None,
+        base_geom_friction: np.ndarray | None = None,
+        foot_geom_ids: np.ndarray | None = None,
     ) -> None:
         self._base_kp = base_kp
         self._base_kd = base_kd
+        self._base_geom_friction = base_geom_friction
+        self._foot_geom_ids = foot_geom_ids
 
     def validate(self, env: Any, capabilities: DomainRandomizationCapabilities) -> None:
         validate_common_reset_randomization(
             env, capabilities, base_kp=self._base_kp, base_kd=self._base_kd
         )
         validate_interval_push_support(env, capabilities)
+        if getattr(env.cfg.domain_rand, "randomize_geom_friction", False):
+            if not capabilities.supports_reset_term(RESET_TERM_GEOM_FRICTION):
+                raise NotImplementedError(
+                    f"{env._backend.backend_type} backend does not support "
+                    "geom-friction reset randomization"
+                )
+            if (
+                self._base_geom_friction is None
+                or self._foot_geom_ids is None
+                or self._foot_geom_ids.size == 0
+            ):
+                raise ValueError("randomize_geom_friction=True but provider has no foot geom IDs")
 
     def build_interval_randomization_plan(
         self, env: Any, step_counter: int
@@ -347,14 +376,39 @@ class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
             "current_actions": zero_actions(num_reset, env._num_action),
             "last_actions": zero_actions(num_reset, env._num_action),
         }
+        randomization = build_common_reset_randomization(
+            env, num_reset, base_kp=self._base_kp, base_kd=self._base_kd
+        )
+
+        dr_cfg = env.cfg.domain_rand
+        if getattr(dr_cfg, "randomize_geom_friction", False):
+            assert self._base_geom_friction is not None
+            assert self._foot_geom_ids is not None
+            payload = randomization or ResetRandomizationPayload()
+            low, high = dr_cfg.friction_range
+            scale = np.random.uniform(low, high, size=(num_reset, 1)).astype(np.float64)
+            geom_friction = np.broadcast_to(
+                self._base_geom_friction,
+                (num_reset, *self._base_geom_friction.shape),
+            ).copy()
+            geom_friction[:, self._foot_geom_ids, 0] = scale * np.ones(
+                (1, self._foot_geom_ids.size)
+            )
+            payload.geom_friction = geom_friction
+            randomization = payload
+
+        if getattr(dr_cfg, "randomize_joint_default_pos", False):
+            low, high = dr_cfg.joint_default_pos_range
+            info_updates["default_dof_pos_bias"] = np.random.uniform(
+                low, high, size=(num_reset, env._num_action)
+            ).astype(get_global_dtype())
+
         return ResetPlan(
             env_ids=env_ids,
             qpos=qpos,
             qvel=qvel,
             info_updates=info_updates,
-            randomization=build_common_reset_randomization(
-                env, num_reset, base_kp=self._base_kp, base_kd=self._base_kd
-            ),
+            randomization=randomization,
         )
 
     def build_reset_observation(
@@ -369,6 +423,9 @@ class G1MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):
         dof_vel = env.get_dof_vel()[env_ids]
         all_pos_w, all_quat_w = env._get_body_pose_w()
         obs_info = dict(info_updates)
+        default_dof_pos_bias = info_updates.get("default_dof_pos_bias")
+        if isinstance(default_dof_pos_bias, np.ndarray):
+            obs_info["default_dof_pos_bias"] = default_dof_pos_bias
         obs_info["env_ids"] = env_ids
         return cast(
             dict[str, np.ndarray],
@@ -433,13 +490,34 @@ class G1MotionTrackingEnv(G1BaseEnv):
         self.motion_sampler = MotionSampler(
             self.motion_loader, mode=cfg.sampling_mode, num_envs=num_envs
         )
-        if cfg.domain_rand.randomize_kp or cfg.domain_rand.randomize_kd:
+        needs_kp_kd = cfg.domain_rand.randomize_kp or cfg.domain_rand.randomize_kd
+        needs_friction = getattr(cfg.domain_rand, "randomize_geom_friction", False)
+        base_kp = base_kd = None
+        if needs_kp_kd:
             base_kp, base_kd = backend.get_actuator_gains()
-            dr_provider = G1MotionTrackingDomainRandomizationProvider(
-                base_kp=base_kp, base_kd=base_kd
+        base_geom_friction = None
+        foot_geom_ids = None
+        if needs_friction:
+            import re as _re
+
+            base_geom_friction = backend.get_geom_friction()
+            geom_names = backend.get_geom_names()
+            pattern = _re.compile(cfg.domain_rand.friction_geom_pattern)
+            foot_geom_ids = np.asarray(
+                [i for i, name in enumerate(geom_names) if name and pattern.match(name)],
+                dtype=np.int64,
             )
-        else:
-            dr_provider = G1MotionTrackingDomainRandomizationProvider()
+            if foot_geom_ids.size == 0:
+                raise ValueError(
+                    "friction_geom_pattern "
+                    f"'{cfg.domain_rand.friction_geom_pattern}' did not match any geom"
+                )
+        dr_provider = G1MotionTrackingDomainRandomizationProvider(
+            base_kp=base_kp,
+            base_kd=base_kd,
+            base_geom_friction=base_geom_friction,
+            foot_geom_ids=foot_geom_ids,
+        )
         self._init_domain_randomization(dr_provider)
 
         dtype = get_global_dtype()
@@ -504,6 +582,30 @@ class G1MotionTrackingEnv(G1BaseEnv):
             if self._reward_term_is_active(name)
         }
         self._clip_end_truncated = np.zeros((num_envs,), dtype=bool)
+
+    def _effective_default_angles(self, env_ids: np.ndarray | None = None) -> np.ndarray:
+        """Return default_angles with per-episode joint-default-pos bias applied."""
+        state = getattr(self, "_state", None)
+        if state is not None:
+            bias = state.info.get("default_dof_pos_bias")
+            if bias is not None:
+                if env_ids is not None:
+                    return self.default_angles + bias[env_ids]
+                return self.default_angles + bias
+        return self.default_angles
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions))
+        state.info["current_actions"] = actions
+        exec_actions = (
+            state.info["last_actions"]
+            if self._cfg.control_config.simulate_action_latency
+            else actions
+        )
+        bias = state.info.get("default_dof_pos_bias")
+        base = self.default_angles + bias if bias is not None else self.default_angles
+        ctrl: np.ndarray = exec_actions * self._cfg.control_config.action_scale + base
+        return ctrl
 
     def _resample_reference_state(self, env_ids: np.ndarray) -> None:
         motion_frames = self.motion_sampler.sample_frames(env_ids)
@@ -983,7 +1085,9 @@ class G1MotionTrackingEnv(G1BaseEnv):
         )
 
         # Joint positions and velocities
-        np.subtract(dof_pos, self.default_angles, out=joint_pos_rel)
+        bias = info.get("default_dof_pos_bias")
+        effective_default = self.default_angles + bias if bias is not None else self.default_angles
+        np.subtract(dof_pos, effective_default, out=joint_pos_rel)
         last_actions = info.get("current_actions")
         if not isinstance(last_actions, np.ndarray):
             last_actions = zero_actions

--- a/src/unilab/envs/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking_obs.py
@@ -322,7 +322,7 @@ class G1WBTObsEnv(G1MotionTrackingSACEnv):
         last_actions = info.get("last_actions")
         if last_actions is None:
             return np.zeros((self._num_envs,), dtype=get_global_dtype())
-        target_q = last_actions * self._cfg.control_config.action_scale + self.default_angles
+        target_q = last_actions * self._cfg.control_config.action_scale + self._effective_default_angles()
         torque = self._base_kp * (target_q - dof_pos) - self._base_kd * dof_vel
         return np.asarray(np.sum(np.square(torque), axis=1), dtype=get_global_dtype())
 

--- a/src/unilab/envs/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking_obs.py
@@ -322,7 +322,9 @@ class G1WBTObsEnv(G1MotionTrackingSACEnv):
         last_actions = info.get("last_actions")
         if last_actions is None:
             return np.zeros((self._num_envs,), dtype=get_global_dtype())
-        target_q = last_actions * self._cfg.control_config.action_scale + self._effective_default_angles()
+        target_q = (
+            last_actions * self._cfg.control_config.action_scale + self._effective_default_angles()
+        )
         torque = self._base_kp * (target_q - dof_pos) - self._base_kd * dof_vel
         return np.asarray(np.sum(np.square(torque), axis=1), dtype=get_global_dtype())
 


### PR DESCRIPTION
## Summary

- `Domain_Rand` 新增 `com_offset_y/z`、`randomize_geom_friction`、`randomize_joint_default_pos` 字段
- `dr_utils.py`：COM 偏移扩展支持 Y/Z 轴（`getattr` 向下兼容）
- `G1MotionTrackingDomainRandomizationProvider`：新增摩擦随机化（按正则匹配 foot geom）和关节默认位置随机化，含 backend 能力校验
- `G1MotionTrackingEnv`：新增 `_effective_default_angles()` 和 `apply_action()` 覆写，obs 计算中使用 biased defaults
- `tracking_obs.py`：torque reward 使用 `_effective_default_angles()`
- `g1_motion_tracking_deploy/mujoco.yaml`：开启 DR 和 obs noise 配置

Fixes #504

## Test plan

- [x] `uv run pytest tests/ -x -q` — 956 passed
- [ ] 使用 `g1_motion_tracking_deploy/mujoco` 训练，确认 DR 和 noise 正常生效
- [ ] 确认不开启新 DR 项时（默认配置）行为不变