### PR TITLE
fix: tolerate non-UTF-8 shell rc files in completion installer

### DIFF
--- a/src/unilab/tools/completion.py
+++ b/src/unilab/tools/completion.py
@@ -636,7 +636,9 @@ def _write_completion_block(
     dry_run: bool,
     force: bool,
 ) -> None:
-    content = rc_file.read_text(encoding="utf-8") if rc_file.exists() else ""
+    content = (
+        rc_file.read_text(encoding="utf-8", errors="surrogateescape") if rc_file.exists() else ""
+    )
     cleaned = _without_completion_block(content, force=force).rstrip()
     block = _completion_block(script_path).rstrip()
     updated = f"{cleaned}\n\n{block}\n" if cleaned else f"{block}\n"
@@ -644,7 +646,7 @@ def _write_completion_block(
         print(updated, end="")
         return
     rc_file.parent.mkdir(parents=True, exist_ok=True)
-    rc_file.write_text(updated, encoding="utf-8")
+    rc_file.write_text(updated, encoding="utf-8", errors="surrogateescape")
     print(f"Installed UniLab completion in {rc_file}")
     print(f"Open a new shell or run: source {rc_file}")
 
@@ -653,12 +655,12 @@ def _remove_completion_block(*, rc_file: Path, dry_run: bool, force: bool) -> No
     if not rc_file.exists():
         print(f"No rc file found: {rc_file}")
         return
-    content = rc_file.read_text(encoding="utf-8")
+    content = rc_file.read_text(encoding="utf-8", errors="surrogateescape")
     updated = _without_completion_block(content, force=force)
     if dry_run:
         print(updated, end="")
         return
-    rc_file.write_text(updated, encoding="utf-8")
+    rc_file.write_text(updated, encoding="utf-8", errors="surrogateescape")
     print(f"Removed UniLab completion from {rc_file}")
 
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from unilab.tools.completion import build_metadata, complete_words
+from unilab.tools.completion import (
+    COMPLETION_BLOCK_END,
+    COMPLETION_BLOCK_START,
+    build_metadata,
+    complete_words,
+    install_main,
+)
 
 
 def _write_completion_fixture(root: Path) -> None:
@@ -330,3 +336,21 @@ def test_demo_name_still_completes_when_leading_flag_present(tmp_path: Path) -> 
     assert complete_words(["uv", "run", "demo", "--refresh", "d"], 4, metadata) == [
         "dance",
     ]
+
+
+def test_completion_install_preserves_non_utf8_rc_file_bytes(tmp_path: Path) -> None:
+    rc_file = tmp_path / ".bashrc"
+    original = b"export OK=1\n# non utf8: \x9c\n"
+    rc_file.write_bytes(original)
+
+    assert install_main(["--shell", "bash", "--rc-file", str(rc_file)]) == 0
+
+    installed = rc_file.read_bytes()
+    assert b"\x9c" in installed
+    assert COMPLETION_BLOCK_START.encode("utf-8") in installed
+    assert COMPLETION_BLOCK_END.encode("utf-8") in installed
+
+    assert install_main(["--shell", "bash", "--rc-file", str(rc_file), "--uninstall"]) == 0
+
+    uninstalled = rc_file.read_bytes()
+    assert uninstalled == original


### PR DESCRIPTION
## Problem

`make setup-motrix` (and `make setup`) failed at the `unilab-complete install` step with a `UnicodeDecodeError`:

```
File ".../unilab/tools/completion.py", line 639, in _write_completion_block
    content = rc_file.read_text(encoding="utf-8") if rc_file.exists() else ""
...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 3993: invalid start byte
```

The completion installer reads the user's shell rc file to splice in its completion block, but read it with **strict** UTF-8 decoding. When the rc file contains a non-UTF-8 byte — e.g. a Warp terminal "Auto-Warpify" hook line ending in a stray `0x9c` — `_write_completion_block` / `_remove_completion_block` crash, aborting the make target.

The installer does not own the user's rc file content, so it must tolerate whatever bytes are already there rather than assuming clean UTF-8.

## Fix

Read and write the rc file with `errors="surrogateescape"` in both `_write_completion_block` and `_remove_completion_block`. Unknown bytes are decoded to surrogate placeholders and re-encoded to their **exact original bytes** on write, so the installer can edit its own block while leaving the user's pre-existing (non-UTF-8) content byte-for-byte intact.

## Validation

- `make setup-motrix` now completes end-to-end; completion block installed in `~/.bashrc`, and the original `0x9c` byte is verified preserved after the round-trip.
- `uv run pytest -k completion` → 15 passed, 1 skipped.
- `make test-all` run. The only failures are two pre-existing, environment-only tests in `tests/ipc/test_replay_pipeline_double_buffer.py` (require the CUDA toolkit — `CUDA_HOME not set and nvcc not found`); both fail identically on clean `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)