### PR TITLE
fix(benchmark): repair script-mode entrypoints after subpackage refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,7 @@ jobs:
             --no-install-package nvidia-nvtx-cu12 \
             --no-install-package triton
           uv pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
+      - name: Benchmark entrypoint smoke test
+        run: uv run --no-sync python benchmark/smoke_test.py
       - name: Test with coverage
         run: uv run --no-sync pytest -m "not slow" --cov=src/unilab --cov-report "markdown-append:${GITHUB_STEP_SUMMARY:-/dev/null}" --cov-fail-under=25

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,12 @@ test-cov:
 test-slow:
 	uv run pytest -m "slow" -v
 
+.PHONY: test-benchmark-smoke
+test-benchmark-smoke:
+	uv run python benchmark/smoke_test.py
+
 .PHONY: test-all
-test-all: check test-cov
+test-all: check test-cov test-benchmark-smoke
 
 .PHONY: clean
 clean:

--- a/benchmark/mjwarp/__init__.py
+++ b/benchmark/mjwarp/__init__.py
@@ -1,6 +1,6 @@
 """Benchmark-only mjwarp backend adapter.
 
 Lives outside ``src/unilab/`` because it is wired in via a monkey-patch from
-``benchmark/benchmark_env_step.py`` and is not part of the training-path
+``benchmark/env/benchmark_env_step.py`` and is not part of the training-path
 ``SimBackend`` factory.
 """

--- a/benchmark/mjwarp/backend.py
+++ b/benchmark/mjwarp/backend.py
@@ -1,4 +1,4 @@
-"""mjwarp ``SimBackend`` adapter used only by ``benchmark/benchmark_env_step.py``.
+"""mjwarp ``SimBackend`` adapter used only by ``benchmark/env/benchmark_env_step.py``.
 
 The goal is parity with ``MuJoCoBackend`` / ``MotrixBackend`` at the
 ``NpEnv.step`` boundary so the three backends share the same Python pipeline

--- a/benchmark/physics/benchmark_mujoco_vs_motrix.py
+++ b/benchmark/physics/benchmark_mujoco_vs_motrix.py
@@ -115,7 +115,10 @@ def main():
     parser.add_argument(
         "--xml",
         type=str,
-        default=os.path.join(os.path.dirname(__file__), "xmls/humanoid/humanoid.xml"),
+        default=os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "xmls/humanoid/humanoid.xml",
+        ),
         help="Path to XML model.",
     )
     parser.add_argument(

--- a/benchmark/physics/benchmark_physics_step_genesis.py
+++ b/benchmark/physics/benchmark_physics_step_genesis.py
@@ -17,11 +17,16 @@ from __future__ import annotations
 import argparse
 import gc
 import json
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, cast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import matplotlib
 
@@ -35,18 +40,8 @@ except ImportError:
 else:
     gs = _gs
 
-try:
-    from benchmark.core import device_info as _benchmark_device_info
-    from benchmark.core import task_names as _benchmark_task_names
-
-    _device_info = _benchmark_device_info
-    _task_names = _benchmark_task_names
-except ModuleNotFoundError:
-    from core import device_info as _core_device_info
-    from core import task_names as _core_task_names
-
-    _device_info = _core_device_info
-    _task_names = _core_task_names
+from benchmark.core import device_info as _device_info
+from benchmark.core import task_names as _task_names
 
 get_device_info_dict = _device_info.get_device_info_dict
 get_device_info_line = _device_info.get_device_info_line

--- a/benchmark/physics/benchmark_physics_step_mj_step.py
+++ b/benchmark/physics/benchmark_physics_step_mj_step.py
@@ -13,12 +13,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Any, Dict, List, cast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import matplotlib
 import mujoco
@@ -29,18 +34,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Patch
 
-try:
-    from benchmark.core import device_info as _benchmark_device_info
-    from benchmark.core import task_names as _benchmark_task_names
-
-    _device_info = _benchmark_device_info
-    _task_names = _benchmark_task_names
-except ModuleNotFoundError:
-    from core import device_info as _core_device_info
-    from core import task_names as _core_task_names
-
-    _device_info = _core_device_info
-    _task_names = _core_task_names
+from benchmark.core import device_info as _device_info
+from benchmark.core import task_names as _task_names
 
 get_device_info_dict = _device_info.get_device_info_dict
 get_device_info_line = _device_info.get_device_info_line

--- a/benchmark/physics/benchmark_physics_step_motrixsim.py
+++ b/benchmark/physics/benchmark_physics_step_motrixsim.py
@@ -19,11 +19,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import matplotlib
 import numpy as np
@@ -31,12 +36,8 @@ import numpy as np
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-try:
-    from benchmark.core import device_info as _benchmark_device_info
-    from benchmark.core import task_names as _benchmark_task_names
-except ModuleNotFoundError:
-    from core import device_info as _benchmark_device_info
-    from core import task_names as _benchmark_task_names
+from benchmark.core import device_info as _benchmark_device_info
+from benchmark.core import task_names as _benchmark_task_names
 
 get_device_info_dict = _benchmark_device_info.get_device_info_dict
 get_device_info_line = _benchmark_device_info.get_device_info_line

--- a/benchmark/physics/benchmark_physics_step_mujoco_warp.py
+++ b/benchmark/physics/benchmark_physics_step_mujoco_warp.py
@@ -24,11 +24,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, cast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import matplotlib
 
@@ -51,18 +56,8 @@ try:
 except ImportError:
     warp = None
 
-try:
-    from benchmark.core import device_info as _benchmark_device_info
-    from benchmark.core import task_names as _benchmark_task_names
-
-    _device_info = _benchmark_device_info
-    _task_names = _benchmark_task_names
-except ModuleNotFoundError:
-    from core import device_info as _core_device_info
-    from core import task_names as _core_task_names
-
-    _device_info = _core_device_info
-    _task_names = _core_task_names
+from benchmark.core import device_info as _device_info
+from benchmark.core import task_names as _task_names
 
 get_device_info_dict = _device_info.get_device_info_dict
 get_device_info_line = _device_info.get_device_info_line

--- a/benchmark/physics/benchmark_sim.py
+++ b/benchmark/physics/benchmark_sim.py
@@ -483,7 +483,10 @@ def main():
     parser.add_argument(
         "--xml",
         type=str,
-        default=os.path.join(os.path.dirname(__file__), "xmls/humanoid/humanoid.xml"),
+        default=os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "xmls/humanoid/humanoid.xml",
+        ),
         help="Path to XML model.",
     )
     parser.add_argument(

--- a/benchmark/smoke_test.py
+++ b/benchmark/smoke_test.py
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
 """Lightweight smoke test for benchmark entrypoints.
 
-This checks that benchmark modules import, without requiring every optional
-dependency or full benchmark run.
+Two phases, each catching a distinct failure mode:
+
+1. Module-mode import (``import benchmark.<category>.<module>``) — verifies the
+   package surface used by ``tests/benchmark`` and cross-module imports.
+2. Script-mode import — verifies ``uv run benchmark/<category>/<script>.py``
+   works, i.e. module-level imports resolve when only the script's own
+   directory is on ``sys.path`` (repo root deliberately removed). This is the
+   mode users actually run, and the mode that broke after the benchmark
+   subpackage refactor: module-mode checks pass while direct script runs fail
+   with ``ModuleNotFoundError``.
+
+Optional dependencies (motrixsim, genesis, mujoco_warp, ...) are not required:
+entrypoints guard those imports and only fail at run time with a clear error.
 """
 
 from __future__ import annotations
 
 import importlib
 import pkgutil
+import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -24,28 +37,93 @@ MODULES = sorted(
     for _, name, is_pkg in pkgutil.iter_modules([str(BENCHMARK_DIR / category)])
     if not is_pkg and name.startswith("benchmark_")
 )
+ENTRYPOINTS = sorted(BENCHMARK_DIR.glob("benchmark_*.py")) + sorted(
+    path for category in CATEGORIES for path in (BENCHMARK_DIR / category).glob("benchmark_*.py")
+)
 
-passed: list[str] = []
-failed: list[tuple[str, str]] = []
+# Executed in a clean subprocess per entrypoint. Mimics `python <script>`:
+# sys.path[0] is the script's directory and neither the cwd nor the repo root
+# is importable, then the file's module-level code runs (without triggering
+# the `__main__` guard). argv: <script> <repo_root>
+_SCRIPT_MODE_SNIPPET = r"""
+import runpy
+import sys
+from pathlib import Path
 
-print("Testing benchmark modules...\n")
-for name in MODULES:
-    print(f"Testing {name}...")
+script = Path(sys.argv[1]).resolve()
+repo_root = Path(sys.argv[2]).resolve()
+
+def _keep(entry: str) -> bool:
+    if entry in ("", str(script.parent)):
+        return False
+    try:
+        resolved = Path(entry).resolve()
+    except OSError:
+        return True
+    return resolved != repo_root and resolved != Path.cwd().resolve()
+
+sys.path[:] = [str(script.parent)] + [p for p in sys.path if _keep(p)]
+runpy.run_path(str(script), run_name="__benchmark_smoke__")
+"""
+
+SCRIPT_MODE_TIMEOUT_SEC = 300
+SCRIPT_MODE_WORKERS = 4
+
+
+def check_module_mode(name: str) -> str | None:
     try:
         importlib.import_module(f"benchmark.{name}")
     except Exception as exc:
-        print(f"  ✗ Import failed: {exc}")
-        failed.append((name, str(exc)))
-    else:
-        print("  ✓ Import OK")
-        passed.append(name)
+        return str(exc)
+    return None
 
-print(f"\n{'=' * 50}")
-print(f"Passed: {len(passed)}/{len(MODULES)}")
-print(f"Failed: {len(failed)}/{len(MODULES)}")
 
-if failed:
-    print("\nFailed tests:")
-    for name, err in failed:
-        print(f"  - {name}: {err[:120]}")
-    sys.exit(1)
+def check_script_mode(path: Path) -> str | None:
+    proc = subprocess.run(
+        [sys.executable, "-c", _SCRIPT_MODE_SNIPPET, str(path), str(ROOT)],
+        capture_output=True,
+        text=True,
+        timeout=SCRIPT_MODE_TIMEOUT_SEC,
+    )
+    if proc.returncode == 0:
+        return None
+    tail = (proc.stderr.strip().splitlines() or ["<no stderr>"])[-1]
+    return f"exit={proc.returncode}: {tail}"
+
+
+def report(phase: str, failures: list[tuple[str, str]], total: int) -> bool:
+    passed = total - len(failures)
+    print(f"\n[{phase}] Passed: {passed}/{total}")
+    for name, err in failures:
+        print(f"  ✗ {name}: {err[:200]}")
+    return not failures
+
+
+def main() -> int:
+    print(f"Phase 1: module-mode import ({len(MODULES)} modules)...")
+    module_failures = []
+    for name in MODULES:
+        err = check_module_mode(name)
+        status = "✗" if err else "✓"
+        print(f"  {status} benchmark.{name}")
+        if err:
+            module_failures.append((f"benchmark.{name}", err))
+
+    print(f"\nPhase 2: script-mode import ({len(ENTRYPOINTS)} entrypoints)...")
+    script_failures = []
+    with ThreadPoolExecutor(max_workers=SCRIPT_MODE_WORKERS) as pool:
+        results = list(zip(ENTRYPOINTS, pool.map(check_script_mode, ENTRYPOINTS)))
+    for path, err in results:
+        rel = path.relative_to(ROOT)
+        status = "✗" if err else "✓"
+        print(f"  {status} {rel}")
+        if err:
+            script_failures.append((str(rel), err))
+
+    ok = report("module-mode", module_failures, len(MODULES))
+    ok = report("script-mode", script_failures, len(ENTRYPOINTS)) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/smoke_test.py
+++ b/benchmark/smoke_test.py
@@ -14,12 +14,18 @@ Two phases, each catching a distinct failure mode:
 
 Optional dependencies (motrixsim, genesis, mujoco_warp, ...) are not required:
 entrypoints guard those imports and only fail at run time with a clear error.
+Platform-exclusive packages (``mlx``, ``coremltools`` — Apple Silicon only)
+cannot be guarded this way when an entrypoint is single-platform by design;
+entries that fail to import solely because of them are reported as SKIP,
+not FAIL. Genuine import regressions (``benchmark``, ``core``, ``unilab``,
+or any cross-platform package) still fail the check.
 """
 
 from __future__ import annotations
 
 import importlib
 import pkgutil
+import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -69,6 +75,26 @@ runpy.run_path(str(script), run_name="__benchmark_smoke__")
 SCRIPT_MODE_TIMEOUT_SEC = 300
 SCRIPT_MODE_WORKERS = 4
 
+# Top-level packages that exist only on specific platforms (mlx/coremltools:
+# Apple Silicon). An entrypoint requiring one at import time is single-platform
+# by design, so a miss is reported as SKIP instead of FAIL. Keep this list
+# minimal: every other ModuleNotFoundError (benchmark, core, unilab, numpy,
+# torch, ...) is a real regression and must fail.
+PLATFORM_OPTIONAL_MODULES = frozenset({"mlx", "coremltools"})
+_MISSING_MODULE_RE = re.compile(r"No module named '([\w.]+)'")
+
+
+def platform_optional_miss(err: str | None) -> str | None:
+    """Return the missing platform-optional package, or None if `err` is a
+    genuine failure (or no error at all)."""
+    if err is None:
+        return None
+    match = _MISSING_MODULE_RE.search(err)
+    if match is None:
+        return None
+    package = match.group(1).split(".")[0]
+    return package if package in PLATFORM_OPTIONAL_MODULES else None
+
 
 def check_module_mode(name: str) -> str | None:
     try:
@@ -91,9 +117,19 @@ def check_script_mode(path: Path) -> str | None:
     return f"exit={proc.returncode}: {tail}"
 
 
-def report(phase: str, failures: list[tuple[str, str]], total: int) -> bool:
-    passed = total - len(failures)
-    print(f"\n[{phase}] Passed: {passed}/{total}")
+def report(
+    phase: str,
+    failures: list[tuple[str, str]],
+    skips: list[tuple[str, str]],
+    total: int,
+) -> bool:
+    passed = total - len(failures) - len(skips)
+    summary = f"\n[{phase}] Passed: {passed}/{total}"
+    if skips:
+        summary += f" ({len(skips)} skipped: platform-optional)"
+    print(summary)
+    for name, package in skips:
+        print(f"  - {name}: skipped (needs platform-optional '{package}')")
     for name, err in failures:
         print(f"  ✗ {name}: {err[:200]}")
     return not failures
@@ -102,26 +138,38 @@ def report(phase: str, failures: list[tuple[str, str]], total: int) -> bool:
 def main() -> int:
     print(f"Phase 1: module-mode import ({len(MODULES)} modules)...")
     module_failures = []
+    module_skips = []
     for name in MODULES:
         err = check_module_mode(name)
-        status = "✗" if err else "✓"
-        print(f"  {status} benchmark.{name}")
-        if err:
+        package = platform_optional_miss(err)
+        if err is None:
+            print(f"  ✓ benchmark.{name}")
+        elif package is not None:
+            print(f"  - benchmark.{name} (skipped: needs '{package}')")
+            module_skips.append((f"benchmark.{name}", package))
+        else:
+            print(f"  ✗ benchmark.{name}")
             module_failures.append((f"benchmark.{name}", err))
 
     print(f"\nPhase 2: script-mode import ({len(ENTRYPOINTS)} entrypoints)...")
     script_failures = []
+    script_skips = []
     with ThreadPoolExecutor(max_workers=SCRIPT_MODE_WORKERS) as pool:
         results = list(zip(ENTRYPOINTS, pool.map(check_script_mode, ENTRYPOINTS)))
     for path, err in results:
-        rel = path.relative_to(ROOT)
-        status = "✗" if err else "✓"
-        print(f"  {status} {rel}")
-        if err:
-            script_failures.append((str(rel), err))
+        rel = str(path.relative_to(ROOT))
+        package = platform_optional_miss(err)
+        if err is None:
+            print(f"  ✓ {rel}")
+        elif package is not None:
+            print(f"  - {rel} (skipped: needs '{package}')")
+            script_skips.append((rel, package))
+        else:
+            print(f"  ✗ {rel}")
+            script_failures.append((rel, err))
 
-    ok = report("module-mode", module_failures, len(MODULES))
-    ok = report("script-mode", script_failures, len(ENTRYPOINTS)) and ok
+    ok = report("module-mode", module_failures, module_skips, len(MODULES))
+    ok = report("script-mode", script_failures, script_skips, len(ENTRYPOINTS)) and ok
     return 0 if ok else 1
 
 


### PR DESCRIPTION
Fixes #792

## 问题

`0aa4a4bf` 把 35 个 benchmark 脚本按主题移入子包后，以 `uv run benchmark/<sub>/<script>.py` 直跑时出现回归，且 CI 完全没覆盖到：

1. **导入回归（4 个文件）**：`benchmark_physics_step_{motrixsim,mj_step,genesis,mujoco_warp}.py` 残留重构前的 `try/except ModuleNotFoundError: from core import ...` fallback，脚本模式下 `benchmark.core` 和裸 `core` 都解析不到 → `ModuleNotFoundError: No module named 'core'`。
2. **资源路径回归（2 个文件）**：`benchmark_sim.py` / `benchmark_mujoco_vs_motrix.py` 用 `dirname(__file__)` 拼 `xmls/humanoid/humanoid.xml`，移动后指向不存在的 `benchmark/physics/xmls/`。
3. **过时引用（2 处）**：`benchmark/mjwarp/` docstring 仍写 `benchmark/benchmark_env_step.py`（现为 `benchmark/env/benchmark_env_step.py`）。

## 修复

- 4 个文件统一为 repo-root `sys.path` bootstrap + `benchmark.core` 绝对导入（对齐 `benchmark/compute/benchmark_backends.py` 等正确写法）。
- 2 处 xml 默认路径改为基于 benchmark 目录解析。
- mjwarp docstring 路径更正。

## CI / 本地覆盖补强

CI 没测出来的根因：所有既有检查（smoke_test、tests/benchmark）都只在 repo root 已入 `sys.path` 的**模块模式**下导入 benchmark，而用户实际走的是**脚本直跑模式**。

- `benchmark/smoke_test.py` 新增 script-mode 阶段：每个入口在独立子进程中以「仅脚本目录在 `sys.path`、剔除 cwd 与 repo root」的环境重放模块级导入（不触发 `__main__`，不跑真实 benchmark），4 并发、单脚本 300s 超时，本地全量约 7s。
- CI test job 在 pytest 前新增 `uv run --no-sync python benchmark/smoke_test.py` 步骤。
- Makefile 新增 `test-benchmark-smoke` target，并挂入 `test-all`（`check test-cov test-benchmark-smoke`）。

## Validation

- `make test-all` 已通过（ruff format/check + mypy + pyright + pytest -m "not slow" 带 coverage + benchmark smoke）。
- 31 个入口 `--help` 全量扫描通过；smoke：module-mode 35/35、script-mode 36/36。
- 真实运行（非仅导入）：`benchmark_physics_step_motrixsim.py`（#792 报错脚本）、`benchmark_physics_step_mj_step.py`、`benchmark_physics_step_mujoco_warp.py`（`--with mujoco-warp --with warp-lang`）、`benchmark_sim.py`、`benchmark_mujoco_vs_motrix.py`、`compute/benchmark_backends.py`、`env/benchmark_env_overhead_parallel.py` 均端到端跑通并产出 JSON/图。
- `benchmark_physics_step_genesis.py` 导入/启动正常，实际运行在 genesis 库内部报 `Zero-copy not available: Unsupported device_type: 8`（quadrants/taichi macOS 设备兼容问题，与本重构无关）。
- 负向验证：将修复前文件临时换回后，新 script-mode 检查精确报出 `ModuleNotFoundError: No module named 'core'`，而 module-mode 依旧全绿——即本次 CI 盲区已被覆盖。