### PR TITLE
docs: 补充 make setup 的 python3-dev 前置依赖说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ cd UniLab
 
 # 2. Install dependencies
 # Pick the setup command for your platform.
+#
+# Prerequisite: the `mujoco` extra compiles a native extension during `uv sync`
+# and needs Python development headers when using a system Python:
+#   Ubuntu / Debian: sudo apt-get install build-essential python3-dev
+#   macOS:           xcode-select --install
+#   Windows:         MSVC Build Tools
+# (uv-managed Pythons from `uv python install` already bundle the headers.)
 
 # Linux CUDA, macOS, or Windows
 make setup

--- a/README_zh.md
+++ b/README_zh.md
@@ -94,6 +94,13 @@ cd UniLab
 
 # 2. 安装依赖
 # 请按你的平台选择对应的安装命令。
+#
+# 前置条件：`mujoco` extra 会在 `uv sync` 时编译原生扩展，
+# 使用系统 Python 时需要 Python 开发头文件：
+#   Ubuntu / Debian：sudo apt-get install build-essential python3-dev
+#   macOS：          xcode-select --install
+#   Windows：        MSVC Build Tools
+# （通过 `uv python install` 安装的 uv 托管 Python 已自带头文件。）
 
 # Linux CUDA、macOS 或 Windows
 make setup

--- a/docs/sphinx/source/en/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/en/1-getting_started/2-installation.md
@@ -12,6 +12,8 @@ live in the getting-started and algorithm pages.
 - For the `mujoco` extra: a C++17 toolchain and Python development headers,
   because `mujoco-uni-runtime` ships as a source distribution and compiles its
   native extension during `uv sync` (against the locked mujoco version).
+  Without them, `make setup` fails while building `mujoco-uni-runtime` with
+  `fatal error: Python.h: No such file or directory`.
   - macOS: `xcode-select --install`
   - Ubuntu / Debian: `sudo apt-get install build-essential python3-dev`
   - Windows: MSVC Build Tools

--- a/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
@@ -10,7 +10,8 @@
   `docs/sphinx/source/zh_CN/1-getting_started/2-installation.md`。
 - 使用 `mujoco` extra 时：需要 C++17 工具链和 Python 开发头文件，
   因为 `mujoco-uni-runtime` 仅以源码分发，`uv sync` 时会就地编译其原生扩展
-  （针对 lock 钉住的 mujoco 版本）。
+  （针对 lock 钉住的 mujoco 版本）。缺少这些依赖时，`make setup` 会在编译
+  `mujoco-uni-runtime` 时失败，报错 `fatal error: Python.h: No such file or directory`。
   - macOS：`xcode-select --install`
   - Ubuntu / Debian：`sudo apt-get install build-essential python3-dev`
   - Windows：MSVC Build Tools


### PR DESCRIPTION
Fixes #878

## 背景

在干净的 Ubuntu / Debian 系统上使用系统 Python 执行 `make setup` 时，`mujoco-uni-runtime` 以源码分发就地编译原生扩展，缺少 Python 开发头文件会失败：`fatal error: Python.h: No such file or directory`。README 快速上手此前完全没有提示该前置条件。

## 修改内容

- `README.md` / `README_zh.md`：快速上手「安装依赖」步骤前新增分系统前置提示
  - Ubuntu / Debian：`sudo apt-get install build-essential python3-dev`
  - macOS：`xcode-select --install`
  - Windows：MSVC Build Tools
  - 注明 uv 托管 Python（`uv python install`）已自带头文件
- `docs/sphinx/source/en/1-getting_started/2-installation.md` 及 `zh_CN` 对应页：Requirements 一节补充错误特征 `fatal error: Python.h: No such file or directory`，便于用户按报错检索

## Validation

- `make test-all` 已通过：ruff format/check、mypy、pyright（0 errors）、pytest 1631 passed / 29 skipped / 1 xfailed、benchmark smoke 35/36（1 个平台可选 mlx 跳过）
- 注：首次运行因本机 `mujoco-uni-runtime` 扩展按 mujoco 3.10.0 编译、与当前 lock 的 3.8.0 不匹配而失败，已按 Makefile 注释流程（`uv cache clean` + `--reinstall-package`）重建后通过，与本次改动无关