### PR TITLE
fix: improve uv run tab completion for #520

### DIFF
--- a/scripts/completions/unilab.bash
+++ b/scripts/completions/unilab.bash
@@ -7,10 +7,14 @@ _unilab_uv_complete() {
         return 0
     fi
 
+    local script_dir repo_root
+    script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+    repo_root="$(cd -- "$script_dir/../.." && pwd -P)"
+
     local candidates
     if ! mapfile -t candidates < <(
         uv run --no-sync unilab-complete --cword "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null \
-            || uv run --no-sync python -m unilab.tools.completion --cword "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null
+            || PYTHONPATH="$repo_root/src${PYTHONPATH:+:$PYTHONPATH}" uv run --no-sync python -m unilab.tools.completion --cword "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null
     ); then
         return 0
     fi

--- a/scripts/completions/unilab.zsh
+++ b/scripts/completions/unilab.zsh
@@ -6,10 +6,14 @@ _unilab_uv_complete() {
         return 0
     fi
 
+    local script_path repo_root
+    script_path="${${(%):-%x}:A}"
+    repo_root="${script_path:h:h:h}"
+
     local output
     output="$(
         uv run --no-sync unilab-complete --cword "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null \
-            || uv run --no-sync python -m unilab.tools.completion --cword "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null
+            || PYTHONPATH="$repo_root/src${PYTHONPATH:+:$PYTHONPATH}" uv run --no-sync python -m unilab.tools.completion --cword "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null
     )" || return 0
 
     if [[ -z "$output" ]]; then

--- a/src/unilab/__init__.py
+++ b/src/unilab/__init__.py
@@ -1,9 +1,7 @@
 """UniLab package initialization."""
 
-import os
-
-from etils import epath
+from pathlib import Path
 
 __version__ = "0.0.0"
 
-ROOT_PATH = epath.Path(__file__).parent
+ROOT_PATH = Path(__file__).resolve().parent

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -436,12 +436,13 @@ def _load_run_choices(
     log_root = _first_yaml_section_scalar(owner_paths, "training", "log_root")
     if log_root is not None:
         log_root_path = Path(log_root)
-        base_log_root = log_root_path if log_root_path.is_absolute() else metadata.root / log_root_path
-    else:
-        algo_log_name = (
-            _first_yaml_section_scalar(owner_paths, "algo", "algo_log_name")
-            or DEFAULT_ALGO_LOG_NAMES.get(selected_algo)
+        base_log_root = (
+            log_root_path if log_root_path.is_absolute() else metadata.root / log_root_path
         )
+    else:
+        algo_log_name = _first_yaml_section_scalar(
+            owner_paths, "algo", "algo_log_name"
+        ) or DEFAULT_ALGO_LOG_NAMES.get(selected_algo)
         if algo_log_name is None:
             return _matching(candidates, prefix)
         base_log_root = metadata.root / "logs" / algo_log_name

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -21,6 +21,14 @@ RUN_PATH_ROOTS = ("benchmark", "scripts")
 RUN_PATH_SUFFIXES = (".py", ".sh")
 RUN_PATH_IGNORED_PARTS = ("__pycache__", "outputs")
 SCRIPT_ASSIGNMENT_PATTERN = re.compile(r'^([A-Za-z0-9_.-]+)\s*=\s*"([^"]+)"\s*(?:#.*)?$')
+DEFAULT_ALGO_LOG_NAMES = {
+    "ppo": "rsl_rl_ppo",
+    "mlx_ppo": "mlx_rl_train",
+    "appo": "appo",
+    "sac": "fast_sac",
+    "td3": "fast_td3",
+    "flashsac": "flash_sac",
+}
 COMPLETION_BLOCK_START = "# >>> unilab completion >>>"
 COMPLETION_BLOCK_END = "# <<< unilab completion <<<"
 SUPPORTED_SHELLS = ("bash", "zsh")
@@ -41,6 +49,7 @@ class CompletionMetadata:
     choices: dict[str, dict[str, tuple[str, ...]]]
     tasks: tuple[TaskCompletionEntry, ...]
     run_paths: tuple[str, ...] = ()
+    root: Path | None = None
 
 
 def _find_project_root(start: Path) -> Path | None:
@@ -216,6 +225,7 @@ def build_metadata(root: Path | None = None) -> CompletionMetadata:
         choices={command: _parser_choices(command) for command in training_commands},
         tasks=_task_entries(selected_root),
         run_paths=_run_path_entries(selected_root),
+        root=selected_root,
     )
 
 
@@ -306,6 +316,146 @@ def _task_choices(
     return _matching(tuple(sorted(tasks)), prefix)
 
 
+def _profile_choices(
+    metadata: CompletionMetadata,
+    *,
+    prefix: str,
+    selected_algo: str | None,
+    selected_sim: str | None,
+    selected_task: str | None,
+) -> list[str]:
+    profiles: set[str] = set()
+    for entry in metadata.tasks:
+        if selected_algo is not None and entry.algo != selected_algo:
+            continue
+        if selected_sim is not None and entry.sim != selected_sim:
+            continue
+        if selected_task is not None and entry.task != selected_task:
+            continue
+        owner_prefix = f"{entry.sim}_"
+        if not entry.owner.startswith(owner_prefix):
+            continue
+        profile = entry.owner[len(owner_prefix) :]
+        if profile:
+            profiles.add(profile)
+    return _matching(tuple(sorted(profiles)), prefix)
+
+
+def _strip_yaml_scalar(value: str) -> str:
+    selected = value.split("#", 1)[0].strip()
+    if len(selected) >= 2 and selected[0] == selected[-1] and selected[0] in {'"', "'"}:
+        return selected[1:-1]
+    return selected
+
+
+def _yaml_section_scalar(path: Path, section: str, key: str) -> str | None:
+    if not path.is_file():
+        return None
+    in_section = False
+    section_indent = 0
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+        if indent == 0 and stripped.endswith(":"):
+            in_section = stripped[:-1] == section
+            section_indent = indent
+            continue
+        if not in_section:
+            continue
+        if indent <= section_indent:
+            break
+        if stripped.startswith(f"{key}:"):
+            return _strip_yaml_scalar(stripped.split(":", 1)[1])
+    return None
+
+
+def _owner_yaml_paths(
+    root: Path,
+    *,
+    selected_algo: str,
+    selected_task: str,
+    selected_sim: str,
+    selected_profile: str | None,
+) -> tuple[Path, ...]:
+    try:
+        route = cli.build_route(selected_algo, selected_task, selected_sim, selected_profile)
+    except SystemExit:
+        return ()
+
+    route_path = root / "conf" / route.config_group / "task" / route.owner_task
+    if not route_path.is_file():
+        return ()
+
+    paths = [route_path]
+    if selected_profile is not None:
+        try:
+            base_route = cli.build_route(selected_algo, selected_task, selected_sim, None)
+        except SystemExit:
+            base_route = None
+        if base_route is not None:
+            base_path = root / "conf" / base_route.config_group / "task" / base_route.owner_task
+            if base_path not in paths:
+                paths.append(base_path)
+    return tuple(paths)
+
+
+def _first_yaml_section_scalar(paths: Sequence[Path], section: str, key: str) -> str | None:
+    for path in paths:
+        selected = _yaml_section_scalar(path, section, key)
+        if selected not in (None, ""):
+            return selected
+    return None
+
+
+def _load_run_choices(
+    metadata: CompletionMetadata,
+    *,
+    prefix: str,
+    selected_algo: str | None,
+    selected_task: str | None,
+    selected_sim: str | None,
+    selected_profile: str | None,
+) -> list[str]:
+    candidates = ["-1"]
+    if metadata.root is None or not selected_algo or not selected_task or not selected_sim:
+        return _matching(candidates, prefix)
+
+    owner_paths = _owner_yaml_paths(
+        metadata.root,
+        selected_algo=selected_algo,
+        selected_task=selected_task,
+        selected_sim=selected_sim,
+        selected_profile=selected_profile,
+    )
+    if not owner_paths:
+        return _matching(candidates, prefix)
+
+    task_name = _first_yaml_section_scalar(owner_paths, "training", "task_name") or selected_task
+    log_root = _first_yaml_section_scalar(owner_paths, "training", "log_root")
+    if log_root is not None:
+        log_root_path = Path(log_root)
+        base_log_root = log_root_path if log_root_path.is_absolute() else metadata.root / log_root_path
+    else:
+        algo_log_name = (
+            _first_yaml_section_scalar(owner_paths, "algo", "algo_log_name")
+            or DEFAULT_ALGO_LOG_NAMES.get(selected_algo)
+        )
+        if algo_log_name is None:
+            return _matching(candidates, prefix)
+        base_log_root = metadata.root / "logs" / algo_log_name
+
+    task_log_root = base_log_root / task_name
+    if task_log_root.is_dir():
+        candidates.extend(
+            path.name
+            for path in sorted(task_log_root.iterdir())
+            if path.is_dir() and cli.RUN_ID_PATTERN.fullmatch(path.name) is not None
+        )
+    return _dedupe(_matching(candidates, prefix))
+
+
 def complete_words(
     words: Sequence[str],
     cword: int,
@@ -341,6 +491,23 @@ def complete_words(
         )
     if previous in choices:
         return _matching(choices[previous], current)
+    if command == "eval" and previous == "--load-run":
+        return _load_run_choices(
+            selected_metadata,
+            prefix=current,
+            selected_algo=option_values.get("--algo"),
+            selected_task=option_values.get("--task"),
+            selected_sim=option_values.get("--sim"),
+            selected_profile=option_values.get("--profile"),
+        )
+    if command in {"train", "eval"} and previous == "--profile":
+        return _profile_choices(
+            selected_metadata,
+            prefix=current,
+            selected_algo=option_values.get("--algo"),
+            selected_sim=option_values.get("--sim"),
+            selected_task=option_values.get("--task"),
+        )
     if current == "" or current.startswith("-") or previous == command:
         return _matching(_available_flags(selected_metadata, command, used_options), current)
     return []

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -22,6 +22,48 @@ def _write_completion_fixture(root: Path) -> None:
     (root / "benchmark" / "core" / "runner.py").write_text("", encoding="utf-8")
     (root / "scripts").mkdir()
     (root / "scripts" / "play_viser.py").write_text("", encoding="utf-8")
+    owner_files = {
+        root / "conf" / "ppo" / "task" / "go1" / "mujoco.yaml": """
+training:
+  task_name: Go1
+  sim_backend: mujoco
+""",
+        root / "conf" / "ppo" / "task" / "go1" / "mujoco_hora.yaml": """
+defaults:
+  - /task/go1/mujoco
+  - _self_
+algo:
+  algo_log_name: hora_ppo
+""",
+        root / "conf" / "ppo" / "task" / "go1" / "motrix_lab.yaml": """
+training:
+  task_name: Go1
+  sim_backend: motrix
+""",
+        root / "conf" / "ppo" / "task" / "go2" / "mujoco_lab.yaml": """
+training:
+  task_name: Go2
+  sim_backend: mujoco
+""",
+        root / "conf" / "ppo" / "task" / "go3" / "mujoco_custom.yaml": """
+training:
+  task_name: Go3
+  sim_backend: mujoco
+  log_root: custom_logs
+""",
+    }
+    for path, content in owner_files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content.strip() + "\n", encoding="utf-8")
+
+    for path in [
+        root / "logs" / "rsl_rl_ppo" / "Go1" / "2026-01-01_00-00-00_mujoco",
+        root / "logs" / "rsl_rl_ppo" / "Go1" / "2026-01-02_00-00-00_mujoco",
+        root / "logs" / "rsl_rl_ppo" / "Go2" / "2026-02-01_00-00-00_mujoco",
+        root / "logs" / "hora_ppo" / "Go1" / "2026-03-01_00-00-00_mujoco",
+        root / "custom_logs" / "Go3" / "2026-04-01_00-00-00_mujoco",
+    ]:
+        path.mkdir(parents=True)
 
 
 def test_uv_run_command_position_includes_project_scripts_and_run_paths(tmp_path: Path) -> None:
@@ -51,3 +93,148 @@ def test_uv_run_unknown_command_arguments_defer_to_shell_completion(tmp_path: Pa
     metadata = build_metadata(tmp_path)
 
     assert complete_words(["uv", "run", "benchmark/benchmark_sim.py", ""], 3, metadata) == []
+
+
+def test_eval_load_run_value_position_completes_latest_run_alias(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    choices = complete_words(["uv", "run", "eval", "--load-run", ""], 4, metadata)
+    assert choices == ["-1"]
+    assert "--algo" not in choices
+    assert complete_words(["uv", "run", "eval", "--load-run", "-"], 4, metadata) == ["-1"]
+    assert complete_words(["uv", "run", "eval", "--load-run", "run"], 4, metadata) == []
+
+
+def test_eval_load_run_value_position_completes_task_run_dirs(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(
+        [
+            "uv",
+            "run",
+            "eval",
+            "--algo",
+            "ppo",
+            "--task",
+            "go1",
+            "--sim",
+            "mujoco",
+            "--load-run",
+            "",
+        ],
+        10,
+        metadata,
+    ) == ["-1", "2026-01-01_00-00-00_mujoco", "2026-01-02_00-00-00_mujoco"]
+    assert complete_words(
+        [
+            "uv",
+            "run",
+            "eval",
+            "--algo",
+            "ppo",
+            "--task",
+            "go1",
+            "--sim",
+            "mujoco",
+            "--load-run",
+            "2026-01-02",
+        ],
+        10,
+        metadata,
+    ) == ["2026-01-02_00-00-00_mujoco"]
+
+
+def test_eval_load_run_completion_respects_profile_log_name(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(
+        [
+            "uv",
+            "run",
+            "eval",
+            "--algo",
+            "ppo",
+            "--task",
+            "go1",
+            "--sim",
+            "mujoco",
+            "--profile",
+            "hora",
+            "--load-run",
+            "",
+        ],
+        12,
+        metadata,
+    ) == ["-1", "2026-03-01_00-00-00_mujoco"]
+
+
+def test_eval_load_run_completion_respects_training_log_root(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(
+        [
+            "uv",
+            "run",
+            "eval",
+            "--algo",
+            "ppo",
+            "--task",
+            "go3",
+            "--sim",
+            "mujoco",
+            "--profile",
+            "custom",
+            "--load-run",
+            "",
+        ],
+        12,
+        metadata,
+    ) == ["-1", "2026-04-01_00-00-00_mujoco"]
+
+
+def test_train_profile_value_position_completes_profile_names(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(
+        ["uv", "run", "train", "--algo", "ppo", "--sim", "mujoco", "--profile", ""],
+        8,
+        metadata,
+    ) == ["custom", "hora", "lab"]
+    choices = complete_words(
+        ["uv", "run", "train", "--algo", "ppo", "--sim", "mujoco", "--profile", "h"],
+        8,
+        metadata,
+    )
+    assert choices == ["hora"]
+    assert "--algo" not in choices
+    assert complete_words(
+        ["uv", "run", "train", "--algo", "ppo", "--task", "go1", "--sim", "mujoco", "--profile", ""],
+        10,
+        metadata,
+    ) == ["hora"]
+    assert complete_words(
+        ["uv", "run", "train", "--algo", "ppo", "--task", "go1", "--sim", "motrix", "--profile", ""],
+        10,
+        metadata,
+    ) == ["lab"]
+    assert complete_words(
+        ["uv", "run", "eval", "--algo", "ppo", "--sim", "mujoco", "--profile", "h"],
+        8,
+        metadata,
+    ) == ["hora"]
+
+
+def test_task_completion_respects_selected_profile(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(
+        ["uv", "run", "train", "--algo", "ppo", "--sim", "mujoco", "--profile", "hora", "--task", ""],
+        10,
+        metadata,
+    ) == ["go1"]

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -213,12 +213,36 @@ def test_train_profile_value_position_completes_profile_names(tmp_path: Path) ->
     assert choices == ["hora"]
     assert "--algo" not in choices
     assert complete_words(
-        ["uv", "run", "train", "--algo", "ppo", "--task", "go1", "--sim", "mujoco", "--profile", ""],
+        [
+            "uv",
+            "run",
+            "train",
+            "--algo",
+            "ppo",
+            "--task",
+            "go1",
+            "--sim",
+            "mujoco",
+            "--profile",
+            "",
+        ],
         10,
         metadata,
     ) == ["hora"]
     assert complete_words(
-        ["uv", "run", "train", "--algo", "ppo", "--task", "go1", "--sim", "motrix", "--profile", ""],
+        [
+            "uv",
+            "run",
+            "train",
+            "--algo",
+            "ppo",
+            "--task",
+            "go1",
+            "--sim",
+            "motrix",
+            "--profile",
+            "",
+        ],
         10,
         metadata,
     ) == ["lab"]
@@ -234,7 +258,19 @@ def test_task_completion_respects_selected_profile(tmp_path: Path) -> None:
     metadata = build_metadata(tmp_path)
 
     assert complete_words(
-        ["uv", "run", "train", "--algo", "ppo", "--sim", "mujoco", "--profile", "hora", "--task", ""],
+        [
+            "uv",
+            "run",
+            "train",
+            "--algo",
+            "ppo",
+            "--sim",
+            "mujoco",
+            "--profile",
+            "hora",
+            "--task",
+            "",
+        ],
         10,
         metadata,
     ) == ["go1"]


### PR DESCRIPTION
## 摘要

- 修复 `uv run eval --load-run <TAB>` 的误导补全：现在返回已支持的 latest-run 别名 `-1`，并在已有 `--algo` / `--task` / `--sim` 上下文时补全当前任务日志目录下的真实 run 目录名，不再返回无关 flags。
- 为 `train/eval --profile <TAB>` 增加值补全：从已有 task owner metadata 中派生 profile 名称。
- 改善 bash/zsh completion 在源码 checkout 下的 fallback：从被 source 的 completion 脚本路径解析 repo root，并通过 `PYTHONPATH=<repo>/src` 调用 Python module。
- 移除 `unilab.__init__` 中不必要的 `etils` 依赖，使轻量 completion import 可以在完整运行时依赖不可用时工作。
- 增加 completion 测试，覆盖 `--load-run` 的 `-1` 和真实 run 目录候选、profile 候选过滤、前缀匹配、`training.log_root`、profile 覆盖 `algo_log_name`，以及选中 profile 后的 task 过滤。

用户可见行为变化：

- `eval --load-run <TAB>` 现在提示 `-1` 和匹配的真实 run 目录名，不再提示无效 flags。
- `train/eval --profile <TAB>` 在存在 profile owner YAML 时会提示匹配的 profile 名称。
- 在 console script 尚不可用的源码 checkout 中，completion fallback 更稳健。

训练影响：

- 预期不影响训练行为。
- 预期不影响后端运行时行为。

## 验证

- [x] `make check`
- [x] `uv run --active --no-sync pytest -m "not slow"`
- [x] `python -m pytest`
- [x] 下方列出的任务专项验证

验证结果说明：

- `PYTHONPATH=src uv run --no-sync python -m unilab.tools.completion --cword 2 -- uv run ""` 返回了预期的一层候选：`train`、`eval`、`demo`、`unilab-complete`、`unilab-export-scene`、`unilab-viz-nan`、`benchmark/`、`scripts/`。
- source `scripts/completions/unilab.bash` 后直接调用 `_unilab_uv_complete`，返回了同样的一层候选。
- `zsh -n scripts/completions/unilab.zsh` 通过。
- `uv sync --active --extra motrix` 完成依赖同步。
- `uv run --active --no-sync pytest tests/test_completion.py -q` 通过：`9 passed in 0.07s`。
- `uv run --active --no-sync pytest -m "not slow"` 通过：`1006 passed, 15 skipped, 254 deselected, 62 warnings in 68.80s`。
- `uv pip install --python "$CONDA_PREFIX/bin/python" -e ".[motrix]" --group dev` 已将 UniLab 运行和开发依赖安装到 `conda activate unilab` 对应的 Python 环境中。
- `python -m pytest tests/test_completion.py -q` 通过：`9 passed in 0.07s`。
- `python -m pytest` 通过。由于仓库 `pyproject.toml` 默认 `addopts = "--tb=short -m 'not slow'"`，实际执行的是非 slow 集合：`1006 passed, 15 skipped, 254 deselected, 62 warnings in 39.54s`。

## 影响

- 后端影响：`none`
- 平台影响：`both`
- 预期训练影响：`no`