### PR TITLE
fix: rsl-rl TensorBoard time-axis resets after algo.load_run (#441)

### DIFF
--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -30,7 +30,11 @@ from unilab.training import (
     parse_checkpoint_path,
     should_run_playback,
 )
-from unilab.training.experiment import ExperimentTracker, patch_rsl_rl_wandb_writer
+from unilab.training.experiment import (
+    ExperimentTracker,
+    patch_rsl_rl_resume_state,
+    patch_rsl_rl_wandb_writer,
+)
 from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
 from unilab.utils.device import get_default_device
 
@@ -356,6 +360,8 @@ def main(cfg: DictConfig) -> None:
             )
             train_cfg["runner"]["logger"] = logger_type
             train_cfg["logger"] = logger_type
+
+            patch_rsl_rl_resume_state()
 
             if tracker is not None and logger_type == "wandb":
                 patch_rsl_rl_wandb_writer()

--- a/src/unilab/training/experiment.py
+++ b/src/unilab/training/experiment.py
@@ -461,3 +461,59 @@ def patch_rsl_rl_wandb_writer() -> None:
 
     wandb_utils.WandbSummaryWriter = PatchedWandbSummaryWriter
     setattr(wandb_utils, "_UNILAB_PATCHED", True)
+
+
+def patch_rsl_rl_resume_state() -> None:
+    """Persist + restore ``Logger.tot_time`` / ``tot_timesteps`` across resume.
+
+    Without this patch, rsl-rl's ``Logger.__init__`` writes ``tot_time = 0`` and
+    ``tot_timesteps = 0`` and ``OnPolicyRunner.load`` never refreshes them, so the
+    ``Train/mean_reward/time`` and ``Train/mean_episode_length/time`` TensorBoard
+    scalars (which use ``int(self.tot_time)`` as their step) restart from 0 on
+    every resumed run and visually overlap the original segment. See issue #441.
+
+    The patch wraps ``OnPolicyRunner.save`` / ``OnPolicyRunner.load`` to round-trip
+    a ``unilab_logger_state`` key in the saved dict. Legacy checkpoints (without
+    the key) load unchanged.
+    """
+    try:
+        from rsl_rl.runners.on_policy_runner import OnPolicyRunner
+    except Exception:
+        return
+
+    if getattr(OnPolicyRunner, "_UNILAB_RESUME_PATCHED", False):
+        return
+
+    import torch
+
+    def _patched_save(self: Any, path: str, infos: dict | None = None) -> None:
+        saved_dict = self.alg.save()
+        saved_dict["iter"] = self.current_learning_iteration
+        saved_dict["infos"] = infos
+        saved_dict["unilab_logger_state"] = {
+            "tot_time": float(getattr(self.logger, "tot_time", 0.0)),
+            "tot_timesteps": int(getattr(self.logger, "tot_timesteps", 0)),
+        }
+        torch.save(saved_dict, path)
+        self.logger.save_model(path, self.current_learning_iteration)
+
+    def _patched_load(
+        self: Any,
+        path: str,
+        load_cfg: dict | None = None,
+        strict: bool = True,
+        map_location: str | None = None,
+    ) -> Any:
+        loaded_dict = torch.load(path, weights_only=False, map_location=map_location)
+        load_iteration = self.alg.load(loaded_dict, load_cfg, strict)
+        if load_iteration:
+            self.current_learning_iteration = loaded_dict["iter"]
+        state = loaded_dict.get("unilab_logger_state")
+        if state is not None:
+            self.logger.tot_time = float(state.get("tot_time", 0.0))
+            self.logger.tot_timesteps = int(state.get("tot_timesteps", 0))
+        return loaded_dict["infos"]
+
+    OnPolicyRunner.save = _patched_save  # type: ignore[assignment]
+    OnPolicyRunner.load = _patched_load  # type: ignore[assignment]
+    OnPolicyRunner._UNILAB_RESUME_PATCHED = True  # type: ignore[attr-defined]

--- a/tests/training/test_resume_logger_state.py
+++ b/tests/training/test_resume_logger_state.py
@@ -1,0 +1,145 @@
+"""Regression tests for issue #441 — TensorBoard time-axis resets after resume.
+
+The bug surface is ``rsl_rl.utils.logger.Logger.tot_time`` /
+``tot_timesteps`` being used as the step for ``Train/mean_reward/time`` and
+``Train/mean_episode_length/time`` while ``OnPolicyRunner.load`` does not
+restore them. ``patch_rsl_rl_resume_state`` round-trips both counters via the
+saved checkpoint's ``unilab_logger_state`` key.
+
+These tests bypass ``OnPolicyRunner.__init__`` (which needs a full VecEnv and
+PPO algorithm) by stubbing the few attributes ``save`` / ``load`` actually
+touch. That keeps the patch surface — not the integration — under test, and
+avoids pulling MuJoCo or simulator dependencies into a unit test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+pytest.importorskip("rsl_rl")
+
+from rsl_rl.runners.on_policy_runner import OnPolicyRunner  # noqa: E402
+
+from unilab.training.experiment import patch_rsl_rl_resume_state
+
+
+class _AlgStub:
+    def __init__(self, returns_iter: bool = True) -> None:
+        self._returns_iter = returns_iter
+
+    def save(self) -> dict:
+        return {
+            "actor_state_dict": {},
+            "critic_state_dict": {},
+            "optimizer_state_dict": {},
+        }
+
+    def load(self, _loaded_dict: dict, _load_cfg: dict | None, _strict: bool) -> bool:
+        return self._returns_iter
+
+
+class _LoggerStub:
+    def __init__(self) -> None:
+        self.tot_time = 0.0
+        self.tot_timesteps = 0
+        self.saved_models: list[tuple[str, int]] = []
+
+    def save_model(self, path: str, it: int) -> None:
+        self.saved_models.append((path, it))
+
+
+def _make_stub_runner(
+    *,
+    iter: int = 0,
+    tot_time: float = 0.0,
+    tot_timesteps: int = 0,
+    alg_returns_iter: bool = True,
+) -> Any:
+    runner = OnPolicyRunner.__new__(OnPolicyRunner)
+    runner.alg = _AlgStub(returns_iter=alg_returns_iter)  # type: ignore[assignment]
+    runner.logger = _LoggerStub()  # type: ignore[assignment]
+    runner.logger.tot_time = tot_time
+    runner.logger.tot_timesteps = tot_timesteps
+    runner.current_learning_iteration = iter
+    return runner
+
+
+def test_patch_is_idempotent() -> None:
+    patch_rsl_rl_resume_state()
+    save_after_first = OnPolicyRunner.save
+    load_after_first = OnPolicyRunner.load
+    patch_rsl_rl_resume_state()
+    assert OnPolicyRunner.save is save_after_first
+    assert OnPolicyRunner.load is load_after_first
+    assert getattr(OnPolicyRunner, "_UNILAB_RESUME_PATCHED", False) is True
+
+
+def test_save_round_trip_restores_logger_counters(tmp_path: Path) -> None:
+    patch_rsl_rl_resume_state()
+
+    saver = _make_stub_runner(iter=100, tot_time=987.5, tot_timesteps=4096 * 100)
+    ckpt = tmp_path / "model_100.pt"
+    saver.save(str(ckpt))
+
+    # The unilab key must land in the file so external readers (e.g. analysis
+    # scripts) can recover wall-clock progress without rerunning the trainer.
+    raw = torch.load(str(ckpt), weights_only=False)
+    assert "unilab_logger_state" in raw
+    assert raw["unilab_logger_state"]["tot_time"] == pytest.approx(987.5)
+    assert raw["unilab_logger_state"]["tot_timesteps"] == 4096 * 100
+    assert raw["iter"] == 100
+    assert saver.logger.saved_models == [(str(ckpt), 100)]
+
+    loader = _make_stub_runner(iter=0, tot_time=0.0, tot_timesteps=0)
+    loader.load(str(ckpt))
+
+    assert loader.current_learning_iteration == 100
+    assert loader.logger.tot_time == pytest.approx(987.5)
+    assert loader.logger.tot_timesteps == 4096 * 100
+
+
+def test_load_legacy_checkpoint_without_unilab_state(tmp_path: Path) -> None:
+    """Pre-patch checkpoints must still load; logger counters keep their defaults."""
+    patch_rsl_rl_resume_state()
+
+    legacy = {
+        "actor_state_dict": {},
+        "critic_state_dict": {},
+        "optimizer_state_dict": {},
+        "iter": 50,
+        "infos": None,
+    }
+    ckpt = tmp_path / "model_50_legacy.pt"
+    torch.save(legacy, str(ckpt))
+
+    loader = _make_stub_runner(iter=0, tot_time=0.0, tot_timesteps=0)
+    loader.load(str(ckpt))
+
+    assert loader.current_learning_iteration == 50
+    assert loader.logger.tot_time == 0.0
+    assert loader.logger.tot_timesteps == 0
+
+
+def test_load_does_not_overwrite_iter_when_alg_skips_iteration(tmp_path: Path) -> None:
+    """If ``alg.load`` returns False the runner's iter must not be clobbered.
+
+    Mirrors the upstream behaviour at ``OnPolicyRunner.load`` so the patch
+    does not change the contract for partial loads (e.g. policy-only).
+    """
+    patch_rsl_rl_resume_state()
+
+    saver = _make_stub_runner(iter=200, tot_time=12.0, tot_timesteps=10)
+    ckpt = tmp_path / "model_200.pt"
+    saver.save(str(ckpt))
+
+    loader = _make_stub_runner(iter=7, alg_returns_iter=False)
+    loader.load(str(ckpt))
+
+    assert loader.current_learning_iteration == 7  # untouched
+    # Logger state still restored — wall-clock is independent of alg load_cfg.
+    assert loader.logger.tot_time == pytest.approx(12.0)
+    assert loader.logger.tot_timesteps == 10


### PR DESCRIPTION
## Summary

Fixes #441. On resume (`algo.load_run != "-1"`) the TensorBoard scalars
`Train/mean_reward/time` and `Train/mean_episode_length/time` restart their
x-axis at 0. Root cause: upstream rsl-rl 5.0.1's `Logger.tot_time` and
`tot_timesteps` are initialised to 0 and never restored by
`OnPolicyRunner.load`, while these two scalars use `int(self.tot_time)` as
their step.

This PR adds `patch_rsl_rl_resume_state()` next to the existing
`patch_rsl_rl_wandb_writer` monkey-patch in `src/unilab/training/experiment.py`,
which wraps `OnPolicyRunner.save/load` to round-trip both counters via a new
optional `unilab_logger_state` key in the saved checkpoint. The upstream pip
package is not modified.

The `Perf/*` scalars listed in the issue use `it` as the step, and
`current_learning_iteration` is already restored by upstream `load()`; their
apparent "fresh start" in TB is a log-dir artifact, not a step bug. This PR
does not change their behavior.

## Scope

- Train path of `scripts/train_rsl_rl.py` only — fresh runs and `play_only`
  are unaffected.
- Algorithm math, networks, optimizers, env, registry, Hydra configs, and
  every other trainer (HIM / MLX / APPO / SAC / TD3 / FlashSAC) are untouched.
- Fresh-run checkpoints carry ~32 extra bytes (two counters) and are otherwise
  identical.
- Legacy checkpoints load with `tot_time = 0` (identical to current behavior).
- New checkpoints load cleanly in unpatched rsl-rl (extra key ignored).
- Multi-GPU: counters are local; no inter-rank communication added.

## Changes

| File | Lines | Description |
|---|---|---|
| `src/unilab/training/experiment.py` | +56 | New idempotent `patch_rsl_rl_resume_state()` |
| `scripts/train_rsl_rl.py` | +7 / -1 | Import + patch call before runner construction |
| `tests/training/test_resume_logger_state.py` | +146 | 4 regression cases: idempotency, round-trip, legacy ckpt, partial load semantics |

## Validation

- [x] `uv run pytest tests/training/test_resume_logger_state.py -v` (4 cases, all green)
- [x] `uv run ruff check` + `uv run mypy` on changed files
- [x] `make test-all` passing
- [x] **Manual resume smoke test (motion tracking, MuJoCo backend)**:

  ```bash
  # Step 1 — fresh run, save every 20 iter up to 50
  uv run scripts/train_rsl_rl.py \
      task=g1_motion_tracking/mujoco \
      training.logger=tensorboard \
      algo.max_iterations=50 \
      algo.save_interval=20

  # Step 2 — resume from that run for another 50 iter
  uv run scripts/train_rsl_rl.py \
      task=g1_motion_tracking/mujoco \
      training.logger=tensorboard \
      algo.max_iterations=50 \
      algo.save_interval=20 \
      algo.load_run=2026-06-01_20-27-56_mujoco
