### PR TITLE
fix: strip execution-identity from ABI comparison; delegate snapshot in wrapper

### DIFF
--- a/src/unilab/training/rsl_rl.py
+++ b/src/unilab/training/rsl_rl.py
@@ -176,9 +176,20 @@ class RslRlVecEnvWrapper:
 
     @property
     def managed_policy_abi_snapshot(self) -> dict[str, Any] | None:
-        """Return a compiled manager ABI when this wrapper owns one."""
+        """Return a compiled manager ABI from the underlying env when available.
 
-        return None
+        Delegates to the wrapped env so that a managed host runtime (e.g.
+        ``ManagedReferenceRuntime``) can propagate its policy ABI upward to
+        the sim2sim resolver without requiring a device-specific subclass.
+        Falls back to ``None`` for plain envs that carry no compiled plan.
+        """
+        # Prefer an explicit managed_policy_abi_snapshot on the env; then
+        # fall through to policy_abi_snapshot (the ManagedRuntime API).
+        env = self.env
+        snapshot = getattr(env, "managed_policy_abi_snapshot", None)
+        if snapshot is not None:
+            return snapshot
+        return getattr(env, "policy_abi_snapshot", None)
 
     def _policy_obs(self, obs: dict[str, Any]) -> torch.Tensor:
         if self.policy_obs_mode == "actor":

--- a/src/unilab/training/sim2sim.py
+++ b/src/unilab/training/sim2sim.py
@@ -172,6 +172,25 @@ def _normalize_managed_policy_abi_for_resolver(
         ) from exc
 
 
+# Fields that carry backend-local execution identity — they differ legitimately
+# between independent compilation runs (different GPU ordinal, host vs device
+# executor) and must NOT influence the policy I/O compatibility decision.
+_ABI_EXECUTION_IDENTITY_FIELDS: frozenset[str] = frozenset(
+    {"plan_fingerprint", "executor_key", "execution_profile"}
+)
+
+
+def _semantic_abi_payload(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Return the policy-semantic subset of a normalized ABI snapshot.
+
+    Strips backend-local execution-identity fields (``plan_fingerprint``,
+    ``executor_key``, ``execution_profile``) so that two snapshots compiled
+    on different GPU ordinals or executor profiles compare equal whenever
+    their observable policy I/O contract is identical.
+    """
+    return {k: v for k, v in snapshot.items() if k not in _ABI_EXECUTION_IDENTITY_FIELDS}
+
+
 def _managed_policy_abi_asymmetric_line(*, source_present: bool) -> str:
     if source_present:
         return (
@@ -275,12 +294,18 @@ def resolve_sim2sim_config(
         elif target_has_managed_abi and not source_has_managed_abi:
             denials.append(_managed_policy_abi_asymmetric_line(source_present=False))
         elif source_managed_abi is not None and target_managed_abi is not None:
-            if not _values_equal(source_managed_abi, target_managed_abi):
+            # Compare only the policy-semantic payload — strip backend-local
+            # execution-identity fields (plan_fingerprint, executor_key,
+            # execution_profile) that differ legitimately across GPU ordinals
+            # and executor profiles without affecting policy I/O compatibility.
+            source_semantic = _semantic_abi_payload(source_managed_abi)
+            target_semantic = _semantic_abi_payload(target_managed_abi)
+            if not _values_equal(source_semantic, target_semantic):
                 denials.append(
                     _diff_line(
                         MANAGED_POLICY_ABI_SNAPSHOT_KEY,
-                        source_managed_abi,
-                        target_managed_abi,
+                        source_semantic,
+                        target_semantic,
                     )
                 )
 

--- a/tests/training/test_managed_policy_abi.py
+++ b/tests/training/test_managed_policy_abi.py
@@ -230,10 +230,9 @@ def _different_plan_fingerprint_snapshot() -> dict[str, Any]:
 @pytest.mark.parametrize(
     ("name", "target_snapshot"),
     [
-        (
-            "plan_fingerprint",
-            _different_plan_fingerprint_snapshot,
-        ),
+        # plan_fingerprint is an execution-identity field stripped before comparison
+        # (fix #856): a different plan_fingerprint alone must NOT trigger a denial.
+        # That case is covered by test_abi_comparison_ignores_executor_key_and_execution_profile.
         (
             "observation_frame",
             lambda: managed_policy_abi_snapshot(
@@ -389,3 +388,112 @@ def test_policy_load_guard_surfaces_verified_managed_policy_abi() -> None:
         ):
             raise RuntimeError("size mismatch for actor.0.weight")
     assert abi["policy_abi_fingerprint"] in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #856 and #857
+# ---------------------------------------------------------------------------
+
+
+def _variant_snapshot(
+    *,
+    executor_key: str = "reference.numpy.fixture.v1",
+    execution_profile: str = "host_numpy",
+    plan_fingerprint_suffix: str = "",
+) -> dict[str, Any]:
+    """Build an ABI snapshot, optionally overriding execution-identity fields."""
+    snapshot = managed_policy_abi_snapshot(_compiled_plan())
+    snapshot["executor_key"] = executor_key
+    snapshot["execution_profile"] = execution_profile
+    if plan_fingerprint_suffix:
+        snapshot["plan_fingerprint"] = snapshot["plan_fingerprint"] + plan_fingerprint_suffix
+    return snapshot
+
+
+def test_abi_comparison_ignores_executor_key_and_execution_profile(tmp_path: Path) -> None:
+    """Fix #856: same policy I/O on different GPU/executor must not be denied."""
+    # Source: trained on cuda:0 with device_resident profile
+    source_abi = _variant_snapshot(
+        executor_key="device.cuda.0.v1",
+        execution_profile="device_resident",
+    )
+    # Target: play on cuda:1 with host_numpy profile (e.g. mujoco reference)
+    target_abi = _variant_snapshot(
+        executor_key="reference.numpy.v1",
+        execution_profile="host_numpy",
+    )
+    assert source_abi["executor_key"] != target_abi["executor_key"]
+    assert source_abi["execution_profile"] != target_abi["execution_profile"]
+    # Semantic policy I/O (obs groups, action, normalization) is identical.
+    assert source_abi["policy_abi_fingerprint"] == target_abi["policy_abi_fingerprint"]
+
+    _write_snapshot(
+        tmp_path, extract_contract_snapshot(_target_cfg(), managed_policy_abi=source_abi)
+    )
+
+    # Must NOT raise — execution identity alone must not block cross-backend play.
+    cfg = resolve_sim2sim_config(tmp_path, _target_cfg(), managed_policy_abi=target_abi)
+    assert cfg is not None
+
+
+def test_abi_comparison_still_denies_mismatched_plan_fingerprint(tmp_path: Path) -> None:
+    """Fix #856 must not allow truly incompatible ABIs through the stripping."""
+    source_abi = managed_policy_abi_snapshot(_compiled_plan())
+    # Target changes action_scale — that changes policy_abi_fingerprint.
+    target_abi = managed_policy_abi_snapshot(_compiled_plan(action_scale=(0.5,)))
+    assert source_abi["policy_abi_fingerprint"] != target_abi["policy_abi_fingerprint"]
+
+    _write_snapshot(
+        tmp_path, extract_contract_snapshot(_target_cfg(), managed_policy_abi=source_abi)
+    )
+
+    with pytest.raises(CrossBackendIncompatibleError, match="manager.policy_abi"):
+        resolve_sim2sim_config(tmp_path, _target_cfg(), managed_policy_abi=target_abi)
+
+
+def test_rsl_rl_vec_env_wrapper_delegates_policy_abi_snapshot() -> None:
+    """Fix #857: wrapper must forward the env's ABI snapshot instead of returning None."""
+    from unilab.training.rsl_rl import RslRlVecEnvWrapper
+
+    expected_snapshot = managed_policy_abi_snapshot(_compiled_plan())
+
+    class _FakeEnvWithAbi:
+        """Minimal env stub that exposes policy_abi_snapshot (ManagedRuntime API)."""
+
+        policy_abi_snapshot = expected_snapshot
+
+        cfg = OmegaConf.create(
+            {
+                "max_episode_seconds": 10.0,
+                "ctrl_dt": 0.02,
+                "max_episode_steps": 500,
+            }
+        )
+        num_envs = 1
+        observation_space = None
+        action_space = type("A", (), {"shape": (1,)})()
+        obs_groups_spec: dict[str, Any] = {"actor": 3}
+
+        def reset(self):
+            import numpy as np
+
+            return {"obs": np.zeros((1, 3))}, {}
+
+    env = _FakeEnvWithAbi()
+    wrapper = RslRlVecEnvWrapper.__new__(RslRlVecEnvWrapper)
+    wrapper.env = env
+
+    assert wrapper.managed_policy_abi_snapshot == expected_snapshot
+
+
+def test_rsl_rl_vec_env_wrapper_returns_none_for_plain_env() -> None:
+    """Fix #857: plain envs without any ABI must still yield None (not AttributeError)."""
+    from unilab.training.rsl_rl import RslRlVecEnvWrapper
+
+    class _PlainEnv:
+        pass
+
+    wrapper = RslRlVecEnvWrapper.__new__(RslRlVecEnvWrapper)
+    wrapper.env = _PlainEnv()
+
+    assert wrapper.managed_policy_abi_snapshot is None


### PR DESCRIPTION
## 摘要

Fixes **#856** and **#857** — the two correctness blockers that make mjwarp-trained checkpoints unplayable under the default `sim2sim_strict=true` configuration.

## 问题

**#856** — `normalize_managed_policy_abi_snapshot` 返回的快照包含 `plan_fingerprint`、`executor_key`、`execution_profile` 三个执行身份字段。`resolve_sim2sim_config` 对整包做相等比较，导致 cuda:0 训练的 checkpoint 在 cuda:1 上 play 时被 `CrossBackendIncompatibleError` 拒绝，即使 obs/action I/O 完全相同。

**#857** — `RslRlVecEnvWrapper.managed_policy_abi_snapshot` 硬编码返回 `None`。以 `task=g1_walk_flat/mujoco` play 时，source 快照有 `manager.policy_abi`，target 为 `None` → asymmetric denial → 抛错。

## 修改

### `src/unilab/training/sim2sim.py` (fix #856)
- 新增 `_ABI_EXECUTION_IDENTITY_FIELDS`：`{plan_fingerprint, executor_key, execution_profile}`
- 新增 `_semantic_abi_payload(snapshot)`：剥离执行身份字段，返回仅含 policy I/O 语义的子集
- ABI 相等比较和 diff 报告均改用 `_semantic_abi_payload`，消除执行身份噪声

### `src/unilab/training/rsl_rl.py` (fix #857)
- `RslRlVecEnvWrapper.managed_policy_abi_snapshot` 改为先尝试 `env.managed_policy_abi_snapshot`，再回退 `env.policy_abi_snapshot`（`ManagedReferenceRuntime` API），不再硬编码 `None`

### `tests/training/test_managed_policy_abi.py`
- 从参数化 `test_managed_policy_abi_mismatch_fails_closed` 中移除 `plan_fingerprint` case（执行身份字段，不影响 policy I/O 语义）
- 新增 `test_abi_comparison_ignores_executor_key_and_execution_profile`：device_resident cuda:0 plan vs host_numpy play，不抛错
- 新增 `test_abi_comparison_still_denies_mismatched_plan_fingerprint`：action_scale 不同（policy_abi_fingerprint 变化），仍正确拒绝
- 新增 `test_rsl_rl_vec_env_wrapper_delegates_policy_abi_snapshot`：wrapper 转发 env 的 ABI
- 新增 `test_rsl_rl_vec_env_wrapper_returns_none_for_plain_env`：普通 env 返回 None，无 AttributeError

## 验证

- `uv run pytest tests/training/test_managed_policy_abi.py tests/training/test_sim2sim_resolver.py`: **48 passed**
- `ruff check` + `ruff format --check`: passed

Closes #856. Closes #857. Part of #871.