### PR TITLE
fix: align off-policy logger timing and header

### DIFF
--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -439,7 +439,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             train_start_threshold = self.train_start_threshold
             prepared_tick: int | None = None
 
-            training_e2e_start_ns = time.perf_counter_ns() if trace_recorder else 0
+            training_e2e_start_ns = 0
 
             # ---- training loop ----
             for iteration in range(1, max_iterations + 1):
@@ -549,6 +549,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                         end_ns=time.perf_counter_ns(),
                         args={"iteration": iteration},
                     )
+                if iteration == 1:
+                    train_start_wall = logger.start_training_timer()
+                    if trace_recorder:
+                        training_e2e_start_ns = time.perf_counter_ns()
                 self._drain_metrics(
                     metrics_queue,
                     reward_history,

--- a/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
+++ b/src/unilab/algos/torch/offpolicy/multi_gpu_runner.py
@@ -393,6 +393,8 @@ def _learner_worker(
             collector_wait_time = (
                 time.perf_counter() - wait_start - collector_wait_overhead if rank == 0 else 0.0
             )
+            if rank == 0 and it == 1 and logger is not None:
+                logger.start_training_timer()
 
             _barrier_initial_start = time.perf_counter()
             dist.barrier()

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -393,7 +393,7 @@ class OffPolicyRunner(AsyncRunner):
         reward_stats_ptr = 0
         train_start_threshold = self.train_start_threshold
 
-        training_e2e_start_ns = time.perf_counter_ns() if trace_recorder else 0
+        training_e2e_start_ns = 0
 
         # Training loop
         for iteration in range(1, max_iterations + 1):
@@ -511,6 +511,10 @@ class OffPolicyRunner(AsyncRunner):
                     end_ns=time.perf_counter_ns(),
                     args={"iteration": iteration},
                 )
+            if iteration == 1:
+                train_start_wall = logger.start_training_timer()
+                if trace_recorder:
+                    training_e2e_start_ns = time.perf_counter_ns()
             self._drain_metrics(
                 metrics_queue,
                 reward_history,

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -320,16 +320,28 @@ class BaseTrainingLogger:
         self,
         *,
         include_status: bool,
+        include_identity: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         elapsed = time.time() - self._start_time if self._start_time else 0
         eta = self._estimate_eta()
-        fields: list[tuple[str, str]] = [
-            (f" {self.algo_name}", "bold cyan"),
-            (self.env_name, "bold white"),
-            (f"iter {self._iteration}/{self.max_iterations}", "yellow"),
-            (f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}", "green"),
-        ]
+        fields: list[tuple[str, str]] = []
+        if include_identity:
+            fields.extend(
+                [
+                    (f" {self.algo_name}", "bold cyan"),
+                    (self.env_name, "bold white"),
+                ]
+            )
+        fields.extend(
+            [
+                (f"iter {self._iteration}/{self.max_iterations}", "yellow"),
+                (
+                    f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}",
+                    "green",
+                ),
+            ]
+        )
         if eta:
             fields.append((f"ETA {eta}", "bold magenta"))
         if self._mean_ep_length > 0:

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -372,8 +372,8 @@ class BaseTrainingLogger:
             expand=True,
             pad_edge=False,
         )
-        table.add_column("Rewards", style="white", ratio=1)
-        table.add_column("Value", justify="right", ratio=2)
+        table.add_column("Rewards", style="white", width=21, no_wrap=True)
+        table.add_column("Value", justify="right", ratio=2, no_wrap=True)
 
         if self._reward_history:
             recent = list(self._reward_history)

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -321,6 +321,7 @@ class BaseTrainingLogger:
         *,
         include_status: bool,
         include_identity: bool = True,
+        include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         elapsed = time.time() - self._start_time if self._start_time else 0
@@ -333,14 +334,13 @@ class BaseTrainingLogger:
                     (self.env_name, "bold white"),
                 ]
             )
-        fields.extend(
-            [
-                (f"iter {self._iteration}/{self.max_iterations}", "yellow"),
-                (
-                    f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}",
-                    "green",
-                ),
-            ]
+        if include_iteration:
+            fields.append((f"iter {self._iteration}/{self.max_iterations}", "yellow"))
+        fields.append(
+            (
+                f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}",
+                "green",
+            )
         )
         if eta:
             fields.append((f"ETA {eta}", "bold magenta"))

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -243,6 +243,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         *,
         include_status: bool,
         include_identity: bool = True,
+        include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         iter_steps_per_sec = self._get_iter_steps_per_sec()
@@ -261,6 +262,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         return super()._build_compact_header(
             include_status=include_status,
             include_identity=include_identity,
+            include_iteration=include_iteration,
             extra_fields=header_extra_fields,
         )
 
@@ -550,6 +552,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         header = self._build_compact_header(
             include_status=self._status != "Training",
             include_identity=False,
+            include_iteration=False,
         )
         left = self._build_metrics_table()
         right = self._build_reward_table()
@@ -567,6 +570,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         title.append(f" {self.algo_name} ", style="bold cyan")
         title.append("|", style="dim")
         title.append(f" {self.env_name} ", style="bold white")
+        title.append("|", style="dim")
+        title.append(f" iter {self._iteration}/{self.max_iterations} ", style="yellow")
         return Panel(
             Group(header, Text(""), grid, Text(""), bottom),
             title=title,

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -39,6 +39,12 @@ OFFPOLICY_COLLECTOR_TIMING_LABELS = {
     "sync_coordination_ms": "Sync Coordination",
 }
 
+OFFPOLICY_ENV_STEP_DETAIL_KEYS = (
+    "env_step_backend_ms",
+    "env_step_update_state_ms",
+    "env_step_reset_done_ms",
+)
+
 
 def _metric_backend_key(key: str) -> str:
     """Keep canonical slash metrics intact; namespace legacy flat metrics under train/."""
@@ -643,18 +649,31 @@ class OffPolicyLogger(BaseTrainingLogger):
             learner_items.append(("Param Sync", _fmt_phase(self._learner_param_sync_time)))
         learner_items.append(("Weight Sync", _fmt_phase(self._weight_sync_time)))
         learner_items.append(("Iter Wall", f"{self._get_iter_wall_time() * 1000:>7.1f}ms  100%"))
-        collector_items = [
-            (OFFPOLICY_COLLECTOR_TIMING_LABELS.get(key, key), f"{value:.1f}ms")
-            for key, value in sorted(
-                self._collector_timing.items(),
-                key=lambda item: (
-                    OFFPOLICY_COLLECTOR_TIMING_ORDER.get(
-                        item[0], len(OFFPOLICY_COLLECTOR_TIMING_ORDER)
-                    ),
-                    item[0],
+        sorted_collector_timing = sorted(
+            self._collector_timing.items(),
+            key=lambda item: (
+                OFFPOLICY_COLLECTOR_TIMING_ORDER.get(
+                    item[0], len(OFFPOLICY_COLLECTOR_TIMING_ORDER)
                 ),
-            )
+                item[0],
+            ),
+        )
+        env_step_detail_keys = [
+            key for key, _ in sorted_collector_timing if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS
         ]
+        last_env_step_detail_key = env_step_detail_keys[-1] if env_step_detail_keys else None
+        collector_items: list[tuple[str, str]] = []
+        for key, value in sorted_collector_timing:
+            label = OFFPOLICY_COLLECTOR_TIMING_LABELS.get(key, key)
+            value_text = f"{value:.1f}ms"
+            if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS:
+                if self._unicode_console:
+                    connector = "└─" if key == last_env_step_detail_key else "├─"
+                else:
+                    connector = "`-" if key == last_env_step_detail_key else "+-"
+                label = f"[dim]{label}[/]"
+                value_text = f"[dim cyan]{connector} {value_text}[/]"
+            collector_items.append((label, value_text))
         system_items = [
             ("Buffer", f"{self._buffer_size:,}"),
         ]

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from rich import box
@@ -144,6 +145,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._staging_pool_max: int = 0
         self._status: str = "Initializing..."
         self._terminal_refresh_started: bool = False
+        self._training_timer_started: bool = False
 
     def _format_tensorboard_message(self, tb_dir: str) -> str:
         return f"[dim]TensorBoard logging to: {tb_dir}[/]"
@@ -153,6 +155,13 @@ class OffPolicyLogger(BaseTrainingLogger):
 
     def start(self, *, status: str = "Warming up..."):
         super().start(status=status)
+
+    def start_training_timer(self) -> float:
+        """Start the measured training window after collector warm-up is complete."""
+        if not self._training_timer_started:
+            self._start_time = time.time()
+            self._training_timer_started = True
+        return self._start_time
 
     def finish(self, *, title: str = "Training Summary", extra_summary: str = ""):
         super().finish(
@@ -227,6 +236,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self,
         *,
         include_status: bool,
+        include_identity: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         iter_steps_per_sec = self._get_iter_steps_per_sec()
@@ -244,6 +254,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             header_extra_fields.extend(extra_fields)
         return super()._build_compact_header(
             include_status=include_status,
+            include_identity=include_identity,
             extra_fields=header_extra_fields,
         )
 
@@ -530,7 +541,10 @@ class OffPolicyLogger(BaseTrainingLogger):
             self._refresh()
 
     def _build_display(self) -> Panel:
-        header = self._build_compact_header(include_status=True)
+        header = self._build_compact_header(
+            include_status=self._status != "Training",
+            include_identity=False,
+        )
         left = self._build_metrics_table()
         right = self._build_reward_table()
         bottom = self._build_timing_table()
@@ -539,13 +553,17 @@ class OffPolicyLogger(BaseTrainingLogger):
         grid.add_column(width=2)
         grid.add_column(ratio=1)
         grid.add_row(left, "", right)
+        title = Text()
+        if self._unicode_console:
+            title.append(" 🚀")
+        title.append(" UniLab Off-Policy Training ", style="bold")
+        title.append("|", style="dim")
+        title.append(f" {self.algo_name} ", style="bold cyan")
+        title.append("|", style="dim")
+        title.append(f" {self.env_name} ", style="bold white")
         return Panel(
             Group(header, Text(""), grid, Text(""), bottom),
-            title=(
-                "[bold] 🚀 UniLab Off-Policy Training [/]"
-                if self._unicode_console
-                else "[bold] UniLab Off-Policy Training [/]"
-            ),
+            title=title,
             border_style="bright_blue",
             padding=(0, 1),
         )

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -668,11 +668,11 @@ class OffPolicyLogger(BaseTrainingLogger):
             value_text = f"{value:.1f}ms"
             if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS:
                 if self._unicode_console:
-                    connector = "└─" if key == last_env_step_detail_key else "├─"
+                    connector = "─┘" if key == last_env_step_detail_key else "─┤"
                 else:
-                    connector = "`-" if key == last_env_step_detail_key else "+-"
+                    connector = "-'" if key == last_env_step_detail_key else "-+"
                 label = f"[dim]{label}[/]"
-                value_text = f"[dim cyan]{connector} {value_text}[/]"
+                value_text = f"[dim cyan]{value_text} {connector}[/]"
             collector_items.append((label, value_text))
         system_items = [
             ("Buffer", f"{self._buffer_size:,}"),

--- a/src/unilab/logging/onpolicy.py
+++ b/src/unilab/logging/onpolicy.py
@@ -222,6 +222,7 @@ class OnPolicyLogger(BaseTrainingLogger):
         *,
         include_status: bool,
         include_identity: bool = True,
+        include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         iter_time = self._collect_time + self._train_time
@@ -234,5 +235,6 @@ class OnPolicyLogger(BaseTrainingLogger):
         return super()._build_compact_header(
             include_status=include_status,
             include_identity=include_identity,
+            include_iteration=include_iteration,
             extra_fields=header_extra_fields,
         )

--- a/src/unilab/logging/onpolicy.py
+++ b/src/unilab/logging/onpolicy.py
@@ -221,6 +221,7 @@ class OnPolicyLogger(BaseTrainingLogger):
         self,
         *,
         include_status: bool,
+        include_identity: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
         iter_time = self._collect_time + self._train_time
@@ -232,5 +233,6 @@ class OnPolicyLogger(BaseTrainingLogger):
             header_extra_fields.extend(extra_fields)
         return super()._build_compact_header(
             include_status=include_status,
+            include_identity=include_identity,
             extra_fields=header_extra_fields,
         )

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -187,7 +187,7 @@ def test_offpolicy_logger_training_timer_excludes_warmup_from_elapsed_and_eta(
     assert "30s" not in header.plain
 
 
-def test_offpolicy_logger_moves_identity_to_panel_title_and_omits_training_status() -> None:
+def test_offpolicy_logger_moves_identity_and_iteration_to_panel_title() -> None:
     logger = OffPolicyLogger(
         algo_name="FastSAC",
         max_iterations=5000,
@@ -197,13 +197,20 @@ def test_offpolicy_logger_moves_identity_to_panel_title_and_omits_training_statu
     )
     logger._unicode_console = True
     logger.start_training_timer()
-    logger.log_step(iteration=1, extra_info={"throughput_steps": 4096})
+    logger.log_step(iteration=5000, extra_info={"throughput_steps": 4096})
 
     display = logger._build_display()
-    header = logger._build_compact_header(include_status=False, include_identity=False)
+    header = logger._build_compact_header(
+        include_status=False,
+        include_identity=False,
+        include_iteration=False,
+    )
 
     assert isinstance(display.title, type(header))
-    assert display.title.plain == " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat "
+    assert display.title.plain == (
+        " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | iter 5000/5000 "
+    )
     assert "FastSAC" not in header.plain
     assert "G1WalkFlat" not in header.plain
+    assert "iter 5000/5000" not in header.plain
     assert "Training" not in header.plain

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -91,8 +91,8 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
         {
             "weight_sync_ms": 0.1,
             "action_select_ms": 0.2,
-            "env_step_ms": 3.0,
-            "env_step_backend_ms": 1.5,
+            "env_step_ms": 14.0,
+            "env_step_backend_ms": 12.5,
             "env_step_update_state_ms": 1.0,
             "env_step_reset_done_ms": 0.5,
             "replay_ms": 0.3,
@@ -115,12 +115,24 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
     assert collector_value_cells == [
         "0.1ms",
         "0.2ms",
-        "3.0ms",
-        "[dim cyan]├─ 1.5ms[/]",
-        "[dim cyan]├─ 1.0ms[/]",
-        "[dim cyan]└─ 0.5ms[/]",
+        "14.0ms",
+        "[dim cyan]12.5ms ─┤[/]",
+        "[dim cyan]1.0ms ─┤[/]",
+        "[dim cyan]0.5ms ─┘[/]",
         "0.3ms",
     ]
+
+    console = Console(width=100, record=True, force_terminal=False)
+    with console.capture() as capture:
+        console.print(table)
+    connector_columns = [
+        line.index(connector)
+        for line in capture.get().splitlines()
+        for connector in ("┤", "┘")
+        if connector in line
+    ]
+    assert len(connector_columns) == 3
+    assert len(set(connector_columns)) == 1
 
 
 def test_offpolicy_reward_component_names_stay_on_one_line_at_narrow_width() -> None:

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import unilab.logging.common as common_logger_module
 from unilab.logging.offpolicy import OffPolicyLogger
 
 
@@ -108,3 +109,53 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
         "  Reset Done",
         "Replay",
     ]
+
+
+def test_offpolicy_logger_training_timer_excludes_warmup_from_elapsed_and_eta(
+    monkeypatch,
+) -> None:
+    now = 100.0
+    monkeypatch.setattr(common_logger_module.time, "time", lambda: now)
+
+    logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        max_iterations=2,
+        num_envs=8,
+        env_name="G1WalkFlat",
+        log_backend="no_print",
+    )
+    logger._unicode_console = False
+    logger.start()
+
+    now = 130.0
+    assert logger.start_training_timer() == 130.0
+
+    now = 132.0
+    logger.log_step(iteration=1, extra_info={"throughput_steps": 8})
+
+    header = logger._build_compact_header(include_status=False, include_identity=False)
+    assert "time 2s" in header.plain
+    assert "ETA 2s" in header.plain
+    assert "30s" not in header.plain
+
+
+def test_offpolicy_logger_moves_identity_to_panel_title_and_omits_training_status() -> None:
+    logger = OffPolicyLogger(
+        algo_name="FastSAC",
+        max_iterations=5000,
+        num_envs=4096,
+        env_name="G1WalkFlat",
+        log_backend="no_print",
+    )
+    logger._unicode_console = True
+    logger.start_training_timer()
+    logger.log_step(iteration=1, extra_info={"throughput_steps": 4096})
+
+    display = logger._build_display()
+    header = logger._build_compact_header(include_status=False, include_identity=False)
+
+    assert isinstance(display.title, type(header))
+    assert display.title.plain == " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat "
+    assert "FastSAC" not in header.plain
+    assert "G1WalkFlat" not in header.plain
+    assert "Training" not in header.plain

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.console import Console
+
 import unilab.logging.common as common_logger_module
 from unilab.logging.offpolicy import OffPolicyLogger
 
@@ -99,16 +101,50 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
 
     table = logger._build_timing_table()
     collector_cells = list(table.columns[2].cells)
+    collector_value_cells = list(table.columns[3].cells)
 
     assert collector_cells == [
         "Weight Sync",
         "Action Select",
         "Env Step",
-        "  Backend Step",
-        "  Update State",
-        "  Reset Done",
+        "[dim]  Backend Step[/]",
+        "[dim]  Update State[/]",
+        "[dim]  Reset Done[/]",
         "Replay",
     ]
+    assert collector_value_cells == [
+        "0.1ms",
+        "0.2ms",
+        "3.0ms",
+        "[dim cyan]├─ 1.5ms[/]",
+        "[dim cyan]├─ 1.0ms[/]",
+        "[dim cyan]└─ 0.5ms[/]",
+        "0.3ms",
+    ]
+
+
+def test_offpolicy_reward_component_names_stay_on_one_line_at_narrow_width() -> None:
+    logger = OffPolicyLogger(
+        algo_name="SAC",
+        max_iterations=2,
+        num_envs=8,
+        env_name="Dummy",
+        log_backend="no_print",
+    )
+    logger._reward_history.extend([1.0, 2.0])
+    logger._latest_reward_components = {
+        "reward/penalty_action_rate": -0.1,
+        "reward/penalty_ang_vel_xy": -0.2,
+        "reward/penalty_orientation": -0.3,
+    }
+    console = Console(width=47, record=True, force_terminal=False)
+
+    console.print(logger._build_reward_table())
+    output_lines = console.export_text().splitlines()
+
+    for component in ("penalty action rate", "penalty ang vel xy", "penalty orientation"):
+        matching_lines = [line for line in output_lines if component in line]
+        assert len(matching_lines) == 1
 
 
 def test_offpolicy_logger_training_timer_excludes_warmup_from_elapsed_and_eta(

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import queue
+import time
 from collections import deque
 from typing import cast
 
@@ -209,6 +210,7 @@ class _FakeLogger:
         self.step_calls: list[dict] = []
         self.finish_calls = 0
         self.close_calls = 0
+        self.training_timer_start_calls = 0
         self._total_steps = 0
         self._buffer_size = 0
         self._mean_ep_length = 0.0
@@ -220,6 +222,10 @@ class _FakeLogger:
 
     def start(self) -> None:
         pass
+
+    def start_training_timer(self) -> float:
+        self.training_timer_start_calls += 1
+        return time.time()
 
     def log_status(self, status: str) -> None:
         del status
@@ -514,6 +520,7 @@ def test_offpolicy_runner_sync_waits_for_train_start_threshold(
     assert replay_buffer.sample_sizes_at_call == [threshold]
     assert trainer_done_queue.put_calls == [1, 1, 1, 1]
     assert logger.step_calls and logger.step_calls[0]["iteration"] == 1
+    assert logger.training_timer_start_calls == 1
     assert "collect_time" not in logger.step_calls[0]
     assert "learner_replay_wait_time" not in logger.step_calls[0]
     assert "wait_time" not in logger.step_calls[0]
@@ -601,6 +608,7 @@ def test_offpolicy_runner_async_waits_for_train_start_threshold(
     assert replay_buffer.sample_calls == 1
     assert replay_buffer.sample_sizes_at_call == [threshold]
     assert logger.step_calls and logger.step_calls[0]["iteration"] == 1
+    assert logger.training_timer_start_calls == 1
     assert "collect_time" not in logger.step_calls[0]
     assert "learner_replay_wait_time" not in logger.step_calls[0]
     assert "wait_time" not in logger.step_calls[0]
@@ -1261,6 +1269,7 @@ def test_flashsac_double_buffer_runner_trace_writes_b_path_events(
     logger = _FakeLogger.last_instance
     assert logger is not None
     assert logger.step_calls
+    assert logger.training_timer_start_calls == 1
     assert logger.step_calls[0]["extra_info"]["throughput_steps"] == 2
 
 
@@ -1588,6 +1597,7 @@ def test_multi_gpu_learner_worker_logs_wall_clock_and_per_rank_batch_context(
     )
 
     assert logger.step_calls
+    assert logger.training_timer_start_calls == 1
     step = logger.step_calls[-1]
     assert "wait_time" not in step
     assert step["collector_wait_time"] == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

- start off-policy elapsed-time and ETA accounting only after the replay buffer first becomes ready for learner work, excluding collector startup, MuJoCo chunk tuning, and initial replay warm-up
- align the completed-run `training_wall_time_sec` and Perfetto `learner/training_e2e` window with the same boundary for single-GPU runners
- move the algorithm, task, and current iteration into the panel title (`🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | iter 5000/5000`), remove iteration from the compact statistics row, and remove the normal `| Training` suffix while preserving error statuses
- keep Reward component labels such as `penalty action rate`, `penalty ang vel xy`, and `penalty orientation` on one line in narrow terminals
- render Env Step detail timings as dim cyan children with right-aligned mirrored tree connectors (`12.5ms ─┤`, `1.0ms ─┤`, `0.5ms ─┘`), keeping the tree aligned across different numeric widths
- cover the logger output and timer boundary across legacy single-GPU, double-buffer, and multi-GPU runners

## Linked Work

- Issue: none
- Milestone: none

## Validation

- [x] `make check`
- [x] `uv run pytest -m "not slow"`
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/algos/test_offpolicy_logger.py -q
uv run pytest tests/algos/test_offpolicy_logger.py tests/algos/test_offpolicy_runner_unit.py -q
uv run pytest tests/algos/test_offpolicy_logger.py tests/algos/test_offpolicy_runner_unit.py tests/utils/test_experiment_tracking.py -q
make test-all
```

`make test-all`: 1634 passed, 29 skipped, 267 deselected, 1 xfailed; benchmark smoke test passed (2 platform-optional MLX entries skipped).

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no; training behavior is unchanged, while terminal and run-summary timing accounting changes

## Artifacts

- W&B: none
- benchmark result: benchmark smoke test passed
- video / screenshot: none
- ONNX / checkpoint: none

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed (not needed; terminal presentation only)
- [ ] Linked the driving issue (none provided)
- [x] Noted any follow-up work explicitly (none)