### PR TITLE
fix: isolate macOS MuJoCo demo mjpython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ runs/
 run_config.json
 run_summary.json
 .worktrees/
+.tmp/
 *.log
 .DS_Store
 .ipynb_checkpoints/

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import platform
+import shutil
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -12,6 +14,8 @@ from pathlib import Path
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.assets.hub import resolve_checkpoint_file
+
+_OFFICIAL_MUJOCO_PACKAGE = "mujoco==3.8.0"
 
 
 @dataclass(frozen=True)
@@ -89,7 +93,7 @@ def _build_play_interactive_command(
             f"{owner_yaml}"
         )
     command = [
-        sys.executable,
+        *_play_interactive_command_prefix(selected_root),
         str(script),
     ]
     if spec.algo == "hora_distill":
@@ -102,6 +106,104 @@ def _build_play_interactive_command(
         ]
     )
     return command
+
+
+def _play_interactive_command_prefix(root: Path) -> list[str]:
+    if platform.system() != "Darwin":
+        return [sys.executable]
+
+    _ensure_mujoco_uni_mjpython_app(root)
+    return [_current_env_mjpython()]
+
+
+def _official_mujoco_env(root: Path) -> Path:
+    return root / ".tmp" / "mjpython-demo"
+
+
+def _official_mujoco_app_mjpython(env_root: Path) -> Path:
+    site_packages = (
+        env_root
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    return site_packages / "mujoco" / "MuJoCo_(mjpython).app" / "Contents" / "MacOS" / "mjpython"
+
+
+def _official_mujoco_app(env_root: Path) -> Path:
+    return _official_mujoco_app_mjpython(env_root).parents[2]
+
+
+def _mujoco_package_dir() -> Path:
+    spec = importlib.util.find_spec("mujoco")
+    if spec is None or spec.origin is None:
+        raise SystemExit("macOS MuJoCo demos require the project mujoco-uni package.")
+    return Path(spec.origin).resolve().parent
+
+
+def _mujoco_uni_mjpython_app() -> Path:
+    return _mujoco_package_dir() / "MuJoCo_(mjpython).app"
+
+
+def _ensure_official_mujoco_env(root: Path) -> Path:
+    env_root = _official_mujoco_env(root)
+    env_mjpython = env_root / "bin" / "mjpython"
+    if env_mjpython.is_file() and _official_mujoco_app_mjpython(env_root).is_file():
+        return env_root
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise SystemExit(
+            "macOS MuJoCo demos require `uv` to create an isolated official MuJoCo "
+            "mjpython environment."
+        )
+
+    env_root.parent.mkdir(parents=True, exist_ok=True)
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    subprocess.run([uv, "venv", str(env_root), "--python", python_version], check=True)
+    subprocess.run(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(env_root / "bin" / "python"),
+            _OFFICIAL_MUJOCO_PACKAGE,
+        ],
+        check=True,
+    )
+    if not env_mjpython.is_file() or not _official_mujoco_app_mjpython(env_root).is_file():
+        raise SystemExit(
+            "Failed to create the isolated official MuJoCo mjpython environment for "
+            "macOS demo playback."
+        )
+    return env_root
+
+
+def _ensure_mujoco_uni_mjpython_app(root: Path) -> None:
+    dest = _mujoco_uni_mjpython_app()
+    if (dest / "Contents" / "MacOS" / "mjpython").is_file():
+        return
+
+    official_env = _ensure_official_mujoco_env(root)
+    shutil.copytree(_official_mujoco_app(official_env), dest, dirs_exist_ok=True)
+    if not (dest / "Contents" / "MacOS" / "mjpython").is_file():
+        raise SystemExit(f"Failed to materialize MuJoCo mjpython app at {dest}")
+
+
+def _current_env_mjpython() -> str:
+    if Path(sys.executable).name == "mjpython":
+        return sys.executable
+
+    venv_mjpython = Path(sys.executable).with_name("mjpython")
+    if venv_mjpython.is_file():
+        return str(venv_mjpython)
+
+    mjpython = shutil.which("mjpython")
+    if mjpython is not None:
+        return mjpython
+
+    raise SystemExit("macOS MuJoCo demos require `mjpython` in the active environment.")
 
 
 def build_demo_command(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,9 +310,10 @@ def test_demo_eval_entry_passes_checkpoint_as_load_run_override(
 
 
 def test_demo_play_interactive_entry_assembles_locomani_command(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _make_demo_checkout(tmp_path, demo_name="locomani")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
     abs_pt = str(tmp_path / "fake" / "model_0.pt")
     command = demo.build_demo_command(
         demo_name="locomani", checkpoint_path=abs_pt, device="cpu", root=tmp_path
@@ -327,9 +328,10 @@ def test_demo_play_interactive_entry_assembles_locomani_command(
 
 
 def test_demo_play_interactive_entry_assembles_inhandgrasp_command(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _make_demo_checkout(tmp_path, demo_name="inhandgrasp")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
     abs_pt = str(tmp_path / "fake" / "model_0.pt")
     command = demo.build_demo_command(
         demo_name="inhandgrasp",
@@ -344,6 +346,69 @@ def test_demo_play_interactive_entry_assembles_inhandgrasp_command(
     assert "task=sharpa_inhand/mujoco_nodr" in command
     assert f"algo.load_run={abs_pt}" in command
     assert "training.device=cpu" in command
+
+
+def test_demo_play_interactive_linux_does_not_materialize_mjpython_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_demo_checkout(tmp_path, demo_name="locomani")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
+
+    def fail_materialize(_: Path) -> None:
+        raise AssertionError("Linux demo path must not touch macOS mjpython setup")
+
+    monkeypatch.setattr(demo, "_ensure_mujoco_uni_mjpython_app", fail_materialize)
+
+    command = demo.build_demo_command(
+        demo_name="locomani",
+        checkpoint_path="/tmp/fake/model_0.pt",
+        root=tmp_path,
+    )
+
+    assert command[0] == sys.executable
+
+
+def test_demo_play_interactive_uses_mjpython_on_macos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_demo_checkout(tmp_path, demo_name="locomani")
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    fake_python = venv_bin / "python"
+    fake_mjpython = venv_bin / "mjpython"
+    fake_python.write_text("", encoding="utf-8")
+    fake_mjpython.write_text("", encoding="utf-8")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(demo.sys, "executable", str(fake_python))
+    monkeypatch.setattr(demo, "_ensure_mujoco_uni_mjpython_app", lambda root: None)
+
+    command = demo.build_demo_command(
+        demo_name="locomani",
+        checkpoint_path="/tmp/fake/model_0.pt",
+        root=tmp_path,
+    )
+
+    assert command[0] == str(fake_mjpython)
+    assert command[1] == str(tmp_path / "scripts" / "play_interactive.py")
+
+
+def test_demo_play_interactive_materializes_mujoco_uni_mjpython_app_on_macos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[Path] = []
+    _make_demo_checkout(tmp_path, demo_name="locomani")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(demo, "_ensure_mujoco_uni_mjpython_app", lambda root: calls.append(root))
+    monkeypatch.setattr(demo, "_current_env_mjpython", lambda: "/tmp/mjpython")
+
+    command = demo.build_demo_command(
+        demo_name="locomani",
+        checkpoint_path="/tmp/fake/model_0.pt",
+        root=tmp_path,
+    )
+
+    assert command[0] == "/tmp/mjpython"
+    assert calls == [tmp_path]
 
 
 def test_demo_play_interactive_requires_owner_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route macOS MuJoCo play_interactive demos through the active env mjpython
- materialize the official MuJoCo 3.8.0 mjpython app into the mujoco-uni package when needed
- keep Linux/Ubuntu demo paths on the current Python executable and add regression coverage

## Validation
- uv run pytest tests/test_cli.py
- make test-all (completed by user)
- uv run demo inhandgrasp reached the MuJoCo viewer startup stage