### PR TITLE
perf: group mjwarp G1 reset mutations

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -57,6 +57,7 @@ from unilab.base.backend.mutation import (
     MutationContractError,
     MutationEntityKind,
     MutationFieldKind,
+    MutationSelectorMode,
     MutationSpec,
     MutationTargetKind,
     MutationTargetSpec,
@@ -760,11 +761,11 @@ class MjwarpBackend(SimBackend):
         selector = spec.selector_spec
         if selector is None:
             raise MutationContractError("mjwarp typed mutation selector must be explicit")
-        raw_selector = selector.require_exact_singleton(context="mjwarp typed reset")
         if spec.target_kind is not MutationTargetKind.SIMULATION_STATE:
             raise MutationContractError("mjwarp typed mutation selector has an unsupported target")
 
         if spec.entity_kind is MutationEntityKind.BODY:
+            raw_selector = selector.require_exact_singleton(context="mjwarp typed root reset")
             root_targets = {
                 "state.root.position": MutationFieldKind.POSITION,
                 "state.root.orientation": MutationFieldKind.ORIENTATION,
@@ -803,26 +804,37 @@ class MjwarpBackend(SimBackend):
         expected_field = field_targets.get(spec.target_key)
         if expected_field is None or spec.field_kind is not expected_field:
             raise MutationContractError("mjwarp typed DoF reset has an unsupported field kind")
-        joint_id = self._mujoco.mj_name2id(
-            self._cpu_model,
-            self._mujoco.mjtObj.mjOBJ_JOINT,
-            raw_selector,
-        )
-        if joint_id < 0 or int(self._cpu_model.jnt_type[joint_id]) != int(
-            self._mujoco.mjtJoint.mjJNT_HINGE
-        ):
+        if selector.mode is not MutationSelectorMode.EXACT:
             raise MutationContractError(
-                f"mjwarp typed reset selector {raw_selector!r} must resolve one hinge joint"
+                "mjwarp typed DoF reset only supports exact mutation selectors"
             )
-        if spec.field_kind is MutationFieldKind.POSITION:
-            coordinate = int(self._cpu_model.jnt_qposadr[joint_id]) - self._root_qpos_dim
-            count = self._num_dof_pos
-        else:
-            coordinate = int(self._cpu_model.jnt_dofadr[joint_id]) - self._root_qvel_dim
-            count = self._num_dof_vel
-        if coordinate < 0 or coordinate >= count:
-            raise MutationContractError("mjwarp typed reset coordinate is out of range")
-        return (coordinate,)
+        coordinates: list[int] = []
+        for raw_selector in selector.expressions:
+            joint_id = self._mujoco.mj_name2id(
+                self._cpu_model,
+                self._mujoco.mjtObj.mjOBJ_JOINT,
+                raw_selector,
+            )
+            if joint_id < 0 or int(self._cpu_model.jnt_type[joint_id]) != int(
+                self._mujoco.mjtJoint.mjJNT_HINGE
+            ):
+                raise MutationContractError(
+                    f"mjwarp typed reset selector {raw_selector!r} must resolve one hinge joint"
+                )
+            if spec.field_kind is MutationFieldKind.POSITION:
+                coordinate = int(self._cpu_model.jnt_qposadr[joint_id]) - self._root_qpos_dim
+                count = self._num_dof_pos
+            else:
+                coordinate = int(self._cpu_model.jnt_dofadr[joint_id]) - self._root_qvel_dim
+                count = self._num_dof_vel
+            if coordinate < 0 or coordinate >= count:
+                raise MutationContractError("mjwarp typed reset coordinate is out of range")
+            coordinates.append(coordinate)
+        if len(set(coordinates)) != len(coordinates):
+            raise MutationContractError(
+                "mjwarp typed DoF reset selector resolved duplicate coordinates"
+            )
+        return tuple(coordinates)
 
     def bind_mutation_plan(self, specs: tuple[MutationSpec, ...]) -> BoundMutationPlan:
         """Bind the narrow typed reset contract without exposing raw Warp objects."""

--- a/src/unilab/envs/locomotion/g1/managed_device.py
+++ b/src/unilab/envs/locomotion/g1/managed_device.py
@@ -73,7 +73,6 @@ from .managed_reference import (
     _g1_state_requirements,
     _G1KernelConfig,
     _kernel_config,
-    _reset_suffix_for_dof,
     _reset_term_key,
     _validate_reference_profile,
 )
@@ -112,8 +111,7 @@ def _device_reset_templates(
     *,
     placement: BufferPlacement,
     root: Any,
-    reset_position: tuple[Any, ...],
-    reset_velocity: tuple[Any, ...],
+    dofs: Any,
 ) -> tuple[MutationTemplate, ...]:
     templates: list[MutationTemplate] = []
     for suffix, target_key, field_kind, row_shape in _ROOT_RESET_SUFFIXES:
@@ -137,35 +135,24 @@ def _device_reset_templates(
                 ),
             )
         )
-    for index, selector in enumerate(reset_position):
+    # The bound contract expands this scalar template to one row per selected
+    # DoF, preserving selector order while reducing DoF index-copy dispatches
+    # from 58 to 2 per reset barrier.
+    for key_suffix, target_key, field_kind in (
+        ("dof_position", "state.dof.position", MutationFieldKind.POSITION),
+        (
+            "dof_angular_velocity",
+            "state.dof.angular_velocity",
+            MutationFieldKind.ANGULAR_VELOCITY,
+        ),
+    ):
         templates.append(
             MutationTemplate(
-                key_suffix=_reset_suffix_for_dof(kind="position", index=index),
-                target_key="state.dof.position",
+                key_suffix=key_suffix,
+                target_key=target_key,
                 target_kind=MutationTargetKind.SIMULATION_STATE,
-                selector=selector,
-                field_kind=MutationFieldKind.POSITION,
-                trigger=MutationTrigger.RESET,
-                commit_phase=MutationCommitPhase.RESET,
-                operation=MutationOperation.SET,
-                baseline=MutationBaseline.DEFAULT,
-                persistence=MutationPersistence.EPISODE,
-                recompute=MutationRecomputeLevel.KINEMATICS,
-                value_template=_device_manager_buffer(
-                    placement=placement,
-                    row_shape=(1,),
-                    lifetime=BufferLifetime.UNTIL_COMMIT,
-                ),
-            )
-        )
-    for index, selector in enumerate(reset_velocity):
-        templates.append(
-            MutationTemplate(
-                key_suffix=_reset_suffix_for_dof(kind="velocity", index=index),
-                target_key="state.dof.angular_velocity",
-                target_kind=MutationTargetKind.SIMULATION_STATE,
-                selector=selector,
-                field_kind=MutationFieldKind.ANGULAR_VELOCITY,
+                selector=dofs,
+                field_kind=field_kind,
                 trigger=MutationTrigger.RESET,
                 commit_phase=MutationCommitPhase.RESET,
                 operation=MutationOperation.SET,
@@ -224,13 +211,12 @@ def compile_g1_managed_device_task(
         raise G1ManagedDeviceError("G1 device executor requires unique named actuators")
     action_dim = len(actuator_names)
     _action_scale(cfg, action_dim)
-    root, dofs, reset_position, reset_velocity = _g1_selectors(actuator_names)
+    root, dofs, _, _ = _g1_selectors(actuator_names)
     state_requirements = _g1_state_requirements(root=root, dofs=dofs, action_dim=action_dim)
     reset_templates = _device_reset_templates(
         placement=placement,
         root=root,
-        reset_position=reset_position,
-        reset_velocity=reset_velocity,
+        dofs=dofs,
     )
 
     registry = TermRegistry()
@@ -422,8 +408,8 @@ class G1ManagedDeviceKernel:
         self._observation_indices: tuple[int, int] | None = None
         self._mutation_plan: BoundMutationPlan | None = None
         self._root_reset_indices: tuple[int, int, int, int] | None = None
-        self._position_reset_indices: tuple[int, ...] | None = None
-        self._velocity_reset_indices: tuple[int, ...] | None = None
+        self._position_reset_index: int | None = None
+        self._velocity_reset_index: int | None = None
         self._action_scale = torch.as_tensor(
             config.action_scale, dtype=torch.float32, device=self._device
         )
@@ -480,18 +466,10 @@ class G1ManagedDeviceKernel:
             raise G1ManagedDeviceError("G1 device plan requires typed reset mutations")
         mutation_indices = {spec.term_key: index for index, spec in enumerate(mutation_plan.specs)}
         root_keys = tuple(_reset_term_key(suffix=item[0]) for item in _ROOT_RESET_SUFFIXES)
-        position_keys = tuple(
-            _reset_term_key(suffix=_reset_suffix_for_dof(kind="position", index=index))
-            for index in range(self._action_dim)
-        )
-        velocity_keys = tuple(
-            _reset_term_key(suffix=_reset_suffix_for_dof(kind="velocity", index=index))
-            for index in range(self._action_dim)
-        )
+        position_key = _reset_term_key(suffix="dof_position")
+        velocity_key = _reset_term_key(suffix="dof_angular_velocity")
         missing_mutations = tuple(
-            key
-            for key in (*root_keys, *position_keys, *velocity_keys)
-            if key not in mutation_indices
+            key for key in (*root_keys, position_key, velocity_key) if key not in mutation_indices
         )
         if missing_mutations:
             raise G1ManagedDeviceError(
@@ -502,8 +480,8 @@ class G1ManagedDeviceKernel:
         self._observation_indices = observation_indices
         self._mutation_plan = mutation_plan
         self._root_reset_indices = tuple(mutation_indices[key] for key in root_keys)  # type: ignore[assignment]
-        self._position_reset_indices = tuple(mutation_indices[key] for key in position_keys)
-        self._velocity_reset_indices = tuple(mutation_indices[key] for key in velocity_keys)
+        self._position_reset_index = mutation_indices[position_key]
+        self._velocity_reset_index = mutation_indices[velocity_key]
 
     def _require_binding(self) -> ManagedKernelBinding:
         if self._binding is None:
@@ -512,17 +490,17 @@ class G1ManagedDeviceKernel:
 
     def _require_reset_indices(
         self,
-    ) -> tuple[tuple[int, int, int, int], tuple[int, ...], tuple[int, ...]]:
+    ) -> tuple[tuple[int, int, int, int], int, int]:
         if (
             self._root_reset_indices is None
-            or self._position_reset_indices is None
-            or self._velocity_reset_indices is None
+            or self._position_reset_index is None
+            or self._velocity_reset_index is None
         ):
             raise G1ManagedDeviceError("G1 device reset indices are not bound")
         return (
             self._root_reset_indices,
-            self._position_reset_indices,
-            self._velocity_reset_indices,
+            self._position_reset_index,
+            self._velocity_reset_index,
         )
 
     @staticmethod
@@ -1029,7 +1007,7 @@ class G1ManagedDeviceKernel:
             raise G1ManagedDeviceError("G1 device reset mask is incompatible")
         self._sample_reset(task)
         task.reset_mask.copy_(active_mask, non_blocking=True)
-        root_indices, position_indices, velocity_indices = self._require_reset_indices()
+        root_indices, position_index, velocity_index = self._require_reset_indices()
         root_values = (
             task.reset_qpos[:, :3],
             task.reset_qpos[:, 3:7],
@@ -1038,14 +1016,8 @@ class G1ManagedDeviceKernel:
         )
         for mutation_index, source in zip(root_indices, root_values, strict=True):
             task.reset_values[mutation_index][:, 0, :].copy_(source, non_blocking=True)
-        for dof_index, mutation_index in enumerate(position_indices):
-            task.reset_values[mutation_index][:, 0, 0].copy_(
-                task.reset_qpos[:, 7 + dof_index], non_blocking=True
-            )
-        for dof_index, mutation_index in enumerate(velocity_indices):
-            task.reset_values[mutation_index][:, 0, 0].copy_(
-                task.reset_qvel[:, 6 + dof_index], non_blocking=True
-            )
+        task.reset_values[position_index][:, :, 0].copy_(task.reset_qpos[:, 7:], non_blocking=True)
+        task.reset_values[velocity_index][:, :, 0].copy_(task.reset_qvel[:, 6:], non_blocking=True)
         return DeviceResetPayload(active_mask=task.reset_mask, values=task.reset_values)
 
     def complete_reset(

--- a/tests/base/test_mjwarp_typed_reset.py
+++ b/tests/base/test_mjwarp_typed_reset.py
@@ -572,6 +572,24 @@ def test_mjwarp_typed_reset_binding_and_commit_faults_fail_closed() -> None:
         == mutation_plan.specs[mutation_plan.spec_index("reset.hinge.position")].target.entity_ids
     )
 
+    grouped_hinges = (_HINGE, "right_hip_pitch_joint")
+    grouped_selector = MutationSelectorSpec(
+        semantic_key="robot.managed_hinges",
+        mode=MutationSelectorMode.EXACT,
+        expressions=grouped_hinges,
+        entity_ids=(17, 23),
+    )
+    grouped = replace(
+        specs[4],
+        target=replace(specs[4].target, selector=grouped_selector),
+    )
+    grouped_plan = backend.bind_mutation_plan((grouped,))
+    expected_coordinates = tuple(
+        int(value) for value in backend.get_joint_dof_pos_indices(grouped_hinges)
+    )
+    assert grouped_plan.specs[0].target.entity_ids == expected_coordinates
+    assert grouped_plan.specs[0].value_buffer.row_shape == (2, 1)
+
     compiled_root_selector = MutationSelectorSpec(
         semantic_key="robot.managed_root",
         mode=MutationSelectorMode.EXACT,
@@ -604,18 +622,6 @@ def test_mjwarp_typed_reset_binding_and_commit_faults_fail_closed() -> None:
                     mode=MutationSelectorMode.REGEX,
                     expressions=(".*hip.*",),
                     entity_ids=(17,),
-                ),
-            ),
-        ),
-        replace(
-            specs[4],
-            target=replace(
-                specs[4].target,
-                selector=MutationSelectorSpec(
-                    semantic_key="robot.two_hinges",
-                    mode=MutationSelectorMode.EXACT,
-                    expressions=(_HINGE, "right_hip_pitch_joint"),
-                    entity_ids=(17, 23),
                 ),
             ),
         ),

--- a/tests/training/test_device_lifecycle.py
+++ b/tests/training/test_device_lifecycle.py
@@ -447,9 +447,10 @@ def _force_root_state(
                 elif target_key == "state.root.orientation":
                     root_orientation = value
             else:
-                entity_id = spec.target.entity_ids[0]
-                column = dof_columns[target_key][entity_id]
-                value[:, 0, 0].copy_(source[:, column], non_blocking=True)
+                columns = tuple(
+                    dof_columns[target_key][entity_id] for entity_id in spec.target.entity_ids
+                )
+                value[:, :, 0].copy_(source[:, columns], non_blocking=True)
             values.append(value)
         assert root_position is not None
         assert root_orientation is not None
@@ -517,6 +518,34 @@ def _force_root_state(
     handle = completion_event.handle
     assert isinstance(handle, DeviceCompletion)
     return handle
+
+
+def test_device_g1_reset_plan_groups_all_actuated_dofs() -> None:
+    """The production reset barrier stages two DoF fields, not one field per joint."""
+
+    with _runtime_fixture(num_envs=4, seed=0, max_episode_steps=100) as fixture:
+        runtime = fixture.runtime
+        mutation_plan = runtime.kernel_binding.mutation_plan
+        assert mutation_plan is not None
+        assert len(runtime.plan.mutation_specs) == len(mutation_plan.specs) == 6
+
+        compiled_by_target = {spec.target.target_key: spec for spec in runtime.plan.mutation_specs}
+        bound_by_target = {spec.target.target_key: spec for spec in mutation_plan.specs}
+        state_by_key = {field.key: field for field in runtime.bound_plan.state.fields}
+
+        for target_key, state_key in (
+            ("state.dof.position", "g1.dof.position"),
+            ("state.dof.angular_velocity", "g1.dof.angular_velocity"),
+        ):
+            compiled = compiled_by_target[target_key]
+            selector = compiled.target.selector_spec
+            assert selector is not None
+            assert len(selector.expressions) == fixture.backend.num_actuators == 29
+
+            bound = bound_by_target[target_key]
+            assert bound.target.entity_ids == state_by_key[state_key].identity.entity_ids
+            assert len(bound.target.entity_ids) == fixture.backend.num_actuators
+            assert bound.value_buffer.row_shape == (fixture.backend.num_actuators, 1)
 
 
 def _assert_final_contract(snapshot: _TransitionSnapshot, expected_done: torch.Tensor) -> None:


### PR DESCRIPTION
Closes #805
Part of #705
Blocks #802 until the merged integration SHA passes one complete strict 40-case capture.

## 根因与修复

G1 device reset 原来把 29 个 DoF position 和 29 个 DoF velocity 编译为 58 个独立 typed mutation，reset barrier 因而产生 58 次 DoF index_copy_ staging。修复保持 typed mutation owner 边界不变：

- MutationSelectorMode.EXACT 的 DoF reset 允许一个显式 selector 按冻结顺序绑定多个 hinge joint，重复、未知、非 hinge 或越界 coordinate 继续 fail closed。
- G1 device task 将 29 个 position 与 29 个 velocity mutation 分别合并为一个预分配 buffer；root 四项 mutation 不变。
- reset barrier 的 DoF staging 从 58 次降为 2 次，不增加 D2H、global synchronize、热路径 allocation、asset metadata 或 backend 私有探测。
- mujoco 与 mjwarp 仍是两个独立 backend；修改只位于 manager device task 与 mjwarp typed-reset adapter owner layer。

实现 commit：ec70758aac8b4a51d93e56d472416fd7f84194a4。CUPTI focused trace：/tmp/issue805_grouped_reset_trace_v2.json，SHA256 d240fb70d309753f4c589c8c4ff4892e3aa5ee7eeb862204897a844ebf3d133d。

## Frozen b128 focused gate

候选 commit：d0cc8324d292d7f14604d3ea9cf33218d0880afa，严格后代于 Phase 5 PPO RSS amendment freeze ddd017687562581b7a78027e9b70e2c33eab7200。冻结交错顺序下，MuJoCo-host / mjwarp-device 各 5 个 public owner worker 一次完成，无 filter、retry、fallback 或 replacement。

原始目录：/tmp/issue805_b128_d0cc8324_formal

- focused summary SHA256：7324a1b072b376262aab8b8dad53fcab0e5680a5446d8cc2b087db6e3c85dd3f
- SHA receipt SHA256：8c390a058bf09c2baed691334c5d4bad8d1ff0588f3197489faf855abc138a5e
- b128 p50 ratio：0.827188 <= 1.05
- b128 p95 ratio：0.826894 <= 1.05
- b128 FPS ratio：1.208918 >= 0.952381
- b128 RSS ratio：1.255190 <= 1.26
- host/device FPS population CV：0.004004 / 0.008340 <= 0.15

逐 case 复算验证 frozen metadata/order、训练进程 return code、scripts/train_rsl_rl.py public route、owner/profile/run config、scalar 全覆盖、raw-to-summary exact equality、source ancestry 和唯一 PID/run ID。前后环境检查均无 foreign GPU compute process；后置 CPU load 按冻结协议只记录、不执行 gate。为修复系统 NVML 580.173.02 与 kernel driver 570.133.07 不一致，采样进程仅通过 LD_LIBRARY_PATH 使用已校验的 matching 570.133.07 userspace library；未修改系统文件且未重启。

## Validation

- 真实 CUDA near-risk suite：72 passed，覆盖 typed-reset oracle/fail-closed、grouped plan、all/selected reset、graph、stream/event、transfer、transition ABI、PPO storage、logger/runner 与长循环地址稳定性。
- benchmark/PPO/selector targeted suite：28 passed, 1 deselected。
- make test-all：2071 passed, 50 skipped, 363 deselected, 1 xfailed；ruff、mypy、pyright 通过。
- claim audit、backend isolation、workflow trigger audit、Phase 5 schema audit：PASS。
- git diff --check 与最终 clean worktree：PASS。

## 自审

第一轮按训练效率与结构化审查：合并发生在 mutation compile/bind owner 边界，runtime 仍只消费 typed batch；固定 buffer 和 selector 绑定均在 cold path，避免把 task 特例扩散到 runner 或 benchmark。

第二轮按一致性与复用性审查：multi-hinge exact selector 是 backend contract 的通用能力，root reset、selected-row semantics、buffer lifetime、terminal/reset observation 和 device transfer budget 均由真实 CUDA 回归锁定；非法 selector 继续 fail closed。

本 PR 不修改 frozen matrix、warmup、ordering、aggregation、measurement scope 或 retry 规则，也不提交 focused 数据到 acceptance。Phase 5 manifest 仍为 7 planned / 0 verified；合入后必须从新的 integration SHA 连续重采完整 40-case strict artifact，全部 integrity/performance/behavior/memory/transfer/profiler gate PASS 后才能 promotion #802。