### PR TITLE
Fix/clean critic obs

### DIFF
--- a/conf/appo/task/go2_joystick_flat/motrix.yaml
+++ b/conf/appo/task/go2_joystick_flat/motrix.yaml
@@ -8,9 +8,6 @@ algo:
   max_iterations: 180
 env:
   sim_dt: 0.015
-algorithm:
-  num_learning_epochs: 25
-  num_mini_batches: 8
 reward:
   scales:
     tracking_lin_vel: 1.0

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -176,19 +176,30 @@ class Go1WalkTask(Go1BaseEnv):
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
         command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         obs = np.concatenate(
-            [gyro, -gravity, diff, dof_vel, last_actions, command, feet_phase],
+            [
+                noisy_gyro,
+                -noisy_gravity,
+                noisy_diff,
+                noisy_dof_vel,
+                last_actions,
+                command,
+                feet_phase,
+            ],
             axis=1,
             dtype=get_global_dtype(),
         )
-        critic = np.concatenate([obs, linvel], axis=1, dtype=get_global_dtype())
+        critic = np.concatenate(
+            [gyro, -gravity, diff, dof_vel, last_actions, command, feet_phase, linvel],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
         return {"obs": obs, "critic": critic}
 
     def _compute_reward(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:

--- a/src/unilab/envs/locomotion/go2/footstand.py
+++ b/src/unilab/envs/locomotion/go2/footstand.py
@@ -247,6 +247,7 @@ class Go2FootStandTask(Go2HandStandTask):
             (num_envs, self._obs_history_len, _FOOTSTAND_FRAME_OBS_DIM),
             dtype=get_global_dtype(),
         )
+        self._critic_obs_history = np.zeros_like(self._obs_history)
         self._base_geom_friction = self._backend.get_geom_friction()
         self._floor_geom_id = self._backend.get_geom_id(self._cfg.asset.ground)
         self._base_body_id = self._backend.get_body_id(self._cfg.asset.base_name)
@@ -514,12 +515,22 @@ class Go2FootStandTask(Go2HandStandTask):
         noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
         last_actions = info.get("last_actions", np.zeros_like(diff))
 
-        obs = np.concatenate(
+        obs_frame = np.concatenate(
             [noisy_linvel, noisy_gyro, noisy_gravity, noisy_diff, noisy_dof_vel, last_actions],
             axis=1,
             dtype=get_global_dtype(),
         )
-        obs = self._update_obs_history(obs, env_ids=env_ids)
+        critic_frame = np.concatenate(
+            [linvel, gyro, gravity, diff, dof_vel, last_actions],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
+        obs = self._update_obs_history(obs_frame, env_ids=env_ids, history_attr="_obs_history")
+        critic_obs = self._update_obs_history(
+            critic_frame,
+            env_ids=env_ids,
+            history_attr="_critic_obs_history",
+        )
         torques = np.asarray(info.get("torques", np.zeros_like(dof_pos)), dtype=get_global_dtype())
         if accelerometer is None:
             accelerometer = np.zeros_like(gyro)
@@ -527,7 +538,7 @@ class Go2FootStandTask(Go2HandStandTask):
             global_angvel = np.zeros_like(gyro)
         critic = np.concatenate(
             [
-                obs,
+                critic_obs,
                 gyro,
                 accelerometer,
                 linvel,
@@ -543,20 +554,24 @@ class Go2FootStandTask(Go2HandStandTask):
         return {"obs": obs, "critic": critic}
 
     def _update_obs_history(
-        self, frame_obs: np.ndarray, *, env_ids: np.ndarray | None = None
+        self,
+        frame_obs: np.ndarray,
+        *,
+        env_ids: np.ndarray | None = None,
+        history_attr: str = "_obs_history",
     ) -> np.ndarray:
         frame_obs = np.asarray(frame_obs, dtype=get_global_dtype())
         batch_size = int(frame_obs.shape[0])
         history_len = self._obs_history_len
         expected_shape = (self._num_envs, history_len, _FOOTSTAND_FRAME_OBS_DIM)
-        history = getattr(self, "_obs_history", None)
+        history = getattr(self, history_attr, None)
         if history is None or history.shape != expected_shape:
             if env_ids is None and batch_size == self._num_envs:
-                self._obs_history = np.zeros(expected_shape, dtype=get_global_dtype())
-                history = self._obs_history
+                history = np.zeros(expected_shape, dtype=get_global_dtype())
+                setattr(self, history_attr, history)
             elif env_ids is not None:
-                self._obs_history = np.zeros(expected_shape, dtype=get_global_dtype())
-                history = self._obs_history
+                history = np.zeros(expected_shape, dtype=get_global_dtype())
+                setattr(self, history_attr, history)
             else:
                 repeated = np.broadcast_to(
                     frame_obs[:, None, :], (batch_size, history_len, frame_obs.shape[1])

--- a/src/unilab/envs/locomotion/go2/handstand.py
+++ b/src/unilab/envs/locomotion/go2/handstand.py
@@ -259,19 +259,22 @@ class Go2HandStandTask(Go2BaseEnv):
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
         # command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         obs = np.concatenate(
-            [gyro, -gravity, diff, dof_vel, last_actions],
+            [noisy_gyro, -noisy_gravity, noisy_diff, noisy_dof_vel, last_actions],
             axis=1,
             dtype=get_global_dtype(),
         )
-        critic = np.concatenate([obs, linvel, height], axis=1, dtype=get_global_dtype())
+        critic = np.concatenate(
+            [gyro, -gravity, diff, dof_vel, last_actions, linvel, height],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
         return {"obs": obs, "critic": critic}
 
     # state = jp.hstack([

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -217,19 +217,30 @@ class Go2WalkTask(Go2BaseEnv):
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+        noisy_dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
         command = info["commands"]
         last_actions = info.get("current_actions", np.zeros_like(diff))
         obs = np.concatenate(
-            [gyro, -gravity, diff, dof_vel, last_actions, command, feet_phase],
+            [
+                noisy_gyro,
+                -noisy_gravity,
+                noisy_diff,
+                noisy_dof_vel,
+                last_actions,
+                command,
+                feet_phase,
+            ],
             axis=1,
             dtype=get_global_dtype(),
         )
-        critic = np.concatenate([obs, linvel], axis=1, dtype=get_global_dtype())
+        critic = np.concatenate(
+            [gyro, -gravity, diff, dof_vel, last_actions, command, feet_phase, linvel],
+            axis=1,
+            dtype=get_global_dtype(),
+        )
         return {"obs": obs, "critic": critic}
 
     def _compute_reward(self, info: dict, linvel, gyro, dof_pos) -> np.ndarray:

--- a/src/unilab/envs/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/envs/locomotion/go2_arm/manip_loco.py
@@ -250,7 +250,7 @@ class Go2ArmManipLocoDRProvider(LocomotionDRProvider):
                 sliced_info[k] = v[env_ids]
             else:
                 sliced_info[k] = v
-        raw = env._compute_raw_obs(  # type: ignore[no-any-return]
+        actor_raw = env._compute_raw_obs(  # type: ignore[no-any-return]
             sliced_info,
             linvel,
             gyro,
@@ -260,9 +260,22 @@ class Go2ArmManipLocoDRProvider(LocomotionDRProvider):
             ee_local_pos[env_ids],
             env.curr_ee_goal_cart[env_ids],
             env.feet_phase[env_ids],
+            add_noise=True,
+        )
+        critic_raw = env._compute_raw_obs(  # type: ignore[no-any-return]
+            sliced_info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+            ee_local_pos[env_ids],
+            env.curr_ee_goal_cart[env_ids],
+            env.feet_phase[env_ids],
+            add_noise=False,
         )
         del n
-        return env._update_history(raw, env_ids=env_ids)  # type: ignore[no-any-return]
+        return env._update_history(actor_raw, env_ids=env_ids, critic_raw_obs=critic_raw)  # type: ignore[no-any-return]
 
 
 @registry.env("Go2ArmManipLoco", sim_backend="motrix")
@@ -773,6 +786,8 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
         ee_local_pos: np.ndarray,
         ee_goal_cart: np.ndarray,
         feet_phase: np.ndarray,
+        *,
+        add_noise: bool = True,
     ) -> np.ndarray:
         """Compute single-step 79-dim obs (no history).
 
@@ -780,14 +795,15 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
                 diff(18)+dof_vel(18)+ee_local_pos(3)+ee_goal_cart(3)+ee_error(3)+
                 last_actions(18) = 79
         """
-        noise_cfg = self._cfg.noise_config
         diff = dof_pos - self.default_angles
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
-        dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
-        ee_local_pos = self._obs_noise(ee_local_pos, noise_cfg.scale_ee_pos)
+        if add_noise:
+            noise_cfg = self._cfg.noise_config
+            linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+            gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+            gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+            diff = self._obs_noise(diff, noise_cfg.scale_joint_angle)
+            dof_vel = self._obs_noise(dof_vel, noise_cfg.scale_joint_vel)
+            ee_local_pos = self._obs_noise(ee_local_pos, noise_cfg.scale_ee_pos)
         n = len(dof_pos)
         command = info["commands"] if info["commands"].shape[0] == n else info["commands"][:n]
         last_actions = info.get(
@@ -816,25 +832,28 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
         self,
         raw_obs: np.ndarray,
         env_ids: np.ndarray | None = None,
+        *,
+        critic_raw_obs: np.ndarray | None = None,
     ) -> dict[str, np.ndarray]:
         """Update history buffers and return obs dict (with or without env_ids slice).
 
-        Actor buffer stores obs WITHOUT linvel (raw_obs[:, 3:], 72-dim) so the actor
-        cannot shortcut the estimator.  Critic buffer stores full 75-dim obs (linvel
-        at [0:3] is used as estimator supervision signal).
+        Actor buffer stores obs WITHOUT linvel (raw_obs[:, 3:], 76-dim) so the actor
+        cannot shortcut the estimator. Critic buffer stores clean full 79-dim obs
+        when a separate critic_raw_obs is provided.
         """
-        A = self._actor_one_step_dim  # 72
-        C = self._critic_one_step_dim  # 75
+        A = self._actor_one_step_dim  # 76
+        C = self._critic_one_step_dim  # 79
         H_a = self._cfg.history.num_actor_history
         H_c = self._cfg.history.num_critic_history
         actor_step = raw_obs[:, 3:] if raw_obs.ndim == 2 else raw_obs[3:]
+        critic_step = raw_obs if critic_raw_obs is None else critic_raw_obs
         if env_ids is None:
             if H_a > 1:
                 self._history_obs_buf = np.roll(self._history_obs_buf, -A, axis=1)
             self._history_obs_buf[:, -A:] = actor_step
             if H_c > 1:
                 self._history_critic_buf = np.roll(self._history_critic_buf, -C, axis=1)
-            self._history_critic_buf[:, -C:] = raw_obs
+            self._history_critic_buf[:, -C:] = critic_step
             return {
                 "obs": self._history_obs_buf.copy(),
                 "critic": self._history_critic_buf.copy(),
@@ -847,7 +866,7 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
                 self._history_critic_buf[env_ids] = np.roll(
                     self._history_critic_buf[env_ids], -C, axis=1
                 )
-            self._history_critic_buf[env_ids, -C:] = raw_obs
+            self._history_critic_buf[env_ids, -C:] = critic_step
             return {
                 "obs": self._history_obs_buf[env_ids].copy(),
                 "critic": self._history_critic_buf[env_ids].copy(),
@@ -865,10 +884,31 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
         ee_goal_cart: np.ndarray,
         feet_phase: np.ndarray,
     ) -> dict[str, np.ndarray]:
-        raw = self._compute_raw_obs(
-            info, linvel, gyro, gravity, dof_pos, dof_vel, ee_local_pos, ee_goal_cart, feet_phase
+        actor_raw = self._compute_raw_obs(
+            info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+            ee_local_pos,
+            ee_goal_cart,
+            feet_phase,
+            add_noise=True,
         )
-        return self._update_history(raw)
+        critic_raw = self._compute_raw_obs(
+            info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+            ee_local_pos,
+            ee_goal_cart,
+            feet_phase,
+            add_noise=False,
+        )
+        return self._update_history(actor_raw, critic_raw_obs=critic_raw)
 
     def _compute_reward(
         self,

--- a/src/unilab/envs/locomotion/go2w/joystick.py
+++ b/src/unilab/envs/locomotion/go2w/joystick.py
@@ -434,23 +434,40 @@ class Go2WJoystickEnv(Go2WBaseEnv):
         leg_diff = dof_pos[:, :NUM_LEG_ACTIONS] - self.default_angles[:NUM_LEG_ACTIONS]
         leg_vel = dof_vel[:, :NUM_LEG_ACTIONS]
         wheel_vel = dof_vel[:, NUM_LEG_ACTIONS:]
-        gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
-        gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
-        leg_diff = self._obs_noise(leg_diff, noise_cfg.scale_joint_angle)
-        leg_vel = self._obs_noise(leg_vel, noise_cfg.scale_joint_vel)
-        wheel_vel = self._obs_noise(wheel_vel, noise_cfg.scale_wheel_vel)
-        linvel = self._obs_noise(linvel, noise_cfg.scale_linvel)
+        noisy_gyro = self._obs_noise(gyro, noise_cfg.scale_gyro)
+        noisy_gravity = self._obs_noise(gravity, noise_cfg.scale_gravity)
+        noisy_leg_diff = self._obs_noise(leg_diff, noise_cfg.scale_joint_angle)
+        noisy_leg_vel = self._obs_noise(leg_vel, noise_cfg.scale_joint_vel)
+        noisy_wheel_vel = self._obs_noise(wheel_vel, noise_cfg.scale_wheel_vel)
         num_obs = gyro.shape[0]
         last_actions = info.get("current_actions", np.zeros((num_obs, self._num_action)))
         motor_ctrl = info.get("torques", np.zeros((num_obs, self._num_action), dtype=dof_pos.dtype))
 
         obs = np.concatenate(
-            [gyro, -gravity, leg_diff, leg_vel, wheel_vel, last_actions, info["commands"]],
+            [
+                noisy_gyro,
+                -noisy_gravity,
+                noisy_leg_diff,
+                noisy_leg_vel,
+                noisy_wheel_vel,
+                last_actions,
+                info["commands"],
+            ],
             axis=1,
             dtype=get_global_dtype(),
         )
         critic = np.concatenate(
-            [obs, linvel, motor_ctrl],
+            [
+                gyro,
+                -gravity,
+                leg_diff,
+                leg_vel,
+                wheel_vel,
+                last_actions,
+                info["commands"],
+                linvel,
+                motor_ctrl,
+            ],
             axis=1,
             dtype=get_global_dtype(),
         )

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -276,8 +276,19 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             targets=targets,
             tactile=tactile,
             contact_pos=contact_pos,
+            add_noise=True,
+        )
+        critic_init_frame = env._build_policy_frame(
+            dof_pos=hand_qpos_f,
+            targets=targets,
+            tactile=tactile,
+            contact_pos=contact_pos,
+            add_noise=False,
         )
         obs_lag_history = repeat_obs_history(init_frame, env.cfg.obs_history_len).astype(dtype)
+        critic_obs_lag_history = repeat_obs_history(
+            critic_init_frame, env.cfg.obs_history_len
+        ).astype(dtype)
 
         object_default_pose = np.concatenate(
             [object_pos_f, object_quat.astype(dtype)], axis=1
@@ -306,6 +317,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             "d_gain": d_gain,
             "critic_info": critic_info,
             "obs_lag_history": obs_lag_history,
+            "critic_obs_lag_history": critic_obs_lag_history,
             "proprio_hist": env._update_proprio_history(obs_lag_history),
         }
         return info_updates
@@ -1219,13 +1231,15 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         targets: np.ndarray,
         tactile: np.ndarray,
         contact_pos: np.ndarray,
+        *,
+        add_noise: bool = True,
     ) -> np.ndarray:
         dof_pos_f = np.asarray(dof_pos, dtype=self._np_dtype)
         targets_f = np.asarray(targets, dtype=self._np_dtype)
 
         dof_norm = self._normalize_joint_pos(dof_pos_f)
         joint_noise_scale = float(self._cfg.domain_rand.joint_noise_scale)
-        if joint_noise_scale > 0.0:
+        if add_noise and joint_noise_scale > 0.0:
             dof_norm += (
                 np.random.uniform(-1.0, 1.0, size=dof_norm.shape).astype(self._np_dtype)
                 * joint_noise_scale
@@ -1306,6 +1320,7 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         self,
         policy_obs: np.ndarray,
         critic_info: np.ndarray,
+        critic_policy_obs: np.ndarray | None = None,
     ) -> dict[str, np.ndarray]:
         """Pack actor and privileged info into the env observation groups.
 
@@ -1322,10 +1337,12 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             )
             return {"obs": flattened_obs}
 
+        if critic_policy_obs is None:
+            critic_policy_obs = policy_obs
         return {
             "obs": self._clip_observation_values(policy_obs),
             "critic": self._clip_observation_values(
-                np.concatenate([policy_obs, critic_info], axis=1).astype(self._np_dtype)
+                np.concatenate([critic_policy_obs, critic_info], axis=1).astype(self._np_dtype)
             ),
         }
 
@@ -1343,26 +1360,48 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             targets=targets,
             tactile=tactile,
             contact_pos=contact_pos,
+            add_noise=True,
+        )
+        critic_frame = self._build_policy_frame(
+            dof_pos=dof_pos,
+            targets=targets,
+            tactile=tactile,
+            contact_pos=contact_pos,
+            add_noise=False,
         )
         batch_size = int(frame.shape[0])
 
         history = info.get("obs_lag_history")
+        critic_history = info.get("critic_obs_lag_history")
         if history is None:
             history = repeat_obs_history(frame, self._cfg.obs_history_len).astype(self._np_dtype)
         else:
             history = np.asarray(history, dtype=self._np_dtype)
             history[:, :-1] = history[:, 1:]
             history[:, -1] = frame
+        if critic_history is None:
+            critic_history = repeat_obs_history(critic_frame, self._cfg.obs_history_len).astype(
+                self._np_dtype
+            )
+        else:
+            critic_history = np.asarray(critic_history, dtype=self._np_dtype)
+            critic_history[:, :-1] = critic_history[:, 1:]
+            critic_history[:, -1] = critic_frame
 
         info["obs_lag_history"] = history
+        info["critic_obs_lag_history"] = critic_history
         info["proprio_hist"] = self._update_proprio_history(history)
 
         obs = np.asarray(
             history[:, -self._cfg.obs_lag_steps :].reshape(batch_size, -1),
             dtype=self._np_dtype,
         )
+        critic_obs = np.asarray(
+            critic_history[:, -self._cfg.obs_lag_steps :].reshape(batch_size, -1),
+            dtype=self._np_dtype,
+        )
         critic_info = self._build_critic_info(info, batch_size=batch_size, object_pos=object_pos)
-        return self._pack_observations(obs, critic_info)
+        return self._pack_observations(obs, critic_info, critic_policy_obs=critic_obs)
 
     def _compute_reward(
         self,

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -276,19 +276,8 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             targets=targets,
             tactile=tactile,
             contact_pos=contact_pos,
-            add_noise=True,
-        )
-        critic_init_frame = env._build_policy_frame(
-            dof_pos=hand_qpos_f,
-            targets=targets,
-            tactile=tactile,
-            contact_pos=contact_pos,
-            add_noise=False,
         )
         obs_lag_history = repeat_obs_history(init_frame, env.cfg.obs_history_len).astype(dtype)
-        critic_obs_lag_history = repeat_obs_history(
-            critic_init_frame, env.cfg.obs_history_len
-        ).astype(dtype)
 
         object_default_pose = np.concatenate(
             [object_pos_f, object_quat.astype(dtype)], axis=1
@@ -317,7 +306,6 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             "d_gain": d_gain,
             "critic_info": critic_info,
             "obs_lag_history": obs_lag_history,
-            "critic_obs_lag_history": critic_obs_lag_history,
             "proprio_hist": env._update_proprio_history(obs_lag_history),
         }
         return info_updates
@@ -1231,15 +1219,13 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         targets: np.ndarray,
         tactile: np.ndarray,
         contact_pos: np.ndarray,
-        *,
-        add_noise: bool = True,
     ) -> np.ndarray:
         dof_pos_f = np.asarray(dof_pos, dtype=self._np_dtype)
         targets_f = np.asarray(targets, dtype=self._np_dtype)
 
         dof_norm = self._normalize_joint_pos(dof_pos_f)
         joint_noise_scale = float(self._cfg.domain_rand.joint_noise_scale)
-        if add_noise and joint_noise_scale > 0.0:
+        if joint_noise_scale > 0.0:
             dof_norm += (
                 np.random.uniform(-1.0, 1.0, size=dof_norm.shape).astype(self._np_dtype)
                 * joint_noise_scale
@@ -1320,7 +1306,6 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         self,
         policy_obs: np.ndarray,
         critic_info: np.ndarray,
-        critic_policy_obs: np.ndarray | None = None,
     ) -> dict[str, np.ndarray]:
         """Pack actor and privileged info into the env observation groups.
 
@@ -1337,12 +1322,10 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             )
             return {"obs": flattened_obs}
 
-        if critic_policy_obs is None:
-            critic_policy_obs = policy_obs
         return {
             "obs": self._clip_observation_values(policy_obs),
             "critic": self._clip_observation_values(
-                np.concatenate([critic_policy_obs, critic_info], axis=1).astype(self._np_dtype)
+                np.concatenate([policy_obs, critic_info], axis=1).astype(self._np_dtype)
             ),
         }
 
@@ -1360,48 +1343,26 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             targets=targets,
             tactile=tactile,
             contact_pos=contact_pos,
-            add_noise=True,
-        )
-        critic_frame = self._build_policy_frame(
-            dof_pos=dof_pos,
-            targets=targets,
-            tactile=tactile,
-            contact_pos=contact_pos,
-            add_noise=False,
         )
         batch_size = int(frame.shape[0])
 
         history = info.get("obs_lag_history")
-        critic_history = info.get("critic_obs_lag_history")
         if history is None:
             history = repeat_obs_history(frame, self._cfg.obs_history_len).astype(self._np_dtype)
         else:
             history = np.asarray(history, dtype=self._np_dtype)
             history[:, :-1] = history[:, 1:]
             history[:, -1] = frame
-        if critic_history is None:
-            critic_history = repeat_obs_history(critic_frame, self._cfg.obs_history_len).astype(
-                self._np_dtype
-            )
-        else:
-            critic_history = np.asarray(critic_history, dtype=self._np_dtype)
-            critic_history[:, :-1] = critic_history[:, 1:]
-            critic_history[:, -1] = critic_frame
 
         info["obs_lag_history"] = history
-        info["critic_obs_lag_history"] = critic_history
         info["proprio_hist"] = self._update_proprio_history(history)
 
         obs = np.asarray(
             history[:, -self._cfg.obs_lag_steps :].reshape(batch_size, -1),
             dtype=self._np_dtype,
         )
-        critic_obs = np.asarray(
-            critic_history[:, -self._cfg.obs_lag_steps :].reshape(batch_size, -1),
-            dtype=self._np_dtype,
-        )
         critic_info = self._build_critic_info(info, batch_size=batch_size, object_pos=object_pos)
-        return self._pack_observations(obs, critic_info, critic_policy_obs=critic_obs)
+        return self._pack_observations(obs, critic_info)
 
     def _compute_reward(
         self,


### PR DESCRIPTION
## Summary

Fix critic observations to use clean, non-noisy observation terms across tasks that previously reused noisy actor observations or actor history.

Affected tasks:
- `Go1JoystickFlat`
- `Go2JoystickFlat`
- `Go2HandStand`
- `Go2FootStand`
- `Go2ArmManipLoco`
- `Go2WJoystickFlat`
- `SharpaInhandRotation`

## What Changed

- Split actor and critic observation construction where actor obs applies observation noise.
- Rebuilt critic obs from clean source tensors instead of concatenating noisy actor obs.
- Added separate clean critic history buffers for history-based tasks:
  - `Go2FootStand`
  - `Go2ArmManipLoco`
  - `SharpaInhandRotation`
- Updated reset/domain-randomization observation paths to initialize clean critic history separately from noisy actor history.
- Kept rough locomotion and G1 motion tracking unchanged because they already construct critic obs from clean source terms.

## Validation

- `make test-all` passed.