### PR TITLE
feat: add teaser scene renderer with HF scene-dir resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ src/unilab/assets/motions/g1/*.npz
 src/unilab/assets/motions/g1/*.csv
 src/unilab/assets/motions/g1/flip
 src/unilab/assets/motions/g1/flip_npz
+
+# Scene assets (downloaded from HF at runtime)
+src/unilab/assets/scenes/teaser/
 cache/
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ demo = "unilab.cli:demo_main"
 unilab-complete = "unilab.tools.completion:main"
 unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
+unilab-render-teaser = "unilab.tools.render_teaser:main"
 
 [project.optional-dependencies]
 motrix = ["motrixsim-core==0.8.1.dev104632"]

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -1,6 +1,6 @@
-"""Cold-path motion asset resolver with Hugging Face fallback.
+"""Cold-path asset resolver with Hugging Face fallback.
 
-Guarantees that requested motion files exist on disk before returning.
+Guarantees that requested asset files exist on disk before returning.
 When a file is missing locally, it is downloaded from the configured
 Hugging Face dataset repo and placed under ``ASSETS_ROOT_PATH`` so that
 existing path references remain valid.
@@ -20,7 +20,8 @@ from unilab.assets import ASSETS_ROOT_PATH
 
 logger = logging.getLogger(__name__)
 
-_HF_REPO_ID = "unilabsim/unilab-motions"
+_HF_MOTIONS_REPO_ID = "unilabsim/unilab-motions"
+_HF_SCENES_REPO_ID = "unilabsim/unilab-scenes"
 _HF_REPO_TYPE = "dataset"
 _HF_OFFICIAL_ENDPOINT = "https://huggingface.co"
 
@@ -72,11 +73,11 @@ def _resolve_single(path_str: str) -> str:
     return _download_from_hf(relative)
 
 
-def _hf_download(hf_hub_download, relative_path: str) -> str:  # type: ignore[no-untyped-def]
+def _hf_download(hf_hub_download, relative_path: str, *, repo_id: str) -> str:  # type: ignore[no-untyped-def]
     """Call ``hf_hub_download`` with the standard arguments."""
     return str(
         hf_hub_download(
-            repo_id=_HF_REPO_ID,
+            repo_id=repo_id,
             filename=relative_path,
             repo_type=_HF_REPO_TYPE,
             local_dir=str(ASSETS_ROOT_PATH),
@@ -84,8 +85,12 @@ def _hf_download(hf_hub_download, relative_path: str) -> str:  # type: ignore[no
     )
 
 
-def _download_from_hf(relative_path: str) -> str:
-    """Download *relative_path* from the HF dataset repo.
+def _download_from_hf(
+    relative_path: str,
+    *,
+    repo_id: str = _HF_MOTIONS_REPO_ID,
+) -> str:
+    """Download *relative_path* from an HF dataset repo.
 
     If the current ``HF_ENDPOINT`` (e.g. a mirror) fails, automatically
     retries with the official ``https://huggingface.co`` endpoint.
@@ -94,17 +99,17 @@ def _download_from_hf(relative_path: str) -> str:
         from huggingface_hub import hf_hub_download
     except ImportError:
         raise ImportError(
-            f"Motion file '{relative_path}' not found locally. "
+            f"Asset file '{relative_path}' not found locally. "
             "Install huggingface_hub to enable automatic downloading:\n"
             "  uv sync\n"
             "Or:\n"
             "  uv pip install huggingface_hub"
         ) from None
 
-    logger.info("Downloading %s from HF repo %s ...", relative_path, _HF_REPO_ID)
+    logger.info("Downloading %s from HF repo %s ...", relative_path, repo_id)
 
     try:
-        local_path = _hf_download(hf_hub_download, relative_path)
+        local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
     except Exception:
         # If a mirror endpoint is configured and it failed, retry with
         # the official endpoint before giving up.
@@ -118,7 +123,7 @@ def _download_from_hf(relative_path: str) -> str:
             original = os.environ["HF_ENDPOINT"]
             os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
             try:
-                local_path = _hf_download(hf_hub_download, relative_path)
+                local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
             finally:
                 os.environ["HF_ENDPOINT"] = original
         else:
@@ -126,3 +131,72 @@ def _download_from_hf(relative_path: str) -> str:
 
     logger.info("Downloaded to %s", local_path)
     return local_path
+
+
+# ---------------------------------------------------------------------------
+# Scene directory resolver
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_download(snapshot_download_fn, directory: str, *, repo_id: str) -> str:  # type: ignore[no-untyped-def]
+    """Call ``snapshot_download`` with the standard arguments."""
+    return str(
+        snapshot_download_fn(
+            repo_id=repo_id,
+            repo_type=_HF_REPO_TYPE,
+            allow_patterns=f"{directory}/**",
+            local_dir=str(ASSETS_ROOT_PATH),
+        )
+    )
+
+
+def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
+    """Ensure a scene directory exists locally, downloading from HF if needed.
+
+    Args:
+        directory: ``ASSETS_ROOT_PATH``-relative directory path
+            (e.g. ``"scenes/teaser"``).
+        marker: A file inside the directory used to check completeness.
+
+    Returns:
+        Absolute ``Path`` to the resolved directory.
+    """
+    target = ASSETS_ROOT_PATH / directory
+    if (target / marker).is_file():
+        return target
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        raise ImportError(
+            f"Scene directory '{directory}' not found locally. "
+            "Install huggingface_hub to enable automatic downloading:\n"
+            "  uv sync\n"
+            "Or:\n"
+            "  uv pip install huggingface_hub"
+        ) from None
+
+    repo_id = _HF_SCENES_REPO_ID
+    logger.info("Downloading %s from HF repo %s ...", directory, repo_id)
+
+    try:
+        _snapshot_download(snapshot_download, directory, repo_id=repo_id)
+    except Exception:
+        current_endpoint = os.environ.get("HF_ENDPOINT", "")
+        if current_endpoint and current_endpoint != _HF_OFFICIAL_ENDPOINT:
+            logger.warning(
+                "Download failed with HF_ENDPOINT=%s, retrying with %s ...",
+                current_endpoint,
+                _HF_OFFICIAL_ENDPOINT,
+            )
+            original = os.environ["HF_ENDPOINT"]
+            os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
+            try:
+                _snapshot_download(snapshot_download, directory, repo_id=repo_id)
+            finally:
+                os.environ["HF_ENDPOINT"] = original
+        else:
+            raise
+
+    logger.info("Downloaded scene directory to %s", target)
+    return target

--- a/src/unilab/tools/render_teaser.py
+++ b/src/unilab/tools/render_teaser.py
@@ -1,0 +1,86 @@
+"""Render the packaged MotrixSim teaser scene.
+
+This is a visual-only entrypoint for the paper-cover teaser asset. It loads the
+MJCF scene once, creates static scene data, and keeps the Motrix renderer alive
+without advancing simulation.
+
+Scene assets are downloaded automatically from HuggingFace on first run.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from unilab.assets import ASSETS_ROOT_PATH
+
+TEASER_DIR = ASSETS_ROOT_PATH / "scenes" / "teaser"
+DEFAULT_SCENE = TEASER_DIR / "teaser.xml"
+TEASER_SYSTEM_CAMERA_LOOKAT = [-1.0e-7, -0.0035363, 0.75]
+TEASER_SYSTEM_CAMERA_DISTANCE = 5.6876
+TEASER_SYSTEM_CAMERA_ELEVATION = -30.0
+TEASER_SYSTEM_CAMERA_AZIMUTH = 90.0
+TEASER_RENDER_FPS = 60.0
+TEASER_LOG_LEVEL = "WARN"
+
+
+def _render_settings() -> Any:
+    from motrixsim.render import RenderSettings
+
+    settings = RenderSettings.quality()
+    settings.enable_shadow = True
+    settings.enable_ssgi = True
+    settings.simplify_render_mesh = False
+    return settings
+
+
+def _set_teaser_system_camera_view(render: Any) -> None:
+    render.set_main_camera(None)
+    render.system_camera.set_view(
+        TEASER_SYSTEM_CAMERA_LOOKAT,
+        TEASER_SYSTEM_CAMERA_DISTANCE,
+        TEASER_SYSTEM_CAMERA_ELEVATION,
+        TEASER_SYSTEM_CAMERA_AZIMUTH,
+    )
+
+
+def _load_teaser_model() -> tuple[Any, Any]:
+    import motrixsim as mtx
+
+    from unilab.assets.hub import resolve_scene_dir
+
+    resolve_scene_dir("scenes/teaser")
+
+    if not DEFAULT_SCENE.is_file():
+        raise FileNotFoundError(f"Teaser scene file does not exist: {DEFAULT_SCENE}")
+    model = mtx.load_model(str(DEFAULT_SCENE))
+    data = mtx.SceneData(model)
+    model.forward_kinematic(data)
+    return model, data
+
+
+def _run() -> None:
+    from motrixsim.render import RenderApp
+
+    model, data = _load_teaser_model()
+    frame_dt = 1.0 / TEASER_RENDER_FPS
+
+    with RenderApp(TEASER_LOG_LEVEL) as render:
+        settings = _render_settings()
+        render.launch(model, render_settings=settings)
+        _set_teaser_system_camera_view(render)
+
+        try:
+            while not render.is_closed:
+                render.sync(data)
+                time.sleep(frame_dt)
+        except KeyboardInterrupt:
+            return
+
+
+def main() -> None:
+    _run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -1,4 +1,4 @@
-"""Tests for the motion asset resolver (``unilab.assets.hub``)."""
+"""Tests for the asset resolvers (``unilab.assets.hub``)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.assets.hub import resolve_motion_files
+from unilab.assets.hub import resolve_motion_files, resolve_scene_dir
 
 # ---------------------------------------------------------------------------
 # Local-path fast path
@@ -102,3 +102,48 @@ def test_resolve_relative_path_falls_back_to_hf():
         repo_type="dataset",
         local_dir=str(ASSETS_ROOT_PATH),
     )
+
+
+# ---------------------------------------------------------------------------
+# Scene directory resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_scene_dir_returns_immediately_when_marker_exists(tmp_path: Path):
+    """When the marker file exists, resolve_scene_dir returns without
+    downloading anything."""
+    scene_dir = tmp_path / "scenes" / "teaser"
+    scene_dir.mkdir(parents=True)
+    (scene_dir / "teaser.xml").write_text("<mujoco/>")
+
+    with patch("unilab.assets.hub.ASSETS_ROOT_PATH", tmp_path):
+        result = resolve_scene_dir("scenes/teaser")
+
+    assert result == scene_dir
+
+
+def test_resolve_scene_dir_calls_snapshot_download_when_missing():
+    """When the marker file is absent, resolve_scene_dir triggers a
+    snapshot_download with the correct arguments."""
+    fake_snapshot = MagicMock(return_value=str(ASSETS_ROOT_PATH))
+    fake_module = MagicMock()
+    fake_module.snapshot_download = fake_snapshot
+
+    with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+        resolve_scene_dir("scenes/teaser")
+
+    fake_snapshot.assert_called_once_with(
+        repo_id="unilabsim/unilab-scenes",
+        repo_type="dataset",
+        allow_patterns="scenes/teaser/**",
+        local_dir=str(ASSETS_ROOT_PATH),
+    )
+
+
+def test_resolve_scene_dir_raises_import_error_when_hf_hub_missing(tmp_path: Path):
+    """When the scene directory is missing and huggingface_hub is not
+    installed, a clear ImportError is raised."""
+    with patch("unilab.assets.hub.ASSETS_ROOT_PATH", tmp_path):
+        with patch.dict("sys.modules", {"huggingface_hub": None}):
+            with pytest.raises(ImportError, match="huggingface_hub"):
+                resolve_scene_dir("scenes/teaser")

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -122,21 +122,22 @@ def test_resolve_scene_dir_returns_immediately_when_marker_exists(tmp_path: Path
     assert result == scene_dir
 
 
-def test_resolve_scene_dir_calls_snapshot_download_when_missing():
+def test_resolve_scene_dir_calls_snapshot_download_when_missing(tmp_path: Path):
     """When the marker file is absent, resolve_scene_dir triggers a
     snapshot_download with the correct arguments."""
-    fake_snapshot = MagicMock(return_value=str(ASSETS_ROOT_PATH))
+    fake_snapshot = MagicMock(return_value=str(tmp_path))
     fake_module = MagicMock()
     fake_module.snapshot_download = fake_snapshot
 
-    with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
-        resolve_scene_dir("scenes/teaser")
+    with patch("unilab.assets.hub.ASSETS_ROOT_PATH", tmp_path):
+        with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+            resolve_scene_dir("scenes/teaser")
 
     fake_snapshot.assert_called_once_with(
         repo_id="unilabsim/unilab-scenes",
         repo_type="dataset",
         allow_patterns="scenes/teaser/**",
-        local_dir=str(ASSETS_ROOT_PATH),
+        local_dir=str(tmp_path),
     )
 
 

--- a/tests/test_render_teaser.py
+++ b/tests/test_render_teaser.py
@@ -1,0 +1,65 @@
+"""Tests for the teaser scene renderer (``unilab.tools.render_teaser``)."""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from unilab.tools import render_teaser
+
+
+def test_set_teaser_system_camera_view_uses_packaged_view():
+    class FakeSystemCamera:
+        def __init__(self):
+            self.view = None
+
+        def set_view(self, lookat, distance, elevation, azimuth):
+            self.view = {
+                "lookat": lookat,
+                "distance": distance,
+                "elevation": elevation,
+                "azimuth": azimuth,
+            }
+
+    class FakeRender:
+        def __init__(self):
+            self.main_camera = "unset"
+            self.system_camera = FakeSystemCamera()
+
+        def set_main_camera(self, camera):
+            self.main_camera = camera
+
+    render = FakeRender()
+    render_teaser._set_teaser_system_camera_view(render)
+
+    assert render.main_camera is None
+    assert render.system_camera.view == {
+        "lookat": render_teaser.TEASER_SYSTEM_CAMERA_LOOKAT,
+        "distance": render_teaser.TEASER_SYSTEM_CAMERA_DISTANCE,
+        "elevation": render_teaser.TEASER_SYSTEM_CAMERA_ELEVATION,
+        "azimuth": render_teaser.TEASER_SYSTEM_CAMERA_AZIMUTH,
+    }
+
+
+def test_render_teaser_has_no_cli_parameters():
+    assert list(inspect.signature(render_teaser.main).parameters) == []
+
+
+def test_load_teaser_model_calls_resolve_scene_dir():
+    """_load_teaser_model must call resolve_scene_dir before loading."""
+    mock_resolve = MagicMock(return_value=render_teaser.TEASER_DIR)
+
+    fake_model = MagicMock()
+    fake_data = MagicMock()
+    fake_mtx = MagicMock()
+    fake_mtx.load_model.return_value = fake_model
+    fake_mtx.SceneData.return_value = fake_data
+
+    with (
+        patch("unilab.tools.render_teaser.resolve_scene_dir", mock_resolve),
+        patch.dict("sys.modules", {"motrixsim": fake_mtx}),
+        patch.object(render_teaser, "DEFAULT_SCENE", MagicMock(is_file=MagicMock(return_value=True))),
+    ):
+        render_teaser._load_teaser_model()
+
+    mock_resolve.assert_called_once_with("scenes/teaser")

--- a/tests/test_render_teaser.py
+++ b/tests/test_render_teaser.py
@@ -56,9 +56,11 @@ def test_load_teaser_model_calls_resolve_scene_dir():
     fake_mtx.SceneData.return_value = fake_data
 
     with (
-        patch("unilab.tools.render_teaser.resolve_scene_dir", mock_resolve),
+        patch("unilab.assets.hub.resolve_scene_dir", mock_resolve),
         patch.dict("sys.modules", {"motrixsim": fake_mtx}),
-        patch.object(render_teaser, "DEFAULT_SCENE", MagicMock(is_file=MagicMock(return_value=True))),
+        patch.object(
+            render_teaser, "DEFAULT_SCENE", MagicMock(is_file=MagicMock(return_value=True))
+        ),
     ):
         render_teaser._load_teaser_model()
 


### PR DESCRIPTION
## Summary

- 新增 `unilab-render-teaser` 命令行工具（`src/unilab/tools/render_teaser.py`），加载并渲染打包的 MotrixSim teaser 场景（论文封面用），不推进物理仿真，仅作为可视化入口。
- 在 `src/unilab/assets/hub.py` 中新增 `resolve_scene_dir()`：通过 `huggingface_hub.snapshot_download` 把场景目录（如 `scenes/teaser`）从新的 HF dataset repo `unilabsim/unilab-scenes` 下载到 `ASSETS_ROOT_PATH`，并复用既有的 mirror → official endpoint 回退逻辑。原 motion 下载路径拆出 `_HF_MOTIONS_REPO_ID` / `_HF_SCENES_REPO_ID` 两个常量，文档串改为 "asset" 而不只是 "motion"。
- `pyproject.toml` 注册新的 console script `unilab-render-teaser`；`.gitignore` 忽略下载下来的 scene 资产；新增 `src/unilab/assets/scenes/.gitkeep` 占位。
- 测试：`tests/assets/test_hub.py` 增加 `resolve_scene_dir` 的命中 / 缺失分支用例；新增 `tests/test_render_teaser.py` 覆盖渲染入口的 hub 调用路径。
- 仅触碰 cold-path asset 解析（init / materialization），未引入任何热路径 asset 访问，符合 CLAUDE.md 的 "Cold-path asset access only" 要求。
- 行为面无训练影响，纯新增可视化工具与资产解析能力。

## Linked Work

- Issue:
- Milestone:

## Validation

- [ ] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/assets/test_hub.py tests/test_render_teaser.py
uv run unilab-render-teaser  # 本地手工验证 teaser 场景渲染正常
```

## Impact

- Backend impact: `motrix`（依赖 `motrixsim.render.RenderApp`，`mujoco` 无影响）
- Platform impact: both（macOS / Linux 均通过本地验证）
- Training effect expected: no（visualization-only，不参与任何 rollout / learner 路径）

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot:
- ONNX / checkpoint: N/A

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [ ] Noted any follow-up work explicitly