### PR TITLE
feat: add structured term plan runtime

### DIFF
--- a/docs/sphinx/source/adr/ADR-0000-index.md
+++ b/docs/sphinx/source/adr/ADR-0000-index.md
@@ -19,6 +19,7 @@ orphan: true
 | [ADR-0003 Task Owner And Config Compose Contract](ADR-0003-task-owner-and-config-compose-contract.md) | Config owner | Accepted |
 | [ADR-0004 Registry Bootstrap Contract](ADR-0004-registry-bootstrap-contract.md) | Registry bootstrap | Accepted |
 | [ADR-0005 Unified Obs Critic Env And IPC Contract](ADR-0005-unified-obs-critic-env-and-ipc-contract.md) | Observation / IPC | Accepted |
+| [ADR-0006 Structured Term Plan And NumPy Tier 1 Boundary](ADR-0006-structured-term-plan.md) | Term registry / execution | Accepted |
 
 ## ADR Governance
 

--- a/docs/sphinx/source/adr/ADR-0006-structured-term-plan.md
+++ b/docs/sphinx/source/adr/ADR-0006-structured-term-plan.md
@@ -1,0 +1,47 @@
+---
+orphan: true
+---
+
+# ADR-0006 Structured Term Plan And NumPy Tier 1 Boundary
+
+- Status: Accepted
+- Date: 2026-08-05
+- Owners: Env / Performance maintainers
+- Supersedes: None
+- Superseded by: None
+
+## Context
+
+G1 walk 与 motion tracking 的 NumPy table 和手写 Numba kernel 需要最小的 resolved contract，且不能改变 `NpEnv` lifecycle。
+
+## Decision
+
+1. `unilab.term` 只依赖标准库和 NumPy，拥有 plan/Tier 1，不拥有 task lifecycle。
+2. definition 声明 key、tensor/参数和 callable；config 顺序即 canonical order。
+3. cold path 拒绝重复/未知 term、非法参数和冲突 spec；materialization 一次绑定
+   shape/dtype、分配 buffer 并预建 context。
+4. scale 是 runtime 值；零值跳过 callable，其他数值输出原地乘 scale，termination 只允许 `0/1`。
+5. Numba item 参数顺序固定；后续 Tier 2 必须自动对拍。
+
+## Stable Contracts
+
+- warm `execute()` 只访问 resolved terms/数组；task owner 继续负责 combine 和 lifecycle。
+- 缺失 Numba item 在 Tier 1 合法；Tier 2 必须显式 fail closed，不能静默混跑。
+
+## Alternatives Considered
+
+- manager/compiler 或 DSL：拒绝，复杂度与双 pilot 不成比例。
+- Python 逐 env 调用 item：拒绝，会丢失 vectorized authoring。
+- 继续手工同步 table/order/kernel：拒绝，无法形成 resolved plan。
+
+## Consequences
+
+只交付 synthetic Tier 1；真实 task/Numba assembler 分属后续 issue。
+
+## Evidence In Repo
+
+- `src/unilab/term/`、`tests/term/`；GitHub issues `#918`、`#919`
+
+## Related Documents
+
+- {doc}`ADR Index </adr/ADR-0000-index>`

--- a/src/unilab/term/__init__.py
+++ b/src/unilab/term/__init__.py
@@ -1,0 +1,30 @@
+from .errors import TermBindingError, TermPlanError, TermRegistrationError
+from .plan import ResolvedTermPlan, resolve_term_plan
+from .registry import TermRegistry
+from .spec import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+)
+
+__all__ = [
+    "NamedTensorSpec",
+    "NumpyTermContext",
+    "ParameterKind",
+    "ParameterSpec",
+    "ResolvedTermPlan",
+    "TensorSpec",
+    "TermBindingError",
+    "TermConfig",
+    "TermDefinition",
+    "TermKind",
+    "TermPlanError",
+    "TermRegistrationError",
+    "TermRegistry",
+    "resolve_term_plan",
+]

--- a/src/unilab/term/errors.py
+++ b/src/unilab/term/errors.py
@@ -1,0 +1,17 @@
+"""Stable diagnostics for structured term registration and execution."""
+
+
+class TermContractError(ValueError):
+    """Base class for invalid term definitions, plans, or bound views."""
+
+
+class TermRegistrationError(TermContractError):
+    """Raised when a registry entry violates the definition contract."""
+
+
+class TermPlanError(TermContractError):
+    """Raised when configured terms cannot form one deterministic plan."""
+
+
+class TermBindingError(TermContractError):
+    """Raised when runtime arrays do not satisfy a resolved plan."""

--- a/src/unilab/term/plan.py
+++ b/src/unilab/term/plan.py
@@ -1,0 +1,221 @@
+"""Cold-path term resolution and pre-bound NumPy Tier 1 execution."""
+
+from __future__ import annotations
+
+import math
+import numbers
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+
+from .errors import TermBindingError, TermContractError, TermPlanError, TermRegistrationError
+from .registry import TermRegistry
+from .spec import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterValue,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedTerm:
+    name: str
+    definition: TermDefinition
+    scale: float
+    parameters: Mapping[str, ParameterValue]
+
+
+@dataclass(frozen=True)
+class ResolvedTermPlan:
+    terms: tuple[ResolvedTerm, ...]
+    input_specs: Mapping[str, TensorSpec]
+    workspace_specs: Mapping[str, TensorSpec]
+    output_specs: Mapping[str, TensorSpec]
+
+    def materialize(self, *, num_envs: int, inputs: Mapping[str, np.ndarray]) -> NumpyTermRuntime:
+        """Validate input views once and allocate all owned buffers."""
+        if isinstance(num_envs, bool) or not isinstance(num_envs, numbers.Integral) or num_envs < 1:
+            raise TermBindingError(f"num_envs must be a positive integer; got {num_envs!r}")
+        count = int(num_envs)
+        bound_inputs: dict[str, np.ndarray] = {}
+        for name, spec in self.input_specs.items():
+            view = inputs.get(name)
+            if not isinstance(view, np.ndarray):
+                raise TermBindingError(f"missing ndarray input {name!r}")
+            expected_shape = (count, *spec.shape)
+            if view.shape != expected_shape:
+                raise TermBindingError(
+                    f"input {name!r} shape mismatch: {expected_shape} != {view.shape}"
+                )
+            if view.dtype != spec.numpy_dtype:
+                raise TermBindingError(
+                    f"input {name!r} dtype mismatch: {spec.numpy_dtype} != {view.dtype}"
+                )
+            bound_inputs[name] = view
+
+        outputs = _allocate(self.output_specs, count)
+        workspace = _allocate(self.workspace_specs, count)
+        bound: list[_BoundTerm] = []
+        for term in self.terms:
+            definition = term.definition
+            context = NumpyTermContext(
+                inputs=_select(definition.inputs, bound_inputs),
+                parameters=term.parameters,
+                output=outputs[term.name],
+                workspace=_select(definition.workspace, workspace),
+            )
+            bound.append(_BoundTerm(term=term, context=context))
+        return NumpyTermRuntime(terms=tuple(bound), outputs=outputs, workspace=workspace)
+
+
+@dataclass(frozen=True)
+class _BoundTerm:
+    term: ResolvedTerm
+    context: NumpyTermContext
+
+
+class NumpyTermRuntime:
+    """Pre-bound, allocation-stable Python dispatcher for vectorized terms."""
+
+    def __init__(
+        self,
+        *,
+        terms: tuple[_BoundTerm, ...],
+        outputs: dict[str, np.ndarray],
+        workspace: dict[str, np.ndarray],
+    ) -> None:
+        self._terms = terms
+        self._indices = {bound.term.name: index for index, bound in enumerate(terms)}
+        self._scales = np.asarray([bound.term.scale for bound in terms], dtype=np.float64)
+        self.outputs: Mapping[str, np.ndarray] = MappingProxyType(outputs)
+        self.workspace: Mapping[str, np.ndarray] = MappingProxyType(workspace)
+
+    def set_scale(self, name: str, scale: float) -> None:
+        """Update one runtime scale without rebuilding the resolved plan."""
+        index = self._indices.get(name)
+        if index is None:
+            raise TermBindingError(f"unknown term instance {name!r}")
+        self._scales[index] = _validate_scale(
+            self._terms[index].term.definition, scale, name=name, error_type=TermBindingError
+        )
+
+    def execute(self) -> Mapping[str, np.ndarray]:
+        """Execute in config order using only pre-bound views and buffers."""
+        for index, bound in enumerate(self._terms):
+            scale = self._scales[index]
+            output = bound.context.output
+            if scale == 0.0:
+                output.fill(0)
+                continue
+            bound.term.definition.numpy_fn(bound.context)
+            if scale != 1.0:
+                np.multiply(output, scale, out=output)
+        return self.outputs
+
+
+def resolve_term_plan(registry: TermRegistry, configs: Sequence[TermConfig]) -> ResolvedTermPlan:
+    """Resolve config declaration order into one immutable execution plan."""
+    terms: list[ResolvedTerm] = []
+    seen_names: set[str] = set()
+    input_specs: dict[str, TensorSpec] = {}
+    workspace_specs: dict[str, TensorSpec] = {}
+    output_specs: dict[str, TensorSpec] = {}
+
+    for config in configs:
+        if config.name in seen_names:
+            raise TermPlanError(f"duplicate term instance name {config.name!r}")
+        seen_names.add(config.name)
+        definition = registry.resolve(config.term_key)
+        parameters = _resolve_parameters(definition, config.parameters)
+        scale = _validate_scale(definition, config.scale, name=config.name)
+        for item in definition.inputs:
+            _merge_tensor_spec(input_specs, item, owner=definition.key, category="input")
+        for item in definition.workspace:
+            _merge_tensor_spec(workspace_specs, item, owner=definition.key, category="workspace")
+        terms.append(ResolvedTerm(config.name, definition, scale, parameters))
+        output_specs[config.name] = definition.output
+
+    namespace_overlap = set(input_specs) & set(workspace_specs)
+    if namespace_overlap:
+        raise TermPlanError(
+            f"plan uses names as both input and workspace: {sorted(namespace_overlap)}"
+        )
+    return ResolvedTermPlan(
+        terms=tuple(terms),
+        input_specs=MappingProxyType(input_specs),
+        workspace_specs=MappingProxyType(workspace_specs),
+        output_specs=MappingProxyType(output_specs),
+    )
+
+
+def _allocate(specs: Mapping[str, TensorSpec], count: int) -> dict[str, np.ndarray]:
+    return {
+        name: np.zeros((count, *spec.shape), dtype=spec.numpy_dtype) for name, spec in specs.items()
+    }
+
+
+def _select(
+    specs: Sequence[NamedTensorSpec], views: Mapping[str, np.ndarray]
+) -> Mapping[str, np.ndarray]:
+    return MappingProxyType({item.name: views[item.name] for item in specs})
+
+
+def _merge_tensor_spec(
+    merged: dict[str, TensorSpec],
+    item: NamedTensorSpec,
+    *,
+    owner: str,
+    category: str,
+) -> None:
+    existing = merged.get(item.name)
+    if existing is not None and existing != item.tensor:
+        raise TermPlanError(
+            f"{category} {item.name!r} has conflicting specs: {existing!r} vs "
+            f"{item.tensor!r} from term {owner!r}"
+        )
+    merged[item.name] = item.tensor
+
+
+def _resolve_parameters(
+    definition: TermDefinition, configured: Mapping[str, object]
+) -> Mapping[str, ParameterValue]:
+    specs = {item.name: item for item in definition.parameters}
+    unknown = set(configured) - set(specs)
+    if unknown:
+        raise TermPlanError(f"term {definition.key!r} has unknown parameters {sorted(unknown)}")
+    resolved: dict[str, ParameterValue] = {}
+    for name, spec in specs.items():
+        if name in configured:
+            value = configured[name]
+        elif spec.required:
+            raise TermPlanError(f"term {definition.key!r} is missing parameter {name!r}")
+        else:
+            value = spec.default
+        try:
+            resolved[name] = spec.normalize(value)
+        except TermRegistrationError as exc:
+            raise TermPlanError(f"term {definition.key!r}: {exc}") from exc
+    return MappingProxyType(resolved)
+
+
+def _validate_scale(
+    definition: TermDefinition,
+    scale: object,
+    *,
+    name: str,
+    error_type: type[TermContractError] = TermPlanError,
+) -> float:
+    if isinstance(scale, bool) or not isinstance(scale, numbers.Real):
+        raise error_type(f"term {name!r} scale must be a finite scalar")
+    normalized = float(scale)
+    if not math.isfinite(normalized):
+        raise error_type(f"term {name!r} scale must be finite")
+    if definition.kind is TermKind.TERMINATION and normalized not in (0.0, 1.0):
+        raise error_type(f"termination term {name!r} scale must be 0.0 or 1.0; got {normalized}")
+    return normalized

--- a/src/unilab/term/registry.py
+++ b/src/unilab/term/registry.py
@@ -1,0 +1,23 @@
+"""Explicit registry for trusted term implementations."""
+
+from __future__ import annotations
+
+from .errors import TermPlanError, TermRegistrationError
+from .spec import TermDefinition
+
+
+class TermRegistry:
+    def __init__(self) -> None:
+        self._definitions: dict[str, TermDefinition] = {}
+
+    def register(self, definition: TermDefinition) -> TermDefinition:
+        if definition.key in self._definitions:
+            raise TermRegistrationError(f"term key {definition.key!r} is already registered")
+        self._definitions[definition.key] = definition
+        return definition
+
+    def resolve(self, key: str) -> TermDefinition:
+        try:
+            return self._definitions[key]
+        except KeyError as exc:
+            raise TermPlanError(f"unknown term key {key!r}") from exc

--- a/src/unilab/term/spec.py
+++ b/src/unilab/term/spec.py
@@ -1,0 +1,231 @@
+"""Data-only contracts for config-resolved numeric terms."""
+
+from __future__ import annotations
+
+import math
+import numbers
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import DTypeLike
+
+from .errors import TermRegistrationError
+
+_NAME = re.compile(r"^[a-z][a-z0-9_.-]*$")
+ParameterValue: TypeAlias = bool | int | float | str | tuple[bool | int | float | str, ...]
+
+
+class TermKind(str, Enum):
+    REWARD = "reward"
+    OBSERVATION = "observation"
+    TERMINATION = "termination"
+
+
+class ParameterKind(str, Enum):
+    FLOAT = "float"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    STRING = "string"
+
+
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+def _valid_name(value: str, label: str) -> None:
+    if not _NAME.fullmatch(value):
+        raise TermRegistrationError(f"{label} must match {_NAME.pattern!r}; got {value!r}")
+
+
+def _scalar(value: object, kind: ParameterKind, label: str) -> bool | int | float | str:
+    if kind is ParameterKind.BOOLEAN and isinstance(value, bool):
+        return value
+    if kind is ParameterKind.STRING and isinstance(value, str):
+        return value
+    if kind is ParameterKind.INTEGER:
+        if not isinstance(value, bool) and isinstance(value, numbers.Integral):
+            return int(value)
+    if kind is ParameterKind.FLOAT:
+        if not isinstance(value, bool) and isinstance(value, numbers.Real):
+            result = float(value)
+            if math.isfinite(result):
+                return result
+    raise TermRegistrationError(f"{label} must be {kind.value}")
+
+
+def _config_value(value: object, label: str) -> ParameterValue:
+    if isinstance(value, (list, tuple)):
+        items = tuple(_config_value(item, label) for item in value)
+        if any(isinstance(item, tuple) for item in items):
+            raise TermRegistrationError(f"{label} must be a flat scalar tuple")
+        return items  # type: ignore[return-value]
+    if isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    if isinstance(value, numbers.Real) and math.isfinite(float(value)):
+        return float(value)
+    raise TermRegistrationError(f"{label} must be a finite scalar or flat scalar tuple")
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    """Batched tensor shape without the leading environment dimension."""
+
+    shape: tuple[int, ...]
+    dtype: DTypeLike
+
+    def __post_init__(self) -> None:
+        shape = tuple(self.shape)
+        if any(
+            isinstance(dim, bool) or not isinstance(dim, numbers.Integral) or dim <= 0
+            for dim in shape
+        ):
+            raise TermRegistrationError(f"tensor dimensions must be positive: {shape!r}")
+        try:
+            dtype = np.dtype(self.dtype)
+        except TypeError as exc:
+            raise TermRegistrationError(f"invalid tensor dtype {self.dtype!r}") from exc
+        if dtype != np.dtype(np.bool_) and not np.issubdtype(dtype, np.number):
+            raise TermRegistrationError(f"tensor dtype must be numeric or bool; got {dtype.name}")
+        object.__setattr__(self, "shape", tuple(int(dim) for dim in shape))
+        object.__setattr__(self, "dtype", dtype.str)
+
+    @property
+    def numpy_dtype(self) -> np.dtype:
+        return np.dtype(self.dtype)
+
+
+@dataclass(frozen=True)
+class NamedTensorSpec:
+    name: str
+    tensor: TensorSpec
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "tensor name")
+
+
+@dataclass(frozen=True)
+class ParameterSpec:
+    name: str
+    kind: ParameterKind
+    tuple_value: bool = False
+    default: ParameterValue | _Missing = _MISSING
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "parameter name")
+        if not isinstance(self.kind, ParameterKind):
+            raise TermRegistrationError(f"invalid parameter kind {self.kind!r}")
+        if not isinstance(self.default, _Missing):
+            object.__setattr__(self, "default", self.normalize(self.default))
+
+    @property
+    def required(self) -> bool:
+        return isinstance(self.default, _Missing)
+
+    def normalize(self, value: object) -> ParameterValue:
+        label = f"parameter {self.name!r}"
+        if not self.tuple_value:
+            return _scalar(value, self.kind, label)
+        if not isinstance(value, (list, tuple)):
+            raise TermRegistrationError(f"{label} must be a tuple of {self.kind.value}")
+        return tuple(_scalar(item, self.kind, label) for item in value)
+
+
+@dataclass(frozen=True)
+class NumpyTermContext:
+    inputs: Mapping[str, np.ndarray]
+    parameters: Mapping[str, ParameterValue]
+    output: np.ndarray
+    workspace: Mapping[str, np.ndarray]
+
+
+NumpyTermFn: TypeAlias = Callable[[NumpyTermContext], None]
+NumbaItemFn: TypeAlias = Callable[..., None]
+
+
+@dataclass(frozen=True)
+class TermDefinition:
+    """Trusted implementation plus cold-path requirements.
+
+    A future Numba item callable receives inputs, parameters, output, workspace,
+    and row index in declaration order. It is metadata in Tier 1.
+    """
+
+    key: str
+    kind: TermKind
+    numpy_fn: NumpyTermFn
+    output: TensorSpec
+    inputs: tuple[NamedTensorSpec, ...] = field(default_factory=tuple)
+    workspace: tuple[NamedTensorSpec, ...] = field(default_factory=tuple)
+    parameters: tuple[ParameterSpec, ...] = field(default_factory=tuple)
+    numba_item_fn: NumbaItemFn | None = None
+    implementation_version: int = 1
+
+    def __post_init__(self) -> None:
+        _valid_name(self.key, "term key")
+        if not isinstance(self.kind, TermKind) or not callable(self.numpy_fn):
+            raise TermRegistrationError(f"term {self.key!r} has an invalid kind or numpy_fn")
+        if self.numba_item_fn is not None and not callable(self.numba_item_fn):
+            raise TermRegistrationError(f"term {self.key!r} numba_item_fn must be callable")
+        if (
+            isinstance(self.implementation_version, bool)
+            or not isinstance(self.implementation_version, numbers.Integral)
+            or self.implementation_version < 1
+        ):
+            raise TermRegistrationError(f"term {self.key!r} version must be a positive integer")
+        object.__setattr__(self, "implementation_version", int(self.implementation_version))
+        object.__setattr__(self, "inputs", tuple(self.inputs))
+        object.__setattr__(self, "workspace", tuple(self.workspace))
+        object.__setattr__(self, "parameters", tuple(self.parameters))
+        for label, items in (
+            ("input", self.inputs),
+            ("workspace", self.workspace),
+            ("parameter", self.parameters),
+        ):
+            names = [item.name for item in items]
+            if len(names) != len(set(names)):
+                raise TermRegistrationError(f"term {self.key!r} declares duplicate {label}")
+        overlap = {item.name for item in self.inputs} & {item.name for item in self.workspace}
+        if overlap:
+            raise TermRegistrationError(f"term {self.key!r} overlaps input/workspace {overlap}")
+        dtype = self.output.numpy_dtype
+        if self.kind is TermKind.TERMINATION and dtype != np.dtype(np.bool_):
+            raise TermRegistrationError(f"termination term {self.key!r} output must use bool dtype")
+        if self.kind is not TermKind.TERMINATION and not np.issubdtype(dtype, np.floating):
+            raise TermRegistrationError(
+                f"{self.kind.value} term {self.key!r} output must use a floating dtype"
+            )
+
+
+@dataclass(frozen=True)
+class TermConfig:
+    name: str
+    term_key: str
+    scale: float = 1.0
+    parameters: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "term instance name")
+        _valid_name(self.term_key, "term key")
+        if isinstance(self.scale, bool) or not isinstance(self.scale, numbers.Real):
+            raise TermRegistrationError(f"term {self.name!r} scale must be finite")
+        scale = float(self.scale)
+        if not math.isfinite(scale):
+            raise TermRegistrationError(f"term {self.name!r} scale must be finite")
+        parameters = {
+            name: _config_value(value, f"parameter {name!r}")
+            for name, value in self.parameters.items()
+        }
+        for name in parameters:
+            _valid_name(name, "parameter name")
+        object.__setattr__(self, "scale", scale)
+        object.__setattr__(self, "parameters", MappingProxyType(parameters))

--- a/tests/term/test_import_boundary.py
+++ b/tests/term/test_import_boundary.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).parents[2] / "src" / "unilab" / "term"
+BANNED_PREFIXES = (
+    "hydra",
+    "omegaconf",
+    "unilab.algos",
+    "unilab.base",
+    "unilab.envs",
+    "unilab.ipc",
+    "unilab.training",
+)
+
+
+def test_term_package_does_not_import_owner_or_runtime_layers() -> None:
+    violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported = [node.module]
+            else:
+                continue
+            for module in imported:
+                if module.startswith(BANNED_PREFIXES):
+                    violations.append(f"{path.name}:{node.lineno}: {module}")
+
+    assert violations == []

--- a/tests/term/test_plan.py
+++ b/tests/term/test_plan.py
@@ -1,0 +1,197 @@
+from typing import cast
+
+import numpy as np
+import pytest
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    TensorSpec,
+    TermBindingError,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistrationError,
+    TermRegistry,
+    resolve_term_plan,
+)
+
+STATE = NamedTensorSpec("state", TensorSpec((2,), np.float32))
+SCRATCH = NamedTensorSpec("scratch", TensorSpec((), np.float32))
+
+
+def _registry(calls: list[str] | None = None) -> TermRegistry:
+    registry = TermRegistry()
+
+    def reward(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("reward")
+        np.sum(context.inputs["state"], axis=1, out=context.workspace["scratch"])
+        np.multiply(
+            context.workspace["scratch"],
+            cast(float, context.parameters["gain"]),
+            out=context.output,
+        )
+
+    def item(state, gain, output, scratch, index) -> None:
+        scratch[index] = state[index, 0] + state[index, 1]
+        output[index] = scratch[index] * gain
+
+    def observation(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("observation")
+        np.add(
+            context.inputs["state"],
+            cast(tuple[float, ...], context.parameters["offsets"]),
+            out=context.output,
+        )
+
+    def termination(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("termination")
+        np.greater(
+            context.inputs["state"][:, 0],
+            cast(float, context.parameters["threshold"]),
+            out=context.output,
+        )
+
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.sum.v1",
+            TermKind.REWARD,
+            reward,
+            TensorSpec((), np.float32),
+            inputs=(STATE,),
+            workspace=(SCRATCH,),
+            parameters=(ParameterSpec("gain", ParameterKind.FLOAT),),
+            numba_item_fn=item,
+        )
+    )
+    registry.register(
+        TermDefinition(
+            "synthetic.observation.offset.v1",
+            TermKind.OBSERVATION,
+            observation,
+            TensorSpec((2,), np.float32),
+            inputs=(STATE,),
+            workspace=(SCRATCH,),
+            parameters=(
+                ParameterSpec("offsets", ParameterKind.FLOAT, tuple_value=True, default=(0.0, 0.0)),
+            ),
+        )
+    )
+    registry.register(
+        TermDefinition(
+            "synthetic.termination.threshold.v1",
+            TermKind.TERMINATION,
+            termination,
+            TensorSpec((), np.bool_),
+            inputs=(STATE,),
+            parameters=(ParameterSpec("threshold", ParameterKind.FLOAT, default=0.0),),
+        )
+    )
+    return registry
+
+
+def _configs() -> tuple[TermConfig, ...]:
+    return (
+        TermConfig(
+            "actor_offset",
+            "synthetic.observation.offset.v1",
+            parameters={"offsets": [0.5, -0.5]},
+        ),
+        TermConfig(
+            "tracking_reward",
+            "synthetic.reward.sum.v1",
+            scale=2.0,
+            parameters={"gain": 0.25},
+        ),
+        TermConfig("fell", "synthetic.termination.threshold.v1", parameters={"threshold": 2.0}),
+    )
+
+
+def test_plan_executes_in_config_order_and_reuses_buffers() -> None:
+    calls: list[str] = []
+    state = np.array([[1.0, 3.0], [4.0, -2.0]], dtype=np.float32)
+    runtime = resolve_term_plan(_registry(calls), _configs()).materialize(
+        num_envs=2, inputs={"state": state}
+    )
+    outputs = runtime.execute()
+    ids = [id(value) for value in (*outputs.values(), *runtime.workspace.values())]
+
+    assert calls == ["observation", "reward", "termination"]
+    assert tuple(outputs) == ("actor_offset", "tracking_reward", "fell")
+    np.testing.assert_array_equal(outputs["actor_offset"], [[1.5, 2.5], [4.5, -2.5]])
+    np.testing.assert_array_equal(outputs["tracking_reward"], [2.0, 1.0])
+    np.testing.assert_array_equal(outputs["fell"], [False, True])
+    definition = _registry().resolve("synthetic.reward.sum.v1")
+    item_output, item_scratch = np.empty(2, np.float32), np.empty(2, np.float32)
+    assert definition.numba_item_fn is not None
+    for index in range(2):
+        definition.numba_item_fn(state, 0.25, item_output, item_scratch, index)
+    np.testing.assert_array_equal(item_output, outputs["tracking_reward"] / 2.0)
+
+    calls.clear()
+    runtime.set_scale("tracking_reward", 0.0)
+    state += 1.0
+    assert runtime.execute() is outputs
+    assert calls == ["observation", "termination"]
+    assert [id(value) for value in (*outputs.values(), *runtime.workspace.values())] == ids
+    np.testing.assert_array_equal(outputs["tracking_reward"], 0.0)
+
+
+@pytest.mark.parametrize(
+    ("configs", "message"),
+    [
+        ((TermConfig("x", "synthetic.reward.unknown.v1"),), "unknown term key"),
+        ((TermConfig("x", "synthetic.reward.sum.v1"),), "missing parameter"),
+        (
+            (TermConfig("x", "synthetic.reward.sum.v1", parameters={"gain": "fast"}),),
+            "must be float",
+        ),
+        ((TermConfig("x", "synthetic.termination.threshold.v1", scale=0.5),), "0.0 or 1.0"),
+    ],
+)
+def test_plan_rejects_invalid_config(configs, message: str) -> None:
+    with pytest.raises(TermPlanError, match=message):
+        resolve_term_plan(_registry(), configs)
+
+
+def test_plan_rejects_conflicting_workspace_specs() -> None:
+    registry = _registry()
+
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.conflict.v1",
+            TermKind.REWARD,
+            lambda context: context.output.fill(0),
+            TensorSpec((), np.float32),
+            inputs=(STATE,),
+            workspace=(NamedTensorSpec("scratch", TensorSpec((2,), np.float64)),),
+        )
+    )
+    configs = (
+        TermConfig("obs", "synthetic.observation.offset.v1"),
+        TermConfig("conflict", "synthetic.reward.conflict.v1"),
+    )
+    with pytest.raises(TermPlanError, match="workspace 'scratch' has conflicting specs"):
+        resolve_term_plan(registry, configs)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "message"),
+    [
+        ({"state": np.zeros((3, 2), np.float32)}, "shape mismatch"),
+        ({"state": np.zeros((2, 2), np.float64)}, "dtype mismatch"),
+    ],
+)
+def test_materialize_rejects_invalid_bound_views(inputs, message: str) -> None:
+    plan = resolve_term_plan(_registry(), _configs())
+    with pytest.raises(TermBindingError, match=message):
+        plan.materialize(num_envs=2, inputs=inputs)
+
+
+def test_registry_rejects_duplicate_key() -> None:
+    registry = _registry()
+    with pytest.raises(TermRegistrationError, match="already registered"):
+        registry.register(registry.resolve("synthetic.reward.sum.v1"))


### PR DESCRIPTION
## Summary

- add an internal `unilab.term` contract for stable term keys, categories, parameters, tensor/output/workspace specs, and optional Numba item-function metadata
- resolve config-ordered immutable plans with fail-closed validation for duplicate/unknown keys, parameters, shapes, dtypes, and workspace conflicts
- materialize pre-bound NumPy Tier 1 execution with reusable buffers, runtime scale updates, zero-scale skip semantics, and reward/observation/termination coverage
- document the deliberately small architecture and its boundaries in ADR-0006

## Scope / non-goals

This PR uses synthetic fixtures only. It does not migrate G1 walk or motion tracking, add Numba code generation or caching, change `NpEnv`, backend, runner/lifecycle, training ABI, sim2sim/checkpoint behavior, or introduce a general DAG/compiler/DSL.

The implementation is 9 files and 798 inserted lines, within the issue limit.

## Validation

- term-focused coverage: 90%
- local term and documentation checks passed
- `make test-all` passed:
  - 1658 passed
  - 37 skipped
  - 280 deselected
  - 1 xfailed
  - benchmark smoke, module mode: 34/35 (one optional MLX skip)
  - benchmark smoke, script mode: 35/36 (one optional MLX skip)
- Ruff, mypy, and pyright passed
- pyright reported only the existing optional `mlx.core` unresolved warning

Closes #919
