### PR TITLE
fix: align APPO G1 flip Motrix config

### DIFF
--- a/conf/appo/task/g1_flip_tracking/motrix.yaml
+++ b/conf/appo/task/g1_flip_tracking/motrix.yaml
@@ -5,16 +5,17 @@ training:
   play_steps: 1000
 algo:
   num_envs: 1024
-  max_iterations: 5000
+  steps_per_env: 24
+  max_iterations: 3500
   save_interval: 500
   algorithm:
-    num_learning_epochs: 5
-    num_mini_batches: 4
+    num_learning_epochs: 10
+    num_mini_batches: 8
     clip_param: 0.2
     gamma: 0.99
     lam: 0.95
     value_loss_coef: 1.0
-    entropy_coef: 0.01
+    entropy_coef: 0.005
     learning_rate: 1.0e-3
     max_grad_norm: 1.0
     use_clipped_value_loss: true
@@ -28,17 +29,58 @@ algo:
     vtrace_clip_rho: 1.0
     vtrace_clip_c: 1.0
     enable_compile: true
+env:
+  sampling_mode: start
+  truncate_on_clip_end: true
+  sim_dt: 0.005
+  control_config:
+    action_scale:
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+  anchor_pos_z_threshold: 0.5
+  ee_body_pos_z_threshold: 0.5
+  terminate_on_undesired_contacts: true
+  noise_config:
+    level: 0.0
 reward:
   scales:
     motion_global_root_pos: 0.5
     motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
+    motion_body_pos: 2.0
+    motion_body_ori: 1.5
     motion_body_lin_vel: 1.0
     motion_body_ang_vel: 1.0
+    motion_ee_body_pos_z: 2.0
     motion_joint_pos: 0.0
     motion_joint_vel: 0.0
-    action_rate_l2: -0.1
+    action_rate_l2: -0.005
     joint_limit: -10.0
   std_root_pos: 0.3
   std_root_ori: 0.4


### PR DESCRIPTION
## Summary

- Align `conf/appo/task/g1_flip_tracking/motrix.yaml` with the working MuJoCo APPO task parameters.
- Add the Motrix task env overrides used by the working flip tracking setup.
- Preserve backend selection through the Motrix owner YAML.

## Linked Work

- Issue: Fixes #616
- Milestone: none

## Validation

- [x] `make check`
- [ ] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
make check
uv run scripts/train_appo.py task=g1_flip_tracking/motrix --cfg job
uv run pytest tests/scripts/test_train_script_configs.py -q
git diff --check
```

## Impact

- Backend impact: `motrix`
- Platform impact: Linux
- Training effect expected: yes

## Artifacts

- W&B: none
- benchmark result: none
- video / screenshot: none
- ONNX / checkpoint: none

## Checklist

- [x] Added or updated tests where needed
- [ ] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly