### PR TITLE
test: validate mjwarp G1 owners

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -717,8 +717,8 @@ class MjwarpBackend(SimBackend):
 
     def _unsupported_body_kinematics(self, operation: str) -> None:
         raise NotImplementedError(
-            f"mjwarp host_numpy profile does not expose {operation}; bind it through a typed "
-            "state plan after its frame and cache contract are implemented."
+            f"mjwarp host_numpy profile does not expose {operation}; the G1 host adapter "
+            "supports only base, dof, and configured sensor cache reads."
         )
 
     def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -7,16 +7,22 @@ instead of treating an unavailable fake implementation as evidence.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
 
+from unilab.base import registry
 from unilab.base.backend import create_backend
 from unilab.base.backend.mjwarp.dependencies import load_mjwarp_dependencies
 from unilab.base.scene import SceneCfg
+from unilab.training.backend_adapter import BackendAdapter
 
 pytestmark = pytest.mark.slow
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _require_cuda_mjwarp() -> None:
@@ -81,3 +87,51 @@ def test_selected_row_reset_isolated() -> None:
     np.testing.assert_allclose(backend.get_base_pos()[complement], previous_pos[complement])
     np.testing.assert_allclose(backend.get_base_lin_vel()[complement], previous_vel[complement])
     assert np.isfinite(backend.get_sensor_data("pelvis_local_linvel")).all()
+
+
+@pytest.mark.parametrize(
+    ("config_group", "overrides", "algo_name"),
+    [
+        pytest.param("ppo", ["task=g1_walk_flat/mjwarp"], "ppo", id="ppo"),
+        pytest.param(
+            "offpolicy",
+            ["algo=sac", "task=sac/g1_walk_flat/mjwarp"],
+            "sac",
+            id="sac",
+        ),
+    ],
+)
+def test_g1_walk_flat_owner_one_step(
+    config_group: str,
+    overrides: list[str],
+    algo_name: str,
+) -> None:
+    _require_cuda_mjwarp()
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(
+        config_dir=str(REPO_ROOT / "conf" / config_group), version_base="1.3"
+    ):
+        cfg = compose("config", overrides=overrides)
+
+    env_cfg_override = BackendAdapter(
+        cfg,
+        root_dir=REPO_ROOT,
+        algo_name=algo_name,
+    ).build_task_env_cfg_override()
+    registry.ensure_registries()
+    env = registry.make(
+        str(cfg.training.task_name),
+        sim_backend=str(cfg.training.sim_backend),
+        env_cfg_override=env_cfg_override,
+        num_envs=2,
+    )
+
+    action_dim = int(env.action_space.shape[-1])
+    state = env.step(np.zeros((2, action_dim), dtype=np.float32))
+
+    assert set(state.obs) == {"obs", "critic"}
+    assert state.obs["obs"].shape == (2, 98)
+    assert state.obs["critic"].shape == (2, 101)
+    assert np.isfinite(state.obs["obs"]).all()
+    assert np.isfinite(state.obs["critic"]).all()
+    assert np.isfinite(state.reward).all()

--- a/tests/envs/locomotion/g1/test_issue175_regression.py
+++ b/tests/envs/locomotion/g1/test_issue175_regression.py
@@ -69,6 +69,16 @@ _G1_OWNER_CASES = [
         "curriculum_enabled": True,
     },
     {
+        "id": "ppo_mjwarp",
+        "config_group": "ppo",
+        "overrides": ["task=g1_walk_flat/mjwarp"],
+        "task_name": "G1WalkFlat",
+        "backend": "mjwarp",
+        "profile": "legacy",
+        "action_scale": 0.25,
+        "curriculum_enabled": False,
+    },
+    {
         "id": "sac_mjwarp",
         "config_group": "offpolicy",
         "overrides": ["algo=sac", "task=sac/g1_walk_flat/mjwarp"],


### PR DESCRIPTION
## Summary

- validate both `G1WalkFlat + PPO + mjwarp` and `G1WalkFlat + SAC + mjwarp` owner composition
- add real-CUDA one-step smoke coverage through `BackendAdapter`, `registry.make`, and `G1WalkEnv`
- keep the maintainer-validated `SAC + mjwarp + G1WalkFlat` training owner
- keep mjwarp offline record through host snapshots and the task owner's MuJoCo visual model; this PR does not add a native or interactive mjwarp renderer
- remove the stale diagnostic that referred to the deleted manager typed-state plan

## Scope

This is the final child PR of #902. It only validates and narrows the retained host adapter after manager/typed-contract removal. It does not remove the SAC owner or offline rendering path, and it does not add a manager runtime, runner/lifecycle, second task, or additional algorithm owner.

## Validation

- `make test-all` — passed (`1665 passed, 61 skipped, 280 deselected, 1 xfailed`)
- `uv run pytest -q -m slow tests/base/test_mjwarp_backend.py tests/base/test_mjwarp_capabilities.py tests/base/test_mjwarp_differential.py` — passed on real CUDA (`11 passed`)
- focused non-CUDA mjwarp owner/import/playback/support/isolation tests — passed (`80 passed`)

Closes #909
