### PR TITLE
docs(sphinx): sidebar language switcher, default to English

### DIFF
--- a/docs/sphinx/AGENTS.md
+++ b/docs/sphinx/AGENTS.md
@@ -17,26 +17,35 @@ Sphinx 文档写作规则。
 
 ```text
 source/
-├── index.md                 # root landing; language selection is site-level
-├── en/                      # English semantic tree
-├── zh_CN/                   # Chinese tree; legacy numbered paths are kept short-term
+├── index.md                 # root redirect → en/index.html (no language picker)
+├── en/                      # English tree (site root, shown in sidebar nav)
+├── zh_CN/                   # Chinese tree (hidden from sidebar, via switcher only)
 ├── adr/                     # shared ADR, one set
 ├── api_reference/           # shared autodoc output from src/ docstrings
 ├── glossary.md
 ├── changelog.md
 ├── _static/
 └── _templates/
+    ├── sidebar/
+    │   └── lang_switcher.html   # language dropdown in sidebar
+    └── autosummary/
 ```
 
-`source/en/` and `source/zh_CN/` are parallel language roots, but they are **not
-currently a strict 1:1 path mirror**. The Chinese user guide still keeps
+`source/en/` is the **default site root**. Visitors land on `/en/index.html`
+directly (root `index.md` is a redirect). The sidebar navigation tree only
+shows English pages. `source/zh_CN/` pages are built but accessible only
+through the sidebar language switcher — they never appear in the navigation
+tree.
+
+`source/en/` and `source/zh_CN/` are parallel language roots, but they are
+**not currently a strict 1:1 path mirror**. The Chinese user guide still keeps
 compatibility paths such as `01-getting-started.md`, `A-getting-started/`, and
 `C-algorithms/`. Do not rename those paths just to mirror English during an
-unrelated documentation change.
+unrelated documentation change. The language switcher uses an explicit path map
+in `conf.py` (`_LANGUAGE_PATH_FORWARD`) to handle the mismatch.
 
-The root landing uses the site language switcher pattern. Do not add per-page
-language button blocks or hand-written cross-language navigation. Use the root
-language entry and the language switcher for language changes.
+Do not add per-page language button blocks or hand-written cross-language
+navigation. The sidebar language switcher handles language changes globally.
 
 ## Core Principles
 

--- a/docs/sphinx/source/_static/css/custom.css
+++ b/docs/sphinx/source/_static/css/custom.css
@@ -3,12 +3,23 @@
 :root {
     --ul-hero-bg: linear-gradient(135deg, #eff6ff 0%, #ede9fe 50%, #fef3c7 100%);
     --ul-hero-border: rgba(99, 102, 241, 0.18);
+    --ul-hero-text-shadow: none;
     --ul-card-hover: 0 8px 24px rgba(37, 99, 235, 0.10);
 }
 
-body.dark .landing-hero, body[data-theme="dark"] .landing-hero {
-    background: linear-gradient(135deg, #0f172a 0%, #1e1b4b 60%, #312e81 100%);
-    border-color: rgba(96, 165, 250, 0.25);
+/* Dark theme overrides — Furo uses body[data-theme="dark"] for explicit
+   dark mode and the prefers-color-scheme media query for auto (when
+   data-theme="auto"). We mirror both. */
+body[data-theme="dark"] {
+    --ul-hero-bg: linear-gradient(135deg, #0f172a 0%, #1e1b4b 60%, #312e81 100%);
+    --ul-hero-border: rgba(96, 165, 250, 0.25);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not([data-theme="light"]) {
+        --ul-hero-bg: linear-gradient(135deg, #0f172a 0%, #1e1b4b 60%, #312e81 100%);
+        --ul-hero-border: rgba(96, 165, 250, 0.25);
+    }
 }
 
 /* ---------- Language switcher ---------- */
@@ -75,10 +86,19 @@ body.dark .landing-hero, body[data-theme="dark"] .landing-hero {
     font-weight: 800;
     letter-spacing: -0.02em;
     margin: 0.3rem 0 0.5rem 0;
-    background: linear-gradient(90deg, #1e40af, #6d28d9, #be185d);
+    background: var(--ul-hero-h1-gradient, linear-gradient(90deg, #1e40af, #6d28d9, #be185d));
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
+}
+
+body[data-theme="dark"] {
+    --ul-hero-h1-gradient: linear-gradient(90deg, #93c5fd, #c4b5fd, #fbcfe8);
+}
+@media (prefers-color-scheme: dark) {
+    body:not([data-theme="light"]) {
+        --ul-hero-h1-gradient: linear-gradient(90deg, #93c5fd, #c4b5fd, #fbcfe8);
+    }
 }
 
 .landing-hero h3 {
@@ -191,15 +211,26 @@ kbd {
     margin-top: 1rem;
 }
 
-@media (max-width: 640px) {
-    .language-switcher,
-    .landing-language-picker {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .language-switcher__select,
-    .landing-language-picker__select {
-        width: 100%;
-    }
+/* ---------- Sidebar language switcher ---------- */
+.sidebar-lang-switcher {
+    padding: 0.4rem 0.8rem;
+    margin: 0 0 0.2rem 0;
 }
+.sidebar-lang-switcher__select {
+    width: 100%;
+    padding: 0.35rem 0.6rem;
+    font-size: 0.85rem;
+    border: 1px solid var(--color-foreground-border);
+    border-radius: 6px;
+    background: var(--color-background-secondary);
+    color: var(--color-foreground-primary);
+    cursor: pointer;
+    appearance: auto;
+}
+.sidebar-lang-switcher__select:hover {
+    border-color: var(--color-brand-primary);
+}
+
+/* Hide old body-injected language switcher */
+.language-switcher { display: none !important; }
+.landing-language-picker { display: none !important; }

--- a/docs/sphinx/source/_templates/sidebar/lang_switcher.html
+++ b/docs/sphinx/source/_templates/sidebar/lang_switcher.html
@@ -1,0 +1,20 @@
+{# Furo sidebar component: language switcher placed below brand, above search #}
+{%- set current = current_language|default("en") -%}
+{%- set en_target = language_switcher_targets.get("en", "en/index") if language_switcher_targets is defined else "en/index" -%}
+{%- set zh_target = language_switcher_targets.get("zh_CN", "zh_CN/index") if language_switcher_targets is defined else "zh_CN/index" -%}
+<div class="sidebar-lang-switcher">
+  <select class="sidebar-lang-switcher__select" aria-label="Language">
+    <option value="{{ pathto(en_target)|e }}"{% if current == "en" %} selected{% endif %}>English</option>
+    <option value="{{ pathto(zh_target)|e }}"{% if current == "zh_CN" %} selected{% endif %}>简体中文</option>
+  </select>
+</div>
+<script>
+(function(){
+  var sel = document.querySelector(".sidebar-lang-switcher__select");
+  if (!sel) return;
+  sel.addEventListener("change", function(){
+    var url = this.value;
+    if (url) window.location.href = new URL(url, window.location.href).href;
+  });
+})();
+</script>

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -198,6 +198,17 @@ html_favicon = None  # add _static/favicon.ico when ready
 html_baseurl = "https://unilabsim.github.io/UniLab-doc/"
 sitemap_url_scheme = "{link}"
 
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/lang_switcher.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
+    ],
+}
+
 html_theme_options = {
     "sidebar_hide_name": False,
     "navigation_with_keys": True,

--- a/docs/sphinx/source/index.md
+++ b/docs/sphinx/source/index.md
@@ -1,59 +1,21 @@
 ---
 sd_hide_title: true
+orphan: true
 ---
 
 # UniLab Documentation
 
-::::{div} landing-hero
-
-:::{div} landing-hero-text
-
-# UniLab Documentation
-
-### Robot learning infrastructure documentation.
-
-Pick a language to continue:
-
 ```{raw} html
-<div class="landing-language-picker">
-  <label class="landing-language-picker__label" for="landing-language-select">Documentation language</label>
-  <select class="landing-language-picker__select" id="landing-language-select" aria-label="Documentation language">
-    <option value="" selected disabled>Choose a language</option>
-    <option value="en/index.html">English</option>
-    <option value="zh_CN/index.html">简体中文</option>
-  </select>
-</div>
-<script>
-(function () {
-  var select = document.getElementById("landing-language-select");
-  if (!select) {
-    return;
-  }
-  select.addEventListener("change", function () {
-    if (this.value) {
-      window.location.href = this.value;
-    }
-  });
-}());
-</script>
+<meta http-equiv="refresh" content="0; url=en/index.html" />
+<script>window.location.href = "en/index.html";</script>
+<p>Redirecting to <a href="en/index.html">English documentation</a>…</p>
 ```
-
-:::
-
-::::
 
 ```{toctree}
 :hidden:
-:caption: Languages
 
 en/index
 zh_CN/index
-```
-
-```{toctree}
-:hidden:
-:caption: Shared
-
 adr/README
 api_reference/index
 glossary


### PR DESCRIPTION
## Summary

- Move language switcher from page body to left sidebar (below title, above search)
- Root auto-redirects to /en/index.html — no language picker landing page
- Sidebar navigation only shows English docs; zh_CN pages accessible via switcher only
- Fix dark-mode hero background: old CSS selector did not match Furo mechanism, causing light gradient bleed in dark mode
- Hero h1 gradient text gets lighter palette in dark mode for proper contrast

## Test plan

- [x] sphinx-build exit 0
- [x] Root redirects to /en/index.html
- [x] Sidebar shows language dropdown below brand, above search
- [x] Sidebar nav only contains English pages
- [x] Dark mode: hero background uses dark gradient
- [ ] Visual review in browser (light + dark + auto themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)