### PR TITLE
refactor: 收敛 mjwarp unified contract adapter (#889)

### DIFF
--- a/conf/ppo/task/g1_walk_flat/mjwarp.yaml
+++ b/conf/ppo/task/g1_walk_flat/mjwarp.yaml
@@ -1,0 +1,57 @@
+# @package _global_
+# Configured-only mjwarp owner for the unified host contract adapter. Native
+# playback and device-resident training/runtime routing are intentionally absent.
+training:
+  task_name: G1WalkFlat
+  sim_backend: mjwarp
+  no_play: true
+  play_render_mode: none
+algo:
+  num_envs: 2048
+  max_iterations: 2200
+  empirical_normalization: false
+  obs_groups:
+    actor:
+      - actor
+  policy:
+    actor_hidden_dims: [512, 256, 128]
+    critic_hidden_dims: [512, 256, 128]
+env:
+  numba_acceleration: false
+  mjwarp_nconmax: 128
+  mjwarp_njmax: 256
+  domain_rand:
+    randomize_kp: false
+    randomize_kd: false
+    randomize_dof_armature: false
+    randomize_body_gravity_compensation: false
+  control_config:
+    action_scale: 0.25
+  curriculum:
+    enabled: false
+  noise_config:
+    level: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 1.5
+    scale_gyro: 0.2
+reward:
+  scales:
+    tracking_lin_vel: 2.0
+    tracking_ang_vel: 0.2
+    feet_phase: 1.0
+    lin_vel_z: -1.0
+    ang_vel_xy: -0.25
+    base_height: -500.0
+    orientation: -5.0
+    action_rate: -0.01
+    pose: -0.1
+  tracking_sigma: 0.25
+  gait_frequency: 1.5
+  feet_phase_swing_height: 0.09
+  feet_phase_tracking_sigma: 0.008
+  base_height_target: 0.754
+  min_base_height: 0.55
+  max_tilt_deg: 25.0
+  pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
+play_profile:
+  enabled: false

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -12,6 +12,7 @@
 
 - 默认后端是 `mujoco`
 - 切到 Motrix 用统一 CLI 的 `--sim motrix`
+- `--sim mjwarp` 当前只对应 `g1_walk_flat` 的 Configured host adapter，使用前需安装 `mjwarp` extra
 - `--algo`、`--task`、`--sim` 共同选择 owner YAML
 - 不要把 `training.sim_backend` 当独立 backend switch
 
@@ -19,7 +20,8 @@
 
 - `mujoco`: `--render-mode auto` 会导出 `play_video.mp4`
 - `motrix`: `--render-mode auto` 会打开交互式 renderer 窗口，不录制视频，不受 `play_steps` 限制
-- `--render-mode record`: 两个后端都只录制视频
+- `mjwarp`: 当前 owner 禁用 playback，不支持 `auto` 或 `record`
+- `--render-mode record`: MuJoCo 和 Motrix 都只录制视频
 - `--render-mode none`: 不回放
 
 ## Support Matrix
@@ -43,106 +45,108 @@ uv run scripts/generate_support_matrix.py --write
 
 `Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。
 
+`mjwarp` 只为 `g1_walk_flat` 恢复普通 backend identity 和最小 owner；通用 compose 测试不会把它提升到 `Tested`，当前等级封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、原生 playback、terrain、完整 DR 或 production training 支持。
+
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
 
 ### Entrypoint x Task Owner
 
-| Entrypoint | Task owner | MuJoCo | Motrix |
-|------------|------------|--------|--------|
-| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | Tested |
-| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Tested |
-| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | Tested |
-| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
-| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
-| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
-| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | Tested |
-| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
-| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
-| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | Tested |
-| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - |
-| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | Tested |
-| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | Tested |
-| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | Tested |
-| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | Tested |
-| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | Tested |
-| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | Tested |
-| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | Tested |
-| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | Registered |
-| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | Tested |
-| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | Tested |
-| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
-| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | Tested |
-| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | Tested |
-| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | Tested |
-| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | Tested |
-| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | Tested |
-| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | Tested |
-| PPO (torch) | `stewart_balance` (stewart balance) | Tested | Tested |
-| PPO (mlx) | `go1_joystick_flat` (Go1 joystick) | Tested | Tested |
-| PPO (mlx) | `go2_joystick_flat` (Go2 joystick) | Tested | Tested |
-| PPO (mlx) | `go2_joystick_rough` (Go2 joystick rough) | Configured | Configured |
-| PPO (mlx) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | Configured |
-| PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | Configured |
-| PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | Configured |
-| PPO (mlx) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Configured | Configured |
-| PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | Configured |
-| PPO (mlx) | `sharpa_inhand` (Sharpa in-hand) | Configured | Configured |
-| PPO (mlx) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Configured | Configured |
-| PPO (mlx) | `a2_joystick_flat` (a2 joystick flat) | Configured | - |
-| PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Configured | Configured |
-| PPO (mlx) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Configured | Registered |
-| PPO (mlx) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Configured | Configured |
-| PPO (mlx) | `g1_box_tracking` (g1 box tracking) | Configured | Configured |
-| PPO (mlx) | `g1_climb_tracking` (g1 climb tracking) | Configured | Configured |
-| PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | Configured |
-| PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | Configured |
-| PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | Configured |
-| PPO (mlx) | `go2_footstand` (go2 footstand) | Configured | Configured |
-| PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | Configured |
-| PPO (mlx) | `go2w_joystick_rough` (go2w joystick rough) | Configured | Configured |
-| PPO (mlx) | `stewart_balance` (stewart balance) | Configured | Configured |
-| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | Tested |
-| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Tested |
-| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
-| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
-| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Tested |
-| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Tested |
-| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | Tested |
-| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | Tested |
-| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | Tested |
-| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | Tested |
-| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | Tested |
-| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | Registered |
-| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | Tested |
-| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | Tested |
-| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | Tested |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Tested |
-| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | Registered |
-| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | Registered |
-| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | Registered |
-| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | Tested |
-| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | Tested |
-| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | Tested |
-| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | Registered |
-| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | Registered |
-| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | Registered |
-| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | Tested |
-| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | Tested |
-| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered |
-| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | Registered |
-| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | Registered |
-| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested |
-| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | Tested |
+| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix |
+|------------|------------|--------|--------|--------|
+| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
+| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
+| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested |
+| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested |
+| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested |
+| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - | Tested |
+| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested |
+| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested |
+| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | - | Tested |
+| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - |
+| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
+| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Registered |
+| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
+| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | - | Tested |
+| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | - | Tested |
+| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - | Tested |
+| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - | Tested |
+| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - | Tested |
+| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested |
+| PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested |
+| PPO (mlx) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
+| PPO (mlx) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
+| PPO (mlx) | `go2_joystick_rough` (Go2 joystick rough) | Configured | - | Configured |
+| PPO (mlx) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested |
+| PPO (mlx) | `g1_motion_tracking` (G1 motion tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_flip_tracking` (G1 flip tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Configured | - | Configured |
+| PPO (mlx) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Configured | - | Configured |
+| PPO (mlx) | `allegro_inhand` (Allegro in-hand) | Configured | - | Configured |
+| PPO (mlx) | `sharpa_inhand` (Sharpa in-hand) | Configured | - | Configured |
+| PPO (mlx) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Configured | - | Configured |
+| PPO (mlx) | `a2_joystick_flat` (a2 joystick flat) | Configured | - | - |
+| PPO (mlx) | `allegro_inhand_grasp` (allegro inhand grasp) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Configured | - | Configured |
+| PPO (mlx) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Configured | - | Registered |
+| PPO (mlx) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_box_tracking` (g1 box tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_climb_tracking` (g1 climb tracking) | Configured | - | Configured |
+| PPO (mlx) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Configured | - | Configured |
+| PPO (mlx) | `go1_joystick_rough` (go1 joystick rough) | Configured | - | Configured |
+| PPO (mlx) | `go2_arm_manip_loco` (go2 arm manip loco) | Configured | - | Configured |
+| PPO (mlx) | `go2_footstand` (go2 footstand) | Configured | - | Configured |
+| PPO (mlx) | `go2w_joystick_flat` (go2w joystick flat) | Configured | - | Configured |
+| PPO (mlx) | `go2w_joystick_rough` (go2w joystick rough) | Configured | - | Configured |
+| PPO (mlx) | `stewart_balance` (stewart balance) | Configured | - | Configured |
+| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
+| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
+| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered |
+| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested |
+| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested |
+| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested |
+| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered |
+| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested |
+| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Tested |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
+| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered |
+| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered |
+| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
+| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Tested |
+| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Registered |
+| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | - | Registered |
+| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | - | Registered |
+| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | - | Tested |
+| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | - | Tested |
+| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered |
+| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered |
+| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Registered |
+| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Tested |
+| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
 
 ### Source Index
 

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -31,6 +31,21 @@ from unilab.base.backend.batch import (
     RowSelection,
     StateBatchPhase,
 )
+from unilab.base.backend.mutation import (
+    BoundMutationPlan,
+    MutationCapabilityManifest,
+    MutationContractError,
+    MutationEntityKind,
+    MutationFieldKind,
+    MutationSelectorMode,
+    MutationSpec,
+    MutationTargetKind,
+    MutationTargetSpec,
+    TypedBackendMutationBatch,
+)
+from unilab.base.backend.mutation import (
+    bind_mutation_plan as bind_typed_mutation_plan,
+)
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import (
     DomainRandomizationCapabilities,
@@ -46,6 +61,7 @@ from .batch import (
 )
 from .dependencies import load_mjwarp_dependencies
 from .materialization import materialize_mjwarp_scene
+from .mutation import MjwarpHostMutationPlan, mjwarp_host_mutation_capabilities
 
 
 class MjwarpBackend(SimBackend):
@@ -53,8 +69,9 @@ class MjwarpBackend(SimBackend):
 
     State and control cross the host/device boundary only at explicit
     step/reset barriers with bounded, statically declared transfers.  Typed
-    mutation plans, interval DR, rendering, and host-substep-controller
-    combinations remain fail-closed.
+    Model mutation, interval DR, rendering, and host-substep-controller
+    combinations remain fail-closed. The typed reset surface is limited to
+    selected-row floating-root and hinge state used by the manager pilot.
     """
 
     def __init__(
@@ -178,6 +195,7 @@ class MjwarpBackend(SimBackend):
         self._reset_mask_device = deps.warp.zeros(self._num_envs, dtype=bool)
         self._batch_instance_id = f"mjwarp:{id(self):x}"
         self._host_batch_plans: dict[str, MjwarpHostBatchPlan] = {}
+        self._host_mutation_plans: dict[str, MjwarpHostMutationPlan] = {}
 
         # Begin from explicit model defaults, run a forward barrier, and cache
         # the resulting sensors/kinematics.  This avoids an uninitialized host
@@ -481,7 +499,133 @@ class MjwarpBackend(SimBackend):
             existing_host.public_plan.require_compatible(host_bound.public_plan)
             return existing_host.public_plan
         self._host_batch_plans[host_bound.public_plan.fingerprint] = host_bound
+        for mutation_plan in self._host_mutation_plans.values():
+            mutation_plan.register_batch_plan(host_bound.public_plan)
         return host_bound.public_plan
+
+    def _resolve_typed_mutation_selector(self, spec: MutationTargetSpec) -> tuple[int, ...]:
+        selector = spec.selector_spec
+        if selector is None:
+            raise MutationContractError("mjwarp typed mutation selector must be explicit")
+        if spec.target_kind is not MutationTargetKind.SIMULATION_STATE:
+            raise MutationContractError("mjwarp typed mutation only supports simulation state")
+        if spec.entity_kind is MutationEntityKind.BODY:
+            name = selector.require_exact_singleton(context="mjwarp typed root reset")
+            expected_fields = {
+                "state.root.position": MutationFieldKind.POSITION,
+                "state.root.orientation": MutationFieldKind.ORIENTATION,
+                "state.root.linear_velocity": MutationFieldKind.LINEAR_VELOCITY,
+                "state.root.angular_velocity": MutationFieldKind.ANGULAR_VELOCITY,
+            }
+            if expected_fields.get(spec.target_key) is not spec.field_kind:
+                raise MutationContractError(
+                    "mjwarp typed body reset only supports floating-root state targets"
+                )
+            if self._base_body_id is None or (self._root_qpos_dim, self._root_qvel_dim) != (7, 6):
+                raise MutationContractError(
+                    "mjwarp typed root reset requires a named first free-joint base body"
+                )
+            if self._body_ids.get(name) != self._base_body_id:
+                raise MutationContractError(
+                    f"mjwarp typed root selector {name!r} must resolve the base body"
+                )
+            return (self._base_body_id,)
+        if spec.entity_kind is not MutationEntityKind.DOF:
+            raise MutationContractError(
+                "mjwarp typed reset selector must name a floating root body or hinge DoF"
+            )
+        expected_fields = {
+            "state.dof.position": MutationFieldKind.POSITION,
+            "state.dof.angular_velocity": MutationFieldKind.ANGULAR_VELOCITY,
+        }
+        if expected_fields.get(spec.target_key) is not spec.field_kind:
+            raise MutationContractError("mjwarp typed DoF reset has an unsupported field kind")
+        if selector.mode is not MutationSelectorMode.EXACT:
+            raise MutationContractError("mjwarp typed DoF reset requires exact selectors")
+        coordinates: list[int] = []
+        for name in selector.expressions:
+            joint_id = self._mujoco.mj_name2id(
+                self._cpu_model,
+                self._mujoco.mjtObj.mjOBJ_JOINT,
+                name,
+            )
+            if joint_id < 0 or int(self._cpu_model.jnt_type[joint_id]) != int(
+                self._mujoco.mjtJoint.mjJNT_HINGE
+            ):
+                raise MutationContractError(
+                    f"mjwarp typed reset selector {name!r} must resolve one hinge joint"
+                )
+            if spec.field_kind is MutationFieldKind.POSITION:
+                coordinate = int(self._cpu_model.jnt_qposadr[joint_id]) - self._root_qpos_dim
+                count = self._num_dof_pos
+            else:
+                coordinate = int(self._cpu_model.jnt_dofadr[joint_id]) - self._root_qvel_dim
+                count = self._num_dof_vel
+            if coordinate < 0 or coordinate >= count:
+                raise MutationContractError("mjwarp typed reset coordinate is out of range")
+            coordinates.append(coordinate)
+        if len(set(coordinates)) != len(coordinates):
+            raise MutationContractError("mjwarp typed DoF reset resolved duplicate coordinates")
+        return tuple(coordinates)
+
+    def get_mutation_capability_manifest(
+        self,
+        execution_profile: ExecutionProfile,
+    ) -> MutationCapabilityManifest:
+        if execution_profile is not ExecutionProfile.HOST_NUMPY:
+            raise MutationContractError("mjwarp mutations only support the host_numpy profile")
+        return MutationCapabilityManifest(
+            backend_type=self.backend_type,
+            execution_profile=execution_profile,
+            capabilities=mjwarp_host_mutation_capabilities(self),
+        )
+
+    def bind_mutation_plan(self, specs: tuple[MutationSpec, ...]) -> BoundMutationPlan:
+        manifest = self.get_mutation_capability_manifest(ExecutionProfile.HOST_NUMPY)
+        bound = bind_typed_mutation_plan(
+            backend_type=self.backend_type,
+            backend_instance_id=self._batch_instance_id,
+            num_envs=self._num_envs,
+            specs=specs,
+            capabilities=manifest.capabilities,
+            resolve_selector=self._resolve_typed_mutation_selector,
+            capability_manifest=manifest,
+        )
+        existing = self._host_mutation_plans.get(bound.fingerprint)
+        if existing is not None:
+            existing.public_plan.require_compatible(bound)
+            return existing.public_plan
+        runtime_plan = MjwarpHostMutationPlan(
+            public_plan=bound,
+            nq=self._nq,
+            nv=self._nv,
+            state_dtype=np.dtype(self._qpos_cache.dtype).name,
+            root_qpos_dim=self._root_qpos_dim,
+            root_qvel_dim=self._root_qvel_dim,
+        )
+        for batch_plan in self._host_batch_plans.values():
+            runtime_plan.register_batch_plan(batch_plan.public_plan)
+        self._host_mutation_plans[bound.fingerprint] = runtime_plan
+        return bound
+
+    def _require_host_mutation_plan(
+        self,
+        mutation_batch: TypedBackendMutationBatch,
+        plan: BoundBackendPlan,
+    ) -> MjwarpHostMutationPlan:
+        mutation_batch.plan.require_owner(
+            backend_type=self.backend_type,
+            backend_instance_id=self._batch_instance_id,
+        )
+        try:
+            runtime_plan = self._host_mutation_plans[mutation_batch.plan_fingerprint]
+        except KeyError as exc:
+            raise BackendBatchContractError(
+                "mjwarp typed mutation plan was not bound by this backend instance"
+            ) from exc
+        runtime_plan.public_plan.require_compatible(mutation_batch.plan)
+        runtime_plan.require_registered_batch_plan(plan)
+        return runtime_plan
 
     def _require_host_batch_plan(self, plan: BoundBackendPlan) -> MjwarpHostBatchPlan:
         if not isinstance(plan, BoundBackendPlan):
@@ -654,34 +798,40 @@ class MjwarpBackend(SimBackend):
         *,
         mutation_batch: BackendMutationBatch | None = None,
     ) -> BackendResetResult:
-        """Reset selected rows to model defaults through a bound typed plan.
-
-        The minimal host adapter supports only the identity reset
-        (``mutation_batch=None``): selected rows return to the compiled
-        default qpos with zero velocity.  Typed mutation values remain
-        fail-closed on this backend.
-        """
+        """Reset selected rows through identity or cold-bound typed state values."""
         bound = self._require_host_batch_plan(plan)
         if not isinstance(rows, RowSelection):
             raise BackendBatchContractError("mjwarp rows must be a RowSelection")
         if rows.universe_size != self._num_envs:
             raise BackendBatchContractError("mjwarp row universe does not match backend num_envs")
-        if mutation_batch is not None:
-            raise BackendBatchContractError(
-                "mjwarp host_numpy reset only supports the identity reset; "
-                "typed mutation batches are not supported"
+        if mutation_batch is None:
+            row_ids = (
+                np.arange(self._num_envs, dtype=np.intp)
+                if rows.is_all
+                else np.asarray(rows.indices, dtype=np.intp)
+            )
+            self._qpos_cache[row_ids] = np.asarray(self._cpu_model.qpos0, dtype=np.float32)
+            self._qvel_cache[row_ids] = 0.0
+            qpos, qvel = self._qpos_cache, self._qvel_cache
+        else:
+            if not isinstance(mutation_batch, TypedBackendMutationBatch):
+                raise BackendBatchContractError(
+                    "mjwarp identity reset requires mutation_batch=None; typed reset requires "
+                    "a TypedBackendMutationBatch"
+                )
+            if mutation_batch.rows != rows:
+                raise BackendBatchContractError(
+                    "mjwarp typed reset rows must match the mutation envelope"
+                )
+            mutation_plan = self._require_host_mutation_plan(mutation_batch, plan)
+            qpos, qvel, row_ids = mutation_plan.stage_reset_state(
+                mutation_batch,
+                self._qpos_cache,
+                self._qvel_cache,
             )
 
-        row_ids = (
-            np.arange(self._num_envs, dtype=np.intp)
-            if rows.is_all
-            else np.asarray(rows.indices, dtype=np.intp)
-        )
-        self._qpos_cache[row_ids] = np.asarray(self._cpu_model.qpos0, dtype=np.float32)
-        self._qvel_cache[row_ids] = 0.0
-
         self._invalidate_host_batch_state()
-        timings = self._execute_host_reset(row_ids, self._qpos_cache, self._qvel_cache)
+        timings = self._execute_host_reset(row_ids, qpos, qvel)
         read_result = bound.materialize(rows, StateBatchPhase.RESET)
         diagnostics = BackendBatchDiagnostics(
             counters=_worst_reset_counters(self),

--- a/src/unilab/base/backend/mjwarp/capability.py
+++ b/src/unilab/base/backend/mjwarp/capability.py
@@ -1,0 +1,67 @@
+"""Verified typed-reset capability descriptors for the ``mjwarp`` adapter."""
+
+from __future__ import annotations
+
+from ..batch import ExecutionProfile
+from ..mutation import (
+    MutationBaseline,
+    MutationCapabilityCase,
+    MutationCapabilityDescriptor,
+    MutationCapabilityRowScope,
+    MutationCommitPhase,
+    MutationFieldStorageKind,
+    MutationGraphImpact,
+    MutationOperation,
+    MutationPersistence,
+    MutationRecomputeLevel,
+    MutationTrigger,
+)
+
+MJWARP_STATE_RESET_CAPABILITY_ID = "state.qpos_qvel_reset"
+_MANDATORY_TEST = (
+    "tests/manager/test_cross_backend_plan.py::test_mjwarp_advertised_reset_capability"
+)
+_QPOS_TARGETS = frozenset({"state.root.position", "state.root.orientation", "state.dof.position"})
+_QVEL_TARGETS = frozenset(
+    {
+        "state.root.linear_velocity",
+        "state.root.angular_velocity",
+        "state.dof.angular_velocity",
+    }
+)
+
+
+def mjwarp_host_reset_descriptor(*, target_key: str) -> MutationCapabilityDescriptor:
+    """Describe one selected-row host reset translated to adapter-owned storage."""
+
+    if target_key in _QPOS_TARGETS:
+        direct_fields = ("data.qpos",)
+    elif target_key in _QVEL_TARGETS:
+        direct_fields = ("data.qvel",)
+    else:
+        raise ValueError(f"unsupported mjwarp state reset target {target_key!r}")
+    return MutationCapabilityDescriptor(
+        capability_id=MJWARP_STATE_RESET_CAPABILITY_ID,
+        direct_fields=direct_fields,
+        derived_fields=(),
+        storage_kind=MutationFieldStorageKind.DATA_NATIVE,
+        graph_impact=MutationGraphImpact.STABLE_ADDRESS,
+        graph_invalidations=frozenset(),
+        cases=(
+            MutationCapabilityCase(
+                case_id=f"mjwarp.host_numpy.{target_key}.reset",
+                mandatory_test_id=f"{_MANDATORY_TEST}[{target_key}]",
+                execution_profile=ExecutionProfile.HOST_NUMPY,
+                trigger=MutationTrigger.RESET,
+                commit_phase=MutationCommitPhase.RESET,
+                operation=MutationOperation.SET,
+                baseline=MutationBaseline.DEFAULT,
+                persistence=MutationPersistence.EPISODE,
+                recompute=MutationRecomputeLevel.KINEMATICS,
+                row_scope=MutationCapabilityRowScope.SELECTED_ROWS,
+            ),
+        ),
+    )
+
+
+__all__ = ["MJWARP_STATE_RESET_CAPABILITY_ID", "mjwarp_host_reset_descriptor"]

--- a/src/unilab/base/backend/mjwarp/mutation.py
+++ b/src/unilab/base/backend/mjwarp/mutation.py
@@ -1,0 +1,281 @@
+"""Adapter-owned typed simulation-state reset support for ``mjwarp``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ..batch import (
+    BackendBatchContractError,
+    BoundBackendPlan,
+    BufferContract,
+    BufferLayout,
+    BufferLifetime,
+    BufferMutability,
+    BufferOwner,
+    BufferPlacement,
+    ExecutionProfile,
+    RowSelection,
+)
+from ..mutation import (
+    BoundMutationPlan,
+    BoundMutationSpec,
+    MutationBaseline,
+    MutationCapability,
+    MutationCommitPhase,
+    MutationContractError,
+    MutationEntityKind,
+    MutationFieldKind,
+    MutationOperation,
+    MutationPersistence,
+    MutationRecomputeLevel,
+    MutationTargetKind,
+    MutationTrigger,
+    TypedBackendMutationBatch,
+)
+from .capability import mjwarp_host_reset_descriptor
+
+if TYPE_CHECKING:
+    from .backend import MjwarpBackend
+
+
+_ROOT_TARGETS = {
+    "state.root.position": ("qpos", slice(0, 3)),
+    "state.root.orientation": ("qpos", slice(3, 7)),
+    "state.root.linear_velocity": ("qvel", slice(0, 3)),
+    "state.root.angular_velocity": ("qvel", slice(3, 6)),
+}
+_DOF_TARGETS = frozenset({"state.dof.position", "state.dof.angular_velocity"})
+
+
+def _value_template(*, row_shape: tuple[int, ...], dtype: str) -> BufferContract:
+    return BufferContract(
+        row_shape=row_shape,
+        dtype=dtype,
+        layout=BufferLayout.C_CONTIGUOUS,
+        placement=BufferPlacement.host(),
+        owner=BufferOwner.MANAGER,
+        mutability=BufferMutability.READ_ONLY,
+        lifetime=BufferLifetime.UNTIL_COMMIT,
+        dlpack_exportable=False,
+    )
+
+
+def _reset_capability(
+    *,
+    target_key: str,
+    entity_kind: MutationEntityKind,
+    field_kind: MutationFieldKind,
+    entity_count: int,
+    row_shape: tuple[int, ...],
+    dtype: str,
+) -> MutationCapability:
+    return MutationCapability(
+        target_key=target_key,
+        target_kind=MutationTargetKind.SIMULATION_STATE,
+        entity_kind=entity_kind,
+        field_kind=field_kind,
+        entity_count=entity_count,
+        value_template=_value_template(row_shape=row_shape, dtype=dtype),
+        triggers=frozenset({MutationTrigger.RESET}),
+        commit_phases=frozenset({MutationCommitPhase.RESET}),
+        operations=frozenset({MutationOperation.SET}),
+        baselines=frozenset({MutationBaseline.DEFAULT}),
+        persistences=frozenset({MutationPersistence.EPISODE}),
+        recompute_levels=frozenset({MutationRecomputeLevel.KINEMATICS}),
+        descriptor=mjwarp_host_reset_descriptor(target_key=target_key),
+    )
+
+
+def mjwarp_host_mutation_capabilities(backend: MjwarpBackend) -> tuple[MutationCapability, ...]:
+    """Return only the selected-row state reset surface verified by the pilot."""
+
+    dtype = np.dtype(backend._qpos_cache.dtype).name
+    capabilities: list[MutationCapability] = []
+    if backend._base_body_id is not None and (backend._root_qpos_dim, backend._root_qvel_dim) == (
+        7,
+        6,
+    ):
+        for target_key, field_kind, row_shape in (
+            ("state.root.position", MutationFieldKind.POSITION, (3,)),
+            ("state.root.orientation", MutationFieldKind.ORIENTATION, (4,)),
+            ("state.root.linear_velocity", MutationFieldKind.LINEAR_VELOCITY, (3,)),
+            ("state.root.angular_velocity", MutationFieldKind.ANGULAR_VELOCITY, (3,)),
+        ):
+            capabilities.append(
+                _reset_capability(
+                    target_key=target_key,
+                    entity_kind=MutationEntityKind.BODY,
+                    field_kind=field_kind,
+                    entity_count=backend._nbody,
+                    row_shape=row_shape,
+                    dtype=dtype,
+                )
+            )
+    for target_key, field_kind, count in (
+        ("state.dof.position", MutationFieldKind.POSITION, backend._num_dof_pos),
+        (
+            "state.dof.angular_velocity",
+            MutationFieldKind.ANGULAR_VELOCITY,
+            backend._num_dof_vel,
+        ),
+    ):
+        if count > 0:
+            capabilities.append(
+                _reset_capability(
+                    target_key=target_key,
+                    entity_kind=MutationEntityKind.DOF,
+                    field_kind=field_kind,
+                    entity_count=count,
+                    row_shape=(1,),
+                    dtype=dtype,
+                )
+            )
+    if not capabilities:
+        raise BackendBatchContractError(
+            "mjwarp typed state mutation requires a floating root or at least one DoF"
+        )
+    return tuple(capabilities)
+
+
+@dataclass
+class MjwarpHostMutationPlan:
+    """Cold-allocated qpos/qvel staging for one public mutation plan."""
+
+    public_plan: BoundMutationPlan
+    nq: int
+    nv: int
+    state_dtype: str
+    root_qpos_dim: int
+    root_qvel_dim: int
+    _reset_qpos: np.ndarray = field(init=False, repr=False)
+    _reset_qvel: np.ndarray = field(init=False, repr=False)
+    _row_ids: np.ndarray = field(init=False, repr=False)
+    _registered_batch_plans: dict[str, BoundBackendPlan] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        if self.nq <= 0 or self.nv <= 0:
+            raise BackendBatchContractError("mjwarp mutation binding requires positive nq and nv")
+        dtype = np.dtype(self.state_dtype)
+        self._reset_qpos = np.empty((self.public_plan.num_envs, self.nq), dtype=dtype)
+        self._reset_qvel = np.empty((self.public_plan.num_envs, self.nv), dtype=dtype)
+        self._row_ids = np.arange(self.public_plan.num_envs, dtype=np.intp)
+
+    def register_batch_plan(self, plan: BoundBackendPlan) -> None:
+        if plan.num_envs != self.public_plan.num_envs:
+            raise BackendBatchContractError(
+                "mjwarp mutation and state plans must use the same row universe"
+            )
+        if plan.execution_profile is not ExecutionProfile.HOST_NUMPY:
+            raise BackendBatchContractError("mjwarp typed mutations only support host_numpy plans")
+        previous = self._registered_batch_plans.get(plan.fingerprint)
+        if previous is not None:
+            previous.require_compatible(plan)
+            return
+        self._registered_batch_plans[plan.fingerprint] = plan
+
+    def require_registered_batch_plan(self, plan: BoundBackendPlan) -> None:
+        try:
+            registered = self._registered_batch_plans[plan.fingerprint]
+        except KeyError as exc:
+            raise BackendBatchContractError(
+                "mjwarp typed mutation plan was not cold-path paired with this state/control plan"
+            ) from exc
+        registered.require_compatible(plan)
+
+    @staticmethod
+    def _require_value_handle(value: object, rows: RowSelection) -> np.ndarray:
+        buffer = getattr(value, "buffer", None)
+        spec = getattr(value, "spec", None)
+        handle = getattr(buffer, "handle", None)
+        if not isinstance(handle, np.ndarray) or not isinstance(spec, BoundMutationSpec):
+            raise BackendBatchContractError("mjwarp typed mutation value is malformed")
+        expected_shape = (rows.count, *spec.value_buffer.row_shape)
+        if handle.shape != expected_shape or handle.dtype.name != spec.value_buffer.dtype:
+            raise BackendBatchContractError(
+                "mjwarp typed mutation value handle does not match its bound contract"
+            )
+        if not handle.flags.c_contiguous:
+            raise BackendBatchContractError("mjwarp typed mutation values must be C-contiguous")
+        return handle
+
+    def _state_values(
+        self, batch: TypedBackendMutationBatch
+    ) -> tuple[tuple[int, BoundMutationSpec, np.ndarray], ...]:
+        if batch.model.values or batch.wrench.values or batch.task_state.values:
+            raise BackendBatchContractError(
+                "mjwarp typed reset only supports simulation-state values"
+            )
+        window = batch.state.bound_buffer_window
+        if window is not None:
+            values = tuple(
+                (index, self.public_plan.specs[index], window.buffer_at(index)[: batch.rows.count])
+                for index in window.field_indices
+            )
+        else:
+            values = tuple(
+                (value.field_index, value.spec, self._require_value_handle(value, batch.rows))
+                for value in batch.state.values
+            )
+        if tuple(sorted(index for index, _, _ in values)) != tuple(
+            range(len(self.public_plan.specs))
+        ):
+            raise BackendBatchContractError(
+                "mjwarp typed reset must supply every bound simulation-state field once"
+            )
+        return values
+
+    def stage_reset_state(
+        self,
+        batch: TypedBackendMutationBatch,
+        qpos_cache: np.ndarray,
+        qvel_cache: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Patch selected semantic values into stable full-world host staging."""
+
+        self.public_plan.require_compatible(batch.plan)
+        if qpos_cache.shape != self._reset_qpos.shape or qvel_cache.shape != self._reset_qvel.shape:
+            raise BackendBatchContractError(
+                "mjwarp typed reset source cache does not match the bound mutation plan"
+            )
+        if qpos_cache.dtype.name != self.state_dtype or qvel_cache.dtype.name != self.state_dtype:
+            raise BackendBatchContractError(
+                "mjwarp typed reset source cache dtype does not match the bound mutation plan"
+            )
+        rows = batch.rows
+        if not rows.is_all:
+            assert rows.indices is not None
+            self._row_ids[: rows.count] = rows.indices
+        row_ids = self._row_ids[: rows.count]
+        np.copyto(self._reset_qpos, qpos_cache)
+        np.copyto(self._reset_qvel, qvel_cache)
+
+        for _, spec, value in self._state_values(batch):
+            target_key = spec.target.target_key
+            root_target = _ROOT_TARGETS.get(target_key)
+            if root_target is not None:
+                storage_name, columns = root_target
+                storage = self._reset_qpos if storage_name == "qpos" else self._reset_qvel
+                storage[row_ids, columns] = value[:, 0, :]
+                continue
+            if (
+                target_key not in _DOF_TARGETS
+                or spec.target.entity_kind is not MutationEntityKind.DOF
+            ):
+                raise MutationContractError(
+                    "mjwarp typed reset plan contains an unsupported simulation-state target"
+                )
+            offset = (
+                self.root_qpos_dim if target_key == "state.dof.position" else self.root_qvel_dim
+            )
+            storage = self._reset_qpos if target_key == "state.dof.position" else self._reset_qvel
+            columns = np.asarray(spec.target.entity_ids, dtype=np.intp) + offset
+            storage[np.ix_(row_ids, columns)] = value[:, :, 0]
+        return self._reset_qpos, self._reset_qvel, row_ids
+
+
+__all__ = ["MjwarpHostMutationPlan", "mjwarp_host_mutation_capabilities"]

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -730,6 +730,7 @@ class G1WalkRoughCfg(G1WalkFlatCfg):
 
 
 registry.register_env("G1WalkFlat", G1WalkEnv, sim_backend="mujoco")
+registry.register_env("G1WalkFlat", G1WalkEnv, sim_backend="mjwarp")
 registry.register_env("G1WalkFlat", G1WalkEnv, sim_backend="motrix")
 registry.register_env("G1WalkRough", G1WalkEnv, sim_backend="mujoco")
 registry.register_env("G1WalkRough", G1WalkEnv, sim_backend="motrix")

--- a/src/unilab/training/retirement.py
+++ b/src/unilab/training/retirement.py
@@ -26,8 +26,8 @@ class RetiredDevicePathError(RuntimeError):
     """Raised when a request targets the retired device-resident mjwarp path."""
 
 
-RETIRED_TASK_OWNERS: tuple[str, ...] = ("g1_walk_flat/mjwarp",)
-"""Owner ``task/backend`` pairs retired together with the device path."""
+RETIRED_TASK_OWNERS: tuple[str, ...] = ()
+"""Owner identities still retired after the host mjwarp adapter was restored."""
 
 RETIRED_RUNTIME_IMPL = "mjwarp_device_v1"
 """Retired ``algo.runtime_impl`` marker for the device-resident runtime."""
@@ -49,9 +49,9 @@ _MIGRATION_HINT = (
     "The production device-resident mjwarp runtime (runtime_impl "
     f"{RETIRED_RUNTIME_IMPL!r}, execution_profile {RETIRED_EXECUTION_PROFILE!r}, "
     f"resolver {RETIRED_RESOLVER_FRAGMENT!r}) was retired in issue #886 and no "
-    "longer exists. Use the backend-neutral manager path instead, e.g. "
-    "task=g1_walk_flat/mujoco; artifacts produced by a device-resident run "
-    "must be retrained with the mujoco owner."
+    "longer exists. task=g1_walk_flat/mjwarp now selects the Configured "
+    "backend-neutral host adapter; device-resident artifacts are incompatible "
+    "with it and must be retrained."
 )
 
 

--- a/src/unilab/utils/support_matrix.py
+++ b/src/unilab/utils/support_matrix.py
@@ -15,7 +15,7 @@ from unilab.base.registry import ensure_registries
 
 BEGIN_MARKER = "<!-- BEGIN GENERATED SUPPORT MATRIX -->"
 END_MARKER = "<!-- END GENERATED SUPPORT MATRIX -->"
-BACKENDS: tuple[str, str] = ("mujoco", "motrix")
+BACKENDS: tuple[str, ...] = ("mujoco", "mjwarp", "motrix")
 
 _TASK_ORDER = {
     "go1_joystick_flat": 0,
@@ -207,7 +207,9 @@ def _configured_entries(root: Path, spec: EntrypointSpec) -> dict[str, dict[str,
     return entries
 
 
-def _is_tested(spec: EntrypointSpec, task_slug: str, root: Path) -> bool:
+def _is_tested(spec: EntrypointSpec, task_slug: str, backend: str, root: Path) -> bool:
+    if backend == "mjwarp":
+        return False
     if spec.entrypoint_id == "ppo_mlx":
         return task_slug in _mlx_tested_task_slugs(root)
     return spec.generic_tested
@@ -252,7 +254,6 @@ def build_support_rows(root: Path | None = None) -> list[SupportRow]:
             key=lambda item: _task_sort_key(item[0]),
         ):
             env_name = next(iter(configured_backends.values()))
-            tested = _is_tested(spec, task_slug, resolved_root)
             cells = {
                 backend: SupportCell(
                     env_name=env_name,
@@ -261,7 +262,7 @@ def build_support_rows(root: Path | None = None) -> list[SupportRow]:
                         env_name=env_name,
                         configured_backends=configured_backends,
                         registry_backends=registry_backends,
-                        tested=tested,
+                        tested=_is_tested(spec, task_slug, backend, resolved_root),
                         benchmarked=benchmarked,
                         recommended=recommended,
                     ),
@@ -304,19 +305,24 @@ def render_support_matrix(root: Path | None = None) -> str:
         "`Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；"
         "例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。",
         "",
+        "`mjwarp` 只为 `g1_walk_flat` 恢复普通 backend identity 和最小 owner；通用 compose 测试不会把它提升到"
+        " `Tested`，当前等级封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend"
+        " registry identity，不代表对应算法、原生 playback、terrain、完整 DR 或 production training 支持。",
+        "",
         benchmark_note,
         recommendation_note,
         "",
         "### Entrypoint x Task Owner",
         "",
-        "| Entrypoint | Task owner | MuJoCo | Motrix |",
-        "|------------|------------|--------|--------|",
+        "| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix |",
+        "|------------|------------|--------|--------|--------|",
     ]
 
     for row in build_support_rows(resolved_root):
         lines.append(
             f"| {row.entrypoint_label} | `{row.task_slug}` ({row.task_label}) | "
-            f"{row.cells['mujoco'].level.label} | {row.cells['motrix'].level.label} |"
+            f"{row.cells['mujoco'].level.label} | {row.cells['mjwarp'].level.label} | "
+            f"{row.cells['motrix'].level.label} |"
         )
 
     lines.extend(

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -170,9 +170,7 @@ def test_legacy_contract_step_set_state_and_state_reads(backend_type: str) -> No
     np.testing.assert_allclose(
         backend.get_base_pos(), np.tile(target_xyz, (NUM_ENVS, 1)), atol=1e-4
     )
-    np.testing.assert_allclose(
-        np.linalg.norm(backend.get_base_quat(), axis=-1), 1.0, atol=1e-5
-    )
+    np.testing.assert_allclose(np.linalg.norm(backend.get_base_quat(), axis=-1), 1.0, atol=1e-5)
 
 
 def _write_free_hinge_model(tmp_path: Path) -> Path:
@@ -258,7 +256,11 @@ def _typed_requirements(backend) -> BackendIORequirements:
         state_fields=fields,
         control=ControlSpec("hinge.control", control_buffer),
         execution_profile=ExecutionProfile.HOST_NUMPY,
-        hot_path_budget=BackendBatchCounterBudget(allocations=8, state_materializations=2),
+        hot_path_budget=(
+            None
+            if backend.backend_type == "mjwarp"
+            else BackendBatchCounterBudget(allocations=8, state_materializations=2)
+        ),
     )
 
 

--- a/tests/base/test_mjwarp_capabilities.py
+++ b/tests/base/test_mjwarp_capabilities.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from unilab.base.backend import create_backend
+from unilab.base.backend import ExecutionProfile, MutationContractError, create_backend
 from unilab.base.backend.mjwarp.dependencies import load_mjwarp_dependencies
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import IntervalRandomizationPlan, ResetRandomizationPayload
@@ -45,10 +45,17 @@ def test_unsupported_matrix_fails_before_step() -> None:
         backend.apply_interval_randomization(
             IntervalRandomizationPlan(push_perturbation_limit=np.ones((3,), dtype=np.float32))
         )
-    # Typed mutation plans are fail-closed on the minimal host adapter: the
-    # production device-resident mutation surface was retired, and binding a
-    # plan must error before any physics work instead of becoming a no-op.
-    with pytest.raises(NotImplementedError, match="typed backend mutations"):
+    manifest = backend.get_mutation_capability_manifest(ExecutionProfile.HOST_NUMPY)
+    assert {item.target_key for item in manifest.capabilities} == {
+        "state.root.position",
+        "state.root.orientation",
+        "state.root.linear_velocity",
+        "state.root.angular_velocity",
+        "state.dof.position",
+        "state.dof.angular_velocity",
+    }
+    # Empty or unsupported requests still fail during cold binding, before physics.
+    with pytest.raises(MutationContractError, match="non-empty"):
         backend.bind_mutation_plan(())
 
     qpos = np.tile(backend.get_keyframe_qpos("stand"), (1, 1))

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -18,7 +18,7 @@ from omegaconf import OmegaConf
 
 CONF_DIR = Path(__file__).parent.parent.parent / "conf"
 _PPO_MLX_TASKS = {"go1_joystick_flat", "go2_joystick_flat", "g1_walk_flat"}
-_BACKENDS = ("mujoco", "motrix")
+_BACKENDS = ("mujoco", "mjwarp", "motrix")
 _NUMBA_ACCEL_SUPPORTED_TASK_NAMES = {
     "G1MotionTracking",
     "G1MotionTrackingSAC",

--- a/tests/manager/test_cross_backend_plan.py
+++ b/tests/manager/test_cross_backend_plan.py
@@ -13,6 +13,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from unilab.base.backend import (
+    ExecutionProfile,
     RowSelection,
     SimBackend,
     create_backend,
@@ -28,6 +29,14 @@ pytestmark = pytest.mark.slow
 _ATOL = 1.0e-4
 _RTOL = 1.0e-3
 _NUM_ENVS = 32
+_RESET_CAPABILITY_STATE_KEYS = (
+    ("state.root.position", "g1.root.position"),
+    ("state.root.orientation", "g1.root.orientation"),
+    ("state.root.linear_velocity", "g1.root.linear_velocity"),
+    ("state.root.angular_velocity", "g1.root.angular_velocity"),
+    ("state.dof.position", "g1.dof.position"),
+    ("state.dof.angular_velocity", "g1.dof.angular_velocity"),
+)
 
 
 def _reward_config() -> G1WalkRewardConfig:
@@ -167,6 +176,43 @@ def _assert_transition_match(
             actual=np.asarray(actual.info["log"][key]),
             label=f"{label}.log[{key}]",
         )
+
+
+@pytest.mark.parametrize(
+    ("target_key", "state_key"),
+    _RESET_CAPABILITY_STATE_KEYS,
+    ids=tuple(item[0] for item in _RESET_CAPABILITY_STATE_KEYS),
+)
+def test_mjwarp_advertised_reset_capability(target_key: str, state_key: str) -> None:
+    """Each advertised reset target has a real MuJoCo/mjwarp effect oracle."""
+
+    cfg = _cfg()
+    mujoco_backend = _backend("mujoco", cfg)
+    mjwarp_backend = _backend("mjwarp", deepcopy(cfg))
+    try:
+        manifest = mjwarp_backend.get_mutation_capability_manifest(ExecutionProfile.HOST_NUMPY)
+        capability = next(item for item in manifest.capabilities if item.target_key == target_key)
+        assert capability.descriptor is not None
+        assert capability.descriptor.cases[0].mandatory_test_id.endswith(f"[{target_key}]")
+
+        mujoco_runtime = create_g1_managed_reference_runtime(
+            backend=mujoco_backend,
+            cfg=cfg,
+            reset_seed=0,
+        )
+        mjwarp_runtime = create_g1_managed_reference_runtime(
+            backend=mjwarp_backend,
+            cfg=deepcopy(cfg),
+            reset_seed=0,
+        )
+        mujoco_runtime.init_state()
+        mjwarp_runtime.init_state()
+        expected = _copy_public_state(mujoco_backend, mujoco_runtime)[state_key]
+        actual = _copy_public_state(mjwarp_backend, mjwarp_runtime)[state_key]
+        _assert_arrays_close(expected=expected, actual=actual, label=target_key)
+    finally:
+        mujoco_backend.cleanup_scene_assets()
+        mjwarp_backend.cleanup_scene_assets()
 
 
 @contextmanager

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from unilab.utils.support_matrix import EvidenceLevel, build_support_rows
+from unilab.utils.support_matrix import BACKENDS, EvidenceLevel, build_support_rows
 
 
 def _row(entrypoint_label: str, task_slug: str):
@@ -17,7 +17,25 @@ def test_support_matrix_marks_go2_ppo_backends_as_tested():
     row = _row("PPO (torch)", "go2_joystick_flat")
 
     assert row.cells["mujoco"].level == EvidenceLevel.TESTED
+    assert row.cells["mjwarp"].level == EvidenceLevel.MISSING
     assert row.cells["motrix"].level == EvidenceLevel.TESTED
+
+
+def test_support_matrix_caps_g1_mjwarp_at_configured():
+    torch_row = _row("PPO (torch)", "g1_walk_flat")
+    mlx_row = _row("PPO (mlx)", "g1_walk_flat")
+
+    assert BACKENDS == ("mujoco", "mjwarp", "motrix")
+    assert torch_row.cells["mjwarp"].level == EvidenceLevel.CONFIGURED
+    assert mlx_row.cells["mjwarp"].level == EvidenceLevel.CONFIGURED
+
+
+def test_support_matrix_does_not_promote_mjwarp_from_generic_coverage():
+    rows = build_support_rows(Path(__file__).resolve().parents[2])
+
+    assert all(row.cells["mjwarp"].level <= EvidenceLevel.CONFIGURED for row in rows)
+    appo_row = _row("APPO (torch)", "g1_walk_flat")
+    assert appo_row.cells["mjwarp"].level == EvidenceLevel.REGISTERED
 
 
 def test_support_matrix_marks_appo_go1_backends_as_tested():

--- a/tests/training/test_device_path_retirement.py
+++ b/tests/training/test_device_path_retirement.py
@@ -34,32 +34,26 @@ def _write_run_config(run_dir: Path, payload: dict) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Task owner
+# Task owner identity
 # ---------------------------------------------------------------------------
-
-
-def test_retired_task_owner_hydra_path_form_raises() -> None:
-    with pytest.raises(RetiredDevicePathError, match="issue #886"):
-        check_retired_task_owner("g1_walk_flat/mjwarp")
-
-
-def test_retired_task_owner_composed_name_form_raises() -> None:
-    # train scripts see the composed training.task_name/sim_backend pair.
-    with pytest.raises(RetiredDevicePathError, match="g1_walk_flat/mujoco"):
-        check_retired_task_owner("G1WalkFlat/mjwarp")
 
 
 @pytest.mark.parametrize(
     "task",
-    ["g1_walk_flat/mujoco", "G1WalkFlat/mujoco", "go2_joystick_flat/motrix"],
+    [
+        "g1_walk_flat/mujoco",
+        "G1WalkFlat/mujoco",
+        "g1_walk_flat/mjwarp",
+        "G1WalkFlat/mjwarp",
+        "go2_joystick_flat/motrix",
+    ],
 )
 def test_active_task_owners_pass(task: str) -> None:
     check_retired_task_owner(task)
 
 
-def test_retired_task_override_scan_raises() -> None:
-    with pytest.raises(RetiredDevicePathError):
-        check_retired_task_overrides(["task=g1_walk_flat/mjwarp", "algo.num_envs=8"])
+def test_active_mjwarp_task_override_scan_passes() -> None:
+    check_retired_task_overrides(["task=g1_walk_flat/mjwarp", "algo.num_envs=8"])
     check_retired_task_overrides(["task=g1_walk_flat/mujoco", "algo.num_envs=8"])
 
 


### PR DESCRIPTION
## Summary

- 将 mjwarp 接入统一 physics contract 的 host_numpy state/control/reset 路径，并为 G1 manager pilot 增加最小 typed mutation capability manifest。
- 将 Warp model/data、GPU staging 与 selected-row reset 实现封装在 mjwarp adapter owner 内；未声明的 mutation、DR、render 和 callback 路径继续在 bind/materialization 边界 fail closed。
- 恢复 g1_walk_flat/mjwarp registry identity 与最小 PPO owner YAML，将 support evidence 和生成文档固定为 Configured，同时保留旧 device-resident artifact 的明确退役诊断。

## Non-goals

- 不恢复 DeviceManagedRuntime、device-only runner 或专属 task lifecycle。
- 不恢复 CUDA graph/controller、完整 DR、native playback 或 production 性能路径。
- 不将单个 G1 pilot 外推为更多 task、algorithm 或 backend capability 支持。

## Validation

- `make test-all` — passed（1910 passed, 56 skipped, 1 xfailed；benchmark smoke passed）
- CUDA mjwarp conformance/differential slow lane — 31 passed
- config/support/docs/retirement/isolation targeted lane — 249 passed

Closes #889