### PR TITLE
params: update training parameters for flashsac g1_walk_flat mujoco

### DIFF
--- a/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
@@ -3,11 +3,11 @@ training:
   task_name: G1WalkFlat
   sim_backend: mujoco
 algo:
-  num_envs: 2048
+  num_envs: 4096
   learning_starts: 49
-  max_iterations: 6000
+  max_iterations: 5000
   save_interval: 1000
-  updates_per_step: 5
+  updates_per_step: 8
   #use_symmetry: true
   replay_buffer_n: 256
   tau: 0.05


### PR DESCRIPTION
## Summary

- 更新 `flashsac` 的 `g1_walk_flat` 的参数，新参数在mac下比原参数好，在 4090 + 9950x3d 上由 5.3min->5.54min

Fixes #510 

## Validation

- [x] `make test-all`

## Impact

- Backend impact: `mujoco` 
- Platform impact:  both
- Training effect expected: yes