### PR TITLE
feat: add Sharpa APPO Motrix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ Use [docs/README.md](docs/README.md) as the documentation index. High-signal ent
 
 ```bibtex
 @article{jia2026mujocouni,
-  title={MuJoCoUni: Persistent Batched Runtime Primitives for MuJoCo},
-  author={Jia, Yufei and Wu, Junzhe},
-  journal={arXiv preprint arXiv:2605.24922},
-  year={2026}
+  title  = {MuJoCoUni: Persistent Batched Runtime Primitives for MuJoCo},
+  author = {Jia, Yufei and Wu, Junzhe},
+  journal = {arXiv preprint arXiv:2605.24922},
+  year   = {2026}
 }
 
 @software{motrixsim2026,

--- a/conf/appo/task/sharpa_inhand/motrix.yaml
+++ b/conf/appo/task/sharpa_inhand/motrix.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - /task/sharpa_inhand/mujoco
+  - _self_
+
+training:
+  task_name: SharpaInhandRotation
+  sim_backend: motrix
+
+algo:
+  num_envs: 2048
+
+env:
+  sim_dt: 0.01
+  domain_rand:
+    randomize_gravity: true
+    randomize_gravity_direction: false
+    randomize_pd_gains: true

--- a/docs/sphinx/source/zh_CN/user_guide/E-reference/01-backend-support-matrix.md
+++ b/docs/sphinx/source/zh_CN/user_guide/E-reference/01-backend-support-matrix.md
@@ -83,7 +83,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
 | APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
 | APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
-| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Registered |
+| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -43,7 +43,7 @@ def test_support_matrix_marks_sharpa_motrix_phase1_support():
     appo_row = _row("APPO (torch)", "sharpa_inhand")
 
     assert appo_row.cells["mujoco"].level == EvidenceLevel.TESTED
-    assert appo_row.cells["motrix"].level == EvidenceLevel.REGISTERED
+    assert appo_row.cells["motrix"].level == EvidenceLevel.TESTED
     allegro_appo_row = _row("APPO (torch)", "allegro_inhand")
 
     assert allegro_appo_row.cells["mujoco"].level == EvidenceLevel.TESTED

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -887,6 +887,18 @@ def test_g1_motion_tracking_appo_task_exposes_final_reward():
     assert cfg.reward.scales.motion_body_pos == pytest.approx(1.0)
 
 
+def test_sharpa_appo_motrix_owner_uses_backend_specific_overrides():
+    cfg = _appo_cfg(["task=sharpa_inhand/motrix"])
+
+    assert cfg.training.task_name == "SharpaInhandRotation"
+    assert cfg.training.sim_backend == "motrix"
+    assert cfg.algo.num_envs == 2048
+    assert cfg.env.sim_dt == pytest.approx(0.01)
+    assert cfg.env.domain_rand.randomize_gravity is True
+    assert cfg.env.domain_rand.randomize_gravity_direction is False
+    assert cfg.env.domain_rand.randomize_pd_gains is True
+
+
 # ---------------------------------------------------------------------------
 # train_appo.py — motrix runner / play helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- add the APPO Motrix owner config for sharpa_inhand
- enable Sharpa APPO Motrix in the generated backend support matrix
- cover the owner config with compose/support matrix tests
- fix README BibTeX spacing so documentation checks pass

Validation:
- make test-all