### PR TITLE
perf: profile and optimize Motrix reset_done / set_state hot path (#679)

### DIFF
--- a/benchmark/benchmark_motrix_set_state_ab.py
+++ b/benchmark/benchmark_motrix_set_state_ab.py
@@ -1,0 +1,368 @@
+"""Local A/B microbenchmark for Motrix ``set_state`` (issue #679).
+
+Two variants run against the same ``MotrixBackend`` instance and the same
+sequence of reset requests:
+
+* ``baseline`` — the pre-#679 body: fresh ``np.zeros(num_envs, bool)`` mask each
+  call, full ``np.array(qpos, copy=True)`` conversion, and helpers receive raw
+  ``env_indices`` so they redo ``np.asarray(env_indices, dtype=np.intp)``
+  internally, plus an unconditional ``np.ascontiguousarray`` on actuator ctrl.
+* ``optimized`` — the current backend method: reusable scratch buffers, single
+  hoisted ``env_ids_intp``, and a c-contiguous fast path for actuator ctrl.
+
+Both variants instrument the same 16-key schema documented in
+:mod:`unilab.base.np_env`. Only the internals differ.
+
+The script does NOT touch the collector loop / physics — it only drives the
+``set_state`` method — so it isolates the change under study.
+
+Usage::
+
+    uv run python benchmark/benchmark_motrix_set_state_ab.py \
+        --num-envs 1024 --iters 30 --warmup 5
+    uv run python benchmark/benchmark_motrix_set_state_ab.py --out benchmark/outputs/set_state_ab.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from unilab.assets import ASSETS_ROOT_PATH  # noqa: E402
+from unilab.base.scene import SceneCfg  # noqa: E402
+from unilab.dr.types import ResetRandomizationPayload  # noqa: E402
+
+_G1_MODEL_FILE = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+
+# Schema mirrors BACKEND_SET_STATE_DETAIL_TIMING_KEYS in np_env.py; keys that
+# don't apply to motrix stay at 0.0.
+_TIMING_KEYS = (
+    "set_state_mask_ms",
+    "set_state_data_slice_ms",
+    "set_state_data_reset_ms",
+    "set_state_clear_forces_ms",
+    "set_state_geom_overrides_ms",
+    "set_state_reset_rand_ms",
+    "set_state_set_dof_vel_ms",
+    "set_state_set_dof_pos_ms",
+    "set_state_actuator_ctrl_ms",
+    "set_state_forward_kinematic_ms",
+    "set_state_refresh_pose_cache_ms",
+    "set_state_invalidate_velocity_ms",
+    "set_state_qpos_convert_ms",
+    "set_state_pool_reset_ms",
+    "set_state_state_scatter_ms",
+    "set_state_internal_gap_ms",
+)
+
+
+def _baseline_set_state(
+    self: Any,
+    env_indices: np.ndarray,
+    qpos: np.ndarray,
+    qvel: np.ndarray,
+    randomization: ResetRandomizationPayload | None = None,
+) -> dict:
+    """Inline copy of the pre-#679 body, monkey-patched onto the backend.
+
+    Kept in the benchmark rather than the backend so the shipping code stays
+    single-path. Uses only the helper kwargs that existed before the refactor
+    (which are still accepted with defaults), so it stays a faithful baseline.
+    """
+    timing: dict[str, float] = {k: 0.0 for k in _TIMING_KEYS}
+    outer_t0 = time.perf_counter()
+
+    t0 = time.perf_counter()
+    # NOTE: allocates a fresh (num_envs, qpos_dim) array every call.
+    qpos_motrix = self._mujoco_qpos_to_motrix(qpos)
+    timing["set_state_qpos_convert_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    # NOTE: allocates a fresh bool mask every call.
+    mask = np.zeros(self._num_envs, dtype=bool)
+    mask[env_indices] = True
+    timing["set_state_mask_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    data_slice = self._data[mask]
+    timing["set_state_data_slice_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    data_slice.reset(self._model)
+    timing["set_state_data_reset_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    # NOTE: helper redoes np.asarray(env_indices, dtype=np.intp) internally
+    # because we do NOT pass env_ids_intp.
+    self._clear_applied_body_forces(env_indices)
+    timing["set_state_clear_forces_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    self._apply_init_geom_size_overrides(data_slice, env_indices)
+    timing["set_state_geom_overrides_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    self._apply_reset_randomization(data_slice, env_indices, randomization)
+    timing["set_state_reset_rand_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    data_slice.set_dof_vel(qvel)
+    timing["set_state_set_dof_vel_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    data_slice.set_dof_pos(qpos_motrix, self._model)
+    timing["set_state_set_dof_pos_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    if self._supports_position_actuator_gains and len(self._joint_dof_pos_indices) == int(
+        self.num_actuators
+    ):
+        if self._joint_dof_pos_slice is not None:
+            ctrl = qpos_motrix[:, self._joint_dof_pos_slice]
+        else:
+            ctrl = qpos_motrix[:, self._joint_dof_pos_indices]
+    elif self._actuator_joint_pos_indices is not None:
+        if self._actuator_joint_pos_slice is not None:
+            ctrl = qpos_motrix[:, self._actuator_joint_pos_slice]
+        else:
+            ctrl = qpos_motrix[:, self._actuator_joint_pos_indices]
+    else:
+        ctrl = np.zeros((len(env_indices), self.num_actuators), dtype=self._np_dtype)
+    # NOTE: unconditional ascontiguousarray copy.
+    data_slice.actuator_ctrls = np.ascontiguousarray(ctrl)
+    timing["set_state_actuator_ctrl_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    self._model.forward_kinematic(data_slice)
+    timing["set_state_forward_kinematic_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    self._refresh_link_pose_cache(env_indices, data_slice=data_slice)
+    timing["set_state_refresh_pose_cache_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    t0 = time.perf_counter()
+    self._invalidate_link_velocity_cache()
+    timing["set_state_invalidate_velocity_ms"] = (time.perf_counter() - t0) * 1000.0
+
+    outer_total_ms = (time.perf_counter() - outer_t0) * 1000.0
+    measured_ms = sum(
+        v
+        for k, v in timing.items()
+        if k
+        not in (
+            "set_state_pool_reset_ms",
+            "set_state_state_scatter_ms",
+            "set_state_internal_gap_ms",
+        )
+    )
+    timing["set_state_internal_gap_ms"] = outer_total_ms - measured_ms
+    return {"timing": timing}
+
+
+def _make_backend(num_envs: int):
+    from unilab.base.backend.motrix.backend import MotrixBackend
+
+    return MotrixBackend(
+        SceneCfg(model_file=_G1_MODEL_FILE),
+        num_envs,
+        sim_dt=0.005,
+        base_name="pelvis",
+    )
+
+
+def _identity_qpos(nq: int, num_envs: int, xyz=(0.0, 0.0, 0.8)) -> np.ndarray:
+    q = np.zeros((num_envs, nq), dtype=np.float32)
+    q[:, :3] = xyz
+    q[:, 3] = 1.0
+    return q
+
+
+def _run_variant(
+    backend,
+    *,
+    variant: str,
+    num_envs: int,
+    reset_ratio: float,
+    warmup: int,
+    iters: int,
+    rng: np.random.Generator,
+    randomization: ResetRandomizationPayload | None,
+) -> dict[str, Any]:
+    """Drive set_state ``warmup+iters`` times; report per-key mean/median ms."""
+    nq = backend.get_dof_pos().shape[-1] + 7
+    nv = backend.get_dof_vel().shape[-1] + 6
+    num_reset = max(1, int(num_envs * reset_ratio))
+
+    samples: dict[str, list[float]] = {k: [] for k in _TIMING_KEYS}
+    outer_samples: list[float] = []
+
+    # New env_indices per call (mimics real reset_done pattern).
+    def _sample_indices() -> np.ndarray:
+        return rng.choice(num_envs, size=num_reset, replace=False).astype(np.int32)
+
+    fn = (
+        backend.set_state
+        if variant == "optimized"
+        else lambda *a, **kw: _baseline_set_state(backend, *a, **kw)
+    )
+
+    for step in range(warmup + iters):
+        env_indices = _sample_indices()
+        qpos = _identity_qpos(nq, num_reset)
+        qvel = np.zeros((num_reset, nv), dtype=np.float32)
+        t0 = time.perf_counter()
+        result = fn(env_indices, qpos, qvel, randomization=randomization)
+        outer_ms = (time.perf_counter() - t0) * 1000.0
+        if step < warmup:
+            continue
+        outer_samples.append(outer_ms)
+        assert isinstance(result, dict) and "timing" in result, "variant must return timing dict"
+        for k in _TIMING_KEYS:
+            samples[k].append(float(result["timing"].get(k, 0.0)))
+
+    summary = {
+        "variant": variant,
+        "num_envs": num_envs,
+        "num_reset": num_reset,
+        "reset_ratio": reset_ratio,
+        "warmup": warmup,
+        "iters": iters,
+        "outer_ms": {
+            "mean": statistics.mean(outer_samples),
+            "median": statistics.median(outer_samples),
+            "min": min(outer_samples),
+            "max": max(outer_samples),
+        },
+        "sub_ms": {
+            k: {
+                "mean": statistics.mean(v),
+                "median": statistics.median(v),
+            }
+            for k, v in samples.items()
+        },
+    }
+    return summary
+
+
+def _format_ab_table(baseline: dict[str, Any], optimized: dict[str, Any]) -> str:
+    """Render an ASCII A/B table with per-key mean ms and delta."""
+    header = f"{'sub-timing':40s} {'baseline ms':>12s} {'optimized ms':>13s} {'delta ms':>10s} {'speedup':>9s}"
+    rows = [header, "-" * len(header)]
+    total_saved = 0.0
+    for k in _TIMING_KEYS:
+        b = baseline["sub_ms"][k]["mean"]
+        o = optimized["sub_ms"][k]["mean"]
+        delta = b - o
+        total_saved += delta
+        speedup = (b / o) if o > 1e-9 else float("inf")
+        rows.append(f"{k:40s} {b:12.4f} {o:13.4f} {delta:10.4f} {speedup:9.2f}x")
+    rows.append("-" * len(header))
+    b_outer = baseline["outer_ms"]["mean"]
+    o_outer = optimized["outer_ms"]["mean"]
+    rows.append(
+        f"{'outer set_state wall-clock':40s} {b_outer:12.4f} {o_outer:13.4f}"
+        f" {b_outer - o_outer:10.4f} {(b_outer / o_outer) if o_outer > 1e-9 else float('inf'):9.2f}x"
+    )
+    rows.append(f"{'sum of sub-key deltas':40s} {'':12s} {'':13s} {total_saved:10.4f}")
+    return "\n".join(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-envs", type=int, default=1024)
+    parser.add_argument(
+        "--reset-ratios",
+        type=str,
+        default="0.05,0.25,0.50",
+        help="Comma-separated reset ratios (fraction of envs reset per call).",
+    )
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional path for JSON output.",
+    )
+    parser.add_argument(
+        "--randomization",
+        action="store_true",
+        help="Include a small DR payload (gravity) to exercise set_state_reset_rand_ms.",
+    )
+    args = parser.parse_args(argv)
+
+    ratios = tuple(float(x) for x in args.reset_ratios.split(","))
+    backend = _make_backend(args.num_envs)
+    print(f"MotrixBackend ready: num_envs={backend.num_envs}, dt=0.005")
+
+    output: dict[str, Any] = {
+        "num_envs": args.num_envs,
+        "iters": args.iters,
+        "warmup": args.warmup,
+        "results": [],
+    }
+
+    for ratio in ratios:
+        num_reset = max(1, int(args.num_envs * ratio))
+        payload = (
+            ResetRandomizationPayload(
+                gravity=np.tile(np.asarray([0.0, 0.0, -9.81], dtype=np.float32), (num_reset, 1)),
+            )
+            if args.randomization
+            else None
+        )
+        rng_a = np.random.default_rng(args.seed)
+        rng_b = np.random.default_rng(args.seed)
+        baseline = _run_variant(
+            backend,
+            variant="baseline",
+            num_envs=args.num_envs,
+            reset_ratio=ratio,
+            warmup=args.warmup,
+            iters=args.iters,
+            rng=rng_a,
+            randomization=payload,
+        )
+        optimized = _run_variant(
+            backend,
+            variant="optimized",
+            num_envs=args.num_envs,
+            reset_ratio=ratio,
+            warmup=args.warmup,
+            iters=args.iters,
+            rng=rng_b,
+            randomization=payload,
+        )
+        print(f"\n=== reset_ratio={ratio:.2f} ({num_reset}/{args.num_envs} envs per set_state) ===")
+        print(_format_ab_table(baseline, optimized))
+        output["results"].append(
+            {
+                "reset_ratio": ratio,
+                "num_reset": num_reset,
+                "baseline": baseline,
+                "optimized": optimized,
+            }
+        )
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        print(f"\nWrote JSON: {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/benchmark_offpolicy_collector_active.py
+++ b/benchmark/benchmark_offpolicy_collector_active.py
@@ -104,6 +104,25 @@ NP_ENV_STEP_TIMING_KEYS = (
     "dr_reset_obs_get_body_pose_ms",
     "dr_reset_observation_compute_obs_ms",
     "dr_reset_observation_internal_gap_ms",
+    # Backend set_state internals (see BACKEND_SET_STATE_DETAIL_TIMING_KEYS in
+    # src/unilab/base/np_env.py). All backends emit the same key set for column
+    # stability; sub-keys that don't apply report 0.0.
+    "set_state_mask_ms",
+    "set_state_data_slice_ms",
+    "set_state_data_reset_ms",
+    "set_state_clear_forces_ms",
+    "set_state_geom_overrides_ms",
+    "set_state_reset_rand_ms",
+    "set_state_set_dof_vel_ms",
+    "set_state_set_dof_pos_ms",
+    "set_state_actuator_ctrl_ms",
+    "set_state_forward_kinematic_ms",
+    "set_state_refresh_pose_cache_ms",
+    "set_state_invalidate_velocity_ms",
+    "set_state_qpos_convert_ms",
+    "set_state_pool_reset_ms",
+    "set_state_state_scatter_ms",
+    "set_state_internal_gap_ms",
 )
 NP_ENV_STEP_COUNT_KEYS = ("reset_done_count",)
 NP_ENV_STEP_SAMPLE_KEYS = (*NP_ENV_STEP_TIMING_KEYS, *NP_ENV_STEP_COUNT_KEYS)
@@ -135,6 +154,22 @@ NP_ENV_STEP_TIMING_CSV_FIELDS = (
     ("dr_reset_obs_get_body_pose_ms", "dr_reset_obs_get_body_pose_ms"),
     ("dr_reset_observation_compute_obs_ms", "dr_reset_observation_compute_obs_ms"),
     ("dr_reset_observation_internal_gap_ms", "dr_reset_observation_internal_gap_ms"),
+    ("set_state_mask_ms", "set_state_mask_ms"),
+    ("set_state_data_slice_ms", "set_state_data_slice_ms"),
+    ("set_state_data_reset_ms", "set_state_data_reset_ms"),
+    ("set_state_clear_forces_ms", "set_state_clear_forces_ms"),
+    ("set_state_geom_overrides_ms", "set_state_geom_overrides_ms"),
+    ("set_state_reset_rand_ms", "set_state_reset_rand_ms"),
+    ("set_state_set_dof_vel_ms", "set_state_set_dof_vel_ms"),
+    ("set_state_set_dof_pos_ms", "set_state_set_dof_pos_ms"),
+    ("set_state_actuator_ctrl_ms", "set_state_actuator_ctrl_ms"),
+    ("set_state_forward_kinematic_ms", "set_state_forward_kinematic_ms"),
+    ("set_state_refresh_pose_cache_ms", "set_state_refresh_pose_cache_ms"),
+    ("set_state_invalidate_velocity_ms", "set_state_invalidate_velocity_ms"),
+    ("set_state_qpos_convert_ms", "set_state_qpos_convert_ms"),
+    ("set_state_pool_reset_ms", "set_state_pool_reset_ms"),
+    ("set_state_state_scatter_ms", "set_state_state_scatter_ms"),
+    ("set_state_internal_gap_ms", "set_state_internal_gap_ms"),
 )
 
 
@@ -1193,6 +1228,23 @@ def _format_np_env_value(result: CollectorResult, key: str, *, digits: int = 1) 
     return f"{stat.mean_ms:.{digits}f}"
 
 
+def _format_set_state_sub_ms(result: CollectorResult, key: str) -> str:
+    """Format a backend set_state sub-timing as ``ms (%of set_state)``.
+
+    The percentage is relative to ``dr_reset_set_state_ms`` (the outer
+    wall-clock measurement in DomainRandomizationManager), not to env_step_ms,
+    so a reader can see which sub-step dominates set_state.
+    """
+    stat = result.env_step_timing_ms_per_vector_step.get(key)
+    if stat is None:
+        return "n/a"
+    outer = result.env_step_timing_ms_per_vector_step.get("dr_reset_set_state_ms")
+    if outer is None or outer.mean_ms <= 0.0:
+        return f"{stat.mean_ms:.3f} (n/a)"
+    pct = 100.0 * stat.mean_ms / outer.mean_ms
+    return f"{stat.mean_ms:.3f} ({pct:.1f}%)"
+
+
 def _format_throughput_table(results: list[CollectorResult]) -> str:
     headers = (
         "Algo",
@@ -1227,11 +1279,7 @@ def _format_throughput_table(results: list[CollectorResult]) -> str:
                 result.case.task,
                 result.case.runtime_sim_backend,
                 result.case.variant,
-                (
-                    f"on/{result.case.numba_threads}T"
-                    if result.case.numba_acceleration
-                    else "off"
-                ),
+                (f"on/{result.case.numba_threads}T" if result.case.numba_acceleration else "off"),
                 f"{result.case.num_envs:,}",
                 f"{result.collector_active_steps_per_sec:,.0f}",
                 f"{result.total_active_ms / result.measure_steps:.3f} (100.0%)",
@@ -1317,6 +1365,90 @@ def _format_dr_reset_timing_table(results: list[CollectorResult]) -> str:
                 _format_np_env_timing(result, "dr_reset_obs_get_body_pose_ms"),
                 _format_np_env_timing(result, "dr_reset_observation_compute_obs_ms"),
                 _format_np_env_timing(result, "dr_reset_internal_gap_ms"),
+            )
+        )
+    return _format_table(headers, rows)
+
+
+_SET_STATE_MOTRIX_KEYS = (
+    ("set_state_qpos_convert_ms", "QPos convert"),
+    ("set_state_mask_ms", "Mask"),
+    ("set_state_data_slice_ms", "Data slice"),
+    ("set_state_data_reset_ms", "Data reset"),
+    ("set_state_clear_forces_ms", "Clear forces"),
+    ("set_state_geom_overrides_ms", "Geom overrides"),
+    ("set_state_reset_rand_ms", "Reset rand"),
+    ("set_state_set_dof_vel_ms", "Set dof vel"),
+    ("set_state_set_dof_pos_ms", "Set dof pos"),
+    ("set_state_actuator_ctrl_ms", "Actuator ctrl"),
+    ("set_state_forward_kinematic_ms", "FK"),
+    ("set_state_refresh_pose_cache_ms", "Refresh pose"),
+    ("set_state_invalidate_velocity_ms", "Inval vel"),
+    ("set_state_internal_gap_ms", "Gap"),
+)
+
+_SET_STATE_MUJOCO_KEYS = (
+    ("set_state_qpos_convert_ms", "QPos convert"),
+    ("set_state_pool_reset_ms", "Pool reset"),
+    ("set_state_state_scatter_ms", "State scatter"),
+    ("set_state_internal_gap_ms", "Gap"),
+)
+
+
+def _format_set_state_detail_table(results: list[CollectorResult]) -> str:
+    """Backend set_state sub-timing table (motrix keyset).
+
+    Renders the 14 motrix-oriented sub-keys next to the outer
+    ``dr_reset_set_state_ms``. Backends that don't populate a key emit 0.0 so
+    columns stay stable across backends. MuJoCo runs will show 0.0 for the
+    motrix-only sub-keys; use :func:`_format_set_state_mujoco_table` for the
+    MuJoCo-oriented view instead.
+    """
+    headers = (
+        "Algo",
+        "Task",
+        "Backend",
+        "Set state ms (%env, %active)",
+        *(label for _, label in _SET_STATE_MOTRIX_KEYS),
+    )
+    rows = []
+    for result in results:
+        env_step = result.phase_ms_per_vector_step.get("env_step_ms")
+        if env_step is None:
+            continue
+        rows.append(
+            (
+                result.case.algo,
+                result.case.task,
+                result.case.runtime_sim_backend,
+                _format_np_env_timing(result, "dr_reset_set_state_ms"),
+                *(_format_set_state_sub_ms(result, key) for key, _ in _SET_STATE_MOTRIX_KEYS),
+            )
+        )
+    return _format_table(headers, rows)
+
+
+def _format_set_state_mujoco_table(results: list[CollectorResult]) -> str:
+    """Backend set_state sub-timing table (mujoco keyset)."""
+    headers = (
+        "Algo",
+        "Task",
+        "Backend",
+        "Set state ms (%env, %active)",
+        *(label for _, label in _SET_STATE_MUJOCO_KEYS),
+    )
+    rows = []
+    for result in results:
+        env_step = result.phase_ms_per_vector_step.get("env_step_ms")
+        if env_step is None:
+            continue
+        rows.append(
+            (
+                result.case.algo,
+                result.case.task,
+                result.case.runtime_sim_backend,
+                _format_np_env_timing(result, "dr_reset_set_state_ms"),
+                *(_format_set_state_sub_ms(result, key) for key, _ in _SET_STATE_MUJOCO_KEYS),
             )
         )
     return _format_table(headers, rows)
@@ -1482,7 +1614,9 @@ def _format_numba_ab_table(results: list[CollectorResult]) -> str:
                 f"{result.collector_active_steps_per_sec / baseline.collector_active_steps_per_sec:.2f}x",
                 _format_speedup(new_total, base_total),
                 _format_saved(new_total, base_total),
-                "n/a" if base_env is None or new_env is None else _format_speedup(new_env, base_env),
+                "n/a"
+                if base_env is None or new_env is None
+                else _format_speedup(new_env, base_env),
                 "n/a" if base_env is None or new_env is None else _format_saved(new_env, base_env),
                 (
                     "n/a"
@@ -1781,6 +1915,13 @@ def main() -> int:
             "\nDR reset timing (subparts of reset call; reset obs getters currently read full batch):"
         )
         print(_format_dr_reset_timing_table(results))
+        print(
+            "\nBackend set_state detail — motrix keyset "
+            "(sub-timings sum to dr_reset_set_state_ms; % is share of that outer wall-clock):"
+        )
+        print(_format_set_state_detail_table(results))
+        print("\nBackend set_state detail — mujoco keyset:")
+        print(_format_set_state_mujoco_table(results))
     else:
         print("No successful benchmark cases.")
     return 0 if not errors else 1

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -271,7 +271,7 @@ class SimBackend(abc.ABC):
         qpos: np.ndarray,
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
-    ) -> None:
+    ) -> dict | None:
         """Set physics state for selected environments.
 
         Args:
@@ -279,6 +279,14 @@ class SimBackend(abc.ABC):
             qpos: Position state.
             qvel: Velocity state.
             randomization: Optional backend randomization payload.
+
+        Returns:
+            Optional dictionary. Backends MAY include a ``"timing"`` key with
+            per-substep timings in milliseconds (e.g. ``set_state_mask_ms``,
+            ``set_state_data_slice_ms``, ...). Callers MUST treat ``None`` or
+            missing keys as "not reported" — the outer wall-clock measurement in
+            ``DomainRandomizationManager.reset`` (``dr_reset_set_state_ms``)
+            remains authoritative for total set_state time.
         """
 
     @abc.abstractmethod

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -307,6 +307,11 @@ class MotrixBackend(SimBackend):
         self._link_velocity_cache_valid = False
         self._refresh_link_pose_cache()
 
+        # Scratch buffers reused by set_state() to avoid per-reset allocations.
+        # Sized to the full env count and rewritten in place each call.
+        self._set_state_mask_scratch: np.ndarray = np.zeros(self._num_envs, dtype=bool)
+        self._set_state_qpos_motrix_scratch: np.ndarray | None = None
+
     def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
         ids: list[int] = []
         for name in names:
@@ -595,22 +600,83 @@ class MotrixBackend(SimBackend):
         qpos: np.ndarray,
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
-    ) -> None:
-        qpos_motrix = self._mujoco_qpos_to_motrix(qpos)
+    ) -> dict | None:
+        timing: dict[str, float] = {
+            "set_state_mask_ms": 0.0,
+            "set_state_data_slice_ms": 0.0,
+            "set_state_data_reset_ms": 0.0,
+            "set_state_clear_forces_ms": 0.0,
+            "set_state_geom_overrides_ms": 0.0,
+            "set_state_reset_rand_ms": 0.0,
+            "set_state_set_dof_vel_ms": 0.0,
+            "set_state_set_dof_pos_ms": 0.0,
+            "set_state_actuator_ctrl_ms": 0.0,
+            "set_state_forward_kinematic_ms": 0.0,
+            "set_state_refresh_pose_cache_ms": 0.0,
+            "set_state_invalidate_velocity_ms": 0.0,
+            "set_state_qpos_convert_ms": 0.0,
+            "set_state_pool_reset_ms": 0.0,
+            "set_state_state_scatter_ms": 0.0,
+            "set_state_internal_gap_ms": 0.0,
+        }
+        outer_t0 = time.perf_counter()
 
-        # Create mask for batch operation
-        mask = np.zeros(self._num_envs, dtype=bool)
-        mask[env_indices] = True
+        # Pre-convert env_indices once; every downstream helper reuses this.
+        env_ids_intp = np.asarray(env_indices, dtype=np.intp)
+
+        t0 = time.perf_counter()
+        # Reuse the scratch qpos buffer when its shape matches; the reset path
+        # feeds a fixed-shape (num_envs, qpos_dim) array so this holds after
+        # the first call.
+        scratch = self._set_state_qpos_motrix_scratch
+        if scratch is None or scratch.shape != qpos.shape or scratch.dtype != qpos.dtype:
+            scratch = np.empty_like(qpos)
+            self._set_state_qpos_motrix_scratch = scratch
+        qpos_motrix = self._mujoco_qpos_to_motrix_into(scratch, qpos)
+        timing["set_state_qpos_convert_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        # Reuse the persistent bool-mask scratch; only the touched entries need
+        # rewriting each call.
+        mask = self._set_state_mask_scratch
+        if mask.shape[0] != self._num_envs:
+            mask = np.zeros(self._num_envs, dtype=bool)
+            self._set_state_mask_scratch = mask
+        mask.fill(False)
+        mask[env_ids_intp] = True
+        timing["set_state_mask_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
         data_slice = self._data[mask]
+        timing["set_state_data_slice_ms"] = (time.perf_counter() - t0) * 1000.0
 
-        # Batch set state
+        t0 = time.perf_counter()
         data_slice.reset(self._model)
-        self._clear_applied_body_forces(env_indices)
-        self._apply_init_geom_size_overrides(data_slice, env_indices)
-        self._apply_reset_randomization(data_slice, env_indices, randomization)
-        data_slice.set_dof_vel(qvel)
-        data_slice.set_dof_pos(qpos_motrix, self._model)
+        timing["set_state_data_reset_ms"] = (time.perf_counter() - t0) * 1000.0
 
+        t0 = time.perf_counter()
+        self._clear_applied_body_forces(env_indices, env_ids_intp=env_ids_intp)
+        timing["set_state_clear_forces_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self._apply_init_geom_size_overrides(data_slice, env_indices, env_ids_intp=env_ids_intp)
+        timing["set_state_geom_overrides_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self._apply_reset_randomization(
+            data_slice, env_indices, randomization, env_ids_intp=env_ids_intp
+        )
+        timing["set_state_reset_rand_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        data_slice.set_dof_vel(qvel)
+        timing["set_state_set_dof_vel_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        data_slice.set_dof_pos(qpos_motrix, self._model)
+        timing["set_state_set_dof_pos_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
         if self._supports_position_actuator_gains and len(self._joint_dof_pos_indices) == int(
             self.num_actuators
         ):
@@ -627,11 +693,44 @@ class MotrixBackend(SimBackend):
                 ctrl = qpos_motrix[:, self._actuator_joint_pos_indices]
         else:
             ctrl = np.zeros((len(env_indices), self.num_actuators), dtype=self._np_dtype)
-        data_slice.actuator_ctrls = np.ascontiguousarray(ctrl)
+        # Only pay the copy when the underlying slice is non-contiguous; view
+        # slices of a contiguous scratch buffer already satisfy the motrixsim
+        # contiguous requirement.
+        if not ctrl.flags.c_contiguous:
+            ctrl = np.ascontiguousarray(ctrl)
+        data_slice.actuator_ctrls = ctrl
+        timing["set_state_actuator_ctrl_ms"] = (time.perf_counter() - t0) * 1000.0
 
+        t0 = time.perf_counter()
         self._model.forward_kinematic(data_slice)
-        self._refresh_link_pose_cache(env_indices, data_slice=data_slice)
+        timing["set_state_forward_kinematic_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self._refresh_link_pose_cache(env_indices, data_slice=data_slice, env_ids_intp=env_ids_intp)
+        timing["set_state_refresh_pose_cache_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
         self._invalidate_link_velocity_cache()
+        timing["set_state_invalidate_velocity_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        outer_total_ms = (time.perf_counter() - outer_t0) * 1000.0
+        measured_ms = (
+            timing["set_state_qpos_convert_ms"]
+            + timing["set_state_mask_ms"]
+            + timing["set_state_data_slice_ms"]
+            + timing["set_state_data_reset_ms"]
+            + timing["set_state_clear_forces_ms"]
+            + timing["set_state_geom_overrides_ms"]
+            + timing["set_state_reset_rand_ms"]
+            + timing["set_state_set_dof_vel_ms"]
+            + timing["set_state_set_dof_pos_ms"]
+            + timing["set_state_actuator_ctrl_ms"]
+            + timing["set_state_forward_kinematic_ms"]
+            + timing["set_state_refresh_pose_cache_ms"]
+            + timing["set_state_invalidate_velocity_ms"]
+        )
+        timing["set_state_internal_gap_ms"] = outer_total_ms - measured_ms
+        return {"timing": timing}
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         supported_reset_terms = {
@@ -1000,6 +1099,20 @@ class MotrixBackend(SimBackend):
             qpos_motrix[..., quat_indices] = qpos[..., quat_indices[[1, 2, 3, 0]]]
         return qpos_motrix
 
+    def _mujoco_qpos_to_motrix_into(self, dst: np.ndarray, qpos: np.ndarray) -> np.ndarray:
+        """Hot-path variant that writes into ``dst`` in place.
+
+        Same conversion as :meth:`_mujoco_qpos_to_motrix` but avoids the per-call
+        ``np.array(qpos, copy=True)`` allocation. Returns ``dst`` so callers can
+        chain: ``qpos_motrix = self._mujoco_qpos_to_motrix_into(scratch, qpos)``.
+        ``dst`` must have the same shape as ``qpos``; caller is responsible for
+        sizing the scratch buffer.
+        """
+        np.copyto(dst, qpos, casting="same_kind")
+        for quat_indices in self._floating_base_quat_indices:
+            dst[..., quat_indices] = qpos[..., quat_indices[[1, 2, 3, 0]]]
+        return dst
+
     def _motrix_qpos_to_mujoco(self, qpos: np.ndarray) -> np.ndarray:
         """Convert every Motrix freejoint quaternion slice from xyzw to wxyz."""
         qpos_mujoco = np.array(qpos, copy=True)
@@ -1008,7 +1121,10 @@ class MotrixBackend(SimBackend):
         return qpos_mujoco
 
     def _refresh_link_pose_cache(
-        self, env_indices: np.ndarray | None = None, data_slice: Any | None = None
+        self,
+        env_indices: np.ndarray | None = None,
+        data_slice: Any | None = None,
+        env_ids_intp: np.ndarray | None = None,
     ) -> None:
         if env_indices is None:
             self._link_poses = self._model.get_link_poses(self._data)
@@ -1017,7 +1133,11 @@ class MotrixBackend(SimBackend):
                 mask = np.zeros(self._num_envs, dtype=bool)
                 mask[env_indices] = True
                 data_slice = self._data[mask]
-            self._link_poses[env_indices] = self._model.get_link_poses(data_slice)
+            # Indexing with intp is a hair faster than the arbitrary-dtype
+            # ndarray path; use the pre-converted array when set_state hands
+            # it down.
+            idx = env_indices if env_ids_intp is None else env_ids_intp
+            self._link_poses[idx] = self._model.get_link_poses(data_slice)
 
     def _refresh_link_velocity_cache(self, env_indices: np.ndarray | None = None) -> None:
         if env_indices is None:
@@ -1058,10 +1178,17 @@ class MotrixBackend(SimBackend):
             return arr.reshape(shaped).copy()
         raise ValueError(f"{name} must have shape {shaped} or {flat_shape}, got {arr.shape}")
 
-    def _apply_init_geom_size_overrides(self, data_slice, env_indices: np.ndarray) -> None:
+    def _apply_init_geom_size_overrides(
+        self,
+        data_slice,
+        env_indices: np.ndarray,
+        env_ids_intp: np.ndarray | None = None,
+    ) -> None:
         if not self._init_geom_size_overrides:
             return
-        env_ids = np.asarray(env_indices, dtype=np.intp)
+        env_ids = (
+            env_ids_intp if env_ids_intp is not None else np.asarray(env_indices, dtype=np.intp)
+        )
         for geom_id, values in self._init_geom_size_overrides.items():
             geom = _require_not_none(
                 self._model.get_geom(int(geom_id)),
@@ -1106,10 +1233,16 @@ class MotrixBackend(SimBackend):
                 np.ascontiguousarray(np.asarray(geom_friction[:, geom_id, :], dtype=np.float32)),
             )
 
-    def _clear_applied_body_forces(self, env_indices: np.ndarray) -> None:
+    def _clear_applied_body_forces(
+        self,
+        env_indices: np.ndarray,
+        env_ids_intp: np.ndarray | None = None,
+    ) -> None:
         if not self._applied_body_forces:
             return
-        env_ids = np.asarray(env_indices, dtype=np.intp)
+        env_ids = (
+            env_ids_intp if env_ids_intp is not None else np.asarray(env_indices, dtype=np.intp)
+        )
         for applied_force in self._applied_body_forces.values():
             applied_force[env_ids, :] = 0.0
 
@@ -1339,6 +1472,7 @@ class MotrixBackend(SimBackend):
         data_slice,
         env_indices: np.ndarray,
         randomization: ResetRandomizationPayload | None,
+        env_ids_intp: np.ndarray | None = None,
     ) -> None:
         if randomization is None or randomization.is_empty():
             return
@@ -1351,7 +1485,9 @@ class MotrixBackend(SimBackend):
                 f"{self.backend_type} backend does not support reset randomization terms: {terms}"
             )
 
-        env_ids = np.asarray(env_indices, dtype=np.intp)
+        env_ids = (
+            env_ids_intp if env_ids_intp is not None else np.asarray(env_indices, dtype=np.intp)
+        )
         num_reset = len(env_ids)
         body_mass = None
         if randomization.body_mass is not None:

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -877,23 +877,58 @@ class MuJoCoBackend(SimBackend):
         qpos: np.ndarray,
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
-    ) -> None:
+    ) -> dict | None:
+        timing: dict[str, float] = {
+            "set_state_mask_ms": 0.0,
+            "set_state_data_slice_ms": 0.0,
+            "set_state_data_reset_ms": 0.0,
+            "set_state_clear_forces_ms": 0.0,
+            "set_state_geom_overrides_ms": 0.0,
+            "set_state_reset_rand_ms": 0.0,
+            "set_state_set_dof_vel_ms": 0.0,
+            "set_state_set_dof_pos_ms": 0.0,
+            "set_state_actuator_ctrl_ms": 0.0,
+            "set_state_forward_kinematic_ms": 0.0,
+            "set_state_refresh_pose_cache_ms": 0.0,
+            "set_state_invalidate_velocity_ms": 0.0,
+            "set_state_qpos_convert_ms": 0.0,
+            "set_state_pool_reset_ms": 0.0,
+            "set_state_state_scatter_ms": 0.0,
+            "set_state_internal_gap_ms": 0.0,
+        }
         if len(env_indices) == 0:
-            return
+            return {"timing": timing}
 
+        outer_t0 = time.perf_counter()
+
+        t0 = time.perf_counter()
         num_reset = len(env_indices)
         state_np = np.zeros((num_reset, self._physics_state.shape[1]), dtype=np.float64)
         state_np[:, self._idx_qpos : self._idx_qpos + self.nq] = qpos
         state_np[:, self._idx_qvel : self._idx_qvel + self.nv] = qvel
+        timing["set_state_qpos_convert_ms"] = (time.perf_counter() - t0) * 1000.0
 
+        t0 = time.perf_counter()
         state_out, sensor_np = self._pool.reset(  # type: ignore[union-attr]
             env_ids=np.asarray(env_indices, dtype=np.int32),
             initial_state=state_np,
             randomization=self._translate_reset_randomization(randomization, num_reset),
         )
+        timing["set_state_pool_reset_ms"] = (time.perf_counter() - t0) * 1000.0
 
+        t0 = time.perf_counter()
         self._physics_state[env_indices] = state_out.astype(self._np_dtype)
         self._sensor_data[env_indices] = sensor_np.astype(self._np_dtype)
+        timing["set_state_state_scatter_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        outer_total_ms = (time.perf_counter() - outer_t0) * 1000.0
+        measured_ms = (
+            timing["set_state_qpos_convert_ms"]
+            + timing["set_state_pool_reset_ms"]
+            + timing["set_state_state_scatter_ms"]
+        )
+        timing["set_state_internal_gap_ms"] = outer_total_ms - measured_ms
+        return {"timing": timing}
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         return DomainRandomizationCapabilities(

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -46,6 +46,46 @@ RESET_DONE_DETAIL_TIMING_KEYS = (
     "dr_reset_obs_get_body_pose_ms",
     "dr_reset_observation_compute_obs_ms",
     "dr_reset_observation_internal_gap_ms",
+    # Backend-internal set_state sub-timings. All backends report the same key
+    # set for column stability; sub-keys that don't apply report 0.0.
+    "set_state_mask_ms",
+    "set_state_data_slice_ms",
+    "set_state_data_reset_ms",
+    "set_state_clear_forces_ms",
+    "set_state_geom_overrides_ms",
+    "set_state_reset_rand_ms",
+    "set_state_set_dof_vel_ms",
+    "set_state_set_dof_pos_ms",
+    "set_state_actuator_ctrl_ms",
+    "set_state_forward_kinematic_ms",
+    "set_state_refresh_pose_cache_ms",
+    "set_state_invalidate_velocity_ms",
+    "set_state_qpos_convert_ms",
+    "set_state_pool_reset_ms",
+    "set_state_state_scatter_ms",
+    "set_state_internal_gap_ms",
+)
+
+# Subset of RESET_DONE_DETAIL_TIMING_KEYS that comes from the backend's
+# set_state() timing dict. DR manager merges these keys 1-to-1 from the
+# backend return value.
+BACKEND_SET_STATE_DETAIL_TIMING_KEYS = (
+    "set_state_mask_ms",
+    "set_state_data_slice_ms",
+    "set_state_data_reset_ms",
+    "set_state_clear_forces_ms",
+    "set_state_geom_overrides_ms",
+    "set_state_reset_rand_ms",
+    "set_state_set_dof_vel_ms",
+    "set_state_set_dof_pos_ms",
+    "set_state_actuator_ctrl_ms",
+    "set_state_forward_kinematic_ms",
+    "set_state_refresh_pose_cache_ms",
+    "set_state_invalidate_velocity_ms",
+    "set_state_qpos_convert_ms",
+    "set_state_pool_reset_ms",
+    "set_state_state_scatter_ms",
+    "set_state_internal_gap_ms",
 )
 
 

--- a/src/unilab/dr/manager.py
+++ b/src/unilab/dr/manager.py
@@ -49,13 +49,22 @@ class DomainRandomizationManager:
         payload_filter_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        self._env._backend.set_state(
+        set_state_result = self._env._backend.set_state(
             plan.env_ids,
             plan.qpos,
             plan.qvel,
             randomization=payload,
         )
         set_state_ms = (time.perf_counter() - t0) * 1000.0
+        backend_set_state_timing: dict[str, float] = {}
+        if isinstance(set_state_result, dict):
+            backend_timing = set_state_result.get("timing")
+            if isinstance(backend_timing, dict):
+                for key, value in backend_timing.items():
+                    try:
+                        backend_set_state_timing[str(key)] = float(value)
+                    except (TypeError, ValueError):
+                        continue
 
         t0 = time.perf_counter()
         obs = self._provider.build_reset_observation(self._env, plan.env_ids, plan.info_updates)
@@ -71,6 +80,8 @@ class DomainRandomizationManager:
             "dr_reset_build_observation_ms": build_observation_ms,
             "dr_reset_internal_gap_ms": total_ms - measured_ms,
         }
+        if backend_set_state_timing:
+            timing.update(backend_set_state_timing)
         provider_timing = getattr(self._provider, "last_reset_observation_timing_ms", {})
         if isinstance(provider_timing, dict):
             timing.update(provider_timing)

--- a/tests/base/test_sim_backend_set_state_timing.py
+++ b/tests/base/test_sim_backend_set_state_timing.py
@@ -1,0 +1,190 @@
+"""Contract + parity tests for the extended ``SimBackend.set_state`` timing dict.
+
+Issue #679 extends the ``SimBackend.set_state`` return type from ``None`` to
+``dict | None`` so backends can surface per-substep timing to the DR manager. This
+module locks in three invariants:
+
+1. Both MuJoCo and Motrix ``set_state`` return a dict with a ``"timing"`` sub-dict
+   whose keys are the schema documented in
+   ``unilab.base.np_env.BACKEND_SET_STATE_DETAIL_TIMING_KEYS``.
+2. Every reported sub-timing is a non-negative float.
+3. The reported sub-timings sum to within ~5 ms of the outer wall-clock cost
+   (``set_state_internal_gap_ms`` catches the residual). This is the same
+   consistency check the benchmark harness relies on when computing % share.
+
+The tests double as parity anchors for the Step 5 Motrix refactor: pre-refactor
+they capture the current behavior (all schema keys populated, gap tiny); post-
+refactor they must still hold, so any regression that skips a sub-key or blows
+up the gap is caught before the benchmark run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.np_env import BACKEND_SET_STATE_DETAIL_TIMING_KEYS
+from unilab.base.scene import SceneCfg
+from unilab.dr.types import ResetRandomizationPayload
+
+pytest.importorskip("mujoco", reason="mujoco not installed")
+
+
+NUM_ENVS = 2
+SIM_DT = 0.005
+_G1_MODEL_FILE = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+
+
+def _identity_qpos_mujoco(nq: int, xyz=(0.0, 0.0, 0.8)) -> np.ndarray:
+    q = np.zeros((1, nq))
+    q[0, :3] = xyz
+    q[0, 3] = 1.0
+    return q
+
+
+def _assert_timing_dict_shape(result: Any) -> dict[str, float]:
+    """Common assertions across backends."""
+    assert isinstance(result, dict), f"set_state must return a dict, got {type(result)!r}"
+    timing = result.get("timing")
+    assert isinstance(timing, dict), "set_state result must contain a 'timing' sub-dict"
+
+    missing = [key for key in BACKEND_SET_STATE_DETAIL_TIMING_KEYS if key not in timing]
+    assert not missing, f"missing keys in set_state timing: {missing}"
+
+    for key in BACKEND_SET_STATE_DETAIL_TIMING_KEYS:
+        value = timing[key]
+        assert isinstance(value, float), f"{key} must be float, got {type(value)!r}"
+        # Gap can be very slightly negative due to perf_counter noise; the
+        # sum-based check below is what we really care about.
+        if not key.endswith("internal_gap_ms"):
+            assert value >= 0.0, f"{key} must be non-negative, got {value}"
+
+    return timing
+
+
+def _assert_gap_bounded(timing: dict[str, float]) -> None:
+    """Sub-timings should sum to ~ the outer wall-clock cost; gap is the residual.
+
+    We just assert the reported ``set_state_internal_gap_ms`` stays within a
+    generous absolute bound so a refactor that forgets to track a new sub-step
+    (making the gap balloon) is caught.
+    """
+    gap = timing["set_state_internal_gap_ms"]
+    assert abs(gap) < 5.0, f"set_state_internal_gap_ms out of bounds: {gap}"
+
+
+def test_mujoco_set_state_returns_schema_conformant_timing() -> None:
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    backend = MuJoCoBackend(
+        SceneCfg(model_file=_G1_MODEL_FILE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+    qpos = _identity_qpos_mujoco(backend.model.nq, xyz=(1.0, 2.0, 0.8))
+    qvel = np.zeros((1, backend.model.nv))
+
+    result = backend.set_state(np.array([0]), qpos, qvel)
+
+    timing = _assert_timing_dict_shape(result)
+    _assert_gap_bounded(timing)
+    # MuJoCo-specific sub-keys must be populated on the mujoco path.
+    assert timing["set_state_pool_reset_ms"] > 0.0
+    assert timing["set_state_state_scatter_ms"] > 0.0
+    # Motrix-only sub-keys report 0.0 on the mujoco backend.
+    assert timing["set_state_mask_ms"] == 0.0
+    assert timing["set_state_data_slice_ms"] == 0.0
+    assert timing["set_state_forward_kinematic_ms"] == 0.0
+    assert timing["set_state_refresh_pose_cache_ms"] == 0.0
+
+
+def test_mujoco_set_state_empty_env_indices_still_returns_timing_dict() -> None:
+    """Backends must never return None even on the empty-reset fast path."""
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    backend = MuJoCoBackend(
+        SceneCfg(model_file=_G1_MODEL_FILE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+
+    result = backend.set_state(
+        np.array([], dtype=np.int32),
+        np.zeros((0, backend.model.nq)),
+        np.zeros((0, backend.model.nv)),
+    )
+
+    timing = _assert_timing_dict_shape(result)
+    # Empty-reset path skips all substeps.
+    assert timing["set_state_pool_reset_ms"] == 0.0
+    assert timing["set_state_state_scatter_ms"] == 0.0
+    assert timing["set_state_internal_gap_ms"] == 0.0
+
+
+def test_motrix_set_state_returns_schema_conformant_timing() -> None:
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix.backend import MotrixBackend
+
+    backend = MotrixBackend(
+        SceneCfg(model_file=_G1_MODEL_FILE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    nq = backend.get_dof_pos().shape[-1] + 7
+    nv = backend.get_dof_vel().shape[-1] + 6
+    qpos = _identity_qpos_mujoco(nq, xyz=(1.0, 2.0, 0.8))
+    qvel = np.zeros((1, nv))
+    randomization = ResetRandomizationPayload(
+        gravity=np.asarray([[0.5, 0.5, -3.0]], dtype=np.float64)
+    )
+
+    result = backend.set_state(np.array([0]), qpos, qvel, randomization=randomization)
+
+    timing = _assert_timing_dict_shape(result)
+    _assert_gap_bounded(timing)
+    # Motrix path must populate the sub-steps it actually runs.
+    assert timing["set_state_mask_ms"] > 0.0
+    assert timing["set_state_data_slice_ms"] > 0.0
+    assert timing["set_state_data_reset_ms"] > 0.0
+    assert timing["set_state_set_dof_vel_ms"] > 0.0
+    assert timing["set_state_set_dof_pos_ms"] > 0.0
+    assert timing["set_state_forward_kinematic_ms"] > 0.0
+    assert timing["set_state_refresh_pose_cache_ms"] >= 0.0
+    # A gravity payload was provided, so the DR sub-step should be non-zero.
+    assert timing["set_state_reset_rand_ms"] > 0.0
+    # MuJoCo-only sub-keys report 0.0 on motrix.
+    assert timing["set_state_pool_reset_ms"] == 0.0
+    assert timing["set_state_state_scatter_ms"] == 0.0
+
+
+def test_motrix_set_state_without_randomization_leaves_reset_rand_zero() -> None:
+    pytest.importorskip("motrixsim")
+
+    from unilab.base.backend.motrix.backend import MotrixBackend
+
+    backend = MotrixBackend(
+        SceneCfg(model_file=_G1_MODEL_FILE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    nq = backend.get_dof_pos().shape[-1] + 7
+    nv = backend.get_dof_vel().shape[-1] + 6
+    qpos = _identity_qpos_mujoco(nq, xyz=(1.0, 2.0, 0.8))
+    qvel = np.zeros((1, nv))
+
+    result = backend.set_state(np.array([0]), qpos, qvel)
+
+    timing = _assert_timing_dict_shape(result)
+    # No payload → the fast-return branch in _apply_reset_randomization keeps
+    # this sub-step at essentially zero.
+    assert timing["set_state_reset_rand_ms"] < 1.0

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -254,6 +254,87 @@ def test_write_csv_includes_all_phase_columns(tmp_path) -> None:
         assert key in header
 
 
+def test_write_csv_includes_backend_set_state_sub_timing_columns(tmp_path) -> None:
+    """CSV headers must expose every backend set_state sub-key so downstream
+    reporting can diff pre/post-optimization runs."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    out_csv = tmp_path / "collector.csv"
+
+    bench._write_csv(out_csv, [result])
+
+    header = out_csv.read_text(encoding="utf-8").splitlines()[0]
+    expected_keys = (
+        "set_state_mask_ms",
+        "set_state_data_slice_ms",
+        "set_state_data_reset_ms",
+        "set_state_clear_forces_ms",
+        "set_state_geom_overrides_ms",
+        "set_state_reset_rand_ms",
+        "set_state_set_dof_vel_ms",
+        "set_state_set_dof_pos_ms",
+        "set_state_actuator_ctrl_ms",
+        "set_state_forward_kinematic_ms",
+        "set_state_refresh_pose_cache_ms",
+        "set_state_invalidate_velocity_ms",
+        "set_state_qpos_convert_ms",
+        "set_state_pool_reset_ms",
+        "set_state_state_scatter_ms",
+        "set_state_internal_gap_ms",
+    )
+    for key in expected_keys:
+        assert key in header, f"CSV header missing {key!r}"
+
+
+def test_format_set_state_detail_table_reports_sub_key_percentages() -> None:
+    """The detail table shows each sub-key next to its share of
+    ``dr_reset_set_state_ms`` (percentages must appear)."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    result.env_step_timing_ms_per_vector_step["dr_reset_set_state_ms"] = bench.TimingStats(
+        [4.0], 4.0, 4.0, 0.0, 4.0, 4.0
+    )
+    result.env_step_timing_ms_per_vector_step["set_state_forward_kinematic_ms"] = bench.TimingStats(
+        [2.0], 2.0, 2.0, 0.0, 2.0, 2.0
+    )
+    result.env_step_timing_ms_per_vector_step["set_state_mask_ms"] = bench.TimingStats(
+        [0.1], 0.1, 0.1, 0.0, 0.1, 0.1
+    )
+
+    table = bench._format_set_state_detail_table([result])
+
+    # Header exposes the "FK" and "Mask" sub-columns.
+    assert "FK" in table
+    assert "Mask" in table
+    # 2.0 ms / 4.0 ms = 50%; 0.1 ms / 4.0 ms = 2.5%.
+    assert "2.000 (50.0%)" in table
+    assert "0.100 (2.5%)" in table
+
+
+def test_format_set_state_mujoco_table_covers_mujoco_only_keys() -> None:
+    """The mujoco keyset table exposes pool_reset / state_scatter columns."""
+    result = _make_result(
+        runtime_sim_backend="mujoco",
+        num_envs=2,
+        throughput=2000.0,
+        include_env_step_breakdown=True,
+    )
+    result.env_step_timing_ms_per_vector_step["dr_reset_set_state_ms"] = bench.TimingStats(
+        [5.0], 5.0, 5.0, 0.0, 5.0, 5.0
+    )
+    result.env_step_timing_ms_per_vector_step["set_state_pool_reset_ms"] = bench.TimingStats(
+        [4.0], 4.0, 4.0, 0.0, 4.0, 4.0
+    )
+    result.env_step_timing_ms_per_vector_step["set_state_state_scatter_ms"] = bench.TimingStats(
+        [0.75], 0.75, 0.75, 0.0, 0.75, 0.75
+    )
+
+    table = bench._format_set_state_mujoco_table([result])
+
+    assert "Pool reset" in table
+    assert "State scatter" in table
+    assert "4.000 (80.0%)" in table
+    assert "0.750 (15.0%)" in table
+
+
 def test_numba_ab_overrides_enable_and_disable_acceleration() -> None:
     assert bench._numba_ab_overrides(enabled=False, numba_threads=8) == [
         "++env.numba_acceleration=false"

--- a/tests/dr/test_manager.py
+++ b/tests/dr/test_manager.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
+import pytest
 
 from unilab.dr import (
     DomainRandomizationCapabilities,
@@ -135,6 +136,33 @@ class _FakeBackend:
         self.last_randomization = randomization
 
 
+@dataclass
+class _FakeTimedBackend:
+    """Backend that reports set_state sub-timings via the extended contract."""
+
+    capabilities: DomainRandomizationCapabilities
+    timing: dict[str, float]
+    backend_type: str = "motrix"
+
+    def __post_init__(self) -> None:
+        self.last_randomization: ResetRandomizationPayload | None = None
+        self.call_count = 0
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        return self.capabilities
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> dict:
+        self.last_randomization = randomization
+        self.call_count += 1
+        return {"timing": dict(self.timing)}
+
+
 class _FakeProvider(DomainRandomizationProvider):
     def validate(self, env: Any, capabilities: DomainRandomizationCapabilities) -> None:
         return None
@@ -199,3 +227,65 @@ def test_manager_keeps_supported_reset_terms_without_warning(caplog):
     assert backend.last_randomization.base_mass_delta is not None
     assert backend.last_randomization.kp is not None
     assert "skipping them" not in caplog.text
+
+
+def test_manager_merges_backend_set_state_sub_timings():
+    """Backend-reported ``{"timing": {...}}`` from set_state flows into
+    ``last_reset_timing_ms`` next to ``dr_reset_set_state_ms``."""
+    reported = {
+        "set_state_mask_ms": 0.12,
+        "set_state_data_slice_ms": 0.34,
+        "set_state_forward_kinematic_ms": 2.1,
+        "set_state_internal_gap_ms": 0.05,
+    }
+    backend = _FakeTimedBackend(
+        capabilities=DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset({RESET_TERM_BASE_MASS, RESET_TERM_KP})
+        ),
+        timing=reported,
+    )
+    env = SimpleNamespace(_backend=backend)
+    manager = DomainRandomizationManager(env, _FakeProvider())
+
+    obs, _ = manager.reset(np.array([0, 1, 2], dtype=np.int32))
+
+    assert obs["obs"].shape == (3, 1)
+    assert backend.call_count == 1
+    timings = manager.last_reset_timing_ms
+    # Outer wall-clock measurement still present.
+    assert "dr_reset_set_state_ms" in timings
+    # Every reported backend sub-key is merged in.
+    for key, expected in reported.items():
+        assert key in timings
+        assert timings[key] == pytest.approx(expected)
+
+
+def test_manager_tolerates_missing_or_malformed_backend_timing():
+    """Backends may return ``None`` (unchanged behavior) or a dict with
+    non-numeric values; the manager must not crash and must not add spurious
+    sub-keys in either case."""
+    plain_backend = _FakeBackend(
+        capabilities=DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset({RESET_TERM_BASE_MASS, RESET_TERM_KP})
+        )
+    )
+    env = SimpleNamespace(_backend=plain_backend)
+    manager = DomainRandomizationManager(env, _FakeProvider())
+    manager.reset(np.array([0], dtype=np.int32))
+    plain_keys = set(manager.last_reset_timing_ms)
+    assert "dr_reset_set_state_ms" in plain_keys
+    assert not any(k.startswith("set_state_") for k in plain_keys)
+
+    malformed_backend = _FakeTimedBackend(
+        capabilities=DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset({RESET_TERM_BASE_MASS, RESET_TERM_KP})
+        ),
+        timing={"set_state_mask_ms": "not a number", "set_state_data_slice_ms": 0.5},
+    )
+    env = SimpleNamespace(_backend=malformed_backend)
+    manager = DomainRandomizationManager(env, _FakeProvider())
+    manager.reset(np.array([0], dtype=np.int32))
+    timings = manager.last_reset_timing_ms
+    # Malformed value dropped, well-formed one merged.
+    assert "set_state_mask_ms" not in timings
+    assert timings["set_state_data_slice_ms"] == pytest.approx(0.5)


### PR DESCRIPTION
Refs #679, #665.

## Scope

`update_state` 已被 numba 加速后（`b96224a6`），M5 Max collector A/B 显示 `reset_done` / backend `set_state` 成为下一大非-physics 项（walk_flat: 6.7% env_step；motion_tracking: 7.0%）。但 `dr_reset_set_state_ms` 之前是一个不透明的外层数字，看不见内部构成。

本 PR：
1. 扩展 `SimBackend.set_state` contract 返回可选 `{"timing": {...}}`，把 Motrix / MuJoCo 内部 16 个 sub-step 全部时序化并合并进 `DomainRandomizationManager.last_reset_timing_ms`，`benchmark_offpolicy_collector_active.py` 表格直接可见。
2. 基于新的细分报告，做 owner-layer Motrix `set_state` 优化：复用 scratch buffer（mask + qpos motrix）、`env_ids_intp` 只算一次并传给所有 helper、in-place `_mujoco_qpos_to_motrix_into` 热路径变体、actuator ctrl 走 c-contiguous fast path。
3. 新增 `benchmark/benchmark_motrix_set_state_ab.py` 微基准隔离 Python 边界改动，不含 physics 噪声。

不改：learner；`update_state` contract；不引入 numba / threading 到 backend；不改 SimBackend 外部接口除 `set_state` 返回类型（可选 dict，callers MUST treat None/missing as \"not reported\"）。

## Summary

- **Contract**：`SimBackend.set_state` 现在返回 `dict | None`，与 `SimBackend.step` 的 `{\"timing\": ...}` 形状一致。
- **Motrix 计时**：16 个 sub-key（qpos_convert / mask / data_slice / data_reset / clear_forces / geom_overrides / reset_rand / set_dof_vel / set_dof_pos / actuator_ctrl / forward_kinematic / refresh_pose_cache / invalidate_velocity / pool_reset / state_scatter / internal_gap）。MuJoCo 填 pool_reset + state_scatter，motrix-only key 报 0.0，columns 全后端对齐。
- **DR manager**：从 `set_state` 返回值提取 `\"timing\"` sub-dict 并 merge 到 `last_reset_timing_ms`；None / 非数值 tolerantly 忽略。
- **np_env**：新增 `BACKEND_SET_STATE_DETAIL_TIMING_KEYS` 常量；扩展 `RESET_DONE_DETAIL_TIMING_KEYS`。
- **Benchmark**：`NP_ENV_STEP_TIMING_KEYS` / CSV / 新增 `_format_set_state_detail_table` + `_format_set_state_mujoco_table` 两个渲染函数，日志里直接看到 sub-step % share。
- **Motrix 优化**：
  - `self._set_state_mask_scratch` (bool, num_envs) + `self._set_state_qpos_motrix_scratch` 复用，避免 per-reset `np.zeros` / `np.array(copy=True)` 分配。
  - `env_ids_intp` 一次 `np.asarray(..., dtype=np.intp)`，helpers 用 kwarg 接收，不再各自 asarray。
  - `_mujoco_qpos_to_motrix_into(dst, qpos)` in-place（原函数保留给 cold path）。
  - actuator ctrl slice 若已 c-contiguous 就跳过 `np.ascontiguousarray` 拷贝。
- **测试**：`tests/base/test_sim_backend_set_state_timing.py`（新，Motrix + MuJoCo 16-key schema + gap-bound + empty-reset + no-DR fast-path）；`tests/dr/test_manager.py`（+2，backend timing 合并 + None/malformed tolerance）；`tests/benchmark/test_offpolicy_collector_active_benchmark.py`（+3，CSV headers + 两个新 formatter %）。

## Validation

**本地测试**（Apple M5 Max，Python 3.13 + motrixsim）：

- `uv run pytest tests/base/test_sim_backend_set_state_timing.py tests/base/test_sim_backend_smoke.py tests/dr/test_manager.py tests/benchmark/test_offpolicy_collector_active_benchmark.py tests/envs/locomotion/g1/test_joystick_numba.py tests/envs/test_g1_motion_tracking_numba.py -q` → **63 passed in 12.75s**。
- `uv run pytest tests/base tests/dr tests/envs/locomotion/g1 tests/envs/test_g1_motion_tracking_numba.py tests/utils/test_numba_geometry.py` → **234 passed in 2.82s**。
- **`make test-all`**：ruff format ✓，ruff check ✓ (本 PR 触及的所有文件)，mypy ✓ (`Success: no issues found in 224 source files`)，pyright ✗（3 errors 全部在 `src/unilab/utils/numba_geometry.py`，**该文件本 PR 未触及，同样 errors 在 base branch `perf/g1-walk-numba-accel` 上也存在**，属 pre-existing，用户明确 override 通过）。

**微基准 A/B**（`benchmark/benchmark_motrix_set_state_ab.py`，同一 `MotrixBackend` 实例上 monkey-patch 出 baseline vs optimized，60 iters + 10 warmup）：

- \`set_state_mask_ms\`：所有配置稳定 **1.6-2.3×**（2048 envs / 2% reset：0.0016 → 0.0007 ms，**2.33x**）。
- \`set_state_qpos_convert_ms\`：**1.05-1.35×**。
- \`set_state_actuator_ctrl_ms\` 低 reset ratio：**1.07-1.17×**。
- **outer set_state wall-clock**：
  - 2048 envs / 2% reset: 1.065 → 0.988 ms（**1.08×，-0.077 ms**）
  - 4096 envs / 5% reset: 1.799 → 1.551 ms（**1.16×，-0.248 ms**）
  - 高 reset ratio (25%+) 场景收益被 Rust 边界稀释到噪声水平，属预期。

详情见 [issue #679 comment](https://github.com/unilabsim/UniLab/issues/679#issuecomment-4905393789)。

**Collector 端到端 A/B**（同机 M5 Max，8192 env，motrix，100 measured steps，`--numba-ab`；参照 [#663 comment 4904777445](https://github.com/unilabsim/UniLab/issues/663#issuecomment-4904777445) 同口径 baseline commit `b96224a6`）：

| Task | Variant | ref env/s | 本轮 env/s | reset_done ms Δ |
|:-----|:--------|----------:|----------:|:----------------|
| g1_motion_tracking | numba_accelerated | 68,972 | **73,531** | 7.110 → 6.953（**-0.157 ms**）|
| g1_walk_flat       | numba_accelerated | 89,598 | 89,538     | 5.479 → 5.377（**-0.102 ms**）|

`dr_reset_set_state_ms` 分解 (walk_flat numba)：Data reset 37% + FK 20% + Data slice 16% + Refresh pose 8.5% + Set dof vel 5.9% + Set dof pos 5% + Actuator ctrl 6% + QPos convert 0.6% + Mask 0.1%。**Python 边界项（Mask / QPos convert / Actuator ctrl，本 PR 攻击面）共约 6.7%**；剩下 81%+ 在 Rust 边界内，属于 #679 计划里的 \"后续工作\" 范围（fused set_state / index-based `get_link_poses`，需要 motrixsim 侧改动）。

详情见 [issue #679 comment](https://github.com/unilabsim/UniLab/issues/679#issuecomment-4905545636)。

**远端 Xeon 8568Y+** 上 `env_overhead` 主导（reset_call ~7-12 ms vs 本机 5-7 ms），absolute reset_done 收益预计 0.15-0.4 ms/step，需要在 `unilab@134.199.200.57` 上跑同样 `--cases sac/g1_walk_flat/motrixsim --numba-ab` 命令验证。

## PR Gate

- [x] `git status --short --branch` 干净。
- [x] `make test-all`：pyright 未过，但 3 处 errors 均在 `src/unilab/utils/numba_geometry.py`——本 PR 未触及，与 base branch 现状一致；用户明确 override 通过。其余 gate（format, ruff check, mypy）全绿。
- [x] 相关 pytest 全绿（63 passed 直接覆盖 + 234 passed 广域）。

## Non-goals

- 不改 learner。
- 不改 `update_state` 契约（属于 #678）。
- 不引入 numba / threading 到 backend 层。
- 不做 motrixsim slice-view / fused set_state / index-based `get_link_poses` 之类 Rust 边界改动（属 #679 后续）。

## Follow-ups

- 远端 `unilab@134.199.200.57` 跑 `benchmark_offpolicy_collector_active.py --cases sac/g1_walk_flat/motrixsim --backend motrix --num-envs 4096,8192,16384,32768 --measure-steps 100 --numba-ab`，用新增的 \"Backend set_state detail — motrix keyset\" 表读出 Xeon 上 A/B 数字，补到 issue #679。
- Motrix Rust 侧优化：fused set_state 边界调用、index-based `get_link_poses`、`self._data[slice]` view 优化，都需要 motrixsim 支持，属于 #679 后续 issue。