### PR TITLE
test: freeze Phase 5 PPO RSS threshold amendment

### DIFF
--- a/benchmark/rl/benchmark_mjwarp_ppo.py
+++ b/benchmark/rl/benchmark_mjwarp_ppo.py
@@ -38,7 +38,6 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence, cast
 
 import numpy as np
-from omegaconf import OmegaConf
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
@@ -74,6 +73,9 @@ from unilab.tools.g1_baseline_provenance import (  # noqa: E402
 )
 from unilab.tools.issue705_thresholds import (  # noqa: E402
     ThresholdManifest,
+    load_amendment_freeze_receipt,
+    load_freeze_receipt,
+    load_threshold_amendment,
     load_threshold_manifest,
 )
 
@@ -84,6 +86,12 @@ PROFILE = "device_resident"
 DEFAULT_BASELINE_PLAN = Path("tests/acceptance/issue_705/g1_mujoco_baseline_plan.yaml")
 DEFAULT_THRESHOLD_MANIFEST = Path("tests/acceptance/issue_705/g1_threshold_manifest.yaml")
 DEFAULT_THRESHOLD_RECEIPT = Path("tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml")
+DEFAULT_THRESHOLD_AMENDMENT = Path(
+    "tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml"
+)
+DEFAULT_THRESHOLD_AMENDMENT_RECEIPT = Path(
+    "tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment_freeze_receipt.yaml"
+)
 DEFAULT_OUTPUT = Path("/tmp/unilab_issue705_mjwarp_device_ppo.json")
 DEFAULT_TRACE_OUTPUT = Path("/tmp/unilab_issue705_mjwarp_device_ppo_trace.json")
 THROUGHPUT_MODES = ("mujoco_host", "mjwarp_device")
@@ -120,6 +128,9 @@ SOURCE_INPUTS = (
     "tests/acceptance/issue_705/g1_mujoco_baseline_plan.yaml",
     "tests/acceptance/issue_705/g1_threshold_manifest.yaml",
     "tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml",
+    "tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml",
+    "tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment_freeze_receipt.yaml",
+    "docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md",
     "tests/benchmark/test_mjwarp_ppo_benchmark.py",
     "uv.lock",
 )
@@ -162,6 +173,10 @@ class BenchmarkBinding:
     threshold_manifest_path: Path
     threshold_manifest_sha256: str
     threshold_freeze_commit: str
+    amendment_id: str
+    amendment_manifest_path: Path
+    amendment_manifest_sha256: str
+    amendment_freeze_commit: str
     batch_sizes: tuple[int, ...]
     process_repeats: int
     behavior_seeds: tuple[int, ...]
@@ -245,18 +260,12 @@ def _git(*args: str) -> str:
     return result.stdout.strip()
 
 
-def _load_yaml(path: Path) -> Mapping[str, Any]:
-    try:
-        value = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-    except Exception as exc:  # noqa: BLE001 - normalize YAML failures at the benchmark boundary.
-        raise MjwarpPpoBenchmarkError(f"cannot load {path}: {type(exc).__name__}: {exc}") from exc
-    return _mapping(value, str(path))
-
-
 def load_binding(
     *,
     threshold_manifest_path: Path = DEFAULT_THRESHOLD_MANIFEST,
     threshold_receipt_path: Path = DEFAULT_THRESHOLD_RECEIPT,
+    threshold_amendment_path: Path = DEFAULT_THRESHOLD_AMENDMENT,
+    threshold_amendment_receipt_path: Path = DEFAULT_THRESHOLD_AMENDMENT_RECEIPT,
     baseline_plan_path: Path = DEFAULT_BASELINE_PLAN,
 ) -> BenchmarkBinding:
     """Bind the exact frozen matrix before a benchmark command can be constructed."""
@@ -271,11 +280,37 @@ def load_binding(
         if threshold_receipt_path.is_absolute()
         else ROOT_DIR / threshold_receipt_path
     )
+    amendment_path = (
+        threshold_amendment_path
+        if threshold_amendment_path.is_absolute()
+        else ROOT_DIR / threshold_amendment_path
+    )
+    amendment_receipt_path = (
+        threshold_amendment_receipt_path
+        if threshold_amendment_receipt_path.is_absolute()
+        else ROOT_DIR / threshold_amendment_receipt_path
+    )
     plan_path = (
         baseline_plan_path if baseline_plan_path.is_absolute() else ROOT_DIR / baseline_plan_path
     )
     manifest: ThresholdManifest = load_threshold_manifest(manifest_path, repo_root=ROOT_DIR)
-    receipt = _load_yaml(receipt_path)
+    receipt = load_freeze_receipt(
+        receipt_path,
+        manifest=manifest,
+        repo_root=ROOT_DIR,
+    )
+    amendment = load_threshold_amendment(
+        amendment_path,
+        base_manifest=manifest,
+        base_receipt=receipt,
+        repo_root=ROOT_DIR,
+    )
+    amendment_receipt = load_amendment_freeze_receipt(
+        amendment_receipt_path,
+        amendment=amendment,
+        base_receipt=receipt,
+        repo_root=ROOT_DIR,
+    )
     data = manifest.data
     measurement = _mapping(data.get("measurement"), "measurement")
     gates = _mapping(data.get("gates"), "gates")
@@ -290,17 +325,7 @@ def load_binding(
     baseline_plan = _load_plan(plan_path)
 
     manifest_sha = sha256_file(manifest_path)
-    if receipt.get("threshold_set_id") != data.get("threshold_set_id"):
-        raise MjwarpPpoBenchmarkError("threshold receipt set id differs from manifest")
-    if receipt.get("manifest_path") != threshold_manifest_path.as_posix():
-        raise MjwarpPpoBenchmarkError(
-            "threshold receipt manifest path differs from benchmark binding"
-        )
-    if receipt.get("manifest_sha256") != manifest_sha:
-        raise MjwarpPpoBenchmarkError("threshold receipt SHA does not match manifest")
-    freeze_commit = receipt.get("freeze_commit")
-    if not _is_commit(freeze_commit):
-        raise MjwarpPpoBenchmarkError("threshold receipt freeze_commit must be a full SHA")
+    freeze_commit = receipt.freeze_commit
 
     batches_raw = measurement.get("batch_sizes")
     if not isinstance(batches_raw, list):
@@ -326,7 +351,11 @@ def load_binding(
         threshold_set_id=_string(data.get("threshold_set_id"), "threshold_set_id"),
         threshold_manifest_path=threshold_manifest_path,
         threshold_manifest_sha256=manifest_sha,
-        threshold_freeze_commit=cast(str, freeze_commit),
+        threshold_freeze_commit=freeze_commit,
+        amendment_id=amendment.amendment_id,
+        amendment_manifest_path=threshold_amendment_path,
+        amendment_manifest_sha256=sha256_file(amendment_path),
+        amendment_freeze_commit=amendment_receipt.freeze_commit,
         batch_sizes=batch_sizes,
         process_repeats=_integer(
             measurement.get("env_process_repeats"), "env_process_repeats", minimum=5
@@ -349,9 +378,7 @@ def load_binding(
         episode_length_median_ratio_min=_number(
             training.get("episode_length_median_ratio_min"), "episode length gate"
         ),
-        host_memory_ratio_max=_number(
-            memory.get("host_preferred_metric_ratio_max"), "host memory gate"
-        ),
+        host_memory_ratio_max=amendment.host_memory_ratio_max,
         device_peak_reserved_capacity_ratio_max=_number(
             memory.get("device_peak_reserved_capacity_ratio_max"), "device capacity gate"
         ),
@@ -375,6 +402,23 @@ def load_binding(
         gpu_capacity_bytes=_integer(hardware.get("gpu_memory_mib"), "GPU memory MiB", minimum=1)
         * 1024**2,
     )
+
+
+def _threshold_payload(binding: BenchmarkBinding) -> dict[str, Any]:
+    return {
+        "base": {
+            "threshold_set_id": binding.threshold_set_id,
+            "manifest_path": binding.threshold_manifest_path.as_posix(),
+            "manifest_sha256": binding.threshold_manifest_sha256,
+            "freeze_commit": binding.threshold_freeze_commit,
+        },
+        "amendment": {
+            "amendment_id": binding.amendment_id,
+            "manifest_path": binding.amendment_manifest_path.as_posix(),
+            "manifest_sha256": binding.amendment_manifest_sha256,
+            "freeze_commit": binding.amendment_freeze_commit,
+        },
+    }
 
 
 def expected_case_ids(binding: BenchmarkBinding) -> tuple[str, ...]:
@@ -1243,12 +1287,12 @@ def _validate_source_at_commit(
     commit = source.get("commit")
     if not isinstance(commit, str) or not _is_commit(commit):
         return
-    if commit == binding.threshold_freeze_commit:
-        errors.append("candidate commit cannot equal threshold freeze commit")
+    if commit == binding.amendment_freeze_commit:
+        errors.append("candidate commit cannot equal amendment freeze commit")
     for command, error in (
         (
-            ["git", "merge-base", "--is-ancestor", binding.threshold_freeze_commit, commit],
-            "candidate commit does not descend from threshold freeze",
+            ["git", "merge-base", "--is-ancestor", binding.amendment_freeze_commit, commit],
+            "candidate commit does not descend from amendment freeze",
         ),
         (
             ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
@@ -1329,12 +1373,7 @@ def _integrity_validation_errors(
         if root.get("profile") != PROFILE:
             errors.append("artifact profile must be device_resident")
         threshold = _mapping(root.get("threshold"), "threshold")
-        expected_threshold = {
-            "threshold_set_id": active_binding.threshold_set_id,
-            "manifest_path": active_binding.threshold_manifest_path.as_posix(),
-            "manifest_sha256": active_binding.threshold_manifest_sha256,
-            "freeze_commit": active_binding.threshold_freeze_commit,
-        }
+        expected_threshold = _threshold_payload(active_binding)
         if threshold != expected_threshold:
             errors.append("threshold differs from frozen binding")
         source = _mapping(root.get("source"), "source")
@@ -1346,8 +1385,8 @@ def _integrity_validation_errors(
         _sha256(source.get("tree_sha256"), "source.tree_sha256")
         _sha256(source.get("uv_lock_sha256"), "source.uv_lock_sha256")
         _sha256(source.get("owner_yaml_sha256"), "source.owner_yaml_sha256")
-        if commit == active_binding.threshold_freeze_commit:
-            errors.append("candidate commit cannot equal threshold freeze commit")
+        if commit == active_binding.amendment_freeze_commit:
+            errors.append("candidate commit cannot equal amendment freeze commit")
 
         hardware = _mapping(root.get("hardware"), "hardware")
         expected_hardware = {
@@ -1870,9 +1909,9 @@ def collect_artifact(
     binding = load_binding()
     baseline_plan = _load_plan(ROOT_DIR / DEFAULT_BASELINE_PLAN)
     source = _source_payload()
-    if source["commit"] == binding.threshold_freeze_commit:
+    if source["commit"] == binding.amendment_freeze_commit:
         raise MjwarpPpoBenchmarkError(
-            "candidate benchmark cannot run at the threshold freeze commit"
+            "candidate benchmark cannot run at the amendment freeze commit"
         )
     hardware = _hardware_payload(baseline_plan)
     preflight_before = _preflight_payload(baseline_plan)
@@ -1897,12 +1936,7 @@ def collect_artifact(
         "profile": PROFILE,
         "generated_at": _utc_now(),
         "source": source,
-        "threshold": {
-            "threshold_set_id": binding.threshold_set_id,
-            "manifest_path": binding.threshold_manifest_path.as_posix(),
-            "manifest_sha256": binding.threshold_manifest_sha256,
-            "freeze_commit": binding.threshold_freeze_commit,
-        },
+        "threshold": _threshold_payload(binding),
         "hardware": hardware,
         "execution": {
             "process_isolation": True,

--- a/docs/sphinx/source/adr/ADR-0000-index.md
+++ b/docs/sphinx/source/adr/ADR-0000-index.md
@@ -19,6 +19,7 @@ orphan: true
 | [ADR-0003 Task Owner And Config Compose Contract](ADR-0003-task-owner-and-config-compose-contract.md) | Config owner | Accepted |
 | [ADR-0004 Registry Bootstrap Contract](ADR-0004-registry-bootstrap-contract.md) | Registry bootstrap | Accepted |
 | [ADR-0005 Unified Obs Critic Env And IPC Contract](ADR-0005-unified-obs-critic-env-and-ipc-contract.md) | Observation / IPC | Accepted |
+| [ADR-0006 Phase 5 PPO RSS Threshold Amendment](ADR-0006-phase5-ppo-rss-threshold-amendment.md) | Evidence / threshold governance | Accepted |
 
 ## ADR Governance
 

--- a/docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md
+++ b/docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md
@@ -1,0 +1,80 @@
+---
+orphan: true
+---
+
+# ADR-0006 Phase 5 PPO RSS Threshold Amendment
+
+语言: 简体中文
+
+- Status: Accepted
+- Date: 2026-07-30
+- Owners: RL infrastructure maintainers
+- Supersedes: None
+- Superseded by: None
+
+## Context
+
+Issue #705 的 Phase 0 threshold manifest 在候选实现前冻结，并由独立 commit、Git blob 和
+SHA-256 receipt 保护。Phase 5 PPO benchmark 在两个完整 40-case capture 和后续 b128 focused
+capture 中，mjwarp/MuJoCo 的进程树 peak RSS median ratio 稳定落在约 `1.248` 到 `1.2517`。
+最新 clean candidate 的 b128 延迟和吞吐均有余量，RSS 只比 `1.25` 上限多约 3.29 MB。
+
+项目 owner 决定接受这部分 allocator/runtime 常驻差异，将 Phase 5 PPO RSS ratio 上限调整为
+`1.26`。原 Phase 0 manifest 已被 Phase 4 和其他验收链消费，直接改写它会破坏已有 evidence
+的 provenance，也会让修改后的 threshold 与历史结果无法区分。
+
+## Decision
+
+1. Phase 0 threshold manifest 和 freeze receipt 保持逐字节不变。
+2. 新增版本化 amendment `g1-phase5-ppo-rss-ratio-v1`，只覆盖 Phase 5 PPO artifact 的进程树
+   peak RSS median ratio，将上限从 `1.25` 调整到 `1.26`。
+3. amendment 仅适用于 `issue705-mjwarp-device-ppo-benchmark-v1` 的
+   `device_resident` profile，并覆盖 throughput paired lane 与 behavior lane。所有其他 threshold、
+   profile、artifact 和 acceptance phase 继续使用 base manifest。
+4. amendment 使用独立 manifest 和 freeze receipt。receipt 绑定 amendment manifest 的
+   SHA-256、Git blob 和先于 candidate 的 freeze commit。
+5. Phase 5 PPO artifact 必须同时记录 base threshold 和 amendment provenance；candidate commit
+   必须是 amendment freeze commit 的严格后代。缺失、scope 不匹配、hash/blob 篡改或祖先关系
+   不成立时 fail closed。
+6. amendment 不改变 matrix、warmup、进程隔离、worker 顺序、采样、aggregation、retry、GPU
+   memory、transfer/sync、训练行为或延迟/吞吐 gate。
+
+## Stable Contracts
+
+- `g1_threshold_manifest.yaml` 的 `host_preferred_metric_ratio_max` 仍为 `1.25`。
+- Phase 5 PPO benchmark 只有在 base 与 amendment 两套 receipt 都有效时才能构造执行计划。
+- 有效 artifact 的 threshold payload 同时包含 base 和 amendment 的 id/path/hash/freeze commit。
+- RSS boundary `<= 1.26` 通过，`> 1.26` 失败；其余 gate 继续读取 immutable base manifest。
+- threshold amendment PR 不包含 candidate benchmark 结果或 production runtime 修改。
+
+## Alternatives Considered
+
+- 直接修改 Phase 0 manifest。拒绝原因：会使既有 Phase 4 evidence 失去原始 threshold identity，
+  并形成 post-hoc 改写历史。
+- 在 benchmark 代码中直接把常量改成 `1.26`。拒绝原因：缺少独立 schema、scope、receipt 和
+  ancestry，无法证明结果使用了哪个 threshold 版本。
+- 对 b128 单独放宽、其他 batch 保持 `1.25`。拒绝原因：现有 metric contract 是统一的
+  end-to-end process RSS ratio；按观测结果特判 batch 会引入 post-hoc selection。
+
+## Consequences
+
+- 后续 Phase 5 candidate 必须基于 amendment freeze commit 之后的 clean integration commit 重采。
+- 历史 failed diagnostic artifact 不会自动转为 evidence；必须运行完整 40-case matrix并重新生成
+  双 provenance artifact。
+- `1.26` 成为 Phase 5 PPO host RSS 的唯一有效上限，进一步修改仍需新的 ADR、child issue、
+  threshold-only PR 和先于 candidate 的 freeze receipt。
+
+## Evidence In Repo
+
+- Base manifest: `tests/acceptance/issue_705/g1_threshold_manifest.yaml`
+- Amendment manifest: `tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml`
+- Validator: `src/unilab/tools/issue705_thresholds.py`
+- PPO consumer: `benchmark/rl/benchmark_mjwarp_ppo.py`
+- Contract tests: `tests/tools/test_issue705_threshold_amendment.py`
+
+## Related Documents
+
+- [Issue #705](https://github.com/unilabsim/UniLab/issues/705)
+- [Issue #807](https://github.com/unilabsim/UniLab/issues/807)
+- {doc}`ADR Index </adr/README>`
+- {doc}`协作流程 </zh_CN/4-developer_guide/5-contributing_workflow>`

--- a/src/unilab/tools/issue705_thresholds.py
+++ b/src/unilab/tools/issue705_thresholds.py
@@ -26,6 +26,14 @@ ISSUE = 705
 THRESHOLD_SET_ID = "g1-manager-mjwarp-v1"
 THRESHOLD_MANIFEST_PATH = Path("tests/acceptance/issue_705/g1_threshold_manifest.yaml")
 FREEZE_RECEIPT_PATH = Path("tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml")
+AMENDMENT_SCHEMA_VERSION = 1
+AMENDMENT_ISSUE = 807
+AMENDMENT_ID = "g1-phase5-ppo-rss-ratio-v1"
+AMENDMENT_MANIFEST_PATH = Path("tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml")
+AMENDMENT_FREEZE_RECEIPT_PATH = Path(
+    "tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment_freeze_receipt.yaml"
+)
+AMENDMENT_ADR_PATH = Path("docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md")
 BASELINE_PLAN_PATH = Path("tests/acceptance/issue_705/g1_mujoco_baseline_plan.yaml")
 BASELINE_ARTIFACT_PATH = Path("tests/acceptance/issue_705/artifacts/g1_mujoco_phase0_baseline.json")
 
@@ -58,6 +66,32 @@ class ThresholdManifest:
 
 @dataclass(frozen=True)
 class FreezeReceipt:
+    source_path: Path
+    data: Mapping[str, Any]
+    git_history_verified: bool = False
+
+    @property
+    def freeze_commit(self) -> str:
+        return str(self.data["freeze_commit"])
+
+
+@dataclass(frozen=True)
+class ThresholdAmendment:
+    source_path: Path
+    data: Mapping[str, Any]
+
+    @property
+    def amendment_id(self) -> str:
+        return str(self.data["amendment_id"])
+
+    @property
+    def host_memory_ratio_max(self) -> float:
+        change = cast(Mapping[str, Any], self.data["change"])
+        return float(change["amended_value"])
+
+
+@dataclass(frozen=True)
+class AmendmentFreezeReceipt:
     source_path: Path
     data: Mapping[str, Any]
     git_history_verified: bool = False
@@ -282,6 +316,69 @@ _GOVERNANCE_KEYS = (
     "candidate_result_and_threshold_change_same_pr_forbidden",
     "threshold_change_requires",
     "failure_semantics",
+)
+_AMENDMENT_ROOT_KEYS = (
+    "schema_version",
+    "issue",
+    "amendment_id",
+    "state",
+    "base_threshold",
+    "scope",
+    "change",
+    "governance",
+)
+_AMENDMENT_BASE_KEYS = (
+    "threshold_set_id",
+    "manifest_path",
+    "manifest_sha256",
+    "freeze_commit",
+)
+_AMENDMENT_SCOPE_KEYS = (
+    "phase",
+    "artifact_kind",
+    "profile",
+    "benchmark_path",
+    "metric",
+    "threshold_path",
+    "lanes",
+    "references",
+    "aggregation",
+    "comparison",
+)
+_AMENDMENT_CHANGE_KEYS = (
+    "previous_value",
+    "amended_value",
+    "owner_decision_date",
+    "rationale",
+)
+_AMENDMENT_GOVERNANCE_KEYS = (
+    "adr_path",
+    "child_issue_url",
+    "base_manifest_immutable",
+    "all_unlisted_thresholds_inherit_base",
+    "candidate_commit_must_descend_from_amendment_freeze",
+    "candidate_and_amendment_same_commit_forbidden",
+    "amendment_and_candidate_same_pr_forbidden",
+    "threshold_only_pr",
+    "no_protocol_change",
+)
+_AMENDMENT_RECEIPT_KEYS = (
+    "schema_version",
+    "issue",
+    "amendment_id",
+    "manifest_path",
+    "manifest_sha256",
+    "manifest_git_blob",
+    "freeze_commit",
+    "base_threshold_set_id",
+    "base_manifest_sha256",
+    "base_freeze_commit",
+    "issue_url",
+    "adr_path",
+    "change_policy",
+    "creation_verification",
+    "shallow_checkout_policy",
+    "final_merge_method",
 )
 
 
@@ -772,6 +869,214 @@ def load_threshold_manifest(path: Path, *, repo_root: Path) -> ThresholdManifest
     if errors:
         raise ThresholdValidationError(path, errors)
     return ThresholdManifest(source_path=path, data=raw)
+
+
+def _validate_amendment_schema(raw: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    root = _mapping(raw, "amendment", _AMENDMENT_ROOT_KEYS, errors)
+    base = _mapping(
+        root.get("base_threshold"),
+        "base_threshold",
+        _AMENDMENT_BASE_KEYS,
+        errors,
+    )
+    scope = _mapping(root.get("scope"), "scope", _AMENDMENT_SCOPE_KEYS, errors)
+    references = _mapping(
+        scope.get("references"),
+        "scope.references",
+        ("throughput", "behavior"),
+        errors,
+    )
+    change = _mapping(root.get("change"), "change", _AMENDMENT_CHANGE_KEYS, errors)
+    governance = _mapping(
+        root.get("governance"),
+        "governance",
+        _AMENDMENT_GOVERNANCE_KEYS,
+        errors,
+    )
+
+    _integer(root.get("schema_version"), "schema_version", errors, minimum=1)
+    _integer(root.get("issue"), "issue", errors, minimum=1)
+    for key in ("amendment_id", "state"):
+        _string(root.get(key), key, errors)
+    for key in _AMENDMENT_BASE_KEYS:
+        _string(base.get(key), f"base_threshold.{key}", errors)
+    _integer(scope.get("phase"), "scope.phase", errors, minimum=1)
+    for key in (
+        "artifact_kind",
+        "profile",
+        "benchmark_path",
+        "metric",
+        "threshold_path",
+        "aggregation",
+        "comparison",
+    ):
+        _string(scope.get(key), f"scope.{key}", errors)
+    for index, lane in enumerate(_list(scope.get("lanes"), "scope.lanes", errors)):
+        _string(lane, f"scope.lanes[{index}]", errors)
+    for key in ("throughput", "behavior"):
+        _string(references.get(key), f"scope.references.{key}", errors)
+    for key in ("previous_value", "amended_value"):
+        _number(change.get(key), f"change.{key}", errors)
+    for key in ("owner_decision_date", "rationale"):
+        _string(change.get(key), f"change.{key}", errors)
+    for key in ("adr_path", "child_issue_url"):
+        _string(governance.get(key), f"governance.{key}", errors)
+    for key in _AMENDMENT_GOVERNANCE_KEYS[2:]:
+        _boolean(governance.get(key), f"governance.{key}", errors)
+    return errors
+
+
+def _amendment_policy_errors(raw: Mapping[str, Any]) -> list[str]:
+    expected: dict[str, Any] = {
+        "schema_version": AMENDMENT_SCHEMA_VERSION,
+        "issue": AMENDMENT_ISSUE,
+        "amendment_id": AMENDMENT_ID,
+        "state": "frozen",
+        "base_threshold.threshold_set_id": THRESHOLD_SET_ID,
+        "base_threshold.manifest_path": THRESHOLD_MANIFEST_PATH.as_posix(),
+        "scope.phase": 5,
+        "scope.artifact_kind": "issue705-mjwarp-device-ppo-benchmark-v1",
+        "scope.profile": "device_resident",
+        "scope.benchmark_path": "benchmark/rl/benchmark_mjwarp_ppo.py",
+        "scope.metric": "process_tree_peak_rss_median_bytes_ratio",
+        "scope.threshold_path": "gates.memory.host_preferred_metric_ratio_max",
+        "scope.lanes": ["throughput", "behavior"],
+        "scope.references": {
+            "throughput": "paired_mujoco_host_same_batch",
+            "behavior": "phase0_mujoco_ppo",
+        },
+        "scope.aggregation": "median_of_independent_process_peaks",
+        "scope.comparison": "candidate_over_reference_lte",
+        "change.previous_value": 1.25,
+        "change.amended_value": 1.26,
+        "change.owner_decision_date": "2026-07-30",
+        "governance.adr_path": AMENDMENT_ADR_PATH.as_posix(),
+        "governance.child_issue_url": "https://github.com/unilabsim/UniLab/issues/807",
+        "governance.base_manifest_immutable": True,
+        "governance.all_unlisted_thresholds_inherit_base": True,
+        "governance.candidate_commit_must_descend_from_amendment_freeze": True,
+        "governance.candidate_and_amendment_same_commit_forbidden": True,
+        "governance.amendment_and_candidate_same_pr_forbidden": True,
+        "governance.threshold_only_pr": True,
+        "governance.no_protocol_change": True,
+    }
+    errors: list[str] = []
+    for path, wanted in expected.items():
+        actual = _get_path(raw, path)
+        if isinstance(wanted, float) and isinstance(actual, (int, float)):
+            if math.isclose(float(actual), wanted, rel_tol=0.0, abs_tol=1e-12):
+                continue
+        elif actual == wanted:
+            continue
+        errors.append(f"{path}: frozen amendment value is {wanted!r}, got {actual!r}")
+    return errors
+
+
+def load_threshold_amendment(
+    path: Path,
+    *,
+    base_manifest: ThresholdManifest,
+    base_receipt: FreezeReceipt,
+    repo_root: Path,
+) -> ThresholdAmendment:
+    """Load the narrowly scoped Phase-5 PPO RSS threshold amendment."""
+
+    raw = _load_yaml_mapping(path)
+    errors = _validate_amendment_schema(raw)
+    errors.extend(_amendment_policy_errors(raw))
+    base = cast(Mapping[str, Any], raw.get("base_threshold", {}))
+    expected_base = {
+        "threshold_set_id": base_manifest.data["threshold_set_id"],
+        "manifest_path": THRESHOLD_MANIFEST_PATH.as_posix(),
+        "manifest_sha256": sha256_file(base_manifest.source_path),
+        "freeze_commit": base_receipt.freeze_commit,
+    }
+    for key, expected in expected_base.items():
+        if base.get(key) != expected:
+            errors.append(
+                f"base_threshold.{key}: expected frozen base {expected!r}, got {base.get(key)!r}"
+            )
+    if base_receipt.data.get("manifest_sha256") != expected_base["manifest_sha256"]:
+        errors.append("base_threshold: base receipt does not bind the current base manifest")
+    base_memory = cast(Mapping[str, Any], base_manifest.gates["memory"])
+    previous = cast(Mapping[str, Any], raw.get("change", {})).get("previous_value")
+    if previous != base_memory.get("host_preferred_metric_ratio_max"):
+        errors.append("change.previous_value: does not match the immutable base threshold")
+    if not (repo_root / AMENDMENT_ADR_PATH).is_file():
+        errors.append(f"governance.adr_path: file does not exist: {AMENDMENT_ADR_PATH}")
+    if errors:
+        raise ThresholdValidationError(path, errors)
+    return ThresholdAmendment(source_path=path, data=raw)
+
+
+def load_amendment_freeze_receipt(
+    path: Path,
+    *,
+    amendment: ThresholdAmendment,
+    base_receipt: FreezeReceipt,
+    repo_root: Path,
+    verify_git: bool = True,
+) -> AmendmentFreezeReceipt:
+    """Validate the amendment's own commit/hash/blob receipt."""
+
+    raw = _load_yaml_mapping(path)
+    errors: list[str] = []
+    receipt = _mapping(raw, "receipt", _AMENDMENT_RECEIPT_KEYS, errors)
+    for key in _AMENDMENT_RECEIPT_KEYS:
+        if key in {"schema_version", "issue"}:
+            _integer(receipt.get(key), key, errors, minimum=1)
+        else:
+            _string(receipt.get(key), key, errors)
+    expected_values = {
+        "schema_version": AMENDMENT_SCHEMA_VERSION,
+        "issue": AMENDMENT_ISSUE,
+        "amendment_id": AMENDMENT_ID,
+        "manifest_path": AMENDMENT_MANIFEST_PATH.as_posix(),
+        "base_threshold_set_id": THRESHOLD_SET_ID,
+        "base_manifest_sha256": base_receipt.data["manifest_sha256"],
+        "base_freeze_commit": base_receipt.freeze_commit,
+        "issue_url": "https://github.com/unilabsim/UniLab/issues/807",
+        "adr_path": AMENDMENT_ADR_PATH.as_posix(),
+        "change_policy": "phase5_ppo_only_base_thresholds_immutable",
+        "creation_verification": "full_git_history",
+        "shallow_checkout_policy": "current_hash_and_receipt",
+        "final_merge_method": "merge_commit",
+    }
+    for key, expected in expected_values.items():
+        if receipt.get(key) != expected:
+            errors.append(f"{key}: expected {expected!r}, got {receipt.get(key)!r}")
+    manifest_sha = sha256_file(amendment.source_path)
+    if receipt.get("manifest_sha256") != manifest_sha:
+        errors.append(
+            f"manifest_sha256: expected current {manifest_sha}, got {receipt.get('manifest_sha256')!r}"
+        )
+    for key in ("manifest_sha256", "base_manifest_sha256"):
+        if not _SHA256_RE.fullmatch(str(receipt.get(key, ""))):
+            errors.append(f"{key}: expected sha256:<64 lowercase hex>")
+    freeze_commit = str(receipt.get("freeze_commit", ""))
+    if not _COMMIT_RE.fullmatch(freeze_commit):
+        errors.append("freeze_commit: expected full lowercase commit SHA")
+    manifest_blob = str(receipt.get("manifest_git_blob", ""))
+    if not _GIT_BLOB_RE.fullmatch(manifest_blob):
+        errors.append("manifest_git_blob: expected full Git object ID")
+    git_history_verified = False
+    if verify_git and _COMMIT_RE.fullmatch(freeze_commit):
+        git_errors, git_history_verified = _git_receipt_errors(
+            repo_root=repo_root,
+            freeze_commit=freeze_commit,
+            manifest_path=AMENDMENT_MANIFEST_PATH,
+            manifest_bytes=amendment.source_path.read_bytes(),
+            expected_blob=manifest_blob,
+        )
+        errors.extend(git_errors)
+    if errors:
+        raise ThresholdValidationError(path, errors)
+    return AmendmentFreezeReceipt(
+        source_path=path,
+        data=raw,
+        git_history_verified=git_history_verified,
+    )
 
 
 _RECEIPT_KEYS = (

--- a/src/unilab/tools/issue705_thresholds.py
+++ b/src/unilab/tools/issue705_thresholds.py
@@ -1070,6 +1070,27 @@ def load_amendment_freeze_receipt(
             expected_blob=manifest_blob,
         )
         errors.extend(git_errors)
+        if git_history_verified and base_receipt.git_history_verified:
+            if freeze_commit == base_receipt.freeze_commit:
+                errors.append("freeze_commit: amendment must be after the base threshold freeze")
+            else:
+                try:
+                    base_ancestor = _git(
+                        repo_root,
+                        [
+                            "merge-base",
+                            "--is-ancestor",
+                            base_receipt.freeze_commit,
+                            freeze_commit,
+                        ],
+                        check=False,
+                    )
+                    if base_ancestor.returncode != 0:
+                        errors.append(
+                            "freeze_commit: amendment must descend from the base threshold freeze"
+                        )
+                except OSError as exc:
+                    errors.append(f"freeze_commit: cannot verify base ancestry: {exc}")
     if errors:
         raise ThresholdValidationError(path, errors)
     return AmendmentFreezeReceipt(

--- a/tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml
+++ b/tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+issue: 807
+amendment_id: g1-phase5-ppo-rss-ratio-v1
+state: frozen
+
+base_threshold:
+  threshold_set_id: g1-manager-mjwarp-v1
+  manifest_path: tests/acceptance/issue_705/g1_threshold_manifest.yaml
+  manifest_sha256: sha256:c39e3a001d5c516982b33eae1be684b58e4b6f85d2610fb253e5742321b62a74
+  freeze_commit: a2419b342b8663998b2e29cf20a4dce49b3127f5
+
+scope:
+  phase: 5
+  artifact_kind: issue705-mjwarp-device-ppo-benchmark-v1
+  profile: device_resident
+  benchmark_path: benchmark/rl/benchmark_mjwarp_ppo.py
+  metric: process_tree_peak_rss_median_bytes_ratio
+  threshold_path: gates.memory.host_preferred_metric_ratio_max
+  lanes:
+    - throughput
+    - behavior
+  references:
+    throughput: paired_mujoco_host_same_batch
+    behavior: phase0_mujoco_ppo
+  aggregation: median_of_independent_process_peaks
+  comparison: candidate_over_reference_lte
+
+change:
+  previous_value: 1.25
+  amended_value: 1.26
+  owner_decision_date: "2026-07-30"
+  rationale: Preserve the measured b128 allocator margin without changing the benchmark protocol.
+
+governance:
+  adr_path: docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md
+  child_issue_url: https://github.com/unilabsim/UniLab/issues/807
+  base_manifest_immutable: true
+  all_unlisted_thresholds_inherit_base: true
+  candidate_commit_must_descend_from_amendment_freeze: true
+  candidate_and_amendment_same_commit_forbidden: true
+  amendment_and_candidate_same_pr_forbidden: true
+  threshold_only_pr: true
+  no_protocol_change: true

--- a/tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment_freeze_receipt.yaml
+++ b/tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment_freeze_receipt.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+issue: 807
+amendment_id: g1-phase5-ppo-rss-ratio-v1
+manifest_path: tests/acceptance/issue_705/g1_phase5_ppo_threshold_amendment.yaml
+manifest_sha256: sha256:9d4d9df42ec6312964ff29fffc86af7ff452cf000cfd3e37645f3358b9428656
+manifest_git_blob: 610a33767d1c02d198b6853d877bf8afe2a64427
+freeze_commit: ddd017687562581b7a78027e9b70e2c33eab7200
+base_threshold_set_id: g1-manager-mjwarp-v1
+base_manifest_sha256: sha256:c39e3a001d5c516982b33eae1be684b58e4b6f85d2610fb253e5742321b62a74
+base_freeze_commit: a2419b342b8663998b2e29cf20a4dce49b3127f5
+issue_url: https://github.com/unilabsim/UniLab/issues/807
+adr_path: docs/sphinx/source/adr/ADR-0006-phase5-ppo-rss-threshold-amendment.md
+change_policy: phase5_ppo_only_base_thresholds_immutable
+creation_verification: full_git_history
+shallow_checkout_policy: current_hash_and_receipt
+final_merge_method: merge_commit

--- a/tests/benchmark/test_mjwarp_ppo_benchmark.py
+++ b/tests/benchmark/test_mjwarp_ppo_benchmark.py
@@ -161,12 +161,7 @@ def _artifact() -> tuple[dict[str, Any], ppo_benchmark.BenchmarkBinding]:
             "uv_lock_sha256": "sha256:" + "6" * 64,
             "owner_yaml_sha256": "sha256:" + "7" * 64,
         },
-        "threshold": {
-            "threshold_set_id": binding.threshold_set_id,
-            "manifest_path": binding.threshold_manifest_path.as_posix(),
-            "manifest_sha256": binding.threshold_manifest_sha256,
-            "freeze_commit": binding.threshold_freeze_commit,
-        },
+        "threshold": ppo_benchmark._threshold_payload(binding),
         "hardware": {
             "gpu_name": binding.gpu_name,
             "gpu_uuid": binding.gpu_uuid,
@@ -304,6 +299,51 @@ def test_complete_artifact_passes_independent_gate_recomputation() -> None:
     artifact, binding = _artifact()
     assert artifact["gate"] == {"passed": True, "errors": []}
     assert ppo_benchmark.validate_artifact(artifact, binding=binding) == ()
+
+
+def test_phase5_rss_amendment_boundary_passes_and_excess_fails() -> None:
+    artifact, binding = _artifact()
+    assert binding.host_memory_ratio_max == pytest.approx(1.26)
+    for case in artifact["cases"]:
+        if case["lane"] != "throughput" or case["batch_size"] != 128:
+            continue
+        peak_rss = 1_000_000_000 if case["mode"] == "mujoco_host" else 1_260_000_000
+        case["raw"]["memory_samples"][0]["rss_bytes"] = peak_rss
+        case["raw"]["run_summary"]["peak_process_rss_bytes"] = peak_rss
+    _refresh(artifact, binding)
+    assert ppo_benchmark.validate_artifact(artifact, binding=binding) == ()
+
+    for case in artifact["cases"]:
+        if (
+            case["lane"] == "throughput"
+            and case["batch_size"] == 128
+            and case["mode"] == "mjwarp_device"
+        ):
+            case["raw"]["memory_samples"][0]["rss_bytes"] += 1
+            case["raw"]["run_summary"]["peak_process_rss_bytes"] += 1
+    _refresh(artifact, binding)
+    assert any("RSS violates" in error for error in artifact["gate"]["errors"])
+
+
+@pytest.mark.parametrize(
+    ("commit_field", "message"),
+    [
+        ("threshold_freeze_commit", "does not descend from amendment freeze"),
+        ("amendment_freeze_commit", "cannot equal amendment freeze commit"),
+    ],
+)
+def test_candidate_must_strictly_descend_from_amendment_freeze(
+    commit_field: str, message: str
+) -> None:
+    binding = ppo_benchmark.load_binding()
+    errors: list[str] = []
+    ppo_benchmark._validate_source_at_commit(
+        {"commit": getattr(binding, commit_field)},
+        binding,
+        ppo_benchmark.ROOT_DIR,
+        errors,
+    )
+    assert any(message in error for error in errors)
 
 
 def test_gate_is_not_self_referential_and_recorded_result_must_match() -> None:
@@ -450,7 +490,7 @@ def test_scalar_failure_nonfinite_value_and_filtered_iteration_fail_closed() -> 
 
 def test_provenance_owner_policy_and_aggregate_tampering_fail_closed() -> None:
     artifact, binding = _artifact()
-    artifact["threshold"]["manifest_sha256"] = "sha256:" + "0" * 64
+    artifact["threshold"]["amendment"]["manifest_sha256"] = "sha256:" + "0" * 64
     artifact["hardware"]["gpu_uuid"] = "wrong-gpu"
     artifact["source"]["dirty"] = True
     device_case = next(case for case in artifact["cases"] if case["mode"] == "mjwarp_device")
@@ -464,6 +504,14 @@ def test_provenance_owner_policy_and_aggregate_tampering_fail_closed() -> None:
     assert any("source must be clean" in error for error in errors)
     assert any("execution profile" in error for error in errors)
     assert any("aggregates are not" in error for error in errors)
+
+
+@pytest.mark.parametrize("provenance_key", ["base", "amendment"])
+def test_threshold_requires_base_and_amendment_provenance(provenance_key: str) -> None:
+    artifact, binding = _artifact()
+    artifact["threshold"].pop(provenance_key)
+    errors = ppo_benchmark.validate_artifact(artifact, binding=binding)
+    assert any("threshold differs from frozen binding" in error for error in errors)
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_issue705_threshold_amendment.py
+++ b/tests/tools/test_issue705_threshold_amendment.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from omegaconf import OmegaConf
+
+from unilab.tools.g1_baseline_provenance import sha256_file
+from unilab.tools.issue705_thresholds import (
+    AMENDMENT_MANIFEST_PATH,
+    FreezeReceipt,
+    ThresholdValidationError,
+    load_threshold_amendment,
+    load_threshold_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_MANIFEST_PATH = REPO_ROOT / "tests/acceptance/issue_705/g1_threshold_manifest.yaml"
+AMENDMENT_PATH = REPO_ROOT / AMENDMENT_MANIFEST_PATH
+
+
+@pytest.fixture(scope="module")
+def base_manifest():
+    return load_threshold_manifest(BASE_MANIFEST_PATH, repo_root=REPO_ROOT)
+
+
+@pytest.fixture(scope="module")
+def base_receipt(base_manifest):
+    return FreezeReceipt(
+        source_path=Path("<memory>"),
+        data={
+            "threshold_set_id": base_manifest.data["threshold_set_id"],
+            "manifest_sha256": sha256_file(BASE_MANIFEST_PATH),
+            "freeze_commit": "a2419b342b8663998b2e29cf20a4dce49b3127f5",
+        },
+    )
+
+
+def _write_mutated_amendment(tmp_path: Path, mutate: Callable[[dict[str, Any]], None]) -> Path:
+    raw = OmegaConf.to_container(OmegaConf.load(AMENDMENT_PATH), resolve=False)
+    assert isinstance(raw, dict)
+    mutate(raw)
+    destination = tmp_path / "amendment.yaml"
+    OmegaConf.save(OmegaConf.create(raw), destination)
+    return destination
+
+
+def test_amendment_is_narrow_and_preserves_base(base_manifest, base_receipt) -> None:
+    amendment = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=base_receipt,
+        repo_root=REPO_ROOT,
+    )
+
+    assert amendment.amendment_id == "g1-phase5-ppo-rss-ratio-v1"
+    assert amendment.host_memory_ratio_max == pytest.approx(1.26)
+    assert base_manifest.gates["memory"]["host_preferred_metric_ratio_max"] == pytest.approx(1.25)
+    assert amendment.data["scope"]["artifact_kind"] == ("issue705-mjwarp-device-ppo-benchmark-v1")
+    assert amendment.data["scope"]["lanes"] == ["throughput", "behavior"]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda raw: raw.update({"unexpected": True}), "unknown key `unexpected`"),
+        (lambda raw: raw["change"].update({"amended_value": 1.27}), "frozen amendment value"),
+        (lambda raw: raw["change"].update({"previous_value": 1.24}), "previous_value"),
+        (lambda raw: raw["scope"].update({"profile": "host_fused"}), "scope.profile"),
+        (lambda raw: raw["scope"].pop("lanes"), "missing key `lanes`"),
+        (
+            lambda raw: raw["governance"].update({"no_protocol_change": False}),
+            "no_protocol_change",
+        ),
+        (
+            lambda raw: raw["base_threshold"].update({"manifest_sha256": "sha256:" + "0" * 64}),
+            "base_threshold.manifest_sha256",
+        ),
+    ],
+)
+def test_amendment_rejects_scope_value_and_provenance_tampering(
+    tmp_path: Path,
+    base_manifest,
+    base_receipt,
+    mutate: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    path = _write_mutated_amendment(tmp_path, mutate)
+    with pytest.raises(ThresholdValidationError, match=message):
+        load_threshold_amendment(
+            path,
+            base_manifest=base_manifest,
+            base_receipt=base_receipt,
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_amendment_requires_the_declared_adr(tmp_path: Path, base_manifest, base_receipt) -> None:
+    path = _write_mutated_amendment(
+        tmp_path,
+        lambda raw: raw["governance"].update({"adr_path": "docs/missing.md"}),
+    )
+    with pytest.raises(ThresholdValidationError, match="governance.adr_path"):
+        load_threshold_amendment(
+            path,
+            base_manifest=base_manifest,
+            base_receipt=base_receipt,
+            repo_root=REPO_ROOT,
+        )

--- a/tests/tools/test_issue705_threshold_amendment.py
+++ b/tests/tools/test_issue705_threshold_amendment.py
@@ -8,9 +8,13 @@ from omegaconf import OmegaConf
 
 from unilab.tools.g1_baseline_provenance import sha256_file
 from unilab.tools.issue705_thresholds import (
+    AMENDMENT_FREEZE_RECEIPT_PATH,
     AMENDMENT_MANIFEST_PATH,
     FreezeReceipt,
+    ThresholdAmendment,
     ThresholdValidationError,
+    load_amendment_freeze_receipt,
+    load_freeze_receipt,
     load_threshold_amendment,
     load_threshold_manifest,
 )
@@ -18,6 +22,8 @@ from unilab.tools.issue705_thresholds import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_MANIFEST_PATH = REPO_ROOT / "tests/acceptance/issue_705/g1_threshold_manifest.yaml"
 AMENDMENT_PATH = REPO_ROOT / AMENDMENT_MANIFEST_PATH
+BASE_RECEIPT_PATH = REPO_ROOT / "tests/acceptance/issue_705/g1_threshold_freeze_receipt.yaml"
+AMENDMENT_RECEIPT_PATH = REPO_ROOT / AMENDMENT_FREEZE_RECEIPT_PATH
 
 
 @pytest.fixture(scope="module")
@@ -42,6 +48,15 @@ def _write_mutated_amendment(tmp_path: Path, mutate: Callable[[dict[str, Any]], 
     assert isinstance(raw, dict)
     mutate(raw)
     destination = tmp_path / "amendment.yaml"
+    OmegaConf.save(OmegaConf.create(raw), destination)
+    return destination
+
+
+def _write_mutated_receipt(tmp_path: Path, mutate: Callable[[dict[str, Any]], None]) -> Path:
+    raw = OmegaConf.to_container(OmegaConf.load(AMENDMENT_RECEIPT_PATH), resolve=False)
+    assert isinstance(raw, dict)
+    mutate(raw)
+    destination = tmp_path / "receipt.yaml"
     OmegaConf.save(OmegaConf.create(raw), destination)
     return destination
 
@@ -106,5 +121,157 @@ def test_amendment_requires_the_declared_adr(tmp_path: Path, base_manifest, base
             path,
             base_manifest=base_manifest,
             base_receipt=base_receipt,
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_real_amendment_receipt_binds_hash_blob_and_freeze(base_manifest) -> None:
+    real_base_receipt = load_freeze_receipt(
+        BASE_RECEIPT_PATH,
+        manifest=base_manifest,
+        repo_root=REPO_ROOT,
+    )
+    amendment = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+    receipt = load_amendment_freeze_receipt(
+        AMENDMENT_RECEIPT_PATH,
+        amendment=amendment,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+
+    assert receipt.freeze_commit == "ddd017687562581b7a78027e9b70e2c33eab7200"
+    assert receipt.data["manifest_git_blob"] == "610a33767d1c02d198b6853d877bf8afe2a64427"
+    assert receipt.data["manifest_sha256"] == sha256_file(AMENDMENT_PATH)
+    assert receipt.git_history_verified is True
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda raw: raw.update({"unexpected": True}), "unknown key `unexpected`"),
+        (lambda raw: raw.pop("freeze_commit"), "missing key `freeze_commit`"),
+        (
+            lambda raw: raw.update({"manifest_sha256": "sha256:" + "0" * 64}),
+            "expected current",
+        ),
+        (
+            lambda raw: raw.update({"base_manifest_sha256": "sha256:" + "0" * 64}),
+            "base_manifest_sha256",
+        ),
+        (lambda raw: raw.update({"freeze_commit": "short"}), "full lowercase commit SHA"),
+    ],
+)
+def test_amendment_receipt_rejects_schema_and_binding_tampering(
+    tmp_path: Path,
+    base_manifest,
+    mutate: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    real_base_receipt = load_freeze_receipt(
+        BASE_RECEIPT_PATH,
+        manifest=base_manifest,
+        repo_root=REPO_ROOT,
+    )
+    amendment = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+    path = _write_mutated_receipt(tmp_path, mutate)
+    with pytest.raises(ThresholdValidationError, match=message):
+        load_amendment_freeze_receipt(
+            path,
+            amendment=amendment,
+            base_receipt=real_base_receipt,
+            repo_root=REPO_ROOT,
+            verify_git=False,
+        )
+
+
+def test_amendment_receipt_rejects_wrong_git_blob(tmp_path: Path, base_manifest) -> None:
+    real_base_receipt = load_freeze_receipt(
+        BASE_RECEIPT_PATH,
+        manifest=base_manifest,
+        repo_root=REPO_ROOT,
+    )
+    amendment = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+    path = _write_mutated_receipt(
+        tmp_path,
+        lambda raw: raw.update({"manifest_git_blob": "0" * 40}),
+    )
+
+    with pytest.raises(ThresholdValidationError, match="commit contains"):
+        load_amendment_freeze_receipt(
+            path,
+            amendment=amendment,
+            base_receipt=real_base_receipt,
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_amendment_receipt_rejects_manifest_changed_after_freeze(
+    tmp_path: Path, base_manifest
+) -> None:
+    real_base_receipt = load_freeze_receipt(
+        BASE_RECEIPT_PATH,
+        manifest=base_manifest,
+        repo_root=REPO_ROOT,
+    )
+    original = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+    changed_path = tmp_path / AMENDMENT_MANIFEST_PATH.name
+    changed_path.write_bytes(AMENDMENT_PATH.read_bytes() + b"\n# post-freeze tamper\n")
+    changed = ThresholdAmendment(source_path=changed_path, data=original.data)
+    receipt_path = _write_mutated_receipt(
+        tmp_path,
+        lambda raw: raw.update({"manifest_sha256": sha256_file(changed_path)}),
+    )
+
+    with pytest.raises(ThresholdValidationError, match="manifest bytes differ"):
+        load_amendment_freeze_receipt(
+            receipt_path,
+            amendment=changed,
+            base_receipt=real_base_receipt,
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_amendment_receipt_rejects_unresolvable_freeze(tmp_path: Path, base_manifest) -> None:
+    real_base_receipt = load_freeze_receipt(
+        BASE_RECEIPT_PATH,
+        manifest=base_manifest,
+        repo_root=REPO_ROOT,
+    )
+    amendment = load_threshold_amendment(
+        AMENDMENT_PATH,
+        base_manifest=base_manifest,
+        base_receipt=real_base_receipt,
+        repo_root=REPO_ROOT,
+    )
+    path = _write_mutated_receipt(
+        tmp_path,
+        lambda raw: raw.update({"freeze_commit": "c" * 40}),
+    )
+
+    with pytest.raises(ThresholdValidationError, match="cannot verify Git object"):
+        load_amendment_freeze_receipt(
+            path,
+            amendment=amendment,
+            base_receipt=real_base_receipt,
             repo_root=REPO_ROOT,
         )


### PR DESCRIPTION
Part of #705

## Summary
- 新增 Phase 5 PPO RSS threshold amendment g1-phase5-ppo-rss-ratio-v1
- 保持 Phase 0 manifest、freeze receipt 和 Phase 4 provenance 不变
- 仅对 issue705-mjwarp-device-ppo-benchmark-v1 / device_resident 的 throughput 与 behavior RSS lane 将 ratio 上限从 1.25 调整为 1.26
- benchmark artifact 同时记录 base 与 amendment provenance，并要求 candidate 严格后于 amendment freeze
- 增加 ADR、严格 schema、Git blob/hash/ancestor 校验、边界与篡改测试

## Freeze
- Commit A (amendment freeze): ddd017687562581b7a78027e9b70e2c33eab7200
- Commit B (receipt + consumer): 734ef2c6
- Amendment manifest SHA256: sha256:9d4d9df42ec6312964ff29fffc86af7ff452cf000cfd3e37645f3358b9428656
- Amendment manifest Git blob: 610a33767d1c02d198b6853d877bf8afe2a64427

## Validation
- make test-all: 2071 passed, 50 skipped, 362 deselected, 1 xfailed
- uv run scripts/validate_issue705_phase.py --phase 5 --mode schema: PASS
- uv run scripts/audit_issue705_claims.py --all: PASS
- uv run scripts/audit_issue705_workflow_triggers.py: PASS
- uv run scripts/audit_issue705_backend_isolation.py: PASS
- targeted amendment/PPO contract tests: 116 passed

No candidate benchmark artifact or production runtime change is included.