### PR TITLE
fix: unlock locomani and inhandgrasp demo camera

### DIFF
--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -52,6 +52,10 @@ DEMO_REGISTRY: dict[str, DemoSpec] = {
 }
 
 _LOCAL_ONLY_CHECKPOINT_DEMOS = {"sharpa_appo_student"}
+_DEMO_PLAY_INTERACTIVE_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "locomani": ("interactive.camera_follow_body=false",),
+    "inhandgrasp": ("interactive.camera_follow_body=false",),
+}
 
 
 def _repo_root() -> Path:
@@ -261,6 +265,7 @@ def build_demo_command(
     extra: list[str] = []
     if device is not None:
         extra.append(f"training.device={device}")
+    extra.extend(_DEMO_PLAY_INTERACTIVE_OVERRIDES.get(demo_name, ()))
 
     if spec.entry == "eval":
         return build_command(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,6 +342,7 @@ def test_demo_play_interactive_entry_assembles_locomani_command(
     assert command[4:8] == ["--task", "go2_arm_manip_loco", "--sim", "mujoco"]
     assert f"algo.load_run={abs_pt}" in command
     assert "training.device=cpu" in command
+    assert "interactive.camera_follow_body=false" in command
 
 
 def test_demo_play_interactive_entry_assembles_wallflip2_command(
@@ -381,6 +382,7 @@ def test_demo_play_interactive_entry_assembles_inhandgrasp_command(
     assert command[4:8] == ["--task", "sharpa_inhand", "--sim", "mujoco_nodr"]
     assert f"algo.load_run={abs_pt}" in command
     assert "training.device=cpu" in command
+    assert "interactive.camera_follow_body=false" in command
 
 
 def test_demo_play_interactive_hora_distill_nodr_command(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- disable body-follow camera only for `uv run demo locomani`
- disable body-follow camera only for `uv run demo inhandgrasp`
- add CLI assertions so those demo commands keep emitting `interactive.camera_follow_body=false`

## Validation
- `uv run pytest tests/test_cli.py -k "locomani or inhandgrasp or hora_distill_nodr"`
- `make test-all`
