### PR TITLE
chore: use public motrixsim-core release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ unilab-render-teaser = "unilab.tools.render_teaser:main"
 unilab-import-robot = "unilab.tools.import_robot:main"
 
 [project.optional-dependencies]
-motrix = ["motrixsim-core==0.8.1.dev104665"]
+motrix = ["motrixsim-core==0.8.1"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]
@@ -65,7 +65,6 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.uv.sources]
-motrixsim-core = { index = "motphys-pypi" }
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform=='linux'" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2188,26 +2188,23 @@ wheels = [
 
 [[package]]
 name = "motrixsim-core"
-version = "0.8.1.dev104665"
-source = { registry = "https://pypi.motphys.com/simple/" }
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8edf31dae9034b7bbefe212cd6da6aea60cea20870ef01873ee7dd9067db2cc" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe10e09491701cd49791e9950099cc168aa17a75eaeb9738bffda5137e7dfa0e" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp310-cp310-win_amd64.whl", hash = "sha256:332440fe47cda9d3d97f1772510b004f28631230de2d9b1d7a1525ae8c1f9684" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25b8d068df0fa10e861ca7d23f96569bed5bec63d9b4207358177eb3404e470c" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:680dc47a8f3ec03610bc42b7c7c822b3813ea807db759710802745f1427502c2" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp311-cp311-win_amd64.whl", hash = "sha256:9cafd333d86aa457a51873488959191be8ea7b89e2ee6561ad2e07f3095a3080" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3352d692b98f5fc9a6ae231f9c5ab258701ce3ecd7b4423e9897e28c6ee44d6b" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a24e88243786bce09834ea7d3b9104b0d0f6801eca5e81304cc9b52fc81d0882" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp312-cp312-win_amd64.whl", hash = "sha256:e2315b282e45ef9f8fdc771c86efb44b6b86c883f49c97bcdd7f7e588f577634" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b4b54895b04ef8c593238ec829cf8e6d10200fd993ab036c6e9c556295905ac1" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332744f7556f61c1c4e9ad5f4521de3aee4d1418e16d08b7932359e4a24e3d52" },
-    { url = "https://pypi.motphys.com/packages/motrixsim_core-0.8.1.dev104665-cp313-cp313-win_amd64.whl", hash = "sha256:4181802459c8ce7b4dae3bcb300f6638c475d0c205ea35536c0ef04578bc7800" },
+    { url = "https://files.pythonhosted.org/packages/8f/ca/336cab70911a4d30f3b4a0dd648b7f9bbea5c460b7a8927d5df62ab484e0/motrixsim_core-0.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca3487a6d2d35a596c6175b8600e217409f5af12f30221159374fc37c270120a", size = 52160186, upload-time = "2026-06-02T10:46:06.921Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/308729725ee5d1aa8793370e7f6be8f24b8281eb1af31f69fe8808655439/motrixsim_core-0.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:15b47ebf8d1c08fe6818ce0e125ee34b141587c3cfac15c5f8f184dbf282539a", size = 40385700, upload-time = "2026-06-02T10:46:56.574Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4b/2ca69b28c464453ebbba432f1f40dd7fab4bd54204523a6d68fc964ede92/motrixsim_core-0.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ae17489d0f3f981a9c5bbadabb25145917b892a00373d9de028be9b2ea19501", size = 52160235, upload-time = "2026-06-02T10:47:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/01/bcf7abe04c72a9e657dca3c6ec8d77eb102b892810b2daa75c8dc324a657/motrixsim_core-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1a3e986d38757f9d61e223b63c738d146a5aa0bdafeca8770792dcd765a8e3ef", size = 46978480, upload-time = "2026-06-02T10:47:13.516Z" },
+    { url = "https://files.pythonhosted.org/packages/03/22/216f1b2d36f93d5444159ad4e8c7126b745497008c65a0aab39c966d30fe/motrixsim_core-0.8.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03297b4aa2d8cb51f3e04f3292f66bb3d246ee7ad3114239163ff83746e687cd", size = 52166009, upload-time = "2026-06-02T10:46:36.528Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/48/158da69b3f6643a80e82928b078c557e7d750247248a75dabd95cac26d83/motrixsim_core-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:8eda573a11ef67c57116126f6b206c0cfb7b0736c1f62572be9188e5d6889a9a", size = 40399172, upload-time = "2026-06-02T10:46:47.584Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/20069cdd64848fef3a5d88cd8e402cb53281743a1662d31f6344cb7c3dce/motrixsim_core-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b83d28c770ceb13e0410beeaefd2453a3defbfb20775fe4b4fd83f0cbfe87458", size = 46975585, upload-time = "2026-06-02T10:45:53.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c1/3dd1207c70c6cfa06fd8b86d11fd86d5b944478ee1d71797ebda62d75789/motrixsim_core-0.8.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dddcc80a897a5c4e17ac406ce79cfe1e9e26ca6235d81e18efe8f1ae2465beb", size = 52165335, upload-time = "2026-06-02T10:46:27.631Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c2/d404fc6c30a3d3126187ed39d538df27c40f984decd63207f8045eedc913/motrixsim_core-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:c55e61569ff2502a6e2581f9435afd1ed807c1c8c2009a5b50e0191a1c5661f1", size = 40399240, upload-time = "2026-06-02T10:47:04.567Z" },
 ]
 
 [[package]]
@@ -4576,7 +4573,7 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1.dev104665", index = "https://pypi.motphys.com/simple/" },
+    { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.1" },
     { name = "mujoco-uni", specifier = "==3.8.0" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
     { name = "notebook", specifier = ">=7.5.5" },


### PR DESCRIPTION
  ## Summary

  - Update the `motrix` optional dependency from `motrixsim-core==0.8.1.dev104665` to `motrixsim-core==0.8.1`.
  - Remove the explicit `motrixsim-core` uv source override so the package resolves from PyPI.
  - Update `uv.lock` with the public PyPI wheels for `motrixsim-core==0.8.1`.
  - Expected user-facing impact: `uv sync --extra motrix` should no longer require resolving `motrixsim-core` from the internal Motphys index.

  ## Linked Work

  - Issue:  Fixes #565
  - Milestone:

  ## Validation

  - [ ] `make check`
  - [ ] `uv run pytest -m "not slow"`
  - [ ] Additional task-specific validation listed below

  ## Impact

  - Backend impact: motrix
  - Platform impact: both
  - Training effect expected: no

  ## Artifacts

  - W&B:
  - benchmark result:
  - video / screenshot:
  - ONNX / checkpoint:

  ## Checklist

  - [ ] Added or updated tests where needed
  - [ ] Updated docs if behavior or workflow changed
  - [ ] Linked the driving issue
  - [x] Noted any follow-up work explicitly