### PR TITLE
fix infinite error in eval mode

### DIFF
--- a/src/unilab/base/backend/mujoco/playback.py
+++ b/src/unilab/base/backend/mujoco/playback.py
@@ -103,6 +103,13 @@ def run_mujoco_playback(
                 **cam_kw,
             )
 
+    if not frames:
+        # Rendering was skipped (e.g. no usable off-screen GL backend on a
+        # headless host). render_many already warned with actionable guidance;
+        # don't fail the eval/play run — just skip the video export.
+        print(f"[playback] No frames rendered; skipping video export to {output_video}.")
+        return None
+
     import mediapy as media
 
     ctrl_dt = float(env_cfg_value(env, "ctrl_dt", 1.0 / 60.0))

--- a/src/unilab/visualization/render_many.py
+++ b/src/unilab/visualization/render_many.py
@@ -17,7 +17,10 @@ import imageio
 
 _USER_MUJOCO_GL = os.environ.get("MUJOCO_GL")
 
-_EGL_PROBE_SCRIPT = textwrap.dedent(
+# Backend-agnostic probe: build a tiny off-screen scene and render one frame.
+# Used to verify that a given MUJOCO_GL backend (egl / osmesa / glfw / ...) can
+# actually create a rendering context on this host before we commit to it.
+_GL_PROBE_SCRIPT = textwrap.dedent(
     '''
     import mujoco
 
@@ -40,14 +43,23 @@ _EGL_PROBE_SCRIPT = textwrap.dedent(
 )
 
 
-def _egl_runtime_usable() -> bool:
+def _gl_backend_runtime_usable(backend: str) -> bool:
+    """Return True if *backend* can create and render an off-screen MuJoCo scene.
+
+    The probe runs in a clean subprocess so a broken / half-initialized GL driver
+    cannot corrupt or crash this process.
+    """
+    if not backend:
+        return False
+
     env = os.environ.copy()
-    env["MUJOCO_GL"] = "egl"
-    env.setdefault("MUJOCO_EGL_DEVICE_ID", "0")
+    env["MUJOCO_GL"] = backend
+    if backend == "egl":
+        env.setdefault("MUJOCO_EGL_DEVICE_ID", "0")
 
     try:
         subprocess.run(
-            [sys.executable, "-c", _EGL_PROBE_SCRIPT],
+            [sys.executable, "-c", _GL_PROBE_SCRIPT],
             env=env,
             check=True,
             stdout=subprocess.DEVNULL,
@@ -57,15 +69,23 @@ def _egl_runtime_usable() -> bool:
     except (OSError, subprocess.SubprocessError):
         return False
 
-    os.environ.setdefault("MUJOCO_EGL_DEVICE_ID", env["MUJOCO_EGL_DEVICE_ID"])
+    if backend == "egl":
+        os.environ.setdefault("MUJOCO_EGL_DEVICE_ID", env["MUJOCO_EGL_DEVICE_ID"])
     return True
+
+
+def _egl_runtime_usable() -> bool:
+    """Probe the EGL backend specifically (GPU-backed off-screen rendering)."""
+    return _gl_backend_runtime_usable("egl")
 
 
 def _resolve_gl_backend() -> str:
     """Pick a valid MUJOCO_GL backend for the current platform.
 
     Respects an explicit user setting unless it's provably invalid (e.g. egl
-    on macOS).  Falls back to glfw when EGL is requested but not available.
+    on macOS).  Prefers GPU-backed EGL, then software OSMesa on headless hosts.
+    ``glfw`` is only chosen when a display is available, because it requires an
+    X11 context and would otherwise fail in every render worker.
     """
     current = os.environ.get("MUJOCO_GL", "")
     safe_values = {"glfw", "osmesa", "disabled"}
@@ -82,6 +102,15 @@ def _resolve_gl_backend() -> str:
     if _egl_runtime_usable():
         return "egl"
 
+    # No EGL. On a headless host glfw cannot work (it needs an X11 display), so
+    # prefer software rendering. We return "osmesa" even when its presence is
+    # unverified here: it is the only headless-capable backend, and the playback
+    # pre-flight check (render_backend_usable) turns an unusable backend into a
+    # single clear warning instead of a GLFW failure that respawns workers.
+    if not os.environ.get("DISPLAY"):
+        return "osmesa"
+
+    # A display is available; glfw can create an off-screen context.
     return "glfw"
 
 
@@ -90,6 +119,30 @@ os.environ["MUJOCO_GL"] = _resolve_gl_backend()
 
 import mujoco  # noqa: E402
 import numpy as np
+
+
+def render_backend_usable() -> bool:
+    """Whether the resolved MUJOCO_GL backend can actually render on this host.
+
+    A cheap one-off subprocess probe used before spawning render workers, so a
+    host that cannot render (no EGL, no OSMesa, no display) degrades to a clear
+    warning instead of an endless worker-respawn loop.
+    """
+    return _gl_backend_runtime_usable(os.environ.get("MUJOCO_GL", ""))
+
+
+def _warn_render_unavailable() -> None:
+    """Emit a single actionable message when off-screen rendering is impossible."""
+    backend = os.environ.get("MUJOCO_GL", "<unset>")
+    has_display = "set" if os.environ.get("DISPLAY") else "unset"
+    print(
+        "[render] MuJoCo off-screen rendering is unavailable "
+        f"(MUJOCO_GL={backend!r}, DISPLAY={has_display}); skipping video recording.\n"
+        "[render] On a headless host install software rendering "
+        "(e.g. `apt-get install libosmesa6`) or enable EGL on a GPU "
+        "(`MUJOCO_GL=egl`), then re-run with `--render-mode record`.",
+        file=sys.stderr,
+    )
 
 
 def get_grid_offsets(num_envs, spacing=1.0):
@@ -408,6 +461,10 @@ def render_states_get_frames(
         print("No states to render.")
         return []
 
+    if not render_backend_usable():
+        _warn_render_unavailable()
+        return []
+
     num_envs = state_list[0].shape[0]
     offsets = get_grid_offsets(num_envs, spacing=render_spacing)
     shape = (width, height)
@@ -427,7 +484,7 @@ def render_states_get_frames(
         )
     ]
 
-    frames = []
+    frames: list[Any] = []
 
     if num_processes <= 1:
         # Serial execution
@@ -440,16 +497,35 @@ def render_states_get_frames(
         finally:
             _close_worker()
     else:
-        # Use multiprocessing Pool
-        # On macOS, use spawn to avoid forking OpenGL/MuJoCo contexts.
+        # Use a process pool. ProcessPoolExecutor (unlike multiprocessing.Pool)
+        # fails fast with BrokenProcessPool when a worker dies during init or a
+        # task, instead of silently respawning the dead worker forever — which
+        # would turn a single render failure into an unbounded error-log flood
+        # (see issue #605). spawn avoids forking OpenGL/MuJoCo contexts.
         import multiprocessing
+        from concurrent.futures import BrokenExecutor, ProcessPoolExecutor
 
         ctx = multiprocessing.get_context("spawn")
-        with ctx.Pool(
-            processes=num_processes, initializer=init_worker, initargs=(model_path, shape)
-        ) as pool:
-            results = pool.map(render_frame_job, tasks)
-            frames.extend(results)
+        chunksize = max(1, len(tasks) // (num_processes * 4))
+        try:
+            with ProcessPoolExecutor(
+                max_workers=num_processes,
+                mp_context=ctx,
+                initializer=init_worker,
+                initargs=(model_path, shape),
+            ) as pool:
+                frames = list(pool.map(render_frame_job, tasks, chunksize=chunksize))
+        except BrokenExecutor as exc:
+            # A worker died during init or a task (bad model, OOM, or an
+            # unusable GL backend). Fail fast instead of respawning forever.
+            print(
+                f"[render] A render worker terminated before completing "
+                f"({type(exc).__name__}: {exc}); skipping video recording. "
+                "If this host is headless, ensure a usable MUJOCO_GL backend "
+                "(egl on a GPU, or install OSMesa for software rendering).",
+                file=sys.stderr,
+            )
+            return []
 
     return frames
 
@@ -650,6 +726,10 @@ def render_states_get_frames_tracking(
         print("No states to render.")
         return []
 
+    if not render_backend_usable():
+        _warn_render_unavailable()
+        return []
+
     num_envs = state_list[0].shape[0]
     offsets = get_grid_offsets(num_envs, spacing=render_spacing)
     shape = (width, height)
@@ -717,6 +797,10 @@ def render_states_to_video(
         cam_lookat=cam_lookat,
         render_spacing=render_spacing,
     )
+
+    if not frames:
+        print(f"No frames rendered; skipping video write to {output_path}.")
+        return
 
     print(f"Saving video to {output_path}...")
     imageio.mimsave(output_path, frames, fps=fps)

--- a/tests/utils/test_render_many.py
+++ b/tests/utils/test_render_many.py
@@ -34,9 +34,23 @@ def test_resolve_gl_backend_uses_egl_when_probe_succeeds(monkeypatch) -> None:
     assert render_many._resolve_gl_backend() == "egl"
 
 
-def test_resolve_gl_backend_falls_back_to_glfw_when_probe_fails(monkeypatch) -> None:
+def test_resolve_gl_backend_uses_osmesa_when_headless_and_egl_unavailable(monkeypatch) -> None:
+    # Headless host (no DISPLAY): glfw cannot work, so software rendering wins.
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.delenv("MUJOCO_GL", raising=False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+
+    render_many = _reload_render_many(monkeypatch)
+    monkeypatch.setattr(render_many, "_egl_runtime_usable", lambda: False)
+
+    assert render_many._resolve_gl_backend() == "osmesa"
+
+
+def test_resolve_gl_backend_uses_glfw_when_display_present_and_egl_unavailable(monkeypatch) -> None:
+    # A display is available: glfw can create an off-screen context.
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("MUJOCO_GL", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
 
     render_many = _reload_render_many(monkeypatch)
     monkeypatch.setattr(render_many, "_egl_runtime_usable", lambda: False)
@@ -106,3 +120,68 @@ def test_offset_freejoint_object_qpos_handles_arbitrary_object_body(monkeypatch)
     assert data.qpos[1] == pytest.approx(0.0)
     assert data.qpos[7] == pytest.approx(1.5)
     assert data.qpos[8] == pytest.approx(-2.0)
+
+
+def test_render_backend_usable_reflects_resolved_backend(monkeypatch) -> None:
+    render_many = _reload_render_many(monkeypatch)
+
+    seen: dict[str, str] = {}
+
+    def _fake_probe(backend: str) -> bool:
+        seen["backend"] = backend
+        return backend == "egl"
+
+    monkeypatch.setattr(render_many, "_gl_backend_runtime_usable", _fake_probe)
+
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    assert render_many.render_backend_usable() is True
+    assert seen["backend"] == "egl"
+
+    monkeypatch.setenv("MUJOCO_GL", "osmesa")
+    assert render_many.render_backend_usable() is False
+
+
+def test_render_states_get_frames_skips_when_backend_unusable(monkeypatch) -> None:
+    render_many = _reload_render_many(monkeypatch)
+    monkeypatch.setattr(render_many, "render_backend_usable", lambda: False)
+
+    frames = render_many.render_states_get_frames(
+        [np.zeros((1, 8), dtype=np.float32)],
+        "/no/such/model.xml",
+        num_processes=4,
+    )
+
+    assert frames == []
+
+
+def test_render_states_get_frames_tracking_skips_when_backend_unusable(monkeypatch) -> None:
+    render_many = _reload_render_many(monkeypatch)
+    monkeypatch.setattr(render_many, "render_backend_usable", lambda: False)
+
+    frames = render_many.render_states_get_frames_tracking(
+        [np.zeros((1, 8), dtype=np.float32)],
+        "/no/such/model.xml",
+    )
+
+    assert frames == []
+
+
+def test_render_states_get_frames_fails_fast_on_worker_init_error(monkeypatch) -> None:
+    """A failing pool initializer must NOT respawn workers forever (issue #605).
+
+    ProcessPoolExecutor raises BrokenProcessPool quickly instead of hanging, and
+    render_states_get_frames degrades to an empty result + warning.
+    """
+    # Skip the EGL probe in spawned workers (they inherit MUJOCO_GL via os.environ).
+    monkeypatch.setenv("MUJOCO_GL", "osmesa")
+    render_many = _reload_render_many(monkeypatch)
+    # Bypass the parent pre-flight so we exercise the pool's fail-fast path.
+    monkeypatch.setattr(render_many, "render_backend_usable", lambda: True)
+
+    frames = render_many.render_states_get_frames(
+        [np.zeros((1, 8), dtype=np.float32)],
+        "/nonexistent/model/path.xml",  # init_worker raises while loading this
+        num_processes=2,
+    )
+
+    assert frames == []


### PR DESCRIPTION
## Summary(概述)

 修复在 headless(无显示器)机器上运行 `eval --render-mode record`(MuJoCo)时的无限刷错误日志 + 卡死问题 —— issue #605 。
- **为什么改:** 两个根本原因。
  1. headless 机器上没有可用的 EGL 时,`_resolve_gl_backend` 会回退到 **`glfw`**,而 glfw 需要 X11 显示。没有 `DISPLAY` 时,每个渲染 worker 的 `mujoco.Renderer()` 都会抛 `mujoco.FatalError: an OpenGL platform library has not been loaded`。
  2. 渲染用的是 `multiprocessing.Pool`,当 worker 的 `initializer` 抛异常时它会**静默地无限重启** worker —— 于是同一段 traceback 反复打印、`pool.map` 永不返回(无限日志 + 卡死)。
- **对用户 / 训练的影响:** 对训练**无影响**。仅改动 play/record 路径 —— 在无法渲染的机器上,eval 现在会打印一条可操作的警告、跳过视频、干净退出(exit 0),而不是刷爆日志。

**具体改动**
- `_resolve_gl_backend`:headless(无 `DISPLAY`)且无 EGL 时,改为回退到 **OSMesa**(软件渲染),不再用 `glfw`。macOS 行为不变(仍是 `glfw`)。
- 渲染进程池:`multiprocessing.Pool` → `concurrent.futures.ProcessPoolExecutor`,worker 失败时**快速失败**抛 `BrokenProcessPool`,不再无限重启。
- 兜底:新增预检 `render_backend_usable()` + `_warn_render_unavailable()`;若没有可用后端(或 worker 死亡),只打印**一条**警告并返回 `[]`。`run_mujoco_playback` / `render_states_to_video` 随后跳过写视频,而不是在空帧上崩溃。

## Linked Work(关联工作)

- Issue: #605
- Milestone: —

## Validation(验证)

- [x] `make check`
- [x] `uv run pytest -m "not slow"`(通过 `make test-all`)
- [x] 下方列出的额外验证

实际执行的命令:

```bash
make test-all
# ruff check          -> All checks passed!
# ruff format --check -> 414 files left unchanged
# mypy src/unilab     -> Success: no issues found in 215 source files
# pyright             -> 0 errors, 1 warning(既有的 mlx.core import,无关)
# pytest -m "not slow" --cov -> 1261 passed, 12 skipped, 255 deselected, 0 failed;
```

额外验证:
- 在 headless 机器上通过强制 `MUJOCO_GL=glfw`(无 `DISPLAY`)忠实复现出报告中一字不差的错误:`mujoco.FatalError: an OpenGL platform library has not been loaded`。
- 证明旧的 `multiprocessing.Pool` 在几秒内重启数百个 worker 并卡死(rc=124);新的 `ProcessPoolExecutor` 约 0.05s 抛出 `BrokenProcessPool`。
- 验证了四条失败路径 —— GL 上下文失败、非 GL 的 init 失败(坏模型)、worker 任务中途暴毙(OOM/段错误)、完整 `render_states_to_video` 管线 —— 全部降级为「一条警告 + 跳过视频 + exit 0」,没有 traceback 刷屏。
- Reporter已确认该分支修复生效。

> 注:`tests/utils/test_render_many.py` 在 `GITHUB_ACTIONS` 下会被跳过(CI runner 没有稳定的 EGL/GLFW 后端),所以这些新测试只在本地运行、不在 CI 跑。CI 仍会校验 ruff / mypy / pyright 及其余全部用例。

## Impact(影响面)

- Backend impact: `mujoco`
- Platform impact: Linux(headless)—— 惠及任何无 EGL/无显示器的机器;macOS 不受影响。
- Training effect expected: **no**(仅 play/eval 路径;collector/learner 不 import 这些模块)

## Artifacts(产物)

- W&B: —
- benchmark result: —
- video / screenshot: —
- ONNX / checkpoint: —

## Checklist(检查项)

- [x] 按需新增/更新了测试
- [ ] 行为或流程变化时更新文档(不适用 —— 无流程变化)
- [x] 关联了驱动该 PR 的 issue
- [x] 明确记录了后续工作(无)
