### PR TITLE
feat(offpolicy): add motrix owner config for flashsac g1_walk_flat

### DIFF
--- a/conf/offpolicy/task/flashsac/g1_walk_flat/motrix.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/motrix.yaml
@@ -1,0 +1,61 @@
+# @package _global_
+# Motrix owner for FlashSAC G1 walk flat.
+# Keeps the mujoco owner's FlashSAC algo identity (num_envs/updates_per_step/
+# replay_buffer_n/tau plus the distributional critic from conf/offpolicy/algo/flashsac.yaml)
+# while adopting the Motrix-direction env + reward tuning used by the SAC motrix owner
+# (kp/kd randomization off, retuned reward shaping, tighter feet-phase sigma).
+# control_config.action_scale stays 1.0 to keep sim2sim DENYLIST parity with mujoco.
+training:
+  task_name: G1WalkFlat
+  sim_backend: motrix
+algo:
+  num_envs: 4096
+  learning_starts: 49
+  max_iterations: 5000
+  save_interval: 1000
+  updates_per_step: 8
+  replay_buffer_n: 256
+  tau: 0.05
+env:
+  control_config:
+    action_scale: 1.0
+  gait_phase_init_mode: "offset_phase"
+  reset_base_qvel_limit: 0.5
+  domain_rand:
+    randomize_kp: false
+    randomize_kd: false
+  curriculum:
+    enabled: true
+    initial_scale: 0.5
+    min_scale: 0.5
+    max_scale: 1.0
+    level_down_threshold: 150.0
+    level_up_threshold: 750.0
+    degree: 0.001
+  noise_config:
+    level: 0.0
+    scale_gyro: 0.0
+    scale_gravity: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.1
+    scale_linvel: 0.0
+reward:
+  scales:
+    tracking_lin_vel: 2.2
+    tracking_ang_vel: 1.8
+    penalty_ang_vel_xy: -1.2
+    penalty_orientation: -12.0
+    penalty_action_rate: -2.5
+    pose: -0.6
+    penalty_feet_ori: -5.0
+    feet_phase: 6.0
+    alive: 12.0
+  tracking_sigma: 0.25
+  base_height_target: 0.754
+  min_base_height: 0.3
+  max_tilt_deg: 65.0
+  gait_frequency: 1.5
+  feet_phase_swing_height: 0.09
+  feet_phase_tracking_sigma: 0.008
+  close_feet_threshold: 0.15
+  pose_weights: [0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -111,7 +111,7 @@ uv run scripts/generate_support_matrix.py --write
 | TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | Tested |
 | TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
 | FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |
-| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
+| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
 
 ### Source Index
 


### PR DESCRIPTION
## Summary

Adds the Motrix owner config for FlashSAC on `G1WalkFlat`, completing the mujoco/motrix owner pair under `conf/offpolicy/task/flashsac/g1_walk_flat/`.

- New `conf/offpolicy/task/flashsac/g1_walk_flat/motrix.yaml`:
  - Keeps the mujoco FlashSAC algo identity (`num_envs=4096`, `updates_per_step=8`, `replay_buffer_n=256`, `tau=0.05`, `learning_starts=49`, plus the distributional critic from `conf/offpolicy/algo/flashsac.yaml`).
  - Adopts Motrix-direction env + reward tuning from the SAC motrix owner: `randomize_kp/kd` off, retuned reward shaping, tighter `feet_phase_tracking_sigma` (0.008).
  - Keeps `env.control_config.action_scale: 1.0` to preserve sim2sim DENYLIST parity with the mujoco owner.
- Regenerated `docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md` (FlashSAC `g1_walk_flat` motrix → Tested) via `uv run scripts/generate_support_matrix.py --write`, required by the docs-contract test.

## Validation

- `make test-all` completed: `1383 passed, 27 skipped, 258 deselected` (ruff format/check, mypy, pyright all green).
- `tests/scripts/test_check_docs.py` passes (support matrix no longer stale).