### PR TITLE
perf: upgrade motrixsim-core to dev104632

### DIFF
--- a/docs/sphinx/source/en/user_guide/backends/motrix.md
+++ b/docs/sphinx/source/en/user_guide/backends/motrix.md
@@ -1,7 +1,7 @@
 # Motrix Backend
 
 Motrix is an optional backend installed through the `motrix` extra. The pinned
-package is `motrixsim-core==0.8.1.dev103923` in `pyproject.toml`, and the adapter
+package is `motrixsim-core==0.8.1.dev104632` in `pyproject.toml`, and the adapter
 lives under `src/unilab/base/backend/motrix/`.
 
 ## Setup

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -43,7 +43,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.7.1.dev102197"]
+motrix = ["motrixsim-core==0.8.1.dev104632"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.8.1.dev103923"]
+motrix = ["motrixsim-core==0.8.1.dev104632"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2188,7 +2188,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.8.1.dev103923"
+version = "0.8.1.dev104632"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2196,18 +2196,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:17c4ab142b6c5cfe19bedc888a74d43bf554189f952b7940ccc969e3dee1c2af" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:366b5bbd0d52354bbfec2f899e4d4e1d8fac5876d7143f3ece2c24fe6892d15a" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp310-cp310-win_amd64.whl", hash = "sha256:a723d103d3af98b17157538820980094a924573fd9b3d7acad0fc88f0d5a464e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b0462c71df7df85f0d729fbc89f127c638b0808f81618d2f1fc84884b2c3a32e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:910adc6d4694392d9b493ce7b4feafba3ba7d3be17d3b84fb1afb572cadf8134" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp311-cp311-win_amd64.whl", hash = "sha256:826a6d505cabd149e7c2bca5ffd37302ca2678b10b6c76a62a5eb01bf12d490d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dd054f4a3ae7934c20de77602442ca59142175cc74b76bf980c815eeeaebc94e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cae788889bf4c67aa00d7f590223ee5c35eac35fa4b0836758a2504eeacdf29" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp312-cp312-win_amd64.whl", hash = "sha256:fcb84763cd12936ed7dbc31816c380bf85ff8f0a8ca021525f10a1846f32f464" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16d87f44401ccb189a0b4cc323512a3d934afb9025261e2440ea1320c15c5203" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12bb810a1e3b79f0901c815b89ce4c1786e2a80126855c77dfbd179666ff832d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev103923-cp313-cp313-win_amd64.whl", hash = "sha256:fdd2b4fccbb75900ea8f3c96d53384038a02d56eeff83e0fd37e8ecfb97693e5" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e988e74fbb92c2fcd2df7375ebfadceab7e720f2d5eabca67a4e02ae28ba4197" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94b994b2dbb7d7ad7e25f30d803af241fde8fdbdfe8004e88c7c89779862af82" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-win_amd64.whl", hash = "sha256:0f804a1fd051fca5b1cca96bbccd50215387ca56be714b8f45bb98fe3562659e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5126de3f53351eba13ee59b59d3156a9d5c744001e3f9b49bbc210e09b550e8" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0dadaf513fc369ca5d80da30293298ccb0d41faf9b5aa351787fae8c90fe2a" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-win_amd64.whl", hash = "sha256:b86dd41c12b55604b5a2f42fd25a32c7fc9fe2a7b2ea5fce6a21dc93a9fdab62" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12a91cdbdf21fda6f9244ce7470ef812261925d8a3d1535ed89e609d691e860d" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:203bf623c191e118e17cf86896b8ed9604986d7dd6cb54dae4c56bbe6f975ae2" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-win_amd64.whl", hash = "sha256:92539572bd539e6d9fb0352afbfce1f888d3b6354b479b876ca2d55426fadf25" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5b86e661ca4cd3b6ed03809546ea76f2b35934776e0e62e2565f3df562654114" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da9898a00b41a0380b6df3b9d3e4a26836067a0dc76a9676fc5d726c81fad4ac" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-win_amd64.whl", hash = "sha256:2b37acfc4f95cb3566cfa7302b6dbd22c3f12303b315385cb929305f79880eca" },
 ]
 
 [[package]]
@@ -4576,7 +4576,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev103923", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104632", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
     { name = "notebook", specifier = ">=7.5.5" },

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -2197,7 +2197,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.7.1.dev102197"
+version = "0.8.1.dev104632"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2205,18 +2205,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8fad2d5a4d62aefc193f96eb75275b2e8bfa79782743a11ecaa6c135eb8d7a36" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f243deb4e8f3f8ca50ed03f8f17b77166e172d981f06bb58d90e8286bd48601e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp310-cp310-win_amd64.whl", hash = "sha256:71f349bb7992f814e8313110ca677215eb422714efb9b27590ef1a9c8bb45fc2" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edadd108c9d66e83cbab997fa5ab2d4bcff86cf9a401496ce9341a51d77ba4a5" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395952a9058f2839cb884c7aabdf4a93ee909bd04249ca4b0e07fc593562b7fe" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp311-cp311-win_amd64.whl", hash = "sha256:7d8e9096e6d107b16f264e6263988910344173783464caa607a4b631de000647" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9ca7cc02f875aaef640e42eba051ed33a1d832d3e05bc3235c35e9868441391" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:facdcde4a8055a5e90827784d85cb9b4f5d3b93645e5377098b2cc0007591875" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp312-cp312-win_amd64.whl", hash = "sha256:8417561f5877ed2bfa9ae798d9ac22df10ff438bf6b3cd22474ead563c739a7d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd9c6862d29b44d2fb5547b285ecbdc5af784a43e562a545819301f89090faea" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6d72d5be0726679ce1a7be3ad4ad9c3f9c5fc3fae30fabdc6d9f200b7cad5e2" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.7.1.dev102197-cp313-cp313-win_amd64.whl", hash = "sha256:ccb4d5673215267c1296f618a8153013c0cdb68bbeef9f17100cc8b4cff1bccc" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e988e74fbb92c2fcd2df7375ebfadceab7e720f2d5eabca67a4e02ae28ba4197" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94b994b2dbb7d7ad7e25f30d803af241fde8fdbdfe8004e88c7c89779862af82" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-win_amd64.whl", hash = "sha256:0f804a1fd051fca5b1cca96bbccd50215387ca56be714b8f45bb98fe3562659e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5126de3f53351eba13ee59b59d3156a9d5c744001e3f9b49bbc210e09b550e8" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0dadaf513fc369ca5d80da30293298ccb0d41faf9b5aa351787fae8c90fe2a" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-win_amd64.whl", hash = "sha256:b86dd41c12b55604b5a2f42fd25a32c7fc9fe2a7b2ea5fce6a21dc93a9fdab62" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12a91cdbdf21fda6f9244ce7470ef812261925d8a3d1535ed89e609d691e860d" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:203bf623c191e118e17cf86896b8ed9604986d7dd6cb54dae4c56bbe6f975ae2" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-win_amd64.whl", hash = "sha256:92539572bd539e6d9fb0352afbfce1f888d3b6354b479b876ca2d55426fadf25" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5b86e661ca4cd3b6ed03809546ea76f2b35934776e0e62e2565f3df562654114" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da9898a00b41a0380b6df3b9d3e4a26836067a0dc76a9676fc5d726c81fad4ac" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-win_amd64.whl", hash = "sha256:2b37acfc4f95cb3566cfa7302b6dbd22c3f12303b315385cb929305f79880eca" },
 ]
 
 [[package]]
@@ -4579,7 +4579,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.7.1.dev102197", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104632", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- upgrade `motrixsim-core` from `0.8.1.dev103923` to `0.8.1.dev104632` for the default profile
- align the ROCm profile and both lockfiles with `0.8.1.dev104632`
- update the Motrix backend setup documentation

## G1 Walk Flat Benchmark

Device: AMD Ryzen 7 9700X

| Batch | Old latency | Old throughput | New latency | New throughput | Throughput gain |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 256 | 53.310 ms | 9.60 万 fps | 44.387 ms | 11.53 万 fps | +20.1% |
| 512 | 104.817 ms | 9.77 万 fps | 89.790 ms | 11.40 万 fps | +16.7% |
| 1024 | 209.932 ms | 9.76 万 fps | 178.841 ms | 11.45 万 fps | +17.3% |
| 2048 | 421.040 ms | 9.73 万 fps | 352.560 ms | 11.62 万 fps | +19.4% |
| 4096 | 840.178 ms | 9.75 万 fps | 743.592 ms | 11.02 万 fps | +13.0% |
| 8192 | 1678.340 ms | 9.76 万 fps | 1448.300 ms | 11.31 万 fps | +15.9% |
| 16384 | 3356.562 ms | 9.76 万 fps | 2909.820 ms | 11.26 万 fps | +15.4% |

Across the seven batch sizes, average throughput increases by about **16.8%**.

## Behavior Scope

- Motrix backend dependency changes only; no UniLab backend contract or adapter behavior changes.
- MuJoCo behavior is unchanged.
- Default and ROCm dependency profiles now resolve the same MotrixSim version.

## Validation

- `make test-all`
- `uv lock --check`
- `uv lock --project /tmp/unilab-rocm-lock --check`
- `git diff --check`
- `uv run --extra motrix python -c "from importlib.metadata import version; import motrixsim; print(version('motrixsim-core'))"` -> `0.8.1.dev104632`

Driving issue: direct dependency upgrade request; no linked GitHub issue.