### PR TITLE
docs: add star history to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,22 @@ Use the published [UniLab documentation](https://unilabsim.github.io/UniLab-doc/
 
 Join our [Discord server](https://discord.gg/EPCuguRmGX) to chat with the community and get help.
 
-| WeChat Group | WeChat Assistant |
+| WeChat Group | Author WeChat |
 | :---: | :---: |
-| <img src="docs/sphinx/source/_static/assets/unilab-wechat-group.jpg" alt="UniLab WeChat group QR code" width="220"> | <img src="docs/sphinx/source/_static/assets/unilab-wechat-assistant.jpg" alt="UniLab WeChat assistant QR code" width="150"> |
-| Scan to join the UniLab WeChat group. | If the group is full, add the assistant and include `unilab交流` in your message. |
+| <img src="docs/sphinx/source/_static/assets/unilab-wechat-group.jpg" alt="UniLab WeChat group QR code" width="220"> | <img src="docs/sphinx/source/_static/assets/unilab-wechat-assistant.jpg" alt="UniLab author WeChat QR code" width="150"> |
+| Scan to join the UniLab WeChat group. | If the group is full, add the author and include `unilab交流` in your message. |
+
+## ⭐ Star History
+
+<p align="center">
+  <a href="https://www.star-history.com/unilabsim/UniLab">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&legend=top-left" />
+      <img src="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&legend=top-left" alt="UniLab Star History Chart" width="70%">
+    </picture>
+  </a>
+</p>
 
 ## 🧾 Citation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -172,10 +172,22 @@ uv run eval --algo ppo --task go2_arm_manip_loco --sim motrix --load-run -1
 
 海外用户可加入我们的 [Discord 服务器](https://discord.gg/EPCuguRmGX) 交流与获取帮助。
 
-| 微信群 | 小助手微信 |
+| 微信群 | 作者微信 |
 | :---: | :---: |
-| <img src="docs/sphinx/source/_static/assets/unilab-wechat-group.jpg" alt="UniLab 微信群二维码" width="220"> | <img src="docs/sphinx/source/_static/assets/unilab-wechat-assistant.jpg" alt="UniLab 小助手微信二维码" width="150"> |
-| 扫码加入 UniLab 微信群。 | 如果微信群已满，请添加小助手微信，并备注 `unilab交流`。 |
+| <img src="docs/sphinx/source/_static/assets/unilab-wechat-group.jpg" alt="UniLab 微信群二维码" width="220"> | <img src="docs/sphinx/source/_static/assets/unilab-wechat-assistant.jpg" alt="UniLab 作者微信二维码" width="150"> |
+| 扫码加入 UniLab 微信群。 | 如果微信群已满，请添加作者微信，并备注`unilab交流`。 |
+
+## ⭐ Star 趋势
+
+<p align="center">
+  <a href="https://www.star-history.com/unilabsim/UniLab">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&legend=top-left" />
+      <img src="https://api.star-history.com/chart?repos=unilabsim/UniLab&type=date&legend=top-left" alt="UniLab Star 趋势图" width="70%">
+    </picture>
+  </a>
+</p>
 
 ## 🧾 引用
 


### PR DESCRIPTION
## Summary
- Add Star History chart to the English and Chinese READMEs near the community section
- Rename WeChat assistant wording to author WeChat
- Update WeChat note instructions to include name, affiliation, and `unilab交流`

## Validation
- `make test-all` passed: 1187 passed, 30 skipped, 255 deselected