### PR TITLE
fix: update appo  go2_joystick_flat and fix logger start time

### DIFF
--- a/conf/appo/task/go2_joystick_flat/motrix.yaml
+++ b/conf/appo/task/go2_joystick_flat/motrix.yaml
@@ -3,8 +3,14 @@ training:
   task_name: Go2JoystickFlat
   sim_backend: motrix
 algo:
-  num_envs: 1024
-  max_iterations: 150
+  num_envs: 512
+  steps_per_env: 24
+  max_iterations: 180
+env:
+  sim_dt: 0.015
+algorithm:
+  num_learning_epochs: 25
+  num_mini_batches: 8
 reward:
   scales:
     tracking_lin_vel: 1.0

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -261,12 +261,12 @@ class APPORunner(AsyncRunner):
             log_backend=logger_type,
         )
         logger.set_collection_sync(True, env_steps_per_sync)
-        logger.start()
         logger.log_status(
             f"Waiting for first rollout... "
             f"(staging_pool={self.staging_pool_size}, "
             f"epochs={learner.num_learning_epochs})"
         )
+        logger_started = False
 
         reward_history: deque = deque(maxlen=200)
         latest_reward_components: dict = {}
@@ -299,6 +299,10 @@ class APPORunner(AsyncRunner):
                     f"[yellow]Warning: Timeout waiting for data at iteration {iteration}[/]"
                 )
                 continue
+
+            if not logger_started:
+                logger.start(status="Training")
+                logger_started = True
 
             available_on_arrive = rollout_ring_buffer.available()
             wait_time = time.time() - wait_start

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -147,8 +147,8 @@ class _FakeLogger:
     def set_collection_sync(self, enabled: bool, env_steps_per_sync: int) -> None:
         del enabled, env_steps_per_sync
 
-    def start(self) -> None:
-        pass
+    def start(self, *, status: str = "") -> None:
+        del status
 
     def log_status(self, status: str) -> None:
         del status


### PR DESCRIPTION
## Summary

- update appo go2_joystick_flat params: 19s->12s
- delayed APPO’s Rich live board until the first rollout arrives, so Motrix startup noise ‘Motphys profiler initialized: disabled’ no longer causes the training panel to redraw twice

## Validation

- [x] `make test-all`

## Artifacts

<img width="1584" height="496" alt="8882047f471aff3b615dffb16fa62897" src="https://github.com/user-attachments/assets/c4b52503-02f8-4aa8-8f45-9844f38741ee" />
