### PR TITLE
Tune/locomotion rough task

### DIFF
--- a/conf/ppo/task/go1_joystick_flat/motrix.yaml
+++ b/conf/ppo/task/go1_joystick_flat/motrix.yaml
@@ -2,7 +2,20 @@
 training:
   task_name: Go1JoystickFlat
   sim_backend: motrix
+  play_steps: 500
+  play_env_num: 16
+  cam_tracking: true
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 9
+
+interactive:
+  action_mode: policy
+  policy_obs_mode: auto
+  camera_follow_body: true
+  use_env_visual_model: false
+  
 algo:
+  num_envs: 1024
   max_iterations: 151
   obs_groups:
     actor:

--- a/conf/ppo/task/go1_joystick_flat/mujoco.yaml
+++ b/conf/ppo/task/go1_joystick_flat/mujoco.yaml
@@ -2,7 +2,21 @@
 training:
   task_name: Go1JoystickFlat
   sim_backend: mujoco
+  play_steps: 500
+  play_env_num: 16
+  render_spacing: 0.0
+  cam_tracking: true
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 9
+
+interactive:
+  action_mode: policy
+  policy_obs_mode: auto
+  camera_follow_body: true
+  use_env_visual_model: false
+
 algo:
+  num_envs: 1024
   max_iterations: 151
   obs_groups:
     actor:

--- a/conf/ppo/task/go1_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go1_joystick_rough/motrix.yaml
@@ -15,9 +15,9 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 4096
+  num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 600
+  max_iterations: 1000
   empirical_normalization: false
   obs_groups:
     actor:

--- a/conf/ppo/task/go1_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go1_joystick_rough/motrix.yaml
@@ -82,7 +82,6 @@ reward:
     ang_vel_xy: -0.05
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     stand_still: -2.0
     hip_pos: -0.5

--- a/conf/ppo/task/go1_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go1_joystick_rough/mujoco.yaml
@@ -32,7 +32,7 @@ algo:
     entropy_coef: 1.0e-2
 
 env:
-  sim_dt: 0.002
+  sim_dt: 0.001
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125
@@ -83,7 +83,6 @@ reward:
     ang_vel_xy: -0.05
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     stand_still: -2.0
     hip_pos: -0.5

--- a/conf/ppo/task/go1_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go1_joystick_rough/mujoco.yaml
@@ -16,9 +16,9 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 4096
+  num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 600
+  max_iterations: 1000
   empirical_normalization: false
   obs_groups:
     actor:
@@ -32,7 +32,7 @@ algo:
     entropy_coef: 1.0e-2
 
 env:
-  sim_dt: 0.001
+  sim_dt: 0.005
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125
@@ -46,7 +46,7 @@ env:
   terrain_curriculum:
     enabled: false
   scene:
-    model_file: src/unilab/assets/robots/go1/go1.xml
+    model_file: src/unilab/assets/robots/go1/go1_mujoco.xml
     fragment_files:
       - src/unilab/assets/robots/go1/locomotion_task.xml
     terrain:

--- a/conf/ppo/task/go1_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go1_joystick_rough/mujoco.yaml
@@ -32,6 +32,7 @@ algo:
     entropy_coef: 1.0e-2
 
 env:
+  sim_dt: 0.002
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -81,7 +81,6 @@ reward:
     ang_vel_xy: -0.05
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     stand_still: -2.0
     hip_pos: -0.5

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -17,7 +17,7 @@ interactive:
 algo:
   num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 1000
+  max_iterations: 1500
   empirical_normalization: false
   obs_groups:
     actor:
@@ -31,7 +31,6 @@ algo:
     entropy_coef: 1.0e-2
 
 env:
-  sim_dt: 0.005
   render_offset_mode: zero
   control_config:
     action_scale: 0.25
@@ -100,7 +99,7 @@ reward:
     feet_gait: 0.5
     upward: 1.0
   tracking_sigma: 0.25
-  base_height_target: 0.33
+  base_height_target: 0.3
   stand_still_command_threshold: 0.1
   joint_pos_penalty_stand_still_scale: 5.0
   joint_pos_penalty_velocity_threshold: 0.5

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -15,7 +15,7 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 2048
+  num_envs: 4096
   num_steps_per_env: 24
   max_iterations: 1500
   empirical_normalization: false

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -15,7 +15,7 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 4096
+  num_envs: 2048
   num_steps_per_env: 24
   max_iterations: 1000
   empirical_normalization: false
@@ -31,6 +31,7 @@ algo:
     entropy_coef: 1.0e-2
 
 env:
+  sim_dt: 0.005
   render_offset_mode: zero
   control_config:
     action_scale: 0.25

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -16,9 +16,9 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 4096
+  num_envs: 1024
   num_steps_per_env: 24
-  max_iterations: 1000
+  max_iterations: 1500
   empirical_normalization: false
   obs_groups:
     actor:
@@ -32,7 +32,7 @@ algo:
     entropy_coef: 1.0e-2
     
 env:
-  sim_dt: 0.002
+  sim_dt: 0.001
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125
@@ -83,7 +83,6 @@ reward:
     ang_vel_xy: -0.05
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     stand_still: -2.0
     hip_pos: -0.5

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -18,7 +18,7 @@ interactive:
 algo:
   num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 1000
+  max_iterations: 1500
   empirical_normalization: false
   obs_groups:
     actor:
@@ -32,6 +32,7 @@ algo:
     entropy_coef: 1.0e-2
     
 env:
+  sim_dt: 0.002
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125
@@ -100,7 +101,7 @@ reward:
     feet_gait: 0.5
     upward: 1.0
   tracking_sigma: 0.25
-  base_height_target: 0.33
+  base_height_target: 0.3
   stand_still_command_threshold: 0.1
   joint_pos_penalty_stand_still_scale: 5.0
   joint_pos_penalty_velocity_threshold: 0.5

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -16,9 +16,9 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 1024
+  num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 1500
+  max_iterations: 1000
   empirical_normalization: false
   obs_groups:
     actor:
@@ -32,7 +32,6 @@ algo:
     entropy_coef: 1.0e-2
     
 env:
-  sim_dt: 0.001
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125
@@ -46,7 +45,7 @@ env:
   terrain_curriculum:
     enabled: false
   scene:
-    model_file: src/unilab/assets/robots/go2/go2.xml
+    model_file: src/unilab/assets/robots/go2/go2_mujoco.xml
     fragment_files:
       - src/unilab/assets/robots/go2/locomotion_task.xml
     terrain:

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -16,7 +16,7 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 2048
+  num_envs: 4096
   num_steps_per_env: 24
   max_iterations: 1500
   empirical_normalization: false

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -32,6 +32,7 @@ algo:
     entropy_coef: 1.0e-2
     
 env:
+  sim_dt: 0.002
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125

--- a/conf/ppo/task/go2w_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/motrix.yaml
@@ -17,7 +17,7 @@ interactive:
 algo:
   num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 2000
+  max_iterations: 1200
   empirical_normalization: false
   obs_groups:
     actor:

--- a/conf/ppo/task/go2w_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/motrix.yaml
@@ -32,8 +32,9 @@ env:
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
   control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
+    action_scale: 0.25
+    hip_action_scale: 0.125
+    wheel_action_scale: 5.0
     wheel_Kd: 0.5
     clip_actions: 100.0
     simulate_action_latency: false
@@ -67,7 +68,6 @@ reward:
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
     joint_acc_wheel_l2: -2.5e-9
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     action_rate: -0.01
     stand_still: -2.0

--- a/conf/ppo/task/go2w_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/motrix.yaml
@@ -2,6 +2,18 @@
 training:
   task_name: Go2WJoystickRough
   sim_backend: motrix
+  play_steps: 500
+  play_env_num: 16
+  cam_tracking: true
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 9
+
+interactive:
+  action_mode: policy
+  policy_obs_mode: auto
+  camera_follow_body: true
+  use_env_visual_model: false
+
 algo:
   num_envs: 2048
   num_steps_per_env: 24
@@ -16,6 +28,8 @@ env:
   render_offset_mode: zero
   scene:
     model_file: src/unilab/assets/robots/go2w/go2w.xml
+    fragment_files:
+      - src/unilab/assets/robots/go2w/locomotion_task.xml
     terrain:
       hfield_name: terrain_hfield
       geom_name: floor

--- a/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
@@ -18,7 +18,7 @@ interactive:
 algo:
   num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 2000
+  max_iterations: 1200
   empirical_normalization: false
   obs_groups:
     actor:

--- a/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
@@ -4,7 +4,7 @@ training:
   sim_backend: mujoco
 algo:
   num_envs: 2048
-  num_steps_per_env: 48
+  num_steps_per_env: 24
   max_iterations: 5000
   empirical_normalization: false
   obs_groups:
@@ -13,6 +13,7 @@ algo:
     critic:
       - critic
 env:
+  sim_dt: 0.002
   scene:
     model_file: src/unilab/assets/robots/go2w/go2w.xml
     terrain:
@@ -48,13 +49,13 @@ env:
     added_mass_range: [-1.0, 3.0]
     random_com: true
     com_offset_x: [-0.05, 0.05]
-    randomize_kp: false
+    randomize_kp: true
     kp_multiplier_range: [0.5, 1.0]
-    randomize_kd: false
+    randomize_kd: true
     kd_multiplier_range: [0.5, 1.0]
     push_robots: true
-    push_interval: 500
-    max_force: [0.5, 0.5, 0.0]
+    push_interval: 625
+    max_force: [1.0, 1.0, 0.5]
     push_body_name: base_link
 reward:
   scales:
@@ -62,6 +63,7 @@ reward:
     tracking_ang_vel: 1.5
     lin_vel_z: -2.0
     ang_vel_xy: -0.05
+    orientation: -2.0
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
     joint_acc_wheel_l2: -2.5e-9

--- a/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
@@ -13,7 +13,7 @@ algo:
     critic:
       - critic
 env:
-  sim_dt: 0.002
+  sim_dt: 0.005
   scene:
     model_file: src/unilab/assets/robots/go2w/go2w.xml
     terrain:
@@ -32,8 +32,9 @@ env:
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
   control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
+    action_scale: 0.25
+    hip_action_scale: 0.125
+    wheel_action_scale: 5.0
     wheel_Kd: 0.5
     clip_actions: 100.0
     simulate_action_latency: false
@@ -67,7 +68,6 @@ reward:
     joint_torques_l2: -2.5e-5
     joint_acc_l2: -2.5e-7
     joint_acc_wheel_l2: -2.5e-9
-    joint_pos_limits: -5.0
     joint_power: -2.0e-5
     action_rate: -0.01
     stand_still: -2.0

--- a/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
@@ -2,10 +2,23 @@
 training:
   task_name: Go2WJoystickRough
   sim_backend: mujoco
+  play_steps: 500
+  play_env_num: 16
+  render_spacing: 0.0
+  cam_tracking: true
+  cam_tracking_env_idx: 0
+  cam_tracking_extra_envs: 9
+
+interactive:
+  action_mode: policy
+  policy_obs_mode: auto
+  camera_follow_body: true
+  use_env_visual_model: false
+
 algo:
   num_envs: 2048
   num_steps_per_env: 24
-  max_iterations: 5000
+  max_iterations: 2000
   empirical_normalization: false
   obs_groups:
     actor:
@@ -13,9 +26,10 @@ algo:
     critic:
       - critic
 env:
-  sim_dt: 0.005
   scene:
-    model_file: src/unilab/assets/robots/go2w/go2w.xml
+    model_file: src/unilab/assets/robots/go2w/go2w_mujoco.xml
+    fragment_files:
+      - src/unilab/assets/robots/go2w/locomotion_task.xml
     terrain:
       hfield_name: terrain_hfield
       geom_name: floor

--- a/src/unilab/assets/robots/go1/go1.xml
+++ b/src/unilab/assets/robots/go1/go1.xml
@@ -1,11 +1,11 @@
 <mujoco model="go1">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option cone="elliptic" impratio="100" timestep="0.01"/>
+  <option cone="elliptic" impratio="100" ccd_iterations="500" timestep="0.01"/>
 
   <default>
     <default class="go1">
-      <geom friction="0.6" margin="0.001" condim="1"/>
+      <geom friction="0.6" margin="0.001" condim="1" solref="0.01 1"/>
       <joint axis="0 1 0" damping="2" armature="0.01" frictionloss="0.2"/>
       <position kp="100" forcerange="-23.7 23.7"/>
       <default class="abduction">
@@ -24,7 +24,8 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2" material="dark"/>
       </default>
       <default class="collision">
-        <geom group="3" type="capsule" contype="1" conaffinity="2"/>
+        <geom group="3" type="capsule" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1"/>
         <default class="hip_left1">
           <geom size="0.046 0.02" pos="0 0.045 0" quat="1 1 0 0" type="cylinder"/>
         </default>
@@ -59,7 +60,8 @@
           <geom size="0.01" fromto="0.02 0 -0.13 0 0 -0.2"/>
         </default>
         <default class="foot">
-          <geom type="sphere" size="0.023" pos="0 0 -0.213" priority="1" solimp="0.015 1 0.023" condim="6"
+          <geom type="sphere" size="0.023" pos="0 0 -0.213" priority="1"
+            solref="0.01 1" solimp="0.015 1 0.023" margin="0.005" condim="6"
             friction="0.8 0.02 0.01"/>
         </default>
       </default>

--- a/src/unilab/assets/robots/go1/go1_mujoco.xml
+++ b/src/unilab/assets/robots/go1/go1_mujoco.xml
@@ -5,7 +5,7 @@
 
   <default>
     <default class="go1">
-      <geom friction="0.6" margin="0.001" condim="1"/>
+      <geom friction="0.6" margin="0.001" condim="1" solref="0.01 1"/>
       <joint axis="0 1 0" damping="2" armature="0.01" frictionloss="0.2"/>
       <position kp="100" forcerange="-23.7 23.7"/>
       <default class="abduction">
@@ -24,7 +24,8 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2" material="dark"/>
       </default>
       <default class="collision">
-        <geom group="3" type="capsule" contype="1" conaffinity="2"/>
+        <geom group="3" type="capsule" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1"/>
         <default class="hip_left1">
           <geom size="0.046 0.02" pos="0 0.045 0" quat="1 1 0 0" type="cylinder"/>
         </default>
@@ -59,7 +60,8 @@
           <geom size="0.01" fromto="0.02 0 -0.13 0 0 -0.2"/>
         </default>
         <default class="foot">
-          <geom type="sphere" size="0.023" pos="0 0 -0.213" priority="1" solimp="0.015 1 0.023" condim="6"
+          <geom type="sphere" size="0.023" pos="0 0 -0.213" priority="1"
+            solref="0.01 1" solimp="0.015 1 0.023" margin="0.005" condim="6"
             friction="0.8 0.02 0.01"/>
         </default>
       </default>
@@ -232,20 +234,6 @@
     <framepos objtype="site" objname="FL" name="FL_pos"/>
     <framepos objtype="site" objname="RR" name="RR_pos"/>
     <framepos objtype="site" objname="RL" name="RL_pos"/>
-
-    <!-- <framepos objtype="site" objname="imu" name="position"/>
-    <framepos objtype="site" objname="imu" name="position"/>
-    <framepos objtype="site" objname="imu" name="position"/>
-    <framepos objtype="site" objname="imu" name="position"/> -->
-    <!-- <framelinvel objtype="site" objname="FR" name="FR_global_linvel"/>
-    <framelinvel objtype="site" objname="FL" name="FL_global_linvel"/>
-    <framelinvel objtype="site" objname="RR" name="RR_global_linvel"/>
-    <framelinvel objtype="site" objname="RL" name="RL_global_linvel"/>
-    <framepos objtype="site" objname="FR" name="FR_pos" reftype="site" refname="imu"/>
-    <framepos objtype="site" objname="FL" name="FL_pos" reftype="site" refname="imu"/>
-    <framepos objtype="site" objname="RR" name="RR_pos" reftype="site" refname="imu"/>
-    <framepos objtype="site" objname="RL" name="RL_pos" reftype="site" refname="imu"/>
-    <framepos objtype="site" objname="head" name="head_pos"/> -->
 
   </sensor>
 

--- a/src/unilab/assets/robots/go2/go2.xml
+++ b/src/unilab/assets/robots/go2/go2.xml
@@ -1,11 +1,11 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option cone="elliptic" impratio="100" timestep="0.02"/>
+  <option cone="elliptic" impratio="100" ccd_iterations="500" timestep="0.02"/>
 
   <default>
     <default class="go2">
-      <geom friction="0.6" margin="0.001" condim="1"/>
+      <geom friction="0.6" margin="0.001" condim="1" solref="0.01 1"/>
       <joint axis="0 1 0" damping="0.5" armature="0.01" frictionloss="0.2"/>
       <position forcerange="-23.7 23.7" kp="35"/>
       <default class="abduction">
@@ -27,10 +27,11 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2"/>
       </default>
       <default class="collision">
-        <geom group="3"  contype="1" conaffinity="2"/>
+        <geom group="3" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1"/>
         <default class="foot">
-          <geom size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-            friction="0.4 0.02 0.01"/>
+          <geom size="0.022" pos="-0.002 0 -0.213" priority="1"
+            margin="0.005" condim="6" solref="0.01 1" friction="0.4 0.02 0.01"/>
         </default>
       </default>
     </default>

--- a/src/unilab/assets/robots/go2/go2_mujoco.xml
+++ b/src/unilab/assets/robots/go2/go2_mujoco.xml
@@ -1,11 +1,11 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option cone="elliptic" impratio="100" timestep="0.02"/>
+  <option cone="elliptic" impratio="100" ccd_iterations="500" timestep="0.02"/>
 
   <default>
     <default class="go2">
-      <geom friction="0.6" margin="0.001" condim="1"/>
+      <geom friction="0.6" margin="0.001" condim="1" solref="0.01 1"/>
       <joint axis="0 1 0" damping="0.5" armature="0.01" frictionloss="0.2"/>
       <position forcerange="-23.7 23.7" kp="35"/>
       <default class="abduction">
@@ -27,10 +27,11 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2"/>
       </default>
       <default class="collision">
-        <geom group="3"  contype="1" conaffinity="2"/>
+        <geom group="3" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1"/>
         <default class="foot">
-          <geom size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-            friction="0.4 0.02 0.01"/>
+          <geom size="0.022" pos="-0.002 0 -0.213" priority="1"
+            margin="0.005" condim="6" solref="0.01 1" friction="0.4 0.02 0.01"/>
         </default>
       </default>
     </default>
@@ -203,25 +204,14 @@
   <sensor>
 
     <gyro site="imu" name="gyro"/>
-    <!-- <accelerometer site="imu" name="accelerometer"/> -->
     <velocimeter site="imu" name="local_linvel"/>
     <framezaxis objtype="site" objname="imu" name="upvector"/>
-
-    <!-- <framequat objtype="site" objname="imu" name="orientation"/> -->
     <framepos objtype="site" objname="imu" name="global_position"/>
     <framelinvel objtype="site" objname="imu" name="global_linvel"/>
-    <!-- <frameangvel objtype="site" objname="imu" name="global_angvel"/> -->
-
-    <!-- <framelinvel objtype="site" objname="FR" name="FR_global_linvel"/>
-    <framelinvel objtype="site" objname="FL" name="FL_global_linvel"/>
-    <framelinvel objtype="site" objname="RR" name="RR_global_linvel"/>
-    <framelinvel objtype="site" objname="RL" name="RL_global_linvel"/> -->
-
     <framepos objtype="geom" objname="FR" name="FR_pos"/>
     <framepos objtype="geom" objname="FL" name="FL_pos"/>
     <framepos objtype="geom" objname="RR" name="RR_pos"/>
     <framepos objtype="geom" objname="RL" name="RL_pos"/>
-
     <framelinvel objtype="geom" objname="FR" name="FR_vel"/>
     <framelinvel objtype="geom" objname="FL" name="FL_vel"/>
     <framelinvel objtype="geom" objname="RR" name="RR_vel"/>

--- a/src/unilab/assets/robots/go2/locomotion_task.xml
+++ b/src/unilab/assets/robots/go2/locomotion_task.xml
@@ -1,9 +1,9 @@
 <mujoco model="go2 locomotion task">
   <sensor>
-    <contact name="FL_foot_contact" geom1="floor" geom2="FL" data="found" num="1" reduce="mindist"/>
-    <contact name="FR_foot_contact" geom1="floor" geom2="FR" data="found" num="1" reduce="mindist"/>
-    <contact name="RL_foot_contact" geom1="floor" geom2="RL" data="found" num="1" reduce="mindist"/>
-    <contact name="RR_foot_contact" geom1="floor" geom2="RR" data="found" num="1" reduce="mindist"/>
+    <contact name="FL_foot_contact" geom1="floor" geom2="FL" data="force" num="1" reduce="mindist"/>
+    <contact name="FR_foot_contact" geom1="floor" geom2="FR" data="force" num="1" reduce="mindist"/>
+    <contact name="RL_foot_contact" geom1="floor" geom2="RL" data="force" num="1" reduce="mindist"/>
+    <contact name="RR_foot_contact" geom1="floor" geom2="RR" data="force" num="1" reduce="mindist"/>
 
     <contact name="base1_contact" geom1="floor" geom2="base1" data="found" num="1" reduce="mindist"/>
     <contact name="base2_contact" geom1="floor" geom2="base2" data="found" num="1" reduce="mindist"/>

--- a/src/unilab/assets/robots/go2w/go2w.xml
+++ b/src/unilab/assets/robots/go2w/go2w.xml
@@ -1,11 +1,11 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="../go2/assets" autolimits="true" />
 
-  <option cone="elliptic" impratio="100" />
+  <option cone="elliptic" impratio="100" ccd_iterations="500" />
 
   <default>
     <default class="go2">
-      <geom friction="0.4" margin="0.001" condim="1" />
+      <geom friction="0.4" margin="0.001" condim="1" solref="0.01 1" />
       <joint axis="0 1 0" damping="0.1" armature="0.01" frictionloss="0.2" />
       <motor ctrlrange="-23.7 23.7" />
       <default class="abduction">
@@ -27,10 +27,11 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2" />
       </default>
       <default class="collision">
-        <geom group="3" contype="1" conaffinity="2" />
+        <geom group="3" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1" />
         <default class="foot">
-          <geom size="0.022" priority="1" condim="6"
-            friction="0.8 0.02 0.01" />
+          <geom size="0.022" priority="1" margin="0.005" condim="6"
+            solref="0.01 1" friction="0.8 0.02 0.01" />
         </default>
       </default>
     </default>
@@ -110,7 +111,8 @@
               <joint name="FL_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom type="mesh" quat="0.0 1.0 0.0 0.0" mesh="wheel_convex" class="foot" />
+              <geom name="FL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
+                mesh="wheel_convex" class="foot" />
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -155,7 +157,7 @@
               <joint name="FR_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom type="mesh" mesh="wheel_convex" class="foot"/>
+              <geom name="FR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -200,7 +202,8 @@
               <joint name="RL_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom type="mesh" quat="0.0 1.0 0.0 0.0" mesh="wheel_convex" class="foot"/>
+              <geom name="RL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
+                mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -247,7 +250,7 @@
               <joint name="RR_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom type="mesh" mesh="wheel_convex" class="foot"/>
+              <geom name="RR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->

--- a/src/unilab/assets/robots/go2w/go2w.xml
+++ b/src/unilab/assets/robots/go2w/go2w.xml
@@ -1,11 +1,11 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="../go2/assets" autolimits="true" />
 
-  <option cone="elliptic" impratio="100" ccd_iterations="500" />
+  <option cone="elliptic" impratio="100" />
 
   <default>
     <default class="go2">
-      <geom friction="0.4" margin="0.001" condim="1" solref="0.01 1" />
+      <geom friction="0.4" margin="0.001" condim="1" />
       <joint axis="0 1 0" damping="0.1" armature="0.01" frictionloss="0.2" />
       <motor ctrlrange="-23.7 23.7" />
       <default class="abduction">
@@ -27,11 +27,10 @@
         <geom type="mesh" contype="0" conaffinity="0" group="2" />
       </default>
       <default class="collision">
-        <geom group="3" contype="1" conaffinity="2"
-          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1" />
+        <geom group="3" contype="1" conaffinity="2" />
         <default class="foot">
-          <geom size="0.022" priority="1" margin="0.005" condim="6"
-            solref="0.01 1" friction="0.8 0.02 0.01" />
+          <geom size="0.022" priority="1" condim="6"
+            friction="0.8 0.02 0.01" />
         </default>
       </default>
     </default>
@@ -111,8 +110,7 @@
               <joint name="FL_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom name="FL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
-                mesh="wheel_convex" class="foot" />
+              <geom type="mesh" quat="0.0 1.0 0.0 0.0" mesh="wheel_convex" class="foot" />
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -157,7 +155,7 @@
               <joint name="FR_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom name="FR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
+              <geom type="mesh" mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -202,8 +200,7 @@
               <joint name="RL_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom name="RL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
-                mesh="wheel_convex" class="foot"/>
+              <geom type="mesh" quat="0.0 1.0 0.0 0.0" mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->
@@ -250,7 +247,7 @@
               <joint name="RR_wheel_joint" pos="0 0 0" axis="0 1 0" />
               <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
 
-              <geom name="RR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
+              <geom type="mesh" mesh="wheel_convex" class="foot"/>
 
               <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
                 quat="0.707107 0.707107 0 0" class="foot" /> -->

--- a/src/unilab/assets/robots/go2w/go2w_mujoco.xml
+++ b/src/unilab/assets/robots/go2w/go2w_mujoco.xml
@@ -1,0 +1,356 @@
+<mujoco model="go2">
+  <compiler angle="radian" meshdir="../go2/assets" autolimits="true" />
+
+  <option cone="elliptic" impratio="100" ccd_iterations="500" />
+
+  <default>
+    <default class="go2">
+      <geom friction="0.4" margin="0.001" condim="1" solref="0.01 1" />
+      <joint axis="0 1 0" damping="0.1" armature="0.01" frictionloss="0.2" />
+      <motor ctrlrange="-23.7 23.7" />
+      <default class="abduction">
+        <joint axis="1 0 0" range="-1.0472 1.0472" />
+      </default>
+      <default class="hip">
+        <default class="front_hip">
+          <joint range="-1.5708 3.4907" />
+        </default>
+        <default class="back_hip">
+          <joint range="-0.5236 4.5379" />
+        </default>
+      </default>
+      <default class="knee">
+        <joint range="-2.7227 -0.83776" />
+        <motor ctrlrange="-45.43 45.43" />
+      </default>
+      <default class="visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2" />
+      </default>
+      <default class="collision">
+        <geom group="3" contype="1" conaffinity="2"
+          friction="0 0 0" margin="0.001" condim="1" solref="0.01 1" />
+        <default class="foot">
+          <geom size="0.022" priority="1" margin="0.005" condim="6"
+            solref="0.01 1" friction="0.8 0.02 0.01" />
+        </default>
+      </default>
+    </default>
+  </default>
+
+  <asset>
+    <material name="metal" rgba=".9 .95 .95 1" />
+    <material name="black" rgba="0 0 0 1" />
+    <material name="white" rgba="1 1 1 1" />
+    <material name="gray" rgba="0.671705 0.692426 0.774270 1" />
+
+    <mesh file="base_0.obj" />
+    <mesh file="base_1.obj" />
+    <mesh file="base_2.obj" />
+    <mesh file="base_3.obj" />
+    <mesh file="base_4.obj" />
+    <mesh file="hip_0.obj" />
+    <mesh file="hip_1.obj" />
+    <mesh file="thigh_0.obj" />
+    <mesh file="thigh_1.obj" />
+    <mesh file="thigh_mirror_0.obj" />
+    <mesh file="thigh_mirror_1.obj" />
+    <mesh file="calf.stl" />
+    <mesh file="calf_mirror.stl" />
+    <mesh file="wheel.stl" />
+    <mesh file="wheel_convex.stl" />
+
+  </asset>
+
+  <worldbody>
+    <body name="base_link" pos="0 0 0.6" childclass="go2">
+      <inertial pos="0.021112 0 -0.005366" quat="-0.000543471 0.713435 -0.00173769 0.700719"
+        mass="6.921"
+        diaginertia="0.107027 0.0980771 0.0244531" />
+      <freejoint />
+      <geom mesh="base_0" material="black" class="visual" />
+      <geom mesh="base_1" material="black" class="visual" />
+      <geom mesh="base_2" material="black" class="visual" />
+      <geom mesh="base_3" material="white" class="visual" />
+      <geom mesh="base_4" material="gray" class="visual" />
+      <geom size="0.1881 0.04675 0.057" type="box" class="collision" />
+      <geom size="0.05 0.045" pos="0.285 0 0.01" type="cylinder" class="collision" />
+      <geom size="0.047" pos="0.293 0 -0.06" class="collision" />
+      <site name="imu" pos="-0.02557 0 0.04232" />
+      <body name="FL_hip" pos="0.1934 0.0465 0">
+        <inertial pos="-0.0054 0.00194 -0.000105" quat="0.497014 0.499245 0.505462 0.498237"
+          mass="0.678"
+          diaginertia="0.00088403 0.000596003 0.000479967" />
+        <joint name="FL_hip_joint" class="abduction" />
+        <geom mesh="hip_0" material="metal" class="visual" />
+        <geom mesh="hip_1" material="gray" class="visual" />
+        <geom size="0.046 0.02" pos="0 0.08 0" quat="1 1 0 0" type="cylinder" class="collision" />
+        <body name="FL_thigh" pos="0 0.0955 0">
+          <inertial pos="-0.00374 -0.0223 -0.0327" quat="0.829533 0.0847635 -0.0200632 0.551623"
+            mass="1.152"
+            diaginertia="0.00594973 0.00584149 0.000878787" />
+          <joint name="FL_thigh_joint" class="front_hip" />
+          <geom mesh="thigh_0" material="metal" class="visual" />
+          <geom mesh="thigh_1" material="gray" class="visual" />
+          <geom size="0.1065 0.01225 0.017" pos="0 0 -0.1065" quat="0.707107 0 0.707107 0"
+            type="box" class="collision" />
+          <body name="FL_calf" pos="0 0 -0.213">
+            <inertial pos="0.00629595 -0.000622121 -0.141417"
+              quat="0.710672 0.00154099 -0.00450087 0.703508"
+              mass="0.241352" diaginertia="0.0014901 0.00146356 5.31397e-05" />
+            <joint name="FL_calf_joint" class="knee" />
+            <geom mesh="calf" material="gray" class="visual" />
+            <geom size="0.012 0.06" pos="0.008 0 -0.06" quat="0.994493 0 -0.104807 0"
+              type="cylinder" class="collision" />
+            <geom size="0.011 0.0325" pos="0.02 0 -0.148" quat="0.999688 0 0.0249974 0"
+              type="cylinder" class="collision" />
+
+            <body name="FL_wheel_link" pos="0 0 -0.2264">
+              <inertial pos="-0.0 0.04 -0.0"
+                quat="0.661419 0.248219 0.250051 0.662108" mass="0.98"
+                diaginertia="0.003 0.0016 0.0016" />
+              <joint name="FL_wheel_joint" pos="0 0 0" axis="0 1 0" />
+              <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
+
+              <geom name="FL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
+                mesh="wheel_convex" class="foot" />
+
+              <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
+                quat="0.707107 0.707107 0 0" class="foot" /> -->
+            </body>
+
+          </body>
+        </body>
+      </body>
+      <body name="FR_hip" pos="0.1934 -0.0465 0">
+        <inertial pos="-0.0054 -0.00194 -0.000105" quat="0.498237 0.505462 0.499245 0.497014"
+          mass="0.678"
+          diaginertia="0.00088403 0.000596003 0.000479967" />
+        <joint name="FR_hip_joint" class="abduction" />
+        <geom mesh="hip_0" material="metal" class="visual" quat="4.63268e-05 1 0 0" />
+        <geom mesh="hip_1" material="gray" class="visual" quat="4.63268e-05 1 0 0" />
+        <geom size="0.046 0.02" pos="0 -0.08 0" quat="0.707107 0.707107 0 0" type="cylinder"
+          class="collision" />
+        <body name="FR_thigh" pos="0 -0.0955 0">
+          <inertial pos="-0.00374 0.0223 -0.0327" quat="0.551623 -0.0200632 0.0847635 0.829533"
+            mass="1.152"
+            diaginertia="0.00594973 0.00584149 0.000878787" />
+          <joint name="FR_thigh_joint" class="front_hip" />
+          <geom mesh="thigh_mirror_0" material="metal" class="visual" />
+          <geom mesh="thigh_mirror_1" material="gray" class="visual" />
+          <geom size="0.1065 0.01225 0.017" pos="0 0 -0.1065" quat="0.707107 0 0.707107 0"
+            type="box" class="collision" />
+          <body name="FR_calf" pos="0 0 -0.213">
+            <inertial pos="0.00629595 0.000622121 -0.141417"
+              quat="0.703508 -0.00450087 0.00154099 0.710672"
+              mass="0.241352" diaginertia="0.0014901 0.00146356 5.31397e-05" />
+            <joint name="FR_calf_joint" class="knee" />
+            <geom mesh="calf_mirror" material="gray" class="visual" />
+            <geom size="0.013 0.06" pos="0.01 0 -0.06" quat="0.995004 0 -0.0998334 0"
+              type="cylinder" class="collision" />
+            <geom size="0.011 0.0325" pos="0.02 0 -0.148" quat="0.999688 0 0.0249974 0"
+              type="cylinder" class="collision" />
+
+            <body name="FR_wheel_link" pos="0 0 -0.2264">
+              <inertial pos="-0.0 -0.04 -0.0"
+                quat="0.661419 0.248219 0.250051 0.662108" mass="0.98"
+                diaginertia="0.003 0.0016 0.0016" />
+              <joint name="FR_wheel_joint" pos="0 0 0" axis="0 1 0" />
+              <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
+
+              <geom name="FR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
+
+              <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
+                quat="0.707107 0.707107 0 0" class="foot" /> -->
+            </body>
+
+          </body>
+        </body>
+      </body>
+      <body name="RL_hip" pos="-0.1934 0.0465 0">
+        <inertial pos="0.0054 0.00194 -0.000105" quat="0.505462 0.498237 0.497014 0.499245"
+          mass="0.678"
+          diaginertia="0.00088403 0.000596003 0.000479967" />
+        <joint name="RL_hip_joint" class="abduction" />
+        <geom mesh="hip_0" material="metal" class="visual" quat="4.63268e-05 0 1 0" />
+        <geom mesh="hip_1" material="gray" class="visual" quat="4.63268e-05 0 1 0" />
+        <geom size="0.046 0.02" pos="0 0.08 0" quat="0.707107 0.707107 0 0" type="cylinder"
+          class="collision" />
+        <body name="RL_thigh" pos="0 0.0955 0">
+          <inertial pos="-0.00374 -0.0223 -0.0327" quat="0.829533 0.0847635 -0.0200632 0.551623"
+            mass="1.152"
+            diaginertia="0.00594973 0.00584149 0.000878787" />
+          <joint name="RL_thigh_joint" class="back_hip" />
+          <geom mesh="thigh_0" material="metal" class="visual" />
+          <geom mesh="thigh_1" material="gray" class="visual" />
+          <geom size="0.1065 0.01225 0.017" pos="0 0 -0.1065" quat="0.707107 0 0.707107 0"
+            type="box" class="collision" />
+          <body name="RL_calf" pos="0 0 -0.213">
+            <inertial pos="0.00629595 -0.000622121 -0.141417"
+              quat="0.710672 0.00154099 -0.00450087 0.703508"
+              mass="0.241352" diaginertia="0.0014901 0.00146356 5.31397e-05" />
+            <joint name="RL_calf_joint" class="knee" />
+            <geom mesh="calf" material="gray" class="visual" />
+            <geom size="0.013 0.06" pos="0.01 0 -0.06" quat="0.995004 0 -0.0998334 0"
+              type="cylinder" class="collision" />
+            <geom size="0.011 0.0325" pos="0.02 0 -0.148" quat="0.999688 0 0.0249974 0"
+              type="cylinder" class="collision" />
+
+            <body name="RL_wheel_link" pos="0 0 -0.2264">
+              <inertial pos="-0.0 0.04 -0.0"
+                quat="0.661419 0.248219 0.250051 0.662108" mass="0.98"
+                diaginertia="0.003 0.0016 0.0016" />
+              <joint name="RL_wheel_joint" pos="0 0 0" axis="0 1 0" />
+              <geom type="mesh" quat="0.0 1.0 0.0 0.0" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
+
+              <geom name="RL_wheel_collision" type="mesh" quat="0.0 1.0 0.0 0.0"
+                mesh="wheel_convex" class="foot"/>
+
+              <!-- <geom type="cylinder" size="0.08 0.02" pos="0 0.050764 0"
+                quat="0.707107 0.707107 0 0" class="foot" /> -->
+            </body>
+
+          </body>
+        </body>
+      </body>
+      <body name="RR_hip" pos="-0.1934 -0.0465 0">
+        <inertial pos="0.0054 -0.00194 -0.000105" quat="0.499245 0.497014 0.498237 0.505462"
+          mass="0.678"
+          diaginertia="0.00088403 0.000596003 0.000479967" />
+        <joint name="RR_hip_joint" class="abduction" />
+        <geom mesh="hip_0" material="metal" class="visual"
+          quat="2.14617e-09 4.63268e-05 4.63268e-05 -1" />
+        <geom mesh="hip_1" material="gray" class="visual"
+          quat="2.14617e-09 4.63268e-05 4.63268e-05 -1" />
+        <geom size="0.046 0.02" pos="0 -0.08 0" quat="0.707107 0.707107 0 0" type="cylinder"
+          class="collision" />
+        <body name="RR_thigh" pos="0 -0.0955 0">
+          <inertial pos="-0.00374 0.0223 -0.0327" quat="0.551623 -0.0200632 0.0847635 0.829533"
+            mass="1.152"
+            diaginertia="0.00594973 0.00584149 0.000878787" />
+          <joint name="RR_thigh_joint" class="back_hip" />
+          <geom mesh="thigh_mirror_0" material="metal" class="visual" />
+          <geom mesh="thigh_mirror_1" material="gray" class="visual" />
+          <geom size="0.1065 0.01225 0.017" pos="0 0 -0.1065" quat="0.707107 0 0.707107 0"
+            type="box" class="collision" />
+          <body name="RR_calf" pos="0 0 -0.213">
+            <inertial pos="0.00629595 0.000622121 -0.141417"
+              quat="0.703508 -0.00450087 0.00154099 0.710672"
+              mass="0.241352" diaginertia="0.0014901 0.00146356 5.31397e-05" />
+            <joint name="RR_calf_joint" class="knee" />
+            <geom mesh="calf_mirror" material="gray" class="visual" />
+            <geom size="0.013 0.06" pos="0.01 0 -0.06" quat="0.995004 0 -0.0998334 0"
+              type="cylinder" class="collision" />
+            <geom size="0.011 0.0325" pos="0.02 0 -0.148" quat="0.999688 0 0.0249974 0"
+              type="cylinder" class="collision" />
+
+            <body name="RR_wheel_link" pos="0 0 -0.2264">
+              <inertial pos="-0.0 -0.04 -0.0"
+                quat="0.661419 0.248219 0.250051 0.662108" mass="0.98"
+                diaginertia="0.003 0.0016 0.0016" />
+              <joint name="RR_wheel_joint" pos="0 0 0" axis="0 1 0" />
+              <geom type="mesh" rgba="0.15 0.15 0.15 1" mesh="wheel" class="visual"/>
+
+              <geom name="RR_wheel_collision" type="mesh" mesh="wheel_convex" class="foot"/>
+
+              <!-- <geom type="cylinder" size="0.08 0.02" pos="0 -0.050764 0"
+                quat="0.707107 0.707107 0 0" class="foot" /> -->
+            </body>
+
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor class="abduction" name="FR_hip" joint="FR_hip_joint" />
+    <motor class="hip" name="FR_thigh" joint="FR_thigh_joint" />
+    <motor class="knee" name="FR_calf" joint="FR_calf_joint" />
+
+    <motor class="abduction" name="FL_hip" joint="FL_hip_joint" />
+    <motor class="hip" name="FL_thigh" joint="FL_thigh_joint" />
+    <motor class="knee" name="FL_calf" joint="FL_calf_joint" />
+
+    <motor class="abduction" name="RR_hip" joint="RR_hip_joint" />
+    <motor class="hip" name="RR_thigh" joint="RR_thigh_joint" />
+    <motor class="knee" name="RR_calf" joint="RR_calf_joint" />
+
+    <motor class="abduction" name="RL_hip" joint="RL_hip_joint" />
+    <motor class="hip" name="RL_thigh" joint="RL_thigh_joint" />
+    <motor class="knee" name="RL_calf" joint="RL_calf_joint" />
+
+    <motor ctrlrange="-15 15" name="FR_wheel" joint="FR_wheel_joint" />
+    <motor ctrlrange="-15 15" name="FL_wheel" joint="FL_wheel_joint" />
+    <motor ctrlrange="-15 15" name="RR_wheel" joint="RR_wheel_joint" />
+    <motor ctrlrange="-15 15" name="RL_wheel" joint="RL_wheel_joint" />
+  </actuator>
+
+  <sensor>
+    <jointpos name="FR_hip_pos" joint="FR_hip_joint" />
+    <jointpos name="FR_thigh_pos" joint="FR_thigh_joint" />
+    <jointpos name="FR_calf_pos" joint="FR_calf_joint" />
+
+    <jointpos name="FL_hip_pos" joint="FL_hip_joint" />
+    <jointpos name="FL_thigh_pos" joint="FL_thigh_joint" />
+    <jointpos name="FL_calf_pos" joint="FL_calf_joint" />
+
+    <jointpos name="RR_hip_pos" joint="RR_hip_joint" />
+    <jointpos name="RR_thigh_pos" joint="RR_thigh_joint" />
+    <jointpos name="RR_calf_pos" joint="RR_calf_joint" />
+
+    <jointpos name="RL_hip_pos" joint="RL_hip_joint" />
+    <jointpos name="RL_thigh_pos" joint="RL_thigh_joint" />
+    <jointpos name="RL_calf_pos" joint="RL_calf_joint" />
+
+    <jointpos name="FR_wheel_pos" joint="FR_wheel_joint" />
+    <jointpos name="FL_wheel_pos" joint="FL_wheel_joint" />
+    <jointpos name="RR_wheel_pos" joint="RR_wheel_joint" />
+    <jointpos name="RL_wheel_pos" joint="RL_wheel_joint" />
+
+    <jointvel name="FR_hip_vel" joint="FR_hip_joint" />
+    <jointvel name="FR_thigh_vel" joint="FR_thigh_joint" />
+    <jointvel name="FR_calf_vel" joint="FR_calf_joint" />
+    <jointvel name="FL_hip_vel" joint="FL_hip_joint" />
+    <jointvel name="FL_thigh_vel" joint="FL_thigh_joint" />
+    <jointvel name="FL_calf_vel" joint="FL_calf_joint" />
+    <jointvel name="RR_hip_vel" joint="RR_hip_joint" />
+    <jointvel name="RR_thigh_vel" joint="RR_thigh_joint" />
+    <jointvel name="RR_calf_vel" joint="RR_calf_joint" />
+    <jointvel name="RL_hip_vel" joint="RL_hip_joint" />
+    <jointvel name="RL_thigh_vel" joint="RL_thigh_joint" />
+    <jointvel name="RL_calf_vel" joint="RL_calf_joint" />
+
+    <jointvel name="FR_wheel_vel" joint="FR_wheel_joint"/>
+    <jointvel name="FL_wheel_vel" joint="FL_wheel_joint"/>
+    <jointvel name="RR_wheel_vel" joint="RR_wheel_joint"/>
+    <jointvel name="RL_wheel_vel" joint="RL_wheel_joint"/>
+
+    <jointactuatorfrc name="FR_hip_torque" joint="FR_hip_joint"/>
+    <jointactuatorfrc name="FR_thigh_torque" joint="FR_thigh_joint"/>
+    <jointactuatorfrc name="FR_calf_torque" joint="FR_calf_joint"/>
+    <jointactuatorfrc name="FL_hip_torque" joint="FL_hip_joint"/>
+    <jointactuatorfrc name="FL_thigh_torque" joint="FL_thigh_joint"/>
+    <jointactuatorfrc name="FL_calf_torque" joint="FL_calf_joint"/>
+    <jointactuatorfrc name="RR_hip_torque" joint="RR_hip_joint"/>
+    <jointactuatorfrc name="RR_thigh_torque" joint="RR_thigh_joint"/>
+    <jointactuatorfrc name="RR_calf_torque" joint="RR_calf_joint"/>
+    <jointactuatorfrc name="RL_hip_torque" joint="RL_hip_joint"/>
+    <jointactuatorfrc name="RL_thigh_torque" joint="RL_thigh_joint"/>
+    <jointactuatorfrc name="RL_calf_torque" joint="RL_calf_joint"/>
+
+    <jointactuatorfrc name="FR_wheel_torque" joint="FR_wheel_joint" />
+    <jointactuatorfrc name="FL_wheel_torque" joint="FL_wheel_joint" />
+    <jointactuatorfrc name="RR_wheel_torque" joint="RR_wheel_joint" />
+    <jointactuatorfrc name="RL_wheel_torque" joint="RL_wheel_joint" />
+
+    <framequat name="imu_quat" objtype="site" objname="imu"/>
+    <gyro name="gyro" site="imu"/>
+    <accelerometer name="imu_acc" site="imu" />
+    <velocimeter name="local_linvel" site="imu"/>
+    <framezaxis name="upvector" objtype="site" objname="imu"/>
+
+    <framepos name="frame_pos" objtype="site" objname="imu" />
+    <framelinvel name="frame_vel" objtype="site" objname="imu" />
+  </sensor>
+
+</mujoco>

--- a/src/unilab/base/backend/mujoco/xml.py
+++ b/src/unilab/base/backend/mujoco/xml.py
@@ -282,6 +282,23 @@ def _ensure_child(parent: ET.Element, query: str, xml: str) -> None:
         parent.append(ET.fromstring(xml))
 
 
+def _merge_robot_option(root: ET.Element, robot_path: Path) -> None:
+    """Preserve robot-level MuJoCo solver/contact options after MjSpec.attach."""
+    robot_option = ET.parse(robot_path).getroot().find("option")
+    if robot_option is None:
+        return
+
+    option = root.find("option")
+    if option is None:
+        option = ET.Element("option")
+        insert_at = 0
+        compiler = root.find("compiler")
+        if compiler is not None:
+            insert_at = list(root).index(compiler) + 1
+        root.insert(insert_at, option)
+    option.attrib.update(robot_option.attrib)
+
+
 def _ensure_generated_hfield_scene_visuals(root: ET.Element, geom_name: str) -> None:
     asset = root.find("asset")
     if asset is None:
@@ -482,6 +499,7 @@ def materialize_mujoco_hfield_attached_scene(
     root = ET.fromstring(spec.to_xml())
     _strip_attach_prefixes(root)
     _flatten_attach_main_default(root)
+    _merge_robot_option(root, robot_path)
     _ensure_generated_hfield_scene_visuals(root, geom_name)
     for fragment_file in fragment_files:
         _merge_scene_fragment(root, _resolve_scene_fragment_path(fragment_file, robot_path))

--- a/src/unilab/envs/locomotion/go1/rough.py
+++ b/src/unilab/envs/locomotion/go1/rough.py
@@ -350,7 +350,6 @@ class Go1JoystickRoughEnv(Go1WalkTask):
             "joint_torques_l2": gated(rewards.dof_torques_l2),
             "dof_acc_l2": gated(rewards.dof_acc_l2),
             "joint_acc_l2": gated(rewards.dof_acc_l2),
-            "joint_pos_limits": gated(rewards.joint_pos_limits),
             "joint_power": gated(rewards.joint_power),
             "stand_still": _stand_still,
             "hip_pos": self._reward_hip_pos,

--- a/src/unilab/envs/locomotion/go1/rough.py
+++ b/src/unilab/envs/locomotion/go1/rough.py
@@ -660,7 +660,8 @@ class Go1JoystickRoughEnv(Go1WalkTask):
 
     def _reward_contact_forces(self, ctx: RewardContext) -> np.ndarray:
         force_norm = np.linalg.norm(self.feet_force, axis=2)
-        violation = np.clip(force_norm - self._reward_cfg.contact_forces_threshold, 0.0, None)
+        force_clip = np.minimum(force_norm, 1500.0)
+        violation = np.clip(force_clip - self._reward_cfg.contact_forces_threshold, 0.0, None)
         return np.asarray(
             np.sum(violation, axis=1) * self._upright_scale(ctx.gravity),
             dtype=get_global_dtype(),

--- a/src/unilab/envs/locomotion/go2/rough.py
+++ b/src/unilab/envs/locomotion/go2/rough.py
@@ -330,7 +330,6 @@ class Go2JoystickRoughEnv(Go2WalkTask):
             "joint_torques_l2": gated(rewards.dof_torques_l2),
             "dof_acc_l2": gated(rewards.dof_acc_l2),
             "joint_acc_l2": gated(rewards.dof_acc_l2),
-            "joint_pos_limits": gated(rewards.joint_pos_limits),
             "joint_power": gated(rewards.joint_power),
             "stand_still": _stand_still,
             "hip_pos": self._reward_hip_pos,

--- a/src/unilab/envs/locomotion/go2/rough.py
+++ b/src/unilab/envs/locomotion/go2/rough.py
@@ -626,9 +626,11 @@ class Go2JoystickRoughEnv(Go2WalkTask):
 
     def _reward_contact_forces(self, ctx: RewardContext) -> np.ndarray:
         force_norm = np.linalg.norm(self.feet_force, axis=2)
-        violation = np.clip(force_norm - self._reward_cfg.contact_forces_threshold, 0.0, None)
+        force_clip = np.minimum(force_norm, 1500.0)
+        violation = np.clip(force_clip - self._reward_cfg.contact_forces_threshold, 0.0, None)
         return np.asarray(
-            np.sum(violation, axis=1) * self._upright_scale(ctx.gravity), dtype=get_global_dtype()
+            np.sum(violation, axis=1) * self._upright_scale(ctx.gravity),
+            dtype=get_global_dtype(),
         )
 
     def _reward_feet_air_time(self, ctx: RewardContext) -> np.ndarray:

--- a/src/unilab/envs/locomotion/go2/rough.py
+++ b/src/unilab/envs/locomotion/go2/rough.py
@@ -58,6 +58,7 @@ from unilab.terrains import (
 # pyright: reportIncompatibleVariableOverride=false, reportAttributeAccessIssue=false, reportCallIssue=false
 
 GO2_HIP_INDICES = np.asarray([0, 3, 6, 9], dtype=np.int32)
+GO2_ACTUATOR_TO_DOF_INDICES = np.asarray([3, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8], dtype=np.int32)
 GO2_FRONT_LEFT = 0
 GO2_FRONT_RIGHT = 1
 GO2_REAR_LEFT = 2
@@ -221,7 +222,7 @@ class Go2JoystickRoughDomainRandomizationProvider(Go2JoystickDomainRandomization
         qpos = np.tile(env._init_qpos, (num_reset, 1))
         qvel = np.tile(env._init_qvel, (num_reset, 1))
         qpos[:, 0:2] += np.random.uniform(-0.5, 0.5, (num_reset, 2))
-        qpos[:, 2] += np.random.uniform(0.1, 0.3, (num_reset,))
+        qpos[:, 2] += np.random.uniform(0.25, 0.5, (num_reset,))
         qpos[:, 0:3] += env._spawn.origins_for(env_ids)
         roll = np.random.uniform(-3.14, 3.14, (num_reset,))
         pitch = np.random.uniform(-3.14, 3.14, (num_reset,))
@@ -272,6 +273,7 @@ class Go2JoystickRoughEnv(Go2WalkTask):
             dtype=get_global_dtype(),
         )
         self._action_scale[GO2_HIP_INDICES] = float(cfg.control_config.hip_action_scale)
+        self._default_angles_actuator = self.default_angles[GO2_ACTUATOR_TO_DOF_INDICES]
         joint_range = self._backend.get_joint_range()
         self._joint_range = (
             np.asarray(joint_range, dtype=get_global_dtype()) if joint_range is not None else None
@@ -367,7 +369,8 @@ class Go2JoystickRoughEnv(Go2WalkTask):
             else clipped_actions
         )
         return np.asarray(
-            exec_actions * self._action_scale + self.default_angles, dtype=get_global_dtype()
+            exec_actions * self._action_scale + self._default_angles_actuator,
+            dtype=get_global_dtype(),
         )
 
     def update_state(self, state: NpEnvState) -> NpEnvState:
@@ -522,9 +525,11 @@ class Go2JoystickRoughEnv(Go2WalkTask):
         )
         if self._cfg.control_config.simulate_action_latency:
             actions = np.asarray(info.get("last_actions", actions), dtype=get_global_dtype())
-        targets = actions * self._action_scale + self.default_angles
+        targets_actuator = actions * self._action_scale + self._default_angles_actuator
+        targets_dof = np.empty_like(targets_actuator)
+        targets_dof[:, GO2_ACTUATOR_TO_DOF_INDICES] = targets_actuator
         torques = (
-            float(self._cfg.control_config.Kp) * (targets - dof_pos)
+            float(self._cfg.control_config.Kp) * (targets_dof - dof_pos)
             - float(self._cfg.control_config.Kd) * dof_vel
         )
         return np.asarray(torques, dtype=get_global_dtype())
@@ -767,6 +772,7 @@ def _gait_async_reward(
 __all__ = [
     "DEFAULT_SCAN_POINTS_X",
     "DEFAULT_SCAN_POINTS_Y",
+    "GO2_ACTUATOR_TO_DOF_INDICES",
     "GO2_HIP_INDICES",
     "Go2JoystickRoughCfg",
     "Go2JoystickRoughDomainRandomizationProvider",

--- a/src/unilab/envs/locomotion/go2w/base.py
+++ b/src/unilab/envs/locomotion/go2w/base.py
@@ -63,6 +63,7 @@ class NoiseConfig(BaseNoiseConfig):
 @dataclass
 class ControlConfig(PdControlConfig):
     action_scale: float = 0.25
+    hip_action_scale: float | None = None
     wheel_action_scale: float = 10.0
     wheel_Kd: float = 0.5  # noqa: N815 - Hydra config key kept for compatibility.
     clip_actions: float = 1.0

--- a/src/unilab/envs/locomotion/go2w/joystick.py
+++ b/src/unilab/envs/locomotion/go2w/joystick.py
@@ -244,6 +244,7 @@ class Go2WJoystickEnv(Go2WBaseEnv):
         )
         super().__init__(cfg, backend, num_envs)
         self._np_dtype = get_global_dtype()
+        self._leg_action_scale = self._build_leg_action_scale()
         self._reward_cfg = cfg.reward_config
         self._enable_reward_log = True
         ctrl_range = np.asarray(self._backend.get_actuator_ctrl_range(), dtype=np.float64)
@@ -302,6 +303,17 @@ class Go2WJoystickEnv(Go2WBaseEnv):
         if vel.shape != expected_shape:
             raise ValueError(f"Go2W joint velocity sensor stack must have shape {expected_shape}")
 
+    def _build_leg_action_scale(self) -> np.ndarray:
+        scale = np.full(
+            (NUM_LEG_ACTIONS,),
+            float(self._cfg.control_config.action_scale),
+            dtype=self._np_dtype,
+        )
+        hip_action_scale = self._cfg.control_config.hip_action_scale
+        if hip_action_scale is not None:
+            scale[GO2W_HIP_INDICES] = float(hip_action_scale)
+        return scale
+
     def _init_reward_functions(self) -> None:
         self._reward_fns: dict[str, Any] = {
             "tracking_lin_vel": rewards.tracking_lin_vel,
@@ -320,7 +332,6 @@ class Go2WJoystickEnv(Go2WBaseEnv):
             "joint_acc_l2": self._reward_dof_acc,
             "wheel_acc": self._reward_wheel_acc,
             "joint_acc_wheel_l2": self._reward_wheel_acc,
-            "joint_pos_limits": rewards.joint_pos_limits,
             "stand_still": self._reward_stand_still,
             "hip_pos": self._reward_hip_pos,
             "dof_error": self._reward_dof_error,
@@ -369,7 +380,7 @@ class Go2WJoystickEnv(Go2WBaseEnv):
 
         leg_targets = (
             exec_actions[:, :NUM_LEG_ACTIONS]
-            * np.asarray(self._cfg.control_config.action_scale, dtype=self._np_dtype)
+            * self._leg_action_scale
             + self.default_angles[:NUM_LEG_ACTIONS]
         )
         wheel_velocity_targets = (

--- a/src/unilab/envs/locomotion/go2w/joystick.py
+++ b/src/unilab/envs/locomotion/go2w/joystick.py
@@ -379,8 +379,7 @@ class Go2WJoystickEnv(Go2WBaseEnv):
         )
 
         leg_targets = (
-            exec_actions[:, :NUM_LEG_ACTIONS]
-            * self._leg_action_scale
+            exec_actions[:, :NUM_LEG_ACTIONS] * self._leg_action_scale
             + self.default_angles[:NUM_LEG_ACTIONS]
         )
         wheel_velocity_targets = (

--- a/src/unilab/envs/locomotion/go2w/rough.py
+++ b/src/unilab/envs/locomotion/go2w/rough.py
@@ -254,7 +254,6 @@ class Go2WJoystickRoughEnv(Go2WJoystickEnv):
             "joint_acc_l2": gated(self._reward_dof_acc),
             "wheel_acc": gated(self._reward_wheel_acc),
             "joint_acc_wheel_l2": gated(self._reward_wheel_acc),
-            "joint_pos_limits": gated(rewards.joint_pos_limits),
             "stand_still": _stand_still,
             "hip_pos": gated(self._reward_hip_pos),
             "dof_error": gated(self._reward_dof_error),

--- a/src/unilab/envs/locomotion/go2w/rough.py
+++ b/src/unilab/envs/locomotion/go2w/rough.py
@@ -35,7 +35,6 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )
-from unilab.envs.locomotion.go2.rough import Go2RoughTerrainCfg, RoughTerminationConfig
 from unilab.envs.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
 from unilab.envs.locomotion.go2w.joystick import (
     Go2WJoystickCfg,
@@ -43,6 +42,17 @@ from unilab.envs.locomotion.go2w.joystick import (
     Go2WJoystickEnv,
     build_go2w_backend_reset_randomization,
     sample_go2w_heading_commands,
+)
+from unilab.terrains import (
+    SubTerrainCfg,
+    TerrainGeneratorCfg,
+    flat,
+    hf_pyramid_slope,
+    hf_pyramid_slope_inv,
+    pyramid_stairs,
+    pyramid_stairs_inv,
+    random_rough,
+    wave_terrain,
 )
 
 # pyright: reportIncompatibleVariableOverride=false, reportAttributeAccessIssue=false, reportCallIssue=false
@@ -58,6 +68,66 @@ class Go2WRoughCommands(Commands):
     heading_range: list[float] = field(default_factory=lambda: [-np.pi, np.pi])
 
 
+@dataclass
+class RoughTerminationConfig:
+    terrain_out_of_bounds: bool = True
+    terrain_distance_buffer: float = 3.0
+
+
+@dataclass(kw_only=True)
+class Go2WRoughTerrainCfg(TerrainGeneratorCfg):
+    size: tuple[float, float] = (8.0, 8.0)
+    num_rows: int = 6
+    num_cols: int = 6
+    border_width: float = 1.0
+    add_lights: bool = True
+    horizontal_scale: float = 0.1
+
+    sub_terrains: dict[str, SubTerrainCfg] = field(
+        default_factory=lambda: {
+            "flat": flat(proportion=0.0),
+            "pyramid_stairs": pyramid_stairs(
+                proportion=0.1,
+                step_height_range=(0.025, 0.10),
+                step_width=0.4,
+                platform_width=3.0,
+                border_width=0.2,
+            ),
+            "pyramid_stairs_inv": pyramid_stairs_inv(
+                proportion=0.1,
+                step_height_range=(0.025, 0.10),
+                step_width=0.4,
+                platform_width=3.0,
+                border_width=0.2,
+            ),
+            "hf_pyramid_slope": hf_pyramid_slope(
+                proportion=0.2,
+                slope_range=(0.0, 0.3),
+                platform_width=2.0,
+                border_width=0.2,
+            ),
+            "hf_pyramid_slope_inv": hf_pyramid_slope_inv(
+                proportion=0.2,
+                slope_range=(0.0, 0.3),
+                platform_width=2.0,
+                border_width=0.2,
+            ),
+            "random_rough": random_rough(
+                proportion=0.3,
+                noise_range=(0.01, 0.06),
+                noise_step=0.01,
+                border_width=0.2,
+            ),
+            "wave_terrain": wave_terrain(
+                proportion=0.3,
+                amplitude_range=(0.0, 0.12),
+                num_waves=4,
+                border_width=0.2,
+            ),
+        }
+    )
+
+
 @registry.envcfg("Go2WJoystickRough")
 @dataclass
 class Go2WJoystickRoughCfg(Go2WJoystickCfg):
@@ -70,7 +140,7 @@ class Go2WJoystickRoughCfg(Go2WJoystickCfg):
                 str(ASSETS_ROOT_PATH / "robots" / "go2w" / "locomotion_task.xml"),
             ],
             terrain=TerrainSceneCfg(
-                generator=Go2RoughTerrainCfg(),
+                generator=Go2WRoughTerrainCfg(),
                 hfield_name="terrain_hfield",
                 geom_name="floor",
             ),

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -371,13 +371,13 @@ def test_ppo_go2w_rough_mujoco_uses_terrain_generator():
     assert cfg.env.commands.heading_range == pytest.approx([-3.141592653589793, 3.141592653589793])
     assert "rel_standing_envs" not in cfg.env.commands
     assert cfg.env.control_config.clip_actions == pytest.approx(100.0)
-    assert cfg.env.control_config.action_scale == pytest.approx(0.5)
-    assert cfg.env.control_config.wheel_action_scale == pytest.approx(10.0)
-    assert cfg.env.domain_rand.randomize_kp is False
-    assert cfg.env.domain_rand.randomize_kd is False
+    assert cfg.env.control_config.action_scale == pytest.approx(0.25)
+    assert cfg.env.control_config.hip_action_scale == pytest.approx(0.125)
+    assert cfg.env.control_config.wheel_action_scale == pytest.approx(5.0)
+    assert cfg.env.domain_rand.randomize_kp is True
+    assert cfg.env.domain_rand.randomize_kd is True
     assert cfg.env.domain_rand.kp_multiplier_range == [0.5, 1.0]
     assert cfg.reward.scales.tracking_lin_vel == pytest.approx(3.0)
-    assert cfg.reward.scales.joint_pos_limits == pytest.approx(-5.0)
     assert cfg.reward.scales.hip_pos == pytest.approx(-2.0)
     assert cfg.reward.scales.joint_mirror == pytest.approx(-0.05)
     assert cfg.reward.only_positive_rewards is False
@@ -392,8 +392,9 @@ def test_ppo_go2w_rough_motrix_uses_yaw_reset_and_strong_control():
     assert cfg.env.commands.vel_limit == [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]
     assert cfg.env.commands.heading_range == pytest.approx([-3.141592653589793, 3.141592653589793])
     assert "rel_standing_envs" not in cfg.env.commands
-    assert cfg.env.control_config.action_scale == pytest.approx(0.5)
-    assert cfg.env.control_config.wheel_action_scale == pytest.approx(10.0)
+    assert cfg.env.control_config.action_scale == pytest.approx(0.25)
+    assert cfg.env.control_config.hip_action_scale == pytest.approx(0.125)
+    assert cfg.env.control_config.wheel_action_scale == pytest.approx(5.0)
     assert cfg.env.domain_rand.randomize_kp is True
     assert cfg.env.domain_rand.randomize_kd is True
     assert cfg.reward.scales.orientation == pytest.approx(-2.0)

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -360,7 +360,7 @@ def test_ppo_go2w_rough_mujoco_uses_terrain_generator():
 
     assert cfg.training.task_name == "Go2WJoystickRough"
     assert cfg.training.sim_backend == "mujoco"
-    assert str(cfg.env.scene.model_file).endswith("src/unilab/assets/robots/go2w/go2w.xml")
+    assert str(cfg.env.scene.model_file).endswith("src/unilab/assets/robots/go2w/go2w_mujoco.xml")
     assert cfg.env.scene.terrain.hfield_name == "terrain_hfield"
     assert cfg.env.scene.terrain.geom_name == "floor"
     assert cfg.env.terrain_scan.hfield_name == "terrain_hfield"
@@ -381,7 +381,7 @@ def test_ppo_go2w_rough_mujoco_uses_terrain_generator():
     assert cfg.reward.scales.hip_pos == pytest.approx(-2.0)
     assert cfg.reward.scales.joint_mirror == pytest.approx(-0.05)
     assert cfg.reward.only_positive_rewards is False
-    assert cfg.algo.max_iterations == 5000
+    assert cfg.algo.max_iterations == 1200
 
 
 def test_ppo_go2w_rough_motrix_uses_yaw_reset_and_strong_control():
@@ -400,7 +400,7 @@ def test_ppo_go2w_rough_motrix_uses_yaw_reset_and_strong_control():
     assert cfg.reward.scales.orientation == pytest.approx(-2.0)
     assert cfg.reward.scales.hip_pos == pytest.approx(-0.5)
     assert cfg.reward.scales.upward == pytest.approx(1.0)
-    assert cfg.algo.max_iterations == 2000
+    assert cfg.algo.max_iterations == 1200
 
 
 def test_offpolicy_g1_walk_flat_motrix_preserves_backend_env_overrides():

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -333,7 +333,7 @@ def test_ppo_go2_joystick_rough_motrix_task_compose():
     assert cfg.training.task_name == "Go2JoystickRough"
     assert cfg.training.sim_backend == "motrix"
     assert cfg.algo.num_envs == 4096
-    assert cfg.algo.max_iterations == 1000
+    assert cfg.algo.max_iterations == 1500
     assert cfg.env.render_offset_mode == "zero"
     assert cfg.env.scene.model_file.endswith("go2.xml")
     assert cfg.env.scene.terrain.generator.num_rows == 6

--- a/tests/envs/locomotion/go2w/test_go2w_motor_control.py
+++ b/tests/envs/locomotion/go2w/test_go2w_motor_control.py
@@ -191,6 +191,7 @@ def test_go2w_apply_action_maps_legs_to_targets_and_wheels_to_velocity_targets()
     env._num_envs = 1
     env._num_action = NUM_GO2W_ACTIONS
     env.default_angles = DEFAULT_GO2W_ANGLES.astype(np.float32)
+    env._leg_action_scale = env._build_leg_action_scale()
     state = NpEnvState(
         obs={},
         reward=np.zeros((1,), dtype=np.float32),

--- a/tests/envs/locomotion/test_go2_terrain_spawn.py
+++ b/tests/envs/locomotion/test_go2_terrain_spawn.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -115,6 +117,29 @@ def test_go2_rough_base_height_reward_uses_terrain_relative_height():
     env._terrain_surface_sample_height = surface.sample_height
 
     np.testing.assert_allclose(env._reward_base_height_values(), np.asarray([0.5, 0.35]))
+
+
+def test_go2_rough_pd_torque_estimate_returns_dof_order():
+    from unilab.envs.locomotion.go2.rough import (
+        GO2_ACTUATOR_TO_DOF_INDICES,
+        Go2JoystickRoughEnv,
+    )
+
+    env = Go2JoystickRoughEnv.__new__(Go2JoystickRoughEnv)
+    env._num_action = 12
+    env._cfg = SimpleNamespace(
+        control_config=SimpleNamespace(Kp=2.0, Kd=0.5, simulate_action_latency=False)
+    )
+    env._action_scale = np.ones((12,), dtype=np.float32)
+    env.default_angles = np.arange(12, dtype=np.float32)
+    env._default_angles_actuator = env.default_angles[GO2_ACTUATOR_TO_DOF_INDICES]
+    dof_pos = np.zeros((1, 12), dtype=np.float32)
+    dof_vel = np.zeros((1, 12), dtype=np.float32)
+    info = {"current_actions": np.zeros((1, 12), dtype=np.float32)}
+
+    torques = env._estimate_pd_torques(info, dof_pos, dof_vel)
+
+    np.testing.assert_allclose(torques, 2.0 * env.default_angles[None, :])
 
 
 def test_default_spawn_used_when_flat():

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -25,8 +25,49 @@ def _go2_robot() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "go2" / "go2.xml")
 
 
+def _go1_robot() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go1" / "go1.xml")
+
+
+def _go2w_robot() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go2w" / "go2w.xml")
+
+
 def _go2_locomotion_task() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "go2" / "locomotion_task.xml")
+
+
+def _go1_locomotion_task() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go1" / "locomotion_task.xml")
+
+
+def _go2w_locomotion_task() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go2w" / "locomotion_task.xml")
+
+
+def _geom_id(model, mujoco, name: str) -> int:
+    geom_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, name)
+    assert geom_id >= 0
+    return geom_id
+
+
+def _assert_geom_contact_params(
+    model,
+    mujoco,
+    *,
+    name: str,
+    condim: int,
+    margin: float,
+    friction: tuple[float, float, float],
+) -> None:
+    geom_id = _geom_id(model, mujoco, name)
+    assert int(model.geom_condim[geom_id]) == condim
+    assert float(model.geom_margin[geom_id]) == pytest.approx(margin)
+    assert model.geom_friction[geom_id][0] == pytest.approx(friction[0])
+    assert model.geom_friction[geom_id][1] == pytest.approx(friction[1])
+    assert model.geom_friction[geom_id][2] == pytest.approx(friction[2])
+    assert model.geom_solref[geom_id][0] == pytest.approx(0.01)
+    assert model.geom_solref[geom_id][1] == pytest.approx(1.0)
 
 
 def test_inject_mujoco_tracking_sensors_uses_mjspec_and_preserves_contract() -> None:
@@ -142,13 +183,39 @@ def test_materialize_mujoco_hfield_attached_scene_composes_robot_and_task_fragme
     assert scene_xml.is_file()
     scene_root = ET.parse(scene_xml).getroot()
     compiler = scene_root.find("compiler")
+    option = scene_root.find("option")
     assert compiler is None or compiler.get("discardvisual") != "true"
+    assert option is not None
+    assert option.get("cone") == "elliptic"
+    assert option.get("impratio") == "100"
+    assert option.get("ccd_iterations") == "500"
     assert scene_root.find("./asset/texture[@name='groundplane']") is not None
     assert scene_root.find("./asset/material[@name='groundplane']") is not None
     assert scene_root.find("./visual/headlight") is not None
-    assert scene_root.find(".//geom[@name='floor']").get("material") == "groundplane"
+    floor_geom = scene_root.find(".//geom[@name='floor']")
+    assert floor_geom is not None
+    assert floor_geom.get("material") == "groundplane"
     reloaded_model = mujoco.MjModel.from_xml_path(str(scene_xml))
     assert model.ngeom < reloaded_model.ngeom
+    assert int(model.opt.cone) == int(mujoco.mjtCone.mjCONE_ELLIPTIC)
+    assert model.opt.impratio == pytest.approx(100.0)
+    assert model.opt.ccd_iterations == 500
+    _assert_geom_contact_params(
+        model,
+        mujoco,
+        name="FL",
+        condim=6,
+        margin=0.005,
+        friction=(0.4, 0.02, 0.01),
+    )
+    _assert_geom_contact_params(
+        model,
+        mujoco,
+        name="FL_thigh_geom",
+        condim=1,
+        margin=0.001,
+        friction=(0.0, 0.0, 0.0),
+    )
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_HFIELD, "terrain_hfield") >= 0
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "FL_foot_contact") >= 0
@@ -156,6 +223,85 @@ def test_materialize_mujoco_hfield_attached_scene_composes_robot_and_task_fragme
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "home") >= 0
     assert mujoco.mj_name2id(reloaded_model, mujoco.mjtObj.mjOBJ_HFIELD, "terrain_hfield") >= 0
     assert mujoco.mj_name2id(reloaded_model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0
+
+
+def test_materialize_mujoco_hfield_attached_scene_preserves_go1_collision_xml(
+    tmp_path,
+) -> None:
+    mujoco = pytest.importorskip("mujoco")
+
+    from unilab.terrains import TerrainGeneratorCfg, flat
+
+    cfg = TerrainGeneratorCfg(
+        size=(4.0, 4.0),
+        horizontal_scale=0.2,
+        border_width=0.0,
+        num_rows=1,
+        num_cols=1,
+        sub_terrains={"flat": flat()},
+    )
+
+    model, terrain_origins = materialize_mujoco_hfield_attached_scene(
+        model_file=_go1_robot(),
+        terrain_cfg=cfg,
+        output_dir=tmp_path,
+        fragment_files=[_go1_locomotion_task()],
+    )
+
+    assert terrain_origins.shape == (1, 1, 3)
+    assert model.opt.ccd_iterations == 500
+    _assert_geom_contact_params(
+        model,
+        mujoco,
+        name="FL",
+        condim=6,
+        margin=0.005,
+        friction=(0.8, 0.02, 0.01),
+    )
+    _assert_geom_contact_params(
+        model,
+        mujoco,
+        name="FL_thigh_geom",
+        condim=1,
+        margin=0.001,
+        friction=(0.0, 0.0, 0.0),
+    )
+    assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, "FL_foot_contact") >= 0
+
+
+def test_materialize_mujoco_hfield_attached_scene_preserves_go2w_collision_xml(
+    tmp_path,
+) -> None:
+    mujoco = pytest.importorskip("mujoco")
+
+    from unilab.terrains import TerrainGeneratorCfg, flat
+
+    cfg = TerrainGeneratorCfg(
+        size=(4.0, 4.0),
+        horizontal_scale=0.2,
+        border_width=0.0,
+        num_rows=1,
+        num_cols=1,
+        sub_terrains={"flat": flat()},
+    )
+
+    model, terrain_origins = materialize_mujoco_hfield_attached_scene(
+        model_file=_go2w_robot(),
+        terrain_cfg=cfg,
+        output_dir=tmp_path,
+        fragment_files=[_go2w_locomotion_task()],
+    )
+
+    assert terrain_origins.shape == (1, 1, 3)
+    assert model.opt.ccd_iterations == 500
+    _assert_geom_contact_params(
+        model,
+        mujoco,
+        name="FL_wheel_collision",
+        condim=6,
+        margin=0.005,
+        friction=(0.8, 0.02, 0.01),
+    )
 
 
 def test_materialize_mujoco_hfield_attached_scene_accepts_repo_relative_fragments(

--- a/tests/utils/test_xml_utils.py
+++ b/tests/utils/test_xml_utils.py
@@ -25,12 +25,24 @@ def _go2_robot() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "go2" / "go2.xml")
 
 
+def _go2_mujoco_robot() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go2" / "go2_mujoco.xml")
+
+
 def _go1_robot() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "go1" / "go1.xml")
 
 
+def _go1_mujoco_robot() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go1" / "go1_mujoco.xml")
+
+
 def _go2w_robot() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "go2w" / "go2w.xml")
+
+
+def _go2w_mujoco_robot() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "go2w" / "go2w_mujoco.xml")
 
 
 def _go2_locomotion_task() -> str:
@@ -171,7 +183,7 @@ def test_materialize_mujoco_hfield_attached_scene_composes_robot_and_task_fragme
     cfg.seed = 0
 
     model, terrain_origins = materialize_mujoco_hfield_attached_scene(
-        model_file=_go2_robot(),
+        model_file=_go2_mujoco_robot(),
         terrain_cfg=cfg,
         output_dir=tmp_path,
         fragment_files=[_go2_locomotion_task()],
@@ -188,7 +200,6 @@ def test_materialize_mujoco_hfield_attached_scene_composes_robot_and_task_fragme
     assert option is not None
     assert option.get("cone") == "elliptic"
     assert option.get("impratio") == "100"
-    assert option.get("ccd_iterations") == "500"
     assert scene_root.find("./asset/texture[@name='groundplane']") is not None
     assert scene_root.find("./asset/material[@name='groundplane']") is not None
     assert scene_root.find("./visual/headlight") is not None
@@ -242,7 +253,7 @@ def test_materialize_mujoco_hfield_attached_scene_preserves_go1_collision_xml(
     )
 
     model, terrain_origins = materialize_mujoco_hfield_attached_scene(
-        model_file=_go1_robot(),
+        model_file=_go1_mujoco_robot(),
         terrain_cfg=cfg,
         output_dir=tmp_path,
         fragment_files=[_go1_locomotion_task()],
@@ -286,7 +297,7 @@ def test_materialize_mujoco_hfield_attached_scene_preserves_go2w_collision_xml(
     )
 
     model, terrain_origins = materialize_mujoco_hfield_attached_scene(
-        model_file=_go2w_robot(),
+        model_file=_go2w_mujoco_robot(),
         terrain_cfg=cfg,
         output_dir=tmp_path,
         fragment_files=[_go2w_locomotion_task()],


### PR DESCRIPTION
## Summary

- Provided separate go1/go2/go2w_mujoco.xml models for collision-sensitive mujoco to avoid training crashes.

- Added options to the robot.xml file for the merged scene.

- Adjusted various rough tasks to ensure appropriate training results.

## Validation

- [x] `make test-all`

## Impact

- Backend impact: both
- Platform impact: both
- Training effect expected: yes

## Artifacts

 - go1_joystick_rough/mujoco:
<img width="797" height="416" alt="203a7b1f-a97e-4784-af05-e6bdd25973e4" src="https://github.com/user-attachments/assets/e76a2d19-a55b-402b-8331-073c561a1fc7" />

https://github.com/user-attachments/assets/14a6d1d7-1f53-439d-91af-f8dc9df47165

 - go2_joystick_rough/mujoco:
<img width="791" height="418" alt="f51b0416-f83c-4789-a145-191adc0f3542" src="https://github.com/user-attachments/assets/dfda2bcd-a16e-471b-80e9-fed20a445aa0" />

https://github.com/user-attachments/assets/2bfdb07d-1d40-4470-bd1f-98891aec8c2f

 - go2w_joystick_rough/mujoco:
<img width="795" height="404" alt="f16949a8-8278-41c7-bf56-c1e792d340e5" src="https://github.com/user-attachments/assets/e2098b05-2261-4fc2-85b0-e24791a8080b" />

https://github.com/user-attachments/assets/f9a4e8db-11e4-4986-9ad3-b934c0fa3b78
