### PR TITLE
feat: migrate motion tracking numpy path to term plan

### DIFF
--- a/conf/ppo/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking/mujoco.yaml
@@ -14,6 +14,12 @@ algo:
     entropy_coef: 0.005
 env:
   numba_acceleration: false
+  term_plan:
+    preambles: [motion.tracking.preamble.transforms.v1]
+    observations:
+      obs: [motion.tracking.observation.actor_command.v1, motion.tracking.observation.actor_anchor_pos.v1, motion.tracking.observation.actor_anchor_ori.v1, motion.tracking.observation.actor_linvel.v1, motion.tracking.observation.actor_gyro.v1, motion.tracking.observation.actor_joint_pos.v1, motion.tracking.observation.actor_dof_vel.v1, motion.tracking.observation.actor_actions.v1]
+      critic: [motion.tracking.observation.critic_command.v1, motion.tracking.observation.critic_anchor_pos.v1, motion.tracking.observation.critic_anchor_ori.v1, motion.tracking.observation.critic_linvel.v1, motion.tracking.observation.critic_gyro.v1, motion.tracking.observation.critic_joint_pos.v1, motion.tracking.observation.critic_dof_vel.v1, motion.tracking.observation.critic_actions.v1, motion.tracking.observation.critic_body_pos.v1, motion.tracking.observation.critic_body_ori.v1]
+    terminations: [motion.tracking.termination.failures.v1]
 reward:
   scales:
     motion_global_root_pos: 0.5

--- a/src/unilab/envs/motion_tracking/common/config.py
+++ b/src/unilab/envs/motion_tracking/common/config.py
@@ -16,6 +16,7 @@ from unilab.base.scene import SceneCfg
 from unilab.envs.locomotion.g1.base import G1BaseCfg
 
 from .rewards import RewardConfig
+from .terms import DEFAULT_OBSERVATIONS, DEFAULT_TERMINATIONS, PREAMBLE_KEY
 
 
 @dataclass
@@ -40,6 +41,15 @@ class VelocityRandomization:
     roll: tuple[float, float] = (-0.52, 0.52)
     pitch: tuple[float, float] = (-0.52, 0.52)
     yaw: tuple[float, float] = (-0.78, 0.78)
+
+
+@dataclass
+class MotionTermPlanConfig:
+    preambles: list[str] = field(default_factory=lambda: [PREAMBLE_KEY])
+    observations: dict[str, list[str]] = field(
+        default_factory=lambda: {name: list(terms) for name, terms in DEFAULT_OBSERVATIONS.items()}
+    )
+    terminations: list[str] = field(default_factory=lambda: list(DEFAULT_TERMINATIONS))
 
 
 @dataclass
@@ -161,6 +171,7 @@ class MotionTrackingCfg(G1BaseCfg):
     terminate_on_undesired_contacts: bool = False
     numba_acceleration: bool = False
     numba_num_threads: int | None = None
+    term_plan: MotionTermPlanConfig | None = None
 
 
 @dataclass

--- a/src/unilab/envs/motion_tracking/common/terms.py
+++ b/src/unilab/envs/motion_tracking/common/terms.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType, SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    ResolvedTermPlan,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistry,
+    resolve_term_plan,
+)
+from unilab.utils.geometry import (
+    np_gravity_z_in_body_from_quat,
+    np_write_relative_anchor_transform_pos_rot6d,
+)
+
+from . import rewards
+from .observations import write_body_ori6_in_anchor_frame, write_body_pos_in_anchor_frame
+from .transforms import write_relative_transforms
+
+PREAMBLE_KEY = "motion.tracking.preamble.transforms.v1"
+REWARD_KEYS = {
+    name: f"motion.tracking.reward.{name}.v1"
+    for name in (
+        "motion_global_root_pos",
+        "motion_global_root_ori",
+        "motion_body_pos",
+        "motion_body_ori",
+        "motion_body_lin_vel",
+        "motion_body_ang_vel",
+        "motion_ee_body_pos_z",
+        "motion_joint_pos",
+        "motion_joint_vel",
+        "action_rate_l2",
+        "joint_limit",
+        "undesired_contacts",
+    )
+}
+DEFAULT_TERMINATIONS = ("motion.tracking.termination.failures.v1",)
+
+_OBS_META = {
+    f"motion.tracking.observation.{key}.v1": (group, label, source, width, workspace)
+    for group, entries in {
+        "obs": (
+            ("actor_command", "command", "motion_command", -2, True),
+            ("actor_anchor_pos", "anchor_pos", "motion_anchor_pos_b", 3, True),
+            ("actor_anchor_ori", "anchor_ori", "motion_anchor_ori_b", 6, True),
+            ("actor_linvel", "linvel", "noisy_linvel", 3, False),
+            ("actor_gyro", "gyro", "noisy_gyro", 3, False),
+            ("actor_joint_pos", "joint_pos", "noisy_joint_pos_rel", -1, False),
+            ("actor_dof_vel", "dof_vel", "noisy_dof_vel", -1, False),
+            ("actor_actions", "actions", "obs_actions", -1, False),
+        ),
+        "critic": (
+            ("critic_command", "command", "motion_command", -2, True),
+            ("critic_anchor_pos", "anchor_pos", "motion_anchor_pos_b", 3, True),
+            ("critic_anchor_ori", "anchor_ori", "motion_anchor_ori_b", 6, True),
+            ("critic_linvel", "linvel", "linvel", 3, False),
+            ("critic_gyro", "gyro", "gyro", 3, False),
+            ("critic_joint_pos", "joint_pos", "joint_pos_rel", -1, True),
+            ("critic_dof_vel", "dof_vel", "dof_vel", -1, False),
+            ("critic_actions", "actions", "obs_actions", -1, False),
+            ("critic_body_pos", "body_pos", "robot_body_pos_b", -3, True),
+            ("critic_body_ori", "body_ori", "robot_body_ori_b", -6, True),
+        ),
+    }.items()
+    for key, label, source, width, workspace in entries
+}
+DEFAULT_OBSERVATIONS = {
+    group: [key for key, meta in _OBS_META.items() if meta[0] == group]
+    for group in ("obs", "critic")
+}
+
+
+def _param(ctx: NumpyTermContext, name: str) -> float:
+    return cast(float, ctx.parameters[name])
+
+
+# fmt: off
+def _preamble(ctx: NumpyTermContext) -> None:
+    inputs, work = ctx.inputs, ctx.workspace
+    i = cast(int, ctx.parameters["anchor_body_idx"])
+    write_relative_transforms(
+        motion_body_pos_w=inputs["motion_body_pos_w"], motion_body_quat_w=inputs["motion_body_quat_w"],
+        robot_body_pos_w=inputs["robot_body_pos_w"], robot_body_quat_w=inputs["robot_body_quat_w"],
+        anchor_body_idx=i, delta_pos_w=work["delta_pos_w"], delta_ori_w=work["delta_ori_w"],
+        body_vec_error=work["body_vec_error"], scalar_scratch=work["env_error"],
+        scalar_scratch2=work["term_scratch"], out_body_pos_w=work["ref_body_pos_w"],
+        out_body_quat_w=work["ref_body_quat_w"],
+    )
+    motion_pos, motion_quat = inputs["motion_body_pos_w"][:, i], inputs["motion_body_quat_w"][:, i]
+    robot_pos, robot_quat = inputs["robot_body_pos_w"][:, i], inputs["robot_body_quat_w"][:, i]
+    np_write_relative_anchor_transform_pos_rot6d(
+        robot_pos, robot_quat, motion_pos, motion_quat,
+        work["motion_anchor_pos_b"], work["motion_anchor_ori_b"],
+    )
+    n = inputs["dof_pos"].shape[1]
+    work["motion_command"][:, :n], work["motion_command"][:, n:] = inputs["motion_joint_pos"], inputs["motion_joint_vel"]
+    np.subtract(inputs["dof_pos"], inputs["effective_default_angles"], out=work["joint_pos_rel"])
+    write_body_pos_in_anchor_frame(
+        robot_pos, robot_quat, inputs["robot_body_pos_w"], work["robot_body_pos_b"],
+        body_vec_error=work["body_vec_error"],
+    )
+    write_body_ori6_in_anchor_frame(robot_quat, inputs["robot_body_quat_w"], work["robot_body_ori_b"])
+    ctx.output.fill(0.0)
+# fmt: on
+
+
+def _copy(ctx: NumpyTermContext) -> None:
+    np.copyto(
+        ctx.output,
+        next(iter((*ctx.inputs.values(), *ctx.workspace.values()))).reshape(ctx.output.shape),
+    )
+
+
+# fmt: off
+class _RewardAdapter:
+    """Cold-bound adapter around the existing vectorized owner term."""
+
+    def __init__(self, fn: Any) -> None:
+        self.fn = fn
+        self.bound: rewards.RewardContext | None = None
+
+    def __call__(self, ctx: NumpyTermContext) -> None:
+        if self.bound is None:
+            get = lambda name: ctx.inputs.get(name)  # noqa: E731
+            work = lambda name: ctx.workspace.get(name)  # noqa: E731
+            std = cast(float, ctx.parameters.get("std", 1.0))
+            std_cfg = SimpleNamespace(**{name: std for name in (
+                "std_root_pos", "std_root_ori", "std_body_pos", "std_body_ori",
+                "std_body_lin_vel", "std_body_ang_vel", "std_joint_pos", "std_joint_vel",
+            )})
+            indices = np.asarray(ctx.parameters.get("indices", ()), dtype=np.intp)
+            env_error, indexed_error, indexed_mask = work("env_error"), work("indexed_error"), work("indexed_mask")
+            direct_fields = (
+                "robot_body_pos_w", "robot_body_quat_w", "robot_body_lin_vel_w",
+                "robot_body_ang_vel_w", "dof_pos", "dof_vel", "joint_lower", "joint_upper",
+            )
+            scratch_fields = (
+                "body_vec_error", "joint_error", "joint_error_upper", "quat_error_w", "quat_error_x",
+            )
+            motion_fields = (
+                "body_pos_w", "body_quat_w", "body_lin_vel_w", "body_ang_vel_w", "joint_pos", "joint_vel",
+            )
+            self.bound = rewards.RewardContext(
+                info={"current_actions": get("current_actions"), "last_actions": get("last_actions")},
+                motion_data=SimpleNamespace(**{name: get(f"motion_{name}") for name in motion_fields}),
+                ref_body_pos_w=work("ref_body_pos_w"), ref_body_quat_w=work("ref_body_quat_w"), reward_config=std_cfg,
+                anchor_body_idx=cast(int, ctx.parameters.get("anchor_body_idx", 0)),
+                ee_body_indices=indices, undesired_contact_body_indices=indices,
+                undesired_contact_z_threshold=cast(float, ctx.parameters.get("threshold", 0.0)),
+                num_envs=ctx.output.shape[0], env_error=env_error if env_error is not None else ctx.output,
+                reward_term=ctx.output,
+                ee_pos_error_z=None if indexed_error is None else indexed_error[:, : len(indices)],
+                undesired_contact_mask=None if indexed_mask is None else indexed_mask[:, : len(indices)],
+                **{name: get(name) for name in direct_fields},
+                **{name: work(name) for name in scratch_fields},
+            )
+        result = self.fn(self.bound)
+        if result is not ctx.output:
+            np.copyto(ctx.output, result)
+# fmt: on
+
+
+# fmt: off
+def _termination(ctx: NumpyTermContext) -> None:
+    i = cast(int, ctx.parameters["anchor_body_idx"])
+    error = ctx.workspace["env_error"]
+    np.subtract(ctx.inputs["motion_body_pos_w"][:, i, 2], ctx.inputs["robot_body_pos_w"][:, i, 2], out=error)
+    np.abs(error, out=error)
+    np.greater(error, _param(ctx, "anchor_pos_z_threshold"), out=ctx.output)
+    if cast(bool, ctx.parameters["check_anchor_ori"]):
+        np.subtract(np_gravity_z_in_body_from_quat(ctx.inputs["motion_body_quat_w"][:, i]),
+                    np_gravity_z_in_body_from_quat(ctx.inputs["robot_body_quat_w"][:, i]), out=error)
+        np.abs(error, out=error)
+        np.logical_or(ctx.output, error > _param(ctx, "anchor_ori_threshold"), out=ctx.output)
+    for prefix, source in (("ee", ctx.workspace["ref_body_pos_w"]), ("contact", None)):
+        indices = cast(tuple[int, ...], ctx.parameters[f"{prefix}_indices"])
+        if not indices:
+            continue
+        mask = ctx.workspace["indexed_mask"][:, : len(indices)]
+        if source is None:
+            np.less(ctx.inputs["robot_body_pos_w"][:, indices, 2], _param(ctx, "contact_threshold"), out=mask)
+        else:
+            indexed_error = ctx.workspace["indexed_error"][:, : len(indices)]
+            np.subtract(source[:, indices, 2], ctx.inputs["robot_body_pos_w"][:, indices, 2], out=indexed_error)
+            np.abs(indexed_error, out=indexed_error)
+            np.greater(indexed_error, _param(ctx, "ee_threshold"), out=mask)
+        np.logical_or.reduce(mask, axis=1, out=error)
+        np.logical_or(ctx.output, error, out=ctx.output)
+# fmt: on
+
+
+@dataclass(frozen=True)
+class MotionResolvedTermPlan:
+    plan: ResolvedTermPlan
+    reward_outputs: tuple[tuple[str, str], ...]
+    reward_available: Mapping[str, bool]
+    observation_outputs: Mapping[str, tuple[str, ...]]
+    observation_labels: Mapping[str, tuple[str, ...]]
+    termination_outputs: tuple[str, ...]
+
+    @property
+    def observation_dims(self) -> dict[str, int]:
+        return {
+            group: sum(self.plan.output_specs[name].shape[0] for name in names)
+            for group, names in self.observation_outputs.items()
+        }
+
+
+def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dtype) -> TermRegistry:
+    registry = TermRegistry()
+    # fmt: off
+    shapes = {
+        "motion_body_pos_w": (n_body, 3), "motion_body_quat_w": (n_body, 4),
+        "motion_body_lin_vel_w": (n_body, 3), "motion_body_ang_vel_w": (n_body, 3),
+        "motion_joint_pos": (n_action,), "motion_joint_vel": (n_action,),
+        "robot_body_pos_w": (n_body, 3), "robot_body_quat_w": (n_body, 4),
+        "robot_body_lin_vel_w": (n_body, 3), "robot_body_ang_vel_w": (n_body, 3),
+        "dof_pos": (n_action,), "dof_vel": (n_action,), "linvel": (3,), "gyro": (3,),
+        "noisy_linvel": (3,), "noisy_gyro": (3,), "noisy_joint_pos_rel": (n_action,),
+        "noisy_dof_vel": (n_action,), "current_actions": (n_action,),
+        "last_actions": (n_action,), "obs_actions": (n_action,),
+        "effective_default_angles": (n_action,), "joint_lower": (n_action,),
+        "joint_upper": (n_action,),
+    }
+    work_shapes = {
+        "delta_pos_w": (3,), "delta_ori_w": (4,), "body_vec_error": (n_body, 3),
+        "env_error": (), "term_scratch": (), "ref_body_pos_w": (n_body, 3),
+        "ref_body_quat_w": (n_body, 4), "motion_anchor_pos_b": (3,),
+        "motion_anchor_ori_b": (6,), "motion_command": (2 * n_action,),
+        "joint_pos_rel": (n_action,), "robot_body_pos_b": (n_body, 3),
+        "robot_body_ori_b": (n_body, 6), "quat_error_w": (n_body,),
+        "quat_error_x": (n_body,), "joint_error": (n_action,),
+        "joint_error_upper": (n_action,), "indexed_error": (n_indexed,),
+        "indexed_mask": (n_indexed,),
+    }
+    # fmt: on
+    # The remaining declarations are a compact registry table.
+    # fmt: off
+    def ins(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(NamedTensorSpec(name, TensorSpec(shapes[name], dtype)) for name in names)
+
+    def work(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(NamedTensorSpec(name, TensorSpec(work_shapes[name], np.bool_ if name == "indexed_mask" else dtype)) for name in names)
+
+    def register(key: str, kind: TermKind, fn: Any, output: TensorSpec,
+                 inputs: tuple[str, ...] = (), workspace: tuple[str, ...] = (),
+                 parameters: tuple[ParameterSpec, ...] = ()) -> None:
+        registry.register(TermDefinition(key, kind, fn, output, inputs=ins(*inputs),
+                                         workspace=work(*workspace), parameters=parameters))
+
+    scalar = TensorSpec((), dtype)
+
+    def float_param(name: str) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.FLOAT)
+
+    def int_param(name: str, many: bool = False) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.INTEGER, tuple_value=many)
+
+    def bool_param(name: str) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.BOOLEAN)
+
+    preamble_inputs = (
+        "motion_body_pos_w", "motion_body_quat_w", "motion_joint_pos", "motion_joint_vel",
+        "robot_body_pos_w", "robot_body_quat_w", "dof_pos", "effective_default_angles",
+    )
+    preamble_work = (
+        "delta_pos_w", "delta_ori_w", "body_vec_error", "env_error", "term_scratch",
+        "ref_body_pos_w", "ref_body_quat_w", "motion_anchor_pos_b", "motion_anchor_ori_b",
+        "motion_command", "joint_pos_rel", "robot_body_pos_b", "robot_body_ori_b",
+    )
+    register(PREAMBLE_KEY, TermKind.OBSERVATION, _preamble, scalar, preamble_inputs,
+             preamble_work, (int_param("anchor_body_idx"),))
+
+    # (function, inputs, workspace, parameters); kept compact so the paired
+    # authoring surface is auditable as one table.
+    reward_defs = {
+        "motion_global_root_pos": (rewards.motion_global_root_pos, ("motion_body_pos_w", "robot_body_pos_w"), ("env_error",), (int_param("anchor_body_idx"), float_param("std"))),
+        "motion_global_root_ori": (rewards.motion_global_root_ori, ("motion_body_quat_w", "robot_body_quat_w"), ("env_error",), (int_param("anchor_body_idx"), float_param("std"))),
+        "motion_body_pos": (rewards.motion_body_pos, ("robot_body_pos_w",), ("ref_body_pos_w", "body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_body_ori": (rewards.motion_body_ori, ("robot_body_quat_w",), ("ref_body_quat_w", "quat_error_w", "quat_error_x", "env_error"), (float_param("std"),)),
+        "motion_body_lin_vel": (rewards.motion_body_lin_vel, ("motion_body_lin_vel_w", "robot_body_lin_vel_w"), ("body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_body_ang_vel": (rewards.motion_body_ang_vel, ("motion_body_ang_vel_w", "robot_body_ang_vel_w"), ("body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_ee_body_pos_z": (rewards.motion_ee_body_pos_z, ("robot_body_pos_w",), ("ref_body_pos_w", "indexed_error", "env_error"), (int_param("indices", True), float_param("std"))),
+        "motion_joint_pos": (rewards.motion_joint_pos, ("motion_joint_pos", "dof_pos"), ("joint_error", "env_error"), (float_param("std"),)),
+        "motion_joint_vel": (rewards.motion_joint_vel, ("motion_joint_vel", "dof_vel"), ("joint_error", "env_error"), (float_param("std"),)),
+        "action_rate_l2": (rewards.action_rate_l2, ("current_actions", "last_actions"), ("joint_error", "env_error"), ()),
+        "joint_limit": (rewards.joint_limit, ("joint_lower", "joint_upper", "dof_pos"), ("joint_error", "joint_error_upper"), ()),
+        "undesired_contacts": (rewards.undesired_contacts, ("robot_body_pos_w",), ("indexed_mask", "env_error"), (int_param("indices", True), float_param("threshold"))),
+    }
+    for name, (fn, inputs, workspace, params) in reward_defs.items():
+        register(REWARD_KEYS[name], TermKind.REWARD, _RewardAdapter(fn), scalar, inputs, workspace, params)
+
+    for key, (group, _label, source, width, is_workspace) in _OBS_META.items():
+        resolved_width = {-1: n_action, -2: 2 * n_action, -3: 3 * n_body, -6: 6 * n_body}.get(width, width)
+        register(key, TermKind.OBSERVATION, _copy, TensorSpec((resolved_width,), dtype),
+                 workspace=(source,) if is_workspace else (),
+                 inputs=() if is_workspace else (source,))
+
+    termination_params = (
+        int_param("anchor_body_idx"), float_param("anchor_pos_z_threshold"),
+        bool_param("check_anchor_ori"), float_param("anchor_ori_threshold"),
+        int_param("ee_indices", True), float_param("ee_threshold"),
+        int_param("contact_indices", True), float_param("contact_threshold"),
+    )
+    register(DEFAULT_TERMINATIONS[0], TermKind.TERMINATION, _termination, TensorSpec((), np.bool_),
+             ("motion_body_pos_w", "motion_body_quat_w", "robot_body_pos_w", "robot_body_quat_w"),
+             ("ref_body_pos_w", "env_error", "indexed_error", "indexed_mask"), termination_params)
+    return registry
+
+
+# fmt: on
+
+
+def resolve_motion_term_plan(
+    *,
+    cfg: Any,
+    n_action: int,
+    n_body: int,
+    anchor_body_idx: int,
+    ee_indices: np.ndarray,
+    undesired_indices: np.ndarray,
+    config: Any,
+    dtype: np.dtype,
+) -> MotionResolvedTermPlan:
+    """Resolve the task-owned motion tracking numeric plan."""
+    n_indexed = max(1, len(ee_indices), len(undesired_indices))
+    registry = _build_registry(n_action=n_action, n_body=n_body, n_indexed=n_indexed, dtype=dtype)
+    configs: list[TermConfig] = []
+    for index, key in enumerate(config.preambles):
+        configs.append(
+            TermConfig(
+                f"preamble.term{index}",
+                key,
+                parameters={"anchor_body_idx": anchor_body_idx} if key == PREAMBLE_KEY else {},
+            )
+        )
+
+    # fmt: off
+    std_names = {
+        "motion_global_root_pos": "std_root_pos", "motion_global_root_ori": "std_root_ori",
+        "motion_body_pos": "std_body_pos", "motion_body_ori": "std_body_ori",
+        "motion_body_lin_vel": "std_body_lin_vel", "motion_body_ang_vel": "std_body_ang_vel",
+        "motion_ee_body_pos_z": "std_body_pos", "motion_joint_pos": "std_joint_pos",
+        "motion_joint_vel": "std_joint_vel",
+    }
+    # fmt: on
+    available = {
+        "motion_ee_body_pos_z": bool(len(ee_indices)),
+        "joint_limit": cfg._joint_lower is not None,
+        "undesired_contacts": bool(len(undesired_indices)),
+    }
+    reward_outputs = []
+    for name, scale in cfg._cfg.reward_config.scales.items():
+        key = REWARD_KEYS.get(name)
+        if key is None:
+            if scale != 0.0:
+                raise TermPlanError(f"motion tracking has unknown nonzero reward term {name!r}")
+            continue
+        params: dict[str, object] = {}
+        if name in std_names:
+            params["std"] = float(getattr(cfg._cfg.reward_config, std_names[name]))
+        if name in ("motion_global_root_pos", "motion_global_root_ori"):
+            params["anchor_body_idx"] = anchor_body_idx
+        if name == "motion_ee_body_pos_z":
+            params["indices"] = ee_indices.tolist()
+        if name == "undesired_contacts":
+            params.update(
+                indices=undesired_indices.tolist(), threshold=cfg._cfg.undesired_contact_z_threshold
+            )
+        output = f"reward.{name}"
+        configs.append(
+            TermConfig(
+                output, key, scale=scale if available.get(name, True) else 0.0, parameters=params
+            )
+        )
+        reward_outputs.append((name, output))
+
+    termination_outputs = []
+    termination_params = {
+        "anchor_body_idx": anchor_body_idx,
+        "anchor_pos_z_threshold": cfg._cfg.anchor_pos_z_threshold,
+        "check_anchor_ori": cfg._cfg.anchor_ori_threshold < 2.0,
+        "anchor_ori_threshold": cfg._cfg.anchor_ori_threshold,
+        "ee_indices": ee_indices.tolist(),
+        "ee_threshold": cfg._cfg.ee_body_pos_z_threshold,
+        "contact_indices": undesired_indices.tolist()
+        if cfg._cfg.terminate_on_undesired_contacts
+        else [],
+        "contact_threshold": cfg._cfg.undesired_contact_z_threshold,
+    }
+    for index, key in enumerate(config.terminations):
+        name = f"termination.term{index}"
+        configs.append(
+            TermConfig(
+                name, key, parameters=termination_params if key == DEFAULT_TERMINATIONS[0] else {}
+            )
+        )
+        termination_outputs.append(name)
+
+    if set(config.observations) != {"obs", "critic"}:
+        raise TermPlanError("motion observation layout must define exactly 'obs' and 'critic'")
+    observation_outputs, observation_labels = {}, {}
+    for group in ("obs", "critic"):
+        keys = config.observations[group]
+        if not isinstance(keys, (list, tuple)) or not keys or len(keys) != len(set(keys)):
+            raise TermPlanError(
+                f"motion observation group {group!r} must be a non-empty unique list"
+            )
+        names, labels = [], []
+        for index, key in enumerate(keys):
+            meta = _OBS_META.get(key)
+            if meta is None:
+                registry.resolve(key)
+            assert meta is not None
+            if meta[0] != group:
+                raise TermPlanError(f"observation term {key!r} does not belong to group {group!r}")
+            name = f"observation.{group}.term{index}"
+            configs.append(TermConfig(name, key))
+            names.append(name)
+            labels.append(meta[1])
+        observation_outputs[group] = tuple(names)
+        observation_labels[group] = tuple(labels)
+
+    return MotionResolvedTermPlan(
+        plan=resolve_term_plan(registry, configs),
+        reward_outputs=tuple(reward_outputs),
+        reward_available=MappingProxyType(available),
+        observation_outputs=MappingProxyType(observation_outputs),
+        observation_labels=MappingProxyType(observation_labels),
+        termination_outputs=tuple(termination_outputs),
+    )

--- a/src/unilab/envs/motion_tracking/common/tracking.py
+++ b/src/unilab/envs/motion_tracking/common/tracking.py
@@ -26,6 +26,7 @@ from .motion_loader import MotionData, MotionLoader, MotionSampler
 from .reset import build_motion_reference_state
 from .rewards import RewardContext, build_reward_functions, compute_reward
 from .terminations import compute_terminations
+from .terms import MotionResolvedTermPlan, resolve_motion_term_plan
 from .transforms import update_relative_transforms
 
 
@@ -171,6 +172,10 @@ class MotionTrackingEnv(G1BaseEnv):
             for name, reward_fn in self._reward_fns.items()
             if self._reward_term_is_active(name)
         }
+        self._resolved_terms: MotionResolvedTermPlan | None = None
+        self._term_runtime: Any = None
+        if cfg.term_plan is not None and not cfg.numba_acceleration:
+            self._init_term_plan(cfg.term_plan)
         self._numba_accelerator = None
         if cfg.numba_acceleration:
             from unilab.envs.motion_tracking.common.numba import MotionTrackingNumbaAccelerator
@@ -279,7 +284,57 @@ class MotionTrackingEnv(G1BaseEnv):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
+        resolved = getattr(self, "_resolved_terms", None)
+        if resolved is not None:
+            return dict(resolved.observation_dims)
         return observations.obs_groups_spec(self)
+
+    def _init_term_plan(self, config: Any) -> None:
+        dtype = np.dtype(get_global_dtype())
+        resolved = resolve_motion_term_plan(
+            cfg=self,
+            n_action=self._num_action,
+            n_body=self._n_motion_bodies,
+            anchor_body_idx=self.anchor_body_idx,
+            ee_indices=self.ee_body_indices,
+            undesired_indices=self.undesired_contact_body_indices,
+            config=config,
+            dtype=dtype,
+        )
+        inputs = {
+            name: np.zeros((self._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (("joint_lower", self._joint_lower), ("joint_upper", self._joint_upper)):
+            if name in inputs and value is not None:
+                np.copyto(inputs[name], value)
+        runtime = resolved.plan.materialize(num_envs=self._num_envs, inputs=inputs)
+        self._resolved_terms = resolved
+        self._term_inputs = inputs
+        self._term_runtime = runtime
+        self._term_obs = {
+            group: np.empty((self._num_envs, width), dtype=dtype)
+            for group, width in resolved.observation_dims.items()
+        }
+        self._term_reward = np.empty((self._num_envs,), dtype=dtype)
+        self._term_terminated = np.empty((self._num_envs,), dtype=np.bool_)
+        self.body_pos_relative_w = runtime.workspace["ref_body_pos_w"]
+        self.body_quat_relative_w = runtime.workspace["ref_body_quat_w"]
+        runtime.execute()  # Bind active owner reward adapters on the cold path.
+        self._sync_term_reward_scales()
+
+    def _sync_term_reward_scales(self) -> None:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        active = []
+        for reward_name, output_name in self._resolved_terms.reward_outputs:
+            configured = self._cfg.reward_config.scales[reward_name]
+            scale = (
+                configured if self._resolved_terms.reward_available.get(reward_name, True) else 0.0
+            )
+            self._term_runtime.set_scale(output_name, scale)
+            if configured != 0.0:
+                active.append((reward_name, output_name))
+        self._active_term_rewards = tuple(active)
 
     def _actor_obs_dim(self, n: int) -> int:
         return observations.actor_obs_dim(n)
@@ -376,37 +431,44 @@ class MotionTrackingEnv(G1BaseEnv):
             obs = numba_result.obs
             state.info["log"] = numba_result.log
         else:
-            # Compute relative body transforms (for observations and rewards)
-            self._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
-
-            # Compute terminations
-            terminated = self._compute_terminations(
-                motion_data, robot_body_pos_w, robot_body_quat_w
-            )
-
-            # Compute reward
-            reward = self._compute_reward(
-                state.info,
-                motion_data,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                robot_body_lin_vel_w,
-                robot_body_ang_vel_w,
-                dof_pos,
-                dof_vel,
-            )
-
-            # Compute observations
-            obs = self._compute_obs(
-                state.info,
-                motion_data,
-                linvel,
-                gyro,
-                dof_pos,
-                dof_vel,
-                robot_body_pos_w,
-                robot_body_quat_w,
-            )
+            if getattr(self, "_term_runtime", None) is not None:
+                obs, reward, terminated = self._compute_term_state(
+                    state.info,
+                    motion_data,
+                    linvel,
+                    gyro,
+                    dof_pos,
+                    dof_vel,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                    robot_body_lin_vel_w,
+                    robot_body_ang_vel_w,
+                )
+            else:
+                self._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
+                terminated = self._compute_terminations(
+                    motion_data, robot_body_pos_w, robot_body_quat_w
+                )
+                reward = self._compute_reward(
+                    state.info,
+                    motion_data,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                    robot_body_lin_vel_w,
+                    robot_body_ang_vel_w,
+                    dof_pos,
+                    dof_vel,
+                )
+                obs = self._compute_obs(
+                    state.info,
+                    motion_data,
+                    linvel,
+                    gyro,
+                    dof_pos,
+                    dof_vel,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                )
 
         # Update failure statistics for adaptive sampling
         self.motion_sampler.update_failure_stats(terminated)
@@ -483,7 +545,7 @@ class MotionTrackingEnv(G1BaseEnv):
         robot_body_quat_w: np.ndarray,
     ) -> dict[str, np.ndarray]:
         """Compute observations as dict with actor and critic groups."""
-        return observations.compute_obs(
+        result = observations.compute_obs(
             self,
             info,
             motion_data,
@@ -494,6 +556,164 @@ class MotionTrackingEnv(G1BaseEnv):
             robot_body_pos_w,
             robot_body_quat_w,
         )
+        resolved = getattr(self, "_resolved_terms", None)
+        if resolved is None:
+            return result
+        n = dof_pos.shape[1]
+        layouts = {
+            "obs": (
+                ("command", 2 * n),
+                ("anchor_pos", 3),
+                ("anchor_ori", 6),
+                ("linvel", 3),
+                ("gyro", 3),
+                ("joint_pos", n),
+                ("dof_vel", n),
+                ("actions", n),
+            ),
+            "critic": (
+                ("command", 2 * n),
+                ("anchor_pos", 3),
+                ("anchor_ori", 6),
+                ("linvel", 3),
+                ("gyro", 3),
+                ("joint_pos", n),
+                ("dof_vel", n),
+                ("actions", n),
+                ("body_pos", self._n_motion_bodies * 3),
+                ("body_ori", self._n_motion_bodies * 6),
+            ),
+        }
+        selected = {}
+        for group, layout in layouts.items():
+            start, slices = 0, {}
+            for label, width in layout:
+                slices[label] = slice(start, start + width)
+                start += width
+            selected[group] = np.concatenate(
+                [result[group][:, slices[label]] for label in resolved.observation_labels[group]],
+                axis=1,
+                dtype=get_global_dtype(),
+            )
+        return selected
+
+    @staticmethod
+    def _copy_term_input(inputs: dict[str, np.ndarray], name: str, value: np.ndarray) -> None:
+        if name in inputs:
+            np.copyto(inputs[name], value, casting="same_kind")
+
+    def _populate_term_inputs(
+        self,
+        info: dict,
+        motion_data: Any,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        robot_body_pos_w: np.ndarray,
+        robot_body_quat_w: np.ndarray,
+        robot_body_lin_vel_w: np.ndarray,
+        robot_body_ang_vel_w: np.ndarray,
+    ) -> None:
+        inputs, copy = self._term_inputs, self._copy_term_input
+        for name, value in (
+            ("motion_body_pos_w", motion_data.body_pos_w),
+            ("motion_body_quat_w", motion_data.body_quat_w),
+            ("motion_body_lin_vel_w", motion_data.body_lin_vel_w),
+            ("motion_body_ang_vel_w", motion_data.body_ang_vel_w),
+            ("motion_joint_pos", motion_data.joint_pos),
+            ("motion_joint_vel", motion_data.joint_vel),
+            ("robot_body_pos_w", robot_body_pos_w),
+            ("robot_body_quat_w", robot_body_quat_w),
+            ("robot_body_lin_vel_w", robot_body_lin_vel_w),
+            ("robot_body_ang_vel_w", robot_body_ang_vel_w),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+            ("linvel", linvel),
+            ("gyro", gyro),
+        ):
+            copy(inputs, name, value)
+        zero = self._zero_actions
+        current = info.get("current_actions")
+        current = current if isinstance(current, np.ndarray) else zero
+        previous = info.get("last_actions")
+        previous = previous if isinstance(previous, np.ndarray) else zero
+        for name, value in (
+            ("current_actions", current),
+            ("last_actions", previous),
+            ("obs_actions", current),
+        ):
+            copy(inputs, name, value)
+        effective_default = self._effective_default_angles()
+        copy(inputs, "effective_default_angles", effective_default)
+
+        noise = self._cfg.noise_config
+        for name, value, scale in (
+            ("noisy_linvel", linvel, noise.scale_linvel),
+            ("noisy_gyro", gyro, noise.scale_gyro),
+        ):
+            if name in inputs:
+                copy(inputs, name, self._obs_noise(value, scale))
+        if "noisy_joint_pos_rel" in inputs:
+            np.subtract(dof_pos, effective_default, out=inputs["noisy_joint_pos_rel"])
+            copy(
+                inputs,
+                "noisy_joint_pos_rel",
+                self._obs_noise(inputs["noisy_joint_pos_rel"], noise.scale_joint_angle),
+            )
+        copy(inputs, "noisy_dof_vel", self._obs_noise(dof_vel, noise.scale_joint_vel))
+
+    def _compute_term_state(
+        self,
+        info: dict,
+        motion_data: Any,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        robot_body_pos_w: np.ndarray,
+        robot_body_quat_w: np.ndarray,
+        robot_body_lin_vel_w: np.ndarray,
+        robot_body_ang_vel_w: np.ndarray,
+    ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray]:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        self._populate_term_inputs(
+            info,
+            motion_data,
+            linvel,
+            gyro,
+            dof_pos,
+            dof_vel,
+            robot_body_pos_w,
+            robot_body_quat_w,
+            robot_body_lin_vel_w,
+            robot_body_ang_vel_w,
+        )
+        outputs = self._term_runtime.execute()
+        for group, names in self._resolved_terms.observation_outputs.items():
+            start = 0
+            for name in names:
+                width = outputs[name].shape[1]
+                np.copyto(self._term_obs[group][:, start : start + width], outputs[name])
+                start += width
+        self._term_reward.fill(0.0)
+        for _, name in self._resolved_terms.reward_outputs:
+            np.add(self._term_reward, outputs[name], out=self._term_reward)
+        self._term_reward *= self._cfg.ctrl_dt
+        self._term_terminated.fill(False)
+        for name in self._resolved_terms.termination_outputs:
+            np.logical_or(self._term_terminated, outputs[name], out=self._term_terminated)
+
+        steps = info.get("steps")
+        should_log = self._enable_reward_log and (
+            int(steps[0]) % 4 == 0 if isinstance(steps, np.ndarray) else True
+        )
+        log = {} if should_log else info.get("log", {})
+        if should_log:
+            for reward_name, name in self._active_term_rewards:
+                log[f"reward/{reward_name}"] = float(np.mean(outputs[name]))
+        info["log"] = log
+        return self._term_obs, self._term_reward, self._term_terminated
 
     def _compute_reward(
         self,

--- a/src/unilab/envs/motion_tracking/common/transforms.py
+++ b/src/unilab/envs/motion_tracking/common/transforms.py
@@ -19,21 +19,51 @@ def update_relative_transforms(
     robot_body_quat_w: np.ndarray,
 ) -> None:
     """Update relative body transforms for tracking."""
+    write_relative_transforms(
+        motion_body_pos_w=motion_data.body_pos_w,
+        motion_body_quat_w=motion_data.body_quat_w,
+        robot_body_pos_w=robot_body_pos_w,
+        robot_body_quat_w=robot_body_quat_w,
+        anchor_body_idx=env.anchor_body_idx,
+        delta_pos_w=env._delta_pos_w,
+        delta_ori_w=env._delta_ori_w,
+        body_vec_error=env._body_vec_error,
+        scalar_scratch=env._env_error,
+        scalar_scratch2=env._reward_term,
+        out_body_pos_w=env.body_pos_relative_w,
+        out_body_quat_w=env.body_quat_relative_w,
+    )
+
+
+def write_relative_transforms(
+    *,
+    motion_body_pos_w: np.ndarray,
+    motion_body_quat_w: np.ndarray,
+    robot_body_pos_w: np.ndarray,
+    robot_body_quat_w: np.ndarray,
+    anchor_body_idx: int,
+    delta_pos_w: np.ndarray,
+    delta_ori_w: np.ndarray,
+    body_vec_error: np.ndarray,
+    scalar_scratch: np.ndarray,
+    scalar_scratch2: np.ndarray,
+    out_body_pos_w: np.ndarray,
+    out_body_quat_w: np.ndarray,
+) -> None:
+    """Write reference transforms using only declared array buffers."""
     # Get anchor states
-    anchor_pos_w = motion_data.body_pos_w[:, env.anchor_body_idx]
-    anchor_quat_w = motion_data.body_quat_w[:, env.anchor_body_idx]
-    robot_anchor_pos_w = robot_body_pos_w[:, env.anchor_body_idx]
-    robot_anchor_quat_w = robot_body_quat_w[:, env.anchor_body_idx]
+    anchor_pos_w = motion_body_pos_w[:, anchor_body_idx]
+    anchor_quat_w = motion_body_quat_w[:, anchor_body_idx]
+    robot_anchor_pos_w = robot_body_pos_w[:, anchor_body_idx]
+    robot_anchor_quat_w = robot_body_quat_w[:, anchor_body_idx]
 
     # Compute delta transform: keep robot's XY position, use motion's Z height
     # and apply yaw-only rotation difference.
-    delta_pos_w = env._delta_pos_w
     delta_pos_w[:] = robot_anchor_pos_w
     delta_pos_w[:, 2] = anchor_pos_w[:, 2]
 
     # Compute yaw-only rotation difference, equivalent to
     # np_yaw_quat(np_quat_mul(robot_anchor_quat_w, np_quat_inv(anchor_quat_w))).
-    delta_ori_w = env._delta_ori_w
     rw, rx, ry, rz = (
         robot_anchor_quat_w[:, 0],
         robot_anchor_quat_w[:, 1],
@@ -59,11 +89,11 @@ def update_relative_transforms(
     dz1 = delta_ori_w[:, 3]
     dw = dw1[:, None]
     dz = dz1[:, None]
-    mw = motion_data.body_quat_w[..., 0]
-    mx = motion_data.body_quat_w[..., 1]
-    my = motion_data.body_quat_w[..., 2]
-    mz = motion_data.body_quat_w[..., 3]
-    out_quat = env.body_quat_relative_w
+    mw = motion_body_quat_w[..., 0]
+    mx = motion_body_quat_w[..., 1]
+    my = motion_body_quat_w[..., 2]
+    mz = motion_body_quat_w[..., 3]
+    out_quat = out_body_quat_w
     out_quat[..., 0] = dw * mw
     out_quat[..., 0] -= dz * mz
     out_quat[..., 1] = dw * mx
@@ -73,16 +103,16 @@ def update_relative_transforms(
     out_quat[..., 3] = dw * mz
     out_quat[..., 3] += dz * mw
 
-    rel_pos = env._body_vec_error
+    rel_pos = body_vec_error
     vx = rel_pos[..., 0]
     vy = rel_pos[..., 1]
     vz = rel_pos[..., 2]
-    np.subtract(motion_data.body_pos_w[..., 0], anchor_pos_w[:, None, 0], out=vx)
-    np.subtract(motion_data.body_pos_w[..., 1], anchor_pos_w[:, None, 1], out=vy)
-    np.subtract(motion_data.body_pos_w[..., 2], anchor_pos_w[:, None, 2], out=vz)
+    np.subtract(motion_body_pos_w[..., 0], anchor_pos_w[:, None, 0], out=vx)
+    np.subtract(motion_body_pos_w[..., 1], anchor_pos_w[:, None, 1], out=vy)
+    np.subtract(motion_body_pos_w[..., 2], anchor_pos_w[:, None, 2], out=vz)
 
-    yaw_cross = env._env_error
-    yaw_z2 = env._reward_term
+    yaw_cross = scalar_scratch
+    yaw_z2 = scalar_scratch2
     np.multiply(dw1, dz1, out=yaw_cross)
     yaw_cross *= 2.0
     np.square(dz1, out=yaw_z2)
@@ -90,7 +120,7 @@ def update_relative_transforms(
     yaw_cross_2d = yaw_cross[:, None]
     yaw_z2_2d = yaw_z2[:, None]
 
-    out_pos = env.body_pos_relative_w
+    out_pos = out_body_pos_w
     out_pos[..., 0] = vx
     out_pos[..., 0] -= yaw_cross_2d * vy
     out_pos[..., 0] -= yaw_z2_2d * vx

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -18,6 +18,7 @@ from unilab.base.scene import SceneCfg
 from ..common.config import (
     Domain_Rand,
     DomainRand,
+    MotionTermPlanConfig,
     MotionTrackingCfg,
     MotionTrackingDeployEnvCfg,
     PoseRandomization,
@@ -41,7 +42,7 @@ _build_motion_reference_state = build_motion_reference_state
 class G1MotionTrackingEnvCfg(MotionTrackingCfg):
     """Registered configuration for G1 motion tracking."""
 
-    pass
+    term_plan: MotionTermPlanConfig | None = field(default_factory=MotionTermPlanConfig)
 
 
 @registry.envcfg("G1MotionTrackingDeploy")

--- a/tests/envs/test_g1_motion_tracking_numba.py
+++ b/tests/envs/test_g1_motion_tracking_numba.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
+from unilab.envs.motion_tracking.common import observations
+from unilab.envs.motion_tracking.common.config import MotionTermPlanConfig
 from unilab.envs.motion_tracking.common.numba import (
     NUMBA_AVAILABLE,
     MotionTrackingNumbaAccelerator,
@@ -37,6 +39,70 @@ def test_numba_accelerator_rejects_unsupported_active_reward_terms():
     if NUMBA_AVAILABLE:
         with pytest.raises(ValueError, match="does not support active reward terms"):
             MotionTrackingNumbaAccelerator.from_env(env)
+
+
+def test_motion_term_plan_matches_legacy_numpy_and_reuses_workspace():
+    n = 8
+    env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
+    env._cfg.noise_config.level = 1.0
+
+    motion_data, robot_state, info = _make_batch(n, seed=11)
+    body_pos, body_quat, body_linvel, body_angvel, dof_pos, dof_vel = robot_state
+    rng = np.random.default_rng(12)
+    linvel = rng.normal(size=(n, 3)).astype(np.float32)
+    gyro = rng.normal(size=(n, 3)).astype(np.float32)
+    env._update_relative_transforms(motion_data, body_pos, body_quat)
+    expected_termination = env._compute_terminations(motion_data, body_pos, body_quat).copy()
+    expected_reward = env._compute_reward(
+        {**info, "log": {}},
+        motion_data,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+        dof_pos,
+        dof_vel,
+    ).copy()
+    np.random.seed(13)
+    expected_obs = observations.compute_obs(
+        env, info, motion_data, linvel, gyro, dof_pos, dof_vel, body_pos, body_quat
+    )
+    expected_obs = {name: value.copy() for name, value in expected_obs.items()}
+
+    env._init_term_plan(MotionTermPlanConfig())
+    np.random.seed(13)
+    actual = env._compute_term_state(
+        {**info, "log": {}},
+        motion_data,
+        linvel,
+        gyro,
+        dof_pos,
+        dof_vel,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+    )
+    workspace_ids = tuple(id(value) for value in env._term_runtime.workspace.values())
+
+    np.testing.assert_allclose(actual[0]["obs"], expected_obs["obs"], rtol=2e-5, atol=2e-5)
+    np.testing.assert_allclose(actual[0]["critic"], expected_obs["critic"], rtol=2e-5, atol=2e-5)
+    np.testing.assert_allclose(actual[1], expected_reward, rtol=2e-5, atol=2e-5)
+    np.testing.assert_array_equal(actual[2], expected_termination)
+    env._compute_term_state(
+        {**info, "log": {}},
+        motion_data,
+        linvel,
+        gyro,
+        dof_pos,
+        dof_vel,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+    )
+    assert tuple(id(value) for value in env._term_runtime.workspace.values()) == workspace_ids
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
@@ -100,17 +166,7 @@ def test_g1_motion_tracking_numba_reward_termination_parity():
 def test_g1_motion_tracking_numba_update_state_parity_without_noise():
     n = 512
     env = _make_env(n, include_undesired=True)
-    env.default_angles = np.linspace(-0.2, 0.2, env._num_action).astype(np.float32)
-    env._actor_obs_width = env._actor_obs_dim(env._num_action)
-    env._critic_base_obs_width = env._critic_base_obs_dim(env._num_action)
-    env._critic_obs_width = env._critic_base_obs_width + env._n_motion_bodies * 9
-    env._motion_anchor_pos_b = np.empty((n, 3), dtype=np.float32)
-    env._motion_anchor_ori_b = np.empty((n, 6), dtype=np.float32)
-    env._joint_pos_rel = np.empty((n, env._num_action), dtype=np.float32)
-    env._motion_command = np.empty((n, env._num_action * 2), dtype=np.float32)
-    env._zero_actions = np.zeros((n, env._num_action), dtype=np.float32)
-    env._body_vec_tmp = np.empty((n, env._n_motion_bodies, 3), dtype=np.float32)
-    env._cfg.noise_config = _NoiseCfg()
+    _prepare_observation_buffers(env, n)
 
     motion_data, robot_state, info = _make_batch(n, seed=2)
     (
@@ -263,6 +319,20 @@ class _NoiseCfg:
     scale_gyro: float = 0.1
     scale_joint_angle: float = 0.02
     scale_joint_vel: float = 0.3
+
+
+def _prepare_observation_buffers(env: Any, n: int) -> None:
+    env.default_angles = np.linspace(-0.2, 0.2, env._num_action).astype(np.float32)
+    env._actor_obs_width = env._actor_obs_dim(env._num_action)
+    env._critic_base_obs_width = env._critic_base_obs_dim(env._num_action)
+    env._critic_obs_width = env._critic_base_obs_width + env._n_motion_bodies * 9
+    env._motion_anchor_pos_b = np.empty((n, 3), dtype=np.float32)
+    env._motion_anchor_ori_b = np.empty((n, 6), dtype=np.float32)
+    env._joint_pos_rel = np.empty((n, env._num_action), dtype=np.float32)
+    env._motion_command = np.empty((n, env._num_action * 2), dtype=np.float32)
+    env._zero_actions = np.zeros((n, env._num_action), dtype=np.float32)
+    env._body_vec_tmp = np.empty((n, env._n_motion_bodies, 3), dtype=np.float32)
+    env._cfg.noise_config = _NoiseCfg()
 
 
 def _make_env(n: int, *, include_undesired: bool) -> Any:


### PR DESCRIPTION
## Summary

- register the G1 motion tracking transform preamble, 12 rewards, combined termination, and actor/critic observation terms in one resolved plan
- prebind numeric inputs and reuse plan-owned output/workspace buffers while preserving reference sampling, failure accounting, frame advance, teleport, truncation, and autoreset ownership
- make the PPO MuJoCo owner YAML declare the pilot term layout; non-pilot motion configs retain the legacy path and the experimental hand-written Numba accelerator is unchanged

## Validation

- make test-all: 1662 passed, 37 skipped, 280 deselected, 1 xfailed
- benchmark smoke: module 34/35 and script 35/36; only optional MLX skipped
- motion NumPy term-plan parity with actor noise enabled: passed
- motion hand-written Numba slow parity: 2 passed
- clip-end, teleport, adaptive-failure ordering, and final-observation focused regressions: passed
- mypy and pyright: passed; existing optional mlx.core warning only

Fixes #921