### PR TITLE
Fix/fix go2 mujoco collision

### DIFF
--- a/conf/ppo/task/go1_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go1_joystick_rough/motrix.yaml
@@ -42,6 +42,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   terrain_curriculum:
     enabled: false
   scene:

--- a/conf/ppo/task/go1_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go1_joystick_rough/mujoco.yaml
@@ -43,6 +43,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   terrain_curriculum:
     enabled: false
   scene:

--- a/conf/ppo/task/go2_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2_joystick_rough/motrix.yaml
@@ -42,6 +42,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   terrain_curriculum:
     enabled: false
   scene:

--- a/conf/ppo/task/go2_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2_joystick_rough/mujoco.yaml
@@ -16,7 +16,7 @@ interactive:
   use_env_visual_model: false
 
 algo:
-  num_envs: 4096
+  num_envs: 2048
   num_steps_per_env: 24
   max_iterations: 1500
   empirical_normalization: false
@@ -43,6 +43,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   terrain_curriculum:
     enabled: false
   scene:

--- a/conf/ppo/task/go2w_joystick_rough/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/motrix.yaml
@@ -45,6 +45,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125

--- a/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_rough/mujoco.yaml
@@ -45,6 +45,7 @@ env:
     resampling_time: 10.0
     heading_command: true
     heading_range: [-3.141592653589793, 3.141592653589793]
+    rel_standing_envs: 0.1
   control_config:
     action_scale: 0.25
     hip_action_scale: 0.125

--- a/src/unilab/assets/robots/go2/go2_mujoco.xml
+++ b/src/unilab/assets/robots/go2/go2_mujoco.xml
@@ -1,7 +1,7 @@
 <mujoco model="go2">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option cone="elliptic" impratio="100" ccd_iterations="500" timestep="0.02"/>
+  <option cone="elliptic" impratio="100" ccd_iterations="500" timestep="0.01"/>
 
   <default>
     <default class="go2">
@@ -30,8 +30,9 @@
         <geom group="3" contype="1" conaffinity="2"
           friction="0 0 0" margin="0.001" condim="1" solref="0.01 1"/>
         <default class="foot">
-          <geom size="0.022" pos="-0.002 0 -0.213" priority="1"
-            margin="0.005" condim="6" solref="0.01 1" friction="0.4 0.02 0.01"/>
+          <geom type="sphere" size="0.022" pos="-0.002 0 -0.213" priority="1"
+            solref="0.01 1" solimp="0.015 1 0.023" margin="0.005" condim="6" 
+            friction="0.4 0.02 0.01"/>
         </default>
       </default>
     </default>

--- a/src/unilab/envs/locomotion/go1/rough.py
+++ b/src/unilab/envs/locomotion/go1/rough.py
@@ -226,7 +226,11 @@ class Go1JoystickRoughCfg(Go1JoystickCfg):
 class Go1JoystickRoughDomainRandomizationProvider(Go1JoystickDomainRandomizationProvider):
     def _sample_commands(self, env: Any, num_reset: int) -> np.ndarray:
         commands = super()._sample_commands(env, num_reset)
-        zero_small_xy_commands(commands, threshold=0.001)
+        zero_small_xy_commands(commands, threshold=0.08)
+        standing_prob = env.cfg.commands.rel_standing_envs
+        if standing_prob > 0.0:
+            standing = np.random.uniform(size=(num_reset,)) < min(standing_prob, 1.0)
+            commands[standing] = 0.0
         if env.cfg.commands.heading_command:
             commands[:, 2] = 0.0
         return commands
@@ -564,7 +568,7 @@ class Go1JoystickRoughEnv(Go1WalkTask):
                 sampled = np.random.uniform(low=low, high=high, size=(num_resample, 3)).astype(
                     get_global_dtype()
                 )
-                zero_small_xy_commands(sampled, threshold=0.001)
+                zero_small_xy_commands(sampled, threshold=0.08)
                 commands_arr[resample_mask] = sampled
                 if self._cfg.commands.heading_command:
                     heading_commands = self._ensure_heading_commands(info, commands_arr.shape[0])

--- a/src/unilab/envs/locomotion/go2/rough.py
+++ b/src/unilab/envs/locomotion/go2/rough.py
@@ -212,7 +212,11 @@ class Go2JoystickRoughCfg(Go2JoystickCfg):
 class Go2JoystickRoughDomainRandomizationProvider(Go2JoystickDomainRandomizationProvider):
     def _sample_commands(self, env: Any, num_reset: int) -> np.ndarray:
         commands = super()._sample_commands(env, num_reset)
-        zero_small_xy_commands(commands, threshold=0.001)
+        zero_small_xy_commands(commands, threshold=0.08)
+        standing_prob = env.cfg.commands.rel_standing_envs
+        if standing_prob > 0.0:
+            standing = np.random.uniform(size=(num_reset,)) < min(standing_prob, 1.0)
+            commands[standing] = 0.0
         if env.cfg.commands.heading_command:
             commands[:, 2] = 0.0
         return commands
@@ -548,7 +552,7 @@ class Go2JoystickRoughEnv(Go2WalkTask):
                 sampled = np.random.uniform(low=low, high=high, size=(num_resample, 3)).astype(
                     get_global_dtype()
                 )
-                zero_small_xy_commands(sampled, threshold=0.001)
+                zero_small_xy_commands(sampled, threshold=0.08)
                 commands_arr[resample_mask] = sampled
                 if self._cfg.commands.heading_command:
                     heading_commands = self._ensure_heading_commands(info, commands_arr.shape[0])

--- a/src/unilab/envs/locomotion/go2w/rough.py
+++ b/src/unilab/envs/locomotion/go2w/rough.py
@@ -154,13 +154,12 @@ class Go2WJoystickRoughCfg(Go2WJoystickCfg):
 
 class Go2WJoystickRoughDomainRandomizationProvider(Go2WJoystickDomainRandomizationProvider):
     def _sample_commands(self, env: Any, num_reset: int) -> np.ndarray:
-        low = np.asarray(env.cfg.commands.vel_limit[0], dtype=get_global_dtype())
-        high = np.asarray(env.cfg.commands.vel_limit[1], dtype=get_global_dtype())
-        commands = np.asarray(
-            np.random.uniform(low=low, high=high, size=(num_reset, 3)),
-            dtype=get_global_dtype(),
-        )
-        zero_small_xy_commands(commands, threshold=0.001)
+        commands = super()._sample_commands(env, num_reset)
+        zero_small_xy_commands(commands, threshold=0.08)
+        standing_prob = env.cfg.commands.rel_standing_envs
+        if standing_prob > 0.0:
+            standing = np.random.uniform(size=(num_reset,)) < min(standing_prob, 1.0)
+            commands[standing] = 0.0
         if env.cfg.commands.heading_command:
             commands[:, 2] = 0.0
         return commands
@@ -338,7 +337,7 @@ class Go2WJoystickRoughEnv(Go2WJoystickEnv):
                 sampled = np.random.uniform(low=low, high=high, size=(num_resample, 3)).astype(
                     get_global_dtype()
                 )
-                zero_small_xy_commands(sampled, threshold=0.001)
+                zero_small_xy_commands(commands, threshold=0.08)
                 commands_arr[resample_mask] = sampled
                 if self._cfg.commands.heading_command:
                     heading_commands = self._ensure_heading_commands(info, commands_arr.shape[0])

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -456,7 +456,6 @@ def test_ppo_go2w_rough_mujoco_uses_terrain_generator():
     assert cfg.env.commands.heading_command is True
     assert cfg.env.commands.vel_limit == [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]
     assert cfg.env.commands.heading_range == pytest.approx([-3.141592653589793, 3.141592653589793])
-    assert "rel_standing_envs" not in cfg.env.commands
     assert cfg.env.control_config.clip_actions == pytest.approx(100.0)
     assert cfg.env.control_config.action_scale == pytest.approx(0.25)
     assert cfg.env.control_config.hip_action_scale == pytest.approx(0.125)
@@ -478,7 +477,6 @@ def test_ppo_go2w_rough_motrix_uses_yaw_reset_and_strong_control():
     assert cfg.training.sim_backend == "motrix"
     assert cfg.env.commands.vel_limit == [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]
     assert cfg.env.commands.heading_range == pytest.approx([-3.141592653589793, 3.141592653589793])
-    assert "rel_standing_envs" not in cfg.env.commands
     assert cfg.env.control_config.action_scale == pytest.approx(0.25)
     assert cfg.env.control_config.hip_action_scale == pytest.approx(0.125)
     assert cfg.env.control_config.wheel_action_scale == pytest.approx(5.0)


### PR DESCRIPTION
## Summary

- 使用更新的接触求解器参数，修复 Go2 MuJoCo 脚部碰撞设置。

- 支持 `rel_standing_envs` 和更宽的小命令归零阈值，使 Go1、Go2 和 Go2W 的 rough task 的 commands sampling 保持一致。

- 将 Go2 MuJoCo PPO 的 num_envs 减少到 2048。

## Validation

- [x] `make test-all`

## Artifacts

- Before

https://github.com/user-attachments/assets/32eb4fdd-3cc9-4716-94fc-9f7011d1453d

 - After

https://github.com/user-attachments/assets/046a1be0-d1a9-41b3-b4f4-30e73354f9d8

<img width="824" height="412" alt="image" src="https://github.com/user-attachments/assets/ccfa8b07-e03e-4668-a1a8-bfcda654de30" />

## Problems that still exist #584 

- 在 887 次迭代后静默退出。（偶发的，将 sim_dt 增加到 0.2 可以快速重现此问题） 
- CLI：`uv run train --algo ppo --task go2_joystick_rough --sim mujoco`
