### PR TITLE
feat: support Go2ArmManipLoco PPO on Motrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ uv run eval --algo appo --task go2_joystick_flat --sim motrix --load-run -1 --re
 
 On macOS / MacBook, the UniLab CLI routes Motrix interactive playback through `mxpython` when needed. Motrix defaults to interactive playback; use `--render-mode record` for headless video export or `--render-mode none` to skip playback. Detailed script-level commands are in the [Training Guide](docs/sphinx/source/zh_CN/1-user_guide/3-training.md).
 
+The Go2Arm manipulation-locomotion PPO task also supports Motrix after installing the `motrix` extra:
+
+```bash
+uv run train --algo ppo --task go2_arm_manip_loco --sim motrix
+uv run eval --algo ppo --task go2_arm_manip_loco --sim motrix --load-run -1
+```
+
 <!-- On Linux AMD / ROCm workstations, `make sync-rocm` requires ROCm 7.1 or newer, installs the PyTorch ROCm 7.2 wheel (`torch==2.11.0+rocm7.2`), and activates the ROCm profile as the current `pyproject.toml` / `uv.lock` so regular `uv run ...` commands work after setup. Restore `pyproject.toml` / `uv.lock` from git to switch back to the default CUDA / macOS profile. -->
 
 <!-- On Linux Intel Arc / iGPU workstations, `make sync-xpu` installs the PyTorch XPU wheel (`torch==2.7.0+xpu`) which bundles the Intel oneAPI compiler/SYCL runtimes. The GPU userspace driver itself must come from the system package manager — on Ubuntu 24.04+ / 26.04 install `intel-opencl-icd` and `libze-intel-gpu1` (kernel 6.2+ ships the i915 driver). Use `uv run --no-sync ...` after the swap so `uv` does not resync the default Linux CUDA wheel. Off-policy training (`--algo sac` / `--algo flashsac`) supports bf16 mixed precision via `training.use_amp=true` on XPU; on-policy PPO does not need AMP. -->
@@ -100,6 +107,11 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco
 
 ```bash
 uv run train --algo sac --task g1_motion_tracking --sim motrix
+```
+
+```bash
+uv run train --algo ppo --task go2_arm_manip_loco --sim motrix
+uv run eval --algo ppo --task go2_arm_manip_loco --sim motrix --load-run -1
 ```
 
 ```bash

--- a/conf/ppo/task/go2_arm_manip_loco/motrix.yaml
+++ b/conf/ppo/task/go2_arm_manip_loco/motrix.yaml
@@ -1,0 +1,117 @@
+# @package _global_
+training:
+  task_name: Go2ArmManipLoco
+  sim_backend: motrix
+algo:
+  num_envs: 4096
+  max_iterations: 3000
+  empirical_normalization: true
+  obs_groups:
+    actor:
+      - actor
+  policy:
+    init_noise_std: 0.5
+  algorithm:
+    learning_rate: 3.0e-4
+    entropy_coef: 1.0e-3
+    num_mini_batches: 4
+play_profile:
+  enabled: true
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/go2_arm/scene_flat.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
+reward:
+  scales:
+    # locomotion: tracking
+    tracking_lin_vel: 2.0 #1.0
+    tracking_ang_vel: 0.5 #0.2
+    # locomotion: velocity / orientation penalties
+    lin_vel_z: -5.0
+    ang_vel_xy: -0.1
+    roll: -5.0 #-2.0
+    # locomotion: height / pose
+    base_height: -100 #-20.0   # go2+arm 躯干振荡更大（有机械臂质量），-100 会与步态产生对抗
+    similar_to_default: -0.0   # 对齐 Go2 Joystick（L1）
+    leg_pose: -0.1              # 保留但不使用（被 similar_to_default 替代）
+    dof_pos_limits: 0.0        # 保留但不使用（未配置软限位）
+    # locomotion: effort penalties
+    action_rate: -0.005
+    torques: 0.0               # 保留但不使用（backend 未提供 torques）
+    energy: 0.0                # 保留但不使用
+    dof_vel: 0.0               # 保留但不使用
+    dof_acc: 0.0               # 保留但不使用
+    # locomotion: gait（对齐 Go2 Joystick）
+    stand_still: -0.5
+    contact: 0.24
+    swing_feet_z: 4.0
+    foot_drag: -0.1
+    # manipulation rewards
+    object_distance: 2.0
+    object_distance_l2: -0.5
+    # arm collision penalty
+    arm_collision: -1.0
+  tracking_sigma: 0.25
+  base_height_target: 0.3
+  object_sigma: 0.1
+env:
+  goal_ee:
+    sphere_l_range:     [0.3, 0.6]
+    sphere_phi_range:   [-1.2566, 1.0472]
+    sphere_theta_range: [-2.3562, 2.3562]
+    traj_time_range:    [1.0, 3.0]
+    hold_time_range:    [0.5, 2.0]
+    collision_upper_limits: [0.3, 0.15, -0.115]
+    collision_lower_limits: [-0.2, -0.15, -0.515]
+    underground_limit: -0.57
+    num_collision_check_samples: 10
+    num_resample_attempts: 10
+    default_orn_roll: 0.0
+    arm_induced_pitch: 0.78
+    delta_orn_r: [-0.5, 0.5]
+    delta_orn_p: [-0.5, 0.5]
+    delta_orn_y: [-0.5, 0.5]
+    init_ee_cart: [0.25, 0.0, 0.25]
+  control_config:
+    arm_action_scale: 0.0
+  ik:
+    damping: 0.05
+    gain: 1.0
+    dq_clip: 0.2
+    use_orientation: true
+    orientation_mode: target  # target: 跟踪采样姿态；zero_error: 用 Jrot 约束姿态变化但不追姿态
+  commands:
+    vel_limit:
+      - [-0.6, -0.4, -0.8]   # 对齐 Go2 Joystick 默认范围
+      - [1.0, 0.4, 0.8]
+    zero_command_prob: 0.15  # 显式采样 command=0，训练稳定站立
+    resample_time_s: 4.0   # 不设置表示 null，不做中途重采样（对齐 Joystick）
+  curriculum:
+    enable: false             # 对齐 Joystick（无课程学习）
+  domain_rand:
+    randomize_base_mass: false
+    added_mass_range: [-1.0, 1.0]
+    randomize_body_mass: true
+    body_mass_multiplier_range: [0.9, 1.1]
+    random_com: true
+    com_offset_x: [-0.03, 0.03]
+    randomize_gravity: false
+    randomize_ground_friction: true
+    ground_friction_multiplier_range: [0.8, 1.2]
+    randomize_dof_armature: false
+    dof_armature_multiplier_range: [0.8, 1.2]
+    push_robots: true
+    push_interval: 500
+    max_force: [1.2, 1.2, 0.6]
+    push_body_name: base
+    randomize_kp: false
+    kp_multiplier_range: [0.9, 1.1]
+    randomize_kd: false
+    kd_multiplier_range: [0.9, 1.1]
+  arm_stage:
+    freeze_arm_joints: false
+    disable_ee_goal_trajectory: false
+    fixed_ee_goal_cart: [0.15, 0.0, 0.25]

--- a/docs/sphinx/source/zh_CN/1-user_guide/5-reference/1-backend-support-matrix.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/5-reference/1-backend-support-matrix.md
@@ -53,7 +53,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
 | PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
 | PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | Tested |
-| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - |
+| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | Tested |
 | PPO (torch) | `go2_handstand` (go2 handstand) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | Tested |
 | PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | Tested |
@@ -72,7 +72,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_climb_tracking` (g1 climb tracking) | Configured | Configured |
 | PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
 | PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | Configured |
-| PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | - |
+| PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | Configured |
 | PPO (mlx) | `go2_handstand` (go2 handstand) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | Configured |
 | PPO (mlx) | `go2w_joystick_rough` (go2w joystick rough) | Configured | Configured |

--- a/src/unilab/algos/mlx/common/normalization.py
+++ b/src/unilab/algos/mlx/common/normalization.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import mlx.core as mx
 
 
 class EmpiricalNormalization:
     """Normalize features using running mean/std over batch axis."""
 
-    def __init__(self, shape: int, eps: float = 1e-2, dtype=mx.float32) -> None:
+    def __init__(self, shape: int, eps: float = 1e-2, dtype: Any | None = None) -> None:
         self.eps = float(eps)
-        self.dtype = dtype
+        self.dtype = mx.float32 if dtype is None else dtype
         self.mean = mx.zeros((1, shape), dtype=self.dtype)
         self.var = mx.ones((1, shape), dtype=self.dtype)
         self.std = mx.ones((1, shape), dtype=self.dtype)
@@ -39,9 +41,9 @@ class EmpiricalNormalization:
 class EmpiricalDiscountedVariationNormalization:
     """Reward normalization with running std of discounted returns."""
 
-    def __init__(self, eps: float = 1e-2, gamma: float = 0.99, dtype=mx.float32) -> None:
-        self.dtype = dtype
-        self.emp_norm = EmpiricalNormalization(shape=1, eps=eps, dtype=dtype)
+    def __init__(self, eps: float = 1e-2, gamma: float = 0.99, dtype: Any | None = None) -> None:
+        self.dtype = mx.float32 if dtype is None else dtype
+        self.emp_norm = EmpiricalNormalization(shape=1, eps=eps, dtype=self.dtype)
         self.gamma = float(gamma)
         self.avg: mx.array | None = None
 

--- a/src/unilab/algos/mlx/common/rollout_storage.py
+++ b/src/unilab/algos/mlx/common/rollout_storage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Generator, Union
+from typing import Any, Dict, Generator, Union
 
 import mlx.core as mx
 
@@ -18,9 +18,10 @@ class RolloutBuffer:
     action_dim: int
     gamma: float
     lam: float
-    dtype: mx.Dtype = mx.float32
+    dtype: Any | None = None
 
     def __post_init__(self) -> None:
+        self.dtype = mx.float32 if self.dtype is None else self.dtype
         self.observations: Union[list[mx.array], mx.array] = []
         self.actions: Union[list[mx.array], mx.array] = []
         self.log_probs: Union[list[mx.array], mx.array] = []

--- a/src/unilab/algos/mlx/ppo/model.py
+++ b/src/unilab/algos/mlx/ppo/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -27,16 +27,16 @@ class MLPActorCritic(nn.Module):
         obs_normalization: bool = False,
         noise_std_type: str = "log",
         state_dependent_std: bool = False,
-        dtype=mx.float32,
+        dtype: Any | None = None,
     ) -> None:
         super().__init__()
         self.action_dim = int(action_dim)
-        self.dtype = dtype
+        self.dtype = mx.float32 if dtype is None else dtype
         self.noise_std_type = noise_std_type
         self.state_dependent_std = bool(state_dependent_std)
         self.obs_normalization = bool(obs_normalization)
         self.obs_normalizer = (
-            EmpiricalNormalization(obs_dim, dtype=dtype) if self.obs_normalization else None
+            EmpiricalNormalization(obs_dim, dtype=self.dtype) if self.obs_normalization else None
         )
         actor_output_dim = action_dim * 2 if self.state_dependent_std else action_dim
         self.actor = MLP(obs_dim, actor_output_dim, actor_hidden_dims, activation=activation)

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -338,6 +338,86 @@ class MotrixBackend(SimBackend):
             ids.append(int(bid))
         return np.array(ids, dtype=np.int32)
 
+    def get_site_ids(self, names: Sequence[str]) -> np.ndarray:
+        ids: list[int] = []
+        for name in names:
+            sid = self._model.get_site_index(name)
+            if sid is None or sid < 0:
+                raise ValueError(f"Site '{name}' not found in Motrix model")
+            ids.append(int(sid))
+        return np.array(ids, dtype=np.int32)
+
+    def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices: list[int] = []
+        for name in names:
+            joint = self._resolve_single_dof_joint(name)
+            indices.append(int(joint.dof_vel_index))
+        return np.array(indices, dtype=np.int32)
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices: list[int] = []
+        for name in names:
+            joint = self._resolve_single_dof_joint(name)
+            indices.append(self._joint_dof_local_index(name, int(joint.dof_pos_index), pos=True))
+        return np.array(indices, dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices: list[int] = []
+        for name in names:
+            joint = self._resolve_single_dof_joint(name)
+            indices.append(self._joint_dof_local_index(name, int(joint.dof_vel_index), pos=False))
+        return np.array(indices, dtype=np.int32)
+
+    def get_site_jacobian_w(
+        self,
+        site_id: int,
+        dof_indices: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        sid = int(site_id)
+        if sid < 0 or sid >= int(self._model.num_sites):
+            raise ValueError(f"site_id out of range: {sid}")
+
+        site = self._model.sites[sid]
+        jac = np.asarray(site.get_jacobian(self._data), dtype=self._np_dtype)
+        if jac.ndim != 3 or jac.shape[0] != self._num_envs or jac.shape[1] != 6:
+            raise ValueError(
+                f"Motrix site Jacobian for site {sid} must have shape "
+                f"({self._num_envs}, 6, n), got {jac.shape}"
+            )
+
+        site_dof_indices = np.asarray(site.dof_vel_indices, dtype=np.int64).reshape(-1)
+        col_by_dof = {int(dof_index): col for col, dof_index in enumerate(site_dof_indices)}
+        requested = np.asarray(dof_indices, dtype=np.int64).reshape(-1)
+        cols: list[int] = []
+        for dof_index in requested:
+            key = int(dof_index)
+            if key not in col_by_dof:
+                raise ValueError(f"DoF index {key} is not present in site {sid} Jacobian")
+            cols.append(col_by_dof[key])
+
+        selected = jac[:, :, np.asarray(cols, dtype=np.intp)]
+        # Motrix returns angular rows first and linear rows second.
+        jacp = selected[:, 3:6, :]
+        jacr = selected[:, 0:3, :]
+        return jacp, jacr
+
+    def _resolve_single_dof_joint(self, name: str):
+        jid = self._model.get_joint_index(name)
+        if jid is None or jid < 0:
+            raise ValueError(f"Joint '{name}' not found in Motrix model")
+        joint = self._model.joints[int(jid)]
+        if int(getattr(joint, "num_dof_vel", 1)) != 1:
+            raise ValueError(f"Joint '{name}' is not a single-DoF joint")
+        return joint
+
+    def _joint_dof_local_index(self, name: str, model_index: int, *, pos: bool) -> int:
+        all_indices = self._joint_dof_pos_indices if pos else self._joint_dof_vel_indices
+        matches = np.flatnonzero(all_indices == int(model_index))
+        if matches.size != 1:
+            space = "qpos" if pos else "qvel"
+            raise ValueError(f"Joint '{name}' {space} index {model_index} is not in joint DoFs")
+        return int(matches[0])
+
     def get_geom_id(self, name: str) -> int:
         geom_id = self._model.get_geom_index(name)
         if geom_id is None or geom_id < 0:

--- a/src/unilab/envs/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/envs/locomotion/go2_arm/manip_loco.py
@@ -265,6 +265,7 @@ class Go2ArmManipLocoDRProvider(LocomotionDRProvider):
         return env._update_history(raw, env_ids=env_ids)  # type: ignore[no-any-return]
 
 
+@registry.env("Go2ArmManipLoco", sim_backend="motrix")
 @registry.env("Go2ArmManipLoco", sim_backend="mujoco")
 class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
     _cfg: Go2ArmManipLocoCfg
@@ -272,19 +273,30 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
     def __init__(self, cfg: Go2ArmManipLocoCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:
             raise ValueError("reward_config must be provided via Hydra configuration")
-        if backend_type != "mujoco":
-            raise ValueError("Go2ArmManipLoco currently supports only the mujoco backend")
+        if backend_type not in {"mujoco", "motrix"}:
+            raise ValueError(
+                "Go2ArmManipLoco supports only the mujoco and motrix backends, "
+                f"got {backend_type!r}"
+            )
 
         scene = _resolve_go2_arm_scene(cfg)
+        backend_kwargs: dict[str, Any] = {
+            "base_name": cfg.asset.base_name,
+            "push_body_name": cfg.domain_rand.push_body_name,
+        }
+        if backend_type == "motrix":
+            backend_kwargs["motrix_max_iterations"] = cfg.iterations
+        else:
+            backend_kwargs["position_actuator_gains"] = build_go2_arm_position_gains(
+                cfg.control_config
+            )
+            backend_kwargs["iterations"] = cfg.iterations
         backend = create_backend(
             backend_type,
             scene,
             num_envs,
             cfg.sim_dt,
-            base_name=cfg.asset.base_name,
-            push_body_name=cfg.domain_rand.push_body_name,
-            position_actuator_gains=build_go2_arm_position_gains(cfg.control_config),
-            iterations=cfg.iterations,
+            **backend_kwargs,
         )
         super().__init__(cfg, backend, num_envs)
         if self._num_action != 18:

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -192,6 +192,19 @@ def test_supported_task_composes(
     _assert_reward_populated(cfg, task_file)
 
 
+def test_ppo_go2_arm_manip_loco_motrix_preserves_backend_overrides():
+    cfg = _compose("ppo", overrides=["task=go2_arm_manip_loco/motrix"])
+
+    assert cfg.training.task_name == "Go2ArmManipLoco"
+    assert cfg.training.sim_backend == "motrix"
+    assert cfg.algo.num_envs == 4096
+    assert cfg.algo.max_iterations == 3000
+    assert cfg.reward.scales.tracking_lin_vel == pytest.approx(2.0)
+    assert cfg.env.domain_rand.randomize_dof_armature is False
+    assert cfg.env.domain_rand.randomize_kp is False
+    assert cfg.env.domain_rand.randomize_kd is False
+
+
 def test_offpolicy_g1_walk_flat_motrix_sac_preserves_backend_overrides():
     cfg = _compose("offpolicy", overrides=["algo=sac", "task=sac/g1_walk_flat/motrix"])
 

--- a/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
+++ b/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
@@ -75,6 +75,16 @@ def test_go2_arm_manip_loco_cfg_registered():
     assert registry.contains("Go2ArmManipLoco")
 
 
+def test_go2_arm_manip_loco_registers_motrix_backend():
+    """Go2ArmManipLoco should route through both MuJoCo and Motrix backends."""
+    _ensure_go2_arm_manip_loco_registered()
+    registry = _registry_module()
+    meta = registry._envs["Go2ArmManipLoco"]
+
+    assert meta.support_sim_backend("mujoco")
+    assert meta.support_sim_backend("motrix")
+
+
 def test_go2_arm_manip_loco_cfg_declares_scene_for_playback():
     """MuJoCo video playback needs the original visual scene, not only legacy model_file."""
     from unilab.base.scene import SceneCfg

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -774,6 +774,35 @@ def test_build_ppo_play_env_cfg_override_resolves_relative_ground_texture(
     )
 
 
+def test_go2_arm_manip_loco_motrix_eval_uses_visual_floor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mod = _train_rsl_rl(monkeypatch)
+    cfg = _ppo_cfg(["task=go2_arm_manip_loco/motrix", "training.play_only=true"])
+
+    captured = {}
+
+    def _fake_materialize(source_model_file, **kwargs):
+        captured["source_model_file"] = source_model_file
+        captured.update(kwargs)
+        return "/tmp/go2_arm_manip_loco_play_scene.xml"
+
+    monkeypatch.setattr(mod, "materialize_scene_visual_override", _fake_materialize)
+
+    env_cfg_override = mod.build_ppo_play_env_cfg_override(cfg)
+
+    assert captured["source_model_file"] == str(
+        mod.ROOT_DIR / "src/unilab/assets/robots/go2_arm/scene_flat.xml"
+    )
+    assert captured["ground_texture_file"] == str(
+        mod.ROOT_DIR / "src/unilab/assets/robots/g1/textures/floor.png"
+    )
+    assert captured["skybox_rgb1"] == [0.90, 0.90, 0.91]
+    assert captured["skybox_rgb2"] == [0.68, 0.68, 0.70]
+    assert captured["ground_texrepeat"] == [0.25, 0.25]
+    assert env_cfg_override["scene"].model_file == "/tmp/go2_arm_manip_loco_play_scene.xml"
+
+
 def test_run_motrix_rsl_play_loop_uses_render_spacing_and_offset_mode():
     import numpy as np
     import torch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,13 @@ import pytest
 from unilab import cli
 
 
-def _make_minimal_checkout(root: Path, *, algo: str = "ppo") -> None:
+def _make_minimal_checkout(
+    root: Path, *, algo: str = "ppo", task: str = "go2_joystick_flat"
+) -> None:
     (root / "scripts").mkdir(parents=True)
     (root / "scripts" / "train_rsl_rl.py").write_text("", encoding="utf-8")
-    (root / "conf" / algo / "task" / "go2_joystick_flat").mkdir(parents=True)
-    (root / "conf" / algo / "task" / "go2_joystick_flat" / "motrix.yaml").write_text(
+    (root / "conf" / algo / "task" / task).mkdir(parents=True)
+    (root / "conf" / algo / "task" / task / "motrix.yaml").write_text(
         "training:\n  sim_backend: motrix\n",
         encoding="utf-8",
     )
@@ -97,6 +99,43 @@ def test_train_profile_routes_to_owner_variant(tmp_path: Path) -> None:
         str(tmp_path / "scripts" / "train_rsl_rl.py"),
         "task=sharpa_inhand/mujoco_hora",
     ]
+
+
+def test_go2_arm_manip_loco_motrix_train_and_eval_route_to_owner_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_minimal_checkout(tmp_path, task="go2_arm_manip_loco")
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+    train_command = cli.build_command(
+        mode="train",
+        algo="ppo",
+        task="go2_arm_manip_loco",
+        sim="motrix",
+        overrides=[],
+        root=tmp_path,
+    )
+    eval_command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="go2_arm_manip_loco",
+        sim="motrix",
+        overrides=[],
+        load_run="-1",
+        root=tmp_path,
+    )
+
+    assert train_command[1:] == [
+        str(tmp_path / "scripts" / "train_rsl_rl.py"),
+        "task=go2_arm_manip_loco/motrix",
+    ]
+    assert eval_command[1:3] == [
+        str(tmp_path / "scripts" / "train_rsl_rl.py"),
+        "task=go2_arm_manip_loco/motrix",
+    ]
+    assert "training.play_only=true" in eval_command
+    assert "algo.load_run=-1" in eval_command
 
 
 def test_macos_motrix_eval_requires_mxpython(


### PR DESCRIPTION
## Summary

- add the `go2_arm_manip_loco/motrix` PPO task owner config
- register `Go2ArmManipLoco` for the Motrix backend while preserving the 18-actuator contract
- add MotrixBackend site/joint kinematics methods needed by the Go2Arm IK path
- cover config composition, backend registration, play-profile scene override, and CLI route behavior
- document the new Go2ArmManipLoco Motrix train/eval commands

## Linked Work

- Issue: Closes #537
- Milestone:

## Validation

- [ ] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/config/test_config_system.py tests/envs/locomotion/go2_arm/test_manip_loco_contract.py tests/scripts/test_train_scripts.py tests/test_cli.py
uv run train --algo ppo --task go2_arm_manip_loco --sim motrix training.no_play=true algo.max_iterations=1 algo.num_envs=1
```

Targeted pytest result: `220 passed, 8 skipped, 7 deselected`.

## Impact

- Backend impact: motrix
- Platform impact: both
- Training effect expected: yes

## Artifacts

- W&B:
- benchmark result:
- video / screenshot:
- ONNX / checkpoint:

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly

Follow-up: full long-horizon Go2ArmManipLoco Motrix benchmark/training quality validation is not included in this PR; this PR validates routing, config composition, backend contract coverage, and a one-iteration smoke run.
