### PR TITLE
refactor: 统一物理后端 contract 收敛 Phase 1 (#888)

### DIFF
--- a/scripts/manip_loco/benchmark_site_jacobian.py
+++ b/scripts/manip_loco/benchmark_site_jacobian.py
@@ -74,14 +74,14 @@ def _serial_site_jacobian(
     backend: Any, site_id: int, dof_indices: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
     dof_indices = np.asarray(dof_indices, dtype=np.int32).reshape(-1)
-    num_envs = int(backend._num_envs)
+    num_envs = int(backend.num_envs)
     jacp_out = np.zeros((num_envs, 3, len(dof_indices)), dtype=np.float64)
     jacr_out = np.zeros((num_envs, 3, len(dof_indices)), dtype=np.float64)
-    state_snapshot = np.asarray(backend._physics_state, dtype=np.float64).copy()
+    state_snapshot = np.asarray(backend.get_physics_state(), dtype=np.float64).copy()
 
     for env_idx in range(num_envs):
-        variant_idx = int(backend._model_assignments[env_idx])
-        model = backend._model_variants[variant_idx]
+        # Public contract: per-env model variant used by playback.
+        model = backend.get_playback_model(env_idx)
         data = mujoco.MjData(model)
         mujoco.mj_setState(
             model,
@@ -112,7 +112,6 @@ def _print_stats(tag: str, ms_values: Sequence[float]) -> None:
 @dataclass
 class BenchResult:
     num_envs: int
-    backend_threads: int
     correctness_ok: bool
     parallel_median_ms: float
     parallel_p95_ms: float
@@ -125,15 +124,15 @@ class BenchResult:
 
 def _format_markdown_table(results: Sequence[BenchResult]) -> str:
     lines = [
-        "| num_envs | backend_threads | correctness | par_median_ms | par_p95_ms | ser_median_ms | ser_p95_ms | speedup(serial/par) | step_median_ms | jacobian_step_ratio_pct |",
-        "|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| num_envs | correctness | par_median_ms | par_p95_ms | ser_median_ms | ser_p95_ms | speedup(serial/par) | step_median_ms | jacobian_step_ratio_pct |",
+        "|---:|:---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for r in results:
         step_med = "-" if r.step_median_ms is None else f"{r.step_median_ms:.3f}"
         jac_ratio = "-" if r.jacobian_step_ratio_pct is None else f"{r.jacobian_step_ratio_pct:.2f}"
         lines.append(
             "| "
-            f"{r.num_envs} | {r.backend_threads} | {'PASS' if r.correctness_ok else 'FAIL'} | "
+            f"{r.num_envs} | {'PASS' if r.correctness_ok else 'FAIL'} | "
             f"{r.parallel_median_ms:.3f} | {r.parallel_p95_ms:.3f} | "
             f"{r.serial_median_ms:.3f} | {r.serial_p95_ms:.3f} | "
             f"{r.speedup:.3f}x | {step_med} | {jac_ratio} |"
@@ -216,7 +215,6 @@ def _run_one_case(
 
         return BenchResult(
             num_envs=num_envs,
-            backend_threads=int(getattr(backend, "_n_threads", -1)),
             correctness_ok=True,
             parallel_median_ms=par_median,
             parallel_p95_ms=_pct(par_ms, 95),
@@ -303,7 +301,6 @@ def main(cfg: DictConfig) -> None:
         results.append(result)
         print(
             "result: "
-            f"threads={result.backend_threads}, "
             f"par_median={result.parallel_median_ms:.3f} ms, "
             f"ser_median={result.serial_median_ms:.3f} ms, "
             f"speedup={result.speedup:.3f}x"

--- a/scripts/manip_loco/diagnose_go2_arm_ik.py
+++ b/scripts/manip_loco/diagnose_go2_arm_ik.py
@@ -71,10 +71,36 @@ def _make_env(args: argparse.Namespace):
 
 
 def _state_qpos_qvel(backend: Any) -> tuple[np.ndarray, np.ndarray]:
-    state = np.asarray(backend.get_physics_state()[0], dtype=np.float64)
-    qpos = state[backend._idx_qpos : backend._idx_qpos + backend.nq].copy()
-    qvel = state[backend._idx_qvel : backend._idx_qvel + backend.nv].copy()
+    """Reconstruct full qpos/qvel through the public backend state contract.
+
+    Go2 has a floating base, so qpos is [base pos (3), base quat wxyz (4),
+    joint positions] and qvel is [base linear velocity (3), base angular
+    velocity (3), joint velocities]; joint ``i`` sits at
+    ``root_qpos_dim + i`` in qpos.
+    """
+    qpos = np.concatenate(
+        [
+            np.asarray(backend.get_base_pos()[0], dtype=np.float64),
+            np.asarray(backend.get_base_quat()[0], dtype=np.float64),
+            np.asarray(backend.get_dof_pos()[0], dtype=np.float64),
+        ]
+    )
+    qvel = np.concatenate(
+        [
+            np.asarray(backend.get_base_lin_vel()[0], dtype=np.float64),
+            np.asarray(backend.get_base_ang_vel()[0], dtype=np.float64),
+            np.asarray(backend.get_dof_vel()[0], dtype=np.float64),
+        ]
+    )
     return qpos, qvel
+
+
+def _root_qpos_dim(backend: Any) -> int:
+    """Floating-base qpos dimension implied by the public base state contract."""
+    return int(
+        np.asarray(backend.get_base_pos()).shape[1]
+        + np.asarray(backend.get_base_quat()).shape[1]
+    )
 
 
 def _restore_state(env: Any, qpos: np.ndarray, qvel: np.ndarray) -> None:
@@ -89,7 +115,7 @@ def _force_go2_home(env: Any, home_qpos: np.ndarray) -> None:
     """Clamp floating base and leg joints to home while preserving arm state."""
     backend = env._backend
     qpos, qvel = _state_qpos_qvel(backend)
-    first_arm_qpos = backend._root_qpos_dim + int(env.arm_dof_pos_indices[0])
+    first_arm_qpos = _root_qpos_dim(backend) + int(env.arm_dof_pos_indices[0])
     first_arm_qvel = int(env.arm_jacobian_dof_indices[0])
     qpos[:first_arm_qpos] = home_qpos[:first_arm_qpos]
     qvel[:first_arm_qvel] = 0.0
@@ -116,7 +142,7 @@ def run_jacobian_fd_check(env: Any, eps: float) -> dict[str, Any]:
 
     for col, qpos_idx_rel in enumerate(env.arm_dof_pos_indices):
         qpos = qpos0.copy()
-        qpos[backend._root_qpos_dim + qpos_idx_rel] += eps
+        qpos[_root_qpos_dim(backend) + qpos_idx_rel] += eps
         _restore_state(env, qpos, qvel0)
         ee_pos = env.get_ee_local_pose()[0].copy()[0]
         fd[:, col] = (ee_pos - ee0) / eps

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -49,7 +49,7 @@ class BackendHeightScanner(abc.ABC):
 
 @dataclass(frozen=True)
 class BackendTerrainSpawnData:
-    """Cold-path terrain metadata required by locomotion spawn managers."""
+    """Cold-path terrain spawn metadata owned by the backend."""
 
     origins: np.ndarray
     surface_sampler: object | None = None
@@ -73,7 +73,7 @@ def normalize_play_render_mode(play_render_mode: str | None) -> str:
     mode = "auto" if play_render_mode is None else str(play_render_mode).strip().lower()
     if mode not in PLAY_RENDER_MODES:
         joined = ", ".join(sorted(PLAY_RENDER_MODES))
-        raise ValueError(f"training.play_render_mode must be one of: {joined}; got {mode!r}.")
+        raise ValueError(f"play render mode must be one of: {joined}; got {mode!r}.")
     return mode
 
 
@@ -246,7 +246,7 @@ class SimBackend(abc.ABC):
         raise NotImplementedError(f"{self.__class__.__name__} does not expose dof armature")
 
     def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
-        """Resolve MuJoCo-style body IDs used by motion datasets."""
+        """Resolve backend-native body IDs used by motion datasets."""
         raise NotImplementedError(f"{self.__class__.__name__} does not expose motion body ids")
 
     def cleanup_scene_assets(self) -> None:
@@ -418,24 +418,6 @@ class SimBackend(abc.ABC):
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         """Apply a scheduled interval randomization plan."""
 
-    def apply_body_linear_velocity_delta(
-        self,
-        body_ids: np.ndarray,
-        velocity_delta: np.ndarray,
-    ) -> None:
-        """Apply a world-frame linear-velocity delta to specific bodies.
-
-        Args:
-            body_ids: Body ids whose linear velocities should be perturbed.
-            velocity_delta: Velocity delta with shape ``(num_envs, len(body_ids), 3)``.
-
-        Returns:
-            None. Backends that support this mutate their pending simulation state.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support interval body velocity perturbation"
-        )
-
     def apply_body_force(
         self,
         body_ids: np.ndarray,
@@ -486,7 +468,17 @@ class SimBackend(abc.ABC):
         camera_kwargs: dict[str, Any] | None = None,
         extra_data_getter: Callable[[], np.ndarray | None] | None = None,
     ) -> str | None:
-        """Execute backend-owned playback for an env wrapper."""
+        """Execute backend-owned playback for an env wrapper.
+
+        Known boundary: ``env`` is the owning env wrapper, not a physics-layer
+        concept. Current playback implementations read env-level configuration
+        (e.g. ``cfg.scene``, ``cfg.ctrl_dt``, ``cfg.render_spacing``) and
+        env-owned playback helpers (``get_playback_model``,
+        ``get_physics_state_snapshot``) that have no backend-native equivalent
+        yet. The parameter stays on this contract until playback asset/config
+        resolution moves onto backend-owned metadata; backends must only use
+        it on the cold playback path.
+        """
         raise NotImplementedError(f"{self.__class__.__name__} does not support playback execution")
 
     def init_renderer(

--- a/src/unilab/base/backend/batch.py
+++ b/src/unilab/base/backend/batch.py
@@ -322,9 +322,7 @@ def _validate_profile(
     control: ControlSpec,
 ) -> None:
     _enum(execution_profile, ExecutionProfile, "execution_profile")
-    expected_space = (
-        MemorySpace.HOST if execution_profile is ExecutionProfile.HOST_NUMPY else MemorySpace.DEVICE
-    )
+    expected_space = MemorySpace.HOST
     buffers = [field.buffer for field in fields]
     buffers.append(control.buffer)
     if any(buffer.placement.memory_space is not expected_space for buffer in buffers):
@@ -344,9 +342,7 @@ def _validate_state_profile(
     fields: tuple[StateFieldSpec, ...],
 ) -> None:
     _enum(execution_profile, ExecutionProfile, "execution_profile")
-    expected_space = (
-        MemorySpace.HOST if execution_profile is ExecutionProfile.HOST_NUMPY else MemorySpace.DEVICE
-    )
+    expected_space = MemorySpace.HOST
     if any(field.buffer.placement.memory_space is not expected_space for field in fields):
         raise BackendBatchContractError(
             f"{execution_profile.value} requires every state buffer in "

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -826,7 +826,21 @@ class MotrixBackend(SimBackend):
         if plan.body_linear_velocity_delta is not None:
             if plan.body_ids is None:
                 raise ValueError("Interval body-velocity perturbation requires body_ids")
-            self.apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
+            self._apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
+
+    def _apply_body_linear_velocity_delta(
+        self,
+        body_ids: np.ndarray,
+        velocity_delta: np.ndarray,
+    ) -> None:
+        """Apply a world-frame linear-velocity delta to specific bodies.
+
+        Backend-internal hook for ``apply_interval_randomization``; it is not
+        part of the public ``SimBackend`` surface.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support interval body velocity perturbation"
+        )
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
         return BackendPlayCapabilities(

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -1540,7 +1540,21 @@ class MuJoCoBackend(SimBackend):
         if plan.body_linear_velocity_delta is not None:
             if plan.body_ids is None:
                 raise ValueError("Interval body-velocity perturbation requires body_ids")
-            self.apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
+            self._apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
+
+    def _apply_body_linear_velocity_delta(
+        self,
+        body_ids: np.ndarray,
+        velocity_delta: np.ndarray,
+    ) -> None:
+        """Apply a world-frame linear-velocity delta to specific bodies.
+
+        Backend-internal hook for ``apply_interval_randomization``; it is not
+        part of the public ``SimBackend`` surface.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support interval body velocity perturbation"
+        )
 
     def push_robots(self, force_range: Sequence[float] | np.ndarray) -> None:
         self._pending_xfrc_applied.fill(0.0)

--- a/src/unilab/base/backend/mutation.py
+++ b/src/unilab/base/backend/mutation.py
@@ -716,11 +716,7 @@ class MutationCapabilityManifest:
 
         case_ids: list[str] = []
         mandatory_test_ids: list[str] = []
-        expected_space = (
-            MemorySpace.HOST
-            if self.execution_profile is ExecutionProfile.HOST_NUMPY
-            else MemorySpace.DEVICE
-        )
+        expected_space = MemorySpace.HOST
         for capability in canonical:
             descriptor = capability.descriptor
             if descriptor is None:

--- a/src/unilab/manager/__init__.py
+++ b/src/unilab/manager/__init__.py
@@ -30,6 +30,7 @@ from .plan import (
 )
 from .registry import TermRegistry
 from .runtime import (
+    ManagedEnvState,
     ManagedKernelBinding,
     ManagedLifecycleEvent,
     ManagedLifecyclePhase,
@@ -75,6 +76,7 @@ __all__ = [
     "FrozenParameters",
     "ManagerContractError",
     "ManagedPolicyABISnapshotError",
+    "ManagedEnvState",
     "ManagedLifecycleEvent",
     "ManagedLifecyclePhase",
     "ManagedKernelBinding",

--- a/src/unilab/manager/runtime.py
+++ b/src/unilab/manager/runtime.py
@@ -8,6 +8,7 @@ backend, selector, registry, asset, or model object.
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
@@ -32,7 +33,6 @@ from unilab.base.backend.batch import (
     StateBatchPhase,
 )
 from unilab.base.backend.mutation import BoundMutationPlan
-from unilab.base.np_env import NpEnvState
 
 from .entities import ManagerContractError
 from .fingerprint import managed_policy_abi_snapshot, validate_compiled_plan_fingerprints
@@ -562,6 +562,28 @@ def _require_full_array(
     return array
 
 
+@dataclass
+class ManagedEnvState:
+    """Manager-owned lifecycle state returned by ``init_state()``/``step()``.
+
+    The fields intentionally mirror the env-layer ``NpEnvState`` contract
+    (dict observations, vector reward/termination flags, info mapping), but
+    the type is owned by the manager layer so the runtime never depends on
+    the env contract.  Conversion to ``NpEnvState`` is only allowed at env
+    adapter boundaries.
+    """
+
+    obs: dict[str, np.ndarray]
+    reward: np.ndarray
+    terminated: np.ndarray
+    truncated: np.ndarray
+    info: dict[str, Any]
+    final_observation: dict[str, np.ndarray] | None = None
+
+    def replace(self, **updates: Any) -> "ManagedEnvState":
+        return dataclasses.replace(self, **updates)
+
+
 class ManagedReferenceRuntime:
     """Host reference runtime with one canonical terminal/autoreset lifecycle.
 
@@ -723,7 +745,7 @@ class ManagedReferenceRuntime:
             "final_observation": self._compat_final_observation,
             "_final_observation": self._final_observation_mask,
         }
-        self._state: NpEnvState | None = None
+        self._state: ManagedEnvState | None = None
         self._task_state: object | None = None
         self._last_trace: tuple[ManagedLifecycleEvent, ...] = ()
         self._trace_events: list[ManagedLifecycleEvent] = []
@@ -824,7 +846,7 @@ class ManagedReferenceRuntime:
         return self._kernel_binding
 
     @property
-    def state(self) -> NpEnvState | None:
+    def state(self) -> ManagedEnvState | None:
         return self._state
 
     @property
@@ -1173,7 +1195,7 @@ class ManagedReferenceRuntime:
             "backend reset_batch did not invalidate the terminal StateBatch lease"
         )
 
-    def init_state(self) -> NpEnvState:
+    def init_state(self) -> ManagedEnvState:
         self._begin_trace()
         self._task_state = self._kernel.create_task_state(
             num_envs=self._num_envs, dtype=self._dtype
@@ -1185,7 +1207,7 @@ class ManagedReferenceRuntime:
         self._truncated.fill(False)
         self._steps.fill(0)
         self._info["log"].clear()
-        self._state = NpEnvState(
+        self._state = ManagedEnvState(
             obs=self._obs,
             reward=self._reward,
             terminated=self._terminated,
@@ -1201,7 +1223,7 @@ class ManagedReferenceRuntime:
         self._finish_trace()
         return self._state
 
-    def step(self, actions: np.ndarray) -> NpEnvState:
+    def step(self, actions: np.ndarray) -> ManagedEnvState:
         if self._state is None:
             raise ManagedRuntimeError("managed runtime step requires init_state() first")
         assert self._state is not None
@@ -1329,6 +1351,7 @@ class ManagedReferenceRuntime:
 
 
 __all__ = [
+    "ManagedEnvState",
     "ManagedLifecycleEvent",
     "ManagedLifecyclePhase",
     "ManagedKernelBinding",

--- a/src/unilab/tools/backend_isolation.py
+++ b/src/unilab/tools/backend_isolation.py
@@ -18,6 +18,53 @@ _SHARED_RUNTIME_MODULES = frozenset(
         "playback_common",
     }
 )
+# Explicit cold-path exceptions: shared utilities that currently live in the
+# mujoco adapter package while sibling backends consume them.  Migrating these
+# helpers to a backend-neutral location is deferred to a follow-up issue; until
+# then these (owner, module prefix) pairs may import the sibling module.
+_SIBLING_COLD_PATH_EXCEPTIONS = frozenset(
+    {
+        ("drake", "unilab.base.backend.mujoco.playback"),
+        ("mjwarp", "unilab.base.backend.mujoco.xml"),
+    }
+)
+# The physics layer (unilab.base.backend) must stay importable without the
+# training/config stack so a future unisim extraction keeps a clean boundary.
+# These prefixes are forbidden at runtime and under TYPE_CHECKING alike.
+_PHYSICS_FORBIDDEN_IMPORT_PREFIXES = (
+    "hydra",
+    "omegaconf",
+    "unilab.envs",
+    "unilab.training",
+    "unilab.algos",
+    "unilab.manager",
+    "unilab.ipc",
+)
+# Documented unilab-internal dependencies of the physics layer.  Every entry
+# records an open decision for the future unisim extraction.
+_PHYSICS_ALLOWED_UNILAB_IMPORTS = {
+    # numpy-only DR payload types shared with the DR owner layer; unisim
+    # extraction decision: move the payload types into the physics package.
+    "unilab.dr.types": "move payload types into the physics package",
+    # Scene/materialization input; its downstream unilab.terrains imports are
+    # scene inputs too.  Extraction decision: move with the scene contract.
+    "unilab.base.scene": "move with the scene/materialization contract",
+    # Terrain materialization input reached through scene composition.
+    # Extraction decision: keep as a scene-level dependency.
+    "unilab.terrains": "keep as a scene-level materialization dependency",
+    # Global host dtype configuration.  Extraction decision: replace with an
+    # explicit backend construction option.
+    "unilab.dtype_config": "replace with an explicit backend construction option",
+    # TYPE_CHECKING-only EnvCfg import in base/backend/__init__.py.  A runtime
+    # import is a violation; extraction decision: type the factory on a local
+    # protocol instead of EnvCfg.
+    "unilab.base.base": "TYPE_CHECKING-only; replace with a local protocol",
+    # Offline playback frame rendering used by the cold-path playback helpers.
+    # Extraction decision: move playback rendering behind the play contract or
+    # into the physics package.
+    "unilab.visualization": "move playback rendering behind the play contract",
+}
+_PHYSICS_TYPE_CHECKING_ONLY_IMPORTS = frozenset({"unilab.base.base"})
 _RAW_BACKEND_MEMBERS = frozenset({"model"})
 _DIAGNOSTIC_MEMBERS = frozenset({"__class__"})
 
@@ -198,6 +245,37 @@ def _backend_owner(target: str, packages: frozenset[str]) -> str | None:
     return owner if owner in packages else None
 
 
+def _match_prefix(target: str, prefixes: Iterable[str]) -> str | None:
+    for prefix in prefixes:
+        if target == prefix or target.startswith(f"{prefix}."):
+            return prefix
+    return None
+
+
+def _module_name_for_path(source_root: Path, path: Path) -> str:
+    relative = path.relative_to(source_root.parent).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _type_checking_nodes(tree: ast.Module) -> set[int]:
+    ids: set[int] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.Name)
+            and test.id == "TYPE_CHECKING"
+            or isinstance(test, ast.Attribute)
+            and test.attr == "TYPE_CHECKING"
+        ):
+            ids.update(id(child) for child in ast.walk(node))
+    return ids
+
+
 def _audit_runtime_module(
     *,
     root: Path,
@@ -206,6 +284,7 @@ def _audit_runtime_module(
     owner: str,
     packages: frozenset[str],
     tree: ast.Module,
+    sibling_exceptions: frozenset[tuple[str, str]],
 ) -> list[BackendIsolationViolation]:
     violations: list[BackendIsolationViolation] = []
     aliases: dict[str, str] = {}
@@ -230,6 +309,11 @@ def _audit_runtime_module(
         for target in _import_targets(node, module_name):
             target_owner = _backend_owner(target, packages)
             if target_owner is not None and target_owner != owner:
+                if any(
+                    exception_owner == owner and _match_prefix(target, (prefix,)) is not None
+                    for exception_owner, prefix in sibling_exceptions
+                ):
+                    continue
                 violations.append(
                     _violation(
                         root=root,
@@ -295,6 +379,72 @@ def _audit_runtime_module(
     return violations
 
 
+def _audit_physics_layer_imports(
+    *,
+    root: Path,
+    path: Path,
+    module_name: str,
+    tree: ast.Module,
+) -> list[BackendIsolationViolation]:
+    """Fail closed on physics-layer imports of the training/config stack."""
+
+    violations: list[BackendIsolationViolation] = []
+    type_checking_nodes = _type_checking_nodes(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        for target in _import_targets(node, module_name):
+            forbidden = _match_prefix(target, _PHYSICS_FORBIDDEN_IMPORT_PREFIXES)
+            if forbidden is not None:
+                violations.append(
+                    _violation(
+                        root=root,
+                        path=path,
+                        node=node,
+                        code="physics-layer-forbidden-import",
+                        message=(
+                            f"physics layer must not import the config/training stack "
+                            f"({forbidden}): {target}"
+                        ),
+                    )
+                )
+                continue
+            if not target.startswith("unilab."):
+                continue
+            if target == "unilab" or _match_prefix(target, (_BACKEND_PREFIX,)) is not None:
+                continue
+            allowed = _match_prefix(target, tuple(_PHYSICS_ALLOWED_UNILAB_IMPORTS))
+            if allowed is None:
+                violations.append(
+                    _violation(
+                        root=root,
+                        path=path,
+                        node=node,
+                        code="physics-layer-undocumented-import",
+                        message=(
+                            f"physics layer import is not in the documented allowlist: {target}"
+                        ),
+                    )
+                )
+            elif (
+                allowed in _PHYSICS_TYPE_CHECKING_ONLY_IMPORTS
+                and id(node) not in type_checking_nodes
+            ):
+                violations.append(
+                    _violation(
+                        root=root,
+                        path=path,
+                        node=node,
+                        code="physics-layer-forbidden-import",
+                        message=(
+                            f"{allowed} is a TYPE_CHECKING-only physics layer dependency; "
+                            f"a runtime import is forbidden: {target}"
+                        ),
+                    )
+                )
+    return violations
+
+
 def _sim_backend_public_members(
     *,
     root: Path,
@@ -336,17 +486,33 @@ class _BackendContractUseVisitor(ast.NodeVisitor):
         root: Path,
         path: Path,
         public_members: frozenset[str],
+        strict_probes: bool = True,
     ) -> None:
         self._root = root
         self._path = path
         self._public_members = public_members
+        # Runtime layers (envs/dr/manager/training/np_env) forbid all
+        # getattr/hasattr capability probing on backend expressions.  Cold-path
+        # scripts may probe public names with a graceful fallback; private or
+        # dynamic probe targets stay forbidden there too.  Direct access to
+        # non-contract members is flagged in every layer either way.
+        self._strict_probes = strict_probes
         self._alias_scopes: list[set[str]] = [{"_backend"}]
         self.violations: list[BackendIsolationViolation] = []
 
     def _is_backend_expression(self, node: ast.AST) -> bool:
         if isinstance(node, ast.Name):
             return any(node.id in scope for scope in reversed(self._alias_scopes))
-        return isinstance(node, ast.Attribute) and node.attr == "_backend"
+        if isinstance(node, ast.Attribute) and node.attr == "_backend":
+            return True
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "_backend"
+        )
 
     def _add(self, node: ast.AST, code: str, message: str) -> None:
         self.violations.append(
@@ -391,11 +557,18 @@ class _BackendContractUseVisitor(ast.NodeVisitor):
             and node.args
             and self._is_backend_expression(node.args[0])
         ):
-            self._add(
-                node,
-                "dynamic-backend-probe",
-                f"{node.func.id} capability probing bypasses the SimBackend contract",
+            target = node.args[1] if len(node.args) >= 2 else None
+            public_constant_target = (
+                isinstance(target, ast.Constant)
+                and isinstance(target.value, str)
+                and not target.value.startswith("_")
             )
+            if self._strict_probes or not public_constant_target:
+                self._add(
+                    node,
+                    "dynamic-backend-probe",
+                    f"{node.func.id} capability probing bypasses the SimBackend contract",
+                )
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
@@ -424,8 +597,15 @@ class _BackendContractUseVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def _contract_source_paths(source_root: Path) -> tuple[Path, ...]:
-    roots = (source_root / "envs", source_root / "dr")
+def _contract_source_paths(root: Path) -> tuple[Path, ...]:
+    source_root = root / "src" / "unilab"
+    roots = (
+        source_root / "envs",
+        source_root / "dr",
+        source_root / "manager",
+        source_root / "training",
+        root / "scripts",
+    )
     paths: list[Path] = []
     for scan_root in roots:
         if scan_root.is_dir():
@@ -442,15 +622,27 @@ def _missing_path_violation(
     return _violation(root=root, path=path, code=code, message=message)
 
 
-def audit_backend_isolation(root: Path) -> BackendIsolationReport:
+def audit_backend_isolation(
+    root: Path,
+    *,
+    sibling_exceptions: Iterable[tuple[str, str]] | None = None,
+) -> BackendIsolationReport:
     """Audit backend runtime imports and env/DR use of ``SimBackend``.
 
     ``root`` is the repository root containing ``src/unilab``.  The audit is
     fail-closed for missing roots, malformed backend packages, unreadable or
     invalid Python, and an invalid ``SimBackend`` declaration.
+
+    ``sibling_exceptions`` overrides the documented cold-path sibling import
+    exceptions; each entry is an ``(owner, module_prefix)`` pair.
     """
 
     root = root.resolve()
+    exceptions = (
+        _SIBLING_COLD_PATH_EXCEPTIONS
+        if sibling_exceptions is None
+        else frozenset(sibling_exceptions)
+    )
     source_root = root / "src" / "unilab"
     backend_root = source_root / "base" / "backend"
     base_path = backend_root / "base.py"
@@ -515,32 +707,55 @@ def audit_backend_isolation(root: Path) -> BackendIsolationReport:
                     f"backend package {package_name!r} is missing backend.py",
                 )
             )
-        for filename in sorted(_RUNTIME_FILENAMES):
-            path = package_dir / filename
-            if path.is_file():
-                runtime_paths.append((package_name, path))
+        for path in sorted(package_dir.glob("*.py")):
+            runtime_paths.append((package_name, path))
 
     frozen_packages = frozenset(packages)
     runtime_modules: list[str] = []
     for owner, path in runtime_paths:
-        module_name = f"{_BACKEND_PREFIX}.{owner}.{path.stem}"
+        module_name = _module_name_for_path(source_root, path)
         runtime_modules.append(module_name)
+        # Relative imports inside __init__.py resolve against the package
+        # itself, so resolve them against a synthetic child module name.
+        resolution_name = (
+            f"{module_name}.__init__" if path.stem == "__init__" else module_name
+        )
         tree = _parse_source(path, root=root, violations=violations)
         if tree is not None:
             violations.extend(
                 _audit_runtime_module(
                     root=root,
                     path=path,
-                    module_name=module_name,
+                    module_name=resolution_name,
                     owner=owner,
                     packages=frozen_packages,
                     tree=tree,
+                    sibling_exceptions=exceptions,
                 )
             )
 
-    base_tree = (
-        _parse_source(base_path, root=root, violations=violations) if base_path.is_file() else None
-    )
+    physics_trees: dict[Path, ast.Module | None] = {}
+    for path in sorted(backend_root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = _parse_source(path, root=root, violations=violations)
+        physics_trees[path] = tree
+        if tree is None:
+            continue
+        violations.extend(
+            _audit_physics_layer_imports(
+                root=root,
+                path=path,
+                module_name=(
+                    f"{_module_name_for_path(source_root, path)}.__init__"
+                    if path.stem == "__init__"
+                    else _module_name_for_path(source_root, path)
+                ),
+                tree=tree,
+            )
+        )
+
+    base_tree = physics_trees.get(base_path) if base_path.is_file() else None
     public_members = _sim_backend_public_members(
         root=root,
         path=base_path,
@@ -548,7 +763,8 @@ def audit_backend_isolation(root: Path) -> BackendIsolationReport:
         violations=violations,
     )
 
-    contract_paths = _contract_source_paths(source_root)
+    contract_paths = _contract_source_paths(root)
+    scripts_root = root / "scripts"
     for path in contract_paths:
         tree = _parse_source(path, root=root, violations=violations)
         if tree is None:
@@ -557,6 +773,7 @@ def audit_backend_isolation(root: Path) -> BackendIsolationReport:
             root=root,
             path=path,
             public_members=public_members,
+            strict_probes=not path.is_relative_to(scripts_root),
         )
         visitor.visit(tree)
         violations.extend(visitor.violations)

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -1,0 +1,382 @@
+"""Cross-backend conformance suite driven only through the public contract.
+
+Every interaction goes through ``create_backend`` and the public ``SimBackend``
+surface.  MuJoCo must pass the full legacy and typed flow; mjwarp runs when a
+CUDA Warp device is available (slow lane); motrix/drake must at least fail
+closed with ``NotImplementedError`` on the typed batch contract.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import (
+    BackendBatchCounterBudget,
+    BackendIORequirements,
+    BoundFieldIdentity,
+    BufferContract,
+    BufferLayout,
+    BufferLifetime,
+    BufferMutability,
+    BufferOwner,
+    BufferPlacement,
+    BufferView,
+    ControlBatch,
+    ControlSpec,
+    ExecutionProfile,
+    MutationBaseline,
+    MutationCommitPhase,
+    MutationEntityKind,
+    MutationFieldKind,
+    MutationOperation,
+    MutationPersistence,
+    MutationRecomputeLevel,
+    MutationSpec,
+    MutationTargetKind,
+    MutationTargetSpec,
+    MutationTrigger,
+    MutationValueBatch,
+    PhysicalUnit,
+    ReferenceFrame,
+    RowSelection,
+    SimulationStateMutationBatch,
+    StateEntityKind,
+    StateFieldKind,
+    StateFieldSpec,
+    TypedBackendMutationBatch,
+    create_backend,
+)
+from unilab.base.scene import SceneCfg
+from unilab.tools.backend_isolation import audit_backend_isolation
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+_FACTORY_FILE = SRC_ROOT / "unilab" / "base" / "backend" / "__init__.py"
+_BACKEND_CLASS_NAMES = frozenset(
+    {"MuJoCoBackend", "MotrixBackend", "DrakeBackend", "MjwarpBackend"}
+)
+
+NUM_ENVS = 2
+SIM_DT = 0.005
+_G1_SCENE = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+
+
+def _module_available(module: str) -> bool:
+    return importlib.util.find_spec(module) is not None
+
+
+def _mjwarp_cuda_available() -> bool:
+    from unilab.base.backend.mjwarp.dependencies import (
+        load_mjwarp_dependencies,
+        mjwarp_dependencies_available,
+    )
+
+    if not mjwarp_dependencies_available():
+        return False
+    try:
+        return bool(load_mjwarp_dependencies().warp.get_device().is_cuda)
+    except Exception:
+        return False
+
+
+def _drake_batch_available() -> bool:
+    try:
+        from unilab.base.backend.drake.backend import ensure_drake_batch_available
+    except ImportError:
+        return False
+    available, _ = ensure_drake_batch_available()
+    return bool(available)
+
+
+def _require_backend(backend_type: str) -> None:
+    if backend_type == "mujoco":
+        pytest.importorskip("mujoco", reason="mujoco not installed")
+    elif backend_type == "motrix":
+        pytest.importorskip("motrixsim", reason="motrixsim not installed")
+    elif backend_type == "mjwarp":
+        if not _mjwarp_cuda_available():
+            pytest.skip("mjwarp requires an active CUDA Warp device")
+    elif backend_type == "drake":
+        if not _drake_batch_available():
+            pytest.skip("drake batch extension not available")
+
+
+_BACKEND_PARAMS = [
+    pytest.param("mujoco", id="mujoco"),
+    pytest.param("motrix", id="motrix"),
+    pytest.param("drake", id="drake"),
+    pytest.param("mjwarp", id="mjwarp", marks=pytest.mark.slow),
+]
+
+
+def test_backend_classes_are_only_instantiated_through_create_backend() -> None:
+    offenders: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if path == _FACTORY_FILE or "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name in _BACKEND_CLASS_NAMES:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: {name}(")
+    assert not offenders, "direct backend instantiation outside create_backend:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_real_repo_backend_isolation_audit_passes() -> None:
+    report = audit_backend_isolation(REPO_ROOT)
+    assert report.ok, "\n".join(violation.format() for violation in report.violations)
+
+
+@pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
+def test_legacy_contract_step_set_state_and_state_reads(backend_type: str) -> None:
+    _require_backend(backend_type)
+
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=_G1_SCENE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+
+    assert backend.num_envs == NUM_ENVS
+    assert backend.num_actuators > 0
+
+    backend.step(np.zeros((NUM_ENVS, backend.num_actuators)), nsteps=2)
+
+    default_qpos = np.asarray(backend.get_default_qpos())
+    qpos = np.broadcast_to(default_qpos, (NUM_ENVS, default_qpos.shape[0])).copy()
+    target_xyz = np.array([1.0, 2.0, 0.8])
+    qpos[:, :3] = target_xyz
+    qvel = np.zeros((NUM_ENVS, len(backend.get_init_qvel())))
+    backend.set_state(np.arange(NUM_ENVS, dtype=np.int32), qpos, qvel)
+
+    np.testing.assert_allclose(
+        backend.get_base_pos(), np.tile(target_xyz, (NUM_ENVS, 1)), atol=1e-4
+    )
+    np.testing.assert_allclose(
+        np.linalg.norm(backend.get_base_quat(), axis=-1), 1.0, atol=1e-5
+    )
+
+
+def _write_free_hinge_model(tmp_path: Path) -> Path:
+    model_file = tmp_path / "conformance_free_hinge.xml"
+    model_file.write_text(
+        """
+<mujoco model="conformance_free_hinge">
+  <option timestep="0.01" gravity="0 0 0"/>
+  <worldbody>
+    <body name="payload">
+      <freejoint name="payload_free"/>
+      <geom name="payload_geom" type="sphere" size="0.1" mass="1"/>
+      <body name="hinge_link" pos="0 0 0.15">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom name="hinge_geom" type="capsule" fromto="0 0 0 0 0 0.15" size="0.02" mass="0.1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hinge_motor" joint="hinge" gear="1"/>
+  </actuator>
+</mujoco>
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return model_file
+
+
+def _state_buffer(dtype: np.dtype) -> BufferContract:
+    return BufferContract(
+        row_shape=(1,),
+        dtype=dtype.name,
+        layout=BufferLayout.C_CONTIGUOUS,
+        placement=BufferPlacement.host(),
+        owner=BufferOwner.BACKEND,
+        mutability=BufferMutability.READ_ONLY,
+        lifetime=BufferLifetime.BORROWED_UNTIL_MUTATION,
+        dlpack_exportable=False,
+    )
+
+
+def _typed_requirements(backend) -> BackendIORequirements:
+    dtype = np.dtype(backend.get_init_qvel().dtype)
+    position_id = tuple(int(value) for value in backend.get_joint_dof_pos_indices(("hinge",)))
+    velocity_id = tuple(int(value) for value in backend.get_joint_dof_vel_indices(("hinge",)))
+    state_buffer = _state_buffer(dtype)
+    fields = (
+        StateFieldSpec(
+            semantic_key="hinge.position",
+            identity=BoundFieldIdentity(
+                entity_kind=StateEntityKind.DOF,
+                field_kind=StateFieldKind.POSITION,
+                entity_ids=position_id,
+            ),
+            frame=ReferenceFrame.JOINT,
+            unit=PhysicalUnit.RADIAN,
+            buffer=state_buffer,
+        ),
+        StateFieldSpec(
+            semantic_key="hinge.angular_velocity",
+            identity=BoundFieldIdentity(
+                entity_kind=StateEntityKind.DOF,
+                field_kind=StateFieldKind.ANGULAR_VELOCITY,
+                entity_ids=velocity_id,
+            ),
+            frame=ReferenceFrame.JOINT,
+            unit=PhysicalUnit.RADIAN_PER_SECOND,
+            buffer=state_buffer,
+        ),
+    )
+    control_buffer = BufferContract(
+        row_shape=(backend.num_actuators,),
+        dtype=dtype.name,
+        layout=BufferLayout.C_CONTIGUOUS,
+        placement=BufferPlacement.host(),
+        owner=BufferOwner.MANAGER,
+        mutability=BufferMutability.READ_ONLY,
+        lifetime=BufferLifetime.UNTIL_STEP_COMPLETE,
+        dlpack_exportable=False,
+    )
+    return BackendIORequirements(
+        state_fields=fields,
+        control=ControlSpec("hinge.control", control_buffer),
+        execution_profile=ExecutionProfile.HOST_NUMPY,
+        hot_path_budget=BackendBatchCounterBudget(allocations=8, state_materializations=2),
+    )
+
+
+def _reset_spec(dtype: np.dtype, *, term_key: str, target_key: str, field_kind) -> MutationSpec:
+    return MutationSpec(
+        term_key=term_key,
+        target=MutationTargetSpec(
+            target_key=target_key,
+            target_kind=MutationTargetKind.SIMULATION_STATE,
+            entity_kind=MutationEntityKind.DOF,
+            field_kind=field_kind,
+            selector="hinge",
+        ),
+        trigger=MutationTrigger.RESET,
+        commit_phase=MutationCommitPhase.RESET,
+        operation=MutationOperation.SET,
+        baseline=MutationBaseline.DEFAULT,
+        persistence=MutationPersistence.EPISODE,
+        recompute=MutationRecomputeLevel.KINEMATICS,
+        value_template=BufferContract(
+            row_shape=(1,),
+            dtype=dtype.name,
+            layout=BufferLayout.C_CONTIGUOUS,
+            placement=BufferPlacement.host(),
+            owner=BufferOwner.MANAGER,
+            mutability=BufferMutability.READ_ONLY,
+            lifetime=BufferLifetime.UNTIL_COMMIT,
+            dlpack_exportable=False,
+        ),
+    )
+
+
+def _state_value(mutation_plan, term_key: str, rows: RowSelection, values: np.ndarray):
+    field_index = mutation_plan.spec_index(term_key)
+    contract = mutation_plan.specs[field_index].value_buffer
+    handle = np.ascontiguousarray(values, dtype=contract.dtype)
+    return MutationValueBatch(
+        plan=mutation_plan,
+        field_index=field_index,
+        rows=rows,
+        buffer=BufferView(handle, handle.shape, contract),
+    )
+
+
+@pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
+def test_typed_contract_bind_step_read_reset(backend_type: str, tmp_path: Path) -> None:
+    _require_backend(backend_type)
+
+    kwargs = {"chunk_size": NUM_ENVS, "bench_nsteps": 1} if backend_type == "mujoco" else {}
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=str(_write_free_hinge_model(tmp_path))),
+        NUM_ENVS,
+        0.01,
+        base_name="payload",
+        **kwargs,
+    )
+    backend.materialize()
+    requirements = _typed_requirements(backend)
+
+    if backend_type in ("motrix", "drake"):
+        # Fail-closed on the typed contract is conformant for backends that do
+        # not implement typed batches yet.
+        with pytest.raises(NotImplementedError, match="does not support typed backend batches"):
+            backend.bind_task_io(requirements)
+        return
+
+    dtype = np.dtype(backend.get_init_qvel().dtype)
+    plan = backend.bind_task_io(requirements)
+    rows = RowSelection.all(NUM_ENVS)
+
+    before = backend.read_state_batch(plan, rows)
+    before_position = np.asarray(before.state.buffer("hinge.position").handle).copy()
+    assert before_position.shape == (NUM_ENVS, 1)
+
+    mutation_plan = backend.bind_mutation_plan(
+        (
+            _reset_spec(
+                dtype,
+                term_key="reset.hinge.position",
+                target_key="state.dof.position",
+                field_kind=MutationFieldKind.POSITION,
+            ),
+            _reset_spec(
+                dtype,
+                term_key="reset.hinge.velocity",
+                target_key="state.dof.angular_velocity",
+                field_kind=MutationFieldKind.ANGULAR_VELOCITY,
+            ),
+        )
+    )
+    position = np.asarray([[[0.5]], [[-0.25]]], dtype=dtype)
+    velocity = np.asarray([[[1.0]], [[-2.0]]], dtype=dtype)
+    mutation = TypedBackendMutationBatch(
+        plan=mutation_plan,
+        rows=rows,
+        state=SimulationStateMutationBatch(
+            (
+                _state_value(mutation_plan, "reset.hinge.position", rows, position),
+                _state_value(mutation_plan, "reset.hinge.velocity", rows, velocity),
+            )
+        ),
+    )
+    reset_result = backend.reset_batch(plan, rows, mutation_batch=mutation)
+    reset_position = np.asarray(reset_result.reset_state.buffer("hinge.position").handle)
+    reset_velocity = np.asarray(reset_result.reset_state.buffer("hinge.angular_velocity").handle)
+    np.testing.assert_allclose(reset_position, position[:, 0, :], atol=1e-5)
+    np.testing.assert_allclose(reset_velocity, velocity[:, 0, :], atol=1e-5)
+
+    control = np.zeros((NUM_ENVS, *plan.control.buffer.row_shape), dtype=plan.control.buffer.dtype)
+    terminal = backend.step_batch(
+        plan,
+        ControlBatch(
+            plan=plan,
+            rows=rows,
+            buffer=BufferView(control, control.shape, plan.control.buffer),
+        ),
+    )
+    terminal_position = np.asarray(terminal.terminal_state.buffer("hinge.position").handle)
+    assert terminal_position.shape == (NUM_ENVS, 1)
+    assert np.all(np.isfinite(terminal_position))

--- a/tests/manager/test_fused_executor.py
+++ b/tests/manager/test_fused_executor.py
@@ -3,7 +3,7 @@
 The reference and fused candidates receive independent physics instances.  The
 test never treats the fused kernel's arrays as an oracle: generated vectors,
 the separate reference executor, terminal/final observations, and lifecycle
-trace all have to agree through the public ``NpEnvState`` contract.
+trace all have to agree through the public ``ManagedEnvState`` contract.
 """
 
 from __future__ import annotations
@@ -27,7 +27,6 @@ from unilab.base.backend import (
     create_backend,
     env_backend_kwargs,
 )
-from unilab.base.np_env import NpEnvState
 from unilab.envs.locomotion.g1 import managed_fused as fused_module
 from unilab.envs.locomotion.g1.joystick import G1WalkEnv, G1WalkFlatCfg, G1WalkRewardConfig
 from unilab.envs.locomotion.g1.managed_fused import (
@@ -45,7 +44,7 @@ from unilab.envs.locomotion.g1.managed_schema import (
     G1_STATE_KEYS,
     build_g1_kernel_config,
 )
-from unilab.manager import ManagedReferenceRuntime, ManagedRuntimeError
+from unilab.manager import ManagedEnvState, ManagedReferenceRuntime, ManagedRuntimeError
 
 _ATOL = 1.0e-6
 _RTOL = 1.0e-5
@@ -137,7 +136,7 @@ def _assert_array_close(*, expected: np.ndarray, actual: np.ndarray, label: str)
     np.testing.assert_allclose(expected, actual, atol=_ATOL, rtol=_RTOL, err_msg=label)
 
 
-def _assert_state_close(*, expected: NpEnvState, actual: NpEnvState, label: str) -> None:
+def _assert_state_close(*, expected: ManagedEnvState, actual: ManagedEnvState, label: str) -> None:
     assert tuple(expected.obs) == tuple(actual.obs), f"{label}: observation keys differ"
     for key in expected.obs:
         _assert_array_close(

--- a/tests/manager/test_g1_reference_differential.py
+++ b/tests/manager/test_g1_reference_differential.py
@@ -24,7 +24,7 @@ from unilab.envs.locomotion.g1.managed_reference import (
     G1ManagedReferenceError,
     create_g1_managed_reference_runtime,
 )
-from unilab.manager import ManagedLifecyclePhase, ManagedReferenceRuntime
+from unilab.manager import ManagedEnvState, ManagedLifecyclePhase, ManagedReferenceRuntime
 
 _ATOL = 1.0e-6
 _RTOL = 1.0e-5
@@ -133,7 +133,7 @@ def _assert_close(*, expected: np.ndarray, actual: np.ndarray, label: str) -> No
     )
 
 
-def _assert_state_matches(*, expected: NpEnvState, actual: NpEnvState, label: str) -> None:
+def _assert_state_matches(*, expected: NpEnvState, actual: ManagedEnvState, label: str) -> None:
     assert tuple(expected.obs) == tuple(actual.obs), f"{label}: observation group keys differ"
     for key in expected.obs:
         _assert_close(
@@ -236,7 +236,7 @@ def _step_pair(
     managed_backend: SimBackend,
     actions: np.ndarray,
     label: str,
-) -> tuple[NpEnvState, NpEnvState]:
+) -> tuple[NpEnvState, ManagedEnvState]:
     expected = legacy.step(actions.copy())
     with _forbid_managed_hot_path_fallbacks(managed_backend):
         actual = managed.step(actions.copy())

--- a/tests/tools/test_backend_isolation.py
+++ b/tests/tools/test_backend_isolation.py
@@ -67,7 +67,31 @@ def _codes(root: Path) -> set[str]:
     return {violation.code for violation in audit_backend_isolation(root).violations}
 
 
-def test_clean_runtime_and_cold_sibling_adapter_pass(tmp_path: Path) -> None:
+def test_clean_runtime_and_shared_module_imports_pass(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/mujoco/playback.py": (
+                "from unilab.base.backend.playback_common import write_playback_video\n"
+            ),
+        },
+    )
+
+    report = audit_backend_isolation(root)
+
+    assert report.ok
+    assert report.backend_packages == ("motrix", "mujoco")
+    # Every package file is audited, including __init__.py re-export modules.
+    assert report.runtime_modules == (
+        "unilab.base.backend.motrix",
+        "unilab.base.backend.motrix.backend",
+        "unilab.base.backend.mujoco",
+        "unilab.base.backend.mujoco.backend",
+        "unilab.base.backend.mujoco.playback",
+    )
+
+
+def test_sibling_import_in_any_package_file_fails_closed(tmp_path: Path) -> None:
     root = _fixture_repo(
         tmp_path,
         {
@@ -79,12 +103,32 @@ def test_clean_runtime_and_cold_sibling_adapter_pass(tmp_path: Path) -> None:
 
     report = audit_backend_isolation(root)
 
-    assert report.ok
-    assert report.backend_packages == ("motrix", "mujoco")
-    assert report.runtime_modules == (
-        "unilab.base.backend.motrix.backend",
-        "unilab.base.backend.mujoco.backend",
+    assert "sibling-runtime-import" in {violation.code for violation in report.violations}
+    assert any(
+        violation.path == "src/unilab/base/backend/mujoco/playback.py"
+        for violation in report.violations
     )
+
+
+def test_documented_sibling_cold_path_exception_passes(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/mujoco/playback.py": (
+                "def run_mujoco_playback():\n    pass\n"
+            ),
+            "src/unilab/base/backend/motrix/playback.py": (
+                "from unilab.base.backend.mujoco.playback import run_mujoco_playback\n"
+            ),
+        },
+    )
+
+    report = audit_backend_isolation(
+        root,
+        sibling_exceptions={("motrix", "unilab.base.backend.mujoco.playback")},
+    )
+
+    assert report.ok
 
 
 @pytest.mark.parametrize(
@@ -235,3 +279,177 @@ def test_missing_and_empty_runtime_roots_fail_closed(tmp_path: Path) -> None:
     assert "empty-runtime-root" in {violation.code for violation in empty_report.violations}
     with pytest.raises(BackendIsolationAuditError, match="backend isolation audit failed"):
         empty_report.require_ok()
+
+
+@pytest.mark.parametrize(
+    "forbidden_import",
+    (
+        "import hydra\n",
+        "from omegaconf import DictConfig\n",
+        "from unilab.envs.task import Task\n",
+        "from unilab.training import create_env\n",
+        "from unilab.algos import ppo\n",
+        "from unilab.manager import ManagedEnvState\n",
+        "from unilab.ipc import async_runner\n",
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    from unilab.training import create_env\n",
+    ),
+)
+def test_physics_layer_forbidden_imports_fail_closed(
+    tmp_path: Path, forbidden_import: str
+) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {"src/unilab/base/backend/mujoco/backend.py": forbidden_import},
+    )
+
+    assert "physics-layer-forbidden-import" in _codes(root)
+
+
+@pytest.mark.parametrize(
+    "allowed_import",
+    (
+        "from unilab.dr.types import ResetRandomizationPayload\n",
+        "from unilab.base.scene import SceneCfg\n",
+        "from unilab.terrains.terrain_generator import TerrainGeneratorCfg\n",
+        "from unilab.dtype_config import get_global_dtype\n",
+        "from unilab.visualization import render_many\n",
+        (
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    from unilab.base.base import EnvCfg\n"
+        ),
+    ),
+)
+def test_physics_layer_documented_allowlist_passes(tmp_path: Path, allowed_import: str) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/mujoco/backend.py": (
+                allowed_import + "from ..base import SimBackend\n"
+            ),
+        },
+    )
+
+    assert audit_backend_isolation(root).ok
+
+
+def test_physics_layer_undocumented_unilab_import_fails_closed(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/mujoco/backend.py": (
+                "from unilab.utils.rotation import quat_apply\n"
+            ),
+        },
+    )
+
+    assert "physics-layer-undocumented-import" in _codes(root)
+
+
+def test_physics_layer_type_checking_only_import_at_runtime_fails_closed(
+    tmp_path: Path,
+) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/__init__.py": (
+                "from unilab.base.base import EnvCfg\n"
+            ),
+        },
+    )
+
+    report = audit_backend_isolation(root)
+
+    assert "physics-layer-forbidden-import" in {violation.code for violation in report.violations}
+    assert any(
+        violation.path == "src/unilab/base/backend/__init__.py"
+        for violation in report.violations
+    )
+
+
+def test_physics_layer_audit_covers_shared_modules(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {"src/unilab/base/backend/playback_common.py": "import hydra\n"},
+    )
+
+    assert "physics-layer-forbidden-import" in _codes(root)
+
+
+def test_scripts_private_probe_fails_closed(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "scripts/tool.py": (
+                "def diag(env):\n"
+                "    backend = getattr(env, '_backend', None)\n"
+                "    return getattr(backend, '_n_threads', -1)\n"
+            ),
+        },
+    )
+
+    report = audit_backend_isolation(root)
+
+    assert "dynamic-backend-probe" in {violation.code for violation in report.violations}
+    assert any(violation.path == "scripts/tool.py" for violation in report.violations)
+
+
+def test_scripts_public_probe_and_contract_calls_pass(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "scripts/tool.py": (
+                "def diag(env):\n"
+                "    backend = getattr(env, '_backend', None)\n"
+                "    if not hasattr(backend, 'allowed'):\n"
+                "        return None\n"
+                "    optional = getattr(backend, 'scene_visual_model_file', None)\n"
+                "    backend.allowed()\n"
+                "    return optional\n"
+            ),
+        },
+    )
+
+    assert audit_backend_isolation(root).ok
+
+
+def test_runtime_layers_keep_strict_probe_rules(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/manager/scene.py": (
+                "def diag(env):\n"
+                "    backend = getattr(env, '_backend', None)\n"
+                "    return getattr(backend, 'scene_visual_model_file', None)\n"
+            ),
+            "src/unilab/training/run.py": (
+                "def diag(env):\n"
+                "    return hasattr(env._backend, 'allowed')\n"
+            ),
+        },
+    )
+
+    report = audit_backend_isolation(root)
+
+    assert "dynamic-backend-probe" in {violation.code for violation in report.violations}
+    assert {violation.path for violation in report.violations} == {
+        "src/unilab/manager/scene.py",
+        "src/unilab/training/run.py",
+    }
+
+
+def test_scripts_private_backend_member_via_getattr_alias_fails_closed(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "scripts/tool.py": (
+                "def diag(env):\n"
+                "    backend = getattr(env, '_backend', None)\n"
+                "    return backend._model\n"
+            ),
+        },
+    )
+
+    assert "private-backend-member" in _codes(root)


### PR DESCRIPTION
## Summary

执行 #888(#882 Roadmap Phase 1):收敛统一物理后端 contract,建立未来可提取为独立 `unisim` package 的 owner 边界(只整理边界,不创建独立 package)。

**contract 收敛**

- 解除 manager runtime 对 `NpEnvState` 的反向依赖:新增 manager 层 `ManagedEnvState`(镜像 NpEnvState 字段,归属 manager 层),`manager/runtime.py` 不再 import `np_env`;
- 精简 `SimBackend` 公共 surface:`apply_body_linear_velocity_delta` 无外部调用方,下沉为 mujoco/motrix adapter 私有方法;
- 措辞 backend-neutral 化:`normalize_play_render_mode` 错误消息不再引用 `training.play_render_mode`;`get_motion_body_ids` 去掉 "MuJoCo-style";`BackendTerrainSpawnData` 去掉 spawn-manager 措辞;
- placement 语义清理:删除单成员 `ExecutionProfile` 下不可达的 `MemorySpace.DEVICE` 死分支(`batch.py`/`mutation.py`);placement 保持纯 buffer 属性,各 backend 的 fail-closed profile 守卫保留;
- `run_playback(env, ...)` 经调查三个实现深度依赖 env wrapper(cfg/playback model/physics-state getter),保守保留签名,docstring 标注为已知边界(列入后续 issue)。

**owner 边界机械化(`tools/backend_isolation.py`)**

- **import audit**(新):`src/unilab/base/backend/**` 禁止 import `hydra`/`omegaconf`/`unilab.envs`/`unilab.training`/`unilab.algos`/`unilab.manager`/`unilab.ipc`(运行期与 TYPE_CHECKING 同样禁止);允许依赖进入带注释的 allowlist(`dr.types`/`base.scene`/`terrains`/`dtype_config`/`base.base`(TYPE_CHECKING-only)/`visualization`),每项注明 unisim 提取待决策;
- **private-access audit**:caller 扫描从 `envs/`、`dr/`、`np_env.py` 扩展到 `manager/`、`training/`、`scripts/`;visitor 精化(getattr 别名追踪、scripts 冷路径公开名带 fallback 探测放行、runtime 层保持严格);两个 manip_loco 诊断脚本全部迁移到公开 `SimBackend` API(IK 脚本行为实测逐位等价);
- **sibling runtime audit**:从仅扫 `backend.py`/`batch.py` 扩展到包内全部文件;两个既有 sibling 冷路径依赖(`drake→mujoco.playback`、`mjwarp→mujoco.xml`)进入文档化例外,迁移留给后续 issue。

**conformance suite(新 `tests/base/test_backend_conformance.py`)**

- factory-only 构造断言(AST 扫描 `src/`,四个 backend 类无绕过 `create_backend` 的直接实例化);
- 参数化 legacy contract:`create_backend` → `step` → `set_state` → state read(mujoco 全过、motrix 实跑通过、drake 不可用 skip、mjwarp slow 车道);
- 参数化 typed contract:`bind_task_io` → `read_state_batch` → `bind_mutation_plan`+`reset_batch` → `step_batch`;motrix/drake 断言干净抛 `NotImplementedError`(fail-closed 即 conformant);
- 真实仓库 `audit_backend_isolation` 集成断言。

## Acceptance Criteria 对照

- [x] 所有 backend 经由同一个公开 physics contract 构造、bind、step 和 reset(conformance suite 机械化;typed 入口未实现的 backend fail-closed);
- [x] Host/device placement 是同一 API 的 buffer 属性,不产生第二套 manager、env、runner 或 training lifecycle(Phase 0 已删 device lifecycle,本 PR 清理残留死分支);
- [x] Physics layer 不依赖 Hydra、task、reward、learner、runner 或 manager,并由 import audit 验证(真实仓库零违规);
- [x] Manager、env 和 training 不访问 backend 私有 model/data/runtime,并由机械化检查验证(扫描覆盖 manager/env/training/scripts,零违规);
- [x] 小型 backend conformance suite 建立并通过;
- [x] 当前 physics boundary 具备未来提取为 `unisim` 的单向依赖结构;本 PR 不创建独立 package。

## Validation

- 核心测试(沿用用户对本任务序列的指示,跳过 `make test-all` 中无关测试):tests/base、manager、training、tools、config、envs/locomotion/g1、scripts、dr、utils 共 **1123 passed / 0 failed**(23 skipped 为 motrix/drake 不可用与 slow 车道 deselect);
- `ruff check src/ scripts/ tests/` 通过;`mypy src/unilab` 267 文件零 issue;
- `audit_backend_isolation` 真实仓库直跑:ok=True,0 violations(runtime_modules=19, contract_files=126);
- conformance 实测:mujoco legacy+typed 全过,motrix legacy 实跑通过,drake skip,mjwarp slow 车道 deselect(GPU 车道沿用既有 marker);
- `make test-all` 未完整运行(用户明确指示本任务序列只跑核心测试)。

## 留给后续 issue(代码注释已标注)

- `scene_visual_model_file`/`scene_artifacts_dir` 提升为 `SimBackend` contract 成员后,收紧 scripts probe 规则;
- `drake→mujoco.playback`、`mjwarp→mujoco.xml` 两个冷路径共享工具迁移到 backend-neutral 位置;
- allowlist 各项(`dr.types`、`dtype_config`、`visualization` 等)的 unisim 提取决策;
- `run_playback` 的 env 依赖重设计(playback contract 归位)。

## ADR 关联(契约改动必备)

- ADR-0001(runtime model and layer boundaries):manager/env/backend 分层边界;
- ADR-0002(backend capability boundary for play and snapshot):backend capability 边界与 fail-closed;
- 本 PR 不引入 ADR 未覆盖的新结构决策,无需新增 ADR。

## 平台/后端行为说明

- mujoco:行为不变(contract 措辞与私有方法下沉,无运行期语义变化);conformance legacy+typed 全过;
- motrix:行为不变,legacy conformance 实跑通过;typed 入口保持既有 fail-closed;
- drake:本机不可用 skip,contract surface 改动对其同为 fail-closed 默认;
- macOS/Linux:仅源码层改动,无平台相关路径变化;audit 与 conformance 为纯静态/CPU 检查。

Refs #888, #882, #705

