### PR TITLE
fix: reduce demo playback robot count

### DIFF
--- a/conf/ppo/task/g1_box_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_box_tracking/motrix.yaml
@@ -2,7 +2,7 @@
 training:
   task_name: G1BoxTracking
   sim_backend: motrix
-  play_env_num: 128
+  play_env_num: 16
   play_steps: 1000
 algo:
   num_envs: 1024

--- a/conf/ppo/task/g1_motion_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking/motrix.yaml
@@ -2,7 +2,7 @@
 training:
   task_name: G1MotionTracking
   sim_backend: motrix
-  play_env_num: 128
+  play_env_num: 16
   play_steps: 1000
 algo:
   num_envs: 1024

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -795,7 +795,7 @@ def test_build_ppo_play_env_cfg_override_applies_g1_motion_tracking_play_profile
 ):
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix", "training.play_only=true"])
-    assert cfg.training.play_env_num == 128
+    assert cfg.training.play_env_num == 16
 
     monkeypatch.setattr(
         mod,
@@ -805,7 +805,7 @@ def test_build_ppo_play_env_cfg_override_applies_g1_motion_tracking_play_profile
 
     env_cfg_override = mod.build_ppo_play_env_cfg_override(cfg)
 
-    assert cfg.training.play_env_num == 128
+    assert cfg.training.play_env_num == 16
     assert env_cfg_override["render_spacing"] == pytest.approx(2.5)
     assert env_cfg_override["scene"].model_file == "/tmp/g1_motion_tracking_play_scene.xml"
     assert env_cfg_override["reward_config"]["scales"]["motion_body_pos"] == pytest.approx(1.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ def _make_minimal_checkout(
 
 
 def _pretend_motrix_is_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "unilab.cli", cli)
     monkeypatch.setattr(
         cli,
         "find_spec",

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -230,7 +230,7 @@ def test_backend_adapter_env_cfg_override_for_motrix_sac_g1_walk_flat():
 
 def test_backend_adapter_builds_play_scene_override():
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix", "training.play_only=true"])
-    assert cfg.training.play_env_num == 128
+    assert cfg.training.play_env_num == 16
     captured: dict[str, object] = {}
 
     def _fake_materializer(source_model_file: str, **kwargs) -> str:
@@ -245,7 +245,7 @@ def test_backend_adapter_builds_play_scene_override():
         scene_materializer=_fake_materializer,
     ).build_play_env_cfg_override()
 
-    assert cfg.training.play_env_num == 128
+    assert cfg.training.play_env_num == 16
     assert env_cfg_override["render_spacing"] == pytest.approx(2.5)
     assert env_cfg_override["scene"].model_file == "/tmp/g1_motion_tracking_play_scene.xml"
     assert captured["ground_texture_file"] == str(


### PR DESCRIPTION
## Summary
- Reduce Motrix play-time env count for dance and boxtracking from 128 to 16.
- Update tests that asserted the old play env count.
- Stabilize the CLI test against unilab.cli module reloads.

## Validation
- make test-all