### PR TITLE
fix: avoid duplicate offpolicy logger startup frames

### DIFF
--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -219,7 +219,7 @@ class BaseTrainingLogger:
 
     def _stop_live(self) -> None:
         if self._live is not None:
-            self._live.update(self._build_display(), refresh=True)
+            self._live.update(self._build_display(), refresh=False)
             self._live.stop()
             self._live = None
             self._last_live_refresh_time = None

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -159,7 +159,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_target = target
         pct = current / max(target, 1) * 100
         self._status = f"Buffer fill: {current:,}/{target:,} ({pct:.0f}%)"
-        if not self._terminal_refresh_started:
+        if self._terminal_refresh_started:
             self._refresh()
 
     def _get_iter_steps_per_sec(self) -> float | None:
@@ -518,8 +518,10 @@ class OffPolicyLogger(BaseTrainingLogger):
 
     def log_status(self, status: str):
         self._status = status
-        if not self._terminal_refresh_started or "[red]" in status or "ERROR" in status:
+        if "[red]" in status or "ERROR" in status:
             self._refresh(force=True)
+        elif self._terminal_refresh_started:
+            self._refresh()
 
     def _build_display(self) -> Panel:
         header = self._build_compact_header(include_status=True)

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from unilab.logging.offpolicy import OffPolicyLogger
+
+
+def test_offpolicy_logger_defers_warmup_refresh_until_training_step(monkeypatch) -> None:
+    logger = OffPolicyLogger(
+        algo_name="SAC",
+        max_iterations=2,
+        num_envs=8,
+        env_name="Dummy",
+        log_backend="none",
+    )
+    refresh_calls: list[bool] = []
+
+    def fake_refresh(*, force: bool = False) -> None:
+        refresh_calls.append(force)
+
+    monkeypatch.setattr(logger, "_refresh", fake_refresh)
+
+    logger.log_buffer_fill(32, 64)
+    logger.log_status("Replay pipeline: cpu_pinned_double_buffer")
+
+    assert refresh_calls == []
+    assert logger._buffer_size == 32
+    assert logger._buffer_target == 64
+
+    logger.log_status("[red]ERROR: Collector died[/]")
+    assert refresh_calls == [True]
+
+    refresh_calls.clear()
+    logger.log_step(
+        iteration=1,
+        metrics={"loss/q": 0.5},
+        reward=1.0,
+        extra_info={"throughput_steps": 8},
+    )
+    logger.log_status("Training")
+    logger.log_buffer_fill(64, 64)
+
+    assert refresh_calls == [False, False, False]
+
+
+def test_offpolicy_logger_stop_live_lets_rich_do_final_refresh() -> None:
+    logger = OffPolicyLogger(
+        algo_name="SAC",
+        max_iterations=2,
+        num_envs=8,
+        env_name="Dummy",
+        log_backend="none",
+    )
+
+    class _FakeLive:
+        def __init__(self) -> None:
+            self.update_calls: list[bool] = []
+            self.stop_calls = 0
+
+        def update(self, renderable: Any, *, refresh: bool) -> None:
+            del renderable
+            self.update_calls.append(refresh)
+
+        def stop(self) -> None:
+            self.stop_calls += 1
+
+    live = _FakeLive()
+    logger._live = live  # type: ignore[assignment]
+    logger._last_live_refresh_time = 123.0
+
+    logger._stop_live()
+
+    assert live.update_calls == [False]
+    assert live.stop_calls == 1
+    assert logger._live is None
+    assert logger._last_live_refresh_time is None


### PR DESCRIPTION
Summary
- Defer off-policy warmup status/dashboard refreshes until the first training step has real metrics.
- Let Rich Live perform the final refresh on stop instead of forcing an extra duplicate frame.
- Add focused logger regression tests for warmup refresh behavior and Live stop handling.

Validation
- make test-all