### PR TITLE
benchmark: add numba env overhead profile

### DIFF
--- a/benchmark/numba_profile/README.md
+++ b/benchmark/numba_profile/README.md
@@ -1,120 +1,118 @@
-# numba_profile — fused `update_state` for `g1_motion_tracking`
+# numba_profile：面向 `g1_motion_tracking` 的 fused `update_state` profile
 
-Standalone profile answering: **how much does a Numba prange fusion of the
-single-threaded "Env overhead" (obs/reward/termination) buy, and can it be done
-without wrecking the structured, config-driven reward code?**
+这个目录用于回答一个具体问题：把单进程训练里单线程执行的 Env
+overhead（obs / reward / termination）改成 Numba `prange` 融合 kernel，收益
+上限有多大；同时，这种改法是否还能保留 UniLab 现有的结构化、配置驱动
+reward 写法。
 
-Follow-up to issues **#651** (collector active-throughput target), **#663**
-(parallelise Env overhead), and **#665** (Numba prange fusion ceiling). This
-directory validates the task-specific `g1_motion_tracking` reward + termination
-hot slice, implements the structured Numba scheme, and measures **speed** and
-**numerical consistency** side by side.
+这是 issues **#651**（collector active throughput 目标）、**#663**（Env
+overhead 并行化）和 **#665**（Numba `prange` 融合上限）的后续验证。本目录验证的是
+`g1_motion_tracking` 的 task-specific reward + termination 热路径切片，提供
+结构化 Numba 实现，并把**速度**和**数值一致性**放在同一套脚本里验证。
 
-No MuJoCo/Motrix needed: this profile starts after backend state has already been
-materialised into typed arrays, then runs the pure array math over robot state
-vs. a motion reference. We synthesise those arrays at the real shapes/dtypes.
+不需要 MuJoCo / Motrix：这个 profile 从 backend 状态已经 materialize 成 typed
+arrays 之后开始，只运行机器人状态和 motion reference 之间的纯数组计算。输入数组用
+真实 shape / dtype 合成。
 
-## Files
+## 文件说明
 
-| File | Role |
+| 文件 | 作用 |
 |------|------|
-| `spec.py` | Single source of truth — dims, `RewardConfig` scales/stds, thresholds, `TERM_ORDER`. Mirrors `tracking.py` (line refs inline). |
-| `state.py` | Deterministic synthetic batch at real shapes (N envs × 14 bodies × 29 DoF), ~2% terminations. |
-| `numpy_reference.py` | **Golden oracle** — each `_reward_*` / `_compute_terminations` ported from `tracking.py`, faithful math. |
-| `numba_terms.py` | Single-source `@njit(inline="always")` scalar device fns, one per term (`.py_func` debuggable). |
-| `numba_fused.py` | `@njit(parallel=True)` prange driver: static superset gated by a scale vector, per-thread log scratch, numpy fallback. |
-| `test_parity.py` | Consistency: numba vs numpy on reward, terminations, per-term log; device `.py_func` vs numpy. |
-| `bench.py` | Speed: numpy vs numba across `num_envs` and thread counts. |
+| `spec.py` | 单一事实源：维度、`RewardConfig` scales/stds、termination 阈值、`TERM_ORDER`。与 `tracking.py` 对齐，行号写在注释里。 |
+| `state.py` | 按真实 shape 构造确定性的 synthetic batch：`N envs x 14 bodies x 29 DoF`，约 2% termination。 |
+| `numpy_reference.py` | golden oracle：把 `tracking.py` 中的 `_reward_*` / `_compute_terminations` 数学逻辑逐项 port 到 numpy。 |
+| `numba_terms.py` | 每个 reward term 一个 `@njit(inline="always")` scalar device function，`.py_func` 可用于 Python 侧调试。 |
+| `numba_fused.py` | `@njit(parallel=True)` 的 `prange` driver：静态 term superset、scale vector gate、per-thread log scratch、numpy fallback。 |
+| `test_parity.py` | 一致性验证：numba vs numpy 的 reward、termination、per-term log，以及 device `.py_func` vs numpy。 |
+| `bench.py` | 性能验证：按 `num_envs` 和线程数对比 numpy 与 numba。 |
 
-## Run
+## 运行
 
 ```bash
-uv run --with numba python -m benchmark.numba_profile.test_parity      # consistency
-uv run --with numba python -m benchmark.numba_profile.bench            # speed (8k + 32k)
+uv run --with numba python -m benchmark.numba_profile.test_parity
+uv run --with numba python -m benchmark.numba_profile.bench
 PROBE_NUM_ENVS=32768 uv run --with numba python -m benchmark.numba_profile.bench
 ```
 
-`numba` is the only extra dep. Use `uv run --with numba ...` for a one-shot run,
-or install it once with `uv pip install numba`.
+`numba` 是唯一额外依赖。一次性运行可用 `uv run --with numba ...`；如果本地环境已经
+固定，也可以先执行 `uv pip install numba`。
 
-## Faithfulness — how this maps to the real task
+## 与真实 task 的对应关系
 
-The hot-slice math is copied from `src/unilab/envs/motion_tracking/g1/tracking.py`:
+热路径数学逻辑来自 `src/unilab/envs/motion_tracking/g1/tracking.py`：
 
-- **11 default reward-scale terms** (`RewardConfig.scales`, tracking.py:44) with
-  the exact default `scales` and `std_*`. Default has 8 nonzero-scale terms;
-  `motion_ee_body_pos_z` / `motion_joint_pos` / `motion_joint_vel` are `0.0` and
-  skipped, exactly as the real loop does. The real `_init_reward_functions`
-  registry also contains `undesired_contacts`, but the default config has no
-  scale for it, so it is outside this default-scale profile.
-- **Reward math** per term ported 1:1 — anchor pos/ori (`_quat_error` via
-  `2·acos|dot|`), per-body mean xyz error, joint-limit violation, action-rate L2,
-  `exp(-err/std²)`, final `reward *= ctrl_dt` (0.02).
-- **Terminations** (`_compute_terminations`, tracking.py:978): anchor-Z,
-  anchor-orientation via body-frame gravity-z (tracking.py:276), end-effector-Z.
-- **Dims**: `NUM_ACTION=29`, 14 tracked bodies, anchor = `torso_link` (idx 7),
-  ee = `{ankles, wrists}` (idx 3,6,10,13).
+- **11 个默认 reward-scale terms**：来自 `RewardConfig.scales`，保留默认
+  `scales` 和 `std_*`。默认有 8 个非零 scale；`motion_ee_body_pos_z` /
+  `motion_joint_pos` / `motion_joint_vel` 为 `0.0`，和真实 reward loop 一样跳过。
+  真实 `_init_reward_functions` registry 里还有 `undesired_contacts`，但默认 config
+  没有给它 scale，因此不属于这个 default-scale profile。
+- **Reward 数学逐项 port**：anchor pos / ori、`2 * acos(abs(dot))` 的 quat error、
+  per-body mean xyz error、joint-limit violation、action-rate L2、`exp(-err/std^2)`、
+  最终 `reward *= ctrl_dt`，其中 `ctrl_dt = 0.02`。
+- **Termination 逻辑逐项 port**：anchor-Z、基于 body-frame gravity-z 的
+  anchor-orientation、end-effector-Z。
+- **维度对齐真实配置**：`NUM_ACTION = 29`，14 个 tracked bodies，anchor body 为
+  `torso_link`（idx 7），end-effectors 为 `{ankles, wrists}`（idx 3、6、10、13）。
 
-The one deviation is intentional: we feed **synthetic** robot/motion arrays
-instead of stepping physics, because the fusion target is Env overhead, not
-physics. Magnitudes are tuned so rewards are non-degenerate and ~2% of envs
-terminate, matching the reset/copy pressure used in the #665 probe.
+唯一有意偏离：这里喂 synthetic robot / motion arrays，而不是 stepping physics。
+原因是本 profile 验证的是 Env overhead 里的数组计算切片，不是 physics。输入幅度调到
+reward 非退化，并产生约 2% termination，用来匹配 #665 probe 中的 reset/copy 压力。
 
-## The structured scheme — speed *and* maintainability
+## 结构化方案
 
-The design keeps every property of the original config-driven reward code while
-fusing the machine code:
+这个实现的目标不是把 reward 写死到一个难维护的大 kernel 里，而是在保留配置驱动
+属性的前提下做机器码融合：
 
-1. **Single-source terms** (`numba_terms.py`). One scalar `@njit(inline="always")`
-   function per term. The kernel inlines them → machine-code fusion (no
-   intermediate `(N,·)` arrays), but the source keeps one readable function per
-   term, and `fn.py_func` runs/debugs in plain Python. You give up *vectorised
-   numpy style* and nothing else.
-2. **Static superset + scale vector** (`numba_fused.py`). No codegen, no runtime
-   dict (nopython can't). The kernel evaluates the full `TERM_ORDER` superset;
-   a dense `scale` vector built on the **cold path** from the config dict gates
-   each term (`scale==0` → contributes 0, matching the numpy `continue`).
-   **Weights stay in config**, never baked into compiled code.
-3. **Registry / single ordering.** `spec.TERM_ORDER` owns name↔index for the
-   numpy oracle, the kernel, and the log. `numpy_reference.NUMPY_TERMS` pairs
-   each name with its numpy fn; `test_parity` walks them.
-4. **Per-thread log scratch.** Per-term reward means accumulate into
-   `(nthreads, N_TERMS)` indexed by `get_thread_id()`, summed on the main thread
-   after. A shared `log[k] += …` would false-share one cache line and cap
-   scaling at ~5x (#665 §2) — the correctness of this is why the parity test
-   checks every per-term log value, not just the total.
-5. **Consistency as a gate.** `numpy_reference.py` is retained as the oracle;
-   parity is `rtol=1e-4` (fastmath/FMA reorders float ops, so bit-exactness is
-   not expected). Adding a term = numpy fn + njit fn + one `TERM_ORDER` entry;
-   the test enforces they agree.
-6. **Fallback.** `update_state(force="auto")` drops to numpy below 256 envs where
-   launch/barrier cost dominates.
+1. **单一 term 源码**：`numba_terms.py` 中每个 reward term 一个 scalar
+   `@njit(inline="always")` 函数。kernel 编译时内联这些函数，因此没有中间
+   `(N, ...)` 数组；源码层面仍然保持“一项 reward 一个函数”，且 `.py_func` 可在
+   Python 侧调试。
+2. **静态 superset + scale vector**：`numba_fused.py` 不做 codegen，也不在 nopython
+   中传 runtime dict。kernel 固定覆盖 `TERM_ORDER` superset；冷路径从 config dict
+   构造 dense `scale` vector。`scale == 0` 时贡献为 0，等价于 numpy 参考实现里的
+   `continue`。权重仍由 config 拥有，不 baked into compiled code。
+3. **统一 registry / 顺序**：`spec.TERM_ORDER` 负责 name 与 index 的唯一映射；
+   numpy oracle、numba kernel 和 per-term log 都共享这个顺序。
+4. **per-thread log scratch**：每个线程写自己的 `(nthreads, N_TERMS)` scratch，再在主
+   线程聚合。直接共享 `log[k] += ...` 会在 cache line 上 false sharing，是 #665 中
+   已经测到的 scaling ceiling。
+5. **一致性作为 gate**：`numpy_reference.py` 保留为 oracle；`test_parity.py` 验证
+   total reward、termination、每个 active per-term log，以及 device `.py_func` 与
+   numpy term 的一致性。由于 `fastmath` / FMA 会重排浮点计算，验证采用容差而非
+   bit-exact。
+6. **小 batch fallback**：`update_state(force="auto")` 在 `num_envs < 256` 时回落到
+   numpy，因为并行 kernel 的 launch / barrier 成本不划算。
 
-## Results (Xeon 8568Y+, 160T — standalone profile run)
+## 结果
 
-`update_state` slice only (reward + termination), float32:
+以下数字来自 Xeon 8568Y+、160T 上的一次 standalone profile run。它们是本目录
+`update_state` micro-slice 的结果，不是 #665 原始 standalone probe 数字，也不是完整
+训练路径吞吐。
 
-| num_envs | numpy | numba 1T (fusion) | numba best | speedup |
-|---------:|------:|------------------:|-----------:|--------:|
-| 8 192  | 8.63 ms | 2.67 ms (**3.2x**) | 0.33 ms @ 48T | **26.6x** |
-| 32 768 | 35.57 ms | 10.65 ms (**3.3x**) | 0.73 ms @ 64T | **49.0x** |
+`update_state` 切片只包含 reward + termination，dtype 为 float32：
 
-Consistent with #665's thesis: single-core **fusion ≈ 3.2–3.3x** (kills the
-per-term intermediate arrays), **parallel ≈ 8–15x** on top in this standalone
-profile, and **larger batch scales higher** (barrier/launch cost amortised).
-Parity: total reward and every per-term log match to tolerance; terminations
-exact.
+| num_envs | numpy | numba 1T（fusion） | numba best | speedup |
+|---------:|------:|-------------------:|-----------:|--------:|
+| 8 192  | 8.63 ms | 2.67 ms（3.2x） | 0.33 ms @ 48T | 26.6x |
+| 32 768 | 35.57 ms | 10.65 ms（3.3x） | 0.73 ms @ 64T | 49.0x |
 
-## Scope / caveats (from #665)
+结论与 #665 的判断一致：单核 fusion 主要消除 per-term intermediate arrays，带来约
+3.2-3.3x；在这个 standalone profile 中，多线程并行又带来约 8-15x；batch 越大，
+launch / barrier 成本越容易摊薄。
 
-- **This is half the Env overhead.** `reset_done` (backend `set_state`) and the
-  4× RNG `standard_normal` for obs noise are separate ceilings Numba prange does
-  not address here.
-- **Obs assembly** (concat) is left in numpy — it's concat-bound, not the fusion
-  win; a real integration would share the same fused kernel boundary.
-- Numbers are the `update_state` micro-slice; end-to-end collector throughput
-  gains are diluted by physics and reset. #665's motion_tracking overhead −71%,
-  ~+72% throughput figure is a projection for that server/profile, not a result
-  from an integrated training path.
-- **Warmup**: first call JIT-compiles (~0.1 s). `cache=True` persists it to
-  `__pycache__/*.nbi` across processes.
+一致性方面，total reward 和每个 per-term log 都在容差内匹配，termination exact。
+
+## 范围和 caveats
+
+- 这不是完整 `NpEnv.update_state` 的通用 numba 化。真实热路径还包含 backend getter、
+  sampler、obs dict/info、reset/RNG 等边界；落地时更合理的形态是 task-owned typed
+  snapshot + task-specific fused kernel。
+- 这里只覆盖 reward + termination 这一段。`reset_done`（backend `set_state`）和 obs
+  noise 的多次 `standard_normal` 是另外的 ceiling，Numba `prange` 不会自动解决。
+- Obs assembly / concat 没有在这个 profile 中优化；它更接近 concat-bound，真实集成时
+  需要重新确定 kernel 边界。
+- 端到端 collector throughput 会被 physics、reset、RNG、obs assembly 稀释。#665 中
+  motion_tracking overhead -71%、throughput 约 +72% 是针对当时服务器/profile 的投影，
+  不是本目录已经完成的集成训练结果。
+- 首次调用会触发 JIT 编译；`cache=True` 会把编译产物缓存在
+  `__pycache__/*.nbi` / `*.nbc`，跨进程复用。

--- a/benchmark/numba_profile/README.md
+++ b/benchmark/numba_profile/README.md
@@ -1,0 +1,120 @@
+# numba_profile — fused `update_state` for `g1_motion_tracking`
+
+Standalone profile answering: **how much does a Numba prange fusion of the
+single-threaded "Env overhead" (obs/reward/termination) buy, and can it be done
+without wrecking the structured, config-driven reward code?**
+
+Follow-up to issues **#651** (collector active-throughput target), **#663**
+(parallelise Env overhead), and **#665** (Numba prange fusion ceiling). This
+directory validates the task-specific `g1_motion_tracking` reward + termination
+hot slice, implements the structured Numba scheme, and measures **speed** and
+**numerical consistency** side by side.
+
+No MuJoCo/Motrix needed: this profile starts after backend state has already been
+materialised into typed arrays, then runs the pure array math over robot state
+vs. a motion reference. We synthesise those arrays at the real shapes/dtypes.
+
+## Files
+
+| File | Role |
+|------|------|
+| `spec.py` | Single source of truth — dims, `RewardConfig` scales/stds, thresholds, `TERM_ORDER`. Mirrors `tracking.py` (line refs inline). |
+| `state.py` | Deterministic synthetic batch at real shapes (N envs × 14 bodies × 29 DoF), ~2% terminations. |
+| `numpy_reference.py` | **Golden oracle** — each `_reward_*` / `_compute_terminations` ported from `tracking.py`, faithful math. |
+| `numba_terms.py` | Single-source `@njit(inline="always")` scalar device fns, one per term (`.py_func` debuggable). |
+| `numba_fused.py` | `@njit(parallel=True)` prange driver: static superset gated by a scale vector, per-thread log scratch, numpy fallback. |
+| `test_parity.py` | Consistency: numba vs numpy on reward, terminations, per-term log; device `.py_func` vs numpy. |
+| `bench.py` | Speed: numpy vs numba across `num_envs` and thread counts. |
+
+## Run
+
+```bash
+uv run --with numba python -m benchmark.numba_profile.test_parity      # consistency
+uv run --with numba python -m benchmark.numba_profile.bench            # speed (8k + 32k)
+PROBE_NUM_ENVS=32768 uv run --with numba python -m benchmark.numba_profile.bench
+```
+
+`numba` is the only extra dep. Use `uv run --with numba ...` for a one-shot run,
+or install it once with `uv pip install numba`.
+
+## Faithfulness — how this maps to the real task
+
+The hot-slice math is copied from `src/unilab/envs/motion_tracking/g1/tracking.py`:
+
+- **11 default reward-scale terms** (`RewardConfig.scales`, tracking.py:44) with
+  the exact default `scales` and `std_*`. Default has 8 nonzero-scale terms;
+  `motion_ee_body_pos_z` / `motion_joint_pos` / `motion_joint_vel` are `0.0` and
+  skipped, exactly as the real loop does. The real `_init_reward_functions`
+  registry also contains `undesired_contacts`, but the default config has no
+  scale for it, so it is outside this default-scale profile.
+- **Reward math** per term ported 1:1 — anchor pos/ori (`_quat_error` via
+  `2·acos|dot|`), per-body mean xyz error, joint-limit violation, action-rate L2,
+  `exp(-err/std²)`, final `reward *= ctrl_dt` (0.02).
+- **Terminations** (`_compute_terminations`, tracking.py:978): anchor-Z,
+  anchor-orientation via body-frame gravity-z (tracking.py:276), end-effector-Z.
+- **Dims**: `NUM_ACTION=29`, 14 tracked bodies, anchor = `torso_link` (idx 7),
+  ee = `{ankles, wrists}` (idx 3,6,10,13).
+
+The one deviation is intentional: we feed **synthetic** robot/motion arrays
+instead of stepping physics, because the fusion target is Env overhead, not
+physics. Magnitudes are tuned so rewards are non-degenerate and ~2% of envs
+terminate, matching the reset/copy pressure used in the #665 probe.
+
+## The structured scheme — speed *and* maintainability
+
+The design keeps every property of the original config-driven reward code while
+fusing the machine code:
+
+1. **Single-source terms** (`numba_terms.py`). One scalar `@njit(inline="always")`
+   function per term. The kernel inlines them → machine-code fusion (no
+   intermediate `(N,·)` arrays), but the source keeps one readable function per
+   term, and `fn.py_func` runs/debugs in plain Python. You give up *vectorised
+   numpy style* and nothing else.
+2. **Static superset + scale vector** (`numba_fused.py`). No codegen, no runtime
+   dict (nopython can't). The kernel evaluates the full `TERM_ORDER` superset;
+   a dense `scale` vector built on the **cold path** from the config dict gates
+   each term (`scale==0` → contributes 0, matching the numpy `continue`).
+   **Weights stay in config**, never baked into compiled code.
+3. **Registry / single ordering.** `spec.TERM_ORDER` owns name↔index for the
+   numpy oracle, the kernel, and the log. `numpy_reference.NUMPY_TERMS` pairs
+   each name with its numpy fn; `test_parity` walks them.
+4. **Per-thread log scratch.** Per-term reward means accumulate into
+   `(nthreads, N_TERMS)` indexed by `get_thread_id()`, summed on the main thread
+   after. A shared `log[k] += …` would false-share one cache line and cap
+   scaling at ~5x (#665 §2) — the correctness of this is why the parity test
+   checks every per-term log value, not just the total.
+5. **Consistency as a gate.** `numpy_reference.py` is retained as the oracle;
+   parity is `rtol=1e-4` (fastmath/FMA reorders float ops, so bit-exactness is
+   not expected). Adding a term = numpy fn + njit fn + one `TERM_ORDER` entry;
+   the test enforces they agree.
+6. **Fallback.** `update_state(force="auto")` drops to numpy below 256 envs where
+   launch/barrier cost dominates.
+
+## Results (Xeon 8568Y+, 160T — standalone profile run)
+
+`update_state` slice only (reward + termination), float32:
+
+| num_envs | numpy | numba 1T (fusion) | numba best | speedup |
+|---------:|------:|------------------:|-----------:|--------:|
+| 8 192  | 8.63 ms | 2.67 ms (**3.2x**) | 0.33 ms @ 48T | **26.6x** |
+| 32 768 | 35.57 ms | 10.65 ms (**3.3x**) | 0.73 ms @ 64T | **49.0x** |
+
+Consistent with #665's thesis: single-core **fusion ≈ 3.2–3.3x** (kills the
+per-term intermediate arrays), **parallel ≈ 8–15x** on top in this standalone
+profile, and **larger batch scales higher** (barrier/launch cost amortised).
+Parity: total reward and every per-term log match to tolerance; terminations
+exact.
+
+## Scope / caveats (from #665)
+
+- **This is half the Env overhead.** `reset_done` (backend `set_state`) and the
+  4× RNG `standard_normal` for obs noise are separate ceilings Numba prange does
+  not address here.
+- **Obs assembly** (concat) is left in numpy — it's concat-bound, not the fusion
+  win; a real integration would share the same fused kernel boundary.
+- Numbers are the `update_state` micro-slice; end-to-end collector throughput
+  gains are diluted by physics and reset. #665's motion_tracking overhead −71%,
+  ~+72% throughput figure is a projection for that server/profile, not a result
+  from an integrated training path.
+- **Warmup**: first call JIT-compiles (~0.1 s). `cache=True` persists it to
+  `__pycache__/*.nbi` across processes.

--- a/benchmark/numba_profile/__init__.py
+++ b/benchmark/numba_profile/__init__.py
@@ -1,0 +1,6 @@
+"""Standalone numba-fusion profile for the ``g1_motion_tracking`` update_state.
+
+Faithfully replicates the real task's reward + termination (no MuJoCo/Motrix
+needed — the target is the backend-agnostic Env overhead) and implements the
+structured numba scheme discussed for issues #663 / #665.  See README.md.
+"""

--- a/benchmark/numba_profile/bench.py
+++ b/benchmark/numba_profile/bench.py
@@ -1,0 +1,104 @@
+"""Speed benchmark: numpy oracle vs. fused numba kernel for the
+``g1_motion_tracking`` update_state (reward + termination).
+
+Measures the Env-overhead slice issue #663/#665 identified as the single-threaded
+bottleneck.  Reports, per ``num_envs`` and thread count:
+
+  * numpy baseline ms, numba ms, speedup,
+  * single-core numba ms (fusion-only gain, no parallelism),
+  * throughput (env/s) for the overhead slice,
+  * a first-call compile time (amortised once per process; ``cache=True`` reuses
+    it across runs).
+
+This is the update_state half only — per issue #665, reset_done and RNG are
+separate bottlenecks not addressed here.
+
+Run:
+    python -m benchmark.numba_profile.bench
+    PROBE_NUM_ENVS=32768 python -m benchmark.numba_profile.bench
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from numba import get_num_threads, set_num_threads
+
+from . import numpy_reference as ref
+from .numba_fused import FusedUpdateState
+from .state import make_batch
+
+
+def _time(fn, iters: int, warmup: int = 3) -> float:
+    for _ in range(warmup):
+        fn()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    return (time.perf_counter() - t0) / iters * 1e3  # ms/call
+
+
+def _bench_size(num_envs: int, thread_counts: list[int], iters: int) -> None:
+    b = make_batch(num_envs, seed=0)
+    max_threads = get_num_threads()
+
+    # numpy baseline
+    numpy_ms = _time(lambda: ref.update_state(b), iters)
+
+    # numba: compile once (first call), then time
+    driver1 = FusedUpdateState(num_threads=1)
+    t0 = time.perf_counter()
+    driver1(b)  # triggers JIT compile on first process run
+    compile_ms = (time.perf_counter() - t0) * 1e3
+    single_ms = _time(lambda: driver1(b), iters)
+
+    print(f"\n── num_envs = {num_envs:>6}  (iters={iters}, host threads={max_threads}) ──")
+    print(f"  numpy baseline           : {numpy_ms:8.3f} ms")
+    print(
+        f"  numba 1 thread (fusion)  : {single_ms:8.3f} ms   "
+        f"({numpy_ms / single_ms:5.2f}x vs numpy)   [compile {compile_ms:.0f} ms once]"
+    )
+
+    best = (single_ms, 1)
+    for nt in thread_counts:
+        if nt > max_threads:
+            continue
+        driver = FusedUpdateState(num_threads=nt)
+        driver(b)  # warm this thread setting
+        ms = _time(lambda: driver(b), iters)
+        env_per_s = num_envs / (ms * 1e-3)
+        marker = ""
+        if ms < best[0]:
+            best = (ms, nt)
+            marker = " *"
+        print(
+            f"  numba {nt:>3} threads         : {ms:8.3f} ms   "
+            f"({numpy_ms / ms:5.2f}x)   {env_per_s / 1e6:5.2f}M env/s{marker}"
+        )
+
+    set_num_threads(max_threads)
+    best_ms, best_nt = best
+    print(
+        f"  BEST: {numpy_ms / best_ms:.1f}x at {best_nt} threads "
+        f"(fusion {numpy_ms / single_ms:.1f}x + parallel {single_ms / best_ms:.1f}x)"
+    )
+
+
+def main() -> None:
+    default_envs = int(os.environ.get("PROBE_NUM_ENVS", "8192"))
+    sizes = sorted({default_envs, 8192, 32768}) if default_envs in (8192, 32768) else [default_envs]
+    thread_counts = [2, 4, 8, 16, 24, 32, 48, 64]
+    iters = int(os.environ.get("PROBE_ITERS", "50"))
+
+    print("=" * 70)
+    print("SPEED — g1_motion_tracking update_state (reward + termination)")
+    print("numpy oracle vs fused numba prange kernel")
+    print("=" * 70)
+    for n in sizes:
+        _bench_size(n, thread_counts, iters)
+    print("\nNote: update_state slice only; reset_done / RNG are separate (issue #665).")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/numba_profile/numba_fused.py
+++ b/benchmark/numba_profile/numba_fused.py
@@ -1,0 +1,213 @@
+"""Fused numba ``update_state`` kernel for ``g1_motion_tracking``.
+
+Realises the structured scheme:
+
+  * **Pillar 2 (config-first, no codegen):** the kernel is a *static superset*
+    of every term in ``spec.TERM_ORDER``.  A dense ``scale`` vector (built on the
+    cold path from the config dict) gates each term — ``scale==0`` contributes
+    exactly 0, matching the numpy loop's ``continue``.  Weights stay in config,
+    never baked into compiled code.
+  * **Pillar 1 (single source):** each term is the inlined device function from
+    ``numba_terms.py`` — same code the ``.py_func`` debug path uses.
+  * **Pillar 4 (per-thread log scratch):** per-term reward means accumulate into
+    ``(nthreads, N_TERMS)`` scratch indexed by thread id, summed on the main
+    thread afterwards.  Writing a shared ``log[k] += ...`` would false-share one
+    cache line across all threads and cap scaling at ~5x (issue #665 §2).
+  * **Pillar 6 (fallback):** ``update_state`` transparently drops to the numpy
+    oracle for small batches or when explicitly forced.
+
+Termination is fused into the same prange loop (issue #665: reset/termination is
+the co-bottleneck; folding it in costs nothing once we already stream each row).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numba import get_num_threads, get_thread_id, njit, prange, set_num_threads
+
+from . import numba_terms as T
+from . import spec
+from .numpy_reference import compute_terminations
+from .numpy_reference import update_state as _numpy_update_state
+from .state import Batch
+
+
+@njit(parallel=True, fastmath=True, cache=True, nogil=True)
+def _fused_update_kernel(
+    motion_pos,
+    motion_quat,
+    motion_lin_vel,
+    motion_ang_vel,
+    motion_jp,
+    motion_jv,
+    ref_pos,
+    ref_quat,
+    robot_pos,
+    robot_quat,
+    robot_lin_vel,
+    robot_ang_vel,
+    dof_pos,
+    dof_vel,
+    cur_act,
+    last_act,
+    joint_lower,
+    joint_upper,
+    scale,  # (N_TERMS,) float64 — term gates/weights, TERM_ORDER
+    std,  # (N_TERMS,) float64 — per-term exp std
+    anchor,  # int — anchor body index
+    ee_idx,  # (n_ee,) int32
+    n_body,
+    n_action,
+    ctrl_dt,
+    anchor_pos_z_thr,
+    anchor_ori_thr,
+    ee_pos_z_thr,
+    reward,  # (N,) out
+    terminated,  # (N,) bool out
+    log_scratch,  # (nthreads, N_TERMS) out — indexed by get_thread_id()
+):
+    n = reward.shape[0]
+    for i in prange(n):
+        tid = get_thread_id()  # actual executing thread -> no cross-thread scratch collisions
+
+        # ── reward: static superset, each term gated by its scale ───────────
+        r = 0.0
+        # index k must match spec.TERM_ORDER
+        w = T.motion_global_root_pos_i(motion_pos, robot_pos, anchor, std[0], i) * scale[0]
+        r += w
+        log_scratch[tid, 0] += w
+        w = T.motion_global_root_ori_i(motion_quat, robot_quat, anchor, std[1], i) * scale[1]
+        r += w
+        log_scratch[tid, 1] += w
+        w = T.motion_body_pos_i(ref_pos, robot_pos, n_body, std[2], i) * scale[2]
+        r += w
+        log_scratch[tid, 2] += w
+        w = T.motion_body_ori_i(ref_quat, robot_quat, n_body, std[3], i) * scale[3]
+        r += w
+        log_scratch[tid, 3] += w
+        w = T.motion_body_lin_vel_i(motion_lin_vel, robot_lin_vel, n_body, std[4], i) * scale[4]
+        r += w
+        log_scratch[tid, 4] += w
+        w = T.motion_body_ang_vel_i(motion_ang_vel, robot_ang_vel, n_body, std[5], i) * scale[5]
+        r += w
+        log_scratch[tid, 5] += w
+        w = T.motion_ee_body_pos_z_i(ref_pos, robot_pos, ee_idx, std[6], i) * scale[6]
+        r += w
+        log_scratch[tid, 6] += w
+        w = T.motion_joint_pos_i(motion_jp, dof_pos, n_action, std[7], i) * scale[7]
+        r += w
+        log_scratch[tid, 7] += w
+        w = T.motion_joint_vel_i(motion_jv, dof_vel, n_action, std[8], i) * scale[8]
+        r += w
+        log_scratch[tid, 8] += w
+        w = T.action_rate_l2_i(cur_act, last_act, n_action, i) * scale[9]
+        r += w
+        log_scratch[tid, 9] += w
+        w = T.joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, i) * scale[10]
+        r += w
+        log_scratch[tid, 10] += w
+        reward[i] = r * ctrl_dt
+
+        # ── termination (fused) ─────────────────────────────────────────────
+        term = False
+        if abs(motion_pos[i, anchor, 2] - robot_pos[i, anchor, 2]) > anchor_pos_z_thr:
+            term = True
+        mgz = 2.0 * (motion_quat[i, anchor, 1] ** 2 + motion_quat[i, anchor, 2] ** 2) - 1.0
+        rgz = 2.0 * (robot_quat[i, anchor, 1] ** 2 + robot_quat[i, anchor, 2] ** 2) - 1.0
+        if abs(mgz - rgz) > anchor_ori_thr:
+            term = True
+        for k in range(ee_idx.shape[0]):
+            if abs(ref_pos[i, ee_idx[k], 2] - robot_pos[i, ee_idx[k], 2]) > ee_pos_z_thr:
+                term = True
+        terminated[i] = term
+
+
+class FusedUpdateState:
+    """Cold-path-initialised driver holding the config-derived vectors.
+
+    Mirrors how the real env would build ``scale``/``std`` once at reset and call
+    a hot kernel each step — no per-step config parsing.
+    """
+
+    def __init__(self, scales: dict[str, float] | None = None, num_threads: int | None = None):
+        self.scale = spec.scale_vector(scales)
+        self.std = spec.std_vector()
+        self.ee_idx = spec.EE_BODY_INDICES
+        self.num_threads = num_threads
+
+    def __call__(self, b: Batch) -> tuple[np.ndarray, np.ndarray, dict]:
+        if self.num_threads is not None:
+            set_num_threads(self.num_threads)
+        nthreads = get_num_threads()
+        n = b.num_envs
+
+        reward = np.empty(n, dtype=np.float32)
+        terminated = np.empty(n, dtype=np.bool_)
+        log_scratch = np.zeros((nthreads, spec.N_TERMS), dtype=np.float64)
+
+        _fused_update_kernel(
+            b.motion_body_pos_w,
+            b.motion_body_quat_w,
+            b.motion_body_lin_vel_w,
+            b.motion_body_ang_vel_w,
+            b.motion_joint_pos,
+            b.motion_joint_vel,
+            b.ref_body_pos_relative_w,
+            b.ref_body_quat_relative_w,
+            b.robot_body_pos_w,
+            b.robot_body_quat_w,
+            b.robot_body_lin_vel_w,
+            b.robot_body_ang_vel_w,
+            b.dof_pos,
+            b.dof_vel,
+            b.current_actions,
+            b.last_actions,
+            b.joint_lower,
+            b.joint_upper,
+            self.scale,
+            self.std,
+            spec.ANCHOR_BODY_IDX,
+            self.ee_idx,
+            spec.N_BODY,
+            spec.NUM_ACTION,
+            spec.CTRL_DT,
+            spec.ANCHOR_POS_Z_THRESHOLD,
+            spec.ANCHOR_ORI_THRESHOLD,
+            spec.EE_BODY_POS_Z_THRESHOLD,
+            reward,
+            terminated,
+            log_scratch,
+        )
+
+        # aggregate per-thread scratch -> per-term mean, for active terms only
+        term_sums = log_scratch.sum(axis=0)  # (N_TERMS,)
+        log = {
+            f"reward/{name}": float(term_sums[k] / n)
+            for k, name in enumerate(spec.TERM_ORDER)
+            if self.scale[k] != 0.0
+        }
+        return reward, terminated, log
+
+
+# Min batch below which the parallel kernel's launch/barrier cost is not worth
+# it and we fall back to numpy (pillar 6). Tuned conservatively; see bench.py.
+_FALLBACK_MIN_ENVS = 256
+
+
+def update_state(
+    b: Batch,
+    scales: dict[str, float] | None = None,
+    num_threads: int | None = None,
+    force: str = "auto",
+) -> tuple[np.ndarray, np.ndarray, dict]:
+    """Reward + termination via numba, with numpy fallback for small batches.
+
+    ``force`` in {"auto", "numba", "numpy"} pins the path (bench/test use it).
+    """
+    if force == "numpy" or (force == "auto" and b.num_envs < _FALLBACK_MIN_ENVS):
+        return _numpy_update_state(b, scales)
+    driver = FusedUpdateState(scales=scales, num_threads=num_threads)
+    return driver(b)
+
+
+__all__ = ["FusedUpdateState", "update_state", "compute_terminations"]

--- a/benchmark/numba_profile/numba_terms.py
+++ b/benchmark/numba_profile/numba_terms.py
@@ -1,0 +1,152 @@
+"""Single-source **numba** device functions — one per reward term.
+
+Each ``@njit(inline="always")`` function computes *one* term for *one*
+environment row ``i`` and mirrors the matching function in
+``numpy_reference.py`` line-for-line (scalar instead of vectorised).  Three
+payoffs from one definition (support pillar 1 of the plan):
+
+  * the fused kernel ``inline``s them -> machine-code fusion, no intermediate
+    ``(N, ...)`` arrays (the 2.3-3.8x single-core win in issue #665);
+  * ``fn.py_func`` is the plain-Python version -> set a breakpoint, unit-test it;
+  * scalar form reads closer to the math than the ``out=`` numpy in tracking.py.
+
+Term identity/ordering is owned by ``spec.TERM_ORDER``; this module only
+supplies the arithmetic.
+"""
+
+from __future__ import annotations
+
+import math
+
+from numba import njit
+
+
+def _dev(fn):
+    """Device-function decorator: inlined into the kernel, GIL-free, cached.
+
+    ``inline="always"`` is what turns these separate readable functions into a
+    single fused machine-code loop when called from the prange kernel.
+    """
+    return njit(inline="always", fastmath=True, cache=True, nogil=True)(fn)
+
+
+@_dev
+def _exp_reward(error, std):
+    return math.exp(error / -(std * std))
+
+
+# ── anchor (root) terms ─────────────────────────────────────────────────────
+@_dev
+def motion_global_root_pos_i(motion_pos, robot_pos, a, std, i):
+    dx = motion_pos[i, a, 0] - robot_pos[i, a, 0]
+    dy = motion_pos[i, a, 1] - robot_pos[i, a, 1]
+    dz = motion_pos[i, a, 2] - robot_pos[i, a, 2]
+    return _exp_reward(dx * dx + dy * dy + dz * dz, std)
+
+
+@_dev
+def _quat_angle_sq(qa, qb, i, a):
+    dot = (
+        qa[i, a, 0] * qb[i, a, 0]
+        + qa[i, a, 1] * qb[i, a, 1]
+        + qa[i, a, 2] * qb[i, a, 2]
+        + qa[i, a, 3] * qb[i, a, 3]
+    )
+    dot = abs(dot)
+    if dot > 1.0:
+        dot = 1.0
+    ang = 2.0 * math.acos(dot)
+    return ang * ang
+
+
+@_dev
+def motion_global_root_ori_i(motion_quat, robot_quat, a, std, i):
+    return _exp_reward(_quat_angle_sq(motion_quat, robot_quat, i, a), std)
+
+
+# ── per-body mean terms ─────────────────────────────────────────────────────
+@_dev
+def _mean_body_xyz_sq_err_i(ref, act, n_body, i):
+    acc = 0.0
+    for bdy in range(n_body):
+        dx = ref[i, bdy, 0] - act[i, bdy, 0]
+        dy = ref[i, bdy, 1] - act[i, bdy, 1]
+        dz = ref[i, bdy, 2] - act[i, bdy, 2]
+        acc += dx * dx + dy * dy + dz * dz
+    return acc / n_body
+
+
+@_dev
+def motion_body_pos_i(ref_pos, robot_pos, n_body, std, i):
+    return _exp_reward(_mean_body_xyz_sq_err_i(ref_pos, robot_pos, n_body, i), std)
+
+
+@_dev
+def motion_body_ori_i(ref_quat, robot_quat, n_body, std, i):
+    acc = 0.0
+    for bdy in range(n_body):
+        acc += _quat_angle_sq(ref_quat, robot_quat, i, bdy)
+    return _exp_reward(acc / n_body, std)
+
+
+@_dev
+def motion_body_lin_vel_i(motion_v, robot_v, n_body, std, i):
+    return _exp_reward(_mean_body_xyz_sq_err_i(motion_v, robot_v, n_body, i), std)
+
+
+@_dev
+def motion_body_ang_vel_i(motion_w, robot_w, n_body, std, i):
+    return _exp_reward(_mean_body_xyz_sq_err_i(motion_w, robot_w, n_body, i), std)
+
+
+# ── end-effector / joint terms ──────────────────────────────────────────────
+@_dev
+def motion_ee_body_pos_z_i(ref_pos, robot_pos, ee_idx, std, i):
+    acc = 0.0
+    for k in range(ee_idx.shape[0]):
+        e = ref_pos[i, ee_idx[k], 2] - robot_pos[i, ee_idx[k], 2]
+        acc += e * e
+    return _exp_reward(acc / ee_idx.shape[0], std)
+
+
+@_dev
+def _mean_joint_sq_err_i(ref, act, n_action, i):
+    acc = 0.0
+    for j in range(n_action):
+        d = ref[i, j] - act[i, j]
+        acc += d * d
+    return acc / n_action
+
+
+@_dev
+def motion_joint_pos_i(motion_jp, dof_pos, n_action, std, i):
+    return _exp_reward(_mean_joint_sq_err_i(motion_jp, dof_pos, n_action, i), std)
+
+
+@_dev
+def motion_joint_vel_i(motion_jv, dof_vel, n_action, std, i):
+    return _exp_reward(_mean_joint_sq_err_i(motion_jv, dof_vel, n_action, i), std)
+
+
+@_dev
+def action_rate_l2_i(cur, last, n_action, i):
+    acc = 0.0
+    for j in range(n_action):
+        d = cur[i, j] - last[i, j]
+        acc += d * d
+    return acc
+
+
+@_dev
+def joint_limit_i(dof_pos, lower, upper, n_action, i):
+    acc = 0.0
+    for j in range(n_action):
+        lo = lower[j] - dof_pos[i, j]
+        if lo < 0.0:
+            lo = 0.0
+        hi = dof_pos[i, j] - upper[j]
+        if hi < 0.0:
+            hi = 0.0
+        v = lo + hi
+        acc += v * v
+    return acc

--- a/benchmark/numba_profile/numpy_reference.py
+++ b/benchmark/numba_profile/numpy_reference.py
@@ -1,0 +1,184 @@
+"""Faithful **numpy** reference for ``g1_motion_tracking`` reward + termination.
+
+This is the golden oracle: each function mirrors the corresponding
+``_reward_*`` / ``_compute_terminations`` in
+``src/unilab/envs/motion_tracking/g1/tracking.py`` (line refs inline).  The
+numba kernel is validated bit-for-tolerance against this file, and it doubles
+as the human-readable spec of what the kernel computes.
+
+Style note: the real task hand-rolls ``out=`` numpy calls to reuse scratch
+buffers; here we favour plain vectorised expressions for readability — the
+arithmetic is identical, only the memory management differs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from . import spec
+from .state import Batch
+
+_DT = np.float32
+
+
+# ── error helpers (tracking.py:1262-1303) ───────────────────────────────────
+def _mean_body_xyz_squared_error(reference: np.ndarray, actual: np.ndarray) -> np.ndarray:
+    """Mean over bodies of the per-body squared xyz error (tracking.py:1262)."""
+    diff = reference - actual  # (N, n_body, 3)
+    per_body = np.sum(diff * diff, axis=2)  # (N, n_body)
+    return np.sum(per_body, axis=1) / reference.shape[1]  # (N,)
+
+
+def _quat_error_sq_body(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """(2*acos(|dot|))^2 per body (tracking.py:1280)."""
+    dot = np.abs(np.sum(q1 * q2, axis=-1))  # (N, n_body)
+    dot = np.clip(dot, 0.0, 1.0)
+    ang = 2.0 * np.arccos(dot)
+    return ang * ang
+
+
+def _exp_reward(error: np.ndarray, std: float) -> np.ndarray:
+    """exp(-error / std^2)  (tracking.py:1299)."""
+    return np.exp(error / -(std * std))
+
+
+# ── reward terms (one function per tracking.py:_reward_*) ────────────────────
+def motion_global_root_pos(b: Batch) -> np.ndarray:  # tracking.py:1306
+    a = spec.ANCHOR_BODY_IDX
+    diff = b.motion_body_pos_w[:, a] - b.robot_body_pos_w[:, a]
+    err = np.sum(diff * diff, axis=1)
+    return _exp_reward(err, spec.REWARD_SPEC.std_root_pos)
+
+
+def motion_global_root_ori(b: Batch) -> np.ndarray:  # tracking.py:1322
+    a = spec.ANCHOR_BODY_IDX
+    dot = np.abs(np.sum(b.motion_body_quat_w[:, a] * b.robot_body_quat_w[:, a], axis=1))
+    dot = np.clip(dot, 0.0, 1.0)
+    ang = 2.0 * np.arccos(dot)
+    return _exp_reward(ang * ang, spec.REWARD_SPEC.std_root_ori)
+
+
+def motion_body_pos(b: Batch) -> np.ndarray:  # tracking.py:1341
+    err = _mean_body_xyz_squared_error(b.ref_body_pos_relative_w, b.robot_body_pos_w)
+    return _exp_reward(err, spec.REWARD_SPEC.std_body_pos)
+
+
+def motion_body_ori(b: Batch) -> np.ndarray:  # tracking.py:1346
+    per_body = _quat_error_sq_body(b.ref_body_quat_relative_w, b.robot_body_quat_w)
+    err = np.sum(per_body, axis=1) / per_body.shape[1]
+    return _exp_reward(err, spec.REWARD_SPEC.std_body_ori)
+
+
+def motion_body_lin_vel(b: Batch) -> np.ndarray:  # tracking.py:1355
+    err = _mean_body_xyz_squared_error(b.motion_body_lin_vel_w, b.robot_body_lin_vel_w)
+    return _exp_reward(err, spec.REWARD_SPEC.std_body_lin_vel)
+
+
+def motion_body_ang_vel(b: Batch) -> np.ndarray:  # tracking.py:1361
+    err = _mean_body_xyz_squared_error(b.motion_body_ang_vel_w, b.robot_body_ang_vel_w)
+    return _exp_reward(err, spec.REWARD_SPEC.std_body_ang_vel)
+
+
+def motion_ee_body_pos_z(b: Batch) -> np.ndarray:  # tracking.py:1367
+    ee = spec.EE_BODY_INDICES
+    diff = b.ref_body_pos_relative_w[:, ee, 2] - b.robot_body_pos_w[:, ee, 2]
+    err = np.sum(diff * diff, axis=1) / ee.size
+    return _exp_reward(err, spec.REWARD_SPEC.std_body_pos)
+
+
+def motion_joint_pos(b: Batch) -> np.ndarray:  # tracking.py:1379
+    diff = b.motion_joint_pos - b.dof_pos
+    err = np.sum(diff * diff, axis=1) / b.dof_pos.shape[1]
+    return _exp_reward(err, spec.REWARD_SPEC.std_joint_pos)
+
+
+def motion_joint_vel(b: Batch) -> np.ndarray:  # tracking.py:1388
+    diff = b.motion_joint_vel - b.dof_vel
+    err = np.sum(diff * diff, axis=1) / b.dof_vel.shape[1]
+    return _exp_reward(err, spec.REWARD_SPEC.std_joint_vel)
+
+
+def action_rate_l2(b: Batch) -> np.ndarray:  # tracking.py:1408
+    diff = b.current_actions - b.last_actions
+    return np.sum(diff * diff, axis=1)
+
+
+def joint_limit(b: Batch) -> np.ndarray:  # tracking.py:1414
+    low = np.maximum(b.joint_lower - b.dof_pos, 0.0)
+    high = np.maximum(b.dof_pos - b.joint_upper, 0.0)
+    viol = low + high
+    return np.sum(viol * viol, axis=1)
+
+
+# Registry pairing name -> numpy fn (index-aligned with spec.TERM_ORDER).
+NUMPY_TERMS = {
+    "motion_global_root_pos": motion_global_root_pos,
+    "motion_global_root_ori": motion_global_root_ori,
+    "motion_body_pos": motion_body_pos,
+    "motion_body_ori": motion_body_ori,
+    "motion_body_lin_vel": motion_body_lin_vel,
+    "motion_body_ang_vel": motion_body_ang_vel,
+    "motion_ee_body_pos_z": motion_ee_body_pos_z,
+    "motion_joint_pos": motion_joint_pos,
+    "motion_joint_vel": motion_joint_vel,
+    "action_rate_l2": action_rate_l2,
+    "joint_limit": joint_limit,
+}
+
+
+def compute_reward(b: Batch, scales: dict[str, float] | None = None) -> tuple[np.ndarray, dict]:
+    """Faithful port of ``_compute_reward`` (tracking.py:1209).
+
+    Returns ``(reward, per_term_weighted_mean)``.  Skips ``scale == 0`` terms
+    exactly like the real loop, then multiplies the sum by ``ctrl_dt``.
+    """
+    s = spec.REWARD_SPEC.scales if scales is None else scales
+    n = b.num_envs
+    reward = np.zeros(n, dtype=_DT)
+    log: dict[str, float] = {}
+    for name in spec.TERM_ORDER:
+        scale = s.get(name, 0.0)
+        if scale == 0:
+            continue
+        weighted = NUMPY_TERMS[name](b).astype(_DT) * _DT(scale)
+        reward += weighted
+        log[f"reward/{name}"] = float(np.sum(weighted) / weighted.size)
+    reward *= _DT(spec.CTRL_DT)
+    return reward, log
+
+
+def compute_terminations(b: Batch) -> np.ndarray:
+    """Faithful port of ``_compute_terminations`` (tracking.py:978)."""
+    a = spec.ANCHOR_BODY_IDX
+    terminated = np.zeros(b.num_envs, dtype=bool)
+
+    # anchor position error (z only)
+    dz = np.abs(b.motion_body_pos_w[:, a, 2] - b.robot_body_pos_w[:, a, 2])
+    terminated |= dz > spec.ANCHOR_POS_Z_THRESHOLD
+
+    # anchor orientation via body-frame gravity-z (tracking.py:276)
+    if spec.ANCHOR_ORI_THRESHOLD < 2.0:
+        mq = b.motion_body_quat_w[:, a]
+        rq = b.robot_body_quat_w[:, a]
+        m_gz = 2.0 * (mq[:, 1] * mq[:, 1] + mq[:, 2] * mq[:, 2]) - 1.0
+        r_gz = 2.0 * (rq[:, 1] * rq[:, 1] + rq[:, 2] * rq[:, 2]) - 1.0
+        terminated |= np.abs(m_gz - r_gz) > spec.ANCHOR_ORI_THRESHOLD
+
+    # end-effector z error (any)
+    ee = spec.EE_BODY_INDICES
+    ee_dz = np.abs(b.ref_body_pos_relative_w[:, ee, 2] - b.robot_body_pos_w[:, ee, 2])
+    terminated |= np.any(ee_dz > spec.EE_BODY_POS_Z_THRESHOLD, axis=1)
+
+    if spec.TERMINATE_ON_UNDESIRED_CONTACTS:
+        uc = spec.UNDESIRED_CONTACT_INDICES
+        below = b.robot_body_pos_w[:, uc, 2] < spec.UNDESIRED_CONTACT_Z_THRESHOLD
+        terminated |= np.any(below, axis=1)
+
+    return terminated
+
+
+def update_state(b: Batch, scales: dict[str, float] | None = None):
+    """Reward + termination — the numpy half of ``update_state`` overhead."""
+    reward, log = compute_reward(b, scales)
+    terminated = compute_terminations(b)
+    return reward, terminated, log

--- a/benchmark/numba_profile/spec.py
+++ b/benchmark/numba_profile/spec.py
@@ -1,0 +1,139 @@
+"""Faithful, single-source spec of the ``g1_motion_tracking`` update_state.
+
+Every constant here is copied verbatim from the real task so the profile
+stays honest.  When ``tracking.py`` changes, this is the *one* file to
+resync.  Provenance (all in ``src/unilab/envs/motion_tracking/g1/tracking.py``):
+
+  - ``RewardConfig`` scales / std_*        -> lines 44-70
+  - ``G1MotionTrackingCfg.body_names``      -> lines 151-166  (n_body = 14)
+  - ``anchor_body_name = "torso_link"``     -> line 150  (index 7)
+  - ``ee_body_names``                       -> lines 180-185 (indices 3,6,10,13)
+  - termination thresholds                  -> lines 177-187
+  - ``ctrl_dt = 0.02``                      -> g1/base.py:51
+  - ``num_action = 29``                     -> G1 action space (issue #665 act_dim=29)
+
+The reward loop in ``_compute_reward`` (tracking.py:1243) iterates
+``cfg.scales.items()`` and *skips* ``scale == 0`` terms.  We preserve the term
+identity and ordering here in ``TERM_ORDER`` so the numpy oracle, the numba
+kernel, and the per-term log all agree on index <-> name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+# ── robot / body dimensions (faithful to G1MotionTrackingCfg) ───────────────
+NUM_ACTION = 29  # G1 actuated DoF
+BODY_NAMES: tuple[str, ...] = (
+    "pelvis",
+    "left_hip_roll_link",
+    "left_knee_link",
+    "left_ankle_roll_link",
+    "right_hip_roll_link",
+    "right_knee_link",
+    "right_ankle_roll_link",
+    "torso_link",
+    "left_shoulder_roll_link",
+    "left_elbow_link",
+    "left_wrist_yaw_link",
+    "right_shoulder_roll_link",
+    "right_elbow_link",
+    "right_wrist_yaw_link",
+)
+N_BODY = len(BODY_NAMES)  # 14
+ANCHOR_BODY_NAME = "torso_link"
+ANCHOR_BODY_IDX = BODY_NAMES.index(ANCHOR_BODY_NAME)  # 7
+EE_BODY_NAMES: tuple[str, ...] = (
+    "left_ankle_roll_link",
+    "right_ankle_roll_link",
+    "left_wrist_yaw_link",
+    "right_wrist_yaw_link",
+)
+EE_BODY_INDICES = np.array(
+    [BODY_NAMES.index(n) for n in EE_BODY_NAMES], dtype=np.int32
+)  # 3,6,10,13
+# undesired-contact bodies = every tracked body that is not an end-effector
+UNDESIRED_CONTACT_INDICES = np.array(
+    [i for i, n in enumerate(BODY_NAMES) if n not in set(EE_BODY_NAMES)], dtype=np.int32
+)
+
+CTRL_DT = 0.02
+
+# ── termination thresholds (faithful) ───────────────────────────────────────
+ANCHOR_POS_Z_THRESHOLD = 0.25
+ANCHOR_ORI_THRESHOLD = 0.8  # < 2.0 so the gravity-z check is active
+EE_BODY_POS_Z_THRESHOLD = 0.25
+UNDESIRED_CONTACT_Z_THRESHOLD = 0.05
+TERMINATE_ON_UNDESIRED_CONTACTS = False  # default: off
+
+
+@dataclass(frozen=True)
+class RewardSpec:
+    """Mirror of ``RewardConfig`` (tracking.py:44)."""
+
+    scales: dict[str, float] = field(
+        default_factory=lambda: {
+            "motion_global_root_pos": 0.5,
+            "motion_global_root_ori": 0.5,
+            "motion_body_pos": 1.0,
+            "motion_body_ori": 1.0,
+            "motion_body_lin_vel": 1.0,
+            "motion_body_ang_vel": 1.0,
+            "motion_ee_body_pos_z": 0.0,
+            "motion_joint_pos": 0.0,
+            "motion_joint_vel": 0.0,
+            "action_rate_l2": -0.1,
+            "joint_limit": -10.0,
+        }
+    )
+    std_root_pos: float = 0.3
+    std_root_ori: float = 0.4
+    std_body_pos: float = 0.3
+    std_body_ori: float = 0.4
+    std_body_lin_vel: float = 1.0
+    std_body_ang_vel: float = 3.14
+    std_joint_pos: float = 0.2
+    std_joint_vel: float = 1.0
+
+
+REWARD_SPEC = RewardSpec()
+
+# Canonical ordering shared by numpy oracle, numba kernel, and log aggregation.
+# Same keys/order as RewardConfig.scales -> the kernel is a static superset and
+# per-term scale==0 simply contributes 0 (matching the numpy ``continue``).
+TERM_ORDER: tuple[str, ...] = tuple(REWARD_SPEC.scales.keys())
+N_TERMS = len(TERM_ORDER)
+TERM_INDEX = {name: i for i, name in enumerate(TERM_ORDER)}
+
+
+def scale_vector(scales: dict[str, float] | None = None) -> np.ndarray:
+    """Build the dense ``(N_TERMS,)`` scale vector in ``TERM_ORDER``.
+
+    Assembled once on a cold path (reset/init) and handed to the kernel —
+    weights stay owned by config, never baked into compiled code.
+    """
+    src = REWARD_SPEC.scales if scales is None else scales
+    return np.array([src.get(name, 0.0) for name in TERM_ORDER], dtype=np.float64)
+
+
+def std_vector(spec: RewardSpec = REWARD_SPEC) -> np.ndarray:
+    """Per-term exponential std in ``TERM_ORDER`` (0 where a term has no std).
+
+    Matches which ``std_*`` each ``_reward_motion_*`` reads in tracking.py.
+    """
+    per_term = {
+        "motion_global_root_pos": spec.std_root_pos,
+        "motion_global_root_ori": spec.std_root_ori,
+        "motion_body_pos": spec.std_body_pos,
+        "motion_body_ori": spec.std_body_ori,
+        "motion_body_lin_vel": spec.std_body_lin_vel,
+        "motion_body_ang_vel": spec.std_body_ang_vel,
+        "motion_ee_body_pos_z": spec.std_body_pos,  # ee uses std_body_pos
+        "motion_joint_pos": spec.std_joint_pos,
+        "motion_joint_vel": spec.std_joint_vel,
+        "action_rate_l2": 0.0,  # not an exp reward
+        "joint_limit": 0.0,
+    }
+    return np.array([per_term[name] for name in TERM_ORDER], dtype=np.float64)

--- a/benchmark/numba_profile/state.py
+++ b/benchmark/numba_profile/state.py
@@ -1,0 +1,157 @@
+"""Deterministic synthetic batch reproducing the arrays that
+``g1_motion_tracking``'s reward + termination read every step.
+
+We do **not** run MuJoCo/Motrix — the numba target is the backend-agnostic
+``update_state`` overhead (obs/reward/termination), which is pure array math on
+robot state vs. a motion reference (issue #663/#665).  So we synthesise those
+arrays at the exact shapes/dtypes the real task uses, with magnitudes chosen so
+rewards land in a sane range and terminations stay sparse (~2%), matching a
+mid-training regime.
+
+Field provenance (arrays consumed by tracking.py reward/termination):
+
+  motion_data.body_pos_w      (N, 14, 3)   _reward_motion_global_root_pos / body_pos
+  motion_data.body_quat_w     (N, 14, 4)   _reward_motion_global_root_ori / body_ori
+  motion_data.body_lin_vel_w  (N, 14, 3)   _reward_motion_body_lin_vel
+  motion_data.body_ang_vel_w  (N, 14, 3)   _reward_motion_body_ang_vel
+  motion_data.joint_pos/vel   (N, 29)      _reward_motion_joint_pos/vel  (scale 0)
+  ref_body_pos_relative_w     (N, 14, 3)   _reward_motion_body_pos / ee / termination
+  ref_body_quat_relative_w    (N, 14, 4)   _reward_motion_body_ori
+  robot_body_*_w              same shapes  robot side of every error
+  dof_pos / dof_vel           (N, 29)
+  current_actions/last_actions(N, 29)      _reward_action_rate_l2
+  joint_lower / joint_upper   (29,)        _reward_joint_limit
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from . import spec
+
+
+@dataclass
+class Batch:
+    """All arrays a single ``update_state`` call reads (float32, C-contiguous)."""
+
+    # motion reference (world frame)
+    motion_body_pos_w: np.ndarray
+    motion_body_quat_w: np.ndarray
+    motion_body_lin_vel_w: np.ndarray
+    motion_body_ang_vel_w: np.ndarray
+    motion_joint_pos: np.ndarray
+    motion_joint_vel: np.ndarray
+    # motion reference expressed in the anchor frame (body_pos/quat_relative_w)
+    ref_body_pos_relative_w: np.ndarray
+    ref_body_quat_relative_w: np.ndarray
+    # robot state (world frame)
+    robot_body_pos_w: np.ndarray
+    robot_body_quat_w: np.ndarray
+    robot_body_lin_vel_w: np.ndarray
+    robot_body_ang_vel_w: np.ndarray
+    dof_pos: np.ndarray
+    dof_vel: np.ndarray
+    current_actions: np.ndarray
+    last_actions: np.ndarray
+    # static joint limits (shared across envs)
+    joint_lower: np.ndarray
+    joint_upper: np.ndarray
+
+    @property
+    def num_envs(self) -> int:
+        return self.dof_pos.shape[0]
+
+
+def _unit_quats(rng: np.random.Generator, shape: tuple[int, ...]) -> np.ndarray:
+    """Random unit quaternions (wxyz), last axis size 4."""
+    q = rng.standard_normal((*shape, 4)).astype(np.float32)
+    q /= np.linalg.norm(q, axis=-1, keepdims=True)
+    return q
+
+
+def _perturb_quats(rng: np.random.Generator, q: np.ndarray, sigma: float) -> np.ndarray:
+    """Small perturbation of unit quats, renormalised — keeps ori error modest."""
+    out = q + sigma * rng.standard_normal(q.shape).astype(np.float32)
+    out /= np.linalg.norm(out, axis=-1, keepdims=True)
+    return out
+
+
+def make_batch(num_envs: int, seed: int = 0, dtype=np.float32) -> Batch:
+    """Build a reproducible batch of ``num_envs`` environments.
+
+    Faithful tracking regime: motion reference, the anchor-relative reference,
+    and the robot all track a common per-env target with small errors, so
+    exponential rewards are non-degenerate and terminations stay sparse (~2%,
+    per issue #663) — the robot is *mostly* following the clip.
+    """
+    rng = np.random.default_rng(seed)
+    n, nb, na = num_envs, spec.N_BODY, spec.NUM_ACTION
+
+    def f32(a):
+        return np.ascontiguousarray(a, dtype=dtype)
+
+    # ── common per-env targets the robot is tracking ────────────────────────
+    tgt_pos = rng.uniform(-1.0, 1.0, (n, nb, 3)).astype(np.float32)
+    tgt_quat = _unit_quats(rng, (n, nb))
+    tgt_lin_vel = rng.uniform(-2.0, 2.0, (n, nb, 3)).astype(np.float32)
+    tgt_ang_vel = rng.uniform(-3.0, 3.0, (n, nb, 3)).astype(np.float32)
+    tgt_jp = rng.uniform(-1.0, 1.0, (n, na)).astype(np.float32)
+    tgt_jv = rng.uniform(-2.0, 2.0, (n, na)).astype(np.float32)
+
+    # small per-source jitter around the shared target
+    p, v, qs = 0.04, 0.10, 0.02
+
+    # ── motion reference (world) ≈ target ───────────────────────────────────
+    motion_body_pos_w = f32(tgt_pos + p * rng.standard_normal((n, nb, 3)))
+    motion_body_quat_w = f32(_perturb_quats(rng, tgt_quat, qs))
+    motion_body_lin_vel_w = f32(tgt_lin_vel + v * rng.standard_normal((n, nb, 3)))
+    motion_body_ang_vel_w = f32(tgt_ang_vel + v * rng.standard_normal((n, nb, 3)))
+    motion_joint_pos = f32(tgt_jp + 0.03 * rng.standard_normal((n, na)))
+    motion_joint_vel = f32(tgt_jv + 0.05 * rng.standard_normal((n, na)))
+
+    # ── anchor-relative reference ≈ target ──────────────────────────────────
+    ref_body_pos_relative_w = f32(tgt_pos + p * rng.standard_normal((n, nb, 3)))
+    ref_body_quat_relative_w = f32(_perturb_quats(rng, tgt_quat, qs))
+
+    # ── robot state ≈ target + slightly larger error ────────────────────────
+    robot_body_pos_w = f32(tgt_pos + 0.06 * rng.standard_normal((n, nb, 3)))
+    robot_body_quat_w = f32(_perturb_quats(rng, tgt_quat, 0.03))
+    robot_body_lin_vel_w = f32(tgt_lin_vel + v * rng.standard_normal((n, nb, 3)))
+    robot_body_ang_vel_w = f32(tgt_ang_vel + v * rng.standard_normal((n, nb, 3)))
+    dof_pos = f32(tgt_jp + 0.05 * rng.standard_normal((n, na)))
+    dof_vel = f32(tgt_jv + 0.10 * rng.standard_normal((n, na)))
+    current_actions = f32(rng.uniform(-1.0, 1.0, (n, na)))
+    last_actions = f32(current_actions + 0.1 * rng.standard_normal((n, na)))
+
+    # ── static joint limits, with dof_pos mostly inside them ─────────────────
+    joint_lower = f32(np.full(na, -2.5))
+    joint_upper = f32(np.full(na, 2.5))
+
+    # Inject ~2% terminations on the anchor-Z channel so both paths exercise the
+    # termination branch identically.
+    n_term = max(1, int(0.02 * n))
+    term_ids = rng.choice(n, size=n_term, replace=False)
+    robot_body_pos_w[term_ids, spec.ANCHOR_BODY_IDX, 2] += 0.6  # > 0.25 threshold
+
+    return Batch(
+        motion_body_pos_w=motion_body_pos_w,
+        motion_body_quat_w=motion_body_quat_w,
+        motion_body_lin_vel_w=motion_body_lin_vel_w,
+        motion_body_ang_vel_w=motion_body_ang_vel_w,
+        motion_joint_pos=motion_joint_pos,
+        motion_joint_vel=motion_joint_vel,
+        ref_body_pos_relative_w=ref_body_pos_relative_w,
+        ref_body_quat_relative_w=ref_body_quat_relative_w,
+        robot_body_pos_w=robot_body_pos_w,
+        robot_body_quat_w=robot_body_quat_w,
+        robot_body_lin_vel_w=robot_body_lin_vel_w,
+        robot_body_ang_vel_w=robot_body_ang_vel_w,
+        dof_pos=dof_pos,
+        dof_vel=dof_vel,
+        current_actions=current_actions,
+        last_actions=last_actions,
+        joint_lower=joint_lower,
+        joint_upper=joint_upper,
+    )

--- a/benchmark/numba_profile/test_parity.py
+++ b/benchmark/numba_profile/test_parity.py
@@ -1,0 +1,121 @@
+"""Consistency: the numba kernel must equal the numpy oracle within tolerance.
+
+Run standalone (``python -m benchmark.numba_profile.test_parity``) or under
+pytest.  We compare, over a fresh synthetic batch:
+
+  * total reward (per env),
+  * termination mask (exact — booleans),
+  * every active per-term reward-mean in the log dict,
+  * each device function's ``.py_func`` vs its numpy sibling (pillar 1: the
+    scalar source really is the same math).
+
+Tolerance is ``rtol=1e-4`` on float32 reductions: ``fastmath``/FMA reorders
+float ops, so bit-exactness is neither expected nor required (issue #665 asks
+for "逐 bit 或在容差内一致").
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from . import numba_terms as T
+from . import numpy_reference as ref
+from . import spec
+from .numba_fused import update_state
+from .state import make_batch
+
+RTOL, ATOL = 1e-4, 1e-5
+
+
+def _check(name, a, b, rtol=RTOL, atol=ATOL):
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    max_abs = float(np.max(np.abs(a - b))) if a.size else 0.0
+    ok = np.allclose(a, b, rtol=rtol, atol=atol)
+    print(f"  [{'OK ' if ok else 'BAD'}] {name:<34} max|Δ|={max_abs:.3e}")
+    assert ok, f"{name} mismatch: max|Δ|={max_abs:.3e}"
+
+
+def test_device_functions_match_numpy():
+    """Each ``.py_func`` device fn reproduces its vectorised numpy sibling."""
+    b = make_batch(64, seed=1)
+    a = spec.ANCHOR_BODY_IDX
+    print("device-function parity (.py_func vs numpy):")
+
+    def per_env(fn):
+        return np.array([fn(i) for i in range(b.num_envs)])
+
+    _check(
+        "motion_global_root_pos",
+        per_env(
+            lambda i: T.motion_global_root_pos_i.py_func(
+                b.motion_body_pos_w, b.robot_body_pos_w, a, spec.REWARD_SPEC.std_root_pos, i
+            )
+        ),
+        ref.motion_global_root_pos(b),
+    )
+    _check(
+        "motion_body_ori",
+        per_env(
+            lambda i: T.motion_body_ori_i.py_func(
+                b.ref_body_quat_relative_w,
+                b.robot_body_quat_w,
+                spec.N_BODY,
+                spec.REWARD_SPEC.std_body_ori,
+                i,
+            )
+        ),
+        ref.motion_body_ori(b),
+    )
+    _check(
+        "motion_body_ang_vel",
+        per_env(
+            lambda i: T.motion_body_ang_vel_i.py_func(
+                b.motion_body_ang_vel_w,
+                b.robot_body_ang_vel_w,
+                spec.N_BODY,
+                spec.REWARD_SPEC.std_body_ang_vel,
+                i,
+            )
+        ),
+        ref.motion_body_ang_vel(b),
+    )
+    _check(
+        "joint_limit",
+        per_env(
+            lambda i: T.joint_limit_i.py_func(
+                b.dof_pos, b.joint_lower, b.joint_upper, spec.NUM_ACTION, i
+            )
+        ),
+        ref.joint_limit(b),
+    )
+
+
+def test_update_state_parity():
+    """Full fused kernel vs numpy oracle: reward, terminations, per-term log."""
+    for n in (512, 8192):
+        b = make_batch(n, seed=7)
+        r_np, term_np, log_np = ref.update_state(b)
+        r_nb, term_nb, log_nb = update_state(b, force="numba", num_threads=8)
+        print(f"\nupdate_state parity @ num_envs={n}:")
+        _check("reward", r_nb, r_np)
+        assert np.array_equal(term_nb, term_np), (
+            f"termination mismatch: {int((term_nb != term_np).sum())} envs differ"
+        )
+        print(f"  [OK ] terminations exact           ({int(term_np.sum())} done)")
+        assert log_np.keys() == log_nb.keys(), (log_np.keys(), log_nb.keys())
+        for k in log_np:
+            _check(f"log {k}", log_nb[k], log_np[k], rtol=1e-3, atol=1e-6)
+
+
+def main():
+    print("=" * 66)
+    print("NUMBA vs NUMPY PARITY — g1_motion_tracking update_state")
+    print("=" * 66)
+    test_device_functions_match_numpy()
+    test_update_state_parity()
+    print("\nALL PARITY CHECKS PASSED ✅")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a standalone numba env-overhead profiling harness under benchmark/numba_profile.
- Include numpy reference, numba term/fused implementations, state/spec helpers, parity coverage, and usage docs.

## Validation
- make test-all