### PR TITLE
feat: assemble motion tracking Numba plan

### DIFF
--- a/benchmark/env/benchmark_g1_motion_tracking_numba.py
+++ b/benchmark/env/benchmark_g1_motion_tracking_numba.py
@@ -3,8 +3,8 @@
 
 This benchmark has two scopes:
 
-* default hot slice: reward plus termination, using deterministic synthetic
-  arrays and the real ``G1MotionTrackingEnv`` reward/termination methods;
+* default hot slice: fused update-state numerics, using deterministic synthetic
+  arrays and the real ``G1MotionTrackingEnv`` owner methods;
 * default ``--e2e``: collector-side A/B through
   ``benchmark_offpolicy_collector_active.py`` without learner updates.
 
@@ -45,6 +45,7 @@ except Exception:  # pragma: no cover - plotting is optional in benchmark script
 
 from benchmark.core.device_info import get_device_info_dict, get_device_info_line
 from unilab.dtype_config import get_global_dtype
+from unilab.envs.motion_tracking.common.config import MotionTermPlanConfig
 from unilab.envs.motion_tracking.common.numba import (
     MotionTrackingNumbaAccelerator,
 )
@@ -132,8 +133,8 @@ class ComponentCase:
     num_envs: int
     numba_threads: int
     relative_transform_ms: float
-    numpy_reward_termination_ms: float
-    numba_reward_termination_ms: float
+    numpy_plan_state_ms: float
+    numba_plan_state_ms: float
     numpy_update_state_ms: float
     numba_update_state_ms: float
     numpy_total_ms: float
@@ -199,6 +200,7 @@ class SyntheticCfg:
     ee_body_names: tuple[str, ...] = G1MotionTrackingCfg.ee_body_names
     undesired_contact_z_threshold: float = G1MotionTrackingCfg.undesired_contact_z_threshold
     terminate_on_undesired_contacts: bool = G1MotionTrackingCfg.terminate_on_undesired_contacts
+    term_plan: MotionTermPlanConfig = field(default_factory=MotionTermPlanConfig)
 
 
 @dataclass
@@ -371,33 +373,19 @@ def make_batch(num_envs: int, spec: ProfileSpec, seed: int) -> SyntheticBatch:
 
 
 def compute_numpy(batch: SyntheticBatch) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
-    env = batch.env
-    info = {**batch.info, "log": {}}
-    terminated = env._compute_terminations(
-        batch.motion_data, batch.robot_body_pos_w, batch.robot_body_quat_w
-    )
-    reward = env._compute_reward(
-        info,
-        batch.motion_data,
-        batch.robot_body_pos_w,
-        batch.robot_body_quat_w,
-        batch.robot_body_lin_vel_w,
-        batch.robot_body_ang_vel_w,
-        batch.dof_pos,
-        batch.dof_vel,
-    )
-    return reward, terminated, info.get("log", {})
+    _, reward, terminated, log = compute_numpy_update_state(batch)
+    return reward, terminated, log
 
 
 def compute_numba(
     batch: SyntheticBatch, accelerator: MotionTrackingNumbaAccelerator
 ) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
     info = {**batch.info, "log": {}}
-    out = accelerator.compute(
+    out = accelerator.compute_update_state(
         info=info,
         motion_data=batch.motion_data,
-        ref_body_pos_w=batch.env.body_pos_relative_w,
-        ref_body_quat_w=batch.env.body_quat_relative_w,
+        linvel=batch.linvel,
+        gyro=batch.gyro,
         robot_body_pos_w=batch.robot_body_pos_w,
         robot_body_quat_w=batch.robot_body_quat_w,
         robot_body_lin_vel_w=batch.robot_body_lin_vel_w,
@@ -454,7 +442,6 @@ def compute_numba_update_state(
     batch: SyntheticBatch, accelerator: MotionTrackingNumbaAccelerator
 ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray, dict[str, float]]:
     info = {**batch.info, "log": {}}
-    noise_cfg = batch.env._cfg.noise_config
     out = accelerator.compute_update_state(
         info=info,
         motion_data=batch.motion_data,
@@ -466,18 +453,8 @@ def compute_numba_update_state(
         robot_body_quat_w=batch.robot_body_quat_w,
         robot_body_lin_vel_w=batch.robot_body_lin_vel_w,
         robot_body_ang_vel_w=batch.robot_body_ang_vel_w,
-        ref_body_pos_w=batch.env.body_pos_relative_w,
-        ref_body_quat_w=batch.env.body_quat_relative_w,
-        motion_anchor_pos_b=batch.env._motion_anchor_pos_b,
-        motion_anchor_ori_b=batch.env._motion_anchor_ori_b,
-        joint_pos_rel=batch.env._joint_pos_rel,
         scales=batch.env._cfg.reward_config.scales,
         enable_log=True,
-        noise_level=noise_cfg.level,
-        noise_scale_linvel=noise_cfg.scale_linvel,
-        noise_scale_gyro=noise_cfg.scale_gyro,
-        noise_scale_joint_angle=noise_cfg.scale_joint_angle,
-        noise_scale_joint_vel=noise_cfg.scale_joint_vel,
     )
     return out.obs, out.reward, out.terminated, out.log
 
@@ -612,8 +589,8 @@ def bench_one(
         num_envs=num_envs,
         numba_threads=int(best_numba.threads or 1),
         relative_transform_ms=relative_mean,
-        numpy_reward_termination_ms=numpy_mean,
-        numba_reward_termination_ms=best_numba.mean_ms,
+        numpy_plan_state_ms=numpy_mean,
+        numba_plan_state_ms=best_numba.mean_ms,
         numpy_update_state_ms=numpy_update_state_mean,
         numba_update_state_ms=numba_update_state_mean,
         numpy_total_ms=numpy_total_ms,
@@ -646,8 +623,8 @@ def _component_case_to_dict(case: ComponentCase) -> dict[str, Any]:
         "num_envs": case.num_envs,
         "numba_threads": case.numba_threads,
         "relative_transform_ms": case.relative_transform_ms,
-        "numpy_reward_termination_ms": case.numpy_reward_termination_ms,
-        "numba_reward_termination_ms": case.numba_reward_termination_ms,
+        "numpy_plan_state_ms": case.numpy_plan_state_ms,
+        "numba_plan_state_ms": case.numba_plan_state_ms,
         "numpy_update_state_ms": case.numpy_update_state_ms,
         "numba_update_state_ms": case.numba_update_state_ms,
         "numpy_total_ms": case.numpy_total_ms,
@@ -858,8 +835,8 @@ def _format_component_table(records: list[ComponentCase]) -> str:
         "envs",
         "threads",
         "rel ms",
-        "numpy reward+term ms",
-        "numba reward+term ms",
+        "numpy plan-state ms",
+        "numba plan-state ms",
         "numpy update_state ms",
         "numba update_state ms",
         "update_state speedup",
@@ -870,8 +847,8 @@ def _format_component_table(records: list[ComponentCase]) -> str:
             str(record.num_envs),
             str(record.numba_threads),
             f"{record.relative_transform_ms:.3f}",
-            f"{record.numpy_reward_termination_ms:.3f}",
-            f"{record.numba_reward_termination_ms:.3f}",
+            f"{record.numpy_plan_state_ms:.3f}",
+            f"{record.numba_plan_state_ms:.3f}",
             f"{record.numpy_update_state_ms:.3f}",
             f"{record.numba_update_state_ms:.3f}",
             f"{record.speedup_vs_numpy:.2f}x",
@@ -1128,9 +1105,7 @@ def save_plots(
     best_by_case = _best_numba_by_case(records)
 
     fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(21, 6))
-    fig.suptitle(
-        f"G1 motion tracking Numba reward+termination benchmark\n{device_info}", fontsize=13
-    )
+    fig.suptitle(f"G1 motion tracking Numba fused plan-state benchmark\n{device_info}", fontsize=13)
 
     ax1, ax2, ax3 = axes
     for profile in profiles:
@@ -1270,7 +1245,7 @@ def write_report(
         "skipped_threads": getattr(args, "skipped_threads", None),
         "numba_max_threads": getattr(args, "numba_max_threads", None),
         "scope": (
-            "G1 motion tracking reward+termination hot slice plus full update_state "
+            "G1 motion tracking fused plan-state hot slice plus repeated update_state "
             "array-path reconciliation; synthetic arrays"
         ),
         "e2e_enabled": args.e2e,
@@ -1294,7 +1269,7 @@ def write_report(
     summary_lines = [
         "# G1 motion tracking Numba benchmark",
         "",
-        "Scope: reward plus termination for `G1MotionTrackingEnv.update_state`, using",
+        "Scope: fused numeric state for `G1MotionTrackingEnv.update_state`, using",
         "deterministic synthetic arrays. The component table additionally measures the",
         "full array portion of `update_state`: relative transforms, reward, termination,",
         "and actor/critic observation assembly. Backend state getters, motion sampling,",
@@ -1304,7 +1279,7 @@ def write_report(
         "",
         "Definitions:",
         "",
-        "- `vs numpy`: numpy reward+termination time divided by numba reward+termination time.",
+        "- `vs numpy`: NumPy plan-state time divided by Numba plan-state time.",
         "- `vs numba1T`: numba 1-thread time divided by numba N-thread time.",
         "- `parallel eff`: `vs numba1T / N`; this is the only parallel-efficiency column.",
         "",
@@ -1493,7 +1468,7 @@ def main() -> None:
     args.skipped_threads = sorted({threads for threads in args.threads if threads > max_threads})
 
     print("=" * 80)
-    print("G1 motion tracking Numba benchmark: reward + termination")
+    print("G1 motion tracking Numba benchmark: fused plan state")
     print("=" * 80)
     print(f"host numba threads: {max_threads}")
     print(

--- a/benchmark/env/test_g1_motion_tracking_numba_benchmark.py
+++ b/benchmark/env/test_g1_motion_tracking_numba_benchmark.py
@@ -21,7 +21,9 @@ def test_g1_motion_tracking_numba_benchmark_builds_records_and_matches_numpy() -
     assert any(record.path == "numba_accelerator" and record.threads == 1 for record in records)
     assert component.profile == "sac_default"
     assert component.speedup_vs_numpy > 0.0
-    assert component.numpy_total_ms >= component.numpy_reward_termination_ms
+    assert component.numpy_plan_state_ms > 0.0
+    assert component.numba_plan_state_ms > 0.0
+    assert component.numpy_total_ms > 0.0
     assert all(
         record.parallel_speedup_vs_numba_1t is not None
         for record in records
@@ -67,8 +69,8 @@ def test_g1_motion_tracking_numba_benchmark_formats_component_records() -> None:
         num_envs=1024,
         numba_threads=8,
         relative_transform_ms=0.5,
-        numpy_reward_termination_ms=1.0,
-        numba_reward_termination_ms=0.25,
+        numpy_plan_state_ms=1.0,
+        numba_plan_state_ms=0.25,
         numpy_update_state_ms=3.0,
         numba_update_state_ms=1.5,
         numpy_total_ms=1.5,
@@ -80,7 +82,9 @@ def test_g1_motion_tracking_numba_benchmark_formats_component_records() -> None:
     table = bench._format_component_table([record])
 
     assert payload["relative_transform_ms"] == 0.5
+    assert payload["numba_plan_state_ms"] == 0.25
     assert "rel ms" in table
+    assert "numba plan-state ms" in table
     assert "numpy update_state ms" in table
     assert "2.00x" in table
 

--- a/src/unilab/envs/motion_tracking/common/numba.py
+++ b/src/unilab/envs/motion_tracking/common/numba.py
@@ -9,52 +9,33 @@ accelerator is not.
 from __future__ import annotations
 
 import math
+import time
 from dataclasses import dataclass
 from typing import Any, Mapping
 
 import numpy as np
 
+from unilab.dtype_config import get_global_dtype
 from unilab.utils.numba_geometry import (
     quat_angle_sq_at,
     quat_gravity_z_at,
-    write_body_pos_relative_to_anchor_at,
-    write_body_quat_relative_6d_to_anchor_at,
     write_relative_anchor_transform_at,
     write_yaw_aligned_body_transforms_at,
 )
 
 try:  # pragma: no cover - exercised in environments with numba installed
-    from numba import get_num_threads, get_thread_id, njit, prange, set_num_threads
+    from numba import get_num_threads, njit, set_num_threads
 
     NUMBA_AVAILABLE = True
 except Exception:  # pragma: no cover - default test env may not install numba
-    get_num_threads = get_thread_id = njit = prange = set_num_threads = None  # type: ignore[assignment]
+    get_num_threads = njit = set_num_threads = None  # type: ignore[assignment]
     NUMBA_AVAILABLE = False
 
 
-TERM_ORDER: tuple[str, ...] = (
-    "motion_global_root_pos",
-    "motion_global_root_ori",
-    "motion_body_pos",
-    "motion_body_ori",
-    "motion_body_lin_vel",
-    "motion_body_ang_vel",
-    "motion_ee_body_pos_z",
-    "motion_joint_pos",
-    "motion_joint_vel",
-    "action_rate_l2",
-    "joint_limit",
-    "undesired_contacts",
-)
-TERM_INDEX = {name: i for i, name in enumerate(TERM_ORDER)}
-SUPPORTED_TERMS = frozenset(TERM_ORDER)
-
-
-@dataclass(frozen=True)
-class G1MotionTrackingNumbaResult:
-    reward: np.ndarray
-    terminated: np.ndarray
-    log: dict[str, float]
+NUMBA_PREAMBLE_ITEM = None
+NUMBA_REWARD_ITEMS: dict[str, Any] = {}
+NUMBA_OBSERVATION_ITEM = None
+NUMBA_TERMINATION_ITEM = None
 
 
 @dataclass(frozen=True)
@@ -71,7 +52,9 @@ def _active_terms(scales: Mapping[str, float]) -> frozenset[str]:
 
 def unsupported_terms(scales: Mapping[str, float]) -> frozenset[str]:
     """Return nonzero reward terms this task-specific kernel cannot compute."""
-    return _active_terms(scales) - SUPPORTED_TERMS
+    from unilab.envs.motion_tracking.common.terms import REWARD_KEYS
+
+    return _active_terms(scales) - REWARD_KEYS.keys()
 
 
 def is_available(scales: Mapping[str, float]) -> bool:
@@ -220,142 +203,6 @@ if NUMBA_AVAILABLE:
                     return True
         return False
 
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_kernel(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
-        anchor,
-        ee_indices,
-        undesired_indices,
-        ctrl_dt,
-        anchor_pos_z_threshold,
-        anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        reward,
-        terminated,
-        log_scratch,
-    ):
-        n = reward.shape[0]
-        n_body = robot_body_pos_w.shape[1]
-        n_action = dof_pos.shape[1]
-        for i in prange(n):
-            tid = get_thread_id()
-            total = 0.0
-
-            w = (
-                motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
-                * scale[0]
-            )
-            total += w
-            log_scratch[tid, 0] += w
-
-            w = (
-                motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
-                * scale[1]
-            )
-            total += w
-            log_scratch[tid, 1] += w
-
-            w = motion_body_pos_i(ref_body_pos_w, robot_body_pos_w, n_body, std[2], i) * scale[2]
-            total += w
-            log_scratch[tid, 2] += w
-
-            w = motion_body_ori_i(ref_body_quat_w, robot_body_quat_w, n_body, std[3], i) * scale[3]
-            total += w
-            log_scratch[tid, 3] += w
-
-            w = (
-                motion_body_lin_vel_i(
-                    motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i
-                )
-                * scale[4]
-            )
-            total += w
-            log_scratch[tid, 4] += w
-
-            w = (
-                motion_body_ang_vel_i(
-                    motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i
-                )
-                * scale[5]
-            )
-            total += w
-            log_scratch[tid, 5] += w
-
-            w = (
-                motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
-                * scale[6]
-            )
-            total += w
-            log_scratch[tid, 6] += w
-
-            w = motion_joint_pos_i(motion_joint_pos, dof_pos, n_action, std[7], i) * scale[7]
-            total += w
-            log_scratch[tid, 7] += w
-
-            w = motion_joint_vel_i(motion_joint_vel, dof_vel, n_action, std[8], i) * scale[8]
-            total += w
-            log_scratch[tid, 8] += w
-
-            w = action_rate_l2_i(current_actions, last_actions, n_action, i) * scale[9]
-            total += w
-            log_scratch[tid, 9] += w
-
-            w = (
-                joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
-                * scale[10]
-            )
-            total += w
-            log_scratch[tid, 10] += w
-
-            w = (
-                undesired_contacts_i(
-                    robot_body_pos_w, undesired_indices, undesired_contact_z_threshold, i
-                )
-                * scale[11]
-            )
-            total += w
-            log_scratch[tid, 11] += w
-
-            reward[i] = total * ctrl_dt
-            terminated[i] = terminated_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                ref_body_pos_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                ee_indices,
-                undesired_indices,
-                anchor_pos_z_threshold,
-                anchor_ori_threshold,
-                ee_body_pos_z_threshold,
-                undesired_contact_z_threshold,
-                terminate_on_undesired_contacts,
-                i,
-            )
-
     @_dev
     def _write_reference_transforms_i(
         motion_body_pos_w,
@@ -402,733 +249,428 @@ if NUMBA_AVAILABLE:
             i,
         )
 
-    @njit(fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_i(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
+
+if NUMBA_AVAILABLE:
+
+    @_dev
+    def _write_body_workspace_i(
+        body_pos_w,
+        body_quat_w,
         anchor,
-        ee_indices,
-        undesired_indices,
-        n_body,
-        n_action,
-        ctrl_dt,
-        anchor_pos_z_threshold,
-        anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        log_scratch,
-        reward,
-        terminated,
-        tid,
+        body_pos_b,
+        body_ori_b,
         i,
     ):
-        total = 0.0
+        anchor_px = body_pos_w[i, anchor, 0]
+        anchor_py = body_pos_w[i, anchor, 1]
+        anchor_pz = body_pos_w[i, anchor, 2]
+        aw = body_quat_w[i, anchor, 0]
+        ax = body_quat_w[i, anchor, 1]
+        ay = body_quat_w[i, anchor, 2]
+        az = body_quat_w[i, anchor, 3]
+        for body in range(body_pos_w.shape[1]):
+            vx = body_pos_w[i, body, 0] - anchor_px
+            vy = body_pos_w[i, body, 1] - anchor_py
+            vz = body_pos_w[i, body, 2] - anchor_pz
+            ix, iy, iz = -ax, -ay, -az
+            tx = 2.0 * (iy * vz - iz * vy)
+            ty = 2.0 * (iz * vx - ix * vz)
+            tz = 2.0 * (ix * vy - iy * vx)
+            body_pos_b[i, body, 0] = vx + aw * tx + iy * tz - iz * ty
+            body_pos_b[i, body, 1] = vy + aw * ty + iz * tx - ix * tz
+            body_pos_b[i, body, 2] = vz + aw * tz + ix * ty - iy * tx
 
-        w = (
-            motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
-            * scale[0]
-        )
-        total += w
-        log_scratch[tid, 0] += w
+            bw = body_quat_w[i, body, 0]
+            bx = body_quat_w[i, body, 1]
+            by = body_quat_w[i, body, 2]
+            bz = body_quat_w[i, body, 3]
+            rw = aw * bw + ax * bx + ay * by + az * bz
+            rx = aw * bx - ax * bw - ay * bz + az * by
+            ry = aw * by + ax * bz - ay * bw - az * bx
+            rz = aw * bz - ax * by + ay * bx - az * bw
+            body_ori_b[i, body, 0] = 1.0 - 2.0 * (ry * ry + rz * rz)
+            body_ori_b[i, body, 1] = 2.0 * (rx * ry - rw * rz)
+            body_ori_b[i, body, 2] = 2.0 * (rx * ry + rw * rz)
+            body_ori_b[i, body, 3] = 1.0 - 2.0 * (rx * rx + rz * rz)
+            body_ori_b[i, body, 4] = 2.0 * (rx * rz - rw * ry)
+            body_ori_b[i, body, 5] = 2.0 * (ry * rz + rw * rx)
 
-        w = (
-            motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
-            * scale[1]
-        )
-        total += w
-        log_scratch[tid, 1] += w
-
-        w = motion_body_pos_i(ref_body_pos_w, robot_body_pos_w, n_body, std[2], i) * scale[2]
-        total += w
-        log_scratch[tid, 2] += w
-
-        w = motion_body_ori_i(ref_body_quat_w, robot_body_quat_w, n_body, std[3], i) * scale[3]
-        total += w
-        log_scratch[tid, 3] += w
-
-        w = (
-            motion_body_lin_vel_i(motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i)
-            * scale[4]
-        )
-        total += w
-        log_scratch[tid, 4] += w
-
-        w = (
-            motion_body_ang_vel_i(motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i)
-            * scale[5]
-        )
-        total += w
-        log_scratch[tid, 5] += w
-
-        w = (
-            motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
-            * scale[6]
-        )
-        total += w
-        log_scratch[tid, 6] += w
-
-        w = motion_joint_pos_i(motion_joint_pos, dof_pos, n_action, std[7], i) * scale[7]
-        total += w
-        log_scratch[tid, 7] += w
-
-        w = motion_joint_vel_i(motion_joint_vel, dof_vel, n_action, std[8], i) * scale[8]
-        total += w
-        log_scratch[tid, 8] += w
-
-        w = action_rate_l2_i(current_actions, last_actions, n_action, i) * scale[9]
-        total += w
-        log_scratch[tid, 9] += w
-
-        w = (
-            joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
-            * scale[10]
-        )
-        total += w
-        log_scratch[tid, 10] += w
-
-        w = (
-            undesired_contacts_i(
-                robot_body_pos_w, undesired_indices, undesired_contact_z_threshold, i
-            )
-            * scale[11]
-        )
-        total += w
-        log_scratch[tid, 11] += w
-
-        reward[i] = total * ctrl_dt
-        terminated[i] = terminated_i(
+    @_dev
+    def _plan_preamble_i(
+        motion_body_pos_w,
+        motion_body_quat_w,
+        motion_joint_pos,
+        motion_joint_vel,
+        robot_body_pos_w,
+        robot_body_quat_w,
+        dof_pos,
+        effective_default_angles,
+        anchor,
+        delta_pos_w,
+        delta_ori_w,
+        body_vec_error,
+        env_error,
+        term_scratch,
+        ref_body_pos_w,
+        ref_body_quat_w,
+        motion_anchor_pos_b,
+        motion_anchor_ori_b,
+        motion_command,
+        joint_pos_rel,
+        robot_body_pos_b,
+        robot_body_ori_b,
+        i,
+    ):
+        anchor_idx = int(anchor)
+        n_body = robot_body_pos_w.shape[1]
+        _write_reference_transforms_i(
             motion_body_pos_w,
             motion_body_quat_w,
+            robot_body_pos_w,
+            robot_body_quat_w,
+            anchor_idx,
+            n_body,
             ref_body_pos_w,
+            ref_body_quat_w,
+            i,
+        )
+        _write_motion_anchor_i(
+            motion_body_pos_w,
+            motion_body_quat_w,
             robot_body_pos_w,
             robot_body_quat_w,
-            anchor,
-            ee_indices,
-            undesired_indices,
-            anchor_pos_z_threshold,
-            anchor_ori_threshold,
-            ee_body_pos_z_threshold,
-            undesired_contact_z_threshold,
-            terminate_on_undesired_contacts,
-            i,
-        )
-
-    @_dev
-    def _write_joint_pos_rel_i(
-        dof_pos,
-        default_angles,
-        default_dof_pos_bias,
-        has_default_dof_pos_bias,
-        joint_pos_rel,
-        n_action,
-        i,
-    ):
-        for j in range(n_action):
-            default = default_angles[j]
-            if has_default_dof_pos_bias:
-                default += default_dof_pos_bias[i, j]
-            joint_pos_rel[i, j] = dof_pos[i, j] - default
-
-    @_dev
-    def _write_actor_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        actor_noise_linvel,
-        actor_noise_gyro,
-        actor_noise_joint_pos,
-        actor_noise_dof_vel,
-        actor_obs,
-        is_deploy_actor,
-        n_action,
-        i,
-    ):
-        out = 0
-        for j in range(n_action):
-            actor_obs[i, out + j] = motion_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = motion_joint_vel[i, j]
-        out += n_action
-        if not is_deploy_actor:
-            actor_obs[i, out] = motion_anchor_pos_b[i, 0]
-            actor_obs[i, out + 1] = motion_anchor_pos_b[i, 1]
-            actor_obs[i, out + 2] = motion_anchor_pos_b[i, 2]
-            out += 3
-        for k in range(6):
-            actor_obs[i, out + k] = motion_anchor_ori_b[i, k]
-        out += 6
-        if not is_deploy_actor:
-            actor_obs[i, out] = linvel[i, 0] + actor_noise_linvel[i, 0]
-            actor_obs[i, out + 1] = linvel[i, 1] + actor_noise_linvel[i, 1]
-            actor_obs[i, out + 2] = linvel[i, 2] + actor_noise_linvel[i, 2]
-            out += 3
-        actor_obs[i, out] = gyro[i, 0] + actor_noise_gyro[i, 0]
-        actor_obs[i, out + 1] = gyro[i, 1] + actor_noise_gyro[i, 1]
-        actor_obs[i, out + 2] = gyro[i, 2] + actor_noise_gyro[i, 2]
-        out += 3
-        for j in range(n_action):
-            actor_obs[i, out + j] = joint_pos_rel[i, j] + actor_noise_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = dof_vel[i, j] + actor_noise_dof_vel[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = current_actions[i, j]
-
-    @_dev
-    def _write_critic_base_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        critic_obs,
-        n_action,
-        i,
-    ):
-        out = 0
-        for j in range(n_action):
-            critic_obs[i, out + j] = motion_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = motion_joint_vel[i, j]
-        out += n_action
-        critic_obs[i, out] = motion_anchor_pos_b[i, 0]
-        critic_obs[i, out + 1] = motion_anchor_pos_b[i, 1]
-        critic_obs[i, out + 2] = motion_anchor_pos_b[i, 2]
-        out += 3
-        for k in range(6):
-            critic_obs[i, out + k] = motion_anchor_ori_b[i, k]
-        out += 6
-        critic_obs[i, out] = linvel[i, 0]
-        critic_obs[i, out + 1] = linvel[i, 1]
-        critic_obs[i, out + 2] = linvel[i, 2]
-        out += 3
-        critic_obs[i, out] = gyro[i, 0]
-        critic_obs[i, out + 1] = gyro[i, 1]
-        critic_obs[i, out + 2] = gyro[i, 2]
-        out += 3
-        for j in range(n_action):
-            critic_obs[i, out + j] = joint_pos_rel[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = dof_vel[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = current_actions[i, j]
-
-    @_dev
-    def _write_critic_body_pos_i(
-        robot_body_pos_w,
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        out,
-        i,
-    ):
-        write_body_pos_relative_to_anchor_at(
-            robot_body_pos_w,
-            robot_body_quat_w,
-            anchor,
-            n_body,
-            critic_obs,
-            i,
-            out,
-        )
-
-    @_dev
-    def _write_critic_body_ori_i(
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        out,
-        i,
-    ):
-        write_body_quat_relative_6d_to_anchor_at(
-            robot_body_quat_w,
-            anchor,
-            n_body,
-            critic_obs,
-            i,
-            out,
-        )
-
-    @_dev
-    def _write_critic_linvel_tail_i(linvel, critic_obs, out, i):
-        if critic_obs.shape[1] > out:
-            critic_obs[i, out] = linvel[i, 0]
-            critic_obs[i, out + 1] = linvel[i, 1]
-            critic_obs[i, out + 2] = linvel[i, 2]
-
-    @_dev
-    def _write_critic_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        n_action,
-        i,
-    ):
-        _write_critic_base_obs_i(
-            motion_joint_pos,
-            motion_joint_vel,
+            anchor_idx,
             motion_anchor_pos_b,
             motion_anchor_ori_b,
-            linvel,
-            gyro,
-            dof_vel,
-            current_actions,
-            joint_pos_rel,
-            critic_obs,
-            n_action,
             i,
         )
-        body_pos_offset = n_action * 5 + 15
-        body_ori_offset = body_pos_offset + n_body * 3
-        tail_offset = body_ori_offset + n_body * 6
-        _write_critic_body_pos_i(
+        for j in range(dof_pos.shape[1]):
+            motion_command[i, j] = motion_joint_pos[i, j]
+            motion_command[i, dof_pos.shape[1] + j] = motion_joint_vel[i, j]
+            joint_pos_rel[i, j] = dof_pos[i, j] - effective_default_angles[i, j]
+        _write_body_workspace_i(
             robot_body_pos_w,
             robot_body_quat_w,
-            critic_obs,
-            anchor,
-            n_body,
-            body_pos_offset,
+            anchor_idx,
+            robot_body_pos_b,
+            robot_body_ori_b,
             i,
         )
-        _write_critic_body_ori_i(
-            robot_body_quat_w,
-            critic_obs,
-            anchor,
-            n_body,
-            body_ori_offset,
-            i,
-        )
-        _write_critic_linvel_tail_i(linvel, critic_obs, tail_offset, i)
 
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_update_state_kernel(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        linvel,
-        gyro,
-        dof_pos,
-        dof_vel,
-        default_angles,
-        default_dof_pos_bias,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
+    @_dev
+    def _root_pos_plan_i(motion_pos, robot_pos, anchor, std, env_error, i):
+        return motion_global_root_pos_i(motion_pos, robot_pos, int(anchor), std, i)
+
+    @_dev
+    def _root_ori_plan_i(motion_quat, robot_quat, anchor, std, env_error, i):
+        return motion_global_root_ori_i(motion_quat, robot_quat, int(anchor), std, i)
+
+    @_dev
+    def _body_pos_plan_i(robot_pos, std, ref_pos, body_error, env_error, i):
+        return motion_body_pos_i(ref_pos, robot_pos, robot_pos.shape[1], std, i)
+
+    @_dev
+    def _body_ori_plan_i(robot_quat, std, ref_quat, quat_w, quat_x, env_error, i):
+        return motion_body_ori_i(ref_quat, robot_quat, robot_quat.shape[1], std, i)
+
+    @_dev
+    def _body_lin_vel_plan_i(motion_vel, robot_vel, std, body_error, env_error, i):
+        return motion_body_lin_vel_i(motion_vel, robot_vel, robot_vel.shape[1], std, i)
+
+    @_dev
+    def _body_ang_vel_plan_i(motion_vel, robot_vel, std, body_error, env_error, i):
+        return motion_body_ang_vel_i(motion_vel, robot_vel, robot_vel.shape[1], std, i)
+
+    @_dev
+    def _ee_pos_plan_i(robot_pos, indices, std, ref_pos, indexed_error, env_error, i):
+        return motion_ee_body_pos_z_i(ref_pos, robot_pos, indices, std, i)
+
+    @_dev
+    def _joint_pos_plan_i(motion_pos, dof_pos, std, joint_error, env_error, i):
+        return motion_joint_pos_i(motion_pos, dof_pos, dof_pos.shape[1], std, i)
+
+    @_dev
+    def _joint_vel_plan_i(motion_vel, dof_vel, std, joint_error, env_error, i):
+        return motion_joint_vel_i(motion_vel, dof_vel, dof_vel.shape[1], std, i)
+
+    @_dev
+    def _action_rate_plan_i(current, previous, joint_error, env_error, i):
+        return action_rate_l2_i(current, previous, current.shape[1], i)
+
+    @_dev
+    def _joint_limit_plan_i(lower, upper, dof_pos, joint_error, joint_upper, i):
+        acc = 0.0
+        for j in range(dof_pos.shape[1]):
+            low = lower[i, j] - dof_pos[i, j]
+            high = dof_pos[i, j] - upper[i, j]
+            violation = (low if low > 0.0 else 0.0) + (high if high > 0.0 else 0.0)
+            acc += violation * violation
+        return acc
+
+    @_dev
+    def _undesired_plan_i(robot_pos, indices, threshold, indexed_mask, env_error, i):
+        return undesired_contacts_i(robot_pos, indices, threshold, i)
+
+    @_dev
+    def _termination_plan_i(
+        motion_pos,
+        motion_quat,
+        robot_pos,
+        robot_quat,
         anchor,
-        ee_indices,
-        undesired_indices,
-        ctrl_dt,
-        anchor_pos_z_threshold,
+        anchor_pos_threshold,
+        check_anchor_ori,
         anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        has_default_dof_pos_bias,
-        is_deploy_actor,
-        actor_noise_linvel,
-        actor_noise_gyro,
-        actor_noise_joint_pos,
-        actor_noise_dof_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        joint_pos_rel,
-        actor_obs,
-        critic_obs,
-        reward,
-        terminated,
-        log_scratch,
+        ee_indices,
+        ee_threshold,
+        contact_indices,
+        contact_threshold,
+        ref_pos,
+        env_error,
+        indexed_error,
+        indexed_mask,
+        i,
     ):
-        n = reward.shape[0]
-        n_body = robot_body_pos_w.shape[1]
-        n_action = dof_pos.shape[1]
+        anchor_idx = int(anchor)
+        if abs(motion_pos[i, anchor_idx, 2] - robot_pos[i, anchor_idx, 2]) > anchor_pos_threshold:
+            return True
+        if check_anchor_ori != 0.0:
+            motion_gravity_z = quat_gravity_z_at(motion_quat, anchor_idx, i)
+            robot_gravity_z = quat_gravity_z_at(robot_quat, anchor_idx, i)
+            if abs(motion_gravity_z - robot_gravity_z) > anchor_ori_threshold:
+                return True
+        for index in range(ee_indices.shape[0]):
+            body_idx = ee_indices[index]
+            if abs(ref_pos[i, body_idx, 2] - robot_pos[i, body_idx, 2]) > ee_threshold:
+                return True
+        for index in range(contact_indices.shape[0]):
+            if robot_pos[i, contact_indices[index], 2] < contact_threshold:
+                return True
+        return False
 
-        for i in prange(n):
-            _write_reference_transforms_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                n_body,
-                ref_body_pos_w,
-                ref_body_quat_w,
-                i,
-            )
-            _write_motion_anchor_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                i,
-            )
-            _compute_reward_termination_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                motion_body_lin_vel_w,
-                motion_body_ang_vel_w,
-                motion_joint_pos,
-                motion_joint_vel,
-                ref_body_pos_w,
-                ref_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                robot_body_lin_vel_w,
-                robot_body_ang_vel_w,
-                dof_pos,
-                dof_vel,
-                current_actions,
-                last_actions,
-                joint_lower,
-                joint_upper,
-                scale,
-                std,
-                anchor,
-                ee_indices,
-                undesired_indices,
-                n_body,
-                n_action,
-                ctrl_dt,
-                anchor_pos_z_threshold,
-                anchor_ori_threshold,
-                ee_body_pos_z_threshold,
-                undesired_contact_z_threshold,
-                terminate_on_undesired_contacts,
-                has_joint_limits,
-                log_scratch,
-                reward,
-                terminated,
-                get_thread_id(),
-                i,
-            )
-            _write_joint_pos_rel_i(
-                dof_pos,
-                default_angles,
-                default_dof_pos_bias,
-                has_default_dof_pos_bias,
-                joint_pos_rel,
-                n_action,
-                i,
-            )
-            _write_actor_obs_i(
-                motion_joint_pos,
-                motion_joint_vel,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                linvel,
-                gyro,
-                dof_vel,
-                current_actions,
-                joint_pos_rel,
-                actor_noise_linvel,
-                actor_noise_gyro,
-                actor_noise_joint_pos,
-                actor_noise_dof_vel,
-                actor_obs,
-                is_deploy_actor,
-                n_action,
-                i,
-            )
-            _write_critic_obs_i(
-                motion_joint_pos,
-                motion_joint_vel,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                linvel,
-                gyro,
-                dof_vel,
-                current_actions,
-                joint_pos_rel,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                critic_obs,
-                anchor,
-                n_body,
-                n_action,
-                i,
-            )
+    @_dev
+    def _copy_plan_i(source, output, offset, i):
+        if source.ctypes.data == output.ctypes.data + offset * output.itemsize:
+            return
+        width = source.size // source.shape[0]
+        for j in range(width):
+            output[i, offset + j] = source.flat[i * width + j]
+
+    NUMBA_PREAMBLE_ITEM = _plan_preamble_i
+    NUMBA_REWARD_ITEMS = {
+        "motion_global_root_pos": _root_pos_plan_i,
+        "motion_global_root_ori": _root_ori_plan_i,
+        "motion_body_pos": _body_pos_plan_i,
+        "motion_body_ori": _body_ori_plan_i,
+        "motion_body_lin_vel": _body_lin_vel_plan_i,
+        "motion_body_ang_vel": _body_ang_vel_plan_i,
+        "motion_ee_body_pos_z": _ee_pos_plan_i,
+        "motion_joint_pos": _joint_pos_plan_i,
+        "motion_joint_vel": _joint_vel_plan_i,
+        "action_rate_l2": _action_rate_plan_i,
+        "joint_limit": _joint_limit_plan_i,
+        "undesired_contacts": _undesired_plan_i,
+    }
+    NUMBA_OBSERVATION_ITEM = _copy_plan_i
+    NUMBA_TERMINATION_ITEM = _termination_plan_i
 
 
 class MotionTrackingNumbaAccelerator:
-    """Driver that keeps config-derived arrays and calls the fused kernel."""
+    """Resolved-plan Numba driver for the G1 motion-tracking pilot."""
 
-    def __init__(
-        self,
-        *,
-        num_envs: int,
-        num_action: int,
-        ctrl_dt: float,
-        reward_config: Any,
-        anchor_body_idx: int,
-        ee_body_indices: np.ndarray,
-        undesired_contact_body_indices: np.ndarray,
-        joint_lower: np.ndarray | None,
-        joint_upper: np.ndarray | None,
-        default_angles: np.ndarray,
-        actor_obs_width: int,
-        critic_obs_width: int,
-        is_deploy_actor: bool,
-        anchor_pos_z_threshold: float,
-        anchor_ori_threshold: float,
-        ee_body_pos_z_threshold: float,
-        undesired_contact_z_threshold: float,
-        terminate_on_undesired_contacts: bool,
-        num_threads: int | None = None,
-    ) -> None:
-        self.num_envs = int(num_envs)
-        self.num_action = int(num_action)
-        self.ctrl_dt = float(ctrl_dt)
-        self.anchor_body_idx = int(anchor_body_idx)
-        self.ee_body_indices = np.asarray(ee_body_indices, dtype=np.int32)
-        self.undesired_contact_body_indices = np.asarray(
-            undesired_contact_body_indices, dtype=np.int32
+    def __init__(self, env: Any, *, num_threads: int | None = None) -> None:
+        from unilab.envs.motion_tracking.common.terms import resolve_motion_term_plan
+        from unilab.term.numba import FusedOutputLayout, materialize_numba_plan
+
+        config = env._cfg.term_plan
+        if config is None:
+            raise ValueError(
+                "MotionTracking fused Numba execution requires env.term_plan; disable "
+                "numba_acceleration for profiles that retain the legacy NumPy path"
+            )
+        dtype = np.dtype(get_global_dtype())
+        resolved = resolve_motion_term_plan(
+            cfg=env,
+            n_action=env._num_action,
+            n_body=env._n_motion_bodies,
+            anchor_body_idx=env.anchor_body_idx,
+            ee_indices=env.ee_body_indices,
+            undesired_indices=env.undesired_contact_body_indices,
+            config=config,
+            dtype=dtype,
         )
-        self.anchor_pos_z_threshold = float(anchor_pos_z_threshold)
-        self.anchor_ori_threshold = float(anchor_ori_threshold)
-        self.ee_body_pos_z_threshold = float(ee_body_pos_z_threshold)
-        self.undesired_contact_z_threshold = float(undesired_contact_z_threshold)
-        self.terminate_on_undesired_contacts = bool(terminate_on_undesired_contacts)
-        self.default_angles = np.asarray(default_angles, dtype=np.float64)
-        self.actor_obs_width = int(actor_obs_width)
-        self.critic_obs_width = int(critic_obs_width)
-        self.is_deploy_actor = bool(is_deploy_actor)
+        inputs = {
+            name: np.zeros((env._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (
+            ("joint_lower", env._joint_lower),
+            ("joint_upper", env._joint_upper),
+            ("effective_default_angles", env.default_angles),
+        ):
+            if name in inputs and value is not None:
+                np.copyto(inputs[name], np.broadcast_to(value, inputs[name].shape))
+        observations = {
+            group: np.empty((env._num_envs, width), dtype=dtype)
+            for group, width in resolved.observation_dims.items()
+        }
+        layout = FusedOutputLayout(
+            preambles=resolved.preamble_outputs,
+            rewards=tuple(output for _, output in resolved.reward_outputs),
+            observations=resolved.observation_outputs,
+            terminations=resolved.termination_outputs,
+        )
+        self.runtime = materialize_numba_plan(
+            resolved.plan,
+            layout,
+            num_envs=env._num_envs,
+            inputs=inputs,
+            observations=observations,
+            reward=np.empty((env._num_envs,), dtype=dtype),
+            terminated=np.empty((env._num_envs,), dtype=np.bool_),
+        )
+        self.env = env
+        self.resolved = resolved
+        self.inputs = inputs
+        self._owned_inputs = inputs.copy()
+        self.obs = observations
+        self.num_envs = env._num_envs
         self.num_threads = num_threads
-        self.has_joint_limits = joint_lower is not None and joint_upper is not None
-        if self.has_joint_limits:
-            self.joint_lower = np.asarray(joint_lower, dtype=np.float64)
-            self.joint_upper = np.asarray(joint_upper, dtype=np.float64)
-        else:
-            self.joint_lower = np.zeros((self.num_action,), dtype=np.float64)
-            self.joint_upper = np.zeros((self.num_action,), dtype=np.float64)
-        self.scale = np.zeros((len(TERM_ORDER),), dtype=np.float64)
-        self.std = self._build_std_vector(reward_config)
-        self._zero_actions = np.zeros((self.num_envs, self.num_action), dtype=np.float64)
-        self._zero_default_dof_pos_bias = np.zeros(
-            (self.num_envs, self.num_action), dtype=np.float64
-        )
-        self._zero_linvel_noise = np.zeros((self.num_envs, 3), dtype=np.float64)
-        self._zero_gyro_noise = np.zeros((self.num_envs, 3), dtype=np.float64)
-        self._zero_joint_noise = np.zeros((self.num_envs, self.num_action), dtype=np.float64)
+        self.ctrl_dt = float(env._cfg.ctrl_dt)
+        self.first_jit_ms: float | None = None
+        self._reward_outputs = dict(resolved.reward_outputs)
+        self._scale_snapshot: tuple[float, ...] | None = None
+        self._plan_indices = {term.name: index for index, term in enumerate(resolved.plan.terms)}
+        self._log_scratch: np.ndarray | None = None
+        claimed_workspace = set()
+        for group, names in resolved.observation_outputs.items():
+            offset = 0
+            for term_name in names:
+                term = resolved.plan.terms[self._plan_indices[term_name]]
+                width = resolved.plan.output_specs[term_name].shape[0]
+                if len(term.definition.workspace) == 1:
+                    source = term.definition.workspace[0].name
+                    spec = resolved.plan.workspace_specs[source]
+                    if source not in claimed_workspace:
+                        output = observations[group]
+                        inner_strides = []
+                        stride = output.itemsize
+                        for dimension in reversed(spec.shape):
+                            inner_strides.append(stride)
+                            stride *= dimension
+                        view = np.ndarray(
+                            (env._num_envs, *spec.shape),
+                            dtype=spec.numpy_dtype,
+                            buffer=output,
+                            offset=offset * output.itemsize,
+                            strides=(output.strides[0], *reversed(inner_strides)),
+                        )
+                        self.runtime.bind_workspace(source, view)
+                        claimed_workspace.add(source)
+                offset += width
+        workspace = self.runtime.workspace
+        env.body_pos_relative_w = workspace["ref_body_pos_w"]
+        env.body_quat_relative_w = workspace["ref_body_quat_w"]
+        env._motion_anchor_pos_b = workspace["motion_anchor_pos_b"]
+        env._motion_anchor_ori_b = workspace["motion_anchor_ori_b"]
+        env._motion_command = workspace["motion_command"]
+        env._joint_pos_rel = workspace["joint_pos_rel"]
+
+    @property
+    def compile_info(self):
+        return self.runtime.compile_info
 
     @classmethod
     def from_env(cls, env: Any, num_threads: int | None = None) -> "MotionTrackingNumbaAccelerator":
         if not NUMBA_AVAILABLE:
             raise RuntimeError(
-                "MotionTracking numba_acceleration=True requires numba. Install it or run "
-                "through `uv run --with numba ...`; disable numba_acceleration to use the "
-                "numpy path."
+                "MotionTracking numba_acceleration=True requires numba. Install it or "
+                "disable numba_acceleration to use the NumPy path."
             )
-        unsupported = unsupported_terms(env._cfg.reward_config.scales)
-        if unsupported:
-            raise ValueError(
-                "MotionTracking Numba accelerator does not support active reward terms "
-                f"{sorted(unsupported)}. Disable numba_acceleration or add these terms to "
-                "src/unilab/envs/motion_tracking/common/numba.py."
-            )
-        default_angles = getattr(env, "default_angles", None)
-        if default_angles is None:
-            default_angles = np.zeros((env._num_action,), dtype=np.float64)
-        actor_obs_width = getattr(env, "_actor_obs_width", env._num_action * 5 + 15)
-        critic_obs_width = (
-            env.obs_groups_spec["critic"]
-            if hasattr(env, "obs_groups_spec")
-            else (env._num_action * 5 + 15 + len(env._cfg.body_names) * 9)
-        )
-        return cls(
-            num_envs=env.num_envs,
-            num_action=env._num_action,
-            ctrl_dt=env._cfg.ctrl_dt,
-            reward_config=env._cfg.reward_config,
-            anchor_body_idx=env.anchor_body_idx,
-            ee_body_indices=env.ee_body_indices,
-            undesired_contact_body_indices=env.undesired_contact_body_indices,
-            joint_lower=env._joint_lower,
-            joint_upper=env._joint_upper,
-            default_angles=default_angles,
-            actor_obs_width=actor_obs_width,
-            critic_obs_width=critic_obs_width,
-            is_deploy_actor=actor_obs_width == env._num_action * 5 + 9,
-            anchor_pos_z_threshold=env._cfg.anchor_pos_z_threshold,
-            anchor_ori_threshold=env._cfg.anchor_ori_threshold,
-            ee_body_pos_z_threshold=env._cfg.ee_body_pos_z_threshold,
-            undesired_contact_z_threshold=env._cfg.undesired_contact_z_threshold,
-            terminate_on_undesired_contacts=env._cfg.terminate_on_undesired_contacts,
-            num_threads=num_threads,
-        )
-
-    def _build_std_vector(self, reward_config: Any) -> np.ndarray:
-        per_term = {
-            "motion_global_root_pos": reward_config.std_root_pos,
-            "motion_global_root_ori": reward_config.std_root_ori,
-            "motion_body_pos": reward_config.std_body_pos,
-            "motion_body_ori": reward_config.std_body_ori,
-            "motion_body_lin_vel": reward_config.std_body_lin_vel,
-            "motion_body_ang_vel": reward_config.std_body_ang_vel,
-            "motion_ee_body_pos_z": reward_config.std_body_pos,
-            "motion_joint_pos": reward_config.std_joint_pos,
-            "motion_joint_vel": reward_config.std_joint_vel,
-            "action_rate_l2": 0.0,
-            "joint_limit": 0.0,
-            "undesired_contacts": 0.0,
-        }
-        return np.array([per_term[name] for name in TERM_ORDER], dtype=np.float64)
+        return cls(env, num_threads=num_threads)
 
     def _sync_scales(self, scales: Mapping[str, float]) -> None:
-        unsupported = unsupported_terms(scales)
+        unsupported = _active_terms(scales) - self._reward_outputs.keys()
         if unsupported:
             raise ValueError(
-                "MotionTracking Numba accelerator does not support active reward terms "
-                f"{sorted(unsupported)}. Disable numba_acceleration or add these terms to "
-                "src/unilab/envs/motion_tracking/common/numba.py."
+                f"MotionTracking Numba plan does not support active reward terms {sorted(unsupported)}"
             )
-        self.scale.fill(0.0)
-        for name, value in scales.items():
-            idx = TERM_INDEX.get(name)
-            if idx is not None:
-                self.scale[idx] = float(value)
+        snapshot = tuple(float(scales.get(name, 0.0)) for name in self._reward_outputs)
+        if snapshot == self._scale_snapshot:
+            return
+        for reward_name, output_name in self._reward_outputs.items():
+            configured = scales.get(reward_name, 0.0)
+            scale = configured if self.resolved.reward_available.get(reward_name, True) else 0.0
+            self.runtime.set_scale(output_name, scale)
+        self._scale_snapshot = snapshot
 
-    def compute(
+    def _bind_inputs(
         self,
         *,
         info: dict[str, Any],
         motion_data: Any,
-        ref_body_pos_w: np.ndarray,
-        ref_body_quat_w: np.ndarray,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
         robot_body_pos_w: np.ndarray,
         robot_body_quat_w: np.ndarray,
         robot_body_lin_vel_w: np.ndarray,
         robot_body_ang_vel_w: np.ndarray,
-        dof_pos: np.ndarray,
-        dof_vel: np.ndarray,
-        scales: Mapping[str, float],
-        enable_log: bool,
-    ) -> G1MotionTrackingNumbaResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1MotionTracking Numba accelerator was constructed while numba is "
-                "unavailable; this indicates an invalid accelerator state."
+    ) -> None:
+        def bind(name: str, value: np.ndarray) -> None:
+            if name in self.inputs:
+                self.inputs[name] = np.asarray(value)
+
+        for name, value in (
+            ("motion_body_pos_w", motion_data.body_pos_w),
+            ("motion_body_quat_w", motion_data.body_quat_w),
+            ("motion_body_lin_vel_w", motion_data.body_lin_vel_w),
+            ("motion_body_ang_vel_w", motion_data.body_ang_vel_w),
+            ("motion_joint_pos", motion_data.joint_pos),
+            ("motion_joint_vel", motion_data.joint_vel),
+            ("robot_body_pos_w", robot_body_pos_w),
+            ("robot_body_quat_w", robot_body_quat_w),
+            ("robot_body_lin_vel_w", robot_body_lin_vel_w),
+            ("robot_body_ang_vel_w", robot_body_ang_vel_w),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+            ("linvel", linvel),
+            ("gyro", gyro),
+        ):
+            bind(name, value)
+        zero = self.env._zero_actions
+        current = info.get("current_actions")
+        current = current if isinstance(current, np.ndarray) else zero
+        previous = info.get("last_actions")
+        previous = previous if isinstance(previous, np.ndarray) else zero
+        bind("current_actions", current)
+        bind("last_actions", previous)
+        bind("obs_actions", current)
+
+        effective = self._owned_inputs["effective_default_angles"]
+        bias = info.get("default_dof_pos_bias")
+        if isinstance(bias, np.ndarray):
+            np.add(self.env.default_angles, bias, out=effective)
+        else:
+            np.copyto(effective, np.broadcast_to(self.env.default_angles, effective.shape))
+        bind("effective_default_angles", effective)
+
+        noise = self.env._cfg.noise_config
+        if "noisy_linvel" in self.inputs:
+            bind("noisy_linvel", self.env._obs_noise(linvel, noise.scale_linvel))
+        if "noisy_gyro" in self.inputs:
+            bind("noisy_gyro", self.env._obs_noise(gyro, noise.scale_gyro))
+        if "noisy_joint_pos_rel" in self.inputs:
+            noisy_joint = self._owned_inputs["noisy_joint_pos_rel"]
+            np.subtract(dof_pos, effective, out=noisy_joint)
+            bind(
+                "noisy_joint_pos_rel",
+                self.env._obs_noise(noisy_joint, noise.scale_joint_angle),
             )
-        self._sync_scales(scales)
-        if self.num_threads is not None:
-            set_num_threads(self.num_threads)
-
-        dtype = dof_pos.dtype
-        current_actions = np.asarray(info.get("current_actions", self._zero_actions), dtype=dtype)
-        last_actions = np.asarray(info.get("last_actions", self._zero_actions), dtype=dtype)
-        reward = np.empty((dof_pos.shape[0],), dtype=dtype)
-        terminated = np.empty((dof_pos.shape[0],), dtype=np.bool_)
-        log_scratch = np.zeros((get_num_threads(), len(TERM_ORDER)), dtype=np.float64)
-
-        _compute_reward_termination_kernel(
-            motion_data.body_pos_w,
-            motion_data.body_quat_w,
-            motion_data.body_lin_vel_w,
-            motion_data.body_ang_vel_w,
-            motion_data.joint_pos,
-            motion_data.joint_vel,
-            ref_body_pos_w,
-            ref_body_quat_w,
-            robot_body_pos_w,
-            robot_body_quat_w,
-            robot_body_lin_vel_w,
-            robot_body_ang_vel_w,
-            dof_pos,
-            dof_vel,
-            current_actions,
-            last_actions,
-            self.joint_lower,
-            self.joint_upper,
-            self.scale,
-            self.std,
-            self.anchor_body_idx,
-            self.ee_body_indices,
-            self.undesired_contact_body_indices,
-            self.ctrl_dt,
-            self.anchor_pos_z_threshold,
-            self.anchor_ori_threshold,
-            self.ee_body_pos_z_threshold,
-            self.undesired_contact_z_threshold,
-            self.terminate_on_undesired_contacts,
-            self.has_joint_limits,
-            reward,
-            terminated,
-            log_scratch,
-        )
-
-        step_count = info.get("steps")
-        should_log = enable_log and (
-            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
-        )
-        log = {} if should_log else info.get("log", {})
-        if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / dof_pos.shape[0])
-        return G1MotionTrackingNumbaResult(reward=reward, terminated=terminated, log=log)
+        if "noisy_dof_vel" in self.inputs:
+            bind("noisy_dof_vel", self.env._obs_noise(dof_vel, noise.scale_joint_vel))
+        self.runtime.bind_inputs(self.inputs)
 
     def compute_update_state(
         self,
@@ -1143,131 +685,52 @@ class MotionTrackingNumbaAccelerator:
         robot_body_quat_w: np.ndarray,
         robot_body_lin_vel_w: np.ndarray,
         robot_body_ang_vel_w: np.ndarray,
-        ref_body_pos_w: np.ndarray,
-        ref_body_quat_w: np.ndarray,
-        motion_anchor_pos_b: np.ndarray,
-        motion_anchor_ori_b: np.ndarray,
-        joint_pos_rel: np.ndarray,
         scales: Mapping[str, float],
         enable_log: bool,
-        noise_level: float,
-        noise_scale_linvel: float,
-        noise_scale_gyro: float,
-        noise_scale_joint_angle: float,
-        noise_scale_joint_vel: float,
     ) -> G1MotionTrackingNumbaUpdateStateResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1MotionTracking Numba accelerator was constructed while numba is "
-                "unavailable; this indicates an invalid accelerator state."
-            )
-        self._sync_scales(scales)
-        if self.num_threads is not None:
-            set_num_threads(self.num_threads)
-
-        dtype = dof_pos.dtype
-        n = dof_pos.shape[0]
-        if n != self.num_envs:
+        if dof_pos.shape[0] != self.num_envs:
             raise ValueError(
                 "G1MotionTracking Numba update_state only supports full-batch updates; "
-                f"got {n} rows for configured num_envs={self.num_envs}."
+                f"got {dof_pos.shape[0]} rows for configured num_envs={self.num_envs}."
             )
-
-        current_actions = np.asarray(info.get("current_actions", self._zero_actions), dtype=dtype)
-        last_actions = np.asarray(info.get("last_actions", self._zero_actions), dtype=dtype)
-        default_dof_pos_bias = info.get("default_dof_pos_bias")
-        has_default_dof_pos_bias = isinstance(default_dof_pos_bias, np.ndarray)
-        if has_default_dof_pos_bias:
-            default_dof_pos_bias_arr = np.asarray(default_dof_pos_bias, dtype=dtype)
-        else:
-            default_dof_pos_bias_arr = self._zero_default_dof_pos_bias.astype(dtype, copy=False)
-
-        noise_level = float(noise_level)
-        if noise_level > 0.0:
-            actor_noise_linvel = np.random.uniform(-1.0, 1.0, linvel.shape).astype(dtype)
-            actor_noise_linvel *= noise_level * float(noise_scale_linvel)
-            actor_noise_gyro = np.random.uniform(-1.0, 1.0, gyro.shape).astype(dtype)
-            actor_noise_gyro *= noise_level * float(noise_scale_gyro)
-            actor_noise_joint_pos = np.random.uniform(-1.0, 1.0, dof_pos.shape).astype(dtype)
-            actor_noise_joint_pos *= noise_level * float(noise_scale_joint_angle)
-            actor_noise_dof_vel = np.random.uniform(-1.0, 1.0, dof_vel.shape).astype(dtype)
-            actor_noise_dof_vel *= noise_level * float(noise_scale_joint_vel)
-        else:
-            actor_noise_linvel = self._zero_linvel_noise.astype(dtype, copy=False)
-            actor_noise_gyro = self._zero_gyro_noise.astype(dtype, copy=False)
-            actor_noise_joint_pos = self._zero_joint_noise.astype(dtype, copy=False)
-            actor_noise_dof_vel = self._zero_joint_noise.astype(dtype, copy=False)
-
-        actor_obs = np.empty((n, self.actor_obs_width), dtype=dtype)
-        critic_obs = np.empty((n, self.critic_obs_width), dtype=dtype)
-        reward = np.empty((n,), dtype=dtype)
-        terminated = np.empty((n,), dtype=np.bool_)
-        log_scratch = np.zeros((get_num_threads(), len(TERM_ORDER)), dtype=np.float64)
-
-        _compute_update_state_kernel(
-            motion_data.body_pos_w,
-            motion_data.body_quat_w,
-            motion_data.body_lin_vel_w,
-            motion_data.body_ang_vel_w,
-            motion_data.joint_pos,
-            motion_data.joint_vel,
-            robot_body_pos_w,
-            robot_body_quat_w,
-            robot_body_lin_vel_w,
-            robot_body_ang_vel_w,
-            linvel,
-            gyro,
-            dof_pos,
-            dof_vel,
-            self.default_angles,
-            default_dof_pos_bias_arr,
-            current_actions,
-            last_actions,
-            self.joint_lower,
-            self.joint_upper,
-            self.scale,
-            self.std,
-            self.anchor_body_idx,
-            self.ee_body_indices,
-            self.undesired_contact_body_indices,
-            self.ctrl_dt,
-            self.anchor_pos_z_threshold,
-            self.anchor_ori_threshold,
-            self.ee_body_pos_z_threshold,
-            self.undesired_contact_z_threshold,
-            self.terminate_on_undesired_contacts,
-            self.has_joint_limits,
-            has_default_dof_pos_bias,
-            self.is_deploy_actor,
-            actor_noise_linvel,
-            actor_noise_gyro,
-            actor_noise_joint_pos,
-            actor_noise_dof_vel,
-            ref_body_pos_w,
-            ref_body_quat_w,
-            motion_anchor_pos_b,
-            motion_anchor_ori_b,
-            joint_pos_rel,
-            actor_obs,
-            critic_obs,
-            reward,
-            terminated,
-            log_scratch,
+        self._sync_scales(scales)
+        self._bind_inputs(
+            info=info,
+            motion_data=motion_data,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
+            robot_body_pos_w=robot_body_pos_w,
+            robot_body_quat_w=robot_body_quat_w,
+            robot_body_lin_vel_w=robot_body_lin_vel_w,
+            robot_body_ang_vel_w=robot_body_ang_vel_w,
         )
+        if self.num_threads is not None:
+            set_num_threads(self.num_threads)
+        nthreads = get_num_threads()
+        if self._log_scratch is None or self._log_scratch.shape[0] != nthreads:
+            self._log_scratch = np.empty((nthreads, len(self.resolved.plan.terms)), np.float64)
+        self._log_scratch.fill(0.0)
+        started = time.perf_counter()
+        self.runtime.execute(reward_multiplier=self.ctrl_dt, log_scratch=self._log_scratch)
+        if self.first_jit_ms is None:
+            self.first_jit_ms = (time.perf_counter() - started) * 1e3
 
-        step_count = info.get("steps")
+        steps = info.get("steps")
         should_log = enable_log and (
-            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
+            int(steps[0]) % 4 == 0 if isinstance(steps, np.ndarray) else True
         )
         log = {} if should_log else info.get("log", {})
         if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / n)
+            sums = self._log_scratch.sum(axis=0)
+            for reward_name, output_name in self._reward_outputs.items():
+                if scales.get(reward_name, 0.0) != 0.0:
+                    index = self._plan_indices[output_name]
+                    log[f"reward/{reward_name}"] = float(sums[index] / self.num_envs)
         return G1MotionTrackingNumbaUpdateStateResult(
-            obs={"obs": actor_obs, "critic": critic_obs},
-            reward=reward,
-            terminated=terminated,
+            obs=self.obs,
+            reward=self.runtime.reward,
+            terminated=self.runtime.terminated,
             log=log,
         )

--- a/src/unilab/envs/motion_tracking/common/terms.py
+++ b/src/unilab/envs/motion_tracking/common/terms.py
@@ -206,6 +206,7 @@ def _termination(ctx: NumpyTermContext) -> None:
 @dataclass(frozen=True)
 class MotionResolvedTermPlan:
     plan: ResolvedTermPlan
+    preamble_outputs: tuple[str, ...]
     reward_outputs: tuple[tuple[str, str], ...]
     reward_available: Mapping[str, bool]
     observation_outputs: Mapping[str, tuple[str, ...]]
@@ -221,6 +222,8 @@ class MotionResolvedTermPlan:
 
 
 def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dtype) -> TermRegistry:
+    from . import numba as motion_numba
+
     registry = TermRegistry()
     # fmt: off
     shapes = {
@@ -258,9 +261,10 @@ def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dty
 
     def register(key: str, kind: TermKind, fn: Any, output: TensorSpec,
                  inputs: tuple[str, ...] = (), workspace: tuple[str, ...] = (),
-                 parameters: tuple[ParameterSpec, ...] = ()) -> None:
+                 parameters: tuple[ParameterSpec, ...] = (), numba_item_fn: Any = None) -> None:
         registry.register(TermDefinition(key, kind, fn, output, inputs=ins(*inputs),
-                                         workspace=work(*workspace), parameters=parameters))
+                                         workspace=work(*workspace), parameters=parameters,
+                                         numba_item_fn=numba_item_fn))
 
     scalar = TensorSpec((), dtype)
 
@@ -283,7 +287,7 @@ def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dty
         "motion_command", "joint_pos_rel", "robot_body_pos_b", "robot_body_ori_b",
     )
     register(PREAMBLE_KEY, TermKind.OBSERVATION, _preamble, scalar, preamble_inputs,
-             preamble_work, (int_param("anchor_body_idx"),))
+             preamble_work, (int_param("anchor_body_idx"),), motion_numba.NUMBA_PREAMBLE_ITEM)
 
     # (function, inputs, workspace, parameters); kept compact so the paired
     # authoring surface is auditable as one table.
@@ -302,13 +306,15 @@ def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dty
         "undesired_contacts": (rewards.undesired_contacts, ("robot_body_pos_w",), ("indexed_mask", "env_error"), (int_param("indices", True), float_param("threshold"))),
     }
     for name, (fn, inputs, workspace, params) in reward_defs.items():
-        register(REWARD_KEYS[name], TermKind.REWARD, _RewardAdapter(fn), scalar, inputs, workspace, params)
+        register(REWARD_KEYS[name], TermKind.REWARD, _RewardAdapter(fn), scalar, inputs, workspace,
+                 params, motion_numba.NUMBA_REWARD_ITEMS.get(name))
 
     for key, (group, _label, source, width, is_workspace) in _OBS_META.items():
         resolved_width = {-1: n_action, -2: 2 * n_action, -3: 3 * n_body, -6: 6 * n_body}.get(width, width)
         register(key, TermKind.OBSERVATION, _copy, TensorSpec((resolved_width,), dtype),
                  workspace=(source,) if is_workspace else (),
-                 inputs=() if is_workspace else (source,))
+                 inputs=() if is_workspace else (source,),
+                 numba_item_fn=motion_numba.NUMBA_OBSERVATION_ITEM)
 
     termination_params = (
         int_param("anchor_body_idx"), float_param("anchor_pos_z_threshold"),
@@ -318,7 +324,8 @@ def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dty
     )
     register(DEFAULT_TERMINATIONS[0], TermKind.TERMINATION, _termination, TensorSpec((), np.bool_),
              ("motion_body_pos_w", "motion_body_quat_w", "robot_body_pos_w", "robot_body_quat_w"),
-             ("ref_body_pos_w", "env_error", "indexed_error", "indexed_mask"), termination_params)
+             ("ref_body_pos_w", "env_error", "indexed_error", "indexed_mask"), termination_params,
+             motion_numba.NUMBA_TERMINATION_ITEM)
     return registry
 
 
@@ -340,14 +347,17 @@ def resolve_motion_term_plan(
     n_indexed = max(1, len(ee_indices), len(undesired_indices))
     registry = _build_registry(n_action=n_action, n_body=n_body, n_indexed=n_indexed, dtype=dtype)
     configs: list[TermConfig] = []
+    preamble_outputs = []
     for index, key in enumerate(config.preambles):
+        name = f"preamble.term{index}"
         configs.append(
             TermConfig(
-                f"preamble.term{index}",
+                name,
                 key,
                 parameters={"anchor_body_idx": anchor_body_idx} if key == PREAMBLE_KEY else {},
             )
         )
+        preamble_outputs.append(name)
 
     # fmt: off
     std_names = {
@@ -437,6 +447,7 @@ def resolve_motion_term_plan(
 
     return MotionResolvedTermPlan(
         plan=resolve_term_plan(registry, configs),
+        preamble_outputs=tuple(preamble_outputs),
         reward_outputs=tuple(reward_outputs),
         reward_available=MappingProxyType(available),
         observation_outputs=MappingProxyType(observation_outputs),

--- a/src/unilab/envs/motion_tracking/common/tracking.py
+++ b/src/unilab/envs/motion_tracking/common/tracking.py
@@ -401,7 +401,6 @@ class MotionTrackingEnv(G1BaseEnv):
 
         numba_accelerator = getattr(self, "_numba_accelerator", None)
         if numba_accelerator is not None:
-            noise_cfg = self._cfg.noise_config
             numba_result = numba_accelerator.compute_update_state(
                 info=state.info,
                 motion_data=motion_data,
@@ -413,18 +412,8 @@ class MotionTrackingEnv(G1BaseEnv):
                 robot_body_quat_w=robot_body_quat_w,
                 robot_body_lin_vel_w=robot_body_lin_vel_w,
                 robot_body_ang_vel_w=robot_body_ang_vel_w,
-                ref_body_pos_w=self.body_pos_relative_w,
-                ref_body_quat_w=self.body_quat_relative_w,
-                motion_anchor_pos_b=self._motion_anchor_pos_b,
-                motion_anchor_ori_b=self._motion_anchor_ori_b,
-                joint_pos_rel=self._joint_pos_rel,
                 scales=self._cfg.reward_config.scales,
                 enable_log=self._enable_reward_log,
-                noise_level=noise_cfg.level,
-                noise_scale_linvel=noise_cfg.scale_linvel,
-                noise_scale_gyro=noise_cfg.scale_gyro,
-                noise_scale_joint_angle=noise_cfg.scale_joint_angle,
-                noise_scale_joint_vel=noise_cfg.scale_joint_vel,
             )
             terminated = numba_result.terminated
             reward = numba_result.reward

--- a/src/unilab/term/numba.py
+++ b/src/unilab/term/numba.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from .errors import TermBindingError, TermPlanError
 from .plan import NumpyTermRuntime, ResolvedTermPlan
+from .spec import ParameterKind
 
 try:  # pragma: no cover - optional dependency boundary
     from numba import njit, prange
@@ -62,6 +63,7 @@ class FusedNumbaRuntime:
         kernel: Any,
         compile_info: FusedCompileInfo,
         parameters: np.ndarray,
+        tuple_parameters: tuple[np.ndarray, ...],
         inputs: Mapping[str, np.ndarray],
         observations: Mapping[str, np.ndarray],
         reward: np.ndarray,
@@ -73,13 +75,17 @@ class FusedNumbaRuntime:
         self._numpy_runtime = numpy_runtime
         self._kernel = kernel
         self._inputs = tuple(inputs[name] for name in plan.input_specs)
-        self._workspace = tuple(numpy_runtime.workspace[name] for name in plan.workspace_specs)
+        workspace = dict(numpy_runtime.workspace)
+        self.workspace: Mapping[str, np.ndarray] = MappingProxyType(workspace)
+        self._workspace_views = workspace
+        self._workspace = tuple(workspace[name] for name in plan.workspace_specs)
         self._observations = tuple(observations[name] for name in layout.observations)
         self.reward = reward
         self.terminated = terminated
         self._indices = {term.name: index for index, term in enumerate(plan.terms)}
         self.scales = np.asarray([term.scale for term in plan.terms], dtype=np.float64)
         self.parameters = parameters
+        self._tuple_parameters = tuple_parameters
 
     def bind_inputs(self, inputs: Mapping[str, np.ndarray]) -> None:
         """Rebind task-owned views, validating only identities that changed."""
@@ -97,6 +103,19 @@ class FusedNumbaRuntime:
             views.append(view)
         self._inputs = tuple(views)
 
+    def bind_workspace(self, name: str, view: np.ndarray) -> None:
+        """Bind a validated task-owned workspace view on the materialization path."""
+        spec = self.plan.workspace_specs.get(name)
+        if spec is None:
+            raise TermBindingError(f"unknown workspace {name!r}")
+        expected = (self.reward.shape[0], *spec.shape)
+        if view.shape != expected or view.dtype != spec.numpy_dtype:
+            raise TermBindingError(
+                f"workspace {name!r} must have shape {expected} and dtype {spec.numpy_dtype}"
+            )
+        self._workspace_views[name] = view
+        self._workspace = tuple(self._workspace_views[item] for item in self.plan.workspace_specs)
+
     def set_scale(self, name: str, scale: float) -> None:
         index = self._indices.get(name)
         if index is None:
@@ -108,6 +127,7 @@ class FusedNumbaRuntime:
         self._kernel(
             self._inputs,
             self.parameters,
+            self._tuple_parameters,
             self._workspace,
             self.scales,
             self._observations,
@@ -141,7 +161,7 @@ def materialize_numba_plan(
     assert njit is not None
     _validate_layout(plan, layout, observations, num_envs=num_envs)
     numpy_runtime = plan.materialize(num_envs=num_envs, inputs=inputs)
-    parameters = _flatten_parameters(plan)
+    parameters, tuple_parameters = _pack_parameters(plan)
     _validate_numba_definitions(plan)
     _validate_output("reward", reward, (num_envs,), np.floating)
     _validate_output("terminated", terminated, (num_envs,), np.bool_)
@@ -162,6 +182,7 @@ def materialize_numba_plan(
         kernel=kernel,
         compile_info=info,
         parameters=parameters,
+        tuple_parameters=tuple_parameters,
         inputs=inputs,
         observations=observations,
         reward=reward,
@@ -200,17 +221,30 @@ def _validate_layout(
         _validate_output(group, value, (num_envs, width), np.floating)  # type: ignore[arg-type]
 
 
-def _flatten_parameters(plan: ResolvedTermPlan) -> np.ndarray:
-    values: list[float] = []
+def _pack_parameters(plan: ResolvedTermPlan) -> tuple[np.ndarray, tuple[np.ndarray, ...]]:
+    scalars: list[float] = []
+    tuples: list[np.ndarray] = []
     for term in plan.terms:
         for spec in term.definition.parameters:
             value = term.parameters[spec.name]
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if spec.tuple_value:
+                if not isinstance(value, tuple) or spec.kind is ParameterKind.STRING:
+                    raise TermPlanError(
+                        f"Numba fused term {term.name!r} requires numeric tuple parameters"
+                    )
+                dtype = {
+                    ParameterKind.BOOLEAN: np.bool_,
+                    ParameterKind.INTEGER: np.int64,
+                    ParameterKind.FLOAT: np.float64,
+                }[spec.kind]
+                tuples.append(np.asarray(value, dtype=dtype))
+            elif isinstance(value, (bool, int, float)):
+                scalars.append(float(value))
+            else:
                 raise TermPlanError(
                     f"Numba fused term {term.name!r} requires scalar numeric parameters"
                 )
-            values.append(float(value))
-    return np.asarray(values, dtype=np.float64)
+    return np.asarray(scalars, dtype=np.float64), tuple(tuples)
 
 
 def _validate_numba_definitions(plan: ResolvedTermPlan) -> None:
@@ -225,7 +259,15 @@ def _cache_key(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> str:
 
     payload = {
         "terms": [
-            (term.name, term.definition.key, term.definition.implementation_version)
+            (
+                term.name,
+                term.definition.key,
+                term.definition.implementation_version,
+                tuple(
+                    (spec.name, spec.kind.value, spec.tuple_value)
+                    for spec in term.definition.parameters
+                ),
+            )
             for term in plan.terms
         ],
         "inputs": specs(plan.input_specs),
@@ -258,14 +300,14 @@ def _build_kernel(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> tuple[An
 
     namespace: dict[str, Any] = {"prange": prange, "get_thread_id": get_thread_id}
     lines = [
-        "def fused(inputs, parameters, workspace, scales, observations, reward, terminated, log_scratch, reward_multiplier):",
+        "def fused(inputs, parameters, tuple_parameters, workspace, scales, observations, reward, terminated, log_scratch, reward_multiplier):",
         "    n = reward.shape[0]",
         "    for i in prange(n):",
         "        tid = get_thread_id()",
         "        reward[i] = 0.0",
         "        terminated[i] = False",
     ]
-    parameter_offset = 0
+    scalar_offset = tuple_offset = 0
     for index, term in enumerate(plan.terms):
         definition = term.definition
         if definition.numba_item_fn is None:
@@ -273,7 +315,13 @@ def _build_kernel(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> tuple[An
         fn_name = f"item_{index}"
         namespace[fn_name] = definition.numba_item_fn
         args = [f"inputs[{input_indices[item.name]}]" for item in definition.inputs]
-        args.extend(f"parameters[{parameter_offset + i}]" for i in range(len(term.parameters)))
+        for spec in definition.parameters:
+            if spec.tuple_value:
+                args.append(f"tuple_parameters[{tuple_offset}]")
+                tuple_offset += 1
+            else:
+                args.append(f"parameters[{scalar_offset}]")
+                scalar_offset += 1
         args.extend(f"workspace[{workspace_indices[item.name]}]" for item in definition.workspace)
         joined = ", ".join(args)
         joined = f"{joined}, " if joined else ""
@@ -295,7 +343,6 @@ def _build_kernel(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> tuple[An
             lines.append(f"            {fn_name}({joined}observations[{group_index}], {offset}, i)")
         else:
             lines.append(f"            {fn_name}({joined}i)")
-        parameter_offset += len(term.parameters)
     lines.append("        reward[i] *= reward_multiplier")
     exec("\n".join(lines), namespace)  # noqa: S102 - trusted registry functions only
     return namespace["fused"], namespace

--- a/tests/envs/test_g1_motion_tracking_numba.py
+++ b/tests/envs/test_g1_motion_tracking_numba.py
@@ -37,7 +37,7 @@ def test_numba_accelerator_rejects_unsupported_active_reward_terms():
     env = _make_env(8, include_undesired=False)
     env._cfg.reward_config.scales = {"motion_body_pos": 1.0, "custom": 1.0}
     if NUMBA_AVAILABLE:
-        with pytest.raises(ValueError, match="does not support active reward terms"):
+        with pytest.raises(ValueError, match="unknown nonzero reward term"):
             MotionTrackingNumbaAccelerator.from_env(env)
 
 
@@ -110,6 +110,7 @@ def test_motion_term_plan_matches_legacy_numpy_and_reuses_workspace():
 def test_g1_motion_tracking_numba_reward_termination_parity():
     n = 512
     env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
     motion_data, robot_state, info = _make_batch(n, seed=0)
     (
         robot_body_pos_w,
@@ -135,15 +136,15 @@ def test_g1_motion_tracking_numba_reward_termination_parity():
     log_np = dict(info["log"])
 
     accel = MotionTrackingNumbaAccelerator.from_env(env, num_threads=2)
-    out = accel.compute(
+    out = accel.compute_update_state(
         info={
             "steps": np.zeros((n,), dtype=np.uint32),
             "current_actions": info["current_actions"],
             "last_actions": info["last_actions"],
         },
         motion_data=motion_data,
-        ref_body_pos_w=env.body_pos_relative_w,
-        ref_body_quat_w=env.body_quat_relative_w,
+        linvel=np.zeros((n, 3), dtype=np.float32),
+        gyro=np.zeros((n, 3), dtype=np.float32),
         robot_body_pos_w=robot_body_pos_w,
         robot_body_quat_w=robot_body_quat_w,
         robot_body_lin_vel_w=robot_body_lin_vel_w,
@@ -216,24 +217,64 @@ def test_g1_motion_tracking_numba_update_state_parity_without_noise():
         robot_body_quat_w=robot_body_quat_w,
         robot_body_lin_vel_w=robot_body_lin_vel_w,
         robot_body_ang_vel_w=robot_body_ang_vel_w,
-        ref_body_pos_w=env.body_pos_relative_w,
-        ref_body_quat_w=env.body_quat_relative_w,
-        motion_anchor_pos_b=env._motion_anchor_pos_b,
-        motion_anchor_ori_b=env._motion_anchor_ori_b,
-        joint_pos_rel=env._joint_pos_rel,
         scales=env._cfg.reward_config.scales,
         enable_log=True,
-        noise_level=0.0,
-        noise_scale_linvel=0.0,
-        noise_scale_gyro=0.0,
-        noise_scale_joint_angle=0.0,
-        noise_scale_joint_vel=0.0,
     )
 
     np.testing.assert_allclose(out.reward, reward_np, rtol=1e-4, atol=1e-5)
     np.testing.assert_array_equal(out.terminated, terminated_np)
     np.testing.assert_allclose(out.obs["obs"], obs_np["obs"], rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(out.obs["critic"], obs_np["critic"], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
+def test_g1_motion_tracking_numba_uses_owner_noise_and_reuses_outputs(monkeypatch):
+    n = 8
+    env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
+    env._cfg.noise_config.level = 1.0
+    monkeypatch.setattr(
+        env,
+        "_obs_noise",
+        lambda data, scale: np.asarray(data + 0.025, dtype=np.float32),
+    )
+    motion_data, robot_state, info = _make_batch(n, seed=23)
+    body_pos, body_quat, body_linvel, body_angvel, dof_pos, dof_vel = robot_state
+    linvel = np.zeros((n, 3), dtype=np.float32)
+    gyro = np.zeros((n, 3), dtype=np.float32)
+    accel = MotionTrackingNumbaAccelerator.from_env(env, num_threads=2)
+
+    def compute():
+        return accel.compute_update_state(
+            info=info,
+            motion_data=motion_data,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
+            robot_body_pos_w=body_pos,
+            robot_body_quat_w=body_quat,
+            robot_body_lin_vel_w=body_linvel,
+            robot_body_ang_vel_w=body_angvel,
+            scales=env._cfg.reward_config.scales,
+            enable_log=False,
+        )
+
+    out = compute()
+    sensor_offset = env._num_action * 2 + 3 + 6
+    np.testing.assert_allclose(
+        out.obs["obs"][:, sensor_offset : sensor_offset + 3],
+        out.obs["critic"][:, sensor_offset : sensor_offset + 3] + 0.025,
+    )
+    output_ids = tuple(id(value) for value in (*out.obs.values(), out.reward, out.terminated))
+
+    repeated = compute()
+
+    assert accel.first_jit_ms is not None
+    assert (
+        tuple(id(value) for value in (*repeated.obs.values(), repeated.reward, repeated.terminated))
+        == output_ids
+    )
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
@@ -310,6 +351,7 @@ class _Cfg:
     ee_body_names: tuple[str, ...] = G1MotionTrackingCfg.ee_body_names
     undesired_contact_z_threshold: float = G1MotionTrackingCfg.undesired_contact_z_threshold
     terminate_on_undesired_contacts: bool = False
+    term_plan: MotionTermPlanConfig = field(default_factory=MotionTermPlanConfig)
 
 
 @dataclass
@@ -422,12 +464,22 @@ def _make_batch(n: int, seed: int):
     target_joint_vel = rng.uniform(-2.0, 2.0, (n, na)).astype(np.float32)
 
     motion_data = _MotionData(
-        body_pos_w=np.ascontiguousarray(target_pos + 0.03 * rng.standard_normal((n, nb, 3))),
+        body_pos_w=np.ascontiguousarray(
+            target_pos + 0.03 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
         body_quat_w=np.ascontiguousarray(_perturb_quats(rng, target_quat, 0.02)),
-        body_lin_vel_w=np.ascontiguousarray(target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3))),
-        body_ang_vel_w=np.ascontiguousarray(target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3))),
-        joint_pos=np.ascontiguousarray(target_joint_pos + 0.03 * rng.standard_normal((n, na))),
-        joint_vel=np.ascontiguousarray(target_joint_vel + 0.05 * rng.standard_normal((n, na))),
+        body_lin_vel_w=np.ascontiguousarray(
+            target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
+        body_ang_vel_w=np.ascontiguousarray(
+            target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
+        joint_pos=np.ascontiguousarray(
+            target_joint_pos + 0.03 * rng.standard_normal((n, na)), dtype=np.float32
+        ),
+        joint_vel=np.ascontiguousarray(
+            target_joint_vel + 0.05 * rng.standard_normal((n, na)), dtype=np.float32
+        ),
     )
     robot_body_pos_w = np.ascontiguousarray(
         target_pos + 0.05 * rng.standard_normal((n, nb, 3)), dtype=np.float32

--- a/tests/envs/test_motion_tracking_rewards.py
+++ b/tests/envs/test_motion_tracking_rewards.py
@@ -14,6 +14,7 @@ import numpy as np
 from unilab.envs.motion_tracking.common import numba as numba_mod
 from unilab.envs.motion_tracking.common import rewards
 from unilab.envs.motion_tracking.common.rewards import RewardConfig, RewardContext
+from unilab.envs.motion_tracking.common.terms import REWARD_KEYS
 
 
 def _make_ctx(*, scales: dict[str, float] | None = None) -> RewardContext:
@@ -85,8 +86,11 @@ def _make_ctx(*, scales: dict[str, float] | None = None) -> RewardContext:
     )
 
 
-def test_build_reward_functions_matches_numba_term_order():
-    assert set(rewards.build_reward_functions()) == set(numba_mod.TERM_ORDER)
+def test_build_reward_functions_matches_registered_reward_terms():
+    expected = set(rewards.build_reward_functions())
+    assert expected == set(REWARD_KEYS)
+    if numba_mod.NUMBA_AVAILABLE:
+        assert expected == set(numba_mod.NUMBA_REWARD_ITEMS)
 
 
 def test_motion_joint_pos_term_matches_hand_computed():

--- a/tests/term/test_numba.py
+++ b/tests/term/test_numba.py
@@ -38,6 +38,21 @@ def _reward_numpy(context: NumpyTermContext) -> None:
     np.multiply(context.workspace["scratch"][:, 0], context.parameters["gain"], out=context.output)
 
 
+@numba.njit(inline="always", fastmath=True, nogil=True)
+def _typed_parameter_item(state, enabled, offset, indices, index):
+    value = 0.0
+    if enabled:
+        for column in indices:
+            value += state[index, column]
+    return value + offset
+
+
+def _typed_parameter_numpy(context: NumpyTermContext) -> None:
+    context.output.fill(float(context.parameters["offset"]))
+    if context.parameters["enabled"]:
+        context.output += context.inputs["state"][:, context.parameters["indices"]].sum(axis=1)
+
+
 def _plan(
     *,
     dtype: type[np.floating] = np.float32,
@@ -140,3 +155,38 @@ def test_fused_materialization_fails_closed_without_numba_item() -> None:
     clear_numba_plan_cache()
     with pytest.raises(TermPlanError, match="no Numba item implementation"):
         _materialize(_plan(item_fn=None))
+
+
+def test_fused_plan_executes_bool_int_and_typed_tuple_parameters() -> None:
+    registry = TermRegistry()
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.typed.v1",
+            TermKind.REWARD,
+            _typed_parameter_numpy,
+            TensorSpec((), np.float32),
+            inputs=(NamedTensorSpec("state", TensorSpec((2,), np.float32)),),
+            parameters=(
+                ParameterSpec("enabled", ParameterKind.BOOLEAN),
+                ParameterSpec("offset", ParameterKind.INTEGER),
+                ParameterSpec("indices", ParameterKind.INTEGER, tuple_value=True),
+            ),
+            numba_item_fn=_typed_parameter_item,
+        )
+    )
+    plan = resolve_term_plan(
+        registry,
+        (
+            TermConfig(
+                "typed",
+                "synthetic.reward.typed.v1",
+                parameters={"enabled": True, "offset": 3, "indices": (0, 1)},
+            ),
+        ),
+    )
+    runtime, inputs = _materialize(plan)
+    scratch = np.zeros((numba.get_num_threads(), 1), dtype=np.float64)
+
+    runtime.execute(reward_multiplier=1.0, log_scratch=scratch)
+
+    np.testing.assert_allclose(runtime.reward, inputs["state"].sum(axis=1) + 3.0)


### PR DESCRIPTION
Fixes #923

## Summary

- register motion tracking preamble, reward, observation, and termination Numba item functions on the existing resolved term plan
- extend the shared fused assembler narrowly for bool/int scalar parameters, typed tuple parameters, parameter-schema cache keys, and cold-path workspace view binding
- replace the motion tracking hand-written full aggregator and fixed term order with the automatic fused plan while preserving task-owned noise and lifecycle orchestration
- reuse preallocated actor/critic, reward, termination, and shared workspace buffers; remove the legacy accelerator path
- update the focused benchmark from reward/termination wording to full fused plan-state measurements

## Owner boundaries

- no backend, runner, `NpEnv` lifecycle, training ABI, checkpoint, sim2sim, asset, or regular CI changes
- motion reference sampling, adaptive failure accounting, frame advance, clip-end behavior, teleport, and final observation remain task-owned
- this PR completes only the G1 motion-tracking pilot; it does not promote other task families

## Validation

- `make test-all`
  - 1667 passed, 37 skipped, 280 deselected, 1 xfailed
  - Ruff, mypy, Pyright, and benchmark import smoke passed
- `uv run pytest -q tests/envs/test_g1_motion_tracking_numba.py -m slow`
  - 2 passed
- `uv run pytest -q tests/envs/test_env_configs.py -k 'g1_motion_tracking_clip_end'`
  - 5 passed
- shared assembler execution now explicitly covers bool/int scalar and typed tuple parameters
- actor owner-noise / clean critic boundary, output buffer reuse, and first-JIT reporting are covered

## Performance

Command:

```text
uv run python -m benchmark.env.benchmark_g1_motion_tracking_numba --profiles sac_default --num-envs 2048 8192 --threads 8 --iters 80 --warmup 8 --no-e2e
```

8-thread full fused plan-state results versus the pre-migration hand-written `_compute_update_state_kernel` baseline:

| envs | current | old baseline | retained |
|---:|---:|---:|---:|
| 2048 | 10.43M env/s | 10.72M env/s | 97.3% |
| 8192 | 12.24M env/s | 11.60M env/s | 105.5% |

Both exceed the 90% acceptance gate. Parity maxima were about 1.0e-7 for reward and 7.2e-7 for critic observation, with zero termination mismatches.

Cold/cache measurements at N=2048, 8 threads:

- cache miss assembly: 0.813 ms; first JIT execute: 11876.861 ms
- cache-hit assembly: 0.001 ms; first warm execute: 0.198 ms

## Scope size

- 9 files
- +640 / -1045 lines
