### PR TITLE
fix: 消除 collector subprocess 静默崩溃、JIT 编译隐式依赖和 OOM

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -363,7 +363,9 @@ _LANGUAGE_ROOT_INDEX = {
 # table keeps the language switcher landing on the closest equivalent page
 # instead of bouncing to the language index. Forward direction only — reverse
 # map is computed below.
-_LANGUAGE_PATH_FORWARD: dict[str, str] = {}
+_LANGUAGE_PATH_FORWARD: dict[str, str] = {
+    "en/1-getting_started/5-faq": "zh_CN/1-getting_started/5-faq",
+}
 # Keyed by (current_pagename, target_language) → target_pagename.
 _LANGUAGE_PATH_MAP: dict[tuple[str, str], str] = {}
 for _en_page, _zh_page in _LANGUAGE_PATH_FORWARD.items():

--- a/docs/sphinx/source/en/1-getting_started/0-index.md
+++ b/docs/sphinx/source/en/1-getting_started/0-index.md
@@ -31,6 +31,13 @@ Replay checkpoints, export video, and use demo mode.
 Find the directories that own scripts, configs, envs, backends, and docs.
 :::
 
+:::{grid-item-card} FAQ
+:link: 5-faq
+:link-type: doc
+Install and first-run issues: proxy direct connection, HuggingFace SOCKS,
+off-policy JIT compilation prerequisites, and video export.
+:::
+
 ::::
 
 For daily training options after the first run, use
@@ -44,4 +51,5 @@ For daily training options after the first run, use
 2-installation
 3-evaluation_and_playback
 4-project_structure
+5-faq
 ```

--- a/docs/sphinx/source/en/1-getting_started/5-faq.md
+++ b/docs/sphinx/source/en/1-getting_started/5-faq.md
@@ -1,0 +1,140 @@
+# FAQ
+
+Common problems when installing and first running UniLab, organized as
+symptom -> fix. Most relate to proxy environments (HTTP / SOCKS5), the JIT
+compilation dependencies of off-policy algorithms, or video export.
+
+## motrixsim-core download times out
+
+```
+× Failed to download `motrixsim-core==0.8.1.dev104665`
+╰─▶ operation timed out
+```
+
+`pypi.motphys.com` is hosted in mainland China and is often unreachable through
+an overseas proxy. Bypass it with `no_proxy`:
+
+```bash
+export no_proxy="pypi.motphys.com"
+export NO_PROXY="pypi.motphys.com"
+make setup-motrix
+```
+
+Set both cases because `uv`'s Rust HTTP client checks both variable names.
+
+## httpx SOCKS proxy missing socksio
+
+```
+ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
+```
+
+`huggingface_hub` uses `httpx`, which requires `socksio` once it detects
+`ALL_PROXY=socks5://...`. Install it into the project `.venv/` (not conda):
+
+```bash
+uv pip install httpx[socks] --python .venv/bin/python
+```
+
+Or switch to an HTTP proxy to avoid SOCKS entirely:
+
+```bash
+unset all_proxy ALL_PROXY
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+```
+
+## SAC / TD3 training exits immediately (exit code 247)
+
+```
+resource_tracker: There appear to be 5 leaked semaphore objects to clean up at shutdown
+```
+
+Off-policy algorithms JIT-compile the C++ CUDA extension `unilab_native_h2d`
+inside the collector subprocess. When compilation fails the subprocess exits
+silently with no traceback. Run the same task with `--sim mujoco` to see the
+full error.
+
+Compilation needs three prerequisites:
+
+**Missing C++ compiler** — `c++: not found`:
+
+```bash
+sudo apt-get install build-essential
+```
+
+**Missing CUDA Toolkit headers** — `cuda_runtime_api.h: No such file`:
+
+```bash
+conda install -c nvidia cuda-toolkit=12.8 -y
+```
+
+The PyTorch pip wheel ships only the runtime `.so`, not the compile headers.
+PPO/APPO do not need the Toolkit; the SAC/TD3 JIT compilation does.
+
+**conda CUDA Toolkit header path is non-standard**:
+
+```bash
+export CUDA_HOME=$CONDA_PREFIX
+export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
+```
+
+conda places headers under `targets/x86_64-linux/include/` instead of
+`$CUDA_HOME/include/`. Once set, the JIT result is cached to
+`~/.cache/torch_extensions/` and is not recompiled on later runs.
+
+## conda install connection fails
+
+```
+CondaHTTPError: HTTP 000 CONNECTION FAILED for url
+```
+
+conda does not read the shell's `http_proxy`. Configure it separately:
+
+```bash
+conda config --set proxy_servers.http http://127.0.0.1:7897
+conda config --set proxy_servers.https http://127.0.0.1:7897
+```
+
+## ffmpeg missing
+
+```
+RuntimeError: Program 'ffmpeg' is not found
+```
+
+Replay video recording after training needs ffmpeg:
+
+```bash
+sudo apt install ffmpeg
+```
+
+## Persistent environment variables
+
+Add the following to `~/.bashrc`:
+
+```bash
+# Proxy
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+export no_proxy="pypi.motphys.com,localhost,127.0.0.1"
+export NO_PROXY="pypi.motphys.com,localhost,127.0.0.1"
+
+# CUDA Toolkit (conda path, adjust to your install)
+export CUDA_HOME=/home/<user>/anaconda3/envs/unilab
+export CPLUS_INCLUDE_PATH=$CUDA_HOME/targets/x86_64-linux/include
+
+# HuggingFace mirror
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+## Quick reference
+
+| Symptom | Fix |
+|---------|-----|
+| motrixsim-core timeout | `no_proxy=pypi.motphys.com` |
+| socksio not installed | `uv pip install httpx[socks] --python .venv/bin/python` |
+| SAC/TD3 exits immediately (247) | run with `--sim mujoco` to see the full error |
+| `c++: not found` | `sudo apt install build-essential` |
+| `cuda_runtime_api.h` missing | `conda install -c nvidia cuda-toolkit=12.8` |
+| CUDA headers path wrong | `export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include` |
+| conda HTTP 000 | `conda config --set proxy_servers.https http://127.0.0.1:7897` |
+| ffmpeg not found | `sudo apt install ffmpeg` |

--- a/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
@@ -29,10 +29,10 @@
 找到负责 scripts、configs、envs、backends 和 docs 的各个目录。
 :::
 
-:::{grid-item-card} 代理与网络配置
-:link: 5-proxy_setup
+:::{grid-item-card} 常见问题
+:link: 5-faq
 :link-type: doc
-在代理环境下安装 UniLab：解决 motphys.com 直连、HuggingFace SOCKS、CUDA Toolkit 头文件路径等常见问题。
+安装与首次运行的常见问题：代理直连、HuggingFace SOCKS、off-policy JIT 编译依赖、视频导出等。
 :::
 
 ::::
@@ -48,5 +48,5 @@
 2-installation
 3-evaluation_and_playback
 4-project_structure
-5-proxy_setup
+5-faq
 ```

--- a/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
@@ -29,6 +29,18 @@
 找到负责 scripts、configs、envs、backends 和 docs 的各个目录。
 :::
 
+:::{grid-item-card} 代理与网络配置
+:link: 5-proxy_setup
+:link-type: doc
+在代理环境下安装 UniLab：解决 motphys.com 直连、HuggingFace SOCKS、CUDA Toolkit 头文件路径等常见问题。
+:::
+
+:::{grid-item-card} 环境配置全过程记录
+:link: 6-troubleshooting_journal
+:link-type: doc
+从零安装到训练成功的完整问题排查日志，包含根因分析和解决方案。
+:::
+
 ::::
 
 完成第一次运行后，日常训练选项请参阅
@@ -42,4 +54,6 @@
 2-installation
 3-evaluation_and_playback
 4-project_structure
+5-proxy_setup
+6-troubleshooting_journal
 ```

--- a/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/0-index.md
@@ -35,12 +35,6 @@
 在代理环境下安装 UniLab：解决 motphys.com 直连、HuggingFace SOCKS、CUDA Toolkit 头文件路径等常见问题。
 :::
 
-:::{grid-item-card} 环境配置全过程记录
-:link: 6-troubleshooting_journal
-:link-type: doc
-从零安装到训练成功的完整问题排查日志，包含根因分析和解决方案。
-:::
-
 ::::
 
 完成第一次运行后，日常训练选项请参阅
@@ -55,5 +49,4 @@
 3-evaluation_and_playback
 4-project_structure
 5-proxy_setup
-6-troubleshooting_journal
 ```

--- a/docs/sphinx/source/zh_CN/1-getting_started/5-faq.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/5-faq.md
@@ -1,6 +1,7 @@
-# 代理环境配置
+# 常见问题
 
-代理环境（HTTP / SOCKS5）下安装 UniLab 的常见问题与解决方案。
+安装与首次运行 UniLab 时的常见问题，按 现象 → 解决 组织。多数与代理环境
+（HTTP / SOCKS5）、off-policy 算法的 JIT 编译依赖或视频导出相关。
 
 ## motrixsim-core 下载超时
 

--- a/docs/sphinx/source/zh_CN/1-getting_started/5-proxy_setup.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/5-proxy_setup.md
@@ -1,0 +1,418 @@
+# 代理环境下的安装指南
+
+本文档记录在使用网络代理（HTTP / SOCKS5）的环境下安装 UniLab 时遇到的典型问题、根因分析与解决方案。适用于国内开发者或任何需要通过代理访问外网的场景。
+
+## 背景知识
+
+### uv 与 conda 的关系
+
+UniLab 使用 [uv](https://github.com/astral-sh/uv) 管理 Python 依赖。`uv sync` 会在项目根目录下创建独立的 `.venv/` 虚拟环境，**与 conda 环境互不干扰**。
+
+```
+conda env (unilab)          ← 提供 Python 解释器 + uv 可执行文件
+  └── UniLab/.venv/         ← uv sync 创建的项目虚拟环境，所有依赖装在这里
+```
+
+- conda 环境只是外层隔离，提供干净的 Python 版本和 `uv` 命令。
+- 所有项目依赖通过 `uv sync` 安装到 `.venv/`，训练命令通过 `uv run` 执行。
+- **手动 `uv pip install` 时，如果当前激活了 conda 环境，包会默认装到 conda 而不是 `.venv/`**——这是一个常见陷阱。
+
+### UniLab 的包源结构
+
+UniLab 的依赖来自三个不同的包源：
+
+| 包源 | 用途 | 示例包 |
+|------|------|--------|
+| PyPI (pypi.org) | 大部分通用依赖 | numpy, torch, gymnasium |
+| PyTorch cu128 索引 | CUDA 版 PyTorch wheel | torch==2.7.0+cu128 |
+| Motphys 私有 PyPI (`pypi.motphys.com`) | MotrixSim 物理引擎 | motrixsim-core |
+
+这三个包源对代理的需求各不相同，这正是问题根源。
+
+---
+
+## 问题 1：motrixsim-core 下载超时
+
+### 现象
+
+```
+× Failed to download `motrixsim-core==0.8.1.dev104665`
+├─▶ Request failed after 3 retries in 49.5s
+├─▶ Failed to fetch:
+│   `https://pypi.motphys.com/packages/motrixsim_core-...whl`
+├─▶ error sending request for url
+╰─▶ operation timed out
+```
+
+### 根因
+
+代理服务器（如 Clash、V2Ray 等）转发到 `pypi.motphys.com`（Motphys 私有 PyPI）时超时。可能的原因：
+
+1. **代理路由不当**：代理将 `pypi.motphys.com` 的流量发往海外节点，但该服务器部署在国内，经过代理反而变慢或不可达。
+2. **代理协议不兼容**：某些代理对非标准端口或私有证书的 HTTPS 连接处理异常。
+3. **DNS 解析冲突**：代理的远端 DNS 解析与本地 DNS 解析到不同的服务器 IP。
+
+### 解决方案
+
+通过 `no_proxy` 环境变量让 `pypi.motphys.com` 绕过代理、直连访问：
+
+```bash
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+export no_proxy="pypi.motphys.com"
+export NO_PROXY="pypi.motphys.com"
+
+make setup-motrix
+```
+
+> **为什么要同时设 `no_proxy` 和 `NO_PROXY`？**
+>
+> 不同的工具和库读取不同的变量名。`curl` 和多数 Linux 工具读 `no_proxy`（小写），部分 Java / Go 工具读 `NO_PROXY`（大写）。`uv` 内部使用 Rust 的 HTTP 客户端，两者都会检查。同时设置可确保所有工具链都能正确绕过。
+
+### 判断依据
+
+如果你的环境**不使用代理**或 `pypi.motphys.com` 能直接访问，则不会遇到此问题。可以用以下命令测试：
+
+```bash
+# 不走代理直连测试
+curl --noproxy '*' -I https://pypi.motphys.com/simple/
+# 走代理测试
+curl -x http://127.0.0.1:7897 -I https://pypi.motphys.com/simple/
+```
+
+如果直连成功但走代理失败，就需要 `no_proxy` 设置。
+
+---
+
+## 问题 2：httpx SOCKS 代理缺少 socksio
+
+### 现象
+
+```
+ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
+Make sure to install httpx using `pip install httpx[socks]`
+```
+
+### 根因
+
+UniLab 的依赖 `huggingface_hub` 使用 `httpx` 作为 HTTP 客户端，用于从 Hugging Face 下载模型和数据（如 demo checkpoint、grasp cache 等）。
+
+当系统配置了 SOCKS5 代理时（通常通过 `all_proxy` 或 `ALL_PROXY` 环境变量），`httpx` 需要额外的 `socksio` 包来处理 SOCKS 协议。但 `httpx` 的默认安装不包含 `socksio`，UniLab 的 `pyproject.toml` 也没有将其列为依赖（因为并非所有用户都需要代理）。
+
+**代理协议说明：**
+
+| 协议 | 环境变量示例 | 常见软件 |
+|------|-------------|---------|
+| HTTP 代理 | `http_proxy=http://127.0.0.1:7897` | 多数场景，httpx 原生支持 |
+| SOCKS5 代理 | `all_proxy=socks5://127.0.0.1:7897` | Clash/V2Ray 的 SOCKS 端口，需 socksio |
+
+很多代理软件（如 Clash）同时监听 HTTP 和 SOCKS5 端口。如果你的 shell 配置（`~/.bashrc`、`~/.zshrc`）中设了 `all_proxy=socks5://...`，即使 `http_proxy` 用的是 HTTP 协议，`httpx` 也会尝试走 SOCKS5。
+
+### 解决方案
+
+**方案 A：安装 socksio（推荐）**
+
+```bash
+uv pip install httpx[socks] --python .venv/bin/python
+```
+
+> **关键：必须指定 `--python .venv/bin/python`**
+>
+> 如果当前激活了 conda 环境，`uv pip install` 默认会将包安装到 conda 环境的 site-packages，而非项目的 `.venv/`。加上 `--python .venv/bin/python` 确保安装到正确位置。
+>
+> 验证安装位置：
+> ```bash
+> uv run python -c "import socksio; print(socksio.__file__)"
+> # 应该输出 .venv/ 下的路径
+> ```
+
+**方案 B：改用 HTTP 代理（避免 SOCKS）**
+
+如果你的代理软件同时提供 HTTP 和 SOCKS5 端口，可以只使用 HTTP 协议，不需要 socksio：
+
+```bash
+# 只设 http/https 代理，不设 all_proxy
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+unset all_proxy
+unset ALL_PROXY
+```
+
+检查当前环境变量：
+
+```bash
+env | grep -i proxy
+```
+
+如果输出中有 `all_proxy=socks5://...` 或 `ALL_PROXY=socks5://...`，这就是触发 SOCKS 报错的来源。
+
+---
+
+## 问题 3：SAC / TD3 训练立即退出（exit code 247）
+
+### 现象
+
+```
+Motphys profiler initialized: disabled
+resource_tracker: There appear to be 5 leaked semaphore objects to clean up at shutdown
+```
+
+只有这两行输出，然后进程退出，exit code 247。没有 Python traceback。
+
+### 根因
+
+SAC / TD3 等 off-policy 算法需要 JIT 编译一个 C++ CUDA 扩展 `unilab_native_h2d`（用于高效 host-to-device 数据搬运）。编译在 collector subprocess 中触发，如果编译失败，subprocess 直接 crash，父进程只收到退出信号，错误信息被吞掉。
+
+用 `--sim mujoco` 运行相同任务可以看到完整 traceback（mujoco 变体不使用 subprocess collector），从而定位根因。
+
+这个编译过程需要三个前置条件，缺任何一个都会失败：
+
+### 3a. 缺少 C++ 编译器
+
+**报错**（通过 mujoco 变体可见）：
+
+```
+/bin/sh: 1: c++: not found
+```
+
+**解决**：
+
+```bash
+sudo apt-get install build-essential
+```
+
+这会安装 `gcc`、`g++`、`make` 等编译工具链。
+
+### 3b. 缺少 CUDA Toolkit 头文件
+
+**报错**：
+
+```
+fatal error: cuda_runtime_api.h: 没有那个文件或目录
+```
+
+**原因**：系统只有 NVIDIA 驱动（`nvidia-smi` 能用），没有 CUDA Toolkit。PyTorch 的 pip wheel 虽然包含 CUDA runtime 库（`.so`），但不包含编译所需的头文件（`.h`）。JIT 编译需要完整 CUDA Toolkit。
+
+**解决**：
+
+```bash
+# 先给 conda 配代理（见问题 4），然后安装
+conda install -n unilab -c nvidia cuda-toolkit=12.8 -y
+```
+
+> **驱动 vs Toolkit 的区别**：
+> - **NVIDIA 驱动**：让 GPU 能工作，`nvidia-smi` 能用。随系统或 `.run` 安装。
+> - **CUDA Toolkit**：包含 `nvcc` 编译器、`cuda_runtime_api.h` 等头文件、cuBLAS/cuDNN 等开发库。通过 `conda`、`apt` 或 NVIDIA 官网安装。
+> - PyTorch pip wheel 自带运行时 `.so`，跑 PPO/APPO 不需要 Toolkit；但 SAC/TD3 的 JIT 编译需要。
+
+### 3c. conda CUDA Toolkit 头文件路径不标准
+
+**报错**：安装了 CUDA Toolkit 但仍然 `cuda_runtime_api.h: 没有那个文件`。
+
+**原因**：通过 conda 安装的 CUDA Toolkit 把头文件放在 `$CONDA_PREFIX/targets/x86_64-linux/include/` 而非 PyTorch JIT 期望的 `$CUDA_HOME/include/`。
+
+**解决**：
+
+```bash
+export CUDA_HOME=$CONDA_PREFIX  # 即 /home/<user>/anaconda3/envs/unilab
+export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
+```
+
+设好后，JIT 编译结果会缓存到 `~/.cache/torch_extensions/`，后续启动不再重新编译。
+
+---
+
+## 问题 4：conda install 连接失败
+
+### 现象
+
+```
+CondaHTTPError: HTTP 000 CONNECTION FAILED for url
+<https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.13.1.3-0.conda>
+```
+
+### 根因
+
+conda 有自己的网络栈，**不读取 shell 的 `http_proxy` / `https_proxy` 环境变量**。即使 shell 中配了代理，conda 仍然直连，在需要代理的网络中就会连接失败。
+
+### 解决方案
+
+**方案 A：给 conda 配代理（推荐）**
+
+```bash
+conda config --set proxy_servers.http http://127.0.0.1:7897
+conda config --set proxy_servers.https http://127.0.0.1:7897
+```
+
+这会写入 `~/.condarc`，全局生效。
+
+**方案 B：在 `.condarc` 中直接编辑**
+
+```yaml
+# ~/.condarc
+proxy_servers:
+  http: http://127.0.0.1:7897
+  https: http://127.0.0.1:7897
+```
+
+**方案 C：使用清华 conda 镜像**
+
+如果代理不稳定，可以改用国内镜像源避开代理：
+
+```yaml
+# ~/.condarc
+channels:
+  - defaults
+default_channels:
+  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
+  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/r
+custom_channels:
+  nvidia: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
+```
+
+> **注意**：nvidia channel 的清华镜像可能不包含最新版本的 `cuda-toolkit`。如果镜像版本不够新，仍需使用方案 A（配代理）从官方源安装。
+
+---
+
+## 完整安装流程（代理环境）
+
+综合以上所有问题，国内代理环境下的推荐安装流程：
+
+```bash
+# 0. 安装 uv（如果没有）
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 1. 创建 conda 环境
+conda create -n unilab python=3.13
+conda activate unilab
+pip install uv
+
+# 2. 给 conda 配代理（根据你的端口修改）
+conda config --set proxy_servers.http http://127.0.0.1:7897
+conda config --set proxy_servers.https http://127.0.0.1:7897
+
+# 3. 安装系统依赖
+sudo apt-get install build-essential cmake ffmpeg
+
+# 4. 安装 CUDA Toolkit（SAC/TD3 等 off-policy 算法需要）
+conda install -c nvidia cuda-toolkit=12.8 -y
+
+# 5. 克隆仓库
+git clone https://github.com/unilabsim/UniLab.git
+cd UniLab
+
+# 6. 配置代理环境变量（根据你的代理端口修改）
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+export no_proxy="pypi.motphys.com"
+export NO_PROXY="pypi.motphys.com"
+unset all_proxy
+unset ALL_PROXY
+
+# 7. 安装 Python 依赖
+make setup-motrix
+
+# 8. 如果需要 SOCKS 代理支持
+uv pip install httpx[socks] --python .venv/bin/python
+
+# 9. 配置运行时环境变量
+export CUDA_HOME=$CONDA_PREFIX
+export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
+export HF_ENDPOINT=https://hf-mirror.com
+
+# 10. 验证安装
+uv run python -c "
+import torch
+print(f'torch {torch.__version__}, CUDA: {torch.cuda.is_available()}')
+import unilab; print('unilab OK')
+import mujoco; print(f'mujoco {mujoco.__version__}')
+try:
+    import motrixsim; print('motrixsim OK')
+except ImportError:
+    print('motrixsim not installed (optional)')
+"
+
+# 11. 激活 shell 补全
+source ~/.bashrc
+
+# 12. 冒烟测试
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
+  algo.max_iterations=1 algo.num_envs=16 training.no_play=true
+
+# 13. 运行 demo
+uv run demo dance
+```
+
+## 持久化环境配置
+
+将以下内容添加到 `~/.bashrc` 或 `~/.zshrc`，避免每次手动 export：
+
+```bash
+# UniLab 代理配置
+export http_proxy=http://127.0.0.1:7897
+export https_proxy=http://127.0.0.1:7897
+export no_proxy="pypi.motphys.com,localhost,127.0.0.1"
+export NO_PROXY="pypi.motphys.com,localhost,127.0.0.1"
+
+# CUDA Toolkit（conda 安装路径）
+export CUDA_HOME=$CONDA_PREFIX
+export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
+
+# HuggingFace 镜像
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+> **注意**：`$CONDA_PREFIX` 只有在 conda 环境激活后才有值。如果 shell 启动时未自动激活 conda 环境，需要写完整路径：
+> ```bash
+> export CUDA_HOME=/home/<user>/anaconda3/envs/unilab
+> export CPLUS_INCLUDE_PATH=$CUDA_HOME/targets/x86_64-linux/include
+> ```
+
+## 常见排查命令
+
+```bash
+# 查看当前所有代理相关环境变量
+env | grep -i proxy
+
+# 测试 PyPI 连通性（走代理）
+curl -I https://pypi.org/simple/
+
+# 测试 Motphys PyPI 连通性（直连）
+curl --noproxy '*' -I https://pypi.motphys.com/simple/
+
+# 测试 HuggingFace 连通性
+curl -I https://huggingface.co
+
+# 检查 conda 代理配置
+conda config --show proxy_servers
+
+# 检查 CUDA Toolkit
+nvcc --version
+ls $CUDA_HOME/targets/x86_64-linux/include/cuda_runtime_api.h
+
+# 检查 C++ 编译器
+g++ --version
+
+# 检查 .venv 中已安装的包
+uv pip list --python .venv/bin/python | grep -E "torch|mujoco|motrix|socksio|httpx"
+
+# 检查 JIT 编译缓存
+ls ~/.cache/torch_extensions/
+
+# 检查 uv pip install 的默认目标环境
+uv pip install --dry-run httpx[socks]  # 看 "Using Python ... environment at: ..."
+```
+
+## 问题速查表
+
+| 现象 | 根因 | 解决 |
+|------|------|------|
+| `motrixsim-core` 下载超时 | 代理无法转发 motphys.com | `no_proxy=pypi.motphys.com` |
+| `socksio` not installed | SOCKS5 代理 + httpx | `uv pip install httpx[socks] --python .venv/bin/python` |
+| SAC/TD3 立即退出 (247) | subprocess JIT 编译失败 | 用 `--sim mujoco` 看完整报错 |
+| `c++: not found` | 缺编译器 | `sudo apt-get install build-essential` |
+| `cuda_runtime_api.h` 缺失 | 缺 CUDA Toolkit | `conda install -c nvidia cuda-toolkit=12.8` |
+| CUDA headers 仍找不到 | conda 头文件路径不标准 | `export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include` |
+| conda HTTP 000 连接失败 | conda 不读 shell 代理 | `conda config --set proxy_servers.https http://127.0.0.1:7897` |
+| PPO/APPO 正常但 SAC 不行 | on-policy 不需要 JIT | 只有 off-policy 需要 CUDA Toolkit + g++ |
+| `ffmpeg` not found (视频导出) | 缺 ffmpeg 系统包 | `sudo apt install ffmpeg` |

--- a/docs/sphinx/source/zh_CN/1-getting_started/5-proxy_setup.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/5-proxy_setup.md
@@ -1,418 +1,136 @@
-# 代理环境下的安装指南
+# 代理环境配置
 
-本文档记录在使用网络代理（HTTP / SOCKS5）的环境下安装 UniLab 时遇到的典型问题、根因分析与解决方案。适用于国内开发者或任何需要通过代理访问外网的场景。
+代理环境（HTTP / SOCKS5）下安装 UniLab 的常见问题与解决方案。
 
-## 背景知识
-
-### uv 与 conda 的关系
-
-UniLab 使用 [uv](https://github.com/astral-sh/uv) 管理 Python 依赖。`uv sync` 会在项目根目录下创建独立的 `.venv/` 虚拟环境，**与 conda 环境互不干扰**。
-
-```
-conda env (unilab)          ← 提供 Python 解释器 + uv 可执行文件
-  └── UniLab/.venv/         ← uv sync 创建的项目虚拟环境，所有依赖装在这里
-```
-
-- conda 环境只是外层隔离，提供干净的 Python 版本和 `uv` 命令。
-- 所有项目依赖通过 `uv sync` 安装到 `.venv/`，训练命令通过 `uv run` 执行。
-- **手动 `uv pip install` 时，如果当前激活了 conda 环境，包会默认装到 conda 而不是 `.venv/`**——这是一个常见陷阱。
-
-### UniLab 的包源结构
-
-UniLab 的依赖来自三个不同的包源：
-
-| 包源 | 用途 | 示例包 |
-|------|------|--------|
-| PyPI (pypi.org) | 大部分通用依赖 | numpy, torch, gymnasium |
-| PyTorch cu128 索引 | CUDA 版 PyTorch wheel | torch==2.7.0+cu128 |
-| Motphys 私有 PyPI (`pypi.motphys.com`) | MotrixSim 物理引擎 | motrixsim-core |
-
-这三个包源对代理的需求各不相同，这正是问题根源。
-
----
-
-## 问题 1：motrixsim-core 下载超时
-
-### 现象
+## motrixsim-core 下载超时
 
 ```
 × Failed to download `motrixsim-core==0.8.1.dev104665`
-├─▶ Request failed after 3 retries in 49.5s
-├─▶ Failed to fetch:
-│   `https://pypi.motphys.com/packages/motrixsim_core-...whl`
-├─▶ error sending request for url
 ╰─▶ operation timed out
 ```
 
-### 根因
-
-代理服务器（如 Clash、V2Ray 等）转发到 `pypi.motphys.com`（Motphys 私有 PyPI）时超时。可能的原因：
-
-1. **代理路由不当**：代理将 `pypi.motphys.com` 的流量发往海外节点，但该服务器部署在国内，经过代理反而变慢或不可达。
-2. **代理协议不兼容**：某些代理对非标准端口或私有证书的 HTTPS 连接处理异常。
-3. **DNS 解析冲突**：代理的远端 DNS 解析与本地 DNS 解析到不同的服务器 IP。
-
-### 解决方案
-
-通过 `no_proxy` 环境变量让 `pypi.motphys.com` 绕过代理、直连访问：
+`pypi.motphys.com` 部署在国内，通过代理访问反而不可达。设 `no_proxy` 绕过：
 
 ```bash
-export http_proxy=http://127.0.0.1:7897
-export https_proxy=http://127.0.0.1:7897
 export no_proxy="pypi.motphys.com"
 export NO_PROXY="pypi.motphys.com"
-
 make setup-motrix
 ```
 
-> **为什么要同时设 `no_proxy` 和 `NO_PROXY`？**
->
-> 不同的工具和库读取不同的变量名。`curl` 和多数 Linux 工具读 `no_proxy`（小写），部分 Java / Go 工具读 `NO_PROXY`（大写）。`uv` 内部使用 Rust 的 HTTP 客户端，两者都会检查。同时设置可确保所有工具链都能正确绕过。
+同时设大小写是因为 `uv` 的 Rust HTTP 客户端两者都检查。
 
-### 判断依据
-
-如果你的环境**不使用代理**或 `pypi.motphys.com` 能直接访问，则不会遇到此问题。可以用以下命令测试：
-
-```bash
-# 不走代理直连测试
-curl --noproxy '*' -I https://pypi.motphys.com/simple/
-# 走代理测试
-curl -x http://127.0.0.1:7897 -I https://pypi.motphys.com/simple/
-```
-
-如果直连成功但走代理失败，就需要 `no_proxy` 设置。
-
----
-
-## 问题 2：httpx SOCKS 代理缺少 socksio
-
-### 现象
+## httpx SOCKS 代理缺少 socksio
 
 ```
 ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
-Make sure to install httpx using `pip install httpx[socks]`
 ```
 
-### 根因
-
-UniLab 的依赖 `huggingface_hub` 使用 `httpx` 作为 HTTP 客户端，用于从 Hugging Face 下载模型和数据（如 demo checkpoint、grasp cache 等）。
-
-当系统配置了 SOCKS5 代理时（通常通过 `all_proxy` 或 `ALL_PROXY` 环境变量），`httpx` 需要额外的 `socksio` 包来处理 SOCKS 协议。但 `httpx` 的默认安装不包含 `socksio`，UniLab 的 `pyproject.toml` 也没有将其列为依赖（因为并非所有用户都需要代理）。
-
-**代理协议说明：**
-
-| 协议 | 环境变量示例 | 常见软件 |
-|------|-------------|---------|
-| HTTP 代理 | `http_proxy=http://127.0.0.1:7897` | 多数场景，httpx 原生支持 |
-| SOCKS5 代理 | `all_proxy=socks5://127.0.0.1:7897` | Clash/V2Ray 的 SOCKS 端口，需 socksio |
-
-很多代理软件（如 Clash）同时监听 HTTP 和 SOCKS5 端口。如果你的 shell 配置（`~/.bashrc`、`~/.zshrc`）中设了 `all_proxy=socks5://...`，即使 `http_proxy` 用的是 HTTP 协议，`httpx` 也会尝试走 SOCKS5。
-
-### 解决方案
-
-**方案 A：安装 socksio（推荐）**
+`huggingface_hub` 使用 `httpx`，检测到 `ALL_PROXY=socks5://...` 后需要
+`socksio`。安装到项目 `.venv/`（不是 conda）：
 
 ```bash
 uv pip install httpx[socks] --python .venv/bin/python
 ```
 
-> **关键：必须指定 `--python .venv/bin/python`**
->
-> 如果当前激活了 conda 环境，`uv pip install` 默认会将包安装到 conda 环境的 site-packages，而非项目的 `.venv/`。加上 `--python .venv/bin/python` 确保安装到正确位置。
->
-> 验证安装位置：
-> ```bash
-> uv run python -c "import socksio; print(socksio.__file__)"
-> # 应该输出 .venv/ 下的路径
-> ```
-
-**方案 B：改用 HTTP 代理（避免 SOCKS）**
-
-如果你的代理软件同时提供 HTTP 和 SOCKS5 端口，可以只使用 HTTP 协议，不需要 socksio：
+或改用 HTTP 代理避开 SOCKS：
 
 ```bash
-# 只设 http/https 代理，不设 all_proxy
+unset all_proxy ALL_PROXY
 export http_proxy=http://127.0.0.1:7897
 export https_proxy=http://127.0.0.1:7897
-unset all_proxy
-unset ALL_PROXY
 ```
 
-检查当前环境变量：
-
-```bash
-env | grep -i proxy
-```
-
-如果输出中有 `all_proxy=socks5://...` 或 `ALL_PROXY=socks5://...`，这就是触发 SOCKS 报错的来源。
-
----
-
-## 问题 3：SAC / TD3 训练立即退出（exit code 247）
-
-### 现象
+## SAC / TD3 训练立即退出（exit code 247）
 
 ```
-Motphys profiler initialized: disabled
 resource_tracker: There appear to be 5 leaked semaphore objects to clean up at shutdown
 ```
 
-只有这两行输出，然后进程退出，exit code 247。没有 Python traceback。
+Off-policy 算法在 collector subprocess 中 JIT 编译 C++ CUDA 扩展
+`unilab_native_h2d`。编译失败时 subprocess 静默退出，无 traceback。
+用 `--sim mujoco` 跑同一任务可以看到完整报错。
 
-### 根因
+编译需要三个前置条件：
 
-SAC / TD3 等 off-policy 算法需要 JIT 编译一个 C++ CUDA 扩展 `unilab_native_h2d`（用于高效 host-to-device 数据搬运）。编译在 collector subprocess 中触发，如果编译失败，subprocess 直接 crash，父进程只收到退出信号，错误信息被吞掉。
-
-用 `--sim mujoco` 运行相同任务可以看到完整 traceback（mujoco 变体不使用 subprocess collector），从而定位根因。
-
-这个编译过程需要三个前置条件，缺任何一个都会失败：
-
-### 3a. 缺少 C++ 编译器
-
-**报错**（通过 mujoco 变体可见）：
-
-```
-/bin/sh: 1: c++: not found
-```
-
-**解决**：
+**缺 C++ 编译器** — `c++: not found`：
 
 ```bash
 sudo apt-get install build-essential
 ```
 
-这会安装 `gcc`、`g++`、`make` 等编译工具链。
-
-### 3b. 缺少 CUDA Toolkit 头文件
-
-**报错**：
-
-```
-fatal error: cuda_runtime_api.h: 没有那个文件或目录
-```
-
-**原因**：系统只有 NVIDIA 驱动（`nvidia-smi` 能用），没有 CUDA Toolkit。PyTorch 的 pip wheel 虽然包含 CUDA runtime 库（`.so`），但不包含编译所需的头文件（`.h`）。JIT 编译需要完整 CUDA Toolkit。
-
-**解决**：
+**缺 CUDA Toolkit 头文件** — `cuda_runtime_api.h: 没有那个文件`：
 
 ```bash
-# 先给 conda 配代理（见问题 4），然后安装
-conda install -n unilab -c nvidia cuda-toolkit=12.8 -y
+conda install -c nvidia cuda-toolkit=12.8 -y
 ```
 
-> **驱动 vs Toolkit 的区别**：
-> - **NVIDIA 驱动**：让 GPU 能工作，`nvidia-smi` 能用。随系统或 `.run` 安装。
-> - **CUDA Toolkit**：包含 `nvcc` 编译器、`cuda_runtime_api.h` 等头文件、cuBLAS/cuDNN 等开发库。通过 `conda`、`apt` 或 NVIDIA 官网安装。
-> - PyTorch pip wheel 自带运行时 `.so`，跑 PPO/APPO 不需要 Toolkit；但 SAC/TD3 的 JIT 编译需要。
+PyTorch pip wheel 只含运行时 `.so`，不含编译头文件。PPO/APPO 不需要
+Toolkit，SAC/TD3 的 JIT 编译需要。
 
-### 3c. conda CUDA Toolkit 头文件路径不标准
-
-**报错**：安装了 CUDA Toolkit 但仍然 `cuda_runtime_api.h: 没有那个文件`。
-
-**原因**：通过 conda 安装的 CUDA Toolkit 把头文件放在 `$CONDA_PREFIX/targets/x86_64-linux/include/` 而非 PyTorch JIT 期望的 `$CUDA_HOME/include/`。
-
-**解决**：
+**conda CUDA Toolkit 头文件路径不标准**：
 
 ```bash
-export CUDA_HOME=$CONDA_PREFIX  # 即 /home/<user>/anaconda3/envs/unilab
+export CUDA_HOME=$CONDA_PREFIX
 export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
 ```
 
-设好后，JIT 编译结果会缓存到 `~/.cache/torch_extensions/`，后续启动不再重新编译。
+conda 把头文件放在 `targets/x86_64-linux/include/` 而非
+`$CUDA_HOME/include/`。设好后 JIT 结果缓存到
+`~/.cache/torch_extensions/`，后续不再编译。
 
----
-
-## 问题 4：conda install 连接失败
-
-### 现象
+## conda install 连接失败
 
 ```
 CondaHTTPError: HTTP 000 CONNECTION FAILED for url
-<https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.13.1.3-0.conda>
 ```
 
-### 根因
-
-conda 有自己的网络栈，**不读取 shell 的 `http_proxy` / `https_proxy` 环境变量**。即使 shell 中配了代理，conda 仍然直连，在需要代理的网络中就会连接失败。
-
-### 解决方案
-
-**方案 A：给 conda 配代理（推荐）**
+conda 不读 shell 的 `http_proxy`。单独配置：
 
 ```bash
 conda config --set proxy_servers.http http://127.0.0.1:7897
 conda config --set proxy_servers.https http://127.0.0.1:7897
 ```
 
-这会写入 `~/.condarc`，全局生效。
+## ffmpeg 缺失
 
-**方案 B：在 `.condarc` 中直接编辑**
-
-```yaml
-# ~/.condarc
-proxy_servers:
-  http: http://127.0.0.1:7897
-  https: http://127.0.0.1:7897
+```
+RuntimeError: Program 'ffmpeg' is not found
 ```
 
-**方案 C：使用清华 conda 镜像**
-
-如果代理不稳定，可以改用国内镜像源避开代理：
-
-```yaml
-# ~/.condarc
-channels:
-  - defaults
-default_channels:
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/r
-custom_channels:
-  nvidia: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-```
-
-> **注意**：nvidia channel 的清华镜像可能不包含最新版本的 `cuda-toolkit`。如果镜像版本不够新，仍需使用方案 A（配代理）从官方源安装。
-
----
-
-## 完整安装流程（代理环境）
-
-综合以上所有问题，国内代理环境下的推荐安装流程：
+训练完成后回放录制视频需要 ffmpeg：
 
 ```bash
-# 0. 安装 uv（如果没有）
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 1. 创建 conda 环境
-conda create -n unilab python=3.13
-conda activate unilab
-pip install uv
-
-# 2. 给 conda 配代理（根据你的端口修改）
-conda config --set proxy_servers.http http://127.0.0.1:7897
-conda config --set proxy_servers.https http://127.0.0.1:7897
-
-# 3. 安装系统依赖
-sudo apt-get install build-essential cmake ffmpeg
-
-# 4. 安装 CUDA Toolkit（SAC/TD3 等 off-policy 算法需要）
-conda install -c nvidia cuda-toolkit=12.8 -y
-
-# 5. 克隆仓库
-git clone https://github.com/unilabsim/UniLab.git
-cd UniLab
-
-# 6. 配置代理环境变量（根据你的代理端口修改）
-export http_proxy=http://127.0.0.1:7897
-export https_proxy=http://127.0.0.1:7897
-export no_proxy="pypi.motphys.com"
-export NO_PROXY="pypi.motphys.com"
-unset all_proxy
-unset ALL_PROXY
-
-# 7. 安装 Python 依赖
-make setup-motrix
-
-# 8. 如果需要 SOCKS 代理支持
-uv pip install httpx[socks] --python .venv/bin/python
-
-# 9. 配置运行时环境变量
-export CUDA_HOME=$CONDA_PREFIX
-export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
-export HF_ENDPOINT=https://hf-mirror.com
-
-# 10. 验证安装
-uv run python -c "
-import torch
-print(f'torch {torch.__version__}, CUDA: {torch.cuda.is_available()}')
-import unilab; print('unilab OK')
-import mujoco; print(f'mujoco {mujoco.__version__}')
-try:
-    import motrixsim; print('motrixsim OK')
-except ImportError:
-    print('motrixsim not installed (optional)')
-"
-
-# 11. 激活 shell 补全
-source ~/.bashrc
-
-# 12. 冒烟测试
-uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
-  algo.max_iterations=1 algo.num_envs=16 training.no_play=true
-
-# 13. 运行 demo
-uv run demo dance
+sudo apt install ffmpeg
 ```
 
-## 持久化环境配置
+## 持久化环境变量
 
-将以下内容添加到 `~/.bashrc` 或 `~/.zshrc`，避免每次手动 export：
+将以下内容添加到 `~/.bashrc`：
 
 ```bash
-# UniLab 代理配置
+# 代理
 export http_proxy=http://127.0.0.1:7897
 export https_proxy=http://127.0.0.1:7897
 export no_proxy="pypi.motphys.com,localhost,127.0.0.1"
 export NO_PROXY="pypi.motphys.com,localhost,127.0.0.1"
 
-# CUDA Toolkit（conda 安装路径）
-export CUDA_HOME=$CONDA_PREFIX
-export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include
+# CUDA Toolkit（conda 路径，按实际修改）
+export CUDA_HOME=/home/<user>/anaconda3/envs/unilab
+export CPLUS_INCLUDE_PATH=$CUDA_HOME/targets/x86_64-linux/include
 
 # HuggingFace 镜像
 export HF_ENDPOINT=https://hf-mirror.com
 ```
 
-> **注意**：`$CONDA_PREFIX` 只有在 conda 环境激活后才有值。如果 shell 启动时未自动激活 conda 环境，需要写完整路径：
-> ```bash
-> export CUDA_HOME=/home/<user>/anaconda3/envs/unilab
-> export CPLUS_INCLUDE_PATH=$CUDA_HOME/targets/x86_64-linux/include
-> ```
+## 速查表
 
-## 常见排查命令
-
-```bash
-# 查看当前所有代理相关环境变量
-env | grep -i proxy
-
-# 测试 PyPI 连通性（走代理）
-curl -I https://pypi.org/simple/
-
-# 测试 Motphys PyPI 连通性（直连）
-curl --noproxy '*' -I https://pypi.motphys.com/simple/
-
-# 测试 HuggingFace 连通性
-curl -I https://huggingface.co
-
-# 检查 conda 代理配置
-conda config --show proxy_servers
-
-# 检查 CUDA Toolkit
-nvcc --version
-ls $CUDA_HOME/targets/x86_64-linux/include/cuda_runtime_api.h
-
-# 检查 C++ 编译器
-g++ --version
-
-# 检查 .venv 中已安装的包
-uv pip list --python .venv/bin/python | grep -E "torch|mujoco|motrix|socksio|httpx"
-
-# 检查 JIT 编译缓存
-ls ~/.cache/torch_extensions/
-
-# 检查 uv pip install 的默认目标环境
-uv pip install --dry-run httpx[socks]  # 看 "Using Python ... environment at: ..."
-```
-
-## 问题速查表
-
-| 现象 | 根因 | 解决 |
-|------|------|------|
-| `motrixsim-core` 下载超时 | 代理无法转发 motphys.com | `no_proxy=pypi.motphys.com` |
-| `socksio` not installed | SOCKS5 代理 + httpx | `uv pip install httpx[socks] --python .venv/bin/python` |
-| SAC/TD3 立即退出 (247) | subprocess JIT 编译失败 | 用 `--sim mujoco` 看完整报错 |
-| `c++: not found` | 缺编译器 | `sudo apt-get install build-essential` |
-| `cuda_runtime_api.h` 缺失 | 缺 CUDA Toolkit | `conda install -c nvidia cuda-toolkit=12.8` |
-| CUDA headers 仍找不到 | conda 头文件路径不标准 | `export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include` |
-| conda HTTP 000 连接失败 | conda 不读 shell 代理 | `conda config --set proxy_servers.https http://127.0.0.1:7897` |
-| PPO/APPO 正常但 SAC 不行 | on-policy 不需要 JIT | 只有 off-policy 需要 CUDA Toolkit + g++ |
-| `ffmpeg` not found (视频导出) | 缺 ffmpeg 系统包 | `sudo apt install ffmpeg` |
+| 现象 | 解决 |
+|------|------|
+| motrixsim-core 超时 | `no_proxy=pypi.motphys.com` |
+| socksio not installed | `uv pip install httpx[socks] --python .venv/bin/python` |
+| SAC/TD3 立即退出 (247) | 用 `--sim mujoco` 看完整报错 |
+| `c++: not found` | `sudo apt install build-essential` |
+| `cuda_runtime_api.h` 缺失 | `conda install -c nvidia cuda-toolkit=12.8` |
+| CUDA headers 路径不对 | `export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/targets/x86_64-linux/include` |
+| conda HTTP 000 | `conda config --set proxy_servers.https http://127.0.0.1:7897` |
+| ffmpeg not found | `sudo apt install ffmpeg` |

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -220,6 +220,19 @@ class APPORunner(AsyncRunner):
                 learner.learning_rate = _optimizer_lr_from_state(learner.optimizer)
             _sync_resume_target_actor(learner)
 
+        # --- memory budget check ---
+        from unilab.ipc.memory_budget import estimate_appo_bytes, warn_if_over_budget
+
+        mem_est = estimate_appo_bytes(
+            num_envs=self.num_envs,
+            steps_per_env=self.steps_per_env,
+            obs_dim=self.obs_dim,
+            action_dim=self.action_dim,
+            critic_dim=self.critic_dim,
+            num_slots=4,
+        )
+        warn_if_over_budget(mem_est, label="APPO")
+
         # Create shared rollout IPC ring buffer; learner-side tensor lifetime is
         # owned by the bounded staging pool below.
         rollout_ring_buffer = RolloutRingBuffer(
@@ -414,10 +427,7 @@ class APPORunner(AsyncRunner):
         }
         self.last_run_summary = summary
 
-    def _check_collector_alive(self) -> bool:
-        if self._collector_process is not None and not self._collector_process.is_alive():
-            return False
-        return True
+    # _check_collector_alive() inherited from AsyncRunner base class
 
     @staticmethod
     def _drain_metrics(queue, reward_history, reward_components, logger):

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -103,7 +103,9 @@ def appo_collector_fn(
 ):
     """Entry point for the APPO collector subprocess.
 
-    Creates environment + policy, collects rollouts, writes raw payloads to the IPC ring buffer.
+    Creates environment + policy, collects rollouts, writes raw payloads
+    to the IPC ring buffer. Error handling is provided by the
+    ``_collector_entry_wrapper`` in ``async_runner.py``.
     """
     from copy import deepcopy
 
@@ -361,16 +363,7 @@ def appo_collector_fn(
                 write_buf["last_critic"][:] = critic_np
             ring_buffer.signal_write_done()  # atomic increment, non-blocking
 
-    except Exception as e:
-        import traceback
-
-        print(f"\n[APPO WORKER CRASH]: {e}\n", file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
-        if metrics_queue is not None:
-            try:
-                metrics_queue.put_nowait({"error": str(e)})
-            except Exception:
-                pass
+    except Exception:
         stop_event.set()
         raise
 

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -79,6 +79,20 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         ckpt_path: str | None = None
         iteration = 0
 
+        # --- memory budget check ---
+        from unilab.ipc.memory_budget import estimate_offpolicy_bytes, warn_if_over_budget
+
+        mem_est = estimate_offpolicy_bytes(
+            num_envs=self.num_envs,
+            replay_buffer_n=self.replay_buffer_n,
+            obs_dim=self.obs_dim,
+            action_dim=self.action_dim,
+            critic_dim=self.critic_obs_dim,
+            batch_size=self.batch_size,
+            updates_per_step=self.updates_per_step,
+        )
+        warn_if_over_budget(mem_est, label=f"Off-policy ({self.algo_type})")
+
         # --- replay buffer (packed CPU shared storage) ---
         buffer_capacity = self.replay_buffer_n * self.num_envs
         replay_buffer = ReplayBuffer(

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -593,10 +593,7 @@ class OffPolicyRunner(AsyncRunner):
             self._active_logger = None
         super().close()
 
-    def _check_collector_alive(self) -> bool:
-        if self._collector_process is not None and not self._collector_process.is_alive():
-            return False
-        return True
+    # _check_collector_alive() inherited from AsyncRunner base class
 
     @staticmethod
     def _drain_metrics(queue, reward_history, reward_components, logger, trace_recorder=None):

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -229,51 +229,43 @@ def off_policy_collector_fn(
     collector_pack_shared_slots=None,
     **kwargs,
 ):
-    """Entry point for the off-policy collector subprocess."""
-    import sys
-    import traceback
+    """Entry point for the off-policy collector subprocess.
 
-    try:
-        print("[Collector] Entry point called", file=sys.stderr, flush=True)
-        _run_collector(
-            stop_event=stop_event,
-            env_name=env_name,
-            num_envs=num_envs,
-            replay_buffer=replay_buffer,
-            weight_sync_name=weight_sync_name,
-            weight_param_shapes=weight_param_shapes,
-            algo_type=algo_type,
-            actor_hidden_dim=actor_hidden_dim,
-            use_layer_norm=use_layer_norm,
-            learning_starts=learning_starts,
-            metrics_queue=metrics_queue,
-            weight_sync_lock=weight_sync_lock,
-            sync_collection=sync_collection,
-            collection_ready_queue=collection_ready_queue,
-            trainer_done_queue=trainer_done_queue,
-            env_steps_per_sync=env_steps_per_sync,
-            obs_normalization=obs_normalization,
-            shared_obs_normalizer_stats=shared_obs_normalizer_stats,
-            sim_backend=sim_backend,
-            env_cfg_override=env_cfg_override,
-            obs_dim=obs_dim,
-            action_dim=action_dim,
-            actor_kwargs=actor_kwargs,
-            seed=seed,
-            trace_enabled=trace_enabled,
-            trace_thread_time=trace_thread_time,
-            collector_pack_request_queue=collector_pack_request_queue,
-            collector_pack_ready_queue=collector_pack_ready_queue,
-            collector_pack_shared_slots=collector_pack_shared_slots,
-        )
-    except Exception as e:
-        print(f"[Collector] Exception: {e}", file=sys.stderr, flush=True)
-        traceback.print_exc(file=sys.stderr)
-        if metrics_queue is not None:
-            try:
-                metrics_queue.put_nowait({"error": str(e)})
-            except Exception:
-                pass
+    Error handling is provided by ``_collector_entry_wrapper`` in
+    ``async_runner.py``.
+    """
+    print("[Collector] Entry point called", file=sys.stderr, flush=True)
+    _run_collector(
+        stop_event=stop_event,
+        env_name=env_name,
+        num_envs=num_envs,
+        replay_buffer=replay_buffer,
+        weight_sync_name=weight_sync_name,
+        weight_param_shapes=weight_param_shapes,
+        algo_type=algo_type,
+        actor_hidden_dim=actor_hidden_dim,
+        use_layer_norm=use_layer_norm,
+        learning_starts=learning_starts,
+        metrics_queue=metrics_queue,
+        weight_sync_lock=weight_sync_lock,
+        sync_collection=sync_collection,
+        collection_ready_queue=collection_ready_queue,
+        trainer_done_queue=trainer_done_queue,
+        env_steps_per_sync=env_steps_per_sync,
+        obs_normalization=obs_normalization,
+        shared_obs_normalizer_stats=shared_obs_normalizer_stats,
+        sim_backend=sim_backend,
+        env_cfg_override=env_cfg_override,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        actor_kwargs=actor_kwargs,
+        seed=seed,
+        trace_enabled=trace_enabled,
+        trace_thread_time=trace_thread_time,
+        collector_pack_request_queue=collector_pack_request_queue,
+        collector_pack_ready_queue=collector_pack_ready_queue,
+        collector_pack_shared_slots=collector_pack_shared_slots,
+    )
 
 
 def _run_collector(

--- a/src/unilab/ipc/async_runner.py
+++ b/src/unilab/ipc/async_runner.py
@@ -101,14 +101,15 @@ class AsyncRunner(ABC):
         self._error_send = None
 
     def _check_collector_alive(self) -> bool:
-        """Check if collector is alive; raise with full diagnostic if dead."""
+        """Check if collector is alive. Prints full diagnostic if dead."""
         if self._collector_process is None:
             return True
         if self._collector_process.is_alive():
             return True
 
         death_info = self._read_collector_error()
-        raise RuntimeError(death_info)
+        print(f"\n{death_info}\n", file=sys.stderr, flush=True)
+        return False
 
     def _read_collector_error(self) -> str:
         """Read error info from dead collector — pipe first, then exit code."""
@@ -139,8 +140,7 @@ class AsyncRunner(ABC):
             if exitcode is not None and exitcode != 0 and exitcode != -15:
                 death_info = self._read_collector_error()
                 print(
-                    f"\n[AsyncRunner] Collector exited with code {exitcode}:\n"
-                    f"{death_info}\n",
+                    f"\n[AsyncRunner] Collector exited with code {exitcode}:\n{death_info}\n",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/src/unilab/ipc/async_runner.py
+++ b/src/unilab/ipc/async_runner.py
@@ -3,10 +3,38 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import sys
 from abc import ABC, abstractmethod
 from typing import Any, Callable
 
+from unilab.ipc.collector_error import (
+    ExceptionWrapper,
+    collector_error_guard,
+    create_error_pipe,
+    format_collector_death,
+)
+
 _SPAWN_CTX = mp.get_context("spawn")
+
+
+def _collector_entry_wrapper(
+    target_fn: Callable,
+    error_conn: Any,
+    kwargs: dict,
+) -> None:
+    """Top-level wrapper for collector subprocess entry point.
+
+    Ensures ALL exceptions (including import errors and env creation
+    failures) are captured and sent to the parent via the error pipe.
+    """
+    label = kwargs.pop("_error_label", "collector")
+    with collector_error_guard(
+        error_conn=error_conn,
+        metrics_queue=kwargs.get("metrics_queue"),
+        stop_event=kwargs.get("stop_event"),
+        label=label,
+    ):
+        target_fn(**kwargs)
 
 
 class AsyncRunner(ABC):
@@ -15,6 +43,7 @@ class AsyncRunner(ABC):
     Manages:
     - Shared memory allocation/cleanup
     - Collector process lifecycle
+    - Error propagation from collector subprocess
     - Training loop skeleton
     """
 
@@ -40,6 +69,8 @@ class AsyncRunner(ABC):
         self._collector_process: Any = None
         self._stop_event = _SPAWN_CTX.Event()
         self._shared_resources: list = []
+        self._error_recv: Any = None
+        self._error_send: Any = None
 
     @abstractmethod
     def _get_default_device(self) -> str:
@@ -58,8 +89,41 @@ class AsyncRunner(ABC):
     ) -> None: ...
 
     def _start_collector(self, target_fn: Callable, kwargs: dict) -> None:
-        self._collector_process = _SPAWN_CTX.Process(target=target_fn, kwargs=kwargs, daemon=True)
+        self._error_recv, self._error_send = create_error_pipe()
+
+        self._collector_process = _SPAWN_CTX.Process(
+            target=_collector_entry_wrapper,
+            args=(target_fn, self._error_send, kwargs),
+            daemon=True,
+        )
         self._collector_process.start()
+        self._error_send.close()
+        self._error_send = None
+
+    def _check_collector_alive(self) -> bool:
+        """Check if collector is alive; raise with full diagnostic if dead."""
+        if self._collector_process is None:
+            return True
+        if self._collector_process.is_alive():
+            return True
+
+        death_info = self._read_collector_error()
+        raise RuntimeError(death_info)
+
+    def _read_collector_error(self) -> str:
+        """Read error info from dead collector — pipe first, then exit code."""
+        traceback_text = None
+        if self._error_recv is not None:
+            try:
+                if self._error_recv.poll(timeout=0.1):
+                    obj = self._error_recv.recv()
+                    if isinstance(obj, ExceptionWrapper):
+                        traceback_text = obj.exc_msg
+            except (EOFError, OSError):
+                pass
+
+        exitcode = getattr(self._collector_process, "exitcode", None)
+        return format_collector_death(exitcode, traceback_text)
 
     def close(self) -> None:
         self._stop_event.set()
@@ -68,11 +132,37 @@ class AsyncRunner(ABC):
             if self._collector_process.is_alive():
                 self._collector_process.terminate()
                 self._collector_process.join(timeout=5)
+
+        if self._collector_process is not None:
+            exitcode = getattr(self._collector_process, "exitcode", None)
+            # -15 (SIGTERM) is expected during normal close()
+            if exitcode is not None and exitcode != 0 and exitcode != -15:
+                death_info = self._read_collector_error()
+                print(
+                    f"\n[AsyncRunner] Collector exited with code {exitcode}:\n"
+                    f"{death_info}\n",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
         for resource in self._shared_resources:
             if hasattr(resource, "cleanup"):
                 resource.cleanup()
             elif hasattr(resource, "close"):
                 resource.close()
+
+        if self._error_recv is not None:
+            try:
+                self._error_recv.close()
+            except Exception:
+                pass
+            self._error_recv = None
+        if self._error_send is not None:
+            try:
+                self._error_send.close()
+            except Exception:
+                pass
+            self._error_send = None
 
     def __del__(self):
         try:

--- a/src/unilab/ipc/collector_error.py
+++ b/src/unilab/ipc/collector_error.py
@@ -7,13 +7,12 @@ reach the parent process — even when stderr is lost or interleaved.
 
 from __future__ import annotations
 
+import multiprocessing as _mp
 import signal
 import sys
 import traceback
 from contextlib import contextmanager
 from typing import Any
-
-import multiprocessing as _mp
 
 _SPAWN_CTX = _mp.get_context("spawn")
 
@@ -33,12 +32,12 @@ class ExceptionWrapper:
         self.where = where
 
     def reraise(self) -> None:
-        msg = (
-            f"Caught {self.exc_type.__name__} {self.where}.\n"
-            f"Original traceback:\n{self.exc_msg}"
-        )
+        exc_type = self.exc_type
+        if exc_type is None:
+            raise RuntimeError(f"Unknown exception {self.where}.\n{self.exc_msg}")
+        msg = f"Caught {exc_type.__name__} {self.where}.\nOriginal traceback:\n{self.exc_msg}"
         try:
-            raise self.exc_type(msg)
+            raise exc_type(msg)
         except TypeError:
             raise RuntimeError(msg) from None
 
@@ -69,8 +68,7 @@ def collector_error_guard(
     except Exception:
         wrapper = ExceptionWrapper(where=f"in {label}")
         print(
-            f"\n{'=' * 60}\n[{label.upper()} CRASH]\n"
-            f"{wrapper.exc_msg}\n{'=' * 60}\n",
+            f"\n{'=' * 60}\n[{label.upper()} CRASH]\n{wrapper.exc_msg}\n{'=' * 60}\n",
             file=sys.stderr,
             flush=True,
         )

--- a/src/unilab/ipc/collector_error.py
+++ b/src/unilab/ipc/collector_error.py
@@ -1,0 +1,125 @@
+"""Cross-process error propagation for collector subprocesses.
+
+Uses a Pipe + ExceptionWrapper pattern (proven by PyTorch DataLoader and
+CPython's ProcessPoolExecutor) to ensure collector tracebacks always
+reach the parent process — even when stderr is lost or interleaved.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import traceback
+from contextlib import contextmanager
+from typing import Any
+
+import multiprocessing as _mp
+
+_SPAWN_CTX = _mp.get_context("spawn")
+
+
+class ExceptionWrapper:
+    """Picklable exception + traceback for cross-process propagation.
+
+    Stores the exception type and a pre-formatted traceback string
+    (not exc_info — that would create reference cycles preventing GC
+    of objects in the exception scope).
+    """
+
+    def __init__(self, where: str = "in collector"):
+        exc_info = sys.exc_info()
+        self.exc_type = exc_info[0]
+        self.exc_msg = "".join(traceback.format_exception(*exc_info))
+        self.where = where
+
+    def reraise(self) -> None:
+        msg = (
+            f"Caught {self.exc_type.__name__} {self.where}.\n"
+            f"Original traceback:\n{self.exc_msg}"
+        )
+        try:
+            raise self.exc_type(msg)
+        except TypeError:
+            raise RuntimeError(msg) from None
+
+
+def create_error_pipe() -> tuple[Any, Any]:
+    """Create a unidirectional pipe for error reporting.
+
+    Returns (recv_conn, send_conn). Parent keeps recv, child gets send.
+    """
+    return _SPAWN_CTX.Pipe(duplex=False)
+
+
+@contextmanager
+def collector_error_guard(
+    error_conn: Any | None = None,
+    metrics_queue: Any | None = None,
+    stop_event: Any | None = None,
+    label: str = "collector",
+):
+    """Context manager that catches all exceptions in collector subprocess.
+
+    Sends a picklable ExceptionWrapper through the error pipe so the
+    parent process can surface the full traceback. Also pushes to
+    metrics_queue for fast-path detection by the training loop.
+    """
+    try:
+        yield
+    except Exception:
+        wrapper = ExceptionWrapper(where=f"in {label}")
+        print(
+            f"\n{'=' * 60}\n[{label.upper()} CRASH]\n"
+            f"{wrapper.exc_msg}\n{'=' * 60}\n",
+            file=sys.stderr,
+            flush=True,
+        )
+        if error_conn is not None:
+            try:
+                error_conn.send(wrapper)
+            except Exception:
+                pass
+        if metrics_queue is not None:
+            try:
+                metrics_queue.put_nowait({"error": wrapper.exc_msg})
+            except Exception:
+                pass
+        if stop_event is not None:
+            try:
+                stop_event.set()
+            except Exception:
+                pass
+        raise
+
+
+def format_collector_death(exitcode: int | None, traceback_text: str | None = None) -> str:
+    """Format a human-readable death report for a collector process."""
+    parts = []
+
+    if traceback_text:
+        parts.append("Collector process crashed.")
+        parts.append(f"\n{'─' * 50}")
+        parts.append(traceback_text.rstrip())
+        parts.append(f"{'─' * 50}")
+    elif exitcode is not None and exitcode < 0:
+        sig_num = -exitcode
+        sig_name = _signal_name(sig_num)
+        parts.append(f"Collector process killed by signal {sig_num} ({sig_name}).")
+        parts.append("  No Python traceback available — killed externally.")
+        if sig_num == 9:
+            parts.append("  Common cause: OOM killer. Check: dmesg | grep -i oom")
+        elif sig_num == 11:
+            parts.append("  Common cause: segfault in native code (C++/CUDA).")
+    elif exitcode is not None:
+        parts.append(f"Collector process exited with code {exitcode}.")
+    else:
+        parts.append("Collector process died (exit code unknown).")
+
+    return "\n".join(parts)
+
+
+def _signal_name(sig_num: int) -> str:
+    try:
+        return signal.Signals(sig_num).name
+    except (ValueError, AttributeError):
+        return f"SIG{sig_num}"

--- a/src/unilab/ipc/memory_budget.py
+++ b/src/unilab/ipc/memory_budget.py
@@ -1,0 +1,117 @@
+"""Memory budget estimation for async RL training buffers.
+
+Pure functions that estimate memory usage and warn if the system
+is likely to OOM before allocating large shared buffers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def estimate_offpolicy_bytes(
+    num_envs: int,
+    replay_buffer_n: int,
+    obs_dim: int,
+    action_dim: int,
+    critic_dim: int,
+    batch_size: int,
+    updates_per_step: int,
+) -> dict[str, int]:
+    """Estimate memory for off-policy replay buffer + double-buffer slots."""
+    row_width = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
+    capacity = replay_buffer_n * num_envs
+    replay_bytes = capacity * row_width * 4
+
+    sample_count = batch_size * updates_per_step
+    slot_bytes = sample_count * row_width * 4 * 2
+
+    total = replay_bytes + slot_bytes
+    return {
+        "replay_buffer": replay_bytes,
+        "double_buffer_slots": slot_bytes,
+        "total": total,
+        "breakdown": (
+            f"Replay: {replay_bytes / 1024**2:.0f} MB "
+            f"({num_envs} envs × {replay_buffer_n} steps × {row_width} cols × 4B)\n"
+            f"  Double-buffer: {slot_bytes / 1024**2:.0f} MB "
+            f"({sample_count} samples × {row_width} cols × 4B × 2 slots)"
+        ),
+    }
+
+
+def estimate_appo_bytes(
+    num_envs: int,
+    steps_per_env: int,
+    obs_dim: int,
+    action_dim: int,
+    critic_dim: int,
+    num_slots: int = 4,
+) -> dict[str, int]:
+    """Estimate memory for APPO rollout ring buffer."""
+    per_step = obs_dim + action_dim + 1 + 1 + 1 + 1 + critic_dim
+    per_slot = num_envs * steps_per_env * per_step * 4
+    last_obs_per_slot = num_envs * (obs_dim + critic_dim) * 4
+    total_per_slot = per_slot + last_obs_per_slot
+    total = total_per_slot * num_slots
+
+    return {
+        "ring_buffer": total,
+        "total": total,
+        "breakdown": (
+            f"Ring buffer: {total / 1024**2:.0f} MB "
+            f"({num_slots} slots × {num_envs} envs × {steps_per_env} steps × "
+            f"{per_step} cols × 4B)"
+        ),
+    }
+
+
+def get_available_memory_bytes() -> int | None:
+    """Best-effort available memory detection."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError):
+        pass
+
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except ImportError:
+        pass
+
+    return None
+
+
+def warn_if_over_budget(
+    estimated: dict[str, int],
+    label: str,
+    threshold: float = 0.8,
+) -> None:
+    """Print a warning if estimated memory exceeds threshold of available."""
+    if os.environ.get("UNILAB_SKIP_MEMORY_CHECK"):
+        return
+
+    available = get_available_memory_bytes()
+    if available is None:
+        return
+
+    total = estimated["total"]
+    ratio = total / available
+
+    if ratio > threshold:
+        est_gb = total / 1024**3
+        avail_gb = available / 1024**3
+        breakdown = estimated.get("breakdown", "")
+        print(
+            f"\n[Memory Warning] {label}: estimated {est_gb:.1f} GB, "
+            f"available {avail_gb:.1f} GB ({ratio:.0%} usage).\n"
+            f"  {breakdown}\n"
+            f"  Consider reducing algo.num_envs or algo.replay_buffer_n.\n"
+            f"  Suppress: export UNILAB_SKIP_MEMORY_CHECK=1\n",
+            file=sys.stderr,
+            flush=True,
+        )

--- a/src/unilab/ipc/memory_budget.py
+++ b/src/unilab/ipc/memory_budget.py
@@ -18,7 +18,7 @@ def estimate_offpolicy_bytes(
     critic_dim: int,
     batch_size: int,
     updates_per_step: int,
-) -> dict[str, int]:
+) -> dict[str, int | str]:
     """Estimate memory for off-policy replay buffer + double-buffer slots."""
     row_width = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
     capacity = replay_buffer_n * num_envs
@@ -48,7 +48,7 @@ def estimate_appo_bytes(
     action_dim: int,
     critic_dim: int,
     num_slots: int = 4,
-) -> dict[str, int]:
+) -> dict[str, int | str]:
     """Estimate memory for APPO rollout ring buffer."""
     per_step = obs_dim + action_dim + 1 + 1 + 1 + 1 + critic_dim
     per_slot = num_envs * steps_per_env * per_step * 4
@@ -79,7 +79,8 @@ def get_available_memory_bytes() -> int | None:
 
     try:
         import psutil
-        return psutil.virtual_memory().available
+
+        return int(psutil.virtual_memory().available)
     except ImportError:
         pass
 
@@ -87,7 +88,7 @@ def get_available_memory_bytes() -> int | None:
 
 
 def warn_if_over_budget(
-    estimated: dict[str, int],
+    estimated: dict[str, int | str],
     label: str,
     threshold: float = 0.8,
 ) -> None:
@@ -99,7 +100,7 @@ def warn_if_over_budget(
     if available is None:
         return
 
-    total = estimated["total"]
+    total = int(estimated["total"])
     ratio = total / available
 
     if ratio > threshold:

--- a/src/unilab/ipc/replay_pipelines/native_h2d.py
+++ b/src/unilab/ipc/replay_pipelines/native_h2d.py
@@ -1,34 +1,127 @@
-"""Optional native H2D submit helper for replay pipeline experiments."""
+"""Optional native H2D submit helper with graceful fallback.
+
+Pre-validates build prerequisites before attempting JIT compilation.
+Falls back to ``dst.copy_(src, non_blocking=True)`` on a side stream
+when the native extension is unavailable — functionally identical for
+pinned-memory transfers (the ROCm path already uses this).
+"""
 
 from __future__ import annotations
 
+import logging
+import shutil
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 
 import torch
-from torch.utils.cpp_extension import CUDA_HOME, load
+
+logger = logging.getLogger(__name__)
 
 _SOURCE = Path(__file__).with_name("native_h2d_ext.cpp")
+_NATIVE_AVAILABLE: bool | None = None
+_DIAGNOSTIC: str = ""
+
+
+def _check_build_prerequisites() -> tuple[bool, str]:
+    """Pre-validate JIT compilation requirements."""
+    try:
+        from torch.utils.cpp_extension import is_ninja_available
+        if not is_ninja_available():
+            return False, "ninja not found. Install: pip install ninja"
+    except ImportError:
+        return False, "torch.utils.cpp_extension unavailable"
+
+    from torch.utils.cpp_extension import get_cxx_compiler
+    compiler = get_cxx_compiler()
+    if shutil.which(compiler) is None:
+        return False, (
+            f"C++ compiler '{compiler}' not found. "
+            f"Install: sudo apt install g++"
+        )
+
+    from torch.utils.cpp_extension import CUDA_HOME
+    if CUDA_HOME is None:
+        return False, (
+            "CUDA_HOME not set and nvcc not found. "
+            "Install CUDA toolkit or set CUDA_HOME."
+        )
+
+    header = Path(CUDA_HOME) / "include" / "cuda_runtime_api.h"
+    if not header.exists():
+        targets_header = Path(CUDA_HOME) / "targets" / "x86_64-linux" / "include" / "cuda_runtime_api.h"
+        if not targets_header.exists():
+            return False, (
+                f"cuda_runtime_api.h not found in {CUDA_HOME}/include/ "
+                f"or targets/x86_64-linux/include/. "
+                f"Verify CUDA toolkit installation."
+            )
+
+    if not _SOURCE.exists():
+        return False, f"Extension source not found: {_SOURCE}"
+
+    return True, ""
 
 
 @lru_cache(maxsize=1)
-def _load_extension():
-    extra_include_paths = []
-    if CUDA_HOME is not None:
-        extra_include_paths.append(str(Path(CUDA_HOME) / "include"))
-    return load(
-        name="unilab_native_h2d",
-        sources=[str(_SOURCE)],
-        extra_cflags=["-O3"],
-        extra_include_paths=extra_include_paths,
-        verbose=False,
-    )
+def _try_load_extension() -> Any | None:
+    global _NATIVE_AVAILABLE, _DIAGNOSTIC
+
+    ok, reason = _check_build_prerequisites()
+    if not ok:
+        _DIAGNOSTIC = reason
+        _NATIVE_AVAILABLE = False
+        logger.info(
+            "Native H2D extension unavailable: %s. "
+            "Using pure-PyTorch async copy (no performance impact for pinned memory).",
+            reason,
+        )
+        return None
+
+    try:
+        from torch.utils.cpp_extension import CUDA_HOME, load
+        extra_include_paths = []
+        if CUDA_HOME is not None:
+            extra_include_paths.append(str(Path(CUDA_HOME) / "include"))
+            targets_include = Path(CUDA_HOME) / "targets" / "x86_64-linux" / "include"
+            if targets_include.exists():
+                extra_include_paths.append(str(targets_include))
+        ext = load(
+            name="unilab_native_h2d",
+            sources=[str(_SOURCE)],
+            extra_cflags=["-O3"],
+            extra_include_paths=extra_include_paths,
+            verbose=False,
+        )
+        _NATIVE_AVAILABLE = True
+        return ext
+    except Exception as exc:
+        _DIAGNOSTIC = f"Compilation failed: {exc}"
+        _NATIVE_AVAILABLE = False
+        logger.warning(
+            "Native H2D compilation failed: %s. Using pure-PyTorch fallback.", exc
+        )
+        return None
 
 
-def ensure_available() -> None:
-    """Build/load the native helper before measured H2D submissions."""
-    _load_extension()
+def is_available() -> bool:
+    """True if native extension is loaded or loadable."""
+    global _NATIVE_AVAILABLE
+    if _NATIVE_AVAILABLE is None:
+        _try_load_extension()
+    return bool(_NATIVE_AVAILABLE)
+
+
+def get_diagnostic() -> str:
+    """Human-readable reason for unavailability."""
+    if _NATIVE_AVAILABLE is None:
+        _try_load_extension()
+    return _DIAGNOSTIC
+
+
+def ensure_available() -> bool:
+    """Attempt to load native extension. Returns True if available."""
+    return is_available()
 
 
 def submit_h2d(
@@ -37,5 +130,9 @@ def submit_h2d(
     stream: torch.cuda.Stream,
 ) -> None:
     """Submit one async H2D copy on an existing CUDA stream."""
-    ext = cast(Any, _load_extension())
-    ext.submit_h2d(dst, src, int(stream.cuda_stream))
+    ext = _try_load_extension()
+    if ext is not None:
+        ext.submit_h2d(dst, src, int(stream.cuda_stream))
+    else:
+        with torch.cuda.stream(stream):
+            dst.copy_(src, non_blocking=True)

--- a/src/unilab/ipc/replay_pipelines/native_h2d.py
+++ b/src/unilab/ipc/replay_pipelines/native_h2d.py
@@ -27,29 +27,30 @@ def _check_build_prerequisites() -> tuple[bool, str]:
     """Pre-validate JIT compilation requirements."""
     try:
         from torch.utils.cpp_extension import is_ninja_available
+
         if not is_ninja_available():
             return False, "ninja not found. Install: pip install ninja"
     except ImportError:
         return False, "torch.utils.cpp_extension unavailable"
 
     from torch.utils.cpp_extension import get_cxx_compiler
+
     compiler = get_cxx_compiler()
     if shutil.which(compiler) is None:
-        return False, (
-            f"C++ compiler '{compiler}' not found. "
-            f"Install: sudo apt install g++"
-        )
+        return False, (f"C++ compiler '{compiler}' not found. Install: sudo apt install g++")
 
     from torch.utils.cpp_extension import CUDA_HOME
+
     if CUDA_HOME is None:
         return False, (
-            "CUDA_HOME not set and nvcc not found. "
-            "Install CUDA toolkit or set CUDA_HOME."
+            "CUDA_HOME not set and nvcc not found. Install CUDA toolkit or set CUDA_HOME."
         )
 
     header = Path(CUDA_HOME) / "include" / "cuda_runtime_api.h"
     if not header.exists():
-        targets_header = Path(CUDA_HOME) / "targets" / "x86_64-linux" / "include" / "cuda_runtime_api.h"
+        targets_header = (
+            Path(CUDA_HOME) / "targets" / "x86_64-linux" / "include" / "cuda_runtime_api.h"
+        )
         if not targets_header.exists():
             return False, (
                 f"cuda_runtime_api.h not found in {CUDA_HOME}/include/ "
@@ -80,6 +81,7 @@ def _try_load_extension() -> Any | None:
 
     try:
         from torch.utils.cpp_extension import CUDA_HOME, load
+
         extra_include_paths = []
         if CUDA_HOME is not None:
             extra_include_paths.append(str(Path(CUDA_HOME) / "include"))
@@ -98,9 +100,7 @@ def _try_load_extension() -> Any | None:
     except Exception as exc:
         _DIAGNOSTIC = f"Compilation failed: {exc}"
         _NATIVE_AVAILABLE = False
-        logger.warning(
-            "Native H2D compilation failed: %s. Using pure-PyTorch fallback.", exc
-        )
+        logger.warning("Native H2D compilation failed: %s. Using pure-PyTorch fallback.", exc)
         return None
 
 

--- a/src/unilab/ipc/replay_pipelines/transfer/cuda_like.py
+++ b/src/unilab/ipc/replay_pipelines/transfer/cuda_like.py
@@ -39,9 +39,19 @@ class CudaLikeReplayTransferBackend:
         self.direct_pinned_shared = False
 
         if self.h2d_submitter == "pybind11":
-            from unilab.ipc.replay_pipelines.native_h2d import ensure_available
+            from unilab.ipc.replay_pipelines.native_h2d import get_diagnostic, is_available
 
-            ensure_available()
+            if not is_available():
+                import sys
+
+                print(
+                    f"[ReplayTransfer] Native H2D unavailable, using torch_copy_stream.\n"
+                    f"  Reason: {get_diagnostic()}\n"
+                    f"  Performance impact: negligible for pinned-memory transfers.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                self.h2d_submitter = "torch_copy_stream"
 
     def register_host_slots(self, slots: list[torch.Tensor]) -> None:
         for slot in slots:


### PR DESCRIPTION
## 背景

在实际安装和使用 UniLab 的过程中，我们遇到了一系列相互关联的问题，严重影响了新用户的 onboarding 体验：

1. **SAC/TD3 训练在 motrix 后端下只输出 semaphore warning 后立即退出**（exit code 247），没有任何 Python traceback。我们花了大量时间才定位到根因是 collector subprocess 中 JIT 编译失败（缺少 g++/CUDA headers），而错误信息被完全吞掉了。

2. **off-policy 算法依赖 JIT 编译的 C++ CUDA 扩展**（native_h2d），但 g++ 和 CUDA Toolkit 不是 Python 依赖，安装文档也未提及。缺少时只会在 subprocess 中产生 ninja build 的底层报错，且被问题 1 吞掉。

3. **默认 2048 envs 的 SAC 训练在 32GB RAM 机器上直接被 OOM killer 杀掉**，用户无任何提示。

核心原则：**但凡有报错信息，必须显示出来。**

## 变更内容

### 1. Collector Subprocess 错误传播（P0）

**设计模式**：参考 PyTorch DataLoader 的 ExceptionWrapper + CPython ProcessPoolExecutor 的 _RemoteTraceback，使用 multiprocessing.Pipe 实现跨进程错误传播。

**新增 src/unilab/ipc/collector_error.py**：
- ExceptionWrapper：可 pickle 的异常容器，存储异常类型 + 格式化后的 traceback 字符串（不存储 exc_info 以避免引用循环）
- collector_error_guard()：上下文管理器，包裹 collector 入口点。捕获所有异常后通过 Pipe 发送给父进程，同时保留 metrics_queue 快速路径
- format_collector_death()：根据 exit code / signal 生成人类可读的死亡报告

**修改 src/unilab/ipc/async_runner.py**：
- _start_collector() 创建 error Pipe，用 _collector_entry_wrapper 包裹 target function
- 新增 _check_collector_alive() 在基类中统一实现：子进程死亡时从 Pipe 读取 traceback，结合 exit code 生成完整诊断
- close() 在正常关闭后检查非零退出码（SIGTERM -15 除外）并打印
- 子类（OffPolicyRunner、APPORunner）不再重复实现 _check_collector_alive()

**修改 Worker 入口**：
- appo/worker.py：此前完全无错误处理，异常直接导致 subprocess 静默退出。现在由 wrapper 统一捕获
- offpolicy/worker.py：移除冗余的内部 try/except（原先的 stderr 打印在 daemon subprocess 中不可见），由 wrapper 统一处理

**效果对比**：

修复前：
```
Motphys profiler initialized: disabled
resource_tracker: There appear to be 5 leaked semaphore objects...
（然后什么都没有，进程消失）
```

修复后：
```
Collector process crashed.
──────────────────────────────────────────────────
Traceback (most recent call last):
  File ".../worker.py", line 310, in _run_collector
    ...
RuntimeError: Error building extension 'unilab_native_h2d': ...
  /bin/sh: 1: c++: not found
──────────────────────────────────────────────────
```

### 2. native_h2d JIT 编译守卫 + 自动降级（P0）

**设计模式**：参考 PyTorch3D 的条件编译 + PyTorch Geometric 的 module-level boolean flag。

**修改 native_h2d.py**：
- 新增 _check_build_prerequisites()：预检查 ninja、g++、CUDA_HOME、cuda_runtime_api.h（包括 conda 的非标准 targets/x86_64-linux/include/ 路径）
- ensure_available() 不再抛异常，返回 bool
- submit_h2d() 在 native 不可用时降级为 dst.copy_(src, non_blocking=True) + torch.cuda.stream()

**修改 cuda_like.py**：
- __init__ 中检查 is_available()，不可用时自动切换 h2d_submitter = torch_copy_stream
- 这是 ROCm 已经在用的路径（line 99-100），已经过验证
- 性能影响：对 pinned memory 传输几乎为零（PyTorch 官方文档确认）

### 3. 内存预算估算（P1）

**新增 memory_budget.py**：
- estimate_offpolicy_bytes()：估算 replay buffer + double-buffer slots 内存
- estimate_appo_bytes()：估算 rollout ring buffer 内存
- get_available_memory_bytes()：解析 /proc/meminfo，psutil 降级
- warn_if_over_budget()：超过可用内存 80% 时打印结构化警告，可通过 UNILAB_SKIP_MEMORY_CHECK=1 抑制

### 4. 代理环境安装文档

**新增 proxy_setup.md**：5 个常见问题的根因分析与解决方案，包含完整的代理环境安装流程。添加 ffmpeg 到系统依赖。

## 验证

- [x] PPO (on-policy) 冒烟测试通过
- [x] APPO (async on-policy) 冒烟测试通过
- [x] SAC (off-policy) 冒烟测试通过
- [x] 正常关闭时不输出误报（SIGTERM -15 过滤）
- [x] 所有新模块 import 正常，无循环依赖
- [x] native_h2d 在有 CUDA Toolkit 时正常编译使用

## 设计决策

1. **Pipe 而非 SharedMemory**：spawn context 下 pickle 更可靠，与 PyTorch DataLoader 一致
2. **torch_copy_stream 作为降级路径**：ROCm 已验证，pinned memory 下性能差异可忽略
3. **内存检查只是 warning**：用户可能有 swap 或知道自己在做什么

🤖 Generated with [Claude Code](https://claude.com/claude-code)