### PR TITLE
chore: upgrade motrixsim core

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/3-backends/2-motrix.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/2-motrix.md
@@ -1,7 +1,7 @@
 # Motrix Backend
 
 Motrix is an optional backend installed through the `motrix` extra. The pinned
-package is `motrixsim-core==0.8.1.dev104632` in `pyproject.toml`, and the adapter
+package is `motrixsim-core==0.8.1.dev104665` in `pyproject.toml`, and the adapter
 lives under `src/unilab/base/backend/motrix/`.
 
 ## Setup

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -43,7 +43,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.8.1.dev104632"]
+motrix = ["motrixsim-core==0.8.1.dev104665"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ unilab-export-scene = "unilab.tools.export_scene:main"
 unilab-render-teaser = "unilab.tools.render_teaser:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.8.1.dev104632"]
+motrix = ["motrixsim-core==0.8.1.dev104665"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2188,7 +2188,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.8.1.dev104632"
+version = "0.8.1.dev104665"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2196,18 +2196,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e988e74fbb92c2fcd2df7375ebfadceab7e720f2d5eabca67a4e02ae28ba4197" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94b994b2dbb7d7ad7e25f30d803af241fde8fdbdfe8004e88c7c89779862af82" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-win_amd64.whl", hash = "sha256:0f804a1fd051fca5b1cca96bbccd50215387ca56be714b8f45bb98fe3562659e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5126de3f53351eba13ee59b59d3156a9d5c744001e3f9b49bbc210e09b550e8" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0dadaf513fc369ca5d80da30293298ccb0d41faf9b5aa351787fae8c90fe2a" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-win_amd64.whl", hash = "sha256:b86dd41c12b55604b5a2f42fd25a32c7fc9fe2a7b2ea5fce6a21dc93a9fdab62" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12a91cdbdf21fda6f9244ce7470ef812261925d8a3d1535ed89e609d691e860d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:203bf623c191e118e17cf86896b8ed9604986d7dd6cb54dae4c56bbe6f975ae2" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-win_amd64.whl", hash = "sha256:92539572bd539e6d9fb0352afbfce1f888d3b6354b479b876ca2d55426fadf25" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5b86e661ca4cd3b6ed03809546ea76f2b35934776e0e62e2565f3df562654114" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da9898a00b41a0380b6df3b9d3e4a26836067a0dc76a9676fc5d726c81fad4ac" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-win_amd64.whl", hash = "sha256:2b37acfc4f95cb3566cfa7302b6dbd22c3f12303b315385cb929305f79880eca" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8edf31dae9034b7bbefe212cd6da6aea60cea20870ef01873ee7dd9067db2cc" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe10e09491701cd49791e9950099cc168aa17a75eaeb9738bffda5137e7dfa0e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-win_amd64.whl", hash = "sha256:332440fe47cda9d3d97f1772510b004f28631230de2d9b1d7a1525ae8c1f9684" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25b8d068df0fa10e861ca7d23f96569bed5bec63d9b4207358177eb3404e470c" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:680dc47a8f3ec03610bc42b7c7c822b3813ea807db759710802745f1427502c2" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-win_amd64.whl", hash = "sha256:9cafd333d86aa457a51873488959191be8ea7b89e2ee6561ad2e07f3095a3080" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3352d692b98f5fc9a6ae231f9c5ab258701ce3ecd7b4423e9897e28c6ee44d6b" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a24e88243786bce09834ea7d3b9104b0d0f6801eca5e81304cc9b52fc81d0882" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-win_amd64.whl", hash = "sha256:e2315b282e45ef9f8fdc771c86efb44b6b86c883f49c97bcdd7f7e588f577634" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b4b54895b04ef8c593238ec829cf8e6d10200fd993ab036c6e9c556295905ac1" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332744f7556f61c1c4e9ad5f4521de3aee4d1418e16d08b7932359e4a24e3d52" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-win_amd64.whl", hash = "sha256:4181802459c8ce7b4dae3bcb300f6638c475d0c205ea35536c0ef04578bc7800" },
 ]
 
 [[package]]
@@ -4576,7 +4576,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104632", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104665", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
     { name = "notebook", specifier = ">=7.5.5" },

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -2197,7 +2197,7 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.8.1.dev104632"
+version = "0.8.1.dev104665"
 source = { registry = "https://pypi.motphys.com/simple/" }
 dependencies = [
     { name = "absl-py" },
@@ -2205,18 +2205,18 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e988e74fbb92c2fcd2df7375ebfadceab7e720f2d5eabca67a4e02ae28ba4197" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94b994b2dbb7d7ad7e25f30d803af241fde8fdbdfe8004e88c7c89779862af82" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp310-cp310-win_amd64.whl", hash = "sha256:0f804a1fd051fca5b1cca96bbccd50215387ca56be714b8f45bb98fe3562659e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5126de3f53351eba13ee59b59d3156a9d5c744001e3f9b49bbc210e09b550e8" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0dadaf513fc369ca5d80da30293298ccb0d41faf9b5aa351787fae8c90fe2a" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp311-cp311-win_amd64.whl", hash = "sha256:b86dd41c12b55604b5a2f42fd25a32c7fc9fe2a7b2ea5fce6a21dc93a9fdab62" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12a91cdbdf21fda6f9244ce7470ef812261925d8a3d1535ed89e609d691e860d" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:203bf623c191e118e17cf86896b8ed9604986d7dd6cb54dae4c56bbe6f975ae2" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp312-cp312-win_amd64.whl", hash = "sha256:92539572bd539e6d9fb0352afbfce1f888d3b6354b479b876ca2d55426fadf25" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5b86e661ca4cd3b6ed03809546ea76f2b35934776e0e62e2565f3df562654114" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da9898a00b41a0380b6df3b9d3e4a26836067a0dc76a9676fc5d726c81fad4ac" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104632-cp313-cp313-win_amd64.whl", hash = "sha256:2b37acfc4f95cb3566cfa7302b6dbd22c3f12303b315385cb929305f79880eca" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8edf31dae9034b7bbefe212cd6da6aea60cea20870ef01873ee7dd9067db2cc" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe10e09491701cd49791e9950099cc168aa17a75eaeb9738bffda5137e7dfa0e" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-win_amd64.whl", hash = "sha256:332440fe47cda9d3d97f1772510b004f28631230de2d9b1d7a1525ae8c1f9684" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25b8d068df0fa10e861ca7d23f96569bed5bec63d9b4207358177eb3404e470c" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:680dc47a8f3ec03610bc42b7c7c822b3813ea807db759710802745f1427502c2" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-win_amd64.whl", hash = "sha256:9cafd333d86aa457a51873488959191be8ea7b89e2ee6561ad2e07f3095a3080" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3352d692b98f5fc9a6ae231f9c5ab258701ce3ecd7b4423e9897e28c6ee44d6b" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a24e88243786bce09834ea7d3b9104b0d0f6801eca5e81304cc9b52fc81d0882" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-win_amd64.whl", hash = "sha256:e2315b282e45ef9f8fdc771c86efb44b6b86c883f49c97bcdd7f7e588f577634" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b4b54895b04ef8c593238ec829cf8e6d10200fd993ab036c6e9c556295905ac1" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332744f7556f61c1c4e9ad5f4521de3aee4d1418e16d08b7932359e4a24e3d52" },
+    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-win_amd64.whl", hash = "sha256:4181802459c8ce7b4dae3bcb300f6638c475d0c205ea35536c0ef04578bc7800" },
 ]
 
 [[package]]
@@ -4579,7 +4579,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104632", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104665", index = "https://pypi.motphys.com/simple/" },
     { name = "mujoco-uni", specifier = "==3.8.0rc2", index = "https://test.pypi.org/simple/" },
     { name = "notebook", specifier = ">=7.5.5" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- Bump the `motrix` extra from `motrixsim-core==0.8.1.dev104632` to `0.8.1.dev104665`.
- Refresh both default and ROCm uv lockfiles for the new MotrixSim wheel hashes.
- Update the Motrix backend docs to point at the new pinned version.

This pulls in the MotrixSim build that fixes the macOS `render-mode=record` failure during Motrix native video capture.

## Validation

- `make test-all`
  - `1032 passed, 14 skipped, 254 deselected, 62 warnings`
  - Pyright completed with the existing `mlx.core` missing-import warning on this Linux environment.
