### PR TITLE
feat: migrate G1 walk numpy path to term plan

### DIFF
--- a/conf/ppo/task/g1_walk_flat/mujoco.yaml
+++ b/conf/ppo/task/g1_walk_flat/mujoco.yaml
@@ -16,6 +16,11 @@ algo:
     critic_hidden_dims: [512, 256, 128]
 env:
   numba_acceleration: false
+  term_plan:
+    observations:
+      obs: [g1.walk.observation.actor_gyro.v1, g1.walk.observation.actor_gravity.v1, g1.walk.observation.actor_dof_pos.v1, g1.walk.observation.actor_dof_vel.v1, g1.walk.observation.actor_actions.v1, g1.walk.observation.actor_commands.v1, g1.walk.observation.actor_gait_phase.v1]
+      critic: [g1.walk.observation.critic_gyro.v1, g1.walk.observation.critic_gravity.v1, g1.walk.observation.critic_dof_pos.v1, g1.walk.observation.critic_dof_vel.v1, g1.walk.observation.critic_actions.v1, g1.walk.observation.critic_commands.v1, g1.walk.observation.critic_gait_phase.v1, g1.walk.observation.critic_linvel.v1]
+    terminations: [g1.walk.termination.tilt_or_height.v1]
   control_config:
     action_scale: 0.25
   curriculum:

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -27,6 +27,15 @@ from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
+from unilab.envs.locomotion.g1.terms import (
+    DEFAULT_OBSERVATION_TERMS,
+    DEFAULT_TERMINATION_TERMS,
+    compute_feet_phase_contact_targets,
+    compute_feet_phase_height_targets,
+    compute_forward_command_mask,
+    compute_forward_speed_gate,
+    resolve_g1_walk_term_plan,
+)
 
 
 @dataclass
@@ -75,31 +84,6 @@ def build_upper_body_pose_weights(pose_weights: list[float]) -> np.ndarray:
     return np.asarray(weights, dtype=get_global_dtype())
 
 
-def compute_feet_phase_height_targets(
-    gait_phase: np.ndarray, swing_height: float
-) -> tuple[np.ndarray, np.ndarray]:
-    def cubic_bezier_height(phi: np.ndarray, swing_height: float) -> np.ndarray:
-        phi_normalized = np.fmod(phi + np.pi, 2 * np.pi) - np.pi
-        x = (phi_normalized + np.pi) / (2 * np.pi)
-
-        def cubic_bezier_interpolation(
-            y_start: np.ndarray, y_end: np.ndarray, t: np.ndarray
-        ) -> np.ndarray:
-            y_diff = y_end - y_start
-            bezier = t**3 + 3 * (t**2 * (1 - t))
-            return np.asarray(y_start + y_diff * bezier, dtype=get_global_dtype())
-
-        stance = cubic_bezier_interpolation(np.zeros_like(x), np.full_like(x, swing_height), 2 * x)
-        swing = cubic_bezier_interpolation(
-            np.full_like(x, swing_height), np.zeros_like(x), 2 * x - 1
-        )
-        return np.where(x <= 0.5, stance, swing)
-
-    left_target = cubic_bezier_height(gait_phase[:, 0], swing_height)
-    right_target = cubic_bezier_height(gait_phase[:, 1], swing_height)
-    return left_target, right_target
-
-
 LEFT_FOOT_CONTACT_SENSORS = [f"left_foot_contact_{i}" for i in range(4)]
 RIGHT_FOOT_CONTACT_SENSORS = [f"right_foot_contact_{i}" for i in range(4)]
 
@@ -116,23 +100,6 @@ def _scalarize_sensor_values(sensor_values: np.ndarray) -> np.ndarray:
 def compute_aggregated_foot_contact(backend: Any, sensor_names: list[str]) -> np.ndarray:
     contacts = [_scalarize_sensor_values(backend.get_sensor_data(name)) for name in sensor_names]
     return np.asarray(np.any(np.stack(contacts, axis=1) > 0.5, axis=1), dtype=np.bool_)
-
-
-def compute_feet_phase_contact_targets(
-    gait_phase: np.ndarray, swing_height: float
-) -> tuple[np.ndarray, np.ndarray]:
-    left_target, right_target = compute_feet_phase_height_targets(gait_phase, swing_height)
-    contact_height_threshold = swing_height * 0.5
-    return left_target <= contact_height_threshold, right_target <= contact_height_threshold
-
-
-def compute_forward_speed_gate(linvel: np.ndarray, min_forward_speed: float) -> np.ndarray:
-    forward_speed = np.maximum(linvel[:, 0], 0.0)
-    return np.asarray(forward_speed >= min_forward_speed, dtype=get_global_dtype())
-
-
-def compute_forward_command_mask(commands: np.ndarray) -> np.ndarray:
-    return np.asarray(np.maximum(commands[:, 0], 0.0) > 1.0e-6, dtype=get_global_dtype())
 
 
 @dataclass
@@ -199,6 +166,16 @@ class CurriculumConfig:
 
 
 @dataclass
+class G1WalkTermPlanConfig:
+    observations: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            name: list(terms) for name, terms in DEFAULT_OBSERVATION_TERMS.items()
+        }
+    )
+    terminations: list[str] = field(default_factory=lambda: list(DEFAULT_TERMINATION_TERMS))
+
+
+@dataclass
 class G1WalkEnvCfg(G1BaseCfg):
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
@@ -215,6 +192,7 @@ class G1WalkEnvCfg(G1BaseCfg):
     curriculum: CurriculumConfig = field(default_factory=CurriculumConfig)
     numba_acceleration: bool = False
     numba_num_threads: int | None = None
+    term_plan: G1WalkTermPlanConfig | None = None
 
 
 class G1WalkDomainRandomizationProvider(LocomotionDRProvider):
@@ -324,6 +302,10 @@ class G1WalkEnv(G1BaseEnv):
             )
 
         self._init_reward_functions()
+        self._resolved_terms: Any = None
+        self._term_runtime: Any = None
+        if cfg.term_plan is not None and not cfg.numba_acceleration:
+            self._init_term_plan(cfg.term_plan)
         self._numba_accelerator = None
         if cfg.numba_acceleration:
             from unilab.envs.locomotion.g1.joystick_numba import G1WalkNumbaAccelerator
@@ -347,8 +329,52 @@ class G1WalkEnv(G1BaseEnv):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
+        if getattr(self, "_resolved_terms", None) is not None:
+            return dict(self._resolved_terms.observation_dims)
         # gyro(3) + gravity(3) + diff(29) + dof_vel(29) + action(29) + cmd(3) + phase(2) = 98
         return {"obs": 98, "critic": 101}
+
+    def _init_term_plan(self, config: G1WalkTermPlanConfig) -> None:
+        resolved = resolve_g1_walk_term_plan(
+            num_action=self._num_action,
+            reward_cfg=self._reward_cfg,
+            observations=config.observations,
+            terminations=config.terminations,
+            walk_profile=self._uses_walk_observation_profile(),
+        )
+        inputs = {
+            name: np.zeros((self._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (
+            ("default_angles", self.default_angles),
+            ("pose_weights", self._pose_weights),
+            ("upper_body_pose_weights", self._upper_body_pose_weights),
+        ):
+            if name in inputs:
+                np.copyto(inputs[name], np.broadcast_to(value, inputs[name].shape))
+        runtime = resolved.plan.materialize(num_envs=self._num_envs, inputs=inputs)
+        obs = {
+            group: np.empty((self._num_envs, width), dtype=get_global_dtype())
+            for group, width in resolved.observation_dims.items()
+        }
+        self._resolved_terms = resolved
+        self._term_inputs = inputs
+        self._term_runtime = runtime
+        self._term_obs = obs
+        self._term_reward = np.empty((self._num_envs,), dtype=get_global_dtype())
+        self._term_terminated = np.empty((self._num_envs,), dtype=np.bool_)
+        self._sync_term_reward_scales()
+
+    def _sync_term_reward_scales(self) -> None:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        active = []
+        for reward_name, output_name in self._resolved_terms.reward_outputs:
+            scale = self._reward_cfg.scales[reward_name]
+            self._term_runtime.set_scale(output_name, scale)
+            if scale != 0.0:
+                active.append((reward_name, output_name))
+        self._active_term_rewards = tuple(active)
 
     def _init_reward_functions(self):
         self._reward_fns: dict[str, Any] = {
@@ -404,14 +430,19 @@ class G1WalkEnv(G1BaseEnv):
             obs = accel_result.obs
             state.info["log"] = accel_result.log
         else:
-            max_tilt_rad = np.deg2rad(self._reward_cfg.max_tilt_deg)
-            tilt = np.arccos(np.clip(gravity[:, 2], -1, 1))
-            terminated = np.logical_or(
-                tilt > max_tilt_rad,
-                self._terrain_relative_base_height() < self._reward_cfg.min_base_height,
-            )
-            reward = self._compute_reward(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
-            obs = self._compute_obs(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
+            if self._term_runtime is not None:
+                obs, reward, terminated = self._compute_term_state(
+                    state.info, linvel, gyro, gravity, dof_pos, dof_vel
+                )
+            else:
+                max_tilt_rad = np.deg2rad(self._reward_cfg.max_tilt_deg)
+                tilt = np.arccos(np.clip(gravity[:, 2], -1, 1))
+                terminated = np.logical_or(
+                    tilt > max_tilt_rad,
+                    self._terrain_relative_base_height() < self._reward_cfg.min_base_height,
+                )
+                reward = self._compute_reward(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
+                obs = self._compute_obs(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
 
         state = state.replace(obs=obs, reward=reward, terminated=terminated)
 
@@ -423,6 +454,8 @@ class G1WalkEnv(G1BaseEnv):
         episode_lengths = state.info["steps"][done_indices] + 1
         self._episode_tracker.update(episode_lengths)
         self._penalty_curriculum.update(self._episode_tracker.average_length)
+        if getattr(self, "_term_runtime", None) is not None:
+            self._sync_term_reward_scales()
 
         if "log" not in state.info:
             state.info["log"] = {}
@@ -434,7 +467,152 @@ class G1WalkEnv(G1BaseEnv):
         )
         return state
 
+    @staticmethod
+    def _copy_term_input(inputs: dict[str, np.ndarray], name: str, value: np.ndarray) -> None:
+        if name in inputs:
+            np.copyto(inputs[name], value, casting="same_kind")
+
+    def _populate_term_inputs(
+        self,
+        inputs: dict[str, np.ndarray],
+        info: dict,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        gravity: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+    ) -> None:
+        copy = self._copy_term_input
+        for name, value in (
+            ("linvel", linvel),
+            ("gyro", gyro),
+            ("gravity", gravity),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+        ):
+            copy(inputs, name, value)
+
+        count = linvel.shape[0]
+        for name, width in (
+            ("commands", 3),
+            ("current_actions", self._num_action),
+            ("last_actions", self._num_action),
+            ("gait_phase", 2),
+        ):
+            if name in inputs:
+                value = info.get(name)
+                if value is None:
+                    inputs[name].fill(0)
+                else:
+                    copy(inputs, name, np.asarray(value).reshape(count, width))
+
+        if "dof_pos_diff" in inputs:
+            np.subtract(dof_pos, self.default_angles, out=inputs["dof_pos_diff"])
+        noisy_sources = (
+            ("noisy_gyro", gyro, self._cfg.noise_config.scale_gyro),
+            ("noisy_gravity", gravity, self._cfg.noise_config.scale_gravity),
+            (
+                "noisy_dof_pos",
+                dof_pos - self.default_angles,
+                self._cfg.noise_config.scale_joint_angle,
+            ),
+            ("noisy_dof_vel", dof_vel, self._cfg.noise_config.scale_joint_vel),
+        )
+        for name, value, scale in noisy_sources:
+            if name not in inputs:
+                continue
+            copy(inputs, name, value)
+            noisy = self._obs_noise(inputs[name], scale)
+            if noisy is not inputs[name]:
+                copy(inputs, name, noisy)
+
+        if "base_height" in inputs:
+            copy(inputs, "base_height", self._backend.get_base_pos()[:, 2])
+        for name in ("left_foot_pos", "right_foot_pos", "left_foot_quat", "right_foot_quat"):
+            if name in inputs:
+                copy(inputs, name, self._backend.get_sensor_data(name))
+        if "left_contact" in inputs or "right_contact" in inputs:
+            copy(
+                inputs,
+                "left_contact",
+                compute_aggregated_foot_contact(self._backend, LEFT_FOOT_CONTACT_SENSORS),
+            )
+            copy(
+                inputs,
+                "right_contact",
+                compute_aggregated_foot_contact(self._backend, RIGHT_FOOT_CONTACT_SENSORS),
+            )
+
+    def _assemble_term_observations(
+        self, outputs: Any, target: dict[str, np.ndarray]
+    ) -> dict[str, np.ndarray]:
+        assert self._resolved_terms is not None
+        for group, names in self._resolved_terms.observation_outputs.items():
+            start = 0
+            for name in names:
+                width = outputs[name].shape[1]
+                np.copyto(target[group][:, start : start + width], outputs[name])
+                start += width
+        return target
+
+    def _compute_term_state(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray]:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        self._populate_term_inputs(
+            self._term_inputs,
+            info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+        )
+        outputs = self._term_runtime.execute()
+        self._assemble_term_observations(outputs, self._term_obs)
+        self._term_reward.fill(0)
+        for _, name in self._resolved_terms.reward_outputs:
+            np.add(self._term_reward, outputs[name], out=self._term_reward)
+        np.multiply(self._term_reward, self._cfg.ctrl_dt, out=self._term_reward)
+        self._term_terminated.fill(False)
+        for name in self._resolved_terms.termination_outputs:
+            np.logical_or(self._term_terminated, outputs[name], out=self._term_terminated)
+
+        steps = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
+        should_log = self._enable_reward_log and int(steps[0]) % 4 == 0
+        log = {} if should_log else info.get("log", {})
+        if should_log:
+            for reward_name, name in self._active_term_rewards:
+                log[f"reward/{reward_name}"] = float(np.mean(outputs[name]))
+        info["log"] = log
+        return self._term_obs, self._term_reward, self._term_terminated
+
     def _compute_obs(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> dict[str, np.ndarray]:
+        legacy = G1WalkEnv._compute_legacy_obs(self, info, linvel, gyro, gravity, dof_pos, dof_vel)
+        if getattr(self, "_resolved_terms", None) is None:
+            return legacy
+        actor_layout = self._actor_symmetry_obs_layout()
+        layouts = {"obs": actor_layout, "critic": (*actor_layout, ("linvel", 3))}
+        selected = {}
+        for group, layout in layouts.items():
+            start = 0
+            slices = {}
+            for label, width in layout:
+                slices[label] = slice(start, start + width)
+                start += width
+            selected[group] = np.concatenate(
+                [
+                    legacy[group][:, slices[label]]
+                    for label in self._resolved_terms.observation_labels[group]
+                ],
+                axis=1,
+                dtype=get_global_dtype(),
+            )
+        return selected
+
+    def _compute_legacy_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
@@ -527,6 +705,16 @@ class G1WalkEnv(G1BaseEnv):
         )
 
     def get_symmetry_obs_layouts(self) -> dict[str, SymmetryObsLayout]:
+        if getattr(self, "_resolved_terms", None) is not None:
+            return {
+                group: tuple(
+                    (label, self._resolved_terms.plan.output_specs[name].shape[0])
+                    for label, name in zip(
+                        self._resolved_terms.observation_labels[group], names, strict=True
+                    )
+                )
+                for group, names in self._resolved_terms.observation_outputs.items()
+            }
         actor_layout = self._actor_symmetry_obs_layout()
         return {
             "obs": actor_layout,
@@ -710,6 +898,7 @@ class G1WalkRewardConfig(G1RewardConfig):
 @dataclass
 class G1WalkFlatCfg(G1WalkEnvCfg):
     reward_config: G1WalkRewardConfig | None = None
+    term_plan: G1WalkTermPlanConfig | None = field(default_factory=G1WalkTermPlanConfig)
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
@@ -722,6 +911,7 @@ class G1WalkFlatCfg(G1WalkEnvCfg):
 @registry.envcfg("G1WalkRough")
 @dataclass
 class G1WalkRoughCfg(G1WalkFlatCfg):
+    term_plan: G1WalkTermPlanConfig | None = None
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_rough.xml")
@@ -746,6 +936,7 @@ class G1Walk23DofEnv(G1WalkEnv):
 @registry.envcfg("G1Walk23DofFlat")
 @dataclass
 class G1Walk23DofFlatCfg(G1WalkFlatCfg):
+    term_plan: G1WalkTermPlanConfig | None = None
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat_23dof.xml")

--- a/src/unilab/envs/locomotion/g1/terms.py
+++ b/src/unilab/envs/locomotion/g1/terms.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, cast
+
+import numpy as np
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    ResolvedTermPlan,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistry,
+    resolve_term_plan,
+)
+
+F32 = np.float32
+
+REWARD_TERM_KEYS = {
+    name: f"g1.walk.reward.{implementation}.v1"
+    for name, implementation in {
+        "tracking_lin_vel": "tracking_lin_vel",
+        "tracking_ang_vel": "tracking_ang_vel",
+        "forward_progress": "forward_progress",
+        "under_speed": "under_speed",
+        "lin_vel_z": "lin_vel_z",
+        "orientation": "orientation",
+        "penalty_orientation": "orientation",
+        "ang_vel_xy": "ang_vel_xy",
+        "penalty_ang_vel_xy": "ang_vel_xy",
+        "action_rate": "action_rate",
+        "penalty_action_rate": "action_rate",
+        "base_height": "base_height",
+        "pose": "pose",
+        "upper_body_pose": "upper_body_pose",
+        "penalty_feet_ori": "feet_ori",
+        "feet_phase": "feet_phase",
+        "feet_phase_contrast": "feet_phase_contrast",
+        "feet_phase_contact": "feet_phase_contact",
+        "feet_double_stance": "feet_double_stance",
+        "alive": "alive",
+    }.items()
+}
+
+DEFAULT_OBSERVATION_TERMS: dict[str, list[str]] = {
+    "obs": [
+        "g1.walk.observation.actor_gyro.v1",
+        "g1.walk.observation.actor_gravity.v1",
+        "g1.walk.observation.actor_dof_pos.v1",
+        "g1.walk.observation.actor_dof_vel.v1",
+        "g1.walk.observation.actor_actions.v1",
+        "g1.walk.observation.actor_commands.v1",
+        "g1.walk.observation.actor_gait_phase.v1",
+    ],
+    "critic": [
+        "g1.walk.observation.critic_gyro.v1",
+        "g1.walk.observation.critic_gravity.v1",
+        "g1.walk.observation.critic_dof_pos.v1",
+        "g1.walk.observation.critic_dof_vel.v1",
+        "g1.walk.observation.critic_actions.v1",
+        "g1.walk.observation.critic_commands.v1",
+        "g1.walk.observation.critic_gait_phase.v1",
+        "g1.walk.observation.critic_linvel.v1",
+    ],
+}
+DEFAULT_TERMINATION_TERMS = ["g1.walk.termination.tilt_or_height.v1"]
+
+_OBS_META = {
+    key: (group, label, source, width)
+    for group, entries in {
+        "obs": (
+            ("actor_gyro", "gyro", "noisy_gyro", 3),
+            ("actor_gravity", "gravity", "noisy_gravity", 3),
+            ("actor_dof_pos", "dof_pos", "noisy_dof_pos", -1),
+            ("actor_dof_vel", "dof_vel", "noisy_dof_vel", -1),
+            ("actor_actions", "actions", "current_actions", -1),
+            ("actor_commands", "command", "commands", 3),
+            ("actor_gait_phase", "gait_phase", "gait_phase", 2),
+        ),
+        "critic": (
+            ("critic_gyro", "gyro", "gyro", 3),
+            ("critic_gravity", "gravity", "gravity", 3),
+            ("critic_dof_pos", "dof_pos", "dof_pos_diff", -1),
+            ("critic_dof_vel", "dof_vel", "dof_vel", -1),
+            ("critic_actions", "actions", "current_actions", -1),
+            ("critic_commands", "command", "commands", 3),
+            ("critic_gait_phase", "gait_phase", "gait_phase", 2),
+            ("critic_linvel", "linvel", "linvel", 3),
+        ),
+    }.items()
+    for name, label, source, width in entries
+    for key in (f"g1.walk.observation.{name}.v1",)
+}
+
+
+def compute_feet_phase_height_targets(
+    gait_phase: np.ndarray, swing_height: float
+) -> tuple[np.ndarray, np.ndarray]:
+    def height(phi: np.ndarray) -> np.ndarray:
+        normalized = np.fmod(phi + np.pi, 2 * np.pi) - np.pi
+        x = (normalized + np.pi) / (2 * np.pi)
+        stance_t = 2 * x
+        swing_t = 2 * x - 1
+        stance = swing_height * (stance_t**3 + 3 * stance_t**2 * (1 - stance_t))
+        swing = swing_height * (1 - (swing_t**3 + 3 * swing_t**2 * (1 - swing_t)))
+        return np.where(x <= 0.5, stance, swing)
+
+    return height(gait_phase[:, 0]), height(gait_phase[:, 1])
+
+
+def compute_feet_phase_contact_targets(
+    gait_phase: np.ndarray, swing_height: float
+) -> tuple[np.ndarray, np.ndarray]:
+    left, right = compute_feet_phase_height_targets(gait_phase, swing_height)
+    threshold = swing_height * 0.5
+    return left <= threshold, right <= threshold
+
+
+def compute_forward_speed_gate(linvel: np.ndarray, minimum: float) -> np.ndarray:
+    return np.asarray(np.maximum(linvel[:, 0], 0.0) >= minimum, dtype=F32)
+
+
+def compute_forward_command_mask(commands: np.ndarray) -> np.ndarray:
+    return np.asarray(np.maximum(commands[:, 0], 0.0) > 1.0e-6, dtype=F32)
+
+
+def _parameter(context: NumpyTermContext, name: str) -> float:
+    return cast(float, context.parameters[name])
+
+
+def _store(context: NumpyTermContext, value: np.ndarray) -> None:
+    np.copyto(context.output, value, casting="same_kind")
+
+
+def _tracking_lin_vel(context: NumpyTermContext) -> None:
+    error = np.sum(
+        np.square(context.inputs["commands"][:, :2] - context.inputs["linvel"][:, :2]), axis=1
+    )
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")))
+
+
+def _tracking_ang_vel(context: NumpyTermContext) -> None:
+    error = np.square(context.inputs["commands"][:, 2] - context.inputs["gyro"][:, 2])
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")))
+
+
+def _forward_progress(context: NumpyTermContext) -> None:
+    commanded = np.maximum(context.inputs["commands"][:, 0], 1.0e-6)
+    forward = np.maximum(context.inputs["linvel"][:, 0], 0.0)
+    _store(context, np.minimum(forward / commanded, 1.0))
+
+
+def _under_speed(context: NumpyTermContext) -> None:
+    commanded = np.maximum(context.inputs["commands"][:, 0], 1.0e-6)
+    forward = np.maximum(context.inputs["linvel"][:, 0], 0.0)
+    _store(context, np.maximum(context.inputs["commands"][:, 0] - forward, 0.0) / commanded)
+
+
+def _squared_columns(source: str, columns: slice):
+    def term(context: NumpyTermContext) -> None:
+        np.sum(np.square(context.inputs[source][:, columns]), axis=1, out=context.output)
+
+    return term
+
+
+def _action_rate(context: NumpyTermContext) -> None:
+    diff = context.inputs["current_actions"] - context.inputs["last_actions"]
+    np.sum(np.square(diff), axis=1, out=context.output)
+
+
+def _base_height(context: NumpyTermContext) -> None:
+    np.square(
+        context.inputs["base_height"] - _parameter(context, "base_height_target"),
+        out=context.output,
+    )
+
+
+def _weighted_pose(weights: str):
+    def term(context: NumpyTermContext) -> None:
+        diff = context.inputs["dof_pos"] - context.inputs["default_angles"]
+        np.sum(context.inputs[weights] * np.square(diff), axis=1, out=context.output)
+
+    return term
+
+
+def _feet_ori(context: NumpyTermContext) -> None:
+    left, right = context.inputs["left_foot_quat"], context.inputs["right_foot_quat"]
+    _store(
+        context,
+        np.square(left[:, 1])
+        + np.square(left[:, 2])
+        + np.square(right[:, 1])
+        + np.square(right[:, 2]),
+    )
+
+
+def _gait_gate(context: NumpyTermContext) -> np.ndarray:
+    return compute_forward_speed_gate(
+        context.inputs["linvel"], _parameter(context, "min_forward_speed")
+    )
+
+
+def _feet_phase(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_height_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    error = np.square(context.inputs["left_foot_pos"][:, 2] - left)
+    error += np.square(context.inputs["right_foot_pos"][:, 2] - right)
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")) * _gait_gate(context))
+
+
+def _feet_phase_contrast(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_height_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    actual = context.inputs["left_foot_pos"][:, 2] - context.inputs["right_foot_pos"][:, 2]
+    _store(
+        context,
+        np.exp(-np.square(actual - (left - right)) / _parameter(context, "tracking_sigma"))
+        * _gait_gate(context),
+    )
+
+
+def _feet_phase_contact(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_contact_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    matches = 0.5 * (
+        (context.inputs["left_contact"] == left).astype(F32)
+        + (context.inputs["right_contact"] == right).astype(F32)
+    )
+    _store(context, matches * _gait_gate(context))
+
+
+def _feet_double_stance(context: NumpyTermContext) -> None:
+    stance = np.logical_and(context.inputs["left_contact"], context.inputs["right_contact"])
+    _store(context, stance.astype(F32) * compute_forward_command_mask(context.inputs["commands"]))
+
+
+def _alive(context: NumpyTermContext) -> None:
+    context.output.fill(1.0)
+
+
+def _scaled_copy(context: NumpyTermContext) -> None:
+    np.multiply(
+        next(iter(context.inputs.values())),
+        _parameter(context, "multiplier"),
+        out=context.output,
+    )
+
+
+def _tilt_or_height(context: NumpyTermContext) -> None:
+    tilt = np.arccos(np.clip(context.inputs["gravity"][:, 2], -1.0, 1.0))
+    np.logical_or(
+        tilt > _parameter(context, "max_tilt_rad"),
+        context.inputs["base_height"] < _parameter(context, "min_base_height"),
+        out=context.output,
+    )
+
+
+@dataclass(frozen=True)
+class G1WalkResolvedTermPlan:
+    plan: ResolvedTermPlan
+    reward_outputs: tuple[tuple[str, str], ...]
+    observation_outputs: Mapping[str, tuple[str, ...]]
+    observation_labels: Mapping[str, tuple[str, ...]]
+    termination_outputs: tuple[str, ...]
+
+    @property
+    def observation_dims(self) -> dict[str, int]:
+        return {
+            group: sum(self.plan.output_specs[name].shape[0] for name in names)
+            for group, names in self.observation_outputs.items()
+        }
+
+
+def _build_registry(num_action: int) -> TermRegistry:
+    registry = TermRegistry()
+    shapes = {
+        "linvel": (3,),
+        "gyro": (3,),
+        "gravity": (3,),
+        "dof_pos": (num_action,),
+        "dof_vel": (num_action,),
+        "dof_pos_diff": (num_action,),
+        "noisy_gyro": (3,),
+        "noisy_gravity": (3,),
+        "noisy_dof_pos": (num_action,),
+        "noisy_dof_vel": (num_action,),
+        "base_height": (),
+        "commands": (3,),
+        "current_actions": (num_action,),
+        "last_actions": (num_action,),
+        "gait_phase": (2,),
+        "default_angles": (num_action,),
+        "pose_weights": (num_action,),
+        "upper_body_pose_weights": (num_action,),
+        "left_foot_pos": (3,),
+        "right_foot_pos": (3,),
+        "left_foot_quat": (4,),
+        "right_foot_quat": (4,),
+        "left_contact": (),
+        "right_contact": (),
+    }
+
+    def inputs(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(
+            NamedTensorSpec(name, TensorSpec(shapes[name], np.bool_ if "contact" in name else F32))
+            for name in names
+        )
+
+    float_param = lambda name: ParameterSpec(name, ParameterKind.FLOAT)  # noqa: E731
+    definitions = (
+        ("tracking_lin_vel", _tracking_lin_vel, ("linvel", "commands"), ("tracking_sigma",)),
+        ("tracking_ang_vel", _tracking_ang_vel, ("gyro", "commands"), ("tracking_sigma",)),
+        ("forward_progress", _forward_progress, ("linvel", "commands"), ()),
+        ("under_speed", _under_speed, ("linvel", "commands"), ()),
+        ("lin_vel_z", _squared_columns("linvel", slice(2, 3)), ("linvel",), ()),
+        ("orientation", _squared_columns("gravity", slice(0, 2)), ("gravity",), ()),
+        ("ang_vel_xy", _squared_columns("gyro", slice(0, 2)), ("gyro",), ()),
+        ("action_rate", _action_rate, ("current_actions", "last_actions"), ()),
+        ("base_height", _base_height, ("base_height",), ("base_height_target",)),
+        ("pose", _weighted_pose("pose_weights"), ("dof_pos", "default_angles", "pose_weights"), ()),
+        (
+            "upper_body_pose",
+            _weighted_pose("upper_body_pose_weights"),
+            ("dof_pos", "default_angles", "upper_body_pose_weights"),
+            (),
+        ),
+        ("feet_ori", _feet_ori, ("left_foot_quat", "right_foot_quat"), ()),
+        (
+            "feet_phase",
+            _feet_phase,
+            ("linvel", "gait_phase", "left_foot_pos", "right_foot_pos"),
+            ("swing_height", "tracking_sigma", "min_forward_speed"),
+        ),
+        (
+            "feet_phase_contrast",
+            _feet_phase_contrast,
+            ("linvel", "gait_phase", "left_foot_pos", "right_foot_pos"),
+            ("swing_height", "tracking_sigma", "min_forward_speed"),
+        ),
+        (
+            "feet_phase_contact",
+            _feet_phase_contact,
+            ("linvel", "gait_phase", "left_contact", "right_contact"),
+            ("swing_height", "min_forward_speed"),
+        ),
+        (
+            "feet_double_stance",
+            _feet_double_stance,
+            ("commands", "left_contact", "right_contact"),
+            (),
+        ),
+        ("alive", _alive, (), ()),
+    )
+    for name, function, input_names, parameter_names in definitions:
+        registry.register(
+            TermDefinition(
+                f"g1.walk.reward.{name}.v1",
+                TermKind.REWARD,
+                function,
+                TensorSpec((), F32),
+                inputs=inputs(*input_names),
+                parameters=tuple(float_param(p) for p in parameter_names),
+            )
+        )
+
+    for key, (_, _, source, width) in _OBS_META.items():
+        registry.register(
+            TermDefinition(
+                key,
+                TermKind.OBSERVATION,
+                _scaled_copy,
+                TensorSpec((num_action if width == -1 else width,), F32),
+                inputs=inputs(source),
+                parameters=(float_param("multiplier"),),
+            )
+        )
+    registry.register(
+        TermDefinition(
+            DEFAULT_TERMINATION_TERMS[0],
+            TermKind.TERMINATION,
+            _tilt_or_height,
+            TensorSpec((), np.bool_),
+            inputs=inputs("gravity", "base_height"),
+            parameters=(float_param("max_tilt_rad"), float_param("min_base_height")),
+        )
+    )
+    return registry
+
+
+def _reward_parameters(name: str, cfg: Any) -> dict[str, float]:
+    if name in ("tracking_lin_vel", "tracking_ang_vel"):
+        return {"tracking_sigma": float(cfg.tracking_sigma)}
+    if name == "base_height":
+        return {"base_height_target": float(cfg.base_height_target)}
+    if name in ("feet_phase", "feet_phase_contrast"):
+        return {
+            "swing_height": float(cfg.feet_phase_swing_height),
+            "tracking_sigma": float(cfg.feet_phase_tracking_sigma),
+            "min_forward_speed": float(cfg.min_forward_speed_for_gait_reward),
+        }
+    if name == "feet_phase_contact":
+        return {
+            "swing_height": float(cfg.feet_phase_swing_height),
+            "min_forward_speed": float(cfg.min_forward_speed_for_gait_reward),
+        }
+    return {}
+
+
+def resolve_g1_walk_term_plan(
+    *,
+    num_action: int,
+    reward_cfg: Any,
+    observations: Mapping[str, Sequence[str]],
+    terminations: Sequence[str],
+    walk_profile: bool,
+) -> G1WalkResolvedTermPlan:
+    """Resolve the task config into one reward/observation/termination plan."""
+    registry = _build_registry(num_action)
+    configs: list[TermConfig] = []
+    reward_outputs: list[tuple[str, str]] = []
+    for name, scale in reward_cfg.scales.items():
+        key = REWARD_TERM_KEYS.get(name)
+        if key is None:
+            if scale != 0.0:
+                raise TermPlanError(f"G1 walk has unknown nonzero reward term {name!r}")
+            continue
+        output_name = f"reward.{name}"
+        configs.append(
+            TermConfig(
+                output_name, key, scale=scale, parameters=_reward_parameters(name, reward_cfg)
+            )
+        )
+        reward_outputs.append((name, output_name))
+
+    if set(observations) != {"obs", "critic"}:
+        raise TermPlanError("G1 walk observation layout must define exactly 'obs' and 'critic'")
+    observation_outputs: dict[str, tuple[str, ...]] = {}
+    observation_labels: dict[str, tuple[str, ...]] = {}
+    multipliers = {
+        "actor_gyro": 0.25 if walk_profile else 1.0,
+        "actor_dof_vel": 0.05 if walk_profile else 1.0,
+        "critic_gyro": 0.25 if walk_profile else 1.0,
+        "critic_dof_vel": 0.05 if walk_profile else 1.0,
+        "critic_linvel": 2.0 if walk_profile else 1.0,
+        "actor_gravity": -1.0,
+        "critic_gravity": -1.0,
+    }
+    for group in ("obs", "critic"):
+        keys = observations[group]
+        if not isinstance(keys, (list, tuple)) or not keys:
+            raise TermPlanError(f"G1 walk observation group {group!r} must be a non-empty list")
+        if len(keys) != len(set(keys)):
+            raise TermPlanError(f"G1 walk observation group {group!r} contains duplicate terms")
+        names, labels = [], []
+        for key in keys:
+            meta = _OBS_META.get(key)
+            if meta is None:
+                registry.resolve(key)
+            assert meta is not None
+            declared_group, label, _, _ = meta
+            if declared_group != group:
+                raise TermPlanError(f"observation term {key!r} does not belong to group {group!r}")
+            name = f"observation.{group}.{label}"
+            configs.append(
+                TermConfig(
+                    name,
+                    key,
+                    parameters={"multiplier": multipliers.get(key.rsplit(".", 2)[-2], 1.0)},
+                )
+            )
+            names.append(name)
+            labels.append(label)
+        observation_outputs[group] = tuple(names)
+        observation_labels[group] = tuple(labels)
+
+    if not isinstance(terminations, (list, tuple)) or not terminations:
+        raise TermPlanError("G1 walk termination layout must be a non-empty list")
+    termination_outputs = []
+    for index, key in enumerate(terminations):
+        name = f"termination.term{index}"
+        configs.append(
+            TermConfig(
+                name,
+                key,
+                parameters={
+                    "max_tilt_rad": math.radians(float(reward_cfg.max_tilt_deg)),
+                    "min_base_height": float(reward_cfg.min_base_height),
+                },
+            )
+        )
+        termination_outputs.append(name)
+
+    return G1WalkResolvedTermPlan(
+        plan=resolve_term_plan(registry, configs),
+        reward_outputs=tuple(reward_outputs),
+        observation_outputs=MappingProxyType(observation_outputs),
+        observation_labels=MappingProxyType(observation_labels),
+        termination_outputs=tuple(termination_outputs),
+    )

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -11,6 +11,8 @@ from omegaconf import OmegaConf
 
 from unilab.base import registry
 from unilab.base.registry import ensure_registries
+from unilab.envs.locomotion.g1 import terms as g1_terms
+from unilab.envs.locomotion.g1.joystick import G1WalkRewardConfig
 from unilab.training.backend_adapter import BackendAdapter
 
 ROOT_DIR = Path(__file__).parents[4]
@@ -263,3 +265,93 @@ def test_g1_walk_tasks_are_registered():
 
     assert registry.contains("G1WalkFlat")
     assert registry.contains("G1WalkRough")
+
+
+def test_g1_flat_term_plan_matches_legacy_numpy_and_reuses_outputs():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    env = cast(
+        Any,
+        registry.make("G1WalkFlat", sim_backend="mujoco", num_envs=2, env_cfg_override=override),
+    )
+    try:
+        env._cfg.noise_config.level = 0.0
+        rng = np.random.default_rng(7)
+        info = {
+            "steps": np.zeros(2, dtype=np.uint32),
+            "commands": rng.normal(size=(2, 3)).astype(np.float32),
+            "current_actions": rng.normal(size=(2, 29)).astype(np.float32),
+            "last_actions": rng.normal(size=(2, 29)).astype(np.float32),
+            "gait_phase": rng.uniform(0, 2 * np.pi, size=(2, 2)).astype(np.float32),
+        }
+        linvel = rng.normal(size=(2, 3)).astype(np.float32)
+        gyro = rng.normal(size=(2, 3)).astype(np.float32)
+        gravity = np.tile(np.array([0.01, -0.02, 0.99], np.float32), (2, 1))
+        dof_pos = rng.normal(size=(2, 29)).astype(np.float32)
+        dof_vel = rng.normal(size=(2, 29)).astype(np.float32)
+
+        expected_reward = env._compute_reward(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        expected_obs = env._compute_legacy_obs(info, linvel, gyro, gravity, dof_pos, dof_vel)
+        expected_terminated = (np.arccos(gravity[:, 2]) > np.deg2rad(25.0)) | (
+            env._backend.get_base_pos()[:, 2] < 0.55
+        )
+        obs, reward, terminated = env._compute_term_state(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        output_ids = (id(obs["obs"]), id(obs["critic"]), id(reward), id(terminated))
+
+        np.testing.assert_allclose(reward, expected_reward, rtol=2e-6, atol=2e-6)
+        np.testing.assert_allclose(obs["obs"], expected_obs["obs"], rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(obs["critic"], expected_obs["critic"], rtol=1e-6, atol=1e-6)
+        np.testing.assert_array_equal(terminated, expected_terminated)
+        repeated = env._compute_term_state(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        assert tuple(id(value) for value in (*repeated[0].values(), *repeated[1:])) == output_ids
+    finally:
+        env.close()
+
+
+def test_g1_flat_term_config_controls_layout_and_reward_scale():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    cfg.env.term_plan.observations.obs = list(reversed(cfg.env.term_plan.observations.obs[:-1]))
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    env = cast(
+        Any,
+        registry.make("G1WalkFlat", sim_backend="mujoco", num_envs=1, env_cfg_override=override),
+    )
+    try:
+        assert env.obs_groups_spec == {"obs": 96, "critic": 101}
+        assert [name for name, _ in env.get_symmetry_obs_layouts()["obs"]] == [
+            "command",
+            "actions",
+            "dof_vel",
+            "dof_pos",
+            "gravity",
+            "gyro",
+        ]
+        assert "feet_phase" in dict(env._active_term_rewards)
+        env._reward_cfg.scales["feet_phase"] = 0.0
+        env._sync_term_reward_scales()
+        assert "feet_phase" not in dict(env._active_term_rewards)
+        env._reward_cfg.scales["feet_phase"] = 1.0
+        env._sync_term_reward_scales()
+        assert "feet_phase" in dict(env._active_term_rewards)
+    finally:
+        env.close()
+
+
+def test_g1_flat_term_plan_rejects_unknown_nonzero_reward():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    reward_cfg = G1WalkRewardConfig(**OmegaConf.to_container(cfg.reward, resolve=True))
+    reward_cfg.scales["custom"] = 1.0
+    with pytest.raises(g1_terms.TermPlanError, match="unknown nonzero reward"):
+        g1_terms.resolve_g1_walk_term_plan(
+            num_action=29,
+            reward_cfg=reward_cfg,
+            observations=g1_terms.DEFAULT_OBSERVATION_TERMS,
+            terminations=g1_terms.DEFAULT_TERMINATION_TERMS,
+            walk_profile=False,
+        )


### PR DESCRIPTION
## Summary

- add task-owned G1 walk reward, observation, and termination definitions plus a cold-path resolver over the structured term contract from #919
- migrate the `G1WalkFlat` NumPy `update_state` path to one resolved plan with pre-bound inputs, reusable outputs, runtime reward scales, config-derived observation dimensions, and synchronized symmetry/reset layouts
- expose the pilot observation and termination layout in the PPO MuJoCo owner YAML while continuing to use existing reward YAML order, weights, and numeric parameters
- fail closed for unknown nonzero reward terms and invalid observation layouts

## Scope / non-goals

This is the G1WalkFlat NumPy pilot only. `G1WalkRough`, 23DoF tasks, motion tracking, backend contracts, runners, training/checkpoint/sim2sim behavior, and the experimental hand-written Numba accelerator are unchanged. Numba remains a baseline for the later Tier 2 issue.

The implementation changes 4 files and adds 799 net lines, within #920's limits.

## Validation

- `make test-all` passed on the final commit:
  - 1661 passed
  - 37 skipped
  - 280 deselected
  - 1 xfailed
  - Ruff, mypy, and pyright passed; pyright reported only the existing optional `mlx.core` warning
  - benchmark smoke, module mode: 34/35 (one optional MLX skip)
  - benchmark smoke, script mode: 35/36 (one optional MLX skip)
- G1 Numba slow parity: 2 passed
- G1 lifecycle/noise/symmetry and config-focused regression suite: 245 passed, 2 deselected
- focused source coverage: G1 term definitions 85%, G1 joystick owner 83%

Closes #920
