### PR TITLE
fix: collect coverage from src package path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,4 @@ jobs:
             --no-install-package triton
           uv pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Test with coverage
-        run: uv run --no-sync pytest -m "not slow" --cov=unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25
+        run: uv run --no-sync pytest -m "not slow" --cov=src/unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	uv run pytest -m "not slow" --cov=unilab --cov-report=term-missing
+	uv run pytest -m "not slow" --cov=src/unilab --cov-report=term-missing
 
 .PHONY: test-slow
 test-slow:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ markers = [
 addopts = "--tb=short -m 'not slow'"
 
 [tool.coverage.run]
-source = ["unilab"]
+source = ["src/unilab"]
 omit = ["*/rsl_rl/*"]
 
 [tool.coverage.report]

--- a/tests/scripts/test_repo_hygiene.py
+++ b/tests/scripts/test_repo_hygiene.py
@@ -29,6 +29,14 @@ def test_script_usage_examples_do_not_invoke_python_for_repo_scripts():
     assert errors == []
 
 
+def test_coverage_commands_use_src_package_path():
+    root = Path(__file__).resolve().parents[2]
+
+    assert 'source = ["src/unilab"]' in (root / "pyproject.toml").read_text(encoding="utf-8")
+    assert "--cov=src/unilab" in (root / "Makefile").read_text(encoding="utf-8")
+    assert "--cov=src/unilab" in (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+
 def test_source_command_anti_patterns_flags_python_script_invocation(tmp_path):
     script_path = tmp_path / "scripts" / "tool.py"
     script_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- switch local and CI coverage collection from `--cov=unilab` to `--cov=src/unilab`
- align `[tool.coverage.run].source` with the src-layout package path
- add a repo hygiene regression test to keep Makefile, CI, and pyproject coverage targets aligned

Fixes #597

## Validation

- `uv run pytest tests/scripts/test_repo_hygiene.py -q`
- `uv run pytest tests/test_cli.py -q --cov=src/unilab --cov-report=term-missing`
- `make test-cov`
- `make test-all` (`1188 passed, 30 skipped, 255 deselected`; coverage report generated, total 70%)
