### PR TITLE
fix: route teaser demo through mxpython on macOS

### DIFF
--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -147,17 +147,26 @@ def _python_executable_for_route(mode: str, sim: str, overrides: Sequence[str]) 
     if platform.system() != "Darwin" or not _needs_motrix_renderer(mode, sim, overrides):
         return sys.executable
 
+    return _mxpython_executable()
+
+
+def _mxpython_executable() -> str:
     if Path(sys.executable).name == "mxpython":
         return sys.executable
 
     mxpython = shutil.which("mxpython")
-    if mxpython is None:
-        raise SystemExit(
-            "macOS Motrix playback uses the native renderer and must be launched with "
-            "`mxpython`. Install the Motrix extra so `mxpython` is on PATH, or use "
-            "`training.no_play=true` for non-rendering training."
-        )
-    return mxpython
+    if mxpython is not None:
+        return mxpython
+
+    venv_mxpython = Path(sys.executable).with_name("mxpython")
+    if venv_mxpython.is_file():
+        return str(venv_mxpython)
+
+    raise SystemExit(
+        "macOS Motrix playback uses the native renderer and must be launched with "
+        "`mxpython`. Install the Motrix extra so `mxpython` is on PATH, or use "
+        "`training.no_play=true` for non-rendering training."
+    )
 
 
 def build_route(algo: str, task: str, sim: str, profile: str | None = None) -> Route:

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -116,7 +117,22 @@ def build_demo_command(
     raise SystemExit(f"Unknown demo entry kind: {spec.entry!r}")
 
 
+def _mxpython_executable() -> str:
+    from unilab.cli import _mxpython_executable as resolve_mxpython_executable
+
+    return resolve_mxpython_executable()
+
+
 def _run_teaser_demo() -> int:
+    if platform.system() == "Darwin" and Path(sys.executable).name != "mxpython":
+        command = [
+            _mxpython_executable(),
+            str(_repo_root() / "src" / "unilab" / "tools" / "render_teaser.py"),
+        ]
+        env = os.environ.copy()
+        env.setdefault("UV_PROJECT_ENVIRONMENT", str(_repo_root() / ".venv"))
+        return subprocess.run(command, check=False, env=env).returncode
+
     from unilab.tools.render_teaser import main as render_teaser_main
 
     render_teaser_main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from importlib.machinery import ModuleSpec
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -75,6 +76,34 @@ def test_macos_motrix_train_no_play_uses_current_python(
     assert command[0] == sys.executable
 
 
+def test_macos_motrix_finds_uv_venv_mxpython_when_not_on_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    fake_python = venv_bin / "python"
+    fake_mxpython = venv_bin / "mxpython"
+    fake_python.write_text("", encoding="utf-8")
+    fake_mxpython.write_text("", encoding="utf-8")
+    _make_minimal_checkout(tmp_path)
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli.sys, "executable", str(fake_python))
+
+    command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="go2_joystick_flat",
+        sim="motrix",
+        overrides=[],
+        load_run="-1",
+        root=tmp_path,
+    )
+
+    assert command[0] == str(fake_mxpython)
+
+
 def test_train_profile_routes_to_owner_variant(tmp_path: Path) -> None:
     (tmp_path / "scripts").mkdir(parents=True)
     (tmp_path / "scripts" / "train_rsl_rl.py").write_text("", encoding="utf-8")
@@ -145,6 +174,7 @@ def test_macos_motrix_eval_requires_mxpython(
     _pretend_motrix_is_installed(monkeypatch)
     monkeypatch.setattr(cli.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli.sys, "executable", str(tmp_path / "python"))
 
     with pytest.raises(SystemExit, match="mxpython"):
         cli.build_command(
@@ -338,6 +368,7 @@ def test_demo_teaser_run_demo_invokes_render_teaser_main(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     called: list[str] = []
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
 
     def fake_render_teaser_main() -> None:
         called.append("rendered")
@@ -356,10 +387,44 @@ def test_demo_teaser_run_demo_invokes_render_teaser_main(
     assert called == ["rendered"]
 
 
+def test_demo_teaser_uses_mxpython_subprocess_on_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, str]]] = []
+    monkeypatch.setattr(demo.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(demo.sys, "executable", "/tmp/unilab/.venv/bin/python")
+    monkeypatch.setattr(demo, "_mxpython_executable", lambda: "/tmp/unilab/.venv/bin/mxpython")
+
+    def fake_run(command: list[str], *, check: bool, env: dict[str, str]) -> SimpleNamespace:
+        assert check is False
+        calls.append((command, env))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(demo.subprocess, "run", fake_run)
+
+    def fail_render_teaser_main() -> None:
+        raise AssertionError("macOS teaser must route through mxpython")
+
+    import unilab.tools.render_teaser as render_teaser_module
+
+    monkeypatch.setattr(render_teaser_module, "main", fail_render_teaser_main)
+
+    rc = demo.run_demo(demo_name="teaser")
+
+    assert rc == 0
+    command, env = calls[0]
+    assert command == [
+        "/tmp/unilab/.venv/bin/mxpython",
+        str(demo._repo_root() / "src" / "unilab" / "tools" / "render_teaser.py"),
+    ]
+    assert env["UV_PROJECT_ENVIRONMENT"] == str(demo._repo_root() / ".venv")
+
+
 def test_demo_main_teaser_dispatches_to_render_teaser(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     called: list[str] = []
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
 
     def fake_render_teaser_main() -> None:
         called.append("rendered")


### PR DESCRIPTION
## Summary
- route the renderer-only teaser demo through mxpython on macOS so Motrix creates its event loop on the required main thread
- make mxpython discovery work for uv-managed virtualenvs where mxpython is available at .venv/bin/mxpython but not on PATH
- add CLI/demo tests for the macOS teaser route and uv venv mxpython fallback

## Validation
- uv run demo teaser opened successfully on macOS; window was manually closed after confirming playback
- make test-all