### PR TITLE
fix(sac): support multi-gpu obs normalization

### DIFF
--- a/conf/offpolicy/algo/sac.yaml
+++ b/conf/offpolicy/algo/sac.yaml
@@ -24,7 +24,7 @@ critic_lr: 3.0e-4
 actor_hidden_dim: 512
 critic_hidden_dim: 768
 num_atoms: 101
-obs_normalization: true
+obs_normalization: false
 use_layer_norm: true
 use_symmetry: false
 actor: {}

--- a/docs/sphinx/source/en/2-user_guide/1-training/4-multi_gpu.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/4-multi_gpu.md
@@ -24,6 +24,11 @@ cost of larger inter-rank parameter drift. In `local_sgd` mode, optimizer state
 is intentionally rank-local and is not averaged at the synchronization boundary;
 this avoids extending communication to AdamW momentum state.
 
+When `algo.obs_normalization=true`, each learner rank updates its observation
+normalizer from cross-rank global batch moments; rank 0 publishes the matching
+mean/std to the CPU collector at the same synchronization point as actor
+weights.
+
 For strict per-update gradient averaging, set
 `training.multi_gpu_sync_mode=sync_sgd`. That mode is closer to single-GPU
 global-batch semantics, but it performs many more collectives and is usually a
@@ -50,7 +55,6 @@ single-GPU `algo.batch_size=8192` corresponds to two-GPU
 
 - SAC only: `training.num_gpus > 1` rejects TD3, FlashSAC, PPO, MLX PPO, and APPO.
 - CUDA is required; select physical cards with `CUDA_VISIBLE_DEVICES`.
-- This validation round requires `algo.obs_normalization=false`.
 - SAC symmetry augmentation is not supported in multi-GPU mode. If the task
   owner enables it by default, set `algo.use_symmetry=false`.
 - Collection must stay synchronized; do not set `training.no_sync_collection=true`.
@@ -63,7 +67,6 @@ Two adjacent visible GPUs:
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -74,7 +77,6 @@ For non-adjacent physical GPUs, map them into the visible set with
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -85,7 +87,6 @@ playback:
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false \
   algo.max_iterations=10 \
   algo.num_envs=512 \
@@ -118,7 +119,6 @@ compare steady-state `perf/iter_ms`, `timing/learner_train_ms`,
 - `Only SAC supports training.num_gpus > 1`: only SAC is validated right now.
 - `SAC multi-GPU training requires a CUDA device`: CUDA is unavailable, or
   `training.device` was set to CPU.
-- `requires algo.obs_normalization=false`: add `algo.obs_normalization=false`.
 - `set training.num_gpus=1 or algo.use_symmetry=false`: multi-GPU SAC does not
   support symmetry augmentation yet; add `algo.use_symmetry=false`.
 

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
@@ -30,7 +30,6 @@ Two-GPU MuJoCo example:
 ```bash
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -46,8 +45,8 @@ playback video. See {doc}`/en/1-getting_started/3-evaluation_and_playback`.
   runs, the global update batch is `algo.batch_size * training.num_gpus`.
 - `algo.max_iterations=500`
 - `training.use_amp=true` in the shared off-policy config
-- Multi-GPU SAC uses `training.num_gpus=<N>`; this validation round requires
-  `algo.obs_normalization=false` and does not support `algo.use_symmetry=true`.
+- Multi-GPU SAC uses `training.num_gpus=<N>`; `algo.use_symmetry=true` is not
+  supported yet.
 - Multi-GPU SAC defaults to `training.multi_gpu_sync_mode=local_sgd` and
   `training.multi_gpu_sync_interval=1`.
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/4-multi_gpu.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/4-multi_gpu.md
@@ -20,6 +20,10 @@ learner iteration 同步一次；增大该值可以进一步减少 4 卡、8 卡
 增加 rank 间参数漂移。`local_sgd` 下 optimizer state 按设计保持 rank-local，不在同
 步边界平均，以避免把通信量扩展到 AdamW 动量状态。
 
+开启 `algo.obs_normalization=true` 时，每个 learner rank 使用跨 rank 聚合后的全局
+batch moments 更新 observation normalizer；rank0 在发布 actor 权重给 CPU
+collector 的同一同步点发布对应 mean/std。
+
 如需严格的每次 update 梯度平均，可显式设置
 `training.multi_gpu_sync_mode=sync_sgd`。该模式更接近单卡 global batch 的同步
 SGD 语义，但通信次数更多，通常不适合没有高速 GPU 互联的机器。
@@ -42,7 +46,6 @@ batch**，不是跨所有 GPU 的 global batch。`training.num_gpus=N` 时，每
 
 - 只支持 SAC：`training.num_gpus > 1` 会拒绝 TD3、FlashSAC、PPO、MLX PPO 和 APPO。
 - 必须使用 CUDA 设备；用 `CUDA_VISIBLE_DEVICES` 选择物理卡。
-- 本轮验证要求 `algo.obs_normalization=false`。
 - SAC 的对称增强当前不支持多卡；若任务 owner 默认开启，需要设置
   `algo.use_symmetry=false`。
 - 采集必须同步；不要设置 `training.no_sync_collection=true`。
@@ -55,7 +58,6 @@ batch**，不是跨所有 GPU 的 global batch。`training.num_gpus=N` 时，每
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -66,7 +68,6 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -76,7 +77,6 @@ CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoc
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
   training.multi_gpu_sync_mode=local_sgd \
-  algo.obs_normalization=false \
   algo.use_symmetry=false \
   algo.max_iterations=10 \
   algo.num_envs=512 \
@@ -106,8 +106,6 @@ ring-buffer 窗口，让 CPU 随机 gather 与下一次 env step 重叠，同时
 - `Only SAC supports training.num_gpus > 1`：当前只验证 SAC。
 - `SAC multi-GPU training requires a CUDA device`：没有可用 CUDA，或
   `training.device` 被设成了 CPU。
-- `requires algo.obs_normalization=false`：显式追加
-  `algo.obs_normalization=false`。
 - `set training.num_gpus=1 or algo.use_symmetry=false`：多卡 SAC 暂不支持对称增
   强，显式追加 `algo.use_symmetry=false`。
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -26,7 +26,6 @@ uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
 ```bash
 CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.num_gpus=2 \
-  algo.obs_normalization=false \
   algo.use_symmetry=false
 ```
 
@@ -42,8 +41,7 @@ CUDA_VISIBLE_DEVICES=0,7 uv run train --algo sac --task g1_walk_flat --sim mujoc
   update batch 为 `algo.batch_size * training.num_gpus`。
 - `algo.max_iterations=500`
 - 共享 off-policy 配置中的 `training.use_amp=true`
-- 多 GPU SAC 使用 `training.num_gpus=<N>`；当前验证要求
-  `algo.obs_normalization=false`，且不支持 `algo.use_symmetry=true`。
+- 多 GPU SAC 使用 `training.num_gpus=<N>`；当前不支持 `algo.use_symmetry=true`。
 - 多 GPU SAC 默认 `training.multi_gpu_sync_mode=local_sgd`，
   `training.multi_gpu_sync_interval=1`。
 

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -265,6 +265,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             "use_amp": cfg.training.use_amp,
             "amp_dtype": cfg.algo.algo_params.amp_dtype,
             "use_compile": cfg.algo.algo_params.use_compile,
+            "obs_normalization": cfg.algo.obs_normalization,
             "use_symmetry": cfg.algo.use_symmetry,
             "symmetry_augmentation": _symmetry_aug,
             "critic_obs_dim": _critic_dim,
@@ -275,10 +276,6 @@ def build_runner(algo_name: str, cfg: DictConfig):
         if num_gpus > 1:
             from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
 
-            if cfg.algo.obs_normalization:
-                raise ValueError(
-                    "SAC multi-GPU validation currently requires algo.obs_normalization=false"
-                )
             if not str(_device).startswith("cuda"):
                 raise ValueError("SAC multi-GPU training requires a CUDA device")
             return MultiGPUOffPolicyRunner(
@@ -302,7 +299,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
                 device=_device,
                 actor_hidden_dim=cfg.algo.actor_hidden_dim,
                 use_layer_norm=cfg.algo.use_layer_norm,
-                obs_normalization=False,
+                obs_normalization=cfg.algo.obs_normalization,
                 sim_backend=cfg.training.sim_backend,
                 env_cfg_override=env_cfg_override,
                 actor_kwargs=_actor_kwargs,

--- a/src/unilab/algos/torch/common/normalization.py
+++ b/src/unilab/algos/torch/common/normalization.py
@@ -44,16 +44,33 @@ class EmpiricalNormalization(nn.Module):
         batch_size = x.shape[0]
         batch_mean = torch.mean(x, dim=0, keepdim=True)
         batch_var = torch.var(x, dim=0, keepdim=True, unbiased=False)
+        self.update_from_moments(batch_mean, batch_var, batch_size)
 
-        new_count = self.count + batch_size
+    @torch.no_grad()
+    def update_from_moments(
+        self,
+        batch_mean: torch.Tensor,
+        batch_var: torch.Tensor,
+        batch_count: int | torch.Tensor,
+    ) -> None:
+        """Update running stats from precomputed batch moments."""
+        batch_mean = batch_mean.to(device=self._mean.device, dtype=self._mean.dtype).view_as(
+            self._mean
+        )
+        batch_var = batch_var.to(device=self._var.device, dtype=self._var.dtype).view_as(self._var)
+        batch_count_t = torch.as_tensor(batch_count, device=self.count.device).to(
+            dtype=self.count.dtype
+        )
+
+        new_count = self.count + batch_count_t
 
         # Welford's online algorithm
         delta = batch_mean - self._mean
-        self._mean.copy_(self._mean + delta * (batch_size / new_count))
+        self._mean.copy_(self._mean + delta * (batch_count_t / new_count))
         delta2 = batch_mean - self._mean
         m_a = self._var * self.count
-        m_b = batch_var * batch_size
-        M2 = m_a + m_b + delta2.pow(2) * (self.count * batch_size / new_count)
+        m_b = batch_var * batch_count_t
+        M2 = m_a + m_b + delta2.pow(2) * (self.count * batch_count_t / new_count)
         self._var.copy_(M2 / new_count)
         self._std.copy_(self._var.sqrt())
         self.count.copy_(new_count)

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -20,6 +20,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 from unilab.algos.torch.common.compile import get_torch_compile_for_cuda
+from unilab.algos.torch.common.normalization import EmpiricalNormalization
 from unilab.base.augmentation import SymmetryAugmentation
 
 FAST_SAC_DISTRIBUTED_SYNC_MODES = {"sync_sgd", "local_sgd"}
@@ -408,6 +409,7 @@ class FastSACLearner:
         use_amp: bool = False,
         amp_dtype: str = "auto",
         use_compile: bool = False,
+        obs_normalization: bool = False,
         symmetry_augmentation: SymmetryAugmentation | None = None,
         world_size: int = 1,
         distributed_sync_mode: str = "sync_sgd",
@@ -469,6 +471,12 @@ class FastSACLearner:
         # Entropy coefficient
         self.log_alpha = torch.tensor([math.log(alpha_init)], requires_grad=True, device=device)
         self.target_entropy = -action_dim * target_entropy_ratio
+
+        self.obs_normalizer: EmpiricalNormalization | nn.Identity
+        if obs_normalization:
+            self.obs_normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
+        else:
+            self.obs_normalizer = nn.Identity()
 
         # fused AdamW requires CUDA; MPS and CPU do not support it
         _fused = isinstance(device, str) and device.startswith("cuda")
@@ -552,6 +560,53 @@ class FastSACLearner:
             self._device_type, dtype=self._amp_dtype, enabled=self.use_amp
         )
 
+    def _distributed_normalization_ready(self) -> bool:
+        return self.world_size > 1 and dist.is_available() and dist.is_initialized()
+
+    @torch.no_grad()
+    def _update_obs_normalizer(self, obs: torch.Tensor) -> None:
+        if isinstance(self.obs_normalizer, nn.Identity):
+            return
+        normalizer = cast(EmpiricalNormalization, self.obs_normalizer)
+        if not self._distributed_normalization_ready():
+            normalizer.update(obs)
+            return
+
+        obs_for_stats = obs.detach().to(dtype=normalizer._mean.dtype)
+        obs_dim = int(obs_for_stats.shape[-1])
+        moment_payload = torch.cat(
+            [
+                obs_for_stats.sum(dim=0),
+                obs_for_stats.square().sum(dim=0),
+                torch.tensor(
+                    [obs_for_stats.shape[0]],
+                    device=obs_for_stats.device,
+                    dtype=obs_for_stats.dtype,
+                ),
+            ]
+        )
+        dist.all_reduce(moment_payload, op=dist.ReduceOp.SUM)
+        batch_count = moment_payload[-1].clamp_min(1.0)
+        batch_mean = (moment_payload[:obs_dim] / batch_count).view_as(normalizer._mean)
+        batch_var = (
+            moment_payload[obs_dim : 2 * obs_dim] / batch_count - batch_mean.view(-1).square()
+        ).clamp_min(0.0)
+        normalizer.update_from_moments(
+            batch_mean,
+            batch_var.view_as(normalizer._var),
+            batch_count.round().to(dtype=normalizer.count.dtype),
+        )
+
+    def normalize_obs(self, obs: torch.Tensor, update: bool = False) -> torch.Tensor:
+        """Normalize actor observations using synchronized running statistics."""
+        if isinstance(self.obs_normalizer, nn.Identity):
+            return obs
+        normalizer = cast(EmpiricalNormalization, self.obs_normalizer)
+        if update:
+            self._update_obs_normalizer(obs)
+            return cast(torch.Tensor, normalizer(obs, update=False))
+        return cast(torch.Tensor, normalizer(obs, update=False))
+
     def _reduce_gradients(self, model: nn.Module) -> None:
         """All-reduce gradients across all workers and divide by world_size.
 
@@ -614,6 +669,9 @@ class FastSACLearner:
             for parameter in module.parameters():
                 dist.broadcast(parameter.data, src=src)
         dist.broadcast(self.log_alpha.data, src=src)
+        if not isinstance(self.obs_normalizer, nn.Identity):
+            for buffer in self.obs_normalizer.buffers():
+                dist.broadcast(buffer, src=src)
 
     def _get_actions_and_log_probs_for_critic(
         self,
@@ -737,6 +795,9 @@ class FastSACLearner:
             dones = dones.repeat(2)
             truncated = truncated.repeat(2)
 
+        self.normalize_obs(obs, update=True)
+        next_obs = self.normalize_obs(next_obs, update=False)
+
         qf_loss, target_q_max, target_q_min, next_log_probs = self._critic_loss_tensors(
             critic_obs,
             actions,
@@ -814,6 +875,7 @@ class FastSACLearner:
                 dim=0,
             )
 
+        obs = self.normalize_obs(obs, update=False)
         actor_loss, policy_entropy, action_std = self._actor_loss_tensors(obs, critic_obs)
 
         # Skip if NaN
@@ -867,6 +929,11 @@ class FastSACLearner:
             "actor_optimizer": self.actor_optimizer.state_dict(),
             "q_optimizer": self.q_optimizer.state_dict(),
             "alpha_optimizer": self.alpha_optimizer.state_dict(),
+            "obs_normalizer": (
+                self.obs_normalizer.state_dict()
+                if hasattr(self.obs_normalizer, "state_dict")
+                else None
+            ),
             "update_count": self.update_count,
         }
 
@@ -879,6 +946,8 @@ class FastSACLearner:
         self.actor_optimizer.load_state_dict(state_dict["actor_optimizer"])
         self.q_optimizer.load_state_dict(state_dict["q_optimizer"])
         self.alpha_optimizer.load_state_dict(state_dict["alpha_optimizer"])
+        if state_dict.get("obs_normalizer") and hasattr(self.obs_normalizer, "load_state_dict"):
+            self.obs_normalizer.load_state_dict(state_dict["obs_normalizer"])
         self.update_count = state_dict.get("update_count", 0)
 
 

--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -92,6 +92,7 @@ class FastSACRunner(OffPolicyRunner):
             max_grad_norm=max_grad_norm,
             use_amp=use_amp,
             amp_dtype=amp_dtype,
+            obs_normalization=obs_normalization,
             use_symmetry=use_symmetry,
             symmetry_augmentation=symmetry_augmentation,
             world_size=getattr(self, "world_size", world_size),

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -33,7 +33,7 @@ from unilab.algos.torch.offpolicy.runner import (
     replay_buffer_ready_for_learning,
 )
 from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
-from unilab.ipc import SharedWeightSync
+from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX
 from unilab.ipc.replay_buffer import ReplayBuffer
 from unilab.ipc.replay_pipelines.multi_gpu_cpu_pinned import MultiGPUCPUPinnedReplayPipeline
@@ -125,6 +125,22 @@ def _put_trainer_done_or_stop(trainer_done_queue: Any, stop_event: Any) -> bool:
     return False
 
 
+def _publish_obs_normalizer_stats(learner: Any, shared_obs_normalizer_stats: Any) -> None:
+    if shared_obs_normalizer_stats is None:
+        return
+    normalizer = getattr(learner, "obs_normalizer", None)
+    if normalizer is None:
+        return
+    try:
+        mean = normalizer.mean
+        std = normalizer.std
+    except Exception:
+        return
+    if not torch.is_tensor(mean) or not torch.is_tensor(std):
+        return
+    shared_obs_normalizer_stats.put((mean.detach().cpu().numpy(), std.detach().cpu().numpy()))
+
+
 def _learner_worker(
     rank: int,
     world_size: int,
@@ -206,6 +222,8 @@ def _learner_worker(
         sync_interval = normalize_multi_gpu_sync_interval(
             int(runner_kwargs.get("multi_gpu_sync_interval", 1))
         )
+        obs_normalization = bool(runner_kwargs.get("obs_normalization", False))
+        shared_obs_normalizer_stats = runner_kwargs.get("shared_obs_normalizer_stats")
         learning_starts = max(int(runner_kwargs.get("learning_starts", 0)), 0)
         train_start_threshold = compute_train_start_threshold(batch_size, learning_starts, num_envs)
         sample_count = batch_size * updates_per_step
@@ -439,6 +457,8 @@ def _learner_worker(
                 learner.update_count += 1
                 weight_sync_time = 0.0
                 if sync_mode != "local_sgd" or did_param_sync:
+                    if obs_normalization:
+                        _publish_obs_normalizer_stats(learner, shared_obs_normalizer_stats)
                     weight_sync_start = time.perf_counter()
                     weight_sync.write_weights(learner.actor.state_dict())
                     weight_sync_time = time.perf_counter() - weight_sync_start
@@ -673,6 +693,9 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
             )
 
         metrics_queue = _SPAWN_CTX.Queue(maxsize=100)
+        shared_obs_normalizer_stats = None
+        if self.obs_normalization:
+            shared_obs_normalizer_stats = SharedObsNormStats(_SPAWN_CTX)
         collector_pack_request_queues = [_SPAWN_CTX.Queue(maxsize=2) for _ in range(self.num_gpus)]
         collector_pack_ready_queues = [_SPAWN_CTX.Queue(maxsize=2) for _ in range(self.num_gpus)]
         sample_count = self.batch_size * self.updates_per_step
@@ -703,8 +726,8 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
             "collection_ready_queue": collection_ready_queue,
             "trainer_done_queue": trainer_done_queue,
             "env_steps_per_sync": self.env_steps_per_sync,
-            "obs_normalization": False,
-            "shared_obs_normalizer_stats": None,
+            "obs_normalization": self.obs_normalization,
+            "shared_obs_normalizer_stats": shared_obs_normalizer_stats,
             "sim_backend": self.sim_backend,
             "env_cfg_override": self.env_cfg_override,
             "obs_dim": self.obs_dim,
@@ -748,6 +771,8 @@ class MultiGPUOffPolicyRunner(OffPolicyRunner):
             "multi_gpu_sync_mode": self.multi_gpu_sync_mode,
             "multi_gpu_sync_interval": self.multi_gpu_sync_interval,
             "algo_type": self.algo_type,
+            "obs_normalization": self.obs_normalization,
+            "shared_obs_normalizer_stats": shared_obs_normalizer_stats,
         }
 
         try:

--- a/src/unilab/structured_configs.py
+++ b/src/unilab/structured_configs.py
@@ -54,7 +54,7 @@ class SACConfig(BaseConfig):
     actor_hidden_dim: int = 512
     critic_hidden_dim: int = 768
     num_atoms: int = 101
-    obs_normalization: bool = True
+    obs_normalization: bool = False
     use_layer_norm: bool = True
     use_symmetry: bool = False
     actor: dict[str, Any] = field(default_factory=dict)

--- a/tests/algos/test_fast_sac_symmetry_contract.py
+++ b/tests/algos/test_fast_sac_symmetry_contract.py
@@ -137,6 +137,62 @@ def test_fast_sac_learner_exposes_multi_gpu_initial_sync_contract():
     learner.sync_initial_parameters(src=0)
 
 
+def test_fast_sac_obs_normalization_uses_global_distributed_moments(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    learner = FastSACLearner(
+        obs_dim=2,
+        action_dim=1,
+        critic_obs_dim=3,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+        obs_normalization=True,
+        world_size=2,
+    )
+
+    monkeypatch.setattr(learner_module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(learner_module.dist, "is_initialized", lambda: True)
+
+    def fake_all_reduce(tensor, op=None):
+        del op
+        remote_moments = torch.tensor([12.0, 16.0, 74.0, 130.0, 2.0])
+        tensor.add_(remote_moments)
+
+    monkeypatch.setattr(learner_module.dist, "all_reduce", fake_all_reduce)
+
+    learner.normalize_obs(torch.tensor([[1.0, 3.0], [3.0, 5.0]]), update=True)
+
+    torch.testing.assert_close(learner.obs_normalizer.mean, torch.tensor([4.0, 6.0]))
+    torch.testing.assert_close(
+        learner.obs_normalizer.std,
+        torch.full((2,), 5.0**0.5),
+    )
+    assert int(learner.obs_normalizer.count.item()) == 4
+
+    restored = FastSACLearner(
+        obs_dim=2,
+        action_dim=1,
+        critic_obs_dim=3,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+        obs_normalization=True,
+    )
+    restored.load_state_dict(learner.get_state_dict())
+    torch.testing.assert_close(restored.obs_normalizer.mean, learner.obs_normalizer.mean)
+
+
 def test_multi_gpu_offpolicy_runner_rejects_sac_symmetry_capability():
     from unilab.algos.torch.offpolicy.multi_gpu_runner import MultiGPUOffPolicyRunner
 

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -113,15 +113,65 @@ def test_td3_dispatches_to_double_buffer_runner(monkeypatch: pytest.MonkeyPatch)
     assert runner.kwargs["learner"].kwargs["critic_obs_dim"] == 6
 
 
-def test_sac_multi_gpu_rejects_obs_normalization_until_synchronized():
+def test_sac_multi_gpu_passes_obs_normalization_to_learner_and_runner(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import gymnasium as gym
+
+    mod = _offpolicy()
     cfg = _offpolicy_cfg(
         [
             "algo=sac",
             "training.num_gpus=2",
+            "training.device=cuda",
+            "algo.obs_normalization=true",
+            "algo.use_symmetry=false",
         ]
     )
-    with pytest.raises(ValueError, match="requires algo.obs_normalization=false"):
-        _offpolicy().build_runner("sac", cfg)
+
+    class _FakeEnv:
+        obs_groups_spec = {"obs": 4, "critic": 6}
+        action_space = gym.spaces.Box(-1.0, 1.0, shape=(2,))
+
+        def build_symmetry_augmentation(self, device=None):
+            return None
+
+        def close(self):
+            pass
+
+    class _FakeLearner:
+        class actor:
+            @staticmethod
+            def state_dict():
+                return {"w": MagicMock(shape=(4,))}
+
+        update_count = 0
+
+        def __init__(self, *args, **kwargs):
+            del args
+            self.kwargs = kwargs
+
+    class _FakeRunner:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(mod, "ensure_registries", lambda: None)
+    monkeypatch.setattr(mod, "create_env", lambda *args, **kwargs: _FakeEnv())
+
+    import unilab.algos.torch.fast_sac.learner as learner_mod
+
+    monkeypatch.setattr(learner_mod, "FastSACLearner", _FakeLearner)
+
+    import unilab.algos.torch.offpolicy.multi_gpu_runner as mg_mod
+
+    monkeypatch.setattr(mg_mod, "MultiGPUOffPolicyRunner", _FakeRunner)
+
+    runner = mod.build_runner("sac", cfg)
+
+    assert isinstance(runner, _FakeRunner)
+    assert runner.kwargs["obs_normalization"] is True
+    assert runner.kwargs["learner"].kwargs["obs_normalization"] is True
+    assert runner.kwargs["learner_kwargs"]["obs_normalization"] is True
 
 
 @pytest.mark.parametrize("device", ["cpu", "mps"])

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -1170,6 +1170,7 @@ def test_multi_gpu_runner_passes_explicit_runtime_context_to_collector(
         sync_collection=True,
         env_steps_per_sync=1,
         device="cpu",
+        obs_normalization=True,
         sim_backend="motrix",
         env_cfg_override={"reward_config": {"scales": {"alive": 1.0}}},
     )
@@ -1184,6 +1185,8 @@ def test_multi_gpu_runner_passes_explicit_runtime_context_to_collector(
 
     assert captured["sim_backend"] == "motrix"
     assert captured["env_cfg_override"] == {"reward_config": {"scales": {"alive": 1.0}}}
+    assert captured["obs_normalization"] is True
+    assert captured["shared_obs_normalizer_stats"] is not None
 
 
 def test_multi_gpu_runner_allocates_replay_critic_storage(
@@ -1215,6 +1218,7 @@ def test_multi_gpu_runner_allocates_replay_critic_storage(
         sync_collection=True,
         env_steps_per_sync=1,
         device="cpu",
+        obs_normalization=True,
     )
     monkeypatch.setattr(runner, "_start_collector", lambda *args, **kwargs: None)
 
@@ -1260,6 +1264,7 @@ def test_multi_gpu_runner_spawn_receives_algorithm_agnostic_learner_and_rank_ipc
         sync_collection=True,
         env_steps_per_sync=1,
         device="cpu",
+        obs_normalization=True,
     )
     monkeypatch.setattr(runner, "_start_collector", lambda *args, **kwargs: None)
 
@@ -1271,8 +1276,35 @@ def test_multi_gpu_runner_spawn_receives_algorithm_agnostic_learner_and_rank_ipc
     assert args[2] == {"obs_dim": 4, "action_dim": 2}
     assert args[3]["multi_gpu_sync_mode"] == "local_sgd"
     assert args[3]["multi_gpu_sync_interval"] == 3
+    assert args[3]["obs_normalization"] is True
+    assert args[3]["shared_obs_normalizer_stats"] is not None
     assert len(cast(list, args[13])) == 2
     assert len(cast(list, args[14])) == 2
+
+
+def test_multi_gpu_publish_obs_normalizer_stats() -> None:
+    class _Normalizer:
+        mean = torch.tensor([1.0, 2.0])
+        std = torch.tensor([3.0, 4.0])
+
+    class _Learner:
+        obs_normalizer = _Normalizer()
+
+    class _SharedStats:
+        def __init__(self) -> None:
+            self.put_calls: list[tuple[object, object]] = []
+
+        def put(self, stats) -> None:
+            self.put_calls.append(stats)
+
+    shared_stats = _SharedStats()
+
+    multi_gpu_runner_module._publish_obs_normalizer_stats(_Learner(), shared_stats)
+
+    assert len(shared_stats.put_calls) == 1
+    mean, std = shared_stats.put_calls[0]
+    assert mean.tolist() == [1.0, 2.0]
+    assert std.tolist() == [3.0, 4.0]
 
 
 def test_multi_gpu_learner_worker_logs_wall_clock_and_per_rank_batch_context(

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -56,6 +56,7 @@ def test_sac_config_defaults():
     assert cfg.num_envs == 4096
     assert cfg.batch_size == 8192
     assert cfg.use_symmetry is False
+    assert cfg.obs_normalization is False
     assert isinstance(cfg.algo_params, SACAlgoParams)
     assert cfg.algo_params.alpha_init == 0.01
     assert cfg.algo_params.use_compile is True

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -2447,7 +2447,6 @@ def test_offpolicy_sac_multi_gpu_requires_cuda_device():
             "task=sac/g1_walk_flat/mujoco",
             "training.num_gpus=2",
             "training.device=cpu",
-            "algo.obs_normalization=false",
         ]
     )
 
@@ -2463,7 +2462,6 @@ def test_offpolicy_sac_multi_gpu_requires_cuda_even_with_explicit_symmetry_disab
             "training.num_gpus=2",
             "training.device=cpu",
             "algo.use_symmetry=false",
-            "algo.obs_normalization=false",
         ]
     )
 


### PR DESCRIPTION
## Summary
- add FastSAC observation normalization support and checkpoint round-trip
- synchronize multi-GPU SAC normalizer stats from cross-rank batch moments and publish rank0 stats to the collector
- keep SAC obs normalization disabled by default to preserve previous single-GPU behavior

## Validation
- `make test-all`