### PR TITLE
feat: add SAC G1 mjwarp task owner

### DIFF
--- a/conf/offpolicy/task/sac/g1_walk_flat/mjwarp.yaml
+++ b/conf/offpolicy/task/sac/g1_walk_flat/mjwarp.yaml
@@ -1,0 +1,67 @@
+# @package _global_
+# Configured-only SAC owner for the mjwarp host adapter. Offline record reuses
+# MuJoCo rendering; native playback and device-resident runtime are absent.
+training:
+  task_name: G1WalkFlat
+  sim_backend: mjwarp
+  play_render_mode: record
+algo:
+  num_envs: 2048
+  learning_starts: 10
+  max_iterations: 5000
+  save_interval: 1000
+  updates_per_step: 8
+  use_symmetry: true
+  algo_params:
+    alpha_init: 0.001
+    target_entropy_ratio: 0.0
+env:
+  numba_acceleration: false
+  mjwarp_nconmax: 128
+  mjwarp_njmax: 256
+  render_spacing: 2.0
+  control_config:
+    action_scale: 1.0
+  gait_phase_init_mode: "offset_phase"
+  reset_base_qvel_limit: 0.5
+  domain_rand:
+    randomize_kp: false
+    randomize_kd: false
+    randomize_dof_armature: false
+    randomize_body_gravity_compensation: false
+  curriculum:
+    enabled: true
+    initial_scale: 0.5
+    min_scale: 0.5
+    max_scale: 1.0
+    level_down_threshold: 150.0
+    level_up_threshold: 750.0
+    degree: 0.001
+  noise_config:
+    level: 0.0
+    scale_gyro: 0.0
+    scale_gravity: 0.0
+    scale_joint_angle: 0.01
+    scale_joint_vel: 0.1
+    scale_linvel: 0.0
+    seed: null
+reward:
+  scales:
+    tracking_lin_vel: 2.0
+    tracking_ang_vel: 1.5
+    penalty_ang_vel_xy: -1.0
+    penalty_orientation: -10.0
+    penalty_action_rate: -4.0
+    pose: -0.5
+    penalty_feet_ori: -20.0
+    feet_phase: 5.0
+    alive: 10.0
+  tracking_sigma: 0.25
+  base_height_target: 0.754
+  min_base_height: 0.3
+  max_tilt_deg: 65.0
+  gait_frequency: 1.5
+  feet_phase_swing_height: 0.09
+  feet_phase_tracking_sigma: 0.04
+  close_feet_threshold: 0.15
+  pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/conf/ppo/task/g1_walk_flat/mjwarp.yaml
+++ b/conf/ppo/task/g1_walk_flat/mjwarp.yaml
@@ -5,7 +5,6 @@
 training:
   task_name: G1WalkFlat
   sim_backend: mjwarp
-  no_play: false
   play_render_mode: record
 algo:
   num_envs: 2048

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -12,7 +12,7 @@
 
 - 默认后端是 `mujoco`
 - 切到 Motrix 用统一 CLI 的 `--sim motrix`
-- `--sim mjwarp` 当前只对应 `g1_walk_flat` 的 Configured host adapter，使用前需安装 `mjwarp` extra
+- `--sim mjwarp` 当前只对应 `g1_walk_flat` host adapter；PPO (torch) 与 SAC (torch) 为 Tested，其他入口按下方矩阵查证，使用前需安装 `mjwarp` extra
 - `--algo`、`--task`、`--sim` 共同选择 owner YAML
 - 不要把 `training.sim_backend` 当独立 backend switch
 
@@ -26,7 +26,7 @@
 
 ## Support Matrix
 
-下面的矩阵由 registry、owner YAML 和测试清单自动汇总；不要手工编辑表格内容。需要刷新时运行：
+下面的矩阵由 registry、owner YAML 和测试/验证清单自动汇总；不要手工编辑表格内容。需要刷新时运行：
 
 ```bash
 uv run scripts/generate_support_matrix.py --write
@@ -39,13 +39,13 @@ uv run scripts/generate_support_matrix.py --write
 |------|--------------|
 | `Registered` | `ensure_registries()` 导入后的 `registry.list_registered_envs()` 中存在该 env/backend。 |
 | `Configured` | 存在对应的 owner YAML：`conf/{ppo,appo,offpolicy}/task/...`。 |
-| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合。这里的 `Tested` 包含 config compose 与脚本/运行时测试，不等同于默认推荐路径。 |
+| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合，或存在显式 maintainer 完整训练验证并具备近风险自动化测试。这里的 `Tested` 不等同于默认推荐路径。 |
 | `Benchmarked` | 存在与该组合绑定的已提交 benchmark manifest。 |
 | `Recommended` | 仓库中存在显式 recommendation 元数据。 |
 
-`Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。
+`Tested` 只描述仓库中已有自动化覆盖或显式 maintainer 训练验证，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。
 
-`mjwarp` 只为 `g1_walk_flat` 提供 Configured host adapter；它已测试通过显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，但不支持 `auto`、interactive 或 native playback。通用 compose 和该 playback 覆盖不会把 entrypoint 支持等级提升到 `Tested`，当前仍封顶为 `Configured`。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
+`mjwarp` 只支持 `g1_walk_flat` host adapter。PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`；PPO (mlx) 仍为 `Configured`。mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
 
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
@@ -57,7 +57,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
 | PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
 | PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested |
-| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested |
+| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
 | PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
 | PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested |
 | PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested |
@@ -128,7 +128,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered |
 | APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested |
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
-| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Tested |
+| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
 | SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
 | SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
@@ -153,6 +153,7 @@ uv run scripts/generate_support_matrix.py --write
 - Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.base.registry.ensure_registries()`.
 - Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/offpolicy/task/**`.
 - Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.
+- Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.
 - MLX-specific compose coverage only upgrades task owners listed in `tests/config/test_config_system.py::_PPO_MLX_TASKS`: `go1_joystick_flat`, `go2_joystick_flat`, `g1_walk_flat`.
 - MLX runtime smoke: `tests/algos/test_mlx_ppo.py::test_mlx_ppo_one_iteration_real_env` currently exercises `go2_joystick_flat/mujoco`.
 <!-- END GENERATED SUPPORT MATRIX -->

--- a/src/unilab/training/retirement.py
+++ b/src/unilab/training/retirement.py
@@ -49,8 +49,8 @@ _MIGRATION_HINT = (
     "The production device-resident mjwarp runtime (runtime_impl "
     f"{RETIRED_RUNTIME_IMPL!r}, execution_profile {RETIRED_EXECUTION_PROFILE!r}, "
     f"resolver {RETIRED_RESOLVER_FRAGMENT!r}) was retired in issue #886 and no "
-    "longer exists. task=g1_walk_flat/mjwarp now selects the Configured "
-    "backend-neutral host adapter; device-resident artifacts are incompatible "
+    "longer exists. task=g1_walk_flat/mjwarp now selects the backend-neutral "
+    "host adapter; device-resident artifacts are incompatible "
     "with it and must be retrained."
 )
 

--- a/src/unilab/utils/support_matrix.py
+++ b/src/unilab/utils/support_matrix.py
@@ -17,6 +17,15 @@ BEGIN_MARKER = "<!-- BEGIN GENERATED SUPPORT MATRIX -->"
 END_MARKER = "<!-- END GENERATED SUPPORT MATRIX -->"
 BACKENDS: tuple[str, ...] = ("mujoco", "mjwarp", "motrix")
 
+# Maintainer-confirmed completed training validations. Keep this mapping narrow:
+# generic config/contract coverage must not promote an unvalidated entrypoint.
+_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS = frozenset(
+    {
+        ("ppo_torch", "g1_walk_flat"),
+        ("sac_torch", "g1_walk_flat"),
+    }
+)
+
 _TASK_ORDER = {
     "go1_joystick_flat": 0,
     "go2_joystick_flat": 1,
@@ -209,7 +218,10 @@ def _configured_entries(root: Path, spec: EntrypointSpec) -> dict[str, dict[str,
 
 def _is_tested(spec: EntrypointSpec, task_slug: str, backend: str, root: Path) -> bool:
     if backend == "mjwarp":
-        return False
+        return (
+            spec.entrypoint_id,
+            task_slug,
+        ) in _MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS
     if spec.entrypoint_id == "ppo_mlx":
         return task_slug in _mlx_tested_task_slugs(root)
     return spec.generic_tested
@@ -298,18 +310,18 @@ def render_support_matrix(root: Path | None = None) -> str:
         "|------|--------------|",
         "| `Registered` | `ensure_registries()` 导入后的 `registry.list_registered_envs()` 中存在该 env/backend。 |",
         "| `Configured` | 存在对应的 owner YAML：`conf/{ppo,appo,offpolicy}/task/...`。 |",
-        "| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合。这里的 `Tested` 包含 config compose 与脚本/运行时测试，不等同于默认推荐路径。 |",
+        "| `Tested` | `tests/` 中有自动化覆盖该 entrypoint/task owner/backend 组合，或存在显式 maintainer 完整训练验证并具备近风险自动化测试。这里的 `Tested` 不等同于默认推荐路径。 |",
         "| `Benchmarked` | 存在与该组合绑定的已提交 benchmark manifest。 |",
         "| `Recommended` | 仓库中存在显式 recommendation 元数据。 |",
         "",
-        "`Tested` 只描述仓库中已有自动化覆盖，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；"
-        "例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。",
+        "`Tested` 只描述仓库中已有自动化覆盖或显式 maintainer 训练验证，不代表该组合具备同名 MuJoCo "
+        "owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。",
         "",
-        "`mjwarp` 只为 `g1_walk_flat` 提供 Configured host adapter；它已测试通过显式、有限步数的 `record`"
-        " 并复用 MuJoCo 离线 renderer，但不支持 `auto`、interactive 或 native playback。通用 compose 和该"
-        " playback 覆盖不会把 entrypoint 支持等级提升到 `Tested`，当前仍封顶为 `Configured`。其他"
-        " entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、"
-        "完整 DR 或 production training 支持。",
+        "`mjwarp` 只支持 `g1_walk_flat` host adapter。PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 "
+        "backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`；PPO (mlx) 仍为 `Configured`。"
+        "mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、"
+        "interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry "
+        "identity，不代表对应算法、terrain、完整 DR 或 production training 支持。",
         "",
         benchmark_note,
         recommendation_note,
@@ -335,6 +347,7 @@ def render_support_matrix(root: Path | None = None) -> str:
             "- Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.base.registry.ensure_registries()`.",
             "- Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/offpolicy/task/**`.",
             "- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.",
+            "- Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.",
             "- MLX-specific compose coverage only upgrades task owners listed in `tests/config/test_config_system.py::_PPO_MLX_TASKS`: "
             + ", ".join(f"`{task}`" for task in mlx_tested_tasks)
             + ".",

--- a/tests/base/test_mjwarp_playback.py
+++ b/tests/base/test_mjwarp_playback.py
@@ -77,7 +77,7 @@ def test_mjwarp_plan_is_explicit_and_finite() -> None:
 def test_g1_mjwarp_owner_enables_explicit_record_profile() -> None:
     owner = OmegaConf.load(REPO_ROOT / "conf" / "ppo" / "task" / "g1_walk_flat" / "mjwarp.yaml")
 
-    assert owner.training.no_play is False
+    assert OmegaConf.select(owner, "training.no_play") is None
     assert owner.training.play_render_mode == "record"
     assert owner.play_profile.enabled is True
     assert owner.play_profile.env.render_spacing == 2.0

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -303,6 +303,35 @@ def test_offpolicy_g1_walk_flat_motrix_preserves_backend_specific_algo_value():
     assert motrix_cfg.algo.use_symmetry is False
 
 
+def test_offpolicy_g1_walk_flat_mjwarp_owner_preserves_sac_contract():
+    mujoco_cfg = _compose("offpolicy", overrides=["algo=sac", "task=sac/g1_walk_flat/mujoco"])
+    mjwarp_cfg = _compose("offpolicy", overrides=["algo=sac", "task=sac/g1_walk_flat/mjwarp"])
+
+    assert mjwarp_cfg.training.sim_backend == "mjwarp"
+    assert mjwarp_cfg.training.no_play is False
+    assert mjwarp_cfg.training.play_render_mode == "record"
+    assert mjwarp_cfg.algo.num_envs == mujoco_cfg.algo.num_envs
+    assert mjwarp_cfg.algo.use_symmetry is mujoco_cfg.algo.use_symmetry is True
+    assert mjwarp_cfg.env.control_config.action_scale == pytest.approx(
+        mujoco_cfg.env.control_config.action_scale
+    )
+    assert mjwarp_cfg.env.mjwarp_nconmax == 128
+    assert mjwarp_cfg.env.mjwarp_njmax == 256
+    assert mjwarp_cfg.env.render_spacing == pytest.approx(2.0)
+    assert mjwarp_cfg.env.domain_rand.randomize_kp is False
+    assert mjwarp_cfg.env.domain_rand.randomize_kd is False
+    assert OmegaConf.to_container(mjwarp_cfg.reward, resolve=True) == OmegaConf.to_container(
+        mujoco_cfg.reward, resolve=True
+    )
+
+
+def test_ppo_g1_mjwarp_inherits_enabled_playback_default():
+    cfg = _compose("ppo", overrides=["task=g1_walk_flat/mjwarp"])
+
+    assert cfg.training.no_play is False
+    assert cfg.training.play_render_mode == "record"
+
+
 def test_ppo_g1_backend_specific_hyperparams_remain_separate():
     mujoco_cfg = _compose("ppo", overrides=["task=g1_walk_flat/mujoco"])
     motrix_cfg = _compose("ppo", overrides=["task=g1_walk_flat/motrix"])

--- a/tests/envs/locomotion/g1/test_issue175_regression.py
+++ b/tests/envs/locomotion/g1/test_issue175_regression.py
@@ -69,6 +69,16 @@ _G1_OWNER_CASES = [
         "curriculum_enabled": True,
     },
     {
+        "id": "sac_mjwarp",
+        "config_group": "offpolicy",
+        "overrides": ["algo=sac", "task=sac/g1_walk_flat/mjwarp"],
+        "task_name": "G1WalkFlat",
+        "backend": "mjwarp",
+        "profile": "walk",
+        "action_scale": 1.0,
+        "curriculum_enabled": True,
+    },
+    {
         "id": "sac_rough",
         "config_group": "offpolicy",
         "overrides": ["algo=sac", "task=sac/g1_walk_rough/mujoco"],

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -21,19 +21,29 @@ def test_support_matrix_marks_go2_ppo_backends_as_tested():
     assert row.cells["motrix"].level == EvidenceLevel.TESTED
 
 
-def test_support_matrix_caps_g1_mjwarp_at_configured():
+def test_support_matrix_marks_validated_g1_mjwarp_entrypoints_as_tested():
     torch_row = _row("PPO (torch)", "g1_walk_flat")
     mlx_row = _row("PPO (mlx)", "g1_walk_flat")
+    sac_row = _row("SAC (torch)", "g1_walk_flat")
 
     assert BACKENDS == ("mujoco", "mjwarp", "motrix")
-    assert torch_row.cells["mjwarp"].level == EvidenceLevel.CONFIGURED
+    assert torch_row.cells["mjwarp"].level == EvidenceLevel.TESTED
     assert mlx_row.cells["mjwarp"].level == EvidenceLevel.CONFIGURED
+    assert sac_row.cells["mjwarp"].level == EvidenceLevel.TESTED
 
 
-def test_support_matrix_does_not_promote_mjwarp_from_generic_coverage():
+def test_support_matrix_does_not_promote_unvalidated_mjwarp_entries():
     rows = build_support_rows(Path(__file__).resolve().parents[2])
 
-    assert all(row.cells["mjwarp"].level <= EvidenceLevel.CONFIGURED for row in rows)
+    tested = {
+        (row.entrypoint_label, row.task_slug)
+        for row in rows
+        if row.cells["mjwarp"].level >= EvidenceLevel.TESTED
+    }
+    assert tested == {
+        ("PPO (torch)", "g1_walk_flat"),
+        ("SAC (torch)", "g1_walk_flat"),
+    }
     appo_row = _row("APPO (torch)", "g1_walk_flat")
     assert appo_row.cells["mjwarp"].level == EvidenceLevel.REGISTERED
 


### PR DESCRIPTION
## Summary

- add a SAC `g1_walk_flat/mjwarp` owner with backend-safe randomization, capacity, reward, and offline record settings
- inherit the global enabled playback default instead of repeating `no_play: false` in mjwarp owners
- record maintainer-validated PPO and SAC mjwarp training support as `Tested` while keeping PPO MLX at `Configured`
- refresh the generated support matrix and add owner/compose/support regression coverage

## Validation

- `make test-all`
  - 1922 passed, 56 skipped, 320 deselected, 1 xfailed
  - Ruff format/check passed
  - mypy passed
  - pyright: 0 errors, 4 optional-dependency warnings
  - benchmark smoke passed in module and script modes

CUDA-specific slow tests remain deselected by the repository `test-all` target. PPO and SAC `g1_walk_flat/mjwarp` completed-training validation was confirmed by the maintainer and is recorded explicitly rather than inferred from generic compose coverage.