### PR TITLE
Feat/issue 634 mujoco adaptive chunksize

### DIFF
--- a/conf/appo/config.yaml
+++ b/conf/appo/config.yaml
@@ -116,6 +116,10 @@ interactive:
 
 env:
   post_step_forward_sensor: false
+  # adaptive_chunk_size: auto-tune the MuJoCo BatchEnvPool chunk_size at materialize
+  # (cache-backed). chunk_size (int) manually overrides and wins; null => use default.
+  adaptive_chunk_size: true
+  chunk_size: null
 
 hydra:
   run:

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -77,6 +77,10 @@ interactive:
 
 env:
   post_step_forward_sensor: false
+  # adaptive_chunk_size: auto-tune the MuJoCo BatchEnvPool chunk_size at materialize
+  # (cache-backed). chunk_size (int) manually overrides and wins; null => use default.
+  adaptive_chunk_size: true
+  chunk_size: null
 
 hydra:
   run:

--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -127,6 +127,10 @@ viser:
 
 env:
   post_step_forward_sensor: false
+  # adaptive_chunk_size: auto-tune the MuJoCo BatchEnvPool chunk_size at materialize
+  # (cache-backed). chunk_size (int) manually overrides and wins; null => use default.
+  adaptive_chunk_size: true
+  chunk_size: null
 
 hydra:
   run:

--- a/conf/ppo/config_mlx.yaml
+++ b/conf/ppo/config_mlx.yaml
@@ -78,6 +78,10 @@ training:
 
 env:
   post_step_forward_sensor: false
+  # adaptive_chunk_size: auto-tune the MuJoCo BatchEnvPool chunk_size at materialize
+  # (cache-backed). chunk_size (int) manually overrides and wins; null => use default.
+  adaptive_chunk_size: true
+  chunk_size: null
 
 hydra:
   run:

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -1,8 +1,25 @@
-from typing import Any, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
 
 from unilab.base.scene import SceneCfg
 
 from .base import SimBackend
+
+if TYPE_CHECKING:
+    from unilab.base.base import EnvCfg
+
+
+def env_backend_kwargs(cfg: "EnvCfg") -> dict:
+    """Bundle EnvCfg-level backend tuning fields for create_backend(**...)."""
+    return {
+        "post_step_forward_sensor": cfg.post_step_forward_sensor,
+        "motrix_max_iterations": cfg.motrix_max_iterations,
+        "chunk_size": cfg.chunk_size,
+        "adaptive_chunk_size": cfg.adaptive_chunk_size,
+        "bench_nsteps": cfg.sim_substeps,
+    }
+
 
 _MUJOCO_XML_EXPORTS = frozenset(
     {
@@ -69,12 +86,18 @@ def create_backend(
     position_actuator_gains = kwargs.pop("position_actuator_gains", None)
     motrix_max_iterations = kwargs.pop("motrix_max_iterations", None)
     post_step_forward_sensor = kwargs.pop("post_step_forward_sensor", None)
+    chunk_size = kwargs.pop("chunk_size", None)
+    adaptive_chunk_size = kwargs.pop("adaptive_chunk_size", False)
+    bench_nsteps = kwargs.pop("bench_nsteps", 1)
     if backend_type == "mujoco":
         MuJoCoBackend = _load_mujoco_backend()
         if position_actuator_gains is not None:
             kwargs["position_actuator_gains"] = position_actuator_gains
         if post_step_forward_sensor is not None:
             kwargs["post_step_forward_sensor"] = post_step_forward_sensor
+        kwargs["chunk_size"] = chunk_size
+        kwargs["adaptive_chunk_size"] = adaptive_chunk_size
+        kwargs["bench_nsteps"] = bench_nsteps
         return cast(SimBackend, MuJoCoBackend(scene, num_envs, sim_dt, **kwargs))
     if backend_type == "motrix":
         MotrixBackend, motrix_available = _load_motrix_backend()

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -279,6 +279,9 @@ class MuJoCoBackend(SimBackend):
         iterations: int | None = None,
         push_body_name: Optional[str] = None,
         post_step_forward_sensor: bool = False,
+        chunk_size: Optional[int] = None,
+        adaptive_chunk_size: bool = False,
+        bench_nsteps: int = 1,
     ):
         scene_context = _build_mujoco_scene_context(scene)
         self.scene_model_file = scene_context.model_file
@@ -294,6 +297,10 @@ class MuJoCoBackend(SimBackend):
         self._sim_dt = float(sim_dt)
         self._iterations = None if iterations is None else int(iterations)
         self._post_step_forward_sensor = bool(post_step_forward_sensor)
+        self._manual_chunk_size = None if chunk_size is None else int(chunk_size)
+        self._adaptive_chunk_size = bool(adaptive_chunk_size)
+        self._bench_nsteps = max(1, int(bench_nsteps))
+        self._chunk_size: int | None = None
         self._position_actuator_gains = (
             None if position_actuator_gains is None else dict(position_actuator_gains)
         )
@@ -796,6 +803,7 @@ class MuJoCoBackend(SimBackend):
             nstep=nsteps,
             control=control_traj,
             control_spec=control_spec,
+            chunk_size=self._chunk_size,
             return_sensor=True,
             post_step_forward_sensor=self._post_step_forward_sensor,
         )
@@ -841,6 +849,7 @@ class MuJoCoBackend(SimBackend):
                 nstep=1,
                 control=control_traj,
                 control_spec=control_spec,
+                chunk_size=self._chunk_size,
                 return_sensor=True,
                 post_step_forward_sensor=self._post_step_forward_sensor,
             )
@@ -920,6 +929,23 @@ class MuJoCoBackend(SimBackend):
         if self._pool is not None:
             raise RuntimeError("MuJoCo backend pool is already materialized")
         self._pool = self._build_pool()
+
+        from unilab.base.backend.mujoco.chunk_tuner import resolve_chunk_size
+
+        self._chunk_size = resolve_chunk_size(
+            pool=self._pool,
+            state=self._physics_state,
+            model=self._model,
+            n_variants=len(self._model_variants),
+            num_envs=self._num_envs,
+            nthread=self._n_threads,
+            dtype=self._np_dtype,
+            post_step_forward_sensor=self._post_step_forward_sensor,
+            bench_nsteps=self._bench_nsteps,
+            manual_chunk_size=self._manual_chunk_size,
+            adaptive=self._adaptive_chunk_size,
+            model_file=self._model_file,
+        )
 
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         if plan.is_empty():

--- a/src/unilab/base/backend/mujoco/chunk_tuner.py
+++ b/src/unilab/base/backend/mujoco/chunk_tuner.py
@@ -227,7 +227,15 @@ def file_lock(lock_path: Path):
             f.close()
 
 
-def _median_step_time(
+def _aggregate_times(times) -> float:
+    """Reduce repeated samples to one estimate. Use ``min``: background load only
+    inflates a sample (never deflates it below the compute-bound floor), so the
+    minimum is the most stable proxy for the uncontended cost a dedicated training
+    box sees -- unlike the median, which a loaded machine biases upward."""
+    return float(min(times))
+
+
+def _robust_step_time(
     pool, state, nstep, control, chunk_size, post_step_forward_sensor, reps
 ) -> float:
     times = []
@@ -243,7 +251,7 @@ def _median_step_time(
             post_step_forward_sensor=post_step_forward_sensor,
         )
         times.append(time.perf_counter() - t0)
-    return float(np.median(times))
+    return _aggregate_times(times)
 
 
 def benchmark_chunk_sizes(
@@ -255,12 +263,13 @@ def benchmark_chunk_sizes(
     control,
     post_step_forward_sensor,
     warmup=2,
-    reps=5,
+    reps=20,
     time_budget_s=25.0,  # headroom for the heaviest envs (~16k) to sweep all candidates
 ) -> dict[int | None, float]:
-    """Median wall-clock of a representative ``pool.step`` per candidate.
+    """Min wall-clock of a representative ``pool.step`` per candidate.
 
-    ``None`` (native default) is always measured as the baseline anchor.
+    Each candidate is sampled ``reps`` times and reduced via ``min`` (uncontended
+    cost). ``None`` (native default) is always measured as the baseline anchor.
     """
     results: dict[int | None, float] = {}
     start = time.perf_counter()
@@ -275,7 +284,7 @@ def benchmark_chunk_sizes(
                 return_sensor=True,
                 post_step_forward_sensor=post_step_forward_sensor,
             )
-        results[cs] = _median_step_time(
+        results[cs] = _robust_step_time(
             pool, state, nstep, control, cs, post_step_forward_sensor, reps
         )
         if time.perf_counter() - start > time_budget_s:

--- a/src/unilab/base/backend/mujoco/chunk_tuner.py
+++ b/src/unilab/base/backend/mujoco/chunk_tuner.py
@@ -1,0 +1,402 @@
+"""Adaptive thread-pool ``chunk_size`` selection for the MuJoCo BatchEnvPool.
+
+All probing/benchmarking happens on the cold path (``materialize()``), never on
+``step``/``reset``. Results are cached on disk keyed by model signature + device
+fingerprint + (num_envs, nthread, dtype, ...) so repeated trainings reuse them.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import math
+import os
+import platform
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+MAX_CANDIDATES = 16
+
+
+def _emit(msg: str) -> None:
+    """Surface a one-time chunk_size decision on the terminal.
+
+    Collector envs materialize inside ``spawn`` subprocesses whose root logger is
+    unconfigured (default level WARNING), so ``logger.info`` would be dropped and
+    the benchmark table would never reach the terminal. When INFO is not enabled,
+    fall back to a direct stderr write (the same channel the collector uses for
+    its own diagnostics); otherwise log normally so the main process sees no
+    duplicate line.
+    """
+    if logger.isEnabledFor(logging.INFO):
+        logger.info(msg)
+    else:
+        print(f"[unilab.chunk_size] {msg}", file=sys.stderr, flush=True)
+
+
+def _native_default_chunk(num_envs: int, nthread: int) -> int:
+    """The chunk_size BatchEnvPool uses when ``chunk_size=None`` -- mujoco's own
+    default ``max(1, nbatch // (10 * nthread))`` (see mujoco ``batch_env`` /
+    ``rollout``). Shown next to ``default``/``None`` so the log is unambiguous."""
+    return max(1, int(num_envs) // (10 * max(1, int(nthread))))
+
+
+def _chosen_label(chosen: int | None, default_chunk: int) -> str:
+    """Spell out the effective chunk_size for the native default (``None``)."""
+    return f"None(={default_chunk})" if chosen is None else str(chosen)
+
+
+def _format_candidate_table(per_candidate_ms: dict, default_chunk: int) -> str:
+    """Render a stored ``per_candidate_ms`` mapping (keys ``"None"``/``"4"``/...,
+    values in ms) as ``default(=5)=9.38ms, 1=25.43ms, ...`` -- native default first
+    (annotated with its actual chunk_size), then candidates in ascending order."""
+
+    def sort_key(k: str):
+        return (0, -1) if k == "None" else (1, int(k))
+
+    def label(k: str) -> str:
+        return f"default(={default_chunk})" if k == "None" else k
+
+    return ", ".join(
+        f"{label(k)}={per_candidate_ms[k]:.2f}ms" for k in sorted(per_candidate_ms, key=sort_key)
+    )
+
+
+def _emit_cache_hit(value: int | None, per_candidate_ms: dict | None, default_chunk: int) -> None:
+    """Report a cache hit. Include the stored candidate breakdown when present so the
+    full benchmark stays visible on every run, not only the first (cold) one."""
+    chosen = _chosen_label(value, default_chunk)
+    if per_candidate_ms:
+        _emit(
+            f"chunk_size: cache hit -> chosen={chosen} | "
+            f"{_format_candidate_table(per_candidate_ms, default_chunk)}"
+        )
+    else:
+        _emit(f"chunk_size: cache hit -> {chosen}")
+
+
+def make_candidates(num_envs: int, nthread: int) -> list[int]:
+    """Candidate chunk_sizes within ``[1, upper]``, densified at the sweet spot.
+
+    ``upper = ceil(num_envs / nthread)`` is a hard ceiling: a chunk_size beyond it
+    produces fewer chunks than threads, leaving threads idle -> always slower. The
+    optimum sits near ``heur = num_envs / (10 * nthread)`` (~10 chunks per thread),
+    so the band around it is sampled densely while the always-bad large chunks are
+    never generated.
+    """
+    if num_envs < 1:
+        raise ValueError(f"num_envs must be >= 1, got {num_envs}")
+    nthread = max(1, int(nthread))
+    upper = max(1, math.ceil(num_envs / nthread))
+    if upper == 1:
+        return [1]
+    heur = min(upper, max(1, round(num_envs / (10 * nthread))))
+    cands: set[int] = {1, upper, heur}
+    for m in (0.5, 1.5, 2.0, 3.0):  # densify around the expected optimum
+        cands.add(min(upper, max(1, round(heur * m))))
+    c = 1  # geometric coverage of [1, upper]
+    while c < upper:
+        cands.add(c)
+        c = max(c + 1, round(c * 1.8))
+    cands.add(upper)
+    return sorted(cands)
+
+
+def filter_candidates(
+    candidates: list[int],
+    num_envs: int,
+    *,
+    max_candidates: int = MAX_CANDIDATES,
+) -> list[int]:
+    """Clamp to ``[1, num_envs]``, dedup, sort. If over the cap, trim the coarse
+    middle while keeping the low/optimum band (smallest values) plus the coarsest
+    anchor -- never log-spaced (which used to drop the optimum)."""
+    valid = sorted({c for c in candidates if 1 <= c <= num_envs})
+    if len(valid) <= max_candidates:
+        return valid
+    return sorted(set(valid[: max_candidates - 1]) | {valid[-1]})
+
+
+def device_fingerprint() -> dict[str, Any]:
+    """Coarse, deterministic local-device descriptor for the cache key."""
+    return {
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "cpu_count": int(os.cpu_count() or 1),
+    }
+
+
+def model_signature(model: Any, n_variants: int) -> dict[str, int]:
+    """Structural determinants of per-step cost (proxy for 'task')."""
+    return {
+        "nq": int(model.nq),
+        "nv": int(model.nv),
+        "nbody": int(model.nbody),
+        "njnt": int(model.njnt),
+        "nu": int(model.nu),
+        "ngeom": int(model.ngeom),
+        "nsensordata": int(model.nsensordata),
+        "n_variants": int(n_variants),
+    }
+
+
+def make_cache_key(
+    *,
+    backend_type: str,
+    model_sig: dict,
+    device: dict,
+    num_envs: int,
+    nthread: int,
+    dtype: Any,
+    post_step_forward_sensor: bool,
+    bench_nsteps: int,
+) -> str:
+    payload = {
+        "backend_type": backend_type,
+        "model": model_sig,
+        "device": device,
+        "num_envs": int(num_envs),
+        "nthread": int(nthread),
+        "dtype": np.dtype(dtype).name,
+        "post_step_forward_sensor": bool(post_step_forward_sensor),
+        "bench_nsteps": int(bench_nsteps),
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(blob.encode("utf-8")).hexdigest()
+
+
+def cache_path() -> Path:
+    override = os.environ.get("UNILAB_CHUNK_SIZE_CACHE")
+    if override:
+        return Path(override)
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    root = Path(xdg) if xdg else Path.home() / ".cache"
+    return root / "unilab" / "chunk_size.json"
+
+
+def load_cache(path: Path) -> dict:
+    try:
+        with Path(path).open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def store_cache(path: Path, key: str, value: dict) -> None:
+    path = Path(path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = load_cache(path)
+        data[key] = value
+        tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+    except OSError as e:
+        logger.warning("chunk_size cache write failed: %s", e)
+
+
+@contextlib.contextmanager
+def file_lock(lock_path: Path):
+    """Best-effort inter-process exclusive lock; no-op where fcntl is absent."""
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    lock_path = Path(lock_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    f = lock_path.open("w")
+    try:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        finally:
+            f.close()
+
+
+def _median_step_time(
+    pool, state, nstep, control, chunk_size, post_step_forward_sensor, reps
+) -> float:
+    times = []
+    for _ in range(reps):
+        s = state.copy()
+        t0 = time.perf_counter()
+        pool.step(
+            s,
+            nstep=nstep,
+            control=control,
+            chunk_size=chunk_size,
+            return_sensor=True,
+            post_step_forward_sensor=post_step_forward_sensor,
+        )
+        times.append(time.perf_counter() - t0)
+    return float(np.median(times))
+
+
+def benchmark_chunk_sizes(
+    pool,
+    state,
+    nstep,
+    candidates,
+    *,
+    control,
+    post_step_forward_sensor,
+    warmup=2,
+    reps=5,
+    time_budget_s=25.0,  # headroom for the heaviest envs (~16k) to sweep all candidates
+) -> dict[int | None, float]:
+    """Median wall-clock of a representative ``pool.step`` per candidate.
+
+    ``None`` (native default) is always measured as the baseline anchor.
+    """
+    results: dict[int | None, float] = {}
+    start = time.perf_counter()
+    for cs in [None, *candidates]:
+        for _ in range(warmup):
+            s = state.copy()
+            pool.step(
+                s,
+                nstep=nstep,
+                control=control,
+                chunk_size=cs,
+                return_sensor=True,
+                post_step_forward_sensor=post_step_forward_sensor,
+            )
+        results[cs] = _median_step_time(
+            pool, state, nstep, control, cs, post_step_forward_sensor, reps
+        )
+        if time.perf_counter() - start > time_budget_s:
+            logger.warning("chunk_size benchmark time budget exceeded; using partial results")
+            break
+    return results
+
+
+def select_chunk_size(
+    timings: dict[int | None, float], base: int, *, margin=0.03, tie_tol=0.02
+) -> int | None:
+    baseline = timings.get(None)
+    cand: dict[int, float] = {k: v for k, v in timings.items() if k is not None}
+    if not cand:
+        return None
+    best_cs = min(cand, key=lambda k: cand[k])
+    best_t = cand[best_cs]
+    if baseline is not None and best_t > baseline * (1.0 - margin):
+        return None  # not worth leaving the native default
+    band: list[int] = [k for k, v in cand.items() if v <= best_t * (1.0 + tie_tol)]
+    return min(band, key=lambda c: (abs(c - base), c))
+
+
+def _log_benchmark_table(
+    timings: dict[int | None, float], chosen: int | None, default_chunk: int
+) -> None:
+    def label(k: int | None) -> str:
+        return f"default(={default_chunk})" if k is None else str(k)
+
+    rows = ", ".join(
+        f"{label(k)}={v * 1000:.2f}ms"
+        for k, v in sorted(timings.items(), key=lambda kv: (kv[0] is not None, kv[0]))
+    )
+    _emit(f"chunk_size benchmark: {rows} -> chosen={_chosen_label(chosen, default_chunk)}")
+
+
+def resolve_chunk_size(
+    *,
+    pool,
+    state,
+    model,
+    n_variants: int,
+    num_envs: int,
+    nthread: int,
+    dtype,
+    post_step_forward_sensor: bool,
+    bench_nsteps: int,
+    manual_chunk_size: int | None,
+    adaptive: bool,
+    backend_type: str = "mujoco",
+    model_file: str | None = None,
+) -> int | None:
+    # 1. manual override always wins (highest priority).
+    if manual_chunk_size is not None:
+        _emit(f"chunk_size: manual override = {int(manual_chunk_size)}")
+        return int(manual_chunk_size)
+    # 2. adaptive disabled -> native default.
+    if not adaptive:
+        return None
+    # 2b. Nothing to tune: num_envs <= nthread means at most one work-chunk, so
+    #     chunk_size cannot change anything. Skip benchmark/cache/log entirely -- this
+    #     silences the num_envs=1 setup envs APPO/off-policy build just to read dims.
+    if math.ceil(num_envs / max(1, nthread)) <= 1:
+        return None
+    default_chunk = _native_default_chunk(num_envs, nthread)  # what chunk_size=None uses
+    # 3. cache lookup.
+    device = device_fingerprint()
+    model_sig = model_signature(model, n_variants)
+    key = make_cache_key(
+        backend_type=backend_type,
+        model_sig=model_sig,
+        device=device,
+        num_envs=num_envs,
+        nthread=nthread,
+        dtype=dtype,
+        post_step_forward_sensor=post_step_forward_sensor,
+        bench_nsteps=bench_nsteps,
+    )
+    path = cache_path()
+    hit = load_cache(path).get(key)
+    if hit is not None:
+        value = hit.get("chunk_size")
+        _emit_cache_hit(value, hit.get("per_candidate_ms"), default_chunk)
+        return value if value is None else int(value)
+    # 4. miss -> lock -> re-check -> benchmark -> store.
+    with file_lock(path.with_name(path.name + ".lock")):
+        hit = load_cache(path).get(key)
+        if hit is not None:
+            value = hit.get("chunk_size")
+            _emit_cache_hit(value, hit.get("per_candidate_ms"), default_chunk)
+            return value if value is None else int(value)
+        base = math.ceil(num_envs / max(1, nthread))  # upper anchor for the select tie-break
+        candidates = filter_candidates(make_candidates(num_envs, nthread), num_envs)
+        try:
+            control = np.zeros((num_envs, bench_nsteps, int(model.nu)), dtype=np.float64)
+            timings = benchmark_chunk_sizes(
+                pool,
+                state,
+                bench_nsteps,
+                candidates,
+                control=control,
+                post_step_forward_sensor=post_step_forward_sensor,
+            )
+        except Exception as e:  # benchmark must never crash training
+            logger.warning("chunk_size benchmark failed (%s); using native default", e)
+            return None
+        chosen = select_chunk_size(timings, base)
+        _log_benchmark_table(timings, chosen, default_chunk)
+        try:
+            store_cache(
+                path,
+                key,
+                {
+                    "chunk_size": chosen,
+                    "per_candidate_ms": {str(k): v * 1000 for k, v in timings.items()},
+                    "model_file": model_file,
+                    "hostname": socket.gethostname(),
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                "chunk_size cache store failed (%s); continuing with chosen=%s", e, chosen
+            )
+        return chosen

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -36,6 +36,8 @@ class EnvCfg:
     render_offset_mode: str = "grid"
     motrix_max_iterations: Optional[int] = None
     post_step_forward_sensor: bool = False
+    adaptive_chunk_size: bool = True
+    chunk_size: Optional[int] = None
 
     @property
     def max_episode_steps(self) -> Optional[int]:

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -12,7 +12,7 @@ from etils import epath
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.augmentation import SymmetryObsLayout
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.curriculum import EpisodeLengthTracker, PenaltyCurriculum
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
@@ -275,8 +275,7 @@ class G1WalkEnv(G1BaseEnv):
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -8,7 +8,7 @@ from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
@@ -103,8 +103,7 @@ class Go1WalkTask(Go1BaseEnv):
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         self._terrain_surface_sampler = getattr(backend, "terrain_surface_sampler", None)
         terrain_origins = getattr(backend, "terrain_origins", None)

--- a/src/unilab/envs/locomotion/go2/footstand.py
+++ b/src/unilab/envs/locomotion/go2/footstand.py
@@ -8,7 +8,7 @@ from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import ResetPlan, ResetRandomizationPayload
@@ -137,8 +137,7 @@ class Go2HandStandTask(Go2BaseEnv):
             push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=bool(getattr(cfg, "add_body_sensors", False)),
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
@@ -113,8 +113,7 @@ class Go2WalkTask(Go2BaseEnv):
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         self._terrain_surface_sampler = getattr(backend, "terrain_surface_sampler", None)
         self._terrain_surface_sample_height = self._resolve_terrain_surface_sample_height()

--- a/src/unilab/envs/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/envs/locomotion/go2_arm/manip_loco.py
@@ -305,6 +305,9 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
             )
             backend_kwargs["iterations"] = cfg.iterations
             backend_kwargs["post_step_forward_sensor"] = cfg.post_step_forward_sensor
+            backend_kwargs["chunk_size"] = cfg.chunk_size
+            backend_kwargs["adaptive_chunk_size"] = cfg.adaptive_chunk_size
+            backend_kwargs["bench_nsteps"] = cfg.sim_substeps
         backend = create_backend(
             backend_type,
             scene,

--- a/src/unilab/envs/locomotion/go2w/joystick.py
+++ b/src/unilab/envs/locomotion/go2w/joystick.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import DomainRandomizationCapabilities, ResetPlan, ResetRandomizationPayload
@@ -240,8 +240,7 @@ class Go2WJoystickEnv(Go2WBaseEnv):
             cfg.sim_dt,
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
         self._np_dtype = get_global_dtype()

--- a/src/unilab/envs/manipulation/allegro_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/rotation.py
@@ -10,7 +10,7 @@ from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import (
@@ -274,8 +274,7 @@ class AllegroRotationPPO(AllegroBaseEnv):
                 "kd": cfg.control_config.kd,
                 "actuator_ids": slice(0, 16),
             },
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from unilab.assets.hub import resolve_grasp_cache_files
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.dr import (
     DomainRandomizationCapabilities,
@@ -485,8 +485,7 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             base_name=cfg.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
 

--- a/src/unilab/envs/manipulation/stewart/balance.py
+++ b/src/unilab/envs/manipulation/stewart/balance.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import SimBackend, create_backend
+from unilab.base.backend import SimBackend, create_backend, env_backend_kwargs
 from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.scene import SceneCfg
@@ -158,6 +158,7 @@ class StewartBalanceEnv(NpEnv):
             cfg.sim_dt,
             base_name=cfg.base_name,
             add_body_sensors=True,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
 

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import (
@@ -462,8 +462,7 @@ class G1MotionTrackingEnv(G1BaseEnv):
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
+            **env_backend_kwargs(cfg),
         )
         super().__init__(cfg, backend, num_envs)
 

--- a/tests/base/backend/test_mujoco_chunk_size_wiring.py
+++ b/tests/base/backend/test_mujoco_chunk_size_wiring.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+
+from unilab.base.backend import env_backend_kwargs
+from unilab.base.base import EnvCfg
+
+pytest.importorskip("mujoco", reason="mujoco not installed")
+
+try:
+    from mujoco.batch_env import BatchEnvPool  # noqa: F401
+except Exception:
+    pytest.skip(
+        "mujoco.batch_env not available (platform/libstdc++ issue)", allow_module_level=True
+    )
+
+import mujoco
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.mujoco.backend import MuJoCoBackend
+from unilab.base.scene import SceneCfg
+
+_MODEL_FILE = str(ASSETS_ROOT_PATH / "robots" / "go2_arm" / "scene_flat.xml")
+_NUM_ENVS = 4
+
+
+def test_envcfg_chunk_size_defaults():
+    cfg = EnvCfg()
+    assert cfg.adaptive_chunk_size is True
+    assert cfg.chunk_size is None
+
+
+def test_envcfg_chunk_size_overridable():
+    cfg = EnvCfg(adaptive_chunk_size=False, chunk_size=128)
+    assert cfg.adaptive_chunk_size is False
+    assert cfg.chunk_size == 128
+
+
+def test_env_backend_kwargs_maps_fields():
+    cfg = EnvCfg(ctrl_dt=0.02, sim_dt=0.005, chunk_size=64, adaptive_chunk_size=False)
+    kw = env_backend_kwargs(cfg)
+    assert kw["chunk_size"] == 64
+    assert kw["adaptive_chunk_size"] is False
+    assert kw["bench_nsteps"] == cfg.sim_substeps == 4  # round(0.02/0.005)
+    assert kw["post_step_forward_sensor"] == cfg.post_step_forward_sensor
+    assert "motrix_max_iterations" in kw
+
+
+def _build_small_backend(**backend_kwargs):
+    """Build a minimal real MuJoCoBackend.
+
+    Mirrors the SceneCfg + construction used in
+    ``tests/base/backend/test_mujoco_site_jacobian.py``, forwarding
+    ``**backend_kwargs`` into ``MuJoCoBackend(...)`` and calling ``.materialize()``.
+    """
+    backend = MuJoCoBackend(
+        SceneCfg(model_file=_MODEL_FILE),
+        num_envs=_NUM_ENVS,
+        sim_dt=0.01,
+        base_name="base",
+        **backend_kwargs,
+    )
+    backend.materialize()
+    return backend
+
+
+def test_step_passes_resolved_chunk_size(monkeypatch):
+    backend = _build_small_backend(chunk_size=7, adaptive_chunk_size=False)
+    assert backend._chunk_size == 7
+
+    seen = {}
+    real_step = backend._pool.step
+
+    def _spy(state, **kw):
+        seen["chunk_size"] = kw.get("chunk_size")
+        return real_step(state, **kw)
+
+    monkeypatch.setattr(backend._pool, "step", _spy)
+    nu = backend._model.nu
+    backend.step(np.zeros((backend.num_envs, nu), dtype=np.float64), nsteps=1)
+    assert seen["chunk_size"] == 7
+
+
+def test_hot_path_does_no_xml_parse(monkeypatch):
+    """Acceptance ③: step/reset must not parse asset/XML (any entrypoint)."""
+    backend = _build_small_backend(adaptive_chunk_size=False)  # cold path done
+
+    # Install all parse spies AFTER the cold-path materialize so only hot-path
+    # (step) parses are counted. Spy multiple XML entrypoints, not just MjSpec.
+    spec_calls = {"n": 0}
+    model_calls = {"n": 0}
+    orig_from_file = mujoco.MjSpec.from_file
+    orig_from_xml_path = mujoco.MjModel.from_xml_path
+
+    def _counting_from_file(*a, **k):
+        spec_calls["n"] += 1
+        return orig_from_file(*a, **k)
+
+    def _counting_from_xml_path(*a, **k):
+        model_calls["n"] += 1
+        return orig_from_xml_path(*a, **k)
+
+    monkeypatch.setattr(mujoco.MjSpec, "from_file", staticmethod(_counting_from_file))
+    monkeypatch.setattr(mujoco.MjModel, "from_xml_path", staticmethod(_counting_from_xml_path))
+    nu = backend._model.nu
+    backend.step(np.zeros((backend.num_envs, nu), dtype=np.float64), nsteps=1)
+    assert spec_calls["n"] == 0
+    assert model_calls["n"] == 0
+
+
+def test_benchmark_runs_and_logs_table_on_adaptive(caplog, monkeypatch, tmp_path):
+    """Acceptance ④: adaptive path benchmarks and emits a per-candidate table.
+
+    Point the chunk_size cache at an empty ``tmp_path`` file so the resolve is a
+    guaranteed MISS (no warm-cache short-circuit) and never pollutes the real
+    ``~/.cache/unilab/chunk_size.json``. A clean miss forces the benchmark path,
+    so we can assert the benchmark-table INFO record specifically.
+    """
+    import logging
+
+    from unilab.base.backend.mujoco import backend as backend_mod
+
+    # Force nthread < num_envs so there is genuinely something to tune; otherwise the
+    # resolve short-circuits (num_envs <= nthread => one chunk => no benchmark). With
+    # cpu_count()==1, nthread = min(_NUM_ENVS, 2) = 2 < _NUM_ENVS, deterministically.
+    monkeypatch.setattr(backend_mod, "cpu_count", lambda: 1)
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "chunk_size.json"))
+    with caplog.at_level(logging.INFO, logger="unilab.base.backend.mujoco.chunk_tuner"):
+        backend = _build_small_backend(adaptive_chunk_size=True, chunk_size=None)
+    assert backend._chunk_size is None or isinstance(backend._chunk_size, int)
+    # Forced miss -> _log_benchmark_table emits the "chunk_size benchmark" record.
+    assert any("chunk_size benchmark" in r.message for r in caplog.records)

--- a/tests/base/backend/test_mujoco_chunk_tuner.py
+++ b/tests/base/backend/test_mujoco_chunk_tuner.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import math
 from pathlib import Path
@@ -273,6 +274,20 @@ def test_cache_hit_without_candidate_table_still_emits_chosen(capsys, monkeypatc
     monkeypatch.setattr(ct.logger, "level", logging.WARNING)
     ct._emit_cache_hit(4, None, default_chunk=1)
     assert "cache hit -> 4" in capsys.readouterr().err
+
+
+def test_aggregate_times_returns_min():
+    # min rejects background-load spikes (which only inflate, never deflate) and
+    # estimates the uncontended per-step cost a dedicated training box actually sees.
+    assert ct._aggregate_times([0.003, 0.001, 0.002]) == pytest.approx(0.001)
+    assert ct._aggregate_times([0.05, 0.0061, 0.006, 0.0062]) == pytest.approx(0.006)
+
+
+def test_benchmark_reps_default_is_stable():
+    # reps=5 was too few to reject noise on a loaded machine; the default must be
+    # large enough that the per-candidate estimate is stable.
+    reps = inspect.signature(ct.benchmark_chunk_sizes).parameters["reps"].default
+    assert reps >= 15, reps
 
 
 def test_benchmark_respects_time_budget():

--- a/tests/base/backend/test_mujoco_chunk_tuner.py
+++ b/tests/base/backend/test_mujoco_chunk_tuner.py
@@ -1,0 +1,418 @@
+import logging
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unilab.base.backend.mujoco import chunk_tuner as ct
+
+
+def test_make_candidates_never_exceeds_upper():
+    # upper = ceil(num_envs/nthread): a chunk beyond it yields fewer chunks than
+    # threads -> idle threads -> always slower, so it must never be a candidate.
+    for num_envs, nthread in [(4096, 16), (2048, 40), (1024, 40), (4096, 40)]:
+        upper = math.ceil(num_envs / nthread)
+        cands = ct.make_candidates(num_envs, nthread)
+        assert max(cands) == upper, (num_envs, nthread, max(cands), upper)
+        assert all(1 <= c <= upper for c in cands)
+        assert 1 in cands
+        assert cands == sorted(set(cands))
+
+
+def test_make_candidates_covers_sweet_spot():
+    # optimum sits near heur = num_envs/(10*nthread); a candidate must land in the band.
+    for num_envs, nthread, lo, hi in [(2048, 40, 3, 9), (1024, 40, 2, 7), (4096, 40, 8, 41)]:
+        cands = ct.make_candidates(num_envs, nthread)
+        assert any(lo <= c <= hi for c in cands), (num_envs, nthread, cands)
+
+
+def test_make_candidates_regression_g1walk_optimum_present():
+    # for 2048 envs / 40 threads the sweet-spot chunks (~4-6) must be candidates and
+    # the always-bad large chunks (> upper) must be excluded.
+    cands = ct.make_candidates(2048, 40)
+    assert any(4 <= c <= 6 for c in cands), cands
+    assert 1024 not in cands and 2048 not in cands
+
+
+def test_make_candidates_num_envs_one():
+    assert ct.make_candidates(num_envs=1, nthread=8) == [1]
+
+
+def test_make_candidates_fewer_envs_than_threads():
+    # nbatch <= nthread -> upper=1 -> only chunk_size=1 is sensible.
+    assert ct.make_candidates(num_envs=20, nthread=40) == [1]
+
+
+def test_make_candidates_rejects_bad_num_envs():
+    with pytest.raises(ValueError):
+        ct.make_candidates(num_envs=0, nthread=8)
+
+
+def test_filter_candidates_clamps_and_dedups():
+    out = ct.filter_candidates([0, 1, 1, 5, 4096, 9000], num_envs=4096)
+    assert out == [1, 5, 4096]
+
+
+def test_filter_candidates_capping_keeps_low_band_and_top_anchor():
+    # capping must NOT drop the low/optimum band (the old log-spacing bug); it trims
+    # the coarse middle, keeping the smallest values + the coarsest anchor.
+    out = ct.filter_candidates(list(range(1, 60)), num_envs=4096, max_candidates=8)
+    assert len(out) <= 8
+    assert 1 in out and max(out) == 59
+    assert all(c in out for c in (2, 3, 4, 5))
+
+
+def test_make_and_filter_g1walk_finds_optimum_band():
+    cands = ct.filter_candidates(ct.make_candidates(2048, 40), num_envs=2048)
+    assert any(4 <= c <= 6 for c in cands)
+    assert max(cands) == math.ceil(2048 / 40)
+    assert 1024 not in cands and 2048 not in cands
+
+
+class _FakeModel:
+    nq = 30
+    nv = 29
+    nbody = 16
+    njnt = 28
+    nu = 12
+    ngeom = 40
+    nsensordata = 100
+
+
+def test_device_fingerprint_has_expected_keys():
+    fp = ct.device_fingerprint()
+    assert set(fp) >= {"system", "machine", "cpu_count"}
+    assert isinstance(fp["cpu_count"], int) and fp["cpu_count"] >= 1
+
+
+def test_model_signature_reads_structural_fields():
+    sig = ct.model_signature(_FakeModel(), n_variants=3)
+    assert sig == {
+        "nq": 30,
+        "nv": 29,
+        "nbody": 16,
+        "njnt": 28,
+        "nu": 12,
+        "ngeom": 40,
+        "nsensordata": 100,
+        "n_variants": 3,
+    }
+
+
+def test_make_cache_key_deterministic_and_sensitive():
+    common = dict(
+        backend_type="mujoco",
+        model_sig=ct.model_signature(_FakeModel(), 1),
+        device={"system": "Linux", "machine": "x86_64", "cpu_count": 32},
+        num_envs=4096,
+        nthread=64,
+        dtype=np.float32,
+        post_step_forward_sensor=False,
+        bench_nsteps=4,
+    )
+    k1 = ct.make_cache_key(**common)
+    k2 = ct.make_cache_key(**common)
+    assert k1 == k2
+    assert ct.make_cache_key(**{**common, "num_envs": 2048}) != k1
+    assert ct.make_cache_key(**{**common, "dtype": np.float64}) != k1
+
+
+def test_cache_path_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom.json"
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(target))
+    assert ct.cache_path() == target
+
+
+def test_cache_path_xdg(monkeypatch, tmp_path):
+    monkeypatch.delenv("UNILAB_CHUNK_SIZE_CACHE", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    assert ct.cache_path() == tmp_path / "unilab" / "chunk_size.json"
+
+
+def test_load_missing_cache_returns_empty(tmp_path):
+    assert ct.load_cache(tmp_path / "nope.json") == {}
+
+
+def test_store_then_load_roundtrip_and_merge(tmp_path):
+    path = tmp_path / "c.json"
+    ct.store_cache(path, "k1", {"chunk_size": 7})
+    ct.store_cache(path, "k2", {"chunk_size": None})
+    data = ct.load_cache(path)
+    assert data["k1"]["chunk_size"] == 7
+    assert data["k2"]["chunk_size"] is None
+
+
+def test_file_lock_acquires_and_releases(tmp_path):
+    lock = tmp_path / "c.lock"
+    with ct.file_lock(lock):
+        pass
+    with ct.file_lock(lock):  # re-acquire after release must not deadlock
+        pass
+
+
+class _FakePool:
+    def __init__(self):
+        self.seen = []
+
+    def step(
+        self,
+        state,
+        *,
+        nstep,
+        control=None,
+        control_spec=0,
+        chunk_size=None,
+        return_sensor=False,
+        post_step_forward_sensor=False,
+    ):
+        self.seen.append(chunk_size)
+        return state, np.zeros((state.shape[0], 1))
+
+
+def test_benchmark_visits_all_candidates_plus_baseline():
+    pool = _FakePool()
+    state = np.zeros((8, 5), dtype=np.float64)
+    timings = ct.benchmark_chunk_sizes(
+        pool,
+        state,
+        nstep=2,
+        candidates=[1, 2],
+        control=None,
+        post_step_forward_sensor=False,
+        warmup=1,
+        reps=2,
+    )
+    assert set(timings) == {None, 1, 2}
+    assert all(isinstance(v, float) and v >= 0.0 for v in timings.values())
+    assert None in pool.seen and 1 in pool.seen and 2 in pool.seen
+
+
+def test_select_picks_fastest_above_margin():
+    timings = {None: 1.0, 128: 0.95, 256: 0.90, 512: 0.80}
+    assert ct.select_chunk_size(timings, base=256) == 512
+
+
+def test_select_keeps_default_when_margin_not_met():
+    timings = {None: 1.0, 256: 0.99}
+    assert ct.select_chunk_size(timings, base=256) is None
+
+
+def test_select_tiebreaks_toward_base():
+    timings = {None: 1.0, 200: 0.80, 256: 0.805, 4096: 0.81}
+    assert ct.select_chunk_size(timings, base=256) == 256
+
+
+def test_select_adopts_candidate_at_exact_margin():
+    # best_t exactly at the boundary (margin=0.5 -> baseline*(1-0.5)=0.5, exact float);
+    # spec '>= margin to adopt' means adopt the candidate, not keep the default.
+    timings = {None: 1.0, 256: 0.5}
+    assert ct.select_chunk_size(timings, base=256, margin=0.5) == 256
+
+
+def test_emit_falls_back_to_stderr_when_info_disabled(capsys, monkeypatch):
+    # Spawn collector subprocesses leave the root logger unconfigured (default
+    # level WARNING), which drops INFO. _emit must still surface the line on the
+    # terminal via stderr so the candidate benchmark is visible there.
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)
+    ct._emit("chunk_size benchmark: default=1.00ms, 4=0.80ms -> chosen=4")
+    err = capsys.readouterr().err
+    assert "chunk_size benchmark" in err
+    assert "chosen=4" in err
+
+
+def test_emit_uses_logger_when_info_enabled(capsys, caplog):
+    # Main process (Hydra-configured, INFO enabled): go through logging, NOT a
+    # raw stderr print, so there is no duplicate line.
+    caplog.set_level(logging.INFO, logger=ct.logger.name)
+    ct._emit("chunk_size: cache hit -> 4")
+    assert "chunk_size: cache hit -> 4" not in capsys.readouterr().err
+    assert any("cache hit -> 4" in r.message for r in caplog.records)
+
+
+def test_log_benchmark_table_surfaces_candidates_without_logging(capsys, monkeypatch):
+    # End-to-end: with INFO disabled (subprocess), the full candidate table must
+    # reach stderr, including every candidate's timing and the chosen value.
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)
+    ct._log_benchmark_table({None: 0.006, 1: 0.013, 4: 0.005, 26: 0.007}, chosen=4, default_chunk=2)
+    err = capsys.readouterr().err
+    assert "default(=2)=6.00ms" in err
+    assert "4=5.00ms" in err
+    assert "26=7.00ms" in err
+    assert "chosen=4" in err
+
+
+def test_format_candidate_table_sorts_default_first_then_numeric():
+    table = ct._format_candidate_table({"None": 9.38, "1": 25.43, "52": 14.59, "4": 9.15}, 5)
+    assert table == "default(=5)=9.38ms, 1=25.43ms, 4=9.15ms, 52=14.59ms"
+
+
+def test_cache_hit_emits_full_candidate_table_without_logging(capsys, monkeypatch, tmp_path):
+    # Warm cache + spawn collector (INFO disabled): the cache-hit line must carry the
+    # stored per-candidate breakdown, not just the chosen value -- otherwise the
+    # candidate info is invisible on every run after the first cold benchmark.
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "c.json"))
+    monkeypatch.setattr(
+        ct, "benchmark_chunk_sizes", lambda *a, **k: {None: 0.009, 1: 0.025, 4: 0.0091}
+    )
+    ct.resolve_chunk_size(**_resolve_kwargs())  # miss -> benchmark -> stores per_candidate_ms
+    capsys.readouterr()  # discard first-call output
+
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)  # simulate spawn collector
+    ct.resolve_chunk_size(**_resolve_kwargs())  # hit -> must emit the table
+    err = capsys.readouterr().err
+    assert "cache hit" in err
+    assert "default(=1)=9.00ms" in err  # _resolve_kwargs: 8 // (10*4) = 0 -> clamp to 1
+    assert "1=25.00ms" in err
+    assert "4=9.10ms" in err
+
+
+def test_cache_hit_without_candidate_table_still_emits_chosen(capsys, monkeypatch):
+    # Legacy entries (or any entry missing per_candidate_ms) must not crash and must
+    # still report the chosen value.
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)
+    ct._emit_cache_hit(4, None, default_chunk=1)
+    assert "cache hit -> 4" in capsys.readouterr().err
+
+
+def test_benchmark_respects_time_budget():
+    pool = _FakePool()
+    state = np.zeros((8, 5), dtype=np.float64)
+    timings = ct.benchmark_chunk_sizes(
+        pool,
+        state,
+        nstep=2,
+        candidates=[1, 2, 4, 8],
+        control=None,
+        post_step_forward_sensor=False,
+        warmup=0,
+        reps=1,
+        time_budget_s=0.0,
+    )
+    assert set(timings).issubset({None, 1, 2, 4, 8})
+    assert len(timings) < 5  # budget fired -> stopped early
+
+
+def _resolve_kwargs(**over):
+    base = dict(
+        pool=_FakePool(),
+        state=np.zeros((8, 5), dtype=np.float64),
+        model=_FakeModel(),
+        n_variants=1,
+        num_envs=8,
+        nthread=4,
+        dtype=np.float32,
+        post_step_forward_sensor=False,
+        bench_nsteps=2,
+        manual_chunk_size=None,
+        adaptive=True,
+    )
+    base.update(over)
+    return base
+
+
+def test_resolve_manual_override_wins(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("benchmark must not run for manual override")
+
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", _boom)
+    assert ct.resolve_chunk_size(**_resolve_kwargs(manual_chunk_size=42)) == 42
+
+
+def test_resolve_off_returns_none(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("benchmark must not run when adaptive=False")
+
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", _boom)
+    assert ct.resolve_chunk_size(**_resolve_kwargs(adaptive=False)) is None
+
+
+def test_native_default_chunk_matches_mujoco_formula():
+    # BatchEnvPool's default when chunk_size=None: max(1, nbatch // (10 * nthread)).
+    assert ct._native_default_chunk(2048, 40) == 5
+    assert ct._native_default_chunk(1024, 40) == 2
+    assert ct._native_default_chunk(4, 2) == 1  # 4 // 20 = 0 -> clamped to 1
+    assert ct._native_default_chunk(100, 1) == 10
+
+
+def test_benchmark_table_annotates_default_and_chosen_with_native_chunk(capsys, monkeypatch):
+    # "default"/"None" must show the actual chunk_size the native default resolves to.
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)
+    ct._log_benchmark_table({None: 0.010, 5: 0.009}, chosen=None, default_chunk=5)
+    err = capsys.readouterr().err
+    assert "default(=5)=10.00ms" in err
+    assert "chosen=None(=5)" in err
+
+
+def test_cache_hit_annotates_default_with_native_chunk(capsys, monkeypatch):
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)
+    ct._emit_cache_hit(None, {"None": 10.23, "5": 9.99}, default_chunk=5)
+    err = capsys.readouterr().err
+    assert "default(=5)=10.23ms" in err
+    assert "chosen=None(=5)" in err
+
+
+def test_resolve_skips_everything_when_nothing_to_tune(monkeypatch, tmp_path, capsys):
+    # num_envs <= nthread -> at most one work-chunk -> chunk_size is a no-op. Must
+    # return None WITHOUT benchmarking, caching, or emitting a line (this kills the
+    # noisy num_envs=1 setup-env benchmark that APPO/off-policy emit).
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "c.json"))
+    calls = {"n": 0}
+
+    def _spy(*a, **k):
+        calls["n"] += 1
+        return {None: 1.0, 1: 1.0}
+
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", _spy)
+    monkeypatch.setattr(ct.logger, "level", logging.WARNING)  # any _emit would hit stderr
+
+    assert ct.resolve_chunk_size(**_resolve_kwargs(num_envs=1, nthread=1)) is None
+    assert ct.resolve_chunk_size(**_resolve_kwargs(num_envs=20, nthread=40)) is None
+    assert calls["n"] == 0  # benchmark never attempted
+    assert not (tmp_path / "c.json").exists()  # nothing cached
+    assert capsys.readouterr().err == ""  # nothing printed
+
+
+def test_resolve_cache_hit_skips_benchmark(monkeypatch, tmp_path):
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "c.json"))
+    calls = {"n": 0}
+
+    def _bench(*a, **k):
+        calls["n"] += 1
+        return {None: 1.0, 4: 0.5}
+
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", _bench)
+
+    first = ct.resolve_chunk_size(**_resolve_kwargs())  # miss -> benchmark
+    second = ct.resolve_chunk_size(**_resolve_kwargs())  # hit -> no benchmark
+    assert first == second
+    assert calls["n"] == 1
+
+
+def test_resolve_cache_miss_runs_benchmark_and_persists(monkeypatch, tmp_path):
+    cache = tmp_path / "c.json"
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(cache))
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", lambda *a, **k: {None: 1.0, 4: 0.5})
+    chosen = ct.resolve_chunk_size(**_resolve_kwargs())
+    assert chosen == 4
+    assert cache.exists()
+    assert any(v.get("chunk_size") == 4 for v in ct.load_cache(cache).values())
+
+
+def test_resolve_cache_hit_none_is_valid(monkeypatch, tmp_path):
+    # A prior benchmark concluded native default is best (chunk_size=None).
+    # That is a legitimate cached value: a second call must return None and NOT re-benchmark.
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "c.json"))
+    calls = {"n": 0}
+
+    def _bench(*a, **k):
+        calls["n"] += 1
+        return {None: 0.5, 4: 1.0}  # baseline fastest -> select_chunk_size returns None
+
+    monkeypatch.setattr(ct, "benchmark_chunk_sizes", _bench)
+
+    first = ct.resolve_chunk_size(**_resolve_kwargs())  # miss -> benchmark -> chosen=None
+    second = ct.resolve_chunk_size(**_resolve_kwargs())  # hit on key presence -> no benchmark
+    assert first is None
+    assert second is None
+    assert calls["n"] == 1

--- a/tests/base/test_backend_pre_step_control.py
+++ b/tests/base/test_backend_pre_step_control.py
@@ -56,6 +56,7 @@ class _FakeMuJoCoPool:
         control_spec,
         return_sensor=False,
         post_step_forward_sensor=False,
+        chunk_size=None,
     ):
         self.step_calls.append(
             {
@@ -64,6 +65,7 @@ class _FakeMuJoCoPool:
                 "control_spec": control_spec,
                 "return_sensor": return_sensor,
                 "post_step_forward_sensor": post_step_forward_sensor,
+                "chunk_size": chunk_size,
             }
         )
         state_out = np.asarray(state) + 1.0
@@ -91,6 +93,7 @@ def _fake_mujoco_backend(pre_step_control_fn=None, post_step_forward_sensor=Fals
     backend._sensor_data = np.zeros((1, 1), dtype=np.float32)
     backend._pending_xfrc_applied = np.zeros((1, 0), dtype=np.float64)
     backend._post_step_forward_sensor = post_step_forward_sensor
+    backend._chunk_size = None
     backend._pool = _FakeMuJoCoPool()
     return backend
 
@@ -105,6 +108,7 @@ def test_mujoco_step_without_pre_step_control_keeps_batched_nsteps() -> None:
     assert backend._pool.step_calls[0]["nstep"] == 3
     assert backend._pool.step_calls[0]["return_sensor"] is True
     assert backend._pool.step_calls[0]["post_step_forward_sensor"] is False
+    assert backend._pool.step_calls[0]["chunk_size"] is None
     assert backend._pool.forward_calls == []
     expected_control = np.broadcast_to(ctrl[:, None, :], (1, 3, ctrl.shape[-1]))
     np.testing.assert_allclose(backend._pool.step_calls[0]["control"], expected_control)
@@ -140,6 +144,7 @@ def test_mujoco_step_with_pre_step_control_recomputes_each_physics_step() -> Non
     assert [call["nstep"] for call in backend._pool.step_calls] == [1, 1, 1]
     assert all(call["return_sensor"] is True for call in backend._pool.step_calls)
     assert all(call["post_step_forward_sensor"] is True for call in backend._pool.step_calls)
+    assert all(call["chunk_size"] is None for call in backend._pool.step_calls)
     assert backend._pool.forward_calls == []
     np.testing.assert_allclose(seen_sensors, [[[0.0]], [[1.0]], [[2.0]]])
     np.testing.assert_allclose(backend._pool.step_calls[0]["control"], (ctrl + 1)[:, None, :])


### PR DESCRIPTION
# feat(mujoco)：按任务 / 按设备的自适应最优 `chunk_size`

Fixes #634

## 概述

MuJoCo `BatchEnvPool` 用线程池并行物理 `step`,`chunk_size` 决定每个工作块包含多少个 env。
原生默认值 `max(1, num_envs // (10·nthread))` 是一个**固定启发式**,不随任务和本地设备调整,
在很多 env 上没有吃满采集吞吐。

本 PR 引入**自适应 `chunk_size`**:在环境 *materialize*(冷路径)阶段,对一小批候选 chunk
做一次 benchmark,选出最快的(带安全裕度),并把结果按 `(任务结构, 设备, num_envs, …)` 落盘缓存。
热路径(`step`/`reset`)只读取已解析出的整数 —— **不解析 asset/XML、不做能力探测**。
该选择对物理结果**位级一致(physics-neutral)**,因此是纯吞吐收益。

## 改动内容(4 个 commit)

| Commit | 层 | 内容 |
|--------|----|------|
| `feat(mujoco): adaptive chunk_size tuner` | 核心 | `chunk_tuner.py`:候选生成、冷路径 benchmark、磁盘缓存、选择、终端输出 + 单测 |
| `feat(mujoco): wire … into EnvCfg, create_backend, step hot path` | 后端 | `EnvCfg.adaptive_chunk_size/chunk_size`、`env_backend_kwargs`、后端 `materialize()`/`step()` 接线 + 接线/热路径测试 |
| `feat(envs): roll adaptive chunk_size to all PPO mujoco envs` | 环境 | 10 个 PPO mujoco env 统一经 `env_backend_kwargs` 建后端 |
| `feat(config): expose env.adaptive_chunk_size/chunk_size toggles` | 配置 | `ppo`、`appo`、`offpolicy`、`mlx` 配置声明这两个键 |

## 工作原理

- **候选集**锚定在最优点附近 `num_envs/(10·nthread)`,且永不超过 `ceil(num_envs/nthread)`
  (更大的 chunk → 块数少于线程数 → 线程空转 → 必然更慢)。
  `num_envs ≤ nthread` 视为无意义(只有一个块),**直接跳过**:不 benchmark、不缓存、不打印
  —— 由此静默掉 APPO/off-policy 为读取维度而建的 `num_envs=1` 探针 env。
- **Benchmark** 仅在 `materialize()` 跑一次,逐候选测量代表性的 `pool.step`,并以原生默认值为基线。
- **选择**默认保留原生默认,除非某候选以裕度(3%)胜出;并对启发式锚点做 tie-break。
- **缓存**位于 `~/.cache/unilab/chunk_size.json`(可用 `UNILAB_CHUNK_SIZE_CACHE` 覆盖),
  key 由后端、任务结构签名、设备指纹(system/machine/cpu_count)、`num_envs`、`nthread`、
  dtype、sensor 标志、bench 步数共同决定。**设备或 num_envs 改变 → key 改变 → 重新 benchmark**。
  删掉该文件即可强制重测。
- **输出**:这次性的决策即使在 spawn collector 子进程里也会打到终端(日志未配置时回退到 stderr);
  缓存命中会回放完整候选表;`default`/`None` 会标注它实际解析到的 chunk_size。

## 使用方法

两个键都是一等配置(无需前导 `+` 即可覆盖):

```bash
# 默认:自适应开启
uv run train --algo=ppo --task=g1_walk_flat --sim mujoco

# 手动指定 chunk_size(优先级高于 benchmark)
uv run train --algo=ppo --task=g1_walk_flat --sim mujoco env.chunk_size=8

# 关闭自适应(使用原生默认)
uv run train --algo=ppo --task=g1_walk_flat --sim mujoco env.adaptive_chunk_size=false
```


## Benchmark 输出示例(验收项)

`g1_walk_flat` @ `num_envs=2048`,40 线程(原生默认 chunk = `2048 // （10*n
_thread） = 5`):

```
[unilab.chunk_size] chunk_size benchmark: default(=5)=10.25ms, 1=29.17ms, 2=13.07ms,
  4=10.85ms, 5=11.30ms, 7=11.63ms, 8=11.36ms, 10=11.69ms, 13=12.00ms, 15=12.30ms,
  23=12.99ms, 41=14.37ms, 52=14.50ms -> chosen=None(=5)
```

一个非默认 chunk 胜出的例子 —— `go1_joystick_flat` @ `num_envs=1024`(默认 chunk = 2):

```
[unilab.chunk_size] chunk_size benchmark: default(=2)=6.68ms, 1=12.94ms, 2=6.79ms, 3=4.79ms,
  4=3.45ms, 6=3.62ms, 7=3.55ms, 9=3.52ms, 13=3.51ms, 23=5.18ms, 26=4.51ms -> chosen=9
```

这里 `chunk=9`(约 3.5ms)把原生默认的 `step` 耗时(约 6.7ms)几乎砍半。同 seed、150 迭代的
wall-clock A/B(开发机):`go1` 约 **采集 +16% / 总 +7.5%**,`stewart_balance` 约
**+14% / +10.7%**;`g1_walk_flat` 解析为原生默认(≈ 持平)。
(总收益 < 采集收益,因为 GPU learner 不受影响。)

## 验证

- `make test-all`:**1351 passed,12 skipped**。
- 已提交代码上的 CI 门禁:`ruff check` ✅、`ruff format --check`(428 文件)✅、`mypy src/unilab` ✅。
- 新增测试覆盖:候选生成、`num_envs ≤ nthread` 跳过、缓存命中/未命中/读写往返、手动覆盖、
  热路径"不解析 XML"不变量、终端/stderr 输出、原生默认注解。


