### PR TITLE
feat: add motrix config for g1 motion deploy

### DIFF
--- a/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
@@ -1,0 +1,107 @@
+# @package _global_
+training:
+  task_name: G1MotionTrackingDeploy
+  sim_backend: motrix
+  play_env_num: 16
+  play_steps: 1000
+algo:
+  num_envs: 1024
+  max_iterations: 15000
+  save_interval: 500
+  obs_groups:
+    actor:
+      - actor
+  algorithm:
+    entropy_coef: 0.005
+  noise_config:
+    level: 1.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 2.5
+  scene:
+    enabled: true
+    source_model_file: src/unilab/assets/robots/g1/scene_flat.xml
+    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
+    skybox_rgb1: [0.90, 0.90, 0.91]
+    skybox_rgb2: [0.68, 0.68, 0.70]
+    ground_texrepeat: [0.25, 0.25]
+env:
+  sim_dt: 0.005
+  sensor:
+    local_linvel: pelvis_local_linvel
+    gyro: pelvis_gyro
+    upvector: pelvis_upvector
+  domain_rand:
+    random_com: true
+    com_offset_x: [-0.025, 0.025]
+    com_offset_y: [-0.05, 0.05]
+    com_offset_z: [-0.05, 0.05]
+    randomize_base_mass: true
+    added_mass_range: [-1.5, 1.5]
+    push_robots: true
+    push_interval: 750
+    max_force: [1.0, 1.0, 0.5]
+    randomize_joint_default_pos: true
+    joint_default_pos_range: [-0.01, 0.01]
+    # randomize_geom_friction omitted: Motrix does not reliably support it
+  noise_config:
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.5
+    scale_gyro: 0.2
+    scale_linvel: 0.5
+    scale_gravity: 0.05
+  control_config:
+    action_scale:
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.5475464629911068
+      - 0.35066146637882434
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.5475464629911068
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.43857731392336724
+      - 0.07450087032950714
+      - 0.07450087032950714
+reward:
+  scales:
+    motion_global_root_pos: 0.5
+    motion_global_root_ori: 0.5
+    motion_body_pos: 1.0
+    motion_body_ori: 1.0
+    motion_body_lin_vel: 1.0
+    motion_body_ang_vel: 1.0
+    motion_joint_pos: 0.0
+    motion_joint_vel: 0.0
+    action_rate_l2: -0.1
+    joint_limit: -10.0
+  std_root_pos: 0.3
+  std_root_ori: 0.4
+  std_body_pos: 0.3
+  std_body_ori: 0.4
+  std_body_lin_vel: 1.0
+  std_body_ang_vel: 3.14
+  std_joint_pos: 0.2
+  std_joint_vel: 1.0

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -64,7 +64,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
 | PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | Tested |
 | PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
-| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Registered |
+| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
 | PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | Tested |
 | PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | Tested |
 | PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - |
@@ -85,7 +85,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
 | PPO (mlx) | `g1_box_tracking` (g1 box tracking) | Configured | Configured |
 | PPO (mlx) | `g1_climb_tracking` (g1 climb tracking) | Configured | Configured |
-| PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Registered |
+| PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
 | PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | Configured |
 | PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | Configured |
 | PPO (mlx) | `go2_footstand` (go2 footstand) | Configured | - |


### PR DESCRIPTION
Fixes #655

## Summary

- Add Motrix PPO config for `G1MotionTrackingDeploy`.
- Keep core training, action scale, reward, noise, and sensor settings aligned with the MuJoCo config.
- Omit geom friction randomization for Motrix because it is not reliably supported.

## Validation

- `git diff --check -- conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml`
- `uv --cache-dir /tmp/uv-cache run pytest tests/config/test_locomotion_params.py::test_ppo_g1_motion_tracking_deploy`

## Notes

- Training artifacts, logs, checkpoints, ONNX files, and videos are not included.
