### PR TITLE
bench: profile RNG noise buffer cost

### DIFF
--- a/benchmark/benchmark_g1_joystick_numba.py
+++ b/benchmark/benchmark_g1_joystick_numba.py
@@ -388,7 +388,9 @@ def compute_numpy(
         batch.dof_pos,
         batch.dof_vel,
     )
-    obs = env._compute_obs(info, batch.linvel, batch.gyro, batch.gravity, batch.dof_pos, batch.dof_vel)
+    obs = env._compute_obs(
+        info, batch.linvel, batch.gyro, batch.gravity, batch.dof_pos, batch.dof_vel
+    )
     return obs, reward, terminated, info.get("log", {})
 
 
@@ -498,9 +500,7 @@ def bench_one(
         )
     set_num_threads(max_threads)
     numba_1t = next(
-        record
-        for record in records
-        if record.path == "numba_accelerator" and record.threads == 1
+        record for record in records if record.path == "numba_accelerator" and record.threads == 1
     )
     for record in records:
         if record.path != "numba_accelerator" or record.threads is None:
@@ -784,7 +784,12 @@ def _format_e2e_reconciliation_table(
             num_envs=record.num_envs,
             threads=record.numba_threads,
         )
-        if baseline is None or baseline.update_state_ms is None or numpy_hot is None or numba_hot is None:
+        if (
+            baseline is None
+            or baseline.update_state_ms is None
+            or numpy_hot is None
+            or numba_hot is None
+        ):
             continue
         hot_saved_ms = numpy_hot.mean_ms - numba_hot.mean_ms
         update_saved_ms = baseline.update_state_ms - record.update_state_ms
@@ -1308,7 +1313,9 @@ def main() -> None:
     parity: dict[str, dict[str, float]] = {}
     max_threads = get_num_threads()
     args.numba_max_threads = max_threads
-    args.measured_threads = sorted({1, *(threads for threads in args.threads if threads <= max_threads)})
+    args.measured_threads = sorted(
+        {1, *(threads for threads in args.threads if threads <= max_threads)}
+    )
     args.skipped_threads = sorted({threads for threads in args.threads if threads > max_threads})
 
     print("=" * 80)

--- a/benchmark/benchmark_g1_motion_tracking_numba.py
+++ b/benchmark/benchmark_g1_motion_tracking_numba.py
@@ -333,12 +333,8 @@ def make_batch(num_envs: int, spec: ProfileSpec, seed: int) -> SyntheticBatch:
     )
     robot_body_pos_w = f32(target_pos + 0.06 * rng.standard_normal((num_envs, n_body, 3)))
     robot_body_quat_w = f32(_perturb_quats(rng, target_quat, 0.03))
-    robot_body_lin_vel_w = f32(
-        target_lin_vel + 0.1 * rng.standard_normal((num_envs, n_body, 3))
-    )
-    robot_body_ang_vel_w = f32(
-        target_ang_vel + 0.1 * rng.standard_normal((num_envs, n_body, 3))
-    )
+    robot_body_lin_vel_w = f32(target_lin_vel + 0.1 * rng.standard_normal((num_envs, n_body, 3)))
+    robot_body_ang_vel_w = f32(target_ang_vel + 0.1 * rng.standard_normal((num_envs, n_body, 3)))
     linvel = f32(rng.uniform(-1.0, 1.0, (num_envs, 3)))
     gyro = f32(rng.uniform(-1.0, 1.0, (num_envs, 3)))
     dof_pos = f32(target_joint_pos + 0.05 * rng.standard_normal((num_envs, NUM_ACTION)))
@@ -516,9 +512,7 @@ def check_parity(
     return {
         "max_abs_reward_diff": float(np.max(np.abs(reward_nb - reward_np))),
         "termination_mismatch": float(np.count_nonzero(terminated_nb != terminated_np)),
-        "max_abs_update_state_reward_diff": float(
-            np.max(np.abs(full_reward_nb - full_reward_np))
-        ),
+        "max_abs_update_state_reward_diff": float(np.max(np.abs(full_reward_nb - full_reward_np))),
         "update_state_termination_mismatch": float(
             np.count_nonzero(full_terminated_nb != full_terminated_np)
         ),
@@ -591,9 +585,7 @@ def bench_one(
         )
     set_num_threads(max_threads)
     numba_1t = next(
-        record
-        for record in records
-        if record.path == "numba_accelerator" and record.threads == 1
+        record for record in records if record.path == "numba_accelerator" and record.threads == 1
     )
     for record in records:
         if record.path != "numba_accelerator" or record.threads is None:
@@ -901,9 +893,7 @@ def _format_hot_summary_table(records: list[BenchCase]) -> str:
     best_by_case = _best_numba_by_case(records)
     rows = []
     for profile in sorted({record.profile for record in records}):
-        best_records = [
-            record for key, record in best_by_case.items() if key[0] == profile
-        ]
+        best_records = [record for key, record in best_by_case.items() if key[0] == profile]
         if not best_records:
             continue
         envs = sorted(record.num_envs for record in best_records)
@@ -913,7 +903,9 @@ def _format_hot_summary_table(records: list[BenchCase]) -> str:
             [
                 profile,
                 f"{envs[0]}-{envs[-1]}",
-                ",".join(str(thread) for thread in sorted({record.threads for record in best_records})),
+                ",".join(
+                    str(thread) for thread in sorted({record.threads for record in best_records})
+                ),
                 f"{min(speedups):.2f}x-{max(speedups):.2f}x",
                 f"{max(throughputs):.2f}",
             ]
@@ -1070,7 +1062,12 @@ def _format_e2e_reconciliation_table(
             num_envs=record.num_envs,
             threads=record.numba_threads,
         )
-        if baseline is None or baseline.update_state_ms is None or numpy_hot is None or numba_hot is None:
+        if (
+            baseline is None
+            or baseline.update_state_ms is None
+            or numpy_hot is None
+            or numba_hot is None
+        ):
             continue
         hot_saved_ms = numpy_hot.mean_ms - numba_hot.mean_ms
         update_saved_ms = baseline.update_state_ms - record.update_state_ms
@@ -1131,7 +1128,9 @@ def save_plots(
     best_by_case = _best_numba_by_case(records)
 
     fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(21, 6))
-    fig.suptitle(f"G1 motion tracking Numba reward+termination benchmark\n{device_info}", fontsize=13)
+    fig.suptitle(
+        f"G1 motion tracking Numba reward+termination benchmark\n{device_info}", fontsize=13
+    )
 
     ax1, ax2, ax3 = axes
     for profile in profiles:
@@ -1488,7 +1487,9 @@ def main() -> None:
     parity: dict[str, dict[str, float]] = {}
     max_threads = get_num_threads()
     args.numba_max_threads = max_threads
-    args.measured_threads = sorted({1, *(threads for threads in args.threads if threads <= max_threads)})
+    args.measured_threads = sorted(
+        {1, *(threads for threads in args.threads if threads <= max_threads)}
+    )
     args.skipped_threads = sorted({threads for threads in args.threads if threads > max_threads})
 
     print("=" * 80)

--- a/benchmark/benchmark_numba_random_noise.py
+++ b/benchmark/benchmark_numba_random_noise.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Benchmark Numba RNG against NumPy RNG for UniLab noise-buffer workloads.
+
+Issue #680 asks for an isolated measurement before changing env hot paths. This
+script uses owner-config shapes from G1 motion tracking and G1 walk/joystick
+training profiles, then compares:
+
+* ``numpy_random_uniform_alloc``: current-style ``np.random.uniform(...).astype``;
+* ``numpy_generator_random_out``: NumPy with preallocated output buffers;
+* ``numba_random_prange``: ``np.random.random`` inside an ``njit(parallel=True)``
+  kernel, also writing into preallocated buffers.
+
+Run:
+    uv run python -m benchmark.benchmark_numba_random_noise
+    uv run python benchmark/benchmark_numba_random_noise.py --quick
+    uv run python -m benchmark.benchmark_numba_random_noise --profiles sac_g1_motion_tracking_mujoco --threads 1 4 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, stdev
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import numpy as np
+
+try:  # pragma: no cover - exercised when numba is installed
+    from numba import get_num_threads, njit, prange, set_num_threads
+
+    NUMBA_AVAILABLE = True
+except Exception:  # pragma: no cover - benchmark still reports NumPy baselines
+    get_num_threads = njit = prange = set_num_threads = None  # type: ignore[assignment]
+    NUMBA_AVAILABLE = False
+
+from benchmark.core.device_info import get_device_info_dict, get_device_info_line
+
+DEFAULT_THREADS = [1, 2, 4, 8, 16, 32, 64]
+QUICK_THREADS = [1, 2]
+DEFAULT_NUM_ENVS = [1024, 2048, 4096, 8192, 16384, 32768]
+QUICK_NUM_ENVS = [1024, 2048]
+NUM_ACTION = 29
+
+
+@dataclass(frozen=True)
+class NoiseField:
+    name: str
+    width: int
+    scale: float
+
+
+@dataclass(frozen=True)
+class NoiseProfile:
+    name: str
+    owner_config: str
+    default_num_envs: int
+    fields: tuple[NoiseField, ...]
+    note: str
+
+    @property
+    def total_width(self) -> int:
+        return sum(field.width for field in self.fields)
+
+    @property
+    def values_per_step(self) -> int:
+        return self.default_num_envs * self.total_width
+
+
+@dataclass
+class BenchCase:
+    profile: str
+    owner_config: str
+    num_envs: int
+    dtype: str
+    path: str
+    threads: int | None
+    values: int
+    mean_ms: float
+    min_ms: float
+    std_ms: float
+    values_per_s: float
+    speedup_vs_numpy_alloc: float
+    compile_ms: float | None = None
+    deterministic_same_seed: bool | None = None
+    distribution_mean: float | None = None
+    distribution_std: float | None = None
+    distribution_min: float | None = None
+    distribution_max: float | None = None
+
+
+def make_profiles() -> dict[str, NoiseProfile]:
+    """Profiles mirror current env noise calls and owner-config scales.
+
+    G1Walk/G1Joystick still calls ``_obs_noise`` for gyro and gravity even when a
+    scale is zero, so those zero-scale fields are intentionally kept to measure
+    the current hot-path RNG cost.
+    """
+
+    return {
+        "ppo_g1_motion_tracking_motrix": NoiseProfile(
+            name="ppo_g1_motion_tracking_motrix",
+            owner_config="conf/ppo/task/g1_motion_tracking/motrix.yaml",
+            default_num_envs=1024,
+            fields=(
+                NoiseField("linvel", 3, 0.1),
+                NoiseField("gyro", 3, 0.2),
+                NoiseField("joint_pos", NUM_ACTION, 0.01),
+                NoiseField("dof_vel", NUM_ACTION, 1.5),
+            ),
+            note="G1MotionTracking actor observation noise.",
+        ),
+        "sac_g1_motion_tracking_mujoco": NoiseProfile(
+            name="sac_g1_motion_tracking_mujoco",
+            owner_config="conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml",
+            default_num_envs=2048,
+            fields=(
+                NoiseField("linvel", 3, 0.1),
+                NoiseField("gyro", 3, 0.2),
+                NoiseField("joint_pos", NUM_ACTION, 0.01),
+                NoiseField("dof_vel", NUM_ACTION, 1.5),
+            ),
+            note="G1MotionTrackingSAC actor observation noise.",
+        ),
+        "ppo_g1_walk_flat_motrix": NoiseProfile(
+            name="ppo_g1_walk_flat_motrix",
+            owner_config="conf/ppo/task/g1_walk_flat/motrix.yaml",
+            default_num_envs=2048,
+            fields=(
+                NoiseField("gyro", 3, 0.2),
+                NoiseField("gravity", 3, 0.0),
+                NoiseField("joint_pos", NUM_ACTION, 0.01),
+                NoiseField("dof_vel", NUM_ACTION, 1.5),
+            ),
+            note="G1WalkFlat joystick actor observation noise.",
+        ),
+        "sac_g1_walk_flat_mujoco": NoiseProfile(
+            name="sac_g1_walk_flat_mujoco",
+            owner_config="conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml",
+            default_num_envs=2048,
+            fields=(
+                NoiseField("gyro", 3, 0.0),
+                NoiseField("gravity", 3, 0.0),
+                NoiseField("joint_pos", NUM_ACTION, 0.01),
+                NoiseField("dof_vel", NUM_ACTION, 0.1),
+            ),
+            note="G1WalkFlat SAC actor observation noise.",
+        ),
+    }
+
+
+def _dtype(name: str) -> np.dtype:
+    if name == "float32":
+        return np.dtype(np.float32)
+    if name == "float64":
+        return np.dtype(np.float64)
+    raise ValueError(f"unsupported dtype: {name}")
+
+
+def _allocate_buffers(profile: NoiseProfile, num_envs: int, dtype: np.dtype) -> list[np.ndarray]:
+    return [np.empty((num_envs, field.width), dtype=dtype) for field in profile.fields]
+
+
+def _scale_array(profile: NoiseProfile, noise_level: float) -> np.ndarray:
+    return np.asarray([noise_level * field.scale for field in profile.fields], dtype=np.float64)
+
+
+def _numpy_random_uniform_alloc(
+    profile: NoiseProfile,
+    num_envs: int,
+    dtype: np.dtype,
+    noise_level: float,
+) -> list[np.ndarray]:
+    out = []
+    for field in profile.fields:
+        noise = np.random.uniform(-1.0, 1.0, size=(num_envs, field.width)).astype(dtype)
+        noise *= noise_level * field.scale
+        out.append(noise)
+    return out
+
+
+def _numpy_generator_random_out(
+    rng: np.random.Generator,
+    buffers: list[np.ndarray],
+    profile: NoiseProfile,
+    noise_level: float,
+) -> None:
+    for buffer, field in zip(buffers, profile.fields):
+        rng.random(out=buffer, dtype=buffer.dtype)
+        buffer *= 2.0
+        buffer -= 1.0
+        buffer *= noise_level * field.scale
+
+
+if NUMBA_AVAILABLE:
+
+    @njit(cache=True)  # type: ignore[misc]
+    def _numba_seed(seed: int) -> None:
+        np.random.seed(seed)
+
+    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
+    def _numba_fill_four(
+        buffer0: np.ndarray,
+        buffer1: np.ndarray,
+        buffer2: np.ndarray,
+        buffer3: np.ndarray,
+        scales: np.ndarray,
+    ) -> None:
+        n = buffer0.shape[0]
+        for i in prange(n):
+            for j in range(buffer0.shape[1]):
+                buffer0[i, j] = (np.random.random() * 2.0 - 1.0) * scales[0]
+            for j in range(buffer1.shape[1]):
+                buffer1[i, j] = (np.random.random() * 2.0 - 1.0) * scales[1]
+            for j in range(buffer2.shape[1]):
+                buffer2[i, j] = (np.random.random() * 2.0 - 1.0) * scales[2]
+            for j in range(buffer3.shape[1]):
+                buffer3[i, j] = (np.random.random() * 2.0 - 1.0) * scales[3]
+
+
+def _numba_random_prange(buffers: list[np.ndarray], scales: np.ndarray) -> None:
+    if not NUMBA_AVAILABLE:
+        raise RuntimeError("numba is not available")
+    if len(buffers) != 4:
+        raise ValueError("numba benchmark expects exactly four noise fields")
+    _numba_fill_four(buffers[0], buffers[1], buffers[2], buffers[3], scales)
+
+
+def _time_ms(fn: Any, *, iters: int, warmup: int) -> tuple[float, float, float]:
+    for _ in range(warmup):
+        fn()
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - t0) * 1000.0)
+    return mean(samples), min(samples), stdev(samples) if len(samples) > 1 else 0.0
+
+
+def _flatten(buffers: list[np.ndarray]) -> np.ndarray:
+    return np.concatenate([buffer.ravel() for buffer in buffers])
+
+
+def _distribution(buffers: list[np.ndarray]) -> dict[str, float]:
+    flat = _flatten(buffers)
+    if flat.size == 0:
+        return {"mean": 0.0, "std": 0.0, "min": 0.0, "max": 0.0}
+    return {
+        "mean": float(np.mean(flat)),
+        "std": float(np.std(flat)),
+        "min": float(np.min(flat)),
+        "max": float(np.max(flat)),
+    }
+
+
+def _numba_same_seed_is_deterministic(
+    profile: NoiseProfile,
+    num_envs: int,
+    dtype: np.dtype,
+    scales: np.ndarray,
+    threads: int,
+    seed: int,
+) -> bool:
+    if not NUMBA_AVAILABLE:
+        return False
+    previous_threads = get_num_threads()
+    set_num_threads(threads)
+    first = _allocate_buffers(profile, num_envs, dtype)
+    second = _allocate_buffers(profile, num_envs, dtype)
+    _numba_seed(seed)
+    _numba_random_prange(first, scales)
+    _numba_seed(seed)
+    _numba_random_prange(second, scales)
+    set_num_threads(previous_threads)
+    return all(np.array_equal(a, b) for a, b in zip(first, second))
+
+
+def bench_one(
+    *,
+    profile: NoiseProfile,
+    num_envs: int,
+    dtype_name: str = "float32",
+    thread_counts: list[int] | None = None,
+    iters: int = 20,
+    warmup: int = 5,
+    seed: int = 0,
+    noise_level: float = 1.0,
+) -> list[BenchCase]:
+    dtype = _dtype(dtype_name)
+    values = num_envs * profile.total_width
+    records: list[BenchCase] = []
+
+    np.random.seed(seed)
+    numpy_buffers = _numpy_random_uniform_alloc(profile, num_envs, dtype, noise_level)
+    numpy_dist = _distribution(numpy_buffers)
+
+    def numpy_alloc_call() -> None:
+        _numpy_random_uniform_alloc(profile, num_envs, dtype, noise_level)
+
+    numpy_ms, numpy_min, numpy_std = _time_ms(
+        numpy_alloc_call,
+        iters=iters,
+        warmup=warmup,
+    )
+    records.append(
+        BenchCase(
+            profile=profile.name,
+            owner_config=profile.owner_config,
+            num_envs=num_envs,
+            dtype=dtype_name,
+            path="numpy_random_uniform_alloc",
+            threads=None,
+            values=values,
+            mean_ms=numpy_ms,
+            min_ms=numpy_min,
+            std_ms=numpy_std,
+            values_per_s=values / (numpy_ms * 1.0e-3),
+            speedup_vs_numpy_alloc=1.0,
+            distribution_mean=numpy_dist["mean"],
+            distribution_std=numpy_dist["std"],
+            distribution_min=numpy_dist["min"],
+            distribution_max=numpy_dist["max"],
+        )
+    )
+
+    generator_buffers = _allocate_buffers(profile, num_envs, dtype)
+    generator = np.random.default_rng(seed)
+    _numpy_generator_random_out(generator, generator_buffers, profile, noise_level)
+    generator_dist = _distribution(generator_buffers)
+
+    def numpy_out_call() -> None:
+        _numpy_generator_random_out(generator, generator_buffers, profile, noise_level)
+
+    numpy_out_ms, numpy_out_min, numpy_out_std = _time_ms(
+        numpy_out_call,
+        iters=iters,
+        warmup=warmup,
+    )
+    records.append(
+        BenchCase(
+            profile=profile.name,
+            owner_config=profile.owner_config,
+            num_envs=num_envs,
+            dtype=dtype_name,
+            path="numpy_generator_random_out",
+            threads=None,
+            values=values,
+            mean_ms=numpy_out_ms,
+            min_ms=numpy_out_min,
+            std_ms=numpy_out_std,
+            values_per_s=values / (numpy_out_ms * 1.0e-3),
+            speedup_vs_numpy_alloc=numpy_ms / numpy_out_ms,
+            distribution_mean=generator_dist["mean"],
+            distribution_std=generator_dist["std"],
+            distribution_min=generator_dist["min"],
+            distribution_max=generator_dist["max"],
+        )
+    )
+
+    if not NUMBA_AVAILABLE:
+        return records
+
+    assert thread_counts is not None
+    max_threads = get_num_threads()
+    scales = _scale_array(profile, noise_level)
+    previous_threads = max_threads
+    try:
+        for threads in thread_counts:
+            if threads > max_threads:
+                continue
+            set_num_threads(threads)
+            numba_buffers = _allocate_buffers(profile, num_envs, dtype)
+            _numba_seed(seed)
+            t0 = time.perf_counter()
+            _numba_random_prange(numba_buffers, scales)
+            compile_ms = (time.perf_counter() - t0) * 1000.0
+            numba_dist = _distribution(numba_buffers)
+
+            def numba_call() -> None:
+                _numba_random_prange(numba_buffers, scales)
+
+            numba_ms, numba_min, numba_std = _time_ms(
+                numba_call,
+                iters=iters,
+                warmup=warmup,
+            )
+            same_seed = _numba_same_seed_is_deterministic(
+                profile=profile,
+                num_envs=min(num_envs, 256),
+                dtype=dtype,
+                scales=scales,
+                threads=threads,
+                seed=seed,
+            )
+            records.append(
+                BenchCase(
+                    profile=profile.name,
+                    owner_config=profile.owner_config,
+                    num_envs=num_envs,
+                    dtype=dtype_name,
+                    path="numba_random_prange",
+                    threads=threads,
+                    values=values,
+                    mean_ms=numba_ms,
+                    min_ms=numba_min,
+                    std_ms=numba_std,
+                    values_per_s=values / (numba_ms * 1.0e-3),
+                    speedup_vs_numpy_alloc=numpy_ms / numba_ms,
+                    compile_ms=compile_ms,
+                    deterministic_same_seed=same_seed,
+                    distribution_mean=numba_dist["mean"],
+                    distribution_std=numba_dist["std"],
+                    distribution_min=numba_dist["min"],
+                    distribution_max=numba_dist["max"],
+                )
+            )
+    finally:
+        set_num_threads(previous_threads)
+
+    return records
+
+
+def _case_to_dict(case: BenchCase) -> dict[str, Any]:
+    return {
+        "profile": case.profile,
+        "owner_config": case.owner_config,
+        "num_envs": case.num_envs,
+        "dtype": case.dtype,
+        "path": case.path,
+        "threads": case.threads,
+        "values": case.values,
+        "mean_ms": case.mean_ms,
+        "min_ms": case.min_ms,
+        "std_ms": case.std_ms,
+        "values_per_s": case.values_per_s,
+        "mvalues_per_s": case.values_per_s / 1.0e6,
+        "speedup_vs_numpy_alloc": case.speedup_vs_numpy_alloc,
+        "compile_ms": case.compile_ms,
+        "deterministic_same_seed": case.deterministic_same_seed,
+        "distribution_mean": case.distribution_mean,
+        "distribution_std": case.distribution_std,
+        "distribution_min": case.distribution_min,
+        "distribution_max": case.distribution_max,
+    }
+
+
+def _format_table(records: list[BenchCase]) -> str:
+    headers = [
+        "profile",
+        "envs",
+        "path",
+        "thr",
+        "mean ms",
+        "min ms",
+        "M vals/s",
+        "speedup",
+        "seed",
+    ]
+    rows = []
+    for record in records:
+        rows.append(
+            [
+                record.profile,
+                str(record.num_envs),
+                record.path,
+                "-" if record.threads is None else str(record.threads),
+                f"{record.mean_ms:.3f}",
+                f"{record.min_ms:.3f}",
+                f"{record.values_per_s / 1.0e6:.1f}",
+                f"{record.speedup_vs_numpy_alloc:.2f}x",
+                "-" if record.deterministic_same_seed is None else str(record.deterministic_same_seed),
+            ]
+        )
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], len(value))
+
+    def fmt(values: list[str]) -> str:
+        return " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(values))
+
+    out = [fmt(headers), "-+-".join("-" * width for width in widths)]
+    out.extend(fmt(row) for row in rows)
+    return "\n".join(out)
+
+
+def _format_profile_notes(profiles: list[NoiseProfile]) -> str:
+    lines = ["Profiles:"]
+    for profile in profiles:
+        fields = ", ".join(f"{field.name}[{field.width}]x{field.scale:g}" for field in profile.fields)
+        lines.append(f"- {profile.name}: {profile.owner_config}; {fields}")
+    return "\n".join(lines)
+
+
+def _select_profiles(names: list[str]) -> list[NoiseProfile]:
+    profiles = make_profiles()
+    if names == ["all"]:
+        return list(profiles.values())
+    missing = [name for name in names if name not in profiles]
+    if missing:
+        raise ValueError(f"unknown profiles: {missing}; available: {sorted(profiles)}")
+    return [profiles[name] for name in names]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profiles",
+        nargs="+",
+        default=["all"],
+        help="Profile names to run, or 'all'.",
+    )
+    parser.add_argument(
+        "--num-envs",
+        nargs="+",
+        type=int,
+        default=None,
+        help="Override env counts. Defaults to each profile's owner-config count plus benchmark sizes.",
+    )
+    parser.add_argument("--threads", nargs="+", type=int, default=None)
+    parser.add_argument("--dtype", choices=["float32", "float64"], default="float32")
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--noise-level", type=float, default=1.0)
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--output", type=Path, default=None, help="Optional JSON output path.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    selected_profiles = _select_profiles(args.profiles)
+    if args.quick:
+        selected_profiles = selected_profiles[:2]
+        args.iters = min(args.iters, 3)
+        args.warmup = min(args.warmup, 1)
+
+    thread_counts = args.threads or (QUICK_THREADS if args.quick else DEFAULT_THREADS)
+    num_envs_default = QUICK_NUM_ENVS if args.quick else DEFAULT_NUM_ENVS
+
+    if NUMBA_AVAILABLE:
+        max_threads = get_num_threads()
+        skipped_threads = [thread for thread in thread_counts if thread > max_threads]
+        thread_counts = [thread for thread in thread_counts if thread <= max_threads]
+    else:
+        max_threads = 0
+        skipped_threads = thread_counts
+        thread_counts = []
+
+    print("=" * 88)
+    print("Numba RNG vs NumPy RNG: UniLab observation-noise buffer benchmark")
+    print("=" * 88)
+    print(get_device_info_line())
+    print(f"python={platform.python_version()} numpy={np.__version__} numba_available={NUMBA_AVAILABLE}")
+    print(f"host numba threads={max_threads}")
+    if skipped_threads:
+        print(f"skipped numba threads: {skipped_threads}")
+    print(_format_profile_notes(selected_profiles))
+    print(
+        "Seed note: NumPy and Numba RNG streams are not expected to be bit-identical; "
+        "the benchmark only checks same-seed repeatability within each numba thread count."
+    )
+
+    all_records: list[BenchCase] = []
+    for profile in selected_profiles:
+        sizes = args.num_envs or sorted({profile.default_num_envs, *num_envs_default})
+        for num_envs in sizes:
+            print()
+            print(f"profile={profile.name} num_envs={num_envs} values={num_envs * profile.total_width}")
+            records = bench_one(
+                profile=profile,
+                num_envs=num_envs,
+                dtype_name=args.dtype,
+                thread_counts=thread_counts,
+                iters=args.iters,
+                warmup=args.warmup,
+                seed=args.seed,
+                noise_level=args.noise_level,
+            )
+            all_records.extend(records)
+            print(_format_table(records))
+
+    if args.output is not None:
+        payload = {
+            "meta": {
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+                "device": get_device_info_dict(),
+                "numpy_version": np.__version__,
+                "numba_available": NUMBA_AVAILABLE,
+                "dtype": args.dtype,
+                "iters": args.iters,
+                "warmup": args.warmup,
+                "seed": args.seed,
+                "noise_level": args.noise_level,
+            },
+            "results": [_case_to_dict(record) for record in all_records],
+        }
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nSaved JSON: {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_numba_random_noise.py
+++ b/benchmark/benchmark_numba_random_noise.py
@@ -477,7 +477,9 @@ def _format_table(records: list[BenchCase]) -> str:
                 f"{record.min_ms:.3f}",
                 f"{record.values_per_s / 1.0e6:.1f}",
                 f"{record.speedup_vs_numpy_alloc:.2f}x",
-                "-" if record.deterministic_same_seed is None else str(record.deterministic_same_seed),
+                "-"
+                if record.deterministic_same_seed is None
+                else str(record.deterministic_same_seed),
             ]
         )
     widths = [len(header) for header in headers]
@@ -496,7 +498,9 @@ def _format_table(records: list[BenchCase]) -> str:
 def _format_profile_notes(profiles: list[NoiseProfile]) -> str:
     lines = ["Profiles:"]
     for profile in profiles:
-        fields = ", ".join(f"{field.name}[{field.width}]x{field.scale:g}" for field in profile.fields)
+        fields = ", ".join(
+            f"{field.name}[{field.width}]x{field.scale:g}" for field in profile.fields
+        )
         lines.append(f"- {profile.name}: {profile.owner_config}; {fields}")
     return "\n".join(lines)
 
@@ -561,7 +565,9 @@ def main() -> None:
     print("Numba RNG vs NumPy RNG: UniLab observation-noise buffer benchmark")
     print("=" * 88)
     print(get_device_info_line())
-    print(f"python={platform.python_version()} numpy={np.__version__} numba_available={NUMBA_AVAILABLE}")
+    print(
+        f"python={platform.python_version()} numpy={np.__version__} numba_available={NUMBA_AVAILABLE}"
+    )
     print(f"host numba threads={max_threads}")
     if skipped_threads:
         print(f"skipped numba threads: {skipped_threads}")
@@ -576,7 +582,9 @@ def main() -> None:
         sizes = args.num_envs or sorted({profile.default_num_envs, *num_envs_default})
         for num_envs in sizes:
             print()
-            print(f"profile={profile.name} num_envs={num_envs} values={num_envs * profile.total_width}")
+            print(
+                f"profile={profile.name} num_envs={num_envs} values={num_envs * profile.total_width}"
+            )
             records = bench_one(
                 profile=profile,
                 num_envs=num_envs,

--- a/benchmark/benchmark_offpolicy_collector_active.py
+++ b/benchmark/benchmark_offpolicy_collector_active.py
@@ -743,9 +743,9 @@ def _run_active_window_case(
             next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
             rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
             truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
-            combined_dones = (state.terminated | state.truncated).astype(
-                np.float32, copy=False
-            ).ravel()
+            combined_dones = (
+                (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
+            )
             terminal_contract = resolve_terminal_observation_contract(
                 next_obs_batch_size=next_obs_np.shape[0],
                 final_observation=state.final_observation,

--- a/benchmark/benchmark_offpolicy_collector_active.py
+++ b/benchmark/benchmark_offpolicy_collector_active.py
@@ -126,6 +126,15 @@ NP_ENV_STEP_TIMING_KEYS = (
 )
 NP_ENV_STEP_COUNT_KEYS = ("reset_done_count",)
 NP_ENV_STEP_SAMPLE_KEYS = (*NP_ENV_STEP_TIMING_KEYS, *NP_ENV_STEP_COUNT_KEYS)
+NP_RANDOM_PROFILE_FUNCTIONS = (
+    "uniform",
+    "randint",
+    "random",
+    "rand",
+    "randn",
+    "normal",
+    "choice",
+)
 NP_ENV_STEP_TIMING_CSV_FIELDS = (
     ("env_step_total_ms", "np_env_step_total_ms"),
     ("apply_action_ms", "np_env_apply_action_ms"),
@@ -226,6 +235,10 @@ class CollectorResult:
     env_step_overhead_ms_per_vector_step: TimingStats | None = None
     # System-wide CPU utilization (%) over the measured window. NaN if unknown.
     cpu_util_pct: float = float("nan")
+    # NumPy random time measured inside collector env.step() only. This is an
+    # optional benchmark-side monkeypatch used for RNG/noise-buffer profiling.
+    numpy_random_ms_per_vector_step: TimingStats | None = None
+    numpy_random_calls_per_vector_step: TimingStats | None = None
 
 
 def _stats(samples_ms: list[float]) -> TimingStats:
@@ -300,6 +313,54 @@ def _cleanup() -> None:
         torch.cuda.empty_cache()
     if hasattr(torch, "mps") and torch.backends.mps.is_available():
         torch.mps.empty_cache()
+
+
+class _NumpyRandomProfiler:
+    """Measure selected ``np.random`` module calls inside a benchmark window."""
+
+    def __init__(self) -> None:
+        self.enabled = False
+        self.step_ms = 0.0
+        self.step_calls = 0
+        self._originals: dict[str, Any] = {}
+
+    def install(self) -> None:
+        if self._originals:
+            return
+        for name in NP_RANDOM_PROFILE_FUNCTIONS:
+            original = getattr(np.random, name, None)
+            if original is None:
+                continue
+            self._originals[name] = original
+            setattr(np.random, name, self._wrap(original))
+
+    def uninstall(self) -> None:
+        for name, original in self._originals.items():
+            setattr(np.random, name, original)
+        self._originals.clear()
+        self.enabled = False
+
+    def begin_step(self) -> None:
+        self.step_ms = 0.0
+        self.step_calls = 0
+        self.enabled = True
+
+    def end_step(self) -> tuple[float, int]:
+        self.enabled = False
+        return self.step_ms, self.step_calls
+
+    def _wrap(self, fn: Any) -> Any:
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            if not self.enabled:
+                return fn(*args, **kwargs)
+            t0 = time.perf_counter_ns()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                self.step_ms += (time.perf_counter_ns() - t0) / 1e6
+                self.step_calls += 1
+
+        return wrapped
 
 
 def _configure_collector_cpu_threads(cap: int | None = None) -> int:
@@ -552,6 +613,7 @@ def _run_active_window_case(
     actor,
     warmup_steps: int,
     measure_steps: int,
+    profile_numpy_random: bool = False,
 ) -> CollectorResult:
     from unilab.algos.torch.offpolicy.worker import (
         resolve_offpolicy_actor_priv_info,
@@ -590,6 +652,9 @@ def _run_active_window_case(
         "env_step_overhead_ms": [],
     }
     env_step_timing_samples: dict[str, list[float]] = {key: [] for key in NP_ENV_STEP_SAMPLE_KEYS}
+    numpy_random_ms_samples: list[float] = []
+    numpy_random_call_samples: list[float] = []
+    random_profiler = _NumpyRandomProfiler() if profile_numpy_random else None
     total_active_ns = 0
     total_steps = int(warmup_steps) + int(measure_steps)
     if total_steps <= 0 or measure_steps <= 0:
@@ -601,142 +666,160 @@ def _run_active_window_case(
     # "160 cores but only 25% utilized" scaling problem.
     cpu_probe_start: tuple[float, float] | None = None
 
-    for step_idx in range(total_steps):
-        record = step_idx >= warmup_steps
-        if record and cpu_probe_start is None:
-            cpu_probe_start = _read_cpu_times()  # begin measured-window CPU sampling
+    if random_profiler is not None:
+        random_profiler.install()
+    try:
+        for step_idx in range(total_steps):
+            record = step_idx >= warmup_steps
+            if record and cpu_probe_start is None:
+                cpu_probe_start = _read_cpu_times()  # begin measured-window CPU sampling
 
-        phase_start_ns = time.perf_counter_ns()
-        # No learner exists in this benchmark, so weight sync is intentionally a
-        # zero-work phase. Keeping it explicit preserves the training collector's
-        # phase schema.
-        weight_sync_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
+            phase_start_ns = time.perf_counter_ns()
+            # No learner exists in this benchmark, so weight sync is intentionally a
+            # zero-work phase. Keeping it explicit preserves the training collector's
+            # phase schema.
+            weight_sync_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
 
-        phase_start_ns = time.perf_counter_ns()
-        with torch.no_grad():
-            obs_torch = torch.from_numpy(obs_np)
-            dones_torch = torch.from_numpy(prev_dones_np)
-            priv_info_np = resolve_offpolicy_actor_priv_info(
-                algo_type=case.collector_algo_type,
-                obs_np=obs_np,
-                critic_np=critic_np,
-                info=info_dict,
-            )
-            priv_info_torch = torch.from_numpy(priv_info_np) if priv_info_np is not None else None
-            actions_torch = sample_offpolicy_actions(
-                actor=actor,
-                algo_type=case.collector_algo_type,
-                obs_torch=obs_torch,
-                prev_dones_torch=dones_torch,
-                priv_info_torch=priv_info_torch,
-            )
-            actions_np = actions_torch.numpy()
-        action_select_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
+            phase_start_ns = time.perf_counter_ns()
+            with torch.no_grad():
+                obs_torch = torch.from_numpy(obs_np)
+                dones_torch = torch.from_numpy(prev_dones_np)
+                priv_info_np = resolve_offpolicy_actor_priv_info(
+                    algo_type=case.collector_algo_type,
+                    obs_np=obs_np,
+                    critic_np=critic_np,
+                    info=info_dict,
+                )
+                priv_info_torch = (
+                    torch.from_numpy(priv_info_np) if priv_info_np is not None else None
+                )
+                actions_torch = sample_offpolicy_actions(
+                    actor=actor,
+                    algo_type=case.collector_algo_type,
+                    obs_torch=obs_torch,
+                    prev_dones_torch=dones_torch,
+                    priv_info_torch=priv_info_torch,
+                )
+                actions_np = actions_torch.numpy()
+            action_select_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
 
-        phase_start_ns = time.perf_counter_ns()
-        state = env.step(actions_np)
-        env_step_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
-        # Backend-internal physics time (sub-part of env_step_ms). Present for
-        # MuJoCo (via backend.step timing); absent for backends that don't
-        # report it -> NaN, rendered as "n/a".
-        _timing = state.info.get("timing", {}) if isinstance(state.info, dict) else {}
-        physics_ms = _optional_timing_ms(_timing, "backend_physics_ms")
-        env_step_timing_values = {
-            key: _optional_timing_ms(_timing, key)
-            for key in NP_ENV_STEP_SAMPLE_KEYS
-            if key != "env_step_internal_gap_ms"
-        }
-        internal_children = (
-            env_step_timing_values["apply_action_ms"],
-            env_step_timing_values["step_core_ms"],
-            env_step_timing_values["update_state_ms"],
-            env_step_timing_values["reset_done_ms"],
-        )
-        if all(value is not None for value in internal_children):
-            env_step_timing_values["env_step_internal_gap_ms"] = env_step_ms - sum(
-                cast(float, value) for value in internal_children
-            )
-        else:
-            env_step_timing_values["env_step_internal_gap_ms"] = None
-
-        phase_start_ns = time.perf_counter_ns()
-        next_obs_np, next_critic_np = split_obs_dict(state.obs)
-        next_obs_np = np.asarray(next_obs_np, dtype=np.float32)
-        next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
-        rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
-        truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
-        combined_dones = (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
-        terminal_contract = resolve_terminal_observation_contract(
-            next_obs_batch_size=next_obs_np.shape[0],
-            final_observation=state.final_observation,
-            done=combined_dones > 0.5,
-            info=state.info,
-            truncated=truncated_np,
-        )
-        replay_buffer.add(
-            torch.from_numpy(obs_np),
-            torch.from_numpy(actions_np),
-            torch.from_numpy(rewards_np),
-            torch.from_numpy(next_obs_np),
-            torch.from_numpy(combined_dones),
-            torch.from_numpy(truncated_np),
-            terminal_mask=torch.from_numpy(terminal_contract.terminal_mask),
-            terminal_next_obs=(
-                torch.from_numpy(terminal_contract.terminal_obs)
-                if terminal_contract.terminal_obs is not None
-                else None
-            ),
-            critic=torch.from_numpy(critic_np),
-            next_critic=torch.from_numpy(next_critic_np),
-            terminal_next_critic=(
-                torch.from_numpy(terminal_contract.terminal_critic)
-                if terminal_contract.terminal_critic is not None
-                else None
-            ),
-        )
-        replay_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
-
-        phase_start_ns = time.perf_counter_ns()
-        current_ep_rewards += rewards_np
-        current_ep_lengths += 1
-        reset_indices = np.where(combined_dones > 0.5)[0]
-        if len(reset_indices) > 0:
-            ep_rewards.extend(current_ep_rewards[reset_indices].tolist())
-            ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
-            current_ep_rewards[reset_indices] = 0.0
-            current_ep_lengths[reset_indices] = 0
-
-        log_info = state.info.get("log", {})
-        if log_info:
-            for key, value in log_info.items():
-                if key.startswith("reward/"):
-                    ep_reward_components[key].append(value)
-        bookkeeping_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
-
-        obs_np = next_obs_np
-        critic_np = next_critic_np
-        info_dict = state.info
-        prev_dones_np = combined_dones
-
-        if record:
-            phase_values = {
-                "weight_sync_ms": weight_sync_ms,
-                "action_select_ms": action_select_ms,
-                "env_step_ms": env_step_ms,
-                "replay_ms": replay_ms,
-                "bookkeeping_ms": bookkeeping_ms,
+            phase_start_ns = time.perf_counter_ns()
+            if random_profiler is not None and record:
+                random_profiler.begin_step()
+            try:
+                state = env.step(actions_np)
+            finally:
+                if random_profiler is not None and record:
+                    random_ms, random_calls = random_profiler.end_step()
+                    numpy_random_ms_samples.append(random_ms)
+                    numpy_random_call_samples.append(float(random_calls))
+            env_step_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
+            # Backend-internal physics time (sub-part of env_step_ms). Present for
+            # MuJoCo (via backend.step timing); absent for backends that don't
+            # report it -> NaN, rendered as "n/a".
+            _timing = state.info.get("timing", {}) if isinstance(state.info, dict) else {}
+            physics_ms = _optional_timing_ms(_timing, "backend_physics_ms")
+            env_step_timing_values = {
+                key: _optional_timing_ms(_timing, key)
+                for key in NP_ENV_STEP_SAMPLE_KEYS
+                if key != "env_step_internal_gap_ms"
             }
-            step_active_ns = int(sum(phase_values.values()) * 1e6)
-            total_active_ns += step_active_ns
-            for key, value in phase_values.items():
-                samples[key].append(value)
-            # Env-step breakdown is aux only; env_step_ms is the additive phase.
-            if physics_ms is not None:
-                aux_samples["physics_ms"].append(physics_ms)
-                aux_samples["env_step_overhead_ms"].append(env_step_ms - physics_ms)
-            for key, value in env_step_timing_values.items():
-                if value is not None:
-                    env_step_timing_samples[key].append(value)
+            internal_children = (
+                env_step_timing_values["apply_action_ms"],
+                env_step_timing_values["step_core_ms"],
+                env_step_timing_values["update_state_ms"],
+                env_step_timing_values["reset_done_ms"],
+            )
+            if all(value is not None for value in internal_children):
+                env_step_timing_values["env_step_internal_gap_ms"] = env_step_ms - sum(
+                    cast(float, value) for value in internal_children
+                )
+            else:
+                env_step_timing_values["env_step_internal_gap_ms"] = None
+
+            phase_start_ns = time.perf_counter_ns()
+            next_obs_np, next_critic_np = split_obs_dict(state.obs)
+            next_obs_np = np.asarray(next_obs_np, dtype=np.float32)
+            next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
+            rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
+            truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
+            combined_dones = (state.terminated | state.truncated).astype(
+                np.float32, copy=False
+            ).ravel()
+            terminal_contract = resolve_terminal_observation_contract(
+                next_obs_batch_size=next_obs_np.shape[0],
+                final_observation=state.final_observation,
+                done=combined_dones > 0.5,
+                info=state.info,
+                truncated=truncated_np,
+            )
+            replay_buffer.add(
+                torch.from_numpy(obs_np),
+                torch.from_numpy(actions_np),
+                torch.from_numpy(rewards_np),
+                torch.from_numpy(next_obs_np),
+                torch.from_numpy(combined_dones),
+                torch.from_numpy(truncated_np),
+                terminal_mask=torch.from_numpy(terminal_contract.terminal_mask),
+                terminal_next_obs=(
+                    torch.from_numpy(terminal_contract.terminal_obs)
+                    if terminal_contract.terminal_obs is not None
+                    else None
+                ),
+                critic=torch.from_numpy(critic_np),
+                next_critic=torch.from_numpy(next_critic_np),
+                terminal_next_critic=(
+                    torch.from_numpy(terminal_contract.terminal_critic)
+                    if terminal_contract.terminal_critic is not None
+                    else None
+                ),
+            )
+            replay_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
+
+            phase_start_ns = time.perf_counter_ns()
+            current_ep_rewards += rewards_np
+            current_ep_lengths += 1
+            reset_indices = np.where(combined_dones > 0.5)[0]
+            if len(reset_indices) > 0:
+                ep_rewards.extend(current_ep_rewards[reset_indices].tolist())
+                ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
+                current_ep_rewards[reset_indices] = 0.0
+                current_ep_lengths[reset_indices] = 0
+
+            log_info = state.info.get("log", {})
+            if log_info:
+                for key, value in log_info.items():
+                    if key.startswith("reward/"):
+                        ep_reward_components[key].append(value)
+            bookkeeping_ms = (time.perf_counter_ns() - phase_start_ns) / 1e6
+
+            obs_np = next_obs_np
+            critic_np = next_critic_np
+            info_dict = state.info
+            prev_dones_np = combined_dones
+
+            if record:
+                phase_values = {
+                    "weight_sync_ms": weight_sync_ms,
+                    "action_select_ms": action_select_ms,
+                    "env_step_ms": env_step_ms,
+                    "replay_ms": replay_ms,
+                    "bookkeeping_ms": bookkeeping_ms,
+                }
+                step_active_ns = int(sum(phase_values.values()) * 1e6)
+                total_active_ns += step_active_ns
+                for key, value in phase_values.items():
+                    samples[key].append(value)
+                # Env-step breakdown is aux only; env_step_ms is the additive phase.
+                if physics_ms is not None:
+                    aux_samples["physics_ms"].append(physics_ms)
+                    aux_samples["env_step_overhead_ms"].append(env_step_ms - physics_ms)
+                for key, value in env_step_timing_values.items():
+                    if value is not None:
+                        env_step_timing_samples[key].append(value)
+    finally:
+        if random_profiler is not None:
+            random_profiler.uninstall()
 
     # Measured-window system CPU utilization (see cpu_probe_start comment).
     cpu_util_pct = _cpu_util_pct(cpu_probe_start, _read_cpu_times())
@@ -772,6 +855,12 @@ def _run_active_window_case(
         physics_ms_per_vector_step=physics_stats,
         env_step_overhead_ms_per_vector_step=env_step_overhead_stats,
         cpu_util_pct=cpu_util_pct,
+        numpy_random_ms_per_vector_step=(
+            _stats(numpy_random_ms_samples) if numpy_random_ms_samples else None
+        ),
+        numpy_random_calls_per_vector_step=(
+            _stats(numpy_random_call_samples) if numpy_random_call_samples else None
+        ),
     )
 
 
@@ -784,6 +873,7 @@ def _build_and_run_case(
     num_envs: int | None,
     extra_overrides: list[str],
     variant: str = "default",
+    profile_numpy_random: bool = False,
 ) -> CollectorResult:
     from unilab.training import BackendAdapter, ensure_registries
     from unilab.training.seed import apply_training_seed
@@ -844,6 +934,7 @@ def _build_and_run_case(
             actor=actor,
             warmup_steps=warmup_steps,
             measure_steps=measure_steps,
+            profile_numpy_random=profile_numpy_random,
         )
     finally:
         if env is not None:
@@ -867,6 +958,7 @@ def _build_and_run_numba_ab_case(
     num_envs: int | None,
     extra_overrides: list[str],
     numba_threads: int | None,
+    profile_numpy_random: bool = False,
 ) -> list[CollectorResult]:
     _algo, task, _sim = _parse_case(spec)
     if task not in NUMBA_ACCELERATED_TASKS:
@@ -890,6 +982,7 @@ def _build_and_run_numba_ab_case(
                     *_numba_ab_overrides(enabled=enabled, numba_threads=numba_threads),
                 ],
                 variant=variant,
+                profile_numpy_random=profile_numpy_random,
             )
         )
     return records
@@ -935,6 +1028,8 @@ def _write_csv(path: Path, results: list[CollectorResult]) -> None:
         "replay_ms",
         "weight_sync_ms",
         "bookkeeping_ms",
+        "numpy_random_ms",
+        "numpy_random_calls",
         "physics_ms",
         "env_step_overhead_ms",
         "reset_done_count",
@@ -978,6 +1073,16 @@ def _write_csv(path: Path, results: list[CollectorResult]) -> None:
             row["physics_ms"] = (
                 result.physics_ms_per_vector_step.mean_ms
                 if result.physics_ms_per_vector_step is not None
+                else ""
+            )
+            row["numpy_random_ms"] = (
+                result.numpy_random_ms_per_vector_step.mean_ms
+                if result.numpy_random_ms_per_vector_step is not None
+                else ""
+            )
+            row["numpy_random_calls"] = (
+                result.numpy_random_calls_per_vector_step.mean_ms
+                if result.numpy_random_calls_per_vector_step is not None
                 else ""
             )
             row["env_step_overhead_ms"] = (
@@ -1692,6 +1797,19 @@ def _print_result(result: CollectorResult) -> None:
             f"pct_env={_env_step_child_env_pct(result, upper):5.1f}% "
             f"pct_active={_env_step_child_pct(result, upper):5.1f}%"
         )
+    if result.numpy_random_ms_per_vector_step is not None:
+        random_ms = result.numpy_random_ms_per_vector_step.mean_ms
+        random_calls = (
+            result.numpy_random_calls_per_vector_step.mean_ms
+            if result.numpy_random_calls_per_vector_step is not None
+            else 0.0
+        )
+        print(
+            f"  {'numpy_random_ms':<18} mean={random_ms:8.3f} ms  "
+            f"calls={random_calls:5.1f}  "
+            f"pct_env={_env_step_child_env_pct(result, random_ms):5.1f}% "
+            f"pct_active={_env_step_child_pct(result, random_ms):5.1f}%"
+        )
     if result.env_step_timing_ms_per_vector_step:
         reset_count = result.env_step_timing_ms_per_vector_step.get("reset_done_count")
         if reset_count is not None:
@@ -1802,6 +1920,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Numba thread count used by --numba-ab accelerated variants.",
     )
+    parser.add_argument(
+        "--profile-numpy-random",
+        action="store_true",
+        help=(
+            "Measure selected np.random module calls during measured env.step() "
+            "windows and report their collector active share."
+        ),
+    )
     parser.add_argument("--out-json", type=Path, default=DEFAULT_OUTPUT_JSON)
     parser.add_argument("--out-csv", type=Path, default=None)
     parser.add_argument("--continue-on-error", action="store_true")
@@ -1838,6 +1964,7 @@ def main() -> int:
                     num_envs=args.num_envs,
                     extra_overrides=list(args.override),
                     numba_threads=args.numba_threads,
+                    profile_numpy_random=bool(args.profile_numpy_random),
                 )
             else:
                 case_results = [
@@ -1848,6 +1975,7 @@ def main() -> int:
                         replay_capacity_steps=int(args.replay_capacity_steps),
                         num_envs=args.num_envs,
                         extra_overrides=list(args.override),
+                        profile_numpy_random=bool(args.profile_numpy_random),
                     )
                 ]
             results.extend(case_results)
@@ -1881,6 +2009,7 @@ def main() -> int:
             "override": args.override,
             "numba_ab": args.numba_ab,
             "numba_threads": args.numba_threads,
+            "profile_numpy_random": args.profile_numpy_random,
         },
         "results": [_result_to_dict(result) for result in results],
         "errors": errors,

--- a/src/unilab/envs/motion_tracking/g1/motion_tracking_numba.py
+++ b/src/unilab/envs/motion_tracking/g1/motion_tracking_numba.py
@@ -263,15 +263,17 @@ if NUMBA_AVAILABLE:
             tid = get_thread_id()
             total = 0.0
 
-            w = motion_global_root_pos_i(
-                motion_body_pos_w, robot_body_pos_w, anchor, std[0], i
-            ) * scale[0]
+            w = (
+                motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
+                * scale[0]
+            )
             total += w
             log_scratch[tid, 0] += w
 
-            w = motion_global_root_ori_i(
-                motion_body_quat_w, robot_body_quat_w, anchor, std[1], i
-            ) * scale[1]
+            w = (
+                motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
+                * scale[1]
+            )
             total += w
             log_scratch[tid, 1] += w
 
@@ -283,21 +285,28 @@ if NUMBA_AVAILABLE:
             total += w
             log_scratch[tid, 3] += w
 
-            w = motion_body_lin_vel_i(
-                motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i
-            ) * scale[4]
+            w = (
+                motion_body_lin_vel_i(
+                    motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i
+                )
+                * scale[4]
+            )
             total += w
             log_scratch[tid, 4] += w
 
-            w = motion_body_ang_vel_i(
-                motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i
-            ) * scale[5]
+            w = (
+                motion_body_ang_vel_i(
+                    motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i
+                )
+                * scale[5]
+            )
             total += w
             log_scratch[tid, 5] += w
 
-            w = motion_ee_body_pos_z_i(
-                ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i
-            ) * scale[6]
+            w = (
+                motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
+                * scale[6]
+            )
             total += w
             log_scratch[tid, 6] += w
 
@@ -313,9 +322,10 @@ if NUMBA_AVAILABLE:
             total += w
             log_scratch[tid, 9] += w
 
-            w = joint_limit_i(
-                dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i
-            ) * scale[10]
+            w = (
+                joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
+                * scale[10]
+            )
             total += w
             log_scratch[tid, 10] += w
 
@@ -345,7 +355,6 @@ if NUMBA_AVAILABLE:
                 terminate_on_undesired_contacts,
                 i,
             )
-
 
     @_dev
     def _write_reference_transforms_i(
@@ -435,15 +444,17 @@ if NUMBA_AVAILABLE:
     ):
         total = 0.0
 
-        w = motion_global_root_pos_i(
-            motion_body_pos_w, robot_body_pos_w, anchor, std[0], i
-        ) * scale[0]
+        w = (
+            motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
+            * scale[0]
+        )
         total += w
         log_scratch[tid, 0] += w
 
-        w = motion_global_root_ori_i(
-            motion_body_quat_w, robot_body_quat_w, anchor, std[1], i
-        ) * scale[1]
+        w = (
+            motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
+            * scale[1]
+        )
         total += w
         log_scratch[tid, 1] += w
 
@@ -455,19 +466,24 @@ if NUMBA_AVAILABLE:
         total += w
         log_scratch[tid, 3] += w
 
-        w = motion_body_lin_vel_i(
-            motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i
-        ) * scale[4]
+        w = (
+            motion_body_lin_vel_i(motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i)
+            * scale[4]
+        )
         total += w
         log_scratch[tid, 4] += w
 
-        w = motion_body_ang_vel_i(
-            motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i
-        ) * scale[5]
+        w = (
+            motion_body_ang_vel_i(motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i)
+            * scale[5]
+        )
         total += w
         log_scratch[tid, 5] += w
 
-        w = motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i) * scale[6]
+        w = (
+            motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
+            * scale[6]
+        )
         total += w
         log_scratch[tid, 6] += w
 
@@ -483,7 +499,10 @@ if NUMBA_AVAILABLE:
         total += w
         log_scratch[tid, 9] += w
 
-        w = joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i) * scale[10]
+        w = (
+            joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
+            * scale[10]
+        )
         total += w
         log_scratch[tid, 10] += w
 
@@ -728,7 +747,6 @@ if NUMBA_AVAILABLE:
             i,
         )
         _write_critic_linvel_tail_i(linvel, critic_obs, tail_offset, i)
-
 
     @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
     def _compute_update_state_kernel(
@@ -976,8 +994,10 @@ class G1MotionTrackingNumbaAccelerator:
         if default_angles is None:
             default_angles = np.zeros((env._num_action,), dtype=np.float64)
         actor_obs_width = getattr(env, "_actor_obs_width", env._num_action * 5 + 15)
-        critic_obs_width = env.obs_groups_spec["critic"] if hasattr(env, "obs_groups_spec") else (
-            env._num_action * 5 + 15 + len(env._cfg.body_names) * 9
+        critic_obs_width = (
+            env.obs_groups_spec["critic"]
+            if hasattr(env, "obs_groups_spec")
+            else (env._num_action * 5 + 15 + len(env._cfg.body_names) * 9)
         )
         return cls(
             num_envs=env.num_envs,

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -788,9 +788,10 @@ class G1MotionTrackingEnv(G1BaseEnv):
             robot_body_ang_vel_w,
         ) = self._get_body_state_w()
 
-        if self._numba_accelerator is not None:
+        numba_accelerator = getattr(self, "_numba_accelerator", None)
+        if numba_accelerator is not None:
             noise_cfg = self._cfg.noise_config
-            numba_result = self._numba_accelerator.compute_update_state(
+            numba_result = numba_accelerator.compute_update_state(
                 info=state.info,
                 motion_data=motion_data,
                 linvel=linvel,

--- a/src/unilab/utils/numba_geometry.py
+++ b/src/unilab/utils/numba_geometry.py
@@ -9,7 +9,8 @@ knowledge into shared utilities.
 from __future__ import annotations
 
 import math
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeAlias, cast
 
 try:  # pragma: no cover - exercised when optional numba dependency is installed
     from numba import njit
@@ -24,10 +25,23 @@ def _missing_numba(*_args: Any, **_kwargs: Any) -> None:
     raise RuntimeError("numba_geometry helpers require numba to be installed")
 
 
-if NUMBA_GEOMETRY_AVAILABLE:
+NumbaHelper: TypeAlias = Callable[..., Any]
+quat_angle_sq_at: NumbaHelper
+quat_gravity_z_at: NumbaHelper
+quat_yaw_from_components: NumbaHelper
+rotate_vec_by_inv_quat_components: NumbaHelper
+write_quat_first_two_matrix_cols_from_components: NumbaHelper
+write_yaw_aligned_body_transforms_at: NumbaHelper
+write_relative_anchor_transform_at: NumbaHelper
+write_body_pos_relative_to_anchor_at: NumbaHelper
+write_body_quat_relative_6d_to_anchor_at: NumbaHelper
 
-    def _dev(fn):
-        return njit(inline="always", fastmath=True, cache=True, nogil=True)(fn)
+
+if NUMBA_GEOMETRY_AVAILABLE:
+    _njit = cast(Any, njit)
+
+    def _dev(fn: NumbaHelper) -> NumbaHelper:
+        return cast(NumbaHelper, _njit(inline="always", fastmath=True, cache=True, nogil=True)(fn))
 
     @_dev
     def quat_angle_sq_at(q1, q2, item_idx, i):
@@ -161,12 +175,8 @@ if NUMBA_GEOMETRY_AVAILABLE:
             vx = source_body_pos_w[i, body_idx, 0] - anchor_px
             vy = source_body_pos_w[i, body_idx, 1] - anchor_py
             vz = source_body_pos_w[i, body_idx, 2] - anchor_pz
-            out_body_pos_w[i, body_idx, 0] = (
-                vx - yaw_cross * vy - yaw_z2 * vx + target_anchor_px
-            )
-            out_body_pos_w[i, body_idx, 1] = (
-                vy + yaw_cross * vx - yaw_z2 * vy + target_anchor_py
-            )
+            out_body_pos_w[i, body_idx, 0] = vx - yaw_cross * vy - yaw_z2 * vx + target_anchor_px
+            out_body_pos_w[i, body_idx, 1] = vy + yaw_cross * vx - yaw_z2 * vy + target_anchor_py
             out_body_pos_w[i, body_idx, 2] = vz + anchor_pz
 
     @_dev
@@ -236,7 +246,9 @@ if NUMBA_GEOMETRY_AVAILABLE:
         write_quat_first_two_matrix_cols_from_components(rw, rx, ry, rz, out_rot6d_b, i, 0)
 
     @_dev
-    def write_body_pos_relative_to_anchor_at(body_pos_w, anchor_quat_w, anchor, n_body, out, i, offset):
+    def write_body_pos_relative_to_anchor_at(
+        body_pos_w, anchor_quat_w, anchor, n_body, out, i, offset
+    ):
         anchor_px = body_pos_w[i, anchor, 0]
         anchor_py = body_pos_w[i, anchor, 1]
         anchor_pz = body_pos_w[i, anchor, 2]

--- a/tests/benchmark/test_g1_joystick_numba_benchmark.py
+++ b/tests/benchmark/test_g1_joystick_numba_benchmark.py
@@ -133,12 +133,8 @@ def test_g1_joystick_numba_benchmark_formats_e2e_reconciliation() -> None:
 def test_g1_joystick_numba_benchmark_selects_best_hot_slice_threads() -> None:
     records = [
         bench.BenchCase("sac_default", 1024, "numpy_dispatch", None, 1.0, 1.0, 0.0, 1000.0, 1.0),
-        bench.BenchCase(
-            "sac_default", 1024, "numba_accelerator", 2, 0.8, 0.8, 0.0, 1250.0, 1.25
-        ),
-        bench.BenchCase(
-            "sac_default", 1024, "numba_accelerator", 4, 0.6, 0.6, 0.0, 1666.0, 1.67
-        ),
+        bench.BenchCase("sac_default", 1024, "numba_accelerator", 2, 0.8, 0.8, 0.0, 1250.0, 1.25),
+        bench.BenchCase("sac_default", 1024, "numba_accelerator", 4, 0.6, 0.6, 0.0, 1666.0, 1.67),
         bench.BenchCase("ppo_default", 1024, "numba_accelerator", 8, 0.5, 0.5, 0.0, 2000.0, 2.0),
     ]
 

--- a/tests/benchmark/test_g1_motion_tracking_numba_benchmark.py
+++ b/tests/benchmark/test_g1_motion_tracking_numba_benchmark.py
@@ -158,12 +158,8 @@ def test_g1_motion_tracking_numba_benchmark_formats_e2e_reconciliation() -> None
 def test_g1_motion_tracking_numba_benchmark_selects_best_hot_slice_threads() -> None:
     records = [
         bench.BenchCase("sac_default", 1024, "numpy_dispatch", None, 1.0, 1.0, 0.0, 1000.0, 1.0),
-        bench.BenchCase(
-            "sac_default", 1024, "numba_accelerator", 2, 0.8, 0.8, 0.0, 1250.0, 1.25
-        ),
-        bench.BenchCase(
-            "sac_default", 1024, "numba_accelerator", 4, 0.6, 0.6, 0.0, 1666.0, 1.67
-        ),
+        bench.BenchCase("sac_default", 1024, "numba_accelerator", 2, 0.8, 0.8, 0.0, 1250.0, 1.25),
+        bench.BenchCase("sac_default", 1024, "numba_accelerator", 4, 0.6, 0.6, 0.0, 1666.0, 1.67),
         bench.BenchCase("ppo_default", 1024, "numba_accelerator", 8, 0.5, 0.5, 0.0, 2000.0, 2.0),
     ]
 

--- a/tests/benchmark/test_numba_random_noise_benchmark.py
+++ b/tests/benchmark/test_numba_random_noise_benchmark.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from benchmark import benchmark_numba_random_noise as bench
+
+
+def test_numba_random_noise_profiles_match_training_shapes() -> None:
+    profiles = bench.make_profiles()
+
+    motion = profiles["sac_g1_motion_tracking_mujoco"]
+    joystick = profiles["sac_g1_walk_flat_mujoco"]
+
+    assert motion.default_num_envs == 2048
+    assert motion.total_width == 64
+    assert [field.name for field in motion.fields] == [
+        "linvel",
+        "gyro",
+        "joint_pos",
+        "dof_vel",
+    ]
+    assert joystick.total_width == 64
+    assert joystick.fields[0].scale == 0.0
+    assert joystick.fields[1].scale == 0.0
+
+
+def test_numba_random_noise_benchmark_builds_records() -> None:
+    profile = bench.make_profiles()["ppo_g1_motion_tracking_motrix"]
+    threads = [1] if bench.NUMBA_AVAILABLE else []
+
+    records = bench.bench_one(
+        profile=profile,
+        num_envs=32,
+        dtype_name="float32",
+        thread_counts=threads,
+        iters=1,
+        warmup=0,
+        seed=0,
+    )
+
+    paths = {record.path for record in records}
+    assert "numpy_random_uniform_alloc" in paths
+    assert "numpy_generator_random_out" in paths
+    if bench.NUMBA_AVAILABLE:
+        assert "numba_random_prange" in paths
+    assert all(record.values == 32 * profile.total_width for record in records)
+    assert all(record.mean_ms >= 0.0 for record in records)
+    assert all(math.isfinite(record.speedup_vs_numpy_alloc) for record in records)
+
+
+def test_numba_random_noise_zero_scale_fields_are_zeroed() -> None:
+    profile = bench.make_profiles()["sac_g1_walk_flat_mujoco"]
+    buffers = bench._numpy_random_uniform_alloc(
+        profile,
+        num_envs=8,
+        dtype=np.dtype(np.float32),
+        noise_level=1.0,
+    )
+
+    assert np.max(np.abs(buffers[0])) == 0.0
+    assert np.max(np.abs(buffers[1])) == 0.0
+    assert np.max(np.abs(buffers[2])) > 0.0
+
+
+def test_numba_random_noise_formats_records() -> None:
+    record = bench.BenchCase(
+        profile="sac_g1_motion_tracking_mujoco",
+        owner_config="conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml",
+        num_envs=64,
+        dtype="float32",
+        path="numba_random_prange",
+        threads=4,
+        values=4096,
+        mean_ms=0.25,
+        min_ms=0.2,
+        std_ms=0.01,
+        values_per_s=16_384_000.0,
+        speedup_vs_numpy_alloc=2.0,
+        compile_ms=10.0,
+        deterministic_same_seed=True,
+    )
+
+    payload = bench._case_to_dict(record)
+    table = bench._format_table([record])
+
+    assert payload["mvalues_per_s"] == 16.384
+    assert "numba_random_prange" in table
+    assert "2.00x" in table
+    assert "True" in table

--- a/tests/envs/locomotion/g1/test_joystick_numba.py
+++ b/tests/envs/locomotion/g1/test_joystick_numba.py
@@ -247,12 +247,10 @@ def test_g1_walk_numba_update_state_parity_without_noise():
     dof_vel = rng.normal(size=(n, n_action)).astype(np.float32)
 
     max_tilt_rad = np.deg2rad(env._reward_cfg.max_tilt_deg)
-    terminated_np = (
-        np.arccos(np.clip(gravity[:, 2], -1.0, 1.0)) > max_tilt_rad
-    ) | (env._backend.get_base_pos()[:, 2] < env._reward_cfg.min_base_height)
-    reward_np = env._compute_reward(
-        {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+    terminated_np = (np.arccos(np.clip(gravity[:, 2], -1.0, 1.0)) > max_tilt_rad) | (
+        env._backend.get_base_pos()[:, 2] < env._reward_cfg.min_base_height
     )
+    reward_np = env._compute_reward({**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel)
     obs_np = env._compute_obs(info, linvel, gyro, gravity, dof_pos, dof_vel)
 
     accel = G1WalkNumbaAccelerator.from_env(env, num_threads=2)

--- a/tests/envs/test_g1_motion_tracking_numba.py
+++ b/tests/envs/test_g1_motion_tracking_numba.py
@@ -190,9 +190,7 @@ def test_g1_motion_tracking_numba_term_py_funcs_match_numpy_math():
     i = 2
 
     diff = motion_data.body_pos_w[i, env.anchor_body_idx] - robot_body_pos_w[i, env.anchor_body_idx]
-    expected_root_pos = np.exp(
-        -np.sum(diff * diff) / (env._cfg.reward_config.std_root_pos**2)
-    )
+    expected_root_pos = np.exp(-np.sum(diff * diff) / (env._cfg.reward_config.std_root_pos**2))
     assert T.motion_global_root_pos_i.py_func(
         motion_data.body_pos_w,
         robot_body_pos_w,
@@ -203,7 +201,9 @@ def test_g1_motion_tracking_numba_term_py_funcs_match_numpy_math():
 
     body_diff = env.body_pos_relative_w[i] - robot_body_pos_w[i]
     expected_body_pos = np.exp(
-        -np.sum(body_diff * body_diff) / body_diff.shape[0] / (env._cfg.reward_config.std_body_pos**2)
+        -np.sum(body_diff * body_diff)
+        / body_diff.shape[0]
+        / (env._cfg.reward_config.std_body_pos**2)
     )
     assert T.motion_body_pos_i.py_func(
         env.body_pos_relative_w,
@@ -315,9 +315,7 @@ def _make_env(n: int, *, include_undesired: bool) -> Any:
     env._joint_error_upper = np.empty((n, env._num_action), dtype=np.float32)
     env._ee_pos_error_z = np.empty((n, env.ee_body_indices.size), dtype=np.float32)
     env._ee_terminated = np.empty((n, env.ee_body_indices.size), dtype=bool)
-    env._undesired_contact_mask = np.empty(
-        (n, env.undesired_contact_body_indices.size), dtype=bool
-    )
+    env._undesired_contact_mask = np.empty((n, env.undesired_contact_body_indices.size), dtype=bool)
     env._enable_reward_log = True
     env._init_reward_functions()
     env._active_reward_fns = {
@@ -354,12 +352,8 @@ def _make_batch(n: int, seed: int):
     motion_data = _MotionData(
         body_pos_w=np.ascontiguousarray(target_pos + 0.03 * rng.standard_normal((n, nb, 3))),
         body_quat_w=np.ascontiguousarray(_perturb_quats(rng, target_quat, 0.02)),
-        body_lin_vel_w=np.ascontiguousarray(
-            target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3))
-        ),
-        body_ang_vel_w=np.ascontiguousarray(
-            target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3))
-        ),
+        body_lin_vel_w=np.ascontiguousarray(target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3))),
+        body_ang_vel_w=np.ascontiguousarray(target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3))),
         joint_pos=np.ascontiguousarray(target_joint_pos + 0.03 * rng.standard_normal((n, na))),
         joint_vel=np.ascontiguousarray(target_joint_vel + 0.05 * rng.standard_normal((n, na))),
     )

--- a/tests/utils/test_numba_geometry.py
+++ b/tests/utils/test_numba_geometry.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from unilab.utils.rotation import (
-    np_matrix_first_two_cols_from_quat,
-    np_subtract_frame_transforms,
-)
 from unilab.utils.numba_geometry import (
     NUMBA_GEOMETRY_AVAILABLE,
     quat_angle_sq_at,
     write_relative_anchor_transform_at,
+)
+from unilab.utils.rotation import (
+    np_matrix_first_two_cols_from_quat,
+    np_subtract_frame_transforms,
 )
 
 


### PR DESCRIPTION
## Summary
- add a standalone RNG/noise-buffer benchmark for NumPy allocation, NumPy output-buffer reuse, and parallel Numba RNG paths using G1 training-shaped profiles
- add benchmark-side `--profile-numpy-random` support to the off-policy collector active-window benchmark
- record RNG profiling fields in JSON/CSV output and cover the new benchmark behavior with focused tests
- include small gate fixes from `make test-all`: pyright-safe Numba helper typing and a defensive motion-tracking numba accelerator lookup for partial test env construction

## Issue
Closes #680

## Results
Benchmark outputs were generated on the remote test host under `benchmark/outputs/`, not `benchmark/results/`. The final issue comments summarize:
- collector `np.random` share: about `2.30% - 4.07%` of active collector time for real `num_envs=2048` G1 MuJoCo cases
- standalone RNG acceleration: isolated RNG can improve substantially, but the end-to-end collector share is low and parallel Numba RNG is not same-seed repeatable in this benchmark

## Validation
- `uv run ruff check benchmark/benchmark_offpolicy_collector_active.py benchmark/benchmark_numba_random_noise.py tests/benchmark/test_offpolicy_collector_active_benchmark.py tests/benchmark/test_numba_random_noise_benchmark.py`
- `uv run pytest tests/benchmark/test_offpolicy_collector_active_benchmark.py tests/benchmark/test_numba_random_noise_benchmark.py`
- `uv run pytest tests/envs/test_env_configs.py::test_g1_motion_tracking_clip_end_resamples_by_default_without_truncation tests/envs/test_env_configs.py::test_g1_motion_tracking_clip_end_truncates_when_config_enabled tests/envs/test_env_configs.py::test_g1_motion_tracking_clip_end_resample_skips_terminated_envs tests/envs/test_env_configs.py::test_g1_motion_tracking_clip_end_resample_keeps_terminated_final_obs_valid`
- `make test-all`
