### PR TITLE
fix: 对齐 PPO benchmark 的跨 owner DR override

### DIFF
--- a/benchmark/rl/benchmark_mjwarp_ppo.py
+++ b/benchmark/rl/benchmark_mjwarp_ppo.py
@@ -92,8 +92,13 @@ CONTENTION_ITERATIONS = 20
 PROFILE_STEPS = 16
 COMMON_PERFORMANCE_OVERRIDES = (
     "env.noise_config.level=0.0",
-    "env.domain_rand.randomize_kp=false",
-    "env.domain_rand.randomize_kd=false",
+    # ``mujoco`` intentionally leaves these dataclass defaults out of its
+    # owner YAML, whereas the independent ``mjwarp`` owner declares them to
+    # fail closed.  Hydra's force-add/override form is the only config-first
+    # spelling that produces the same explicit benchmark profile for both
+    # owners without changing either production default.
+    "++env.domain_rand.randomize_kp=false",
+    "++env.domain_rand.randomize_kd=false",
     "env.curriculum.enabled=false",
 )
 SOURCE_INPUTS = (

--- a/tests/benchmark/test_mjwarp_ppo_benchmark.py
+++ b/tests/benchmark/test_mjwarp_ppo_benchmark.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import pytest
 from benchmark.rl import benchmark_mjwarp_ppo as ppo_benchmark
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
 
 
 def _scalars(*, iterations: int, fps: float = 30_000.0, reward: float = -0.4) -> dict[str, Any]:
@@ -402,6 +404,34 @@ def test_production_benchmark_uses_side_effect_free_evidence_helpers() -> None:
     assert ppo_benchmark._event_scalars.__module__ == "benchmark.issue705.process_evidence"
     assert "benchmark/issue705/benchmark_g1_phase0.py" not in ppo_benchmark.SOURCE_INPUTS
     assert "benchmark/issue705/process_evidence.py" in ppo_benchmark.SOURCE_INPUTS
+
+
+@pytest.mark.parametrize("backend", ["mujoco", "mjwarp"])
+def test_common_performance_overrides_compose_for_both_owner_configs(backend: str) -> None:
+    """The paired lane must not rely on an owner-specific DR key layout."""
+
+    GlobalHydra.instance().clear()
+    try:
+        with initialize_config_dir(
+            config_dir=str(ppo_benchmark.ROOT_DIR / "conf/ppo"), version_base="1.3"
+        ):
+            cfg = compose(
+                config_name="config",
+                overrides=[
+                    f"task=g1_walk_flat/{backend}",
+                    *ppo_benchmark.COMMON_PERFORMANCE_OVERRIDES,
+                    "hydra.run.dir=.",
+                    "hydra.output_subdir=null",
+                    "hydra/job_logging=disabled",
+                    "hydra/hydra_logging=disabled",
+                ],
+            )
+        assert cfg.env.noise_config.level == 0.0
+        assert cfg.env.curriculum.enabled is False
+        assert cfg.env.domain_rand.randomize_kp is False
+        assert cfg.env.domain_rand.randomize_kd is False
+    finally:
+        GlobalHydra.instance().clear()
 
 
 def test_scalar_failure_nonfinite_value_and_filtered_iteration_fail_closed() -> None:


### PR DESCRIPTION
Part of #705
Closes #795
Blocks #794

## 根因与修复

#794 的首次完整采集在第一个 `mujoco_host` worker 被 Hydra 拒绝：`g1_walk_flat/mujoco` owner 没有显式的 `env.domain_rand` YAML 节点，而 benchmark 以普通 override 传入 kp/kd DR disable。独立 `mjwarp` owner 已声明该节点，导致成对矩阵只在 host lane 失败。

将 benchmark cold-path profile 改为 Hydra `++` force-add/override：该形式对「owner 已声明」与「由 dataclass 默认提供、owner 未声明」两种情况都产生同一显式 config，而不修改任一 production owner YAML 默认值。

## 变更

- `COMMON_PERFORMANCE_OVERRIDES` 使用 `++env.domain_rand.randomize_kp/kd=false`。
- 新增两 owner 的 compose contract test，断言 noise、curriculum、kp/kd DR 均是冻结 performance profile。
- 真实 public owner-route worker 验证：
  - `throughput-mujoco_host-b128-r0` 完成，receipt 记录 `noise=0`, `curriculum=false`, `kp/kd=false`。
  - `throughput-mjwarp_device-b128-r0` 完成，并保留独立 `mjwarp` device-resident policy ABI receipt。

## Contract / benchmark 影响

- 不改训练脚本、backend、owner YAML 或 Phase 5 threshold/manifest。
- 不提交 benchmark artifact，不提升任何 claim；probe 仅证明 host/device paired workers 已可组成，不是性能证据。
- `mujoco` 与 `mjwarp` 继续由独立 owner、backend 和 execution profile 选择。

## Validation

- `uv run pytest tests/benchmark/test_mjwarp_ppo_benchmark.py -q` → `19 passed`
- 真实 workers：`uv run benchmark/rl/benchmark_mjwarp_ppo.py --worker --case-id throughput-mujoco_host-b128-r0 ...`、`... throughput-mjwarp_device-b128-r0 ...` → 均完成且 receipt 已检查。
- `uv run mypy src/unilab`
- `uv run pyright benchmark/rl/benchmark_mjwarp_ppo.py tests/benchmark/test_mjwarp_ppo_benchmark.py`
- `uv run scripts/audit_issue705_backend_isolation.py`
- `uv run scripts/audit_issue705_workflow_triggers.py`
- `uv run scripts/audit_issue705_claims.py --phase 5`
- `uv run scripts/validate_issue705_phase.py --phase 5 --mode schema`
- `make test-all` → `2042 passed, 50 skipped, 359 deselected, 1 xfailed`

## 两轮自查

1. **代码/配置边界**：确认只修改 benchmark cold-path override，未改变 `mujoco` owner 的默认 kp/kd DR 或训练脚本；`++` 不会把 host lane 的 disable 静默漏掉，也不会把 backend-specific 行为泄漏到 runner。
2. **证据/矩阵**：两 owner compose test 和两个真实 worker receipt 均复核实际值；不将 dirty-worktree probe 作为 Phase 5 artifact，不改变 threshold 或 claim status。

## 后续

PR 合入后从 clean integration commit 恢复 #794 的完整 40-case capture；若冻结 gate FAIL，保留诊断 artifact 并创建独立优化 child，不降低阈值。
