### PR TITLE
feat: uv run demo <name> with HF auto-download and tab completion

### DIFF
--- a/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
@@ -52,9 +52,11 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1
 uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
   --load-run -1 --render-mode record
 
-# Demo playback from a local trained checkpoint
-uv run demo
+# Demo playback (fetches a pre-trained checkpoint from Hugging Face on first run)
+uv run demo dance
 ```
+
+Available demo names: `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
 
 On macOS, the CLI routes Motrix interactive playback through `mxpython` when
 needed. Use `--render-mode record` for headless video export or

--- a/docs/sphinx/source/en/1-getting_started/3-evaluation_and_playback.md
+++ b/docs/sphinx/source/en/1-getting_started/3-evaluation_and_playback.md
@@ -12,8 +12,8 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
 uv run eval --algo sac --task g1_walk_flat --sim mujoco --load-run -1 \
     --render-mode record training.export_onnx=false
 
-# Demo (uses a baked-in checkpoint)
-uv run demo
+# Demo (downloads checkpoint from HF on first run)
+uv run demo dance
 ```
 
 Render modes:

--- a/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
@@ -44,10 +44,19 @@ Supported render modes are `auto`, `interactive`, `record`, and `none`.
 ## Demo
 
 ```bash
-uv run demo
-uv run demo --preset go2_joystick_mujoco_ppo
-uv run demo --refresh --device cpu
+uv run demo dance
+uv run demo wallflip
+uv run demo boxtracking
+uv run demo locomani
+uv run demo inhandgrasp
+uv run demo dance --refresh --device cpu
 ```
+
+Available demos: `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
+Each demo fetches a pre-trained checkpoint from the
+`unilabsim/unilab-checkpoints` Hugging Face dataset on first run and caches it
+under `src/unilab/assets/checkpoints/<demo>/model_0.pt`. Pass `--refresh` to
+re-download.
 
 The demo entrypoint is implemented by `src/unilab/demo.py` and routed from
 `src/unilab/cli.py`.

--- a/docs/sphinx/source/zh_CN/1-user_guide/2-training/1-unified-cli.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/2-training/1-unified-cli.md
@@ -61,13 +61,20 @@ uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
 ## demo
 
 ```bash
-uv run demo
-uv run demo --preset go2_joystick_mujoco_ppo
-uv run demo --refresh
-uv run demo --device cpu
+uv run demo dance
+uv run demo wallflip
+uv run demo boxtracking
+uv run demo locomani
+uv run demo inhandgrasp
+uv run demo dance --refresh
+uv run demo dance --device cpu
 ```
 
-`demo` 会从本地预设 run 复制 checkpoint，再走回放命令；不是远端模型下载器。
+可用 demo 名：`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
+首次运行时从 `unilabsim/unilab-checkpoints` Hugging Face dataset 拉取预训练
+checkpoint，落盘到 `src/unilab/assets/checkpoints/<demo>/model_0.pt`，再启动
+交互式回放（motrix 任务走 `train_rsl_rl.py --play_only`，mujoco 任务走
+`scripts/play_interactive.py`）。`--refresh` 强制重新下载。
 
 ## 规则
 

--- a/docs/sphinx/source/zh_CN/1-user_guide/3-training.md
+++ b/docs/sphinx/source/zh_CN/1-user_guide/3-training.md
@@ -9,7 +9,7 @@
 ```bash
 uv run train --algo ppo --task go2_joystick_flat --sim mujoco
 uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
-uv run demo
+uv run demo dance
 ```
 
 ## 训练专题

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -2,24 +2,54 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
-   "source": "# UniLab Demo: 一键回放训练好的策略\n\n这个 notebook 演示如何用 UniLab 的 `demo` 命令，加载一个已经训练好的 checkpoint，\n让机器人在仿真环境中执行学到的策略。\n\n**你不需要任何机器人或强化学习背景**——只需要运行下面的 cell 就能看到效果。\n\n## 它做了什么？\n\n1. 从预设的 checkpoint 目录复制模型文件到 demo 运行目录\n2. 启动 MuJoCo 物理仿真器\n3. 让 Go2 四足机器人用训练好的策略行走\n4. 录制一段回放视频\n\n## 环境准备\n\n> 如果你已经完成了 README 中 Quick Demo 的步骤，可以跳过这一节。\n\n**系统要求**：Python >= 3.10, < 3.14\n\n```bash\n# 1. 安装 uv（Python 包管理器）\ncurl -LsSf https://astral.sh/uv/install.sh | sh\n\n# 2. 克隆仓库\ngit clone <repo-url> && cd UniLab\n\n# 3. 安装依赖\nuv sync\n\n# 4. 激活虚拟环境\nsource .venv/bin/activate\n\n# 5. 验证 CLI 可用\nunilab --help\n```\n\n**前置条件**：本地需要存在训练产出的 checkpoint 文件（位于 `logs/rsl_rl_ppo/Go2JoystickFlatTerrain/` 下）。\n如果你还没有 checkpoint，请先运行 walkthrough notebook 完成一次训练。\n\n> **Colab 不适用**：本项目依赖 MuJoCo 物理仿真器的本地运行环境，不支持 Google Colab。请在本地机器上运行此 notebook。"
+   "source": [
+    "# UniLab Demo: 一键回放预训练策略 / 渲染 teaser 场景\n",
+    "\n",
+    "`uv run demo <name>` 是 UniLab 的最简交互入口：\n",
+    "\n",
+    "- 首次运行从 Hugging Face 自动拉取权重（5 个 checkpoint demo）或场景资源（teaser）。\n",
+    "- 缓存到本地后启动交互式仿真器或场景渲染器。\n",
+    "- 不需要训练，不需要先手动准备 checkpoint。\n",
+    "\n",
+    "## 可用的 6 个 demo\n",
+    "\n",
+    "| 名字 | 类型 | 内容 |\n",
+    "| --- | --- | --- |\n",
+    "| `dance` | checkpoint | G1 全身动作跟踪（dance motion） |\n",
+    "| `wallflip` | checkpoint | G1 后空翻 |\n",
+    "| `boxtracking` | checkpoint | G1 推箱子 |\n",
+    "| `locomani` | checkpoint | Go2 + 机械臂 操作-行走 |\n",
+    "| `inhandgrasp` | checkpoint | Sharpa 手内旋转抓取 |\n",
+    "| `teaser` | renderer | MotrixSim 论文封面场景静态展示 |\n",
+    "\n",
+    "## 环境准备\n",
+    "\n",
+    "如果你已经完成 README 里的 Quick Demo（`make setup-motrix` 或 `uv sync --extra motrix`），可以跳过这一节。\n",
+    "\n",
+    "> **本地运行**：所有 demo 都会打开本地 GUI 窗口（MotrixSim viewer / MuJoCo viewer），**不支持 Google Colab**。"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
-   "source": "## Step 1: 确认环境\n\n检查我们是否在正确的项目根目录，以及 `unilab` CLI 是否可用。"
+   "source": [
+    "## Step 1: 确认环境\n",
+    "\n",
+    "确保在 UniLab 项目根目录下运行本 notebook。"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "# 确保在项目根目录运行\n",
     "root = Path(\".\").resolve()\n",
     "assert (root / \"scripts\").is_dir(), f\"请在 UniLab 项目根目录运行此 notebook，当前目录: {root}\"\n",
     "assert (root / \"conf\").is_dir(), \"缺少 conf/ 目录，请确认项目完整性\"\n",
@@ -27,102 +57,87 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!uv run unilab --help"
-   ]
-  },
-  {
    "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "source": [
-    "## Step 2: 检查 checkpoint 是否存在\n",
+    "## Step 2: 查看 demo 注册表 + 本地缓存状态\n",
     "\n",
-    "demo 命令需要一个预训练好的模型文件。下面检查它是否在预期位置。"
+    "checkpoint 缓存目录是 `src/unilab/assets/checkpoints/<demo名>/model_0.pt`。首次运行 `uv run demo <name>` 会自动从 Hugging Face dataset [`unilabsim/unilab-checkpoints`](https://huggingface.co/datasets/unilabsim/unilab-checkpoints) 拉取。teaser 走的是单独的 [`unilabsim/unilab-scenes`](https://huggingface.co/datasets/unilabsim/unilab-scenes) 仓库，由 `unilab.tools.render_teaser` 内部处理。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
    "source": [
-    "log_dir = root / \"logs\" / \"rsl_rl_ppo\" / \"Go2JoystickFlatTerrain\"\n",
+    "from unilab.assets import ASSETS_ROOT_PATH\n",
+    "from unilab.demo import DEMO_REGISTRY\n",
     "\n",
-    "if log_dir.is_dir():\n",
-    "    runs = sorted(log_dir.iterdir())\n",
-    "    print(f\"找到 {len(runs)} 个训练 run:\")\n",
-    "    for r in runs:\n",
-    "        ckpts = list(r.glob(\"model_*.pt\"))\n",
-    "        print(f\"  {r.name}  ->  {len(ckpts)} 个 checkpoint\")\n",
-    "else:\n",
-    "    print(f\"未找到日志目录: {log_dir}\")\n",
-    "    print(\"请先完成至少一次训练，或手动放置 checkpoint 文件。\")"
+    "cache_dir = ASSETS_ROOT_PATH / \"checkpoints\"\n",
+    "for name in sorted(DEMO_REGISTRY):\n",
+    "    spec = DEMO_REGISTRY[name]\n",
+    "    if spec.entry == \"teaser\":\n",
+    "        status = \"场景资源（首次运行自动从 unilab-scenes 拉取）\"\n",
+    "    else:\n",
+    "        pt = cache_dir / name / \"model_0.pt\"\n",
+    "        status = \"本地已缓存\" if pt.is_file() else \"未缓存（首次运行自动下载）\"\n",
+    "    print(f\"  {name:12s}  entry={spec.entry:18s}  {status}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
-    "## Step 3: 运行 Demo\n",
+    "## Step 3: 运行一个 demo\n",
     "\n",
-    "`unilab demo` 会自动完成以下步骤：\n",
-    "- 找到 preset 对应的 checkpoint\n",
-    "- 复制到 demo 专用目录\n",
-    "- 以 play_only 模式启动仿真，录制视频\n",
+    "下面的 cell 演示如何启动 `dance`。注意每个 demo 都会打开一个**交互式仿真器窗口**（4 个 motrix demo 走 MotrixSim viewer；`locomani` 走 MuJoCo viewer；`teaser` 走 MotrixSim 静态渲染）。在 notebook 里执行时 cell 会**阻塞**，直到你关闭窗口才会返回。\n",
     "\n",
-    "默认 preset 是 `go2_joystick_mujoco_ppo`（Go2 机器人 + 摇杆控制 + MuJoCo 仿真器 + PPO 算法）。"
+    "想看其他几个，把 `dance` 换成 `wallflip` / `boxtracking` / `locomani` / `inhandgrasp` / `teaser` 即可。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!uv run unilab demo"
+    "!uv run demo dance"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "source": [
-    "## Step 4: 查看回放视频\n",
+    "## 选项\n",
     "\n",
-    "如果 demo 成功运行，会在 demo run 目录下生成 `play_video.mp4`。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import Video\n",
+    "- `--refresh` — 强制重新下载 checkpoint（先删除本地缓存再 resolve）。teaser 会忽略这个选项。\n",
+    "- `--device cpu` / `--device cuda:0` — 显式选择推理 device（仅 checkpoint demos 生效）。\n",
     "\n",
-    "demo_run_dir = log_dir / \"demo_go2_joystick_mujoco_ppo_v0\"\n",
-    "video_path = demo_run_dir / \"play_video.mp4\"\n",
+    "```bash\n",
+    "uv run demo dance --refresh\n",
+    "uv run demo wallflip --device cpu\n",
+    "```\n",
     "\n",
-    "if video_path.is_file():\n",
-    "    print(f\"视频路径: {video_path}\")\n",
-    "    display(Video(str(video_path), embed=True, width=640))\n",
-    "else:\n",
-    "    print(f\"未找到视频文件: {video_path}\")\n",
-    "    print(\"可能原因: demo 运行失败，或渲染环境不可用。\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "## Tab 补全\n",
+    "\n",
+    "执行 `make setup-motrix` 后会自动在你的 shell rc 文件里注册补全脚本。新开 shell 后：\n",
+    "\n",
+    "```text\n",
+    "uv run demo <TAB>            → boxtracking dance inhandgrasp locomani teaser wallflip\n",
+    "uv run demo d<TAB>           → dance\n",
+    "uv run demo dance --<TAB>    → --device --refresh\n",
+    "```\n",
+    "\n",
     "## 下一步\n",
     "\n",
-    "- 想了解训练过程？请查看 `unilab_walkthrough_ppo_go1_joystick_mujoco.ipynb`\n",
-    "- 想用其他算法或机器人？运行 `uv run unilab train --help` 查看所有选项\n",
-    "- 想自定义 demo preset？查看 `src/unilab/demo.py` 中的 `DEMO_PRESETS`"
+    "- 想训练自己的 checkpoint：`uv run train --algo ppo --task <task> --sim motrix`\n",
+    "- 想查看底层 dispatch 逻辑：[src/unilab/demo.py](../src/unilab/demo.py) 的 `DEMO_REGISTRY` 和 `build_demo_command`"
    ]
   }
  ],
@@ -138,5 +153,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 _HF_MOTIONS_REPO_ID = "unilabsim/unilab-motions"
 _HF_CACHES_REPO_ID = "unilabsim/unilab-caches"
 _HF_SCENES_REPO_ID = "unilabsim/unilab-scenes"
+_HF_CHECKPOINTS_REPO_ID = "unilabsim/unilab-checkpoints"
 _HF_REPO_TYPE = "dataset"
 _HF_OFFICIAL_ENDPOINT = "https://huggingface.co"
 
@@ -63,6 +64,25 @@ def resolve_grasp_cache_files(
     if isinstance(cache_file, str):
         return _resolve_single(cache_file, repo_id=_HF_CACHES_REPO_ID)
     return [_resolve_single(p, repo_id=_HF_CACHES_REPO_ID) for p in cache_file]
+
+
+def resolve_checkpoint_file(
+    checkpoint_file: str | Sequence[str],
+) -> str | list[str]:
+    """Ensure checkpoint file(s) exist locally, downloading from HF if needed.
+
+    Args:
+        checkpoint_file: Absolute path or ``ASSETS_ROOT_PATH``-relative path
+            (single string or sequence of strings).
+
+    Returns:
+        Resolved absolute path(s) guaranteed to exist on disk.
+        A single string input returns a single string; a sequence input
+        returns a list of strings.
+    """
+    if isinstance(checkpoint_file, str):
+        return _resolve_single(checkpoint_file, repo_id=_HF_CHECKPOINTS_REPO_ID)
+    return [_resolve_single(p, repo_id=_HF_CHECKPOINTS_REPO_ID) for p in checkpoint_file]
 
 
 def _resolve_single(path_str: str, *, repo_id: str = _HF_MOTIONS_REPO_ID) -> str:

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -255,7 +255,7 @@ def _train_eval_parser(*, mode: str) -> argparse.ArgumentParser:
 
 def _demo_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="demo")
-    parser.add_argument("--preset", default="go2_joystick_mujoco_ppo")
+    parser.add_argument("demo_name")
     parser.add_argument("--refresh", action="store_true")
     parser.add_argument("--device", default=None)
     return parser
@@ -294,7 +294,7 @@ def demo_main(argv: Sequence[str] | None = None) -> int:
             f"demo does not accept passthrough Hydra overrides: {', '.join(overrides)}"
         )
     return run_demo(
-        preset_name=args.preset,
+        demo_name=args.demo_name,
         refresh=args.refresh,
         device=args.device,
     )

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -1,39 +1,34 @@
+"""Demo entrypoint: fetch checkpoint from HF, then launch interactive playback."""
+
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.assets.hub import resolve_checkpoint_file
+
 
 @dataclass(frozen=True)
-class DemoPreset:
-    preset_id: str
+class DemoSpec:
     algo: str
     task: str
     sim: str
-    task_name: str
-    algo_log_name: str
-    source_run: str
-    checkpoint_filename: str
-    demo_run: str
-    expected_output: str = "play_video.mp4"
+    entry: str  # "eval" or "play_interactive"
 
 
-DEMO_PRESETS = {
-    "go2_joystick_mujoco_ppo": DemoPreset(
-        preset_id="go2_joystick_mujoco_ppo",
-        algo="ppo",
-        task="go2_joystick_flat",
-        sim="mujoco",
-        task_name="Go2JoystickFlatTerrain",
-        algo_log_name="rsl_rl_ppo",
-        source_run="2026-04-24_01-36-01_mujoco",
-        checkpoint_filename="model_999.pt",
-        demo_run="demo_go2_joystick_mujoco_ppo_v0",
-    )
+DEMO_REGISTRY: dict[str, DemoSpec] = {
+    "dance": DemoSpec(algo="ppo", task="g1_motion_tracking", sim="motrix", entry="eval"),
+    "wallflip": DemoSpec(algo="ppo", task="g1_wall_flip_tracking", sim="motrix", entry="eval"),
+    "boxtracking": DemoSpec(algo="ppo", task="g1_box_tracking", sim="motrix", entry="eval"),
+    "locomani": DemoSpec(
+        algo="ppo", task="go2_arm_manip_loco", sim="mujoco", entry="play_interactive"
+    ),
+    "inhandgrasp": DemoSpec(algo="ppo", task="sharpa_inhand", sim="motrix", entry="eval"),
 }
 
 
@@ -41,72 +36,94 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def get_demo_preset(preset_name: str) -> DemoPreset:
+def get_demo_spec(demo_name: str) -> DemoSpec:
     try:
-        return DEMO_PRESETS[preset_name]
+        return DEMO_REGISTRY[demo_name]
     except KeyError as exc:
-        available = ", ".join(sorted(DEMO_PRESETS))
+        available = ", ".join(sorted(DEMO_REGISTRY))
+        raise SystemExit(f"Unknown demo {demo_name!r}. Available demos: {available}") from exc
+
+
+def _checkpoint_relative_path(demo_name: str) -> str:
+    return f"checkpoints/{demo_name}/model_0.pt"
+
+
+def _refresh_local_checkpoint(demo_name: str) -> None:
+    local = ASSETS_ROOT_PATH / _checkpoint_relative_path(demo_name)
+    if local.exists():
+        local.unlink()
+
+
+def _build_play_interactive_command(
+    *,
+    spec: DemoSpec,
+    checkpoint_path: str,
+    extra_overrides: Sequence[str],
+    root: Path | None = None,
+) -> list[str]:
+    selected_root = root or _repo_root()
+    script = selected_root / "scripts" / "play_interactive.py"
+    if not script.is_file():
+        raise SystemExit(f"Entrypoint script not found: {script}")
+    owner_yaml = selected_root / "conf" / spec.algo / "task" / spec.task / f"{spec.sim}.yaml"
+    if not owner_yaml.is_file():
         raise SystemExit(
-            f"Unknown demo preset {preset_name!r}. Available presets: {available}"
-        ) from exc
-
-
-def _task_log_root(root: Path, preset: DemoPreset) -> Path:
-    return root / "logs" / preset.algo_log_name / preset.task_name
-
-
-def _source_run_dir(root: Path, preset: DemoPreset) -> Path:
-    return _task_log_root(root, preset) / preset.source_run
-
-
-def _demo_run_dir(root: Path, preset: DemoPreset) -> Path:
-    return _task_log_root(root, preset) / preset.demo_run
-
-
-def materialize_demo_run(*, root: Path, preset: DemoPreset, refresh: bool) -> Path:
-    source_run_dir = _source_run_dir(root, preset)
-    source_checkpoint = source_run_dir / preset.checkpoint_filename
-    if not source_checkpoint.is_file():
-        raise SystemExit(f"Demo checkpoint not found. Expected local asset at {source_checkpoint}.")
-
-    demo_run_dir = _demo_run_dir(root, preset)
-    if refresh and demo_run_dir.exists():
-        shutil.rmtree(demo_run_dir)
-
-    demo_checkpoint = demo_run_dir / preset.checkpoint_filename
-    if not demo_checkpoint.is_file():
-        demo_run_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_checkpoint, demo_checkpoint)
-
-    return demo_run_dir
-
-
-def build_demo_command(*, preset: DemoPreset, device: str | None = None) -> list[str]:
-    command = [
+            f"No owner config exists for algo={spec.algo}, task={spec.task}, sim={spec.sim}: "
+            f"{owner_yaml}"
+        )
+    return [
         sys.executable,
-        str(_repo_root() / "scripts" / "train_rsl_rl.py"),
-        f"task={preset.task}/{preset.sim}",
-        "training.play_only=true",
-        f"algo.load_run={preset.demo_run}",
+        str(script),
+        f"task={spec.task}/{spec.sim}",
+        f"algo.load_run={checkpoint_path}",
+        *extra_overrides,
     ]
+
+
+def build_demo_command(
+    *,
+    demo_name: str,
+    checkpoint_path: str,
+    device: str | None = None,
+    root: Path | None = None,
+) -> list[str]:
+    """Assemble the subprocess command for a given demo + resolved checkpoint."""
+    from unilab.cli import build_command
+
+    spec = get_demo_spec(demo_name)
+    extra: list[str] = []
     if device is not None:
-        command.append(f"training.device={device}")
-    return command
+        extra.append(f"training.device={device}")
+
+    if spec.entry == "eval":
+        return build_command(
+            mode="eval",
+            algo=spec.algo,
+            task=spec.task,
+            sim=spec.sim,
+            overrides=[f"algo.load_run={checkpoint_path}", *extra],
+            root=root,
+        )
+    if spec.entry == "play_interactive":
+        return _build_play_interactive_command(
+            spec=spec, checkpoint_path=checkpoint_path, extra_overrides=extra, root=root
+        )
+    raise SystemExit(f"Unknown demo entry kind: {spec.entry!r}")
 
 
-def run_demo(*, preset_name: str, refresh: bool, device: str | None = None) -> int:
-    root = _repo_root()
-    preset = get_demo_preset(preset_name)
-    demo_run_dir = materialize_demo_run(root=root, preset=preset, refresh=refresh)
-    command = build_demo_command(preset=preset, device=device)
+def run_demo(*, demo_name: str, refresh: bool = False, device: str | None = None) -> int:
+    spec = get_demo_spec(demo_name)
+    if refresh:
+        _refresh_local_checkpoint(demo_name)
+    checkpoint_path = resolve_checkpoint_file(_checkpoint_relative_path(demo_name))
+    assert isinstance(checkpoint_path, str)
+
+    command = build_demo_command(
+        demo_name=demo_name, checkpoint_path=checkpoint_path, device=device
+    )
     env = os.environ.copy()
-    env.setdefault("UV_PROJECT_ENVIRONMENT", str(root / ".venv"))
+    env.setdefault("UV_PROJECT_ENVIRONMENT", str(_repo_root() / ".venv"))
     returncode = subprocess.run(command, check=False, env=env).returncode
     if returncode == 0:
-        video_path = demo_run_dir / preset.expected_output
-        print(f"Demo preset: {preset.preset_id}")
-        if video_path.is_file():
-            print(f"Demo video: {video_path}")
-        else:
-            print(f"Demo completed, but expected video was not found: {video_path}")
+        print(f"Demo finished: {demo_name} (algo={spec.algo}, task={spec.task}, sim={spec.sim})")
     return returncode

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -18,7 +18,7 @@ class DemoSpec:
     algo: str
     task: str
     sim: str
-    entry: str  # "eval" or "play_interactive"
+    entry: str  # "eval", "play_interactive", or "teaser"
 
 
 DEMO_REGISTRY: dict[str, DemoSpec] = {
@@ -29,6 +29,7 @@ DEMO_REGISTRY: dict[str, DemoSpec] = {
         algo="ppo", task="go2_arm_manip_loco", sim="mujoco", entry="play_interactive"
     ),
     "inhandgrasp": DemoSpec(algo="ppo", task="sharpa_inhand", sim="motrix", entry="eval"),
+    "teaser": DemoSpec(algo="", task="", sim="", entry="teaser"),
 }
 
 
@@ -108,11 +109,24 @@ def build_demo_command(
         return _build_play_interactive_command(
             spec=spec, checkpoint_path=checkpoint_path, extra_overrides=extra, root=root
         )
+    if spec.entry == "teaser":
+        raise SystemExit(
+            f"Demo {demo_name!r} is a renderer-only entry and has no subprocess command."
+        )
     raise SystemExit(f"Unknown demo entry kind: {spec.entry!r}")
+
+
+def _run_teaser_demo() -> int:
+    from unilab.tools.render_teaser import main as render_teaser_main
+
+    render_teaser_main()
+    return 0
 
 
 def run_demo(*, demo_name: str, refresh: bool = False, device: str | None = None) -> int:
     spec = get_demo_spec(demo_name)
+    if spec.entry == "teaser":
+        return _run_teaser_demo()
     if refresh:
         _refresh_local_checkpoint(demo_name)
     checkpoint_path = resolve_checkpoint_file(_checkpoint_relative_path(demo_name))

--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -457,6 +457,40 @@ def _load_run_choices(
     return _dedupe(_matching(candidates, prefix))
 
 
+_DEMO_FLAGS: tuple[str, ...] = ("--device", "--refresh")
+_DEMO_VALUE_FLAGS: frozenset[str] = frozenset({"--device"})
+
+
+def _demo_name_consumed(words: Sequence[str], cword: int) -> bool:
+    index = 3
+    limit = min(cword, len(words))
+    while index < limit:
+        token = words[index]
+        if token.startswith("--"):
+            index += 2 if token in _DEMO_VALUE_FLAGS else 1
+            continue
+        return True
+    return False
+
+
+def _demo_completions(
+    *,
+    words: Sequence[str],
+    cword: int,
+    current: str,
+    previous: str,
+    used_options: set[str],
+) -> list[str]:
+    from unilab.demo import DEMO_REGISTRY
+
+    if not _demo_name_consumed(words, cword):
+        return _matching(tuple(sorted(DEMO_REGISTRY)), current)
+    if previous in _DEMO_VALUE_FLAGS:
+        return []
+    available_flags = tuple(flag for flag in _DEMO_FLAGS if flag not in used_options)
+    return _matching(available_flags, current)
+
+
 def complete_words(
     words: Sequence[str],
     cword: int,
@@ -508,6 +542,14 @@ def complete_words(
             selected_algo=option_values.get("--algo"),
             selected_sim=option_values.get("--sim"),
             selected_task=option_values.get("--task"),
+        )
+    if command == "demo":
+        return _demo_completions(
+            words=words,
+            cword=cword,
+            current=current,
+            previous=previous,
+            used_options=used_options,
         )
     if current == "" or current.startswith("-") or previous == command:
         return _matching(_available_flags(selected_metadata, command, used_options), current)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,9 +204,11 @@ def test_demo_registry_contains_expected_entries() -> None:
         "boxtracking",
         "locomani",
         "inhandgrasp",
+        "teaser",
     }
     assert demo.DEMO_REGISTRY["locomani"].entry == "play_interactive"
     assert demo.DEMO_REGISTRY["locomani"].sim == "mujoco"
+    assert demo.DEMO_REGISTRY["teaser"].entry == "teaser"
     for name in ("dance", "wallflip", "boxtracking", "inhandgrasp"):
         spec = demo.DEMO_REGISTRY[name]
         assert spec.entry == "eval"
@@ -286,3 +288,46 @@ def test_demo_main_rejects_passthrough_overrides() -> None:
 def test_demo_main_unknown_name_raises_with_available_list() -> None:
     with pytest.raises(SystemExit, match="Available demos"):
         cli.demo_main(["mystery"])
+
+
+def test_demo_teaser_build_command_rejected() -> None:
+    with pytest.raises(SystemExit, match="renderer-only"):
+        demo.build_demo_command(demo_name="teaser", checkpoint_path="/unused.pt")
+
+
+def test_demo_teaser_run_demo_invokes_render_teaser_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    def fake_render_teaser_main() -> None:
+        called.append("rendered")
+
+    import unilab.tools.render_teaser as render_teaser_module
+
+    monkeypatch.setattr(render_teaser_module, "main", fake_render_teaser_main)
+
+    def fail_resolve(_: str) -> str:
+        raise AssertionError("teaser entry must not resolve a checkpoint")
+
+    monkeypatch.setattr(demo, "resolve_checkpoint_file", fail_resolve)
+
+    rc = demo.run_demo(demo_name="teaser")
+    assert rc == 0
+    assert called == ["rendered"]
+
+
+def test_demo_main_teaser_dispatches_to_render_teaser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    def fake_render_teaser_main() -> None:
+        called.append("rendered")
+
+    import unilab.tools.render_teaser as render_teaser_module
+
+    monkeypatch.setattr(render_teaser_module, "main", fake_render_teaser_main)
+    rc = cli.demo_main(["teaser"])
+    assert rc == 0
+    assert called == ["rendered"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from unilab import cli
+from unilab import cli, demo
 
 
 def _make_minimal_checkout(root: Path, *, algo: str = "ppo") -> None:
@@ -183,3 +183,106 @@ def test_macos_motrix_render_mode_record_does_not_require_mxpython(
     )
 
     assert command[0] == sys.executable
+
+
+def _make_demo_checkout(root: Path, *, demo_name: str) -> None:
+    spec = demo.DEMO_REGISTRY[demo_name]
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    (root / "scripts" / "train_rsl_rl.py").write_text("", encoding="utf-8")
+    (root / "scripts" / "play_interactive.py").write_text("", encoding="utf-8")
+    owner_dir = root / "conf" / spec.algo / "task" / spec.task
+    owner_dir.mkdir(parents=True, exist_ok=True)
+    (owner_dir / f"{spec.sim}.yaml").write_text(
+        f"training:\n  sim_backend: {spec.sim}\n", encoding="utf-8"
+    )
+
+
+def test_demo_registry_contains_expected_entries() -> None:
+    assert set(demo.DEMO_REGISTRY) == {
+        "dance",
+        "wallflip",
+        "boxtracking",
+        "locomani",
+        "inhandgrasp",
+    }
+    assert demo.DEMO_REGISTRY["locomani"].entry == "play_interactive"
+    assert demo.DEMO_REGISTRY["locomani"].sim == "mujoco"
+    for name in ("dance", "wallflip", "boxtracking", "inhandgrasp"):
+        spec = demo.DEMO_REGISTRY[name]
+        assert spec.entry == "eval"
+        assert spec.sim == "motrix"
+        assert spec.algo == "ppo"
+
+
+def test_demo_eval_entry_passes_checkpoint_as_load_run_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_demo_checkout(tmp_path, demo_name="dance")
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+    abs_pt = str(tmp_path / "fake" / "model_0.pt")
+    command = demo.build_demo_command(demo_name="dance", checkpoint_path=abs_pt, root=tmp_path)
+
+    assert command[0] == sys.executable
+    assert command[1] == str(tmp_path / "scripts" / "train_rsl_rl.py")
+    assert "task=g1_motion_tracking/motrix" in command
+    assert "training.play_only=true" in command
+    assert f"algo.load_run={abs_pt}" in command
+
+
+def test_demo_play_interactive_entry_assembles_locomani_command(
+    tmp_path: Path,
+) -> None:
+    _make_demo_checkout(tmp_path, demo_name="locomani")
+    abs_pt = str(tmp_path / "fake" / "model_0.pt")
+    command = demo.build_demo_command(
+        demo_name="locomani", checkpoint_path=abs_pt, device="cpu", root=tmp_path
+    )
+
+    assert command[0] == sys.executable
+    assert command[1] == str(tmp_path / "scripts" / "play_interactive.py")
+    assert "task=go2_arm_manip_loco/mujoco" in command
+    assert f"algo.load_run={abs_pt}" in command
+    assert "training.device=cpu" in command
+
+
+def test_demo_play_interactive_requires_owner_yaml(tmp_path: Path) -> None:
+    (tmp_path / "scripts").mkdir(parents=True)
+    (tmp_path / "scripts" / "play_interactive.py").write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="owner config"):
+        demo.build_demo_command(
+            demo_name="locomani",
+            checkpoint_path="/tmp/fake/model_0.pt",
+            root=tmp_path,
+        )
+
+
+def test_demo_play_interactive_requires_script(tmp_path: Path) -> None:
+    spec = demo.DEMO_REGISTRY["locomani"]
+    owner_dir = tmp_path / "conf" / spec.algo / "task" / spec.task
+    owner_dir.mkdir(parents=True)
+    (owner_dir / f"{spec.sim}.yaml").write_text("training:\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="play_interactive.py"):
+        demo.build_demo_command(
+            demo_name="locomani",
+            checkpoint_path="/tmp/fake/model_0.pt",
+            root=tmp_path,
+        )
+
+
+def test_demo_unknown_name_lists_available_demos() -> None:
+    with pytest.raises(SystemExit, match="Available demos"):
+        demo.get_demo_spec("not_a_real_demo")
+
+
+def test_demo_main_rejects_passthrough_overrides() -> None:
+    with pytest.raises(SystemExit, match="passthrough"):
+        cli.demo_main(["dance", "training.device=cpu"])
+
+
+def test_demo_main_unknown_name_raises_with_available_list() -> None:
+    with pytest.raises(SystemExit, match="Available demos"):
+        cli.demo_main(["mystery"])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -274,3 +274,58 @@ def test_task_completion_respects_selected_profile(tmp_path: Path) -> None:
         10,
         metadata,
     ) == ["go1"]
+
+
+def test_demo_positional_completes_all_demo_names(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    choices = complete_words(["uv", "run", "demo", ""], 3, metadata)
+    assert choices == [
+        "boxtracking",
+        "dance",
+        "inhandgrasp",
+        "locomani",
+        "teaser",
+        "wallflip",
+    ]
+
+
+def test_demo_positional_filters_by_prefix(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(["uv", "run", "demo", "d"], 3, metadata) == ["dance"]
+    assert complete_words(["uv", "run", "demo", "t"], 3, metadata) == ["teaser"]
+
+
+def test_demo_flags_completed_after_demo_name(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    choices = complete_words(["uv", "run", "demo", "dance", "--"], 4, metadata)
+    assert choices == ["--device", "--refresh"]
+
+
+def test_demo_used_flag_excluded_from_completions(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    choices = complete_words(["uv", "run", "demo", "dance", "--refresh", "--"], 5, metadata)
+    assert choices == ["--device"]
+
+
+def test_demo_device_value_position_defers_to_shell(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(["uv", "run", "demo", "dance", "--device", ""], 5, metadata) == []
+
+
+def test_demo_name_still_completes_when_leading_flag_present(tmp_path: Path) -> None:
+    _write_completion_fixture(tmp_path)
+    metadata = build_metadata(tmp_path)
+
+    assert complete_words(["uv", "run", "demo", "--refresh", "d"], 4, metadata) == [
+        "dance",
+    ]


### PR DESCRIPTION
## Summary

- **新增 `uv run demo <name>`**：位置参数化的零配置 demo 入口。6 个 demo 名（`dance` / `wallflip` / `boxtracking` / `locomani` / `inhandgrasp` / `teaser`），首次运行自动从 Hugging Face 拉取权重或场景资源到本地缓存，再启动对应的交互式仿真器。
- **复用而非新写**：利用 `algo.load_run` 原生支持绝对路径的事实（`src/unilab/training/run.py:113-117`），把 HF 下载到的 .pt 绝对路径作为 override 透传，**不动训练脚本、不动 `build_command`**。
- **5 个 checkpoint demo 走 motrix/mujoco 回放**：4 个 motrix demo 复用 `cli.build_command(mode="eval")` → `train_rsl_rl.py --play_only`；`locomani` 因为 `play_interactive.py` 是 MuJoCo-only 且 `conf/ppo/task/go2_arm_manip_loco/` 只有 `mujoco.yaml`，单独走 `scripts/play_interactive.py`。
- **`uv run demo teaser` 取代 `unilab-render-teaser` 形式**：作为 `DEMO_REGISTRY` 第 6 项接入，`entry="teaser"` 时跳过 checkpoint 下载，直接调 `unilab.tools.render_teaser:main`；HF 仓库（`unilabsim/unilab-scenes`）和下载链路不变。`unilab-render-teaser` 入口保留作为别名。
- **Tab 补全**：`uv run demo<TAB>` 之后 6 个 demo 名 + `--device` / `--refresh` flag 提示，已用 flag 自动排除，`--device` 值位让位 shell 默认补全。

## Linked Work

- Issue: —
- Milestone: —

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Manual smoke：5 + 1 demos 端到端跑通（用户已在本地依次执行 `uv run demo dance` / `wallflip` / `boxtracking` / `locomani` / `inhandgrasp`，全部成功；HF 下载链路 + 加载 + 仿真器渲染均正常）

Commands actually run:

```bash
make test-all
# Success: no issues found in 205 source files (ruff + mypy + pyright)
# ======== 1051 passed, 12 skipped, 254 deselected, 66 warnings in 50.61s ========

uv run demo dance
uv run demo wallflip
uv run demo boxtracking
uv run demo locomani
uv run demo inhandgrasp
```

## Impact

- Backend impact: **both**（4 demos motrix + locomani mujoco）
- Platform impact: **both**（macOS Motrix 走 mxpython 由 `build_command` 已有路径自动处理；Linux 走 sys.executable）
- Training effect expected: **no**（纯 eval / 渲染路径，未改训练脚本、未改 reward、未改 backend）

## Artifacts

- HF dataset: https://huggingface.co/datasets/unilabsim/unilab-checkpoints（已上传 5 个文件：`checkpoints/<demo>/model_0.pt`；teaser 复用现有 `unilabsim/unilab-scenes`）
- 本地缓存路径: `src/unilab/assets/checkpoints/<demo>/model_0.pt`
- video / screenshot: —
- ONNX: —

## Changed files

```
docs/sphinx/source/en/1-getting_started/1-quick_demo.md              |   6 +-
docs/sphinx/source/en/1-getting_started/3-evaluation_and_playback.md |   4 +-
docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md     |  15 +-
docs/sphinx/source/zh_CN/1-user_guide/2-training/1-unified-cli.md    |  17 +-
docs/sphinx/source/zh_CN/1-user_guide/3-training.md                  |   2 +-
notebook/demo.ipynb                                                  | 141 ++++----
src/unilab/assets/hub.py                                             |  20 +++
src/unilab/cli.py                                                    |   4 +-
src/unilab/demo.py                                                   | 173 +++++++----
src/unilab/tools/completion.py                                       |  42 +++
tests/test_cli.py                                                    | 150 +++++++++-
tests/test_completion.py                                             |  55 ++++
12 files changed, 479 insertions(+), 150 deletions(-)
```

## Checklist

- [x] Added or updated tests where needed（demo 注册表 + dispatch + teaser + tab 补全总计新增 17 个测试）
- [x] Updated docs if behavior or workflow changed（EN/zh_CN CLI 参考、Quick Demo、evaluation_and_playback、训练指南、notebook）
- [x] Linked the driving issue — N/A
- [x] Noted any follow-up work explicitly — 无明显 follow-up；`unilab-render-teaser` 入口保留作为别名，未来如需移除可单独发一个 deprecation PR
