### PR TITLE
feat(x2): add wall flip tracking support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 .vscode/
 .idea/
 .kiro/
+.history/
 
 # Project specific
 logs/
@@ -55,6 +56,7 @@ run_summary.json
 *.temp
 *.tmp
 *~
+src/unilab/assets/checkpoints/
 
 benchmark/outputs/
 src/unilab/algos/torch/rsl_rl
@@ -68,6 +70,11 @@ src/unilab/assets/motions/g1/*.npz
 src/unilab/assets/motions/g1/*.csv
 src/unilab/assets/motions/g1/flip
 src/unilab/assets/motions/g1/flip_npz
+src/unilab/assets/motions/x2/*.npz
+src/unilab/assets/motions/x2/*.csv
+
+# Robot mesh assets (downloaded from HF at runtime)
+src/unilab/assets/robots/x2/meshes/*.STL
 
 # Grasp cache assets (downloaded from HF at runtime)
 src/unilab/assets/caches/*.npy

--- a/README.md
+++ b/README.md
@@ -107,10 +107,16 @@ uv run demo dance
 
 Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
 
-> Mainland China users: motions, scenes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
+> Mainland China users: motions, scenes, robot meshes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
 >
 > ```bash
 > export HF_ENDPOINT=https://hf-mirror.com
+> ```
+
+> X2 robot meshes auto-download from Hugging Face (`unilabsim/unilab-robots`) on first run into `src/unilab/assets/robots/x2/meshes/`; no manual step is needed. To pre-fetch them ahead of time:
+>
+> ```bash
+> uv run unilab-pull-assets --robot x2
 > ```
 
 For training and evaluation:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ make setup-motrix
 uv run demo dance
 ```
 
-Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
+Available demo names: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
 
 > Mainland China users: motions, scenes, robot meshes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
 >

--- a/README_zh.md
+++ b/README_zh.md
@@ -108,11 +108,17 @@ uv run demo dance
 可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
 完整的命令与参数请参阅 [统一 CLI](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/1-cli_reference.html) 页面。
 
-> 中国大陆用户：动作、场景和 demo checkpoint 首次运行时会从 Hugging Face 拉取。如果 `huggingface.co`
+> 中国大陆用户：动作、场景、机器人网格和 demo checkpoint 首次运行时会从 Hugging Face 拉取。如果 `huggingface.co`
 > 无法访问，请在运行 demo 命令前先将客户端切到社区镜像：
 >
 > ```bash
 > export HF_ENDPOINT=https://hf-mirror.com
+> ```
+
+> X2 机器人网格首次运行时会自动从 Hugging Face (`unilabsim/unilab-robots`) 下载到 `src/unilab/assets/robots/x2/meshes/`，无需手动操作。如需提前预拉取：
+>
+> ```bash
+> uv run unilab-pull-assets --robot x2
 > ```
 
 用于训练与评估：

--- a/README_zh.md
+++ b/README_zh.md
@@ -105,7 +105,7 @@ make setup-motrix
 uv run demo dance
 ```
 
-可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo 名称：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
 完整的命令与参数请参阅 [统一 CLI](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/1-cli_reference.html) 页面。
 
 > 中国大陆用户：动作、场景、机器人网格和 demo checkpoint 首次运行时会从 Hugging Face 拉取。如果 `huggingface.co`

--- a/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
+++ b/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
@@ -7,7 +7,7 @@ interactive:
   action_mode: policy
 algo:
   num_envs: 1024
-  max_iterations: 20000
+  max_iterations: 9500
   save_interval: 500
   empirical_normalization: true
   obs_groups:

--- a/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
+++ b/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
@@ -1,0 +1,80 @@
+# @package _global_
+training:
+  task_name: X2WallFlipTracking
+  sim_backend: mujoco
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 20000
+  save_interval: 500
+  empirical_normalization: true
+  obs_groups:
+    actor:
+      - actor
+    critic:
+      - critic
+  algorithm:
+    entropy_coef: 0.005
+    desired_kl: 0.01
+env:
+  sampling_mode: start
+  truncate_on_clip_end: false
+  sim_dt: 0.005
+  control_config:
+    action_scale:
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+  anchor_pos_z_threshold: 0.5
+  ee_body_pos_z_threshold: 0.5
+  terminate_on_undesired_contacts: true
+  noise_config:
+    level: 0.0
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 2.0
+    motion_body_ori: 1.5
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_ee_body_pos_z: 2.0
+    motion_joint_pos: 0.5
+    motion_joint_vel: 0.25
+    action_rate_l2: -0.005
+    joint_limit: -10.0
+    undesired_contacts: -0.1
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
+++ b/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
@@ -2,7 +2,19 @@
 training:
   task_name: X2WallFlipTracking
   sim_backend: mujoco
-  play_steps: 1000
+  play_steps: 300  # 6s play video @ ctrl_dt=0.02 (fps 50)
+  # Offline-render (play) only — does not affect the training loop. 16 envs are
+  # laid out on a 4x4 grid; render_spacing must exceed the per-env wall reach
+  # (~2.14m toward -Y) so neighbouring cells don't overlap. The oblique
+  # azimuth (225) views the grid corner-on with each robot in front of its
+  # wall (azimuth 90 would put the walls between camera and robots); lookat is
+  # the grid centre (offsets span 0..9m in X/Y at spacing 3.0).
+  play_env_num: 16
+  render_spacing: 3.0
+  cam_distance: 14.0
+  cam_azimuth: 225.0
+  cam_elevation: -18.0
+  cam_lookat: [4.5, 4.5, 1.0]
 interactive:
   action_mode: policy
 algo:

--- a/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
+++ b/conf/ppo/task/x2_wall_flip_tracking/mujoco.yaml
@@ -3,6 +3,8 @@ training:
   task_name: X2WallFlipTracking
   sim_backend: mujoco
   play_steps: 1000
+interactive:
+  action_mode: policy
 algo:
   num_envs: 1024
   max_iterations: 20000

--- a/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
@@ -58,12 +58,20 @@ uv run demo dance
 
 Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
 
-Mainland China users: motions, scenes, and demo checkpoints come from Hugging
-Face on first run. If `huggingface.co` is unreachable, switch to the community
-mirror before running training, eval, or demo commands:
+Mainland China users: motions, scenes, robot meshes, and demo checkpoints come
+from Hugging Face on first run. If `huggingface.co` is unreachable, switch to the
+community mirror before running training, eval, or demo commands:
 
 ```bash
 export HF_ENDPOINT=https://hf-mirror.com
+```
+
+X2 robot meshes auto-download from Hugging Face (`unilabsim/unilab-robots`) into
+`src/unilab/assets/robots/x2/meshes/` on first run; no manual step is needed. To
+pre-fetch them:
+
+```bash
+uv run unilab-pull-assets --robot x2
 ```
 
 On macOS, the CLI routes Motrix interactive playback through `mxpython` when

--- a/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
@@ -56,7 +56,7 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
 uv run demo dance
 ```
 
-Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
+Available demo names: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`.
 
 Mainland China users: motions, scenes, robot meshes, and demo checkpoints come
 from Hugging Face on first run. If `huggingface.co` is unreachable, switch to the

--- a/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
@@ -96,13 +96,14 @@ Supported render modes are `auto`, `interactive`, `record`, and `none`.
 ```bash
 uv run demo dance
 uv run demo wallflip
+uv run demo wallflip2
 uv run demo boxtracking
 uv run demo locomani
 uv run demo inhandgrasp
 uv run demo dance --refresh --device cpu
 ```
 
-Available demos: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
+Available demos: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`.
 Each demo fetches a pre-trained checkpoint from the
 `unilabsim/unilab-checkpoints` Hugging Face dataset on first run and caches it
 under `src/unilab/assets/checkpoints/<demo>/model_0.pt`. Pass `--refresh` to

--- a/docs/sphinx/source/en/2-user_guide/4-tasks/2-motion_tracking.md
+++ b/docs/sphinx/source/en/2-user_guide/4-tasks/2-motion_tracking.md
@@ -20,24 +20,27 @@ Each task ships a default motion clip defined in the env config dataclass:
 | `g1_motion_tracking` | `G1MotionTracking` | `dance1_subject2_part.npz` | `conf/ppo/task/g1_motion_tracking/`, `conf/appo/task/g1_motion_tracking/` |
 | `g1_flip_tracking` | `G1FlipTracking` | `flip_360_001__A304.npz` | `conf/ppo/task/g1_flip_tracking/`, `conf/appo/task/g1_flip_tracking/` |
 | `g1_wall_flip_tracking` | `G1WallFlipTracking` | `flip_from_wall_104__A304.npz` | `conf/ppo/task/g1_wall_flip_tracking/`, `conf/appo/task/g1_wall_flip_tracking/` |
+| `x2_wall_flip_tracking` | `X2WallFlipTracking` | `tictacflip_6-3_g1format.npz` | `conf/ppo/task/x2_wall_flip_tracking/` (MuJoCo only) |
 | `g1_climb_tracking` | G1 climb tracking env | clip from env config | `conf/ppo/task/g1_climb_tracking/`, `conf/appo/task/g1_climb_tracking/` |
 | `g1_box_tracking` | G1 box tracking env | clip from env config | `conf/ppo/task/g1_box_tracking/` |
 | `g1_wbt_obs` | `G1MotionTrackingSAC` | shared with `g1_motion_tracking` | `conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml` |
 
 The defaults are set in code: `dance1_subject2_part.npz`
 (`g1/tracking.py`), `flip_360_001__A304.npz` and `flip_from_wall_104__A304.npz`
-(`g1/flip_tracking.py`).
+(`g1/flip_tracking.py`), and `tictacflip_6-3_g1format.npz` (`x2/flip_tracking.py`).
 
 ## PPO And APPO
 
 PPO owner iteration budgets (the `--sim mujoco` owner YAMLs): `g1_motion_tracking`
 runs `algo.max_iterations=15000`; `g1_flip_tracking` and `g1_wall_flip_tracking`
-run `20000`. (The Motrix owner YAML for `g1_flip_tracking` raises this to `30000`.)
+run `20000`; the MuJoCo-only `x2_wall_flip_tracking` runs `9500`. (The Motrix
+owner YAML for `g1_flip_tracking` raises this to `30000`.)
 
 ```bash
 uv run train --algo ppo --task g1_motion_tracking --sim mujoco
 uv run train --algo ppo --task g1_flip_tracking --sim mujoco
 uv run train --algo ppo --task g1_wall_flip_tracking --sim mujoco
+uv run train --algo ppo --task x2_wall_flip_tracking --sim mujoco
 uv run train --algo ppo --task g1_motion_tracking --sim motrix
 uv run train --algo appo --task g1_motion_tracking --sim mujoco training.no_play=true
 uv run train --algo ppo --task g1_motion_tracking --sim mujoco \

--- a/docs/sphinx/source/en/4-developer_guide/7-motion_assets.md
+++ b/docs/sphinx/source/en/4-developer_guide/7-motion_assets.md
@@ -82,6 +82,34 @@ Alternatively, pre-download into the in-repo directory with `--local-dir`
 
 3. Reference the new file path in the env config.
 
+## Robot Mesh Assets
+
+Robot binary meshes (`.STL`) are externalized the same way, on the Hugging Face
+dataset repo
+[unilabsim/unilab-robots](https://huggingface.co/datasets/unilabsim/unilab-robots).
+X2 meshes download lazily on first use and land under their original path
+`src/unilab/assets/robots/x2/meshes/`, so the XML `meshdir` references resolve
+unchanged. Pre-fetch them without running a task:
+
+```bash
+uv run unilab-pull-assets --robot x2
+```
+
+To add a new robot's meshes:
+
+1. Upload to the HF repo, keeping the directory layout identical:
+
+   ```bash
+   huggingface-cli upload unilabsim/unilab-robots \
+     src/unilab/assets/robots/<robot>/meshes robots/<robot>/meshes \
+     --repo-type dataset
+   ```
+
+2. Ignore the local `*.STL` in `.gitignore` (keep a `.gitkeep` so the directory
+   persists).
+3. Resolve the directory once on a cold path from the env, e.g.
+   `resolve_robot_asset_dir("robots/<robot>/meshes", marker="<some>.STL")`.
+
 ## Architecture Notes
 
 - Asset resolver module: `src/unilab/assets/hub.py`
@@ -92,3 +120,7 @@ Alternatively, pre-download into the in-repo directory with `--local-dir`
 - Hot paths (`step` / `reset`) never trigger any file download or parsing.
 - `ASSETS_ROOT_PATH` is unchanged, so the download target matches the
   original local path exactly.
+- Robot meshes use the same directory resolver (`resolve_robot_asset_dir`),
+  integrated at `X2WallFlipTrackingEnv.__init__` in
+  `src/unilab/envs/motion_tracking/x2/flip_tracking.py`, and exposed as the
+  `unilab-pull-assets` CLI.

--- a/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
@@ -43,11 +43,17 @@ uv run demo dance
 
 可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
 
-中国大陆用户：运动、场景和 demo 检查点在首次运行时从 Hugging Face 拉取。如果
+中国大陆用户：运动、场景、机器人网格和 demo 检查点在首次运行时从 Hugging Face 拉取。如果
 `huggingface.co` 无法访问，请在运行训练、评估或 demo 命令前切到社区镜像：
 
 ```bash
 export HF_ENDPOINT=https://hf-mirror.com
+```
+
+X2 机器人网格在首次运行时会自动从 Hugging Face (`unilabsim/unilab-robots`) 下载到 `src/unilab/assets/robots/x2/meshes/`，无需手动操作。如需提前预拉取：
+
+```bash
+uv run unilab-pull-assets --robot x2
 ```
 
 ## 训练与评估

--- a/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
@@ -41,7 +41,7 @@ make setup-motrix
 uv run demo dance
 ```
 
-可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo 名称：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
 
 中国大陆用户：运动、场景、机器人网格和 demo 检查点在首次运行时从 Hugging Face 拉取。如果
 `huggingface.co` 无法访问，请在运行训练、评估或 demo 命令前切到社区镜像：

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
@@ -93,13 +93,14 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1 \
 ```bash
 uv run demo dance
 uv run demo wallflip
+uv run demo wallflip2
 uv run demo boxtracking
 uv run demo locomani
 uv run demo inhandgrasp
 uv run demo dance --refresh --device cpu
 ```
 
-可用的 demo：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
 每个 demo 在首次运行时会从 `unilabsim/unilab-checkpoints` 这个 Hugging Face
 数据集拉取预训练检查点，并缓存到 `src/unilab/assets/checkpoints/<demo>/model_0.pt`。
 传入 `--refresh` 可重新下载。

--- a/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/2-motion_tracking.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/2-motion_tracking.md
@@ -18,23 +18,27 @@ G1 动作追踪任务位于 `src/unilab/envs/motion_tracking/` 下，并通过
 | `g1_motion_tracking` | `G1MotionTracking` | `dance1_subject2_part.npz` | `conf/ppo/task/g1_motion_tracking/`, `conf/appo/task/g1_motion_tracking/` |
 | `g1_flip_tracking` | `G1FlipTracking` | `flip_360_001__A304.npz` | `conf/ppo/task/g1_flip_tracking/`, `conf/appo/task/g1_flip_tracking/` |
 | `g1_wall_flip_tracking` | `G1WallFlipTracking` | `flip_from_wall_104__A304.npz` | `conf/ppo/task/g1_wall_flip_tracking/`, `conf/appo/task/g1_wall_flip_tracking/` |
+| `x2_wall_flip_tracking` | `X2WallFlipTracking` | `tictacflip_6-3_g1format.npz` | `conf/ppo/task/x2_wall_flip_tracking/`（仅 MuJoCo） |
 | `g1_climb_tracking` | G1 climb tracking env | 由 env 配置给出 | `conf/ppo/task/g1_climb_tracking/`, `conf/appo/task/g1_climb_tracking/` |
 | `g1_box_tracking` | G1 box tracking env | 由 env 配置给出 | `conf/ppo/task/g1_box_tracking/` |
 | `g1_wbt_obs` | `G1MotionTrackingSAC` | 与 `g1_motion_tracking` 共用 | `conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml` |
 
 默认值在代码中设定：`dance1_subject2_part.npz`（`g1/tracking.py`），
-`flip_360_001__A304.npz` 与 `flip_from_wall_104__A304.npz`（`g1/flip_tracking.py`）。
+`flip_360_001__A304.npz` 与 `flip_from_wall_104__A304.npz`（`g1/flip_tracking.py`），
+以及 `tictacflip_6-3_g1format.npz`（`x2/flip_tracking.py`）。
 
 ## PPO 与 APPO
 
 PPO owner 迭代预算（`--sim mujoco` owner YAML）：`g1_motion_tracking` 为
 `algo.max_iterations=15000`；`g1_flip_tracking` 和 `g1_wall_flip_tracking` 为
-`20000`。（`g1_flip_tracking` 的 Motrix owner YAML 将其提到 `30000`。）
+`20000`；仅 MuJoCo 的 `x2_wall_flip_tracking` 为 `9500`。（`g1_flip_tracking` 的
+Motrix owner YAML 将其提到 `30000`。）
 
 ```bash
 uv run train --algo ppo --task g1_motion_tracking --sim mujoco
 uv run train --algo ppo --task g1_flip_tracking --sim mujoco
 uv run train --algo ppo --task g1_wall_flip_tracking --sim mujoco
+uv run train --algo ppo --task x2_wall_flip_tracking --sim mujoco
 uv run train --algo ppo --task g1_motion_tracking --sim motrix
 uv run train --algo appo --task g1_motion_tracking --sim mujoco training.no_play=true
 uv run train --algo ppo --task g1_motion_tracking --sim mujoco \

--- a/docs/sphinx/source/zh_CN/4-developer_guide/7-motion_assets.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/7-motion_assets.md
@@ -75,6 +75,31 @@ env:
 
 3. 在 env config 中引用新文件路径即可。
 
+## 机器人网格资产
+
+机器人二进制网格（`.STL`）采用相同方式外置，托管在 Hugging Face 数据集仓库
+[unilabsim/unilab-robots](https://huggingface.co/datasets/unilabsim/unilab-robots)。
+X2 网格在首次使用时按需下载，落盘到原始路径 `src/unilab/assets/robots/x2/meshes/`，
+因此 XML 的 `meshdir` 引用保持有效。无需运行任务即可提前预拉取：
+
+```bash
+uv run unilab-pull-assets --robot x2
+```
+
+新增某个机器人的网格：
+
+1. 上传到 HF 仓库，保持目录结构一致：
+
+   ```bash
+   huggingface-cli upload unilabsim/unilab-robots \
+     src/unilab/assets/robots/<robot>/meshes robots/<robot>/meshes \
+     --repo-type dataset
+   ```
+
+2. 在 `.gitignore` 中忽略本地 `*.STL`（保留 `.gitkeep` 以维持目录）。
+3. 在 env 的冷路径上调用一次目录 resolver，例如
+   `resolve_robot_asset_dir("robots/<robot>/meshes", marker="<某>.STL")`。
+
 ## 架构说明
 
 - 资产解析模块：`src/unilab/assets/hub.py`（`resolve_motion_files`）。
@@ -82,3 +107,6 @@ env:
   `MotionLoader.__init__`，在冷路径上调用一次 resolver。
 - 热路径（`step` / `reset`）**不会**触发任何文件下载或解析。
 - `ASSETS_ROOT_PATH` 定义不变，下载落盘位置与原始本地路径完全一致。
+- 机器人网格使用同一目录 resolver（`resolve_robot_asset_dir`），集成点为
+  `src/unilab/envs/motion_tracking/x2/flip_tracking.py` 中的
+  `X2WallFlipTrackingEnv.__init__`，并通过 `unilab-pull-assets` CLI 暴露。

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -57,6 +57,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
 | PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
 | PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
+| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - |
 | PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | Tested |
@@ -77,6 +78,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | Configured |
 | PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | Configured |
 | PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | Configured |
+| PPO (mlx) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Configured | - |
 | PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand` (Sharpa in-hand) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Configured | Configured |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ unilab-viz-nan = "unilab.tools.viz_nan:main"
 unilab-export-scene = "unilab.tools.export_scene:main"
 unilab-render-teaser = "unilab.tools.render_teaser:main"
 unilab-import-robot = "unilab.tools.import_robot:main"
+unilab-pull-assets = "unilab.tools.pull_assets:main"
 
 [project.optional-dependencies]
 motrix = ["motrixsim-core==0.8.2"]

--- a/scripts/motion/replay_npz.py
+++ b/scripts/motion/replay_npz.py
@@ -16,6 +16,9 @@ Usage:
 
     # Slow-motion (0.5x speed)
     uv run scripts/motion/replay_npz.py --npz_file motion.npz --speed 0.5
+
+Controls:
+    Space: pause/resume
 """
 
 # pyright: reportAttributeAccessIssue=false, reportReturnType=false
@@ -33,8 +36,8 @@ from unilab.assets import ASSETS_ROOT_PATH
 
 def load_npz(npz_file: str) -> dict[str, np.ndarray]:
     """Load NPZ motion file and return arrays as a dict."""
-    data = np.load(npz_file)
-    return {
+    data = np.load(npz_file, allow_pickle=True)
+    motion = {
         "fps": int(data["fps"][0]),
         "joint_pos": data["joint_pos"],
         "joint_vel": data["joint_vel"],
@@ -43,6 +46,9 @@ def load_npz(npz_file: str) -> dict[str, np.ndarray]:
         "body_lin_vel_w": data["body_lin_vel_w"],
         "body_ang_vel_w": data["body_ang_vel_w"],
     }
+    if "joint_names" in data:
+        motion["joint_names"] = data["joint_names"]
+    return motion
 
 
 def default_model_path() -> str:
@@ -50,38 +56,57 @@ def default_model_path() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
 
 
-# G1 joint names matching csv_to_npz.py order
-G1_JOINT_NAMES = [
-    "left_hip_pitch_joint",
-    "left_hip_roll_joint",
-    "left_hip_yaw_joint",
-    "left_knee_joint",
-    "left_ankle_pitch_joint",
-    "left_ankle_roll_joint",
-    "right_hip_pitch_joint",
-    "right_hip_roll_joint",
-    "right_hip_yaw_joint",
-    "right_knee_joint",
-    "right_ankle_pitch_joint",
-    "right_ankle_roll_joint",
-    "waist_yaw_joint",
-    "waist_roll_joint",
-    "waist_pitch_joint",
-    "left_shoulder_pitch_joint",
-    "left_shoulder_roll_joint",
-    "left_shoulder_yaw_joint",
-    "left_elbow_joint",
-    "left_wrist_roll_joint",
-    "left_wrist_pitch_joint",
-    "left_wrist_yaw_joint",
-    "right_shoulder_pitch_joint",
-    "right_shoulder_roll_joint",
-    "right_shoulder_yaw_joint",
-    "right_elbow_joint",
-    "right_wrist_roll_joint",
-    "right_wrist_pitch_joint",
-    "right_wrist_yaw_joint",
-]
+def model_scalar_joint_names(model: mujoco.MjModel) -> list[str]:
+    """Return non-free scalar joints in MuJoCo qpos order."""
+    joints: list[tuple[int, str]] = []
+    for joint_id in range(model.njnt):
+        if model.jnt_type[joint_id] == mujoco.mjtJoint.mjJNT_FREE:
+            continue
+
+        qpos_adr = int(model.jnt_qposadr[joint_id])
+        qvel_adr = int(model.jnt_dofadr[joint_id])
+        next_qpos_adr = int(model.nq)
+        next_qvel_adr = int(model.nv)
+        for other_id in range(model.njnt):
+            other_qpos_adr = int(model.jnt_qposadr[other_id])
+            other_qvel_adr = int(model.jnt_dofadr[other_id])
+            if other_qpos_adr > qpos_adr:
+                next_qpos_adr = min(next_qpos_adr, other_qpos_adr)
+            if other_qvel_adr > qvel_adr:
+                next_qvel_adr = min(next_qvel_adr, other_qvel_adr)
+
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        if not name:
+            raise ValueError(f"Joint id {joint_id} has no name")
+        if next_qpos_adr - qpos_adr != 1 or next_qvel_adr - qvel_adr != 1:
+            raise ValueError(f"Joint '{name}' is not a scalar joint")
+        joints.append((qpos_adr, name))
+    return [name for _, name in sorted(joints)]
+
+
+def resolve_motion_joint_names(
+    motion: dict[str, np.ndarray],
+    model: mujoco.MjModel,
+    num_joints: int,
+) -> list[str]:
+    """Resolve the joint-name order used by joint_pos/joint_vel columns."""
+    if "joint_names" in motion:
+        names = [str(name) for name in motion["joint_names"].tolist()]
+        if len(names) != num_joints:
+            raise ValueError(
+                f"NPZ joint_names length ({len(names)}) does not match joint_pos width ({num_joints})"
+            )
+        print("Joint order: NPZ joint_names")
+        return names
+
+    names = model_scalar_joint_names(model)
+    if len(names) != num_joints:
+        raise ValueError(
+            "NPZ has no joint_names and joint_pos width does not match model scalar joints "
+            f"({num_joints} vs {len(names)})."
+        )
+    print("Joint order: model qpos order (NPZ has no joint_names)")
+    return names
 
 
 def replay(args):
@@ -103,21 +128,18 @@ def replay(args):
 
     model = mujoco.MjModel.from_xml_path(model_file)
     data = mujoco.MjData(model)
+    num_joints = joint_pos.shape[1]
+    joint_names = resolve_motion_joint_names(motion, model, num_joints)
 
     # Resolve joint qpos/qvel addresses
     joint_qpos_adr = []
     joint_qvel_adr = []
-    for name in G1_JOINT_NAMES:
+    for name in joint_names:
         jnt_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
         if jnt_id < 0:
-            print(f"Warning: joint '{name}' not found in model, skipping")
-            joint_qpos_adr.append(None)
-            joint_qvel_adr.append(None)
-        else:
-            joint_qpos_adr.append(model.jnt_qposadr[jnt_id])
-            joint_qvel_adr.append(model.jnt_dofadr[jnt_id])
-
-    num_joints = joint_pos.shape[1]
+            raise ValueError(f"Motion joint '{name}' is not found in model")
+        joint_qpos_adr.append(model.jnt_qposadr[jnt_id])
+        joint_qvel_adr.append(model.jnt_dofadr[jnt_id])
 
     def set_frame(frame_idx: int):
         """Set MuJoCo data to the given motion frame."""
@@ -134,26 +156,49 @@ def replay(args):
             pass
 
         # Set joint positions and velocities
-        for j in range(min(num_joints, len(G1_JOINT_NAMES))):
-            if joint_qpos_adr[j] is not None:
-                data.qpos[joint_qpos_adr[j]] = joint_pos[frame_idx, j]
-            if joint_qvel_adr[j] is not None:
-                data.qvel[joint_qvel_adr[j]] = joint_vel[frame_idx, j]
+        for j in range(num_joints):
+            data.qpos[joint_qpos_adr[j]] = joint_pos[frame_idx, j]
+            data.qvel[joint_qvel_adr[j]] = joint_vel[frame_idx, j]
 
         # Run forward kinematics (no dynamics) to update body positions for rendering
         mujoco.mj_forward(model, data)
 
+    paused = False
+    last_status = ""
+
+    def print_frame_status(frame_idx: int) -> None:
+        nonlocal last_status
+        status = "paused" if paused else "playing"
+        message = f"Frame: {frame_idx + 1}/{num_frames} ({status})"
+        if message != last_status:
+            print(f"\r{message}", end="", flush=True)
+            last_status = message
+
+    def on_key(keycode: int) -> None:
+        nonlocal last_status, paused
+        if keycode == ord(" "):
+            paused = not paused
+            print()
+            print(f"{'Paused' if paused else 'Resumed'} playback.")
+            last_status = ""
+
     print("Opening viewer — close window or press Esc to quit.")
+    print("Controls: Space=pause/resume")
     if args.loop:
         print("Looping enabled.")
 
-    with mujoco.viewer.launch_passive(model, data) as viewer:
+    with mujoco.viewer.launch_passive(model, data, key_callback=on_key) as viewer:
         frame = 0
         while viewer.is_running():
             t0 = time.perf_counter()
 
             set_frame(frame)
             viewer.sync()
+            print_frame_status(frame)
+
+            if paused:
+                time.sleep(0.05)
+                continue
 
             frame += 1
             if frame >= num_frames:
@@ -161,10 +206,10 @@ def replay(args):
                     frame = 0
                 else:
                     print("Playback finished.")
-                    # Keep viewer open at last frame
-                    while viewer.is_running():
-                        time.sleep(0.05)
-                    break
+                    frame = num_frames - 1
+                    paused = True
+                    print()
+                    last_status = ""
 
             # Real-time pacing adjusted by speed factor
             target_dt = dt / args.speed
@@ -172,6 +217,7 @@ def replay(args):
             if target_dt - elapsed > 0:
                 time.sleep(target_dt - elapsed)
 
+    print()
     print("Done.")
 
 

--- a/scripts/motion/x2_csv_to_tracking_npz.py
+++ b/scripts/motion/x2_csv_to_tracking_npz.py
@@ -1,0 +1,279 @@
+"""Convert an X2 root+joint CSV motion to UniLab motion-tracking NPZ format.
+
+The source CSV is expected to contain one frame per row:
+
+- root position xyz
+- root quaternion xyzw
+- 29 X2 joint positions, in MuJoCo joint order
+
+The output layout matches the existing X2 ``*_g1format.npz`` assets consumed by
+the shared humanoid motion-tracking loader.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
+from unilab.envs.common.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
+
+ROOT_QPOS_DIM = 7
+ROOT_QVEL_DIM = 6
+DEFAULT_INPUT = ASSETS_ROOT_PATH / "motions" / "x2" / "csv" / "shangxiaoche_5-28_15.csv"
+DEFAULT_OUTPUT = ASSETS_ROOT_PATH / "motions" / "x2" / "shangxiaoche_5-28_15_g1format.npz"
+DEFAULT_MODEL = ASSETS_ROOT_PATH / "robots" / "x2" / "x2_simple_collision.xml"
+
+
+def _quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
+    q1 = q1.astype(np.float64, copy=False)
+    q2 = q2.astype(np.float64, copy=False)
+    dot = float(np.dot(q1, q2))
+    if dot < 0.0:
+        q2 = -q2
+        dot = -dot
+    if dot > 0.9995:
+        result = q1 + t * (q2 - q1)
+        return (result / np.linalg.norm(result)).astype(np.float32)
+
+    theta = np.arccos(np.clip(dot, -1.0, 1.0))
+    sin_theta = np.sin(theta)
+    w1 = np.sin((1.0 - t) * theta) / sin_theta
+    w2 = np.sin(t * theta) / sin_theta
+    return (w1 * q1 + w2 * q2).astype(np.float32)
+
+
+def _load_csv_qpos(input_path: Path, model_nq: int) -> np.ndarray:
+    try:
+        raw = np.loadtxt(input_path, delimiter=",", dtype=np.float32)
+    except ValueError:
+        raw = np.loadtxt(input_path, delimiter=",", dtype=np.float32, skiprows=1)
+
+    if raw.ndim == 1:
+        raw = raw[None, :]
+    if raw.ndim != 2:
+        raise ValueError(f"Expected 2D CSV data, got shape {raw.shape}")
+    if raw.shape[1] != model_nq:
+        raise ValueError(f"Expected CSV width to match model nq={model_nq}, got {raw.shape[1]}")
+
+    qpos = raw.astype(np.float32, copy=True)
+    # Source CSV stores the root quaternion as xyzw; MuJoCo qpos uses wxyz.
+    qpos[:, 3:7] = raw[:, 3:7][:, [3, 0, 1, 2]]
+    qpos[:, 3:7] = np_quat_ensure_continuity(qpos[:, 3:7])
+    quat_norm = np.linalg.norm(qpos[:, 3:7], axis=1, keepdims=True)
+    if np.any(quat_norm <= 0.0):
+        raise ValueError("Root quaternion contains zero-norm entries")
+    qpos[:, 3:7] /= quat_norm
+    return qpos
+
+
+def _resample_qpos(qpos: np.ndarray, input_fps: int, output_fps: int) -> np.ndarray:
+    if input_fps <= 0 or output_fps <= 0:
+        raise ValueError(f"fps values must be positive, got {input_fps} -> {output_fps}")
+    if input_fps == output_fps:
+        return qpos.astype(np.float32, copy=True)
+    if qpos.shape[0] <= 1:
+        return qpos.astype(np.float32, copy=True)
+
+    duration = (qpos.shape[0] - 1) / float(input_fps)
+    output_times = np.arange(0.0, duration, 1.0 / float(output_fps), dtype=np.float32)
+    if output_times.size == 0:
+        return qpos[:1].astype(np.float32, copy=True)
+
+    source_phase = output_times * float(input_fps)
+    index_0 = np.floor(source_phase).astype(np.int32)
+    index_1 = np.minimum(index_0 + 1, qpos.shape[0] - 1)
+    blend = source_phase - index_0
+
+    out = np.empty((output_times.shape[0], qpos.shape[1]), dtype=np.float32)
+    out[:, :3] = qpos[index_0, :3] * (1.0 - blend[:, None]) + qpos[index_1, :3] * blend[:, None]
+    for frame, t in enumerate(blend):
+        out[frame, 3:7] = _quat_slerp(
+            qpos[index_0[frame], 3:7],
+            qpos[index_1[frame], 3:7],
+            float(t),
+        )
+    out[:, 7:] = qpos[index_0, 7:] * (1.0 - blend[:, None]) + qpos[index_1, 7:] * blend[:, None]
+    out[:, 3:7] = np_quat_ensure_continuity(out[:, 3:7])
+    return out
+
+
+def _qvel_from_qpos(qpos: np.ndarray, fps: int) -> np.ndarray:
+    dt = 1.0 / float(fps)
+    qvel = np.empty((qpos.shape[0], qpos.shape[1] - 1), dtype=np.float32)
+    qvel[:, :3] = np.gradient(qpos[:, :3], dt, axis=0).astype(np.float32)
+    qvel[:, 3:6] = np_quat_angular_velocity(qpos[:, 3:7], dt).astype(np.float32)
+    qvel[:, 6:] = np.gradient(qpos[:, 7:], dt, axis=0).astype(np.float32)
+    return qvel
+
+
+def _target_joint_names(model: mujoco.MjModel) -> list[str]:
+    names: list[str] = []
+    for joint_id in range(model.njnt):
+        if model.jnt_type[joint_id] == mujoco.mjtJoint.mjJNT_FREE:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        if not name:
+            raise ValueError(f"Joint id {joint_id} has no name")
+        names.append(name)
+    return names
+
+
+def _sensor_addresses(model: mujoco.MjModel) -> np.ndarray:
+    sensor_adrs = np.full((model.nbody, 4), -1, dtype=np.int32)
+    prefixes = (
+        "track_pos_w_",
+        "track_quat_w_",
+        "track_linvel_w_",
+        "track_angvel_w_",
+    )
+    for body_id in range(model.nbody):
+        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+        if not body_name:
+            continue
+        for slot, prefix in enumerate(prefixes):
+            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, prefix + body_name)
+            if sensor_id >= 0:
+                sensor_adrs[body_id, slot] = int(model.sensor_adr[sensor_id])
+    return sensor_adrs
+
+
+def _export_body_arrays(
+    model: mujoco.MjModel,
+    qpos: np.ndarray,
+    qvel: np.ndarray,
+    target_joint_names: list[str],
+) -> dict[str, np.ndarray]:
+    data = mujoco.MjData(model)
+    frames = qpos.shape[0]
+    body_pos_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
+    body_quat_w = np.zeros((frames, model.nbody, 4), dtype=np.float32)
+    body_lin_vel_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
+    body_ang_vel_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
+    sensor_adrs = _sensor_addresses(model)
+
+    joint_ids = [
+        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name) for name in target_joint_names
+    ]
+    if any(joint_id < 0 for joint_id in joint_ids):
+        raise ValueError("Target joint list contains joints not found in model")
+
+    for frame in range(frames):
+        data.qpos[:] = qpos[frame]
+        data.qvel[:] = qvel[frame]
+        mujoco.mj_forward(model, data)
+
+        for body_id in range(model.nbody):
+            pos_adr, quat_adr, lin_adr, ang_adr = sensor_adrs[body_id]
+            if pos_adr >= 0:
+                body_pos_w[frame, body_id] = data.sensordata[pos_adr : pos_adr + 3]
+            else:
+                body_pos_w[frame, body_id] = data.xpos[body_id]
+
+            if quat_adr >= 0:
+                body_quat_w[frame, body_id] = data.sensordata[quat_adr : quat_adr + 4]
+            else:
+                body_quat_w[frame, body_id] = data.xquat[body_id]
+
+            if lin_adr >= 0:
+                body_lin_vel_w[frame, body_id] = data.sensordata[lin_adr : lin_adr + 3]
+            if ang_adr >= 0:
+                body_ang_vel_w[frame, body_id] = data.sensordata[ang_adr : ang_adr + 3]
+
+    return {
+        "body_pos_w": body_pos_w,
+        "body_quat_w": body_quat_w,
+        "body_lin_vel_w": body_lin_vel_w,
+        "body_ang_vel_w": body_ang_vel_w,
+    }
+
+
+def convert_csv(
+    input_path: Path,
+    output_path: Path,
+    model_file: Path,
+    input_fps: int,
+    output_fps: int,
+    dry_run: bool,
+) -> None:
+    tmp_model_path, _, _ = inject_mujoco_tracking_sensors(str(model_file))
+    try:
+        model = mujoco.MjModel.from_xml_path(tmp_model_path)
+    finally:
+        Path(tmp_model_path).unlink(missing_ok=True)
+
+    target_names = _target_joint_names(model)
+    qpos_input = _load_csv_qpos(input_path, model.nq)
+    qpos = _resample_qpos(qpos_input, input_fps, output_fps)
+    qvel = _qvel_from_qpos(qpos, output_fps)
+    joint_pos = qpos[:, ROOT_QPOS_DIM:].astype(np.float32)
+    joint_vel = qvel[:, ROOT_QVEL_DIM:].astype(np.float32)
+
+    if joint_pos.shape[1] != len(target_names):
+        raise ValueError(
+            f"CSV joint count {joint_pos.shape[1]} does not match model joints {len(target_names)}"
+        )
+
+    print(f"Source : {input_path}")
+    print(f"Model  : {model_file}")
+    print(f"Output : {output_path}")
+    print(f"frames : {qpos_input.shape[0]} -> {qpos.shape[0]}")
+    print(f"fps    : {input_fps} -> {output_fps}")
+    print(f"joints : {joint_pos.shape[1]}")
+    print(f"bodies : {model.nbody} (MuJoCo body-id layout, including world)")
+
+    if dry_run:
+        print("[dry-run] Validation passed. No output written.")
+        return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    body_arrays = _export_body_arrays(model, qpos, qvel, target_names)
+    np.savez(
+        output_path,
+        fps=np.array([output_fps], dtype=np.int32),
+        joint_pos=joint_pos,
+        joint_vel=joint_vel,
+        **body_arrays,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert an X2 root+joint CSV to UniLab motion-tracking NPZ format."
+    )
+    parser.add_argument("--input", default=str(DEFAULT_INPUT), help="Source X2 CSV path")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="Output NPZ path")
+    parser.add_argument(
+        "--model-file",
+        default=str(DEFAULT_MODEL),
+        help="Target MuJoCo XML used to regenerate body_* arrays",
+    )
+    parser.add_argument("--input-fps", type=int, default=30, help="Source CSV FPS")
+    parser.add_argument("--output-fps", type=int, default=50, help="Output NPZ FPS")
+    parser.add_argument("--dry-run", action="store_true", help="Validate without writing output")
+    args = parser.parse_args()
+
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+    model_file = Path(args.model_file).expanduser().resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input CSV not found: {input_path}")
+    if not model_file.exists():
+        raise FileNotFoundError(f"Model file not found: {model_file}")
+
+    convert_csv(
+        input_path=input_path,
+        output_path=output_path,
+        model_file=model_file,
+        input_fps=args.input_fps,
+        output_fps=args.output_fps,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -24,6 +24,7 @@ _HF_MOTIONS_REPO_ID = "unilabsim/unilab-motions"
 _HF_CACHES_REPO_ID = "unilabsim/unilab-caches"
 _HF_SCENES_REPO_ID = "unilabsim/unilab-scenes"
 _HF_CHECKPOINTS_REPO_ID = "unilabsim/unilab-checkpoints"
+_HF_ROBOTS_REPO_ID = "unilabsim/unilab-robots"
 _HF_REPO_TYPE = "dataset"
 _HF_OFFICIAL_ENDPOINT = "https://huggingface.co"
 
@@ -190,12 +191,16 @@ def _snapshot_download(snapshot_download_fn, directory: str, *, repo_id: str) ->
     )
 
 
-def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
-    """Ensure a scene directory exists locally, downloading from HF if needed.
+def _resolve_snapshot_dir(directory: str, *, repo_id: str, marker: str) -> Path:
+    """Ensure an HF-hosted directory exists locally, downloading if needed.
+
+    If the current ``HF_ENDPOINT`` (e.g. a mirror) fails, automatically
+    retries with the official ``https://huggingface.co`` endpoint.
 
     Args:
         directory: ``ASSETS_ROOT_PATH``-relative directory path
-            (e.g. ``"scenes/teaser"``).
+            (e.g. ``"scenes/teaser"`` or ``"robots/x2/meshes"``).
+        repo_id: HF dataset repo to pull from.
         marker: A file inside the directory used to check completeness.
 
     Returns:
@@ -209,14 +214,13 @@ def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
         from huggingface_hub import snapshot_download
     except ImportError:
         raise ImportError(
-            f"Scene directory '{directory}' not found locally. "
+            f"Asset directory '{directory}' not found locally. "
             "Install huggingface_hub to enable automatic downloading:\n"
             "  uv sync\n"
             "Or:\n"
             "  uv pip install huggingface_hub"
         ) from None
 
-    repo_id = _HF_SCENES_REPO_ID
     logger.info("Downloading %s from HF repo %s ...", directory, repo_id)
 
     try:
@@ -238,5 +242,39 @@ def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
         else:
             raise
 
-    logger.info("Downloaded scene directory to %s", target)
+    logger.info("Downloaded directory to %s", target)
     return target
+
+
+def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
+    """Ensure a scene directory exists locally, downloading from HF if needed.
+
+    Args:
+        directory: ``ASSETS_ROOT_PATH``-relative directory path
+            (e.g. ``"scenes/teaser"``).
+        marker: A file inside the directory used to check completeness.
+
+    Returns:
+        Absolute ``Path`` to the resolved directory.
+    """
+    return _resolve_snapshot_dir(directory, repo_id=_HF_SCENES_REPO_ID, marker=marker)
+
+
+def resolve_robot_asset_dir(directory: str, *, marker: str) -> Path:
+    """Ensure a robot asset directory (e.g. meshes) exists locally.
+
+    Robot binary assets (STL meshes) are hosted on Hugging Face rather than
+    committed to git. They are downloaded on first use and placed under their
+    original path beneath ``ASSETS_ROOT_PATH`` so that XML ``meshdir``
+    references resolve unchanged — no files need to be moved by hand.
+
+    Args:
+        directory: ``ASSETS_ROOT_PATH``-relative directory path
+            (e.g. ``"robots/x2/meshes"``).
+        marker: A file inside the directory used to check completeness
+            (e.g. ``"pelvis.STL"``).
+
+    Returns:
+        Absolute ``Path`` to the resolved directory.
+    """
+    return _resolve_snapshot_dir(directory, repo_id=_HF_ROBOTS_REPO_ID, marker=marker)

--- a/src/unilab/assets/robots/x2/scene_flat.xml
+++ b/src/unilab/assets/robots/x2/scene_flat.xml
@@ -1,0 +1,35 @@
+<mujoco model="x2 simple collision flat scene">
+  <include file="x2_simple_collision.xml"/>
+
+  <statistic center="0 0 0.75" extent="1.2"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="140" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" friction="1.0 0.005 0.0001"/>
+  </worldbody>
+
+  <keyframe>
+    <key name="home"
+      qpos="
+      0 0 0.68
+      1 0 0 0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      0.0 0.0 0.0
+      0.2 0.2 0.0 -0.3 0.0 0.0 0.0
+      0.2 -0.2 0.0 -0.3 0.0 0.0 0.0
+      "/>
+  </keyframe>
+</mujoco>

--- a/src/unilab/assets/robots/x2/scene_flat_with_wall.xml
+++ b/src/unilab/assets/robots/x2/scene_flat_with_wall.xml
@@ -1,0 +1,54 @@
+<mujoco model="x2 simple collision flat scene with wall">
+  <include file="x2_simple_collision.xml"/>
+
+  <statistic center="0 0 0.75" extent="1.2"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="140" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+    <material name="wall_material" rgba="0.7 0.4 0.3 1"/>
+  </asset>
+
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" friction="1.0 0.005 0.0001"/>
+    <!--
+      X2 tictacflip reaches toward negative Y. The wall center is placed just
+      beyond the first clip's furthest ankle-roll Y position (-2.014m), matching
+      the G1 wall-flip convention of putting the wall center about 0.02m past
+      the reference foot reach.
+    -->
+    <body name="wall" pos="0 -2.135 1.0" euler="0.0 0.0 1.5708">
+      <geom
+        name="wall_collision"
+        type="box"
+        size="0.05 1.0 1.0"
+        material="wall_material"
+        contype="1"
+        conaffinity="1"
+        friction="1.0 0.1 0.1"
+        rgba="0.7 0.4 0.3 1"
+      />
+    </body>
+  </worldbody>
+
+  <keyframe>
+    <key name="home"
+      qpos="
+      0 0 0.68
+      1 0 0 0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      0.0 0.0 0.0
+      0.2 0.2 0.0 -0.3 0.0 0.0 0.0
+      0.2 -0.2 0.0 -0.3 0.0 0.0 0.0
+      "/>
+  </keyframe>
+</mujoco>

--- a/src/unilab/assets/robots/x2/scene_flat_with_wall_visual.xml
+++ b/src/unilab/assets/robots/x2/scene_flat_with_wall_visual.xml
@@ -1,0 +1,51 @@
+<mujoco model="x2 simple collision flat scene with wall (render-only visual twin)">
+  <include file="x2_simple_collision.xml"/>
+
+  <statistic center="0 0 0.75" extent="1.2"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="140" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+    <material name="wall_material" rgba="0.7 0.4 0.3 1"/>
+  </asset>
+
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" friction="1.0 0.005 0.0001"/>
+    <!--
+      RENDER-ONLY visual twin of scene_flat_with_wall.xml.
+
+      The wall is declared as a worldbody geom (not a <body>) so the offline grid
+      renderer (unilab.visualization.render_many) treats it as a static terrain
+      geom and replicates one copy under every env cell. This file is never
+      stepped: physics/collision are driven by scene_flat_with_wall.xml, which
+      keeps the wall as a <body> (the checkpoint-trained collision model). The
+      wall pose/size below MUST mirror that body exactly:
+        body pos="0 -2.135 1.0" euler="0 0 1.5708" + geom size="0.05 1.0 1.0"
+      contype/conaffinity are 0 to make it explicit this geom never collides.
+    -->
+    <geom name="wall_collision" type="box" pos="0 -2.135 1.0" euler="0.0 0.0 1.5708"
+      size="0.05 1.0 1.0" material="wall_material" contype="0" conaffinity="0"
+      rgba="0.7 0.4 0.3 1"/>
+  </worldbody>
+
+  <keyframe>
+    <key name="home"
+      qpos="
+      0 0 0.68
+      1 0 0 0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      -0.312 0.0 0.0 0.669 -0.363 0.0
+      0.0 0.0 0.0
+      0.2 0.2 0.0 -0.3 0.0 0.0 0.0
+      0.2 -0.2 0.0 -0.3 0.0 0.0 0.0
+      "/>
+  </keyframe>
+</mujoco>

--- a/src/unilab/assets/robots/x2/x2_simple_collision.xml
+++ b/src/unilab/assets/robots/x2/x2_simple_collision.xml
@@ -11,7 +11,7 @@
               <geom group="2" type="mesh" contype="0" conaffinity="0" density="0" />
           </default>
           <default class="collision">
-              <geom group="3" type="mesh" condim="3" solref="0.02 1.0" solimp="0.9 0.95 0.001" />
+              <geom group="3" type="mesh" />
               <default class="foot">
                   <geom type="sphere" size="0.005" />
               </default>
@@ -95,13 +95,13 @@
                   <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949" />
                   <joint name="left_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.262 0.262" actuatorfrcrange="-24 24" />
                   <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="left_ankle_roll_link" />
-                  <geom name="left_foot1_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot2_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot3_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot4_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot5_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot6_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="left_foot7_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
                 </body>
               </body>
             </body>
@@ -137,13 +137,13 @@
                   <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949" />
                   <joint name="right_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.2625 0.2625" actuatorfrcrange="-24 24" />
                   <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="right_ankle_roll_link" />
-                  <geom name="right_foot1_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot2_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot3_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot4_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot5_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot6_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
-                  <geom name="right_foot7_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
               </body>
             </body>
           </body>
@@ -280,12 +280,6 @@
       </body>
     </body>
   </worldbody>
-  <contact>
-    <exclude body1="pelvis" body2="left_hip_roll_link" />
-    <exclude body1="pelvis" body2="right_hip_roll_link" />
-    <exclude body1="left_wrist_yaw_link" body2="left_wrist_roll_link" />
-    <exclude body1="right_wrist_yaw_link" body2="right_wrist_roll_link" />
-  </contact>
   <actuator>
     <position class="x2" kp="120" kv="5" forcerange="-120 120" name="left_hip_pitch_joint" joint="left_hip_pitch_joint" />
     <position class="x2" kp="100" kv="4" forcerange="-120 120" name="left_hip_roll_joint" joint="left_hip_roll_joint" />
@@ -329,14 +323,8 @@
     <framequat name="body-orientation" objtype="site" objname="imu_0" noise="0" />
     <gyro name="body-angular-velocity" site="imu_0" noise="0.001" />
     <framepos name="body-linear-pos" objtype="site" objname="imu_0" />
-    <velocimeter name="body-linear-vel" site="imu_0" noise="0.001" />
+    <velocimeter name="body-linear-vel" site="imu_0" />
     <accelerometer name="body-linear-acceleration" site="imu_0" noise="0.001" />
-
-    <framequat name="chest-orientation" objtype="site" objname="imu_1" noise="0"/>
-    <gyro name="chest-angular-velocity" site="imu_1" noise="0.001"/>
-    <framepos name="chest-linear-pos" objtype="site" objname="imu_1"/>
-    <velocimeter name="chest-linear-vel" site="imu_1" noise="0.001"/>
-    <accelerometer name="chest-linear-acceleration" site="imu_1" noise="0.001"/>
     
     <jointpos name="jointpos_left_hip_pitch_joint" joint="left_hip_pitch_joint" noise="0" />
     <jointpos name="jointpos_left_hip_roll_joint" joint="left_hip_roll_joint" noise="0" />

--- a/src/unilab/assets/robots/x2/x2_simple_collision.xml
+++ b/src/unilab/assets/robots/x2/x2_simple_collision.xml
@@ -1,0 +1,406 @@
+<mujoco model="x2_simple_collision">
+  <compiler angle="radian" eulerseq="XYZ" meshdir="./meshes" autolimits="true" />
+
+  <option timestep="0.001" />
+
+  <default>
+      <default class="x2">
+          <site rgba="1 0 0 1" size="0.01" group="5" />
+          <joint damping="0.0" armature="0.03" frictionloss="0.3" />
+          <default class="visual">
+              <geom group="2" type="mesh" contype="0" conaffinity="0" density="0" />
+          </default>
+          <default class="collision">
+              <geom group="3" type="mesh" condim="3" solref="0.02 1.0" solimp="0.9 0.95 0.001" />
+              <default class="foot">
+                  <geom type="sphere" size="0.005" />
+              </default>
+          </default>
+      </default>
+  </default>
+  <asset>
+    <mesh name="pelvis" file="pelvis.STL" />
+    <mesh name="imu_in_pelvis_link" file="imu_in_pelvis_link.STL" />
+    <mesh name="left_hip_pitch_link" file="left_hip_pitch_link.STL" />
+    <mesh name="left_hip_roll_link" file="left_hip_roll_link.STL" />
+    <mesh name="col_left_hip_roll_link" file="left_hip_roll_link.STL" scale="1.0 0.9 1.0" />
+    <mesh name="left_hip_yaw_link" file="left_hip_yaw_link.STL" />
+    <mesh name="left_knee_link" file="left_knee_link.STL" />
+    <mesh name="left_ankle_pitch_link" file="left_ankle_pitch_link.STL" />
+    <mesh name="left_ankle_roll_link" file="left_ankle_roll_link.STL" />
+    <mesh name="right_hip_pitch_link" file="right_hip_pitch_link.STL" />
+    <mesh name="right_hip_roll_link" file="right_hip_roll_link.STL" />
+    <mesh name="col_right_hip_roll_link" file="right_hip_roll_link.STL" scale="1.0 0.9 1.0" />
+    <mesh name="right_hip_yaw_link" file="right_hip_yaw_link.STL" />
+    <mesh name="right_knee_link" file="right_knee_link.STL" />
+    <mesh name="right_ankle_pitch_link" file="right_ankle_pitch_link.STL" />
+    <mesh name="right_ankle_roll_link" file="right_ankle_roll_link.STL" />
+    <mesh name="waist_yaw_link" file="waist_yaw_link.STL" />
+    <mesh name="waist_pitch_link" file="waist_pitch_link.STL" />
+    <mesh name="torso_link" file="torso_plus_link.STL" />
+    <mesh name="imu_in_torso_link" file="imu_in_torso_link.STL" />
+    <mesh name="left_shoulder_pitch_link" file="left_shoulder_pitch_link.STL" />
+    <mesh name="left_shoulder_roll_link" file="left_shoulder_roll_link.STL" />
+    <mesh name="left_shoulder_yaw_link" file="left_shoulder_yaw_link.STL" />
+    <mesh name="left_elbow_link" file="left_elbow_link.STL" />
+    <mesh name="left_wrist_yaw_link" file="left_wrist_yaw_link.STL" />
+    <mesh name="left_wrist_pitch_link" file="left_wrist_pitch_link.STL" />
+    <mesh name="left_wrist_roll_link" file="left_wrist_roll_link.STL" />
+    <mesh name="right_shoulder_pitch_link" file="right_shoulder_pitch_link.STL" />
+    <mesh name="right_shoulder_roll_link" file="right_shoulder_roll_link.STL" />
+    <mesh name="right_shoulder_yaw_link" file="right_shoulder_yaw_link.STL" />
+    <mesh name="right_elbow_link" file="right_elbow_link.STL" />
+    <mesh name="right_wrist_yaw_link" file="right_wrist_yaw_link.STL" />
+    <mesh name="right_wrist_pitch_link" file="right_wrist_pitch_link.STL" />
+    <mesh name="right_wrist_roll_link" file="right_wrist_roll_link.STL" />
+    <mesh name="head_yaw_link" file="head_yaw_link.STL" />
+    <mesh name="head_pitch_link" file="head_pitch_link.STL" />
+    <mesh name="imu_in_head_link" file="imu_in_head_link.STL" />
+    
+  </asset>
+
+  <worldbody>
+    <body name="pelvis" pos="0 0 0.68" euler="0 0 0" childclass="x2">
+      <freejoint name="floating_base_joint" />
+      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="pelvis" />
+      <geom class="collision" type="capsule" size="0.0702502" fromto="-0.0054424 -0.0156308 0.00130353 -0.0054424 0.0156308 0.00130353" rgba="0 1 0 0.3" />
+      <geom class="visual" pos="0.0239465 -0.000228682 0.04171" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="imu_in_pelvis_link" />
+      <site name="imu_0" pos="0.0239465 -0.000228682 0.04171" group="3" />
+      <body name="left_hip_pitch_link" pos="0 0.07135 0">
+        <inertial pos="0.00791 0.064136 0.000116" quat="0.70601 0.705897 0.0403038 0.0404307" mass="1.39968" diaginertia="0.00807979 0.007409 0.00155421" />
+        <joint name="left_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.704 2.556" actuatorfrcrange="-120 120" />
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_hip_pitch_link" />
+        <geom class="collision" type="capsule" size="0.0618209" fromto="-0.002075 0.0618209 0 -0.002075 0.0656842 0" rgba="0 1 0 0.3" group="3" />
+        <body name="left_hip_roll_link" pos="-0.000575 0.0657 0">
+          <inertial pos="4.7e-05 0.000231 -0.093505" quat="0.703892 0.00104942 0.00203424 0.710303" mass="1.5848" diaginertia="0.0181021 0.0176713 0.00251468" />
+          <joint name="left_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.235 2.906" actuatorfrcrange="-120 120" />
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_hip_roll_link" />
+          <geom class="collision" type="capsule" size="0.0640003" fromto="0.0005747 2.03345e-06 -0.0834933 0.0005747 2.03345e-06 -0.0149939" rgba="0 1 0 0.3" />
+          <body name="left_hip_yaw_link" pos="0.000575 0 -0.13685">
+            <inertial pos="-0.002375 0.003914 -0.144276" quat="0.647266 -0.0202222 0.00175224 0.761994" mass="2.01055" diaginertia="0.0526993 0.0519961 0.0023845" />
+            <joint name="left_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-1.684 3.43" actuatorfrcrange="-120 120" />
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_hip_yaw_link" />
+            <geom class="collision" type="capsule" size="0.0676597" fromto="-0.00565975 0 -0.180803 -0.00565975 0 -0.068803" rgba="0 1 0 0.3" />
+            <body name="left_knee_link" pos="-0.00766 0.000225 -0.1831">
+              <inertial pos="-0.002655 0.003681 -0.122697" quat="0.437302 -0.00633388 0.00636434 0.89927" mass="1.56821" diaginertia="0.031041 0.0309424 0.00193262" />
+              <joint name="left_knee_joint" pos="0 0 0" axis="0 1 0" range="0 2.4073" actuatorfrcrange="-120 120" />
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_knee_link" />
+              <geom class="collision" type="capsule" size="0.0601612" fromto="0.0027895 -0.000225056 -0.242764 0.0027895 -0.000225056 -0.0082765" rgba="0 1 0 0.3" />
+              <body name="left_ankle_pitch_link" pos="-0.01 -0.000124911 -0.282">
+                <inertial pos="0.011691 -0.000181 0.003548" quat="0.72346 -0.0457688 0.0674454 0.685537" mass="0.747802" diaginertia="0.00117429 0.000984841 0.000709871" />
+                <joint name="left_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.803 0.453" actuatorfrcrange="-36 36" />
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_ankle_pitch_link" />
+                <geom class="collision" type="capsule" size="0.0343" fromto="-0.0068 0 9.51812e-07 0.0045 0 9.51812e-07" rgba="0 1 0 0.3" />
+                <body name="left_ankle_roll_link" pos="-0.00175 0 0">
+                  <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949" />
+                  <joint name="left_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.262 0.262" actuatorfrcrange="-24 24" />
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="left_ankle_roll_link" />
+                  <geom name="left_foot1_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot2_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot3_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot4_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot5_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot6_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="left_foot7_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="right_hip_pitch_link" pos="0 -0.07135 0">
+        <inertial pos="0.007909 -0.064114 0.000131" quat="0.705894 0.706007 -0.0404833 -0.0403565" mass="1.40023" diaginertia="0.00808102 0.007409 0.00155498" />
+        <joint name="right_hip_pitch_joint" pos="0 0 0" axis="0 1 0" range="-2.704 2.556" actuatorfrcrange="-120 120" />
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_hip_pitch_link" />
+        <geom class="collision" type="capsule" size="0.0618209" fromto="-0.00246997 -0.0656842 0 -0.00246997 -0.0618209 0" rgba="0 1 0 0.3" />
+        <body name="right_hip_roll_link" pos="0 -0.0657 0">
+          <inertial pos="-0.000586 -0.000228 -0.093568" quat="0.710476 -8.90189e-06 -0.00101098 0.703721" mass="1.58508" diaginertia="0.0181161 0.017694 0.00251594" />
+          <joint name="right_hip_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.906 0.235" actuatorfrcrange="-120 120" />
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_hip_roll_link" />
+          <geom class="collision" type="capsule" size="0.0640003" fromto="0 -1.93957e-06 -0.0834934 0 -1.93957e-06 -0.0149938" rgba="0 1 0 0.3" />
+          <body name="right_hip_yaw_link" pos="0 0 -0.13685">
+            <inertial pos="-0.002444 -0.003935 -0.144335" quat="0.762367 0.00171388 -0.0204012 0.646821" mass="2.00262" diaginertia="0.0525579 0.0518558 0.0023773" />
+            <joint name="right_hip_yaw_joint" pos="0 0 0" axis="0 0 1" range="-3.43 1.684" actuatorfrcrange="-120 120" />
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_hip_yaw_link" />
+            <geom class="collision" type="capsule" size="0.0676597" fromto="-0.00565975 0 -0.180803 -0.00565975 0 -0.068803" rgba="0 1 0 0.3" />
+            <body name="right_knee_link" pos="-0.00766 -0.000225 -0.1831">
+              <inertial pos="-0.002699 -0.003794 -0.122288" quat="0.90334 0.0065752 -0.00663139 0.428824" mass="1.56588" diaginertia="0.0308703 0.0307718 0.00192491" />
+              <joint name="right_knee_joint" pos="0 0 0" axis="0 1 0" range="0 2.4073" actuatorfrcrange="-120 120" />
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_knee_link" />
+              <geom class="collision" type="capsule" size="0.0601612" fromto="0.0027895 0.000225246 -0.242764 0.0027895 0.000225246 -0.0082765" rgba="0 1 0 0.3" />
+              <body name="right_ankle_pitch_link" pos="-0.01 0.000124911 -0.282">
+                <inertial pos="0.011665 0.000937 0.00394" quat="0.7183 0.0624712 -0.034146 0.692081" mass="0.749566" diaginertia="0.00122381 0.00103716 0.000713034" />
+                <joint name="right_ankle_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.803 0.453" actuatorfrcrange="-36 36" />
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_ankle_pitch_link" />
+                <geom class="collision" type="capsule" size="0.0343" fromto="-0.0068 0 9.51812e-07 0.0045 0 9.51812e-07" rgba="0 1 0 0.3" />
+                <body name="right_ankle_roll_link" pos="-0.00175 0 0">
+                  <inertial pos="0.035428 2.5e-05 -0.049572" quat="0.614657 0.350346 0.350824 0.613496" mass="1.01617" diaginertia="0.007937 0.0068711 0.0025949" />
+                  <joint name="right_ankle_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.2625 0.2625" actuatorfrcrange="-24 24" />
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 0.5 0 1" mesh="right_ankle_roll_link" />
+                  <geom name="right_foot1_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 -0.05 -0.063 0.115 -0.05 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot2_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 -0.0375 -0.063 0.133 -0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot3_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 -0.02 -0.063 0.137 -0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot4_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.062 0 -0.063 0.138 0 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot5_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.061 0.02 -0.063 0.137 0.02 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot6_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.057 0.0375 -0.063 0.133 0.0375 -0.063" rgba="0 1 0 0.3"/>
+                  <geom name="right_foot7_collision" class="collision" type="capsule" group="3" size="0.01" fromto="-0.040 0.05 -0.063 0.115 0.05 -0.063" rgba="0 1 0 0.3"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      </body>
+      <body name="waist_yaw_link" pos="0 0 0.06706">
+        <inertial pos="-0.001359 4.7e-05 0.041703" quat="0.99876 0.000921559 0.0477625 0.0140034" mass="1.66854" diaginertia="0.00503206 0.00499998 0.00283196" />
+        <joint name="waist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-3.43 2.382" actuatorfrcrange="-120 120" />
+        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="waist_yaw_link" />
+        <geom class="collision" type="capsule" size="0.050" fromto="-0.040 0 0.040 0.040 0 0.040" rgba="0 1 0 0.3" />
+        
+        <body name="waist_pitch_link" pos="0 0 0.0880106">
+          <inertial pos="0.008967 -1e-06 0" quat="0.5 0.5 -0.5 0.5" mass="0.392413" diaginertia="0.00023 0.000133 0.000133" />
+          <joint name="waist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.314 0.314" actuatorfrcrange="-48 48" />
+          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="waist_pitch_link" />
+          <geom class="collision" type="capsule" size="0.038" fromto="-0.020 0 0 0.030 0 0" rgba="0 1 0 0.3" />
+          
+          <body name="torso_link">
+          <inertial pos="-0.000188 0.000605 0.191827" quat="0.999959 0.00110321 0.0081892 0.00362262" mass="10.1441" diaginertia="0.479863 0.455999 0.0666413" />
+            <joint name="waist_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.488 0.488" actuatorfrcrange="-48 48" />
+            <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="torso_link" />
+            <geom class="collision" type="capsule" size="0.115" fromto="-0.010 0 0.132 -0.010 0 0.212" rgba="0 1 0 0.3" />
+            <geom class="collision" type="capsule" size="0.023" fromto="-0.15 -0.04 0.325 -0.15 0.04 0.325" rgba="0 1 0 0.3" />
+            <!-- <geom class="collision" type="capsule" size="0.026" fromto="-0.125 0.060 0.305 -0.125 0.060 0.335" rgba="1 1 1 1" /> -->
+            <site name="imu_1" pos="-0.0248787 0.00198528 0.105938" group="3" />
+            <geom class="visual" pos="-0.0248787 0.00198528 0.105938" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.647059 0.619608 0.588235 1" mesh="imu_in_torso_link" />
+            <body name="left_shoulder_pitch_link" pos="0.00329907 0.143032 0.241648" quat="0.994522 0.104528 0 0">
+              <inertial pos="0.003007 0.050014 6.2e-05" quat="0.707145 0.706403 0.027325 0.0139105" mass="0.885896" diaginertia="0.00303104 0.00292896 0.000676999" />
+              <joint name="left_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.08 2.04" actuatorfrcrange="-36 36" />
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="left_shoulder_pitch_link" />
+              <geom class="collision" type="capsule" size="0.0451779" fromto="-0.00162681 0.045178 1.19526e-05 -0.00162681 0.0494221 1.19526e-05" rgba="0 1 0 0.3" />
+              <body name="left_shoulder_roll_link" pos="-0.000499991 0.0495 0">
+                <inertial pos="0.000621 -0.000183 -0.078842" quat="0.706401 0.00587444 0.00386922 0.707777" mass="0.706556" diaginertia="0.00549904 0.00540092 0.000539037" />
+                <joint name="left_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.061 2.993" actuatorfrcrange="-36 36" />
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_shoulder_roll_link" />
+                <geom class="collision" type="capsule" size="0.0524444" fromto="0.0004453 -6.74278e-07 -0.0771634 0.0004453 -6.74278e-07 -0.0097262" rgba="0 1 0 0.3" />
+                <body name="left_shoulder_yaw_link" pos="0.00122424 0 -0.121195" quat="0.999996 0 -0.00298782 0">
+                  <inertial pos="0.010005 0.000179 -0.069477" quat="0.996444 0.00144278 0.0782236 0.0312643" mass="0.704662" diaginertia="0.00438693 0.00436694 0.00044713" />
+                  <joint name="left_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24" />
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_shoulder_yaw_link" />
+                  <geom class="collision" type="capsule" size="0.0451555" fromto="0.00310745 -1.09896e-06 -0.0752051 0.00310745 -1.09896e-06 -0.0251553" rgba="0 1 0 0.3" />
+                  <body name="left_elbow_link" pos="0.014 0.000199986 -0.08295" quat="0.999996 0 0.00298782 0">
+                    <inertial pos="-0.013174 0.003788 -0.080203" quat="0.970867 0.0083727 -0.0764035 -0.226955" mass="0.688008" diaginertia="0.0054008 0.00531735 0.000446844" />
+                    <joint name="left_elbow_joint" pos="0 0 0" axis="0 1 0" range="-2.3556 0" actuatorfrcrange="-24 24" />
+                    <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_elbow_link" />
+                    <geom class="collision" type="capsule" size="0.0423332" fromto="-0.0130287 0.00213197 -0.0832989 -0.0130287 0.00213197 -0.0148127" rgba="0 1 0 0.3" />
+                    <body name="left_wrist_yaw_link" pos="-0.0132797 -9.75488e-05 -0.120576">
+                      <inertial pos="7.6e-05 0.007263 -0.030679" quat="0.992384 -0.122507 -0.00213896 -0.0126728" mass="0.360708" diaginertia="0.000612057 0.000527003 0.00018794" />
+                      <joint name="left_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24" />
+                      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="left_wrist_yaw_link" />
+                      <geom class="collision" type="capsule" size="0.032" fromto="0 0 -0.047 0 0 -0.023" rgba="0 1 0 0.3" />
+                      
+                      <body name="left_wrist_pitch_link" pos="0.000490001 0 -0.0819985" quat="0.999996 0 -0.00298783 0">
+                        <inertial pos="0.011479 0.002282 0.001703" quat="0.258763 0.693211 0.202262 0.641553" mass="0.292062" diaginertia="0.000178433 0.000138482 9.10855e-05" />
+                        <joint name="left_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.558 0.558" actuatorfrcrange="-4.8 4.8" />
+                        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.3 0.3 0.3 1" mesh="left_wrist_pitch_link" />
+                        <geom class="collision" type="capsule" size="0.029" fromto="-0.0065 -0.0015 -0.00124581 0.006 -0.0015 -0.00124581" rgba="0 1 0 0.3" />
+                        <body name="left_wrist_roll_link">
+                          <inertial pos="0.002935 -0.001499 -0.083026" quat="0.606338 0.022665 0.0055862 0.794865" mass="0.30304" diaginertia="0.00278114 0.00266331 0.000205545" />
+                          <joint name="left_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-1.571 0.724" actuatorfrcrange="-4.8 4.8" />
+                          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.898039 0.917647 0.929412 1" mesh="left_wrist_roll_link" />
+                          <geom class="collision" type="capsule" size="0.0485872" fromto="0.0065872 -0.00936239 -0.133114 0.0065872 -0.00936239 -0.0320872" rgba="0 1 0 0.3" />
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+            <body name="right_shoulder_pitch_link" pos="0.00330094 -0.143031 0.241648" quat="0.994522 -0.10453 0 0">
+              <inertial pos="0.002721 -0.050304 3.4e-05" quat="0.706743 0.706967 -0.0144448 -0.0224265" mass="0.885544" diaginertia="0.00303743 0.00294899 0.00067458" />
+              <joint name="right_shoulder_pitch_joint" pos="0 0 0" axis="0 1 0" range="-3.08 2.04" actuatorfrcrange="-36 36" />
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.298039 0.298039 0.298039 1" mesh="right_shoulder_pitch_link" />
+              <geom class="collision" type="capsule" size="0.0450011" fromto="-0.00173747 -0.0495987 -1.27591e-06 -0.00173747 -0.0450011 -1.27591e-06" rgba="0 1 0 0.3" />
+              <body name="right_shoulder_roll_link" pos="-0.0005 -0.0495 0" quat="1 0 7.70015e-05 0">
+                <inertial pos="0.000598 0.000185 -0.079928" quat="0.707532 0.00175816 0.00375761 0.706669" mass="0.696963" diaginertia="0.00548904 0.0054003 0.000529664" />
+                <joint name="right_shoulder_roll_joint" pos="0 0 0" axis="1 0 0" range="-2.993 0.061" actuatorfrcrange="-36 36" />
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_shoulder_roll_link" />
+                <geom class="collision" type="capsule" size="0.0524444" fromto="0.0004433 0 -0.0771056 0.0004433 0 -0.0097244" rgba="0 1 0 0.3" />
+                <body name="right_shoulder_yaw_link" pos="0.0005 0 -0.1212">
+                  <inertial pos="0.010082 -0.000178 -0.069484" quat="0.996531 -0.00117604 0.0784297 -0.0277917" mass="0.704661" diaginertia="0.00438849 0.00436595 0.000445562" />
+                  <joint name="right_shoulder_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24" />
+                  <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_shoulder_yaw_link" />
+                  <geom class="collision" type="capsule" size="0.044822" fromto="0.00344085 1.28523e-06 -0.0734741 0.00344085 1.28523e-06 -0.0245757" rgba="0 1 0 0.3" />
+                  <body name="right_elbow_link" pos="0.014 -0.0002 -0.08295">
+                    <inertial pos="-0.013517 -0.003463 -0.080438" quat="0.973224 -0.00938144 -0.0782816 0.215913" mass="0.687932" diaginertia="0.00542019 0.00534355 0.000444255" />
+                    <joint name="right_elbow_joint" pos="0 0 0" axis="0 1 0" range="-2.3556 0" actuatorfrcrange="-24 24" />
+                    <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_elbow_link" />
+                    <geom class="collision" type="capsule" size="0.0423334" fromto="-0.0117707 -0.00213153 -0.0831608 -0.0117707 -0.00213153 -0.0147232" rgba="0 1 0 0.3" />
+                    <body name="right_wrist_yaw_link" pos="-0.014 9.75261e-05 -0.120694" quat="1 0 0 1.63671e-05">
+                      <inertial pos="0.000153 -0.006979 -0.032069" quat="0.994972 0.0996496 -0.000602255 0.0100452" mass="0.372787" diaginertia="0.00069604 0.000598539 0.000202421" />
+                      <joint name="right_wrist_yaw_joint" pos="0 0 0" axis="0 0 1" range="-2.556 2.556" actuatorfrcrange="-24 24" />
+                      <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="1 1 1 1" mesh="right_wrist_yaw_link" />
+                      <geom class="collision" type="capsule" size="0.032" fromto="0 0 -0.047 0 0 -0.023" rgba="0 1 0 0.3" />
+                      
+                      <body name="right_wrist_pitch_link" pos="0 0 -0.0818" quat="1 0 0 -1.63671e-05">
+                        <inertial pos="0.012092 -0.002544 0.001781" quat="-0.292763 0.682227 -0.235996 0.627027" mass="0.279175" diaginertia="0.000171965 0.00013308 8.19541e-05" />
+                        <joint name="right_wrist_pitch_joint" pos="0 0 0" axis="0 1 0" range="-0.558 0.558" actuatorfrcrange="-4.8 4.8" />
+                        <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.3 0.3 0.3 1" mesh="right_wrist_pitch_link" />
+                        <geom class="collision" type="capsule" size="0.029" fromto="-0.00650001 0.0015 -0.00124581 0.006 0.0015 -0.00124581" rgba="0 1 0 0.3" />
+                        <body name="right_wrist_roll_link">
+                          <inertial pos="0.003056 0.00138 -0.082799" quat="0.794575 0.00682121 0.0232843 0.606681" mass="0.303847" diaginertia="0.002781 0.00266288 0.000206121" />
+                          <joint name="right_wrist_roll_joint" pos="0 0 0" axis="1 0 0" range="-0.724 1.571" actuatorfrcrange="-4.8 4.8" />
+                          <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.898039 0.917647 0.929412 1" mesh="right_wrist_roll_link" />
+                          <geom class="collision" type="capsule" size="0.0487165" fromto="0.00671655 0.00921908 -0.133006 0.00671655 0.00921908 -0.0322166" rgba="0 1 0 0.3" />
+                        </body>
+                      </body>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+            <body name="head_yaw_link" pos="0.00834773 0 0.309397">
+              <inertial pos="-0.003139 0.001399 0.051838" quat="0.999924 -0.00911422 0.00384341 0.00741605" mass="0.720047" diaginertia="0.0038613 0.00323157 0.00110213" />
+              
+              <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.866667 0.866667 0.890196 1" mesh="head_yaw_link" />
+              <geom class="collision" type="capsule" size="0.055" fromto="0 -0.020 0.045 0 0.020 0.045" rgba="0 1 0 0.3" />
+              
+              <body name="head_pitch_link" pos="0 0 0.0889">
+                <inertial pos="0.003033 -6e-05 0.004395" quat="0.695573 -0.162421 -0.145198 0.684628" mass="0.999287" diaginertia="0.0035988 0.00298179 0.00259841" />
+                
+                <geom class="collision" size="0.074 0.05" pos="0 0 0.015" quat="0.499898 0.5 0.5 -0.500102" type="cylinder" rgba="0 1 0 0.3" />
+                <geom class="visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.2 0.2 0.2 1" mesh="head_pitch_link" />
+                
+                <site name="imu_2" pos="0.0259999 -8.25389e-05 0.0176" group="3" />
+                <geom class="visual" pos="0.0259999 -8.25389e-05 0.0176" quat="1 0 0 0" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.647059 0.619608 0.588235 1" mesh="imu_in_head_link" />
+                
+                
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <contact>
+    <exclude body1="pelvis" body2="left_hip_roll_link" />
+    <exclude body1="pelvis" body2="right_hip_roll_link" />
+    <exclude body1="left_wrist_yaw_link" body2="left_wrist_roll_link" />
+    <exclude body1="right_wrist_yaw_link" body2="right_wrist_roll_link" />
+  </contact>
+  <actuator>
+    <position class="x2" kp="120" kv="5" forcerange="-120 120" name="left_hip_pitch_joint" joint="left_hip_pitch_joint" />
+    <position class="x2" kp="100" kv="4" forcerange="-120 120" name="left_hip_roll_joint" joint="left_hip_roll_joint" />
+    <position class="x2" kp="100" kv="4" forcerange="-120 120" name="left_hip_yaw_joint" joint="left_hip_yaw_joint" />
+    <position class="x2" kp="150" kv="5" forcerange="-120 120" name="left_knee_joint" joint="left_knee_joint" />
+    <position class="x2" kp="40" kv="2" forcerange="-36 36" name="left_ankle_pitch_joint" joint="left_ankle_pitch_joint" />
+    <position class="x2" kp="40" kv="2" forcerange="-24 24" name="left_ankle_roll_joint" joint="left_ankle_roll_joint" />
+
+    <position class="x2" kp="120" kv="5" forcerange="-120 120" name="right_hip_pitch_joint" joint="right_hip_pitch_joint" />
+    <position class="x2" kp="100" kv="4" forcerange="-120 120" name="right_hip_roll_joint" joint="right_hip_roll_joint" />
+    <position class="x2" kp="100" kv="4" forcerange="-120 120" name="right_hip_yaw_joint" joint="right_hip_yaw_joint" />
+    <position class="x2" kp="150" kv="5" forcerange="-120 120" name="right_knee_joint" joint="right_knee_joint" />
+    <position class="x2" kp="40" kv="2" forcerange="-36 36" name="right_ankle_pitch_joint" joint="right_ankle_pitch_joint" />
+    <position class="x2" kp="40" kv="2" forcerange="-24 24" name="right_ankle_roll_joint" joint="right_ankle_roll_joint" />
+
+    <position class="x2" kp="40.1792" kv="2.5579" forcerange="-120 120" name="waist_yaw_joint" joint="waist_yaw_joint" />
+    <position class="x2" kp="200" kv="2" forcerange="-48 48" name="waist_pitch_joint" joint="waist_pitch_joint" />
+    <position class="x2" kp="200" kv="2" forcerange="-48 48" name="waist_roll_joint" joint="waist_roll_joint" />
+
+    
+
+    <position class="x2" kp="50" kv="3" forcerange="-36 36" name="left_shoulder_pitch_joint" joint="left_shoulder_pitch_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-36 36" name="left_shoulder_roll_joint" joint="left_shoulder_roll_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-24 24" name="left_shoulder_yaw_joint" joint="left_shoulder_yaw_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-24 24" name="left_elbow_joint" joint="left_elbow_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-24 24" name="left_wrist_yaw_joint" joint="left_wrist_yaw_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-4.8 4.8" name="left_wrist_pitch_joint" joint="left_wrist_pitch_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-4.8 4.8" name="left_wrist_roll_joint" joint="left_wrist_roll_joint" />
+
+    <position class="x2" kp="50" kv="3" forcerange="-36 36" name="right_shoulder_pitch_joint" joint="right_shoulder_pitch_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-36 36" name="right_shoulder_roll_joint" joint="right_shoulder_roll_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-24 24" name="right_shoulder_yaw_joint" joint="right_shoulder_yaw_joint" />
+    <position class="x2" kp="50" kv="3" forcerange="-24 24" name="right_elbow_joint" joint="right_elbow_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-24 24" name="right_wrist_yaw_joint" joint="right_wrist_yaw_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-4.8 4.8" name="right_wrist_pitch_joint" joint="right_wrist_pitch_joint" />
+    <position class="x2" kp="20" kv="2" forcerange="-4.8 4.8" name="right_wrist_roll_joint" joint="right_wrist_roll_joint" />
+  </actuator>
+  <sensor>
+    
+
+    <framequat name="body-orientation" objtype="site" objname="imu_0" noise="0" />
+    <gyro name="body-angular-velocity" site="imu_0" noise="0.001" />
+    <framepos name="body-linear-pos" objtype="site" objname="imu_0" />
+    <velocimeter name="body-linear-vel" site="imu_0" noise="0.001" />
+    <accelerometer name="body-linear-acceleration" site="imu_0" noise="0.001" />
+
+    <framequat name="chest-orientation" objtype="site" objname="imu_1" noise="0"/>
+    <gyro name="chest-angular-velocity" site="imu_1" noise="0.001"/>
+    <framepos name="chest-linear-pos" objtype="site" objname="imu_1"/>
+    <velocimeter name="chest-linear-vel" site="imu_1" noise="0.001"/>
+    <accelerometer name="chest-linear-acceleration" site="imu_1" noise="0.001"/>
+    
+    <jointpos name="jointpos_left_hip_pitch_joint" joint="left_hip_pitch_joint" noise="0" />
+    <jointpos name="jointpos_left_hip_roll_joint" joint="left_hip_roll_joint" noise="0" />
+    <jointpos name="jointpos_left_hip_yaw_joint" joint="left_hip_yaw_joint" noise="0" />
+    <jointpos name="jointpos_left_knee_joint" joint="left_knee_joint" noise="0" />
+    <jointpos name="jointpos_left_ankle_pitch_joint" joint="left_ankle_pitch_joint" noise="0" />
+    <jointpos name="jointpos_left_ankle_roll_joint" joint="left_ankle_roll_joint" noise="0" />
+
+    <jointpos name="jointpos_right_hip_pitch_joint" joint="right_hip_pitch_joint" noise="0" />
+    <jointpos name="jointpos_right_hip_roll_joint" joint="right_hip_roll_joint" noise="0" />
+    <jointpos name="jointpos_right_hip_yaw_joint" joint="right_hip_yaw_joint" noise="0" />
+    <jointpos name="jointpos_right_knee_joint" joint="right_knee_joint" noise="0" />
+    <jointpos name="jointpos_right_ankle_pitch_joint" joint="right_ankle_pitch_joint" noise="0" />
+    <jointpos name="jointpos_right_ankle_roll_joint" joint="right_ankle_roll_joint" noise="0" />
+
+    <jointpos name="jointpos_waist_yaw_joint" joint="waist_yaw_joint" noise="0" />
+    <jointpos name="jointpos_waist_pitch_joint" joint="waist_pitch_joint" noise="0" />
+    <jointpos name="jointpos_waist_roll_joint" joint="waist_roll_joint" noise="0" />
+
+    
+
+    <jointpos name="jointpos_left_shoulder_pitch_joint" joint="left_shoulder_pitch_joint" noise="0" />
+    <jointpos name="jointpos_left_shoulder_roll_joint" joint="left_shoulder_roll_joint" noise="0" />
+    <jointpos name="jointpos_left_shoulder_yaw_joint" joint="left_shoulder_yaw_joint" noise="0" />
+    <jointpos name="jointpos_left_elbow_joint" joint="left_elbow_joint" noise="0" />
+    
+
+    <jointpos name="jointpos_right_shoulder_pitch_joint" joint="right_shoulder_pitch_joint" noise="0" />
+    <jointpos name="jointpos_right_shoulder_roll_joint" joint="right_shoulder_roll_joint" noise="0" />
+    <jointpos name="jointpos_right_shoulder_yaw_joint" joint="right_shoulder_yaw_joint" noise="0" />
+    <jointpos name="jointpos_right_elbow_joint" joint="right_elbow_joint" noise="0" />
+    
+
+    <jointvel name="jointvel_left_hip_pitch_joint" joint="left_hip_pitch_joint" noise="0" />
+    <jointvel name="jointvel_left_hip_roll_joint" joint="left_hip_roll_joint" noise="0" />
+    <jointvel name="jointvel_left_hip_yaw_joint" joint="left_hip_yaw_joint" noise="0" />
+    <jointvel name="jointvel_left_knee_joint" joint="left_knee_joint" noise="0" />
+    <jointvel name="jointvel_left_ankle_pitch_joint" joint="left_ankle_pitch_joint" noise="0" />
+    <jointvel name="jointvel_left_ankle_roll_joint" joint="left_ankle_roll_joint" noise="0" />
+
+    <jointvel name="jointvel_right_hip_pitch_joint" joint="right_hip_pitch_joint" noise="0" />
+    <jointvel name="jointvel_right_hip_roll_joint" joint="right_hip_roll_joint" noise="0" />
+    <jointvel name="jointvel_right_hip_yaw_joint" joint="right_hip_yaw_joint" noise="0" />
+    <jointvel name="jointvel_right_knee_joint" joint="right_knee_joint" noise="0" />
+    <jointvel name="jointvel_right_ankle_pitch_joint" joint="right_ankle_pitch_joint" noise="0" />
+    <jointvel name="jointvel_right_ankle_roll_joint" joint="right_ankle_roll_joint" noise="0" />
+
+    <jointvel name="jointvel_waist_yaw_joint" joint="waist_yaw_joint" noise="0" />
+    <jointvel name="jointvel_waist_pitch_joint" joint="waist_pitch_joint" noise="0" />
+    <jointvel name="jointvel_waist_roll_joint" joint="waist_roll_joint" noise="0" />
+
+    
+
+    <jointvel name="jointvel_left_shoulder_pitch_joint" joint="left_shoulder_pitch_joint" noise="0" />
+    <jointvel name="jointvel_left_shoulder_roll_joint" joint="left_shoulder_roll_joint" noise="0" />
+    <jointvel name="jointvel_left_shoulder_yaw_joint" joint="left_shoulder_yaw_joint" noise="0" />
+    <jointvel name="jointvel_left_elbow_joint" joint="left_elbow_joint" noise="0" />
+    
+
+    <jointvel name="jointvel_right_shoulder_pitch_joint" joint="right_shoulder_pitch_joint" noise="0" />
+    <jointvel name="jointvel_right_shoulder_roll_joint" joint="right_shoulder_roll_joint" noise="0" />
+    <jointvel name="jointvel_right_shoulder_yaw_joint" joint="right_shoulder_yaw_joint" noise="0" />
+    <jointvel name="jointvel_right_elbow_joint" joint="right_elbow_joint" noise="0" />
+    
+
+  </sensor>
+</mujoco>

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -222,7 +222,7 @@ def _build_mujoco_scene_context(scene: SceneCfg) -> _MuJoCoSceneContext:
             return _MuJoCoSceneContext(
                 model_source=scene.model_file,
                 model_file=scene.model_file,
-                visual_model_file=scene.model_file,
+                visual_model_file=scene.visual_model_file or scene.model_file,
             )
         model_source = materialize_scene_fragments(
             scene.model_file,

--- a/src/unilab/base/scene.py
+++ b/src/unilab/base/scene.py
@@ -21,3 +21,9 @@ class SceneCfg:
     model_file: str
     fragment_files: list[str] = field(default_factory=list)
     terrain: TerrainSceneCfg | None = None
+    # Optional render-only model override. When set, offline playback/video
+    # export renders this XML instead of ``model_file`` while physics keeps
+    # using ``model_file``. Used to give the renderer a visual twin of the
+    # scene (e.g. a per-env replicable obstacle) without touching the trained
+    # collision model. ``None`` => render with ``model_file`` (unchanged).
+    visual_model_file: str | None = None

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -29,6 +29,9 @@ class DemoSpec:
 DEMO_REGISTRY: dict[str, DemoSpec] = {
     "dance": DemoSpec(algo="ppo", task="g1_motion_tracking", sim="motrix", entry="eval"),
     "wallflip": DemoSpec(algo="ppo", task="g1_wall_flip_tracking", sim="motrix", entry="eval"),
+    "wallflip2": DemoSpec(
+        algo="ppo", task="x2_wall_flip_tracking", sim="mujoco", entry="play_interactive"
+    ),
     "boxtracking": DemoSpec(algo="ppo", task="g1_box_tracking", sim="motrix", entry="eval"),
     "locomani": DemoSpec(
         algo="ppo", task="go2_arm_manip_loco", sim="mujoco", entry="play_interactive"

--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -1,6 +1,9 @@
 """Motion tracking environments."""
 
-__unilab_registry_modules__ = ("unilab.envs.motion_tracking.g1",)
+__unilab_registry_modules__ = (
+    "unilab.envs.motion_tracking.g1",
+    "unilab.envs.motion_tracking.x2",
+)
 
 from .g1 import (
     BoxMotionData,
@@ -25,6 +28,12 @@ from .g1 import (
     G1WBTObsCfg,
     G1WBTObsEnv,
 )
+from .x2 import (
+    X2MotionTrackingCfg,
+    X2WallFlipTrackingCfg,
+    X2WallFlipTrackingEnv,
+    X2WallFlipTrackingEnvCfg,
+)
 
 __all__ = [
     "G1MotionTrackingCfg",
@@ -48,4 +57,8 @@ __all__ = [
     "G1BoxTrackingEnvCfg",
     "BoxMotionData",
     "BoxMotionLoader",
+    "X2MotionTrackingCfg",
+    "X2WallFlipTrackingCfg",
+    "X2WallFlipTrackingEnv",
+    "X2WallFlipTrackingEnvCfg",
 ]

--- a/src/unilab/envs/motion_tracking/x2/__init__.py
+++ b/src/unilab/envs/motion_tracking/x2/__init__.py
@@ -1,0 +1,15 @@
+"""Motion tracking environments for AgiBot X2."""
+
+from .flip_tracking import (
+    X2MotionTrackingCfg,
+    X2WallFlipTrackingCfg,
+    X2WallFlipTrackingEnv,
+    X2WallFlipTrackingEnvCfg,
+)
+
+__all__ = [
+    "X2MotionTrackingCfg",
+    "X2WallFlipTrackingCfg",
+    "X2WallFlipTrackingEnv",
+    "X2WallFlipTrackingEnvCfg",
+]

--- a/src/unilab/envs/motion_tracking/x2/flip_tracking.py
+++ b/src/unilab/envs/motion_tracking/x2/flip_tracking.py
@@ -1,0 +1,127 @@
+"""X2 motion-tracking profiles backed by the shared humanoid tracker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base import registry
+from unilab.base.scene import SceneCfg
+from unilab.envs.locomotion.g1.base import Sensor
+from unilab.envs.motion_tracking.g1.flip_tracking import (
+    _zero_pose_randomization,
+    _zero_velocity_randomization,
+)
+from unilab.envs.motion_tracking.g1.tracking import (
+    G1MotionTrackingDeployEnv,
+    G1MotionTrackingDeployEnvCfg,
+    PoseRandomization,
+    VelocityRandomization,
+)
+
+
+@dataclass
+class X2MotionTrackingCfg(G1MotionTrackingDeployEnvCfg):
+    """Base X2 motion-tracking config profile."""
+
+    scene: SceneCfg = field(
+        default_factory=lambda: SceneCfg(
+            model_file=str(ASSETS_ROOT_PATH / "robots" / "x2" / "scene_flat.xml")
+        )
+    )
+    motion_file: str | list[str] = str(
+        ASSETS_ROOT_PATH / "motions" / "x2" / "tictacflip_6-3_g1format.npz"
+    )
+    sensor: Sensor = field(
+        default_factory=lambda: Sensor(
+            local_linvel="body-linear-vel",
+            gyro="body-angular-velocity",
+            upvector="body-orientation",
+        )
+    )
+    anchor_body_name: str = "torso_link"
+    body_names: tuple[str, ...] = (
+        "pelvis",
+        "left_hip_pitch_link",
+        "left_hip_roll_link",
+        "left_hip_yaw_link",
+        "left_knee_link",
+        "left_ankle_pitch_link",
+        "left_ankle_roll_link",
+        "right_hip_pitch_link",
+        "right_hip_roll_link",
+        "right_hip_yaw_link",
+        "right_knee_link",
+        "right_ankle_pitch_link",
+        "right_ankle_roll_link",
+        "waist_yaw_link",
+        "waist_pitch_link",
+        "torso_link",
+        "left_shoulder_pitch_link",
+        "left_shoulder_roll_link",
+        "left_shoulder_yaw_link",
+        "left_elbow_link",
+        "left_wrist_yaw_link",
+        "left_wrist_pitch_link",
+        "left_wrist_roll_link",
+        "right_shoulder_pitch_link",
+        "right_shoulder_roll_link",
+        "right_shoulder_yaw_link",
+        "right_elbow_link",
+        "right_wrist_yaw_link",
+        "right_wrist_pitch_link",
+        "right_wrist_roll_link",
+    )
+    ee_body_names: tuple[str, ...] = (
+        "left_ankle_roll_link",
+        "right_ankle_roll_link",
+        "left_wrist_yaw_link",
+        "right_wrist_yaw_link",
+    )
+
+
+@dataclass
+class X2WallFlipTrackingCfg(X2MotionTrackingCfg):
+    """Config profile for wall-assisted X2 flip tracking."""
+
+    scene: SceneCfg = field(
+        default_factory=lambda: SceneCfg(
+            model_file=str(ASSETS_ROOT_PATH / "robots" / "x2" / "scene_flat_with_wall.xml")
+        )
+    )
+    pose_randomization: PoseRandomization = field(default_factory=_zero_pose_randomization)
+    velocity_randomization: VelocityRandomization = field(
+        default_factory=_zero_velocity_randomization
+    )
+    joint_position_range: tuple[float, float] = (0.0, 0.0)
+    sampling_mode: Literal["start", "clip_start", "uniform", "adaptive", "mixed"] = "adaptive"
+    truncate_on_clip_end: bool = False
+    terminate_on_undesired_contacts: bool = True
+    anchor_ori_threshold: float = 1e9
+    anchor_pos_z_threshold: float = 0.5
+    ee_body_pos_z_threshold: float = 0.5
+
+
+@registry.envcfg("X2WallFlipTracking")
+@dataclass
+class X2WallFlipTrackingEnvCfg(X2WallFlipTrackingCfg):
+    """Registered configuration for X2 wall flip tracking."""
+
+    pass
+
+
+@registry.env("X2WallFlipTracking", sim_backend="mujoco")
+class X2WallFlipTrackingEnv(G1MotionTrackingDeployEnv):
+    """X2 wall flip-tracking environment implementation."""
+
+    _cfg: X2WallFlipTrackingCfg
+    _keyframe_name = "home"
+
+    def __init__(self, cfg: X2WallFlipTrackingCfg, num_envs: int = 1, backend_type: str = "mujoco"):
+        # X2 meshes are hosted on Hugging Face, not committed to git. Ensure they
+        # exist locally before the scene XML is parsed by the simulation backend.
+        from unilab.assets.hub import resolve_robot_asset_dir
+
+        resolve_robot_asset_dir("robots/x2/meshes", marker="pelvis.STL")
+        super().__init__(cfg, num_envs=num_envs, backend_type=backend_type)

--- a/src/unilab/envs/motion_tracking/x2/flip_tracking.py
+++ b/src/unilab/envs/motion_tracking/x2/flip_tracking.py
@@ -87,7 +87,13 @@ class X2WallFlipTrackingCfg(X2MotionTrackingCfg):
 
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
-            model_file=str(ASSETS_ROOT_PATH / "robots" / "x2" / "scene_flat_with_wall.xml")
+            model_file=str(ASSETS_ROOT_PATH / "robots" / "x2" / "scene_flat_with_wall.xml"),
+            # Render-only twin: wall as a worldbody geom so the offline grid
+            # renderer replicates it under every env cell (matches G1's per-env
+            # wall view). Physics still uses the <body> wall in model_file.
+            visual_model_file=str(
+                ASSETS_ROOT_PATH / "robots" / "x2" / "scene_flat_with_wall_visual.xml"
+            ),
         )
     )
     pose_randomization: PoseRandomization = field(default_factory=_zero_pose_randomization)

--- a/src/unilab/tools/pull_assets.py
+++ b/src/unilab/tools/pull_assets.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Pre-fetch robot binary assets (meshes) from Hugging Face into their project paths.
+
+Robot STL meshes are hosted on Hugging Face rather than committed to git. They are
+also downloaded automatically on first use, but this command lets you pull them
+ahead of time (e.g. for CI or offline prep) with a single invocation. Files land
+under ``src/unilab/assets/robots/<robot>/meshes/`` — no manual file moving needed.
+
+Usage:
+  uv run unilab-pull-assets               # pull the default robot (x2)
+  uv run unilab-pull-assets --robot x2
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Sequence
+
+from unilab.assets.hub import resolve_robot_asset_dir
+
+# robot name -> (ASSETS_ROOT_PATH-relative dir, completeness marker file)
+_ROBOT_ASSETS: dict[str, tuple[str, str]] = {
+    "x2": ("robots/x2/meshes", "pelvis.STL"),
+}
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--robot",
+        default="x2",
+        choices=sorted(_ROBOT_ASSETS),
+        help="Robot whose meshes to download (default: x2).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _parse_args(argv)
+
+    directory, marker = _ROBOT_ASSETS[args.robot]
+    target = resolve_robot_asset_dir(directory, marker=marker)
+    count = len(list(target.glob("*.STL")))
+    print(f"{args.robot} meshes ready at {target} ({count} STL files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/utils/support_matrix.py
+++ b/src/unilab/utils/support_matrix.py
@@ -26,10 +26,11 @@ _TASK_ORDER = {
     "g1_motion_tracking": 5,
     "g1_flip_tracking": 6,
     "g1_wall_flip_tracking": 7,
-    "allegro_inhand": 8,
-    "allegro_sac": 9,
-    "sharpa_inhand": 10,
-    "sharpa_inhand_grasp": 11,
+    "x2_wall_flip_tracking": 8,
+    "allegro_inhand": 9,
+    "allegro_sac": 10,
+    "sharpa_inhand": 11,
+    "sharpa_inhand_grasp": 12,
 }
 _TASK_LABELS = {
     "go1_joystick_flat": "Go1 joystick",
@@ -40,6 +41,7 @@ _TASK_LABELS = {
     "g1_motion_tracking": "G1 motion tracking",
     "g1_flip_tracking": "G1 flip tracking",
     "g1_wall_flip_tracking": "G1 wall flip tracking",
+    "x2_wall_flip_tracking": "X2 wall flip tracking",
     "allegro_inhand": "Allegro in-hand",
     "allegro_sac": "Allegro SAC in-hand",
     "sharpa_inhand": "Sharpa in-hand",

--- a/tests/base/backend/test_mujoco_scene_context_visual.py
+++ b/tests/base/backend/test_mujoco_scene_context_visual.py
@@ -1,0 +1,48 @@
+"""Render-only visual model override for the MuJoCo scene context.
+
+These cover the cold-path wiring that lets offline playback render a visual twin
+of a scene (e.g. a per-env replicable wall) without touching the trained physics
+model. See ``SceneCfg.visual_model_file`` and ``_build_mujoco_scene_context``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from unilab.base.backend.mujoco.backend import _build_mujoco_scene_context
+from unilab.base.scene import SceneCfg
+
+
+def test_visual_model_file_defaults_to_model_file() -> None:
+    ctx = _build_mujoco_scene_context(SceneCfg(model_file="/tmp/phys.xml"))
+
+    assert ctx.model_file == "/tmp/phys.xml"
+    assert ctx.model_source == "/tmp/phys.xml"
+    # Unset override => renderer uses the physics model (behaviour unchanged for
+    # every task that does not opt in).
+    assert ctx.visual_model_file == "/tmp/phys.xml"
+
+
+def test_visual_model_file_override_is_render_only() -> None:
+    ctx = _build_mujoco_scene_context(
+        SceneCfg(model_file="/tmp/phys.xml", visual_model_file="/tmp/visual.xml")
+    )
+
+    # Physics keeps using model_file; only the render model is swapped.
+    assert ctx.model_file == "/tmp/phys.xml"
+    assert ctx.model_source == "/tmp/phys.xml"
+    assert ctx.visual_model_file == "/tmp/visual.xml"
+
+
+def test_x2_wall_flip_wires_render_only_visual_twin() -> None:
+    from unilab.envs.motion_tracking.x2.flip_tracking import X2WallFlipTrackingEnvCfg
+
+    cfg = X2WallFlipTrackingEnvCfg()
+
+    # Physics = trained <body> wall; render = worldbody-geom twin.
+    assert cfg.scene.model_file.endswith("scene_flat_with_wall.xml")
+    assert cfg.scene.visual_model_file is not None
+    assert cfg.scene.visual_model_file.endswith("scene_flat_with_wall_visual.xml")
+    assert cfg.scene.model_file != cfg.scene.visual_model_file
+    assert Path(cfg.scene.model_file).is_file()
+    assert Path(cfg.scene.visual_model_file).is_file()

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -40,6 +40,7 @@ G1_BEYONDMIMIC_ACTION_SCALE = [
     0.07450087032950714,
     0.07450087032950714,
 ]
+X2_ACTION_SCALE = [0.25] * 29
 
 
 # ---------------------------------------------------------------------------
@@ -600,6 +601,38 @@ def test_ppo_g1_wall_flip_tracking():
     assert cfg.env.truncate_on_clip_end is False
     assert cfg.env.sim_dt == pytest.approx(0.005)
     assert list(cfg.env.control_config.action_scale) == pytest.approx(G1_BEYONDMIMIC_ACTION_SCALE)
+    assert cfg.env.anchor_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.env.ee_body_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.env.terminate_on_undesired_contacts is True
+    assert cfg.env.noise_config.level == pytest.approx(0.0)
+    assert cfg.reward.scales.motion_joint_pos == pytest.approx(0.5)
+    assert cfg.reward.scales.motion_joint_vel == pytest.approx(0.25)
+    assert cfg.reward.scales.motion_body_pos == pytest.approx(2.0)
+    assert cfg.reward.scales.motion_body_ori == pytest.approx(1.5)
+    assert cfg.reward.scales.motion_ee_body_pos_z == pytest.approx(2.0)
+    assert cfg.reward.scales.action_rate_l2 == pytest.approx(-0.005)
+    assert cfg.reward.scales.undesired_contacts == pytest.approx(-0.1)
+
+
+def test_ppo_x2_wall_flip_tracking():
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        cfg = compose("config", overrides=["task=x2_wall_flip_tracking/mujoco"])
+    assert cfg.training.task_name == "X2WallFlipTracking"
+    assert cfg.training.sim_backend == "mujoco"
+    assert cfg.algo.num_envs == 1024
+    assert cfg.algo.max_iterations == 20000
+    assert cfg.algo.empirical_normalization is True
+    assert cfg.algo.obs_groups.critic == ["critic"]
+    assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
+    assert cfg.algo.algorithm.desired_kl == pytest.approx(0.01)
+    assert cfg.env.sampling_mode == "start"
+    assert cfg.env.truncate_on_clip_end is False
+    assert cfg.env.sim_dt == pytest.approx(0.005)
+    assert list(cfg.env.control_config.action_scale) == pytest.approx(X2_ACTION_SCALE)
     assert cfg.env.anchor_pos_z_threshold == pytest.approx(0.5)
     assert cfg.env.ee_body_pos_z_threshold == pytest.approx(0.5)
     assert cfg.env.terminate_on_undesired_contacts is True

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -624,11 +624,13 @@ def test_ppo_x2_wall_flip_tracking():
     assert cfg.training.task_name == "X2WallFlipTracking"
     assert cfg.training.sim_backend == "mujoco"
     assert cfg.algo.num_envs == 1024
-    assert cfg.algo.max_iterations == 20000
+    assert cfg.algo.max_iterations == 9500
     assert cfg.algo.empirical_normalization is True
     assert cfg.algo.obs_groups.critic == ["critic"]
     assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
     assert cfg.algo.algorithm.desired_kl == pytest.approx(0.01)
+    # The `wallflip2` demo relies on the owner config defaulting to policy playback.
+    assert cfg.interactive.action_mode == "policy"
     assert cfg.env.sampling_mode == "start"
     assert cfg.env.truncate_on_clip_end is False
     assert cfg.env.sim_dt == pytest.approx(0.005)

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -56,15 +56,18 @@ def test_registry_bootstrap_and_config_imports_do_not_require_mujoco():
             G1MotionTrackingCfg,
             G1MotionTrackingDeployEnvCfg,
         )
+        from unilab.envs.motion_tracking.x2 import X2WallFlipTrackingCfg
         from unilab.base.registry import ensure_registries
 
         ensure_registries()
         assert callable(create_backend)
         assert registry.contains("G1MotionTracking")
         assert registry.contains("G1MotionTrackingDeploy")
+        assert registry.contains("X2WallFlipTracking")
         assert registry.contains("AllegroInhandRotation")
         G1MotionTrackingCfg()
         G1MotionTrackingDeployEnvCfg()
+        X2WallFlipTrackingCfg()
         AllegroRotationCfg()
         """
     )
@@ -1356,6 +1359,30 @@ def test_g1_wall_flip_tracking_cfg_uses_wall_flip_profile():
 
     assert cfg.scene.model_file.endswith("scene_flat_with_wall.xml")
     assert str(cfg.motion_file).endswith("flip_from_wall_104__A304.npz")
+    assert cfg.pose_randomization.x == (0.0, 0.0)
+    assert cfg.velocity_randomization.x == (0.0, 0.0)
+    assert cfg.joint_position_range == (0.0, 0.0)
+    assert cfg.truncate_on_clip_end is False
+    assert cfg.anchor_ori_threshold == pytest.approx(1e9)
+    assert cfg.anchor_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.ee_body_pos_z_threshold == pytest.approx(0.5)
+    assert cfg.terminate_on_undesired_contacts is True
+    assert cfg.sampling_mode == "adaptive"
+
+
+def test_x2_wall_flip_tracking_cfg_uses_x2_wall_flip_profile():
+    from unilab.envs.motion_tracking.x2 import X2WallFlipTrackingCfg
+
+    cfg = X2WallFlipTrackingCfg()
+
+    assert cfg.scene.model_file.endswith("scene_flat_with_wall.xml")
+    assert str(cfg.motion_file).endswith("tictacflip_6-3_g1format.npz")
+    assert cfg.sensor.local_linvel == "body-linear-vel"
+    assert cfg.sensor.gyro == "body-angular-velocity"
+    assert cfg.anchor_body_name == "torso_link"
+    assert cfg.body_names[0] == "pelvis"
+    assert cfg.body_names[-1] == "right_wrist_roll_link"
+    assert len(cfg.body_names) == 30
     assert cfg.pose_randomization.x == (0.0, 0.0)
     assert cfg.velocity_randomization.x == (0.0, 0.0)
     assert cfg.joint_position_range == (0.0, 0.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,6 +274,7 @@ def test_demo_registry_contains_expected_entries() -> None:
     assert set(demo.DEMO_REGISTRY) == {
         "dance",
         "wallflip",
+        "wallflip2",
         "boxtracking",
         "locomani",
         "sharpa_appo_student",
@@ -282,6 +283,12 @@ def test_demo_registry_contains_expected_entries() -> None:
     }
     assert demo.DEMO_REGISTRY["locomani"].entry == "play_interactive"
     assert demo.DEMO_REGISTRY["locomani"].sim == "mujoco"
+    assert demo.DEMO_REGISTRY["wallflip2"] == demo.DemoSpec(
+        algo="ppo",
+        task="x2_wall_flip_tracking",
+        sim="mujoco",
+        entry="play_interactive",
+    )
     assert demo.DEMO_REGISTRY["inhandgrasp"] == demo.DemoSpec(
         algo="hora_distill",
         task="sharpa_inhand",
@@ -333,6 +340,24 @@ def test_demo_play_interactive_entry_assembles_locomani_command(
     assert command[1] == str(tmp_path / "scripts" / "play_interactive.py")
     assert command[2:4] == ["--algo", "ppo"]
     assert command[4:8] == ["--task", "go2_arm_manip_loco", "--sim", "mujoco"]
+    assert f"algo.load_run={abs_pt}" in command
+    assert "training.device=cpu" in command
+
+
+def test_demo_play_interactive_entry_assembles_wallflip2_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_demo_checkout(tmp_path, demo_name="wallflip2")
+    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
+    abs_pt = str(tmp_path / "fake" / "model_0.pt")
+    command = demo.build_demo_command(
+        demo_name="wallflip2", checkpoint_path=abs_pt, device="cpu", root=tmp_path
+    )
+
+    assert command[0] == sys.executable
+    assert command[1] == str(tmp_path / "scripts" / "play_interactive.py")
+    assert command[2:4] == ["--algo", "ppo"]
+    assert command[4:8] == ["--task", "x2_wall_flip_tracking", "--sim", "mujoco"]
     assert f"algo.load_run={abs_pt}" in command
     assert "training.device=cpu" in command
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -295,6 +295,7 @@ def test_demo_positional_completes_all_demo_names(tmp_path: Path) -> None:
         "sharpa_appo_student",
         "teaser",
         "wallflip",
+        "wallflip2",
     ]
 
 

--- a/tests/utils/test_render_many.py
+++ b/tests/utils/test_render_many.py
@@ -85,6 +85,40 @@ def test_egl_runtime_usable_returns_false_on_probe_failure(monkeypatch) -> None:
     assert render_many._egl_runtime_usable() is False
 
 
+def _reload_render_many_with_geom_enums(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "mujoco",
+        types.SimpleNamespace(
+            mjtGeom=types.SimpleNamespace(mjGEOM_PLANE=0, mjGEOM_HFIELD=1, mjGEOM_BOX=6),
+        ),
+    )
+    sys.modules.pop("unilab.visualization.render_many", None)
+    return importlib.import_module("unilab.visualization.render_many")
+
+
+def test_replicable_terrain_geom_indices_selects_worldbody_box(monkeypatch) -> None:
+    # The x2 wall-flip render twin declares the wall as a group-0 worldbody box
+    # geom precisely so this selector picks it up and the grid renderer
+    # replicates one wall per env cell. Lock that contract in.
+    render_many = _reload_render_many_with_geom_enums(monkeypatch)
+
+    model = types.SimpleNamespace(
+        ngeom=4,
+        # 0: floor plane (worldbody)  1: robot geom (body 5)
+        # 2: wall box (worldbody)     3: group-2 worldbody box (non-default group)
+        geom_group=np.array([0, 0, 0, 2], dtype=np.int32),
+        geom_bodyid=np.array([0, 5, 0, 0], dtype=np.int32),
+        geom_type=np.array([0, 6, 6, 6], dtype=np.int32),
+    )
+
+    indices = render_many._replicable_terrain_geom_indices(model)
+
+    # Only the worldbody box wall (geom 2) is replicable: the plane is skipped,
+    # the body-attached robot geom is skipped, and the non-group-0 geom is skipped.
+    assert indices.tolist() == [2]
+
+
 def test_offset_freejoint_object_qpos_handles_arbitrary_object_body(monkeypatch) -> None:
     render_many = _reload_render_many(monkeypatch)
 


### PR DESCRIPTION
## Summary

- Add X2 wall flip motion-tracking task, config, registry entry, robot assets, scenes, and motion assets.
- Add X2 CSV-to-tracking-NPZ conversion script and update NPZ replay tooling for the wall flip workflow.
- Update support matrix and gitignore entries for local history/checkpoint artifacts.

## Validation

- `make test-all`
  - `1021 passed, 12 skipped, 242 deselected`