### PR TITLE
feat: add G1BoxTracking Motrix training config

### DIFF
--- a/conf/ppo/task/g1_box_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_box_tracking/motrix.yaml
@@ -1,0 +1,60 @@
+# @package _global_
+training:
+  task_name: G1BoxTracking
+  sim_backend: motrix
+  play_env_num: 128
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 40000
+  save_interval: 500
+  empirical_normalization: true
+  obs_groups:
+    actor:
+      - actor
+    critic:
+      - critic
+  algorithm:
+    entropy_coef: 0.002
+    desired_kl: 0.01
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 2.5
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/g1/scene_flat_with_largebox.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
+reward:
+  scales:
+    motion_global_root_pos: 1.0
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.5
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.5
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+    undesired_contacts: -0.1
+    object_global_ref_position_error_exp: 4.0
+    object_global_ref_orientation_error_exp: 3.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0
+  std_object_pos: 0.12
+  std_object_ori: 0.2

--- a/docs/users/zh_CN/E-reference/01-backend-support-matrix.md
+++ b/docs/users/zh_CN/E-reference/01-backend-support-matrix.md
@@ -49,7 +49,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | Tested |
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
-| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | Registered |
+| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | Tested |
 | PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
 | PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
 | PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | Tested |
@@ -68,7 +68,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `sharpa_inhand` (Sharpa in-hand) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
-| PPO (mlx) | `g1_box_tracking` (g1 box tracking) | Configured | Registered |
+| PPO (mlx) | `g1_box_tracking` (g1 box tracking) | Configured | Configured |
 | PPO (mlx) | `g1_climb_tracking` (g1 climb tracking) | Configured | Configured |
 | PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
 | PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | Configured |


### PR DESCRIPTION
## Summary
- 新增 `conf/ppo/task/g1_box_tracking/motrix.yaml`，启用 G1 box tracking 任务的 Motrix 后端训练
- `G1BoxTrackingEnv` 已注册 `sim_backend="motrix"` 但缺少 owner YAML，导致无法通过 `task=g1_box_tracking/motrix` 启动

## Test plan
- [x] `uv run scripts/train_rsl_rl.py task=g1_box_tracking/motrix training.no_play=true algo.max_iterations=0` 正常启动
- [ ] `make test-all` 通过
- [ ] 短时训练 `algo.max_iterations=10` 跑通

Closes #507