### PR TITLE
test: audit issue 705 workflow triggers

### DIFF
--- a/scripts/audit_issue705_workflow_triggers.py
+++ b/scripts/audit_issue705_workflow_triggers.py
@@ -1,0 +1,171 @@
+"""Audit that Issue #705 intermediate PRs cannot trigger GitHub Actions.
+
+The integration branch is intentionally excluded from both pull-request and
+push workflow triggers. This audit is read-only and fails closed.
+
+    uv run scripts/audit_issue705_workflow_triggers.py
+    uv run scripts/audit_issue705_workflow_triggers.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = Path(".github/workflows")
+INTEGRATION_BRANCH = "feat/issue-705-manager-mjwarp"
+ALLOWED_BRANCHES = ("main",)
+
+BRANCH_FILTERED_EVENTS = ("pull_request", "pull_request_target", "push")
+UNFILTERABLE_INTERMEDIATE_EVENTS = (
+    "create",
+    "delete",
+    "pull_request_review",
+    "pull_request_review_comment",
+)
+
+
+@dataclass(frozen=True)
+class TriggerRecord:
+    path: str
+    event: str
+    branches: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowAuditResult:
+    workflow_count: int
+    triggers: tuple[TriggerRecord, ...]
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _workflow_paths(root: Path) -> list[Path]:
+    workflow_dir = root / WORKFLOW_DIR
+    return sorted({*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")})
+
+
+def _load_workflow(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        return None, f"{path}: cannot parse workflow YAML: {type(exc).__name__}: {exc}"
+    if not isinstance(raw, dict):
+        return None, f"{path}: workflow root must be a mapping"
+    return raw, None
+
+
+def _event_map(workflow: dict[str, Any], path: Path) -> tuple[dict[str, Any], list[str]]:
+    raw_on = workflow.get("on")
+    if isinstance(raw_on, str):
+        return {raw_on: None}, []
+    if isinstance(raw_on, list):
+        if not all(isinstance(event, str) for event in raw_on):
+            return {}, [f"{path}: every event in `on` must be a string"]
+        return dict.fromkeys(raw_on), []
+    if isinstance(raw_on, dict):
+        return raw_on, []
+    return {}, [f"{path}: `on` must be a string, list, or mapping"]
+
+
+def _branches_for_event(config: Any, path: Path, event: str) -> tuple[tuple[str, ...], str | None]:
+    if not isinstance(config, dict):
+        return (), f"{path}: `{event}` must declare `branches: [main]` explicitly"
+    if "branches-ignore" in config:
+        return (), f"{path}: `{event}` uses branches-ignore; #705 requires an explicit allowlist"
+
+    raw_branches = config.get("branches")
+    if isinstance(raw_branches, str):
+        branches = (raw_branches,)
+    elif isinstance(raw_branches, list) and all(isinstance(branch, str) for branch in raw_branches):
+        branches = tuple(raw_branches)
+    else:
+        return (), f"{path}: `{event}` must declare `branches: [main]` explicitly"
+
+    if branches != ALLOWED_BRANCHES:
+        return (
+            branches,
+            f"{path}: `{event}` branches must be exactly {list(ALLOWED_BRANCHES)!r}; "
+            f"got {list(branches)!r}",
+        )
+    return branches, None
+
+
+def audit_workflow_triggers(root: Path = REPO_ROOT) -> WorkflowAuditResult:
+    paths = _workflow_paths(root)
+    errors: list[str] = []
+    triggers: list[TriggerRecord] = []
+    if not paths:
+        errors.append(f"{root / WORKFLOW_DIR}: no workflow YAML files found")
+
+    for path in paths:
+        relative_path = str(path.relative_to(root))
+        workflow, load_error = _load_workflow(path)
+        if load_error is not None:
+            errors.append(load_error.replace(str(root) + "/", ""))
+            continue
+        assert workflow is not None
+
+        events, event_errors = _event_map(workflow, Path(relative_path))
+        errors.extend(event_errors)
+        for event in UNFILTERABLE_INTERMEDIATE_EVENTS:
+            if event in events:
+                errors.append(
+                    f"{relative_path}: `{event}` can run during the intermediate PR lifecycle"
+                )
+
+        for event in BRANCH_FILTERED_EVENTS:
+            if event not in events:
+                continue
+            branches, branch_error = _branches_for_event(events[event], Path(relative_path), event)
+            triggers.append(TriggerRecord(relative_path, event, branches))
+            if branch_error is not None:
+                errors.append(branch_error)
+
+    return WorkflowAuditResult(
+        workflow_count=len(paths),
+        triggers=tuple(triggers),
+        errors=tuple(errors),
+    )
+
+
+def _print_human(result: WorkflowAuditResult) -> None:
+    print(
+        f"Issue #705 workflow audit: workflows={result.workflow_count} "
+        f"branch_triggers={len(result.triggers)}"
+    )
+    for trigger in result.triggers:
+        print(f"  PASS {trigger.path}: {trigger.event} -> {list(trigger.branches)!r}")
+    if result.errors:
+        for error in result.errors:
+            print(f"  FAIL {error}")
+        return
+    print(f"PASS: no workflow trigger can target `{INTEGRATION_BRANCH}`")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args()
+
+    result = audit_workflow_triggers()
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        _print_human(result)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_issue705_workflow_audit.py
+++ b/tests/scripts/test_issue705_workflow_audit.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit_issue705_workflow_triggers import audit_workflow_triggers
+
+
+def _write_workflow(root: Path, name: str, content: str) -> None:
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_current_workflows_exclude_issue705_integration_branch() -> None:
+    root = Path(__file__).resolve().parents[2]
+
+    result = audit_workflow_triggers(root)
+
+    assert result.ok, "\n".join(result.errors)
+    assert {(trigger.path, trigger.event, trigger.branches) for trigger in result.triggers} == {
+        (".github/workflows/ci.yml", "pull_request", ("main",)),
+        (".github/workflows/docs.yml", "pull_request", ("main",)),
+        (".github/workflows/docs.yml", "push", ("main",)),
+    }
+
+
+def test_audit_accepts_explicit_main_only_triggers(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+name: CI
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - main
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert result.ok
+    assert {trigger.event for trigger in result.triggers} == {"pull_request", "push"}
+
+
+def test_audit_rejects_integration_branch_target(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+on:
+  pull_request:
+    branches: [main, feat/issue-705-manager-mjwarp]
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("branches must be exactly ['main']" in error for error in result.errors)
+
+
+def test_audit_rejects_implicit_all_branches(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+on: [push, pull_request]
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("must declare `branches: [main]` explicitly" in error for error in result.errors)
+
+
+def test_audit_rejects_branches_ignore(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+on:
+  push:
+    branches-ignore: [main]
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("requires an explicit allowlist" in error for error in result.errors)
+
+
+def test_audit_rejects_unfilterable_pr_activity_event(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "review.yml",
+        """
+on: [pull_request_review]
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("can run during the intermediate PR lifecycle" in error for error in result.errors)
+
+
+def test_audit_rejects_branch_create_event(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "create.yml",
+        """
+on: [create]
+jobs: {}
+""",
+    )
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any(
+        "`create` can run during the intermediate PR lifecycle" in error for error in result.errors
+    )
+
+
+def test_audit_rejects_invalid_yaml(tmp_path: Path) -> None:
+    _write_workflow(tmp_path, "broken.yml", "on: [pull_request\n")
+
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("cannot parse workflow YAML" in error for error in result.errors)
+
+
+def test_audit_rejects_empty_workflow_directory(tmp_path: Path) -> None:
+    result = audit_workflow_triggers(tmp_path)
+
+    assert not result.ok
+    assert any("no workflow YAML files found" in error for error in result.errors)


### PR DESCRIPTION
## Summary

- add a read-only fail-closed audit for #705 intermediate-branch workflow triggers
- cover pull request, push, branch lifecycle, malformed YAML, and empty-workflow failure cases
- leave `.github/workflows/**` unchanged

## Linked Work

- Closes #707
- Part of #705
- Milestone: Phase 0A workflow canary

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation

Commands actually run:

```bash
uv run pytest tests/scripts/test_issue705_workflow_audit.py -v
uv run scripts/audit_issue705_workflow_triggers.py --json
make test-all
```

Result: `1619 passed, 26 skipped, 267 deselected, 1 xfailed`; all 9 Issue #705 audit tests passed.

## Impact

- Backend impact: none
- Platform impact: Linux and repository tooling
- Training effect expected: no

## Artifacts

- Head SHA: `2612f4ec906764d2ecc0ca2b1f8762b3b7034218`
- Base SHA: `8313b4cddfbc53359b7efda796c6ae3df77581aa`
- Remote canary checked twice; latest: `2026-07-28T11:26:54+08:00`
- `statusCheckRollup: null`
- commit check-runs: `0`
- legacy commit statuses: `0`
- Actions runs for head branch: `0`

## Checklist

- [x] Added direct positive and fail-closed tests
- [x] No workflow trigger was modified
- [x] Linked child issue and umbrella issue
- [x] Two local self-review passes completed
