### PR TITLE
feat: add mjwarp offline video playback

### DIFF
--- a/conf/ppo/task/g1_walk_flat/mjwarp.yaml
+++ b/conf/ppo/task/g1_walk_flat/mjwarp.yaml
@@ -1,11 +1,12 @@
 # @package _global_
-# Configured-only mjwarp owner for the unified host contract adapter. Native
-# playback and device-resident training/runtime routing are intentionally absent.
+# Configured-only mjwarp owner for the unified host contract adapter. Offline
+# record reuses MuJoCo rendering; native playback and device-resident runtime
+# routing are intentionally absent.
 training:
   task_name: G1WalkFlat
   sim_backend: mjwarp
-  no_play: true
-  play_render_mode: none
+  no_play: false
+  play_render_mode: record
 algo:
   num_envs: 2048
   max_iterations: 2200
@@ -54,4 +55,6 @@ reward:
   max_tilt_deg: 25.0
   pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
 play_profile:
-  enabled: false
+  enabled: true
+  env:
+    render_spacing: 2.0

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -20,8 +20,8 @@
 
 - `mujoco`: `--render-mode auto` 会导出 `play_video.mp4`
 - `motrix`: `--render-mode auto` 会打开交互式 renderer 窗口，不录制视频，不受 `play_steps` 限制
-- `mjwarp`: 当前 owner 禁用 playback，不支持 `auto` 或 `record`
-- `--render-mode record`: MuJoCo 和 Motrix 都只录制视频
+- `mjwarp`: 仅支持显式、有限步数的 `record`，通过 task owner 的 MuJoCo visual model 离线录制；不支持 `auto`、interactive 或 native renderer
+- `--render-mode record`: MuJoCo、mjwarp 和 Motrix 都只录制视频
 - `--render-mode none`: 不回放
 
 ## Support Matrix
@@ -45,7 +45,7 @@ uv run scripts/generate_support_matrix.py --write
 
 `Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。
 
-`mjwarp` 只为 `g1_walk_flat` 恢复普通 backend identity 和最小 owner；通用 compose 测试不会把它提升到 `Tested`，当前等级封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、原生 playback、terrain、完整 DR 或 production training 支持。
+`mjwarp` 只为 `g1_walk_flat` 提供 Configured host adapter；它已测试通过显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，但不支持 `auto`、interactive 或 native playback。通用 compose 和该 playback 覆盖不会把 entrypoint 支持等级提升到 `Tested`，当前仍封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
 
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -11,11 +11,17 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from os import PathLike
 from typing import Any
 
 import numpy as np
 
-from unilab.base.backend.base import SimBackend
+from unilab.base.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
+    SimBackend,
+    normalize_play_render_mode,
+)
 from unilab.base.backend.batch import (
     BackendBatchContractError,
     BackendBatchDiagnostics,
@@ -62,6 +68,7 @@ from .batch import (
 from .dependencies import load_mjwarp_dependencies
 from .materialization import materialize_mjwarp_scene
 from .mutation import MjwarpHostMutationPlan, mjwarp_host_mutation_capabilities
+from .playback import run_mjwarp_playback, validate_mjwarp_visual_model
 
 
 class MjwarpBackend(SimBackend):
@@ -69,8 +76,9 @@ class MjwarpBackend(SimBackend):
 
     State and control cross the host/device boundary only at explicit
     step/reset barriers with bounded, statically declared transfers.  Typed
-    Model mutation, interval DR, rendering, and host-substep-controller
-    combinations remain fail-closed. The typed reset surface is limited to
+    Model mutation, interval DR, native rendering, and host-substep-controller
+    combinations remain fail-closed. Detached host snapshots support finite
+    MuJoCo-based offline recording. The typed reset surface is limited to
     selected-row floating-root and hinge state used by the manager pilot.
     """
 
@@ -112,6 +120,8 @@ class MjwarpBackend(SimBackend):
         scene_context = materialize_mjwarp_scene(scene)
         self._scene_cleanup_handle = scene_context.cleanup_handle
         self.scene_model_file = scene_context.diagnostic_model_file
+        self.scene_visual_model_file = str(scene.visual_model_file or scene.model_file)
+        self._playback_model_validated = False
         self._pre_step_control_fn = None
         self.backend_type = "mjwarp"
         self._num_envs = int(num_envs)
@@ -186,6 +196,7 @@ class MjwarpBackend(SimBackend):
         # device step or a reset/forward lifecycle barrier.
         self._qpos_cache = np.zeros((self._num_envs, self._nq), dtype=np.float32)
         self._qvel_cache = np.zeros((self._num_envs, self._nv), dtype=np.float32)
+        self._time_cache = np.zeros((self._num_envs,), dtype=np.float32)
         self._sensor_cache = np.zeros(
             (self._num_envs, int(self._cpu_model.nsensordata)),
             dtype=np.float32,
@@ -681,6 +692,7 @@ class MjwarpBackend(SimBackend):
 
         t0 = time.perf_counter()
         self._refresh_host_cache()
+        self._time_cache += np.float32(nsteps * self._sim_dt)
         host_cache_ms = (time.perf_counter() - t0) * 1000.0
         return {
             "control_upload_ms": control_upload_ms,
@@ -726,6 +738,7 @@ class MjwarpBackend(SimBackend):
 
         t0 = time.perf_counter()
         self._refresh_host_cache()
+        self._time_cache[row_ids] = 0.0
         host_cache_ms = (time.perf_counter() - t0) * 1000.0
         return {
             "reset_upload_ms": reset_upload_ms,
@@ -912,11 +925,103 @@ class MjwarpBackend(SimBackend):
     def materialize(self) -> None:
         """Resources are fully materialized during the constructor cold path."""
 
-    def get_playback_model(self, env_index: int | None = None) -> Any:
-        del env_index
-        raise NotImplementedError(
-            "mjwarp host_numpy profile does not support playback model export or rendering."
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        return BackendPlayCapabilities(supports_physics_state_playback=True)
+
+    def resolve_play_render_plan(
+        self,
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        mode = normalize_play_render_mode(play_render_mode)
+        if mode == "none":
+            return BackendPlayRenderPlan(
+                mode="none",
+                headless=True,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        if mode == "auto":
+            raise NotImplementedError(
+                "mjwarp playback does not support auto mode; select record or none explicitly."
+            )
+        if mode == "interactive":
+            raise NotImplementedError(
+                "mjwarp playback does not support interactive or native rendering; "
+                "select record or none."
+            )
+        if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
+            raise ValueError(
+                "mjwarp record playback requires a positive finite training.play_steps value."
+            )
+        if output_video is None:
+            raise ValueError("mjwarp record playback requires an output video path.")
+        return BackendPlayRenderPlan(
+            mode="record",
+            headless=True,
+            record_video=True,
+            num_steps=int(play_steps),
+            output_video=output_video,
         )
+
+    def run_playback(
+        self,
+        *,
+        env: Any,
+        initialize: Any,
+        step: Any,
+        num_steps: int | None,
+        output_video: str | PathLike[str] | None = None,
+        render_spacing: float | None = None,
+        render_offset_mode: str | None = None,
+        headless: bool | None = None,
+        record_video: bool | None = None,
+        frame_state_getter: Any = None,
+        camera_kwargs: dict[str, Any] | None = None,
+        extra_data_getter: Any = None,
+    ) -> str | None:
+        del render_offset_mode
+        should_record = bool(record_video) if record_video is not None else output_video is not None
+        should_run_headless = bool(headless) if headless is not None else should_record
+        return run_mjwarp_playback(
+            backend=self,
+            env=env,
+            initialize=initialize,
+            step=step,
+            num_steps=num_steps,
+            output_video=output_video,
+            render_spacing=render_spacing,
+            headless=should_run_headless,
+            record_video=should_record,
+            snapshot_shape=(self._num_envs, 1 + self._nq + self._nv),
+            frame_state_getter=frame_state_getter,
+            camera_kwargs=camera_kwargs,
+            extra_data_getter=extra_data_getter,
+        )
+
+    def get_physics_state(self) -> np.ndarray:
+        state = np.empty((self._num_envs, 1 + self._nq + self._nv), dtype=np.float32)
+        state[:, 0] = self._time_cache
+        state[:, 1 : 1 + self._nq] = self._qpos_cache
+        state[:, 1 + self._nq :] = self._qvel_cache
+        return state
+
+    def get_playback_model(self, env_index: int | None = None) -> str:
+        if env_index is not None:
+            idx = int(env_index)
+            if idx < 0 or idx >= self._num_envs:
+                raise IndexError(f"env_index must be in [0, {self._num_envs - 1}], got {idx}")
+        if not self._playback_model_validated:
+            self.scene_visual_model_file = validate_mjwarp_visual_model(
+                mujoco=self._mujoco,
+                physics_model=self._cpu_model,
+                model_file=self.scene_visual_model_file,
+            )
+            self._playback_model_validated = True
+        return self.scene_visual_model_file
 
     # ------------------------------------------------------------------ #
     # Legacy getters: cache views only, never direct Warp transfers       #

--- a/src/unilab/base/backend/mjwarp/playback.py
+++ b/src/unilab/base/backend/mjwarp/playback.py
@@ -1,0 +1,145 @@
+"""Cold-path MuJoCo offline playback bridge for ``mjwarp``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from os import PathLike
+from pathlib import Path
+from typing import Any, TypeVar
+
+import numpy as np
+
+from unilab.base.backend.mujoco.playback import run_mujoco_playback
+
+ObsT = TypeVar("ObsT")
+
+
+def validate_mjwarp_visual_model(
+    *,
+    mujoco: Any,
+    physics_model: Any,
+    model_file: str | PathLike[str],
+) -> str:
+    """Validate the detached MuJoCo visual twin used for offline playback."""
+    path = Path(model_file)
+    if not path.is_file():
+        raise ValueError(
+            f"mjwarp offline playback visual model does not exist or is not a file: {path}"
+        )
+    try:
+        visual_model = mujoco.MjModel.from_xml_path(str(path))
+    except Exception as exc:
+        raise ValueError(
+            f"mjwarp offline playback could not load visual model {path}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    physics_dims = (int(physics_model.nq), int(physics_model.nv))
+    visual_dims = (int(visual_model.nq), int(visual_model.nv))
+    if visual_dims != physics_dims:
+        raise ValueError(
+            "mjwarp offline playback visual model state dimensions are incompatible: "
+            f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
+        )
+
+    joint_object = mujoco.mjtObj.mjOBJ_JOINT
+
+    def _joint_layout(model: Any) -> tuple[tuple[str | None, int, int, int], ...]:
+        return tuple(
+            (
+                mujoco.mj_id2name(model, joint_object, joint_id),
+                int(model.jnt_type[joint_id]),
+                int(model.jnt_qposadr[joint_id]),
+                int(model.jnt_dofadr[joint_id]),
+            )
+            for joint_id in range(int(model.njnt))
+        )
+
+    physics_layout = _joint_layout(physics_model)
+    visual_layout = _joint_layout(visual_model)
+    if visual_layout != physics_layout:
+        raise ValueError(
+            "mjwarp offline playback visual model joint layout is incompatible; "
+            "joint names, types, qpos addresses, and dof addresses must match physics."
+        )
+    return str(path)
+
+
+def run_mjwarp_playback(
+    *,
+    backend: Any,
+    env: Any,
+    initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT],
+    num_steps: int | None,
+    output_video: str | PathLike[str] | None,
+    render_spacing: float | None,
+    headless: bool,
+    record_video: bool,
+    snapshot_shape: tuple[int, int],
+    frame_state_getter: Callable[[], np.ndarray] | None,
+    camera_kwargs: dict[str, Any] | None,
+    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+) -> str:
+    """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
+    if not headless:
+        raise NotImplementedError(
+            "mjwarp offline playback does not support interactive rendering; "
+            "use training.play_render_mode=record."
+        )
+    if not record_video:
+        raise ValueError("mjwarp offline playback requires record_video=true.")
+    if isinstance(num_steps, bool) or num_steps is None or int(num_steps) <= 0:
+        raise ValueError("mjwarp record playback requires a positive finite num_steps value.")
+    if output_video is None:
+        raise ValueError("mjwarp record playback requires an output_video path.")
+
+    # Both checks are playback-only cold-path work. Physics construction and
+    # step/reset never import the renderer or parse the visual model.
+    backend.get_playback_model()
+    try:
+        from unilab.visualization import render_many
+
+        renderer_usable = bool(render_many.render_backend_usable())
+    except Exception as exc:
+        raise RuntimeError(
+            "mjwarp offline playback could not initialize the MuJoCo renderer: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    if not renderer_usable:
+        raise RuntimeError(
+            "mjwarp offline playback requires a usable MuJoCo off-screen renderer; "
+            "configure EGL, OSMesa, or GLFW before recording."
+        )
+
+    getter = frame_state_getter or env.get_physics_state_snapshot
+    expected_shape = snapshot_shape
+
+    def _validated_state_getter() -> np.ndarray:
+        state = np.asarray(getter(), dtype=np.float32)
+        if state.shape != expected_shape:
+            raise ValueError(
+                "mjwarp offline playback snapshot must use [time, qpos, qvel] layout "
+                f"with shape {expected_shape}, got {state.shape}."
+            )
+        return state
+
+    result = run_mujoco_playback(
+        env=env,
+        initialize=initialize,
+        step=step,
+        num_steps=int(num_steps),
+        output_video=output_video,
+        render_spacing=render_spacing,
+        headless=True,
+        record_video=True,
+        frame_state_getter=_validated_state_getter,
+        camera_kwargs=camera_kwargs,
+        extra_data_getter=extra_data_getter,
+    )
+    if result is None:
+        raise RuntimeError(
+            "mjwarp offline playback produced no frames; the MuJoCo renderer or worker "
+            "failed after preflight."
+        )
+    return result

--- a/src/unilab/tools/backend_isolation.py
+++ b/src/unilab/tools/backend_isolation.py
@@ -25,6 +25,7 @@ _SHARED_RUNTIME_MODULES = frozenset(
 _SIBLING_COLD_PATH_EXCEPTIONS = frozenset(
     {
         ("drake", "unilab.base.backend.mujoco.playback"),
+        ("mjwarp", "unilab.base.backend.mujoco.playback"),
         ("mjwarp", "unilab.base.backend.mujoco.xml"),
     }
 )

--- a/src/unilab/utils/support_matrix.py
+++ b/src/unilab/utils/support_matrix.py
@@ -305,9 +305,11 @@ def render_support_matrix(root: Path | None = None) -> str:
         "`Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；"
         "例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。",
         "",
-        "`mjwarp` 只为 `g1_walk_flat` 恢复普通 backend identity 和最小 owner；通用 compose 测试不会把它提升到"
-        " `Tested`，当前等级封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend"
-        " registry identity，不代表对应算法、原生 playback、terrain、完整 DR 或 production training 支持。",
+        "`mjwarp` 只为 `g1_walk_flat` 提供 Configured host adapter；它已测试通过显式、有限步数的 `record`"
+        " 并复用 MuJoCo 离线 renderer，但不支持 `auto`、interactive 或 native playback。通用 compose 和该"
+        " playback 覆盖不会把 entrypoint 支持等级提升到 `Tested`，当前仍封顶为 `Configured`。其他"
+        " entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、"
+        "完整 DR 或 production training 支持。",
         "",
         benchmark_note,
         recommendation_note,

--- a/tests/base/test_mjwarp_capabilities.py
+++ b/tests/base/test_mjwarp_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -39,8 +40,10 @@ def test_unsupported_matrix_fails_before_step() -> None:
             offsets=np.zeros((1, 2), dtype=np.float32),
             frame_body_id=1,
         )
-    with pytest.raises(NotImplementedError, match="playback model export"):
-        backend.get_playback_model()
+    assert backend.get_play_capabilities().supports_physics_state_playback
+    assert not backend.get_play_capabilities().supports_native_interactive_renderer
+    assert not backend.get_play_capabilities().supports_native_video_capture
+    assert Path(backend.get_playback_model()).is_file()
     with pytest.raises(NotImplementedError, match="interval randomization"):
         backend.apply_interval_randomization(
             IntervalRandomizationPlan(push_perturbation_limit=np.ones((3,), dtype=np.float32))

--- a/tests/base/test_mjwarp_playback.py
+++ b/tests/base/test_mjwarp_playback.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco", reason="mjwarp playback validation requires mujoco")
+
+import mujoco
+from omegaconf import OmegaConf
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.base import BackendPlayCapabilities
+from unilab.base.backend.mjwarp.backend import MjwarpBackend
+from unilab.base.backend.mjwarp.playback import (
+    run_mjwarp_playback,
+    validate_mjwarp_visual_model,
+)
+from unilab.base.scene import SceneCfg
+
+G1_SCENE = ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _stub_backend(model_file: Path = G1_SCENE, *, num_envs: int = 2) -> MjwarpBackend:
+    backend = object.__new__(MjwarpBackend)
+    model = mujoco.MjModel.from_xml_path(str(model_file))
+    backend._mujoco = mujoco
+    backend._cpu_model = model
+    backend._num_envs = num_envs
+    backend._nq = int(model.nq)
+    backend._nv = int(model.nv)
+    backend._qpos_cache = np.broadcast_to(
+        np.asarray(model.qpos0, dtype=np.float32), (num_envs, int(model.nq))
+    ).copy()
+    backend._qvel_cache = np.zeros((num_envs, int(model.nv)), dtype=np.float32)
+    backend._time_cache = np.zeros((num_envs,), dtype=np.float32)
+    backend.scene_visual_model_file = str(model_file)
+    backend._playback_model_validated = False
+    backend._scene_cleanup_handle = None
+    return backend
+
+
+def test_mjwarp_plan_is_explicit_and_finite() -> None:
+    backend = _stub_backend(num_envs=1)
+    assert backend.get_play_capabilities() == BackendPlayCapabilities(
+        supports_physics_state_playback=True
+    )
+    assert (
+        backend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=3, output_video="play.mp4"
+        ).num_steps
+        == 3
+    )
+    assert (
+        backend.resolve_play_render_plan(
+            play_render_mode="none", play_steps=None, output_video=None
+        ).mode
+        == "none"
+    )
+    with pytest.raises(NotImplementedError, match="auto mode"):
+        backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=3, output_video="play.mp4"
+        )
+    with pytest.raises(NotImplementedError, match="interactive"):
+        backend.resolve_play_render_plan(
+            play_render_mode="interactive", play_steps=3, output_video="play.mp4"
+        )
+    with pytest.raises(ValueError, match="positive finite"):
+        backend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=0, output_video="play.mp4"
+        )
+
+
+def test_g1_mjwarp_owner_enables_explicit_record_profile() -> None:
+    owner = OmegaConf.load(REPO_ROOT / "conf" / "ppo" / "task" / "g1_walk_flat" / "mjwarp.yaml")
+
+    assert owner.training.no_play is False
+    assert owner.training.play_render_mode == "record"
+    assert owner.play_profile.enabled is True
+    assert owner.play_profile.env.render_spacing == 2.0
+
+
+def test_mjwarp_snapshot_is_detached_time_qpos_qvel_layout() -> None:
+    backend = _stub_backend(num_envs=2)
+    backend._time_cache[:] = [0.12, 0.34]
+    backend._qpos_cache[:, 0] = [1.0, 2.0]
+    backend._qvel_cache[:, 0] = [3.0, 4.0]
+
+    snapshot = backend.get_physics_state()
+
+    assert snapshot.shape == (2, 1 + backend._nq + backend._nv)
+    np.testing.assert_allclose(snapshot[:, 0], [0.12, 0.34])
+    np.testing.assert_allclose(snapshot[:, 1 : 1 + backend._nq], backend._qpos_cache)
+    np.testing.assert_allclose(snapshot[:, 1 + backend._nq :], backend._qvel_cache)
+    snapshot.fill(99.0)
+    assert backend._time_cache[0] == pytest.approx(0.12)
+    assert backend._qpos_cache[0, 0] == pytest.approx(1.0)
+
+
+def test_g1_visual_model_and_replay_forward_camera_and_spacing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backend = _stub_backend()
+    env = SimpleNamespace(
+        cfg=SimpleNamespace(ctrl_dt=0.02, scene=SceneCfg(model_file=str(G1_SCENE))),
+        get_playback_model=backend.get_playback_model,
+        get_physics_state_snapshot=backend.get_physics_state,
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("unilab.visualization.render_many.render_backend_usable", lambda: True)
+    monkeypatch.setattr(
+        "unilab.visualization.render_many.render_states_get_frames",
+        lambda states, model_file, **kwargs: (
+            captured.update(states=states, model_file=model_file, render_kwargs=kwargs)
+            or [np.zeros((2, 2, 3), dtype=np.uint8)]
+        ),
+    )
+    monkeypatch.setattr(
+        "unilab.base.backend.playback_common.imageio.mimsave",
+        lambda path, frames, fps: captured.update(video_path=str(path), fps=fps),
+    )
+
+    output = tmp_path / "g1.mp4"
+    result = run_mjwarp_playback(
+        backend=backend,
+        env=env,
+        initialize=lambda: 0,
+        step=lambda obs: obs,
+        num_steps=1,
+        output_video=output,
+        render_spacing=2.0,
+        headless=True,
+        record_video=True,
+        snapshot_shape=(2, 1 + backend._nq + backend._nv),
+        frame_state_getter=None,
+        camera_kwargs={"cam_distance": 4.0, "cam_tracking": False},
+    )
+
+    assert result == str(output)
+    assert captured["model_file"] == str(G1_SCENE)
+    assert captured["states"][0].shape == (  # type: ignore[index]
+        2,
+        1 + backend._nq + backend._nv,
+    )
+    render_kwargs = captured["render_kwargs"]
+    assert render_kwargs["render_spacing"] == 2.0  # type: ignore[index]
+    assert render_kwargs["cam_distance"] == 4.0  # type: ignore[index]
+
+
+def test_mjwarp_playback_rejects_bad_snapshot_and_renderer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backend = _stub_backend(num_envs=1)
+    env = SimpleNamespace(get_physics_state_snapshot=lambda: np.zeros((1, 4), dtype=np.float32))
+    monkeypatch.setattr("unilab.visualization.render_many.render_backend_usable", lambda: True)
+    with pytest.raises(ValueError, match=r"\[time, qpos, qvel\]"):
+        run_mjwarp_playback(
+            backend=backend,
+            env=env,
+            initialize=lambda: 0,
+            step=lambda obs: obs,
+            num_steps=1,
+            output_video=tmp_path / "bad.mp4",
+            render_spacing=1.0,
+            headless=True,
+            record_video=True,
+            snapshot_shape=(1, 1 + backend._nq + backend._nv),
+            frame_state_getter=None,
+            camera_kwargs=None,
+        )
+
+    monkeypatch.setattr("unilab.visualization.render_many.render_backend_usable", lambda: False)
+    with pytest.raises(RuntimeError, match="usable MuJoCo off-screen renderer"):
+        run_mjwarp_playback(
+            backend=backend,
+            env=SimpleNamespace(get_physics_state_snapshot=backend.get_physics_state),
+            initialize=lambda: 0,
+            step=lambda obs: obs,
+            num_steps=1,
+            output_video=tmp_path / "unavailable.mp4",
+            render_spacing=1.0,
+            headless=True,
+            record_video=True,
+            snapshot_shape=(1, 1 + backend._nq + backend._nv),
+            frame_state_getter=None,
+            camera_kwargs=None,
+        )
+
+
+def test_mjwarp_visual_model_diagnostics(tmp_path: Path) -> None:
+    physics = mujoco.MjModel.from_xml_string(
+        "<mujoco><worldbody><body><freejoint name='root'/><geom size='.1'/></body>"
+        "</worldbody></mujoco>"
+    )
+    with pytest.raises(ValueError, match="does not exist or is not a file"):
+        validate_mjwarp_visual_model(
+            mujoco=mujoco, physics_model=physics, model_file=tmp_path / "missing.xml"
+        )
+
+    incompatible = tmp_path / "incompatible.xml"
+    incompatible.write_text(
+        "<mujoco><worldbody><body><joint name='root' type='hinge'/><geom size='.1'/></body>"
+        "</worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="state dimensions are incompatible"):
+        validate_mjwarp_visual_model(mujoco=mujoco, physics_model=physics, model_file=incompatible)
+
+    mismatched = tmp_path / "mismatched.xml"
+    mismatched.write_text(
+        "<mujoco><worldbody><body><freejoint name='other'/><geom size='.1'/></body>"
+        "</worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="joint layout is incompatible"):
+        validate_mjwarp_visual_model(mujoco=mujoco, physics_model=physics, model_file=mismatched)

--- a/tests/tools/test_backend_isolation.py
+++ b/tests/tools/test_backend_isolation.py
@@ -249,6 +249,21 @@ def test_future_mjwarp_package_is_discovered_automatically(tmp_path: Path) -> No
     assert "sibling-runtime-import" in {violation.code for violation in report.violations}
 
 
+def test_mjwarp_playback_uses_documented_mujoco_cold_path_exception(tmp_path: Path) -> None:
+    root = _fixture_repo(
+        tmp_path,
+        {
+            "src/unilab/base/backend/mjwarp/__init__.py": "",
+            "src/unilab/base/backend/mjwarp/backend.py": "",
+            "src/unilab/base/backend/mjwarp/playback.py": (
+                "from unilab.base.backend.mujoco.playback import run_mujoco_playback\n"
+            ),
+        },
+    )
+
+    assert audit_backend_isolation(root).ok
+
+
 def test_syntax_error_and_invalid_layout_fail_closed(tmp_path: Path) -> None:
     syntax_root = _fixture_repo(
         tmp_path / "syntax",


### PR DESCRIPTION
## Summary

- bridge detached mjwarp physics snapshots into the existing MuJoCo offline playback pipeline
- validate visual-model compatibility, snapshot layout, render mode, camera, and grid spacing at the playback boundary
- enable finite headless recording for the G1 mjwarp owner while keeping support at Configured
- add contract, failure-path, backend-isolation, and owner-profile coverage

## Validation

- `make test-all`
  - 1917 passed, 56 skipped, 320 deselected, 1 xfailed
  - benchmark smoke passed in module and script modes
  - mypy passed
  - pyright: 0 errors, 4 existing optional-dependency warnings
- targeted Ruff check passed after restoring unrelated formatter output

CUDA-specific slow tests remain deselected by the repository test-all target. Deterministic tests validate the real G1 MuJoCo model and mock only the rendering boundary.

Fixes #895