### PR TITLE
feat(replay): support MPS gpu-resident replay

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -48,7 +48,7 @@ training:
   replay_prefetch_mode: one_tick
   # Replay batch source for single-GPU off-policy runners:
   # cpu_pinned_double_buffer (collector CPU pack + batch H2D) or
-  # gpu_resident (learner-side GPU mirror of replay storage, GPU-side sampling).
+  # gpu_resident (learner-side CUDA/MPS mirror with device-side sampling).
   replay_pipeline: cpu_pinned_double_buffer
   verbose_metrics: false
   torch_threads:

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
@@ -11,6 +11,13 @@ The off-policy runner decouples CPU simulation from GPU learning through shared
 memory: a collector subprocess fills a CPU-resident replay buffer while the
 learner trains on the GPU.
 
+Single-GPU CUDA and Apple MPS runs may select
+`training.replay_pipeline=gpu_resident`. The CPU replay remains authoritative,
+while the learner maintains a full device mirror and samples on the device.
+This consumes one additional full replay allocation on the device; the default
+remains `cpu_pinned_double_buffer`. On MPS, the learner thread submits mirror
+copies and gathers, avoiding background Metal command submission.
+
 The default FastSAC learner is also the currently validated replay-buffer
 multi-GPU SAC implementation. Enable it with `training.num_gpus > 1`; the host
 side packs and distributes batches in parallel, while the GPU learners default
@@ -25,6 +32,8 @@ constraints.
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco
 uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
+uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.replay_pipeline=gpu_resident
 ```
 
 Two-GPU MuJoCo example:

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -9,6 +9,12 @@ SAC 通过共享的 off-policy 入口 `scripts/train_offpolicy.py` 选择，TD3 
 off-policy runner 通过 shared memory 把 CPU 仿真与 GPU 学习解耦：collector 子进程
 填充驻留在 CPU 上的 replay buffer，learner 在 GPU 上训练。
 
+单 GPU CUDA 或 Apple MPS 训练可选择
+`training.replay_pipeline=gpu_resident`：CPU replay buffer 仍是权威数据源，learner
+另外维护完整的 device mirror 并在 device 上随机采样。该模式会额外占用一份完整
+replay 的 device 内存；默认仍是 `cpu_pinned_double_buffer`。MPS 路径由 learner
+线程提交 mirror copy 和采样，不使用后台 Metal command submission。
+
 默认 FastSAC learner 也是当前已验证的 replay-buffer 多 GPU SAC 实现。多卡模式通过
 `training.num_gpus > 1` 打开，host 侧并行打包并分发 batch，多张 GPU 上的 learner
 默认使用 `training.multi_gpu_sync_mode=local_sgd` 做 delayed-sync 参数平均。custom
@@ -20,6 +26,8 @@ SAC runtime 必须显式声明 distributed learner contract 后才能使用这�
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco
 uv run train --algo sac --task g1_walk_rough --sim motrix training.no_play=true
+uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.replay_pipeline=gpu_resident
 ```
 
 两卡 MuJoCo 训练示例：

--- a/src/unilab/ipc/replay_pipelines/gpu_resident.py
+++ b/src/unilab/ipc/replay_pipelines/gpu_resident.py
@@ -1,20 +1,20 @@
-"""GPU-resident replay mirror pipeline (single-GPU, CUDA only).
+"""GPU-resident replay mirror pipeline for one CUDA or MPS learner.
 
 The packed CPU :class:`ReplayBuffer` stays authoritative: the collector's
-``add()`` path is unchanged and does zero extra CPU work.  A learner-side
-daemon thread incrementally mirrors newly written rows into a GPU-resident
-storage on a side stream, and services learner batch prepares with GPU-side
-sampling (``randint`` + ``index_select``) on the same stream.  There is no
-collector pack request, no pinned batch staging, and no per-tick batch H2D.
+``add()`` path is unchanged and does zero extra CPU work. CUDA uses a
+learner-side daemon and side stream to maintain the mirror. MPS has no public
+stream API and device submission from a background thread is unsafe, so its
+existing learner-thread pipeline calls drive mirror copies and device-side
+sampling (``randint`` + ``index_select``). There is no collector pack request,
+no pinned batch staging, and no per-tick full-batch H2D.
 
 Consistency model:
 
 - The sample domain is ``[0, min(device_visible_ptr, capacity))`` where
-  ``device_visible_ptr`` only advances past rows whose H2D completed (one
-  CUDA event per submitted span batch).
-- Span copies and batch gathers are totally ordered on a single side stream,
-  so a gather observes a consistent snapshot: every span submitted before it
-  is applied, none submitted after it.
+  ``device_visible_ptr`` only advances past rows whose device copy completed.
+- Span copies and batch gathers are totally ordered on the CUDA side stream or
+  the MPS learner-thread command queue. A gather therefore observes every
+  completed span before it and none submitted after it.
 - Ring-overwrite races against concurrent collector CPU writes are the same
   class the CPU pack path already accepts (single writer / snapshot reader).
 """
@@ -48,6 +48,47 @@ def _ring_spans(start: int, end: int, capacity: int) -> List[Tuple[int, int]]:
     return spans
 
 
+def _device_memory_budget(device: torch.device) -> tuple[int, int]:
+    """Return ``(available, total_budget)`` bytes for resident allocations."""
+    if device.type == "cuda":
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        return int(free_bytes), int(total_bytes)
+    if device.type == "mps":
+        recommended_max_memory = getattr(torch.mps, "recommended_max_memory", None)
+        driver_allocated_memory = getattr(torch.mps, "driver_allocated_memory", None)
+        if not callable(recommended_max_memory) or not callable(driver_allocated_memory):
+            raise RuntimeError(
+                "MPS gpu_resident replay requires recommended_max_memory() and "
+                "driver_allocated_memory() for its allocation guard"
+            )
+        total_bytes = int(cast(Any, recommended_max_memory)())
+        allocated_bytes = int(cast(Any, driver_allocated_memory)())
+        return max(0, total_bytes - allocated_bytes), total_bytes
+    raise ValueError(f"Unsupported gpu_resident replay device type {device.type!r}")
+
+
+def _validate_device_memory_budget(
+    device: torch.device,
+    *,
+    required_bytes: int,
+    storage_bytes: int,
+    batch_bytes: int,
+    headroom: float,
+) -> None:
+    available_bytes, total_bytes = _device_memory_budget(device)
+    usable_bytes = int(available_bytes * headroom)
+    if required_bytes <= usable_bytes:
+        return
+    raise RuntimeError(
+        f"GPU-resident replay mirror does not fit on {device.type}: "
+        f"requires {required_bytes / 2**30:.2f} GiB "
+        f"(storage {storage_bytes / 2**30:.2f} + batch slots {batch_bytes / 2**30:.2f}), "
+        f"device available budget {available_bytes / 2**30:.2f} GiB / "
+        f"total budget {total_bytes / 2**30:.2f} GiB "
+        f"({headroom:.0%} of available budget may be used)"
+    )
+
+
 class GPUResidentReplayPipeline:
     """ReplayPipeline backed by a GPU-resident mirror of the packed CPU storage."""
 
@@ -70,13 +111,17 @@ class GPUResidentReplayPipeline:
         self._device = torch.device(device)
         if pack_layout not in {"packed", "sac_graph"}:
             raise ValueError("GPUResidentReplayPipeline pack_layout must be packed or sac_graph")
-        if self._device.type != "cuda":
+        if self._device.type not in {"cuda", "mps"}:
             raise ValueError(
-                "GPUResidentReplayPipeline requires a CUDA device; "
+                "GPUResidentReplayPipeline requires a CUDA or MPS device; "
                 f"got {self._device.type!r} (use cpu_pinned_double_buffer instead)"
             )
+        if self._device.type == "mps" and not torch.backends.mps.is_available():
+            raise ValueError("GPUResidentReplayPipeline requires an available MPS device")
         if not getattr(replay_buffer, "_packed_cpu_storage", False):
             raise ValueError("GPUResidentReplayPipeline requires packed CPU replay storage")
+        self._main_thread_submission = self._device.type == "mps"
+        self._learner_thread_id = threading.get_ident()
         self._pack_layout = pack_layout
         self._use_critic_graph_packed_source = (
             bool(use_critic_graph_packed_source) and self._pack_layout != "sac_graph"
@@ -105,15 +150,13 @@ class GPUResidentReplayPipeline:
         )
         critic_slot_bytes = 2 * self._sample_count * self._critic_graph_packed_width * 4
         required_bytes = storage_bytes + slot_bytes + scratch_bytes + critic_slot_bytes
-        free_bytes, total_bytes = torch.cuda.mem_get_info(self._device)
-        if required_bytes > int(free_bytes * self._MEMORY_HEADROOM):
-            raise RuntimeError(
-                "GPU-resident replay mirror does not fit on device: "
-                f"requires {required_bytes / 2**30:.2f} GiB "
-                f"(storage {storage_bytes / 2**30:.2f} + batch slots "
-                f"{(slot_bytes + scratch_bytes + critic_slot_bytes) / 2**30:.2f}), "
-                f"device free {free_bytes / 2**30:.2f} GiB / total {total_bytes / 2**30:.2f} GiB"
-            )
+        _validate_device_memory_budget(
+            self._device,
+            required_bytes=required_bytes,
+            storage_bytes=storage_bytes,
+            batch_bytes=slot_bytes + scratch_bytes + critic_slot_bytes,
+            headroom=self._MEMORY_HEADROOM,
+        )
 
         self._transfer_backend = build_replay_transfer_backend(
             device=self._device,
@@ -126,11 +169,11 @@ class GPUResidentReplayPipeline:
         self._host_pinned = False
         try:
             self._transfer_backend.register_host_slots([replay_buffer._storage])
-            self._host_pinned = True
+            self._host_pinned = bool(self._transfer_backend.host_pinned)
         except RuntimeError as exc:
             print(
                 f"[GPUResidentReplay] Host storage registration failed ({exc}); "
-                "falling back to pageable H2D on the sync thread.",
+                "falling back to pageable device copies.",
                 flush=True,
             )
         self._gpu_storage: torch.Tensor = torch.empty(
@@ -162,8 +205,12 @@ class GPUResidentReplayPipeline:
             else None
         )
 
-        self._sync_stream = cast(torch.cuda.Stream, torch.cuda.Stream(device=self._device))
-        self._slot_events: list[Any] = [torch.cuda.Event() for _ in range(2)]
+        self._sync_stream: Any | None = None
+        if self._device.type == "cuda":
+            self._sync_stream = cast(torch.cuda.Stream, torch.cuda.Stream(device=self._device))
+            self._slot_events: list[Any] = [torch.cuda.Event() for _ in range(2)]
+        else:
+            self._slot_events = [torch.mps.Event() for _ in range(2)]
         self._span_events: deque[tuple[int, Any]] = deque()
         self._submitted_ptr = 0
         self._visible_ptr = 0
@@ -181,15 +228,19 @@ class GPUResidentReplayPipeline:
         self.last_incremental_h2d_time_s = 0.0
         self._prepare_condition = threading.Condition()
         self._closed = False
-        self._sync_thread = threading.Thread(
-            target=self._sync_worker,
-            name="replay_gpu_resident_sync",
-            daemon=True,
-        )
-        self._sync_thread.start()
+        self._sync_thread: threading.Thread | None = None
+        if not self._main_thread_submission:
+            self._sync_thread = threading.Thread(
+                target=self._sync_worker,
+                name="replay_gpu_resident_sync",
+                daemon=True,
+            )
+            self._sync_thread.start()
 
     @property
     def h2d_submitter(self) -> str:
+        if self._main_thread_submission:
+            return "gpu_resident_mirror_main_thread"
         return "gpu_resident_mirror"
 
     @property
@@ -207,6 +258,7 @@ class GPUResidentReplayPipeline:
             "storage_width": self._storage_width,
             "storage_bytes": int(self._gpu_storage.numel() * self._gpu_storage.element_size()),
             "h2d_submitter": self.h2d_submitter,
+            "device_submission_thread": "learner" if self._main_thread_submission else "daemon",
             "ring_depth": 2,
         }
 
@@ -261,7 +313,41 @@ class GPUResidentReplayPipeline:
             batch["critic_graph_packed_source"] = self._gpu_critic_graph_packed[slot]
         return batch
 
-    # -- sync thread ------------------------------------------------------------
+    # -- device submission ---------------------------------------------------
+
+    def _assert_mps_learner_thread(self) -> None:
+        if self._main_thread_submission and threading.get_ident() != self._learner_thread_id:
+            raise RuntimeError(
+                "MPS gpu_resident replay device work must be submitted from the learner thread"
+            )
+
+    def _drive_mps_learner_thread(self) -> bool:
+        """Advance MPS mirror and gather work from an existing learner call."""
+        if not self._main_thread_submission:
+            return False
+        self._assert_mps_learner_thread()
+        try:
+            did_work = self._submit_new_spans()
+            # MPS exposes events but no side streams. Waiting for just the
+            # mirror events submitted by this pipeline avoids an extra runner
+            # polling interval without globally synchronizing unrelated work.
+            for _, event in self._span_events:
+                event.synchronize()
+            did_work |= self._drain_completed_spans()
+            did_work |= self._service_pending_prepare()
+            if self._prepared_metadata is not None:
+                slot = self._prepared_metadata.batch_gpu_slot
+                if slot is not None:
+                    self._slot_events[slot].synchronize()
+                    self._prepare_state = "ready"
+            return did_work
+        except BaseException as exc:
+            with self._prepare_condition:
+                self._prepare_error = exc
+                self._prepare_condition.notify_all()
+            raise
+
+    # -- CUDA sync thread -----------------------------------------------------
 
     def _sync_worker(self) -> None:
         while True:
@@ -280,6 +366,8 @@ class GPUResidentReplayPipeline:
                 time.sleep(self._POLL_INTERVAL_S)
 
     def _submit_new_spans(self) -> bool:
+        if self._main_thread_submission:
+            self._assert_mps_learner_thread()
         ptr = int(self._replay_buffer.ptr[0])
         if ptr <= self._submitted_ptr:
             return False
@@ -299,8 +387,8 @@ class GPUResidentReplayPipeline:
         start_event = None
         end_event = None
         record_cuda = self._trace_recorder is not None and self._trace_cuda_events
-        with torch.cuda.device(self._device):
-            with torch.cuda.stream(self._sync_stream):
+        if self._device.type == "cuda":
+            with torch.cuda.device(self._device), torch.cuda.stream(self._sync_stream):
                 if record_cuda:
                     start_event = cast(Any, torch.cuda.Event(enable_timing=True))
                     end_event = cast(Any, torch.cuda.Event(enable_timing=True))
@@ -314,6 +402,14 @@ class GPUResidentReplayPipeline:
                     end_event.record()
                 done_event = cast(Any, torch.cuda.Event())
                 done_event.record(self._sync_stream)
+        else:
+            for offset, length in _ring_spans(start, end, self._capacity):
+                self._gpu_storage[offset : offset + length].copy_(
+                    self._replay_buffer._storage[offset : offset + length],
+                    non_blocking=False,
+                )
+            done_event = cast(Any, torch.mps.Event())
+            done_event.record()
         self._span_events.append((end, done_event))
         self._submitted_ptr = end
         self.last_incremental_h2d_time_s = (time.perf_counter_ns() - h2d_begin_ns) / 1e9
@@ -346,7 +442,30 @@ class GPUResidentReplayPipeline:
                 self._prepare_condition.notify_all()
         return drained
 
+    def _gather_rows(self, *, visible_size: int, slot: int, gen: torch.Generator) -> None:
+        indices = torch.randint(
+            0,
+            visible_size,
+            (self._sample_count,),
+            generator=gen,
+            device=self._device,
+        )
+        dst = self._gpu_packed[slot]
+        if self._pack_layout == "sac_graph":
+            assert self._gather_scratch is not None
+            torch.index_select(self._gpu_storage, 0, indices, out=self._gather_scratch)
+            self._replay_buffer.pack_sac_graph_source(self._gather_scratch, out=dst)
+        else:
+            torch.index_select(self._gpu_storage, 0, indices, out=dst)
+        if self._use_critic_graph_packed_source:
+            self._replay_buffer.pack_critic_graph_source(
+                dst,
+                out=self._gpu_critic_graph_packed[slot],
+            )
+
     def _service_pending_prepare(self) -> bool:
+        if self._main_thread_submission:
+            self._assert_mps_learner_thread()
         with self._prepare_condition:
             if self._prepare_state != "preparing" or self._prepare_tick_id is None:
                 return False
@@ -363,34 +482,19 @@ class GPUResidentReplayPipeline:
         start_event = None
         end_event = None
         record_cuda = self._trace_recorder is not None and self._trace_cuda_events
-        with torch.cuda.device(self._device):
-            with torch.cuda.stream(self._sync_stream):
+        if self._device.type == "cuda":
+            with torch.cuda.device(self._device), torch.cuda.stream(self._sync_stream):
                 if record_cuda:
                     start_event = cast(Any, torch.cuda.Event(enable_timing=True))
                     end_event = cast(Any, torch.cuda.Event(enable_timing=True))
                     start_event.record()
-                indices = torch.randint(
-                    0,
-                    visible_size,
-                    (self._sample_count,),
-                    generator=gen,
-                    device=self._device,
-                )
-                dst = self._gpu_packed[slot]
-                if self._pack_layout == "sac_graph":
-                    assert self._gather_scratch is not None
-                    torch.index_select(self._gpu_storage, 0, indices, out=self._gather_scratch)
-                    self._replay_buffer.pack_sac_graph_source(self._gather_scratch, out=dst)
-                else:
-                    torch.index_select(self._gpu_storage, 0, indices, out=dst)
-                if self._use_critic_graph_packed_source:
-                    self._replay_buffer.pack_critic_graph_source(
-                        dst,
-                        out=self._gpu_critic_graph_packed[slot],
-                    )
+                self._gather_rows(visible_size=visible_size, slot=slot, gen=gen)
                 if end_event is not None:
                     end_event.record()
                 self._slot_events[slot].record(self._sync_stream)
+        else:
+            self._gather_rows(visible_size=visible_size, slot=slot, gen=gen)
+            self._slot_events[slot].record()
         metadata = ReplayTickMetadata(
             tick_id=int(tick_id),
             snapshot_ptr=int(self._visible_ptr),
@@ -506,6 +610,8 @@ class GPUResidentReplayPipeline:
                     "pipeline": "gpu_resident",
                 },
             )
+        if self._main_thread_submission:
+            self._drive_mps_learner_thread()
         return True
 
     def batch_ready(self, tick_id: int, sample_count: int) -> bool:
@@ -514,6 +620,8 @@ class GPUResidentReplayPipeline:
             if self._hot_metadata is not None and self._hot_metadata.tick_id != int(tick_id):
                 return False
             return True
+        if self._main_thread_submission:
+            self._drive_mps_learner_thread()
         self._refresh_prepare_state()
         if self._prepared_metadata is None:
             return False
@@ -538,11 +646,17 @@ class GPUResidentReplayPipeline:
         if self._prepared_metadata is None:
             if self._prepare_tick_id is None:
                 self.start_prepare(tick_id, self._sample_count)
-            with self._prepare_condition:
+            if self._main_thread_submission:
                 while self._prepared_metadata is None and self._prepare_error is None:
-                    self._prepare_condition.wait(timeout=0.1)
-                if self._prepare_error is not None:
-                    raise self._prepare_error
+                    did_work = self._drive_mps_learner_thread()
+                    if not did_work:
+                        time.sleep(self._POLL_INTERVAL_S)
+            else:
+                with self._prepare_condition:
+                    while self._prepared_metadata is None and self._prepare_error is None:
+                        self._prepare_condition.wait(timeout=0.1)
+            if self._prepare_error is not None:
+                raise self._prepare_error
             assert self._prepared_metadata is not None
             return self._prepared_metadata
         if self._prepared_metadata.tick_id != int(tick_id):
@@ -567,7 +681,10 @@ class GPUResidentReplayPipeline:
         slot = metadata.batch_gpu_slot
         assert slot is not None
         _t0 = time.perf_counter_ns()
-        torch.cuda.current_stream(self._device).wait_event(self._slot_events[slot])
+        if self._device.type == "cuda":
+            torch.cuda.current_stream(self._device).wait_event(self._slot_events[slot])
+        else:
+            self._slot_events[slot].synchronize()
         if self._trace_recorder is not None:
             _wait_end = time.perf_counter_ns()
             self._trace_recorder.add_slice(
@@ -623,6 +740,12 @@ class GPUResidentReplayPipeline:
             self._prepare_condition.notify_all()
         if self._sync_thread is not None:
             self._sync_thread.join(timeout=2.0)
+        while self._span_events:
+            _, event = self._span_events.popleft()
+            try:
+                event.synchronize()
+            except Exception:
+                pass
         for event in self._slot_events:
             try:
                 event.synchronize()

--- a/tests/ipc/test_replay_pipeline_gpu_resident.py
+++ b/tests/ipc/test_replay_pipeline_gpu_resident.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 
 import pytest
@@ -10,11 +11,15 @@ import torch
 from unilab.ipc.replay_buffer import ReplayBuffer
 from unilab.ipc.replay_pipelines.gpu_resident import (
     GPUResidentReplayPipeline,
+    _device_memory_budget,
     _ring_spans,
+    _validate_device_memory_budget,
 )
 
 _HAS_CUDA = torch.cuda.is_available()
 cuda_only = pytest.mark.skipif(not _HAS_CUDA, reason="CUDA required")
+_HAS_MPS = torch.backends.mps.is_available()
+mps_only = pytest.mark.skipif(not _HAS_MPS, reason="MPS required")
 
 _OBS_DIM = 4
 _ACTION_DIM = 2
@@ -116,9 +121,9 @@ class TestRingSpans:
 
 
 class TestConstructionGuards:
-    def test_non_cuda_device_rejected(self):
+    def test_non_accelerator_device_rejected(self):
         rb = _make_replay(device="cpu")
-        with pytest.raises(ValueError, match="CUDA"):
+        with pytest.raises(ValueError, match="CUDA or MPS"):
             GPUResidentReplayPipeline(rb, device="cpu", sample_count=8)
 
     def test_invalid_pack_layout_rejected(self):
@@ -133,6 +138,25 @@ class TestConstructionGuards:
 
         with pytest.raises(ValueError, match="replay_pipeline"):
             DoubleBufferOffPolicyRunner(replay_pipeline="bogus")
+
+    def test_mps_memory_budget_uses_recommended_budget(self, monkeypatch):
+        monkeypatch.setattr(torch.mps, "recommended_max_memory", lambda: 1_000)
+        monkeypatch.setattr(torch.mps, "driver_allocated_memory", lambda: 250)
+
+        assert _device_memory_budget(torch.device("mps")) == (750, 1_000)
+
+    def test_mps_memory_budget_failure_is_actionable(self, monkeypatch):
+        monkeypatch.setattr(torch.mps, "recommended_max_memory", lambda: 1_000)
+        monkeypatch.setattr(torch.mps, "driver_allocated_memory", lambda: 250)
+
+        with pytest.raises(RuntimeError, match=r"requires .* available budget .* total budget"):
+            _validate_device_memory_budget(
+                torch.device("mps"),
+                required_bytes=601,
+                storage_bytes=500,
+                batch_bytes=101,
+                headroom=0.8,
+            )
 
 
 @cuda_only
@@ -302,5 +326,133 @@ class TestGPUResidentPipeline:
         rb = _make_replay(capacity=64)
         pipeline = pipeline_factory(rb, sample_count=8)
         pipeline.close()
+        assert pipeline._sync_thread is not None
         assert not pipeline._sync_thread.is_alive()
         assert not rb._storage.is_pinned()
+
+
+@mps_only
+class TestMPSGPUResidentPipeline:
+    @pytest.fixture
+    def pipeline_factory(self):
+        created = []
+
+        def _make(rb, **kwargs):
+            kwargs.setdefault("device", "mps")
+            kwargs.setdefault("sample_count", 16)
+            pipeline = GPUResidentReplayPipeline(rb, **kwargs)
+            created.append(pipeline)
+            return pipeline
+
+        yield _make
+        for pipeline in created:
+            pipeline.close()
+
+    def test_allocates_mps_storage_and_samples_on_learner_thread(self, pipeline_factory):
+        rb = _make_replay(capacity=128, device="mps")
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb, sample_count=16)
+
+        batch = pipeline.sample_large_batch(1, 16)
+
+        assert pipeline._sync_thread is None
+        assert pipeline._host_pinned is False
+        assert pipeline.h2d_submitter == "gpu_resident_mirror_main_thread"
+        assert pipeline.transfer_manifest["device_submission_thread"] == "learner"
+        assert all(value.device.type == "mps" for value in batch.values())
+        rewards = batch["rewards"].cpu()
+        expected = _expected_pattern(rb, rewards)
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)
+
+    def test_incremental_mirror_matches_after_ring_wrap(self, pipeline_factory):
+        rb = _make_replay(capacity=64, device="mps")
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        pipeline.sample_large_batch(1, 8)
+        pipeline.after_tick()
+
+        _pattern_add(rb, 64, 48)
+        assert pipeline.start_prepare(2, 8) is True
+        _wait_batch_ready(pipeline, 2, 8)
+        pipeline.sample_large_batch(2, 8)
+
+        assert pipeline._visible_ptr == 112
+        torch.testing.assert_close(pipeline._gpu_storage.cpu(), rb._storage)
+
+    def test_deterministic_seed_produces_same_mps_batch(self, pipeline_factory):
+        rb = _make_replay(capacity=128, device="mps")
+        _pattern_add(rb, 0, 64)
+        first = pipeline_factory(rb, sample_count=16, base_seed=99)
+        first_rewards = first.sample_large_batch(7, 16)["rewards"].cpu().clone()
+        first.close()
+
+        second = pipeline_factory(rb, sample_count=16, base_seed=99)
+        second_rewards = second.sample_large_batch(7, 16)["rewards"].cpu()
+
+        torch.testing.assert_close(first_rewards, second_rewards)
+
+    def test_min_snapshot_ptr_gates_mps_prepare(self, pipeline_factory):
+        rb = _make_replay(capacity=128, device="mps")
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+
+        assert pipeline.start_prepare(5, 8, min_snapshot_ptr=48) is True
+        deadline = time.monotonic() + 2.0
+        while pipeline._visible_ptr < 32 and time.monotonic() < deadline:
+            assert pipeline.batch_ready(5, 8) is False
+            time.sleep(0.001)
+        assert pipeline._visible_ptr == 32
+
+        _pattern_add(rb, 32, 16)
+        _wait_batch_ready(pipeline, 5, 8)
+        batch = pipeline.sample_large_batch(5, 8)
+
+        assert pipeline._visible_ptr == 48
+        assert batch["obs"].shape == (8, rb._obs_dim)
+
+    def test_mps_device_work_rejects_background_thread(self, pipeline_factory):
+        rb = _make_replay(capacity=64, device="mps")
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        errors: list[BaseException] = []
+
+        def drive_from_background() -> None:
+            try:
+                pipeline.batch_ready(1, 8)
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=drive_from_background)
+        thread.start()
+        thread.join(timeout=2.0)
+
+        assert not thread.is_alive()
+        assert len(errors) == 1
+        assert "learner thread" in str(errors[0])
+
+    def test_mps_pipeline_uses_event_waits_not_global_sync(self, pipeline_factory, monkeypatch):
+        rb = _make_replay(capacity=64, device="mps")
+        _pattern_add(rb, 0, 32)
+        pipeline = pipeline_factory(rb, sample_count=8)
+
+        def reject_global_sync() -> None:
+            raise AssertionError("gpu_resident MPS path must not globally synchronize")
+
+        monkeypatch.setattr(torch.mps, "synchronize", reject_global_sync)
+        batch = pipeline.sample_large_batch(1, 8)
+
+        assert batch["obs"].device.type == "mps"
+
+    def test_mps_sac_graph_layout_preserves_columns(self, pipeline_factory):
+        rb = _make_replay(capacity=128, device="mps")
+        _pattern_add(rb, 0, 64)
+        pipeline = pipeline_factory(rb, sample_count=16, pack_layout="sac_graph")
+
+        batch = pipeline.sample_large_batch(1, 16)
+        rewards = batch["rewards"].cpu()
+        expected = _expected_pattern(rb, rewards)
+
+        assert batch["sac_graph_packed_source"].device.type == "mps"
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)


### PR DESCRIPTION
## Summary

- Allow the single-GPU `GPUResidentReplayPipeline` to run on Apple MPS while keeping the packed CPU replay authoritative.
- Keep CUDA on its existing daemon-thread/side-stream path; submit MPS mirror copies and device gathers from the learner thread because PyTorch exposes no public MPS stream API and background Metal submission is unsafe.
- Add MPS event-based completion, pre-allocation memory-budget diagnostics, ring/snapshot/seed coverage, config guidance, and bilingual SAC documentation.
- This is opt-in through `training.replay_pipeline=gpu_resident`; the default remains `cpu_pinned_double_buffer`. It adds one full replay allocation on the learner device.

## Linked Work

- Issue: Closes #894
- Milestone: none

## Validation

- [x] `make check` (covered by `make test-all`)
- [x] `uv run pytest -m "not slow"` (covered by the complete `make test-all` gate)
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/ipc/test_replay_pipeline_gpu_resident.py -q

make test-all

cd docs/sphinx
UNILAB_DOCS_SKIP_AUTODOC=1 uv run --no-project --with-requirements requirements.txt \
  sphinx-build -b html -n source build/html

uv run train --algo sac --task g1_walk_flat --sim mujoco --render-mode none \
  training.device=mps \
  training.replay_pipeline=gpu_resident \
  training.no_play=true \
  training.export_onnx=false \
  training.log_dir=/tmp/unilab-issue894-gpu-resident-wrap-smoke \
  algo.num_envs=32 \
  algo.batch_size=32 \
  algo.replay_buffer_n=16 \
  algo.learning_starts=1 \
  algo.updates_per_step=2 \
  algo.max_iterations=25 \
  algo.save_interval=0 \
  algo.use_symmetry=false \
  algo.algo_params.use_compile=false

uv run benchmark/rl/benchmark_replay_buffer_placement.py \
  --algos sac --tasks g1_walk_flat --sim mujoco \
  --device mps --warmup 10 --repeat 100 \
  --incremental-source pageable --sampled-batch-memory pageable \
  --out-json /tmp/unilab-issue894-replay-placement-mps.json \
  --plot-dir /tmp/unilab-issue894-replay-placement-mps-plots

uv run benchmark/rl/benchmark_replay_buffer_placement.py \
  --algos sac --tasks g1_walk_flat --sim mujoco \
  --device cpu --warmup 10 --repeat 100 \
  --incremental-source pageable --sampled-batch-memory pageable \
  --out-json /tmp/unilab-issue894-replay-placement-cpu.json \
  --plot-dir /tmp/unilab-issue894-replay-placement-cpu-plots
```

Results:

- Targeted replay test: `17 passed, 13 skipped`.
- Complete gate: `1630 passed, 59 skipped, 268 deselected, 1 xfailed`; Ruff, mypy, Pyright, and benchmark smoke passed.
- Strict Sphinx build succeeded. It reported one pre-existing unrelated warning for `en/3-deployment/2-sim_to_sim/7-config_guard.md`.
- Real MPS training completed 25/25 iterations. Replay capacity was 512 rows and total env steps reached 864, so the runner exercised ring wrap without collector, snapshot, or learner failures.

### Apple Silicon replay benchmark

Hardware and parameters:

- Apple M5 Max, 40-core GPU, 128 GB unified memory
- macOS 26.5.2, PyTorch 2.7.0
- SAC `g1_walk_flat` / MuJoCo default replay shape
- Capacity: 1,048,576 rows; full replay: 1.68 GiB
- Sample count: 32,768 rows; sampled batch: 53.75 MiB
- Increment: 2,048 rows; incremental copy: 3.36 MiB
- 10 warmups, 100 measured repetitions; values below are medians

| Operation | Median |
| --- | ---: |
| MPS resident device gather | 0.864 ms |
| Incremental CPU to MPS mirror copy | 0.218 ms |
| Resident scheme total | 1.082 ms/tick |
| CPU pre-sample | 1.876 ms |
| CPU to MPS sampled-batch transfer | 0.783 ms |
| Existing staged scheme total | 2.659 ms/tick |

The isolated replay work was about 2.46x faster for the resident scheme in this run. This is benchmark evidence for the replay path only, not an end-to-end training-speed or convergence claim.

## Impact

- Backend impact: none; replay behavior remains backend-isolated and the smoke used MuJoCo
- Platform impact: macOS MPS support added; existing CUDA path retained
- Training effect expected: yes, only when `training.replay_pipeline=gpu_resident` is explicitly selected

## Artifacts

- W&B: none
- benchmark result: raw JSON produced at `/tmp/unilab-issue894-replay-placement-{mps,cpu}.json`; parameters and medians are included above
- video / screenshot: none
- ONNX / checkpoint: none

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Follow-up scope is explicit: no MPS multi-GPU lane, public replay contract change, permanent benchmark gate, or end-to-end performance guarantee
