### PR TITLE
test: isolate training logs during pytest

### DIFF
--- a/src/unilab/training/run.py
+++ b/src/unilab/training/run.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from os import PathLike
 from pathlib import Path
 
 from omegaconf import DictConfig, OmegaConf
 
 from unilab.base.backend.base import BackendPlayRenderPlan, normalize_play_render_mode
+
+_TEST_LOG_ROOT_ENV = "UNILAB_TEST_LOG_ROOT"
 
 
 def should_run_playback(*, play_only: bool, no_play: bool, play_render_mode: str | None) -> bool:
@@ -38,6 +41,9 @@ def get_log_root(root_dir: str | Path, cfg: DictConfig) -> Path:
     if configured_root:
         log_root = Path(str(configured_root))
         return log_root if log_root.is_absolute() else Path(root_dir) / log_root
+    test_log_root = os.environ.get(_TEST_LOG_ROOT_ENV)
+    if test_log_root:
+        return Path(test_log_root) / str(OmegaConf.select(cfg, "algo.algo_log_name"))
     return Path(root_dir) / "logs" / str(OmegaConf.select(cfg, "algo.algo_log_name"))
 
 
@@ -53,6 +59,9 @@ def get_entrypoint_log_root(
         return (
             configured_root if configured_root.is_absolute() else Path(root_dir) / configured_root
         )
+    test_log_root = os.environ.get(_TEST_LOG_ROOT_ENV)
+    if test_log_root:
+        return Path(test_log_root) / algo_log_name
     return Path(root_dir) / "logs" / algo_log_name
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass
 from typing import Optional
 
@@ -88,6 +89,31 @@ _register_dummy_env()
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+_TEST_SESSION_FAILED = False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if report.failed:
+        global _TEST_SESSION_FAILED
+        _TEST_SESSION_FAILED = True
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_training_logs_for_tests(tmp_path_factory: pytest.TempPathFactory):
+    """Keep training smoke-test artifacts out of the repository log tree."""
+    log_root = tmp_path_factory.mktemp("unilab-training-logs")
+    previous = pytest.MonkeyPatch()
+    previous.setenv("UNILAB_TEST_LOG_ROOT", str(log_root))
+    yield log_root
+    previous.undo()
+    if _TEST_SESSION_FAILED:
+        print(f"Preserving UniLab test training logs after failure: {log_root}")
+    else:
+        shutil.rmtree(log_root, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -2361,6 +2361,7 @@ def test_offpolicy_rejects_algo_task_owner_mismatch(algo: str, task: str):
 
 def test_train_rsl_rl_get_log_root_uses_algo_log_name(monkeypatch: pytest.MonkeyPatch):
     """Verify _get_log_root uses algo.algo_log_name (issue #168)."""
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg()
 
@@ -2374,6 +2375,7 @@ def test_train_rsl_rl_get_log_root_uses_algo_log_name(monkeypatch: pytest.Monkey
 def test_train_rsl_rl_play_missing_checkpoint_skips_env_creation_and_prints_context(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg(["task=go1_joystick_flat/mujoco", "training.play_only=true"])
     cfg.algo.algo_log_name = "custom_ppo"
@@ -2406,6 +2408,7 @@ def test_train_rsl_rl_play_missing_checkpoint_skips_env_creation_and_prints_cont
 def test_train_rsl_rl_play_reports_missing_requested_checkpoint_in_resolved_run(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg(["task=go1_joystick_flat/mujoco", "training.play_only=true"])
     cfg.algo.algo_log_name = "custom_ppo"
@@ -2618,8 +2621,9 @@ def test_train_rsl_rl_record_play_uses_backend_plan(
     assert captured["output_video"] == run_dir / "play_video.mp4"
 
 
-def test_train_appo_get_log_root_uses_algo_log_name():
+def test_train_appo_get_log_root_uses_algo_log_name(monkeypatch: pytest.MonkeyPatch):
     """Verify APPO _get_log_root uses algo.algo_log_name (issue #168)."""
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     mod = _train_appo()
     cfg = _appo_cfg()
 
@@ -2629,8 +2633,11 @@ def test_train_appo_get_log_root_uses_algo_log_name():
     assert "logs/test_appo" in log_root
 
 
-def test_play_resolve_checkpoint_uses_algo_log_name(tmp_path):
+def test_play_resolve_checkpoint_uses_algo_log_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """Verify play_interactive.resolve_checkpoint uses algo_log_name (issue #168)."""
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     mod = _play_interactive()
 
     # Create test directory structure with custom algo_log_name

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -16,8 +16,10 @@ from unilab.base.backend.mujoco.playback import run_mujoco_playback
 from unilab.base.scene import SceneCfg
 from unilab.training import (
     BackendAdapter,
+    get_entrypoint_log_root,
     get_latest_checkpoint,
     get_latest_run,
+    get_log_root,
     parse_checkpoint_path,
     resolve_checkpoint_path,
     resolve_task_checkpoint_path,
@@ -107,7 +109,10 @@ def test_resolve_checkpoint_path_accepts_integer_latest_run(tmp_path: Path):
     assert checkpoint_dir == run_dir
 
 
-def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(tmp_path: Path):
+def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     cfg = _ppo_cfg()
     cfg.algo.algo_log_name = "custom_ppo"
 
@@ -124,7 +129,44 @@ def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(tmp_path: Path):
     assert checkpoint_dir == run_dir
 
 
-def test_parse_checkpoint_path_supports_explicit_checkpoint_from_cfg(tmp_path: Path):
+def test_get_log_root_uses_test_log_root_env_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    cfg = _ppo_cfg()
+    cfg.algo.algo_log_name = "custom_ppo"
+    monkeypatch.setenv("UNILAB_TEST_LOG_ROOT", str(tmp_path / "test-logs"))
+
+    log_root = get_log_root(tmp_path / "repo", cfg)
+
+    assert log_root == tmp_path / "test-logs" / "custom_ppo"
+
+
+def test_get_log_root_keeps_configured_log_root_ahead_of_test_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    cfg = _ppo_cfg(["training.log_root=explicit_logs"])
+    cfg.algo.algo_log_name = "custom_ppo"
+    monkeypatch.setenv("UNILAB_TEST_LOG_ROOT", str(tmp_path / "test-logs"))
+
+    log_root = get_log_root(tmp_path / "repo", cfg)
+
+    assert log_root == tmp_path / "repo" / "explicit_logs"
+
+
+def test_get_entrypoint_log_root_uses_test_log_root_env_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("UNILAB_TEST_LOG_ROOT", str(tmp_path / "test-logs"))
+
+    log_root = get_entrypoint_log_root(tmp_path / "repo", algo_log_name="custom_ppo")
+
+    assert log_root == tmp_path / "test-logs" / "custom_ppo"
+
+
+def test_parse_checkpoint_path_supports_explicit_checkpoint_from_cfg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     cfg = _ppo_cfg()
     cfg.algo.algo_log_name = "custom_ppo"
     cfg.algo.checkpoint = 12
@@ -143,7 +185,10 @@ def test_parse_checkpoint_path_supports_explicit_checkpoint_from_cfg(tmp_path: P
     assert checkpoint_dir == run_dir
 
 
-def test_parse_checkpoint_path_returns_run_dir_when_requested_checkpoint_is_missing(tmp_path: Path):
+def test_parse_checkpoint_path_returns_run_dir_when_requested_checkpoint_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     cfg = _ppo_cfg()
     cfg.algo.algo_log_name = "custom_ppo"
     cfg.algo.checkpoint = 12
@@ -160,7 +205,10 @@ def test_parse_checkpoint_path_returns_run_dir_when_requested_checkpoint_is_miss
     assert checkpoint_dir == run_dir
 
 
-def test_resolve_task_checkpoint_path_supports_explicit_checkpoint(tmp_path: Path):
+def test_resolve_task_checkpoint_path_supports_explicit_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
     run_dir.mkdir(parents=True)
     (run_dir / "model_9.pt").write_bytes(b"")
@@ -179,7 +227,10 @@ def test_resolve_task_checkpoint_path_supports_explicit_checkpoint(tmp_path: Pat
     assert checkpoint_dir == run_dir
 
 
-def test_resolve_task_checkpoint_path_returns_run_dir_when_checkpoint_missing(tmp_path: Path):
+def test_resolve_task_checkpoint_path_returns_run_dir_when_checkpoint_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
     run_dir.mkdir(parents=True)
 
@@ -195,7 +246,10 @@ def test_resolve_task_checkpoint_path_returns_run_dir_when_checkpoint_missing(tm
     assert checkpoint_dir == run_dir
 
 
-def test_resolve_task_checkpoint_path_accepts_integer_latest_run(tmp_path: Path):
+def test_resolve_task_checkpoint_path_accepts_integer_latest_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
     run_dir = tmp_path / "logs" / "custom_ppo" / "MyTask" / "2024-01-01_00-00-00_mujoco"
     run_dir.mkdir(parents=True)
     selected_model = run_dir / "model_12.pt"


### PR DESCRIPTION
## Summary

- route unconfigured training log roots through a pytest-only temporary log root
- install a session fixture that cleans successful test logs and preserves the temp root on failure for debugging
- keep explicit training.log_root and production default logs/<algo> behavior covered by tests

Fixes #583

## Validation

- uv run pytest tests/training/test_training_helpers.py tests/scripts/test_train_scripts.py -q
- make test-all

## Notes

- Confirmed no repository-root logs/ directory was created after make test-all.