### PR TITLE
docs: document SAC multi-GPU training

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/1-training/4-multi_gpu.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/4-multi_gpu.md
@@ -1,21 +1,77 @@
 # Multi-GPU
 
-The current multi-GPU knob lives in the shared off-policy training config as
-`training.num_gpus`. The field is consumed by the off-policy and FlashSAC paths;
-PPO, MLX PPO, and APPO do not expose the same multi-GPU contract.
+The currently validated multi-GPU training path is SAC in replay-buffer mode.
+Use the unified CLI as usual, and enable multiple GPUs with the shared
+off-policy field `training.num_gpus`.
+
+The multi-GPU runner keeps algorithm code separate from IPC: a collector fills
+the CPU replay buffer on the host, the runner packs batches for each learner
+rank on demand, pinned-memory pipelines distribute those batches to multiple
+GPUs in parallel, and the GPU learners average gradients with distributed
+training.
+
+## Preconditions
+
+- SAC only: `training.num_gpus > 1` rejects TD3, FlashSAC, PPO, MLX PPO, and APPO.
+- CUDA is required; select physical cards with `CUDA_VISIBLE_DEVICES`.
+- This validation round requires `algo.obs_normalization=false`.
+- SAC symmetry augmentation is not supported in multi-GPU mode. If the task
+  owner enables it by default, set `algo.use_symmetry=false`.
+- Collection must stay synchronized; do not set `training.no_sync_collection=true`.
+
+## Basic Command
+
+Two adjacent visible GPUs:
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
+```
+
+For non-adjacent physical GPUs, map them into the visible set with
+`CUDA_VISIBLE_DEVICES`. For example, to use physical cards 0 and 7:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
+```
+
+For a short smoke run, reduce iterations and env count, and skip post-training
+playback:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false \
+  algo.max_iterations=10 \
+  algo.num_envs=512 \
   training.no_play=true
 ```
 
-Keep task and backend selection in `--task` and `--sim`:
+Logs still use SAC's default directory: `logs/fast_sac/<TaskName>/`.
 
-```bash
-uv run train --algo td3 --task g1_walk_flat --sim mujoco \
-  training.num_gpus=2
-```
+## Performance Checks
+
+Multi-GPU mainly targets learner update bottlenecks. For small env counts,
+batches, or short runs, distributed startup, batch packing, and gradient
+synchronization can cost more than they save. When comparing single-GPU and
+multi-GPU runs, keep the task, env count, iteration count, playback settings,
+logger, and visible GPUs consistent, then compare steady-state `train_fps`,
+learner step time, and end-to-end iteration time.
+
+## Common Errors
+
+- `Only SAC supports training.num_gpus > 1`: only SAC is validated right now.
+- `SAC multi-GPU training requires a CUDA device`: CUDA is unavailable, or
+  `training.device` was set to CPU.
+- `requires algo.obs_normalization=false`: add `algo.obs_normalization=false`.
+- `set training.num_gpus=1 or algo.use_symmetry=false`: multi-GPU SAC does not
+  support symmetry augmentation yet; add `algo.use_symmetry=false`.
 
 When changing multi-GPU behavior, validate near the off-policy runner and IPC
 boundary rather than only checking a top-level command.

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
@@ -11,11 +11,25 @@ The off-policy runner decouples CPU simulation from GPU learning through shared
 memory: a collector subprocess fills a CPU-resident replay buffer while the
 learner trains on the GPU.
 
+SAC is also the currently validated replay-buffer multi-GPU algorithm. Enable it
+with `training.num_gpus > 1`; the host side packs and distributes batches in
+parallel, while the GPU learners average gradients. See
+{doc}`../1-training/4-multi_gpu` for the full command and constraints.
+
 ## Quick Start
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco
 uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
+```
+
+Two-GPU MuJoCo example:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
 ```
 
 ## Key Fields
@@ -28,6 +42,8 @@ playback video. See {doc}`/en/1-getting_started/3-evaluation_and_playback`.
 - `algo.num_envs=4096`
 - `algo.max_iterations=500`
 - `training.use_amp=true` in the shared off-policy config
+- Multi-GPU SAC uses `training.num_gpus=<N>`; this validation round requires
+  `algo.obs_normalization=false` and does not support `algo.use_symmetry=true`.
 
 The current runner path in `scripts/train_offpolicy.py` requires synchronized
 collection; `training.no_sync_collection=true` is rejected by the script.

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/4-multi_gpu.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/4-multi_gpu.md
@@ -1,21 +1,73 @@
 # 多 GPU
 
-当前的多 GPU 旋钮位于共享的 off-policy 训练配置中，即 `training.num_gpus`。该字段
-由 off-policy 与 FlashSAC 路径消费；PPO、MLX PPO 和 APPO 并不暴露相同的多 GPU
-contract。
+当前已验证的多 GPU 训练路径是 SAC 的 replay-buffer 模式。入口仍然是统一 CLI：
+`uv run train --algo sac ...`，多卡由共享 off-policy 配置字段
+`training.num_gpus` 打开。
+
+多 GPU runner 保持算法与 IPC 隔离：collector 在 host 侧填充 CPU replay buffer，
+runner 根据各 learner rank 的请求打包 batch，并通过 pinned-memory pipeline 并行分
+发到多张 GPU；各 GPU learner 使用分布式平均梯度更新。
+
+## 前置条件
+
+- 只支持 SAC：`training.num_gpus > 1` 会拒绝 TD3、FlashSAC、PPO、MLX PPO 和 APPO。
+- 必须使用 CUDA 设备；用 `CUDA_VISIBLE_DEVICES` 选择物理卡。
+- 本轮验证要求 `algo.obs_normalization=false`。
+- SAC 的对称增强当前不支持多卡；若任务 owner 默认开启，需要设置
+  `algo.use_symmetry=false`。
+- 采集必须同步；不要设置 `training.no_sync_collection=true`。
+
+## 基本命令
+
+两张相邻卡：
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
+```
+
+选择非相邻物理卡时，用 `CUDA_VISIBLE_DEVICES` 映射本次运行可见的卡。例如使用物理
+卡 0 和 7：
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
+```
+
+如果只想做短冒烟验证，可以缩小迭代和环境数，并跳过训练后回放：
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false \
+  algo.max_iterations=10 \
+  algo.num_envs=512 \
   training.no_play=true
 ```
 
-将 task 与 backend 选择保留在 `--task` 和 `--sim` 中：
+日志仍写入 SAC 的默认目录：`logs/fast_sac/<TaskName>/`。
 
-```bash
-uv run train --algo td3 --task g1_walk_flat --sim mujoco \
-  training.num_gpus=2
-```
+## 性能检查
+
+多 GPU 主要减少 learner 更新瓶颈；如果环境数、batch 或迭代数太小，分布式启动、
+batch 打包和梯度同步开销可能超过收益。对比单卡和多卡时，请保持任务、环境数、迭
+代数、回放设置、logger 和可见 GPU 一致，并优先比较稳定阶段的
+`train_fps`、learner step 时间和端到端迭代时间。
+
+## 常见错误
+
+- `Only SAC supports training.num_gpus > 1`：当前只验证 SAC。
+- `SAC multi-GPU training requires a CUDA device`：没有可用 CUDA，或
+  `training.device` 被设成了 CPU。
+- `requires algo.obs_normalization=false`：显式追加
+  `algo.obs_normalization=false`。
+- `set training.num_gpus=1 or algo.use_symmetry=false`：多卡 SAC 暂不支持对称增
+  强，显式追加 `algo.use_symmetry=false`。
 
 修改多 GPU 行为时，请在最接近 off-policy runner 与 IPC 边界处进行验证，而不是仅检
 查顶层命令。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -9,11 +9,24 @@ SAC 通过共享的 off-policy 入口 `scripts/train_offpolicy.py` 选择，TD3 
 off-policy runner 通过 shared memory 把 CPU 仿真与 GPU 学习解耦：collector 子进程
 填充驻留在 CPU 上的 replay buffer，learner 在 GPU 上训练。
 
+SAC 也是当前已验证的 replay-buffer 多 GPU 训练算法。多卡模式通过
+`training.num_gpus > 1` 打开，host 侧并行打包并分发 batch，多张 GPU 上的 learner
+进行平均梯度更新。完整命令与限制见 {doc}`../1-training/4-multi_gpu`。
+
 ## 快速开始
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco
 uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
+```
+
+两卡 MuJoCo 训练示例：
+
+```bash
+CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.num_gpus=2 \
+  algo.obs_normalization=false \
+  algo.use_symmetry=false
 ```
 
 ## 关键字段
@@ -26,6 +39,8 @@ uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
 - `algo.num_envs=4096`
 - `algo.max_iterations=500`
 - 共享 off-policy 配置中的 `training.use_amp=true`
+- 多 GPU SAC 使用 `training.num_gpus=<N>`；当前验证要求
+  `algo.obs_normalization=false`，且不支持 `algo.use_symmetry=true`。
 
 `scripts/train_offpolicy.py` 中当前的 runner 路径要求同步采集；脚本会拒绝
 `training.no_sync_collection=true`。


### PR DESCRIPTION
## Summary
- document the validated SAC replay-buffer multi-GPU training path
- add CUDA_VISIBLE_DEVICES examples, smoke-run command, prerequisites, and common errors
- link the SAC algorithm docs to the multi-GPU training guide

## Validation
- make test-all