### PR TITLE
feat: auto-download Sharpa grasp cache from HF on first use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ src/unilab/assets/motions/g1/*.npz
 src/unilab/assets/motions/g1/*.csv
 src/unilab/assets/motions/g1/flip
 src/unilab/assets/motions/g1/flip_npz
+
+# Grasp cache assets (downloaded from HF at runtime)
+src/unilab/assets/caches/*.npy
+
 cache/
 
 

--- a/conf/appo/task/sharpa_inhand/mujoco.yaml
+++ b/conf/appo/task/sharpa_inhand/mujoco.yaml
@@ -59,7 +59,7 @@ env:
   reset_height_upper: 0.63906
   reset_angle_diff: 0.7853981633974483
   rot_axis: [0.0, 0.0, 1.0]
-  grasp_cache_path: cache/sharpa_grasp_linspace
+  grasp_cache_path: caches/sharpa_grasp_linspace
   sensor:
     tactile_force_sensor_names:
       - contact_right_thumb_elastomer_force

--- a/conf/ppo/task/sharpa_inhand/mujoco.yaml
+++ b/conf/ppo/task/sharpa_inhand/mujoco.yaml
@@ -43,7 +43,7 @@ env:
   reset_height_upper: 0.63906
   reset_angle_diff: 0.7853981633974483
   rot_axis: [0.0, 0.0, 1.0]
-  grasp_cache_path: cache/sharpa_grasp_linspace
+  grasp_cache_path: caches/sharpa_grasp_linspace
   sensor:
     tactile_force_sensor_names:
       - contact_right_thumb_elastomer_force

--- a/conf/ppo/task/sharpa_inhand_grasp/mujoco.yaml
+++ b/conf/ppo/task/sharpa_inhand_grasp/mujoco.yaml
@@ -81,7 +81,7 @@ env:
   reset_height_upper: 0.62406
   reset_angle_diff: 0.5235987755982988
   rot_axis: [0.0, 0.0, 1.0]
-  grasp_cache_path: cache/sharpa_grasp_linspace
+  grasp_cache_path: caches/sharpa_grasp_linspace
   obs:
     observation_mode: flattened
     enable_tactile: true

--- a/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/4-sharpa-inhand.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/4-sharpa-inhand.md
@@ -26,7 +26,10 @@
 
 ## Grasp cache 与 scale
 
-MuJoCo 采集：
+默认 cache 托管在 HF (`unilabsim/unilab-caches`)，首次训练时自动下载到
+`src/unilab/assets/caches/`，无需手动操作。
+
+手动采集（MuJoCo）：
 
 ```bash
 uv run train --algo ppo --task sharpa_inhand_grasp --sim mujoco 'env.domain_rand.scale_list=[0.8]' training.no_play=true
@@ -43,10 +46,7 @@ uv run train --algo ppo --task sharpa_inhand_grasp --sim motrix \
   training.no_play=true
 ```
 
-默认 rotation 读取 `cache/sharpa_grasp_linspace`；Motrix phase-1 读取按 scale 切分的 `<prefix>_<scale>.npy`。
-批量采集时可直接用 `bash scripts/sharpa_collect_grasps.sh 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5 1.6`。
-
-自定义 cache：
+自定义 cache（`<prefix>_<scale>.npy` 命名规则）：
 
 ```bash
 uv run train --algo ppo --task sharpa_inhand --sim mujoco \
@@ -56,8 +56,6 @@ uv run train --algo ppo --task sharpa_inhand --sim motrix \
   env.grasp_cache_path=cache/my_sharpa_grasp_cache \
   training.no_play=true
 ```
-
-Motrix 自定义 cache 前缀需要满足 `<prefix>_<scale>.npy` 命名规则，例如 `cache/my_sharpa_grasp_cache_1.0.npy`。
 
 ## Teacher / student
 

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -1,6 +1,6 @@
-"""Cold-path motion asset resolver with Hugging Face fallback.
+"""Cold-path asset resolver with Hugging Face fallback.
 
-Guarantees that requested motion files exist on disk before returning.
+Guarantees that requested asset files exist on disk before returning.
 When a file is missing locally, it is downloaded from the configured
 Hugging Face dataset repo and placed under ``ASSETS_ROOT_PATH`` so that
 existing path references remain valid.
@@ -20,7 +20,8 @@ from unilab.assets import ASSETS_ROOT_PATH
 
 logger = logging.getLogger(__name__)
 
-_HF_REPO_ID = "unilabsim/unilab-motions"
+_HF_MOTIONS_REPO_ID = "unilabsim/unilab-motions"
+_HF_CACHES_REPO_ID = "unilabsim/unilab-caches"
 _HF_REPO_TYPE = "dataset"
 _HF_OFFICIAL_ENDPOINT = "https://huggingface.co"
 
@@ -40,12 +41,31 @@ def resolve_motion_files(
         returns a list of strings.
     """
     if isinstance(motion_file, str):
-        return _resolve_single(motion_file)
-    return [_resolve_single(p) for p in motion_file]
+        return _resolve_single(motion_file, repo_id=_HF_MOTIONS_REPO_ID)
+    return [_resolve_single(p, repo_id=_HF_MOTIONS_REPO_ID) for p in motion_file]
 
 
-def _resolve_single(path_str: str) -> str:
-    """Resolve one motion file path, downloading if absent."""
+def resolve_grasp_cache_files(
+    cache_file: str | Sequence[str],
+) -> str | list[str]:
+    """Ensure grasp cache file(s) exist locally, downloading from HF if needed.
+
+    Args:
+        cache_file: Absolute path or ``ASSETS_ROOT_PATH``-relative path
+            (single string or sequence of strings).
+
+    Returns:
+        Resolved absolute path(s) guaranteed to exist on disk.
+        A single string input returns a single string; a sequence input
+        returns a list of strings.
+    """
+    if isinstance(cache_file, str):
+        return _resolve_single(cache_file, repo_id=_HF_CACHES_REPO_ID)
+    return [_resolve_single(p, repo_id=_HF_CACHES_REPO_ID) for p in cache_file]
+
+
+def _resolve_single(path_str: str, *, repo_id: str = _HF_MOTIONS_REPO_ID) -> str:
+    """Resolve one asset file path, downloading if absent."""
     path = Path(path_str)
 
     # Already exists locally — fast path.
@@ -65,18 +85,23 @@ def _resolve_single(path_str: str) -> str:
             relative = str(path.relative_to(ASSETS_ROOT_PATH))
         except ValueError:
             raise FileNotFoundError(
-                f"Motion file not found and path is not under "
+                f"Asset file not found and path is not under "
                 f"ASSETS_ROOT_PATH ({ASSETS_ROOT_PATH}): {path_str}"
             ) from None
 
-    return _download_from_hf(relative)
+    return _download_from_hf(relative, repo_id=repo_id)
 
 
-def _hf_download(hf_hub_download, relative_path: str) -> str:  # type: ignore[no-untyped-def]
+def _hf_download(
+    hf_hub_download,  # type: ignore[no-untyped-def]
+    relative_path: str,
+    *,
+    repo_id: str = _HF_MOTIONS_REPO_ID,
+) -> str:
     """Call ``hf_hub_download`` with the standard arguments."""
     return str(
         hf_hub_download(
-            repo_id=_HF_REPO_ID,
+            repo_id=repo_id,
             filename=relative_path,
             repo_type=_HF_REPO_TYPE,
             local_dir=str(ASSETS_ROOT_PATH),
@@ -84,8 +109,12 @@ def _hf_download(hf_hub_download, relative_path: str) -> str:  # type: ignore[no
     )
 
 
-def _download_from_hf(relative_path: str) -> str:
-    """Download *relative_path* from the HF dataset repo.
+def _download_from_hf(
+    relative_path: str,
+    *,
+    repo_id: str = _HF_MOTIONS_REPO_ID,
+) -> str:
+    """Download *relative_path* from an HF dataset repo.
 
     If the current ``HF_ENDPOINT`` (e.g. a mirror) fails, automatically
     retries with the official ``https://huggingface.co`` endpoint.
@@ -94,17 +123,17 @@ def _download_from_hf(relative_path: str) -> str:
         from huggingface_hub import hf_hub_download
     except ImportError:
         raise ImportError(
-            f"Motion file '{relative_path}' not found locally. "
+            f"Asset file '{relative_path}' not found locally. "
             "Install huggingface_hub to enable automatic downloading:\n"
             "  uv sync\n"
             "Or:\n"
             "  uv pip install huggingface_hub"
         ) from None
 
-    logger.info("Downloading %s from HF repo %s ...", relative_path, _HF_REPO_ID)
+    logger.info("Downloading %s from HF repo %s ...", relative_path, repo_id)
 
     try:
-        local_path = _hf_download(hf_hub_download, relative_path)
+        local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
     except Exception:
         # If a mirror endpoint is configured and it failed, retry with
         # the official endpoint before giving up.
@@ -118,7 +147,9 @@ def _download_from_hf(relative_path: str) -> str:
             original = os.environ["HF_ENDPOINT"]
             os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
             try:
-                local_path = _hf_download(hf_hub_download, relative_path)
+                local_path = _hf_download(
+                    hf_hub_download, relative_path, repo_id=repo_id
+                )
             finally:
                 os.environ["HF_ENDPOINT"] = original
         else:

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -147,9 +147,7 @@ def _download_from_hf(
             original = os.environ["HF_ENDPOINT"]
             os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
             try:
-                local_path = _hf_download(
-                    hf_hub_download, relative_path, repo_id=repo_id
-                )
+                local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
             finally:
                 os.environ["HF_ENDPOINT"] = original
         else:

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -197,7 +197,7 @@ class SharpaInhandBaseCfg(EnvCfg):
 
     rot_axis: tuple[float, float, float] = (0.0, 0.0, 1.0)
 
-    grasp_cache_path: str = "cache/sharpa_grasp_linspace"
+    grasp_cache_path: str = str(ASSETS_ROOT_PATH / "caches" / "sharpa_grasp_linspace")
     disable_tactile_ids: list[int] = field(default_factory=list)
     # Match the reference Sharpa object-position reward/privileged-info anchor
     # by using the fixed XML/default object pose instead of the sampled grasp reset.

--- a/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
@@ -296,7 +296,7 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
             return
 
         output_file = resolve_grasp_cache_file(
-            self._cfg.grasp_cache_path or "cache/sharpa_grasp_linspace",
+            self._cfg.grasp_cache_path or "caches/sharpa_grasp_linspace",
             float(self.scale_values[0]),
         )
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
@@ -34,6 +35,7 @@ from unilab.envs.common.rotation import (
     np_quat_mul,
     np_quat_to_axis_angle,
 )
+from unilab.assets.hub import resolve_grasp_cache_files
 from unilab.envs.manipulation.sharpa_inhand.base import (
     SharpaInhandBaseCfg,
     SharpaInhandBaseEnv,
@@ -175,6 +177,9 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
         missing_files: list[str] = []
         for scale_value in np.asarray(env.scale_values, dtype=np.float64):
             cache_file = resolve_grasp_cache_file(env.cfg.grasp_cache_path, float(scale_value))
+            # Auto-download from HF if the cache file is missing locally.
+            resolved = cast(str, resolve_grasp_cache_files(str(cache_file)))
+            cache_file = Path(resolved)
             if not cache_file.exists():
                 missing_files.append(str(cache_file))
                 continue
@@ -182,7 +187,12 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
 
         if missing_files:
             missing = ", ".join(missing_files)
-            raise RuntimeError(f"Missing Sharpa grasp cache file(s): {missing}")
+            raise RuntimeError(
+                f"Missing Sharpa grasp cache file(s): {missing}\n"
+                "Generate them with:\n"
+                "  bash scripts/sharpa_collect_grasps.sh 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5 1.6\n"
+                "See docs/sphinx/source/zh_CN/user_guide/D-tasks/04-sharpa-inhand.md"
+            )
 
         env._grasp_cache = tuple(grasp_caches)
         return cast(tuple[np.ndarray, ...], env._grasp_cache)

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import numpy as np
 
+from unilab.assets.hub import resolve_grasp_cache_files
 from unilab.base import registry
 from unilab.base.backend import create_backend
 from unilab.base.np_env import NpEnvState
@@ -35,7 +36,6 @@ from unilab.envs.common.rotation import (
     np_quat_mul,
     np_quat_to_axis_angle,
 )
-from unilab.assets.hub import resolve_grasp_cache_files
 from unilab.envs.manipulation.sharpa_inhand.base import (
     SharpaInhandBaseCfg,
     SharpaInhandBaseEnv,

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.assets.hub import resolve_motion_files
+from unilab.assets.hub import resolve_grasp_cache_files, resolve_motion_files
 
 # ---------------------------------------------------------------------------
 # Local-path fast path
@@ -98,6 +98,76 @@ def test_resolve_relative_path_falls_back_to_hf():
     assert result == str(local)
     fake_download.assert_called_once_with(
         repo_id="unilabsim/unilab-motions",
+        filename=rel,
+        repo_type="dataset",
+        local_dir=str(ASSETS_ROOT_PATH),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grasp cache resolve — local fast path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_grasp_cache_returns_existing_path(tmp_path: Path):
+    npy = tmp_path / "cache.npy"
+    np.save(npy, np.array([1.0]))
+    assert resolve_grasp_cache_files(str(npy)) == str(npy)
+
+
+def test_resolve_grasp_cache_returns_list_for_list_input(tmp_path: Path):
+    a = tmp_path / "a.npy"
+    b = tmp_path / "b.npy"
+    np.save(a, np.array([1.0]))
+    np.save(b, np.array([2.0]))
+    result = resolve_grasp_cache_files([str(a), str(b)])
+    assert result == [str(a), str(b)]
+
+
+# ---------------------------------------------------------------------------
+# Grasp cache resolve — HF download path (mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_grasp_cache_calls_hf_download_with_caches_repo():
+    """Grasp cache resolver should use the unilab-caches repo, not unilab-motions."""
+    missing = ASSETS_ROOT_PATH / "caches" / "__test_nonexistent__.npy"
+    assert not missing.exists()
+
+    expected_relative = str(missing.relative_to(ASSETS_ROOT_PATH))
+
+    fake_download = MagicMock(return_value=str(missing))
+    fake_module = MagicMock()
+    fake_module.hf_hub_download = fake_download
+
+    with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+        result = resolve_grasp_cache_files(str(missing))
+
+    assert result == str(missing)
+    fake_download.assert_called_once_with(
+        repo_id="unilabsim/unilab-caches",
+        filename=expected_relative,
+        repo_type="dataset",
+        local_dir=str(ASSETS_ROOT_PATH),
+    )
+
+
+def test_resolve_grasp_cache_relative_path_uses_caches_repo():
+    """A relative path triggers HF download with the caches repo."""
+    rel = "caches/__test_nonexistent_rel__.npy"
+    local = ASSETS_ROOT_PATH / rel
+    assert not local.exists()
+
+    fake_download = MagicMock(return_value=str(local))
+    fake_module = MagicMock()
+    fake_module.hf_hub_download = fake_download
+
+    with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+        result = resolve_grasp_cache_files(rel)
+
+    assert result == str(local)
+    fake_download.assert_called_once_with(
+        repo_id="unilabsim/unilab-caches",
         filename=rel,
         repo_type="dataset",
         local_dir=str(ASSETS_ROOT_PATH),

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -172,6 +172,8 @@ def test_resolve_grasp_cache_relative_path_uses_caches_repo():
         repo_type="dataset",
         local_dir=str(ASSETS_ROOT_PATH),
     )
+
+
 # Scene directory resolver
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Generalized `hub.py` to support multiple HF repos via `repo_id` parameter; added `resolve_grasp_cache_files()` pointing to new `unilabsim/unilab-caches` dataset repo.
- Moved default `grasp_cache_path` from `cache/sharpa_grasp_linspace` (CWD-relative) to `src/unilab/assets/caches/sharpa_grasp_linspace` (`ASSETS_ROOT_PATH`-relative).
- Added HF auto-download call in `_load_grasp_cache()` so fresh checkouts can train Sharpa HORA without manually running grasp collection first.
- Improved error message when cache is still missing: now shows the exact generation command and doc link.
- Updated 3 YAML configs, `.gitignore`, docs, and added 4 new test cases.

## Linked Work

- Issue: #478
- Milestone: Sharpa in-hand default cache UX

## Validation

- [x] `uv run pytest tests/assets/test_hub.py -v`
- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] End-to-end: `rm -f src/unilab/assets/caches/*.npy` then `uv run scripts/train_rsl_rl.py task=sharpa_inhand/mujoco_hora` auto-downloads from HF and starts training

Commands actually run:

```bash
rm -f src/unilab/assets/caches/*.npy
uv run scripts/train_rsl_rl.py task=sharpa_inhand/mujoco_hora
uv run pytest tests/assets/test_hub.py -v
```

## Impact

- Backend impact: both (grasp cache path change affects `mujoco` and `motrix` configs)
- Platform impact: both
- Training effect expected: no (same cache data, just delivered via HF instead of manual generation)

## Artifacts

- HF dataset repo: `unilabsim/unilab-caches` (9 scale `.npy` files uploaded)

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly: Allegro cache can follow the same pattern in a future PR
