### PR TITLE
docs: make docs CI prose-only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,32 @@
 name: Docs
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/sphinx/**"
+      - "docs/README.md"
+      - "src/unilab/**"
+      - "scripts/generate_support_matrix.py"
+      - "conf/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/sphinx/**"
+      - "docs/README.md"
+      - "src/unilab/**"
+      - "scripts/generate_support_matrix.py"
+      - "conf/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -15,51 +41,24 @@ jobs:
     name: Build Sphinx
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      UNILAB_DOCS_SKIP_AUTODOC: "1"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.11"
-          cache: pip
 
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-              libgl1 libegl1 libosmesa6 libglfw3 \
-              ffmpeg
-
-      - name: Install doc deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r docs/sphinx/requirements.txt
-
-      - name: Install UniLab (autodoc target)
-        id: install_unilab
-        continue-on-error: true
-        # We skip extras (motrix, mlx) — conf.py provides lightweight MLX
-        # docs stubs, and autodoc_mock_imports covers the remaining heavy deps.
-        # If install fails we still build prose-only.
-        run: pip install -e .
-
-      - name: Configure prose-only fallback
-        if: steps.install_unilab.outcome != 'success'
-        run: |
-          echo "::warning::UniLab install failed — building prose-only docs"
-          echo "UNILAB_DOCS_SKIP_AUTODOC=1" >> "$GITHUB_ENV"
-
-      - name: Build HTML
+      - name: Build prose-only HTML
         working-directory: docs/sphinx
-        run: sphinx-build -b html -n source build/html
-
-      - name: Build linkcheck (non-blocking)
-        continue-on-error: true
-        working-directory: docs/sphinx
-        run: sphinx-build -b linkcheck source build/linkcheck
+        run: >
+          uv run --no-project
+          --with-requirements requirements.txt
+          sphinx-build -b html -n source build/html
 
       - name: Upload built site
         uses: actions/upload-artifact@v4
@@ -67,33 +66,3 @@ jobs:
           name: docs-html
           path: docs/sphinx/build/html
           retention-days: 7
-
-  deploy:
-    name: Deploy to UniLab-doc gh-pages
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Download built site
-        uses: actions/download-artifact@v4
-        with:
-          name: docs-html
-          path: site
-
-      - name: Push to UniLab-doc gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          # SSH deploy key for unilabsim/UniLab-doc (write access required).
-          # Add it once in this repo's Secrets as UNILAB_DOC_DEPLOY_KEY.
-          deploy_key: ${{ secrets.UNILAB_DOC_DEPLOY_KEY }}
-          external_repository: unilabsim/UniLab-doc
-          publish_branch: gh-pages
-          publish_dir: ./site
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
-          commit_message: "docs: deploy from UniLab@${{ github.sha }}"
-          full_commit_message: |
-            docs: deploy from UniLab@${{ github.sha }}
-
-            Source: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ gh pr create --title "fix: xxx" --body "Fixes #174" --base main
 - 架构标准与验证详情：[docs/sphinx/source/zh_CN/2-developer_guide/1-development-standard.md](docs/sphinx/source/zh_CN/2-developer_guide/1-development-standard.md)
 - 协作流程与 PR 规范：[docs/sphinx/source/zh_CN/2-developer_guide/2-collaboration.md](docs/sphinx/source/zh_CN/2-developer_guide/2-collaboration.md)
 - 开发者入口（环境、命令、提交规范）：[CONTRIBUTING.md](CONTRIBUTING.md)
+- 文档本地构建与发布到 UniLab-doc：[docs/sphinx/README.md#本地发布到-unilab-doc](docs/sphinx/README.md#本地发布到-unilab-doc)

--- a/docs/sphinx/AGENTS.md
+++ b/docs/sphinx/AGENTS.md
@@ -7,6 +7,7 @@ Sphinx 文档写作规则。
 ## Ground Truth
 
 - 文档基础设施、构建和部署：`docs/sphinx/README.md`
+- 本地完整构建并发布到 UniLab-doc：`docs/sphinx/README.md#本地发布到-unilab-doc`
 - Sphinx 配置：`docs/sphinx/source/conf.py`
 - 架构标准：`docs/sphinx/source/zh_CN/2-developer_guide/1-development-standard.md`
 - ADR：`docs/sphinx/source/adr/ADR-0000-index.md`
@@ -234,7 +235,7 @@ For docs-only changes, run:
 ```bash
 uv run pytest tests/scripts/test_check_docs.py -q
 cd docs/sphinx
-UNILAB_DOCS_SKIP_AUTODOC=1 uv run sphinx-build -b html -n source build/html
+UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt sphinx-build -b html -n source build/html
 ```
 
 If you changed generated support data, run the generator first. If you changed

--- a/docs/sphinx/README.md
+++ b/docs/sphinx/README.md
@@ -45,76 +45,93 @@ URL 模式:`/`(语言 picker)、`/en/...`、`/zh_CN/...`。两种语言路径 1:
 
 ## 本地构建
 
-需要 Python >= 3.10。建议用 `uv`:
+需要 Python >= 3.10。建议用 `uv`。快速预览散文页时跳过 autodoc:
 
 ```bash
 cd docs/sphinx
-
-# 1. 装文档依赖
-uv venv && source .venv/bin/activate
-uv pip install -r requirements.txt
-
-# 2. 装 UniLab 本身,以便 autodoc 能 import unilab
-#    没装时 conf.py 会自动 fallback 到 "prose-only" 构建,跳过 API reference
-uv pip install -e ../..
-
-# 3. 一次性构建
-make html
-# 输出:build/html/index.html(根 picker)、build/html/en/index.html、build/html/zh_CN/index.html
-
-# 4. live preview(推荐写文档时用)
-make live
-# 默认监听 127.0.0.1:8000
-
-# 5. CI 等价的"严格构建"(warning → error)
-make strict
+UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt sphinx-build -b html -n source build/html
 ```
 
-只想快速预览散文页(跳过 autodoc):
+最终发布前的完整 API 文档构建由开发者在本地执行。先在仓库根目录同步 UniLab
+依赖并安装 Sphinx 依赖,再用 Sphinx 多进程构建:
 
 ```bash
-UNILAB_DOCS_SKIP_AUTODOC=1 make html
+uv sync
+uv pip install -r docs/sphinx/requirements.txt
+cd docs/sphinx
+uv run --no-sync sphinx-build -j auto -b html -n source build/html
+```
+
+需要本地 live preview 时:
+
+```bash
+cd docs/sphinx
+UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt sphinx-autobuild --watch ../../src source build/html -n
 ```
 
 ## CI / 部署
 
 CI 工作流在 `.github/workflows/docs.yml`:
 
-- **PR**: 只 build,不部署。failed 阻塞 PR(只看 build job,deploy 不跑)
-- **push to main**: build + 用 deploy key 把 `build/html`(含 `/`、`/en/`、`/zh_CN/`)推到
-  `unilabsim/UniLab-doc` 的 `gh-pages` 分支
-- **手动**: `workflow_dispatch` 也能触发
+- **PR**: prose-only HTML build,跳过 API reference,failed 阻塞 PR
+- **push to main**: prose-only HTML build,不部署
+- **手动**: `workflow_dispatch` 可在 GitHub Actions 网页端触发同一套 prose-only CI
 
-### Deploy key 配置(一次性 setup)
-
-CI 用 SSH deploy key 跨仓推送,不需要 PAT:
-
-```bash
-# 1. 在本地生成专用 keypair(不要复用个人 SSH key)
-ssh-keygen -t ed25519 -C "unilab-doc-deploy" -f /tmp/unilab_doc_deploy -N ""
-
-# 2. UniLab-doc 仓 → Settings → Deploy keys → Add deploy key
-#    Title: unilab-docs-ci
-#    Key:   贴 /tmp/unilab_doc_deploy.pub
-#    ✅ Allow write access
-
-# 3. UniLab 仓(本仓) → Settings → Secrets and variables → Actions → New repository secret
-#    Name:  UNILAB_DOC_DEPLOY_KEY
-#    Value: 贴 /tmp/unilab_doc_deploy(private,完整内容含 BEGIN/END 行)
-
-# 4. 删除本地副本
-shred -u /tmp/unilab_doc_deploy /tmp/unilab_doc_deploy.pub
-```
-
-CI step 用的是 `peaceiris/actions-gh-pages@v4`,详见 `.github/workflows/docs.yml`。
+CI 明确设置 `UNILAB_DOCS_SKIP_AUTODOC=1`,不执行 `pip install -e .`,不安装 UniLab
+运行时依赖,也不跑 linkcheck。完整构建和站点发布由开发者本地完成。
 
 ### UniLab-doc 仓的 Pages 设置
 
-`Settings → Pages`:
+发布站点托管在 [`unilabsim/UniLab-doc`](https://github.com/unilabsim/UniLab-doc)。
+该仓库的 Pages 设置保持:
+
 - **Source**: Deploy from a branch
 - **Branch**: `gh-pages` / `/ (root)`
 
-第一次 CI 跑完会自动建 `gh-pages` 分支。
+### 本地发布到 UniLab-doc
+
+完整 API 文档在本地构建完成后,把 `docs/sphinx/build/html/` 的内容同步到
+`unilabsim/UniLab-doc` 的 `gh-pages` 分支根目录:
+
+```bash
+# 在 UniLab 仓库根目录
+uv sync
+uv pip install -r docs/sphinx/requirements.txt
+cd docs/sphinx
+uv run --no-sync sphinx-build -j auto -b html -n source build/html
+cd ../..
+```
+
+准备发布仓库。第一次发布时克隆:
+
+```bash
+git clone -b gh-pages git@github.com:unilabsim/UniLab-doc.git ../UniLab-doc
+```
+
+如果本地已经有 `../UniLab-doc`,先更新到最新:
+
+```bash
+git -C ../UniLab-doc checkout gh-pages
+git -C ../UniLab-doc pull --ff-only
+```
+
+同步构建产物并推送:
+
+```bash
+rsync -a --delete --exclude .git docs/sphinx/build/html/ ../UniLab-doc/
+touch ../UniLab-doc/.nojekyll
+
+SOURCE_SHA=$(git rev-parse --short HEAD)
+cd ../UniLab-doc
+git status --short
+git add -A
+git commit -m "docs: publish UniLab@${SOURCE_SHA}"
+git push origin gh-pages
+```
+
+`.nojekyll` 必须保留,否则 GitHub Pages 可能无法正确服务 Sphinx 的 `_static/`
+等目录。推送后站点会更新到 <https://unilabsim.github.io/UniLab-doc/>。
+不要把 `docs/sphinx/build/html/` 提交回 UniLab 主仓。
 
 ## 写新文档的约定
 

--- a/docs/sphinx/source/en/4-developer_guide/4-contributing.md
+++ b/docs/sphinx/source/en/4-developer_guide/4-contributing.md
@@ -31,7 +31,24 @@ For docs-only changes, run:
 ```bash
 uv run pytest tests/scripts/test_check_docs.py -q
 cd docs/sphinx
-UNILAB_DOCS_SKIP_AUTODOC=1 uv run sphinx-build -b html -n source build/html
+UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt sphinx-build -b html -n source build/html
+```
+
+The `Docs` GitHub Actions workflow runs the same prose-only build on matching
+PRs and pushes, and it can also be started from the GitHub Actions web UI via
+`workflow_dispatch`. It does not install UniLab with `pip install -e .`, does
+not generate API reference pages, and does not publish the external docs
+repository.
+
+For a final local refresh of the full site, including API reference pages for
+the `UniLab-doc` publication flow, use a parallel Sphinx build from a synced
+developer environment:
+
+```bash
+uv sync
+uv pip install -r docs/sphinx/requirements.txt
+cd docs/sphinx
+uv run --no-sync sphinx-build -j auto -b html -n source build/html
 ```
 
 ## Commit And PR Expectations

--- a/docs/sphinx/source/zh_CN/2-developer_guide/3-contributing.md
+++ b/docs/sphinx/source/zh_CN/2-developer_guide/3-contributing.md
@@ -40,6 +40,28 @@ make test-slow      # slow 集成测试和训练冒烟测试
 make test-all       # make check && make test-cov
 ```
 
+## Documentation Builds
+
+文档 PR 的 GitHub Actions 只跑 prose-only HTML 构建: 设置
+`UNILAB_DOCS_SKIP_AUTODOC=1`,不执行 `pip install -e .`,不生成 API reference,
+也不发布外部文档仓库。开发者本地快速验证文档改动时运行:
+
+```bash
+uv run pytest tests/scripts/test_check_docs.py -q
+cd docs/sphinx
+UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt sphinx-build -b html -n source build/html
+```
+
+最终刷新完整站点、包含 API reference 并用于 `UniLab-doc` 发布流程时,在本地同步
+UniLab 环境后使用 Sphinx 多进程构建:
+
+```bash
+uv sync
+uv pip install -r docs/sphinx/requirements.txt
+cd docs/sphinx
+uv run --no-sync sphinx-build -j auto -b html -n source build/html
+```
+
 ## Commit Conventions
 
 使用 Conventional Commits:
@@ -112,7 +134,7 @@ uv run pytest -m "slow" -v
 | `pyright` | 在 `ubuntu-slim` 上执行 `uv sync` + `uv run pyright` | ✅ |
 | `test` | 在 `ubuntu-slim` 上以 Python 3.11 执行 `uv sync --extra motrix`，跳过 CUDA torch / nvidia wheel，安装 CPU torch，并用 `uv run --no-sync pytest -m "not slow" --cov=unilab --cov-report markdown-append:$GITHUB_STEP_SUMMARY --cov-fail-under=25` | ✅ |
 
-只有协作元信息改动，例如 `LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，才会跳过 CI。文档改动会触发 CI，并由 `tests/scripts/test_check_docs.py` 校验。
+只有协作元信息改动，例如 `LICENSE`、issue templates、`CODEOWNERS` 和 `.github/pull_request_template.md`，才会跳过 CI。文档改动会触发 CI，并由 `tests/scripts/test_check_docs.py` 校验。`Docs` workflow 是独立的 prose-only Sphinx 校验，支持 PR / push 触发，也可以在 GitHub Actions 网页端通过 `workflow_dispatch` 手动触发。
 
 ## Documentation Expectations
 


### PR DESCRIPTION
## Summary
- restore the Docs workflow for PR, push, and manual triggers while forcing prose-only Sphinx builds
- remove CI UniLab runtime installation, linkcheck, and cross-repo deployment from the docs workflow
- document local full API docs build and UniLab-doc gh-pages publishing steps, with AGENTS links

## Validation
- make test-all