### PR TITLE
feat: add APPO Motrix owner for Go2 joystick

### DIFF
--- a/conf/appo/task/go2_joystick_flat/motrix.yaml
+++ b/conf/appo/task/go2_joystick_flat/motrix.yaml
@@ -1,0 +1,21 @@
+# @package _global_
+training:
+  task_name: Go2JoystickFlat
+  sim_backend: motrix
+algo:
+  num_envs: 1024
+  max_iterations: 150
+reward:
+  scales:
+    tracking_lin_vel: 1.0
+    tracking_ang_vel: 0.2
+    lin_vel_z: -5.0
+    ang_vel_xy: -0.1
+    base_height: -100.0
+    action_rate: -0.005
+    similar_to_default: -0.1
+    alive: 0.0
+    contact: 0.24
+    swing_feet_z: 4.0
+  tracking_sigma: 0.25
+  base_height_target: 0.3

--- a/docs/sphinx/source/zh_CN/user_guide/E-reference/01-backend-support-matrix.md
+++ b/docs/sphinx/source/zh_CN/user_guide/E-reference/01-backend-support-matrix.md
@@ -77,7 +77,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_rough` (go2w joystick rough) | Configured | Configured |
 | APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | Registered |
-| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |
+| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Tested |
 | APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
 | APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |


### PR DESCRIPTION
## Summary
- add APPO owner config for go2_joystick_flat/motrix
- update the generated Chinese backend support matrix to mark APPO Go2 Motrix as tested

## Validation
- uv run scripts/train_appo.py task=go2_joystick_flat/motrix --cfg job
- uv run pytest tests/config/test_config_system.py::test_supported_task_composes tests/scripts/test_support_matrix.py::test_support_matrix_marks_go2_ppo_backends_as_tested
- make test-all