### PR TITLE
docs: define code comment language policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Languages: English | [简体中文](docs/sphinx/source/zh_CN/4-developer_guide/4
 - For user-facing workflow changes, keep `README.md`, `CONTRIBUTING.md`, and the matching localized docs under `docs/` in sync
 - Do not add new owner logic under `src/unilab/utils/`; the current `src/unilab/utils/*.py` files are transition shims only and are scheduled for removal in `0.2.0`
 - Name new owner modules and packages after their responsibility: prefer singular nouns, use plural only for collection-valued contracts, and reserve suffixes such as `_factory` for factory modules
+- Use English for code comments, public API docstrings, internal implementation notes, TODO/FIXME entries, and config comments. Keep Chinese prose in Chinese documentation under `docs/sphinx/source/zh_CN/`; do not duplicate localized explanations inside source comments.
 
 ## Read Before You Start
 

--- a/conf/ppo/task/go2_arm_manip_loco/motrix.yaml
+++ b/conf/ppo/task/go2_arm_manip_loco/motrix.yaml
@@ -34,17 +34,17 @@ reward:
     ang_vel_xy: -0.1
     roll: -5.0 #-2.0
     # locomotion: height / pose
-    base_height: -100 #-20.0   # go2+arm 躯干振荡更大（有机械臂质量），-100 会与步态产生对抗
-    similar_to_default: -0.0   # 对齐 Go2 Joystick（L1）
-    leg_pose: -0.1              # 保留但不使用（被 similar_to_default 替代）
-    dof_pos_limits: 0.0        # 保留但不使用（未配置软限位）
+    base_height: -100 #-20.0   # Go2+arm body oscillates more with arm mass; -100 conflicts with gait.
+    similar_to_default: -0.0   # Align with Go2 Joystick (L1).
+    leg_pose: -0.1              # Kept but unused; replaced by similar_to_default.
+    dof_pos_limits: 0.0        # Kept but unused; soft limits are not configured.
     # locomotion: effort penalties
     action_rate: -0.005
-    torques: 0.0               # 保留但不使用（backend 未提供 torques）
-    energy: 0.0                # 保留但不使用
-    dof_vel: 0.0               # 保留但不使用
-    dof_acc: 0.0               # 保留但不使用
-    # locomotion: gait（对齐 Go2 Joystick）
+    torques: 0.0               # Kept but unused; backend does not expose torques.
+    energy: 0.0                # Kept but unused.
+    dof_vel: 0.0               # Kept but unused.
+    dof_acc: 0.0               # Kept but unused.
+    # locomotion: gait, aligned with Go2 Joystick
     stand_still: -0.5
     contact: 0.24
     swing_feet_z: 4.0
@@ -82,15 +82,15 @@ env:
     gain: 1.0
     dq_clip: 0.2
     use_orientation: true
-    orientation_mode: target  # target: 跟踪采样姿态；zero_error: 用 Jrot 约束姿态变化但不追姿态
+    orientation_mode: target  # target: track sampled orientation; zero_error: constrain orientation change through Jrot without tracking orientation.
   commands:
     vel_limit:
-      - [-0.6, -0.4, -0.8]   # 对齐 Go2 Joystick 默认范围
+      - [-0.6, -0.4, -0.8]   # Align with the default Go2 Joystick range.
       - [1.0, 0.4, 0.8]
-    zero_command_prob: 0.15  # 显式采样 command=0，训练稳定站立
-    resample_time_s: 4.0   # 不设置表示 null，不做中途重采样（对齐 Joystick）
+    zero_command_prob: 0.15  # Explicitly sample command=0 for stable standing.
+    resample_time_s: 4.0   # Omit for null, which disables mid-episode resampling and matches Joystick.
   curriculum:
-    enable: false             # 对齐 Joystick（无课程学习）
+    enable: false             # Align with Joystick; no curriculum.
   domain_rand:
     randomize_base_mass: false
     added_mass_range: [-1.0, 1.0]

--- a/conf/ppo/task/go2_arm_manip_loco/mujoco.yaml
+++ b/conf/ppo/task/go2_arm_manip_loco/mujoco.yaml
@@ -25,17 +25,17 @@ reward:
     ang_vel_xy: -0.1
     roll: -5.0 #-2.0
     # locomotion: height / pose
-    base_height: -100 #-20.0   # go2+arm 躯干振荡更大（有机械臂质量），-100 会与步态产生对抗
-    similar_to_default: -0.0   # 对齐 Go2 Joystick（L1）
-    leg_pose: -0.1              # 保留但不使用（被 similar_to_default 替代）
-    dof_pos_limits: 0.0        # 保留但不使用（未配置软限位）
+    base_height: -100 #-20.0   # Go2+arm body oscillates more with arm mass; -100 conflicts with gait.
+    similar_to_default: -0.0   # Align with Go2 Joystick (L1).
+    leg_pose: -0.1              # Kept but unused; replaced by similar_to_default.
+    dof_pos_limits: 0.0        # Kept but unused; soft limits are not configured.
     # locomotion: effort penalties
     action_rate: -0.005
-    torques: 0.0               # 保留但不使用（backend 未提供 torques）
-    energy: 0.0                # 保留但不使用
-    dof_vel: 0.0               # 保留但不使用
-    dof_acc: 0.0               # 保留但不使用
-    # locomotion: gait（对齐 Go2 Joystick）
+    torques: 0.0               # Kept but unused; backend does not expose torques.
+    energy: 0.0                # Kept but unused.
+    dof_vel: 0.0               # Kept but unused.
+    dof_acc: 0.0               # Kept but unused.
+    # locomotion: gait, aligned with Go2 Joystick
     stand_still: -0.5
     contact: 0.24
     swing_feet_z: 4.0
@@ -73,15 +73,15 @@ env:
     gain: 1.0
     dq_clip: 0.2
     use_orientation: true
-    orientation_mode: target  # target: 跟踪采样姿态；zero_error: 用 Jrot 约束姿态变化但不追姿态
+    orientation_mode: target  # target: track sampled orientation; zero_error: constrain orientation change through Jrot without tracking orientation.
   commands:
     vel_limit:
-      - [-0.6, -0.4, -0.8]   # 对齐 Go2 Joystick 默认范围
+      - [-0.6, -0.4, -0.8]   # Align with the default Go2 Joystick range.
       - [1.0, 0.4, 0.8]
-    zero_command_prob: 0.15  # 显式采样 command=0，训练稳定站立
-    resample_time_s: 4.0   # 不设置表示 null，不做中途重采样（对齐 Joystick）
+    zero_command_prob: 0.15  # Explicitly sample command=0 for stable standing.
+    resample_time_s: 4.0   # Omit for null, which disables mid-episode resampling and matches Joystick.
   curriculum:
-    enable: false             # 对齐 Joystick（无课程学习）
+    enable: false             # Align with Joystick; no curriculum.
   domain_rand:
     randomize_base_mass: false
     added_mass_range: [-1.0, 1.0]

--- a/conf/ppo_him/task/go2_arm_manip_loco/mujoco.yaml
+++ b/conf/ppo_him/task/go2_arm_manip_loco/mujoco.yaml
@@ -68,7 +68,7 @@ env:
     use_orientation: false
   commands:
     vel_limit:
-      - [-0.3, -0.2, -0.4]   # 课程学习起始范围（较小）
+      - [-0.3, -0.2, -0.4]   # Smaller initial range for curriculum learning.
       - [0.5, 0.2, 0.4]
     resample_time_s: 5.0
   curriculum:

--- a/docs/sphinx/source/en/4-developer_guide/4-contributing.md
+++ b/docs/sphinx/source/en/4-developer_guide/4-contributing.md
@@ -36,9 +36,28 @@ Use `uv run` for commands. Do not invoke `python` directly outside `uv run`.
 - Module naming expresses owner responsibility: use singular nouns by default,
   plural only when the semantics are themselves a collection contract, and a
   `_factory` suffix for factory modules.
+- Code comments, public API docstrings, internal implementation notes,
+  TODO/FIXME entries, and config comments use English by default. Chinese prose
+  belongs in the Chinese documentation under `docs/sphinx/source/zh_CN/`, not in
+  source comments or config annotations.
 - When a change affects a user-visible workflow, keep `README.md`,
   `CONTRIBUTING.md`, and the matching pages under `docs/sphinx/source/en/` and
   `docs/sphinx/source/zh_CN/` in sync.
+
+## Comment Language Policy
+
+- Public API docstrings must describe contracts, arguments, return values, and
+  boundary conditions in English.
+- Inline comments should explain non-obvious intent, owner boundaries, or
+  backend/env/config invariants in English. Delete stale comments instead of
+  translating them mechanically.
+- TODO/FIXME comments must be English and should name the owner layer or
+  dependency that can resolve the follow-up.
+- Hydra YAML and example config comments must be English because they are
+  reviewed with the source contract.
+- Existing mixed-language comments should be migrated in small PRs. Prioritize
+  public contracts, backend adapters, env contracts, training runners, config
+  schema, and high-traffic tests before lower-risk examples.
 
 ## Common Commands
 

--- a/docs/sphinx/source/zh_CN/4-developer_guide/4-contributing.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/4-contributing.md
@@ -33,8 +33,22 @@ make sync-xpu
   长期逻辑上移到对应 owner 层或 `src/unilab/base/`。
 - 模块命名表达 owner 职责：默认使用单数名词；只有当语义本身就是集合契约时才用
   复数；工厂模块使用 `_factory` 后缀。
+- 代码注释、公共 API docstring、内部实现说明、TODO/FIXME 与配置注释默认使用
+  英文。中文说明放在 `docs/sphinx/source/zh_CN/` 下的中文文档中，不在源码注释或
+  配置注释中重复本地化说明。
 - 当改动影响用户可见工作流时，保持 `README.md`、`CONTRIBUTING.md`，以及
   `docs/sphinx/source/en/` 与 `docs/sphinx/source/zh_CN/` 下对应页面同步。
+
+## 注释语言规范
+
+- 公共 API docstring 必须用英文描述 contract、参数、返回值与边界条件。
+- inline comment 用英文解释非显而易见的实现意图、owner 边界，或
+  backend/env/config 不变量；过时注释应删除，而不是机械翻译。
+- TODO/FIXME 使用英文，并尽量写明后续处理所属的 owner layer 或外部依赖。
+- Hydra YAML 与示例配置注释使用英文，因为它们与源码 contract 一起 review。
+- 已存在的中英文混用注释按小 PR 分批迁移。优先级为公共 contract、backend
+  adapter、env contract、training runner、config schema 和高频测试，再处理低风险
+  示例。
 
 ## 常用命令
 

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -42,17 +42,18 @@ def create_backend(
     sim_dt: float,
     **kwargs,
 ) -> SimBackend:
-    """创建仿真后端
+    """Create a simulation backend.
 
     Args:
-        backend_type: "mujoco" 或 "motrix"
-        scene: SceneCfg，静态 scene 或组合式 scene 都通过这个 contract 表达
-        num_envs: 环境数量
-        sim_dt: 仿真时间步长
-        **kwargs: 其他参数（position_actuator_gains, motrix_max_iterations 等）
+        backend_type: ``"mujoco"`` or ``"motrix"``.
+        scene: SceneCfg for either static or composed scenes.
+        num_envs: Number of environments.
+        sim_dt: Simulation timestep.
+        **kwargs: Additional backend options such as ``position_actuator_gains``
+            or ``motrix_max_iterations``.
 
     Returns:
-        SimBackend 实例
+        SimBackend instance.
     """
     if scene is None:
         raise ValueError("SceneCfg must be provided")

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -56,7 +56,7 @@ def normalize_play_render_mode(play_render_mode: str | None) -> str:
 
 
 class SimBackend(abc.ABC):
-    """仿真后端统一接口"""
+    """Unified simulation backend contract."""
 
     _pre_step_control_fn: PreStepControlFn | None
     _scene_cleanup_handle: Any | None
@@ -69,12 +69,12 @@ class SimBackend(abc.ABC):
     @property
     @abc.abstractmethod
     def num_envs(self) -> int:
-        """环境数量"""
+        """Number of vectorized environments."""
 
     @property
     @abc.abstractmethod
     def model(self):
-        """底层物理模型"""
+        """Underlying physics model."""
 
     # ------------------------------------------------------------------ #
     # Model properties                                                     #
@@ -83,30 +83,30 @@ class SimBackend(abc.ABC):
     @property
     @abc.abstractmethod
     def num_actuators(self) -> int:
-        """执行器数量"""
+        """Number of actuators."""
 
     @property
     @abc.abstractmethod
     def num_dof_vel(self) -> int:
-        """关节速度自由度数量（不含浮动基座）"""
+        """Number of joint velocity DoFs, excluding the floating base."""
 
     @abc.abstractmethod
     def get_actuator_ctrl_range(self) -> np.ndarray:
-        """获取执行器控制范围
+        """Return actuator control ranges.
 
         Returns:
-            (num_actuators, 2) 数组，列为 [low, high]
+            Array with shape ``(num_actuators, 2)`` and columns ``[low, high]``.
         """
 
     @abc.abstractmethod
     def get_keyframe_qpos(self, name: str) -> np.ndarray:
-        """获取指定关键帧的完整 qpos（含浮动基座）
+        """Return the full qpos for a named keyframe, including the floating base.
 
         Args:
-            name: 关键帧名称（如 "stand"、"home"）
+            name: Keyframe name such as ``"stand"`` or ``"home"``.
 
         Returns:
-            (nq,) 数组
+            Array with shape ``(nq,)``.
         """
 
     def get_default_qpos(self) -> np.ndarray:
@@ -115,24 +115,24 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_init_qvel(self) -> np.ndarray:
-        """获取零初始化的 qvel 向量，维度与 set_state 期望一致
+        """Return a zero-initialized qvel vector compatible with ``set_state``.
 
         Returns:
-            全零数组
+            Zero-filled qvel array.
         """
 
     @abc.abstractmethod
     def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
-        """将 body/link 名称解析为后端整数 ID
+        """Resolve body/link names to backend integer IDs.
 
         Args:
-            names: body/link 名称序列
+            names: Body/link names.
 
         Returns:
-            (len(names),) int32 数组
+            ``int32`` array with shape ``(len(names),)``.
 
         Raises:
-            ValueError: 若名称未找到
+            ValueError: If any name is not found.
         """
 
     def get_body_id(self, name: str) -> int:
@@ -220,10 +220,11 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_joint_range(self) -> np.ndarray | None:
-        """获取关节位置限制（不含浮动基座）
+        """Return joint position limits, excluding the floating base.
 
         Returns:
-            (num_dof, 2) 数组，列为 [low, high]；若后端不支持则返回 None
+            Array with shape ``(num_dof, 2)`` and columns ``[low, high]``, or
+            ``None`` when the backend does not expose limits.
         """
 
     # ------------------------------------------------------------------ #
@@ -232,14 +233,15 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict | None:
-        """执行物理步进
+        """Advance physics.
 
         Args:
-            ctrl: 控制输入 (num_envs, nu)
-            nsteps: 步进次数
+            ctrl: Control input with shape ``(num_envs, nu)``.
+            nsteps: Number of physics substeps.
 
         Returns:
-            可选的 dict，可包含 "timing" key 记录各阶段耗时（ms）
+            Optional dictionary. Backends may include a ``"timing"`` key with
+            per-phase timings in milliseconds.
         """
 
     def set_pre_step_control(self, fn: PreStepControlFn | None) -> None:
@@ -270,13 +272,13 @@ class SimBackend(abc.ABC):
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
     ) -> None:
-        """设置指定环境的物理状态
+        """Set physics state for selected environments.
 
         Args:
-            env_indices: 环境索引
-            qpos: 位置状态
-            qvel: 速度状态
-            randomization: 可选的后端随机化 payload
+            env_indices: Environment indices.
+            qpos: Position state.
+            qvel: Velocity state.
+            randomization: Optional backend randomization payload.
         """
 
     @abc.abstractmethod
@@ -428,7 +430,7 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_base_pos(self) -> np.ndarray:
-        """获取 base 在世界系下的位置
+        """Return base position in the world frame.
 
         Returns:
             (num_envs, 3)
@@ -436,7 +438,7 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_base_quat(self) -> np.ndarray:
-        """获取 base 在世界系下的四元数（wxyz）
+        """Return base quaternion in the world frame as ``wxyz``.
 
         Returns:
             (num_envs, 4)
@@ -444,9 +446,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_base_lin_vel(self) -> np.ndarray:
-        """获取 base 在世界系下的线速度
+        """Return base linear velocity in the world frame.
 
-        即广义速度 qvel 的前 3 维，表达在世界坐标系中。
+        This is the first three dimensions of generalized velocity ``qvel``,
+        expressed in world coordinates.
 
         Returns:
             (num_envs, 3)
@@ -454,12 +457,13 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_base_ang_vel(self) -> np.ndarray:
-        """获取 base 在世界系下的角速度
+        """Return base angular velocity in the world frame.
 
-        即广义速度 qvel 的第 3-5 维，表达在世界坐标系中。
-        注意与陀螺仪（gyro）读数的区别：陀螺仪返回的是角速度在 body/sensor
-        局部坐标系下的分量（即 body frame 表达），而本接口返回的是世界系表达。
-        若需要 body frame 下的角速度，请使用对应的传感器接口gyro。
+        This is dimensions 3-5 of generalized velocity ``qvel``, expressed in
+        world coordinates. It differs from gyro readings: gyro sensors report
+        angular velocity components in the body/sensor local frame, while this
+        contract returns world-frame values. Use the matching sensor contract
+        when body-frame angular velocity is required.
 
         Returns:
             (num_envs, 3)
@@ -471,7 +475,7 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_dof_pos(self) -> np.ndarray:
-        """获取关节位置（不含 base）
+        """Return joint positions, excluding the base.
 
         Returns:
             (num_envs, num_dof)
@@ -479,7 +483,7 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_dof_vel(self) -> np.ndarray:
-        """获取关节速度（不含 base）
+        """Return joint velocities, excluding the base.
 
         Returns:
             (num_envs, num_dof)
@@ -491,10 +495,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在世界系下的位置
+        """Return selected body positions in the world frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
@@ -502,40 +506,40 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在世界系下的四元数（wxyz）
+        """Return selected body quaternions in the world frame as ``wxyz``.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 4)
         """
 
     def get_body_pose_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """获取指定 body 在世界系下的位置和四元数（wxyz）"""
+        """Return selected body positions and quaternions in the world frame."""
         return self.get_body_pos_w(body_ids), self.get_body_quat_w(body_ids)
 
     @abc.abstractmethod
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在世界系下的线速度
+        """Return selected body linear velocities in the world frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
         """
 
     def get_body_vel_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """获取指定 body 在世界系下的线速度和角速度"""
+        """Return selected body linear and angular velocities in the world frame."""
         return self.get_body_lin_vel_w(body_ids), self.get_body_ang_vel_w(body_ids)
 
     @abc.abstractmethod
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在世界系下的角速度
+        """Return selected body angular velocities in the world frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
@@ -581,10 +585,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在 baselink 系下的位置
+        """Return selected body positions in the baselink frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
@@ -592,10 +596,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在 baselink 系下的四元数（wxyz）
+        """Return selected body quaternions in the baselink frame as ``wxyz``.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 4)
@@ -603,10 +607,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在 baselink 系下的线速度
+        """Return selected body linear velocities in the baselink frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
@@ -614,10 +618,10 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
-        """获取指定 body 在 baselink 系下的角速度
+        """Return selected body angular velocities in the baselink frame.
 
         Args:
-            body_ids: body 索引数组
+            body_ids: Body ID array.
 
         Returns:
             (num_envs, len(body_ids), 3)
@@ -628,50 +632,53 @@ class SimBackend(abc.ABC):
     # ------------------------------------------------------------------ #
 
     def get_site_ids(self, names: Sequence[str]) -> np.ndarray:
-        """将 site 名称列表转换为整数 ID 数组。
+        """Resolve site names to integer ID arrays.
 
         Args:
-            names: site 名称列表
+            names: Site names.
 
         Returns:
-            shape (len(names),) 的 int32 ID 数组
+            ``int32`` ID array with shape ``(len(names),)``.
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement get_site_ids")
 
     def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
-        """将关节名称列表转换为速度空间（qvel）的 DoF 索引数组。
+        """Resolve joint names to DoF indices in velocity space (qvel).
 
         Args:
-            names: 关节名称列表
+            names: Joint names.
 
         Returns:
-            shape (len(names),) 的 int32 索引数组（相对于 qvel 起始位置）
+            ``int32`` index array with shape ``(len(names),)`` relative to
+            the qvel start.
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement get_joint_dof_indices")
 
     def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
-        """将关节名称列表转换为位置空间（qpos）的 DoF 索引数组。
+        """Resolve joint names to DoF indices in position space (qpos).
 
-        仅支持单自由度关节（非 free joint）。
+        Only single-DoF joints are supported; free joints are excluded.
 
         Args:
-            names: 关节名称列表
+            names: Joint names.
 
         Returns:
-            shape (len(names),) 的 int32 索引数组（相对于 qpos 中关节部分的起始位置）
+            ``int32`` index array with shape ``(len(names),)`` relative to
+            the joint section of qpos.
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not implement get_joint_dof_pos_indices"
         )
 
     def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
-        """将关节名称列表转换为速度空间（qvel）的 DoF 索引数组（相对于关节部分起始）。
+        """Resolve joint names to DoF indices in velocity space (qvel).
 
         Args:
-            names: 关节名称列表
+            names: Joint names.
 
         Returns:
-            shape (len(names),) 的 int32 索引数组
+            ``int32`` index array with shape ``(len(names),)`` relative to
+            the joint section start.
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not implement get_joint_dof_vel_indices"
@@ -682,14 +689,15 @@ class SimBackend(abc.ABC):
         site_id: int,
         dof_indices: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """批量计算指定 site 相对于指定 DoF 列的世界系 Jacobian。
+        """Compute world-frame Jacobians for one site and selected DoF columns.
 
         Args:
-            site_id: site 整数 ID
-            dof_indices: 要提取的 DoF 列索引，shape (n_dof,)
+            site_id: Integer site ID.
+            dof_indices: DoF column indices to extract, with shape ``(n_dof,)``.
 
         Returns:
-            (jacp, jacr)，各为 shape (num_envs, 3, n_dof) 的平移/旋转 Jacobian
+            ``(jacp, jacr)`` translation/rotation Jacobians, each with shape
+            ``(num_envs, 3, n_dof)``.
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement get_site_jacobian_w")
 
@@ -699,13 +707,13 @@ class SimBackend(abc.ABC):
 
     @abc.abstractmethod
     def get_sensor_data(self, name: str) -> np.ndarray:
-        """获取传感器数据
+        """Return sensor data.
 
         Args:
-            name: 传感器名称
+            name: Sensor name.
 
         Returns:
-            传感器数据数组
+            Sensor data array.
         """
 
     def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -130,7 +130,7 @@ def _build_motrix_scene_context(
 
 
 class MotrixBackend(SimBackend):
-    """MotrixSim 后端实现"""
+    """MotrixSim backend implementation."""
 
     def __init__(
         self,
@@ -266,7 +266,7 @@ class MotrixBackend(SimBackend):
             if link.name:
                 self._link_cache[link.index] = link
 
-        # 运行一次正向运动学，确保初始 link 位置和传感器数据有效。
+        # Run forward kinematics once so initial link poses and sensor data are valid.
         self._model.forward_kinematic(self._data)
         self._link_velocities: np.ndarray | None = None
         self._link_velocity_cache_valid = False
@@ -883,7 +883,7 @@ class MotrixBackend(SimBackend):
         return self._get_body_sensor_values(body_ids, "track_pos_b")
 
     def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
-        # motrixsim framequat sensor 输出 xyzw，转换为接口约定的 wxyz
+        # MotrixSim framequat sensors output xyzw; convert to the wxyz contract.
         return self._xyzw_to_wxyz(self._get_body_sensor_values(body_ids, "track_quat_b"))
 
     def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -265,7 +265,7 @@ def _build_mujoco_scene_context(scene: SceneCfg) -> _MuJoCoSceneContext:
 
 
 class MuJoCoBackend(SimBackend):
-    """MuJoCo 后端实现"""
+    """MuJoCo backend implementation."""
 
     def __init__(
         self,
@@ -313,14 +313,14 @@ class MuJoCoBackend(SimBackend):
         self.backend_type = "mujoco"
         self._pending_xfrc_applied = np.zeros((num_envs, 6 * self._model.nbody), dtype=np.float64)
 
-        # 线程配置
+        # Thread configuration.
         self._n_threads = min(num_envs, cpu_count() * 2)
 
         self._model_variants: tuple[mujoco.MjModel, ...] = (self._model,)
         self._model_assignments = np.zeros((num_envs,), dtype=np.int32)
         self._pool: BatchEnvPool | None = None
 
-        # 索引
+        # State indices.
         self.nq = self._model.nq
         self.nv = self._model.nv
         self._idx_qpos = 1
@@ -329,14 +329,14 @@ class MuJoCoBackend(SimBackend):
         self._num_dof_pos = self.nq - self._root_qpos_dim
         self._num_dof_vel = self.nv - self._root_qvel_dim
 
-        # 状态存储
+        # State storage.
         nstate = mujoco.mj_stateSize(self._model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
         self._physics_state = np.zeros((num_envs, nstate), dtype=self._np_dtype)
-        # 用模型默认 qpos（含 identity 四元数）初始化所有环境
+        # Initialize all envs with the model default qpos, including identity quaternions.
         self._physics_state[:, self._idx_qpos : self._idx_qpos + self._model.nq] = self._model.qpos0
         self._sensor_data = np.zeros((num_envs, self._model.nsensordata), dtype=self._np_dtype)
 
-        # 缓存视图
+        # Cached views.
         self._dof_pos_view = self._physics_state[
             :, self._idx_qpos + self._root_qpos_dim : self._idx_qpos + self.nq
         ]
@@ -365,7 +365,7 @@ class MuJoCoBackend(SimBackend):
             self._base_lin_vel_view = np.zeros((num_envs, 3), dtype=self._np_dtype)
             self._base_ang_vel_view = np.zeros((num_envs, 3), dtype=self._np_dtype)
 
-        # 传感器索引
+        # Sensor indices.
         self._sensor_indices = {}
         self._sensor_views = {}
         for i in range(self._model.nsensor):
@@ -376,7 +376,7 @@ class MuJoCoBackend(SimBackend):
                 self._sensor_indices[name] = list(range(adr, adr + dim))
                 self._sensor_views[name] = self._sensor_data[:, adr : adr + dim]
 
-        # 针对追踪身体传感器的零拷贝视图映射
+        # Zero-copy view mapping for tracked-body sensors.
         if self.add_body_sensors and self._valid_bnames:
 
             def _get_sensor_view(prefix, dim):
@@ -1154,10 +1154,11 @@ class MuJoCoBackend(SimBackend):
         site_id: int,
         dof_indices: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """批量 Jacobian，shape (num_envs, 3, len(dof_indices))。
+        """Return batched Jacobians with shape ``(num_envs, 3, len(dof_indices))``.
 
-        使用 BatchEnvPool.compute_site_jacobians 原生接口，无需每 env 独立 MjData。
-        scalar site_id → pool 返回 (N, 3, nv)（k 维被 squeeze）。
+        This uses the native ``BatchEnvPool.compute_site_jacobians`` API, so it
+        does not allocate one ``MjData`` per env. For a scalar ``site_id``, the
+        pool returns ``(N, 3, nv)`` because the site dimension is squeezed.
         """
         dof_indices = np.asarray(dof_indices, dtype=np.int32).reshape(-1)
         jp, jr = self._pool.compute_site_jacobians(  # type: ignore[union-attr]

--- a/src/unilab/base/backend/mujoco/xml.py
+++ b/src/unilab/base/backend/mujoco/xml.py
@@ -522,10 +522,11 @@ def inject_mujoco_tracking_sensors(
     model_file: str,
     baselink_name: str | None = None,
 ) -> tuple[str, list, list]:
-    """为 MuJoCo 后端注入 tracking sensors。
+    """Inject tracking sensors for the MuJoCo backend.
 
-    注入所有 body 的世界系 (_w) sensors；若指定 baselink_name，
-    同时注入相对 baselink 坐标系的 (_b) sensors。
+    The generated sensors track every body in the world frame (``_w``). When
+    ``baselink_name`` is provided, sensors in the baselink-relative frame
+    (``_b``) are added as well.
 
     Returns:
         (tmp_xml_path, tracked_body_ids, valid_bnames)
@@ -584,27 +585,28 @@ def processed_xml(xml_path):
 
 
 def add_sensor(root, sensor_type, name, **kwargs):
-    """
-    在 MuJoCo XML 的 sensor 节点下添加传感器的通用函数。
+    """Add a sensor child under the MuJoCo XML ``<sensor>`` node.
 
-    参数:
-    - root: XML 的根节点
-    - sensor_type: 传感器标签名 (如 'gyro', 'contact', 'framepos')
-    - name: 传感器的 name 属性
-    - **kwargs: 其他任意属性 (如 site='imu', geom1='floor' 等)
+    Args:
+        root: XML root node.
+        sensor_type: Sensor tag name, such as ``"gyro"``, ``"contact"``, or
+            ``"framepos"``.
+        name: Sensor ``name`` attribute.
+        **kwargs: Additional XML attributes such as ``site="imu"`` or
+            ``geom1="floor"``.
     """
-    # 1. 查找或创建 <sensor> 标签
+    # Find or create the <sensor> node.
     sensor_element = root.find("sensor")
     if sensor_element is None:
         sensor_element = ET.SubElement(root, "sensor")
 
-    # 2. 创建具体的传感器子节点
+    # Create the concrete sensor node.
     sensor = ET.SubElement(sensor_element, sensor_type)
 
-    # 3. 设置必选的 name 属性
+    # Set the required name attribute.
     sensor.set("name", name)
 
-    # 4. 循环设置其他传入的属性
+    # Set any extra attributes passed by the caller.
     for key, value in kwargs.items():
         sensor.set(key, str(value))
 

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -36,7 +36,7 @@ class NpEnvState:
 
 
 class NpEnv(ABEnv):
-    """统一的 numpy 环境基类（backend-agnostic）"""
+    """Backend-agnostic numpy environment base class."""
 
     def __init__(self, cfg: EnvCfg, backend: SimBackend, num_envs: int):
         self._cfg = cfg
@@ -413,11 +413,11 @@ class NpEnv(ABEnv):
 
     @abc.abstractmethod
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
-        """子类实现：action → ctrl"""
+        """Subclasses implement the action-to-control conversion."""
 
     @abc.abstractmethod
     def update_state(self, state: NpEnvState) -> NpEnvState:
-        """子类实现：计算 obs/reward/terminated"""
+        """Subclasses compute observation, reward, and termination state."""
 
     @property
     def play_capabilities(self) -> EnvPlayCapabilities:
@@ -451,7 +451,7 @@ class NpEnv(ABEnv):
         self._autoreset = bool(enabled)
 
     def close(self) -> None:
-        """关闭环境"""
+        """Close the environment and release backend-owned scene assets."""
         cleanup_scene_assets = getattr(self._backend, "cleanup_scene_assets", None)
         if callable(cleanup_scene_assets):
             cleanup_scene_assets()

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -524,7 +524,7 @@ class G1WalkEnv(G1BaseEnv):
         )
 
     def _reward_feet_phase(self, ctx: RewardContext):
-        """步态相位奖励：鼓励正确的摆动腿高度"""
+        """Reward gait phase tracking by encouraging the expected swing-foot height."""
         left_foot = self._backend.get_sensor_data("left_foot_pos")
         right_foot = self._backend.get_sensor_data("right_foot_pos")
         gait_phase = ctx.info.get(
@@ -650,7 +650,7 @@ class G1WalkControlConfig:
 
 @dataclass
 class G1WalkRewardConfig(G1RewardConfig):
-    """对齐 holosoma G1 walking 奖励权重。"""
+    """Align reward weights with holosoma G1 walking."""
 
 
 @registry.envcfg("G1WalkFlat")

--- a/src/unilab/envs/locomotion/go2_arm/base.py
+++ b/src/unilab/envs/locomotion/go2_arm/base.py
@@ -60,8 +60,8 @@ class ControlConfig(ControlConfigBase):
     arm_kd: float | list[float] | None = field(
         default_factory=lambda: [3.5, 3.8, 2.5, 1.5, 1.5, 1.5]
     )
-    # 机械臂动作缩放（独立于腿部 action_scale），IK 已提供主要控制，
-    # policy 仅做残差修正，设小值防止早期随机输出压过 IK
+    # Arm residual action scale, independent from leg action_scale. IK provides
+    # the primary control, so policy output stays small early in training.
     arm_action_scale: float = 0.0
 
 

--- a/tests/base/backend/test_mujoco_site_jacobian.py
+++ b/tests/base/backend/test_mujoco_site_jacobian.py
@@ -60,7 +60,7 @@ def test_get_joint_dof_pos_indices(backend):
     indices = backend.get_joint_dof_pos_indices(list(ARM_JOINT_NAMES))
     assert indices.shape == (6,)
     assert indices.dtype == np.int32
-    # 所有索引在合法 dof_pos 范围内
+    # All indices must stay within the valid dof_pos range.
     assert np.all(indices >= 0)
     assert np.all(indices < backend._num_dof_pos)
 
@@ -85,7 +85,7 @@ def test_get_site_jacobian_shape(backend):
 
 @pytest.mark.slow
 def test_get_site_jacobian_matches_serial(backend):
-    """并行结果与串行逐 env 计算一致（差值 < 1e-6）。"""
+    """Parallel results must match serial per-env computation within 1e-6."""
     import mujoco
 
     site_ids = backend.get_site_ids([EE_SITE_NAME])
@@ -94,7 +94,7 @@ def test_get_site_jacobian_matches_serial(backend):
 
     jacp_par, jacr_par = backend.get_site_jacobian_w(site_id, dof_indices)
 
-    # 串行参考
+    # Serial reference.
     jacp_ser = np.zeros((NUM_ENVS, 3, 6), dtype=np.float64)
     jacr_ser = np.zeros((NUM_ENVS, 3, 6), dtype=np.float64)
     for env_idx in range(NUM_ENVS):

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -921,13 +921,13 @@ def _mx_link_id(mx_model, name: str) -> int:
 
 @pytest.mark.slow
 class TestCrossBackend:
-    """相同 set_state 后，MuJoCo 与 MotrixSim 所有基础接口数值必须一致。"""
+    """MuJoCo and MotrixSim base interfaces must agree after identical set_state."""
 
-    ATOL = 2e-3  # float64 vs float32 + 不同 qpos0 的积累误差
+    ATOL = 2e-3  # float64 vs float32 plus accumulated differences from qpos0.
 
     @pytest.fixture(params=BASIC_ROBOTS)
     def synced(self, request):
-        """创建并同步两后端初始状态，返回 (mj, mx, base_name)。"""
+        """Create both backends, synchronize their initial state, and return them."""
         from unilab.base.backend.motrix.backend import MotrixBackend
         from unilab.base.backend.mujoco.backend import MuJoCoBackend
 
@@ -987,7 +987,7 @@ class TestCrossBackend:
 
 @pytest.mark.slow
 class TestCrossBackendBodySensors:
-    """body 传感器接口双后端对测（G1，add_body_sensors=True）。"""
+    """Cross-check body sensor contracts for G1 with add_body_sensors=True."""
 
     ATOL = 2e-3
 
@@ -1022,7 +1022,7 @@ class TestCrossBackendBodySensors:
 
     @pytest.fixture
     def body_pairs(self, synced):
-        """选前 3 个 body（pelvis + 两个髋关节），分别返回 mujoco IDs 和 motrixsim link IDs。"""
+        """Return MuJoCo and MotrixSim IDs for the first three non-world bodies."""
         mujoco = _mujoco_module()
 
         mj, mx = synced

--- a/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
+++ b/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
@@ -69,7 +69,7 @@ def _ensure_go2_arm_manip_loco_registered() -> None:
 
 
 def test_go2_arm_manip_loco_cfg_registered():
-    """验证配置类已正确注册。"""
+    """Go2ArmManipLoco config should be registered."""
     _ensure_go2_arm_manip_loco_registered()
     registry = _registry_module()
     assert registry.contains("Go2ArmManipLoco")
@@ -106,7 +106,7 @@ def test_go2_arm_manip_loco_cfg_declares_scene_for_playback():
 
 
 def test_go2_arm_ee_goal_collision_check_matches_reference_semantics():
-    """EE goal 路径任一点进入 collision box 或地下都应判为 unsafe。"""
+    """Any EE goal path sample inside the collision box or below ground is unsafe."""
     from unilab.envs.locomotion.go2_arm.manip_loco import (
         EEGoalConfig,
         Go2ArmManipLocoCfg,
@@ -130,7 +130,7 @@ def test_go2_arm_ee_goal_collision_check_matches_reference_semantics():
 
 
 def test_go2_arm_command_moving_mask_includes_all_velocity_axes():
-    """vx/vy/vyaw 任一轴超过阈值都应视为运动 command。"""
+    """A command is moving when vx, vy, or vyaw exceeds the motion threshold."""
     from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)
@@ -155,7 +155,7 @@ def test_go2_arm_command_moving_mask_includes_all_velocity_axes():
 
 
 def test_go2_arm_command_postprocess_can_force_zero_commands():
-    """zero_command_prob 应在小命令归零之外显式注入 exact zero command。"""
+    """zero_command_prob should inject exact zero commands after small-command zeroing."""
     from unilab.envs.locomotion.go2_arm.manip_loco import (
         Go2ArmManipLocoCfg,
         Go2ArmManipLocoEnv,
@@ -182,7 +182,7 @@ def test_go2_arm_command_postprocess_can_force_zero_commands():
 
 
 def test_go2_arm_stand_still_reward_uses_same_command_mask():
-    """stand_still 不应惩罚 lateral/yaw/forward command 下的腿部姿态偏差。"""
+    """stand_still should not penalize leg pose under lateral, yaw, or forward commands."""
     from unilab.envs.locomotion.common.rewards import RewardContext
     from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
@@ -211,7 +211,7 @@ def test_go2_arm_stand_still_reward_uses_same_command_mask():
 
 
 def test_go2_arm_write_feet_phase_updates_indexed_envs():
-    """reset env 子集时也要真正写回 feet_phase，不能被 fancy indexing 拷贝吞掉。"""
+    """Resetting env subsets must write back feet_phase instead of losing fancy-index copies."""
     from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)
@@ -228,7 +228,7 @@ def test_go2_arm_write_feet_phase_updates_indexed_envs():
 
 
 def test_go2_arm_apply_action_uses_arm_action_scale_for_arm_residual():
-    """腿部 residual 用 action_scale，机械臂 residual 用 arm_action_scale。"""
+    """Leg residuals use action_scale while arm residuals use arm_action_scale."""
     from unilab.envs.locomotion.go2_arm.manip_loco import (
         Go2ArmManipLocoCfg,
         Go2ArmManipLocoEnv,
@@ -290,7 +290,7 @@ def test_go2_arm_playback_resolves_visual_scene_model(tmp_path):
 
 @pytest.mark.slow
 def test_go2_arm_obs_groups_spec():
-    """验证 obs_groups_spec 维度正确（actor 76，critic 79）。"""
+    """obs_groups_spec should expose the expected actor and critic dimensions."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=1)
     assert env.obs_groups_spec == {"obs": 76, "critic": 79}
@@ -298,7 +298,7 @@ def test_go2_arm_obs_groups_spec():
 
 @pytest.mark.slow
 def test_go2_arm_reset_step_contract():
-    """验证 init_state/step 返回正确 shape。"""
+    """init_state and step should return the expected shapes."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=2)
     state = env.init_state()
@@ -313,7 +313,7 @@ def test_go2_arm_reset_step_contract():
 
 @pytest.mark.slow
 def test_go2_arm_ee_goal_valid_after_reset():
-    """验证 reset 后末端目标 shape 和有限性。"""
+    """EE goals should have the expected shape and finite values after reset."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=2)
     env.init_state()
@@ -323,12 +323,12 @@ def test_go2_arm_ee_goal_valid_after_reset():
 
 @pytest.mark.slow
 def test_go2_arm_ee_goal_resampling():
-    """验证 ee goal timer 到期后目标发生变化（新字段 _arm_goal_timer / _traj_total_steps）。"""
+    """EE goal should change when the arm goal timer expires."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=4)
     env.init_state()
 
-    # 强制 timer 到期（设为总步数 - 1，step 后触发 >= 条件）
+    # Force timer expiry by setting it to total_steps - 1 before step triggers >=.
     env._arm_goal_timer[:] = env._traj_total_steps - 1
     goal_before = env.curr_ee_goal_cart.copy()
 
@@ -341,12 +341,12 @@ def test_go2_arm_ee_goal_resampling():
 
 @pytest.mark.slow
 def test_go2_arm_ee_goal_interpolation():
-    """验证 timer 处于运动阶段时，每步 curr_ee_goal_cart 在变化（球空间插值）。"""
+    """curr_ee_goal_cart should change during the movement phase via spherical interpolation."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=2)
     env.init_state()
 
-    # 将 timer 置于运动阶段中间，确保不会触发 expiry
+    # Put the timer in the middle of the movement phase so expiry is not triggered.
     env._arm_goal_timer[:] = 0
     env._traj_steps[:] = 100
     env._traj_total_steps[:] = 150
@@ -360,18 +360,18 @@ def test_go2_arm_ee_goal_interpolation():
 
 @pytest.mark.slow
 def test_go2_arm_command_resampling():
-    """验证 command timer 到期后 command 发生变化。"""
+    """Command should change when the command timer expires."""
     _skip_if_no_mujoco()
     env = _make_env(num_envs=4, env_cfg_override={"commands": {"resample_time_s": 0.02}})
     env.init_state()
 
-    # 强制 timer 到期
+    # Force timer expiry.
     env._cmd_timer[:] = env._cmd_resample_steps - 1
     cmd_before = env._state.info["commands"].copy()
 
     actions = np.zeros((4, 18))
     env.step(actions)
 
-    # 至少部分 env 的 command 应该发生变化
+    # At least some env commands should change.
     changed = not np.allclose(env._state.info["commands"], cmd_before)
     assert changed, "commands should have been resampled after timer expiry"


### PR DESCRIPTION
Fixes #581

## Summary
- Define English as the default language for source comments, public API docstrings, TODO/FIXME entries, and config comments.
- Add matching English and Chinese contributing-guide guidance, including migration priorities for existing mixed-language comments.
- Translate a first core batch of comments/docstrings in backend/env contracts, backend adapters, Go2Arm/G1 config annotations, and nearby contract tests without changing behavior or config values.

## Validation
- uv run pytest tests/scripts/test_check_docs.py -q
- uv run pytest tests/base/backend/test_mujoco_site_jacobian.py tests/base/test_sim_backend.py tests/envs/locomotion/go2_arm/test_manip_loco_contract.py -q
- make test-all

## Impact
- Documentation and comment-only cleanup.
- No runtime behavior, backend selection, reward scale, or Hydra owner value changes.