### PR TITLE
test: restore production reward config in device parity fixture

### DIFF
--- a/tests/training/test_device_lifecycle.py
+++ b/tests/training/test_device_lifecycle.py
@@ -163,11 +163,12 @@ def _host_device_fixture(*, num_envs: int, seed: int) -> Iterator[_HostDeviceFix
         observation_noise_level=0.0,
         observation_noise_seed=None,
     )
+    # Use the production reward config (feet_phase, non-zero gait_frequency,
+    # non-zero vel_limit) so the device implementation's independent Bezier /
+    # gait-phase math is covered by the oracle.  Stripping those fields was a
+    # pre-existing workaround that left the highest-risk device term without
+    # any host↔device equivalence evidence (issue #860).
     assert cfg.reward_config is not None
-    cfg.reward_config.scales.pop("feet_phase")
-    cfg.reward_config.gait_frequency = 0.0
-    cfg.reset_base_qvel_limit = 0.0
-    cfg.commands.vel_limit = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
     assert cfg.scene is not None
 
     host_cfg = deepcopy(cfg)


### PR DESCRIPTION
## 摘要

Restores the production reward configuration in the `_host_device_fixture` used by `test_device_g1_transition_matches_verified_host_runtime_on_aligned_state`.

Closes **#860**. Part of **#871**.

## 问题

`_host_device_fixture`（`tests/training/test_device_lifecycle.py:166-170`）在构造宿主/设备运行时对照时，移除了四个生产配置字段：

```python
cfg.reward_config.scales.pop("feet_phase")   # ← 最高风险的device term
cfg.reward_config.gait_frequency = 0.0        # ← 关闭 Bezier 步态时钟
cfg.reset_base_qvel_limit = 0.0
cfg.commands.vel_limit = [[0,0,0],[0,0,0]]
```

前两行直接削减了覆盖目标：device 端 `feet_phase` 实现（`managed_device.py:_bezier_height_into`）是独立手写的 Bezier/步态相位计算，在测试套件中没有其他 host↔device 等价证据。`gait_frequency=0` 且 `feet_phase` 被移除后，device term 从未被 oracle 验证，任何未来的实现漂移都会被掩盖。

## 修改

删除4行覆盖，改用注释说明意图：使用生产配置（`feet_phase=1.0`、`gait_frequency=1.5`、非零 vel_limit）进行对拍。

测试本身已有 `_require_cuda()` 门禁，在 CPU-only runner 上自动跳过；在 GPU runner 上将验证 device Bezier 数学与 host reference 的等价性。

## 验证

- `uv run pytest tests/training/ -m 'not slow and not local_evidence'`: **107 passed, 48 deselected**（CUDA 门控测试被跳过，符合预期）
- `ruff check` + `ruff format --check`: passed