### PR TITLE
fix: ignore non-command fences in doc hydra check

### DIFF
--- a/tests/scripts/doc_checks.py
+++ b/tests/scripts/doc_checks.py
@@ -236,7 +236,19 @@ def check_hydra_keys(content: str, doc_path: Path, root: Path) -> list[str]:
     del root
     errors: list[str] = []
     hydra_pattern = r"(?:^|\s)([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)="
+    command_fence_languages = {"", "bash", "console", "shell", "sh", "text"}
+    in_fence = False
+    fence_language = ""
+
     for line in content.splitlines():
+        fence_match = re.match(r"^\s*```\s*([A-Za-z0-9_+-]*)", line)
+        if fence_match:
+            in_fence = not in_fence
+            fence_language = fence_match.group(1).lower() if in_fence else ""
+            continue
+        if in_fence and fence_language not in command_fence_languages:
+            continue
+
         stripped = line.strip()
         is_cli_line = (
             "scripts/train_" in stripped

--- a/tests/scripts/test_check_docs.py
+++ b/tests/scripts/test_check_docs.py
@@ -60,6 +60,29 @@ Logs live under logs/<algo.algo_log_name>/<task>/.
     assert errors == []
 
 
+def test_check_hydra_keys_ignores_non_command_fenced_blocks():
+    root = Path(__file__).resolve().parents[2]
+    doc_path = root / "README.md"
+    content = """
+```bibtex
+@article{jia2026unilab,
+  title  = {UniLab},
+  author = {UniLab Contributors},
+  year   = {2026}
+}
+```
+
+```bash
+uv run scripts/train_rsl_rl.py missing_key=true task=go1_joystick_flat/mujoco
+```
+"""
+
+    errors = doc_checks.check_hydra_keys(content, doc_path, root)
+
+    assert not any("title" in error or "author" in error or "year" in error for error in errors)
+    assert any("Unknown config key: missing_key" in error for error in errors)
+
+
 def test_check_script_references_ignores_tests_paths():
     root = Path(__file__).resolve().parents[2]
     doc_path = root / "CONTRIBUTING.md"


### PR DESCRIPTION
## Summary
- skip non-command fenced code blocks when checking documented Hydra keys
- add regression coverage for BibTeX blocks while preserving shell command validation

## Validation
- make test-all