### PR TITLE
fix: relax mujoco/warp-lang bounds, let uv.lock pin the defaults (align with mjlab)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 sync:
 	uv sync --extra mujoco --extra motrix
 
-# Switch the MuJoCo solver version (window: >=3.5,<3.11), e.g.
+# Switch the MuJoCo solver version (tested window: >=3.5,<3.11), e.g.
 #   make mujoco MJ=3.8.0
 # Repins mujoco in uv.lock, then rebuilds the mujoco-uni-runtime native
 # extension against it (the extension refuses to load on a version mismatch,

--- a/docs/sphinx/source/en/2-user_guide/3-backends/1-mujoco.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/1-mujoco.md
@@ -1,7 +1,8 @@
 # MuJoCo Backend
 
 MuJoCo is the default backend path in the committed owner configs. The Python
-dependencies are the official `mujoco` package (`>=3.5,<3.11`) plus
+dependencies are the official `mujoco` package (`>=3.5`, with the default
+version pinned by the committed `uv.lock`) plus
 `mujoco-uni-runtime` in `pyproject.toml`, and the adapter lives
 under `src/unilab/base/backend/mujoco/`.
 
@@ -28,8 +29,10 @@ rather than opening the Motrix native interactive renderer.
 
 ## Switching MuJoCo Versions
 
-The mujoco extra supports any solver version in `>=3.5,<3.11`. Fresh installs
-default to the version pinned in the committed `uv.lock` (currently **3.8.0**).
+pyproject only constrains `mujoco>=3.5`; the default solver version is pinned
+by the committed `uv.lock`, and uv's prefer-locked semantics keep ordinary
+relocks from drifting. The tested window is `>=3.5,<3.11` — switch versions
+within it.
 The
 `mujoco-uni-runtime` native extension is compiled against the `mujoco`
 package in this environment and refuses to load against any other version,

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
@@ -78,7 +78,8 @@ Two caveats:
   init-lifecycle model materialization (see `GeomSizeOverride` /
   `ModelVariantSpec` in `src/unilab/dr/types.py`), not reset randomization.
 - `gravity` reset randomization requires a `mujoco-uni-runtime` build that ships
-  it. This repository depends on the official `mujoco` package (`>=3.5,<3.11`)
+  it. This repository depends on the official `mujoco` package (`>=3.5`, with
+  the default version pinned by `uv.lock`)
   plus `mujoco-uni-runtime`, whose `SUPPORTED_FIELDS` includes `gravity`; older
   batch-env packages such as `mujoco-uni==3.6.0.post6` do not.
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/1-mujoco.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/1-mujoco.md
@@ -1,7 +1,7 @@
 # MuJoCo 后端
 
 MuJoCo 是已提交 owner 配置中的默认后端路径。其 Python 依赖为官方
-`mujoco` 包（`>=3.5,<3.11`）加 `mujoco-uni-runtime`（见 `pyproject.toml`），适配层位于
+`mujoco` 包（`>=3.5`，默认版本由已提交的 `uv.lock` 钉住）加 `mujoco-uni-runtime`（见 `pyproject.toml`），适配层位于
 `src/unilab/base/backend/mujoco/` 下。
 
 ## 何时使用
@@ -25,8 +25,9 @@ MuJoCo 在 `src/unilab/base/backend/mujoco/backend.py` 中声明对物理状态�
 
 ## 切换 MuJoCo 版本
 
-mujoco extra 支持 `>=3.5,<3.11` 窗口内的任意求解器版本。全新安装默认使用
-已提交的 `uv.lock` 中钉住的版本（当前为 **3.8.0**）。
+pyproject 只约束 `mujoco>=3.5`；默认求解器版本由已提交的 `uv.lock` 钉住，
+uv 的 prefer-locked 语义保证普通 relock 不会漂移。目前验证过的窗口是
+`>=3.5,<3.11`，切换版本请在该窗口内进行。
 `mujoco-uni-runtime` 的原生扩展针对本环境中的 `mujoco` 编译，且拒绝在其它版本下加载，
 因此切换版本 = 重钉 `mujoco` + 重编扩展：
 

--- a/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
@@ -71,7 +71,7 @@ refresh 行为由 backend 固定：`body_mass`、`body_ipos`、`body_iquat`、
   materialization 表达（见 `src/unilab/dr/types.py` 中的 `GeomSizeOverride` /
   `ModelVariantSpec`），不走 reset 随机化。
 - `gravity` 的 reset 随机化需要包含它的 `mujoco-uni-runtime` 构建。本仓库依赖
-  官方 `mujoco` 包（`>=3.5,<3.11`）加 `mujoco-uni-runtime`，其 `SUPPORTED_FIELDS`
+  官方 `mujoco` 包（`>=3.5`，默认版本由 `uv.lock` 钉住）加 `mujoco-uni-runtime`，其 `SUPPORTED_FIELDS`
   包含 `gravity`；更旧的 batch-env 包（例如 `mujoco-uni==3.6.0.post6`）则没有。
 
 ## 电机控制扩展

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -52,7 +52,9 @@ unilab-pull-assets = "unilab.tools.pull_assets:main"
 
 [project.optional-dependencies]
 mujoco = [
-    "mujoco>=3.5,<3.11",
+    "mujoco>=3.5",
+    # Bound stays loose; uv.rocm.lock pins the default solver version. The
+    # tested window is >=3.5,<3.11 — switch via `make mujoco MJ=<version>`.
     "mujoco-uni-runtime==0.3.0",
     # pybind11/wheel are build requirements of mujoco-uni-runtime, which is
     # compiled in this environment (see no-build-isolation-package below).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,10 @@ unilab-pull-assets = "unilab.tools.pull_assets:main"
 
 [project.optional-dependencies]
 mujoco = [
-    "mujoco>=3.5,<3.11",
+    # Bound stays loose; the committed uv.lock pins the default solver version
+    # (uv prefer-locked semantics). The tested window is >=3.5,<3.11 — switch
+    # within it via `make mujoco MJ=<version>`.
+    "mujoco>=3.5",
     "mujoco-uni-runtime==0.3.0",
     # pybind11/wheel are build requirements of mujoco-uni-runtime, which is
     # compiled in this environment (see no-build-isolation-package below).
@@ -65,10 +68,10 @@ mjwarp = [
     # implementation; it is deliberately a separate optional extra rather
     # than a mode of the ``mujoco`` backend.
     "mujoco-warp==3.10.0.3",
-    # Pin to the 1.14.x line that mjlab locks (mujoco-warp 3.10.0.3 only
-    # requires warp-lang>=1.14); unconstrained resolution pulled the freshly
-    # released 1.16.0, a ~163MB wheel download for no benefit here.
-    "warp-lang>=1.14.0,<1.15",
+    # Bound stays loose like mjlab's; the committed uv.lock pins warp-lang at
+    # the 1.14.x line mjlab validates (mujoco-warp 3.10.0.3 only requires
+    # warp-lang>=1.14). Upgrade deliberately via `uv lock --upgrade-package`.
+    "warp-lang>=1.14.0",
 ]
 motrix = ["motrixsim-core==0.8.2"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,10 @@ mjwarp = [
     # implementation; it is deliberately a separate optional extra rather
     # than a mode of the ``mujoco`` backend.
     "mujoco-warp==3.10.0.3",
-    "warp-lang>=1.14.0",
+    # Pin to the 1.14.x line that mjlab locks (mujoco-warp 3.10.0.3 only
+    # requires warp-lang>=1.14); unconstrained resolution pulled the freshly
+    # released 1.16.0, a ~163MB wheel download for no benefit here.
+    "warp-lang>=1.14.0,<1.15",
 ]
 motrix = ["motrixsim-core==0.8.2"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]

--- a/uv.lock
+++ b/uv.lock
@@ -4873,7 +4873,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
-    { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5,<3.11" },
+    { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5" },
     { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.3.0" },
     { name = "mujoco-warp", marker = "extra == 'mjwarp'", specifier = "==3.10.0.3" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
@@ -4898,7 +4898,7 @@ requires-dist = [
     { name = "typing-extensions" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
-    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0,<1.15" },
+    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
     { name = "wheel", marker = "extra == 'mujoco'" },
 ]
 provides-extras = ["mujoco", "mjwarp", "motrix", "viser"]

--- a/uv.lock
+++ b/uv.lock
@@ -4898,7 +4898,7 @@ requires-dist = [
     { name = "typing-extensions" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
-    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
+    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0,<1.15" },
     { name = "wheel", marker = "extra == 'mujoco'" },
 ]
 provides-extras = ["mujoco", "mjwarp", "motrix", "viser"]
@@ -5024,17 +5024,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.16.0"
+version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/8a/8be711f3b5431a6e0bdb97117d681b03cf2bb95d6fcf8869861900898d88/warp_lang-1.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:19a7590c4484e8250ab19165311d2a1774138663b361c41e8be2865c7515c4ae", size = 25221601, upload-time = "2026-08-03T02:26:38.389Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3d/47feef2eee4739437e19d6949ea231ca4181c9eacbaa39144761e6130d94/warp_lang-1.16.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:96449fc1e3b354185e2f09434fb794b5953ab2e8673b104d7e7f48d5d418bb35", size = 163074225, upload-time = "2026-08-03T02:27:03.632Z" },
-    { url = "https://files.pythonhosted.org/packages/db/96/0c2b070b3101c669955cafd36262548b2e8b00dfdeda3aeb7afbc0f9d65c/warp_lang-1.16.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d4715171bd6821436b82293d774c9a082ace08215c189572b4348d1e48fb8ee8", size = 167563789, upload-time = "2026-08-03T02:27:37.512Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/17/c98fab81156f0d25f17200f52f69210b94a9abba101066736df8cc493522/warp_lang-1.16.0-py3-none-win_amd64.whl", hash = "sha256:8690c9096e0a271985339d4aa4b37675e7d62852620ca861ac032dc85b124542", size = 146387135, upload-time = "2026-08-03T02:28:17.956Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0f/28ba3c563a87adb85884fb59f5f281446f99a338c907e2b3f0b9f2f4a76c/warp_lang-1.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:12656050545cc77bf9b9b155399496c1a6279b5b6c59e407507d6858a2beb4a2", size = 24755239, upload-time = "2026-06-01T15:15:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/32/784829665b0cc6fadada337f103c811b7bf92a951a69c08f7e3cd6ab2580/warp_lang-1.14.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:70cd127d0e9109417099649fedf9d00f39f1307ccb7a6e9fb87661337868d7de", size = 138666257, upload-time = "2026-06-01T15:15:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/1f882dfbf4b2528093722423b389984eb65433ac5ebe53f94a1f9a72c262/warp_lang-1.14.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:f482787e8da9c9ef045601fde99095e16d604fbcc3cbb4a1e0cef0769388b316", size = 140159761, upload-time = "2026-06-01T15:16:04.039Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6a/f530a27d627c19302d40d100ad986b7d1722237866fe178a0c5233a4717e/warp_lang-1.14.0-py3-none-win_amd64.whl", hash = "sha256:936b49ec78237f9760e58cbe9c46ee6f4244aefbd62071c4fa9fd3b313dfa878", size = 121919902, upload-time = "2026-06-01T15:16:05.777Z" },
 ]
 
 [[package]]

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -4646,7 +4646,7 @@ requires-dist = [
     { name = "mediapy" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
-    { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5,<3.11" },
+    { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5" },
     { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.3.0" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
     { name = "notebook", specifier = ">=7.5.5" },


### PR DESCRIPTION
## Summary

- Relax dependency bounds in `pyproject.toml` (and `pyproject.rocm.toml`): `mujoco>=3.5,<3.11` → `mujoco>=3.5`, and warp-lang keeps mjlab's loose `>=1.14.0` (no upper cap).
- Default versions are pinned by the committed lockfiles via uv's prefer-locked semantics: **mujoco 3.10.0**, **warp-lang 1.14.0** — the same warp-lang line mjlab locks (`mujoco-warp` stays at 3.10.0.3, identical to mjlab). Ordinary `uv lock` no longer drifts to freshly released versions (e.g. warp-lang 1.16.0, a ~163MB wheel); upgrades happen only through deliberate `uv lock --upgrade-package` such as `make mujoco MJ=<ver>`.
- Docs (en + zh_CN mujoco backend guide, dr_contract) and the Makefile comment now describe `>=3.5,<3.11` as the *tested window* rather than the dependency constraint, and no longer hardcode the stale 3.8.0 default.
- `uv.rocm.lock`: single-line specifier sync; a full relock under uv 0.12 also rewrites ~100 stale dependency-edge markers, left out to keep this diff reviewable.

## Validation

- `make test-all` passed on the final commits (check + test-cov + benchmark smoke; only the platform-optional `mlx` benchmark skipped).
- `uv lock` confirms no version drift: mujoco stays 3.10.0, warp-lang stays 1.14.0; only specifier metadata changed.