### PR TITLE
feat: add Go2 footstand teacher task

### DIFF
--- a/conf/ppo/task/go2_footstand/mujoco.yaml
+++ b/conf/ppo/task/go2_footstand/mujoco.yaml
@@ -1,0 +1,67 @@
+# @package _global_
+training:
+  task_name: Go2FootStand
+  sim_backend: mujoco
+env:
+  sim_dt: 0.004
+  add_body_sensors: true
+  obs_history_len: 15
+  energy_termination_threshold: 200.0
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
+    scale_gravity: 0.05
+    scale_linvel: 0.1
+  control_config:
+    action_scale: 0.3
+  domain_rand:
+    randomize_floor_friction: true
+    floor_friction_range: [0.4, 1.0]
+    randomize_link_mass: true
+    link_mass_scale_range: [0.9, 1.1]
+    torso_added_mass_range: [-1.0, 1.0]
+    randomize_torso_com: true
+    torso_com_offset_range: [-0.05, 0.05]
+    randomize_dof_armature: true
+    dof_armature_scale_range: [1.0, 1.05]
+    randomize_reset_joint_qpos: true
+    reset_joint_qpos_range: [-0.05, 0.05]
+algo:
+  empirical_normalization: true
+  num_envs: 1024 # 4096  # 1024
+  # max_iterations: 3000
+  max_iterations: 10000
+  obs_groups:
+    actor:
+      - actor
+    critic:
+      - critic
+  policy:
+    init_noise_std: 0.5
+  algorithm:
+    entropy_coef: 0.005
+reward:
+  scales:
+    height: 2.0
+    orientation: 2.0
+    contact: -1.0
+    action_rate: -0.01
+    termination: -2.0
+    dof_pos_limits: -0.5
+    torques: 0.0
+    pose: -0.1
+    penalty_contact: -0.2
+    tar: 0.8
+    rear_feet_contact: 0.5
+    rear_leg_symmetry: -0.2
+    front_leg_motion: -0.05
+    upright_stability: -0.2
+    knee_clearance: -0.5
+    stay_still: -0.1
+    energy: -0.003
+    dof_acc: -2.5e-7
+  tracking_sigma: 0.25
+  base_height_target: 0.3
+  knee_height_target: 0.08

--- a/docs/sphinx/source/en/2-user_guide/4-tasks/1-locomotion.md
+++ b/docs/sphinx/source/en/2-user_guide/4-tasks/1-locomotion.md
@@ -7,7 +7,7 @@ define which algorithm and backend combinations are runnable.
 ## Families
 
 - Go1: `go1_joystick_flat`, `go1_joystick_rough`
-- Go2: `go2_joystick_flat`, `go2_joystick_rough`, `go2_handstand`
+- Go2: `go2_joystick_flat`, `go2_joystick_rough`, `go2_handstand`, `go2_footstand`
 - Go2W: `go2w_joystick_flat`, `go2w_joystick_rough`
 - G1 walking: `g1_walk_flat`, `g1_walk_rough`
 - G1 motion tracking: `g1_motion_tracking`, `g1_flip_tracking`,
@@ -19,6 +19,7 @@ define which algorithm and backend combinations are runnable.
 ```bash
 uv run train --algo ppo --task go2_joystick_flat --sim mujoco
 uv run train --algo ppo --task go2_joystick_rough --sim motrix training.no_play=true
+uv run train --algo ppo --task go2_footstand --sim mujoco training.no_play=true
 uv run train --algo appo --task g1_motion_tracking --sim mujoco training.no_play=true
 uv run train --algo sac --task g1_walk_flat --sim mujoco
 ```

--- a/docs/sphinx/source/en/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/en/5-reference/5-support_matrix.md
@@ -39,6 +39,7 @@ recommendation metadata, so rows do not auto-promote to `Benchmarked` or
 | PPO (torch) | `g1_motion_tracking_deploy` | Tested | Tested |
 | PPO (torch) | `go1_joystick_rough` | Tested | Tested |
 | PPO (torch) | `go2_arm_manip_loco` | Tested | - |
+| PPO (torch) | `go2_footstand` | Tested | - |
 | PPO (torch) | `go2_handstand` | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` | Tested | Tested |
 | PPO (torch) | `go2w_joystick_rough` | Tested | Tested |
@@ -58,6 +59,7 @@ recommendation metadata, so rows do not auto-promote to `Benchmarked` or
 | PPO (mlx) | `g1_motion_tracking_deploy` | Configured | Configured |
 | PPO (mlx) | `go1_joystick_rough` | Configured | Configured |
 | PPO (mlx) | `go2_arm_manip_loco` | Configured | - |
+| PPO (mlx) | `go2_footstand` | Configured | - |
 | PPO (mlx) | `go2_handstand` | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_rough` | Configured | Configured |

--- a/docs/sphinx/source/zh_CN/1-user_guide/0-index.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/0-index.md
@@ -41,6 +41,7 @@ UniLab 中文版用户指南。从一次能跑通的训练开始,再按主题深
 4-tasks/4-sharpa-inhand
 4-tasks/5-go2-rough-terrain
 4-tasks/6-go2-arm-manip-loco
+4-tasks/7-go2-footstand
 5-reference/1-backend-support-matrix
 ```
 

--- a/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/1-task-index.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/1-task-index.md
@@ -14,6 +14,7 @@
 
 - [D.05 Go2 Rough Terrain](5-go2-rough-terrain.md)
 - [D.06 Go2 Arm Manip Loco](6-go2-arm-manip-loco.md)
+- [D.07 Go2 FootStand](7-go2-footstand.md)
 
 ### Allegro Hand
 
@@ -30,6 +31,7 @@
 - [D.02 G1 Motion Tracking](2-g1-motion-tracking.md)
 - [D.05 Go2 Rough Terrain](5-go2-rough-terrain.md)
 - [D.06 Go2 Arm Manip Loco](6-go2-arm-manip-loco.md)
+- [D.07 Go2 FootStand](7-go2-footstand.md)
 
 ### In-hand Manipulation
 

--- a/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/6-go2-arm-manip-loco.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/6-go2-arm-manip-loco.md
@@ -64,3 +64,4 @@ uv run python -c "import mujoco; m=mujoco.MjModel.from_xml_path('src/unilab/asse
 
 - Index: [Documentation](../../0-index.md)
 - Previous: [Go2 Rough Terrain](5-go2-rough-terrain.md)
+- Next: [Go2 FootStand](7-go2-footstand.md)

--- a/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/7-go2-footstand.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/4-tasks/7-go2-footstand.md
@@ -1,0 +1,114 @@
+# Go2 FootStand
+
+语言: 简体中文
+
+本页记录 `go2_footstand` 的 PPO 任务入口、配置位置、整体训练流程和近风险验证命令。
+
+## 任务
+
+- PPO：`go2_footstand`
+- 支持后端：MuJoCo
+
+## 默认命令
+
+```bash
+uv run train --algo ppo --task go2_footstand --sim mujoco training.no_play=true
+uv run eval --algo ppo --task go2_footstand --sim mujoco --load-run -1
+```
+
+## 配置入口
+
+- PPO 配置：`conf/ppo/task/go2_footstand/mujoco.yaml`
+- 环境注册名：`Go2FootStand`
+- 环境实现：`src/unilab/envs/locomotion/go2/footstand.py`
+- Go2 模型 XML：`src/unilab/assets/robots/go2/go2.xml`
+
+## 教师-学生训练流程
+
+FootStand 的完整训练流程分为三步：先训练带特权观测的教师策略，再把教师策略蒸馏到可部署的
+学生策略，最后对学生策略继续做强化学习微调。当前仓库里的 `go2_footstand` 配置对应第一步，
+也就是教师策略的 PPO 训练入口。
+
+1. 教师策略训练
+
+   教师策略可以使用特权观测，其中包括基座线速度等仿真中可以直接获得、但实机部署时不应直接
+   依赖的信息。训练时先让策略在较宽松的功率预算下学会前足站立动作，再通过课程学习逐步收紧
+   功率约束：从约 400 W 过渡到约 200 W。这样可以避免一开始就使用低功率限制导致探索失败，同时
+   让最终策略更接近实机可承受的能耗范围。
+
+2. 学生策略蒸馏
+
+   教师策略训练完成后，将它蒸馏到一个可部署的学生策略上。学生策略的输入只保留实机可获得的
+   观测，不能依赖特权信息。蒸馏阶段的目标是让学生策略在没有特权观测的条件下，尽量复现教师策略
+   的行为。
+
+3. 学生策略微调
+
+   蒸馏后的学生策略还需要继续强化学习微调。微调时使用一个统一的损失目标：一部分来自与教师训练
+   类似的奖励函数，另一部分来自教师策略正则项，用来约束学生策略不要过快偏离教师策略。这样既能
+   保留教师策略学到的稳定动作，又能让学生策略继续适应自己的观测输入和部署约束。
+
+## 仿真到实机注意点
+
+- 特权观测只服务于教师策略训练；可部署的学生策略不应直接读取基座线速度、仿真全局角速度或其他
+  只在仿真中可靠存在的传感量。
+- 功率课程学习的目标是先保证动作能学出来，再逐步适应 200 W 左右的部署约束，避免低功率限制过早
+  压缩探索空间。
+- 学生策略微调阶段的教师正则项用于稳定行为分布，但权重过大时会限制学生策略对实机观测噪声、
+  延迟和接触差异的适应。
+- 实机侧要重点检查惯性测量单元噪声、关节速度噪声、接触状态、执行器带宽和功率估计口径；这些
+  偏差会直接影响前足站立的能耗、姿态和终止条件。
+
+## 观测口径
+
+`Go2FootStand` 的策略网络观测使用 15 帧历史，每帧 45 维：
+
+```text
+linvel(3) + gyro(3) + gravity(3) + joint_position_delta(12) + joint_velocity(12) + last_action(12)
+```
+
+因此策略网络观测维度是 `45 * 15 = 675`。价值网络会在这段历史观测后追加当前时刻的特权观测：
+
+```text
+gyro(3) + accelerometer(3) + linvel(3) + global_angvel(3) + dof_pos(12) + dof_vel(12) + torques(12) + height(1)
+```
+
+价值网络观测维度是 `675 + 49 = 724`。
+
+## 奖励与终止项
+
+该任务的默认奖励来自 `conf/ppo/task/go2_footstand/mujoco.yaml`，主要包括：
+
+- 站立高度、朝向、后脚接触、前腿目标角度；
+- 动作变化率、关节限位、前腿运动、后腿对称、膝盖离地高度、静止约束；
+- 能耗和关节加速度惩罚；
+- 前腿/前身体接触、低高度、坏朝向、能量阈值等终止或惩罚路径。
+
+## 调参提示
+
+- `env.obs_history_len`：策略观测历史长度，当前配置默认为 15。
+- `env.energy_termination_threshold`：高能耗终止阈值。
+- `env.domain_rand`：摩擦、连杆质量、机身质心、关节惯量和重置关节位置随机化。
+- `reward.scales.height`、`orientation`、`rear_feet_contact`：站立姿态和后脚接触权重。
+
+## 近风险检查
+
+```bash
+uv run pytest tests/envs/locomotion/test_go2_footstand.py tests/config/test_locomotion_params.py -q
+```
+
+如果改过 Go2 XML，至少确认 MuJoCo 能加载模型：
+
+```bash
+uv run python -c "import mujoco; m=mujoco.MjModel.from_xml_path('src/unilab/assets/robots/go2/go2.xml'); print(m.nq, m.nv, m.nu, m.nsensor)"
+```
+
+## 关联入口
+
+- 训练规则：看 [03 训练指南](../3-training.md)
+- 任务总索引：看 [D 任务索引](1-task-index.md)
+
+## Navigation
+
+- Index: [Documentation](../../0-index.md)
+- Previous: [Go2 Arm Manip Loco](6-go2-arm-manip-loco.md)

--- a/docs/sphinx/source/zh_CN/1-user_guide/5-reference/1-backend-support-matrix.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/5-reference/1-backend-support-matrix.md
@@ -54,6 +54,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
 | PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | Tested |
 | PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - |
+| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | Tested |
@@ -73,6 +74,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
 | PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | Configured |
 | PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | - |
+| PPO (mlx) | `go2_footstand` (go2 footstand) | Configured | - |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_rough` (go2w joystick rough) | Configured | Configured |

--- a/src/unilab/assets/robots/go2/go2.xml
+++ b/src/unilab/assets/robots/go2/go2.xml
@@ -203,14 +203,14 @@
   <sensor>
 
     <gyro site="imu" name="gyro"/>
-    <!-- <accelerometer site="imu" name="accelerometer"/> -->
+    <accelerometer site="imu" name="accelerometer"/>
     <velocimeter site="imu" name="local_linvel"/>
     <framezaxis objtype="site" objname="imu" name="upvector"/>
 
     <!-- <framequat objtype="site" objname="imu" name="orientation"/> -->
     <framepos objtype="site" objname="imu" name="global_position"/>
     <framelinvel objtype="site" objname="imu" name="global_linvel"/>
-    <!-- <frameangvel objtype="site" objname="imu" name="global_angvel"/> -->
+    <frameangvel objtype="site" objname="imu" name="global_angvel"/>
 
     <!-- <framelinvel objtype="site" objname="FR" name="FR_global_linvel"/>
     <framelinvel objtype="site" objname="FL" name="FL_global_linvel"/>

--- a/src/unilab/envs/locomotion/go2/__init__.py
+++ b/src/unilab/envs/locomotion/go2/__init__.py
@@ -1,3 +1,4 @@
+from .footstand import Go2FootStandCfg, Go2FootStandTask
 from .handstand import Go2HandStandCfg, Go2HandStandTask
 from .joystick import Go2JoystickCfg, Go2WalkTask
 from .rough import Go2JoystickRoughCfg, Go2JoystickRoughEnv

--- a/src/unilab/envs/locomotion/go2/footstand.py
+++ b/src/unilab/envs/locomotion/go2/footstand.py
@@ -1,0 +1,699 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import numpy as np
+
+from unilab.base import registry
+from unilab.base.np_env import NpEnvState
+from unilab.dr import ResetPlan, ResetRandomizationPayload
+from unilab.dtype_config import get_global_dtype
+from unilab.envs.common.rotation import np_quat_apply, np_quat_apply_inverse
+from unilab.envs.locomotion.common import rewards
+from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.envs.locomotion.go2.base import ControlConfig, NoiseConfig
+from unilab.envs.locomotion.go2.handstand import (
+    Go2DomainRandConfig,
+    Go2HandStandCfg,
+    Go2HandStandDomainRandomizationProvider,
+    Go2HandStandTask,
+    JoystickSensor,
+)
+
+_GO2_DOF_TO_CTRL = np.array([3, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8], dtype=np.int32)
+_WORLD_GRAVITY = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+_BODY_FORWARD = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+_FOOTSTAND_FRAME_OBS_DIM = 45
+_FOOTSTAND_PRIVILEGED_TAIL_DIM = 49
+_FOOTSTAND_MIN_OBS_HISTORY_LEN = 15
+_FOOTSTAND_FRONT_FEET = [0, 1]
+_FOOTSTAND_REAR_FEET = [2, 3]
+_FOOTSTAND_FRONT_LEG_IDS = [0, 1, 2, 3, 4, 5]
+_FOOTSTAND_REAR_LEG_IDS = [6, 7, 8, 9, 10, 11]
+_FOOTSTAND_REAR_LEFT_LEG_IDS = [6, 7, 8]
+_FOOTSTAND_REAR_RIGHT_LEG_IDS = [9, 10, 11]
+_FOOTSTAND_REAR_MIRROR_SIGNS = np.array([-1.0, 1.0, 1.0], dtype=np.float32)
+_FOOTSTAND_FRONT_LEG_TARGET = np.array([0.0, 1.82, -1.16, 0.0, 1.82, -1.16])
+_FOOTSTAND_KNEE_BODY_NAMES = ("FL_calf", "FR_calf", "RL_calf", "RR_calf")
+_FOOTSTAND_CONTACT_THRESHOLD = 0.1
+_FOOTSTAND_STAND_HEIGHT_FRACTION = 0.8
+_FOOTSTAND_STAND_ORIENTATION_THRESHOLD = 0.5
+
+
+@dataclass
+class FootstandNoiseConfig(NoiseConfig):
+    level: float = 1.0
+    scale_joint_angle: float = 0.01
+    scale_joint_vel: float = 1.5
+    scale_gyro: float = 0.2
+    scale_gravity: float = 0.05
+    scale_linvel: float = 0.1
+
+
+@dataclass
+class FootstandControlConfig(ControlConfig):
+    clip_actions: float = 1.0
+
+
+@dataclass
+class Go2FootStandDomainRandConfig(Go2DomainRandConfig):
+    randomize_kp: bool = False
+    randomize_kd: bool = False
+    randomize_base_mass: bool = False
+    random_com: bool = False
+    push_robots: bool = False
+
+    randomize_floor_friction: bool = True
+    floor_friction_range: list[float] = field(default_factory=lambda: [0.4, 1.0])
+
+    randomize_link_mass: bool = True
+    link_mass_scale_range: list[float] = field(default_factory=lambda: [0.9, 1.1])
+    torso_added_mass_range: list[float] = field(default_factory=lambda: [-1.0, 1.0])
+
+    randomize_torso_com: bool = True
+    torso_com_offset_range: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+
+    randomize_dof_armature: bool = True
+    dof_armature_scale_range: list[float] = field(default_factory=lambda: [1.0, 1.05])
+
+    randomize_reset_joint_qpos: bool = True
+    reset_joint_qpos_range: list[float] = field(default_factory=lambda: [-0.05, 0.05])
+
+
+@dataclass
+class FootstandSensor(JoystickSensor):
+    accelerometer = "accelerometer"
+    global_angvel = "global_angvel"
+    ternamate_contact = [
+        "RL_hip_contact",
+        "RR_hip_contact",
+        "RL_thigh_contact",
+        "RR_thigh_contact",
+        "RL_calf_contact1",
+        "RL_calf_contact2",
+        "RR_calf_contact1",
+        "RR_calf_contact2",
+    ]
+    penalty_contact = [
+        "FL_hip_contact",
+        "FR_hip_contact",
+        "FL_thigh_contact",
+        "FR_thigh_contact",
+        "FL_calf_contact1",
+        "FL_calf_contact2",
+        "FR_calf_contact1",
+        "FR_calf_contact2",
+    ]
+
+
+@registry.envcfg("Go2FootStand")
+@dataclass
+class Go2FootStandCfg(Go2HandStandCfg):
+    max_episode_seconds: float = 10.0
+    add_body_sensors: bool = True
+    obs_history_len: int = _FOOTSTAND_MIN_OBS_HISTORY_LEN
+    soft_joint_pos_limit_factor: float = 0.9
+    energy_termination_threshold: float = np.inf
+    termination_grace_steps: int = 100
+    termination_height_fraction: float = 0.8
+    termination_orientation_threshold: float = 0.2
+    noise_config: FootstandNoiseConfig = field(default_factory=FootstandNoiseConfig)  # type: ignore[assignment]
+    control_config: FootstandControlConfig = field(  # type: ignore[assignment]
+        default_factory=lambda: FootstandControlConfig(action_scale=0.3)
+    )
+    sensor: FootstandSensor = field(default_factory=FootstandSensor)  # type: ignore[assignment]
+    domain_rand: Go2FootStandDomainRandConfig = field(default_factory=Go2FootStandDomainRandConfig)  # type: ignore[assignment]
+
+
+class Go2FootStandDomainRandomizationProvider(Go2HandStandDomainRandomizationProvider):
+    def _get_reset_randomization_baselines(
+        self, env: Any
+    ) -> tuple[np.ndarray | None, np.ndarray | None, int | None, np.ndarray | None]:
+        return (
+            env._base_body_mass,
+            env._base_geom_friction,
+            env._floor_geom_id,
+            env._base_dof_armature,
+        )
+
+    def build_reset_plan(self, env: Any, env_ids: np.ndarray) -> ResetPlan:
+        plan = super().build_reset_plan(env, env_ids)
+        qpos = np.asarray(plan.qpos, dtype=get_global_dtype()).copy()
+        domain_rand = env.cfg.domain_rand
+        if domain_rand.randomize_reset_joint_qpos:
+            low, high = domain_rand.reset_joint_qpos_range
+            qpos[:, -env._num_action :] += np.random.uniform(
+                low, high, size=(len(env_ids), env._num_action)
+            ).astype(qpos.dtype)
+
+        return ResetPlan(
+            env_ids=plan.env_ids,
+            qpos=qpos,
+            qvel=plan.qvel,
+            info_updates=plan.info_updates,
+            randomization=self._merge_reset_randomization(
+                plan.randomization,
+                env._build_playground_reset_randomization(len(env_ids)),
+            ),
+        )
+
+    @staticmethod
+    def _merge_reset_randomization(
+        base: ResetRandomizationPayload | None,
+        override: ResetRandomizationPayload | None,
+    ) -> ResetRandomizationPayload | None:
+        if base is None or base.is_empty():
+            return override
+        if override is None or override.is_empty():
+            return base
+        return ResetRandomizationPayload(
+            base_mass_delta=base.base_mass_delta,
+            base_com_offset=base.base_com_offset,
+            gravity=base.gravity,
+            body_iquat=override.body_iquat if override.body_iquat is not None else base.body_iquat,
+            body_inertia=override.body_inertia
+            if override.body_inertia is not None
+            else base.body_inertia,
+            body_ipos=override.body_ipos if override.body_ipos is not None else base.body_ipos,
+            body_mass=override.body_mass if override.body_mass is not None else base.body_mass,
+            dof_armature=override.dof_armature
+            if override.dof_armature is not None
+            else base.dof_armature,
+            geom_friction=override.geom_friction
+            if override.geom_friction is not None
+            else base.geom_friction,
+            kp=base.kp,
+            kd=base.kd,
+        )
+
+    def _compute_reset_obs(
+        self,
+        env: Any,
+        env_ids: Any,
+        info_updates: Any,
+        linvel: Any,
+        gyro: Any,
+        gravity: Any,
+        dof_pos: Any,
+        dof_vel: Any,
+    ) -> dict[str, np.ndarray]:
+        height = env._backend.get_sensor_data(env._cfg.sensor.global_pos)[env_ids, -1].reshape(
+            -1, 1
+        )
+        local_gravity = env._get_local_gravity()[env_ids]
+        accelerometer = env._backend.get_sensor_data(env._cfg.sensor.accelerometer)[env_ids]
+        global_angvel = env._backend.get_sensor_data(env._cfg.sensor.global_angvel)[env_ids]
+        env.torso_height[env_ids] = height[:, 0]
+        env._last_dof_vel_for_acc[env_ids, :] = dof_vel
+        env._last_terminated[env_ids] = False
+        env._motor_targets[env_ids] = env._dof_to_ctrl_order(dof_pos)
+        target_dof = env._ctrl_to_dof_order(env._motor_targets[env_ids])
+        info_updates["torques"] = np.asarray(
+            env._cfg.control_config.Kp * (target_dof - dof_pos)
+            - env._cfg.control_config.Kd * dof_vel,
+            dtype=get_global_dtype(),
+        )
+
+        return env._compute_obs(  # type: ignore[no-any-return]
+            info_updates,
+            linvel,
+            gyro,
+            local_gravity,
+            dof_pos,
+            dof_vel,
+            height,
+            accelerometer,
+            global_angvel,
+            env_ids=env_ids,
+        )
+
+
+@registry.env("Go2FootStand", sim_backend="mujoco")
+class Go2FootStandTask(Go2HandStandTask):
+    _cfg: Go2FootStandCfg
+
+    def __init__(self, cfg: Go2FootStandCfg, num_envs=1, backend_type="mujoco"):
+        super().__init__(cfg, num_envs=num_envs, backend_type=backend_type)
+        self._z_des = 0.53
+        self._desired_forward_vec = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+        self._init_footstand_pose_targets()
+        self._init_soft_joint_limits()
+        self._init_motor_target_limits()
+        self._last_dof_vel_for_acc = np.zeros((num_envs, self._num_action), dtype=np.float32)
+        self._last_terminated = np.zeros((num_envs,), dtype=bool)
+        self._motor_targets = np.zeros((num_envs, self._num_action), dtype=get_global_dtype())
+        self._obs_history = np.zeros(
+            (num_envs, self._obs_history_len, _FOOTSTAND_FRAME_OBS_DIM),
+            dtype=get_global_dtype(),
+        )
+        self._base_geom_friction = self._backend.get_geom_friction()
+        self._floor_geom_id = self._backend.get_geom_id(self._cfg.asset.ground)
+        self._base_body_id = self._backend.get_body_id(self._cfg.asset.base_name)
+        self._base_body_mass = self._backend.get_body_mass()
+        self._base_body_ipos = self._backend.get_body_ipos()
+        self._base_dof_armature = self._backend.get_dof_armature()
+        self._knee_body_ids = self._backend.get_body_ids(_FOOTSTAND_KNEE_BODY_NAMES)
+        self._init_domain_randomization(Go2FootStandDomainRandomizationProvider())
+
+    def _init_task_domain_randomization(self) -> None:
+        pass
+
+    def _init_footstand_pose_targets(self) -> None:
+        self.feet_geom_names = list(_FOOTSTAND_FRONT_FEET)
+        self._joint_ids = list(_FOOTSTAND_REAR_LEG_IDS)
+        self._tar_ids = list(_FOOTSTAND_FRONT_LEG_IDS)
+        self.target_angle = np.asarray(_FOOTSTAND_FRONT_LEG_TARGET, dtype=get_global_dtype())
+
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        # Playground state:
+        # linvel(3) + gyro(3) + gravity(3) + diff(12) + dof_vel(12) + last_action(12) = 45.
+        # UniLab stacks the actor state for short-horizon dynamics; critic appends current privileged tail.
+        obs_dim = _FOOTSTAND_FRAME_OBS_DIM * self._obs_history_len
+        return {"obs": obs_dim, "critic": obs_dim + _FOOTSTAND_PRIVILEGED_TAIL_DIM}
+
+    @property
+    def _obs_history_len(self) -> int:
+        return max(_FOOTSTAND_MIN_OBS_HISTORY_LEN, int(self._cfg.obs_history_len))
+
+    def _build_playground_reset_randomization(
+        self, num_reset: int
+    ) -> ResetRandomizationPayload | None:
+        domain_rand = self._cfg.domain_rand
+        payload = ResetRandomizationPayload()
+
+        if domain_rand.randomize_floor_friction:
+            low, high = domain_rand.floor_friction_range
+            geom_friction = np.broadcast_to(
+                self._base_geom_friction, (num_reset, *self._base_geom_friction.shape)
+            ).copy()
+            geom_friction[:, self._floor_geom_id, 0] = np.random.uniform(
+                low, high, size=(num_reset,)
+            )
+            payload.geom_friction = geom_friction
+
+        body_mass = None
+        if domain_rand.randomize_link_mass:
+            low, high = domain_rand.link_mass_scale_range
+            scale = np.random.uniform(low, high, size=(num_reset, self._base_body_mass.size))
+            body_mass = self._base_body_mass.reshape(1, -1) * scale
+        if domain_rand.torso_added_mass_range is not None:
+            low, high = domain_rand.torso_added_mass_range
+            if body_mass is None:
+                body_mass = np.broadcast_to(
+                    self._base_body_mass, (num_reset, self._base_body_mass.size)
+                ).copy()
+            body_mass[:, self._base_body_id] += np.random.uniform(low, high, size=(num_reset,))
+        if body_mass is not None:
+            payload.body_mass = body_mass.astype(np.float64, copy=False)
+
+        if domain_rand.randomize_torso_com:
+            low, high = domain_rand.torso_com_offset_range
+            body_ipos = np.broadcast_to(
+                self._base_body_ipos, (num_reset, *self._base_body_ipos.shape)
+            ).copy()
+            body_ipos[:, self._base_body_id, :] += np.random.uniform(low, high, size=(num_reset, 3))
+            payload.body_ipos = body_ipos
+
+        if domain_rand.randomize_dof_armature:
+            low, high = domain_rand.dof_armature_scale_range
+            dof_armature = np.broadcast_to(
+                self._base_dof_armature, (num_reset, self._base_dof_armature.size)
+            ).copy()
+            dof_armature[:, -self._num_action :] *= np.random.uniform(
+                low, high, size=(num_reset, self._num_action)
+            )
+            payload.dof_armature = dof_armature
+
+        return None if payload.is_empty() else payload
+
+    def _init_reward_functions(self):
+        self._reward_fns: dict[str, Any] = {
+            "height": self._reward_height,
+            "contact": self._cost_contact,
+            "orientation": self._reward_orientation,
+            "oritentation": self._reward_orientation,
+            "action_rate": rewards.action_rate,
+            "termination": self._reward_termination,
+            "dof_pos_limits": self._cost_joint_pos_limits,
+            "torques": self._cost_torques,
+            "pose": self._cost_pose,
+            "penalty_contact": self._reward_penalty_contact,
+            "tar": self._reward_tar,
+            "rear_feet_contact": self._reward_rear_feet_contact,
+            "rear_leg_symmetry": self._cost_rear_leg_symmetry,
+            "front_leg_motion": self._cost_front_leg_motion,
+            "upright_stability": self._cost_upright_stability,
+            "knee_clearance": self._cost_knee_clearance,
+            "stay_still": self._cost_stay_still,
+            "energy": rewards.energy,
+            "dof_acc": rewards.dof_acc,
+        }
+
+    def _dof_to_ctrl_order(self, values: np.ndarray) -> np.ndarray:
+        return np.asarray(values[:, _GO2_DOF_TO_CTRL], dtype=get_global_dtype())
+
+    def _ctrl_to_dof_order(self, values: np.ndarray) -> np.ndarray:
+        return np.asarray(values[:, _GO2_DOF_TO_CTRL], dtype=get_global_dtype())
+
+    def _get_local_gravity(self) -> np.ndarray:
+        gravity = np.broadcast_to(_WORLD_GRAVITY, (self._num_envs, 3))
+        return np.asarray(
+            np_quat_apply_inverse(self._backend.get_base_quat(), gravity), dtype=get_global_dtype()
+        )
+
+    def _get_body_forward(self) -> np.ndarray:
+        forward = np.broadcast_to(_BODY_FORWARD, (self._num_envs, 3))
+        return np.asarray(
+            np_quat_apply(self._backend.get_base_quat(), forward), dtype=get_global_dtype()
+        )
+
+    def _reward_height(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        error = np.abs(self._z_des - self.torso_height)
+        return np.asarray(np.exp(-error / 0.1), dtype=get_global_dtype())
+
+    def _standing_mask(self) -> np.ndarray:
+        height_ready = self.torso_height >= self._z_des * _FOOTSTAND_STAND_HEIGHT_FRACTION
+        orientation_ready = self._orientation_score() >= _FOOTSTAND_STAND_ORIENTATION_THRESHOLD
+        return np.asarray(height_ready & orientation_ready, dtype=get_global_dtype())
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        clip_actions = float(getattr(self._cfg.control_config, "clip_actions", np.inf))
+        actions_np = np.asarray(actions, dtype=get_global_dtype())
+        if np.isfinite(clip_actions):
+            actions_np = np.clip(actions_np, -clip_actions, clip_actions)
+
+        state.info["last_actions"] = state.info.get("current_actions", np.zeros_like(actions_np))
+        state.info["current_actions"] = actions_np
+        exec_actions = (
+            state.info["last_actions"]
+            if self._cfg.control_config.simulate_action_latency
+            else actions_np
+        )
+        self._motor_targets += exec_actions * self._cfg.control_config.action_scale
+        self._clip_motor_targets()
+        return np.asarray(self._motor_targets, dtype=get_global_dtype())
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        linvel = self.get_local_linvel()
+        gyro = self.get_gyro()
+        upvector = self._backend.get_sensor_data("upvector")
+        gravity = self._get_local_gravity()
+        accelerometer = self._backend.get_sensor_data(self._cfg.sensor.accelerometer)
+        global_angvel = self._backend.get_sensor_data(self._cfg.sensor.global_angvel)
+        dof_pos = self.get_dof_pos()
+        dof_vel = self.get_dof_vel()
+        self.feet_force[:, :, :] = 0
+        for i in range(len(self._cfg.sensor.feet_force)):
+            self.feet_force[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_force[i])
+        for i in range(len(self._cfg.sensor.feet_pos)):
+            self.feet_pos[:, i, :] = self._backend.get_sensor_data(self._cfg.sensor.feet_pos[i])
+        self.torso_height = self._backend.get_sensor_data(self._cfg.sensor.global_pos)[:, -1]
+        contact_arrays = []
+        for name in self._cfg.sensor.ternamate_contact:
+            arr = self._backend.get_sensor_data(name)
+            contact_arrays.append(arr)
+        result = np.concatenate(contact_arrays, axis=1)
+
+        state.info["qacc"] = self._estimate_dof_acc(dof_vel)
+        state.info["torques"] = self._estimate_pd_torques(state.info, dof_pos, dof_vel)
+        orientation = self._orientation_score()
+        step_count = state.info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
+        grace_elapsed = step_count >= self._cfg.termination_grace_steps
+        terminated_z = upvector[:, 2] < -0.25
+        terminated_contact = np.any(result, axis=1)
+        terminated_low_height = (
+            self.torso_height < self._z_des * self._cfg.termination_height_fraction
+        )
+        terminated_bad_orientation = orientation < self._cfg.termination_orientation_threshold
+        terminated_pose = grace_elapsed & (terminated_low_height | terminated_bad_orientation)
+        energy = np.sum(np.abs(state.info["torques"]) * np.abs(dof_vel), axis=1)
+        terminated_energy = energy > self._cfg.energy_termination_threshold
+        terminated = np.logical_or.reduce(
+            (terminated_contact, terminated_z, terminated_energy, terminated_pose)
+        )
+        self._last_terminated = terminated.copy()
+        reward = self._compute_reward(state.info, linvel, gyro, dof_pos, dof_vel)
+        obs = self._compute_obs(
+            state.info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+            self.torso_height.reshape(-1, 1),
+            accelerometer,
+            global_angvel,
+        )
+        return state.replace(obs=obs, reward=reward, terminated=terminated)
+
+    def _compute_reward(
+        self,
+        info: dict,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray | None = None,
+    ) -> np.ndarray:
+        dtype = get_global_dtype()
+        reward = np.zeros((self._num_envs,), dtype=dtype)
+        cfg = self._reward_cfg
+        if dof_vel is None:
+            dof_vel = self.get_dof_vel()
+
+        ctx = RewardContext(
+            info=info,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
+            num_envs=self._num_envs,
+            default_angles=self.default_angles,
+            tracking_sigma=cfg.tracking_sigma,
+            base_height_target=cfg.base_height_target,
+            base_height=self._backend.get_base_pos()[:, 2],
+        )
+
+        step_count = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
+        should_log = self._enable_reward_log and (int(step_count[0]) % 4 == 0)
+        log = {} if should_log else info.get("log", {})
+
+        for name, scale in cfg.scales.items():
+            if scale == 0 or name not in self._reward_fns:
+                continue
+            rew = self._reward_fns[name](ctx)
+            weighted_rew = rew * scale
+            reward += weighted_rew
+            if should_log:
+                log[f"reward/{name}"] = float(np.mean(weighted_rew))
+
+        info["log"] = log
+        return np.clip(reward * self._cfg.ctrl_dt, 0.0, 10000.0)
+
+    def _compute_obs(
+        self,
+        info: dict,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        gravity: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        height: np.ndarray,
+        accelerometer: np.ndarray | None = None,
+        global_angvel: np.ndarray | None = None,
+        env_ids: np.ndarray | None = None,
+    ) -> dict[str, np.ndarray]:
+        noise_cfg = self._cfg.noise_config
+        diff = dof_pos - self.default_angles
+        noisy_linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+        last_actions = info.get("last_actions", np.zeros_like(diff))
+
+        obs = np.concatenate(
+            [noisy_linvel, noisy_gyro, noisy_gravity, noisy_diff, noisy_dof_vel, last_actions],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
+        obs = self._update_obs_history(obs, env_ids=env_ids)
+        torques = np.asarray(info.get("torques", np.zeros_like(dof_pos)), dtype=get_global_dtype())
+        if accelerometer is None:
+            accelerometer = np.zeros_like(gyro)
+        if global_angvel is None:
+            global_angvel = np.zeros_like(gyro)
+        critic = np.concatenate(
+            [
+                obs,
+                gyro,
+                accelerometer,
+                linvel,
+                global_angvel,
+                dof_pos,
+                dof_vel,
+                torques,
+                height,
+            ],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
+        return {"obs": obs, "critic": critic}
+
+    def _update_obs_history(
+        self, frame_obs: np.ndarray, *, env_ids: np.ndarray | None = None
+    ) -> np.ndarray:
+        frame_obs = np.asarray(frame_obs, dtype=get_global_dtype())
+        batch_size = int(frame_obs.shape[0])
+        history_len = self._obs_history_len
+        expected_shape = (self._num_envs, history_len, _FOOTSTAND_FRAME_OBS_DIM)
+        history = getattr(self, "_obs_history", None)
+        if history is None or history.shape != expected_shape:
+            if env_ids is None and batch_size == self._num_envs:
+                self._obs_history = np.zeros(expected_shape, dtype=get_global_dtype())
+                history = self._obs_history
+            elif env_ids is not None:
+                self._obs_history = np.zeros(expected_shape, dtype=get_global_dtype())
+                history = self._obs_history
+            else:
+                repeated = np.broadcast_to(
+                    frame_obs[:, None, :], (batch_size, history_len, frame_obs.shape[1])
+                ).copy()
+                return np.asarray(repeated.reshape(batch_size, -1), dtype=get_global_dtype())
+
+        assert history is not None
+        if env_ids is None:
+            if batch_size != self._num_envs:
+                repeated = np.broadcast_to(
+                    frame_obs[:, None, :], (batch_size, history_len, frame_obs.shape[1])
+                ).copy()
+                return np.asarray(repeated.reshape(batch_size, -1), dtype=get_global_dtype())
+            history[:, :-1] = history[:, 1:]
+            history[:, -1] = frame_obs
+            selected_history = history
+        else:
+            env_ids = np.asarray(env_ids, dtype=np.int32)
+            selected_history = np.broadcast_to(
+                frame_obs[:, None, :], (batch_size, history_len, frame_obs.shape[1])
+            ).copy()
+            history[env_ids] = selected_history
+
+        return np.asarray(selected_history.reshape(batch_size, -1), dtype=get_global_dtype())
+
+    def _init_soft_joint_limits(self) -> None:
+        joint_range = self._backend.get_joint_range()
+        if joint_range is None:
+            self._soft_lowers = np.full((self._num_action,), -np.inf, dtype=np.float32)
+            self._soft_uppers = np.full((self._num_action,), np.inf, dtype=np.float32)
+            return
+
+        joint_range = np.asarray(joint_range, dtype=np.float32)
+        centers = (joint_range[:, 0] + joint_range[:, 1]) / 2.0
+        widths = joint_range[:, 1] - joint_range[:, 0]
+        factor = self._cfg.soft_joint_pos_limit_factor
+        self._soft_lowers = centers - 0.5 * widths * factor
+        self._soft_uppers = centers + 0.5 * widths * factor
+
+    def _init_motor_target_limits(self) -> None:
+        joint_range = self._backend.get_joint_range()
+        if joint_range is None:
+            self._target_lowers = np.full((self._num_action,), -np.inf, dtype=get_global_dtype())
+            self._target_uppers = np.full((self._num_action,), np.inf, dtype=get_global_dtype())
+            return
+
+        joint_range = np.asarray(joint_range, dtype=get_global_dtype())
+        lowers = joint_range[:, 0]
+        uppers = joint_range[:, 1]
+        if lowers.size == _GO2_DOF_TO_CTRL.size:
+            lowers = self._dof_to_ctrl_order(lowers.reshape(1, -1))[0]
+            uppers = self._dof_to_ctrl_order(uppers.reshape(1, -1))[0]
+        self._target_lowers = np.asarray(lowers, dtype=get_global_dtype())
+        self._target_uppers = np.asarray(uppers, dtype=get_global_dtype())
+
+    def _clip_motor_targets(self) -> None:
+        lowers = getattr(self, "_target_lowers", None)
+        uppers = getattr(self, "_target_uppers", None)
+        if lowers is None or uppers is None:
+            return
+        np.clip(self._motor_targets, lowers, uppers, out=self._motor_targets)
+
+    def _reward_termination(self, ctx: RewardContext) -> np.ndarray:
+        return self._last_terminated.astype(get_global_dtype())
+
+    def _cost_joint_pos_limits(self, ctx: RewardContext) -> np.ndarray:
+        out_of_limits = -np.clip(ctx.dof_pos - self._soft_lowers, None, 0.0)
+        out_of_limits += np.clip(ctx.dof_pos - self._soft_uppers, 0.0, None)
+        return cast(np.ndarray, np.sum(out_of_limits, axis=1))
+
+    def _cost_stay_still(self, ctx: RewardContext) -> np.ndarray:
+        linvel = self._backend.get_base_lin_vel()
+        angvel = self._backend.get_base_ang_vel()
+        return cast(np.ndarray, np.sum(np.square(linvel[:, :2]), axis=1) + np.square(angvel[:, 2]))
+
+    def _cost_torques(self, ctx: RewardContext) -> np.ndarray:
+        torques = np.asarray(ctx.info.get("torques", np.zeros_like(ctx.dof_pos)))
+        return cast(np.ndarray, np.sum(np.square(torques), axis=1))
+
+    def _estimate_dof_acc(self, dof_vel: np.ndarray) -> np.ndarray:
+        qacc = np.asarray((dof_vel - self._last_dof_vel_for_acc) / self._cfg.ctrl_dt)
+        self._last_dof_vel_for_acc = np.asarray(dof_vel, dtype=np.float32).copy()
+        return np.asarray(qacc, dtype=get_global_dtype())
+
+    def _estimate_pd_torques(
+        self, info: dict, dof_pos: np.ndarray, dof_vel: np.ndarray
+    ) -> np.ndarray:
+        del info
+        targets = self._ctrl_to_dof_order(self._motor_targets)
+        torques = self._cfg.control_config.Kp * (targets - dof_pos)
+        torques -= self._cfg.control_config.Kd * dof_vel
+        return np.asarray(torques, dtype=get_global_dtype())
+
+    def _reward_orientation(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        return self._orientation_score()
+
+    def _orientation_score(self) -> np.ndarray:
+        forward = self._get_body_forward()
+        cos_dist = forward @ self._desired_forward_vec
+        normalized = 0.5 * cos_dist + 0.5
+        return np.asarray(np.square(normalized), dtype=get_global_dtype())
+
+    def _cost_contact(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        feet_contact = self.feet_force[:, self.feet_geom_names, 0] > _FOOTSTAND_CONTACT_THRESHOLD
+        return np.asarray(np.any(feet_contact, axis=1), dtype=get_global_dtype())
+
+    def _reward_rear_feet_contact(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        rear_contact = self.feet_force[:, _FOOTSTAND_REAR_FEET, 0] > _FOOTSTAND_CONTACT_THRESHOLD
+        return np.asarray(np.mean(rear_contact, axis=1), dtype=get_global_dtype())
+
+    def _cost_rear_leg_symmetry(self, ctx: RewardContext) -> np.ndarray:
+        rear_left = ctx.dof_pos[:, _FOOTSTAND_REAR_LEFT_LEG_IDS]
+        rear_right = ctx.dof_pos[:, _FOOTSTAND_REAR_RIGHT_LEG_IDS]
+        mirrored_right = rear_right * _FOOTSTAND_REAR_MIRROR_SIGNS
+        cost = np.mean(np.square(rear_left - mirrored_right), axis=1)
+        rising_mask = 1.0 - self._standing_mask()
+        return np.asarray(cost * rising_mask, dtype=get_global_dtype())
+
+    def _cost_front_leg_motion(self, ctx: RewardContext) -> np.ndarray:
+        assert ctx.dof_vel is not None
+        front_leg_vel = ctx.dof_vel[:, _FOOTSTAND_FRONT_LEG_IDS]
+        cost = np.mean(np.square(front_leg_vel), axis=1)
+        return np.asarray(cost * self._standing_mask(), dtype=get_global_dtype())
+
+    def _cost_upright_stability(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        linvel = self._backend.get_base_lin_vel()
+        angvel = self._backend.get_base_ang_vel()
+        cost = np.sum(np.square(linvel), axis=1) + 0.25 * np.sum(np.square(angvel), axis=1)
+        return np.asarray(cost * self._standing_mask(), dtype=get_global_dtype())
+
+    def _cost_knee_clearance(self, ctx: RewardContext) -> np.ndarray:
+        del ctx
+        target = max(float(self._reward_cfg.knee_height_target), 1e-6)
+        knee_height = self._backend.get_body_pos_w(self._knee_body_ids)[:, :, 2]
+        clearance_error = np.clip(target - knee_height, 0.0, None) / target
+        return np.asarray(np.mean(np.square(clearance_error), axis=1), dtype=get_global_dtype())

--- a/src/unilab/envs/locomotion/go2/handstand.py
+++ b/src/unilab/envs/locomotion/go2/handstand.py
@@ -40,6 +40,7 @@ class RewardConfig:
     tracking_sigma: float
     base_height_target: float
     target_foot_height: float = 0.1
+    knee_height_target: float = 0.08
 
 
 @dataclass
@@ -136,6 +137,7 @@ class Go2HandStandTask(Go2BaseEnv):
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
+            add_body_sensors=bool(getattr(cfg, "add_body_sensors", False)),
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
             motrix_max_iterations=cfg.motrix_max_iterations,
         )
@@ -143,7 +145,7 @@ class Go2HandStandTask(Go2BaseEnv):
         self._enable_reward_log = True
         self._reward_cfg = cfg.reward_config
         self._init_reward_functions()
-        self._init_domain_randomization(Go2HandStandDomainRandomizationProvider())
+        self._init_task_domain_randomization()
         self.phase = np.zeros((num_envs,), dtype=np.float32)
         self.feet_phase = np.zeros((num_envs, len(cfg.sensor.feet_force)), dtype=np.float32)
         # Initialize rear leg (RL, RR) phases with alternating values for gait
@@ -162,6 +164,9 @@ class Go2HandStandTask(Go2BaseEnv):
         self._joint_ids = [0, 1, 2, 3, 4, 5, 6, 9]
         self._tar_ids = [6, 7, 8, 9, 10, 11]
         self.target_angle = np.array([0, 1.82, -1.16, 0.0, 1.82, -1.16])
+
+    def _init_task_domain_randomization(self) -> None:
+        self._init_domain_randomization(Go2HandStandDomainRandomizationProvider())
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -485,6 +485,31 @@ def test_ppo_go2_num_envs():
     assert cfg.algo.max_iterations == 151
 
 
+def test_ppo_go2_footstand_uses_teacher_linvel_task():
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        cfg = compose("config", overrides=["task=go2_footstand/mujoco"])
+
+    assert cfg.training.task_name == "Go2FootStand"
+    assert cfg.training.sim_backend == "mujoco"
+    assert cfg.env.add_body_sensors is True
+    assert cfg.env.obs_history_len == 15
+    assert cfg.env.energy_termination_threshold == pytest.approx(200.0)
+    assert cfg.reward.scales.energy == pytest.approx(-0.003)
+    assert cfg.reward.scales.dof_acc == pytest.approx(-2.5e-7)
+    assert cfg.reward.scales.rear_leg_symmetry == pytest.approx(-0.2)
+    assert cfg.reward.scales.knee_clearance == pytest.approx(-0.5)
+    assert cfg.reward.knee_height_target == pytest.approx(0.08)
+    assert cfg.env.domain_rand.randomize_floor_friction is True
+    assert cfg.env.domain_rand.randomize_link_mass is True
+    assert cfg.env.domain_rand.randomize_torso_com is True
+    assert cfg.env.domain_rand.randomize_dof_armature is True
+    assert cfg.env.domain_rand.randomize_reset_joint_qpos is True
+
+
 def test_ppo_g1_motion_tracking():
     from hydra import compose, initialize_config_dir
     from hydra.core.global_hydra import GlobalHydra

--- a/tests/envs/locomotion/test_go2_footstand.py
+++ b/tests/envs/locomotion/test_go2_footstand.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from unilab.base import registry
+from unilab.base.np_env import NpEnvState
+from unilab.base.registry import ensure_registries
+from unilab.dr import ResetRandomizationPayload
+from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.envs.locomotion.go2.footstand import (
+    FootstandControlConfig,
+    FootstandSensor,
+    Go2FootStandCfg,
+    Go2FootStandDomainRandConfig,
+    Go2FootStandDomainRandomizationProvider,
+    Go2FootStandTask,
+)
+from unilab.envs.locomotion.go2.handstand import RewardConfig
+
+
+def test_go2_footstand_registers_mujoco_only() -> None:
+    ensure_registries()
+
+    meta = registry.list_registered_envs()["Go2FootStand"]
+
+    assert meta["available_backends"] == ["mujoco"]
+
+
+class _OrientationBackend:
+    pass
+
+
+class _JointRangeBackend:
+    def get_joint_range(self) -> np.ndarray:
+        return np.array([[-2.0, 2.0], [0.0, 2.0]], dtype=np.float32)
+
+
+class _BaseMotionBackend:
+    def get_base_lin_vel(self) -> np.ndarray:
+        return np.array([[1.0, 2.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32)
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        return np.array([[0.0, 0.0, 2.0], [0.0, 2.0, 0.0]], dtype=np.float32)
+
+
+class _KneeHeightBackend:
+    def __init__(self, knee_height: np.ndarray) -> None:
+        self._knee_height = knee_height
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        assert body_ids.shape == (4,)
+        out = np.zeros((*self._knee_height.shape, 3), dtype=np.float32)
+        out[:, :, 2] = self._knee_height
+        return out
+
+
+def test_go2_footstand_cfg_uses_rear_body_contact_termination() -> None:
+    cfg = Go2FootStandCfg()
+
+    assert isinstance(cfg.sensor, FootstandSensor)
+    assert "base1_contact" not in cfg.sensor.ternamate_contact
+    assert "RL_calf_contact1" in cfg.sensor.ternamate_contact
+    assert "RR_calf_contact2" in cfg.sensor.ternamate_contact
+    assert "FL_calf_contact1" in cfg.sensor.penalty_contact
+    assert "FR_calf_contact2" in cfg.sensor.penalty_contact
+    assert cfg.noise_config.level == pytest.approx(1.0)
+    assert cfg.noise_config.scale_joint_angle == pytest.approx(0.01)
+    assert cfg.noise_config.scale_joint_vel == pytest.approx(1.5)
+    assert cfg.add_body_sensors is True
+    assert isinstance(cfg.control_config, FootstandControlConfig)
+    assert cfg.control_config.action_scale == pytest.approx(0.3)
+    assert cfg.control_config.clip_actions == pytest.approx(1.0)
+    assert isinstance(cfg.domain_rand, Go2FootStandDomainRandConfig)
+    assert cfg.domain_rand.randomize_kp is False
+    assert cfg.domain_rand.randomize_floor_friction is True
+    assert cfg.obs_history_len == 15
+    assert cfg.soft_joint_pos_limit_factor == pytest.approx(0.9)
+    assert cfg.energy_termination_threshold == np.inf
+    assert cfg.termination_grace_steps == 100
+    assert cfg.termination_height_fraction == pytest.approx(0.8)
+    assert cfg.termination_orientation_threshold == pytest.approx(0.2)
+    assert cfg.max_episode_seconds == pytest.approx(10.0)
+
+
+def test_go2_footstand_orientation_flips_handstand_target() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._backend = _OrientationBackend()
+    env._desired_forward_vec = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+    env._get_body_forward = lambda: np.array(  # type: ignore[method-assign]
+        [[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]], dtype=np.float32
+    )
+
+    reward = env._reward_orientation(
+        RewardContext(
+            info={},
+            linvel=np.zeros((2, 3), dtype=np.float32),
+            gyro=np.zeros((2, 3), dtype=np.float32),
+            dof_pos=np.zeros((2, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(reward, np.array([1.0, 0.0], dtype=np.float32))
+
+
+def test_go2_footstand_soft_joint_limits_use_playground_factor() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg()
+    cfg.soft_joint_pos_limit_factor = 0.5
+    env._cfg = cfg
+    env._num_action = 2
+    env._backend = _JointRangeBackend()
+
+    env._init_soft_joint_limits()
+
+    np.testing.assert_allclose(env._soft_lowers, np.array([-1.0, 0.5], dtype=np.float32))
+    np.testing.assert_allclose(env._soft_uppers, np.array([1.0, 1.5], dtype=np.float32))
+
+
+def test_go2_footstand_reward_functions_include_stability_terms() -> None:
+    env = object.__new__(Go2FootStandTask)
+
+    env._init_reward_functions()
+
+    assert "tar" in env._reward_fns
+    assert "penalty_contact" in env._reward_fns
+    assert "termination" in env._reward_fns
+    assert "rear_feet_contact" in env._reward_fns
+    assert "rear_leg_symmetry" in env._reward_fns
+    assert "front_leg_motion" in env._reward_fns
+    assert "upright_stability" in env._reward_fns
+    assert "knee_clearance" in env._reward_fns
+
+
+def test_go2_footstand_pose_targets_front_legs_and_supports_rear() -> None:
+    env = object.__new__(Go2FootStandTask)
+
+    env._init_footstand_pose_targets()
+
+    assert env.feet_geom_names == [0, 1]
+    assert env._joint_ids == [6, 7, 8, 9, 10, 11]
+    assert env._tar_ids == [0, 1, 2, 3, 4, 5]
+    np.testing.assert_allclose(
+        env.target_angle, np.array([0.0, 1.82, -1.16, 0.0, 1.82, -1.16], dtype=np.float32)
+    )
+
+
+def test_go2_footstand_obs_matches_playground_state_layout() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg()
+    cfg.noise_config.level = 0.0
+    env._cfg = cfg
+    env._num_envs = 1
+    env.default_angles = np.arange(12, dtype=np.float32).reshape(1, 12)
+    env._obs_history = np.zeros((1, cfg.obs_history_len, 45), dtype=np.float32)
+
+    linvel = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+    gyro = np.array([[4.0, 5.0, 6.0]], dtype=np.float32)
+    gravity = np.array([[0.0, 0.0, -1.0]], dtype=np.float32)
+    dof_pos = env.default_angles + 0.5
+    dof_vel = np.arange(12, dtype=np.float32).reshape(1, 12) + 10.0
+    last_actions = np.full((1, 12), 0.25, dtype=np.float32)
+    current_actions = np.full((1, 12), 0.75, dtype=np.float32)
+    accelerometer = np.array([[7.0, 8.0, 9.0]], dtype=np.float32)
+    global_angvel = np.array([[10.0, 11.0, 12.0]], dtype=np.float32)
+    torques = np.arange(12, dtype=np.float32).reshape(1, 12) + 20.0
+
+    obs = env._compute_obs(
+        {"last_actions": last_actions, "current_actions": current_actions, "torques": torques},
+        linvel,
+        gyro,
+        gravity,
+        dof_pos,
+        dof_vel,
+        np.array([[0.53]], dtype=np.float32),
+        accelerometer,
+        global_angvel,
+    )
+
+    current_frame = obs["obs"][:, -45:]
+    assert obs["obs"].shape == (1, 675)
+    assert obs["critic"].shape == (1, 724)
+    np.testing.assert_allclose(obs["obs"][:, : 14 * 45], 0.0)
+    np.testing.assert_allclose(current_frame[:, 0:3], linvel)
+    np.testing.assert_allclose(current_frame[:, 3:6], gyro)
+    np.testing.assert_allclose(current_frame[:, 6:9], gravity)
+    np.testing.assert_allclose(current_frame[:, -12:], last_actions)
+
+
+def test_go2_footstand_reset_obs_fills_history_with_current_frame() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg()
+    cfg.noise_config.level = 0.0
+    env._cfg = cfg
+    env._num_envs = 2
+    env.default_angles = np.zeros((1, 12), dtype=np.float32)
+    env._obs_history = np.zeros((2, cfg.obs_history_len, 45), dtype=np.float32)
+
+    linvel = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+    gyro = np.array([[0.0, 2.0, 0.0]], dtype=np.float32)
+    gravity = np.array([[0.0, 0.0, -1.0]], dtype=np.float32)
+    dof_pos = np.ones((1, 12), dtype=np.float32)
+    dof_vel = np.full((1, 12), 3.0, dtype=np.float32)
+
+    obs = env._compute_obs(
+        {"last_actions": np.full((1, 12), 0.5, dtype=np.float32)},
+        linvel,
+        gyro,
+        gravity,
+        dof_pos,
+        dof_vel,
+        np.array([[0.53]], dtype=np.float32),
+        np.zeros((1, 3), dtype=np.float32),
+        np.zeros((1, 3), dtype=np.float32),
+        env_ids=np.array([1], dtype=np.int32),
+    )
+
+    frames = obs["obs"].reshape(1, cfg.obs_history_len, 45)
+    np.testing.assert_allclose(frames[:, 0, :], frames[:, -1, :])
+    np.testing.assert_allclose(env._obs_history[0], 0.0)
+    np.testing.assert_allclose(env._obs_history[1], frames[0])
+
+
+class _EnergyTerminationBackend:
+    def __init__(self) -> None:
+        self._sensors = {
+            "local_linvel": np.zeros((1, 3), dtype=np.float32),
+            "gyro": np.zeros((1, 3), dtype=np.float32),
+            "upvector": np.array([[0.0, 0.0, 1.0]], dtype=np.float32),
+            "accelerometer": np.zeros((1, 3), dtype=np.float32),
+            "global_angvel": np.zeros((1, 3), dtype=np.float32),
+            "global_position": np.array([[0.0, 0.0, 0.53]], dtype=np.float32),
+        }
+        for name in FootstandSensor.feet_force:
+            self._sensors[name] = np.zeros((1, 1), dtype=np.float32)
+        for name in FootstandSensor.feet_pos:
+            self._sensors[name] = np.zeros((1, 3), dtype=np.float32)
+        for name in FootstandSensor.ternamate_contact:
+            self._sensors[name] = np.zeros((1, 1), dtype=np.float32)
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        return self._sensors[name]
+
+    def get_dof_pos(self) -> np.ndarray:
+        return np.zeros((1, 12), dtype=np.float32)
+
+    def get_dof_vel(self) -> np.ndarray:
+        return np.full((1, 12), 10.0, dtype=np.float32)
+
+    def get_base_quat(self) -> np.ndarray:
+        return np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+
+    def get_base_pos(self) -> np.ndarray:
+        return np.array([[0.0, 0.0, 0.53]], dtype=np.float32)
+
+
+def test_go2_footstand_energy_threshold_terminates() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg(
+        reward_config=RewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
+    )
+    cfg.noise_config.level = 0.0
+    cfg.energy_termination_threshold = 1.0
+    env._cfg = cfg
+    env._reward_cfg = cfg.reward_config
+    env._backend = _EnergyTerminationBackend()
+    env._num_envs = 1
+    env._num_action = 12
+    env._z_des = 0.53
+    env._desired_forward_vec = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+    env.default_angles = np.zeros((1, 12), dtype=np.float32)
+    env.feet_force = np.zeros((1, 4, 1), dtype=np.float32)
+    env.feet_pos = np.zeros((1, 4, 3), dtype=np.float32)
+    env.torso_height = np.zeros((1,), dtype=np.float32)
+    env._last_dof_vel_for_acc = np.zeros((1, 12), dtype=np.float32)
+    env._motor_targets = np.zeros((1, 12), dtype=np.float32)
+    env._last_terminated = np.zeros((1,), dtype=bool)
+    env._enable_reward_log = False
+
+    state = NpEnvState(
+        obs={},
+        reward=np.zeros((1,), dtype=np.float32),
+        terminated=np.zeros((1,), dtype=bool),
+        truncated=np.zeros((1,), dtype=bool),
+        info={
+            "current_actions": np.zeros((1, 12), dtype=np.float32),
+            "last_actions": np.zeros((1, 12), dtype=np.float32),
+        },
+    )
+
+    updated = env.update_state(state)
+
+    assert updated.terminated[0]
+
+
+def test_go2_footstand_action_updates_incremental_motor_targets() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._cfg = Go2FootStandCfg()
+    env._motor_targets = np.zeros((1, 12), dtype=np.float32)
+    state = NpEnvState(
+        obs={},
+        reward=np.zeros((1,), dtype=np.float32),
+        terminated=np.zeros((1,), dtype=bool),
+        truncated=np.zeros((1,), dtype=bool),
+        info={"current_actions": np.full((1, 12), 0.1, dtype=np.float32)},
+    )
+
+    ctrl = env.apply_action(np.full((1, 12), 0.5, dtype=np.float32), state)
+
+    np.testing.assert_allclose(ctrl, np.full((1, 12), 0.15, dtype=np.float32))
+    np.testing.assert_allclose(state.info["last_actions"], np.full((1, 12), 0.1, dtype=np.float32))
+    np.testing.assert_allclose(
+        state.info["current_actions"], np.full((1, 12), 0.5, dtype=np.float32)
+    )
+
+
+def test_go2_footstand_action_clips_policy_actions_and_motor_targets() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._cfg = Go2FootStandCfg()
+    env._motor_targets = np.zeros((1, 2), dtype=np.float32)
+    env._target_lowers = np.array([-0.2, -0.4], dtype=np.float32)
+    env._target_uppers = np.array([0.2, 0.4], dtype=np.float32)
+    state = NpEnvState(
+        obs={},
+        reward=np.zeros((1,), dtype=np.float32),
+        terminated=np.zeros((1,), dtype=bool),
+        truncated=np.zeros((1,), dtype=bool),
+        info={},
+    )
+
+    ctrl = env.apply_action(np.array([[10.0, -10.0]], dtype=np.float32), state)
+
+    np.testing.assert_allclose(
+        state.info["current_actions"], np.array([[1.0, -1.0]], dtype=np.float32)
+    )
+    np.testing.assert_allclose(ctrl, np.array([[0.2, -0.3]], dtype=np.float32))
+
+    ctrl = env.apply_action(np.array([[10.0, -10.0]], dtype=np.float32), state)
+
+    np.testing.assert_allclose(ctrl, np.array([[0.2, -0.4]], dtype=np.float32))
+
+
+def test_go2_footstand_playground_reset_randomization_payload_shapes() -> None:
+    np.random.seed(0)
+    env = object.__new__(Go2FootStandTask)
+    env._cfg = Go2FootStandCfg()
+    env._num_action = 12
+    env._floor_geom_id = 0
+    env._base_body_id = 1
+    env._base_geom_friction = np.ones((3, 3), dtype=np.float64)
+    env._base_body_mass = np.ones((4,), dtype=np.float64)
+    env._base_body_ipos = np.zeros((4, 3), dtype=np.float64)
+    env._base_dof_armature = np.ones((18,), dtype=np.float64)
+
+    payload = env._build_playground_reset_randomization(num_reset=2)
+
+    assert payload is not None
+    assert payload.geom_friction is not None and payload.geom_friction.shape == (2, 3, 3)
+    assert payload.body_mass is not None and payload.body_mass.shape == (2, 4)
+    assert payload.body_ipos is not None and payload.body_ipos.shape == (2, 4, 3)
+    assert payload.dof_armature is not None and payload.dof_armature.shape == (2, 18)
+    assert np.all((payload.geom_friction[:, 0, 0] >= 0.4) & (payload.geom_friction[:, 0, 0] <= 1.0))
+    np.testing.assert_allclose(payload.dof_armature[:, :6], 1.0)
+
+
+def test_go2_footstand_reset_randomization_merges_common_and_playground_terms() -> None:
+    base = ResetRandomizationPayload(
+        base_mass_delta=np.array([0.1], dtype=np.float64),
+        kp=np.ones((1, 12), dtype=np.float64),
+    )
+    playground = ResetRandomizationPayload(
+        body_mass=np.full((1, 4), 2.0, dtype=np.float64),
+        geom_friction=np.full((1, 3, 3), 0.7, dtype=np.float64),
+    )
+
+    merged = Go2FootStandDomainRandomizationProvider._merge_reset_randomization(base, playground)
+
+    assert merged is not None
+    np.testing.assert_allclose(merged.base_mass_delta, base.base_mass_delta)
+    np.testing.assert_allclose(merged.kp, base.kp)
+    np.testing.assert_allclose(merged.body_mass, playground.body_mass)
+    np.testing.assert_allclose(merged.geom_friction, playground.geom_friction)
+
+
+def test_go2_footstand_height_reward_matches_playground_shape() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._z_des = 0.53
+    env.torso_height = np.array([0.53, 0.33, 0.63], dtype=np.float32)
+
+    reward = env._reward_height(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=np.zeros((3, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(
+        reward, np.array([1.0, np.exp(-2.0), np.exp(-1.0)], dtype=np.float32), rtol=1e-6
+    )
+
+
+def test_go2_footstand_contact_cost_only_penalizes_front_feet() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env.feet_geom_names = [0, 1]
+    env.feet_force = np.zeros((3, 4, 1), dtype=np.float32)
+    env.feet_force[0, 0, 0] = 1.0
+    env.feet_force[1, 2, 0] = 1.0
+    env.feet_force[2, 3, 0] = 1.0
+
+    cost = env._cost_contact(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=np.zeros((3, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(cost, np.array([1.0, 0.0, 0.0], dtype=np.float32))
+
+
+def test_go2_footstand_rear_feet_contact_rewards_support_feet() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env.feet_force = np.zeros((3, 4, 1), dtype=np.float32)
+    env.feet_force[0, 2:4, 0] = 1.0
+    env.feet_force[1, 2, 0] = 1.0
+    env.feet_force[2, 0:2, 0] = 1.0
+
+    reward = env._reward_rear_feet_contact(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=np.zeros((3, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(reward, np.array([1.0, 0.5, 0.0], dtype=np.float32))
+
+
+def test_go2_footstand_rear_leg_symmetry_mirrors_hip_sign_only() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._standing_mask = lambda: np.array([0.0, 0.0, 1.0], dtype=np.float32)  # type: ignore[method-assign]
+    dof_pos = np.zeros((3, 12), dtype=np.float32)
+    dof_pos[0, 6:9] = np.array([0.2, 1.0, -1.5], dtype=np.float32)
+    dof_pos[0, 9:12] = np.array([-0.2, 1.0, -1.5], dtype=np.float32)
+    dof_pos[1, 6:9] = np.array([0.2, 1.0, -1.5], dtype=np.float32)
+    dof_pos[1, 9:12] = np.array([0.3, 1.0, -1.5], dtype=np.float32)
+    dof_pos[2, 6:9] = np.array([0.0, 1.2, -1.1], dtype=np.float32)
+    dof_pos[2, 9:12] = np.array([0.0, 0.9, -1.7], dtype=np.float32)
+
+    cost = env._cost_rear_leg_symmetry(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=dof_pos,
+        )
+    )
+
+    np.testing.assert_allclose(
+        cost,
+        np.array([0.0, 0.25 / 3.0, 0.0], dtype=np.float32),
+        rtol=1e-6,
+    )
+
+
+def test_go2_footstand_front_leg_motion_only_penalizes_standing_pose() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._z_des = 0.53
+    env.torso_height = np.array([0.53, 0.53, 0.2], dtype=np.float32)
+    env._orientation_score = lambda: np.array([1.0, 0.4, 1.0], dtype=np.float32)  # type: ignore[method-assign]
+    dof_vel = np.zeros((3, 12), dtype=np.float32)
+    dof_vel[:, 0:6] = 2.0
+
+    cost = env._cost_front_leg_motion(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=np.zeros((3, 12), dtype=np.float32),
+            dof_vel=dof_vel,
+        )
+    )
+
+    np.testing.assert_allclose(cost, np.array([4.0, 0.0, 0.0], dtype=np.float32))
+
+
+def test_go2_footstand_upright_stability_is_standing_gated() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._backend = _BaseMotionBackend()
+    env._z_des = 0.53
+    env.torso_height = np.array([0.53, 0.53], dtype=np.float32)
+    env._orientation_score = lambda: np.array([1.0, 0.4], dtype=np.float32)  # type: ignore[method-assign]
+
+    cost = env._cost_upright_stability(
+        RewardContext(
+            info={},
+            linvel=np.zeros((2, 3), dtype=np.float32),
+            gyro=np.zeros((2, 3), dtype=np.float32),
+            dof_pos=np.zeros((2, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(cost, np.array([6.0, 0.0], dtype=np.float32))
+
+
+def test_go2_footstand_knee_clearance_penalizes_low_knees() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._reward_cfg = RewardConfig(
+        scales={},
+        tracking_sigma=0.25,
+        base_height_target=0.3,
+        knee_height_target=0.1,
+    )
+    env._knee_body_ids = np.array([1, 2, 3, 4], dtype=np.int32)
+    env._backend = _KneeHeightBackend(
+        np.array(
+            [
+                [0.1, 0.12, 0.2, 0.3],
+                [0.05, 0.05, 0.05, 0.05],
+                [0.0, 0.05, 0.1, 0.15],
+            ],
+            dtype=np.float32,
+        )
+    )
+
+    cost = env._cost_knee_clearance(
+        RewardContext(
+            info={},
+            linvel=np.zeros((3, 3), dtype=np.float32),
+            gyro=np.zeros((3, 3), dtype=np.float32),
+            dof_pos=np.zeros((3, 12), dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(cost, np.array([0.0, 0.25, 0.3125], dtype=np.float32))
+
+
+def test_go2_footstand_post_grace_low_height_terminates() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg(
+        reward_config=RewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
+    )
+    cfg.noise_config.level = 0.0
+    cfg.termination_grace_steps = 10
+    env._cfg = cfg
+    env._reward_cfg = cfg.reward_config
+    env._backend = _EnergyTerminationBackend()
+    env._backend._sensors["global_position"] = np.array([[0.0, 0.0, 0.2]], dtype=np.float32)
+    env._num_envs = 1
+    env._num_action = 12
+    env._z_des = 0.53
+    env.default_angles = np.zeros((1, 12), dtype=np.float32)
+    env.feet_force = np.zeros((1, 4, 1), dtype=np.float32)
+    env.feet_pos = np.zeros((1, 4, 3), dtype=np.float32)
+    env.torso_height = np.zeros((1,), dtype=np.float32)
+    env._last_dof_vel_for_acc = np.zeros((1, 12), dtype=np.float32)
+    env._motor_targets = np.zeros((1, 12), dtype=np.float32)
+    env._last_terminated = np.zeros((1,), dtype=bool)
+    env._enable_reward_log = False
+    env._orientation_score = lambda: np.array([1.0], dtype=np.float32)  # type: ignore[method-assign]
+    state = NpEnvState(
+        obs={},
+        reward=np.zeros((1,), dtype=np.float32),
+        terminated=np.zeros((1,), dtype=bool),
+        truncated=np.zeros((1,), dtype=bool),
+        info={
+            "steps": np.array([10], dtype=np.uint32),
+            "current_actions": np.zeros((1, 12), dtype=np.float32),
+            "last_actions": np.zeros((1, 12), dtype=np.float32),
+        },
+    )
+
+    updated = env.update_state(state)
+
+    assert updated.terminated[0]
+
+
+def test_go2_footstand_returned_termination_does_not_alias_reset_bookkeeping() -> None:
+    env = object.__new__(Go2FootStandTask)
+    cfg = Go2FootStandCfg(
+        reward_config=RewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
+    )
+    cfg.noise_config.level = 0.0
+    cfg.termination_grace_steps = 10
+    env._cfg = cfg
+    env._reward_cfg = cfg.reward_config
+    env._backend = _EnergyTerminationBackend()
+    env._backend._sensors["global_position"] = np.array([[0.0, 0.0, 0.2]], dtype=np.float32)
+    env._num_envs = 1
+    env._num_action = 12
+    env._z_des = 0.53
+    env.default_angles = np.zeros((1, 12), dtype=np.float32)
+    env.feet_force = np.zeros((1, 4, 1), dtype=np.float32)
+    env.feet_pos = np.zeros((1, 4, 3), dtype=np.float32)
+    env.torso_height = np.zeros((1,), dtype=np.float32)
+    env._last_dof_vel_for_acc = np.zeros((1, 12), dtype=np.float32)
+    env._motor_targets = np.zeros((1, 12), dtype=np.float32)
+    env._last_terminated = np.zeros((1,), dtype=bool)
+    env._enable_reward_log = False
+    env._orientation_score = lambda: np.array([1.0], dtype=np.float32)  # type: ignore[method-assign]
+    state = NpEnvState(
+        obs={},
+        reward=np.zeros((1,), dtype=np.float32),
+        terminated=np.zeros((1,), dtype=bool),
+        truncated=np.zeros((1,), dtype=bool),
+        info={
+            "steps": np.array([10], dtype=np.uint32),
+            "current_actions": np.zeros((1, 12), dtype=np.float32),
+            "last_actions": np.zeros((1, 12), dtype=np.float32),
+        },
+    )
+
+    updated = env.update_state(state)
+    env._last_terminated[0] = False
+
+    assert updated.terminated[0]
+
+
+def test_go2_footstand_joint_limit_cost_uses_soft_limits() -> None:
+    env = object.__new__(Go2FootStandTask)
+    env._soft_lowers = np.array([-1.0, -1.0], dtype=np.float32)
+    env._soft_uppers = np.array([1.0, 1.0], dtype=np.float32)
+
+    cost = env._cost_joint_pos_limits(
+        RewardContext(
+            info={},
+            linvel=np.zeros((2, 3), dtype=np.float32),
+            gyro=np.zeros((2, 3), dtype=np.float32),
+            dof_pos=np.array([[0.0, 1.5], [-1.25, 0.0]], dtype=np.float32),
+        )
+    )
+
+    np.testing.assert_allclose(cost, np.array([0.5, 0.25], dtype=np.float32))
+
+
+def test_go2_footstand_reset_critic_height_uses_backend_sensor() -> None:
+    pytest.importorskip("mujoco", reason="mujoco not installed")
+    try:
+        from mujoco.batch_env import BatchEnvPool as _  # noqa: F401
+    except Exception:
+        pytest.skip("mujoco.batch_env not available")
+
+    ensure_registries()
+    env = registry.make(
+        "Go2FootStand",
+        sim_backend="mujoco",
+        num_envs=1,
+        env_cfg_override={
+            "reward_config": RewardConfig(
+                scales={"height": 1.0},
+                tracking_sigma=0.25,
+                base_height_target=0.3,
+            )
+        },
+    )
+    try:
+        state = env.init_state()
+        assert state.obs["critic"][0, -1] > 0.1
+    finally:
+        env.close()


### PR DESCRIPTION
## Summary

- Add the MuJoCo PPO owner for `go2_footstand`, including the `Go2FootStand` env, config, registration, and Go2 sensor metadata needed by the task.
- Port only the teacher-side task path with privileged linear-velocity observation; student distillation and fine-tuning entrypoints are documented as workflow context but are not added in this PR.
- Add focused config/env tests and update the user docs plus backend support matrix for the new task.

## Linked Work

- Issue: N/A
- Milestone: N/A

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
env UV_CACHE_DIR=/tmp/uv-cache VIRTUAL_ENV= PYTHONPATH=/home/xander/Code/Others/UniLab-Copy/src:/home/xander/Code/Others/UniLab-Copy make test-all
```

Result: `1057 passed, 15 skipped, 254 deselected, 64 warnings`.

Notes:

- `make test-all` includes `make check` and `uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing`.
- Pyright reported the existing optional MLX import warning for `mlx.core`; no errors were reported.

## Impact

- Backend impact: `mujoco`
- Platform impact: Linux for validation; task is MuJoCo-only in this PR
- Training effect expected: yes, adds a new Go2 FootStand PPO teacher task/config

## Artifacts

- W&B: N/A
- benchmark result: N/A
- video / screenshot: N/A
- ONNX / checkpoint: N/A

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [ ] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up:

- Student distillation and teacher-regularized student fine-tuning are intentionally left out of this PR.
