### PR TITLE
feat: add collector active throughput metric

### DIFF
--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -421,6 +421,7 @@ class APPORunner(AsyncRunner):
                 iteration_time=iteration_time,
                 extra_info={
                     "throughput_steps": num_new * env_steps_per_sync,
+                    "collector_active_steps_per_sec": logger._collector_active_steps_per_sec,
                 },
             )
 
@@ -473,6 +474,12 @@ class APPORunner(AsyncRunner):
 
                 if "collector_timing_ms" in m:
                     logger.update_collector_timing(m["collector_timing_ms"])
+
+                collector_active_steps_per_sec = m.get("collector_active_steps_per_sec")
+                if collector_active_steps_per_sec is not None:
+                    logger.update_collector_active_steps_per_sec(
+                        float(collector_active_steps_per_sec)
+                    )
 
                 if "timeout_rate" in m or "terminated_rate" in m:
                     logger.update_done_rates(

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -336,15 +336,16 @@ def appo_collector_fn(
                     if k.startswith("reward/"):
                         ep_reward_components[k].append(v)
 
-                if metrics_queue is not None and total_steps % (num_envs * 10) == 0 and ep_rewards:
+                if metrics_queue is not None and total_steps % (num_envs * 10) == 0:
                     try:
-                        msg = {
+                        msg: dict[str, Any] = {
                             "total_steps": total_steps,
-                            "mean_ep_reward": statistics.mean(ep_rewards[-100:]),
-                            "mean_ep_length": statistics.mean(ep_lengths[-100:])
-                            if ep_lengths
-                            else 0.0,
                         }
+                        if ep_rewards:
+                            msg["mean_ep_reward"] = statistics.mean(ep_rewards[-100:])
+                            msg["mean_ep_length"] = (
+                                statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
+                            )
                         # Episode completion mode rates
                         total_ep = ep_timeouts + ep_terminates
                         if total_ep > 0:
@@ -358,6 +359,10 @@ def appo_collector_fn(
                             "mlp_infer_ms": ema_mlp_infer_ms,
                             "env_step_ms": ema_env_step_ms,
                         }
+                        if ema_env_step_ms > 0.0:
+                            msg["collector_active_steps_per_sec"] = num_envs / (
+                                ema_env_step_ms / 1000.0
+                            )
                         if ep_reward_components:
                             msg["reward_components"] = {
                                 k: statistics.mean(v) for k, v in ep_reward_components.items() if v

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -402,6 +402,7 @@ class HoraAPPORunner(APPORunner):
                 iteration_time=iteration_time,
                 extra_info={
                     "throughput_steps": num_new * env_steps_per_sync,
+                    "collector_active_steps_per_sec": logger._collector_active_steps_per_sec,
                 },
             )
 

--- a/src/unilab/algos/torch/hora/appo_worker.py
+++ b/src/unilab/algos/torch/hora/appo_worker.py
@@ -356,15 +356,16 @@ def hora_appo_collector_fn(
                     if k.startswith("reward/"):
                         ep_reward_components[k].append(v)
 
-                if metrics_queue is not None and total_steps % (num_envs * 10) == 0 and ep_rewards:
+                if metrics_queue is not None and total_steps % (num_envs * 10) == 0:
                     try:
-                        msg = {
+                        msg: dict[str, Any] = {
                             "total_steps": total_steps,
-                            "mean_ep_reward": statistics.mean(ep_rewards[-100:]),
-                            "mean_ep_length": statistics.mean(ep_lengths[-100:])
-                            if ep_lengths
-                            else 0.0,
                         }
+                        if ep_rewards:
+                            msg["mean_ep_reward"] = statistics.mean(ep_rewards[-100:])
+                            msg["mean_ep_length"] = (
+                                statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
+                            )
                         total_ep = ep_timeouts + ep_terminates
                         if total_ep > 0:
                             msg["timeout_rate"] = ep_timeouts / total_ep
@@ -376,6 +377,10 @@ def hora_appo_collector_fn(
                             "mlp_infer_ms": ema_mlp_infer_ms,
                             "env_step_ms": ema_env_step_ms,
                         }
+                        if ema_env_step_ms > 0.0:
+                            msg["collector_active_steps_per_sec"] = num_envs / (
+                                ema_env_step_ms / 1000.0
+                            )
                         if ep_reward_components:
                             msg["reward_components"] = {
                                 k: statistics.mean(v) for k, v in ep_reward_components.items() if v

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -690,6 +690,9 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                         iteration_time=iteration_time,
                         extra_info={
                             "throughput_steps": self.num_envs * self.env_steps_per_sync,
+                            "collector_active_steps_per_sec": (
+                                logger._collector_active_steps_per_sec
+                            ),
                             **build_offpolicy_sample_info(
                                 replay_batch_size_per_rank=self.batch_size,
                                 updates_per_step=self.updates_per_step,

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -94,6 +94,9 @@ def _drain_metrics(
                 logger.update_ep_length(m["mean_ep_length"])
             if "collector_timing_ms" in m and logger:
                 logger.update_collector_timing(m["collector_timing_ms"])
+            collector_active_steps_per_sec = m.get("collector_active_steps_per_sec")
+            if collector_active_steps_per_sec is not None and logger:
+                logger.update_collector_active_steps_per_sec(float(collector_active_steps_per_sec))
             if ("timeout_rate" in m or "terminated_rate" in m) and logger:
                 logger.update_done_rates(
                     timeout_rate=float(m.get("timeout_rate", 0.0)),
@@ -480,6 +483,9 @@ def _learner_worker(
                         iteration_time=iteration_time,
                         extra_info={
                             "throughput_steps": num_envs * env_steps_per_sync,
+                            "collector_active_steps_per_sec": (
+                                logger._collector_active_steps_per_sec
+                            ),
                             "world_size": world_size,
                             "multi_gpu_sync_mode": sync_mode,
                             "multi_gpu_sync_interval": sync_interval,

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -618,6 +618,7 @@ class OffPolicyRunner(AsyncRunner):
                 iteration_time=iteration_time,
                 extra_info={
                     "throughput_steps": self.num_envs * self.env_steps_per_sync,
+                    "collector_active_steps_per_sec": (logger._collector_active_steps_per_sec),
                     **build_offpolicy_sample_info(
                         replay_batch_size_per_rank=self.batch_size,
                         updates_per_step=self.updates_per_step,
@@ -697,6 +698,12 @@ class OffPolicyRunner(AsyncRunner):
 
                 if "collector_timing_ms" in m:
                     logger.update_collector_timing(m["collector_timing_ms"])
+
+                collector_active_steps_per_sec = m.get("collector_active_steps_per_sec")
+                if collector_active_steps_per_sec is not None:
+                    logger.update_collector_active_steps_per_sec(
+                        float(collector_active_steps_per_sec)
+                    )
 
                 if "timeout_rate" in m or "terminated_rate" in m:
                     logger.update_done_rates(

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -949,6 +949,11 @@ def _run_collector(
                             for k, v in timing_accum_ms.items()
                             if timing_counts[k] > 0
                         }
+                        env_step_ms = msg["collector_timing_ms"].get("env_step_ms", 0.0)
+                        if env_step_ms > 0.0:
+                            msg["collector_active_steps_per_sec"] = num_envs / (
+                                env_step_ms / 1000.0
+                            )
 
                     if done_count_window > 0:
                         msg["timeout_rate"] = timeout_count_window / done_count_window

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -119,6 +119,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._weight_sync_time: float = 0.0
         self._iteration_time: float | None = None
         self._throughput_steps: int = 0
+        self._collector_active_steps_per_sec: float | None = None
         self._world_size: int = 1
         self._multi_gpu_sync_mode: str = ""
         self._multi_gpu_sync_interval: int = 0
@@ -227,6 +228,10 @@ class OffPolicyLogger(BaseTrainingLogger):
         header_extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
             header_extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
+        if self._collector_active_steps_per_sec is not None:
+            header_extra_fields.append(
+                (f"Collector/s {self._collector_active_steps_per_sec:,.0f}", "bold magenta")
+            )
         if effective_samples_per_sec is not None:
             header_extra_fields.append((f"Samples/s {effective_samples_per_sec:,.0f}", "bold cyan"))
         if extra_fields:
@@ -238,6 +243,9 @@ class OffPolicyLogger(BaseTrainingLogger):
 
     def update_collector_timing(self, timing_ms: dict[str, float]):
         self._collector_timing.update(timing_ms)
+
+    def update_collector_active_steps_per_sec(self, steps_per_sec: float):
+        self._collector_active_steps_per_sec = float(steps_per_sec)
 
     def update_done_rates(self, timeout_rate: float, terminated_rate: float):
         self._timeout_rate = float(timeout_rate)
@@ -297,6 +305,12 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._has_iteration_extra_info = extra_info is not None
         if extra_info:
             self._throughput_steps = int(extra_info.get("throughput_steps", 0))
+            collector_active_steps_per_sec = extra_info.get("collector_active_steps_per_sec")
+            self._collector_active_steps_per_sec = (
+                float(collector_active_steps_per_sec)
+                if collector_active_steps_per_sec is not None
+                else None
+            )
             self._world_size = int(extra_info.get("world_size", 1))
             self._multi_gpu_sync_mode = str(extra_info.get("multi_gpu_sync_mode", ""))
             self._multi_gpu_sync_interval = int(extra_info.get("multi_gpu_sync_interval", 0))
@@ -312,6 +326,7 @@ class OffPolicyLogger(BaseTrainingLogger):
                 self._replay_samples_per_iter = self._learner_samples_per_iter
         else:
             self._throughput_steps = 0
+            self._collector_active_steps_per_sec = None
             self._world_size = 1
             self._multi_gpu_sync_mode = ""
             self._multi_gpu_sync_interval = 0
@@ -421,6 +436,12 @@ class OffPolicyLogger(BaseTrainingLogger):
                 writer.add_scalar(f"timing/collector_{key}", value, global_step)
             if iter_steps_per_sec is not None:
                 writer.add_scalar("perf/steps_per_sec", iter_steps_per_sec, global_step)
+            if self._collector_active_steps_per_sec is not None:
+                writer.add_scalar(
+                    "perf/collector_active_steps_per_sec",
+                    self._collector_active_steps_per_sec,
+                    global_step,
+                )
             if effective_samples_per_sec is not None:
                 writer.add_scalar(
                     "perf/effective_samples_per_sec",
@@ -482,6 +503,10 @@ class OffPolicyLogger(BaseTrainingLogger):
                 log_dict[f"timing/collector_{key}"] = value
             if iter_steps_per_sec is not None:
                 log_dict["perf/steps_per_sec"] = iter_steps_per_sec
+            if self._collector_active_steps_per_sec is not None:
+                log_dict["perf/collector_active_steps_per_sec"] = (
+                    self._collector_active_steps_per_sec
+                )
             if effective_samples_per_sec is not None:
                 log_dict["perf/effective_samples_per_sec"] = effective_samples_per_sec
             log_dict["perf/iter_ms"] = iter_wall_time * 1000

--- a/tests/algos/test_appo_runner_unit.py
+++ b/tests/algos/test_appo_runner_unit.py
@@ -163,6 +163,7 @@ class _FakeLogger:
         del kwargs
         self._total_steps = 0
         self._mean_ep_length = 0.0
+        self._collector_active_steps_per_sec = None
         self.step_calls: list[dict] = []
         _FakeLogger.last_instance = self
 
@@ -196,6 +197,9 @@ class _FakeLogger:
 
     def update_collector_timing(self, timing_ms: dict[str, float]) -> None:
         del timing_ms
+
+    def update_collector_active_steps_per_sec(self, steps_per_sec: float) -> None:
+        self._collector_active_steps_per_sec = steps_per_sec
 
     def update_done_rates(self, timeout_rate: float, terminated_rate: float) -> None:
         del timeout_rate, terminated_rate
@@ -347,8 +351,8 @@ def test_appo_runner_logs_learner_timing_for_fps_inputs(
     assert step["train_time"] == pytest.approx(0.5)
     assert step["learner_incremental_h2d_time"] >= 0.0
     assert step["weight_sync_time"] >= 0.0
-    assert step["extra_info"] == {"throughput_steps": 8}
     assert step["extra_info"]["throughput_steps"] == 8
+    assert "collector_active_steps_per_sec" in step["extra_info"]
     assert step["metrics"]["rollouts_read"] == 1.0
     assert step["metrics"]["staging_pool_len"] == 1.0
 

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -163,6 +163,7 @@ class _FakeLogger:
         self._total_steps = 0
         self._buffer_size = 0
         self._mean_ep_length = 0.0
+        self._collector_active_steps_per_sec = None
         _FakeLogger.last_instance = self
 
     def set_collection_sync(self, enabled: bool, env_steps_per_sync: int) -> None:
@@ -192,6 +193,9 @@ class _FakeLogger:
 
     def update_collector_timing(self, timing_ms: dict[str, float]) -> None:
         del timing_ms
+
+    def update_collector_active_steps_per_sec(self, steps_per_sec: float) -> None:
+        self._collector_active_steps_per_sec = steps_per_sec
 
     def update_done_rates(self, timeout_rate: float, terminated_rate: float) -> None:
         del timeout_rate, terminated_rate
@@ -443,6 +447,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     assert "collector_wait_time" in logger.step_calls[0]
     assert logger.step_calls[0]["learner_incremental_h2d_time"] == pytest.approx(0.004)
     assert logger.step_calls[0]["weight_sync_time"] >= 0.0
+    assert logger.step_calls[0]["extra_info"].pop("collector_active_steps_per_sec") is None
     assert logger.step_calls[0]["extra_info"] == {
         "throughput_steps": 2,
         "batch_size_per_rank": 8,
@@ -529,6 +534,7 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
     assert "collector_wait_time" in logger.step_calls[0]
     assert logger.step_calls[0]["learner_incremental_h2d_time"] == pytest.approx(0.004)
     assert logger.step_calls[0]["weight_sync_time"] >= 0.0
+    assert logger.step_calls[0]["extra_info"].pop("collector_active_steps_per_sec") is None
     assert logger.step_calls[0]["extra_info"] == {
         "throughput_steps": 2,
         "batch_size_per_rank": 8,
@@ -653,6 +659,7 @@ def test_offpolicy_runner_logs_symmetry_effective_samples_without_hiding_replay_
     assert "learner_replay_wait_time" not in logger.step_calls[0]
     assert "wait_time" not in logger.step_calls[0]
     assert "collector_wait_time" in logger.step_calls[0]
+    assert logger.step_calls[0]["extra_info"].pop("collector_active_steps_per_sec") is None
     assert logger.step_calls[0]["extra_info"] == {
         "throughput_steps": 2,
         "batch_size_per_rank": 16,
@@ -1416,6 +1423,7 @@ def test_multi_gpu_learner_worker_logs_wall_clock_and_per_rank_batch_context(
     assert step["learner_param_sync_time"] == pytest.approx(0.1)
     assert step["weight_sync_time"] == pytest.approx(0.03)
     assert step["iteration_time"] == pytest.approx(0.8)
+    assert step["extra_info"].pop("collector_active_steps_per_sec") is None
     assert step["extra_info"] == {
         "throughput_steps": 15,
         "world_size": 2,

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -492,6 +492,7 @@ def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
         iteration_time=10.9,
         extra_info={
             "throughput_steps": 8,
+            "collector_active_steps_per_sec": 1234.5,
             "world_size": 2,
             "batch_size_per_rank": 8,
             "effective_batch_size": 16,
@@ -518,6 +519,7 @@ def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
     assert payload["perf/learner_other_pct"] == pytest.approx(0.04 / 10.9 * 100)
     assert payload["perf/learner_accounted_pct"] == pytest.approx(10.86 / 10.9 * 100)
     assert payload["perf/steps_per_sec"] == pytest.approx(8.0 / 10.9)
+    assert payload["perf/collector_active_steps_per_sec"] == pytest.approx(1234.5)
     assert payload["perf/effective_samples_per_sec"] == pytest.approx(32.0 / 10.9)
     for key in (
         "axis/iteration",
@@ -584,6 +586,7 @@ def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_or_distribute
         iteration_time=1.95,
         extra_info={
             "throughput_steps": 16,
+            "collector_active_steps_per_sec": 4321.0,
             "world_size": 2,
             "batch_size_per_rank": 16,
             "effective_batch_size": 32,
@@ -603,6 +606,7 @@ def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_or_distribute
     assert scalars["perf/iter_ms"] == pytest.approx(1_950.0)
     assert scalars["perf/learner_train_pct"] == pytest.approx(0.7 / 1.95 * 100)
     assert scalars["perf/learner_other_pct"] == pytest.approx(0.08 / 1.95 * 100)
+    assert scalars["perf/collector_active_steps_per_sec"] == pytest.approx(4321.0)
     assert scalars["perf/effective_samples_per_sec"] == pytest.approx(64.0 / 1.95)
     for key in (
         "axis/iteration",


### PR DESCRIPTION
## Summary
- report collector active throughput separately from learner wall-clock throughput
- pass collector active throughput through APPO, HORA APPO, and off-policy metric paths
- cover terminal/TensorBoard metric output in unit tests

## Validation
- make test-all