### PR TITLE
feat(replay): opt-in GPU-resident replay pipeline for single-GPU off-policy

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -46,6 +46,10 @@ training:
   trace_cuda_events: true
   nvtx_profile_ranges: false
   replay_prefetch_mode: one_tick
+  # Replay batch source for single-GPU off-policy runners:
+  # cpu_pinned_double_buffer (collector CPU pack + batch H2D) or
+  # gpu_resident (learner-side GPU mirror of replay storage, GPU-side sampling).
+  replay_pipeline: cpu_pinned_double_buffer
   verbose_metrics: false
   torch_threads:
     enabled: true

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -183,8 +183,19 @@ def build_runner(algo_name: str, cfg: DictConfig):
             f"Unsupported training.replay_prefetch_mode={replay_prefetch_mode!r}; "
             "expected 'one_tick'"
         )
+    replay_pipeline = str(getattr(cfg.training, "replay_pipeline", "cpu_pinned_double_buffer"))
+    if replay_pipeline not in {"cpu_pinned_double_buffer", "gpu_resident"}:
+        raise ValueError(
+            f"Unsupported training.replay_pipeline={replay_pipeline!r}; "
+            "expected 'cpu_pinned_double_buffer' or 'gpu_resident'"
+        )
     verbose_metrics = bool(getattr(cfg.training, "verbose_metrics", False))
     num_gpus = int(getattr(cfg.training, "num_gpus", 1))
+    if num_gpus > 1 and replay_pipeline == "gpu_resident":
+        raise ValueError(
+            "training.replay_pipeline='gpu_resident' is single-GPU only; "
+            "multi-GPU replay placement is tracked separately (issue #694 Tier2)"
+        )
     multi_gpu_sync_mode = str(getattr(cfg.training, "multi_gpu_sync_mode", "local_sgd"))
     multi_gpu_sync_interval = int(getattr(cfg.training, "multi_gpu_sync_interval", 1))
     collector_infer_device = str(getattr(cfg.training, "collector_infer_device", "cpu") or "cpu")
@@ -379,6 +390,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             trace_cuda_events=cfg.training.trace_cuda_events,
             replay_prefetch_mode=replay_prefetch_mode,
             verbose_metrics=verbose_metrics,
+            replay_pipeline=replay_pipeline,
             seed=cfg.algo.seed,
             nan_guard_cfg=_nan_guard_cfg,
             collector_infer_device=collector_infer_device,
@@ -466,6 +478,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             trace_cuda_events=cfg.training.trace_cuda_events,
             replay_prefetch_mode=replay_prefetch_mode,
             verbose_metrics=verbose_metrics,
+            replay_pipeline=replay_pipeline,
             actor_kwargs=_actor_kwargs,
             nan_guard_cfg=_nan_guard_cfg,
             collector_infer_device=collector_infer_device,
@@ -482,6 +495,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             env_cfg_override=env_cfg_override,
             replay_prefetch_mode=replay_prefetch_mode,
             verbose_metrics=verbose_metrics,
+            replay_pipeline=replay_pipeline,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
         )

--- a/src/unilab/algos/torch/flash_sac/double_buffer.py
+++ b/src/unilab/algos/torch/flash_sac/double_buffer.py
@@ -47,6 +47,7 @@ def build_flashsac_double_buffer_runner(
     env_cfg_override: dict[str, Any] | None,
     replay_prefetch_mode: str,
     verbose_metrics: bool,
+    replay_pipeline: str = "cpu_pinned_double_buffer",
     nan_guard_cfg: NanGuardCfg | None = None,
     torch_thread_runtime: dict[str, Any] | None = None,
 ) -> Any:
@@ -194,6 +195,7 @@ def build_flashsac_double_buffer_runner(
         trace_cuda_events=cfg.training.trace_cuda_events,
         replay_prefetch_mode=replay_prefetch_mode,
         verbose_metrics=verbose_metrics,
+        replay_pipeline=replay_pipeline,
         nan_guard_cfg=nan_guard_cfg,
         collector_infer_device=collector_infer_device,
         torch_thread_runtime=torch_thread_runtime,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -28,9 +28,11 @@ from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
 from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX
 from unilab.ipc.replay_buffer import ReplayBuffer
+from unilab.ipc.replay_pipelines.base import ReplayPipeline
 from unilab.ipc.replay_pipelines.cpu_pinned_double_buffer import (
     CPUPinnedDoubleBufferReplayPipeline,
 )
+from unilab.ipc.replay_pipelines.gpu_resident import GPUResidentReplayPipeline
 from unilab.logging import OffPolicyLogger, TraceRecorder
 from unilab.training.seed import derive_worker_seed
 
@@ -59,8 +61,14 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         *,
         replay_prefetch_mode: str = "one_tick",
         verbose_metrics: bool = False,
+        replay_pipeline: str = "cpu_pinned_double_buffer",
         **kwargs,
     ):
+        if replay_pipeline not in {"cpu_pinned_double_buffer", "gpu_resident"}:
+            raise ValueError(
+                f"Unsupported replay_pipeline={replay_pipeline!r}; "
+                "expected 'cpu_pinned_double_buffer' or 'gpu_resident'"
+            )
         super().__init__(**kwargs)
         if replay_prefetch_mode != "one_tick":
             raise ValueError(
@@ -68,6 +76,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             )
         self.replay_prefetch_mode = replay_prefetch_mode
         self.verbose_metrics = bool(verbose_metrics)
+        self.replay_pipeline_impl = replay_pipeline
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -241,45 +250,62 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
         # --- replay pipeline (double buffer) ---
         sample_count = self.batch_size * self.updates_per_step
-        collector_pack_request_queue = _SPAWN_CTX.Queue(maxsize=1)
-        collector_pack_ready_queue = _SPAWN_CTX.Queue(maxsize=1)
-        packed_width = int(replay_buffer._storage.shape[1])
-        if use_sac_graph_pack_layout:
-            packed_width = int(replay_buffer.sac_graph_packed_width())
-        collector_pack_shared_slots = [
-            torch.empty((sample_count, packed_width), dtype=torch.float32).share_memory_()
-            for _ in range(2)
-        ]
+        use_gpu_resident_pipeline = self.replay_pipeline_impl == "gpu_resident"
+        collector_pack_request_queue = None
+        collector_pack_ready_queue = None
+        collector_pack_shared_slots = None
         collector_pack_critic_graph_shared_slots = None
-        if use_critic_graph_packed_source:
-            critic_graph_width = int(replay_buffer.critic_graph_packed_width())
-            collector_pack_critic_graph_shared_slots = [
-                torch.empty(
-                    (sample_count, critic_graph_width),
-                    dtype=torch.float32,
-                ).share_memory_()
+        replay_pipeline: ReplayPipeline
+        if use_gpu_resident_pipeline:
+            replay_pipeline = GPUResidentReplayPipeline(
+                replay_buffer,
+                device=self.device,
+                sample_count=sample_count,
+                base_seed=int(self.seed or 0),
+                trace_recorder=trace_recorder,
+                trace_cuda_events=self.trace_cuda_events,
+                pack_layout="sac_graph" if use_sac_graph_pack_layout else "packed",
+                use_critic_graph_packed_source=use_critic_graph_packed_source,
+            )
+        else:
+            collector_pack_request_queue = _SPAWN_CTX.Queue(maxsize=1)
+            collector_pack_ready_queue = _SPAWN_CTX.Queue(maxsize=1)
+            packed_width = int(replay_buffer._storage.shape[1])
+            if use_sac_graph_pack_layout:
+                packed_width = int(replay_buffer.sac_graph_packed_width())
+            collector_pack_shared_slots = [
+                torch.empty((sample_count, packed_width), dtype=torch.float32).share_memory_()
                 for _ in range(2)
             ]
-        _verbose_output_dir: str | None = None
-        if self.verbose_metrics:
-            _vroot = Path(self.trace_output_dir) if self.trace_output_dir else Path(log_dir)
-            _verbose_output_dir = str(_vroot)
-        replay_pipeline = CPUPinnedDoubleBufferReplayPipeline(
-            replay_buffer,
-            device=self.device,
-            sample_count=sample_count,
-            base_seed=int(self.seed or 0),
-            trace_recorder=trace_recorder,
-            trace_cuda_events=self.trace_cuda_events,
-            verbose=self.verbose_metrics,
-            verbose_output_dir=_verbose_output_dir,
-            collector_pack_request_queue=collector_pack_request_queue,
-            collector_pack_ready_queue=collector_pack_ready_queue,
-            collector_pack_shared_slots=collector_pack_shared_slots,
-            pack_layout="sac_graph" if use_sac_graph_pack_layout else "packed",
-            use_critic_graph_packed_source=use_critic_graph_packed_source,
-            collector_pack_critic_graph_shared_slots=collector_pack_critic_graph_shared_slots,
-        )
+            if use_critic_graph_packed_source:
+                critic_graph_width = int(replay_buffer.critic_graph_packed_width())
+                collector_pack_critic_graph_shared_slots = [
+                    torch.empty(
+                        (sample_count, critic_graph_width),
+                        dtype=torch.float32,
+                    ).share_memory_()
+                    for _ in range(2)
+                ]
+            _verbose_output_dir: str | None = None
+            if self.verbose_metrics:
+                _vroot = Path(self.trace_output_dir) if self.trace_output_dir else Path(log_dir)
+                _verbose_output_dir = str(_vroot)
+            replay_pipeline = CPUPinnedDoubleBufferReplayPipeline(
+                replay_buffer,
+                device=self.device,
+                sample_count=sample_count,
+                base_seed=int(self.seed or 0),
+                trace_recorder=trace_recorder,
+                trace_cuda_events=self.trace_cuda_events,
+                verbose=self.verbose_metrics,
+                verbose_output_dir=_verbose_output_dir,
+                collector_pack_request_queue=collector_pack_request_queue,
+                collector_pack_ready_queue=collector_pack_ready_queue,
+                collector_pack_shared_slots=collector_pack_shared_slots,
+                pack_layout="sac_graph" if use_sac_graph_pack_layout else "packed",
+                use_critic_graph_packed_source=use_critic_graph_packed_source,
+                collector_pack_critic_graph_shared_slots=collector_pack_critic_graph_shared_slots,
+            )
         self.replay_h2d_submitter = getattr(
             replay_pipeline,
             "h2d_submitter",
@@ -312,7 +338,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         if hasattr(self.learner, "use_symmetry") and self.learner.use_symmetry:
             logger.log_status("Symmetry augmentation: enabled")
         logger.log_status(format_torch_thread_runtime(self.torch_thread_runtime))
-        logger.log_status("Replay pipeline: cpu_pinned_double_buffer")
+        logger.log_status(f"Replay pipeline: {self.replay_pipeline_impl}")
         logger.log_status(f"Replay prefetch mode: {self.replay_prefetch_mode}")
         logger.log_status(f"Replay pack layout: {self.replay_pack_layout}")
         logger.log_status(f"Replay pack executor: {self.replay_pack_executor}")
@@ -610,7 +636,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                             end_ns=time.perf_counter_ns(),
                             args={
                                 "total_batch": sample_count,
-                                "pipeline": "cpu_pinned_double_buffer",
+                                "pipeline": self.replay_pipeline_impl,
                                 "batch_ready": batch_ready,
                                 "prefetch_mode": self.replay_prefetch_mode,
                                 "replay_pack_layout": self.replay_pack_layout,
@@ -776,7 +802,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     end_ns=time.perf_counter_ns(),
                     args={
                         "iterations": iteration,
-                        "pipeline": "cpu_pinned_double_buffer",
+                        "pipeline": self.replay_pipeline_impl,
                         "replay_h2d_submitter": self.replay_h2d_submitter,
                         "replay_transfer_backend": self.replay_transfer_backend,
                         "learner_log_interval": 1,

--- a/src/unilab/ipc/replay_pipelines/__init__.py
+++ b/src/unilab/ipc/replay_pipelines/__init__.py
@@ -4,9 +4,11 @@ from unilab.ipc.replay_pipelines.base import ReplayPipeline, ReplayTickMetadata
 from unilab.ipc.replay_pipelines.cpu_pinned_double_buffer import (
     CPUPinnedDoubleBufferReplayPipeline,
 )
+from unilab.ipc.replay_pipelines.gpu_resident import GPUResidentReplayPipeline
 
 __all__ = [
     "ReplayPipeline",
     "ReplayTickMetadata",
     "CPUPinnedDoubleBufferReplayPipeline",
+    "GPUResidentReplayPipeline",
 ]

--- a/src/unilab/ipc/replay_pipelines/gpu_resident.py
+++ b/src/unilab/ipc/replay_pipelines/gpu_resident.py
@@ -1,0 +1,637 @@
+"""GPU-resident replay mirror pipeline (single-GPU, CUDA only).
+
+The packed CPU :class:`ReplayBuffer` stays authoritative: the collector's
+``add()`` path is unchanged and does zero extra CPU work.  A learner-side
+daemon thread incrementally mirrors newly written rows into a GPU-resident
+storage on a side stream, and services learner batch prepares with GPU-side
+sampling (``randint`` + ``index_select``) on the same stream.  There is no
+collector pack request, no pinned batch staging, and no per-tick batch H2D.
+
+Consistency model:
+
+- The sample domain is ``[0, min(device_visible_ptr, capacity))`` where
+  ``device_visible_ptr`` only advances past rows whose H2D completed (one
+  CUDA event per submitted span batch).
+- Span copies and batch gathers are totally ordered on a single side stream,
+  so a gather observes a consistent snapshot: every span submitted before it
+  is applied, none submitted after it.
+- Ring-overwrite races against concurrent collector CPU writes are the same
+  class the CPU pack path already accepts (single writer / snapshot reader).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Any, Dict, List, Tuple, cast
+
+import torch
+
+from unilab.ipc.replay_buffer import ReplayBuffer
+from unilab.ipc.replay_pipelines.base import ReplayTickMetadata
+from unilab.ipc.replay_pipelines.transfer import build_replay_transfer_backend
+
+
+def _ring_spans(start: int, end: int, capacity: int) -> List[Tuple[int, int]]:
+    """Split absolute row range ``[start, end)`` into ``(offset, length)`` ring spans."""
+    if end <= start or capacity <= 0:
+        return []
+    spans: List[Tuple[int, int]] = []
+    remaining = end - start
+    offset = start % capacity
+    while remaining > 0:
+        length = min(remaining, capacity - offset)
+        spans.append((offset, length))
+        remaining -= length
+        offset = 0
+    return spans
+
+
+class GPUResidentReplayPipeline:
+    """ReplayPipeline backed by a GPU-resident mirror of the packed CPU storage."""
+
+    _POLL_INTERVAL_S = 0.0005
+    _MEMORY_HEADROOM = 0.8
+
+    def __init__(
+        self,
+        replay_buffer: ReplayBuffer,
+        *,
+        device: str,
+        sample_count: int,
+        base_seed: int = 0,
+        trace_recorder=None,
+        trace_cuda_events: bool = True,
+        pack_layout: str = "packed",
+        use_critic_graph_packed_source: bool = False,
+    ) -> None:
+        self._replay_buffer = replay_buffer
+        self._device = torch.device(device)
+        if pack_layout not in {"packed", "sac_graph"}:
+            raise ValueError("GPUResidentReplayPipeline pack_layout must be packed or sac_graph")
+        if self._device.type != "cuda":
+            raise ValueError(
+                "GPUResidentReplayPipeline requires a CUDA device; "
+                f"got {self._device.type!r} (use cpu_pinned_double_buffer instead)"
+            )
+        if not getattr(replay_buffer, "_packed_cpu_storage", False):
+            raise ValueError("GPUResidentReplayPipeline requires packed CPU replay storage")
+        self._pack_layout = pack_layout
+        self._use_critic_graph_packed_source = (
+            bool(use_critic_graph_packed_source) and self._pack_layout != "sac_graph"
+        )
+        self._sample_count = int(sample_count)
+        self._base_seed = int(base_seed)
+        self._trace_recorder = trace_recorder
+        self._capacity = int(replay_buffer.capacity)
+        self._storage_width = int(replay_buffer._storage.shape[1])
+        self._packed_width = (
+            int(replay_buffer.sac_graph_packed_width())
+            if self._pack_layout == "sac_graph"
+            else self._storage_width
+        )
+        self._critic_graph_packed_width = (
+            int(replay_buffer.critic_graph_packed_width())
+            if self._use_critic_graph_packed_source
+            else 0
+        )
+
+        # -- device memory guard (hard fail: this pipeline is opt-in) --
+        storage_bytes = self._capacity * self._storage_width * 4
+        slot_bytes = 2 * self._sample_count * self._packed_width * 4
+        scratch_bytes = (
+            self._sample_count * self._storage_width * 4 if self._pack_layout == "sac_graph" else 0
+        )
+        critic_slot_bytes = 2 * self._sample_count * self._critic_graph_packed_width * 4
+        required_bytes = storage_bytes + slot_bytes + scratch_bytes + critic_slot_bytes
+        free_bytes, total_bytes = torch.cuda.mem_get_info(self._device)
+        if required_bytes > int(free_bytes * self._MEMORY_HEADROOM):
+            raise RuntimeError(
+                "GPU-resident replay mirror does not fit on device: "
+                f"requires {required_bytes / 2**30:.2f} GiB "
+                f"(storage {storage_bytes / 2**30:.2f} + batch slots "
+                f"{(slot_bytes + scratch_bytes + critic_slot_bytes) / 2**30:.2f}), "
+                f"device free {free_bytes / 2**30:.2f} GiB / total {total_bytes / 2**30:.2f} GiB"
+            )
+
+        self._transfer_backend = build_replay_transfer_backend(
+            device=self._device,
+            ring_depth=2,
+        )
+        self._trace_cuda_events = bool(trace_cuda_events) and (
+            self._transfer_backend.supports_timing_events
+        )
+        self._device_family = self._transfer_backend.device_family
+        self._host_pinned = False
+        try:
+            self._transfer_backend.register_host_slots([replay_buffer._storage])
+            self._host_pinned = True
+        except RuntimeError as exc:
+            print(
+                f"[GPUResidentReplay] Host storage registration failed ({exc}); "
+                "falling back to pageable H2D on the sync thread.",
+                flush=True,
+            )
+        self._gpu_storage: torch.Tensor = torch.empty(
+            (self._capacity, self._storage_width),
+            dtype=torch.float32,
+            device=self._device,
+        )
+        self._gpu_packed = self._transfer_backend.allocate_device_slots(
+            count=2,
+            shape=(self._sample_count, self._packed_width),
+            dtype=torch.float32,
+        )
+        self._gpu_critic_graph_packed: list[torch.Tensor] = (
+            self._transfer_backend.allocate_device_slots(
+                count=2,
+                shape=(self._sample_count, self._critic_graph_packed_width),
+                dtype=torch.float32,
+            )
+            if self._use_critic_graph_packed_source
+            else []
+        )
+        self._gather_scratch: torch.Tensor | None = (
+            torch.empty(
+                (self._sample_count, self._storage_width),
+                dtype=torch.float32,
+                device=self._device,
+            )
+            if self._pack_layout == "sac_graph"
+            else None
+        )
+
+        self._sync_stream = cast(torch.cuda.Stream, torch.cuda.Stream(device=self._device))
+        self._slot_events: list[Any] = [torch.cuda.Event() for _ in range(2)]
+        self._span_events: deque[tuple[int, Any]] = deque()
+        self._submitted_ptr = 0
+        self._visible_ptr = 0
+        self._wrap_skip_warned = False
+
+        self._hot = 0
+        self._cold = 1
+        self._has_hot_batch = False
+        self._hot_metadata: ReplayTickMetadata | None = None
+        self._prepared_metadata: ReplayTickMetadata | None = None
+        self._prepare_tick_id: int | None = None
+        self._prepare_required_ptr = 0
+        self._prepare_state = "idle"
+        self._prepare_error: BaseException | None = None
+        self.last_incremental_h2d_time_s = 0.0
+        self._prepare_condition = threading.Condition()
+        self._closed = False
+        self._sync_thread = threading.Thread(
+            target=self._sync_worker,
+            name="replay_gpu_resident_sync",
+            daemon=True,
+        )
+        self._sync_thread.start()
+
+    @property
+    def h2d_submitter(self) -> str:
+        return "gpu_resident_mirror"
+
+    @property
+    def transfer_manifest(self) -> dict[str, object]:
+        return {
+            "backend": type(self._transfer_backend).__name__,
+            "device": str(self._device),
+            "device_family": self._device_family,
+            "pipeline": "gpu_resident",
+            "host_memory_kind": (
+                self._transfer_backend.host_memory_kind if self._host_pinned else "pageable_shared"
+            ),
+            "host_pinned": self._host_pinned,
+            "storage_rows": self._capacity,
+            "storage_width": self._storage_width,
+            "storage_bytes": int(self._gpu_storage.numel() * self._gpu_storage.element_size()),
+            "h2d_submitter": self.h2d_submitter,
+            "ring_depth": 2,
+        }
+
+    # -- batch views ----------------------------------------------------------
+
+    def _packed_batch_view(self, packed: torch.Tensor) -> Dict[str, torch.Tensor]:
+        rb = self._replay_buffer
+        if self._pack_layout == "sac_graph":
+            c = 0
+            obs_sl = slice(c, c + rb._obs_dim)
+            c += rb._obs_dim
+            critic_sl = slice(c, c + rb._critic_dim)
+            c += rb._critic_dim
+            act_sl = slice(c, c + rb._action_dim)
+            c += rb._action_dim
+            rew_col = c
+            c += 1
+            nobs_sl = slice(c, c + rb._obs_dim)
+            c += rb._obs_dim
+            ncritic_sl = slice(c, c + rb._critic_dim)
+            c += rb._critic_dim
+            done_col = c
+            c += 1
+            trunc_col = c
+            return {
+                "obs": packed[:, obs_sl],
+                "next_obs": packed[:, nobs_sl],
+                "actions": packed[:, act_sl],
+                "rewards": packed[:, rew_col],
+                "dones": packed[:, done_col],
+                "truncated": packed[:, trunc_col],
+                "critic": packed[:, critic_sl],
+                "next_critic": packed[:, ncritic_sl],
+                "sac_graph_packed_source": packed,
+            }
+        batch = {
+            "obs": packed[:, rb._obs_sl],
+            "next_obs": packed[:, rb._nobs_sl],
+            "actions": packed[:, rb._act_sl],
+            "rewards": packed[:, rb._rew_col],
+            "dones": packed[:, rb._done_col],
+            "truncated": packed[:, rb._trunc_col],
+        }
+        if rb._critic_dim > 0:
+            batch["critic"] = packed[:, rb._critic_sl]
+            batch["next_critic"] = packed[:, rb._ncritic_sl]
+        return batch
+
+    def _large_batch_view(self, slot: int) -> Dict[str, torch.Tensor]:
+        batch = self._packed_batch_view(self._gpu_packed[slot])
+        if self._use_critic_graph_packed_source:
+            batch["critic_graph_packed_source"] = self._gpu_critic_graph_packed[slot]
+        return batch
+
+    # -- sync thread ------------------------------------------------------------
+
+    def _sync_worker(self) -> None:
+        while True:
+            if self._closed:
+                return
+            try:
+                did_work = self._submit_new_spans()
+                did_work |= self._drain_completed_spans()
+                did_work |= self._service_pending_prepare()
+            except BaseException as exc:
+                with self._prepare_condition:
+                    self._prepare_error = exc
+                    self._prepare_condition.notify_all()
+                return
+            if not did_work:
+                time.sleep(self._POLL_INTERVAL_S)
+
+    def _submit_new_spans(self) -> bool:
+        ptr = int(self._replay_buffer.ptr[0])
+        if ptr <= self._submitted_ptr:
+            return False
+        if ptr - self._submitted_ptr > self._capacity:
+            skipped = ptr - self._capacity
+            if not self._wrap_skip_warned:
+                print(
+                    "[GPUResidentReplay] mirror fell behind by more than one "
+                    f"capacity; skipping to absolute row {skipped}",
+                    flush=True,
+                )
+                self._wrap_skip_warned = True
+            self._submitted_ptr = skipped
+        start = self._submitted_ptr
+        end = ptr
+        h2d_begin_ns = time.perf_counter_ns()
+        start_event = None
+        end_event = None
+        record_cuda = self._trace_recorder is not None and self._trace_cuda_events
+        with torch.cuda.device(self._device):
+            with torch.cuda.stream(self._sync_stream):
+                if record_cuda:
+                    start_event = cast(Any, torch.cuda.Event(enable_timing=True))
+                    end_event = cast(Any, torch.cuda.Event(enable_timing=True))
+                    start_event.record()
+                for offset, length in _ring_spans(start, end, self._capacity):
+                    self._gpu_storage[offset : offset + length].copy_(
+                        self._replay_buffer._storage[offset : offset + length],
+                        non_blocking=True,
+                    )
+                if end_event is not None:
+                    end_event.record()
+                done_event = cast(Any, torch.cuda.Event())
+                done_event.record(self._sync_stream)
+        self._span_events.append((end, done_event))
+        self._submitted_ptr = end
+        self.last_incremental_h2d_time_s = (time.perf_counter_ns() - h2d_begin_ns) / 1e9
+        if self._trace_recorder is not None and start_event is not None and end_event is not None:
+            self._trace_recorder.add_cuda_pending_span(
+                "gpu/replay_pipeline_storage_h2d",
+                category="gpu",
+                cpu_begin_ns=h2d_begin_ns,
+                start_event=start_event,
+                end_event=end_event,
+                args={
+                    "h2d_bytes": (end - start) * self._storage_width * 4,
+                    "rows": end - start,
+                    "span_start": start,
+                    "span_end": end,
+                    "pinned_memory": self._host_pinned,
+                    "pipeline": "gpu_resident",
+                },
+            )
+        return True
+
+    def _drain_completed_spans(self) -> bool:
+        drained = False
+        while self._span_events and self._span_events[0][1].query():
+            self._visible_ptr = self._span_events[0][0]
+            self._span_events.popleft()
+            drained = True
+        if drained:
+            with self._prepare_condition:
+                self._prepare_condition.notify_all()
+        return drained
+
+    def _service_pending_prepare(self) -> bool:
+        with self._prepare_condition:
+            if self._prepare_state != "preparing" or self._prepare_tick_id is None:
+                return False
+            tick_id = self._prepare_tick_id
+            required_ptr = self._prepare_required_ptr
+            slot = self._cold
+        visible_size = min(self._visible_ptr, self._capacity)
+        if self._visible_ptr < required_ptr or visible_size <= 0:
+            return False
+        sample_seed = self._base_seed + int(tick_id)
+        gen = torch.Generator(device=self._device)
+        gen.manual_seed(sample_seed)
+        gather_begin_ns = time.perf_counter_ns()
+        start_event = None
+        end_event = None
+        record_cuda = self._trace_recorder is not None and self._trace_cuda_events
+        with torch.cuda.device(self._device):
+            with torch.cuda.stream(self._sync_stream):
+                if record_cuda:
+                    start_event = cast(Any, torch.cuda.Event(enable_timing=True))
+                    end_event = cast(Any, torch.cuda.Event(enable_timing=True))
+                    start_event.record()
+                indices = torch.randint(
+                    0,
+                    visible_size,
+                    (self._sample_count,),
+                    generator=gen,
+                    device=self._device,
+                )
+                dst = self._gpu_packed[slot]
+                if self._pack_layout == "sac_graph":
+                    assert self._gather_scratch is not None
+                    torch.index_select(self._gpu_storage, 0, indices, out=self._gather_scratch)
+                    self._replay_buffer.pack_sac_graph_source(self._gather_scratch, out=dst)
+                else:
+                    torch.index_select(self._gpu_storage, 0, indices, out=dst)
+                if self._use_critic_graph_packed_source:
+                    self._replay_buffer.pack_critic_graph_source(
+                        dst,
+                        out=self._gpu_critic_graph_packed[slot],
+                    )
+                if end_event is not None:
+                    end_event.record()
+                self._slot_events[slot].record(self._sync_stream)
+        metadata = ReplayTickMetadata(
+            tick_id=int(tick_id),
+            snapshot_ptr=int(self._visible_ptr),
+            snapshot_size=visible_size,
+            sample_seed=sample_seed,
+            sample_count=self._sample_count,
+            batch_host_slot=None,
+            batch_gpu_slot=slot,
+        )
+        with self._prepare_condition:
+            self._prepared_metadata = metadata
+            self._prepare_state = "gather_submitted"
+            self._prepare_condition.notify_all()
+        if self._trace_recorder is not None:
+            self._trace_recorder.add_slice(
+                "replay_pipeline/gpu_batch_gather_submit",
+                category="replay_pipeline",
+                start_ns=gather_begin_ns,
+                end_ns=time.perf_counter_ns(),
+                args={
+                    "tick_id": int(tick_id),
+                    "batch_gpu_slot": slot,
+                    "sample_count": self._sample_count,
+                    "snapshot_size": visible_size,
+                    "required_ptr": required_ptr,
+                    "visible_ptr": int(self._visible_ptr),
+                    "pack_layout": self._pack_layout,
+                    "pipeline": "gpu_resident",
+                },
+            )
+        if self._trace_recorder is not None and start_event is not None and end_event is not None:
+            self._trace_recorder.add_cuda_pending_span(
+                "gpu/replay_pipeline_batch_gather",
+                category="gpu",
+                cpu_begin_ns=gather_begin_ns,
+                start_event=start_event,
+                end_event=end_event,
+                args={
+                    "tick_id": int(tick_id),
+                    "batch_gpu_slot": slot,
+                    "sample_count": self._sample_count,
+                    "gather_bytes": self._sample_count * self._packed_width * 4,
+                    "pack_layout": self._pack_layout,
+                    "pipeline": "gpu_resident",
+                },
+            )
+        return True
+
+    # -- public API -----------------------------------------------------------
+
+    def _validate_sample_count(self, sample_count: int) -> None:
+        if int(sample_count) != int(self._sample_count):
+            raise ValueError("sample_count must match the value used to allocate the double buffer")
+
+    def _refresh_prepare_state(self) -> None:
+        if self._prepare_error is not None:
+            raise self._prepare_error
+        if self._prepared_metadata is not None:
+            slot = self._prepared_metadata.batch_gpu_slot
+            if slot is not None and self._slot_events[slot].query():
+                self._prepare_state = "ready"
+
+    def start_prepare(
+        self,
+        tick_id: int,
+        sample_count: int,
+        min_snapshot_ptr: int | None = None,
+    ) -> bool:
+        """Schedule a GPU-side gather for the current cold slot.
+
+        Returns True when this call launches new work. If the same tick is
+        already pending or prepared, returns False.
+        """
+        self._validate_sample_count(sample_count)
+        if self._closed:
+            raise RuntimeError("Cannot prepare replay batch after pipeline.close()")
+        self._refresh_prepare_state()
+        with self._prepare_condition:
+            if self._prepared_metadata is not None or self._prepare_state not in {
+                "idle",
+                "ready",
+            }:
+                prepared_tick = (
+                    self._prepared_metadata.tick_id
+                    if self._prepared_metadata is not None
+                    else self._prepare_tick_id
+                )
+                if prepared_tick == int(tick_id):
+                    return False
+                raise RuntimeError(
+                    "Cannot prepare a new replay batch before the previous batch is consumed"
+                )
+            self._prepare_tick_id = int(tick_id)
+            self._prepare_required_ptr = (
+                int(self._replay_buffer.ptr[0])
+                if min_snapshot_ptr is None
+                else int(min_snapshot_ptr)
+            )
+            self._prepared_metadata = None
+            self._prepare_error = None
+            self._prepare_state = "preparing"
+            self._prepare_condition.notify_all()
+        if self._trace_recorder is not None:
+            _req_ns = time.perf_counter_ns()
+            self._trace_recorder.add_slice(
+                "replay_pipeline/gpu_batch_prepare_request",
+                category="replay_pipeline",
+                start_ns=_req_ns,
+                end_ns=time.perf_counter_ns(),
+                args={
+                    "tick_id": int(tick_id),
+                    "required_ptr": self._prepare_required_ptr,
+                    "pipeline": "gpu_resident",
+                },
+            )
+        return True
+
+    def batch_ready(self, tick_id: int, sample_count: int) -> bool:
+        self._validate_sample_count(sample_count)
+        if self._has_hot_batch:
+            if self._hot_metadata is not None and self._hot_metadata.tick_id != int(tick_id):
+                return False
+            return True
+        self._refresh_prepare_state()
+        if self._prepared_metadata is None:
+            return False
+        if self._prepared_metadata.tick_id != int(tick_id):
+            return False
+        return self._prepare_state == "ready"
+
+    def wait_ready(self) -> None:
+        return None
+
+    def wait_until_ready(self, tick_id: int, sample_count: int) -> bool:
+        self._validate_sample_count(sample_count)
+        metadata = self._prepared_or_wait(tick_id)
+        slot = metadata.batch_gpu_slot
+        assert slot is not None
+        self._slot_events[slot].synchronize()
+        self._prepare_state = "ready"
+        return True
+
+    def _prepared_or_wait(self, tick_id: int) -> ReplayTickMetadata:
+        self._refresh_prepare_state()
+        if self._prepared_metadata is None:
+            if self._prepare_tick_id is None:
+                self.start_prepare(tick_id, self._sample_count)
+            with self._prepare_condition:
+                while self._prepared_metadata is None and self._prepare_error is None:
+                    self._prepare_condition.wait(timeout=0.1)
+                if self._prepare_error is not None:
+                    raise self._prepare_error
+            assert self._prepared_metadata is not None
+            return self._prepared_metadata
+        if self._prepared_metadata.tick_id != int(tick_id):
+            raise RuntimeError(
+                f"Prepared replay batch tick {self._prepared_metadata.tick_id} "
+                f"does not match requested tick {tick_id}"
+            )
+        return self._prepared_metadata
+
+    def sample_large_batch(self, tick_id: int, sample_count: int) -> Dict[str, torch.Tensor]:
+        self._validate_sample_count(sample_count)
+        if self._has_hot_batch:
+            if self._hot_metadata is not None and self._hot_metadata.tick_id != int(tick_id):
+                raise RuntimeError(
+                    f"Hot batch tick {self._hot_metadata.tick_id} does not match "
+                    f"requested tick {tick_id}"
+                )
+            return self._large_batch_view(self._hot)
+        if not self.batch_ready(tick_id, sample_count):
+            self.wait_until_ready(tick_id, sample_count)
+        metadata = self._prepared_or_wait(tick_id)
+        slot = metadata.batch_gpu_slot
+        assert slot is not None
+        _t0 = time.perf_counter_ns()
+        torch.cuda.current_stream(self._device).wait_event(self._slot_events[slot])
+        if self._trace_recorder is not None:
+            _wait_end = time.perf_counter_ns()
+            self._trace_recorder.add_slice(
+                "replay_pipeline/batch_h2d_wait",
+                category="replay_pipeline",
+                start_ns=_t0,
+                end_ns=_wait_end,
+                args={"tick_id": tick_id, "batch_gpu_slot": slot, "pipeline": "gpu_resident"},
+            )
+            self._trace_recorder.add_slice(
+                "replay_pipeline/gpu_wait_for_batch",
+                category="replay_pipeline",
+                start_ns=_t0,
+                end_ns=_wait_end,
+                args={"tick_id": tick_id, "batch_gpu_slot": slot, "pipeline": "gpu_resident"},
+            )
+        _swap_ns = time.perf_counter_ns()
+        with self._prepare_condition:
+            old_hot = self._hot
+            old_cold = self._cold
+            if slot != self._cold:
+                raise RuntimeError("Prepared replay batch is not in the current cold slot")
+            self._hot, self._cold = self._cold, self._hot
+            self._has_hot_batch = True
+            self._hot_metadata = metadata
+            self._prepared_metadata = None
+            self._prepare_tick_id = None
+            self._prepare_state = "idle"
+        if self._trace_recorder is not None:
+            self._trace_recorder.add_slice(
+                "replay_pipeline/hot_cold_swap",
+                category="replay_pipeline",
+                start_ns=_swap_ns,
+                end_ns=time.perf_counter_ns(),
+                args={
+                    "tick_id": tick_id,
+                    "old_hot": old_hot,
+                    "old_cold": old_cold,
+                    "new_hot": self._hot,
+                    "new_cold": self._cold,
+                    "pipeline": "gpu_resident",
+                },
+            )
+        return self._large_batch_view(self._hot)
+
+    def after_tick(self) -> None:
+        self._has_hot_batch = False
+        self._hot_metadata = None
+
+    def close(self) -> None:
+        self._closed = True
+        with self._prepare_condition:
+            self._prepare_condition.notify_all()
+        if self._sync_thread is not None:
+            self._sync_thread.join(timeout=2.0)
+        for event in self._slot_events:
+            try:
+                event.synchronize()
+            except Exception:
+                pass
+        self._transfer_backend.close()
+        self._host_pinned = False
+        self._gpu_packed.clear()
+        self._gpu_critic_graph_packed.clear()
+        self._gather_scratch = None
+        if hasattr(self, "_gpu_storage"):
+            del self._gpu_storage

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -87,6 +87,23 @@ def test_same_tick_replay_prefetch_mode_rejected():
         _offpolicy().build_runner("sac", cfg)
 
 
+def test_default_replay_pipeline_is_cpu_pinned_double_buffer():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.replay_pipeline == "cpu_pinned_double_buffer"
+
+
+def test_invalid_replay_pipeline_rejected():
+    cfg = _offpolicy_cfg(["training.replay_pipeline=invalid_pipeline"])
+    with pytest.raises(ValueError, match="Unsupported training.replay_pipeline"):
+        _offpolicy().build_runner("sac", cfg)
+
+
+def test_gpu_resident_replay_pipeline_rejected_for_multi_gpu():
+    cfg = _offpolicy_cfg(["training.replay_pipeline=gpu_resident", "training.num_gpus=2"])
+    with pytest.raises(ValueError, match="single-GPU only"):
+        _offpolicy().build_runner("sac", cfg)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch rejections
 # ---------------------------------------------------------------------------
@@ -1031,7 +1048,9 @@ def test_sac_double_buffer_dispatches_to_correct_runner(monkeypatch: pytest.Monk
     assert replay_kwargs == {
         "replay_buffer_n",
         "replay_prefetch_mode",
+        "replay_pipeline",
     }
+    assert runner.kwargs["replay_pipeline"] == "cpu_pinned_double_buffer"
 
 
 def test_hora_sac_dispatches_through_double_buffer_runner(monkeypatch: pytest.MonkeyPatch):

--- a/tests/ipc/test_replay_pipeline_gpu_resident.py
+++ b/tests/ipc/test_replay_pipeline_gpu_resident.py
@@ -1,0 +1,306 @@
+"""Tests for GPUResidentReplayPipeline."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import torch
+
+from unilab.ipc.replay_buffer import ReplayBuffer
+from unilab.ipc.replay_pipelines.gpu_resident import (
+    GPUResidentReplayPipeline,
+    _ring_spans,
+)
+
+_HAS_CUDA = torch.cuda.is_available()
+cuda_only = pytest.mark.skipif(not _HAS_CUDA, reason="CUDA required")
+
+_OBS_DIM = 4
+_ACTION_DIM = 2
+_CRITIC_DIM = 5
+
+
+def _make_replay(
+    capacity: int = 128,
+    obs_dim: int = _OBS_DIM,
+    action_dim: int = _ACTION_DIM,
+    critic_dim: int = _CRITIC_DIM,
+    device: str = "cuda",
+) -> ReplayBuffer:
+    return ReplayBuffer(
+        capacity=capacity,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        device=device,
+        critic_dim=critic_dim,
+        defer_gpu=True,
+        packed_cpu_storage=True,
+    )
+
+
+def _pattern_add(rb: ReplayBuffer, start_row: int, n: int) -> None:
+    """Add rows whose fields are exact float32 functions of the absolute row id."""
+    obs_dim, action_dim, critic_dim = rb._obs_dim, rb._action_dim, rb._critic_dim
+    rows = torch.arange(start_row, start_row + n, dtype=torch.float32)
+    col = rows.unsqueeze(1)
+    critic = next_critic = None
+    if critic_dim > 0:
+        critic = col * 10000 + torch.arange(critic_dim, dtype=torch.float32)
+        next_critic = col * 100000 + torch.arange(critic_dim, dtype=torch.float32)
+    rb.add(
+        obs=col * 10 + torch.arange(obs_dim, dtype=torch.float32),
+        actions=col * 1000 + torch.arange(action_dim, dtype=torch.float32),
+        rewards=rows.clone(),
+        next_obs=col * 100 + torch.arange(obs_dim, dtype=torch.float32),
+        dones=torch.zeros(n),
+        truncated=torch.ones(n),
+        critic=critic,
+        next_critic=next_critic,
+    )
+
+
+def _expected_pattern(rb: ReplayBuffer, rewards: torch.Tensor) -> dict[str, torch.Tensor]:
+    col = rewards.cpu().unsqueeze(1)
+    out = {
+        "obs": col * 10 + torch.arange(rb._obs_dim, dtype=torch.float32),
+        "next_obs": col * 100 + torch.arange(rb._obs_dim, dtype=torch.float32),
+        "actions": col * 1000 + torch.arange(rb._action_dim, dtype=torch.float32),
+    }
+    if rb._critic_dim > 0:
+        out["critic"] = col * 10000 + torch.arange(rb._critic_dim, dtype=torch.float32)
+        out["next_critic"] = col * 100000 + torch.arange(rb._critic_dim, dtype=torch.float32)
+    return out
+
+
+def _wait_visible(pipeline: GPUResidentReplayPipeline, ptr: int, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while pipeline._visible_ptr < ptr:
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"GPU replay mirror stalled: visible_ptr={pipeline._visible_ptr} < {ptr}"
+            )
+        time.sleep(0.005)
+
+
+def _wait_batch_ready(
+    pipeline: GPUResidentReplayPipeline,
+    tick_id: int,
+    sample_count: int,
+    timeout: float = 15.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not pipeline.batch_ready(tick_id, sample_count):
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"GPU replay batch for tick {tick_id} never became ready")
+        time.sleep(0.01)
+
+
+class TestRingSpans:
+    def test_no_wrap(self):
+        assert _ring_spans(5, 12, 64) == [(5, 7)]
+
+    def test_wrap_split(self):
+        assert _ring_spans(60, 68, 64) == [(60, 4), (0, 4)]
+
+    def test_multiple_wraps(self):
+        assert _ring_spans(62, 136, 64) == [(62, 2), (0, 64), (0, 8)]
+
+    def test_full_ring(self):
+        assert _ring_spans(3, 67, 64) == [(3, 61), (0, 3)]
+
+    def test_empty(self):
+        assert _ring_spans(5, 5, 64) == []
+        assert _ring_spans(5, 3, 64) == []
+        assert _ring_spans(0, 4, 0) == []
+
+
+class TestConstructionGuards:
+    def test_non_cuda_device_rejected(self):
+        rb = _make_replay(device="cpu")
+        with pytest.raises(ValueError, match="CUDA"):
+            GPUResidentReplayPipeline(rb, device="cpu", sample_count=8)
+
+    def test_invalid_pack_layout_rejected(self):
+        rb = _make_replay(device="cpu")
+        with pytest.raises(ValueError, match="pack_layout"):
+            GPUResidentReplayPipeline(rb, device="cpu", sample_count=8, pack_layout="bogus")
+
+    def test_runner_rejects_invalid_replay_pipeline(self):
+        from unilab.algos.torch.offpolicy.double_buffer_runner import (
+            DoubleBufferOffPolicyRunner,
+        )
+
+        with pytest.raises(ValueError, match="replay_pipeline"):
+            DoubleBufferOffPolicyRunner(replay_pipeline="bogus")
+
+
+@cuda_only
+class TestGPUResidentPipeline:
+    @pytest.fixture
+    def pipeline_factory(self):
+        created = []
+
+        def _make(rb, **kwargs):
+            kwargs.setdefault("device", "cuda")
+            kwargs.setdefault("sample_count", 16)
+            pipeline = GPUResidentReplayPipeline(rb, **kwargs)
+            created.append(pipeline)
+            return pipeline
+
+        yield _make
+        for pipeline in created:
+            pipeline.close()
+
+    def test_allocates_gpu_storage_and_slots(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        assert pipeline._gpu_storage.shape == (64, rb._storage.shape[1])
+        assert pipeline._gpu_storage.is_cuda
+        assert len(pipeline._gpu_packed) == 2
+        assert all(slot.is_cuda for slot in pipeline._gpu_packed)
+        assert rb._storage.is_pinned()
+        assert pipeline.h2d_submitter == "gpu_resident_mirror"
+        manifest = pipeline.transfer_manifest
+        assert manifest["pipeline"] == "gpu_resident"
+        assert manifest["storage_rows"] == 64
+        assert manifest["host_pinned"] is True
+
+    def test_mirror_syncs_rows_incrementally(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb)
+        _wait_visible(pipeline, 32)
+        _pattern_add(rb, 32, 16)
+        _wait_visible(pipeline, 48)
+        torch.testing.assert_close(pipeline._gpu_storage[:48].cpu(), rb._storage[:48])
+
+    def test_ring_wraparound_mirror_matches_storage(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb)
+        _wait_visible(pipeline, 64)
+        _pattern_add(rb, 64, 48)
+        _wait_visible(pipeline, 112)
+        torch.testing.assert_close(pipeline._gpu_storage.cpu(), rb._storage)
+
+    def test_sampled_batch_matches_replay_rows(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb, sample_count=16)
+        assert pipeline.start_prepare(1, 16) is True
+        batch = pipeline.sample_large_batch(1, 16)
+        rewards = batch["rewards"].cpu()
+        assert rewards.min() >= 0
+        assert rewards.max() < 64
+        expected = _expected_pattern(rb, rewards)
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)
+        assert (batch["dones"].cpu() == 0).all()
+        assert (batch["truncated"].cpu() == 1).all()
+        assert batch["obs"].is_cuda
+
+    def test_deterministic_seed_produces_same_batch(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 64)
+        p1 = pipeline_factory(rb, sample_count=16, base_seed=99)
+        b1 = p1.sample_large_batch(7, 16)
+        r1 = b1["rewards"].cpu().clone()
+        p1.close()
+        p2 = pipeline_factory(rb, sample_count=16, base_seed=99)
+        b2 = p2.sample_large_batch(7, 16)
+        torch.testing.assert_close(r1, b2["rewards"].cpu())
+
+    def test_min_snapshot_ptr_gates_prepare(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        _wait_visible(pipeline, 32)
+        assert pipeline.start_prepare(5, 8, min_snapshot_ptr=48) is True
+        time.sleep(0.2)
+        assert pipeline.batch_ready(5, 8) is False
+        _pattern_add(rb, 32, 16)
+        _wait_batch_ready(pipeline, 5, 8)
+        batch = pipeline.sample_large_batch(5, 8)
+        assert batch["obs"].shape == (8, rb._obs_dim)
+
+    def test_sample_count_mismatch_is_rejected(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        with pytest.raises(ValueError, match="sample_count"):
+            pipeline.start_prepare(1, 999)
+        with pytest.raises(ValueError, match="sample_count"):
+            pipeline.batch_ready(1, 999)
+
+    def test_prepare_same_tick_idempotent_new_tick_raises(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        assert pipeline.start_prepare(1, 8) is True
+        assert pipeline.start_prepare(1, 8) is False
+        with pytest.raises(RuntimeError, match="consumed"):
+            pipeline.start_prepare(2, 8)
+
+    def test_hot_cold_swap_after_tick(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        pipeline.sample_large_batch(1, 8)
+        first_hot = pipeline._hot
+        pipeline.after_tick()
+        pipeline.start_prepare(2, 8)
+        pipeline.sample_large_batch(2, 8)
+        assert pipeline._hot != first_hot
+
+    def test_hot_batch_tick_mismatch_raises(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        pipeline.sample_large_batch(1, 8)
+        with pytest.raises(RuntimeError, match="Hot batch tick"):
+            pipeline.sample_large_batch(2, 8)
+        assert pipeline.batch_ready(2, 8) is False
+
+    def test_sac_graph_layout_column_order(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb, sample_count=16, pack_layout="sac_graph")
+        batch = pipeline.sample_large_batch(1, 16)
+        src = batch["sac_graph_packed_source"]
+        assert src.shape == (16, rb._storage.shape[1])
+        rewards = batch["rewards"].cpu()
+        expected = _expected_pattern(rb, rewards)
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)
+        # graph order: obs, critic, actions, rew, next_obs, next_critic, done, trunc
+        c = 0
+        torch.testing.assert_close(src[:, c : c + rb._obs_dim].cpu(), expected["obs"])
+        c += rb._obs_dim
+        torch.testing.assert_close(src[:, c : c + rb._critic_dim].cpu(), expected["critic"])
+        c += rb._critic_dim
+        torch.testing.assert_close(src[:, c : c + rb._action_dim].cpu(), expected["actions"])
+
+    def test_critic_graph_packed_source(self, pipeline_factory):
+        rb = _make_replay(capacity=128)
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(
+            rb,
+            sample_count=16,
+            use_critic_graph_packed_source=True,
+        )
+        batch = pipeline.sample_large_batch(1, 16)
+        cg = batch["critic_graph_packed_source"]
+        assert cg.shape == (16, rb.critic_graph_packed_width())
+        expected = _expected_pattern(rb, batch["rewards"].cpu())
+        # critic graph order: critic, actions, rew, next_obs, next_critic, done, trunc
+        torch.testing.assert_close(cg[:, : rb._critic_dim].cpu(), expected["critic"])
+        c = rb._critic_dim
+        torch.testing.assert_close(cg[:, c : c + rb._action_dim].cpu(), expected["actions"])
+
+    def test_close_stops_thread_and_unregisters(self, pipeline_factory):
+        rb = _make_replay(capacity=64)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        pipeline.close()
+        assert not pipeline._sync_thread.is_alive()
+        assert not rb._storage.is_pinned()


### PR DESCRIPTION
## Summary

Issue #694 Tier1/P0（单卡）：为单卡 off-policy（SAC / TD3 / FlashSAC）新增 opt-in 的 GPU-resident replay pipeline（`training.replay_pipeline=gpu_resident`），把 replay 的 add / sample / pack 从 collector CPU 关键路径移除。本 PR 不含 Tier2 多卡内容，#694 保持 open。

- learner 进程内维护 packed CPU replay storage 的 GPU 镜像：整表 `cudaHostRegister` + 后台线程按 chunk 增量 H2D（side stream，7.27 MiB/iter 与 env step 重叠）。
- batch 采样在同一 side stream 上 GPU `randint` + `index_select`；collector CPU pack 与 116.25 MiB/iter batch H2D 消除（PCIe 流量 −94%/iter）。
- 一致性：device-visible write pointer（每 chunk CUDA event 门控）+ gather 与增量 H2D 同流全序 → 采样快照一致；collector `ReplayBuffer.add()` 零改动，CPU storage 仍为 authoritative。
- 默认 `cpu_pinned_double_buffer` 不变；`num_gpus > 1` 组合明确报错（Tier2 范围外）；非 CUDA 设备构造时硬失败（opt-in 不静默回退）。

改动面：新增 `src/unilab/ipc/replay_pipelines/gpu_resident.py`；`DoubleBufferOffPolicyRunner` 按 `training.replay_pipeline` 选择 pipeline（gpu_resident 时不建 collector pack 队列/槽位，worker 侧天然 no-op，worker.py 零改动）；`conf/offpolicy/config.yaml` 新增 `training.replay_pipeline: cpu_pinned_double_buffer`；`scripts/train_offpolicy.py` + FlashSAC builder 透传。

## Validation

- `make test-all`：通过（check / test-cov / test-benchmark-smoke，exit 0）。
- 新增 `tests/ipc/test_replay_pipeline_gpu_resident.py`（21 项：`_ring_spans` 纯函数、镜像一致性、环形覆写、`min_snapshot_ptr` 门控、seed 确定性、sac_graph / critic_graph 列序、close 释放等）+ config/dispatch 测试（默认值、非法值、多卡拒绝）。
- 端到端（本机 1× RTX 6000 Ada，同命令 150 iter 稳态中位数，baseline 为同命令默认 pipeline run）：
  `uv run --extra motrix scripts/train_offpolicy.py algo=sac task=sac/g1_motion_tracking/motrix algo.max_iterations=150 training.replay_pipeline=gpu_resident`

| 指标 | baseline | gpu_resident | Δ |
|---|---:|---:|---:|
| collector `replay_ms` | 12.28 | 1.97（pipeline 归因 0） | pack 10.1 ms/iter 消除 |
| collector cadence | 72.28 ms | 60.4 ms | −16% |
| Collector/s | 30,977 | 35,396 | +14.3% |
| Steps/s | 29,509 | 36,106 | +22.4% |
| learner replay batch wait | 24.6 ms | 11.8 ms | −52% |
| learner exposed replay boundary | 0.078 ms | 0.060 ms | <0.5 ms ✓ |
| 稳态训练循环（剔除 iter1 warmup） | 10.43 s | 8.60 s | −17.5% |
| reward final / best | 0.422 / 0.973 | 0.432 / 0.985 | 学习行为一致 |

trace 分解（见 #694 评论）：`replay_ms` 残值 = authoritative `add` 1.81 ms + marshalling ~0.16 ms（contract 要求，任何 placement 不可移除）；replay batch wait 残值大头为 freshness 契约等待（`min_snapshot_ptr` 等下一个 chunk 产出），非 placement 开销。端到端 wall 对比已剔除 iter 1 一次性 torch.compile warmup（冷/热 inductor cache 差异，与 placement 无关）。

## Out of scope

- Tier2 多卡 replay traffic scaling（2/4/8 GPU）：`MultiGPUOffPolicyRunner` 未动，多卡验证在 #694 继续跟进。
- freshness 放宽（`min_snapshot_ptr=ptr`，可将 batch wait 压至 ~1.5 ms）：训练动力学语义变更，需单独决策。
