### PR TITLE
fix: add deterministic observation noise seed

### DIFF
--- a/conf/offpolicy/task/flashsac/g1_walk_flat/motrix.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/motrix.yaml
@@ -39,6 +39,7 @@ env:
     scale_joint_angle: 0.01
     scale_joint_vel: 0.1
     scale_linvel: 0.0
+    seed: null
 reward:
   scales:
     tracking_lin_vel: 2.2

--- a/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/g1_walk_flat/mujoco.yaml
@@ -31,6 +31,7 @@ env:
     scale_joint_angle: 0.01
     scale_joint_vel: 0.1
     scale_linvel: 0.0
+    seed: null
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml
@@ -30,6 +30,7 @@ env:
     scale_joint_angle: 0.01
     scale_joint_vel: 1.5
     scale_gyro: 0.2
+    seed: null
 reward:
   scales:
     motion_global_root_pos: 1.0

--- a/conf/offpolicy/task/sac/g1_walk_flat/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_flat/motrix.yaml
@@ -28,6 +28,14 @@ env:
     level_down_threshold: 150.0
     level_up_threshold: 750.0
     degree: 0.001
+  noise_config:
+    level: 0.0
+    scale_gyro: 0.0
+    scale_gravity: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.1
+    scale_linvel: 0.0
+    seed: null
 reward:
   scales:
     tracking_lin_vel: 2.2

--- a/conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml
@@ -32,6 +32,7 @@ env:
     scale_joint_angle: 0.01
     scale_joint_vel: 0.1
     scale_linvel: 0.0
+    seed: null
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/conf/offpolicy/task/td3/g1_walk_flat/mujoco.yaml
+++ b/conf/offpolicy/task/td3/g1_walk_flat/mujoco.yaml
@@ -24,6 +24,7 @@ env:
     scale_joint_angle: 0.01
     scale_joint_vel: 0.1
     scale_linvel: 0.0
+    seed: null
 reward:
   scales:
     tracking_lin_vel: 2.0

--- a/src/unilab/envs/locomotion/common/base.py
+++ b/src/unilab/envs/locomotion/common/base.py
@@ -41,6 +41,7 @@ class BaseNoiseConfig:
     scale_gyro: float = 0.2
     scale_gravity: float = 0.05
     scale_linvel: float = 0.1
+    seed: int | None = None
 
 
 @dataclass
@@ -64,6 +65,8 @@ class LocomotionBaseEnv(NpEnv):
         super().__init__(cfg, backend, num_envs)
         self._init_action_space()
         self._num_action = self._action_space.shape[0]
+        self._obs_noise_rng: np.random.Generator | None = None
+        self._obs_noise_seed_override: int | None = None
         self._init_buffers()
         self._spawn: BaseSpawnManager = BaseSpawnManager()
 
@@ -101,13 +104,39 @@ class LocomotionBaseEnv(NpEnv):
         )
         return ctrl
 
+    def seed_observation_noise(self, seed: int | None) -> None:
+        """Reset env-owned observation-noise RNG streams."""
+        if seed is not None and int(seed) < 0:
+            raise ValueError(f"observation noise seed must be non-negative, got {seed}")
+        self._obs_noise_seed_override = int(seed) if seed is not None else None
+        self._obs_noise_rng = None
+
+    def _configured_obs_noise_seed(self) -> int | None:
+        seed = getattr(self, "_obs_noise_seed_override", None)
+        if seed is None:
+            seed = getattr(self._cfg.noise_config, "seed", None)
+        if seed is None:
+            return None
+        seed = int(seed)
+        if seed < 0:
+            raise ValueError(f"observation noise seed must be non-negative, got {seed}")
+        return seed
+
     def _obs_noise(self, data: np.ndarray, scale: float) -> np.ndarray:
         """Apply per-step uniform observation noise scaled by ``noise_config.level``."""
         level = float(self._cfg.noise_config.level)
         if level <= 0.0:
             return data
-        noise = np.random.uniform(-1.0, 1.0, data.shape).astype(data.dtype) * level * scale
-        return data + noise
+        seed = self._configured_obs_noise_seed()
+        if seed is None:
+            noise = np.random.uniform(-1.0, 1.0, data.shape).astype(data.dtype)
+        else:
+            rng = getattr(self, "_obs_noise_rng", None)
+            if rng is None:
+                rng = np.random.default_rng(seed)
+                self._obs_noise_rng = rng
+            noise = rng.uniform(-1.0, 1.0, data.shape).astype(data.dtype)
+        return data + noise * level * scale
 
     def get_local_linvel(self) -> np.ndarray:
         local_linvel: np.ndarray = self._backend.get_sensor_data(self._cfg.sensor.local_linvel)

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -788,9 +788,10 @@ class G1MotionTrackingEnv(G1BaseEnv):
             robot_body_ang_vel_w,
         ) = self._get_body_state_w()
 
-        if self._numba_accelerator is not None:
+        numba_accelerator = getattr(self, "_numba_accelerator", None)
+        if numba_accelerator is not None:
             noise_cfg = self._cfg.noise_config
-            numba_result = self._numba_accelerator.compute_update_state(
+            numba_result = numba_accelerator.compute_update_state(
                 info=state.info,
                 motion_data=motion_data,
                 linvel=linvel,

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -139,6 +139,23 @@ def test_auto_discovery_supports_motrixsim_alias() -> None:
     assert "td3/go2_joystick_flat/motrix" in specs
 
 
+def test_noise_seed_override_composes_for_target_g1_profiles() -> None:
+    for spec in (
+        ("sac", "g1_motion_tracking", "mujoco"),
+        ("sac", "g1_walk_flat", "mujoco"),
+        ("sac", "g1_walk_flat", "motrix"),
+        ("flashsac", "g1_walk_flat", "mujoco"),
+        ("flashsac", "g1_walk_flat", "motrix"),
+        ("td3", "g1_walk_flat", "mujoco"),
+    ):
+        cfg = bench._compose_offpolicy_cfg(
+            *spec,
+            extra_overrides=["env.noise_config.seed=123"],
+        )
+
+        assert cfg.env.noise_config.seed == 123
+
+
 def test_stats_reports_distribution() -> None:
     stats = bench._stats([1.0, 2.0, 3.0])
 

--- a/tests/envs/test_g1_obs_noise.py
+++ b/tests/envs/test_g1_obs_noise.py
@@ -14,8 +14,8 @@ class _ConcreteG1Env(G1BaseEnv):
         raise NotImplementedError
 
 
-def _make_env(level: float) -> G1BaseEnv:
-    cfg = G1BaseCfg(noise_config=NoiseConfig(level=level))
+def _make_env(level: float, *, seed: int | None = None) -> G1BaseEnv:
+    cfg = G1BaseCfg(noise_config=NoiseConfig(level=level, seed=seed))
     env = object.__new__(_ConcreteG1Env)
     env._cfg = cfg
     return env
@@ -36,7 +36,8 @@ class TestObsNoise:
         data = np.ones((4, 10), dtype=np.float32)
         cfg = env._cfg.noise_config
 
-        result = env._obs_noise(data.copy(), cfg.scale_joint_angle)
+        result = env._obs_noise(data, cfg.scale_joint_angle)
+        assert result is data
         np.testing.assert_array_equal(result, data)
 
     def test_noise_bounded_by_level_times_scale(self):
@@ -49,19 +50,49 @@ class TestObsNoise:
         assert np.all(result <= scale)
 
     def test_noise_scales_with_level(self):
-        env_half = _make_env(level=0.5)
-        env_full = _make_env(level=1.0)
-        np.random.seed(42)
+        env_half = _make_env(level=0.5, seed=123)
+        env_full = _make_env(level=1.0, seed=123)
         data = np.zeros((1024, 10), dtype=np.float32)
         scale = 1.0
 
-        np.random.seed(0)
         r_half = env_half._obs_noise(data.copy(), scale)
-        np.random.seed(0)
         r_full = env_full._obs_noise(data.copy(), scale)
 
-        # Same random seed: full-level noise should be exactly 2x half-level noise
         np.testing.assert_allclose(r_full, r_half * 2.0)
+
+    def test_configured_seed_is_reproducible_across_fresh_envs(self):
+        env_a = _make_env(level=1.0, seed=11)
+        env_b = _make_env(level=1.0, seed=11)
+        data = np.zeros((32, 10), dtype=np.float32)
+
+        first_a = env_a._obs_noise(data.copy(), 0.25)
+        first_b = env_b._obs_noise(data.copy(), 0.25)
+        second_a = env_a._obs_noise(data.copy(), 0.25)
+
+        np.testing.assert_allclose(first_a, first_b)
+        assert not np.allclose(first_a, second_a)
+
+    def test_seed_observation_noise_resets_stream(self):
+        env = _make_env(level=1.0)
+        data = np.zeros((32, 10), dtype=np.float32)
+
+        env.seed_observation_noise(17)
+        first = env._obs_noise(data.copy(), 0.25)
+        env.seed_observation_noise(17)
+        replayed = env._obs_noise(data.copy(), 0.25)
+
+        np.testing.assert_allclose(first, replayed)
+
+    def test_seed_observation_noise_overrides_configured_seed(self):
+        env = _make_env(level=1.0, seed=11)
+        replay = _make_env(level=1.0, seed=99)
+        data = np.zeros((32, 10), dtype=np.float32)
+
+        env.seed_observation_noise(99)
+        result = env._obs_noise(data.copy(), 0.25)
+        expected = replay._obs_noise(data.copy(), 0.25)
+
+        np.testing.assert_allclose(result, expected)
 
     def test_noise_preserves_dtype(self):
         for dt in [np.float32, np.float64]:


### PR DESCRIPTION
Fixes #680

## Summary
- add optional observation-noise seeding and reseeding on the locomotion env boundary
- preserve default seed=null behavior on the existing global NumPy RNG path
- add seed=null to target G1 offpolicy owner configs so env.noise_config.seed overrides compose under Hydra struct mode
- keep SAC G1 walk Motrix no-noise semantics explicit with level=0.0

## Validation
- git diff --cached --check
- uv run pytest tests/envs/test_g1_obs_noise.py tests/envs/test_go1_obs_noise.py tests/envs/test_go2_obs_noise.py tests/benchmark/test_offpolicy_collector_active_benchmark.py tests/config/test_locomotion_params.py tests/config/test_config_system.py tests/envs/locomotion/g1/test_joystick_numba.py tests/envs/test_g1_motion_tracking_numba.py tests/envs/test_env_configs.py tests/envs/locomotion/g1/test_issue175_regression.py tests/benchmark/test_g1_joystick_numba_benchmark.py tests/benchmark/test_g1_motion_tracking_numba_benchmark.py -q (295 passed, 26 warnings)
- make test-all attempted; stopped at pyright on existing src/unilab/utils/numba_geometry.py issues, then skipped per maintainer instruction
