### PR TITLE
test: promote phase 2 evidence gate

### DIFF
--- a/scripts/capture_issue705_phase2_evidence.py
+++ b/scripts/capture_issue705_phase2_evidence.py
@@ -1,0 +1,42 @@
+"""Capture real A/C Phase 2 evidence for Issue #705.
+
+Run only from a clean commit and write outside the repository first:
+
+    uv run --extra mjwarp scripts/capture_issue705_phase2_evidence.py \
+      --output /tmp/issue705-phase2-gate.json
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from unilab.tools.issue705_phase2_evidence import (
+    Phase2EvidenceError,
+    capture_phase2_evidence,
+    write_phase2_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = capture_phase2_evidence(REPO_ROOT)
+        write_phase2_evidence(report, args.output)
+    except Phase2EvidenceError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    print(
+        f"PASS: captured Issue #705 Phase 2 A/C evidence at {args.output} "
+        f"for {report['source']['commit_sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/tools/issue705_phase2_evidence.py
+++ b/src/unilab/tools/issue705_phase2_evidence.py
@@ -53,6 +53,17 @@ PHASE2_REQUIRED_TEST_IDS: dict[str, str] = {
     ),
 }
 
+PHASE2_MIN_REPETITIONS: dict[str, int] = {
+    "P2-BACKEND-IDENTITY": 1,
+    "P2-GPU-CORRECTNESS": 2,
+    "P2-RESET-ISOLATION": 3,
+    "P2-TRAJECTORY-DIFFERENTIAL": 3,
+    "P2-DR-OWNER-SEMANTICS": 3,
+    "P2-TRANSFER-ACCOUNTING": 2,
+    "P2-UNSUPPORTED-FAIL-CLOSED": 1,
+    "P2-TRAIN-LIVENESS": 1,
+}
+
 
 class Phase2EvidenceError(RuntimeError):
     """Raised when an evidence capture cannot establish a trustworthy PASS."""
@@ -66,6 +77,7 @@ class Phase2EvidenceCommand:
     lane: str
     argv: tuple[str, ...]
     required_test_ids: tuple[str, ...]
+    repetitions: int
 
 
 PHASE2_COMMANDS = (
@@ -82,6 +94,7 @@ PHASE2_COMMANDS = (
             "-rsxX",
         ),
         required_test_ids=(PHASE2_REQUIRED_TEST_IDS["P2-BACKEND-IDENTITY"],),
+        repetitions=1,
     ),
     Phase2EvidenceCommand(
         name="lane_c_production_cuda",
@@ -114,6 +127,7 @@ PHASE2_COMMANDS = (
                 "P2-TRAIN-LIVENESS",
             )
         ),
+        repetitions=3,
     ),
     Phase2EvidenceCommand(
         name="lane_c_dr_owner_semantics",
@@ -129,6 +143,7 @@ PHASE2_COMMANDS = (
             "-rsxX",
         ),
         required_test_ids=(PHASE2_REQUIRED_TEST_IDS["P2-DR-OWNER-SEMANTICS"],),
+        repetitions=3,
     ),
 )
 
@@ -208,7 +223,9 @@ def _pytest_counts(output: str) -> dict[str, int]:
     return counts
 
 
-def _run_evidence_command(command: Phase2EvidenceCommand, *, root: Path) -> dict[str, Any]:
+def _run_evidence_command(
+    command: Phase2EvidenceCommand, *, root: Path, repetition: int
+) -> dict[str, Any]:
     started = time.perf_counter()
     result = subprocess.run(
         command.argv,
@@ -238,8 +255,10 @@ def _run_evidence_command(command: Phase2EvidenceCommand, *, root: Path) -> dict
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
     return {
-        "name": command.name,
+        "name": f"{command.name}#{repetition}",
+        "series": command.name,
         "lane": command.lane,
+        "repetition": repetition,
         "argv": list(command.argv),
         "required_test_ids": list(command.required_test_ids),
         "exit_code": int(result.returncode),
@@ -265,7 +284,11 @@ def capture_phase2_evidence(root: Path) -> dict[str, Any]:
         raise Phase2EvidenceError(f"git returned an invalid commit SHA: {source_commit!r}")
 
     environment = _cuda_environment(root)
-    commands = [_run_evidence_command(command, root=root) for command in PHASE2_COMMANDS]
+    commands = [
+        _run_evidence_command(command, root=root, repetition=repetition)
+        for command in PHASE2_COMMANDS
+        for repetition in range(1, command.repetitions + 1)
+    ]
     command_by_test = {
         test_id: command.name
         for command in PHASE2_COMMANDS
@@ -294,6 +317,7 @@ def capture_phase2_evidence(root: Path) -> dict[str, Any]:
                 "claim_id": claim_id,
                 "required_test_id": test_id,
                 "command": command_by_test[test_id],
+                "minimum_repetitions": PHASE2_MIN_REPETITIONS[claim_id],
             }
             for claim_id, test_id in PHASE2_REQUIRED_TEST_IDS.items()
         ],
@@ -399,6 +423,7 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
         errors.append("commands: expected non-empty list")
         raw_commands = []
     command_by_name: dict[str, dict[str, Any]] = {}
+    commands_by_series: dict[str, list[dict[str, Any]]] = {}
     seen_lanes: set[str] = set()
     for index, raw_command in enumerate(raw_commands):
         command = _mapping(raw_command, f"commands[{index}]", errors)
@@ -407,6 +432,9 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
             if name in command_by_name:
                 errors.append(f"commands[{index}].name: duplicate {name!r}")
             command_by_name[name] = command
+        series = _string(command.get("series"), f"commands[{index}].series", errors)
+        if series:
+            commands_by_series.setdefault(series, []).append(command)
         lane = _string(command.get("lane"), f"commands[{index}].lane", errors)
         if lane:
             seen_lanes.add(lane)
@@ -439,12 +467,23 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
                     )
     if seen_lanes != {"A", "C"}:
         errors.append(f"commands: expected exactly lanes A/C, got {sorted(seen_lanes)!r}")
+    for expected_command in PHASE2_COMMANDS:
+        matching = commands_by_series.get(expected_command.name, [])
+        repetitions = {
+            _int(command.get("repetition"), f"commands[{index}].repetition", errors)
+            for index, command in enumerate(matching)
+        }
+        if repetitions != set(range(1, expected_command.repetitions + 1)):
+            errors.append(
+                f"commands[{expected_command.name}]: expected repetitions "
+                f"1..{expected_command.repetitions}"
+            )
 
     raw_claims = report.get("claims")
     if not isinstance(raw_claims, list):
         errors.append("claims: expected list")
         raw_claims = []
-    observed_claims: dict[str, tuple[str, str]] = {}
+    observed_claims: dict[str, tuple[str, str, int]] = {}
     for index, raw_claim in enumerate(raw_claims):
         claim = _mapping(raw_claim, f"claims[{index}]", errors)
         claim_id = _string(claim.get("claim_id"), f"claims[{index}].claim_id", errors)
@@ -452,23 +491,31 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
             claim.get("required_test_id"), f"claims[{index}].required_test_id", errors
         )
         command_name = _string(claim.get("command"), f"claims[{index}].command", errors)
+        minimum_repetitions = _int(
+            claim.get("minimum_repetitions"), f"claims[{index}].minimum_repetitions", errors
+        )
         if claim_id:
             if claim_id in observed_claims:
                 errors.append(f"claims[{index}].claim_id: duplicate {claim_id!r}")
-            observed_claims[claim_id] = (test_id, command_name)
+            observed_claims[claim_id] = (test_id, command_name, minimum_repetitions)
     if set(observed_claims) != set(PHASE2_REQUIRED_TEST_IDS):
         errors.append("claims: claim IDs do not exactly match Phase 2 required claims")
     for claim_id, expected_test_id in PHASE2_REQUIRED_TEST_IDS.items():
-        test_id, command_name = observed_claims.get(claim_id, ("", ""))
+        test_id, command_name, minimum_repetitions = observed_claims.get(claim_id, ("", "", -1))
         if test_id != expected_test_id:
             errors.append(f"claims[{claim_id}]: required test mapping does not match")
-        mapped_command: dict[str, Any] | None = command_by_name.get(command_name)
-        if mapped_command is None:
+        if minimum_repetitions != PHASE2_MIN_REPETITIONS[claim_id]:
+            errors.append(f"claims[{claim_id}]: minimum repetitions do not match Phase 2 manifest")
+        mapped_commands = commands_by_series.get(command_name, [])
+        if not mapped_commands:
             errors.append(f"claims[{claim_id}]: references unknown command {command_name!r}")
             continue
-        command_ids = mapped_command.get("required_test_ids")
-        if not isinstance(command_ids, list) or expected_test_id not in command_ids:
-            errors.append(f"claims[{claim_id}]: command does not declare its required test")
+        if len(mapped_commands) < minimum_repetitions:
+            errors.append(f"claims[{claim_id}]: insufficient successful repetitions")
+        for mapped_command in mapped_commands:
+            command_ids = mapped_command.get("required_test_ids")
+            if not isinstance(command_ids, list) or expected_test_id not in command_ids:
+                errors.append(f"claims[{claim_id}]: command does not declare its required test")
     return tuple(errors)
 
 

--- a/src/unilab/tools/issue705_phase2_evidence.py
+++ b/src/unilab/tools/issue705_phase2_evidence.py
@@ -385,6 +385,7 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
         errors.append(f"kind: expected {ARTIFACT_KIND!r}")
     if report.get("issue") != ISSUE or report.get("phase") != PHASE:
         errors.append(f"issue/phase: expected {ISSUE}/{PHASE}")
+    _string(report.get("generated_at_utc"), "generated_at_utc", errors)
 
     source = _mapping(report.get("source"), "source", errors)
     commit = _string(source.get("commit_sha"), "source.commit_sha", errors)
@@ -417,6 +418,9 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
     warp_device = _string(environment.get("warp_device"), "environment.warp_device", errors)
     if warp_device and "cuda" not in warp_device.lower():
         errors.append("environment.warp_device: expected CUDA device")
+    packages = _mapping(environment.get("packages"), "environment.packages", errors)
+    for package_name in ("mujoco", "mujoco-warp", "warp-lang", "torch", "rsl-rl-lib"):
+        _string(packages.get(package_name), f"environment.packages.{package_name}", errors)
 
     raw_commands = report.get("commands")
     if not isinstance(raw_commands, list) or not raw_commands:
@@ -424,6 +428,7 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
         raw_commands = []
     command_by_name: dict[str, dict[str, Any]] = {}
     commands_by_series: dict[str, list[dict[str, Any]]] = {}
+    expected_commands = {command.name: command for command in PHASE2_COMMANDS}
     seen_lanes: set[str] = set()
     for index, raw_command in enumerate(raw_commands):
         command = _mapping(raw_command, f"commands[{index}]", errors)
@@ -433,13 +438,37 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
                 errors.append(f"commands[{index}].name: duplicate {name!r}")
             command_by_name[name] = command
         series = _string(command.get("series"), f"commands[{index}].series", errors)
+        repetition = _int(command.get("repetition"), f"commands[{index}].repetition", errors)
+        if repetition < 1:
+            errors.append(f"commands[{index}].repetition: expected >= 1")
+        if series and name and name != f"{series}#{repetition}":
+            errors.append(f"commands[{index}].name: must equal its series/repetition key")
         if series:
             commands_by_series.setdefault(series, []).append(command)
+            expected = expected_commands.get(series)
+            if expected is None:
+                errors.append(f"commands[{index}].series: unknown series {series!r}")
+            else:
+                if command.get("lane") != expected.lane:
+                    errors.append(f"commands[{index}].lane: does not match {series!r}")
+                if command.get("argv") != list(expected.argv):
+                    errors.append(
+                        f"commands[{index}].argv: does not match registered command {series!r}"
+                    )
+                if command.get("required_test_ids") != list(expected.required_test_ids):
+                    errors.append(f"commands[{index}].required_test_ids: does not match {series!r}")
         lane = _string(command.get("lane"), f"commands[{index}].lane", errors)
         if lane:
             seen_lanes.add(lane)
         if _int(command.get("exit_code"), f"commands[{index}].exit_code", errors) != 0:
             errors.append(f"commands[{index}].exit_code: expected 0")
+        duration = command.get("duration_sec")
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or float(duration) <= 0.0
+        ):
+            errors.append(f"commands[{index}].duration_sec: expected positive number")
         pytest_counts = _mapping(command.get("pytest"), f"commands[{index}].pytest", errors)
         if _int(pytest_counts.get("passed"), f"commands[{index}].pytest.passed", errors) <= 0:
             errors.append(f"commands[{index}].pytest.passed: expected > 0")
@@ -467,6 +496,8 @@ def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[
                     )
     if seen_lanes != {"A", "C"}:
         errors.append(f"commands: expected exactly lanes A/C, got {sorted(seen_lanes)!r}")
+    if set(commands_by_series) != set(expected_commands):
+        errors.append("commands: series do not exactly match the registered Phase 2 commands")
     for expected_command in PHASE2_COMMANDS:
         matching = commands_by_series.get(expected_command.name, [])
         repetitions = {
@@ -525,6 +556,7 @@ __all__ = [
     "OWNER_YAML",
     "PHASE",
     "PHASE2_COMMANDS",
+    "PHASE2_MIN_REPETITIONS",
     "PHASE2_REQUIRED_TEST_IDS",
     "Phase2EvidenceError",
     "capture_phase2_evidence",

--- a/src/unilab/tools/issue705_phase2_evidence.py
+++ b/src/unilab/tools/issue705_phase2_evidence.py
@@ -97,7 +97,6 @@ PHASE2_COMMANDS = (
             PHASE2_REQUIRED_TEST_IDS["P2-GPU-CORRECTNESS"],
             PHASE2_REQUIRED_TEST_IDS["P2-RESET-ISOLATION"],
             PHASE2_REQUIRED_TEST_IDS["P2-TRAJECTORY-DIFFERENTIAL"],
-            PHASE2_REQUIRED_TEST_IDS["P2-DR-OWNER-SEMANTICS"],
             PHASE2_REQUIRED_TEST_IDS["P2-TRANSFER-ACCOUNTING"],
             PHASE2_REQUIRED_TEST_IDS["P2-UNSUPPORTED-FAIL-CLOSED"],
             PHASE2_REQUIRED_TEST_IDS["P2-TRAIN-LIVENESS"],
@@ -110,12 +109,26 @@ PHASE2_COMMANDS = (
                 "P2-GPU-CORRECTNESS",
                 "P2-RESET-ISOLATION",
                 "P2-TRAJECTORY-DIFFERENTIAL",
-                "P2-DR-OWNER-SEMANTICS",
                 "P2-TRANSFER-ACCOUNTING",
                 "P2-UNSUPPORTED-FAIL-CLOSED",
                 "P2-TRAIN-LIVENESS",
             )
         ),
+    ),
+    Phase2EvidenceCommand(
+        name="lane_c_dr_owner_semantics",
+        lane="C",
+        argv=(
+            "uv",
+            "run",
+            "--extra",
+            "mjwarp",
+            "pytest",
+            PHASE2_REQUIRED_TEST_IDS["P2-DR-OWNER-SEMANTICS"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE2_REQUIRED_TEST_IDS["P2-DR-OWNER-SEMANTICS"],),
     ),
 )
 

--- a/src/unilab/tools/issue705_phase2_evidence.py
+++ b/src/unilab/tools/issue705_phase2_evidence.py
@@ -1,0 +1,475 @@
+"""Capture and fail-closed validation for Issue #705 Phase 2 gate evidence.
+
+The capture path runs the production A/C lane commands and records their raw
+pytest output.  The validator deliberately treats the JSON as untrusted: it
+checks provenance, current input hashes, command/test mappings, and mandatory
+skip/xfail counts before a manifest can cite the artifact as PASS evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from unilab.base.backend.mjwarp.dependencies import load_mjwarp_dependencies
+
+ISSUE = 705
+PHASE = 2
+SCHEMA_VERSION = 1
+ARTIFACT_KIND = "issue705-phase2-gate-v1"
+OWNER_YAML = Path("conf/ppo/task/g1_walk_flat/mjwarp.yaml")
+UV_LOCK = Path("uv.lock")
+
+PHASE2_REQUIRED_TEST_IDS: dict[str, str] = {
+    "P2-BACKEND-IDENTITY": (
+        "tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco"
+    ),
+    "P2-GPU-CORRECTNESS": "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+    "P2-RESET-ISOLATION": "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+    "P2-TRAJECTORY-DIFFERENTIAL": (
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco"
+    ),
+    "P2-DR-OWNER-SEMANTICS": (
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled"
+    ),
+    "P2-TRANSFER-ACCOUNTING": (
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan"
+    ),
+    "P2-UNSUPPORTED-FAIL-CLOSED": (
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step"
+    ),
+    "P2-TRAIN-LIVENESS": (
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp"
+    ),
+}
+
+
+class Phase2EvidenceError(RuntimeError):
+    """Raised when an evidence capture cannot establish a trustworthy PASS."""
+
+
+@dataclass(frozen=True)
+class Phase2EvidenceCommand:
+    """One pre-registered command contributing evidence to Phase 2."""
+
+    name: str
+    lane: str
+    argv: tuple[str, ...]
+    required_test_ids: tuple[str, ...]
+
+
+PHASE2_COMMANDS = (
+    Phase2EvidenceCommand(
+        name="lane_a_identity",
+        lane="A",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            "tests/base/test_backend_imports.py",
+            PHASE2_REQUIRED_TEST_IDS["P2-BACKEND-IDENTITY"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE2_REQUIRED_TEST_IDS["P2-BACKEND-IDENTITY"],),
+    ),
+    Phase2EvidenceCommand(
+        name="lane_c_production_cuda",
+        lane="C",
+        argv=(
+            "uv",
+            "run",
+            "--extra",
+            "mjwarp",
+            "pytest",
+            "-m",
+            "slow",
+            PHASE2_REQUIRED_TEST_IDS["P2-GPU-CORRECTNESS"],
+            PHASE2_REQUIRED_TEST_IDS["P2-RESET-ISOLATION"],
+            PHASE2_REQUIRED_TEST_IDS["P2-TRAJECTORY-DIFFERENTIAL"],
+            PHASE2_REQUIRED_TEST_IDS["P2-DR-OWNER-SEMANTICS"],
+            PHASE2_REQUIRED_TEST_IDS["P2-TRANSFER-ACCOUNTING"],
+            PHASE2_REQUIRED_TEST_IDS["P2-UNSUPPORTED-FAIL-CLOSED"],
+            PHASE2_REQUIRED_TEST_IDS["P2-TRAIN-LIVENESS"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=tuple(
+            PHASE2_REQUIRED_TEST_IDS[claim_id]
+            for claim_id in (
+                "P2-GPU-CORRECTNESS",
+                "P2-RESET-ISOLATION",
+                "P2-TRAJECTORY-DIFFERENTIAL",
+                "P2-DR-OWNER-SEMANTICS",
+                "P2-TRANSFER-ACCOUNTING",
+                "P2-UNSUPPORTED-FAIL-CLOSED",
+                "P2-TRAIN-LIVENESS",
+            )
+        ),
+    ),
+)
+
+_PYTEST_COUNT_RE = re.compile(r"(?<![A-Za-z0-9_])(\d+) (passed|skipped|xfailed|xpassed)")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def sha256_file(path: Path) -> str:
+    """Return a stable repository-input hash with the manifest's prefix form."""
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _run_checked(argv: Sequence[str], *, root: Path, context: str) -> str:
+    result = subprocess.run(argv, cwd=root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise Phase2EvidenceError(
+            f"{context} failed with exit {result.returncode}:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def _git(root: Path, *args: str) -> str:
+    return _run_checked(("git", *args), root=root, context=f"git {' '.join(args)}")
+
+
+def _assert_clean_source(root: Path) -> None:
+    dirty = _git(root, "status", "--porcelain")
+    if dirty:
+        raise Phase2EvidenceError(
+            f"Phase 2 evidence must be captured from a clean source tree; found:\n{dirty}"
+        )
+
+
+def _package_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError as exc:
+        raise Phase2EvidenceError(f"required package {name!r} is not installed") from exc
+
+
+def _cuda_environment(root: Path) -> dict[str, Any]:
+    dependencies = load_mjwarp_dependencies()
+    device = dependencies.warp.get_device()
+    if not bool(device.is_cuda):
+        raise Phase2EvidenceError("Phase 2 capture requires an active CUDA Warp device")
+    nvidia_smi = _run_checked(
+        (
+            "nvidia-smi",
+            "--query-gpu=name,uuid,driver_version,memory.total",
+            "--format=csv,noheader",
+        ),
+        root=root,
+        context="nvidia-smi",
+    )
+    return {
+        "platform": platform.platform(),
+        "python": sys.version,
+        "warp_device": str(device),
+        "nvidia_smi": nvidia_smi.splitlines(),
+        "packages": {
+            "mujoco": _package_version("mujoco"),
+            "mujoco-warp": _package_version("mujoco-warp"),
+            "warp-lang": _package_version("warp-lang"),
+            "torch": _package_version("torch"),
+            "rsl-rl-lib": _package_version("rsl-rl-lib"),
+        },
+    }
+
+
+def _pytest_counts(output: str) -> dict[str, int]:
+    counts = {"passed": 0, "skipped": 0, "xfailed": 0, "xpassed": 0}
+    for raw_count, category in _PYTEST_COUNT_RE.findall(output):
+        counts[category] += int(raw_count)
+    return counts
+
+
+def _run_evidence_command(command: Phase2EvidenceCommand, *, root: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    result = subprocess.run(
+        command.argv,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    duration_sec = time.perf_counter() - started
+    combined = f"{result.stdout}\n{result.stderr}"
+    counts = _pytest_counts(combined)
+    errors: list[str] = []
+    if result.returncode != 0:
+        errors.append(f"exit_code={result.returncode}")
+    if counts["passed"] <= 0:
+        errors.append("pytest reported no passed tests")
+    for category in ("skipped", "xfailed", "xpassed"):
+        if counts[category] != 0:
+            errors.append(f"pytest reported {counts[category]} {category}")
+    missing_nodes = [test_id for test_id in command.required_test_ids if test_id not in combined]
+    if missing_nodes:
+        errors.append(f"required test IDs absent from pytest output: {missing_nodes!r}")
+    if errors:
+        raise Phase2EvidenceError(
+            f"{command.name} did not meet Phase 2 evidence requirements ({'; '.join(errors)}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return {
+        "name": command.name,
+        "lane": command.lane,
+        "argv": list(command.argv),
+        "required_test_ids": list(command.required_test_ids),
+        "exit_code": int(result.returncode),
+        "duration_sec": duration_sec,
+        "pytest": counts,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def capture_phase2_evidence(root: Path) -> dict[str, Any]:
+    """Run all required A/C evidence commands and return an immutable report payload."""
+    root = root.resolve()
+    owner_yaml = root / OWNER_YAML
+    lock_path = root / UV_LOCK
+    if not owner_yaml.is_file() or not lock_path.is_file():
+        raise Phase2EvidenceError(
+            "Phase 2 capture requires owner YAML and uv.lock at repository root"
+        )
+    _assert_clean_source(root)
+    source_commit = _git(root, "rev-parse", "HEAD")
+    if not _COMMIT_RE.fullmatch(source_commit):
+        raise Phase2EvidenceError(f"git returned an invalid commit SHA: {source_commit!r}")
+
+    environment = _cuda_environment(root)
+    commands = [_run_evidence_command(command, root=root) for command in PHASE2_COMMANDS]
+    command_by_test = {
+        test_id: command.name
+        for command in PHASE2_COMMANDS
+        for test_id in command.required_test_ids
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": ARTIFACT_KIND,
+        "issue": ISSUE,
+        "phase": PHASE,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "source": {
+            "commit_sha": source_commit,
+            "branch": _git(root, "rev-parse", "--abbrev-ref", "HEAD"),
+            "tree_clean": True,
+        },
+        "inputs": {
+            "owner_yaml": OWNER_YAML.as_posix(),
+            "owner_yaml_sha256": sha256_file(owner_yaml),
+            "uv_lock": UV_LOCK.as_posix(),
+            "uv_lock_sha256": sha256_file(lock_path),
+        },
+        "environment": environment,
+        "claims": [
+            {
+                "claim_id": claim_id,
+                "required_test_id": test_id,
+                "command": command_by_test[test_id],
+            }
+            for claim_id, test_id in PHASE2_REQUIRED_TEST_IDS.items()
+        ],
+        "commands": commands,
+    }
+
+
+def write_phase2_evidence(report: Mapping[str, Any], output: Path) -> None:
+    """Write one human-auditable JSON report after a successful capture."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(dict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_phase2_evidence(path: Path) -> dict[str, Any]:
+    """Load the JSON report, preserving a clear error boundary for test callers."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise Phase2EvidenceError(f"cannot load Phase 2 evidence {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise Phase2EvidenceError(f"Phase 2 evidence {path} must contain a JSON object")
+    return payload
+
+
+def _mapping(value: object, name: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{name}: expected object")
+    return {}
+
+
+def _string(value: object, name: str, errors: list[str]) -> str:
+    if isinstance(value, str) and value:
+        return value
+    errors.append(f"{name}: expected non-empty string")
+    return ""
+
+
+def _int(value: object, name: str, errors: list[str]) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    errors.append(f"{name}: expected integer")
+    return -1
+
+
+def _git_is_ancestor(root: Path, commit: str) -> bool:
+    return (
+        subprocess.run(
+            ("git", "merge-base", "--is-ancestor", commit, "HEAD"),
+            cwd=root,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def validate_phase2_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[str, ...]:
+    """Return every provenance/coverage error instead of trusting a PASS JSON."""
+    root = root.resolve()
+    errors: list[str] = []
+    if report.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version: expected {SCHEMA_VERSION}")
+    if report.get("kind") != ARTIFACT_KIND:
+        errors.append(f"kind: expected {ARTIFACT_KIND!r}")
+    if report.get("issue") != ISSUE or report.get("phase") != PHASE:
+        errors.append(f"issue/phase: expected {ISSUE}/{PHASE}")
+
+    source = _mapping(report.get("source"), "source", errors)
+    commit = _string(source.get("commit_sha"), "source.commit_sha", errors)
+    if commit and not _COMMIT_RE.fullmatch(commit):
+        errors.append("source.commit_sha: expected full 40-character SHA")
+    elif commit and not _git_is_ancestor(root, commit):
+        errors.append("source.commit_sha: must be an ancestor of the current gate commit")
+    if source.get("tree_clean") is not True:
+        errors.append("source.tree_clean: must be true")
+
+    inputs = _mapping(report.get("inputs"), "inputs", errors)
+    if inputs.get("owner_yaml") != OWNER_YAML.as_posix():
+        errors.append("inputs.owner_yaml: unexpected owner YAML")
+    if inputs.get("uv_lock") != UV_LOCK.as_posix():
+        errors.append("inputs.uv_lock: unexpected lock path")
+    for field, path in (
+        ("owner_yaml_sha256", root / OWNER_YAML),
+        ("uv_lock_sha256", root / UV_LOCK),
+    ):
+        observed = _string(inputs.get(field), f"inputs.{field}", errors)
+        if observed and not _SHA256_RE.fullmatch(observed):
+            errors.append(f"inputs.{field}: expected sha256 hash")
+        elif observed and path.is_file() and observed != sha256_file(path):
+            errors.append(f"inputs.{field}: does not match current {path.name}")
+
+    environment = _mapping(report.get("environment"), "environment", errors)
+    nvidia_smi = environment.get("nvidia_smi")
+    if not isinstance(nvidia_smi, list) or not nvidia_smi:
+        errors.append("environment.nvidia_smi: expected non-empty GPU provenance")
+    warp_device = _string(environment.get("warp_device"), "environment.warp_device", errors)
+    if warp_device and "cuda" not in warp_device.lower():
+        errors.append("environment.warp_device: expected CUDA device")
+
+    raw_commands = report.get("commands")
+    if not isinstance(raw_commands, list) or not raw_commands:
+        errors.append("commands: expected non-empty list")
+        raw_commands = []
+    command_by_name: dict[str, dict[str, Any]] = {}
+    seen_lanes: set[str] = set()
+    for index, raw_command in enumerate(raw_commands):
+        command = _mapping(raw_command, f"commands[{index}]", errors)
+        name = _string(command.get("name"), f"commands[{index}].name", errors)
+        if name:
+            if name in command_by_name:
+                errors.append(f"commands[{index}].name: duplicate {name!r}")
+            command_by_name[name] = command
+        lane = _string(command.get("lane"), f"commands[{index}].lane", errors)
+        if lane:
+            seen_lanes.add(lane)
+        if _int(command.get("exit_code"), f"commands[{index}].exit_code", errors) != 0:
+            errors.append(f"commands[{index}].exit_code: expected 0")
+        pytest_counts = _mapping(command.get("pytest"), f"commands[{index}].pytest", errors)
+        if _int(pytest_counts.get("passed"), f"commands[{index}].pytest.passed", errors) <= 0:
+            errors.append(f"commands[{index}].pytest.passed: expected > 0")
+        for category in ("skipped", "xfailed", "xpassed"):
+            if (
+                _int(
+                    pytest_counts.get(category),
+                    f"commands[{index}].pytest.{category}",
+                    errors,
+                )
+                != 0
+            ):
+                errors.append(f"commands[{index}].pytest.{category}: expected 0")
+        required_test_ids = command.get("required_test_ids")
+        stdout = _string(command.get("stdout"), f"commands[{index}].stdout", errors)
+        if not isinstance(required_test_ids, list) or not all(
+            isinstance(item, str) for item in required_test_ids
+        ):
+            errors.append(f"commands[{index}].required_test_ids: expected string list")
+        else:
+            for test_id in required_test_ids:
+                if test_id not in stdout:
+                    errors.append(
+                        f"commands[{index}].stdout: required test {test_id!r} is not present"
+                    )
+    if seen_lanes != {"A", "C"}:
+        errors.append(f"commands: expected exactly lanes A/C, got {sorted(seen_lanes)!r}")
+
+    raw_claims = report.get("claims")
+    if not isinstance(raw_claims, list):
+        errors.append("claims: expected list")
+        raw_claims = []
+    observed_claims: dict[str, tuple[str, str]] = {}
+    for index, raw_claim in enumerate(raw_claims):
+        claim = _mapping(raw_claim, f"claims[{index}]", errors)
+        claim_id = _string(claim.get("claim_id"), f"claims[{index}].claim_id", errors)
+        test_id = _string(
+            claim.get("required_test_id"), f"claims[{index}].required_test_id", errors
+        )
+        command_name = _string(claim.get("command"), f"claims[{index}].command", errors)
+        if claim_id:
+            if claim_id in observed_claims:
+                errors.append(f"claims[{index}].claim_id: duplicate {claim_id!r}")
+            observed_claims[claim_id] = (test_id, command_name)
+    if set(observed_claims) != set(PHASE2_REQUIRED_TEST_IDS):
+        errors.append("claims: claim IDs do not exactly match Phase 2 required claims")
+    for claim_id, expected_test_id in PHASE2_REQUIRED_TEST_IDS.items():
+        test_id, command_name = observed_claims.get(claim_id, ("", ""))
+        if test_id != expected_test_id:
+            errors.append(f"claims[{claim_id}]: required test mapping does not match")
+        mapped_command: dict[str, Any] | None = command_by_name.get(command_name)
+        if mapped_command is None:
+            errors.append(f"claims[{claim_id}]: references unknown command {command_name!r}")
+            continue
+        command_ids = mapped_command.get("required_test_ids")
+        if not isinstance(command_ids, list) or expected_test_id not in command_ids:
+            errors.append(f"claims[{claim_id}]: command does not declare its required test")
+    return tuple(errors)
+
+
+__all__ = [
+    "ARTIFACT_KIND",
+    "ISSUE",
+    "OWNER_YAML",
+    "PHASE",
+    "PHASE2_COMMANDS",
+    "PHASE2_REQUIRED_TEST_IDS",
+    "Phase2EvidenceError",
+    "capture_phase2_evidence",
+    "load_phase2_evidence",
+    "sha256_file",
+    "validate_phase2_evidence",
+    "write_phase2_evidence",
+]

--- a/tests/acceptance/issue_705/artifacts/phase_2_gate.json
+++ b/tests/acceptance/issue_705/artifacts/phase_2_gate.json
@@ -1,0 +1,323 @@
+{
+  "claims": [
+    {
+      "claim_id": "P2-BACKEND-IDENTITY",
+      "command": "lane_a_identity",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco"
+    },
+    {
+      "claim_id": "P2-GPU-CORRECTNESS",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 2,
+      "required_test_id": "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step"
+    },
+    {
+      "claim_id": "P2-RESET-ISOLATION",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 3,
+      "required_test_id": "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated"
+    },
+    {
+      "claim_id": "P2-TRAJECTORY-DIFFERENTIAL",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 3,
+      "required_test_id": "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco"
+    },
+    {
+      "claim_id": "P2-DR-OWNER-SEMANTICS",
+      "command": "lane_c_dr_owner_semantics",
+      "minimum_repetitions": 3,
+      "required_test_id": "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled"
+    },
+    {
+      "claim_id": "P2-TRANSFER-ACCOUNTING",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 2,
+      "required_test_id": "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan"
+    },
+    {
+      "claim_id": "P2-UNSUPPORTED-FAIL-CLOSED",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step"
+    },
+    {
+      "claim_id": "P2-TRAIN-LIVENESS",
+      "command": "lane_c_production_cuda",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp"
+    }
+  ],
+  "commands": [
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_imports.py",
+        "tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.5990536020035506,
+      "exit_code": 0,
+      "lane": "A",
+      "name": "lane_a_identity#1",
+      "pytest": {
+        "passed": 3,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco"
+      ],
+      "series": "lane_a_identity",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 3 items\n\ntests/base/test_backend_imports.py::test_mujoco_backend_import_path_does_not_eagerly_import_motrix PASSED [ 33%]\ntests/base/test_backend_imports.py::test_motrix_backend_import_path_does_not_eagerly_import_mujoco PASSED [ 66%]\ntests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco PASSED [100%]\n\n============================== 3 passed in 0.64s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "-m",
+        "slow",
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 21.02430007899966,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_production_cuda#1",
+      "pytest": {
+        "passed": 11,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp"
+      ],
+      "series": "lane_c_production_cuda",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 11 items\n\ntests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step PASSED [  9%]\ntests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated PASSED [ 18%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-1] PASSED [ 27%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-32] PASSED [ 36%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-1] PASSED [ 45%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-32] PASSED [ 54%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-1] PASSED [ 63%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-32] PASSED [ 72%]\ntests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan PASSED [ 81%]\ntests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step PASSED [ 90%]\ntests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp PASSED [100%]\n\n============================= 11 passed in 18.07s ==============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "-m",
+        "slow",
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 20.208738003995677,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_production_cuda#2",
+      "pytest": {
+        "passed": 11,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 2,
+      "required_test_ids": [
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp"
+      ],
+      "series": "lane_c_production_cuda",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 11 items\n\ntests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step PASSED [  9%]\ntests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated PASSED [ 18%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-1] PASSED [ 27%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-32] PASSED [ 36%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-1] PASSED [ 45%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-32] PASSED [ 54%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-1] PASSED [ 63%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-32] PASSED [ 72%]\ntests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan PASSED [ 81%]\ntests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step PASSED [ 90%]\ntests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp PASSED [100%]\n\n============================= 11 passed in 17.24s ==============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "-m",
+        "slow",
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 21.33113043299818,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_production_cuda#3",
+      "pytest": {
+        "passed": 11,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 3,
+      "required_test_ids": [
+        "tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step",
+        "tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated",
+        "tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco",
+        "tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan",
+        "tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step",
+        "tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp"
+      ],
+      "series": "lane_c_production_cuda",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 11 items\n\ntests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step PASSED [  9%]\ntests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated PASSED [ 18%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-1] PASSED [ 27%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[0-batch-32] PASSED [ 36%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-1] PASSED [ 45%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[1-batch-32] PASSED [ 54%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-1] PASSED [ 63%]\ntests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco[2-batch-32] PASSED [ 72%]\ntests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan PASSED [ 81%]\ntests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step PASSED [ 90%]\ntests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp PASSED [100%]\n\n============================= 11 passed in 18.25s ==============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.7568625989952125,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_dr_owner_semantics#1",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled"
+      ],
+      "series": "lane_c_dr_owner_semantics",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled PASSED [100%]\n\n============================== 1 passed in 0.06s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.7627506459975848,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_dr_owner_semantics#2",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 2,
+      "required_test_ids": [
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled"
+      ],
+      "series": "lane_c_dr_owner_semantics",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled PASSED [100%]\n\n============================== 1 passed in 0.06s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "--extra",
+        "mjwarp",
+        "pytest",
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.762971213000128,
+      "exit_code": 0,
+      "lane": "C",
+      "name": "lane_c_dr_owner_semantics#3",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 3,
+      "required_test_ids": [
+        "tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled"
+      ],
+      "series": "lane_c_dr_owner_semantics",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled PASSED [100%]\n\n============================== 1 passed in 0.06s ===============================\n"
+    }
+  ],
+  "environment": {
+    "nvidia_smi": [
+      "NVIDIA RTX 6000 Ada Generation, GPU-e154a732-d539-0424-cdb2-de408e0c5a21, 570.133.07, 49140 MiB"
+    ],
+    "packages": {
+      "mujoco": "3.10.0",
+      "mujoco-warp": "3.10.0.3",
+      "rsl-rl-lib": "5.0.1",
+      "torch": "2.7.0+cu128",
+      "warp-lang": "1.15.0"
+    },
+    "platform": "Linux-6.8.0-60-generic-x86_64-with-glibc2.35",
+    "python": "3.13.12 (main, Mar  3 2026, 15:01:51) [Clang 21.1.4 ]",
+    "warp_device": "cuda:0"
+  },
+  "generated_at_utc": "2026-07-28T14:38:27.446597+00:00",
+  "inputs": {
+    "owner_yaml": "conf/ppo/task/g1_walk_flat/mjwarp.yaml",
+    "owner_yaml_sha256": "sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe",
+    "uv_lock": "uv.lock",
+    "uv_lock_sha256": "sha256:fe3b4c9dc315a7556464d636b9da02bece2e1ef0b0b8fec1c28d14edbba7540c"
+  },
+  "issue": 705,
+  "kind": "issue705-phase2-gate-v1",
+  "phase": 2,
+  "schema_version": 1,
+  "source": {
+    "branch": "feat/issue-745-phase2-evidence-gate",
+    "commit_sha": "e5e3b6638d72577c66cc474efd072e7a8459e53a",
+    "tree_clean": true
+  }
+}

--- a/tests/acceptance/issue_705/manifests/phase_2.yaml
+++ b/tests/acceptance/issue_705/manifests/phase_2.yaml
@@ -15,9 +15,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco]
     environment: {dependencies: [uv.lock], hardware: any, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [], batch_sizes: [], dtype: null, plan_fingerprint: mjwarp-identity-v1}
     acceptance: {tolerance: {}, thresholds: {identity_aliases: 0}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any eager optional import, identity alias, or owner-route mismatch is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_identity.py::test_mjwarp_identity_is_independent_from_mujoco], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane A import/identity capture passed from a clean source commit; artifact records the owner and lock hashes."}
     invalidation: {paths: [src/unilab/base/backend/**, src/unilab/cli.py, src/unilab/structured_configs.py, conf/**, tests/base/test_mjwarp_identity.py], capabilities: [mjwarp-identity], fingerprints: [mjwarp-identity-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-GPU-CORRECTNESS
     expected: The production mjwarp backend initializes, resets, steps, and refreshes its bound state on a real CUDA device.
@@ -30,9 +30,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step]
     environment: {dependencies: [uv.lock, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0], batch_sizes: [1, 128], dtype: float32, plan_fingerprint: mjwarp-correctness-v1}
     acceptance: {tolerance: {}, thresholds: {mandatory_skips: 0}, repetitions: 2, max_dispersion: 0, failure_semantics: "Fake Warp, benchmark-only code, implicit skip, or host-only execution is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_backend.py::test_real_cuda_init_reset_step], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C production CUDA capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [src/unilab/base/backend/mjwarp/**, conf/ppo/task/g1_walk_flat/mjwarp.yaml, uv.lock, tests/base/test_mjwarp_backend.py], capabilities: [mjwarp-correctness], fingerprints: [mjwarp-correctness-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-RESET-ISOLATION
     expected: Selected-row qpos and qvel reset changes exactly the requested worlds and refreshes terminal/reset state at the canonical barrier.
@@ -45,9 +45,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated]
     environment: {dependencies: [uv.lock, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0, 3, 19], batch_sizes: [17, 128], dtype: float32, plan_fingerprint: mjwarp-reset-v1}
     acceptance: {tolerance: {atol: 1.0e-6, rtol: 1.0e-5}, thresholds: {complement_changes: 0}, repetitions: 3, max_dispersion: 0, failure_semantics: "Any complement-row change, stale reset view, or missing forward is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_backend.py::test_selected_row_reset_isolated], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C selected-row reset capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [src/unilab/base/backend/mjwarp/**, tests/base/test_mjwarp_backend.py], capabilities: [mjwarp-selected-reset], fingerprints: [mjwarp-reset-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-TRAJECTORY-DIFFERENTIAL
     expected: Fixed initial state and action schedules produce bounded single-step and short-trajectory differences between mujoco and mjwarp.
@@ -60,9 +60,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco]
     environment: {dependencies: [uv.lock, mujoco, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0, 1, 2], batch_sizes: [1, 32], dtype: float32, plan_fingerprint: g1-mjwarp-differential-v1}
     acceptance: {tolerance: {state_atol: 1.0e-4, state_rtol: 1.0e-3}, thresholds: {trajectory_steps: 100}, repetitions: 3, max_dispersion: 0, failure_semantics: "Any field outside frozen tolerance or unexplained first mismatch is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_differential.py::test_g1_short_trajectory_matches_mujoco], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C fixed-seed short-trajectory differential capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [src/unilab/base/backend/mujoco/**, src/unilab/base/backend/mjwarp/**, assets/**, tests/base/test_mjwarp_differential.py], capabilities: [mjwarp-dynamics-parity], fingerprints: [g1-mjwarp-differential-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-DR-OWNER-SEMANTICS
     expected: The mjwarp G1 owner either implements selected-row kp/kd mutation with immutable baselines and physics effect or explicitly disables it with an audited semantic difference.
@@ -75,9 +75,9 @@ claims:
     required_test_ids: [tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled]
     environment: {dependencies: [uv.lock, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0, 1], batch_sizes: [32], dtype: float32, plan_fingerprint: mjwarp-g1-dr-v1}
     acceptance: {tolerance: {effect_min: 1.0e-7}, thresholds: {silent_terms: 0}, repetitions: 3, max_dispersion: 0, failure_semantics: "Enabled but ineffective kp/kd DR, cumulative baselines, or row leakage is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/dr/test_mjwarp_g1_dr.py::test_g1_kp_kd_owner_semantics_have_physics_effect_or_are_disabled], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C owner-semantics capture passed with explicit disabled kp/kd DR and no skip or xfail; raw pytest output is retained in the artifact."}
     invalidation: {paths: [conf/ppo/task/g1_walk_flat/mjwarp.yaml, src/unilab/base/backend/mjwarp/**, src/unilab/dr/**, tests/dr/test_mjwarp_g1_dr.py], capabilities: [mjwarp-g1-dr], fingerprints: [mjwarp-g1-dr-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-TRANSFER-ACCOUNTING
     expected: The host compatibility profile performs only the transfers declared by its bound plan and reports every transfer and synchronization.
@@ -90,9 +90,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan]
     environment: {dependencies: [uv.lock, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU with profiler, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0], batch_sizes: [128], dtype: float32, plan_fingerprint: mjwarp-host-transfer-v1}
     acceptance: {tolerance: {}, thresholds: {undeclared_transfers: 0, getter_dependent_transfers: 0}, repetitions: 2, max_dispersion: 0, failure_semantics: "Counter/trace disagreement, hidden numpy conversion, or getter-dependent transfer is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_transfers.py::test_host_profile_transfer_count_matches_bound_plan], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C transfer/profile reconciliation capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [src/unilab/base/backend/mjwarp/**, src/unilab/training/**, tests/base/test_mjwarp_transfers.py], capabilities: [mjwarp-transfer-accounting], fingerprints: [mjwarp-host-transfer-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-UNSUPPORTED-FAIL-CLOSED
     expected: Unsupported DR, Event, render, playback, hfield, Jacobian, and host substep controller combinations fail during compose, compile, or materialization.
@@ -105,9 +105,9 @@ claims:
     required_test_ids: [tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step]
     environment: {dependencies: [uv.lock, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0], batch_sizes: [8], dtype: float32, plan_fingerprint: mjwarp-unsupported-matrix-v1}
     acceptance: {tolerance: {}, thresholds: {late_failures: 0, silent_fallbacks: 0}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any unsupported combination that composes silently, reaches step, or falls back is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/base/test_mjwarp_capabilities.py::test_unsupported_matrix_fails_before_step], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C fail-closed capability capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [src/unilab/base/backend/mjwarp/**, src/unilab/structured_configs.py, conf/ppo/task/g1_walk_flat/mjwarp.yaml, tests/base/test_mjwarp_capabilities.py], capabilities: [mjwarp-unsupported-matrix], fingerprints: [mjwarp-unsupported-matrix-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P2-TRAIN-LIVENESS
     expected: A one-iteration G1 PPO run reaches rollout and learner completion through the production registered mjwarp backend.
@@ -120,6 +120,6 @@ claims:
     required_test_ids: [tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp]
     environment: {dependencies: [uv.lock, torch, mujoco-warp>=3.10.0.3, warp-lang>=1.14.0], hardware: CUDA-capable Linux GPU, owner_yaml: conf/ppo/task/g1_walk_flat/mjwarp.yaml, seeds: [0], batch_sizes: [128], dtype: float32, plan_fingerprint: mjwarp-train-liveness-v1}
     acceptance: {tolerance: {}, thresholds: {completed_iterations: 1, mandatory_skips: 0}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any non-production route, missing rollout or learner stage, crash, skip, or nonfinite value is FAIL; this claim does not imply performance."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_2_gate.json], commit_sha: e5e3b6638d72577c66cc474efd072e7a8459e53a, config_hash: sha256:25dea0ab8d00597a20b8a75867dc26c88d337bbe0815e355fe216fc9d17db3fe, executed_test_ids: [tests/integration/test_mjwarp_train_smoke.py::test_g1_one_iteration_uses_production_mjwarp], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane C production PPO liveness capture passed with no skip or xfail; raw pytest output and GPU provenance are retained in the artifact."}
     invalidation: {paths: [scripts/train_rsl_rl.py, src/unilab/training/**, src/unilab/base/backend/mjwarp/**, conf/ppo/task/g1_walk_flat/mjwarp.yaml, tests/integration/test_mjwarp_train_smoke.py], capabilities: [mjwarp-train-liveness], fingerprints: [mjwarp-train-liveness-v1]}
-    status: planned
+    status: verified

--- a/tests/acceptance/issue_705/test_phase2_evidence.py
+++ b/tests/acceptance/issue_705/test_phase2_evidence.py
@@ -1,0 +1,88 @@
+"""Fail-closed provenance checks for the Issue #705 Phase 2 gate artifact."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts import validate_issue705_phase
+
+from unilab.tools.issue705_phase2_evidence import (
+    PHASE2_MIN_REPETITIONS,
+    PHASE2_REQUIRED_TEST_IDS,
+    load_phase2_evidence,
+    validate_phase2_evidence,
+)
+from unilab.tools.phase_acceptance import ClaimStatus, EvidenceResult, load_phase_acceptance
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARTIFACT_PATH = REPO_ROOT / "tests/acceptance/issue_705/artifacts/phase_2_gate.json"
+MANIFEST_PATH = REPO_ROOT / "tests/acceptance/issue_705/manifests/phase_2.yaml"
+ARTIFACT_REF = "tests/acceptance/issue_705/artifacts/phase_2_gate.json"
+
+
+def test_phase2_gate_artifact_and_manifest_are_fresh_and_complete() -> None:
+    report = load_phase2_evidence(ARTIFACT_PATH)
+    assert validate_phase2_evidence(report, root=REPO_ROOT) == ()
+
+    manifest = load_phase_acceptance(MANIFEST_PATH)
+    claims = {claim.claim_id: claim for claim in manifest.claims}
+    artifact_claims = {claim["claim_id"]: claim for claim in report["claims"]}
+    assert set(claims) == set(PHASE2_REQUIRED_TEST_IDS)
+    assert set(artifact_claims) == set(PHASE2_REQUIRED_TEST_IDS)
+    source_commit = report["source"]["commit_sha"]
+    config_hash = report["inputs"]["owner_yaml_sha256"]
+    for claim_id, test_id in PHASE2_REQUIRED_TEST_IDS.items():
+        claim = claims[claim_id]
+        assert claim.status is ClaimStatus.VERIFIED
+        assert claim.evidence.result is EvidenceResult.PASS
+        assert claim.required_test_ids == (test_id,)
+        assert claim.evidence.executed_test_ids == (test_id,)
+        assert claim.evidence.artifact_refs == (ARTIFACT_REF,)
+        assert claim.evidence.commit_sha == source_commit
+        assert claim.evidence.config_hash == config_hash
+        assert claim.evidence.skipped_test_ids == ()
+        assert claim.evidence.xfailed_test_ids == ()
+        assert artifact_claims[claim_id]["minimum_repetitions"] == PHASE2_MIN_REPETITIONS[claim_id]
+
+    assert validate_issue705_phase.main(["--phase", "2", "--mode", "gate"]) == 0
+
+
+def test_phase2_artifact_faults_fail_closed() -> None:
+    report = load_phase2_evidence(ARTIFACT_PATH)
+
+    skipped = deepcopy(report)
+    skipped["commands"][0]["pytest"]["skipped"] = 1
+    assert any(
+        "skipped: expected 0" in error
+        for error in validate_phase2_evidence(skipped, root=REPO_ROOT)
+    )
+
+    stale = deepcopy(report)
+    stale["source"]["commit_sha"] = "0" * 40
+    assert any("ancestor" in error for error in validate_phase2_evidence(stale, root=REPO_ROOT))
+
+    mismatched_claim = deepcopy(report)
+    mismatched_claim["claims"][0]["required_test_id"] = "tests/does_not_exist.py::test_missing"
+    assert any(
+        "required test mapping" in error
+        for error in validate_phase2_evidence(mismatched_claim, root=REPO_ROOT)
+    )
+
+    altered_command = deepcopy(report)
+    altered_command["commands"][0]["argv"] = ["echo", "not-the-registered-command"]
+    assert any(
+        "does not match registered command" in error
+        for error in validate_phase2_evidence(altered_command, root=REPO_ROOT)
+    )
+
+    incomplete_repetitions = deepcopy(report)
+    incomplete_repetitions["commands"] = [
+        command
+        for command in incomplete_repetitions["commands"]
+        if command["name"] != "lane_c_production_cuda#3"
+    ]
+    assert any(
+        "expected repetitions" in error
+        for error in validate_phase2_evidence(incomplete_repetitions, root=REPO_ROOT)
+    )

--- a/tests/scripts/test_issue705_claim_gap_audit.py
+++ b/tests/scripts/test_issue705_claim_gap_audit.py
@@ -103,9 +103,11 @@ def test_all_phase_manifests_exist_and_pass_schema() -> None:
     assert {
         manifest.phase: {claim.claim_id for claim in manifest.claims} for manifest in manifests
     } == EXPECTED_CLAIMS
+    assert all(claim.status == ClaimStatus.VERIFIED for claim in manifests[2].claims)
     assert all(
         claim.status == ClaimStatus.PLANNED
-        for manifest in manifests[1:]
+        for manifest in manifests
+        if manifest.phase not in {0, 2}
         for claim in manifest.claims
     )
 
@@ -153,12 +155,12 @@ def test_high_risk_claims_require_the_right_evidence_class() -> None:
     assert all(entry.evidence_kind != EvidenceKind.SMOKE for entry in current_acceptance)
 
 
-def test_phase_zero_is_open_and_later_phase_gates_remain_closed() -> None:
+def test_only_evidenced_phase_gates_are_open() -> None:
     manifests, errors = load_phase_manifests(audit_issue705_claims.MANIFEST_DIR, PHASES)
 
     assert errors == ()
-    assert not phase_gate_errors(manifests[0])
-    assert all(phase_gate_errors(manifest) for manifest in manifests[1:])
+    open_phases = {manifest.phase for manifest in manifests if not phase_gate_errors(manifest)}
+    assert open_phases == {0, 2}
 
 
 def test_phase_schema_cli_accepts_each_frozen_manifest(capsys) -> None:


### PR DESCRIPTION
## 摘要

完成 #705 Phase 2E 独立 evidence gate，并将 Phase 2 的 8 个 required claims 提升为 `verified`。

- 新增预注册 capture 工具：只允许 clean source commit，实际执行 `uv run` A/C lane，记录完整 stdout/stderr、exit code、duration、GPU/包版本、source SHA、owner YAML/lock hash、test-to-claim mapping。
- C lane 的 production CUDA suite 与 DR owner-semantics suite 各重跑 3 次；因此满足/超过各 claim 冻结的 1/2/3 次 repetitions。所有 mandatory run 为 exit=0、skip=0、xfail=0、xpass=0。
- 新增 fail-closed artifact validator：检查 source ancestry、输入 hash、CUDA provenance、预注册 argv/lane/test ID、series/repetition、command success 及 manifest binding；fault injection 覆盖 skip、stale SHA、错误 test mapping、错误 argv 和缺失 repetition。
- 提交 raw JSON artifact，并更新 `phase_2.yaml` PASS evidence；`validate_issue705_phase.py --phase 2 --mode gate` 通过。

这只验证独立 `mjwarp` host compatibility correctness slice；不代表高性能、device-resident rollout、manager/fused executor、完整 typed DR 或任务推广已完成。

Closes #745

## 自查

1. 证据链审查：artifact 来自 clean commit `e5e3b6638d72577c66cc474efd072e7a8459e53a`，并绑定当前 owner YAML/`uv.lock` hash；validator 拒绝非 ancestor、输入漂移、命令/claim 映射篡改和 skip/xfail。
2. Gate 语义审查：逐项核对 manifest 的 required test 与 repetition；Phase 2 仅在 8/8 verified 后打开，其他未证据化 Phase 仍 fail-closed。

## Validation

- `uv run --extra mjwarp scripts/capture_issue705_phase2_evidence.py --output /tmp/issue705-phase2-gate-repeated.json`
  - Lane A: 3 passed
  - Lane C production CUDA: 11 passed × 3
  - Lane C DR owner semantics: 1 passed × 3
- `uv run pytest tests/acceptance/issue_705/test_phase2_evidence.py tests/scripts/test_issue705_claim_gap_audit.py tests/tools/test_phase_acceptance.py tests/scripts/test_issue705_phase_acceptance.py -v` (35 passed)
- `uv run scripts/validate_issue705_phase.py --phase 2 --mode schema`
- `uv run scripts/validate_issue705_phase.py --phase 2 --mode gate`
- `uv run scripts/audit_issue705_claims.py --all`
- `uv run scripts/audit_issue705_backend_isolation.py`
- `uv lock --check`
- `make test-all`
