### PR TITLE
fix: validate frozen baseline source at recorded commit

### DIFF
--- a/scripts/validate_issue705_g1_baseline.py
+++ b/scripts/validate_issue705_g1_baseline.py
@@ -16,6 +16,7 @@ from unilab.tools.g1_baseline_provenance import (
     BaselineValidationError,
     load_g1_baseline_artifact,
     load_g1_baseline_plan,
+    verify_g1_baseline_source,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -34,6 +35,7 @@ def _payload(plan_path: Path, artifact_path: Path) -> dict[str, Any]:
             plan,
             repo_root=REPO_ROOT,
         )
+        source_verification = verify_g1_baseline_source(artifact, plan, REPO_ROOT)
     except (BaselineValidationError, OSError, ValueError) as exc:
         errors = list(exc.errors) if isinstance(exc, BaselineValidationError) else [str(exc)]
         return {
@@ -51,6 +53,7 @@ def _payload(plan_path: Path, artifact_path: Path) -> dict[str, Any]:
         "plan": str(plan_path),
         "artifact": str(artifact_path),
         "source_commit": artifact["source"]["commit"],
+        "git_history_verified": source_verification.git_history_verified,
         "plan_sha256": artifact["plan"]["sha256"],
         "lane_counts": dict(sorted(lane_counts.items())),
         "errors": [],
@@ -69,7 +72,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif payload["ok"]:
         print(
             f"PASS source={payload['source_commit']} lanes={payload['lane_counts']} "
-            f"plan={payload['plan_sha256']}"
+            f"plan={payload['plan_sha256']} "
+            f"git_history_verified={payload['git_history_verified']}"
         )
     else:
         print(f"FAIL artifact={payload['artifact']}")

--- a/src/unilab/tools/g1_baseline_provenance.py
+++ b/src/unilab/tools/g1_baseline_provenance.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import subprocess
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -103,6 +104,12 @@ class G1BaselinePlan:
     dr_lane: DrLanePlan
     ppo_lane: PpoLanePlan
     source_path: Path
+
+
+@dataclass(frozen=True)
+class BaselineSourceVerification:
+    errors: tuple[str, ...]
+    git_history_verified: bool
 
 
 class BaselineValidationError(ValueError):
@@ -515,6 +522,59 @@ def source_tree_sha256(root: Path, source_inputs: Sequence[str]) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
+def _git(
+    repo_root: Path,
+    args: Sequence[str],
+    *,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _git_file_bytes(repo_root: Path, commit: str, path: str) -> bytes:
+    return _git(repo_root, ["show", f"{commit}:{path}"]).stdout
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def source_tree_sha256_at_commit(
+    repo_root: Path,
+    source_inputs: Sequence[str],
+    commit: str,
+) -> str:
+    paths: set[str] = set()
+    for source_input in source_inputs:
+        result = _git(
+            repo_root,
+            ["ls-tree", "-r", "--name-only", "-z", commit, "--", source_input],
+        )
+        resolved = {
+            item.decode("utf-8")
+            for item in result.stdout.split(b"\0")
+            if item and "__pycache__" not in item.decode("utf-8").split("/")
+        }
+        if not resolved:
+            raise FileNotFoundError(
+                f"recorded source input does not exist at {commit}: {source_input}"
+            )
+        paths.update(resolved)
+    digest = hashlib.sha256()
+    for path in sorted(paths):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(_git_file_bytes(repo_root, commit, path))
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
 def numeric_stats(values: Sequence[float]) -> dict[str, float | int]:
     array = np.asarray(values, dtype=np.float64)
     if array.ndim != 1 or array.size == 0 or not np.all(np.isfinite(array)):
@@ -872,7 +932,8 @@ def validate_g1_baseline_artifact(
         parser.errors.append("artifact.aggregates: does not recompute from raw case summaries")
 
     if repo_root is not None:
-        _validate_current_source(root, plan, repo_root, parser.errors)
+        verification = verify_g1_baseline_source(root, plan, repo_root)
+        parser.errors.extend(verification.errors)
     return tuple(parser.errors)
 
 
@@ -891,35 +952,88 @@ def load_g1_baseline_artifact(
     return cast(dict[str, Any], raw)
 
 
-def _validate_current_source(
+def verify_g1_baseline_source(
     root: Mapping[str, Any],
     plan: G1BaselinePlan,
     repo_root: Path,
-    errors: list[str],
-) -> None:
+) -> BaselineSourceVerification:
+    errors: list[str] = []
     plan_payload = root.get("plan", {})
     source_payload = root.get("source", {})
-    checks = {
-        "artifact.plan.sha256": (
-            plan_payload.get("sha256"),
-            sha256_file(repo_root / plan.source_path),
-        ),
-        "artifact.source.tree_sha256": (
-            source_payload.get("tree_sha256"),
-            source_tree_sha256(repo_root, plan.source_inputs),
-        ),
-        "artifact.source.uv_lock_sha256": (
-            source_payload.get("uv_lock_sha256"),
-            sha256_file(repo_root / "uv.lock"),
-        ),
-        "artifact.source.owner_yaml_sha256": (
-            source_payload.get("owner_yaml_sha256"),
-            sha256_file(repo_root / plan.owner_yaml),
-        ),
-    }
-    for path, (actual, expected) in checks.items():
-        if actual != expected:
-            errors.append(f"{path}: stale; expected current fingerprint {expected!r}")
+    if not isinstance(plan_payload, Mapping) or not isinstance(source_payload, Mapping):
+        return BaselineSourceVerification(
+            errors=("artifact source verification requires plan and source mappings",),
+            git_history_verified=False,
+        )
+
+    current_plan_sha = sha256_file(repo_root / plan.source_path)
+    if plan_payload.get("sha256") != current_plan_sha:
+        errors.append(
+            "artifact.plan.sha256: frozen plan changed; "
+            f"expected current fingerprint {current_plan_sha!r}"
+        )
+
+    commit = source_payload.get("commit")
+    if not isinstance(commit, str) or _COMMIT_RE.fullmatch(commit) is None:
+        return BaselineSourceVerification(tuple(errors), False)
+    try:
+        commit_exists = _git(
+            repo_root,
+            ["cat-file", "-e", f"{commit}^{{commit}}"],
+            check=False,
+        )
+    except OSError as exc:
+        errors.append(f"artifact.source.commit: cannot invoke Git: {exc}")
+        return BaselineSourceVerification(tuple(errors), False)
+    if commit_exists.returncode != 0:
+        try:
+            shallow = _git(
+                repo_root,
+                ["rev-parse", "--is-shallow-repository"],
+                check=False,
+            )
+        except OSError as exc:
+            errors.append(f"artifact.source.commit: cannot determine repository depth: {exc}")
+            return BaselineSourceVerification(tuple(errors), False)
+        if shallow.returncode == 0 and shallow.stdout.decode().strip() == "true":
+            return BaselineSourceVerification(tuple(errors), False)
+        errors.append("artifact.source.commit: cannot verify Git object in a full-history checkout")
+        return BaselineSourceVerification(tuple(errors), False)
+
+    try:
+        recorded_checks = {
+            "artifact.plan.sha256": (
+                plan_payload.get("sha256"),
+                _sha256_bytes(_git_file_bytes(repo_root, commit, plan.source_path.as_posix())),
+            ),
+            "artifact.source.tree_sha256": (
+                source_payload.get("tree_sha256"),
+                source_tree_sha256_at_commit(repo_root, plan.source_inputs, commit),
+            ),
+            "artifact.source.uv_lock_sha256": (
+                source_payload.get("uv_lock_sha256"),
+                _sha256_bytes(_git_file_bytes(repo_root, commit, "uv.lock")),
+            ),
+            "artifact.source.owner_yaml_sha256": (
+                source_payload.get("owner_yaml_sha256"),
+                _sha256_bytes(_git_file_bytes(repo_root, commit, plan.owner_yaml)),
+            ),
+        }
+        for path, (actual, expected) in recorded_checks.items():
+            if actual != expected:
+                errors.append(
+                    f"{path}: does not match recorded source commit; expected {expected!r}"
+                )
+        ancestor = _git(
+            repo_root,
+            ["merge-base", "--is-ancestor", commit, "HEAD"],
+            check=False,
+        )
+        if ancestor.returncode != 0:
+            errors.append("artifact.source.commit: is not an ancestor of HEAD")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        errors.append(f"artifact.source.commit: cannot verify recorded source: {exc}")
+    return BaselineSourceVerification(tuple(errors), not errors)
 
 
 def _validate_hardware(

--- a/tests/benchmark/test_issue705_g1_baseline_runner.py
+++ b/tests/benchmark/test_issue705_g1_baseline_runner.py
@@ -4,11 +4,13 @@ import ast
 from pathlib import Path
 
 import pytest
+from benchmark.issue705 import benchmark_g1_phase0
 from benchmark.issue705.benchmark_g1_phase0 import (
     DEFAULT_PLAN,
     _build_env_config,
     _load_plan,
     _run_subprocess,
+    _source_payload,
     main,
 )
 
@@ -27,6 +29,20 @@ def test_list_cases_exposes_the_frozen_fifty_process_matrix(capsys) -> None:
 def test_runner_refuses_implicit_expensive_execution() -> None:
     with pytest.raises(SystemExit, match="Refusing to run implicitly"):
         main([])
+
+
+def test_baseline_generation_rejects_a_dirty_source_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _load_plan(DEFAULT_PLAN)
+    monkeypatch.setattr(
+        benchmark_g1_phase0,
+        "_git",
+        lambda *args: " M src/unilab/base/backend/mujoco/backend.py",
+    )
+
+    with pytest.raises(RuntimeError, match="clean git worktree"):
+        _source_payload(plan)
 
 
 def test_env_config_uses_owner_then_applies_frozen_benchmark_profile() -> None:

--- a/tests/scripts/test_issue705_g1_baseline.py
+++ b/tests/scripts/test_issue705_g1_baseline.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scripts.validate_issue705_g1_baseline import PLAN_PATH, _payload, main
+from scripts.validate_issue705_g1_baseline import ARTIFACT_PATH, PLAN_PATH, _payload, main
+
+
+def test_real_artifact_reports_history_verification_status() -> None:
+    payload = _payload(PLAN_PATH, ARTIFACT_PATH)
+
+    assert payload["ok"] is True
+    assert isinstance(payload["git_history_verified"], bool)
 
 
 def test_validator_reports_missing_artifact_without_traceback(tmp_path: Path) -> None:

--- a/tests/tools/test_g1_baseline_provenance_contract.py
+++ b/tests/tools/test_g1_baseline_provenance_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 import uuid
 from dataclasses import asdict, replace
 from pathlib import Path
@@ -10,6 +11,7 @@ from typing import cast
 import pytest
 from omegaconf import OmegaConf
 
+from unilab.tools import g1_baseline_provenance
 from unilab.tools.g1_baseline_provenance import (
     BaselineValidationError,
     G1BaselinePlan,
@@ -21,10 +23,12 @@ from unilab.tools.g1_baseline_provenance import (
     numeric_stats,
     parse_g1_baseline_plan,
     source_tree_sha256,
+    source_tree_sha256_at_commit,
     summarize_dr_raw,
     summarize_env_raw,
     summarize_ppo_raw,
     validate_g1_baseline_artifact,
+    verify_g1_baseline_source,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -263,6 +267,46 @@ def _errors(raw: dict) -> tuple[str, ...]:
     return validate_g1_baseline_artifact(raw, _plan())
 
 
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _recorded_source_fixture(tmp_path: Path) -> tuple[G1BaselinePlan, dict, str]:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/code.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tmp_path / "owner.yaml").write_text("backend: mujoco\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (tmp_path / "plan.yaml").write_text("baseline: frozen\n", encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.name", "Issue 705 Test")
+    _git(tmp_path, "config", "user.email", "issue705@example.invalid")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "baseline")
+    baseline_commit = _git(tmp_path, "rev-parse", "HEAD")
+    plan = replace(
+        _plan(),
+        owner_yaml="owner.yaml",
+        source_inputs=("owner.yaml", "src", "uv.lock"),
+        source_path=Path("plan.yaml"),
+    )
+    root = {
+        "plan": {"sha256": g1_baseline_provenance.sha256_file(tmp_path / "plan.yaml")},
+        "source": {
+            "commit": baseline_commit,
+            "tree_sha256": source_tree_sha256(tmp_path, plan.source_inputs),
+            "uv_lock_sha256": g1_baseline_provenance.sha256_file(tmp_path / "uv.lock"),
+            "owner_yaml_sha256": g1_baseline_provenance.sha256_file(tmp_path / "owner.yaml"),
+        },
+    }
+    return plan, root, baseline_commit
+
+
 def test_frozen_plan_declares_complete_matrix() -> None:
     plan = _plan()
 
@@ -392,6 +436,82 @@ def test_source_tree_hash_changes_with_any_registered_input(tmp_path: Path) -> N
     (tmp_path / "src/code.py").write_text("VALUE = 2\n", encoding="utf-8")
 
     assert source_tree_sha256(tmp_path, ["owner.yaml", "src"]) != before
+
+
+def test_recorded_source_hash_remains_valid_after_candidate_changes(tmp_path: Path) -> None:
+    plan, root, baseline_commit = _recorded_source_fixture(tmp_path)
+    recorded_hash = root["source"]["tree_sha256"]
+
+    (tmp_path / "src/code.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(tmp_path, "add", "src/code.py")
+    _git(tmp_path, "commit", "-q", "-m", "candidate")
+
+    verification = verify_g1_baseline_source(root, plan, tmp_path)
+
+    assert verification.errors == ()
+    assert verification.git_history_verified is True
+    assert (
+        source_tree_sha256_at_commit(
+            tmp_path,
+            plan.source_inputs,
+            baseline_commit,
+        )
+        == recorded_hash
+    )
+    assert source_tree_sha256(tmp_path, plan.source_inputs) != recorded_hash
+
+
+def test_recorded_source_verification_rejects_tamper_and_unknown_commit(
+    tmp_path: Path,
+) -> None:
+    plan, root, _ = _recorded_source_fixture(tmp_path)
+    root["source"]["tree_sha256"] = f"sha256:{'0' * 64}"
+
+    tampered = verify_g1_baseline_source(root, plan, tmp_path)
+    assert any("does not match recorded source commit" in error for error in tampered.errors)
+    assert tampered.git_history_verified is False
+
+    root["source"]["commit"] = "f" * 40
+    unknown = verify_g1_baseline_source(root, plan, tmp_path)
+    assert any("full-history checkout" in error for error in unknown.errors)
+    assert unknown.git_history_verified is False
+
+    root["source"]["commit"] = _git(tmp_path, "rev-parse", "HEAD")
+    missing_input = verify_g1_baseline_source(
+        root,
+        replace(plan, source_inputs=(*plan.source_inputs, "missing.py")),
+        tmp_path,
+    )
+    assert any("recorded source input does not exist" in error for error in missing_input.errors)
+    assert missing_input.git_history_verified is False
+
+
+def test_recorded_source_commit_must_be_an_ancestor_of_candidate(tmp_path: Path) -> None:
+    plan, root, baseline_commit = _recorded_source_fixture(tmp_path)
+    tree = _git(tmp_path, "rev-parse", f"{baseline_commit}^{{tree}}")
+    orphan_commit = _git(tmp_path, "commit-tree", tree, "-m", "orphan")
+    root["source"]["commit"] = orphan_commit
+
+    verification = verify_g1_baseline_source(root, plan, tmp_path)
+
+    assert verification.errors == ("artifact.source.commit: is not an ancestor of HEAD",)
+    assert verification.git_history_verified is False
+
+
+def test_shallow_source_verification_reports_unverified_history(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    plan, root, _ = _recorded_source_fixture(origin)
+    (origin / "src/code.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(origin, "add", "src/code.py")
+    _git(origin, "commit", "-q", "-m", "candidate")
+    shallow = tmp_path / "shallow"
+    _git(tmp_path, "clone", "-q", "--depth=1", f"file://{origin}", str(shallow))
+
+    verification = verify_g1_baseline_source(root, plan, shallow)
+
+    assert verification.errors == ()
+    assert verification.git_history_verified is False
 
 
 def test_load_artifact_normalizes_malformed_json(tmp_path: Path) -> None:

--- a/tests/tools/test_issue705_threshold_freeze_receipt.py
+++ b/tests/tools/test_issue705_threshold_freeze_receipt.py
@@ -35,7 +35,7 @@ def _write_mutated_receipt(tmp_path: Path, mutate: Callable[[dict[str, Any]], No
     return destination
 
 
-def test_real_receipt_resolves_frozen_parent_commit_and_blob(
+def test_real_receipt_reports_whether_frozen_history_is_available(
     manifest: ThresholdManifest,
 ) -> None:
     receipt = load_freeze_receipt(
@@ -47,7 +47,15 @@ def test_real_receipt_resolves_frozen_parent_commit_and_blob(
     assert receipt.freeze_commit == "a2419b342b8663998b2e29cf20a4dce49b3127f5"
     assert receipt.data["manifest_git_blob"] == "f622c724eec1368cf4c28ce9a243a0fcac16d09d"
     assert receipt.data["manifest_sha256"] == sha256_file(MANIFEST_PATH)
-    assert receipt.git_history_verified is True
+    commit_available = (
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{receipt.freeze_commit}^{{commit}}"],
+            cwd=REPO_ROOT,
+            check=False,
+        ).returncode
+        == 0
+    )
+    assert receipt.git_history_verified is commit_available
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- validate frozen G1 baseline source inputs from the artifact recorded Git commit instead of the candidate working tree
- require the recorded commit to be an ancestor when full history is available and fail closed for invalid commits, blobs, and hashes
- make shallow-history fallback explicit through `git_history_verified=false` while preserving the frozen artifact hash chain
- keep baseline generation strict about a clean current worktree
- do not modify the frozen baseline artifact, threshold manifest, freeze receipt, or gate values

## Validation

- `make test-all` (`1854 passed, 26 skipped, 267 deselected, 1 xfailed`)
- baseline provenance validator: PASS, `git_history_verified=true`
- threshold validator: PASS
- claim gap audit: PASS
- Phase 0 acceptance schema: `6 verified`
- workflow audit: PASS

Part of #705.
Resolves #722 after integration into the #705 development branch.