### PR TITLE
test: 固化 Phase 1 typed batch 验收证据

### DIFF
--- a/scripts/capture_issue705_phase1_evidence.py
+++ b/scripts/capture_issue705_phase1_evidence.py
@@ -1,0 +1,42 @@
+"""Capture real A/B Phase 1 evidence for Issue #705.
+
+Run only from a clean commit and write outside the repository first:
+
+    uv run scripts/capture_issue705_phase1_evidence.py \
+      --output /tmp/issue705-phase1-gate.json
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from unilab.tools.issue705_phase1_evidence import (
+    PhaseEvidenceError,
+    capture_phase1_evidence,
+    write_phase1_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = capture_phase1_evidence(REPO_ROOT)
+        write_phase1_evidence(report, args.output)
+    except PhaseEvidenceError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    print(
+        f"PASS: captured Issue #705 Phase 1 A/B evidence at {args.output} "
+        f"for {report['source']['commit_sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unilab/tools/issue705_phase1_evidence.py
+++ b/src/unilab/tools/issue705_phase1_evidence.py
@@ -1,0 +1,241 @@
+"""Fail-closed evidence contract for the Issue #705 Phase 1 gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from unilab.tools.issue705_phase_evidence import (
+    PhaseEvidenceClaim,
+    PhaseEvidenceCommand,
+    PhaseEvidenceError,
+    PhaseEvidenceSpec,
+    capture_phase_evidence,
+    load_phase_evidence,
+    sha256_file,
+    validate_phase_evidence,
+    write_phase_evidence,
+)
+
+ISSUE = 705
+PHASE = 1
+ARTIFACT_KIND = "issue705-phase1-gate-v1"
+MANIFEST_PATH = Path("tests/acceptance/issue_705/manifests/phase_1.yaml")
+MUJOCO_OWNER = Path("conf/ppo/task/g1_walk_flat/mujoco.yaml")
+
+PHASE1_REQUIRED_TEST_IDS: dict[str, str] = {
+    "P1-BATCH-CONTRACT": "tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract",
+    "P1-MUJOCO-REFERENCE": "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference",
+    "P1-MUTATION-CONTRACT": "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed",
+    "P1-HOT-PATH-INSTRUMENTATION": "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters",
+    "P1-DR-COMPATIBILITY": "tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary",
+    "P1-BACKEND-ISOLATION": "tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract",
+}
+
+PHASE1_MIN_REPETITIONS: dict[str, int] = {
+    "P1-BATCH-CONTRACT": 1,
+    "P1-MUJOCO-REFERENCE": 3,
+    "P1-MUTATION-CONTRACT": 2,
+    "P1-HOT-PATH-INSTRUMENTATION": 2,
+    "P1-DR-COMPATIBILITY": 1,
+    "P1-BACKEND-ISOLATION": 1,
+}
+
+PHASE1_MANIFEST_COMMANDS: dict[str, str] = {
+    "P1-BATCH-CONTRACT": "uv run pytest tests/base/test_backend_batch_contract.py -v",
+    "P1-MUJOCO-REFERENCE": "uv run pytest tests/base/test_backend_batch_contract.py -k mujoco -v",
+    "P1-MUTATION-CONTRACT": "uv run pytest tests/dr/test_mutation_contract.py -v",
+    "P1-HOT-PATH-INSTRUMENTATION": (
+        "uv run pytest tests/base/test_backend_batch_contract.py::"
+        "test_managed_hot_path_has_no_dynamic_getters -v"
+    ),
+    "P1-DR-COMPATIBILITY": (
+        "uv run pytest tests/dr/test_mutation_contract.py::"
+        "test_legacy_warning_and_compiled_strict_boundary -v"
+    ),
+    "P1-BACKEND-ISOLATION": (
+        "uv run pytest tests/base/test_backend_batch_contract.py::"
+        "test_runtime_backends_share_only_cold_materialization_contract -v"
+    ),
+}
+
+_CLAIM_CONFIG_INPUTS: dict[str, Path] = {
+    "P1-BATCH-CONTRACT": Path("tests/base/test_backend_batch_contract.py"),
+    "P1-MUJOCO-REFERENCE": MUJOCO_OWNER,
+    "P1-MUTATION-CONTRACT": Path("tests/dr/test_mutation_contract.py"),
+    "P1-HOT-PATH-INSTRUMENTATION": MUJOCO_OWNER,
+    "P1-DR-COMPATIBILITY": Path("tests/dr/test_mutation_contract.py"),
+    "P1-BACKEND-ISOLATION": Path("tests/base/test_backend_batch_contract.py"),
+}
+
+PHASE1_COMMANDS = (
+    PhaseEvidenceCommand(
+        name="lane_a_batch_contract",
+        lane="A",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-BATCH-CONTRACT"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-BATCH-CONTRACT"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-BATCH-CONTRACT"],
+    ),
+    PhaseEvidenceCommand(
+        name="lane_a_backend_isolation",
+        lane="A",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-BACKEND-ISOLATION"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-BACKEND-ISOLATION"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-BACKEND-ISOLATION"],
+    ),
+    PhaseEvidenceCommand(
+        name="lane_b_mujoco_reference",
+        lane="B",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-MUJOCO-REFERENCE"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-MUJOCO-REFERENCE"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-MUJOCO-REFERENCE"],
+    ),
+    PhaseEvidenceCommand(
+        name="lane_b_mutation_contract",
+        lane="B",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-MUTATION-CONTRACT"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-MUTATION-CONTRACT"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-MUTATION-CONTRACT"],
+    ),
+    PhaseEvidenceCommand(
+        name="lane_b_hot_path",
+        lane="B",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-HOT-PATH-INSTRUMENTATION"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-HOT-PATH-INSTRUMENTATION"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-HOT-PATH-INSTRUMENTATION"],
+    ),
+    PhaseEvidenceCommand(
+        name="lane_b_dr_compatibility",
+        lane="B",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            PHASE1_REQUIRED_TEST_IDS["P1-DR-COMPATIBILITY"],
+            "-v",
+            "-rsxX",
+        ),
+        required_test_ids=(PHASE1_REQUIRED_TEST_IDS["P1-DR-COMPATIBILITY"],),
+        repetitions=PHASE1_MIN_REPETITIONS["P1-DR-COMPATIBILITY"],
+    ),
+)
+
+_COMMAND_BY_CLAIM = {
+    "P1-BATCH-CONTRACT": "lane_a_batch_contract",
+    "P1-MUJOCO-REFERENCE": "lane_b_mujoco_reference",
+    "P1-MUTATION-CONTRACT": "lane_b_mutation_contract",
+    "P1-HOT-PATH-INSTRUMENTATION": "lane_b_hot_path",
+    "P1-DR-COMPATIBILITY": "lane_b_dr_compatibility",
+    "P1-BACKEND-ISOLATION": "lane_a_backend_isolation",
+}
+
+_INPUT_FILES = (
+    Path("uv.lock"),
+    MUJOCO_OWNER,
+    Path("src/unilab/tools/issue705_phase_evidence.py"),
+    Path("src/unilab/tools/issue705_phase1_evidence.py"),
+    Path("scripts/capture_issue705_phase1_evidence.py"),
+    Path("tests/tools/test_issue705_phase1_evidence.py"),
+    Path("tests/acceptance/issue_705/test_phase1_evidence.py"),
+    Path("tests/base/test_backend_batch_contract.py"),
+    Path("tests/dr/test_mutation_contract.py"),
+)
+
+PHASE1_SPEC = PhaseEvidenceSpec(
+    issue=ISSUE,
+    phase=PHASE,
+    artifact_kind=ARTIFACT_KIND,
+    manifest_path=MANIFEST_PATH,
+    required_lanes=("A", "B"),
+    input_files=_INPUT_FILES,
+    package_names=("mujoco",),
+    commands=PHASE1_COMMANDS,
+    claims=tuple(
+        PhaseEvidenceClaim(
+            claim_id=claim_id,
+            required_test_id=test_id,
+            command_name=_COMMAND_BY_CLAIM[claim_id],
+            minimum_repetitions=PHASE1_MIN_REPETITIONS[claim_id],
+            config_input=_CLAIM_CONFIG_INPUTS[claim_id],
+            manifest_command=PHASE1_MANIFEST_COMMANDS[claim_id],
+        )
+        for claim_id, test_id in PHASE1_REQUIRED_TEST_IDS.items()
+    ),
+)
+
+
+def capture_phase1_evidence(root: Path) -> dict[str, Any]:
+    """Run every Phase 1 A/B evidence command from a clean source commit."""
+
+    return capture_phase_evidence(PHASE1_SPEC, root)
+
+
+def load_phase1_evidence(path: Path) -> dict[str, Any]:
+    """Load one Phase 1 raw evidence artifact."""
+
+    return load_phase_evidence(path)
+
+
+def validate_phase1_evidence(report: Mapping[str, Any], *, root: Path) -> tuple[str, ...]:
+    """Validate raw evidence and the independent Phase 1 manifest mapping."""
+
+    return validate_phase_evidence(PHASE1_SPEC, report, root=root)
+
+
+def write_phase1_evidence(report: Mapping[str, Any], output: Path) -> None:
+    """Persist a previously validated Phase 1 capture."""
+
+    write_phase_evidence(report, output)
+
+
+__all__ = [
+    "ARTIFACT_KIND",
+    "ISSUE",
+    "MANIFEST_PATH",
+    "PHASE",
+    "PHASE1_COMMANDS",
+    "PHASE1_MIN_REPETITIONS",
+    "PHASE1_REQUIRED_TEST_IDS",
+    "PHASE1_SPEC",
+    "PhaseEvidenceError",
+    "capture_phase1_evidence",
+    "load_phase1_evidence",
+    "sha256_file",
+    "validate_phase1_evidence",
+    "write_phase1_evidence",
+]

--- a/src/unilab/tools/issue705_phase_evidence.py
+++ b/src/unilab/tools/issue705_phase_evidence.py
@@ -1,0 +1,713 @@
+"""Reusable, fail-closed capture primitives for Issue #705 phase evidence.
+
+The phase manifests intentionally keep the acceptance claims human-readable.
+This module supplies the mechanically verifiable companion: a fixed command
+matrix is captured from a clean commit, bound to input hashes and raw pytest
+output, then revalidated against the current manifest.  It is deliberately
+for validation/provenance only; it owns neither a simulator nor task runtime
+behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from unilab.tools.phase_acceptance import ManifestValidationError, load_phase_acceptance
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_PYTEST_COUNT_RE = re.compile(r"(?<![A-Za-z0-9_])(\d+) (passed|skipped|xfailed|xpassed)")
+
+
+class PhaseEvidenceError(RuntimeError):
+    """Raised when a phase capture cannot establish trustworthy evidence."""
+
+
+@dataclass(frozen=True)
+class PhaseEvidenceCommand:
+    """One pre-registered command and its mandatory clean repetitions."""
+
+    name: str
+    lane: str
+    argv: tuple[str, ...]
+    required_test_ids: tuple[str, ...]
+    repetitions: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("phase evidence command name must be non-empty")
+        if self.lane not in {"A", "B", "C", "D"}:
+            raise ValueError("phase evidence command lane must be A, B, C, or D")
+        if not self.argv or any(not isinstance(item, str) or not item for item in self.argv):
+            raise ValueError("phase evidence command argv must be non-empty strings")
+        if not self.required_test_ids or any(
+            not isinstance(item, str) or not item for item in self.required_test_ids
+        ):
+            raise ValueError("phase evidence command requires non-empty test IDs")
+        if len(set(self.required_test_ids)) != len(self.required_test_ids):
+            raise ValueError("phase evidence command test IDs must be unique")
+        if isinstance(self.repetitions, bool) or not isinstance(self.repetitions, int):
+            raise ValueError("phase evidence command repetitions must be an integer")
+        if self.repetitions < 1:
+            raise ValueError("phase evidence command repetitions must be positive")
+
+
+@dataclass(frozen=True)
+class PhaseEvidenceClaim:
+    """One manifest claim mapped to its command and input provenance."""
+
+    claim_id: str
+    required_test_id: str
+    command_name: str
+    minimum_repetitions: int
+    config_input: Path
+    manifest_command: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("claim_id", self.claim_id),
+            ("required_test_id", self.required_test_id),
+            ("command_name", self.command_name),
+            ("manifest_command", self.manifest_command),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"phase evidence claim {name} must be non-empty")
+        if self.config_input.is_absolute() or ".." in self.config_input.parts:
+            raise ValueError("phase evidence claim config input must be repository-relative")
+        if (
+            isinstance(self.minimum_repetitions, bool)
+            or not isinstance(self.minimum_repetitions, int)
+            or self.minimum_repetitions < 1
+        ):
+            raise ValueError("phase evidence claim repetitions must be positive")
+
+
+@dataclass(frozen=True)
+class PhaseEvidenceSpec:
+    """Immutable capture contract for one Issue #705 phase."""
+
+    issue: int
+    phase: int
+    artifact_kind: str
+    manifest_path: Path
+    required_lanes: tuple[str, ...]
+    input_files: tuple[Path, ...]
+    package_names: tuple[str, ...]
+    commands: tuple[PhaseEvidenceCommand, ...]
+    claims: tuple[PhaseEvidenceClaim, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.issue != 705:
+            raise ValueError("Issue #705 phase evidence spec must use issue 705")
+        if isinstance(self.phase, bool) or not isinstance(self.phase, int) or self.phase < 0:
+            raise ValueError("phase evidence spec phase must be non-negative")
+        if not isinstance(self.artifact_kind, str) or not self.artifact_kind:
+            raise ValueError("phase evidence artifact kind must be non-empty")
+        if self.manifest_path.is_absolute() or ".." in self.manifest_path.parts:
+            raise ValueError("phase evidence manifest path must be repository-relative")
+        if not self.required_lanes or any(
+            lane not in {"A", "B", "C", "D"} for lane in self.required_lanes
+        ):
+            raise ValueError("phase evidence spec lanes must be unique A/B/C/D values")
+        if len(set(self.required_lanes)) != len(self.required_lanes):
+            raise ValueError("phase evidence spec lanes must be unique")
+        if not self.input_files or any(
+            path.is_absolute() or ".." in path.parts for path in self.input_files
+        ):
+            raise ValueError("phase evidence inputs must be repository-relative")
+        if len(set(self.input_files)) != len(self.input_files):
+            raise ValueError("phase evidence inputs must be unique")
+        if len(set(self.package_names)) != len(self.package_names) or any(
+            not isinstance(name, str) or not name for name in self.package_names
+        ):
+            raise ValueError("phase evidence packages must be unique non-empty strings")
+        if not self.commands or not self.claims:
+            raise ValueError("phase evidence spec requires commands and claims")
+        command_names = tuple(command.name for command in self.commands)
+        if len(set(command_names)) != len(command_names):
+            raise ValueError("phase evidence command names must be unique")
+        claim_ids = tuple(claim.claim_id for claim in self.claims)
+        if len(set(claim_ids)) != len(claim_ids):
+            raise ValueError("phase evidence claim IDs must be unique")
+        command_by_name = {command.name: command for command in self.commands}
+        expected_lanes = {command.lane for command in self.commands}
+        if expected_lanes != set(self.required_lanes):
+            raise ValueError("phase evidence commands must cover exactly the required lanes")
+        for claim in self.claims:
+            try:
+                command = command_by_name[claim.command_name]
+            except KeyError as exc:
+                raise ValueError("phase evidence claim references an unknown command") from exc
+            if claim.required_test_id not in command.required_test_ids:
+                raise ValueError("phase evidence claim test is absent from its command")
+            if claim.minimum_repetitions != command.repetitions:
+                raise ValueError("phase evidence claim repetitions must match its command")
+
+
+def sha256_file(path: Path) -> str:
+    """Return the canonical hash representation used by acceptance manifests."""
+
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _registered_input_hashes(spec: PhaseEvidenceSpec, root: Path) -> dict[str, str]:
+    return {path.as_posix(): sha256_file(root / path) for path in spec.input_files}
+
+
+def _claim_config_hashes(spec: PhaseEvidenceSpec, root: Path) -> dict[str, str]:
+    return {claim.claim_id: sha256_file(root / claim.config_input) for claim in spec.claims}
+
+
+def _run_checked(argv: Sequence[str], *, root: Path, context: str) -> str:
+    result = subprocess.run(argv, cwd=root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise PhaseEvidenceError(
+            f"{context} failed with exit {result.returncode}:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def _git(root: Path, *args: str) -> str:
+    return _run_checked(("git", *args), root=root, context=f"git {' '.join(args)}")
+
+
+def _assert_clean_source(root: Path) -> None:
+    dirty = _git(root, "status", "--porcelain")
+    if dirty:
+        raise PhaseEvidenceError(
+            "phase evidence must be captured from a clean source tree; found:\n" + dirty
+        )
+
+
+def _package_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError as exc:
+        raise PhaseEvidenceError(f"required package {name!r} is not installed") from exc
+
+
+def _capture_environment(spec: PhaseEvidenceSpec) -> dict[str, Any]:
+    return {
+        "platform": platform.platform(),
+        "python": sys.version,
+        "packages": {name: _package_version(name) for name in spec.package_names},
+    }
+
+
+def _pytest_counts(output: str) -> dict[str, int]:
+    counts = {"passed": 0, "skipped": 0, "xfailed": 0, "xpassed": 0}
+    for raw_count, category in _PYTEST_COUNT_RE.findall(output):
+        counts[category] += int(raw_count)
+    return counts
+
+
+def _run_evidence_command(
+    command: PhaseEvidenceCommand, *, root: Path, repetition: int
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    result = subprocess.run(
+        command.argv,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    duration_sec = time.perf_counter() - started
+    combined = f"{result.stdout}\n{result.stderr}"
+    counts = _pytest_counts(combined)
+    errors: list[str] = []
+    if result.returncode != 0:
+        errors.append(f"exit_code={result.returncode}")
+    if counts["passed"] <= 0:
+        errors.append("pytest reported no passed tests")
+    for category in ("skipped", "xfailed", "xpassed"):
+        if counts[category] != 0:
+            errors.append(f"pytest reported {counts[category]} {category}")
+    missing_nodes = [test_id for test_id in command.required_test_ids if test_id not in combined]
+    if missing_nodes:
+        errors.append(f"required test IDs absent from pytest output: {missing_nodes!r}")
+    if errors:
+        raise PhaseEvidenceError(
+            f"{command.name} did not meet evidence requirements ({'; '.join(errors)}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return {
+        "name": f"{command.name}#{repetition}",
+        "series": command.name,
+        "lane": command.lane,
+        "repetition": repetition,
+        "argv": list(command.argv),
+        "required_test_ids": list(command.required_test_ids),
+        "exit_code": int(result.returncode),
+        "duration_sec": duration_sec,
+        "pytest": counts,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def capture_phase_evidence(spec: PhaseEvidenceSpec, root: Path) -> dict[str, Any]:
+    """Capture every pre-registered command from one clean source commit."""
+
+    root = root.resolve()
+    missing = [path.as_posix() for path in spec.input_files if not (root / path).is_file()]
+    if missing:
+        raise PhaseEvidenceError("phase evidence is missing required inputs: " + ", ".join(missing))
+    _assert_clean_source(root)
+    source_commit = _git(root, "rev-parse", "HEAD")
+    if not _COMMIT_RE.fullmatch(source_commit):
+        raise PhaseEvidenceError(f"git returned an invalid commit SHA: {source_commit!r}")
+    input_hashes = _registered_input_hashes(spec, root)
+    config_hashes = _claim_config_hashes(spec, root)
+    environment = _capture_environment(spec)
+    commands = [
+        _run_evidence_command(command, root=root, repetition=repetition)
+        for command in spec.commands
+        for repetition in range(1, command.repetitions + 1)
+    ]
+    _assert_clean_source(root)
+    if _registered_input_hashes(spec, root) != input_hashes:
+        raise PhaseEvidenceError(
+            "phase evidence commands changed a registered input during capture"
+        )
+    return {
+        "schema_version": spec.schema_version,
+        "kind": spec.artifact_kind,
+        "issue": spec.issue,
+        "phase": spec.phase,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "source": {
+            "commit_sha": source_commit,
+            "branch": _git(root, "rev-parse", "--abbrev-ref", "HEAD"),
+            "tree_clean": True,
+        },
+        "inputs": {"files": input_hashes, "claim_config_hashes": config_hashes},
+        "environment": environment,
+        "claims": [
+            {
+                "claim_id": claim.claim_id,
+                "required_test_id": claim.required_test_id,
+                "command": claim.command_name,
+                "minimum_repetitions": claim.minimum_repetitions,
+                "config_input": claim.config_input.as_posix(),
+            }
+            for claim in spec.claims
+        ],
+        "commands": commands,
+    }
+
+
+def write_phase_evidence(report: Mapping[str, Any], output: Path) -> None:
+    """Write an auditable JSON artifact only after a successful capture."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(dict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_phase_evidence(path: Path) -> dict[str, Any]:
+    """Load one evidence artifact with a domain-specific error on malformed I/O."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PhaseEvidenceError(f"cannot load phase evidence {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PhaseEvidenceError(f"phase evidence {path} must contain a JSON object")
+    return payload
+
+
+def _mapping(value: object, name: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{name}: expected object")
+    return {}
+
+
+def _string(value: object, name: str, errors: list[str]) -> str:
+    if isinstance(value, str) and value:
+        return value
+    errors.append(f"{name}: expected non-empty string")
+    return ""
+
+
+def _integer(value: object, name: str, errors: list[str]) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    errors.append(f"{name}: expected integer")
+    return -1
+
+
+def _keys_match(
+    mapping: Mapping[str, Any], *, expected: set[str], name: str, errors: list[str]
+) -> None:
+    actual = set(mapping)
+    if actual != expected:
+        errors.append(f"{name}: keys do not exactly match the registered schema")
+
+
+def _git_is_ancestor(root: Path, commit: str) -> bool:
+    return (
+        subprocess.run(
+            ("git", "merge-base", "--is-ancestor", commit, "HEAD"),
+            cwd=root,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _validate_inputs(
+    spec: PhaseEvidenceSpec,
+    report: Mapping[str, Any],
+    *,
+    root: Path,
+    errors: list[str],
+) -> None:
+    inputs = _mapping(report.get("inputs"), "inputs", errors)
+    _keys_match(
+        inputs,
+        expected={"files", "claim_config_hashes"},
+        name="inputs",
+        errors=errors,
+    )
+    expected_paths = {path.as_posix() for path in spec.input_files}
+    raw_files = inputs.get("files")
+    if not isinstance(raw_files, dict):
+        errors.append("inputs.files: expected object")
+        raw_files = {}
+    if set(raw_files) != expected_paths:
+        errors.append("inputs.files: paths do not exactly match registered inputs")
+    for path in spec.input_files:
+        key = path.as_posix()
+        observed = _string(raw_files.get(key), f"inputs.files.{key}", errors)
+        current = root / path
+        if not current.is_file():
+            errors.append(f"inputs.files.{key}: current input is missing")
+        elif observed and not _SHA256_RE.fullmatch(observed):
+            errors.append(f"inputs.files.{key}: expected sha256 hash")
+        elif observed and observed != sha256_file(current):
+            errors.append(f"inputs.files.{key}: does not match current input")
+
+    raw_config_hashes = inputs.get("claim_config_hashes")
+    if not isinstance(raw_config_hashes, dict):
+        errors.append("inputs.claim_config_hashes: expected object")
+        raw_config_hashes = {}
+    expected_claims = {claim.claim_id for claim in spec.claims}
+    if set(raw_config_hashes) != expected_claims:
+        errors.append(
+            "inputs.claim_config_hashes: claim IDs do not exactly match registered claims"
+        )
+    for claim in spec.claims:
+        key = claim.claim_id
+        observed = _string(raw_config_hashes.get(key), f"inputs.claim_config_hashes.{key}", errors)
+        current = root / claim.config_input
+        if not current.is_file():
+            errors.append(f"inputs.claim_config_hashes.{key}: current input is missing")
+        elif observed and not _SHA256_RE.fullmatch(observed):
+            errors.append(f"inputs.claim_config_hashes.{key}: expected sha256 hash")
+        elif observed and observed != sha256_file(current):
+            errors.append(f"inputs.claim_config_hashes.{key}: does not match current input")
+
+
+def _validate_environment(
+    spec: PhaseEvidenceSpec, report: Mapping[str, Any], *, errors: list[str]
+) -> None:
+    environment = _mapping(report.get("environment"), "environment", errors)
+    _keys_match(
+        environment,
+        expected={"platform", "python", "packages"},
+        name="environment",
+        errors=errors,
+    )
+    _string(environment.get("platform"), "environment.platform", errors)
+    _string(environment.get("python"), "environment.python", errors)
+    packages = _mapping(environment.get("packages"), "environment.packages", errors)
+    if set(packages) != set(spec.package_names):
+        errors.append("environment.packages: keys do not exactly match registered packages")
+    for package_name in spec.package_names:
+        _string(packages.get(package_name), f"environment.packages.{package_name}", errors)
+
+
+def _validate_commands(
+    spec: PhaseEvidenceSpec, report: Mapping[str, Any], *, errors: list[str]
+) -> dict[str, list[dict[str, Any]]]:
+    raw_commands = report.get("commands")
+    if not isinstance(raw_commands, list) or not raw_commands:
+        errors.append("commands: expected non-empty list")
+        raw_commands = []
+    command_by_name = {command.name: command for command in spec.commands}
+    by_series: dict[str, list[dict[str, Any]]] = {}
+    names: set[str] = set()
+    seen_lanes: set[str] = set()
+    expected_keys = {
+        "name",
+        "series",
+        "lane",
+        "repetition",
+        "argv",
+        "required_test_ids",
+        "exit_code",
+        "duration_sec",
+        "pytest",
+        "stdout",
+        "stderr",
+    }
+    for index, raw_command in enumerate(raw_commands):
+        command = _mapping(raw_command, f"commands[{index}]", errors)
+        _keys_match(command, expected=expected_keys, name=f"commands[{index}]", errors=errors)
+        name = _string(command.get("name"), f"commands[{index}].name", errors)
+        if name:
+            if name in names:
+                errors.append(f"commands[{index}].name: duplicate {name!r}")
+            names.add(name)
+        series = _string(command.get("series"), f"commands[{index}].series", errors)
+        repetition = _integer(command.get("repetition"), f"commands[{index}].repetition", errors)
+        if repetition < 1:
+            errors.append(f"commands[{index}].repetition: expected >= 1")
+        if series and name and name != f"{series}#{repetition}":
+            errors.append(f"commands[{index}].name: must equal its series/repetition key")
+        expected = command_by_name.get(series)
+        if expected is None:
+            errors.append(f"commands[{index}].series: unknown series {series!r}")
+        else:
+            if command.get("lane") != expected.lane:
+                errors.append(f"commands[{index}].lane: does not match {series!r}")
+            if command.get("argv") != list(expected.argv):
+                errors.append(
+                    f"commands[{index}].argv: does not match registered command {series!r}"
+                )
+            if command.get("required_test_ids") != list(expected.required_test_ids):
+                errors.append(f"commands[{index}].required_test_ids: does not match {series!r}")
+            by_series.setdefault(series, []).append(command)
+        lane = _string(command.get("lane"), f"commands[{index}].lane", errors)
+        if lane:
+            seen_lanes.add(lane)
+        if _integer(command.get("exit_code"), f"commands[{index}].exit_code", errors) != 0:
+            errors.append(f"commands[{index}].exit_code: expected 0")
+        duration = command.get("duration_sec")
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or float(duration) <= 0.0
+        ):
+            errors.append(f"commands[{index}].duration_sec: expected positive number")
+        pytest_counts = _mapping(command.get("pytest"), f"commands[{index}].pytest", errors)
+        _keys_match(
+            pytest_counts,
+            expected={"passed", "skipped", "xfailed", "xpassed"},
+            name=f"commands[{index}].pytest",
+            errors=errors,
+        )
+        if _integer(pytest_counts.get("passed"), f"commands[{index}].pytest.passed", errors) <= 0:
+            errors.append(f"commands[{index}].pytest.passed: expected > 0")
+        for category in ("skipped", "xfailed", "xpassed"):
+            if (
+                _integer(
+                    pytest_counts.get(category), f"commands[{index}].pytest.{category}", errors
+                )
+                != 0
+            ):
+                errors.append(f"commands[{index}].pytest.{category}: expected 0")
+        required_test_ids = command.get("required_test_ids")
+        stdout = _string(command.get("stdout"), f"commands[{index}].stdout", errors)
+        if not isinstance(required_test_ids, list) or not all(
+            isinstance(test_id, str) for test_id in required_test_ids
+        ):
+            errors.append(f"commands[{index}].required_test_ids: expected string list")
+        else:
+            for test_id in required_test_ids:
+                if test_id not in stdout:
+                    errors.append(
+                        f"commands[{index}].stdout: required test {test_id!r} is not present"
+                    )
+        if not isinstance(command.get("stderr"), str):
+            errors.append(f"commands[{index}].stderr: expected string")
+    if seen_lanes != set(spec.required_lanes):
+        errors.append(
+            "commands: expected exactly lanes "
+            f"{sorted(spec.required_lanes)!r}, got {sorted(seen_lanes)!r}"
+        )
+    if set(by_series) != set(command_by_name):
+        errors.append("commands: series do not exactly match registered commands")
+    for expected in spec.commands:
+        matching = by_series.get(expected.name, [])
+        repetitions = {
+            _integer(command.get("repetition"), "commands.repetition", errors)
+            for command in matching
+        }
+        if repetitions != set(range(1, expected.repetitions + 1)):
+            errors.append(
+                f"commands[{expected.name}]: expected repetitions 1..{expected.repetitions}"
+            )
+    return by_series
+
+
+def _validate_claims(
+    spec: PhaseEvidenceSpec,
+    report: Mapping[str, Any],
+    *,
+    by_series: Mapping[str, list[dict[str, Any]]],
+    errors: list[str],
+) -> None:
+    raw_claims = report.get("claims")
+    if not isinstance(raw_claims, list):
+        errors.append("claims: expected list")
+        raw_claims = []
+    observed: dict[str, tuple[str, str, int, str]] = {}
+    for index, raw_claim in enumerate(raw_claims):
+        claim = _mapping(raw_claim, f"claims[{index}]", errors)
+        _keys_match(
+            claim,
+            expected={
+                "claim_id",
+                "required_test_id",
+                "command",
+                "minimum_repetitions",
+                "config_input",
+            },
+            name=f"claims[{index}]",
+            errors=errors,
+        )
+        claim_id = _string(claim.get("claim_id"), f"claims[{index}].claim_id", errors)
+        test_id = _string(
+            claim.get("required_test_id"), f"claims[{index}].required_test_id", errors
+        )
+        command_name = _string(claim.get("command"), f"claims[{index}].command", errors)
+        repetitions = _integer(
+            claim.get("minimum_repetitions"), f"claims[{index}].minimum_repetitions", errors
+        )
+        config_input = _string(claim.get("config_input"), f"claims[{index}].config_input", errors)
+        if claim_id:
+            if claim_id in observed:
+                errors.append(f"claims[{index}].claim_id: duplicate {claim_id!r}")
+            observed[claim_id] = (test_id, command_name, repetitions, config_input)
+    expected_claims = {claim.claim_id for claim in spec.claims}
+    if set(observed) != expected_claims:
+        errors.append("claims: claim IDs do not exactly match registered claims")
+    for expected in spec.claims:
+        test_id, command_name, repetitions, config_input = observed.get(
+            expected.claim_id, ("", "", -1, "")
+        )
+        if test_id != expected.required_test_id:
+            errors.append(f"claims[{expected.claim_id}]: required test mapping does not match")
+        if command_name != expected.command_name:
+            errors.append(f"claims[{expected.claim_id}]: command mapping does not match")
+        if repetitions != expected.minimum_repetitions:
+            errors.append(f"claims[{expected.claim_id}]: minimum repetitions do not match")
+        if config_input != expected.config_input.as_posix():
+            errors.append(f"claims[{expected.claim_id}]: config input does not match")
+        matching = by_series.get(command_name, [])
+        if len(matching) < expected.minimum_repetitions:
+            errors.append(f"claims[{expected.claim_id}]: insufficient successful repetitions")
+        for command in matching:
+            test_ids = command.get("required_test_ids")
+            if not isinstance(test_ids, list) or expected.required_test_id not in test_ids:
+                errors.append(f"claims[{expected.claim_id}]: command does not declare its test")
+
+
+def _validate_manifest_contract(spec: PhaseEvidenceSpec, root: Path, *, errors: list[str]) -> None:
+    try:
+        manifest = load_phase_acceptance(root / spec.manifest_path)
+    except ManifestValidationError as exc:
+        errors.extend(f"manifest: {error}" for error in exc.errors)
+        return
+    if manifest.issue != spec.issue or manifest.phase != spec.phase:
+        errors.append(f"manifest: expected issue/phase {spec.issue}/{spec.phase}")
+    if tuple(lane.value for lane in manifest.required_lanes) != spec.required_lanes:
+        errors.append("manifest: required lanes do not match registered evidence spec")
+    manifest_claims = {claim.claim_id: claim for claim in manifest.claims}
+    if set(manifest_claims) != {claim.claim_id for claim in spec.claims}:
+        errors.append("manifest: claim IDs do not exactly match registered claims")
+        return
+    command_by_name = {command.name: command for command in spec.commands}
+    for expected in spec.claims:
+        claim = manifest_claims[expected.claim_id]
+        command = command_by_name[expected.command_name]
+        if claim.required_test_ids != (expected.required_test_id,):
+            errors.append(f"manifest[{expected.claim_id}]: required test mapping does not match")
+        if claim.acceptance.repetitions != expected.minimum_repetitions:
+            errors.append(f"manifest[{expected.claim_id}]: repetitions do not match")
+        if claim.lane.value != command.lane:
+            errors.append(f"manifest[{expected.claim_id}]: lane does not match")
+        if claim.commands != (expected.manifest_command,):
+            errors.append(f"manifest[{expected.claim_id}]: command does not match")
+
+
+def validate_phase_evidence(
+    spec: PhaseEvidenceSpec, report: Mapping[str, Any], *, root: Path
+) -> tuple[str, ...]:
+    """Return all artifact/manifest/provenance errors without trusting PASS JSON."""
+
+    root = root.resolve()
+    errors: list[str] = []
+    expected_top_level = {
+        "schema_version",
+        "kind",
+        "issue",
+        "phase",
+        "generated_at_utc",
+        "source",
+        "inputs",
+        "environment",
+        "claims",
+        "commands",
+    }
+    _keys_match(report, expected=expected_top_level, name="artifact", errors=errors)
+    if report.get("schema_version") != spec.schema_version:
+        errors.append(f"schema_version: expected {spec.schema_version}")
+    if report.get("kind") != spec.artifact_kind:
+        errors.append(f"kind: expected {spec.artifact_kind!r}")
+    if report.get("issue") != spec.issue or report.get("phase") != spec.phase:
+        errors.append(f"issue/phase: expected {spec.issue}/{spec.phase}")
+    _string(report.get("generated_at_utc"), "generated_at_utc", errors)
+
+    source = _mapping(report.get("source"), "source", errors)
+    _keys_match(
+        source,
+        expected={"commit_sha", "branch", "tree_clean"},
+        name="source",
+        errors=errors,
+    )
+    commit = _string(source.get("commit_sha"), "source.commit_sha", errors)
+    if commit and not _COMMIT_RE.fullmatch(commit):
+        errors.append("source.commit_sha: expected full 40-character SHA")
+    elif commit and not _git_is_ancestor(root, commit):
+        errors.append("source.commit_sha: must be an ancestor of the current gate commit")
+    _string(source.get("branch"), "source.branch", errors)
+    if source.get("tree_clean") is not True:
+        errors.append("source.tree_clean: must be true")
+
+    _validate_inputs(spec, report, root=root, errors=errors)
+    _validate_environment(spec, report, errors=errors)
+    commands = _validate_commands(spec, report, errors=errors)
+    _validate_claims(spec, report, by_series=commands, errors=errors)
+    _validate_manifest_contract(spec, root, errors=errors)
+    return tuple(errors)
+
+
+__all__ = [
+    "PhaseEvidenceClaim",
+    "PhaseEvidenceCommand",
+    "PhaseEvidenceError",
+    "PhaseEvidenceSpec",
+    "capture_phase_evidence",
+    "load_phase_evidence",
+    "sha256_file",
+    "validate_phase_evidence",
+    "write_phase_evidence",
+]

--- a/tests/acceptance/issue_705/artifacts/phase_1_gate.json
+++ b/tests/acceptance/issue_705/artifacts/phase_1_gate.json
@@ -1,0 +1,356 @@
+{
+  "claims": [
+    {
+      "claim_id": "P1-BATCH-CONTRACT",
+      "command": "lane_a_batch_contract",
+      "config_input": "tests/base/test_backend_batch_contract.py",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract"
+    },
+    {
+      "claim_id": "P1-MUJOCO-REFERENCE",
+      "command": "lane_b_mujoco_reference",
+      "config_input": "conf/ppo/task/g1_walk_flat/mujoco.yaml",
+      "minimum_repetitions": 3,
+      "required_test_id": "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference"
+    },
+    {
+      "claim_id": "P1-MUTATION-CONTRACT",
+      "command": "lane_b_mutation_contract",
+      "config_input": "tests/dr/test_mutation_contract.py",
+      "minimum_repetitions": 2,
+      "required_test_id": "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed"
+    },
+    {
+      "claim_id": "P1-HOT-PATH-INSTRUMENTATION",
+      "command": "lane_b_hot_path",
+      "config_input": "conf/ppo/task/g1_walk_flat/mujoco.yaml",
+      "minimum_repetitions": 2,
+      "required_test_id": "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters"
+    },
+    {
+      "claim_id": "P1-DR-COMPATIBILITY",
+      "command": "lane_b_dr_compatibility",
+      "config_input": "tests/dr/test_mutation_contract.py",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary"
+    },
+    {
+      "claim_id": "P1-BACKEND-ISOLATION",
+      "command": "lane_a_backend_isolation",
+      "config_input": "tests/base/test_backend_batch_contract.py",
+      "minimum_repetitions": 1,
+      "required_test_id": "tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract"
+    }
+  ],
+  "commands": [
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.4246854949888075,
+      "exit_code": 0,
+      "lane": "A",
+      "name": "lane_a_batch_contract#1",
+      "pytest": {
+        "passed": 24,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract"
+      ],
+      "series": "lane_a_batch_contract",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 24 items\n\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_valid_all_rows] PASSED [  4%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_valid_selected_row_order] PASSED [  8%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_valid_frozen_batch_sizes] PASSED [ 12%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_valid_same_entity_in_distinct_frames] PASSED [ 16%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_shape] PASSED [ 20%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_frame] PASSED [ 25%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_unit] PASSED [ 29%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_dtype] PASSED [ 33%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_layout] PASSED [ 37%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_duplicate_rows] PASSED [ 41%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_row_bounds] PASSED [ 45%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_row_universe] PASSED [ 50%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_placement] PASSED [ 54%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_owner] PASSED [ 58%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_mutability] PASSED [ 62%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_lifetime] PASSED [ 66%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_dlpack_metadata] PASSED [ 70%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_unbound_identity] PASSED [ 75%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_empty_identity] PASSED [ 79%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_duplicate_field] PASSED [ 83%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_duplicate_bound_identity] PASSED [ 87%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_plan_owner] PASSED [ 91%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_plan_fingerprint] PASSED [ 95%]\ntests/base/test_backend_batch_contract.py::test_bound_state_batch_contract[_invalid_plan_metadata_with_reused_fingerprint] PASSED [100%]\n\n============================== 24 passed in 0.07s ==============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.461251380009344,
+      "exit_code": 0,
+      "lane": "A",
+      "name": "lane_a_backend_isolation#1",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract"
+      ],
+      "series": "lane_a_backend_isolation",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract PASSED [100%]\n\n============================== 1 passed in 0.30s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.5367618949967436,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_mujoco_reference#1",
+      "pytest": {
+        "passed": 6,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference"
+      ],
+      "series": "lane_b_mujoco_reference",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 6 items\n\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-1] PASSED [ 16%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-32] PASSED [ 33%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-1] PASSED [ 50%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-32] PASSED [ 66%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-1] PASSED [ 83%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-32] PASSED [100%]\n\n============================== 6 passed in 0.70s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.768950337995193,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_mujoco_reference#2",
+      "pytest": {
+        "passed": 6,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 2,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference"
+      ],
+      "series": "lane_b_mujoco_reference",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 6 items\n\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-1] PASSED [ 16%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-32] PASSED [ 33%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-1] PASSED [ 50%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-32] PASSED [ 66%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-1] PASSED [ 83%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-32] PASSED [100%]\n\n============================== 6 passed in 0.67s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.469291757006431,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_mujoco_reference#3",
+      "pytest": {
+        "passed": 6,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 3,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference"
+      ],
+      "series": "lane_b_mujoco_reference",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 6 items\n\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-1] PASSED [ 16%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[0-32] PASSED [ 33%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-1] PASSED [ 50%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[1-32] PASSED [ 66%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-1] PASSED [ 83%]\ntests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference[2-32] PASSED [100%]\n\n============================== 6 passed in 0.67s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.7300982599990675,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_mutation_contract#1",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed"
+      ],
+      "series": "lane_b_mutation_contract",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed PASSED [100%]\n\n============================== 1 passed in 0.04s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 2.320925987994997,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_mutation_contract#2",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 2,
+      "required_test_ids": [
+        "tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed"
+      ],
+      "series": "lane_b_mutation_contract",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed PASSED [100%]\n\n============================== 1 passed in 0.02s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.9268866179918405,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_hot_path#1",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters"
+      ],
+      "series": "lane_b_hot_path",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters PASSED [100%]\n\n============================== 1 passed in 0.02s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.712760973998229,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_hot_path#2",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 2,
+      "required_test_ids": [
+        "tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters"
+      ],
+      "series": "lane_b_hot_path",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters PASSED [100%]\n\n============================== 1 passed in 0.02s ===============================\n"
+    },
+    {
+      "argv": [
+        "uv",
+        "run",
+        "pytest",
+        "tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary",
+        "-v",
+        "-rsxX"
+      ],
+      "duration_sec": 1.6546676559955813,
+      "exit_code": 0,
+      "lane": "B",
+      "name": "lane_b_dr_compatibility#1",
+      "pytest": {
+        "passed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0
+      },
+      "repetition": 1,
+      "required_test_ids": [
+        "tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary"
+      ],
+      "series": "lane_b_dr_compatibility",
+      "stderr": "",
+      "stdout": "============================= test session starts ==============================\nplatform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/tatp/ws/unilabsim/UniLab/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /home/tatp/ws/unilabsim/UniLab\nconfigfile: pyproject.toml\nplugins: anyio-4.13.0, cov-7.1.0, hydra-core-1.3.2\ncollecting ... collected 1 item\n\ntests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary PASSED [100%]\n\n============================== 1 passed in 0.01s ===============================\n"
+    }
+  ],
+  "environment": {
+    "packages": {
+      "mujoco": "3.10.0"
+    },
+    "platform": "Linux-6.8.0-60-generic-x86_64-with-glibc2.35",
+    "python": "3.13.12 (main, Mar  3 2026, 15:01:51) [Clang 21.1.4 ]"
+  },
+  "generated_at_utc": "2026-07-28T20:55:00.834252+00:00",
+  "inputs": {
+    "claim_config_hashes": {
+      "P1-BACKEND-ISOLATION": "sha256:158fa52e2e4a2cd70d995eb9924303726839a7fa1bd03c394298e371ceb6d981",
+      "P1-BATCH-CONTRACT": "sha256:158fa52e2e4a2cd70d995eb9924303726839a7fa1bd03c394298e371ceb6d981",
+      "P1-DR-COMPATIBILITY": "sha256:62b63d5ce3167e8b5fbf9f21dbf1878a17104bbe36875d71053f362fbf09193b",
+      "P1-HOT-PATH-INSTRUMENTATION": "sha256:aacc7543db7b9cc6f765b0b3096fc88109354e78bfa5c272d86175e1eaee7beb",
+      "P1-MUJOCO-REFERENCE": "sha256:aacc7543db7b9cc6f765b0b3096fc88109354e78bfa5c272d86175e1eaee7beb",
+      "P1-MUTATION-CONTRACT": "sha256:62b63d5ce3167e8b5fbf9f21dbf1878a17104bbe36875d71053f362fbf09193b"
+    },
+    "files": {
+      "conf/ppo/task/g1_walk_flat/mujoco.yaml": "sha256:aacc7543db7b9cc6f765b0b3096fc88109354e78bfa5c272d86175e1eaee7beb",
+      "scripts/capture_issue705_phase1_evidence.py": "sha256:3358c01d369741a793830c1309f5684c90e902e7fa32c04d3dcba5dc279f1b3c",
+      "src/unilab/tools/issue705_phase1_evidence.py": "sha256:aea80b96b4071cd176e81c356fcfb04dd6b3fdadc911d63d2096e346071075f2",
+      "src/unilab/tools/issue705_phase_evidence.py": "sha256:4149f7098d95b91fdbb9749cb455bb5eb49b5115ee30cf7d66bc4e28af2e1b3b",
+      "tests/acceptance/issue_705/test_phase1_evidence.py": "sha256:e465779f1bd3912cfe5eea6860586184e93ec9af7de199b8d90d6be061d11892",
+      "tests/base/test_backend_batch_contract.py": "sha256:158fa52e2e4a2cd70d995eb9924303726839a7fa1bd03c394298e371ceb6d981",
+      "tests/dr/test_mutation_contract.py": "sha256:62b63d5ce3167e8b5fbf9f21dbf1878a17104bbe36875d71053f362fbf09193b",
+      "tests/tools/test_issue705_phase1_evidence.py": "sha256:bf495c34aea35f6a61db0cf861cc8abe327339ae38efdbce696da735d6665b96",
+      "uv.lock": "sha256:fe3b4c9dc315a7556464d636b9da02bece2e1ef0b0b8fec1c28d14edbba7540c"
+    }
+  },
+  "issue": 705,
+  "kind": "issue705-phase1-gate-v1",
+  "phase": 1,
+  "schema_version": 1,
+  "source": {
+    "branch": "feat/issue-769-phase1-evidence-gate",
+    "commit_sha": "21403e2c2d94ee3f7039359889f0de8d7a6a01e3",
+    "tree_clean": true
+  }
+}

--- a/tests/acceptance/issue_705/manifests/phase_1.yaml
+++ b/tests/acceptance/issue_705/manifests/phase_1.yaml
@@ -15,9 +15,9 @@ claims:
     required_test_ids: [tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract]
     environment: {dependencies: [uv.lock], hardware: any, owner_yaml: null, seeds: [0], batch_sizes: [1, 17], dtype: float32, plan_fingerprint: backend-batch-contract-v1}
     acceptance: {tolerance: {}, thresholds: {}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any ambiguous ownership, placement, row, lifetime, or unsupported operation is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:158fa52e2e4a2cd70d995eb9924303726839a7fa1bd03c394298e371ceb6d981, executed_test_ids: [tests/base/test_backend_batch_contract.py::test_bound_state_batch_contract], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane A typed batch-contract evidence completed with no skip, xfail, or xpass; raw output and registered input hashes are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/base/backend/**, tests/base/test_backend_batch_contract.py], capabilities: [typed-backend-batch], fingerprints: [backend-batch-contract-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P1-MUJOCO-REFERENCE
     expected: The mujoco backend implements the bound host batch path and matches frozen getter vectors and reset schedules.
@@ -30,9 +30,9 @@ claims:
     required_test_ids: [tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference]
     environment: {dependencies: [uv.lock, mujoco], hardware: Linux CPU, owner_yaml: conf/ppo/task/g1_walk_flat/mujoco.yaml, seeds: [0, 1, 2], batch_sizes: [1, 32], dtype: float64, plan_fingerprint: mujoco-host-batch-v1}
     acceptance: {tolerance: {atol: 1.0e-10, rtol: 1.0e-8}, thresholds: {materializations_per_barrier: 1}, repetitions: 3, max_dispersion: 0, failure_semantics: "Any field mismatch, row leak, or repeated barrier materialization is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:aacc7543db7b9cc6f765b0b3096fc88109354e78bfa5c272d86175e1eaee7beb, executed_test_ids: [tests/base/test_backend_batch_contract.py::test_mujoco_batch_matches_getter_reference], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane B MuJoCo reference evidence completed three clean repetitions with no skip, xfail, or xpass; raw output and owner-config hash are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/base/backend/mujoco/**, src/unilab/base/backend/base.py, tests/base/test_backend_batch_contract.py], capabilities: [mujoco-host-batch], fingerprints: [mujoco-host-batch-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P1-MUTATION-CONTRACT
     expected: Registry-owned MutationSpec binds to typed model, state, wrench, and task-state mutation batches with strict capability and conflict checks.
@@ -45,9 +45,9 @@ claims:
     required_test_ids: [tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed]
     environment: {dependencies: [uv.lock], hardware: any, owner_yaml: null, seeds: [0, 7], batch_sizes: [1, 19], dtype: float32, plan_fingerprint: mutation-contract-v1}
     acceptance: {tolerance: {}, thresholds: {silent_fallbacks: 0}, repetitions: 2, max_dispersion: 0, failure_semantics: "Any undeclared target, conflict, phase, baseline, persistence, or capability fallback is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:62b63d5ce3167e8b5fbf9f21dbf1878a17104bbe36875d71053f362fbf09193b, executed_test_ids: [tests/dr/test_mutation_contract.py::test_typed_mutation_conflicts_fail_closed], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane B typed mutation evidence completed two clean repetitions with no skip, xfail, or xpass; raw output and test-input hash are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/dr/**, src/unilab/base/backend/**, tests/dr/test_mutation_contract.py], capabilities: [typed-mutation], fingerprints: [mutation-contract-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P1-HOT-PATH-INSTRUMENTATION
     expected: Transfer, synchronization, allocation, getter, selector, and asset access counters expose all managed hot-path violations.
@@ -60,9 +60,9 @@ claims:
     required_test_ids: [tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters]
     environment: {dependencies: [uv.lock], hardware: Linux CPU, owner_yaml: conf/ppo/task/g1_walk_flat/mujoco.yaml, seeds: [0], batch_sizes: [16], dtype: float32, plan_fingerprint: hot-path-counters-v1}
     acceptance: {tolerance: {}, thresholds: {hot_getters: 0, hot_selectors: 0, hot_asset_reads: 0}, repetitions: 2, max_dispersion: 0, failure_semantics: "Any undeclared transfer, sync, allocation, getter, selector, or asset access is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:aacc7543db7b9cc6f765b0b3096fc88109354e78bfa5c272d86175e1eaee7beb, executed_test_ids: [tests/base/test_backend_batch_contract.py::test_managed_hot_path_has_no_dynamic_getters], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane B hot-path instrumentation evidence completed two clean repetitions with no skip, xfail, or xpass; raw output and owner-config hash are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/base/**, src/unilab/envs/**, tests/base/test_backend_batch_contract.py], capabilities: [hot-path-observability], fingerprints: [hot-path-counters-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P1-DR-COMPATIBILITY
     expected: Legacy DomainRandomizationProvider warning and filtering remain an explicit compatibility mode while compiled managed tasks default to strict fail-closed mutation binding.
@@ -75,9 +75,9 @@ claims:
     required_test_ids: [tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary]
     environment: {dependencies: [uv.lock], hardware: Linux CPU, owner_yaml: null, seeds: [0], batch_sizes: [8], dtype: float32, plan_fingerprint: dr-compatibility-boundary-v1}
     acceptance: {tolerance: {}, thresholds: {silent_filters: 0, duplicated_samplers: 0}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any compiled warning-and-continue or duplicated mutation semantics is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:62b63d5ce3167e8b5fbf9f21dbf1878a17104bbe36875d71053f362fbf09193b, executed_test_ids: [tests/dr/test_mutation_contract.py::test_legacy_warning_and_compiled_strict_boundary], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane B strict/legacy boundary evidence completed with no skip, xfail, or xpass; raw output and test-input hash are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/dr/**, src/unilab/base/backend/**, tests/dr/test_mutation_contract.py], capabilities: [dr-compatibility-boundary], fingerprints: [dr-compatibility-boundary-v1]}
-    status: planned
+    status: verified
 
   - claim_id: P1-BACKEND-ISOLATION
     expected: mujoco and mjwarp share only cold-path materialization utilities and never inherit or access each other's runtime-private model data or buffers.
@@ -90,6 +90,6 @@ claims:
     required_test_ids: [tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract]
     environment: {dependencies: [uv.lock], hardware: any, owner_yaml: null, seeds: [], batch_sizes: [], dtype: null, plan_fingerprint: backend-runtime-isolation-v1}
     acceptance: {tolerance: {}, thresholds: {runtime_private_cross_reads: 0}, repetitions: 1, max_dispersion: 0, failure_semantics: "Any runtime inheritance, private cross-read, or manager import of concrete backend modules is FAIL."}
-    evidence: {result: NOT_RUN, artifact_refs: [], commit_sha: null, config_hash: null, executed_test_ids: [], skipped_test_ids: [], xfailed_test_ids: [], summary: ""}
+    evidence: {result: PASS, artifact_refs: [tests/acceptance/issue_705/artifacts/phase_1_gate.json], commit_sha: 21403e2c2d94ee3f7039359889f0de8d7a6a01e3, config_hash: sha256:158fa52e2e4a2cd70d995eb9924303726839a7fa1bd03c394298e371ceb6d981, executed_test_ids: [tests/base/test_backend_batch_contract.py::test_runtime_backends_share_only_cold_materialization_contract], skipped_test_ids: [], xfailed_test_ids: [], summary: "Fresh Lane A backend-isolation evidence completed with no skip, xfail, or xpass; raw output and registered input hashes are retained in the Phase 1 artifact."}
     invalidation: {paths: [src/unilab/base/backend/**, src/unilab/base/np_env.py, src/unilab/envs/**, src/unilab/dr/**, src/unilab/tools/backend_isolation.py, scripts/audit_issue705_backend_isolation.py, tests/base/test_backend_batch_contract.py, tests/tools/test_backend_isolation.py], capabilities: [backend-runtime-isolation], fingerprints: [backend-runtime-isolation-v1]}
-    status: planned
+    status: verified

--- a/tests/acceptance/issue_705/test_phase1_evidence.py
+++ b/tests/acceptance/issue_705/test_phase1_evidence.py
@@ -1,0 +1,88 @@
+"""Freshness and tamper checks for the Issue #705 Phase 1 gate artifact."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts import validate_issue705_phase
+
+from unilab.tools.issue705_phase1_evidence import (
+    PHASE1_MIN_REPETITIONS,
+    PHASE1_REQUIRED_TEST_IDS,
+    load_phase1_evidence,
+    validate_phase1_evidence,
+)
+from unilab.tools.phase_acceptance import ClaimStatus, EvidenceResult, load_phase_acceptance
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARTIFACT_PATH = REPO_ROOT / "tests/acceptance/issue_705/artifacts/phase_1_gate.json"
+MANIFEST_PATH = REPO_ROOT / "tests/acceptance/issue_705/manifests/phase_1.yaml"
+ARTIFACT_REF = "tests/acceptance/issue_705/artifacts/phase_1_gate.json"
+
+
+def test_phase1_gate_artifact_and_manifest_are_fresh_complete_and_promoted() -> None:
+    report = load_phase1_evidence(ARTIFACT_PATH)
+    assert validate_phase1_evidence(report, root=REPO_ROOT) == ()
+
+    manifest = load_phase_acceptance(MANIFEST_PATH)
+    claims = {claim.claim_id: claim for claim in manifest.claims}
+    artifact_claims = {claim["claim_id"]: claim for claim in report["claims"]}
+    config_hashes = report["inputs"]["claim_config_hashes"]
+    source_commit = report["source"]["commit_sha"]
+    assert set(claims) == set(PHASE1_REQUIRED_TEST_IDS)
+    assert set(artifact_claims) == set(PHASE1_REQUIRED_TEST_IDS)
+    for claim_id, test_id in PHASE1_REQUIRED_TEST_IDS.items():
+        claim = claims[claim_id]
+        assert claim.status is ClaimStatus.VERIFIED
+        assert claim.evidence.result is EvidenceResult.PASS
+        assert claim.required_test_ids == (test_id,)
+        assert claim.evidence.executed_test_ids == (test_id,)
+        assert claim.evidence.artifact_refs == (ARTIFACT_REF,)
+        assert claim.evidence.commit_sha == source_commit
+        assert claim.evidence.config_hash == config_hashes[claim_id]
+        assert claim.evidence.skipped_test_ids == ()
+        assert claim.evidence.xfailed_test_ids == ()
+        assert artifact_claims[claim_id]["minimum_repetitions"] == PHASE1_MIN_REPETITIONS[claim_id]
+
+    assert validate_issue705_phase.main(["--phase", "1", "--mode", "gate"]) == 0
+
+
+def test_phase1_gate_artifact_faults_fail_closed() -> None:
+    report = load_phase1_evidence(ARTIFACT_PATH)
+
+    skipped = deepcopy(report)
+    skipped["commands"][0]["pytest"]["skipped"] = 1
+    assert any(
+        "skipped: expected 0" in error
+        for error in validate_phase1_evidence(skipped, root=REPO_ROOT)
+    )
+
+    stale = deepcopy(report)
+    stale["source"]["commit_sha"] = "0" * 40
+    assert any("ancestor" in error for error in validate_phase1_evidence(stale, root=REPO_ROOT))
+
+    altered_input = deepcopy(report)
+    altered_input["inputs"]["files"]["uv.lock"] = f"sha256:{'0' * 64}"
+    assert any(
+        "does not match current input" in error
+        for error in validate_phase1_evidence(altered_input, root=REPO_ROOT)
+    )
+
+    altered_command = deepcopy(report)
+    altered_command["commands"][0]["argv"] = ["echo", "not-the-registered-command"]
+    assert any(
+        "does not match registered command" in error
+        for error in validate_phase1_evidence(altered_command, root=REPO_ROOT)
+    )
+
+    incomplete_repetitions = deepcopy(report)
+    incomplete_repetitions["commands"] = [
+        command
+        for command in incomplete_repetitions["commands"]
+        if command["name"] != "lane_b_mujoco_reference#3"
+    ]
+    assert any(
+        "lane_b_mujoco_reference" in error and "expected repetitions" in error
+        for error in validate_phase1_evidence(incomplete_repetitions, root=REPO_ROOT)
+    )

--- a/tests/tools/test_issue705_phase1_evidence.py
+++ b/tests/tools/test_issue705_phase1_evidence.py
@@ -1,0 +1,192 @@
+"""Synthetic fault coverage for the Issue #705 Phase 1 evidence validator."""
+
+from __future__ import annotations
+
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import unilab.tools.issue705_phase_evidence as generic_evidence
+from unilab.tools.issue705_phase1_evidence import (
+    ARTIFACT_KIND,
+    ISSUE,
+    PHASE,
+    PHASE1_COMMANDS,
+    PHASE1_MIN_REPETITIONS,
+    PHASE1_REQUIRED_TEST_IDS,
+    PHASE1_SPEC,
+    PhaseEvidenceError,
+    capture_phase1_evidence,
+    sha256_file,
+    validate_phase1_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _head() -> str:
+    return subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _valid_report() -> dict[str, Any]:
+    command_rows: list[dict[str, Any]] = []
+    for command in PHASE1_COMMANDS:
+        for repetition in range(1, command.repetitions + 1):
+            command_rows.append(
+                {
+                    "name": f"{command.name}#{repetition}",
+                    "series": command.name,
+                    "lane": command.lane,
+                    "repetition": repetition,
+                    "argv": list(command.argv),
+                    "required_test_ids": list(command.required_test_ids),
+                    "exit_code": 0,
+                    "duration_sec": 0.1,
+                    "pytest": {"passed": 1, "skipped": 0, "xfailed": 0, "xpassed": 0},
+                    "stdout": "\n".join((*command.required_test_ids, "1 passed")),
+                    "stderr": "",
+                }
+            )
+    return {
+        "schema_version": 1,
+        "kind": ARTIFACT_KIND,
+        "issue": ISSUE,
+        "phase": PHASE,
+        "generated_at_utc": "2026-07-28T00:00:00+00:00",
+        "source": {"commit_sha": _head(), "branch": "test", "tree_clean": True},
+        "inputs": {
+            "files": {
+                path.as_posix(): sha256_file(REPO_ROOT / path) for path in PHASE1_SPEC.input_files
+            },
+            "claim_config_hashes": {
+                claim.claim_id: sha256_file(REPO_ROOT / claim.config_input)
+                for claim in PHASE1_SPEC.claims
+            },
+        },
+        "environment": {
+            "platform": "Linux",
+            "python": "test",
+            "packages": {"mujoco": "3.10"},
+        },
+        "claims": [
+            {
+                "claim_id": claim.claim_id,
+                "required_test_id": claim.required_test_id,
+                "command": claim.command_name,
+                "minimum_repetitions": claim.minimum_repetitions,
+                "config_input": claim.config_input.as_posix(),
+            }
+            for claim in PHASE1_SPEC.claims
+        ],
+        "commands": command_rows,
+    }
+
+
+def _capture_fixture_root(tmp_path: Path) -> Path:
+    root = tmp_path / "capture"
+    for path in PHASE1_SPEC.input_files:
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"fixture for {path}\n", encoding="utf-8")
+    subprocess.run(("git", "init", "--quiet"), cwd=root, check=True)
+    subprocess.run(("git", "add", "."), cwd=root, check=True)
+    subprocess.run(
+        (
+            "git",
+            "-c",
+            "user.email=issue705-test@example.invalid",
+            "-c",
+            "user.name=Issue705 Test",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ),
+        cwd=root,
+        check=True,
+    )
+    return root
+
+
+def test_phase1_evidence_validator_accepts_complete_registered_report() -> None:
+    assert validate_phase1_evidence(_valid_report(), root=REPO_ROOT) == ()
+
+
+def test_phase1_evidence_validator_fails_closed_for_provenance_and_execution_faults() -> None:
+    report = _valid_report()
+
+    altered_input = deepcopy(report)
+    altered_input["inputs"]["files"]["uv.lock"] = f"sha256:{'0' * 64}"
+    assert any(
+        "does not match current input" in error
+        for error in validate_phase1_evidence(altered_input, root=REPO_ROOT)
+    )
+
+    missing_repetition = deepcopy(report)
+    missing_repetition["commands"] = [
+        command
+        for command in missing_repetition["commands"]
+        if command["name"] != "lane_b_mujoco_reference#3"
+    ]
+    assert any(
+        "lane_b_mujoco_reference" in error and "expected repetitions" in error
+        for error in validate_phase1_evidence(missing_repetition, root=REPO_ROOT)
+    )
+
+    skipped = deepcopy(report)
+    skipped["commands"][0]["pytest"]["skipped"] = 1
+    assert any(
+        "skipped: expected 0" in error
+        for error in validate_phase1_evidence(skipped, root=REPO_ROOT)
+    )
+
+    stale = deepcopy(report)
+    stale["source"]["commit_sha"] = "0" * 40
+    assert any("ancestor" in error for error in validate_phase1_evidence(stale, root=REPO_ROOT))
+
+    altered_argv = deepcopy(report)
+    altered_argv["commands"][0]["argv"] = ["echo", "not-the-registered-command"]
+    assert any(
+        "does not match registered command" in error
+        for error in validate_phase1_evidence(altered_argv, root=REPO_ROOT)
+    )
+
+
+def test_capture_rejects_registered_input_mutated_by_evidence_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _capture_fixture_root(tmp_path)
+
+    def fake_environment(_: object) -> dict[str, Any]:
+        return {"platform": "Linux", "python": "test", "packages": {"mujoco": "3.10"}}
+
+    def fake_evidence_command(command: Any, *, root: Path, repetition: int) -> dict[str, Any]:
+        (root / "uv.lock").write_text("mutated during capture\n", encoding="utf-8")
+        return {
+            "name": f"{command.name}#{repetition}",
+            "series": command.name,
+            "lane": command.lane,
+            "repetition": repetition,
+            "argv": list(command.argv),
+            "required_test_ids": list(command.required_test_ids),
+            "exit_code": 0,
+            "duration_sec": 0.1,
+            "pytest": {"passed": 1, "skipped": 0, "xfailed": 0, "xpassed": 0},
+            "stdout": "\n".join((*command.required_test_ids, "1 passed")),
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(generic_evidence, "_capture_environment", fake_environment)
+    monkeypatch.setattr(generic_evidence, "_run_evidence_command", fake_evidence_command)
+
+    with pytest.raises(PhaseEvidenceError, match="clean source"):
+        capture_phase1_evidence(root)


### PR DESCRIPTION
Part of #705
Closes #769

## 变更
- 新增可复用、fail-closed 的 #705 phase evidence capture/validator 基元，并以 Phase 1 A/B contract 配置接入；不改变 backend、env、manager 或训练 runtime。
- capture 在执行前后检查 clean tree，并冻结执行前 registered input hash；任何 evidence command 污染 source 或改写注册输入均失败。
- 提交 Phase 1 raw artifact，将六个 typed batch foundation claim 统一提升为 `verified/PASS`，并增加 artifact/manifest/tamper acceptance tests。

## 真实证据
- capture source：clean commit `21403e2c2d94ee3f7039359889f0de8d7a6a01e3`；
- Lane A：batch contract ×1、backend isolation ×1；
- Lane B：MuJoCo reference ×3、mutation contract ×2、hot-path instrumentation ×2、legacy/strict DR boundary ×1；
- 10 次 mandatory execution 全部无 skip、xfail、xpass，artifact 保存 raw pytest stdout/stderr、环境与输入 hash。

这只完成 Phase 1 correctness/provenance gate，不增加 device-resident、完整 DR/Event、fused 性能或训练收敛声明。

## 验证
- `make test-all`
- `uv run ruff format --check ...`、`uv run ruff check ...`、`uv run pyright ...`
- `uv run pytest tests/tools/test_issue705_phase1_evidence.py tests/acceptance/issue_705/test_phase1_evidence.py -v`
- `uv run scripts/validate_issue705_phase.py --phase 1 --mode schema`
- `uv run scripts/validate_issue705_phase.py --phase 1 --mode gate`
- `uv run scripts/audit_issue705_claims.py --phase 1`
- `uv run scripts/audit_issue705_backend_isolation.py`
- `uv run scripts/audit_issue705_workflow_triggers.py`

## 自查
第一轮检查 validator/capture 发现并验证 source/input mutation 负向路径；第二轮核对 clean-capture artifact、manifest SHA、重复次数、无 skip/xfail/xpass、Phase gate 与完整测试。中间 PR 不应触发 GitHub Actions。