### PR TITLE
test: 建立 Issue 705 阶段验收契约

### DIFF
--- a/scripts/validate_issue705_phase.py
+++ b/scripts/validate_issue705_phase.py
@@ -1,0 +1,94 @@
+"""Validate an Issue #705 phase acceptance manifest without executing its commands.
+
+uv run scripts/validate_issue705_phase.py --phase 0 --mode schema
+uv run scripts/validate_issue705_phase.py --phase 0 --mode gate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from unilab.tools.phase_acceptance import (
+    ManifestValidationError,
+    load_phase_acceptance,
+    manifest_status_counts,
+    phase_gate_errors,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_DIR = REPO_ROOT / "tests" / "acceptance" / "issue_705" / "manifests"
+INTEGRATION_BRANCH = "feat/issue-705-manager-mjwarp"
+
+
+def _build_payload(path: Path, mode: str) -> dict[str, object]:
+    try:
+        manifest = load_phase_acceptance(path)
+    except ManifestValidationError as exc:
+        return {
+            "ok": False,
+            "mode": mode,
+            "manifest": str(path),
+            "errors": list(exc.errors),
+        }
+
+    errors: list[str] = []
+    if manifest.issue != 705:
+        errors.append(f"issue: expected 705, got {manifest.issue}")
+    if manifest.integration_branch != INTEGRATION_BRANCH:
+        errors.append(
+            f"integration_branch: expected {INTEGRATION_BRANCH!r}, "
+            f"got {manifest.integration_branch!r}"
+        )
+    if mode == "gate":
+        errors.extend(phase_gate_errors(manifest))
+
+    return {
+        "ok": not errors,
+        "mode": mode,
+        "manifest": str(path),
+        "issue": manifest.issue,
+        "phase": manifest.phase,
+        "required_lanes": [lane.value for lane in manifest.required_lanes],
+        "status_counts": manifest_status_counts(manifest),
+        "errors": errors,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--phase", type=int, required=True)
+    parser.add_argument("--mode", choices=("schema", "gate"), default="schema")
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    path = args.manifest or MANIFEST_DIR / f"phase_{args.phase}.yaml"
+    payload = _build_payload(path, args.mode)
+    if payload.get("phase") is not None and payload["phase"] != args.phase:
+        payload["ok"] = False
+        payload["errors"] = [
+            *payload["errors"],
+            f"phase: requested {args.phase}, manifest declares {payload['phase']}",
+        ]
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload["ok"]:
+        print(
+            f"PASS issue={payload['issue']} phase={payload['phase']} mode={payload['mode']} "
+            f"status_counts={payload['status_counts']}"
+        )
+    else:
+        print(f"FAIL manifest={payload['manifest']} mode={payload['mode']}")
+        for error in payload["errors"]:
+            print(f"  - {error}")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/tools/phase_acceptance.py
+++ b/src/unilab/tools/phase_acceptance.py
@@ -1,0 +1,601 @@
+"""Strict contracts for phased implementation acceptance manifests."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from math import isfinite
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from omegaconf import OmegaConf
+
+SCHEMA_VERSION = 1
+
+_CLAIM_ID_RE = re.compile(r"^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$")
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_CONFIG_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MISSING = object()
+
+
+class AcceptanceLane(str, Enum):
+    PR = "A"
+    BACKEND = "B"
+    GPU = "C"
+    BENCHMARK = "D"
+
+
+class ClaimStatus(str, Enum):
+    PLANNED = "planned"
+    IMPLEMENTED = "implemented"
+    VERIFIED = "verified"
+    PROMOTED = "promoted"
+
+
+class EvidenceResult(str, Enum):
+    NOT_RUN = "NOT_RUN"
+    PASS = "PASS"
+    FAIL = "FAIL"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class EnvironmentSpec:
+    dependencies: tuple[str, ...]
+    hardware: str
+    owner_yaml: str | None
+    seeds: tuple[int, ...]
+    batch_sizes: tuple[int, ...]
+    dtype: str | None
+    plan_fingerprint: str | None
+
+
+@dataclass(frozen=True)
+class AcceptanceSpec:
+    tolerance: tuple[tuple[str, float], ...]
+    thresholds: tuple[tuple[str, float], ...]
+    repetitions: int
+    max_dispersion: float | None
+    failure_semantics: str
+
+
+@dataclass(frozen=True)
+class EvidenceSpec:
+    result: EvidenceResult
+    artifact_refs: tuple[str, ...]
+    commit_sha: str | None
+    config_hash: str | None
+    executed_test_ids: tuple[str, ...]
+    skipped_test_ids: tuple[str, ...]
+    xfailed_test_ids: tuple[str, ...]
+    summary: str
+
+
+@dataclass(frozen=True)
+class InvalidationSpec:
+    paths: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    fingerprints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AcceptanceClaim:
+    claim_id: str
+    expected: str
+    risk: str
+    owner: str
+    oracle: str
+    commands: tuple[str, ...]
+    lane: AcceptanceLane
+    required: bool
+    required_test_ids: tuple[str, ...]
+    environment: EnvironmentSpec
+    acceptance: AcceptanceSpec
+    evidence: EvidenceSpec
+    invalidation: InvalidationSpec
+    status: ClaimStatus
+
+
+@dataclass(frozen=True)
+class PhaseAcceptanceManifest:
+    schema_version: int
+    issue: int
+    phase: int
+    integration_branch: str
+    required_lanes: tuple[AcceptanceLane, ...]
+    claims: tuple[AcceptanceClaim, ...]
+    source: Path
+
+
+class ManifestValidationError(ValueError):
+    def __init__(self, source: Path, errors: list[str] | tuple[str, ...]) -> None:
+        self.source = source
+        self.errors = tuple(errors)
+        detail = "\n".join(f"- {error}" for error in self.errors)
+        super().__init__(f"invalid phase acceptance manifest {source}:\n{detail}")
+
+
+class _Parser:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+
+    def mapping(self, value: Any, path: str, keys: tuple[str, ...]) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            self.errors.append(f"{path}: expected mapping")
+            return {}
+        expected = set(keys)
+        actual = set(value)
+        for key in sorted(expected - actual):
+            self.errors.append(f"{path}: missing key `{key}`")
+        for key in sorted(actual - expected, key=str):
+            self.errors.append(f"{path}: unknown key `{key}`")
+        return value
+
+    def string(self, value: Any, path: str, *, allow_empty: bool = False) -> str:
+        if value is _MISSING:
+            return ""
+        if not isinstance(value, str):
+            self.errors.append(f"{path}: expected string")
+            return ""
+        if not allow_empty and not value.strip():
+            self.errors.append(f"{path}: must not be empty")
+        if "${" in value:
+            self.errors.append(f"{path}: interpolation is not allowed")
+        return value
+
+    def nullable_string(self, value: Any, path: str) -> str | None:
+        if value is _MISSING or value is None:
+            return None
+        return self.string(value, path)
+
+    def integer(self, value: Any, path: str, *, minimum: int | None = None) -> int:
+        if value is _MISSING:
+            return 0
+        if isinstance(value, bool) or not isinstance(value, int):
+            self.errors.append(f"{path}: expected integer")
+            return 0
+        if minimum is not None and value < minimum:
+            self.errors.append(f"{path}: must be >= {minimum}")
+        return int(value)
+
+    def boolean(self, value: Any, path: str) -> bool:
+        if value is _MISSING:
+            return False
+        if not isinstance(value, bool):
+            self.errors.append(f"{path}: expected boolean")
+            return False
+        return value
+
+    def number(self, value: Any, path: str, *, minimum: float | None = None) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            self.errors.append(f"{path}: expected number")
+            return 0.0
+        result = float(value)
+        if not isfinite(result):
+            self.errors.append(f"{path}: must be finite")
+        if minimum is not None and result < minimum:
+            self.errors.append(f"{path}: must be >= {minimum}")
+        return result
+
+    def nullable_number(self, value: Any, path: str, *, minimum: float = 0.0) -> float | None:
+        if value is _MISSING or value is None:
+            return None
+        return self.number(value, path, minimum=minimum)
+
+    def string_list(
+        self,
+        value: Any,
+        path: str,
+        *,
+        allow_empty: bool = True,
+    ) -> tuple[str, ...]:
+        if value is _MISSING:
+            return ()
+        if not isinstance(value, list):
+            self.errors.append(f"{path}: expected list of strings")
+            return ()
+        values = tuple(self.string(item, f"{path}[{index}]") for index, item in enumerate(value))
+        if not allow_empty and not values:
+            self.errors.append(f"{path}: must not be empty")
+        duplicates = sorted(item for item, count in Counter(values).items() if count > 1)
+        if duplicates:
+            self.errors.append(f"{path}: duplicate values {duplicates!r}")
+        return values
+
+    def int_list(self, value: Any, path: str, *, minimum: int) -> tuple[int, ...]:
+        if value is _MISSING:
+            return ()
+        if not isinstance(value, list):
+            self.errors.append(f"{path}: expected list of integers")
+            return ()
+        values = tuple(
+            self.integer(item, f"{path}[{index}]", minimum=minimum)
+            for index, item in enumerate(value)
+        )
+        if len(set(values)) != len(values):
+            self.errors.append(f"{path}: duplicate values")
+        return values
+
+    def number_mapping(
+        self, value: Any, path: str, *, minimum: float | None = None
+    ) -> tuple[tuple[str, float], ...]:
+        if value is _MISSING:
+            return ()
+        if not isinstance(value, dict):
+            self.errors.append(f"{path}: expected mapping of numeric values")
+            return ()
+        rows: list[tuple[str, float]] = []
+        for key, item in sorted(value.items(), key=lambda row: str(row[0])):
+            parsed_key = self.string(key, f"{path}.<key>")
+            rows.append((parsed_key, self.number(item, f"{path}.{parsed_key}", minimum=minimum)))
+        return tuple(rows)
+
+    def enum(self, value: Any, path: str, enum_type: type[Enum], default: Enum) -> Any:
+        if value is _MISSING:
+            return default
+        try:
+            return enum_type(value)
+        except (TypeError, ValueError):
+            allowed = [item.value for item in enum_type]
+            self.errors.append(f"{path}: expected one of {allowed!r}")
+            return default
+
+    def repo_path(self, value: Any, path: str, *, nullable: bool = False) -> str | None:
+        if nullable and (value is _MISSING or value is None):
+            return None
+        parsed = self.string(value, path)
+        candidate = Path(parsed)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            self.errors.append(f"{path}: must be a repository-relative path or glob")
+        return parsed
+
+    def repo_path_list(self, value: Any, path: str) -> tuple[str, ...]:
+        values = self.string_list(value, path, allow_empty=False)
+        for index, item in enumerate(values):
+            candidate = Path(item)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                self.errors.append(f"{path}[{index}]: must be a repository-relative path or glob")
+        return values
+
+
+_ROOT_KEYS = (
+    "schema_version",
+    "issue",
+    "phase",
+    "integration_branch",
+    "required_lanes",
+    "claims",
+)
+_CLAIM_KEYS = (
+    "claim_id",
+    "expected",
+    "risk",
+    "owner",
+    "oracle",
+    "commands",
+    "lane",
+    "required",
+    "required_test_ids",
+    "environment",
+    "acceptance",
+    "evidence",
+    "invalidation",
+    "status",
+)
+_ENVIRONMENT_KEYS = (
+    "dependencies",
+    "hardware",
+    "owner_yaml",
+    "seeds",
+    "batch_sizes",
+    "dtype",
+    "plan_fingerprint",
+)
+_ACCEPTANCE_KEYS = (
+    "tolerance",
+    "thresholds",
+    "repetitions",
+    "max_dispersion",
+    "failure_semantics",
+)
+_EVIDENCE_KEYS = (
+    "result",
+    "artifact_refs",
+    "commit_sha",
+    "config_hash",
+    "executed_test_ids",
+    "skipped_test_ids",
+    "xfailed_test_ids",
+    "summary",
+)
+_INVALIDATION_KEYS = ("paths", "capabilities", "fingerprints")
+
+
+def _parse_environment(parser: _Parser, raw: Any, path: str) -> EnvironmentSpec:
+    values = parser.mapping(raw, path, _ENVIRONMENT_KEYS)
+    return EnvironmentSpec(
+        dependencies=parser.string_list(
+            values.get("dependencies", _MISSING), f"{path}.dependencies", allow_empty=False
+        ),
+        hardware=parser.string(values.get("hardware", _MISSING), f"{path}.hardware"),
+        owner_yaml=parser.repo_path(
+            values.get("owner_yaml", _MISSING), f"{path}.owner_yaml", nullable=True
+        ),
+        seeds=parser.int_list(values.get("seeds", _MISSING), f"{path}.seeds", minimum=0),
+        batch_sizes=parser.int_list(
+            values.get("batch_sizes", _MISSING), f"{path}.batch_sizes", minimum=1
+        ),
+        dtype=parser.nullable_string(values.get("dtype", _MISSING), f"{path}.dtype"),
+        plan_fingerprint=parser.nullable_string(
+            values.get("plan_fingerprint", _MISSING), f"{path}.plan_fingerprint"
+        ),
+    )
+
+
+def _parse_acceptance(parser: _Parser, raw: Any, path: str) -> AcceptanceSpec:
+    values = parser.mapping(raw, path, _ACCEPTANCE_KEYS)
+    return AcceptanceSpec(
+        tolerance=parser.number_mapping(
+            values.get("tolerance", _MISSING), f"{path}.tolerance", minimum=0.0
+        ),
+        thresholds=parser.number_mapping(values.get("thresholds", _MISSING), f"{path}.thresholds"),
+        repetitions=parser.integer(
+            values.get("repetitions", _MISSING), f"{path}.repetitions", minimum=1
+        ),
+        max_dispersion=parser.nullable_number(
+            values.get("max_dispersion", _MISSING), f"{path}.max_dispersion"
+        ),
+        failure_semantics=parser.string(
+            values.get("failure_semantics", _MISSING), f"{path}.failure_semantics"
+        ),
+    )
+
+
+def _parse_evidence(parser: _Parser, raw: Any, path: str) -> EvidenceSpec:
+    values = parser.mapping(raw, path, _EVIDENCE_KEYS)
+    evidence = EvidenceSpec(
+        result=parser.enum(
+            values.get("result", _MISSING),
+            f"{path}.result",
+            EvidenceResult,
+            EvidenceResult.NOT_RUN,
+        ),
+        artifact_refs=parser.string_list(
+            values.get("artifact_refs", _MISSING), f"{path}.artifact_refs"
+        ),
+        commit_sha=parser.nullable_string(values.get("commit_sha", _MISSING), f"{path}.commit_sha"),
+        config_hash=parser.nullable_string(
+            values.get("config_hash", _MISSING), f"{path}.config_hash"
+        ),
+        executed_test_ids=parser.string_list(
+            values.get("executed_test_ids", _MISSING), f"{path}.executed_test_ids"
+        ),
+        skipped_test_ids=parser.string_list(
+            values.get("skipped_test_ids", _MISSING), f"{path}.skipped_test_ids"
+        ),
+        xfailed_test_ids=parser.string_list(
+            values.get("xfailed_test_ids", _MISSING), f"{path}.xfailed_test_ids"
+        ),
+        summary=parser.string(values.get("summary", _MISSING), f"{path}.summary", allow_empty=True),
+    )
+    for index, artifact_ref in enumerate(evidence.artifact_refs):
+        if artifact_ref.startswith("https://"):
+            if not urlparse(artifact_ref).netloc:
+                parser.errors.append(
+                    f"{path}.artifact_refs[{index}]: HTTPS artifact URL requires a host"
+                )
+            continue
+        if "://" in artifact_ref:
+            parser.errors.append(
+                f"{path}.artifact_refs[{index}]: only HTTPS artifact URLs are allowed"
+            )
+            continue
+        candidate = Path(artifact_ref)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            parser.errors.append(
+                f"{path}.artifact_refs[{index}]: must be an HTTPS URL or repository-relative path"
+            )
+    return evidence
+
+
+def _parse_invalidation(parser: _Parser, raw: Any, path: str) -> InvalidationSpec:
+    values = parser.mapping(raw, path, _INVALIDATION_KEYS)
+    return InvalidationSpec(
+        paths=parser.repo_path_list(values.get("paths", _MISSING), f"{path}.paths"),
+        capabilities=parser.string_list(
+            values.get("capabilities", _MISSING), f"{path}.capabilities"
+        ),
+        fingerprints=parser.string_list(
+            values.get("fingerprints", _MISSING), f"{path}.fingerprints"
+        ),
+    )
+
+
+def _validate_evidence_state(parser: _Parser, claim: AcceptanceClaim, path: str) -> None:
+    evidence = claim.evidence
+    if evidence.commit_sha is not None and not _COMMIT_SHA_RE.fullmatch(evidence.commit_sha):
+        parser.errors.append(f"{path}.evidence.commit_sha: expected full 40-character SHA")
+    if evidence.config_hash is not None and not _CONFIG_HASH_RE.fullmatch(evidence.config_hash):
+        parser.errors.append(f"{path}.evidence.config_hash: expected sha256:<64 hex>")
+
+    if claim.status == ClaimStatus.PLANNED:
+        if evidence.result != EvidenceResult.NOT_RUN:
+            parser.errors.append(f"{path}.evidence.result: planned claim must be NOT_RUN")
+        if (
+            evidence.artifact_refs
+            or evidence.commit_sha
+            or evidence.config_hash
+            or evidence.executed_test_ids
+            or evidence.skipped_test_ids
+            or evidence.xfailed_test_ids
+        ):
+            parser.errors.append(f"{path}.evidence: planned claim must not carry pass artifacts")
+
+    if evidence.result == EvidenceResult.PASS and claim.status not in {
+        ClaimStatus.VERIFIED,
+        ClaimStatus.PROMOTED,
+    }:
+        parser.errors.append(f"{path}.status: PASS evidence requires verified or promoted status")
+
+    if claim.status not in {ClaimStatus.VERIFIED, ClaimStatus.PROMOTED}:
+        return
+    if evidence.result != EvidenceResult.PASS:
+        parser.errors.append(f"{path}.evidence.result: verified claim must be PASS")
+    if not evidence.artifact_refs:
+        parser.errors.append(f"{path}.evidence.artifact_refs: verified claim requires artifacts")
+    if evidence.commit_sha is None:
+        parser.errors.append(f"{path}.evidence.commit_sha: expected full 40-character SHA")
+    if evidence.config_hash is None:
+        parser.errors.append(f"{path}.evidence.config_hash: expected sha256:<64 hex>")
+    if not evidence.summary.strip():
+        parser.errors.append(f"{path}.evidence.summary: verified claim requires a summary")
+    if evidence.skipped_test_ids:
+        parser.errors.append(f"{path}.evidence.skipped_test_ids: verified claim cannot skip tests")
+    if evidence.xfailed_test_ids:
+        parser.errors.append(f"{path}.evidence.xfailed_test_ids: verified claim cannot xfail tests")
+
+    executed = set(evidence.executed_test_ids)
+    for test_id in claim.required_test_ids:
+        if test_id not in executed:
+            parser.errors.append(f"{path}.evidence: required test `{test_id}` was not executed")
+        if test_id in evidence.skipped_test_ids:
+            parser.errors.append(f"{path}.evidence: required test `{test_id}` was skipped")
+        if test_id in evidence.xfailed_test_ids:
+            parser.errors.append(f"{path}.evidence: required test `{test_id}` was xfailed")
+
+
+def _parse_claim(parser: _Parser, raw: Any, index: int) -> AcceptanceClaim:
+    path = f"claims[{index}]"
+    values = parser.mapping(raw, path, _CLAIM_KEYS)
+    claim = AcceptanceClaim(
+        claim_id=parser.string(values.get("claim_id", _MISSING), f"{path}.claim_id"),
+        expected=parser.string(values.get("expected", _MISSING), f"{path}.expected"),
+        risk=parser.string(values.get("risk", _MISSING), f"{path}.risk"),
+        owner=parser.string(values.get("owner", _MISSING), f"{path}.owner"),
+        oracle=parser.string(values.get("oracle", _MISSING), f"{path}.oracle"),
+        commands=parser.string_list(
+            values.get("commands", _MISSING), f"{path}.commands", allow_empty=False
+        ),
+        lane=parser.enum(
+            values.get("lane", _MISSING), f"{path}.lane", AcceptanceLane, AcceptanceLane.PR
+        ),
+        required=parser.boolean(values.get("required", _MISSING), f"{path}.required"),
+        required_test_ids=parser.string_list(
+            values.get("required_test_ids", _MISSING),
+            f"{path}.required_test_ids",
+            allow_empty=False,
+        ),
+        environment=_parse_environment(
+            parser, values.get("environment", _MISSING), f"{path}.environment"
+        ),
+        acceptance=_parse_acceptance(
+            parser, values.get("acceptance", _MISSING), f"{path}.acceptance"
+        ),
+        evidence=_parse_evidence(parser, values.get("evidence", _MISSING), f"{path}.evidence"),
+        invalidation=_parse_invalidation(
+            parser, values.get("invalidation", _MISSING), f"{path}.invalidation"
+        ),
+        status=parser.enum(
+            values.get("status", _MISSING),
+            f"{path}.status",
+            ClaimStatus,
+            ClaimStatus.PLANNED,
+        ),
+    )
+    if claim.claim_id and not _CLAIM_ID_RE.fullmatch(claim.claim_id):
+        parser.errors.append(f"{path}.claim_id: expected stable uppercase kebab-case ID")
+    _validate_evidence_state(parser, claim, path)
+    return claim
+
+
+def parse_phase_acceptance(raw: Any, *, source: Path = Path("<memory>")) -> PhaseAcceptanceManifest:
+    parser = _Parser()
+    values = parser.mapping(raw, "manifest", _ROOT_KEYS)
+    schema_version = parser.integer(values.get("schema_version", _MISSING), "schema_version")
+    if schema_version != SCHEMA_VERSION:
+        parser.errors.append(f"schema_version: expected {SCHEMA_VERSION}, got {schema_version!r}")
+    issue = parser.integer(values.get("issue", _MISSING), "issue", minimum=1)
+    phase = parser.integer(values.get("phase", _MISSING), "phase", minimum=0)
+    if phase > 7:
+        parser.errors.append("phase: expected value in range 0..7")
+    integration_branch = parser.string(
+        values.get("integration_branch", _MISSING), "integration_branch"
+    )
+
+    raw_lanes = parser.string_list(
+        values.get("required_lanes", _MISSING), "required_lanes", allow_empty=False
+    )
+    required_lanes = tuple(
+        parser.enum(lane, f"required_lanes[{index}]", AcceptanceLane, AcceptanceLane.PR)
+        for index, lane in enumerate(raw_lanes)
+    )
+
+    raw_claims = values.get("claims", _MISSING)
+    if not isinstance(raw_claims, list):
+        parser.errors.append("claims: expected non-empty list")
+        raw_claims = []
+    elif not raw_claims:
+        parser.errors.append("claims: must not be empty")
+    claims = tuple(_parse_claim(parser, raw, index) for index, raw in enumerate(raw_claims))
+
+    claim_ids = [claim.claim_id for claim in claims]
+    duplicate_ids = sorted(item for item, count in Counter(claim_ids).items() if count > 1)
+    if duplicate_ids:
+        parser.errors.append(f"claims: duplicate claim IDs {duplicate_ids!r}")
+    expected_prefix = f"P{phase}-"
+    for index, claim in enumerate(claims):
+        if claim.claim_id and not claim.claim_id.startswith(expected_prefix):
+            parser.errors.append(
+                f"claims[{index}].claim_id: phase {phase} claim must start with `{expected_prefix}`"
+            )
+
+    required_claim_lanes = {claim.lane for claim in claims if claim.required}
+    if set(required_lanes) != required_claim_lanes:
+        parser.errors.append(
+            "required_lanes: must exactly match lanes used by required claims; "
+            f"declared={sorted(lane.value for lane in set(required_lanes))!r}, "
+            f"used={sorted(lane.value for lane in required_claim_lanes)!r}"
+        )
+
+    if parser.errors:
+        raise ManifestValidationError(source, parser.errors)
+    return PhaseAcceptanceManifest(
+        schema_version=schema_version,
+        issue=issue,
+        phase=phase,
+        integration_branch=integration_branch,
+        required_lanes=required_lanes,
+        claims=claims,
+        source=source,
+    )
+
+
+def load_phase_acceptance(path: Path) -> PhaseAcceptanceManifest:
+    try:
+        config = OmegaConf.load(path)
+        raw = OmegaConf.to_container(config, resolve=False)
+    except Exception as exc:  # noqa: BLE001 - normalize parser failures for the CLI
+        raise ManifestValidationError(
+            path, [f"cannot load YAML: {type(exc).__name__}: {exc}"]
+        ) from exc
+    return parse_phase_acceptance(raw, source=path)
+
+
+def phase_gate_errors(manifest: PhaseAcceptanceManifest) -> tuple[str, ...]:
+    errors: list[str] = []
+    for claim in manifest.claims:
+        if not claim.required:
+            continue
+        if claim.status not in {ClaimStatus.VERIFIED, ClaimStatus.PROMOTED}:
+            errors.append(
+                f"{claim.claim_id}: required claim is {claim.status.value}, expected verified/promoted"
+            )
+    return tuple(errors)
+
+
+def manifest_status_counts(manifest: PhaseAcceptanceManifest) -> dict[str, int]:
+    counts = Counter(claim.status.value for claim in manifest.claims)
+    return {status.value: counts.get(status.value, 0) for status in ClaimStatus}

--- a/tests/acceptance/issue_705/manifests/phase_0.yaml
+++ b/tests/acceptance/issue_705/manifests/phase_0.yaml
@@ -1,0 +1,297 @@
+schema_version: 1
+issue: 705
+phase: 0
+integration_branch: feat/issue-705-manager-mjwarp
+required_lanes: [A, B, D]
+claims:
+  - claim_id: P0-WORKFLOW-CANARY
+    expected: Intermediate PR creation, update, push, merge, and branch lifecycle produce no Actions run.
+    risk: Remote CI/CD is accidentally triggered or treated as an empty successful gate.
+    owner: CI/tooling
+    oracle: GitHub PR status rollup, commit checks/statuses, and branch Actions runs are independently empty.
+    commands:
+      - uv run scripts/audit_issue705_workflow_triggers.py --json
+      - uv run pytest tests/scripts/test_issue705_workflow_audit.py -v
+    lane: A
+    required: true
+    required_test_ids:
+      - tests/scripts/test_issue705_workflow_audit.py::test_current_workflows_exclude_issue705_integration_branch
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_accepts_explicit_main_only_triggers
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_integration_branch_target
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_implicit_all_branches
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_branches_ignore
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_unfilterable_pr_activity_event
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_branch_create_event
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_invalid_yaml
+      - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_empty_workflow_directory
+    environment:
+      dependencies: [uv.lock]
+      hardware: Linux CPU; GitHub API read access
+      owner_yaml: null
+      seeds: []
+      batch_sizes: []
+      dtype: null
+      plan_fingerprint: workflow-trigger-policy-v1
+    acceptance:
+      tolerance: {}
+      thresholds:
+        actions_runs: 0
+        check_runs: 0
+        legacy_statuses: 0
+      repetitions: 2
+      max_dispersion: 0
+      failure_semantics: Any matching trigger, remote run, check, parse ambiguity, or missing workflow is FAIL.
+    evidence:
+      result: PASS
+      artifact_refs:
+        - https://github.com/unilabsim/UniLab/pull/708
+        - https://github.com/unilabsim/UniLab/issues/707
+      commit_sha: 2612f4ec906764d2ecc0ca2b1f8762b3b7034218
+      config_hash: sha256:775da7547f376f9a20461a31da2c13c093d491ca6586af2f832fa29736ceecc6
+      executed_test_ids:
+        - tests/scripts/test_issue705_workflow_audit.py::test_current_workflows_exclude_issue705_integration_branch
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_accepts_explicit_main_only_triggers
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_integration_branch_target
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_implicit_all_branches
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_branches_ignore
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_unfilterable_pr_activity_event
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_branch_create_event
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_invalid_yaml
+        - tests/scripts/test_issue705_workflow_audit.py::test_audit_rejects_empty_workflow_directory
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: PR #708 merged with no status rollup, checks, statuses, or Actions runs.
+    invalidation:
+      paths:
+        - .github/workflows/*.yml
+        - .github/workflows/*.yaml
+        - scripts/audit_issue705_workflow_triggers.py
+        - tests/scripts/test_issue705_workflow_audit.py
+      capabilities: [intermediate-pr-no-remote-ci]
+      fingerprints: [workflow-trigger-policy-v1]
+    status: verified
+
+  - claim_id: P0-ACCEPTANCE-CONTRACT
+    expected: Phase manifests are strict, machine-readable, and fail closed in schema and gate modes.
+    risk: Missing or self-asserted evidence is accepted as phase completion.
+    owner: CI/tooling
+    oracle: Positive, negative, and fault-oriented parser/validator tests plus CLI exit codes.
+    commands:
+      - uv run pytest tests/tools/test_phase_acceptance.py tests/scripts/test_issue705_phase_acceptance.py -v
+      - uv run scripts/validate_issue705_phase.py --phase 0 --mode schema
+    lane: A
+    required: true
+    required_test_ids:
+      - tests/tools/test_phase_acceptance.py
+      - tests/scripts/test_issue705_phase_acceptance.py
+    environment:
+      dependencies: [uv.lock]
+      hardware: any
+      owner_yaml: null
+      seeds: []
+      batch_sizes: []
+      dtype: null
+      plan_fingerprint: phase-acceptance-schema-v1
+    acceptance:
+      tolerance: {}
+      thresholds: {}
+      repetitions: 1
+      max_dispersion: 0
+      failure_semantics: Unknown, missing, inconsistent, skipped, stale, or non-PASS required evidence is FAIL.
+    evidence:
+      result: NOT_RUN
+      artifact_refs: []
+      commit_sha: null
+      config_hash: null
+      executed_test_ids: []
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: Implementation is part of child issue #709; gate evidence is pending merge.
+    invalidation:
+      paths:
+        - src/unilab/tools/phase_acceptance.py
+        - scripts/validate_issue705_phase.py
+        - tests/acceptance/issue_705/manifests/*.yaml
+        - tests/tools/test_phase_acceptance.py
+        - tests/scripts/test_issue705_phase_acceptance.py
+      capabilities: [phase-acceptance]
+      fingerprints: [phase-acceptance-schema-v1]
+    status: implemented
+
+  - claim_id: P0-CLAIM-GAP-AUDIT
+    expected: Every Phase claim maps to an existing test or an owned target test ID and explicit gap.
+    risk: Existing smoke, field-write, or global coverage is misreported as effect or performance evidence.
+    owner: validation
+    oracle: Bidirectional claim-to-test inventory with no ownerless or unclassified gaps.
+    commands:
+      - uv run scripts/audit_issue705_claims.py --phase 0
+    lane: A
+    required: true
+    required_test_ids: [acceptance:P0-CLAIM-GAP-AUDIT]
+    environment:
+      dependencies: [uv.lock]
+      hardware: any
+      owner_yaml: null
+      seeds: []
+      batch_sizes: []
+      dtype: null
+      plan_fingerprint: claim-gap-inventory-v1
+    acceptance:
+      tolerance: {}
+      thresholds:
+        ownerless_gaps: 0
+        unclassified_claims: 0
+      repetitions: 1
+      max_dispersion: 0
+      failure_semantics: Any claim without an owner, oracle, test ID, or explicit gap is FAIL.
+    evidence:
+      result: NOT_RUN
+      artifact_refs: []
+      commit_sha: null
+      config_hash: null
+      executed_test_ids: []
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: ""
+    invalidation:
+      paths: [tests/**, benchmark/**, src/unilab/**, scripts/**]
+      capabilities: [claim-gap-audit]
+      fingerprints: [claim-gap-inventory-v1]
+    status: planned
+
+  - claim_id: P0-DR-CAPABILITY-INVENTORY
+    expected: mjwarp DR fields declare direct and derived storage, recompute, row, graph, memory, and effect-test requirements.
+    risk: A writable field is advertised even though physics does not consume the per-world value.
+    owner: backend/DR
+    oracle: Field inventory completeness checks against mjlab findings and the planned capability matrix.
+    commands:
+      - uv run scripts/validate_issue705_dr_inventory.py
+    lane: B
+    required: true
+    required_test_ids: [acceptance:P0-DR-CAPABILITY-INVENTORY]
+    environment:
+      dependencies: [mujoco-warp>=3.10.0.3, warp-lang>=1.14.0]
+      hardware: Linux CPU for inventory; CUDA GPU for later effect evidence
+      owner_yaml: null
+      seeds: []
+      batch_sizes: []
+      dtype: null
+      plan_fingerprint: mjwarp-dr-capability-inventory-v1
+    acceptance:
+      tolerance: {}
+      thresholds:
+        unowned_fields: 0
+        fields_without_effect_test: 0
+      repetitions: 1
+      max_dispersion: 0
+      failure_semantics: Missing derived field, recompute, row, graph, memory, or effect-test mapping is FAIL.
+    evidence:
+      result: NOT_RUN
+      artifact_refs: []
+      commit_sha: null
+      config_hash: null
+      executed_test_ids: []
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: ""
+    invalidation:
+      paths:
+        - benchmark/mjwarp/**
+        - src/unilab/dr/**
+        - src/unilab/base/backend/**
+        - uv.lock
+      capabilities: [mjwarp-dr]
+      fingerprints: [mjwarp-dr-capability-inventory-v1]
+    status: planned
+
+  - claim_id: P0-BASELINE-PROVENANCE
+    expected: G1 env, PPO, memory, DR, and reset-density baselines are reproducible from raw artifacts.
+    risk: A single best run or raw physics SPS is used as production performance evidence.
+    owner: benchmark/training
+    oracle: Independent-process paired baseline runs with commit, lock, config, hardware, p50/p95, and raw samples.
+    commands:
+      - uv run benchmark/env/benchmark_env_step.py task=g1_walk_flat/mujoco
+      - uv run scripts/train_rsl_rl.py task=g1_walk_flat/mujoco training.no_play=true
+    lane: D
+    required: true
+    required_test_ids: [acceptance:P0-BASELINE-PROVENANCE]
+    environment:
+      dependencies: [uv.lock]
+      hardware: Phase 0 frozen CPU/GPU benchmark host
+      owner_yaml: conf/ppo/task/g1_walk_flat/mujoco.yaml
+      seeds: [0, 1, 2, 3, 4]
+      batch_sizes: [128, 1024, 4096]
+      dtype: float32
+      plan_fingerprint: null
+    acceptance:
+      tolerance: {}
+      thresholds:
+        min_process_repeats: 5
+        min_training_seeds: 5
+      repetitions: 5
+      max_dispersion: null
+      failure_semantics: Missing raw samples/provenance, post-hoc filtering, or unreconciled synchronization is FAIL.
+    evidence:
+      result: NOT_RUN
+      artifact_refs: []
+      commit_sha: null
+      config_hash: null
+      executed_test_ids: []
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: ""
+    invalidation:
+      paths:
+        - benchmark/**
+        - scripts/train_rsl_rl.py
+        - src/unilab/envs/locomotion/g1/**
+        - src/unilab/base/backend/mujoco/**
+        - conf/ppo/task/g1_walk_flat/mujoco.yaml
+        - uv.lock
+      capabilities: [g1-baseline, benchmark-provenance]
+      fingerprints: [g1-phase0-baseline-v1]
+    status: planned
+
+  - claim_id: P0-THRESHOLD-FREEZE
+    expected: Performance, training, DR, memory, and compatibility gates are fixed before candidate measurements.
+    risk: Thresholds are relaxed after results or omit a failing target batch/seed.
+    owner: benchmark/training
+    oracle: Reviewed threshold manifest and validator reject missing or post-hoc-mutated criteria.
+    commands:
+      - uv run scripts/validate_issue705_phase.py --phase 0 --mode gate
+    lane: D
+    required: true
+    required_test_ids: [acceptance:P0-THRESHOLD-FREEZE]
+    environment:
+      dependencies: [uv.lock]
+      hardware: Phase 0 frozen CPU/GPU benchmark host
+      owner_yaml: conf/ppo/task/g1_walk_flat/mujoco.yaml
+      seeds: [0, 1, 2, 3, 4]
+      batch_sizes: [128, 1024, 4096]
+      dtype: float32
+      plan_fingerprint: null
+    acceptance:
+      tolerance: {}
+      thresholds:
+        manager_overhead_ratio_max: 1.05
+        required_training_seeds: 5
+      repetitions: 5
+      max_dispersion: null
+      failure_semantics: Any threshold changed with candidate implementation/results in the same PR is FAIL.
+    evidence:
+      result: NOT_RUN
+      artifact_refs: []
+      commit_sha: null
+      config_hash: null
+      executed_test_ids: []
+      skipped_test_ids: []
+      xfailed_test_ids: []
+      summary: ""
+    invalidation:
+      paths:
+        - tests/acceptance/issue_705/manifests/phase_0.yaml
+        - benchmark/**
+        - conf/ppo/task/g1_walk_flat/mujoco.yaml
+      capabilities: [phase-gate-thresholds]
+      fingerprints: [g1-phase0-thresholds-v1]
+    status: planned

--- a/tests/scripts/test_issue705_phase_acceptance.py
+++ b/tests/scripts/test_issue705_phase_acceptance.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import validate_issue705_phase
+
+from unilab.tools.phase_acceptance import (
+    AcceptanceLane,
+    ClaimStatus,
+    load_phase_acceptance,
+    phase_gate_errors,
+)
+
+
+def test_phase0_manifest_covers_frozen_claims_and_passes_schema() -> None:
+    manifest_path = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "acceptance"
+        / "issue_705"
+        / "manifests"
+        / "phase_0.yaml"
+    )
+
+    manifest = load_phase_acceptance(manifest_path)
+
+    assert {claim.claim_id for claim in manifest.claims} == {
+        "P0-WORKFLOW-CANARY",
+        "P0-ACCEPTANCE-CONTRACT",
+        "P0-CLAIM-GAP-AUDIT",
+        "P0-DR-CAPABILITY-INVENTORY",
+        "P0-BASELINE-PROVENANCE",
+        "P0-THRESHOLD-FREEZE",
+    }
+    assert manifest.claims[0].status == ClaimStatus.VERIFIED
+    assert set(manifest.required_lanes) == {
+        AcceptanceLane.PR,
+        AcceptanceLane.BACKEND,
+        AcceptanceLane.BENCHMARK,
+    }
+    assert phase_gate_errors(manifest)
+
+
+def test_phase0_schema_cli_passes(capsys) -> None:
+    exit_code = validate_issue705_phase.main(["--phase", "0", "--mode", "schema"])
+
+    assert exit_code == 0
+    assert "PASS issue=705 phase=0 mode=schema" in capsys.readouterr().out
+
+
+def test_phase0_gate_cli_fails_until_required_claims_are_verified(capsys) -> None:
+    exit_code = validate_issue705_phase.main(["--phase", "0", "--mode", "gate"])
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "FAIL" in output
+    assert "P0-BASELINE-PROVENANCE" in output
+
+
+def test_cli_rejects_requested_phase_mismatch(tmp_path: Path, capsys) -> None:
+    manifest = tmp_path / "phase_1.yaml"
+    source = validate_issue705_phase.MANIFEST_DIR / "phase_0.yaml"
+    manifest.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    exit_code = validate_issue705_phase.main(
+        ["--phase", "1", "--manifest", str(manifest), "--mode", "schema"]
+    )
+
+    assert exit_code == 1
+    assert "requested 1, manifest declares 0" in capsys.readouterr().out

--- a/tests/tools/test_phase_acceptance.py
+++ b/tests/tools/test_phase_acceptance.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from unilab.tools.phase_acceptance import (
+    AcceptanceLane,
+    ClaimStatus,
+    ManifestValidationError,
+    parse_phase_acceptance,
+    phase_gate_errors,
+)
+
+
+def _claim() -> dict:
+    return {
+        "claim_id": "P0-CONTRACT",
+        "expected": "The contract is enforced.",
+        "risk": "Invalid evidence passes.",
+        "owner": "tooling",
+        "oracle": "Independent validator tests.",
+        "commands": ["uv run pytest tests/tools/test_phase_acceptance.py"],
+        "lane": "A",
+        "required": True,
+        "required_test_ids": ["test:contract"],
+        "environment": {
+            "dependencies": ["uv.lock"],
+            "hardware": "any",
+            "owner_yaml": None,
+            "seeds": [],
+            "batch_sizes": [],
+            "dtype": None,
+            "plan_fingerprint": "contract-v1",
+        },
+        "acceptance": {
+            "tolerance": {},
+            "thresholds": {},
+            "repetitions": 1,
+            "max_dispersion": 0,
+            "failure_semantics": "Any mismatch is FAIL.",
+        },
+        "evidence": {
+            "result": "NOT_RUN",
+            "artifact_refs": [],
+            "commit_sha": None,
+            "config_hash": None,
+            "executed_test_ids": [],
+            "skipped_test_ids": [],
+            "xfailed_test_ids": [],
+            "summary": "",
+        },
+        "invalidation": {
+            "paths": ["src/unilab/tools/phase_acceptance.py"],
+            "capabilities": ["phase-acceptance"],
+            "fingerprints": ["contract-v1"],
+        },
+        "status": "planned",
+    }
+
+
+def _manifest() -> dict:
+    return {
+        "schema_version": 1,
+        "issue": 705,
+        "phase": 0,
+        "integration_branch": "feat/issue-705-manager-mjwarp",
+        "required_lanes": ["A"],
+        "claims": [_claim()],
+    }
+
+
+def _errors(raw: dict) -> tuple[str, ...]:
+    with pytest.raises(ManifestValidationError) as exc_info:
+        parse_phase_acceptance(raw)
+    return exc_info.value.errors
+
+
+def test_valid_planned_manifest_passes_schema_and_fails_gate() -> None:
+    manifest = parse_phase_acceptance(_manifest())
+
+    assert manifest.required_lanes == (AcceptanceLane.PR,)
+    assert manifest.claims[0].status == ClaimStatus.PLANNED
+    assert phase_gate_errors(manifest) == (
+        "P0-CONTRACT: required claim is planned, expected verified/promoted",
+    )
+
+
+def test_verified_manifest_passes_gate_with_complete_evidence() -> None:
+    raw = _manifest()
+    claim = raw["claims"][0]
+    claim["status"] = "verified"
+    claim["evidence"] = {
+        "result": "PASS",
+        "artifact_refs": ["https://github.com/unilabsim/UniLab/pull/708"],
+        "commit_sha": "a" * 40,
+        "config_hash": f"sha256:{'b' * 64}",
+        "executed_test_ids": ["test:contract"],
+        "skipped_test_ids": [],
+        "xfailed_test_ids": [],
+        "summary": "Contract test passed.",
+    }
+
+    manifest = parse_phase_acceptance(raw)
+
+    assert phase_gate_errors(manifest) == ()
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda raw: raw.update({"unknown": True}), "manifest: unknown key `unknown`"),
+        (lambda raw: raw.pop("issue"), "manifest: missing key `issue`"),
+        (lambda raw: raw.update({"schema_version": 2}), "schema_version: expected 1"),
+        (lambda raw: raw.update({"required_lanes": ["Z"]}), "expected one of"),
+        (lambda raw: raw["claims"][0].update({"status": "done"}), "expected one of"),
+        (lambda raw: raw["claims"][0].update({"oracle": ""}), "oracle: must not be empty"),
+        (lambda raw: raw["claims"][0].update({"commands": []}), "commands: must not be empty"),
+        (
+            lambda raw: raw["claims"][0]["invalidation"].update({"paths": ["../outside"]}),
+            "must be a repository-relative path",
+        ),
+    ],
+)
+def test_manifest_rejects_invalid_contract(mutate, message: str) -> None:
+    raw = _manifest()
+    mutate(raw)
+
+    assert any(message in error for error in _errors(raw))
+
+
+def test_manifest_rejects_duplicate_claim_ids() -> None:
+    raw = _manifest()
+    raw["claims"].append(copy.deepcopy(raw["claims"][0]))
+
+    assert any("duplicate claim IDs" in error for error in _errors(raw))
+
+
+def test_verified_manifest_rejects_missing_or_skipped_required_test() -> None:
+    raw = _manifest()
+    claim = raw["claims"][0]
+    claim["status"] = "verified"
+    claim["evidence"] = {
+        "result": "PASS",
+        "artifact_refs": ["artifacts/result.json"],
+        "commit_sha": "a" * 40,
+        "config_hash": f"sha256:{'b' * 64}",
+        "executed_test_ids": [],
+        "skipped_test_ids": ["test:contract"],
+        "xfailed_test_ids": [],
+        "summary": "Incomplete run.",
+    }
+
+    errors = _errors(raw)
+
+    assert any("was not executed" in error for error in errors)
+    assert any("was skipped" in error for error in errors)
+
+
+def test_implemented_manifest_rejects_malformed_evidence_hashes() -> None:
+    raw = _manifest()
+    claim = raw["claims"][0]
+    claim["status"] = "implemented"
+    claim["evidence"]["commit_sha"] = "short"
+    claim["evidence"]["config_hash"] = "sha256:not-a-hash"
+
+    errors = _errors(raw)
+
+    assert any("full 40-character SHA" in error for error in errors)
+    assert any("sha256:<64 hex>" in error for error in errors)
+
+
+def test_planned_manifest_rejects_executed_evidence() -> None:
+    raw = _manifest()
+    raw["claims"][0]["evidence"]["executed_test_ids"] = ["test:contract"]
+
+    assert any("planned claim must not carry pass artifacts" in error for error in _errors(raw))
+
+
+def test_manifest_rejects_non_https_artifact_url() -> None:
+    raw = _manifest()
+    claim = raw["claims"][0]
+    claim["status"] = "implemented"
+    claim["evidence"]["artifact_refs"] = ["http://example.invalid/result.json"]
+
+    assert any("only HTTPS artifact URLs" in error for error in _errors(raw))
+
+
+def test_manifest_rejects_required_lane_mismatch() -> None:
+    raw = _manifest()
+    raw["required_lanes"] = ["A", "D"]
+
+    assert any(
+        "must exactly match lanes used by required claims" in error for error in _errors(raw)
+    )
+
+
+def test_manifest_rejects_nonfinite_or_negative_tolerance() -> None:
+    raw = _manifest()
+    raw["claims"][0]["acceptance"]["tolerance"] = {
+        "nan": float("nan"),
+        "negative": -1.0,
+    }
+
+    errors = _errors(raw)
+
+    assert any("tolerance.nan: must be finite" in error for error in errors)
+    assert any("tolerance.negative: must be >= 0.0" in error for error in errors)
+
+
+def test_manifest_reports_non_string_numeric_key_without_crashing() -> None:
+    raw = _manifest()
+    raw["claims"][0]["acceptance"]["thresholds"] = {"valid": 1, 2: 3}
+
+    assert any("thresholds.<key>: expected string" in error for error in _errors(raw))
+
+
+def test_verified_manifest_rejects_any_claim_xfail() -> None:
+    raw = _manifest()
+    claim = raw["claims"][0]
+    claim["status"] = "verified"
+    claim["evidence"] = {
+        "result": "PASS",
+        "artifact_refs": ["https://github.com/unilabsim/UniLab/pull/708"],
+        "commit_sha": "a" * 40,
+        "config_hash": f"sha256:{'b' * 64}",
+        "executed_test_ids": ["test:contract"],
+        "skipped_test_ids": [],
+        "xfailed_test_ids": ["test:unrelated"],
+        "summary": "Claim test passed but another claim test xfailed.",
+    }
+
+    assert any("verified claim cannot xfail tests" in error for error in _errors(raw))
+
+
+def test_manifest_rejects_interpolation_without_resolving_it() -> None:
+    raw = _manifest()
+    raw["claims"][0]["commands"] = ["${oc.env:UNSAFE_COMMAND}"]
+
+    assert any("interpolation is not allowed" in error for error in _errors(raw))
+
+
+def test_parser_does_not_execute_declared_command(tmp_path: Path) -> None:
+    raw = _manifest()
+    marker = tmp_path / "must-not-exist"
+    raw["claims"][0]["commands"] = [f"touch {marker}"]
+
+    parse_phase_acceptance(raw)
+
+    assert not marker.exists()


### PR DESCRIPTION
Closes #709
Part of #705

## 变更

- 增加严格、fail-closed 的 Phase acceptance manifest schema 与 validator。
- 增加 Phase 0 claim、A/B/C/D lane、oracle、环境指纹、阈值和证据契约。
- 增加 schema/gate CLI 及单元、脚本级回归测试。

## Validation

- `uv run pytest -q tests/tools/test_phase_acceptance.py tests/scripts/test_issue705_phase_acceptance.py`: 25 passed
- mypy: 0 errors
- pyright: 0 errors
- ruff/format: passed
- `make test-all`: 1644 passed, 26 skipped, 267 deselected, 1 xfailed；coverage 70%
- `uv run scripts/audit_issue705_workflow_triggers.py`: PASS
- `uv run scripts/validate_issue705_phase.py --phase 0 --mode schema`: PASS
- `uv run scripts/validate_issue705_phase.py --phase 0 --mode gate`: 预期 exit 1，拒绝五项尚未 verified/promoted 的 required claim

## Review

已完成两轮自审，重点覆盖 malformed evidence state、混合类型 YAML key、NaN/Inf、负 tolerance、HTTPS artifact、planned evidence、verified skip/xfail、lane mismatch 与 canary test ID。

该 PR 按 #705 约定仅合入长期集成分支，不触发远端 CI。