### PR TITLE
feat: add motrix training support for x2 wall flip

### DIFF
--- a/conf/ppo/task/x2_wall_flip_tracking/motrix.yaml
+++ b/conf/ppo/task/x2_wall_flip_tracking/motrix.yaml
@@ -1,0 +1,100 @@
+# @package _global_
+training:
+  task_name: X2WallFlipTracking
+  sim_backend: motrix
+  play_steps: 300  # 6s play video @ ctrl_dt=0.02 (fps 50)
+  play_env_num: 16
+  render_spacing: 3.0
+  cam_distance: 14.0
+  cam_azimuth: 225.0
+  cam_elevation: -18.0
+  cam_lookat: [4.5, 4.5, 1.0]
+interactive:
+  action_mode: policy
+algo:
+  num_envs: 1024
+  max_iterations: 9500
+  save_interval: 500
+  empirical_normalization: true
+  obs_groups:
+    actor:
+      - actor
+    critic:
+      - critic
+  algorithm:
+    entropy_coef: 0.005
+    desired_kl: 0.01
+env:
+  motrix_max_iterations: 3
+  sampling_mode: start
+  truncate_on_clip_end: false
+  sim_dt: 0.005
+  control_config:
+    action_scale:
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+      - 0.25
+  anchor_pos_z_threshold: 0.5
+  ee_body_pos_z_threshold: 0.5
+  terminate_on_undesired_contacts: true
+  noise_config:
+    level: 0.0
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 4.0
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/x2/scene_flat_with_wall.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 2.0
+    motion_body_ori: 1.5
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_ee_body_pos_z: 2.0
+    motion_joint_pos: 0.5
+    motion_joint_vel: 0.25
+    action_rate_l2: -0.005
+    joint_limit: -10.0
+    undesired_contacts: -0.1
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -57,7 +57,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
 | PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
 | PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
-| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - |
+| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | Tested |
 | PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
 | PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | Tested |
@@ -78,7 +78,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | Configured |
 | PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | Configured |
 | PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | Configured |
-| PPO (mlx) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Configured | - |
+| PPO (mlx) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Configured | Configured |
 | PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand` (Sharpa in-hand) | Configured | Configured |
 | PPO (mlx) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Configured | Configured |

--- a/src/unilab/assets/robots/x2/x2_simple_collision.xml
+++ b/src/unilab/assets/robots/x2/x2_simple_collision.xml
@@ -1,5 +1,5 @@
 <mujoco model="x2_simple_collision">
-  <compiler angle="radian" eulerseq="XYZ" meshdir="./meshes" autolimits="true" />
+  <compiler angle="radian" eulerseq="xyz" meshdir="./meshes" autolimits="true" />
 
   <option timestep="0.001" />
 
@@ -11,7 +11,7 @@
               <geom group="2" type="mesh" contype="0" conaffinity="0" density="0" />
           </default>
           <default class="collision">
-              <geom group="3" type="mesh" />
+              <geom group="3" type="mesh" contype="1" conaffinity="2" />
               <default class="foot">
                   <geom type="sphere" size="0.005" />
               </default>

--- a/src/unilab/envs/motion_tracking/x2/flip_tracking.py
+++ b/src/unilab/envs/motion_tracking/x2/flip_tracking.py
@@ -118,6 +118,7 @@ class X2WallFlipTrackingEnvCfg(X2WallFlipTrackingCfg):
 
 
 @registry.env("X2WallFlipTracking", sim_backend="mujoco")
+@registry.env("X2WallFlipTracking", sim_backend="motrix")
 class X2WallFlipTrackingEnv(G1MotionTrackingDeployEnv):
     """X2 wall flip-tracking environment implementation."""
 


### PR DESCRIPTION
Fixes #654

## Summary

- Register `X2WallFlipTracking` for the Motrix backend.
- Add the PPO Motrix owner config for `x2_wall_flip_tracking`.
- Adjust the X2 simple collision XML for Motrix-compatible contact behavior.

## Validation

- `uv --cache-dir /tmp/uv-cache run pytest tests/config/test_locomotion_params.py::test_ppo_x2_wall_flip_tracking tests/base/backend/test_mujoco_scene_context_visual.py::test_x2_wall_flip_wires_render_only_visual_twin tests/envs/test_env_configs.py::test_x2_wall_flip_tracking_cfg_uses_x2_wall_flip_profile`
- Minimal PPO learn smoke for `task=x2_wall_flip_tracking/motrix`

## Notes

- Training artifacts, logs, checkpoints, ONNX files, and videos are not included.
