### PR TITLE
chore: restore CLAUDE.md symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
恢复被 `eb9841c3` 误删的 `CLAUDE.md` symlink，使其重新指向 `AGENTS.md`。

## Validation
- `make test-all` 已运行；1204 passed, 2 failed
- 2 个失败均为 `tests/envs/test_stewart.py`，原因是当前环境未安装 `motrixsim` 包，与本次改动无关