### PR TITLE
test: add mjwarp PPO benchmark contract

### DIFF
--- a/benchmark/issue705/process_evidence.py
+++ b/benchmark/issue705/process_evidence.py
@@ -1,0 +1,282 @@
+"""Side-effect-free process and host evidence helpers for Issue #705 benchmarks.
+
+This module must remain independent of task benchmark modules.  In particular,
+it must never import ``benchmark.env.benchmark_env_step`` because that legacy
+benchmark installs a benchmark-only ``mjwarp`` factory patch at import time.
+Production training and profiler evidence must resolve the registered backend.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import os
+import platform
+import socket
+import subprocess
+import tempfile
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import psutil
+import torch
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+from unilab.tools.g1_baseline_provenance import G1BaselinePlan, load_g1_baseline_plan
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def json_safe(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return json_safe(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {str(key): json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def load_plan(path: Path, *, repo_root: Path) -> G1BaselinePlan:
+    absolute = path if path.is_absolute() else repo_root / path
+    plan = load_g1_baseline_plan(absolute)
+    return dataclasses.replace(plan, source_path=absolute.relative_to(repo_root))
+
+
+def event_scalars(run_dir: Path, tags: Sequence[str]) -> dict[str, list[dict[str, Any]]]:
+    accumulator = EventAccumulator(str(run_dir), size_guidance={"scalars": 0})
+    accumulator.Reload()
+    available = set(accumulator.Tags().get("scalars", []))
+    missing = set(tags) - available
+    if missing:
+        raise RuntimeError(f"training event file is missing scalar tags: {sorted(missing)!r}")
+    return {
+        tag: [
+            {
+                "step": int(event.step),
+                "wall_time": float(event.wall_time),
+                "value": float(event.value),
+            }
+            for event in accumulator.Scalars(tag)
+        ]
+        for tag in tags
+    }
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _process_tree_rss(pid: int) -> int:
+    try:
+        root = psutil.Process(pid)
+        processes = [root, *root.children(recursive=True)]
+    except (psutil.Error, ProcessLookupError):
+        return 0
+    total = 0
+    for process in processes:
+        try:
+            total += int(process.memory_info().rss)
+        except (psutil.Error, ProcessLookupError):
+            continue
+    return total
+
+
+def run_subprocess(
+    command: list[str],
+    plan: G1BaselinePlan,
+    *,
+    repo_root: Path,
+    memory_poll_interval: float | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], str, str]:
+    child_env = os.environ.copy()
+    child_env.update(dict(plan.environment.env_vars))
+    started_at = utc_now()
+    started = time.perf_counter()
+    memory_samples: list[dict[str, Any]] = []
+
+    def set_child_affinity() -> None:
+        os.sched_setaffinity(0, set(plan.hardware.affinity_cpus))
+
+    with tempfile.TemporaryDirectory(prefix="unilab_issue705_process_") as temp_dir:
+        stdout_path = Path(temp_dir) / "stdout.log"
+        stderr_path = Path(temp_dir) / "stderr.log"
+        with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+            process = subprocess.Popen(
+                command,
+                cwd=repo_root,
+                env=child_env,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                preexec_fn=set_child_affinity,
+            )
+            if memory_poll_interval is None:
+                return_code = process.wait()
+            else:
+                while True:
+                    memory_samples.append(
+                        {
+                            "elapsed_sec": time.perf_counter() - started,
+                            "rss_bytes": _process_tree_rss(process.pid),
+                        }
+                    )
+                    try:
+                        return_code = process.wait(timeout=memory_poll_interval)
+                        break
+                    except subprocess.TimeoutExpired:
+                        continue
+        stdout = stdout_path.read_text(encoding="utf-8", errors="replace")
+        stderr = stderr_path.read_text(encoding="utf-8", errors="replace")
+    record = {
+        "run_id": str(uuid.uuid4()),
+        "pid": int(process.pid),
+        "started_at": started_at,
+        "duration_sec": time.perf_counter() - started,
+        "return_code": int(return_code),
+        "command": command,
+        "affinity_cpus": list(plan.hardware.affinity_cpus),
+        "env_vars": dict(plan.environment.env_vars),
+        "stdout_sha256": _sha256_bytes(stdout.encode("utf-8")),
+        "stderr_sha256": _sha256_bytes(stderr.encode("utf-8")),
+    }
+    return record, memory_samples, stdout, stderr
+
+
+def _nvidia_hardware() -> dict[str, Any]:
+    command = [
+        "nvidia-smi",
+        "--query-gpu=name,uuid,memory.total,driver_version",
+        "--format=csv,noheader,nounits",
+    ]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    first = completed.stdout.strip().splitlines()[0]
+    name, uuid_value, memory, driver = [item.strip() for item in first.split(",")]
+    return {
+        "gpu_name": name,
+        "gpu_uuid": uuid_value,
+        "gpu_memory_mib": int(memory),
+        "driver_version": driver,
+    }
+
+
+def _gpu_compute_processes() -> list[dict[str, Any]]:
+    command = [
+        "nvidia-smi",
+        "--query-compute-apps=pid,process_name,used_memory",
+        "--format=csv,noheader,nounits",
+    ]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    processes: list[dict[str, Any]] = []
+    for line in completed.stdout.splitlines():
+        if not line.strip():
+            continue
+        pid, name, used_memory = [item.strip() for item in line.split(",", maxsplit=2)]
+        processes.append(
+            {
+                "pid": int(pid),
+                "process_name": name,
+                "used_memory_mib": int(used_memory),
+            }
+        )
+    return processes
+
+
+def _gpu_idle_sample() -> dict[str, Any]:
+    command = [
+        "nvidia-smi",
+        "--query-gpu=utilization.gpu,memory.used,temperature.gpu,pstate",
+        "--format=csv,noheader,nounits",
+    ]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    utilization, memory, temperature, pstate = [
+        item.strip() for item in completed.stdout.strip().splitlines()[0].split(",")
+    ]
+    return {
+        "utilization_percent": int(utilization),
+        "memory_used_mib": int(memory),
+        "temperature_c": int(temperature),
+        "pstate": pstate,
+    }
+
+
+def preflight_payload(
+    plan: G1BaselinePlan,
+    *,
+    enforce_cpu_load: bool = True,
+) -> dict[str, Any]:
+    load_average = float(os.getloadavg()[0])
+    load_per_core = load_average / plan.hardware.cpu_physical_cores
+    processes = _gpu_compute_processes()
+    samples: list[dict[str, Any]] = []
+    for index in range(plan.preflight.gpu_samples):
+        samples.append(_gpu_idle_sample())
+        if index + 1 < plan.preflight.gpu_samples:
+            time.sleep(plan.preflight.sample_interval_sec)
+    payload = {
+        "timestamp": utc_now(),
+        "load_average_1m": load_average,
+        "load_per_physical_core": load_per_core,
+        "gpu_compute_processes": processes,
+        "gpu_samples": samples,
+    }
+    if enforce_cpu_load and load_per_core > plan.preflight.max_load_per_physical_core:
+        raise RuntimeError(
+            f"preflight CPU load {load_per_core:.3f} exceeds "
+            f"{plan.preflight.max_load_per_physical_core:.3f} per physical core"
+        )
+    if len(processes) > plan.preflight.max_gpu_compute_processes:
+        raise RuntimeError(f"preflight found foreign GPU compute processes: {processes!r}")
+    peak_utilization = max(sample["utilization_percent"] for sample in samples)
+    if peak_utilization > plan.preflight.max_gpu_utilization_percent:
+        raise RuntimeError(
+            f"preflight GPU utilization {peak_utilization}% exceeds "
+            f"{plan.preflight.max_gpu_utilization_percent}%"
+        )
+    return payload
+
+
+def _cpu_model() -> str:
+    for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+        if line.startswith("model name"):
+            return line.split(":", maxsplit=1)[1].strip()
+    return platform.processor() or "unknown"
+
+
+def hardware_payload(plan: G1BaselinePlan) -> dict[str, Any]:
+    payload = {
+        "platform_system": platform.system(),
+        "platform_release": platform.release(),
+        "cpu_model": _cpu_model(),
+        "cpu_physical_cores": int(psutil.cpu_count(logical=False) or 0),
+        "cpu_logical_cores": int(psutil.cpu_count(logical=True) or 0),
+        "affinity_cpus": list(plan.hardware.affinity_cpus),
+        **_nvidia_hardware(),
+        "cuda_runtime": str(
+            getattr(getattr(torch, "version", None), "cuda", None) or "unavailable"
+        ),
+        "torch_version": str(torch.__version__),
+        "hostname": socket.gethostname(),
+    }
+    expected = dataclasses.asdict(plan.hardware)
+    for key, value in expected.items():
+        expected_value = list(value) if isinstance(value, tuple) else value
+        if payload.get(key) != expected_value:
+            raise RuntimeError(
+                f"hardware mismatch for {key}: expected {expected_value!r}, "
+                f"got {payload.get(key)!r}"
+            )
+    return payload

--- a/benchmark/rl/benchmark_mjwarp_ppo.py
+++ b/benchmark/rl/benchmark_mjwarp_ppo.py
@@ -1,0 +1,1930 @@
+"""Fail-closed, process-isolated PPO benchmark for Issue #705's ``mjwarp`` profile.
+
+The benchmark intentionally keeps performance collection outside the training
+entrypoint.  Every measured PPO run is a fresh invocation of the public
+``scripts/train_rsl_rl.py`` owner route, so the resulting evidence covers the
+same Hydra composition, runner lifecycle, tracker receipt and checkpoint path
+as production training.
+
+There are three deliberately separate measurements:
+
+* an interleaved, isolated ``mujoco``/``mjwarp`` throughput matrix at the
+  frozen small/medium/large batch sizes;
+* the frozen five-seed, 100-iteration ``mjwarp`` behavior matrix;
+* a typed-device rollout profiler trace and a separately reported co-located
+  contention matrix.
+
+``--execute`` only accepts a clean committed tree and writes the raw artifact
+outside the repository.  A later evidence PR copies the JSON and its sibling
+trace unchanged into the acceptance artifact directory.  This prevents an
+uncommitted benchmark result from being attributed to a different candidate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence, cast
+
+import numpy as np
+from omegaconf import OmegaConf
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from benchmark.issue705.process_evidence import (  # noqa: E402
+    event_scalars as _event_scalars,
+)
+from benchmark.issue705.process_evidence import (
+    hardware_payload as _hardware_payload,
+)
+from benchmark.issue705.process_evidence import (
+    json_safe as _json_safe,
+)
+from benchmark.issue705.process_evidence import (
+    load_plan as _load_evidence_plan,
+)
+from benchmark.issue705.process_evidence import (
+    preflight_payload as _preflight_payload,
+)
+from benchmark.issue705.process_evidence import (
+    run_subprocess as _run_evidence_subprocess,
+)
+from benchmark.issue705.process_evidence import (
+    utc_now as _utc_now,
+)
+from unilab.tools.g1_baseline_provenance import (  # noqa: E402
+    canonical_sha256,
+    numeric_stats,
+    sha256_file,
+    source_tree_sha256,
+    source_tree_sha256_at_commit,
+)
+from unilab.tools.issue705_thresholds import (  # noqa: E402
+    ThresholdManifest,
+    load_threshold_manifest,
+)
+
+ISSUE = 705
+SCHEMA_VERSION = 1
+ARTIFACT_KIND = "issue705-mjwarp-device-ppo-benchmark-v1"
+PROFILE = "device_resident"
+DEFAULT_BASELINE_PLAN = Path("tests/acceptance/issue_705/g1_mujoco_baseline_plan.yaml")
+DEFAULT_THRESHOLD_MANIFEST = Path("tests/acceptance/issue_705/g1_threshold_manifest.yaml")
+DEFAULT_THRESHOLD_RECEIPT = Path("tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml")
+DEFAULT_OUTPUT = Path("/tmp/unilab_issue705_mjwarp_device_ppo.json")
+DEFAULT_TRACE_OUTPUT = Path("/tmp/unilab_issue705_mjwarp_device_ppo_trace.json")
+THROUGHPUT_MODES = ("mujoco_host", "mjwarp_device")
+THROUGHPUT_ITERATIONS = 20
+CONTENTION_ITERATIONS = 20
+PROFILE_STEPS = 16
+COMMON_PERFORMANCE_OVERRIDES = (
+    "env.noise_config.level=0.0",
+    "env.domain_rand.randomize_kp=false",
+    "env.domain_rand.randomize_kd=false",
+    "env.curriculum.enabled=false",
+)
+SOURCE_INPUTS = (
+    "benchmark/rl/benchmark_mjwarp_ppo.py",
+    "benchmark/issue705/process_evidence.py",
+    "scripts/train_rsl_rl.py",
+    "src/unilab/algos/torch/rsl_rl_ppo.py",
+    "src/unilab/algos/torch/rsl_rl_runtime.py",
+    "src/unilab/base/backend",
+    "src/unilab/base/np_env.py",
+    "src/unilab/envs/locomotion/g1",
+    "src/unilab/manager",
+    "src/unilab/training",
+    "src/unilab/tools/g1_baseline_provenance.py",
+    "src/unilab/tools/issue705_thresholds.py",
+    "conf/ppo/config.yaml",
+    "conf/ppo/task/g1_walk_flat/mujoco.yaml",
+    "conf/ppo/task/g1_walk_flat/mjwarp.yaml",
+    "tests/acceptance/issue_705/g1_mujoco_baseline_plan.yaml",
+    "tests/acceptance/issue_705/g1_threshold_manifest.yaml",
+    "tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml",
+    "tests/benchmark/test_mjwarp_ppo_benchmark.py",
+    "uv.lock",
+)
+REQUIRED_SCALAR_TAGS = (
+    "Perf/total_fps",
+    "Perf/collection_time",
+    "Perf/learning_time",
+    "Train/mean_reward",
+    "Train/mean_episode_length",
+)
+
+
+class MjwarpPpoBenchmarkError(RuntimeError):
+    """Raised when a benchmark input, raw case, or artifact is invalid."""
+
+
+def _load_plan(path: Path) -> Any:
+    return _load_evidence_plan(path, repo_root=ROOT_DIR)
+
+
+def _run_subprocess(
+    command: list[str],
+    plan: Any,
+    *,
+    memory_poll_interval: float | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], str, str]:
+    return _run_evidence_subprocess(
+        command,
+        plan,
+        repo_root=ROOT_DIR,
+        memory_poll_interval=memory_poll_interval,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class BenchmarkBinding:
+    """Immutable Phase-5 subset of the pre-registered Phase-0 thresholds."""
+
+    threshold_set_id: str
+    threshold_manifest_path: Path
+    threshold_manifest_sha256: str
+    threshold_freeze_commit: str
+    batch_sizes: tuple[int, ...]
+    process_repeats: int
+    behavior_seeds: tuple[int, ...]
+    behavior_num_envs: int
+    behavior_steps_per_env: int
+    behavior_iterations: int
+    warmup_iterations: int
+    memory_poll_interval_sec: float
+    max_population_cv_by_batch: Mapping[int, float]
+    p50_latency_ratio_max: float
+    p95_latency_ratio_max: float
+    throughput_ratio_min: float
+    fps_p50_median_ratio_min: float
+    reward_auc_median_drop_max: float
+    final_reward_p50_median_drop_max: float
+    episode_length_median_ratio_min: float
+    host_memory_ratio_max: float
+    device_peak_reserved_capacity_ratio_max: float
+    device_peak_reserved_growth_bytes_max: int
+    h2d_per_policy_step_max: float
+    d2h_per_policy_step_max: float
+    host_global_sync_per_policy_step_max: float
+    baseline_ppo: Mapping[str, Any]
+    affinity_cpus: tuple[int, ...]
+    environment_vars: Mapping[str, str]
+    hydra_overrides: tuple[str, ...]
+    gpu_name: str
+    gpu_uuid: str
+    gpu_driver_version: str
+    gpu_capacity_bytes: int
+
+
+def _mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise MjwarpPpoBenchmarkError(f"{label} must be a mapping")
+    return cast(Mapping[str, Any], value)
+
+
+def _integer(value: object, label: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise MjwarpPpoBenchmarkError(f"{label} must be an integer >= {minimum}")
+    return int(value)
+
+
+def _number(value: object, label: str, *, minimum: float = 0.0) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MjwarpPpoBenchmarkError(f"{label} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result) or result < minimum:
+        raise MjwarpPpoBenchmarkError(f"{label} must be a finite number >= {minimum}")
+    return result
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MjwarpPpoBenchmarkError(f"{label} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, label: str) -> str:
+    result = _string(value, label)
+    if not (result.startswith("sha256:") and len(result) == len("sha256:") + 64):
+        raise MjwarpPpoBenchmarkError(f"{label} must be a sha256:<64 hex> value")
+    if any(character not in "0123456789abcdef" for character in result.removeprefix("sha256:")):
+        raise MjwarpPpoBenchmarkError(f"{label} must use lowercase hexadecimal")
+    return result
+
+
+def _is_commit(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 40
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=ROOT_DIR, check=True, text=True, capture_output=True
+    )
+    return result.stdout.strip()
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    try:
+        value = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
+    except Exception as exc:  # noqa: BLE001 - normalize YAML failures at the benchmark boundary.
+        raise MjwarpPpoBenchmarkError(f"cannot load {path}: {type(exc).__name__}: {exc}") from exc
+    return _mapping(value, str(path))
+
+
+def load_binding(
+    *,
+    threshold_manifest_path: Path = DEFAULT_THRESHOLD_MANIFEST,
+    threshold_receipt_path: Path = DEFAULT_THRESHOLD_RECEIPT,
+    baseline_plan_path: Path = DEFAULT_BASELINE_PLAN,
+) -> BenchmarkBinding:
+    """Bind the exact frozen matrix before a benchmark command can be constructed."""
+
+    manifest_path = (
+        threshold_manifest_path
+        if threshold_manifest_path.is_absolute()
+        else ROOT_DIR / threshold_manifest_path
+    )
+    receipt_path = (
+        threshold_receipt_path
+        if threshold_receipt_path.is_absolute()
+        else ROOT_DIR / threshold_receipt_path
+    )
+    plan_path = (
+        baseline_plan_path if baseline_plan_path.is_absolute() else ROOT_DIR / baseline_plan_path
+    )
+    manifest: ThresholdManifest = load_threshold_manifest(manifest_path, repo_root=ROOT_DIR)
+    receipt = _load_yaml(receipt_path)
+    data = manifest.data
+    measurement = _mapping(data.get("measurement"), "measurement")
+    gates = _mapping(data.get("gates"), "gates")
+    performance = _mapping(gates.get("performance"), "gates.performance")
+    training = _mapping(gates.get("training"), "gates.training")
+    memory = _mapping(gates.get("memory"), "gates.memory")
+    transfer = _mapping(gates.get("transfer"), "gates.transfer")
+    baseline = _mapping(data.get("baseline"), "baseline")
+    hardware = _mapping(baseline.get("hardware"), "baseline.hardware")
+    reference = _mapping(data.get("baseline_reference"), "baseline_reference")
+    baseline_ppo = _mapping(reference.get("ppo"), "baseline_reference.ppo")
+    baseline_plan = _load_plan(plan_path)
+
+    manifest_sha = sha256_file(manifest_path)
+    if receipt.get("threshold_set_id") != data.get("threshold_set_id"):
+        raise MjwarpPpoBenchmarkError("threshold receipt set id differs from manifest")
+    if receipt.get("manifest_path") != threshold_manifest_path.as_posix():
+        raise MjwarpPpoBenchmarkError(
+            "threshold receipt manifest path differs from benchmark binding"
+        )
+    if receipt.get("manifest_sha256") != manifest_sha:
+        raise MjwarpPpoBenchmarkError("threshold receipt SHA does not match manifest")
+    freeze_commit = receipt.get("freeze_commit")
+    if not _is_commit(freeze_commit):
+        raise MjwarpPpoBenchmarkError("threshold receipt freeze_commit must be a full SHA")
+
+    batches_raw = measurement.get("batch_sizes")
+    if not isinstance(batches_raw, list):
+        raise MjwarpPpoBenchmarkError("measurement.batch_sizes must be a list")
+    batch_sizes = tuple(
+        _integer(item, f"measurement.batch_sizes[{index}]", minimum=1)
+        for index, item in enumerate(batches_raw)
+    )
+    if batch_sizes != (128, 1024, 4096):
+        raise MjwarpPpoBenchmarkError(
+            "Phase 5 benchmark batch matrix must remain [128, 1024, 4096]"
+        )
+    cv_raw = _mapping(performance.get("max_population_cv_by_batch"), "performance CV")
+    cv = {batch: _number(cv_raw.get(str(batch)), f"CV[{batch}]") for batch in batch_sizes}
+    if baseline_plan.ppo_lane.seeds != (0, 1, 2, 3, 4):
+        raise MjwarpPpoBenchmarkError("frozen PPO seed matrix must remain [0, 1, 2, 3, 4]")
+    if baseline_plan.ppo_lane.max_iterations != _integer(
+        measurement.get("ppo_iterations"), "measurement.ppo_iterations", minimum=2
+    ):
+        raise MjwarpPpoBenchmarkError("baseline plan and frozen PPO iteration count differ")
+
+    return BenchmarkBinding(
+        threshold_set_id=_string(data.get("threshold_set_id"), "threshold_set_id"),
+        threshold_manifest_path=threshold_manifest_path,
+        threshold_manifest_sha256=manifest_sha,
+        threshold_freeze_commit=cast(str, freeze_commit),
+        batch_sizes=batch_sizes,
+        process_repeats=_integer(
+            measurement.get("env_process_repeats"), "env_process_repeats", minimum=5
+        ),
+        behavior_seeds=baseline_plan.ppo_lane.seeds,
+        behavior_num_envs=baseline_plan.ppo_lane.num_envs,
+        behavior_steps_per_env=baseline_plan.ppo_lane.num_steps_per_env,
+        behavior_iterations=baseline_plan.ppo_lane.max_iterations,
+        warmup_iterations=baseline_plan.ppo_lane.warmup_iterations,
+        memory_poll_interval_sec=baseline_plan.ppo_lane.memory_poll_interval_sec,
+        max_population_cv_by_batch=cv,
+        p50_latency_ratio_max=_number(performance.get("p50_latency_ratio_max"), "p50 latency gate"),
+        p95_latency_ratio_max=_number(performance.get("p95_latency_ratio_max"), "p95 latency gate"),
+        throughput_ratio_min=_number(performance.get("throughput_ratio_min"), "throughput gate"),
+        fps_p50_median_ratio_min=_number(training.get("fps_p50_median_ratio_min"), "fps gate"),
+        reward_auc_median_drop_max=_number(training.get("reward_auc_median_drop_max"), "AUC gate"),
+        final_reward_p50_median_drop_max=_number(
+            training.get("final_reward_p50_median_drop_max"), "final reward gate"
+        ),
+        episode_length_median_ratio_min=_number(
+            training.get("episode_length_median_ratio_min"), "episode length gate"
+        ),
+        host_memory_ratio_max=_number(
+            memory.get("host_preferred_metric_ratio_max"), "host memory gate"
+        ),
+        device_peak_reserved_capacity_ratio_max=_number(
+            memory.get("device_peak_reserved_capacity_ratio_max"), "device capacity gate"
+        ),
+        device_peak_reserved_growth_bytes_max=_integer(
+            memory.get("device_peak_reserved_growth_bytes_max"), "device growth gate"
+        ),
+        h2d_per_policy_step_max=_number(transfer.get("h2d_per_policy_step_max"), "H2D gate"),
+        d2h_per_policy_step_max=_number(transfer.get("d2h_per_policy_step_max"), "D2H gate"),
+        host_global_sync_per_policy_step_max=_number(
+            transfer.get("host_global_sync_per_policy_step_max"), "sync gate"
+        ),
+        baseline_ppo=baseline_ppo,
+        affinity_cpus=baseline_plan.hardware.affinity_cpus,
+        environment_vars=dict(baseline_plan.environment.env_vars),
+        hydra_overrides=baseline_plan.environment.hydra_overrides,
+        gpu_name=_string(hardware.get("gpu_name"), "baseline.hardware.gpu_name"),
+        gpu_uuid=_string(hardware.get("gpu_uuid"), "baseline.hardware.gpu_uuid"),
+        gpu_driver_version=_string(
+            hardware.get("driver_version"), "baseline.hardware.driver_version"
+        ),
+        gpu_capacity_bytes=_integer(hardware.get("gpu_memory_mib"), "GPU memory MiB", minimum=1)
+        * 1024**2,
+    )
+
+
+def expected_case_ids(binding: BenchmarkBinding) -> tuple[str, ...]:
+    """Return the non-filterable complete raw case matrix."""
+
+    result: list[str] = []
+    for batch_size in binding.batch_sizes:
+        for repeat in range(binding.process_repeats):
+            for mode in THROUGHPUT_MODES:
+                result.append(f"throughput-{mode}-b{batch_size}-r{repeat}")
+    for seed in binding.behavior_seeds:
+        result.append(f"behavior-mjwarp_device-seed{seed}")
+    for repeat in range(binding.process_repeats):
+        result.append(f"contention-mjwarp_device-b1024-r{repeat}")
+    return tuple(result)
+
+
+def _throughput_mode_order(repeat_index: int) -> tuple[str, ...]:
+    if repeat_index % 2 == 0:
+        return THROUGHPUT_MODES
+    return tuple(reversed(THROUGHPUT_MODES))
+
+
+def expected_case_specs(binding: BenchmarkBinding) -> dict[str, dict[str, Any]]:
+    """Return the frozen metadata for every process-isolated training worker."""
+
+    specs: dict[str, dict[str, Any]] = {}
+    for batch_size in binding.batch_sizes:
+        for repeat_index in range(binding.process_repeats):
+            for sequence_index, mode in enumerate(_throughput_mode_order(repeat_index)):
+                case_id = f"throughput-{mode}-b{batch_size}-r{repeat_index}"
+                specs[case_id] = {
+                    "lane": "throughput",
+                    "mode": mode,
+                    "batch_size": batch_size,
+                    "seed": repeat_index,
+                    "repeat_index": repeat_index,
+                    "sequence_index": sequence_index,
+                    "iterations": THROUGHPUT_ITERATIONS,
+                }
+    for seed in binding.behavior_seeds:
+        case_id = f"behavior-mjwarp_device-seed{seed}"
+        specs[case_id] = {
+            "lane": "behavior",
+            "mode": "mjwarp_device",
+            "batch_size": binding.behavior_num_envs,
+            "seed": seed,
+            "repeat_index": None,
+            "sequence_index": None,
+            "iterations": binding.behavior_iterations,
+        }
+    for repeat_index in range(binding.process_repeats):
+        case_id = f"contention-mjwarp_device-b1024-r{repeat_index}"
+        specs[case_id] = {
+            "lane": "contention",
+            "mode": "mjwarp_device",
+            "batch_size": 1024,
+            "seed": repeat_index,
+            "repeat_index": repeat_index,
+            "sequence_index": None,
+            "iterations": CONTENTION_ITERATIONS,
+        }
+    if set(specs) != set(expected_case_ids(binding)):
+        raise MjwarpPpoBenchmarkError("internal PPO benchmark case registration differs")
+    return specs
+
+
+def _source_payload() -> dict[str, Any]:
+    if _git("status", "--short"):
+        raise MjwarpPpoBenchmarkError("Phase 5 benchmark execution requires a clean git worktree")
+    commit = _git("rev-parse", "HEAD")
+    return {
+        "commit": commit,
+        "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        "dirty": False,
+        "tree_sha256": source_tree_sha256(ROOT_DIR, SOURCE_INPUTS),
+        "uv_lock_sha256": sha256_file(ROOT_DIR / "uv.lock"),
+        "owner_yaml_sha256": sha256_file(ROOT_DIR / "conf/ppo/task/g1_walk_flat/mjwarp.yaml"),
+    }
+
+
+def _assert_capture_source_unchanged(source: Mapping[str, Any]) -> None:
+    """Reject a long capture whose benchmark inputs changed underneath it."""
+
+    if _git("status", "--short"):
+        raise MjwarpPpoBenchmarkError(
+            "Phase 5 benchmark changed the candidate source during capture"
+        )
+    if _git("rev-parse", "HEAD") != source.get("commit"):
+        raise MjwarpPpoBenchmarkError("candidate HEAD changed during Phase 5 benchmark capture")
+    if source_tree_sha256(ROOT_DIR, SOURCE_INPUTS) != source.get("tree_sha256"):
+        raise MjwarpPpoBenchmarkError("benchmark source inputs changed during capture")
+    if sha256_file(ROOT_DIR / "uv.lock") != source.get("uv_lock_sha256"):
+        raise MjwarpPpoBenchmarkError("uv.lock changed during Phase 5 benchmark capture")
+    if sha256_file(ROOT_DIR / "conf/ppo/task/g1_walk_flat/mjwarp.yaml") != source.get(
+        "owner_yaml_sha256"
+    ):
+        raise MjwarpPpoBenchmarkError("mjwarp owner YAML changed during Phase 5 benchmark capture")
+
+
+def _mode_owner(mode: str) -> tuple[str, str]:
+    if mode == "mujoco_host":
+        return "mujoco", "host_numpy"
+    if mode == "mjwarp_device":
+        return "mjwarp", "device_resident"
+    raise MjwarpPpoBenchmarkError(f"unsupported PPO benchmark mode {mode!r}")
+
+
+def _run_dirs(log_root: Path, backend: str) -> list[Path]:
+    return sorted((log_root / "G1WalkFlat").glob(f"*_{backend}"))
+
+
+def _run_training_case(
+    binding: BenchmarkBinding,
+    baseline_plan: Any,
+    *,
+    mode: str,
+    batch_size: int,
+    seed: int,
+    iterations: int,
+    lane: str,
+    repeat_index: int | None,
+    sequence_index: int | None,
+    common_overrides: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Run one public PPO process and retain every raw output needed by the gate."""
+
+    backend, expected_profile = _mode_owner(mode)
+    with tempfile.TemporaryDirectory(prefix=f"unilab_issue705_p5_{lane}_{mode}_") as temp_dir:
+        log_root = Path(temp_dir) / "logs"
+        command = [
+            "uv",
+            "run",
+            "scripts/train_rsl_rl.py",
+            f"task=g1_walk_flat/{backend}",
+            f"algo.seed={seed}",
+            f"algo.num_envs={batch_size}",
+            f"algo.num_steps_per_env={binding.behavior_steps_per_env}",
+            f"algo.max_iterations={iterations}",
+            "algo.save_interval=1000",
+            "training.no_play=true",
+            "training.logger=tensorboard",
+            f"training.log_root={log_root}",
+            *baseline_plan.environment.hydra_overrides,
+            *COMMON_PERFORMANCE_OVERRIDES,
+            *tuple(common_overrides),
+        ]
+        process, memory_samples, stdout, stderr = _run_subprocess(
+            command,
+            baseline_plan,
+            memory_poll_interval=binding.memory_poll_interval_sec,
+        )
+        if process["return_code"] != 0:
+            raise MjwarpPpoBenchmarkError(
+                f"{lane} {mode} case failed: command={command!r}\n"
+                f"stdout:\n{stdout[-6000:]}\nstderr:\n{stderr[-6000:]}"
+            )
+        run_dirs = _run_dirs(log_root, backend)
+        if len(run_dirs) != 1:
+            raise MjwarpPpoBenchmarkError(
+                f"{lane} {mode} produced {len(run_dirs)} expected run directories"
+            )
+        run_dir = run_dirs[0]
+        run_config = json.loads((run_dir / "run_config.json").read_text(encoding="utf-8"))
+        run_summary = json.loads((run_dir / "run_summary.json").read_text(encoding="utf-8"))
+        scalars = _event_scalars(run_dir, REQUIRED_SCALAR_TAGS)
+
+    raw = {
+        "scalars": scalars,
+        "memory_samples": memory_samples,
+        "run_config": run_config,
+        "run_config_sha256": canonical_sha256(run_config),
+        "run_summary": run_summary,
+    }
+    summary = summarize_training_raw(raw, warmup_iterations=binding.warmup_iterations)
+    case_id = (
+        f"behavior-{mode}-seed{seed}"
+        if lane == "behavior"
+        else f"{lane}-{mode}-b{batch_size}-r{cast(int, repeat_index)}"
+    )
+    return {
+        "case_id": case_id,
+        "lane": lane,
+        "mode": mode,
+        "batch_size": batch_size,
+        "seed": seed,
+        "repeat_index": repeat_index,
+        "sequence_index": sequence_index,
+        "iterations": iterations,
+        "expected_execution_profile": expected_profile,
+        "process": process,
+        "raw": raw,
+        "summary": summary,
+    }
+
+
+def _finite_scalar_values(
+    scalars: Mapping[str, Any], tag: str, *, warmup_iterations: int
+) -> list[float]:
+    points = scalars.get(tag)
+    if not isinstance(points, list):
+        raise MjwarpPpoBenchmarkError(f"missing scalar tag {tag}")
+    values: list[float] = []
+    for index, point in enumerate(points):
+        if not isinstance(point, Mapping):
+            raise MjwarpPpoBenchmarkError(f"scalar {tag}[{index}] must be a mapping")
+        step = _integer(point.get("step"), f"scalar {tag}[{index}].step", minimum=0)
+        if step < warmup_iterations:
+            continue
+        values.append(
+            _number(point.get("value"), f"scalar {tag}[{index}].value", minimum=-float("inf"))
+        )
+    if not values:
+        raise MjwarpPpoBenchmarkError(f"scalar {tag} has no post-warmup values")
+    return values
+
+
+def _reward_auc(points: object, *, warmup_iterations: int) -> float:
+    if not isinstance(points, list):
+        raise MjwarpPpoBenchmarkError("reward scalar points must be a list")
+    selected: list[tuple[int, float]] = []
+    for index, point in enumerate(points):
+        if not isinstance(point, Mapping):
+            raise MjwarpPpoBenchmarkError(f"reward point {index} must be a mapping")
+        step = _integer(point.get("step"), f"reward point {index}.step", minimum=0)
+        if step >= warmup_iterations:
+            selected.append(
+                (
+                    step,
+                    _number(
+                        point.get("value"), f"reward point {index}.value", minimum=-float("inf")
+                    ),
+                )
+            )
+    if len(selected) < 2:
+        raise MjwarpPpoBenchmarkError("reward AUC requires two post-warmup points")
+    selected.sort()
+    return float(np.trapezoid([value for _, value in selected], [step for step, _ in selected]))
+
+
+def summarize_training_raw(raw: Mapping[str, Any], *, warmup_iterations: int) -> dict[str, Any]:
+    """Recompute one worker's training summaries directly from raw scalar events."""
+
+    scalars = _mapping(raw.get("scalars"), "raw.scalars")
+    scalar_stats = {
+        tag: numeric_stats(_finite_scalar_values(scalars, tag, warmup_iterations=warmup_iterations))
+        for tag in REQUIRED_SCALAR_TAGS
+    }
+    collection = _finite_scalar_values(
+        scalars, "Perf/collection_time", warmup_iterations=warmup_iterations
+    )
+    learner = _finite_scalar_values(
+        scalars, "Perf/learning_time", warmup_iterations=warmup_iterations
+    )
+    if len(collection) != len(learner):
+        raise MjwarpPpoBenchmarkError("collection and learner scalar lengths differ")
+    iteration_ms = [
+        (collect + learn) * 1000.0 for collect, learn in zip(collection, learner, strict=True)
+    ]
+    memory_samples = raw.get("memory_samples")
+    if not isinstance(memory_samples, list) or not memory_samples:
+        raise MjwarpPpoBenchmarkError("raw.memory_samples must be a non-empty list")
+    rss_values = [
+        _integer(_mapping(sample, f"memory sample {index}").get("rss_bytes"), f"rss[{index}]")
+        for index, sample in enumerate(memory_samples)
+    ]
+    run_summary = _mapping(raw.get("run_summary"), "raw.run_summary")
+    return {
+        "scalar_stats": scalar_stats,
+        "iteration_wall_ms": numeric_stats(iteration_ms),
+        "collection_ms": numeric_stats([value * 1000.0 for value in collection]),
+        "learner_ms": numeric_stats([value * 1000.0 for value in learner]),
+        "reward_auc": _reward_auc(
+            scalars.get("Train/mean_reward"), warmup_iterations=warmup_iterations
+        ),
+        "peak_rss_bytes": max(rss_values),
+        "peak_gpu_memory_allocated_bytes": _integer(
+            run_summary.get("peak_gpu_memory_allocated_bytes"), "run_summary allocated"
+        ),
+        "peak_gpu_memory_reserved_bytes": _integer(
+            run_summary.get("peak_gpu_memory_reserved_bytes"), "run_summary reserved"
+        ),
+    }
+
+
+def _population_cv(values: Sequence[float]) -> float:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1 or array.size < 2 or not np.all(np.isfinite(array)):
+        raise MjwarpPpoBenchmarkError("population CV requires at least two finite values")
+    mean = float(array.mean())
+    if mean <= 0.0:
+        raise MjwarpPpoBenchmarkError("population CV requires positive mean")
+    return float(array.std(ddof=0) / mean)
+
+
+def _aggregate_cases(cases: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not cases:
+        raise MjwarpPpoBenchmarkError("cannot aggregate an empty case group")
+    summaries = [_mapping(case.get("summary"), "case.summary") for case in cases]
+
+    def stat(name: str, field: str) -> float:
+        return float(
+            statistics.median(float(_mapping(summary[name], name)[field]) for summary in summaries)
+        )
+
+    fps_p50 = [
+        float(_mapping(summary["scalar_stats"], "scalar_stats")["Perf/total_fps"]["p50"])
+        for summary in summaries
+    ]
+    return {
+        "process_count": len(cases),
+        "iteration_p50_median_ms": stat("iteration_wall_ms", "p50"),
+        "iteration_p95_median_ms": stat("iteration_wall_ms", "p95"),
+        "collection_p50_median_ms": stat("collection_ms", "p50"),
+        "learner_p50_median_ms": stat("learner_ms", "p50"),
+        "fps_p50_median": float(statistics.median(fps_p50)),
+        "fps_p50_population_cv": _population_cv(fps_p50),
+        "peak_rss_median_bytes": int(
+            statistics.median(int(summary["peak_rss_bytes"]) for summary in summaries)
+        ),
+        "peak_gpu_reserved_median_bytes": int(
+            statistics.median(
+                int(summary["peak_gpu_memory_reserved_bytes"]) for summary in summaries
+            )
+        ),
+        "peak_gpu_reserved_max_bytes": max(
+            int(summary["peak_gpu_memory_reserved_bytes"]) for summary in summaries
+        ),
+        "peak_gpu_allocated_max_bytes": max(
+            int(summary["peak_gpu_memory_allocated_bytes"]) for summary in summaries
+        ),
+    }
+
+
+def build_aggregates(
+    cases: Sequence[Mapping[str, Any]], binding: BenchmarkBinding
+) -> dict[str, Any]:
+    """Aggregate every planned raw case without dropping an outlier or a failed seed."""
+
+    throughput: dict[str, dict[str, Any]] = {}
+    for batch_size in binding.batch_sizes:
+        per_mode: dict[str, Any] = {}
+        for mode in THROUGHPUT_MODES:
+            selected = [
+                case
+                for case in cases
+                if case.get("lane") == "throughput"
+                and case.get("batch_size") == batch_size
+                and case.get("mode") == mode
+            ]
+            per_mode[mode] = _aggregate_cases(selected)
+        throughput[str(batch_size)] = per_mode
+
+    behavior_cases = [case for case in cases if case.get("lane") == "behavior"]
+    behavior = _aggregate_cases(behavior_cases)
+    summaries = [_mapping(case.get("summary"), "behavior summary") for case in behavior_cases]
+    behavior.update(
+        {
+            "seeds": [
+                int(case["seed"])
+                for case in sorted(behavior_cases, key=lambda item: int(item["seed"]))
+            ],
+            "failed_seeds": [],
+            "nan_seeds": [],
+            "reward_auc_median": float(
+                statistics.median(float(summary["reward_auc"]) for summary in summaries)
+            ),
+            "final_reward_p50_median": float(
+                statistics.median(
+                    float(summary["scalar_stats"]["Train/mean_reward"]["p50"])
+                    for summary in summaries
+                )
+            ),
+            "episode_length_p50_median": float(
+                statistics.median(
+                    float(summary["scalar_stats"]["Train/mean_episode_length"]["p50"])
+                    for summary in summaries
+                )
+            ),
+        }
+    )
+
+    contention_cases = [case for case in cases if case.get("lane") == "contention"]
+    contention = _aggregate_cases(contention_cases)
+    idle = throughput["1024"]["mjwarp_device"]
+    contention.update(
+        {
+            "idle_reference": idle,
+            "co_located_to_idle_iteration_p50_ratio": _ratio(
+                float(contention["iteration_p50_median_ms"]),
+                float(idle["iteration_p50_median_ms"]),
+            ),
+            "co_located_to_idle_iteration_p95_ratio": _ratio(
+                float(contention["iteration_p95_median_ms"]),
+                float(idle["iteration_p95_median_ms"]),
+            ),
+            "co_located_to_idle_fps_p50_ratio": _ratio(
+                float(contention["fps_p50_median"]), float(idle["fps_p50_median"])
+            ),
+        }
+    )
+    return {
+        "throughput": throughput,
+        "behavior": behavior,
+        "contention": contention,
+    }
+
+
+def _trace_transfer_counts(trace: Mapping[str, Any], *, scope_name: str) -> tuple[int, int, int]:
+    events = trace.get("traceEvents")
+    if not isinstance(events, list):
+        raise MjwarpPpoBenchmarkError("profiler trace must contain traceEvents")
+    scopes = [
+        event
+        for event in events
+        if isinstance(event, Mapping)
+        and event.get("name") == scope_name
+        and event.get("cat") == "user_annotation"
+        and isinstance(event.get("ts"), (int, float))
+        and isinstance(event.get("dur"), (int, float))
+    ]
+    if not scopes:
+        raise MjwarpPpoBenchmarkError(f"profiler trace has no {scope_name!r} scope")
+    intervals = tuple(
+        (float(scope["ts"]), float(scope["ts"]) + float(scope["dur"])) for scope in scopes
+    )
+    h2d = d2h = sync = 0
+    for event in events:
+        if not isinstance(event, Mapping) or not isinstance(event.get("ts"), (int, float)):
+            continue
+        timestamp = float(event["ts"])
+        if not any(start <= timestamp <= end for start, end in intervals):
+            continue
+        payload = (
+            str(event.get("name", "")) + " " + json.dumps(event.get("args", {}), sort_keys=True)
+        ).lower()
+        if any(token in payload for token in ("htod", "host to device", "host -> device")):
+            h2d += 1
+        if any(token in payload for token in ("dtoh", "device to host", "device -> host")):
+            d2h += 1
+        if "cudadevicesynchronize" in payload:
+            sync += 1
+    return h2d, d2h, sync
+
+
+def _sha256_path(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _validate_scalar_coverage(scalars: Mapping[str, Any], *, iterations: int, case_id: str) -> None:
+    expected_steps = tuple(range(iterations))
+    for tag in REQUIRED_SCALAR_TAGS:
+        points = scalars.get(tag)
+        if not isinstance(points, list):
+            raise MjwarpPpoBenchmarkError(f"{case_id}: missing scalar tag {tag}")
+        steps = tuple(
+            _integer(
+                _mapping(point, f"{case_id}.{tag}[{index}]").get("step"),
+                f"{case_id}.{tag}[{index}].step",
+            )
+            for index, point in enumerate(points)
+        )
+        if steps != expected_steps:
+            raise MjwarpPpoBenchmarkError(
+                f"{case_id}: scalar {tag} must contain every iteration exactly once"
+            )
+        for index, point in enumerate(points):
+            _number(
+                _mapping(point, f"{case_id}.{tag}[{index}]").get("value"),
+                f"{case_id}.{tag}[{index}].value",
+                minimum=-float("inf"),
+            )
+
+
+def _validate_process_receipt(
+    case: Mapping[str, Any], binding: BenchmarkBinding, errors: list[str]
+) -> None:
+    case_id = _string(case.get("case_id"), "case_id")
+    process = _mapping(case.get("process"), f"{case_id}.process")
+    if process.get("return_code") != 0:
+        errors.append(f"{case_id}: worker did not succeed")
+    command = process.get("command")
+    if not isinstance(command, list) or command[:3] != ["uv", "run", "scripts/train_rsl_rl.py"]:
+        errors.append(f"{case_id}: worker did not use the public train_rsl_rl owner route")
+    elif all(isinstance(item, str) for item in command):
+        backend, _ = _mode_owner(_string(case.get("mode"), f"{case_id}.mode"))
+        required_arguments = {
+            f"task=g1_walk_flat/{backend}",
+            f"algo.seed={case.get('seed')}",
+            f"algo.num_envs={case.get('batch_size')}",
+            f"algo.num_steps_per_env={binding.behavior_steps_per_env}",
+            f"algo.max_iterations={case.get('iterations')}",
+            "training.no_play=true",
+            "training.logger=tensorboard",
+            *binding.hydra_overrides,
+            *COMMON_PERFORMANCE_OVERRIDES,
+        }
+        if not required_arguments.issubset(set(command)):
+            errors.append(f"{case_id}: worker command differs from the frozen owner protocol")
+    if process.get("affinity_cpus") != list(binding.affinity_cpus):
+        errors.append(f"{case_id}: worker affinity differs from frozen benchmark plan")
+    if process.get("env_vars") != dict(binding.environment_vars):
+        errors.append(f"{case_id}: worker thread environment differs from frozen benchmark plan")
+    if not isinstance(process.get("run_id"), str) or not process["run_id"].strip():
+        errors.append(f"{case_id}: worker receipt has no run_id")
+    _number(process.get("duration_sec"), f"{case_id}.process.duration_sec", minimum=0.0)
+    _sha256(process.get("stdout_sha256"), f"{case_id}.process.stdout_sha256")
+    _sha256(process.get("stderr_sha256"), f"{case_id}.process.stderr_sha256")
+
+
+def _validate_orchestrator_receipt(
+    case: Mapping[str, Any], binding: BenchmarkBinding, errors: list[str]
+) -> None:
+    case_id = _string(case.get("case_id"), "case_id")
+    process = _mapping(case.get("orchestrator_process"), f"{case_id}.orchestrator_process")
+    command = process.get("command")
+    if (
+        not isinstance(command, list)
+        or command[:3] != ["uv", "run", "benchmark/rl/benchmark_mjwarp_ppo.py"]
+        or "--worker" not in command
+        or not {"--case-id", case_id}.issubset(set(command))
+    ):
+        errors.append(f"{case_id}: case was not isolated through the registered worker CLI")
+    if process.get("return_code") != 0:
+        errors.append(f"{case_id}: benchmark worker process did not succeed")
+    if process.get("affinity_cpus") != list(binding.affinity_cpus):
+        errors.append(f"{case_id}: benchmark worker affinity differs from frozen plan")
+    if process.get("env_vars") != dict(binding.environment_vars):
+        errors.append(f"{case_id}: benchmark worker environment differs from frozen plan")
+    _number(process.get("duration_sec"), f"{case_id}.orchestrator.duration_sec")
+    _sha256(process.get("stdout_sha256"), f"{case_id}.orchestrator.stdout_sha256")
+    _sha256(process.get("stderr_sha256"), f"{case_id}.orchestrator.stderr_sha256")
+
+
+def _validate_case_shape(
+    case: Mapping[str, Any], binding: BenchmarkBinding, errors: list[str]
+) -> None:
+    case_id = _string(case.get("case_id"), "case_id")
+    expected = expected_case_specs(binding).get(case_id)
+    if expected is None:
+        errors.append(f"{case_id}: is not in the frozen case matrix")
+        return
+    for key, expected_value in expected.items():
+        if case.get(key) != expected_value:
+            errors.append(f"{case_id}: {key} differs from frozen matrix")
+    if case.get("expected_execution_profile") != _mode_owner(expected["mode"])[1]:
+        errors.append(f"{case_id}: expected_execution_profile differs from mode")
+    _validate_orchestrator_receipt(case, binding, errors)
+    _validate_process_receipt(case, binding, errors)
+    if expected["lane"] == "contention":
+        contention = _mapping(case.get("contention"), f"{case_id}.contention")
+        if contention.get("load_worker_return_code") != 0:
+            errors.append(f"{case_id}: owned GPU contention worker did not succeed")
+        if contention.get("load_worker_matrix") != [2048, 2048]:
+            errors.append(f"{case_id}: contention worker matrix differs from protocol")
+        _sha256(contention.get("load_worker_stdout_sha256"), f"{case_id}.contention.stdout_sha256")
+        _sha256(contention.get("load_worker_stderr_sha256"), f"{case_id}.contention.stderr_sha256")
+
+
+def _validate_run_config(
+    case: Mapping[str, Any], binding: BenchmarkBinding, errors: list[str]
+) -> None:
+    case_id = _string(case.get("case_id"), "case_id")
+    raw = _mapping(case.get("raw"), f"{case_id}.raw")
+    run_config = _mapping(raw.get("run_config"), "run_config")
+    if raw.get("run_config_sha256") != canonical_sha256(run_config):
+        errors.append(f"{case.get('case_id')}: run_config SHA does not match raw config")
+    config = _mapping(run_config.get("config"), "run_config.config")
+    training = _mapping(config.get("training"), "run_config.config.training")
+    algo = _mapping(config.get("algo"), "run_config.config.algo")
+    env_config = _mapping(config.get("env"), "run_config.config.env")
+    backend, profile = _mode_owner(_string(case.get("mode"), "case.mode"))
+    if training.get("sim_backend") != backend:
+        errors.append(f"{case.get('case_id')}: owner backend is not {backend}")
+    if backend == "mjwarp" and training.get("execution_profile") != profile:
+        errors.append(f"{case.get('case_id')}: mjwarp owner did not select device_resident")
+    if algo.get("num_envs") != case.get("batch_size"):
+        errors.append(f"{case.get('case_id')}: num_envs differs from case batch")
+    if algo.get("num_steps_per_env") != binding.behavior_steps_per_env:
+        errors.append(f"{case.get('case_id')}: num_steps_per_env differs from frozen plan")
+    if algo.get("max_iterations") != case.get("iterations"):
+        errors.append(f"{case.get('case_id')}: max_iterations differs from case")
+    if algo.get("seed") != case.get("seed"):
+        errors.append(f"{case.get('case_id')}: configured seed differs from case")
+    noise = _mapping(env_config.get("noise_config"), "run_config.config.env.noise_config")
+    domain_rand = _mapping(env_config.get("domain_rand"), "run_config.config.env.domain_rand")
+    curriculum = _mapping(env_config.get("curriculum"), "run_config.config.env.curriculum")
+    if noise.get("level") != 0.0:
+        errors.append(f"{case_id}: observation noise differs from performance protocol")
+    if domain_rand.get("randomize_kp") is not False or domain_rand.get("randomize_kd") is not False:
+        errors.append(f"{case_id}: actuator gain DR differs from performance protocol")
+    if curriculum.get("enabled") is not False:
+        errors.append(f"{case_id}: curriculum differs from performance protocol")
+    if backend == "mjwarp":
+        snapshot = _mapping(run_config.get("contract_snapshot"), "contract_snapshot")
+        policy_abi = snapshot.get("manager.policy_abi")
+        if not isinstance(policy_abi, Mapping):
+            errors.append(f"{case.get('case_id')}: mjwarp run receipt lacks manager.policy_abi")
+        else:
+            for key in (
+                "plan_fingerprint",
+                "policy_abi_fingerprint",
+                "executor_key",
+                "execution_profile",
+            ):
+                if not isinstance(policy_abi.get(key), str) or not policy_abi[key].strip():
+                    errors.append(f"{case_id}: manager.policy_abi.{key} is missing")
+            if policy_abi.get("execution_profile") != PROFILE:
+                errors.append(
+                    f"{case_id}: manager.policy_abi execution profile is not device_resident"
+                )
+    summary = _mapping(raw.get("run_summary"), "run_summary")
+    if summary.get("status") != "completed" or summary.get("completed_iterations") != case.get(
+        "iterations"
+    ):
+        errors.append(f"{case.get('case_id')}: PPO run did not complete the exact iteration budget")
+    _number(summary.get("training_wall_time_sec"), f"{case_id}.run_summary.training_wall_time_sec")
+    _integer(summary.get("peak_process_rss_bytes"), f"{case_id}.run_summary.peak_process_rss_bytes")
+    _integer(
+        summary.get("peak_gpu_memory_allocated_bytes"),
+        f"{case_id}.run_summary.peak_gpu_memory_allocated_bytes",
+    )
+    _integer(
+        summary.get("peak_gpu_memory_reserved_bytes"),
+        f"{case_id}.run_summary.peak_gpu_memory_reserved_bytes",
+    )
+    scalars = _mapping(raw.get("scalars"), f"{case_id}.raw.scalars")
+    _validate_scalar_coverage(
+        scalars,
+        iterations=_integer(case.get("iterations"), f"{case_id}.iterations", minimum=2),
+        case_id=case_id,
+    )
+
+
+def _ratio(value: float | int, reference: float | int) -> float:
+    if reference <= 0:
+        raise MjwarpPpoBenchmarkError("ratio reference must be positive")
+    return float(value) / float(reference)
+
+
+def _recompute_gate(artifact: Mapping[str, Any], binding: BenchmarkBinding) -> list[str]:
+    errors: list[str] = []
+    aggregates = _mapping(artifact.get("aggregates"), "aggregates")
+    behavior = _mapping(aggregates.get("behavior"), "aggregates.behavior")
+    baseline = binding.baseline_ppo
+    throughput = _mapping(aggregates.get("throughput"), "aggregates.throughput")
+    for batch_size in binding.batch_sizes:
+        per_mode = _mapping(throughput.get(str(batch_size)), f"throughput[{batch_size}]")
+        for mode in THROUGHPUT_MODES:
+            result = _mapping(per_mode.get(mode), f"throughput[{batch_size}].{mode}")
+            if result.get("process_count") != binding.process_repeats:
+                errors.append(f"throughput[{batch_size}].{mode}: wrong process count")
+            cv = _number(result.get("fps_p50_population_cv"), f"throughput[{batch_size}].{mode}.cv")
+            if cv > binding.max_population_cv_by_batch[batch_size]:
+                errors.append(
+                    f"throughput[{batch_size}].{mode}: population CV exceeds frozen limit"
+                )
+        host = _mapping(per_mode.get("mujoco_host"), f"throughput[{batch_size}].mujoco_host")
+        device = _mapping(per_mode.get("mjwarp_device"), f"throughput[{batch_size}].mjwarp_device")
+        if (
+            _ratio(
+                _number(
+                    device.get("iteration_p50_median_ms"), f"throughput[{batch_size}].device.p50"
+                ),
+                _number(host.get("iteration_p50_median_ms"), f"throughput[{batch_size}].host.p50"),
+            )
+            > binding.p50_latency_ratio_max
+        ):
+            errors.append(
+                f"throughput[{batch_size}]: iteration p50 violates frozen performance gate"
+            )
+        if (
+            _ratio(
+                _number(
+                    device.get("iteration_p95_median_ms"), f"throughput[{batch_size}].device.p95"
+                ),
+                _number(host.get("iteration_p95_median_ms"), f"throughput[{batch_size}].host.p95"),
+            )
+            > binding.p95_latency_ratio_max
+        ):
+            errors.append(
+                f"throughput[{batch_size}]: iteration p95 violates frozen performance gate"
+            )
+        if (
+            _ratio(
+                _number(device.get("fps_p50_median"), f"throughput[{batch_size}].device.fps"),
+                _number(host.get("fps_p50_median"), f"throughput[{batch_size}].host.fps"),
+            )
+            < binding.throughput_ratio_min
+        ):
+            errors.append(f"throughput[{batch_size}]: FPS violates frozen throughput gate")
+        if (
+            _ratio(
+                _integer(
+                    device.get("peak_rss_median_bytes"), f"throughput[{batch_size}].device.rss"
+                ),
+                _integer(host.get("peak_rss_median_bytes"), f"throughput[{batch_size}].host.rss"),
+            )
+            > binding.host_memory_ratio_max
+        ):
+            errors.append(f"throughput[{batch_size}]: RSS violates frozen memory gate")
+
+    if tuple(behavior.get("seeds", ())) != binding.behavior_seeds:
+        errors.append("behavior seeds do not exactly match frozen [0, 1, 2, 3, 4]")
+    if behavior.get("failed_seeds") or behavior.get("nan_seeds"):
+        errors.append("behavior contains failed or non-finite seeds")
+    if (
+        _ratio(
+            _number(behavior.get("fps_p50_median"), "behavior.fps"),
+            float(baseline["fps_p50_median"]),
+        )
+        < binding.fps_p50_median_ratio_min
+    ):
+        errors.append("behavior FPS p50 median violates frozen training gate")
+    if (
+        _number(behavior.get("reward_auc_median"), "behavior.auc", minimum=-float("inf"))
+        < float(baseline["reward_auc_median"]) - binding.reward_auc_median_drop_max
+    ):
+        errors.append("behavior reward AUC violates frozen training gate")
+    if (
+        _number(behavior.get("final_reward_p50_median"), "behavior.reward", minimum=-float("inf"))
+        < float(baseline["final_reward_p50_median"]) - binding.final_reward_p50_median_drop_max
+    ):
+        errors.append("behavior final reward violates frozen training gate")
+    if (
+        _ratio(
+            _number(behavior.get("episode_length_p50_median"), "behavior.length"),
+            float(baseline["episode_length_p50_median"]),
+        )
+        < binding.episode_length_median_ratio_min
+    ):
+        errors.append("behavior episode length violates frozen training gate")
+    if (
+        _ratio(
+            _integer(behavior.get("peak_rss_median_bytes"), "behavior.rss"),
+            int(baseline["peak_rss_median_bytes"]),
+        )
+        > binding.host_memory_ratio_max
+    ):
+        errors.append("behavior RSS violates frozen memory gate")
+
+    device = _mapping(artifact.get("device"), "device")
+    if _integer(device.get("gpu_capacity_bytes"), "device.capacity") != binding.gpu_capacity_bytes:
+        errors.append("device GPU capacity differs from frozen benchmark host")
+    peak_reserved = _integer(device.get("peak_gpu_reserved_bytes"), "device.reserved")
+    all_device_reserved = [
+        _integer(
+            _mapping(case.get("summary"), f"{case.get('case_id')}.summary").get(
+                "peak_gpu_memory_reserved_bytes"
+            ),
+            f"{case.get('case_id')}.summary.reserved",
+        )
+        for case in _mapping(artifact, "artifact").get("cases", [])
+        if isinstance(case, Mapping) and case.get("mode") == "mjwarp_device"
+    ]
+    if not all_device_reserved or peak_reserved != max(all_device_reserved):
+        errors.append("device reserved memory does not reconcile with all mjwarp cases")
+    if (
+        _ratio(peak_reserved, binding.gpu_capacity_bytes)
+        > binding.device_peak_reserved_capacity_ratio_max
+    ):
+        errors.append("device reserved capacity ratio violates frozen memory gate")
+    if (
+        peak_reserved - int(baseline["peak_gpu_reserved_median_bytes"])
+        > binding.device_peak_reserved_growth_bytes_max
+    ):
+        errors.append("device reserved growth violates frozen memory gate")
+    limits = {
+        "h2d_per_policy_step": binding.h2d_per_policy_step_max,
+        "d2h_per_policy_step": binding.d2h_per_policy_step_max,
+        "host_global_sync_per_policy_step": binding.host_global_sync_per_policy_step_max,
+    }
+    for name, limit in limits.items():
+        if _number(device.get(name), f"device.{name}") > limit:
+            errors.append(f"device {name} violates frozen transfer gate")
+    if device.get("profiler_reconciled") is not True:
+        errors.append("device profiler reconciliation is required")
+    profile_summary = _mapping(device.get("profiler_summary"), "device.profiler_summary")
+    profile_steps = _integer(
+        profile_summary.get("steps"), "device.profiler_summary.steps", minimum=1
+    )
+    if profile_steps != PROFILE_STEPS:
+        errors.append("device profiler summary steps differ from frozen profile protocol")
+    runtime_delta = _mapping(
+        profile_summary.get("runtime_delta"), "device.profiler_summary.runtime_delta"
+    )
+    trace_counts = _mapping(
+        profile_summary.get("trace_counts"), "device.profiler_summary.trace_counts"
+    )
+    counter_keys = (
+        ("host_to_device_transfers", "h2d_per_policy_step"),
+        ("device_to_host_transfers", "d2h_per_policy_step"),
+        ("global_synchronizations", "host_global_sync_per_policy_step"),
+    )
+    for counter_key, metric_key in counter_keys:
+        count = _integer(runtime_delta.get(counter_key), f"device.runtime_delta.{counter_key}")
+        if _integer(trace_counts.get(counter_key), f"device.trace_counts.{counter_key}") != count:
+            errors.append(f"device profiler trace does not reconcile {counter_key}")
+        if _number(device.get(metric_key), f"device.{metric_key}") != count / profile_steps:
+            errors.append(f"device {metric_key} does not reconcile profiler summary")
+    wrapper_delta = _mapping(
+        profile_summary.get("wrapper_delta"), "device.profiler_summary.wrapper_delta"
+    )
+    if _integer(
+        wrapper_delta.get("finite_metric_materializations"),
+        "device.profiler_summary.wrapper_delta.finite_metric_materializations",
+    ) != _integer(device.get("metrics_materializations"), "device.metrics_materializations"):
+        errors.append(
+            "device finite metric materialization count does not reconcile profiler summary"
+        )
+    if _integer(
+        wrapper_delta.get("finite_metric_device_to_host_bytes"),
+        "device.profiler_summary.wrapper_delta.finite_metric_device_to_host_bytes",
+    ) != _integer(
+        device.get("metrics_device_to_host_bytes"), "device.metrics_device_to_host_bytes"
+    ):
+        errors.append("device finite metric bytes do not reconcile profiler summary")
+    backend_receipt = _mapping(
+        profile_summary.get("backend_receipt"), "device.profiler_summary.backend_receipt"
+    )
+    if backend_receipt.get("backend_type") != "mjwarp":
+        errors.append("device profiler backend receipt is not mjwarp")
+    if backend_receipt.get("execution_profile") != PROFILE:
+        errors.append("device profiler execution profile is not device_resident")
+    for key in ("task_plan_fingerprint", "policy_abi_fingerprint", "backend_plan_fingerprint"):
+        if not isinstance(backend_receipt.get(key), str) or not backend_receipt[key].strip():
+            errors.append(f"device profiler backend receipt lacks {key}")
+    trace = _mapping(device.get("profiler_trace"), "device.profiler_trace")
+    _sha256(trace.get("sha256"), "device profiler trace hash")
+    if not _string(trace.get("filename"), "device profiler trace filename"):
+        errors.append("device profiler trace filename is required")
+    return errors
+
+
+def _git_file_sha256(repository: Path, commit: str, path: str) -> str:
+    completed = subprocess.run(
+        ["git", "show", f"{commit}:{path}"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    )
+    return f"sha256:{hashlib.sha256(completed.stdout).hexdigest()}"
+
+
+def _validate_source_at_commit(
+    source: Mapping[str, Any], binding: BenchmarkBinding, repository: Path, errors: list[str]
+) -> None:
+    commit = source.get("commit")
+    if not isinstance(commit, str) or not _is_commit(commit):
+        return
+    if commit == binding.threshold_freeze_commit:
+        errors.append("candidate commit cannot equal threshold freeze commit")
+    for command, error in (
+        (
+            ["git", "merge-base", "--is-ancestor", binding.threshold_freeze_commit, commit],
+            "candidate commit does not descend from threshold freeze",
+        ),
+        (
+            ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
+            "candidate commit is not available in current history",
+        ),
+    ):
+        try:
+            subprocess.run(command, cwd=repository, check=True, capture_output=True)
+        except subprocess.CalledProcessError:
+            errors.append(error)
+    try:
+        expected = {
+            "tree_sha256": source_tree_sha256_at_commit(repository, SOURCE_INPUTS, commit),
+            "uv_lock_sha256": _git_file_sha256(repository, commit, "uv.lock"),
+            "owner_yaml_sha256": _git_file_sha256(
+                repository, commit, "conf/ppo/task/g1_walk_flat/mjwarp.yaml"
+            ),
+        }
+    except (OSError, subprocess.CalledProcessError) as exc:
+        errors.append(f"candidate source verification failed: {type(exc).__name__}: {exc}")
+        return
+    for key, expected_value in expected.items():
+        if source.get(key) != expected_value:
+            errors.append(f"source.{key} does not match candidate commit")
+
+
+def _validate_trace_sibling(
+    root: Mapping[str, Any], artifact_path: Path, errors: list[str]
+) -> None:
+    device = _mapping(root.get("device"), "device")
+    trace = _mapping(device.get("profiler_trace"), "device.profiler_trace")
+    trace_path = artifact_path.parent / _string(trace.get("filename"), "trace filename")
+    if not trace_path.is_file():
+        errors.append("profiler trace sibling is missing")
+        return
+    if trace.get("sha256") != _sha256_path(trace_path):
+        errors.append("profiler trace hash does not match sibling")
+        return
+    try:
+        trace_data = _mapping(json.loads(trace_path.read_text(encoding="utf-8")), "trace")
+        actual = _trace_transfer_counts(trace_data, scope_name="issue705.mjwarp_ppo_rollout")
+        profile = _mapping(device.get("profiler_summary"), "device.profiler_summary")
+        trace_counts = _mapping(profile.get("trace_counts"), "device.profiler_summary.trace_counts")
+        expected = (
+            _integer(trace_counts.get("host_to_device_transfers"), "trace H2D"),
+            _integer(trace_counts.get("device_to_host_transfers"), "trace D2H"),
+            _integer(trace_counts.get("global_synchronizations"), "trace sync"),
+        )
+        if actual != expected:
+            errors.append("profiler trace counts do not match the recorded profiler summary")
+    except (OSError, UnicodeError, json.JSONDecodeError, MjwarpPpoBenchmarkError) as exc:
+        errors.append(f"profiler trace cannot be validated: {type(exc).__name__}: {exc}")
+
+
+def _core_validation_errors(
+    artifact: object,
+    *,
+    binding: BenchmarkBinding | None = None,
+    repo_root: Path | None = None,
+    artifact_path: Path | None = None,
+) -> tuple[str, ...]:
+    """Recompute all raw/provenance/gate facts without inspecting ``artifact.gate``.
+
+    Keeping this function independent of the recorded gate prevents a newly
+    generated artifact from having to validate a self-referential ``gate``
+    member before that member exists.
+    """
+
+    errors: list[str] = []
+    try:
+        root = _mapping(artifact, "artifact")
+        active_binding = binding or load_binding()
+        if root.get("schema_version") != SCHEMA_VERSION:
+            errors.append("schema_version differs")
+        if root.get("issue") != ISSUE or root.get("kind") != ARTIFACT_KIND:
+            errors.append("artifact issue or kind differs")
+        if root.get("profile") != PROFILE:
+            errors.append("artifact profile must be device_resident")
+        threshold = _mapping(root.get("threshold"), "threshold")
+        expected_threshold = {
+            "threshold_set_id": active_binding.threshold_set_id,
+            "manifest_path": active_binding.threshold_manifest_path.as_posix(),
+            "manifest_sha256": active_binding.threshold_manifest_sha256,
+            "freeze_commit": active_binding.threshold_freeze_commit,
+        }
+        if threshold != expected_threshold:
+            errors.append("threshold differs from frozen binding")
+        source = _mapping(root.get("source"), "source")
+        commit = source.get("commit")
+        if not _is_commit(commit):
+            errors.append("source.commit must be a full SHA")
+        if source.get("dirty") is not False:
+            errors.append("benchmark source must be clean")
+        _sha256(source.get("tree_sha256"), "source.tree_sha256")
+        _sha256(source.get("uv_lock_sha256"), "source.uv_lock_sha256")
+        _sha256(source.get("owner_yaml_sha256"), "source.owner_yaml_sha256")
+        if commit == active_binding.threshold_freeze_commit:
+            errors.append("candidate commit cannot equal threshold freeze commit")
+
+        hardware = _mapping(root.get("hardware"), "hardware")
+        expected_hardware = {
+            "gpu_name": active_binding.gpu_name,
+            "gpu_uuid": active_binding.gpu_uuid,
+            "gpu_memory_mib": active_binding.gpu_capacity_bytes // 1024**2,
+            "driver_version": active_binding.gpu_driver_version,
+            "affinity_cpus": list(active_binding.affinity_cpus),
+        }
+        for key, expected_value in expected_hardware.items():
+            if hardware.get(key) != expected_value:
+                errors.append(f"hardware.{key} differs from frozen benchmark host")
+
+        execution = _mapping(root.get("execution"), "execution")
+        if execution.get("process_isolation") is not True:
+            errors.append("execution.process_isolation must be true")
+        if execution.get("throughput_iterations") != THROUGHPUT_ITERATIONS:
+            errors.append("execution.throughput_iterations differs from protocol")
+        if execution.get("contention_iterations") != CONTENTION_ITERATIONS:
+            errors.append("execution.contention_iterations differs from protocol")
+        if execution.get("common_performance_overrides") != list(COMMON_PERFORMANCE_OVERRIDES):
+            errors.append("execution.common_performance_overrides differs from protocol")
+        if execution.get("frozen_hydra_overrides") != list(active_binding.hydra_overrides):
+            errors.append("execution.frozen_hydra_overrides differs from baseline plan")
+        for preflight_key in ("preflight_before", "preflight_after"):
+            preflight = _mapping(execution.get(preflight_key), f"execution.{preflight_key}")
+            if preflight.get("gpu_compute_processes") != []:
+                errors.append(f"execution.{preflight_key} records foreign GPU compute processes")
+
+        device_receipt = _mapping(root.get("device"), "device")
+        profiler_process = _mapping(
+            device_receipt.get("profiler_process"), "device.profiler_process"
+        )
+        profiler_command = profiler_process.get("command")
+        if (
+            not isinstance(profiler_command, list)
+            or profiler_command[:3] != ["uv", "run", "benchmark/rl/benchmark_mjwarp_ppo.py"]
+            or "--profile-worker" not in profiler_command
+        ):
+            errors.append("device profiler did not run in an independent benchmark worker process")
+        if profiler_process.get("return_code") != 0:
+            errors.append("device profiler worker did not succeed")
+        if profiler_process.get("affinity_cpus") != list(active_binding.affinity_cpus):
+            errors.append("device profiler affinity differs from frozen benchmark plan")
+        if profiler_process.get("env_vars") != dict(active_binding.environment_vars):
+            errors.append("device profiler environment differs from frozen benchmark plan")
+        _sha256(profiler_process.get("stdout_sha256"), "device.profiler_process.stdout_sha256")
+        _sha256(profiler_process.get("stderr_sha256"), "device.profiler_process.stderr_sha256")
+
+        cases_value = root.get("cases")
+        if not isinstance(cases_value, list):
+            raise MjwarpPpoBenchmarkError("cases must be a list")
+        cases = cast(list[Mapping[str, Any]], cases_value)
+        expected_ids = expected_case_ids(active_binding)
+        observed: list[str] = []
+        for raw_case in cases_value:
+            try:
+                observed.append(_string(_mapping(raw_case, "case").get("case_id"), "case_id"))
+            except MjwarpPpoBenchmarkError as exc:
+                errors.append(str(exc))
+        if len(observed) != len(expected_ids) or set(observed) != set(expected_ids):
+            errors.append(
+                "raw case matrix is incomplete, duplicated, or contains an unplanned case"
+            )
+        run_ids: list[str] = []
+        mjwarp_policy_abis: list[Mapping[str, Any]] = []
+        for raw_case in cases_value:
+            try:
+                case = _mapping(raw_case, "case")
+                _validate_case_shape(case, active_binding, errors)
+                process = _mapping(case.get("process"), "case.process")
+                run_id = process.get("run_id")
+                if isinstance(run_id, str):
+                    run_ids.append(run_id)
+                _validate_run_config(case, active_binding, errors)
+                raw = _mapping(case.get("raw"), "case.raw")
+                if case.get("mode") == "mjwarp_device":
+                    run_config = _mapping(raw.get("run_config"), "case.raw.run_config")
+                    contract_snapshot = _mapping(
+                        run_config.get("contract_snapshot"), "case.raw.contract_snapshot"
+                    )
+                    mjwarp_policy_abis.append(
+                        _mapping(
+                            contract_snapshot.get("manager.policy_abi"),
+                            "case.raw.contract_snapshot.manager.policy_abi",
+                        )
+                    )
+                expected_summary = summarize_training_raw(
+                    raw, warmup_iterations=active_binding.warmup_iterations
+                )
+                if case.get("summary") != expected_summary:
+                    errors.append(
+                        f"{case.get('case_id')}: summary is not recomputed from raw scalars"
+                    )
+            except MjwarpPpoBenchmarkError as exc:
+                errors.append(str(exc))
+        if len(run_ids) != len(set(run_ids)):
+            errors.append("process-isolated worker receipts reuse a run_id")
+        if len({canonical_sha256(snapshot) for snapshot in mjwarp_policy_abis}) != 1:
+            errors.append("mjwarp process matrix does not share one managed policy ABI")
+        if mjwarp_policy_abis:
+            profile_summary = _mapping(
+                device_receipt.get("profiler_summary"), "device.profiler_summary"
+            )
+            profile_backend = _mapping(
+                profile_summary.get("backend_receipt"),
+                "device.profiler_summary.backend_receipt",
+            )
+            policy_abi = mjwarp_policy_abis[0]
+            if profile_backend.get("task_plan_fingerprint") != policy_abi.get("plan_fingerprint"):
+                errors.append("profiler task plan fingerprint differs from training receipts")
+            if profile_backend.get("policy_abi_fingerprint") != policy_abi.get(
+                "policy_abi_fingerprint"
+            ):
+                errors.append("profiler policy ABI fingerprint differs from training receipts")
+        try:
+            expected_aggregates = build_aggregates(cases, active_binding)
+            if root.get("aggregates") != expected_aggregates:
+                errors.append("aggregates are not an exact recomputation of every raw case")
+            errors.extend(_recompute_gate(root, active_binding))
+        except (KeyError, TypeError, ValueError, MjwarpPpoBenchmarkError) as exc:
+            errors.append(f"aggregate/gate recomputation failed: {type(exc).__name__}: {exc}")
+
+        if repo_root is not None:
+            repository = repo_root.resolve()
+            _validate_source_at_commit(source, active_binding, repository, errors)
+            try:
+                plan = _load_plan(repository / DEFAULT_BASELINE_PLAN)
+                if root.get("hardware") != _hardware_payload(plan):
+                    errors.append("hardware differs from live frozen benchmark host")
+            except Exception as exc:  # noqa: BLE001 - evidence must fail on an unavailable host probe.
+                errors.append(f"hardware validation failed: {type(exc).__name__}: {exc}")
+        if artifact_path is not None:
+            _validate_trace_sibling(root, artifact_path, errors)
+    except MjwarpPpoBenchmarkError as exc:
+        errors.append(str(exc))
+    return tuple(errors)
+
+
+def validate_artifact(
+    artifact: object,
+    *,
+    binding: BenchmarkBinding | None = None,
+    repo_root: Path | None = None,
+    artifact_path: Path | None = None,
+) -> tuple[str, ...]:
+    """Validate the raw artifact and then verify its recorded gate exactly."""
+
+    core_errors = _core_validation_errors(
+        artifact, binding=binding, repo_root=repo_root, artifact_path=artifact_path
+    )
+    gate_errors: list[str] = []
+    try:
+        recorded_gate = _mapping(_mapping(artifact, "artifact").get("gate"), "gate")
+        expected_gate = {"passed": not core_errors, "errors": list(core_errors)}
+        if recorded_gate != expected_gate:
+            gate_errors.append("recorded gate does not match independent core validation")
+    except MjwarpPpoBenchmarkError as exc:
+        gate_errors.append(str(exc))
+    return (*core_errors, *gate_errors)
+
+
+def _device_profile_worker(*, output: Path, steps: int) -> int:
+    """Capture the formal public wrapper rollout path, never a benchmark monkey patch."""
+
+    import torch
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+    from torch.profiler import ProfilerActivity, profile, record_function
+
+    from unilab.training import BackendAdapter, create_env, ensure_registries
+    from unilab.training.rsl_rl_device import DeviceRslRlVecEnvWrapper
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ensure_registries()
+    GlobalHydra.instance().clear()
+    baseline_plan = _load_plan(ROOT_DIR / DEFAULT_BASELINE_PLAN)
+    with initialize_config_dir(config_dir=str(ROOT_DIR / "conf/ppo"), version_base="1.3"):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                "task=g1_walk_flat/mjwarp",
+                "algo.num_envs=128",
+                *baseline_plan.environment.hydra_overrides,
+                *COMMON_PERFORMANCE_OVERRIDES,
+                "hydra.run.dir=.",
+                "hydra.output_subdir=null",
+                "hydra/job_logging=disabled",
+                "hydra/hydra_logging=disabled",
+            ],
+        )
+    env_override = BackendAdapter(
+        cfg, root_dir=ROOT_DIR, algo_name="ppo"
+    ).build_task_env_cfg_override()
+    env = create_env(cfg, num_envs=128, env_cfg_override=env_override)
+    wrapper = DeviceRslRlVecEnvWrapper(env, device="cuda:0", reset_seed=0)
+    try:
+        actions = torch.zeros((wrapper.num_envs, wrapper.num_actions), device=wrapper.device)
+        for _ in range(3):
+            wrapper.step(actions)
+        wrapper.last_transition.completion.event.synchronize()
+        runtime_before = wrapper.runtime.traffic_diagnostics
+        wrapper_before = wrapper.traffic_diagnostics
+        with profile(activities=(ProfilerActivity.CPU, ProfilerActivity.CUDA)) as profiler:
+            with record_function("issue705.mjwarp_ppo_rollout"):
+                for _ in range(steps):
+                    wrapper.step(actions)
+            wrapper.last_transition.completion.event.synchronize()
+        profiler.export_chrome_trace(str(output))
+        trace = _mapping(json.loads(output.read_text(encoding="utf-8")), "profiler trace")
+        h2d, d2h, sync = _trace_transfer_counts(trace, scope_name="issue705.mjwarp_ppo_rollout")
+        runtime_after = wrapper.runtime.traffic_diagnostics
+        wrapper.finish_rollout()
+        wrapper_after = wrapper.traffic_diagnostics
+        policy_abi = wrapper.runtime.policy_abi_snapshot
+        payload = {
+            "steps": steps,
+            "runtime_delta": {
+                "host_to_device_transfers": runtime_after.host_to_device_transfers
+                - runtime_before.host_to_device_transfers,
+                "device_to_host_transfers": runtime_after.device_to_host_transfers
+                - runtime_before.device_to_host_transfers,
+                "global_synchronizations": runtime_after.global_synchronizations
+                - runtime_before.global_synchronizations,
+            },
+            "wrapper_delta": {
+                "action_publications": wrapper_after.action_publications
+                - wrapper_before.action_publications,
+                "finite_metric_materializations": wrapper_after.finite_metric_materializations
+                - wrapper_before.finite_metric_materializations,
+                "finite_metric_device_to_host_bytes": wrapper_after.finite_metric_device_to_host_bytes
+                - wrapper_before.finite_metric_device_to_host_bytes,
+            },
+            "trace_counts": {
+                "host_to_device_transfers": h2d,
+                "device_to_host_transfers": d2h,
+                "global_synchronizations": sync,
+            },
+            "backend_receipt": {
+                "backend_type": wrapper.runtime.bound_plan.backend_type,
+                "execution_profile": wrapper.runtime.bound_plan.execution_profile.value,
+                "task_plan_fingerprint": wrapper.runtime.plan.fingerprint,
+                "policy_abi_fingerprint": policy_abi["policy_abi_fingerprint"],
+                "backend_plan_fingerprint": wrapper.runtime.bound_plan.fingerprint,
+            },
+        }
+        output.with_suffix(".summary.json").write_text(
+            json.dumps(payload, sort_keys=True), encoding="utf-8"
+        )
+    finally:
+        wrapper.close()
+    return 0
+
+
+def _run_profile_case(
+    baseline_plan: Any, *, trace_output: Path
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Capture profiler evidence in a fresh owner-route process."""
+
+    trace_output.parent.mkdir(parents=True, exist_ok=True)
+    summary_output = trace_output.with_suffix(".summary.json")
+    command = [
+        "uv",
+        "run",
+        "benchmark/rl/benchmark_mjwarp_ppo.py",
+        "--profile-worker",
+        "--profile-steps",
+        str(PROFILE_STEPS),
+        "--trace-out",
+        str(trace_output),
+    ]
+    process, _, stdout, stderr = _run_subprocess(command, baseline_plan)
+    if process["return_code"] != 0 or not trace_output.is_file() or not summary_output.is_file():
+        raise MjwarpPpoBenchmarkError(
+            f"device profiler worker failed\nstdout:\n{stdout[-6000:]}\nstderr:\n{stderr[-6000:]}"
+        )
+    try:
+        summary = _mapping(
+            json.loads(summary_output.read_text(encoding="utf-8")), "profile summary"
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise MjwarpPpoBenchmarkError(f"device profile summary cannot be loaded: {exc}") from exc
+    return process, dict(summary)
+
+
+def _contention_worker(*, ready_file: Path, stop_file: Path) -> int:
+    """Run a declared, reproducible GPU compute load until the parent stops it."""
+
+    import torch
+
+    ready_file.parent.mkdir(parents=True, exist_ok=True)
+    stop_file.parent.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda:0")
+    left = torch.randn((2048, 2048), device=device)
+    right = torch.randn((2048, 2048), device=device)
+    result = torch.empty((2048, 2048), device=device)
+    torch.mm(left, right, out=result)
+    torch.cuda.synchronize(device)
+    ready_file.write_text("ready", encoding="utf-8")
+    while not stop_file.exists():
+        torch.mm(left, right, out=result)
+        torch.cuda.synchronize(device)
+    return 0
+
+
+def _run_contention_case(
+    binding: BenchmarkBinding,
+    baseline_plan: Any,
+    *,
+    repeat: int,
+) -> dict[str, Any]:
+    """Measure a device case while an explicitly-owned same-GPU load is active."""
+
+    with tempfile.TemporaryDirectory(prefix="unilab_issue705_p5_contention_") as temp_dir:
+        root = Path(temp_dir)
+        ready = root / "ready"
+        stop = root / "stop"
+        stdout_path = root / "load.stdout"
+        stderr_path = root / "load.stderr"
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            load = subprocess.Popen(
+                [
+                    "uv",
+                    "run",
+                    "benchmark/rl/benchmark_mjwarp_ppo.py",
+                    "--contention-worker",
+                    "--ready-file",
+                    str(ready),
+                    "--stop-file",
+                    str(stop),
+                ],
+                cwd=ROOT_DIR,
+                env={**os.environ, **dict(baseline_plan.environment.env_vars)},
+                stdout=stdout,
+                stderr=stderr,
+                preexec_fn=lambda: os.sched_setaffinity(
+                    0, set(baseline_plan.hardware.affinity_cpus)
+                ),
+            )
+            deadline = time.monotonic() + 60.0
+            while not ready.exists() and time.monotonic() < deadline and load.poll() is None:
+                time.sleep(0.05)
+            if not ready.exists():
+                load.kill()
+                raise MjwarpPpoBenchmarkError("contention worker did not become ready")
+            try:
+                case = _run_training_case(
+                    binding,
+                    baseline_plan,
+                    mode="mjwarp_device",
+                    batch_size=1024,
+                    seed=repeat,
+                    iterations=CONTENTION_ITERATIONS,
+                    lane="contention",
+                    repeat_index=repeat,
+                    sequence_index=None,
+                )
+            finally:
+                stop.write_text("stop", encoding="utf-8")
+                with suppress(subprocess.TimeoutExpired):
+                    load.wait(timeout=30.0)
+                if load.poll() is None:
+                    load.kill()
+        case["contention"] = {
+            "load_worker_return_code": load.returncode,
+            "load_worker_stdout_sha256": _sha256_path(stdout_path),
+            "load_worker_stderr_sha256": _sha256_path(stderr_path),
+            "load_worker_matrix": [2048, 2048],
+        }
+    return case
+
+
+def _execute_worker_case(*, case_id: str, output: Path) -> int:
+    """Execute one registered case and serialize its inner owner-process receipt."""
+
+    binding = load_binding()
+    expected = expected_case_specs(binding).get(case_id)
+    if expected is None:
+        raise MjwarpPpoBenchmarkError(f"worker case {case_id!r} is not registered")
+    baseline_plan = _load_plan(ROOT_DIR / DEFAULT_BASELINE_PLAN)
+    if expected["lane"] == "contention":
+        case = _run_contention_case(
+            binding,
+            baseline_plan,
+            repeat=cast(int, expected["repeat_index"]),
+        )
+    else:
+        case = _run_training_case(
+            binding,
+            baseline_plan,
+            mode=cast(str, expected["mode"]),
+            batch_size=cast(int, expected["batch_size"]),
+            seed=cast(int, expected["seed"]),
+            iterations=cast(int, expected["iterations"]),
+            lane=cast(str, expected["lane"]),
+            repeat_index=cast(int | None, expected["repeat_index"]),
+            sequence_index=cast(int | None, expected["sequence_index"]),
+        )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(_json_safe(case), sort_keys=True), encoding="utf-8")
+    return 0
+
+
+def _run_registered_case_process(
+    baseline_plan: Any,
+    *,
+    case_id: str,
+) -> dict[str, Any]:
+    """Run one benchmark worker in a fresh process and retain both process layers."""
+
+    with tempfile.TemporaryDirectory(prefix=f"unilab_issue705_p5_worker_{case_id}_") as temp_dir:
+        output = Path(temp_dir) / "case.json"
+        command = [
+            "uv",
+            "run",
+            "benchmark/rl/benchmark_mjwarp_ppo.py",
+            "--worker",
+            "--case-id",
+            case_id,
+            "--worker-out",
+            str(output),
+        ]
+        process, _, stdout, stderr = _run_subprocess(command, baseline_plan)
+        if process["return_code"] != 0 or not output.is_file():
+            raise MjwarpPpoBenchmarkError(
+                f"registered worker {case_id} failed\n"
+                f"stdout:\n{stdout[-6000:]}\nstderr:\n{stderr[-6000:]}"
+            )
+        try:
+            case = _mapping(json.loads(output.read_text(encoding="utf-8")), case_id)
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise MjwarpPpoBenchmarkError(f"worker {case_id} output is invalid: {exc}") from exc
+    result = dict(case)
+    result["orchestrator_process"] = process
+    return result
+
+
+def collect_artifact(*, output: Path, trace_output: Path) -> dict[str, Any]:
+    """Execute the complete pre-registered matrix and return a self-validating artifact."""
+
+    output = output.resolve()
+    trace_output = trace_output.resolve()
+    if output.is_relative_to(ROOT_DIR) or trace_output.is_relative_to(ROOT_DIR):
+        raise MjwarpPpoBenchmarkError(
+            "benchmark raw output and trace must be outside the repository"
+        )
+    if output.parent != trace_output.parent or output == trace_output:
+        raise MjwarpPpoBenchmarkError("benchmark artifact and trace must be distinct sibling files")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    binding = load_binding()
+    baseline_plan = _load_plan(ROOT_DIR / DEFAULT_BASELINE_PLAN)
+    source = _source_payload()
+    if source["commit"] == binding.threshold_freeze_commit:
+        raise MjwarpPpoBenchmarkError(
+            "candidate benchmark cannot run at the threshold freeze commit"
+        )
+    hardware = _hardware_payload(baseline_plan)
+    preflight_before = _preflight_payload(baseline_plan)
+    cases: list[dict[str, Any]] = []
+    registered_cases = expected_case_specs(binding)
+    total = len(registered_cases)
+    for case_id in registered_cases:
+        case = _run_registered_case_process(baseline_plan, case_id=case_id)
+        cases.append(case)
+        print(f"[{len(cases):02d}/{total:02d}] {case['case_id']} PASS", flush=True)
+    profile_process, profile_raw = _run_profile_case(baseline_plan, trace_output=trace_output)
+    profile = _mapping(profile_raw, "profile summary")
+    runtime_delta = _mapping(profile.get("runtime_delta"), "profile runtime delta")
+    wrapper_delta = _mapping(profile.get("wrapper_delta"), "profile wrapper delta")
+    trace_counts = _mapping(profile.get("trace_counts"), "profile trace counts")
+    _assert_capture_source_unchanged(source)
+    aggregates = build_aggregates(cases, binding)
+    artifact: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE,
+        "kind": ARTIFACT_KIND,
+        "profile": PROFILE,
+        "generated_at": _utc_now(),
+        "source": source,
+        "threshold": {
+            "threshold_set_id": binding.threshold_set_id,
+            "manifest_path": binding.threshold_manifest_path.as_posix(),
+            "manifest_sha256": binding.threshold_manifest_sha256,
+            "freeze_commit": binding.threshold_freeze_commit,
+        },
+        "hardware": hardware,
+        "execution": {
+            "process_isolation": True,
+            "throughput_iterations": THROUGHPUT_ITERATIONS,
+            "contention_iterations": CONTENTION_ITERATIONS,
+            "frozen_hydra_overrides": list(binding.hydra_overrides),
+            "common_performance_overrides": list(COMMON_PERFORMANCE_OVERRIDES),
+            "preflight_before": preflight_before,
+            "preflight_after": _preflight_payload(baseline_plan, enforce_cpu_load=False),
+        },
+        "cases": cases,
+        "aggregates": aggregates,
+        "device": {
+            "gpu_capacity_bytes": binding.gpu_capacity_bytes,
+            "peak_gpu_reserved_bytes": max(
+                int(case["summary"]["peak_gpu_memory_reserved_bytes"])
+                for case in cases
+                if case["mode"] == "mjwarp_device"
+            ),
+            "h2d_per_policy_step": runtime_delta["host_to_device_transfers"] / PROFILE_STEPS,
+            "d2h_per_policy_step": runtime_delta["device_to_host_transfers"] / PROFILE_STEPS,
+            "host_global_sync_per_policy_step": runtime_delta["global_synchronizations"]
+            / PROFILE_STEPS,
+            "metrics_materializations": wrapper_delta["finite_metric_materializations"],
+            "metrics_device_to_host_bytes": wrapper_delta["finite_metric_device_to_host_bytes"],
+            "profiler_reconciled": (
+                trace_counts["host_to_device_transfers"],
+                trace_counts["device_to_host_transfers"],
+                trace_counts["global_synchronizations"],
+            )
+            == (
+                runtime_delta["host_to_device_transfers"],
+                runtime_delta["device_to_host_transfers"],
+                runtime_delta["global_synchronizations"],
+            ),
+            "profiler_process": profile_process,
+            "profiler_summary": dict(profile),
+            "profiler_trace": {"filename": trace_output.name, "sha256": _sha256_path(trace_output)},
+        },
+    }
+    core_errors = _core_validation_errors(
+        artifact,
+        binding=binding,
+        repo_root=ROOT_DIR,
+        artifact_path=output,
+    )
+    artifact["gate"] = {"passed": not core_errors, "errors": list(core_errors)}
+    errors = validate_artifact(
+        artifact,
+        binding=binding,
+        repo_root=ROOT_DIR,
+        artifact_path=output,
+    )
+    if errors:
+        raise MjwarpPpoBenchmarkError(
+            "generated benchmark artifact failed validation:\n- " + "\n- ".join(errors)
+        )
+    return artifact
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--list-cases", action="store_true")
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--case-id")
+    parser.add_argument("--worker-out", type=Path)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--trace-out", type=Path, default=DEFAULT_TRACE_OUTPUT)
+    parser.add_argument("--validate-artifact", type=Path)
+    parser.add_argument("--profile-worker", action="store_true")
+    parser.add_argument("--profile-steps", type=int, default=PROFILE_STEPS)
+    parser.add_argument("--contention-worker", action="store_true")
+    parser.add_argument("--ready-file", type=Path)
+    parser.add_argument("--stop-file", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.list_cases:
+        for case_id in expected_case_specs(load_binding()):
+            print(case_id)
+        return 0
+    if args.worker:
+        if args.case_id is None or args.worker_out is None:
+            raise SystemExit("worker requires --case-id and --worker-out")
+        return _execute_worker_case(case_id=args.case_id, output=args.worker_out)
+    if args.profile_worker:
+        if args.profile_steps <= 0:
+            raise SystemExit("--profile-steps must be positive")
+        return _device_profile_worker(output=args.trace_out, steps=args.profile_steps)
+    if args.contention_worker:
+        if args.ready_file is None or args.stop_file is None:
+            raise SystemExit("contention worker requires --ready-file and --stop-file")
+        return _contention_worker(ready_file=args.ready_file, stop_file=args.stop_file)
+    if args.validate_artifact is not None:
+        path = args.validate_artifact.resolve()
+        artifact = json.loads(path.read_text(encoding="utf-8"))
+        errors = validate_artifact(artifact, repo_root=ROOT_DIR, artifact_path=path)
+        if errors:
+            print("FAIL")
+            for error in errors:
+                print(f"- {error}")
+            return 1
+        print(f"PASS {path}")
+        return 0
+    if not args.execute:
+        raise SystemExit("Refusing to run implicitly; pass --execute or --validate-artifact")
+    output = args.out.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    artifact = collect_artifact(output=output, trace_output=args.trace_out)
+    output.write_text(json.dumps(_json_safe(artifact), indent=2, sort_keys=True), encoding="utf-8")
+    print(f"PASS wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_mjwarp_ppo_benchmark.py
+++ b/tests/benchmark/test_mjwarp_ppo_benchmark.py
@@ -1,0 +1,463 @@
+"""Contract and tamper tests for the Issue #705 mjwarp PPO benchmark."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from benchmark.rl import benchmark_mjwarp_ppo as ppo_benchmark
+
+
+def _scalars(*, iterations: int, fps: float = 30_000.0, reward: float = -0.4) -> dict[str, Any]:
+    values = {
+        "Perf/total_fps": fps,
+        "Perf/collection_time": 0.8,
+        "Perf/learning_time": 0.06,
+        "Train/mean_reward": reward,
+        "Train/mean_episode_length": 20.0,
+    }
+    return {
+        tag: [
+            {"step": step, "wall_time": float(step), "value": value} for step in range(iterations)
+        ]
+        for tag, value in values.items()
+    }
+
+
+def _case(
+    *,
+    binding: ppo_benchmark.BenchmarkBinding,
+    case_id: str,
+    expected: dict[str, Any],
+    ordinal: int,
+) -> dict[str, Any]:
+    backend, profile = ppo_benchmark._mode_owner(expected["mode"])
+    policy_abi = {
+        "plan_fingerprint": "managed-g1-plan-v1",
+        "policy_abi_fingerprint": "managed-g1-policy-v1",
+        "executor_key": "mjwarp.device.g1.v1",
+        "execution_profile": ppo_benchmark.PROFILE,
+    }
+    run_config = {
+        "run": {"sim_backend": backend, "device": "cuda:0"},
+        "config": {
+            "training": {
+                "sim_backend": backend,
+                **({"execution_profile": profile} if backend == "mjwarp" else {}),
+            },
+            "algo": {
+                "num_envs": expected["batch_size"],
+                "num_steps_per_env": binding.behavior_steps_per_env,
+                "max_iterations": expected["iterations"],
+                "seed": expected["seed"],
+            },
+            "env": {
+                "noise_config": {"level": 0.0},
+                "domain_rand": {"randomize_kp": False, "randomize_kd": False},
+                "curriculum": {"enabled": False},
+            },
+        },
+        "contract_snapshot": ({"manager.policy_abi": policy_abi} if backend == "mjwarp" else {}),
+    }
+    peak_rss = 2_000_000_000 if expected["lane"] == "behavior" else 1_000_000_000
+    raw = {
+        "scalars": _scalars(iterations=expected["iterations"]),
+        "memory_samples": [{"elapsed_sec": 0.0, "rss_bytes": peak_rss}],
+        "run_config": run_config,
+        "run_config_sha256": ppo_benchmark.canonical_sha256(run_config),
+        "run_summary": {
+            "status": "completed",
+            "completed_iterations": expected["iterations"],
+            "training_wall_time_sec": 1.0,
+            "peak_process_rss_bytes": peak_rss,
+            "peak_gpu_memory_allocated_bytes": 200_000_000,
+            "peak_gpu_memory_reserved_bytes": 300_000_000,
+        },
+    }
+    case: dict[str, Any] = {
+        "case_id": case_id,
+        **expected,
+        "expected_execution_profile": profile,
+        "orchestrator_process": {
+            "run_id": f"synthetic-orchestrator-{ordinal}",
+            "duration_sec": 2.0,
+            "return_code": 0,
+            "command": [
+                "uv",
+                "run",
+                "benchmark/rl/benchmark_mjwarp_ppo.py",
+                "--worker",
+                "--case-id",
+                case_id,
+            ],
+            "affinity_cpus": list(binding.affinity_cpus),
+            "env_vars": dict(binding.environment_vars),
+            "stdout_sha256": "sha256:" + "a" * 64,
+            "stderr_sha256": "sha256:" + "b" * 64,
+        },
+        "process": {
+            "run_id": f"synthetic-worker-{ordinal}",
+            "pid": ordinal + 1,
+            "started_at": "2026-07-29T00:00:00+00:00",
+            "duration_sec": 1.0,
+            "return_code": 0,
+            "command": [
+                "uv",
+                "run",
+                "scripts/train_rsl_rl.py",
+                f"task=g1_walk_flat/{backend}",
+                f"algo.seed={expected['seed']}",
+                f"algo.num_envs={expected['batch_size']}",
+                f"algo.num_steps_per_env={binding.behavior_steps_per_env}",
+                f"algo.max_iterations={expected['iterations']}",
+                "training.no_play=true",
+                "training.logger=tensorboard",
+                *binding.hydra_overrides,
+                *ppo_benchmark.COMMON_PERFORMANCE_OVERRIDES,
+            ],
+            "affinity_cpus": list(binding.affinity_cpus),
+            "env_vars": dict(binding.environment_vars),
+            "stdout_sha256": "sha256:" + "1" * 64,
+            "stderr_sha256": "sha256:" + "2" * 64,
+        },
+        "raw": raw,
+        "summary": ppo_benchmark.summarize_training_raw(
+            raw, warmup_iterations=binding.warmup_iterations
+        ),
+    }
+    if expected["lane"] == "contention":
+        case["contention"] = {
+            "load_worker_return_code": 0,
+            "load_worker_stdout_sha256": "sha256:" + "3" * 64,
+            "load_worker_stderr_sha256": "sha256:" + "4" * 64,
+            "load_worker_matrix": [2048, 2048],
+        }
+    return case
+
+
+def _artifact() -> tuple[dict[str, Any], ppo_benchmark.BenchmarkBinding]:
+    binding = ppo_benchmark.load_binding()
+    specs = ppo_benchmark.expected_case_specs(binding)
+    cases = [
+        _case(binding=binding, case_id=case_id, expected=expected, ordinal=ordinal)
+        for ordinal, (case_id, expected) in enumerate(specs.items())
+    ]
+    artifact: dict[str, Any] = {
+        "schema_version": ppo_benchmark.SCHEMA_VERSION,
+        "issue": ppo_benchmark.ISSUE,
+        "kind": ppo_benchmark.ARTIFACT_KIND,
+        "profile": ppo_benchmark.PROFILE,
+        "generated_at": "2026-07-29T00:00:00+00:00",
+        "source": {
+            "commit": "b" * 40,
+            "branch": "feat/issue-789-mjwarp-ppo-benchmark",
+            "dirty": False,
+            "tree_sha256": "sha256:" + "5" * 64,
+            "uv_lock_sha256": "sha256:" + "6" * 64,
+            "owner_yaml_sha256": "sha256:" + "7" * 64,
+        },
+        "threshold": {
+            "threshold_set_id": binding.threshold_set_id,
+            "manifest_path": binding.threshold_manifest_path.as_posix(),
+            "manifest_sha256": binding.threshold_manifest_sha256,
+            "freeze_commit": binding.threshold_freeze_commit,
+        },
+        "hardware": {
+            "gpu_name": binding.gpu_name,
+            "gpu_uuid": binding.gpu_uuid,
+            "gpu_memory_mib": binding.gpu_capacity_bytes // 1024**2,
+            "driver_version": binding.gpu_driver_version,
+            "affinity_cpus": list(binding.affinity_cpus),
+        },
+        "execution": {
+            "process_isolation": True,
+            "throughput_iterations": ppo_benchmark.THROUGHPUT_ITERATIONS,
+            "contention_iterations": ppo_benchmark.CONTENTION_ITERATIONS,
+            "frozen_hydra_overrides": list(binding.hydra_overrides),
+            "common_performance_overrides": list(ppo_benchmark.COMMON_PERFORMANCE_OVERRIDES),
+            "preflight_before": {"gpu_compute_processes": []},
+            "preflight_after": {"gpu_compute_processes": []},
+        },
+        "cases": cases,
+        "aggregates": ppo_benchmark.build_aggregates(cases, binding),
+        "device": {
+            "gpu_capacity_bytes": binding.gpu_capacity_bytes,
+            "peak_gpu_reserved_bytes": 300_000_000,
+            "h2d_per_policy_step": 0.0,
+            "d2h_per_policy_step": 0.0,
+            "host_global_sync_per_policy_step": 0.0,
+            "metrics_materializations": 1,
+            "metrics_device_to_host_bytes": 1,
+            "profiler_reconciled": True,
+            "profiler_process": {
+                "run_id": "synthetic-profiler",
+                "duration_sec": 1.0,
+                "return_code": 0,
+                "command": [
+                    "uv",
+                    "run",
+                    "benchmark/rl/benchmark_mjwarp_ppo.py",
+                    "--profile-worker",
+                ],
+                "affinity_cpus": list(binding.affinity_cpus),
+                "env_vars": dict(binding.environment_vars),
+                "stdout_sha256": "sha256:" + "8" * 64,
+                "stderr_sha256": "sha256:" + "9" * 64,
+            },
+            "profiler_summary": {
+                "steps": ppo_benchmark.PROFILE_STEPS,
+                "runtime_delta": {
+                    "host_to_device_transfers": 0,
+                    "device_to_host_transfers": 0,
+                    "global_synchronizations": 0,
+                },
+                "wrapper_delta": {
+                    "action_publications": ppo_benchmark.PROFILE_STEPS,
+                    "finite_metric_materializations": 1,
+                    "finite_metric_device_to_host_bytes": 1,
+                },
+                "trace_counts": {
+                    "host_to_device_transfers": 0,
+                    "device_to_host_transfers": 0,
+                    "global_synchronizations": 0,
+                },
+                "backend_receipt": {
+                    "backend_type": "mjwarp",
+                    "execution_profile": ppo_benchmark.PROFILE,
+                    "task_plan_fingerprint": "managed-g1-plan-v1",
+                    "policy_abi_fingerprint": "managed-g1-policy-v1",
+                    "backend_plan_fingerprint": "mjwarp-bound-plan-v1",
+                },
+            },
+            "profiler_trace": {
+                "filename": "phase_5_mjwarp_ppo_trace.json",
+                "sha256": "sha256:" + "a" * 64,
+            },
+        },
+    }
+    _refresh(artifact, binding)
+    return artifact, binding
+
+
+def _refresh(artifact: dict[str, Any], binding: ppo_benchmark.BenchmarkBinding) -> None:
+    for case in artifact["cases"]:
+        case["summary"] = ppo_benchmark.summarize_training_raw(
+            case["raw"], warmup_iterations=binding.warmup_iterations
+        )
+    artifact["aggregates"] = ppo_benchmark.build_aggregates(artifact["cases"], binding)
+    artifact["device"]["peak_gpu_reserved_bytes"] = max(
+        case["summary"]["peak_gpu_memory_reserved_bytes"]
+        for case in artifact["cases"]
+        if case["mode"] == "mjwarp_device"
+    )
+    core_errors = ppo_benchmark._core_validation_errors(artifact, binding=binding)
+    artifact["gate"] = {"passed": not core_errors, "errors": list(core_errors)}
+
+
+def test_frozen_matrix_is_complete_and_pair_order_is_interleaved(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    binding = ppo_benchmark.load_binding()
+    specs = ppo_benchmark.expected_case_specs(binding)
+    assert len(specs) == 40
+    assert set(specs) == set(ppo_benchmark.expected_case_ids(binding))
+    assert specs["throughput-mujoco_host-b128-r0"]["sequence_index"] == 0
+    assert specs["throughput-mjwarp_device-b128-r1"]["sequence_index"] == 0
+    assert tuple(specs)[-1] == "contention-mjwarp_device-b1024-r4"
+    assert ppo_benchmark.main(["--list-cases"]) == 0
+    assert capsys.readouterr().out.splitlines() == list(specs)
+
+
+def test_worker_cli_requires_and_forwards_a_registered_case(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(SystemExit, match="requires --case-id"):
+        ppo_benchmark.main(["--worker"])
+    calls: list[tuple[str, Path]] = []
+    monkeypatch.setattr(
+        ppo_benchmark,
+        "_execute_worker_case",
+        lambda *, case_id, output: calls.append((case_id, output)) or 0,
+    )
+    output = tmp_path / "case.json"
+    assert (
+        ppo_benchmark.main(
+            [
+                "--worker",
+                "--case-id",
+                "throughput-mujoco_host-b128-r0",
+                "--worker-out",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    assert calls == [("throughput-mujoco_host-b128-r0", output)]
+
+
+def test_complete_artifact_passes_independent_gate_recomputation() -> None:
+    artifact, binding = _artifact()
+    assert artifact["gate"] == {"passed": True, "errors": []}
+    assert ppo_benchmark.validate_artifact(artifact, binding=binding) == ()
+
+
+def test_gate_is_not_self_referential_and_recorded_result_must_match() -> None:
+    artifact, binding = _artifact()
+    gate = artifact.pop("gate")
+    assert ppo_benchmark._core_validation_errors(artifact, binding=binding) == ()
+    assert any(
+        "gate must be a mapping" in error
+        for error in ppo_benchmark.validate_artifact(artifact, binding=binding)
+    )
+
+    artifact["gate"] = gate
+    artifact["gate"]["passed"] = False
+    assert any(
+        "recorded gate" in error
+        for error in ppo_benchmark.validate_artifact(artifact, binding=binding)
+    )
+
+
+def test_matrix_process_and_contention_tampering_fail_closed() -> None:
+    artifact, binding = _artifact()
+    artifact["cases"].pop()
+    artifact["cases"][0]["process"]["return_code"] = 1
+    artifact["cases"][0]["orchestrator_process"]["command"] = ["uv", "run", "wrong.py"]
+    artifact["cases"][1]["sequence_index"] = 99
+    contention = next(case for case in artifact["cases"] if case["lane"] == "contention")
+    contention["contention"]["load_worker_matrix"] = [1024, 1024]
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding)
+    assert any("matrix is incomplete" in error for error in errors)
+    assert any("worker did not succeed" in error for error in errors)
+    assert any("registered worker CLI" in error for error in errors)
+    assert any("sequence_index differs" in error for error in errors)
+    assert any("contention worker matrix" in error for error in errors)
+
+
+def test_production_benchmark_uses_side_effect_free_evidence_helpers() -> None:
+    assert ppo_benchmark._event_scalars.__module__ == "benchmark.issue705.process_evidence"
+    assert "benchmark/issue705/benchmark_g1_phase0.py" not in ppo_benchmark.SOURCE_INPUTS
+    assert "benchmark/issue705/process_evidence.py" in ppo_benchmark.SOURCE_INPUTS
+
+
+def test_scalar_failure_nonfinite_value_and_filtered_iteration_fail_closed() -> None:
+    artifact, binding = _artifact()
+    first = artifact["cases"][0]
+    first["raw"]["scalars"]["Perf/total_fps"][10]["value"] = float("nan")
+    behavior = next(case for case in artifact["cases"] if case["lane"] == "behavior")
+    behavior["raw"]["scalars"]["Train/mean_reward"].pop()
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding)
+    assert any("finite number" in error for error in errors)
+    assert any("every iteration exactly once" in error for error in errors)
+
+
+def test_provenance_owner_policy_and_aggregate_tampering_fail_closed() -> None:
+    artifact, binding = _artifact()
+    artifact["threshold"]["manifest_sha256"] = "sha256:" + "0" * 64
+    artifact["hardware"]["gpu_uuid"] = "wrong-gpu"
+    artifact["source"]["dirty"] = True
+    device_case = next(case for case in artifact["cases"] if case["mode"] == "mjwarp_device")
+    device_case["raw"]["run_config"]["contract_snapshot"]["manager.policy_abi"][
+        "execution_profile"
+    ] = "host_numpy"
+    artifact["aggregates"]["behavior"]["fps_p50_median"] = 999_999.0
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding)
+    assert any("threshold differs" in error for error in errors)
+    assert any("hardware.gpu_uuid" in error for error in errors)
+    assert any("source must be clean" in error for error in errors)
+    assert any("execution profile" in error for error in errors)
+    assert any("aggregates are not" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("fault", "expected_error"),
+    [
+        ("throughput", "iteration p50 violates"),
+        ("training", "reward AUC violates"),
+        ("memory", "reserved capacity ratio violates"),
+        ("transfer", "h2d_per_policy_step violates"),
+    ],
+)
+def test_each_frozen_gate_failure_is_recomputed_from_raw(fault: str, expected_error: str) -> None:
+    artifact, binding = _artifact()
+    if fault == "throughput":
+        for case in artifact["cases"]:
+            if case["lane"] == "throughput" and case["mode"] == "mjwarp_device":
+                for point in case["raw"]["scalars"]["Perf/collection_time"]:
+                    point["value"] = 2.0
+    elif fault == "training":
+        for case in artifact["cases"]:
+            if case["lane"] == "behavior":
+                for point in case["raw"]["scalars"]["Train/mean_reward"]:
+                    point["value"] = -10.0
+    elif fault == "memory":
+        for case in artifact["cases"]:
+            if case["mode"] == "mjwarp_device":
+                case["raw"]["run_summary"]["peak_gpu_memory_reserved_bytes"] = int(
+                    binding.gpu_capacity_bytes * 0.9
+                )
+    else:
+        profile = artifact["device"]["profiler_summary"]
+        profile["runtime_delta"]["host_to_device_transfers"] = ppo_benchmark.PROFILE_STEPS
+        profile["trace_counts"]["host_to_device_transfers"] = ppo_benchmark.PROFILE_STEPS
+        artifact["device"]["h2d_per_policy_step"] = 1.0
+    _refresh(artifact, binding)
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding)
+    assert any(expected_error in error for error in errors)
+    assert artifact["gate"]["passed"] is False
+
+
+def test_profiler_trace_sidecar_hash_and_counts_are_independently_checked(
+    tmp_path: Path,
+) -> None:
+    artifact, binding = _artifact()
+    artifact_path = tmp_path / "phase_5_mjwarp_ppo.json"
+    trace_path = tmp_path / artifact["device"]["profiler_trace"]["filename"]
+    trace = {
+        "traceEvents": [
+            {
+                "name": "issue705.mjwarp_ppo_rollout",
+                "cat": "user_annotation",
+                "ts": 0.0,
+                "dur": 100.0,
+            }
+        ]
+    }
+    trace_path.write_text(json.dumps(trace), encoding="utf-8")
+    artifact["device"]["profiler_trace"]["sha256"] = ppo_benchmark._sha256_path(trace_path)
+    core_errors = ppo_benchmark._core_validation_errors(
+        artifact, binding=binding, artifact_path=artifact_path
+    )
+    artifact["gate"] = {"passed": not core_errors, "errors": list(core_errors)}
+    assert (
+        ppo_benchmark.validate_artifact(artifact, binding=binding, artifact_path=artifact_path)
+        == ()
+    )
+
+    trace["traceEvents"].append(
+        {"name": "Memcpy DtoH", "cat": "cuda_runtime", "ts": 50.0, "dur": 1.0}
+    )
+    trace_path.write_text(json.dumps(trace), encoding="utf-8")
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding, artifact_path=artifact_path)
+    assert any("trace hash" in error for error in errors)
+
+
+def test_expensive_capture_is_explicit_and_requires_clean_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(SystemExit, match="Refusing to run implicitly"):
+        ppo_benchmark.main([])
+    monkeypatch.setattr(ppo_benchmark, "_git", lambda *_: " M benchmark/rl/benchmark_mjwarp_ppo.py")
+    with pytest.raises(ppo_benchmark.MjwarpPpoBenchmarkError, match="clean git worktree"):
+        ppo_benchmark._source_payload()
+
+
+def test_capture_outputs_must_be_external_siblings(tmp_path: Path) -> None:
+    with pytest.raises(ppo_benchmark.MjwarpPpoBenchmarkError, match="sibling"):
+        ppo_benchmark.collect_artifact(
+            output=tmp_path / "one" / "artifact.json",
+            trace_output=tmp_path / "two" / "trace.json",
+        )


### PR DESCRIPTION
Closes #789

Part of #705

## 变更
- 新增 `benchmark/rl/benchmark_mjwarp_ppo.py`：冻结的 40-case PPO benchmark matrix，提供 `--worker`、`--execute`、`--validate-artifact`、独立 profiler worker 与显式共卡 contention worker。
- 每个样本同时保留 benchmark worker 与正式 `scripts/train_rsl_rl.py` owner route 的独立进程 receipt；raw TensorBoard scalar、RSS、GPU memory、run config/summary、policy ABI、source/lock/owner/hardware/profiler provenance 都进入 artifact。
- validator 从 raw 重算 p50/p95/CV、iteration/collection/learner、training behavior、memory、transfer 与 contention 指标，并对 matrix、source ancestry/tree、阈值 receipt、ABI、trace sibling/hash、worker order 和 recorded gate fail closed。
- 新增 side-effect-free `benchmark/issue705/process_evidence.py`。避免导入旧 `benchmark_env_step` 的 benchmark-only `mjwarp` factory monkey patch，确保 PPO/profiler 只走 production backend registry。
- 新增 15 个 synthetic/tamper tests；本 PR 不提交真实性能 artifact，也不提升 Phase 5 manifest 或 claim 状态。

## Contract / scope
- `mjwarp` 保持独立 backend；benchmark 不读取 backend 私有对象。
- profiler 使用正式 `DeviceRslRlVecEnvWrapper`，只在 rollout scope 外做 completion wait；metrics materialization 单独记录。
- 保持 `P5-TRAIN-PERFORMANCE` 为 target，后续 clean commit capture 才能生成并提交 Phase 5 evidence artifact。

## Validation
- `make test-all` — `2038 passed, 50 skipped, 359 deselected, 1 xfailed`
- `uv run pytest tests/benchmark/test_mjwarp_ppo_benchmark.py tests/benchmark/test_issue705_g1_baseline_runner.py tests/benchmark/test_managed_g1_host_benchmark.py -q` — `34 passed`
- `uv run scripts/audit_issue705_backend_isolation.py`
- `uv run scripts/audit_issue705_workflow_triggers.py`
- `uv run scripts/audit_issue705_claims.py --all`
- `uv run scripts/validate_issue705_phase.py --phase 5 --mode schema`
- 真实 CUDA probe：正式 profiler worker (`--profile-steps 2`) 输出 `H2D=0/D2H=0/global_synchronizations=0`；正式 `throughput-mjwarp_device-b128-r0` worker 完成 20 iteration，并产出 owner/config/scalar receipt。以上仅为连通性 probe，不是性能 gate artifact。

## 自查
1. owner/isolation：发现初版复用 Phase 0 helper 会导入 benchmark-only mjwarp patch，已拆为无副作用 helper，并以真实 production CUDA probe 验证。
2. evidence/gate：将 core validation 与 recorded gate 校验拆分，加入 aggregate/provenance/trace/worker/contention 篡改测试，避免 self-reference 与事后伪造。
