### PR TITLE
feat: package issue 918 Numba roadmap independently

### DIFF
--- a/benchmark/env/benchmark_g1_joystick_numba.py
+++ b/benchmark/env/benchmark_g1_joystick_numba.py
@@ -50,6 +50,7 @@ from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.g1.joystick import (
     G1RewardConfig,
     G1WalkEnv,
+    G1WalkTermPlanConfig,
     build_upper_body_pose_weights,
 )
 from unilab.envs.locomotion.g1.joystick_numba import G1WalkNumbaAccelerator
@@ -131,13 +132,11 @@ FULL_SUPPORTED_SCALES = {
     "base_height": -500.0,
     "pose": -0.5,
     "upper_body_pose": -0.1,
-    "penalty_close_feet_xy": -2.0,
     "penalty_feet_ori": -20.0,
     "feet_phase": 5.0,
     "feet_phase_contrast": 1.0,
     "feet_phase_contact": 1.0,
     "feet_double_stance": -0.2,
-    "feet_air_time": 0.5,
     "alive": 10.0,
 }
 
@@ -220,6 +219,7 @@ class _NoiseCfg:
 class _Cfg:
     ctrl_dt = 0.02
     noise_config = _NoiseCfg()
+    term_plan = G1WalkTermPlanConfig()
 
 
 def make_profile_specs() -> dict[str, ProfileSpec]:

--- a/benchmark/env/benchmark_g1_motion_tracking_numba.py
+++ b/benchmark/env/benchmark_g1_motion_tracking_numba.py
@@ -3,8 +3,8 @@
 
 This benchmark has two scopes:
 
-* default hot slice: reward plus termination, using deterministic synthetic
-  arrays and the real ``G1MotionTrackingEnv`` reward/termination methods;
+* default hot slice: fused update-state numerics, using deterministic synthetic
+  arrays and the real ``G1MotionTrackingEnv`` owner methods;
 * default ``--e2e``: collector-side A/B through
   ``benchmark_offpolicy_collector_active.py`` without learner updates.
 
@@ -45,6 +45,7 @@ except Exception:  # pragma: no cover - plotting is optional in benchmark script
 
 from benchmark.core.device_info import get_device_info_dict, get_device_info_line
 from unilab.dtype_config import get_global_dtype
+from unilab.envs.motion_tracking.common.config import MotionTermPlanConfig
 from unilab.envs.motion_tracking.common.numba import (
     MotionTrackingNumbaAccelerator,
 )
@@ -132,8 +133,8 @@ class ComponentCase:
     num_envs: int
     numba_threads: int
     relative_transform_ms: float
-    numpy_reward_termination_ms: float
-    numba_reward_termination_ms: float
+    numpy_plan_state_ms: float
+    numba_plan_state_ms: float
     numpy_update_state_ms: float
     numba_update_state_ms: float
     numpy_total_ms: float
@@ -199,6 +200,7 @@ class SyntheticCfg:
     ee_body_names: tuple[str, ...] = G1MotionTrackingCfg.ee_body_names
     undesired_contact_z_threshold: float = G1MotionTrackingCfg.undesired_contact_z_threshold
     terminate_on_undesired_contacts: bool = G1MotionTrackingCfg.terminate_on_undesired_contacts
+    term_plan: MotionTermPlanConfig = field(default_factory=MotionTermPlanConfig)
 
 
 @dataclass
@@ -371,33 +373,19 @@ def make_batch(num_envs: int, spec: ProfileSpec, seed: int) -> SyntheticBatch:
 
 
 def compute_numpy(batch: SyntheticBatch) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
-    env = batch.env
-    info = {**batch.info, "log": {}}
-    terminated = env._compute_terminations(
-        batch.motion_data, batch.robot_body_pos_w, batch.robot_body_quat_w
-    )
-    reward = env._compute_reward(
-        info,
-        batch.motion_data,
-        batch.robot_body_pos_w,
-        batch.robot_body_quat_w,
-        batch.robot_body_lin_vel_w,
-        batch.robot_body_ang_vel_w,
-        batch.dof_pos,
-        batch.dof_vel,
-    )
-    return reward, terminated, info.get("log", {})
+    _, reward, terminated, log = compute_numpy_update_state(batch)
+    return reward, terminated, log
 
 
 def compute_numba(
     batch: SyntheticBatch, accelerator: MotionTrackingNumbaAccelerator
 ) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
     info = {**batch.info, "log": {}}
-    out = accelerator.compute(
+    out = accelerator.compute_update_state(
         info=info,
         motion_data=batch.motion_data,
-        ref_body_pos_w=batch.env.body_pos_relative_w,
-        ref_body_quat_w=batch.env.body_quat_relative_w,
+        linvel=batch.linvel,
+        gyro=batch.gyro,
         robot_body_pos_w=batch.robot_body_pos_w,
         robot_body_quat_w=batch.robot_body_quat_w,
         robot_body_lin_vel_w=batch.robot_body_lin_vel_w,
@@ -454,7 +442,6 @@ def compute_numba_update_state(
     batch: SyntheticBatch, accelerator: MotionTrackingNumbaAccelerator
 ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray, dict[str, float]]:
     info = {**batch.info, "log": {}}
-    noise_cfg = batch.env._cfg.noise_config
     out = accelerator.compute_update_state(
         info=info,
         motion_data=batch.motion_data,
@@ -466,18 +453,8 @@ def compute_numba_update_state(
         robot_body_quat_w=batch.robot_body_quat_w,
         robot_body_lin_vel_w=batch.robot_body_lin_vel_w,
         robot_body_ang_vel_w=batch.robot_body_ang_vel_w,
-        ref_body_pos_w=batch.env.body_pos_relative_w,
-        ref_body_quat_w=batch.env.body_quat_relative_w,
-        motion_anchor_pos_b=batch.env._motion_anchor_pos_b,
-        motion_anchor_ori_b=batch.env._motion_anchor_ori_b,
-        joint_pos_rel=batch.env._joint_pos_rel,
         scales=batch.env._cfg.reward_config.scales,
         enable_log=True,
-        noise_level=noise_cfg.level,
-        noise_scale_linvel=noise_cfg.scale_linvel,
-        noise_scale_gyro=noise_cfg.scale_gyro,
-        noise_scale_joint_angle=noise_cfg.scale_joint_angle,
-        noise_scale_joint_vel=noise_cfg.scale_joint_vel,
     )
     return out.obs, out.reward, out.terminated, out.log
 
@@ -612,8 +589,8 @@ def bench_one(
         num_envs=num_envs,
         numba_threads=int(best_numba.threads or 1),
         relative_transform_ms=relative_mean,
-        numpy_reward_termination_ms=numpy_mean,
-        numba_reward_termination_ms=best_numba.mean_ms,
+        numpy_plan_state_ms=numpy_mean,
+        numba_plan_state_ms=best_numba.mean_ms,
         numpy_update_state_ms=numpy_update_state_mean,
         numba_update_state_ms=numba_update_state_mean,
         numpy_total_ms=numpy_total_ms,
@@ -646,8 +623,8 @@ def _component_case_to_dict(case: ComponentCase) -> dict[str, Any]:
         "num_envs": case.num_envs,
         "numba_threads": case.numba_threads,
         "relative_transform_ms": case.relative_transform_ms,
-        "numpy_reward_termination_ms": case.numpy_reward_termination_ms,
-        "numba_reward_termination_ms": case.numba_reward_termination_ms,
+        "numpy_plan_state_ms": case.numpy_plan_state_ms,
+        "numba_plan_state_ms": case.numba_plan_state_ms,
         "numpy_update_state_ms": case.numpy_update_state_ms,
         "numba_update_state_ms": case.numba_update_state_ms,
         "numpy_total_ms": case.numpy_total_ms,
@@ -858,8 +835,8 @@ def _format_component_table(records: list[ComponentCase]) -> str:
         "envs",
         "threads",
         "rel ms",
-        "numpy reward+term ms",
-        "numba reward+term ms",
+        "numpy plan-state ms",
+        "numba plan-state ms",
         "numpy update_state ms",
         "numba update_state ms",
         "update_state speedup",
@@ -870,8 +847,8 @@ def _format_component_table(records: list[ComponentCase]) -> str:
             str(record.num_envs),
             str(record.numba_threads),
             f"{record.relative_transform_ms:.3f}",
-            f"{record.numpy_reward_termination_ms:.3f}",
-            f"{record.numba_reward_termination_ms:.3f}",
+            f"{record.numpy_plan_state_ms:.3f}",
+            f"{record.numba_plan_state_ms:.3f}",
             f"{record.numpy_update_state_ms:.3f}",
             f"{record.numba_update_state_ms:.3f}",
             f"{record.speedup_vs_numpy:.2f}x",
@@ -1128,9 +1105,7 @@ def save_plots(
     best_by_case = _best_numba_by_case(records)
 
     fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(21, 6))
-    fig.suptitle(
-        f"G1 motion tracking Numba reward+termination benchmark\n{device_info}", fontsize=13
-    )
+    fig.suptitle(f"G1 motion tracking Numba fused plan-state benchmark\n{device_info}", fontsize=13)
 
     ax1, ax2, ax3 = axes
     for profile in profiles:
@@ -1270,7 +1245,7 @@ def write_report(
         "skipped_threads": getattr(args, "skipped_threads", None),
         "numba_max_threads": getattr(args, "numba_max_threads", None),
         "scope": (
-            "G1 motion tracking reward+termination hot slice plus full update_state "
+            "G1 motion tracking fused plan-state hot slice plus repeated update_state "
             "array-path reconciliation; synthetic arrays"
         ),
         "e2e_enabled": args.e2e,
@@ -1294,7 +1269,7 @@ def write_report(
     summary_lines = [
         "# G1 motion tracking Numba benchmark",
         "",
-        "Scope: reward plus termination for `G1MotionTrackingEnv.update_state`, using",
+        "Scope: fused numeric state for `G1MotionTrackingEnv.update_state`, using",
         "deterministic synthetic arrays. The component table additionally measures the",
         "full array portion of `update_state`: relative transforms, reward, termination,",
         "and actor/critic observation assembly. Backend state getters, motion sampling,",
@@ -1304,7 +1279,7 @@ def write_report(
         "",
         "Definitions:",
         "",
-        "- `vs numpy`: numpy reward+termination time divided by numba reward+termination time.",
+        "- `vs numpy`: NumPy plan-state time divided by Numba plan-state time.",
         "- `vs numba1T`: numba 1-thread time divided by numba N-thread time.",
         "- `parallel eff`: `vs numba1T / N`; this is the only parallel-efficiency column.",
         "",
@@ -1493,7 +1468,7 @@ def main() -> None:
     args.skipped_threads = sorted({threads for threads in args.threads if threads > max_threads})
 
     print("=" * 80)
-    print("G1 motion tracking Numba benchmark: reward + termination")
+    print("G1 motion tracking Numba benchmark: fused plan state")
     print("=" * 80)
     print(f"host numba threads: {max_threads}")
     print(

--- a/benchmark/env/test_g1_motion_tracking_numba_benchmark.py
+++ b/benchmark/env/test_g1_motion_tracking_numba_benchmark.py
@@ -21,7 +21,9 @@ def test_g1_motion_tracking_numba_benchmark_builds_records_and_matches_numpy() -
     assert any(record.path == "numba_accelerator" and record.threads == 1 for record in records)
     assert component.profile == "sac_default"
     assert component.speedup_vs_numpy > 0.0
-    assert component.numpy_total_ms >= component.numpy_reward_termination_ms
+    assert component.numpy_plan_state_ms > 0.0
+    assert component.numba_plan_state_ms > 0.0
+    assert component.numpy_total_ms > 0.0
     assert all(
         record.parallel_speedup_vs_numba_1t is not None
         for record in records
@@ -67,8 +69,8 @@ def test_g1_motion_tracking_numba_benchmark_formats_component_records() -> None:
         num_envs=1024,
         numba_threads=8,
         relative_transform_ms=0.5,
-        numpy_reward_termination_ms=1.0,
-        numba_reward_termination_ms=0.25,
+        numpy_plan_state_ms=1.0,
+        numba_plan_state_ms=0.25,
         numpy_update_state_ms=3.0,
         numba_update_state_ms=1.5,
         numpy_total_ms=1.5,
@@ -80,7 +82,9 @@ def test_g1_motion_tracking_numba_benchmark_formats_component_records() -> None:
     table = bench._format_component_table([record])
 
     assert payload["relative_transform_ms"] == 0.5
+    assert payload["numba_plan_state_ms"] == 0.25
     assert "rel ms" in table
+    assert "numba plan-state ms" in table
     assert "numpy update_state ms" in table
     assert "2.00x" in table
 

--- a/conf/ppo/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking/mujoco.yaml
@@ -14,6 +14,12 @@ algo:
     entropy_coef: 0.005
 env:
   numba_acceleration: false
+  term_plan:
+    preambles: [motion.tracking.preamble.transforms.v1]
+    observations:
+      obs: [motion.tracking.observation.actor_command.v1, motion.tracking.observation.actor_anchor_pos.v1, motion.tracking.observation.actor_anchor_ori.v1, motion.tracking.observation.actor_linvel.v1, motion.tracking.observation.actor_gyro.v1, motion.tracking.observation.actor_joint_pos.v1, motion.tracking.observation.actor_dof_vel.v1, motion.tracking.observation.actor_actions.v1]
+      critic: [motion.tracking.observation.critic_command.v1, motion.tracking.observation.critic_anchor_pos.v1, motion.tracking.observation.critic_anchor_ori.v1, motion.tracking.observation.critic_linvel.v1, motion.tracking.observation.critic_gyro.v1, motion.tracking.observation.critic_joint_pos.v1, motion.tracking.observation.critic_dof_vel.v1, motion.tracking.observation.critic_actions.v1, motion.tracking.observation.critic_body_pos.v1, motion.tracking.observation.critic_body_ori.v1]
+    terminations: [motion.tracking.termination.failures.v1]
 reward:
   scales:
     motion_global_root_pos: 0.5

--- a/conf/ppo/task/g1_walk_flat/mujoco.yaml
+++ b/conf/ppo/task/g1_walk_flat/mujoco.yaml
@@ -16,6 +16,11 @@ algo:
     critic_hidden_dims: [512, 256, 128]
 env:
   numba_acceleration: false
+  term_plan:
+    observations:
+      obs: [g1.walk.observation.actor_gyro.v1, g1.walk.observation.actor_gravity.v1, g1.walk.observation.actor_dof_pos.v1, g1.walk.observation.actor_dof_vel.v1, g1.walk.observation.actor_actions.v1, g1.walk.observation.actor_commands.v1, g1.walk.observation.actor_gait_phase.v1]
+      critic: [g1.walk.observation.critic_gyro.v1, g1.walk.observation.critic_gravity.v1, g1.walk.observation.critic_dof_pos.v1, g1.walk.observation.critic_dof_vel.v1, g1.walk.observation.critic_actions.v1, g1.walk.observation.critic_commands.v1, g1.walk.observation.critic_gait_phase.v1, g1.walk.observation.critic_linvel.v1]
+    terminations: [g1.walk.termination.tilt_or_height.v1]
   control_config:
     action_scale: 0.25
   curriculum:

--- a/docs/sphinx/source/adr/ADR-0000-index.md
+++ b/docs/sphinx/source/adr/ADR-0000-index.md
@@ -19,6 +19,7 @@ orphan: true
 | [ADR-0003 Task Owner And Config Compose Contract](ADR-0003-task-owner-and-config-compose-contract.md) | Config owner | Accepted |
 | [ADR-0004 Registry Bootstrap Contract](ADR-0004-registry-bootstrap-contract.md) | Registry bootstrap | Accepted |
 | [ADR-0005 Unified Obs Critic Env And IPC Contract](ADR-0005-unified-obs-critic-env-and-ipc-contract.md) | Observation / IPC | Accepted |
+| [ADR-0006 Structured Term Plan And NumPy Tier 1 Boundary](ADR-0006-structured-term-plan.md) | Term registry / execution | Accepted |
 
 ## ADR Governance
 

--- a/docs/sphinx/source/adr/ADR-0006-structured-term-plan.md
+++ b/docs/sphinx/source/adr/ADR-0006-structured-term-plan.md
@@ -1,0 +1,47 @@
+---
+orphan: true
+---
+
+# ADR-0006 Structured Term Plan And NumPy Tier 1 Boundary
+
+- Status: Accepted
+- Date: 2026-08-05
+- Owners: Env / Performance maintainers
+- Supersedes: None
+- Superseded by: None
+
+## Context
+
+G1 walk 与 motion tracking 的 NumPy table 和手写 Numba kernel 需要最小的 resolved contract，且不能改变 `NpEnv` lifecycle。
+
+## Decision
+
+1. `unilab.term` 只依赖标准库和 NumPy，拥有 plan/Tier 1，不拥有 task lifecycle。
+2. definition 声明 key、tensor/参数和 callable；config 顺序即 canonical order。
+3. cold path 拒绝重复/未知 term、非法参数和冲突 spec；materialization 一次绑定
+   shape/dtype、分配 buffer 并预建 context。
+4. scale 是 runtime 值；零值跳过 callable，其他数值输出原地乘 scale，termination 只允许 `0/1`。
+5. Numba item 参数顺序固定；后续 Tier 2 必须自动对拍。
+
+## Stable Contracts
+
+- warm `execute()` 只访问 resolved terms/数组；task owner 继续负责 combine 和 lifecycle。
+- 缺失 Numba item 在 Tier 1 合法；Tier 2 必须显式 fail closed，不能静默混跑。
+
+## Alternatives Considered
+
+- manager/compiler 或 DSL：拒绝，复杂度与双 pilot 不成比例。
+- Python 逐 env 调用 item：拒绝，会丢失 vectorized authoring。
+- 继续手工同步 table/order/kernel：拒绝，无法形成 resolved plan。
+
+## Consequences
+
+只交付 synthetic Tier 1；真实 task/Numba assembler 分属后续 issue。
+
+## Evidence In Repo
+
+- `src/unilab/term/`、`tests/term/`；GitHub issues `#918`、`#919`
+
+## Related Documents
+
+- {doc}`ADR Index </adr/ADR-0000-index>`

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -27,6 +27,15 @@ from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
+from unilab.envs.locomotion.g1.terms import (
+    DEFAULT_OBSERVATION_TERMS,
+    DEFAULT_TERMINATION_TERMS,
+    compute_feet_phase_contact_targets,
+    compute_feet_phase_height_targets,
+    compute_forward_command_mask,
+    compute_forward_speed_gate,
+    resolve_g1_walk_term_plan,
+)
 
 
 @dataclass
@@ -75,31 +84,6 @@ def build_upper_body_pose_weights(pose_weights: list[float]) -> np.ndarray:
     return np.asarray(weights, dtype=get_global_dtype())
 
 
-def compute_feet_phase_height_targets(
-    gait_phase: np.ndarray, swing_height: float
-) -> tuple[np.ndarray, np.ndarray]:
-    def cubic_bezier_height(phi: np.ndarray, swing_height: float) -> np.ndarray:
-        phi_normalized = np.fmod(phi + np.pi, 2 * np.pi) - np.pi
-        x = (phi_normalized + np.pi) / (2 * np.pi)
-
-        def cubic_bezier_interpolation(
-            y_start: np.ndarray, y_end: np.ndarray, t: np.ndarray
-        ) -> np.ndarray:
-            y_diff = y_end - y_start
-            bezier = t**3 + 3 * (t**2 * (1 - t))
-            return np.asarray(y_start + y_diff * bezier, dtype=get_global_dtype())
-
-        stance = cubic_bezier_interpolation(np.zeros_like(x), np.full_like(x, swing_height), 2 * x)
-        swing = cubic_bezier_interpolation(
-            np.full_like(x, swing_height), np.zeros_like(x), 2 * x - 1
-        )
-        return np.where(x <= 0.5, stance, swing)
-
-    left_target = cubic_bezier_height(gait_phase[:, 0], swing_height)
-    right_target = cubic_bezier_height(gait_phase[:, 1], swing_height)
-    return left_target, right_target
-
-
 LEFT_FOOT_CONTACT_SENSORS = [f"left_foot_contact_{i}" for i in range(4)]
 RIGHT_FOOT_CONTACT_SENSORS = [f"right_foot_contact_{i}" for i in range(4)]
 
@@ -116,23 +100,6 @@ def _scalarize_sensor_values(sensor_values: np.ndarray) -> np.ndarray:
 def compute_aggregated_foot_contact(backend: Any, sensor_names: list[str]) -> np.ndarray:
     contacts = [_scalarize_sensor_values(backend.get_sensor_data(name)) for name in sensor_names]
     return np.asarray(np.any(np.stack(contacts, axis=1) > 0.5, axis=1), dtype=np.bool_)
-
-
-def compute_feet_phase_contact_targets(
-    gait_phase: np.ndarray, swing_height: float
-) -> tuple[np.ndarray, np.ndarray]:
-    left_target, right_target = compute_feet_phase_height_targets(gait_phase, swing_height)
-    contact_height_threshold = swing_height * 0.5
-    return left_target <= contact_height_threshold, right_target <= contact_height_threshold
-
-
-def compute_forward_speed_gate(linvel: np.ndarray, min_forward_speed: float) -> np.ndarray:
-    forward_speed = np.maximum(linvel[:, 0], 0.0)
-    return np.asarray(forward_speed >= min_forward_speed, dtype=get_global_dtype())
-
-
-def compute_forward_command_mask(commands: np.ndarray) -> np.ndarray:
-    return np.asarray(np.maximum(commands[:, 0], 0.0) > 1.0e-6, dtype=get_global_dtype())
 
 
 @dataclass
@@ -199,6 +166,16 @@ class CurriculumConfig:
 
 
 @dataclass
+class G1WalkTermPlanConfig:
+    observations: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            name: list(terms) for name, terms in DEFAULT_OBSERVATION_TERMS.items()
+        }
+    )
+    terminations: list[str] = field(default_factory=lambda: list(DEFAULT_TERMINATION_TERMS))
+
+
+@dataclass
 class G1WalkEnvCfg(G1BaseCfg):
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
@@ -215,6 +192,7 @@ class G1WalkEnvCfg(G1BaseCfg):
     curriculum: CurriculumConfig = field(default_factory=CurriculumConfig)
     numba_acceleration: bool = False
     numba_num_threads: int | None = None
+    term_plan: G1WalkTermPlanConfig | None = None
 
 
 class G1WalkDomainRandomizationProvider(LocomotionDRProvider):
@@ -324,6 +302,10 @@ class G1WalkEnv(G1BaseEnv):
             )
 
         self._init_reward_functions()
+        self._resolved_terms: Any = None
+        self._term_runtime: Any = None
+        if cfg.term_plan is not None and not cfg.numba_acceleration:
+            self._init_term_plan(cfg.term_plan)
         self._numba_accelerator = None
         if cfg.numba_acceleration:
             from unilab.envs.locomotion.g1.joystick_numba import G1WalkNumbaAccelerator
@@ -347,8 +329,52 @@ class G1WalkEnv(G1BaseEnv):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
+        if getattr(self, "_resolved_terms", None) is not None:
+            return dict(self._resolved_terms.observation_dims)
         # gyro(3) + gravity(3) + diff(29) + dof_vel(29) + action(29) + cmd(3) + phase(2) = 98
         return {"obs": 98, "critic": 101}
+
+    def _init_term_plan(self, config: G1WalkTermPlanConfig) -> None:
+        resolved = resolve_g1_walk_term_plan(
+            num_action=self._num_action,
+            reward_cfg=self._reward_cfg,
+            observations=config.observations,
+            terminations=config.terminations,
+            walk_profile=self._uses_walk_observation_profile(),
+        )
+        inputs = {
+            name: np.zeros((self._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (
+            ("default_angles", self.default_angles),
+            ("pose_weights", self._pose_weights),
+            ("upper_body_pose_weights", self._upper_body_pose_weights),
+        ):
+            if name in inputs:
+                np.copyto(inputs[name], np.broadcast_to(value, inputs[name].shape))
+        runtime = resolved.plan.materialize(num_envs=self._num_envs, inputs=inputs)
+        obs = {
+            group: np.empty((self._num_envs, width), dtype=get_global_dtype())
+            for group, width in resolved.observation_dims.items()
+        }
+        self._resolved_terms = resolved
+        self._term_inputs = inputs
+        self._term_runtime = runtime
+        self._term_obs = obs
+        self._term_reward = np.empty((self._num_envs,), dtype=get_global_dtype())
+        self._term_terminated = np.empty((self._num_envs,), dtype=np.bool_)
+        self._sync_term_reward_scales()
+
+    def _sync_term_reward_scales(self) -> None:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        active = []
+        for reward_name, output_name in self._resolved_terms.reward_outputs:
+            scale = self._reward_cfg.scales[reward_name]
+            self._term_runtime.set_scale(output_name, scale)
+            if scale != 0.0:
+                active.append((reward_name, output_name))
+        self._active_term_rewards = tuple(active)
 
     def _init_reward_functions(self):
         self._reward_fns: dict[str, Any] = {
@@ -404,14 +430,19 @@ class G1WalkEnv(G1BaseEnv):
             obs = accel_result.obs
             state.info["log"] = accel_result.log
         else:
-            max_tilt_rad = np.deg2rad(self._reward_cfg.max_tilt_deg)
-            tilt = np.arccos(np.clip(gravity[:, 2], -1, 1))
-            terminated = np.logical_or(
-                tilt > max_tilt_rad,
-                self._terrain_relative_base_height() < self._reward_cfg.min_base_height,
-            )
-            reward = self._compute_reward(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
-            obs = self._compute_obs(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
+            if self._term_runtime is not None:
+                obs, reward, terminated = self._compute_term_state(
+                    state.info, linvel, gyro, gravity, dof_pos, dof_vel
+                )
+            else:
+                max_tilt_rad = np.deg2rad(self._reward_cfg.max_tilt_deg)
+                tilt = np.arccos(np.clip(gravity[:, 2], -1, 1))
+                terminated = np.logical_or(
+                    tilt > max_tilt_rad,
+                    self._terrain_relative_base_height() < self._reward_cfg.min_base_height,
+                )
+                reward = self._compute_reward(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
+                obs = self._compute_obs(state.info, linvel, gyro, gravity, dof_pos, dof_vel)
 
         state = state.replace(obs=obs, reward=reward, terminated=terminated)
 
@@ -423,6 +454,8 @@ class G1WalkEnv(G1BaseEnv):
         episode_lengths = state.info["steps"][done_indices] + 1
         self._episode_tracker.update(episode_lengths)
         self._penalty_curriculum.update(self._episode_tracker.average_length)
+        if getattr(self, "_term_runtime", None) is not None:
+            self._sync_term_reward_scales()
 
         if "log" not in state.info:
             state.info["log"] = {}
@@ -434,7 +467,152 @@ class G1WalkEnv(G1BaseEnv):
         )
         return state
 
+    @staticmethod
+    def _copy_term_input(inputs: dict[str, np.ndarray], name: str, value: np.ndarray) -> None:
+        if name in inputs:
+            np.copyto(inputs[name], value, casting="same_kind")
+
+    def _populate_term_inputs(
+        self,
+        inputs: dict[str, np.ndarray],
+        info: dict,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        gravity: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+    ) -> None:
+        copy = self._copy_term_input
+        for name, value in (
+            ("linvel", linvel),
+            ("gyro", gyro),
+            ("gravity", gravity),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+        ):
+            copy(inputs, name, value)
+
+        count = linvel.shape[0]
+        for name, width in (
+            ("commands", 3),
+            ("current_actions", self._num_action),
+            ("last_actions", self._num_action),
+            ("gait_phase", 2),
+        ):
+            if name in inputs:
+                value = info.get(name)
+                if value is None:
+                    inputs[name].fill(0)
+                else:
+                    copy(inputs, name, np.asarray(value).reshape(count, width))
+
+        if "dof_pos_diff" in inputs:
+            np.subtract(dof_pos, self.default_angles, out=inputs["dof_pos_diff"])
+        noisy_sources = (
+            ("noisy_gyro", gyro, self._cfg.noise_config.scale_gyro),
+            ("noisy_gravity", gravity, self._cfg.noise_config.scale_gravity),
+            (
+                "noisy_dof_pos",
+                dof_pos - self.default_angles,
+                self._cfg.noise_config.scale_joint_angle,
+            ),
+            ("noisy_dof_vel", dof_vel, self._cfg.noise_config.scale_joint_vel),
+        )
+        for name, value, scale in noisy_sources:
+            if name not in inputs:
+                continue
+            copy(inputs, name, value)
+            noisy = self._obs_noise(inputs[name], scale)
+            if noisy is not inputs[name]:
+                copy(inputs, name, noisy)
+
+        if "base_height" in inputs:
+            copy(inputs, "base_height", self._backend.get_base_pos()[:, 2])
+        for name in ("left_foot_pos", "right_foot_pos", "left_foot_quat", "right_foot_quat"):
+            if name in inputs:
+                copy(inputs, name, self._backend.get_sensor_data(name))
+        if "left_contact" in inputs or "right_contact" in inputs:
+            copy(
+                inputs,
+                "left_contact",
+                compute_aggregated_foot_contact(self._backend, LEFT_FOOT_CONTACT_SENSORS),
+            )
+            copy(
+                inputs,
+                "right_contact",
+                compute_aggregated_foot_contact(self._backend, RIGHT_FOOT_CONTACT_SENSORS),
+            )
+
+    def _assemble_term_observations(
+        self, outputs: Any, target: dict[str, np.ndarray]
+    ) -> dict[str, np.ndarray]:
+        assert self._resolved_terms is not None
+        for group, names in self._resolved_terms.observation_outputs.items():
+            start = 0
+            for name in names:
+                width = outputs[name].shape[1]
+                np.copyto(target[group][:, start : start + width], outputs[name])
+                start += width
+        return target
+
+    def _compute_term_state(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray]:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        self._populate_term_inputs(
+            self._term_inputs,
+            info,
+            linvel,
+            gyro,
+            gravity,
+            dof_pos,
+            dof_vel,
+        )
+        outputs = self._term_runtime.execute()
+        self._assemble_term_observations(outputs, self._term_obs)
+        self._term_reward.fill(0)
+        for _, name in self._resolved_terms.reward_outputs:
+            np.add(self._term_reward, outputs[name], out=self._term_reward)
+        np.multiply(self._term_reward, self._cfg.ctrl_dt, out=self._term_reward)
+        self._term_terminated.fill(False)
+        for name in self._resolved_terms.termination_outputs:
+            np.logical_or(self._term_terminated, outputs[name], out=self._term_terminated)
+
+        steps = info.get("steps", np.zeros((self._num_envs,), dtype=np.uint32))
+        should_log = self._enable_reward_log and int(steps[0]) % 4 == 0
+        log = {} if should_log else info.get("log", {})
+        if should_log:
+            for reward_name, name in self._active_term_rewards:
+                log[f"reward/{reward_name}"] = float(np.mean(outputs[name]))
+        info["log"] = log
+        return self._term_obs, self._term_reward, self._term_terminated
+
     def _compute_obs(
+        self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
+    ) -> dict[str, np.ndarray]:
+        legacy = G1WalkEnv._compute_legacy_obs(self, info, linvel, gyro, gravity, dof_pos, dof_vel)
+        if getattr(self, "_resolved_terms", None) is None:
+            return legacy
+        actor_layout = self._actor_symmetry_obs_layout()
+        layouts = {"obs": actor_layout, "critic": (*actor_layout, ("linvel", 3))}
+        selected = {}
+        for group, layout in layouts.items():
+            start = 0
+            slices = {}
+            for label, width in layout:
+                slices[label] = slice(start, start + width)
+                start += width
+            selected[group] = np.concatenate(
+                [
+                    legacy[group][:, slices[label]]
+                    for label in self._resolved_terms.observation_labels[group]
+                ],
+                axis=1,
+                dtype=get_global_dtype(),
+            )
+        return selected
+
+    def _compute_legacy_obs(
         self, info: dict, linvel, gyro, gravity, dof_pos, dof_vel
     ) -> dict[str, np.ndarray]:
         noise_cfg = self._cfg.noise_config
@@ -527,6 +705,16 @@ class G1WalkEnv(G1BaseEnv):
         )
 
     def get_symmetry_obs_layouts(self) -> dict[str, SymmetryObsLayout]:
+        if getattr(self, "_resolved_terms", None) is not None:
+            return {
+                group: tuple(
+                    (label, self._resolved_terms.plan.output_specs[name].shape[0])
+                    for label, name in zip(
+                        self._resolved_terms.observation_labels[group], names, strict=True
+                    )
+                )
+                for group, names in self._resolved_terms.observation_outputs.items()
+            }
         actor_layout = self._actor_symmetry_obs_layout()
         return {
             "obs": actor_layout,
@@ -710,6 +898,7 @@ class G1WalkRewardConfig(G1RewardConfig):
 @dataclass
 class G1WalkFlatCfg(G1WalkEnvCfg):
     reward_config: G1WalkRewardConfig | None = None
+    term_plan: G1WalkTermPlanConfig | None = field(default_factory=G1WalkTermPlanConfig)
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
@@ -722,6 +911,7 @@ class G1WalkFlatCfg(G1WalkEnvCfg):
 @registry.envcfg("G1WalkRough")
 @dataclass
 class G1WalkRoughCfg(G1WalkFlatCfg):
+    term_plan: G1WalkTermPlanConfig | None = None
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_rough.xml")
@@ -746,6 +936,7 @@ class G1Walk23DofEnv(G1WalkEnv):
 @registry.envcfg("G1Walk23DofFlat")
 @dataclass
 class G1Walk23DofFlatCfg(G1WalkFlatCfg):
+    term_plan: G1WalkTermPlanConfig | None = None
     scene: SceneCfg = field(
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat_23dof.xml")

--- a/src/unilab/envs/locomotion/g1/joystick_numba.py
+++ b/src/unilab/envs/locomotion/g1/joystick_numba.py
@@ -9,51 +9,26 @@ not installed.
 from __future__ import annotations
 
 import math
+import time
 from dataclasses import dataclass
 from typing import Any, Mapping
 
 import numpy as np
 
+from unilab.dtype_config import get_global_dtype
+
 try:  # pragma: no cover - exercised in environments with numba installed
-    from numba import get_num_threads, get_thread_id, njit, prange, set_num_threads
+    from numba import get_num_threads, njit, set_num_threads
 
     NUMBA_AVAILABLE = True
 except Exception:  # pragma: no cover - default test env may not install numba
-    get_num_threads = get_thread_id = njit = prange = set_num_threads = None  # type: ignore[assignment]
+    get_num_threads = njit = set_num_threads = None  # type: ignore[assignment]
     NUMBA_AVAILABLE = False
 
 
-TERM_ORDER: tuple[str, ...] = (
-    "tracking_lin_vel",
-    "tracking_ang_vel",
-    "forward_progress",
-    "under_speed",
-    "lin_vel_z",
-    "orientation",
-    "penalty_orientation",
-    "ang_vel_xy",
-    "penalty_ang_vel_xy",
-    "action_rate",
-    "penalty_action_rate",
-    "base_height",
-    "pose",
-    "upper_body_pose",
-    "penalty_close_feet_xy",
-    "penalty_feet_ori",
-    "feet_phase",
-    "feet_phase_contrast",
-    "feet_phase_contact",
-    "feet_double_stance",
-    "feet_air_time",
-    "alive",
-)
-TERM_INDEX = {name: i for i, name in enumerate(TERM_ORDER)}
-SUPPORTED_TERMS = frozenset(TERM_ORDER)
-
-FOOT_POSITION_TERMS = frozenset(("penalty_close_feet_xy", "feet_phase", "feet_phase_contrast"))
-FOOT_QUAT_TERMS = frozenset(("penalty_feet_ori",))
-FOOT_CONTACT_TERMS = frozenset(("feet_phase_contact", "feet_double_stance"))
-FEET_AIR_TIME_TERMS = frozenset(("feet_air_time",))
+NUMBA_REWARD_ITEMS: dict[str, Any] = {}
+NUMBA_OBSERVATION_ITEM = None
+NUMBA_TERMINATION_ITEM = None
 
 
 @dataclass(frozen=True)
@@ -77,25 +52,13 @@ def _active_terms(scales: Mapping[str, float]) -> frozenset[str]:
 
 def unsupported_terms(scales: Mapping[str, float]) -> frozenset[str]:
     """Return nonzero reward terms this task-specific kernel cannot compute."""
-    return _active_terms(scales) - SUPPORTED_TERMS
+    from unilab.envs.locomotion.g1.terms import REWARD_TERM_KEYS
+
+    return _active_terms(scales) - REWARD_TERM_KEYS.keys()
 
 
 def is_available(scales: Mapping[str, float]) -> bool:
     return NUMBA_AVAILABLE and not unsupported_terms(scales)
-
-
-def _scalar_sensor(sensor_values: np.ndarray) -> np.ndarray:
-    arr = np.asarray(sensor_values)
-    if arr.ndim == 1:
-        return arr
-    if arr.ndim == 2 and arr.shape[1] == 1:
-        return arr[:, 0]
-    raise ValueError(f"Expected scalar sensor values, got shape {arr.shape}")
-
-
-def _aggregated_contact(backend: Any, sensor_names: tuple[str, ...]) -> np.ndarray:
-    contacts = [_scalar_sensor(backend.get_sensor_data(name)) for name in sensor_names]
-    return np.asarray(np.any(np.stack(contacts, axis=1) > 0.5, axis=1), dtype=np.bool_)
 
 
 if NUMBA_AVAILABLE:
@@ -151,26 +114,8 @@ if NUMBA_AVAILABLE:
         return acc
 
     @_dev
-    def weighted_pose_i(dof_pos, default_angles, weights, n_action, i):
-        acc = 0.0
-        for j in range(n_action):
-            d = dof_pos[i, j] - default_angles[j]
-            acc += weights[j] * d * d
-        return acc
-
-    @_dev
     def base_height_i(base_height, base_height_target, i):
         d = base_height[i] - base_height_target
-        return d * d
-
-    @_dev
-    def close_feet_xy_i(left_foot_pos, right_foot_pos, close_feet_threshold, i):
-        dx = left_foot_pos[i, 0] - right_foot_pos[i, 0]
-        dy = left_foot_pos[i, 1] - right_foot_pos[i, 1]
-        feet_dist = math.sqrt(dx * dx + dy * dy)
-        if feet_dist >= close_feet_threshold:
-            return 0.0
-        d = feet_dist - close_feet_threshold
         return d * d
 
     @_dev
@@ -267,15 +212,6 @@ if NUMBA_AVAILABLE:
         return double_stance * forward_command
 
     @_dev
-    def feet_air_time_i(feet_air_time, i):
-        acc = 0.0
-        if feet_air_time[i, 0] > 0.05 and feet_air_time[i, 0] < 0.5:
-            acc += 1.0
-        if feet_air_time[i, 1] > 0.05 and feet_air_time[i, 1] < 0.5:
-            acc += 1.0
-        return acc
-
-    @_dev
     def terminated_i(gravity, base_height, max_tilt_rad, min_base_height, i):
         gz = gravity[i, 2]
         if gz < -1.0:
@@ -284,551 +220,137 @@ if NUMBA_AVAILABLE:
             gz = 1.0
         return math.acos(gz) > max_tilt_rad or base_height[i] < min_base_height
 
-    @njit(fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_i(
-        linvel,
-        gyro,
-        gravity,
-        dof_pos,
-        base_height,
-        commands,
-        current_actions,
-        last_actions,
-        gait_phase,
-        default_angles,
-        pose_weights,
-        upper_body_pose_weights,
-        left_foot_pos,
-        right_foot_pos,
-        left_foot_quat,
-        right_foot_quat,
-        left_contact,
-        right_contact,
-        feet_air_time,
-        scale,
-        ctrl_dt,
-        tracking_sigma,
-        base_height_target,
-        min_base_height,
-        max_tilt_rad,
-        feet_phase_swing_height,
-        feet_phase_tracking_sigma,
-        min_forward_speed_for_gait_reward,
-        close_feet_threshold,
-        reward,
-        terminated,
-        log_scratch,
-        tid,
-        i,
-    ):
-        n_action = dof_pos.shape[1]
-        r = 0.0
-
-        w = tracking_lin_vel_i(linvel, commands, tracking_sigma, i) * scale[0]
-        r += w
-        log_scratch[tid, 0] += w
-
-        w = tracking_ang_vel_i(gyro, commands, tracking_sigma, i) * scale[1]
-        r += w
-        log_scratch[tid, 1] += w
-
-        w = forward_progress_i(linvel, commands, i) * scale[2]
-        r += w
-        log_scratch[tid, 2] += w
-
-        w = under_speed_i(linvel, commands, i) * scale[3]
-        r += w
-        log_scratch[tid, 3] += w
-
-        w = lin_vel_z_i(linvel, i) * scale[4]
-        r += w
-        log_scratch[tid, 4] += w
-
-        orientation = orientation_i(gravity, i)
-        w = orientation * scale[5]
-        r += w
-        log_scratch[tid, 5] += w
-        w = orientation * scale[6]
-        r += w
-        log_scratch[tid, 6] += w
-
-        ang_vel_xy = ang_vel_xy_i(gyro, i)
-        w = ang_vel_xy * scale[7]
-        r += w
-        log_scratch[tid, 7] += w
-        w = ang_vel_xy * scale[8]
-        r += w
-        log_scratch[tid, 8] += w
-
-        action_rate = action_rate_i(current_actions, last_actions, n_action, i)
-        w = action_rate * scale[9]
-        r += w
-        log_scratch[tid, 9] += w
-        w = action_rate * scale[10]
-        r += w
-        log_scratch[tid, 10] += w
-
-        w = base_height_i(base_height, base_height_target, i) * scale[11]
-        r += w
-        log_scratch[tid, 11] += w
-
-        pose = weighted_pose_i(dof_pos, default_angles, pose_weights, n_action, i)
-        w = pose * scale[12]
-        r += w
-        log_scratch[tid, 12] += w
-        upper_body_pose = weighted_pose_i(
-            dof_pos, default_angles, upper_body_pose_weights, n_action, i
-        )
-        w = upper_body_pose * scale[13]
-        r += w
-        log_scratch[tid, 13] += w
-
-        w = close_feet_xy_i(left_foot_pos, right_foot_pos, close_feet_threshold, i) * scale[14]
-        r += w
-        log_scratch[tid, 14] += w
-
-        w = feet_ori_i(left_foot_quat, right_foot_quat, i) * scale[15]
-        r += w
-        log_scratch[tid, 15] += w
-
-        w = (
-            feet_phase_i(
-                linvel,
-                gait_phase,
-                left_foot_pos,
-                right_foot_pos,
-                feet_phase_swing_height,
-                feet_phase_tracking_sigma,
-                min_forward_speed_for_gait_reward,
-                i,
-            )
-            * scale[16]
-        )
-        r += w
-        log_scratch[tid, 16] += w
-
-        w = (
-            feet_phase_contrast_i(
-                linvel,
-                gait_phase,
-                left_foot_pos,
-                right_foot_pos,
-                feet_phase_swing_height,
-                feet_phase_tracking_sigma,
-                min_forward_speed_for_gait_reward,
-                i,
-            )
-            * scale[17]
-        )
-        r += w
-        log_scratch[tid, 17] += w
-
-        w = (
-            feet_phase_contact_i(
-                linvel,
-                gait_phase,
-                left_contact,
-                right_contact,
-                feet_phase_swing_height,
-                min_forward_speed_for_gait_reward,
-                i,
-            )
-            * scale[18]
-        )
-        r += w
-        log_scratch[tid, 18] += w
-
-        w = feet_double_stance_i(commands, left_contact, right_contact, i) * scale[19]
-        r += w
-        log_scratch[tid, 19] += w
-
-        w = feet_air_time_i(feet_air_time, i) * scale[20]
-        r += w
-        log_scratch[tid, 20] += w
-
-        w = scale[21]
-        r += w
-        log_scratch[tid, 21] += w
-
-        reward[i] = r * ctrl_dt
-        terminated[i] = terminated_i(gravity, base_height, max_tilt_rad, min_base_height, i)
-
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_kernel(
-        linvel,
-        gyro,
-        gravity,
-        dof_pos,
-        dof_vel,
-        base_height,
-        commands,
-        current_actions,
-        last_actions,
-        gait_phase,
-        default_angles,
-        pose_weights,
-        upper_body_pose_weights,
-        left_foot_pos,
-        right_foot_pos,
-        left_foot_quat,
-        right_foot_quat,
-        left_contact,
-        right_contact,
-        feet_air_time,
-        scale,
-        ctrl_dt,
-        tracking_sigma,
-        base_height_target,
-        min_base_height,
-        max_tilt_rad,
-        feet_phase_swing_height,
-        feet_phase_tracking_sigma,
-        min_forward_speed_for_gait_reward,
-        close_feet_threshold,
-        reward,
-        terminated,
-        log_scratch,
-    ):
-        n = reward.shape[0]
-        for i in prange(n):
-            _compute_reward_termination_i(
-                linvel,
-                gyro,
-                gravity,
-                dof_pos,
-                base_height,
-                commands,
-                current_actions,
-                last_actions,
-                gait_phase,
-                default_angles,
-                pose_weights,
-                upper_body_pose_weights,
-                left_foot_pos,
-                right_foot_pos,
-                left_foot_quat,
-                right_foot_quat,
-                left_contact,
-                right_contact,
-                feet_air_time,
-                scale,
-                ctrl_dt,
-                tracking_sigma,
-                base_height_target,
-                min_base_height,
-                max_tilt_rad,
-                feet_phase_swing_height,
-                feet_phase_tracking_sigma,
-                min_forward_speed_for_gait_reward,
-                close_feet_threshold,
-                reward,
-                terminated,
-                log_scratch,
-                get_thread_id(),
-                i,
-            )
+    @_dev
+    def weighted_pose_plan_i(dof_pos, default_angles, weights, i):
+        acc = 0.0
+        for j in range(dof_pos.shape[1]):
+            d = dof_pos[i, j] - default_angles[i, j]
+            acc += weights[i, j] * d * d
+        return acc
 
     @_dev
-    def _write_actor_obs_i(
-        gyro,
-        gravity,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        commands,
-        gait_phase,
-        default_angles,
-        actor_gyro_scale,
-        actor_dof_vel_scale,
-        actor_obs,
-        n_action,
-        i,
-    ):
-        out = 0
-        actor_obs[i, out] = gyro[i, 0] * actor_gyro_scale
-        actor_obs[i, out + 1] = gyro[i, 1] * actor_gyro_scale
-        actor_obs[i, out + 2] = gyro[i, 2] * actor_gyro_scale
-        out += 3
-        actor_obs[i, out] = -gravity[i, 0]
-        actor_obs[i, out + 1] = -gravity[i, 1]
-        actor_obs[i, out + 2] = -gravity[i, 2]
-        out += 3
-        for j in range(n_action):
-            actor_obs[i, out + j] = dof_pos[i, j] - default_angles[j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = dof_vel[i, j] * actor_dof_vel_scale
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = current_actions[i, j]
-        out += n_action
-        actor_obs[i, out] = commands[i, 0]
-        actor_obs[i, out + 1] = commands[i, 1]
-        actor_obs[i, out + 2] = commands[i, 2]
-        out += 3
-        actor_obs[i, out] = gait_phase[i, 0]
-        actor_obs[i, out + 1] = gait_phase[i, 1]
+    def action_rate_plan_i(current_actions, last_actions, i):
+        return action_rate_i(current_actions, last_actions, current_actions.shape[1], i)
 
     @_dev
-    def _write_critic_obs_i(
-        linvel,
-        gyro,
-        gravity,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        commands,
-        gait_phase,
-        default_angles,
-        critic_gyro_scale,
-        critic_dof_vel_scale,
-        critic_linvel_scale,
-        critic_obs,
-        n_action,
-        i,
-    ):
-        out = 0
-        critic_obs[i, out] = gyro[i, 0] * critic_gyro_scale
-        critic_obs[i, out + 1] = gyro[i, 1] * critic_gyro_scale
-        critic_obs[i, out + 2] = gyro[i, 2] * critic_gyro_scale
-        out += 3
-        critic_obs[i, out] = -gravity[i, 0]
-        critic_obs[i, out + 1] = -gravity[i, 1]
-        critic_obs[i, out + 2] = -gravity[i, 2]
-        out += 3
-        for j in range(n_action):
-            critic_obs[i, out + j] = dof_pos[i, j] - default_angles[j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = dof_vel[i, j] * critic_dof_vel_scale
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = current_actions[i, j]
-        out += n_action
-        critic_obs[i, out] = commands[i, 0]
-        critic_obs[i, out + 1] = commands[i, 1]
-        critic_obs[i, out + 2] = commands[i, 2]
-        out += 3
-        critic_obs[i, out] = gait_phase[i, 0]
-        critic_obs[i, out + 1] = gait_phase[i, 1]
-        out += 2
-        critic_obs[i, out] = linvel[i, 0] * critic_linvel_scale
-        critic_obs[i, out + 1] = linvel[i, 1] * critic_linvel_scale
-        critic_obs[i, out + 2] = linvel[i, 2] * critic_linvel_scale
+    def alive_i(i):
+        return 1.0
 
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_update_state_kernel(
-        linvel,
-        gyro,
-        gravity,
-        dof_pos,
-        dof_vel,
-        base_height,
-        commands,
-        current_actions,
-        last_actions,
-        gait_phase,
-        default_angles,
-        pose_weights,
-        upper_body_pose_weights,
-        left_foot_pos,
-        right_foot_pos,
-        left_foot_quat,
-        right_foot_quat,
-        left_contact,
-        right_contact,
-        feet_air_time,
-        scale,
-        ctrl_dt,
-        tracking_sigma,
-        base_height_target,
-        min_base_height,
-        max_tilt_rad,
-        feet_phase_swing_height,
-        feet_phase_tracking_sigma,
-        min_forward_speed_for_gait_reward,
-        close_feet_threshold,
-        actor_gyro_scale,
-        actor_dof_vel_scale,
-        critic_gyro_scale,
-        critic_dof_vel_scale,
-        critic_linvel_scale,
-        actor_obs,
-        critic_obs,
-        reward,
-        terminated,
-        log_scratch,
-    ):
-        n = reward.shape[0]
-        n_action = dof_pos.shape[1]
-        for i in prange(n):
-            tid = get_thread_id()
-            _compute_reward_termination_i(
-                linvel,
-                gyro,
-                gravity,
-                dof_pos,
-                base_height,
-                commands,
-                current_actions,
-                last_actions,
-                gait_phase,
-                default_angles,
-                pose_weights,
-                upper_body_pose_weights,
-                left_foot_pos,
-                right_foot_pos,
-                left_foot_quat,
-                right_foot_quat,
-                left_contact,
-                right_contact,
-                feet_air_time,
-                scale,
-                ctrl_dt,
-                tracking_sigma,
-                base_height_target,
-                min_base_height,
-                max_tilt_rad,
-                feet_phase_swing_height,
-                feet_phase_tracking_sigma,
-                min_forward_speed_for_gait_reward,
-                close_feet_threshold,
-                reward,
-                terminated,
-                log_scratch,
-                tid,
-                i,
-            )
-            _write_actor_obs_i(
-                gyro,
-                gravity,
-                dof_pos,
-                dof_vel,
-                current_actions,
-                commands,
-                gait_phase,
-                default_angles,
-                actor_gyro_scale,
-                actor_dof_vel_scale,
-                actor_obs,
-                n_action,
-                i,
-            )
-            _write_critic_obs_i(
-                linvel,
-                gyro,
-                gravity,
-                dof_pos,
-                dof_vel,
-                current_actions,
-                commands,
-                gait_phase,
-                default_angles,
-                critic_gyro_scale,
-                critic_dof_vel_scale,
-                critic_linvel_scale,
-                critic_obs,
-                n_action,
-                i,
-            )
+    @_dev
+    def scaled_copy_i(source, multiplier, output, offset, i):
+        for j in range(source.shape[1]):
+            output[i, offset + j] = source[i, j] * multiplier
+
+    NUMBA_REWARD_ITEMS = {
+        "tracking_lin_vel": tracking_lin_vel_i,
+        "tracking_ang_vel": tracking_ang_vel_i,
+        "forward_progress": forward_progress_i,
+        "under_speed": under_speed_i,
+        "lin_vel_z": lin_vel_z_i,
+        "orientation": orientation_i,
+        "ang_vel_xy": ang_vel_xy_i,
+        "action_rate": action_rate_plan_i,
+        "base_height": base_height_i,
+        "pose": weighted_pose_plan_i,
+        "upper_body_pose": weighted_pose_plan_i,
+        "feet_ori": feet_ori_i,
+        "feet_phase": feet_phase_i,
+        "feet_phase_contrast": feet_phase_contrast_i,
+        "feet_phase_contact": feet_phase_contact_i,
+        "feet_double_stance": feet_double_stance_i,
+        "alive": alive_i,
+    }
+    NUMBA_OBSERVATION_ITEM = scaled_copy_i
+    NUMBA_TERMINATION_ITEM = terminated_i
 
 
 class G1WalkNumbaAccelerator:
-    """Driver that keeps config-derived arrays and calls the fused kernel."""
+    """Resolved-plan Numba driver for the G1WalkFlat pilot."""
 
-    def __init__(
-        self,
-        *,
-        num_envs: int,
-        num_action: int,
-        ctrl_dt: float,
-        tracking_sigma: float,
-        base_height_target: float,
-        min_base_height: float,
-        max_tilt_deg: float,
-        feet_phase_swing_height: float,
-        feet_phase_tracking_sigma: float,
-        min_forward_speed_for_gait_reward: float,
-        close_feet_threshold: float,
-        default_angles: np.ndarray,
-        pose_weights: np.ndarray,
-        upper_body_pose_weights: np.ndarray,
-        actor_obs_width: int,
-        critic_obs_width: int,
-        walk_observation_profile: bool,
-        num_threads: int | None = None,
-    ) -> None:
-        self.num_envs = int(num_envs)
-        self.num_action = int(num_action)
-        self.ctrl_dt = float(ctrl_dt)
-        self.tracking_sigma = float(tracking_sigma)
-        self.base_height_target = float(base_height_target)
-        self.min_base_height = float(min_base_height)
-        self.max_tilt_rad = float(np.deg2rad(max_tilt_deg))
-        self.feet_phase_swing_height = float(feet_phase_swing_height)
-        self.feet_phase_tracking_sigma = float(feet_phase_tracking_sigma)
-        self.min_forward_speed_for_gait_reward = float(min_forward_speed_for_gait_reward)
-        self.close_feet_threshold = float(close_feet_threshold)
-        self.default_angles = np.asarray(default_angles, dtype=np.float64)
-        self.pose_weights = np.asarray(pose_weights, dtype=np.float64)
-        self.upper_body_pose_weights = np.asarray(upper_body_pose_weights, dtype=np.float64)
-        self.actor_obs_width = int(actor_obs_width)
-        self.critic_obs_width = int(critic_obs_width)
-        self.walk_observation_profile = bool(walk_observation_profile)
+    def __init__(self, env: Any, *, num_threads: int | None = None) -> None:
+        from unilab.envs.locomotion.g1.terms import resolve_g1_walk_term_plan
+        from unilab.term.numba import FusedOutputLayout, materialize_numba_plan
+
+        config = env._cfg.term_plan
+        if config is None:
+            raise ValueError(
+                "G1Walk Numba fused execution requires env.term_plan; disable "
+                "numba_acceleration for tasks that retain the legacy NumPy path"
+            )
+        resolved = resolve_g1_walk_term_plan(
+            num_action=env._num_action,
+            reward_cfg=env._reward_cfg,
+            observations=config.observations,
+            terminations=config.terminations,
+            walk_profile=env._uses_walk_observation_profile(),
+        )
+        inputs = {
+            name: np.zeros((env._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (
+            ("default_angles", env.default_angles),
+            ("pose_weights", env._pose_weights),
+            ("upper_body_pose_weights", env._upper_body_pose_weights),
+        ):
+            if name in inputs:
+                np.copyto(inputs[name], np.broadcast_to(value, inputs[name].shape))
+        observations = {
+            group: np.empty((env._num_envs, width), dtype=get_global_dtype())
+            for group, width in resolved.observation_dims.items()
+        }
+        reward = np.empty((env._num_envs,), dtype=get_global_dtype())
+        terminated = np.empty((env._num_envs,), dtype=np.bool_)
+        layout = FusedOutputLayout(
+            rewards=tuple(output for _, output in resolved.reward_outputs),
+            observations=resolved.observation_outputs,
+            terminations=resolved.termination_outputs,
+        )
+        self.runtime = materialize_numba_plan(
+            resolved.plan,
+            layout,
+            num_envs=env._num_envs,
+            inputs=inputs,
+            observations=observations,
+            reward=reward,
+            terminated=terminated,
+        )
+        self.resolved = resolved
+        self.inputs = inputs
+        self._owned_inputs = inputs.copy()
+        self.obs = observations
+        self.num_envs = env._num_envs
         self.num_threads = num_threads
-        self.scale = np.zeros((len(TERM_ORDER),), dtype=np.float64)
-        self._zero_vec2 = np.zeros((self.num_envs, 2), dtype=np.float64)
-        self._zero_vec3 = np.zeros((self.num_envs, 3), dtype=np.float64)
-        self._zero_vec4 = np.zeros((self.num_envs, 4), dtype=np.float64)
-        self._zero_bool = np.zeros((self.num_envs,), dtype=np.bool_)
+        self.ctrl_dt = float(env._cfg.ctrl_dt)
+        self.first_jit_ms: float | None = None
+        self._reward_outputs = dict(resolved.reward_outputs)
+        self._plan_indices = {term.name: index for index, term in enumerate(resolved.plan.terms)}
+        self._log_scratch: np.ndarray | None = None
+
+    @property
+    def compile_info(self):
+        return self.runtime.compile_info
 
     @classmethod
     def from_env(cls, env: Any, num_threads: int | None = None) -> "G1WalkNumbaAccelerator":
         if not NUMBA_AVAILABLE:
             raise RuntimeError(
-                "G1Walk numba_acceleration=True requires numba. Install it or run through "
-                "`uv run --with numba ...`; disable numba_acceleration to use the numpy path."
+                "G1Walk numba_acceleration=True requires numba. Install it or disable "
+                "numba_acceleration to use the NumPy path."
             )
-        return cls(
-            num_envs=env.num_envs,
-            num_action=env._num_action,
-            ctrl_dt=env._cfg.ctrl_dt,
-            tracking_sigma=env._reward_cfg.tracking_sigma,
-            base_height_target=env._reward_cfg.base_height_target,
-            min_base_height=env._reward_cfg.min_base_height,
-            max_tilt_deg=env._reward_cfg.max_tilt_deg,
-            feet_phase_swing_height=env._reward_cfg.feet_phase_swing_height,
-            feet_phase_tracking_sigma=env._reward_cfg.feet_phase_tracking_sigma,
-            min_forward_speed_for_gait_reward=getattr(
-                env._reward_cfg, "min_forward_speed_for_gait_reward", 0.0
-            ),
-            close_feet_threshold=getattr(env._reward_cfg, "close_feet_threshold", 0.15),
-            default_angles=env.default_angles,
-            pose_weights=env._pose_weights,
-            upper_body_pose_weights=env._upper_body_pose_weights,
-            actor_obs_width=env.obs_groups_spec["obs"],
-            critic_obs_width=env.obs_groups_spec["critic"],
-            walk_observation_profile=env._uses_walk_observation_profile(),
-            num_threads=num_threads,
-        )
+        return cls(env, num_threads=num_threads)
 
     def _sync_scales(self, scales: Mapping[str, float]) -> None:
-        unsupported = unsupported_terms(scales)
+        unsupported = _active_terms(scales) - self._reward_outputs.keys()
         if unsupported:
             raise ValueError(
-                "G1Walk Numba accelerator does not support active reward terms "
-                f"{sorted(unsupported)}. Disable numba_acceleration or add these terms "
-                "to src/unilab/envs/locomotion/g1/joystick_numba.py."
+                f"G1Walk Numba plan does not support active reward terms {sorted(unsupported)}"
             )
-        self.scale.fill(0.0)
-        for name, value in scales.items():
-            idx = TERM_INDEX.get(name)
-            if idx is not None:
-                self.scale[idx] = float(value)
+        for reward_name, output_name in self._reward_outputs.items():
+            self.runtime.set_scale(output_name, scales.get(reward_name, 0.0))
 
-    def compute(
+    def _bind_inputs(
         self,
-        *,
         env: Any,
         info: dict[str, Any],
         linvel: np.ndarray,
@@ -836,118 +358,72 @@ class G1WalkNumbaAccelerator:
         gravity: np.ndarray,
         dof_pos: np.ndarray,
         dof_vel: np.ndarray,
-        scales: Mapping[str, float],
-        enable_log: bool,
-    ) -> G1WalkNumbaResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1Walk Numba accelerator was constructed while numba is unavailable; "
-                "this indicates an invalid accelerator state."
-            )
-        self._sync_scales(scales)
+    ) -> None:
+        def bind(name: str, value: np.ndarray) -> None:
+            if name in self.inputs:
+                self.inputs[name] = np.asarray(value)
 
-        active = _active_terms(scales)
-        backend = env._backend
-        dtype = linvel.dtype
-        base_height = np.asarray(backend.get_base_pos()[:, 2], dtype=dtype)
-        commands = np.asarray(info["commands"], dtype=dtype)
-        current_actions = np.asarray(
-            info.get("current_actions", np.zeros((self.num_envs, self.num_action), dtype=dtype)),
-            dtype=dtype,
+        for name, value in (
+            ("linvel", linvel),
+            ("gyro", gyro),
+            ("gravity", gravity),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+        ):
+            bind(name, value)
+        for name in ("commands", "current_actions", "last_actions", "gait_phase"):
+            if name not in self.inputs:
+                continue
+            value = info.get(name)
+            if value is None:
+                value = self._owned_inputs[name]
+                value.fill(0)
+            bind(name, value)
+
+        if "dof_pos_diff" in self.inputs:
+            target = self._owned_inputs["dof_pos_diff"]
+            np.subtract(dof_pos, env.default_angles, out=target)
+            bind("dof_pos_diff", target)
+        noisy_dof_pos = (
+            self.inputs["dof_pos_diff"]
+            if "dof_pos_diff" in self.inputs
+            else dof_pos - env.default_angles
         )
-        last_actions = np.asarray(
-            info.get("last_actions", np.zeros((self.num_envs, self.num_action), dtype=dtype)),
-            dtype=dtype,
+        noisy_sources = (
+            ("noisy_gyro", gyro, env._cfg.noise_config.scale_gyro),
+            ("noisy_gravity", gravity, env._cfg.noise_config.scale_gravity),
+            (
+                "noisy_dof_pos",
+                noisy_dof_pos,
+                env._cfg.noise_config.scale_joint_angle,
+            ),
+            ("noisy_dof_vel", dof_vel, env._cfg.noise_config.scale_joint_vel),
         )
-        gait_phase = np.asarray(info.get("gait_phase", self._zero_vec2), dtype=dtype)
-        feet_air_time = np.asarray(info.get("feet_air_time", self._zero_vec2), dtype=dtype)
+        for name, value, scale in noisy_sources:
+            if name in self.inputs:
+                bind(name, env._obs_noise(value, scale))
 
-        if active & FOOT_POSITION_TERMS:
-            left_foot_pos = np.asarray(backend.get_sensor_data("left_foot_pos"), dtype=dtype)
-            right_foot_pos = np.asarray(backend.get_sensor_data("right_foot_pos"), dtype=dtype)
-        else:
-            left_foot_pos = right_foot_pos = self._zero_vec3
-
-        if active & FOOT_QUAT_TERMS:
-            left_foot_quat = np.asarray(backend.get_sensor_data("left_foot_quat"), dtype=dtype)
-            right_foot_quat = np.asarray(backend.get_sensor_data("right_foot_quat"), dtype=dtype)
-        else:
-            left_foot_quat = right_foot_quat = self._zero_vec4
-
-        if active & FOOT_CONTACT_TERMS:
-            left_contact = _aggregated_contact(
-                backend,
-                (
-                    "left_foot_contact_0",
-                    "left_foot_contact_1",
-                    "left_foot_contact_2",
-                    "left_foot_contact_3",
-                ),
+        if "base_height" in self.inputs:
+            bind("base_height", env._backend.get_base_pos()[:, 2])
+        for name in ("left_foot_pos", "right_foot_pos", "left_foot_quat", "right_foot_quat"):
+            if name in self.inputs:
+                bind(name, env._backend.get_sensor_data(name))
+        if "left_contact" in self.inputs or "right_contact" in self.inputs:
+            from unilab.envs.locomotion.g1.joystick import (
+                LEFT_FOOT_CONTACT_SENSORS,
+                RIGHT_FOOT_CONTACT_SENSORS,
+                compute_aggregated_foot_contact,
             )
-            right_contact = _aggregated_contact(
-                backend,
-                (
-                    "right_foot_contact_0",
-                    "right_foot_contact_1",
-                    "right_foot_contact_2",
-                    "right_foot_contact_3",
-                ),
+
+            bind(
+                "left_contact",
+                compute_aggregated_foot_contact(env._backend, LEFT_FOOT_CONTACT_SENSORS),
             )
-        else:
-            left_contact = right_contact = self._zero_bool
-
-        if self.num_threads is not None:
-            set_num_threads(self.num_threads)
-        nthreads = get_num_threads()
-        reward = np.empty((linvel.shape[0],), dtype=dtype)
-        terminated = np.empty((linvel.shape[0],), dtype=np.bool_)
-        log_scratch = np.zeros((nthreads, len(TERM_ORDER)), dtype=np.float64)
-
-        _compute_reward_termination_kernel(
-            linvel,
-            gyro,
-            gravity,
-            dof_pos,
-            dof_vel,
-            base_height,
-            commands,
-            current_actions,
-            last_actions,
-            gait_phase,
-            self.default_angles,
-            self.pose_weights,
-            self.upper_body_pose_weights,
-            left_foot_pos,
-            right_foot_pos,
-            left_foot_quat,
-            right_foot_quat,
-            left_contact,
-            right_contact,
-            feet_air_time,
-            self.scale,
-            self.ctrl_dt,
-            self.tracking_sigma,
-            self.base_height_target,
-            self.min_base_height,
-            self.max_tilt_rad,
-            self.feet_phase_swing_height,
-            self.feet_phase_tracking_sigma,
-            self.min_forward_speed_for_gait_reward,
-            self.close_feet_threshold,
-            reward,
-            terminated,
-            log_scratch,
-        )
-
-        step_count = info.get("steps", np.zeros((linvel.shape[0],), dtype=np.uint32))
-        should_log = enable_log and int(step_count[0]) % 4 == 0
-        log = {} if should_log else info.get("log", {})
-        if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / linvel.shape[0])
-        return G1WalkNumbaResult(reward=reward, terminated=terminated, log=log)
+            bind(
+                "right_contact",
+                compute_aggregated_foot_contact(env._backend, RIGHT_FOOT_CONTACT_SENSORS),
+            )
+        self.runtime.bind_inputs(self.inputs)
 
     def compute_update_state(
         self,
@@ -963,146 +439,43 @@ class G1WalkNumbaAccelerator:
         enable_log: bool,
         noise_level: float,
     ) -> G1WalkNumbaUpdateStateResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1Walk Numba accelerator was constructed while numba is unavailable; "
-                "this indicates an invalid accelerator state."
-            )
-        if float(noise_level) > 0.0:
-            raise RuntimeError(
-                "G1Walk numba_acceleration=True does not support observation noise yet. "
-                "Set env.noise_config.level=0.0 or disable numba_acceleration."
-            )
-        self._sync_scales(scales)
-
-        n = linvel.shape[0]
-        if n != self.num_envs:
+        del noise_level  # RNG and noise application remain owned by the task input binder.
+        if linvel.shape[0] != self.num_envs:
             raise ValueError(
                 "G1Walk Numba update_state only supports full-batch updates; "
-                f"got {n} rows for configured num_envs={self.num_envs}."
+                f"got {linvel.shape[0]} rows for configured num_envs={self.num_envs}."
             )
-
-        active = _active_terms(scales)
-        backend = env._backend
-        dtype = linvel.dtype
-        base_height = np.asarray(backend.get_base_pos()[:, 2], dtype=dtype)
-        commands = np.asarray(info["commands"], dtype=dtype)
-        current_actions = np.asarray(
-            info.get("current_actions", np.zeros((self.num_envs, self.num_action), dtype=dtype)),
-            dtype=dtype,
-        )
-        last_actions = np.asarray(
-            info.get("last_actions", np.zeros((self.num_envs, self.num_action), dtype=dtype)),
-            dtype=dtype,
-        )
-        gait_phase = np.asarray(info.get("gait_phase", self._zero_vec2), dtype=dtype)
-        feet_air_time = np.asarray(info.get("feet_air_time", self._zero_vec2), dtype=dtype)
-
-        if active & FOOT_POSITION_TERMS:
-            left_foot_pos = np.asarray(backend.get_sensor_data("left_foot_pos"), dtype=dtype)
-            right_foot_pos = np.asarray(backend.get_sensor_data("right_foot_pos"), dtype=dtype)
-        else:
-            left_foot_pos = right_foot_pos = self._zero_vec3.astype(dtype, copy=False)
-
-        if active & FOOT_QUAT_TERMS:
-            left_foot_quat = np.asarray(backend.get_sensor_data("left_foot_quat"), dtype=dtype)
-            right_foot_quat = np.asarray(backend.get_sensor_data("right_foot_quat"), dtype=dtype)
-        else:
-            left_foot_quat = right_foot_quat = self._zero_vec4.astype(dtype, copy=False)
-
-        if active & FOOT_CONTACT_TERMS:
-            left_contact = _aggregated_contact(
-                backend,
-                (
-                    "left_foot_contact_0",
-                    "left_foot_contact_1",
-                    "left_foot_contact_2",
-                    "left_foot_contact_3",
-                ),
-            )
-            right_contact = _aggregated_contact(
-                backend,
-                (
-                    "right_foot_contact_0",
-                    "right_foot_contact_1",
-                    "right_foot_contact_2",
-                    "right_foot_contact_3",
-                ),
-            )
-        else:
-            left_contact = right_contact = self._zero_bool
-
+        self._sync_scales(scales)
+        self._bind_inputs(env, info, linvel, gyro, gravity, dof_pos, dof_vel)
         if self.num_threads is not None:
             set_num_threads(self.num_threads)
         nthreads = get_num_threads()
-        actor_obs = np.empty((n, self.actor_obs_width), dtype=dtype)
-        critic_obs = np.empty((n, self.critic_obs_width), dtype=dtype)
-        reward = np.empty((n,), dtype=dtype)
-        terminated = np.empty((n,), dtype=np.bool_)
-        log_scratch = np.zeros((nthreads, len(TERM_ORDER)), dtype=np.float64)
+        if self._log_scratch is None or self._log_scratch.shape[0] != nthreads:
+            self._log_scratch = np.empty((nthreads, len(self.resolved.plan.terms)), np.float64)
+        self._log_scratch.fill(0.0)
+        started = time.perf_counter()
+        self.runtime.execute(reward_multiplier=self.ctrl_dt, log_scratch=self._log_scratch)
+        if self.first_jit_ms is None:
+            self.first_jit_ms = (time.perf_counter() - started) * 1e3
 
-        actor_gyro_scale = 0.25 if self.walk_observation_profile else 1.0
-        actor_dof_vel_scale = 0.05 if self.walk_observation_profile else 1.0
-        critic_gyro_scale = 0.25 if self.walk_observation_profile else 1.0
-        critic_dof_vel_scale = 0.05 if self.walk_observation_profile else 1.0
-        critic_linvel_scale = 2.0 if self.walk_observation_profile else 1.0
-
-        _compute_update_state_kernel(
-            linvel,
-            gyro,
-            gravity,
-            dof_pos,
-            dof_vel,
-            base_height,
-            commands,
-            current_actions,
-            last_actions,
-            gait_phase,
-            self.default_angles,
-            self.pose_weights,
-            self.upper_body_pose_weights,
-            left_foot_pos,
-            right_foot_pos,
-            left_foot_quat,
-            right_foot_quat,
-            left_contact,
-            right_contact,
-            feet_air_time,
-            self.scale,
-            self.ctrl_dt,
-            self.tracking_sigma,
-            self.base_height_target,
-            self.min_base_height,
-            self.max_tilt_rad,
-            self.feet_phase_swing_height,
-            self.feet_phase_tracking_sigma,
-            self.min_forward_speed_for_gait_reward,
-            self.close_feet_threshold,
-            actor_gyro_scale,
-            actor_dof_vel_scale,
-            critic_gyro_scale,
-            critic_dof_vel_scale,
-            critic_linvel_scale,
-            actor_obs,
-            critic_obs,
-            reward,
-            terminated,
-            log_scratch,
-        )
-
-        step_count = info.get("steps")
+        steps = info.get("steps")
         should_log = enable_log and (
-            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
+            int(steps[0]) % 4 == 0 if isinstance(steps, np.ndarray) else True
         )
         log = {} if should_log else info.get("log", {})
         if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / n)
+            sums = self._log_scratch.sum(axis=0)
+            for reward_name, output_name in self._reward_outputs.items():
+                index = self._plan_indices[output_name]
+                if self.runtime.scales[index] != 0.0:
+                    log[f"reward/{reward_name}"] = float(sums[index] / self.num_envs)
         return G1WalkNumbaUpdateStateResult(
-            obs={"obs": actor_obs, "critic": critic_obs},
-            reward=reward,
-            terminated=terminated,
+            obs=self.obs,
+            reward=self.runtime.reward,
+            terminated=self.runtime.terminated,
             log=log,
         )
+
+    def compute(self, **kwargs: Any) -> G1WalkNumbaResult:
+        out = self.compute_update_state(noise_level=0.0, **kwargs)
+        return G1WalkNumbaResult(out.reward, out.terminated, out.log)

--- a/src/unilab/envs/locomotion/g1/terms.py
+++ b/src/unilab/envs/locomotion/g1/terms.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, cast
+
+import numpy as np
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    ResolvedTermPlan,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistry,
+    resolve_term_plan,
+)
+
+F32 = np.float32
+
+REWARD_TERM_KEYS = {
+    name: f"g1.walk.reward.{implementation}.v1"
+    for name, implementation in {
+        "tracking_lin_vel": "tracking_lin_vel",
+        "tracking_ang_vel": "tracking_ang_vel",
+        "forward_progress": "forward_progress",
+        "under_speed": "under_speed",
+        "lin_vel_z": "lin_vel_z",
+        "orientation": "orientation",
+        "penalty_orientation": "orientation",
+        "ang_vel_xy": "ang_vel_xy",
+        "penalty_ang_vel_xy": "ang_vel_xy",
+        "action_rate": "action_rate",
+        "penalty_action_rate": "action_rate",
+        "base_height": "base_height",
+        "pose": "pose",
+        "upper_body_pose": "upper_body_pose",
+        "penalty_feet_ori": "feet_ori",
+        "feet_phase": "feet_phase",
+        "feet_phase_contrast": "feet_phase_contrast",
+        "feet_phase_contact": "feet_phase_contact",
+        "feet_double_stance": "feet_double_stance",
+        "alive": "alive",
+    }.items()
+}
+
+DEFAULT_OBSERVATION_TERMS: dict[str, list[str]] = {
+    "obs": [
+        "g1.walk.observation.actor_gyro.v1",
+        "g1.walk.observation.actor_gravity.v1",
+        "g1.walk.observation.actor_dof_pos.v1",
+        "g1.walk.observation.actor_dof_vel.v1",
+        "g1.walk.observation.actor_actions.v1",
+        "g1.walk.observation.actor_commands.v1",
+        "g1.walk.observation.actor_gait_phase.v1",
+    ],
+    "critic": [
+        "g1.walk.observation.critic_gyro.v1",
+        "g1.walk.observation.critic_gravity.v1",
+        "g1.walk.observation.critic_dof_pos.v1",
+        "g1.walk.observation.critic_dof_vel.v1",
+        "g1.walk.observation.critic_actions.v1",
+        "g1.walk.observation.critic_commands.v1",
+        "g1.walk.observation.critic_gait_phase.v1",
+        "g1.walk.observation.critic_linvel.v1",
+    ],
+}
+DEFAULT_TERMINATION_TERMS = ["g1.walk.termination.tilt_or_height.v1"]
+
+_OBS_META = {
+    key: (group, label, source, width)
+    for group, entries in {
+        "obs": (
+            ("actor_gyro", "gyro", "noisy_gyro", 3),
+            ("actor_gravity", "gravity", "noisy_gravity", 3),
+            ("actor_dof_pos", "dof_pos", "noisy_dof_pos", -1),
+            ("actor_dof_vel", "dof_vel", "noisy_dof_vel", -1),
+            ("actor_actions", "actions", "current_actions", -1),
+            ("actor_commands", "command", "commands", 3),
+            ("actor_gait_phase", "gait_phase", "gait_phase", 2),
+        ),
+        "critic": (
+            ("critic_gyro", "gyro", "gyro", 3),
+            ("critic_gravity", "gravity", "gravity", 3),
+            ("critic_dof_pos", "dof_pos", "dof_pos_diff", -1),
+            ("critic_dof_vel", "dof_vel", "dof_vel", -1),
+            ("critic_actions", "actions", "current_actions", -1),
+            ("critic_commands", "command", "commands", 3),
+            ("critic_gait_phase", "gait_phase", "gait_phase", 2),
+            ("critic_linvel", "linvel", "linvel", 3),
+        ),
+    }.items()
+    for name, label, source, width in entries
+    for key in (f"g1.walk.observation.{name}.v1",)
+}
+
+
+def compute_feet_phase_height_targets(
+    gait_phase: np.ndarray, swing_height: float
+) -> tuple[np.ndarray, np.ndarray]:
+    def height(phi: np.ndarray) -> np.ndarray:
+        normalized = np.fmod(phi + np.pi, 2 * np.pi) - np.pi
+        x = (normalized + np.pi) / (2 * np.pi)
+        stance_t = 2 * x
+        swing_t = 2 * x - 1
+        stance = swing_height * (stance_t**3 + 3 * stance_t**2 * (1 - stance_t))
+        swing = swing_height * (1 - (swing_t**3 + 3 * swing_t**2 * (1 - swing_t)))
+        return np.where(x <= 0.5, stance, swing)
+
+    return height(gait_phase[:, 0]), height(gait_phase[:, 1])
+
+
+def compute_feet_phase_contact_targets(
+    gait_phase: np.ndarray, swing_height: float
+) -> tuple[np.ndarray, np.ndarray]:
+    left, right = compute_feet_phase_height_targets(gait_phase, swing_height)
+    threshold = swing_height * 0.5
+    return left <= threshold, right <= threshold
+
+
+def compute_forward_speed_gate(linvel: np.ndarray, minimum: float) -> np.ndarray:
+    return np.asarray(np.maximum(linvel[:, 0], 0.0) >= minimum, dtype=F32)
+
+
+def compute_forward_command_mask(commands: np.ndarray) -> np.ndarray:
+    return np.asarray(np.maximum(commands[:, 0], 0.0) > 1.0e-6, dtype=F32)
+
+
+def _parameter(context: NumpyTermContext, name: str) -> float:
+    return cast(float, context.parameters[name])
+
+
+def _store(context: NumpyTermContext, value: np.ndarray) -> None:
+    np.copyto(context.output, value, casting="same_kind")
+
+
+def _tracking_lin_vel(context: NumpyTermContext) -> None:
+    error = np.sum(
+        np.square(context.inputs["commands"][:, :2] - context.inputs["linvel"][:, :2]), axis=1
+    )
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")))
+
+
+def _tracking_ang_vel(context: NumpyTermContext) -> None:
+    error = np.square(context.inputs["commands"][:, 2] - context.inputs["gyro"][:, 2])
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")))
+
+
+def _forward_progress(context: NumpyTermContext) -> None:
+    commanded = np.maximum(context.inputs["commands"][:, 0], 1.0e-6)
+    forward = np.maximum(context.inputs["linvel"][:, 0], 0.0)
+    _store(context, np.minimum(forward / commanded, 1.0))
+
+
+def _under_speed(context: NumpyTermContext) -> None:
+    commanded = np.maximum(context.inputs["commands"][:, 0], 1.0e-6)
+    forward = np.maximum(context.inputs["linvel"][:, 0], 0.0)
+    _store(context, np.maximum(context.inputs["commands"][:, 0] - forward, 0.0) / commanded)
+
+
+def _squared_columns(source: str, columns: slice):
+    def term(context: NumpyTermContext) -> None:
+        np.sum(np.square(context.inputs[source][:, columns]), axis=1, out=context.output)
+
+    return term
+
+
+def _action_rate(context: NumpyTermContext) -> None:
+    diff = context.inputs["current_actions"] - context.inputs["last_actions"]
+    np.sum(np.square(diff), axis=1, out=context.output)
+
+
+def _base_height(context: NumpyTermContext) -> None:
+    np.square(
+        context.inputs["base_height"] - _parameter(context, "base_height_target"),
+        out=context.output,
+    )
+
+
+def _weighted_pose(weights: str):
+    def term(context: NumpyTermContext) -> None:
+        diff = context.inputs["dof_pos"] - context.inputs["default_angles"]
+        np.sum(context.inputs[weights] * np.square(diff), axis=1, out=context.output)
+
+    return term
+
+
+def _feet_ori(context: NumpyTermContext) -> None:
+    left, right = context.inputs["left_foot_quat"], context.inputs["right_foot_quat"]
+    _store(
+        context,
+        np.square(left[:, 1])
+        + np.square(left[:, 2])
+        + np.square(right[:, 1])
+        + np.square(right[:, 2]),
+    )
+
+
+def _gait_gate(context: NumpyTermContext) -> np.ndarray:
+    return compute_forward_speed_gate(
+        context.inputs["linvel"], _parameter(context, "min_forward_speed")
+    )
+
+
+def _feet_phase(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_height_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    error = np.square(context.inputs["left_foot_pos"][:, 2] - left)
+    error += np.square(context.inputs["right_foot_pos"][:, 2] - right)
+    _store(context, np.exp(-error / _parameter(context, "tracking_sigma")) * _gait_gate(context))
+
+
+def _feet_phase_contrast(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_height_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    actual = context.inputs["left_foot_pos"][:, 2] - context.inputs["right_foot_pos"][:, 2]
+    _store(
+        context,
+        np.exp(-np.square(actual - (left - right)) / _parameter(context, "tracking_sigma"))
+        * _gait_gate(context),
+    )
+
+
+def _feet_phase_contact(context: NumpyTermContext) -> None:
+    left, right = compute_feet_phase_contact_targets(
+        context.inputs["gait_phase"], _parameter(context, "swing_height")
+    )
+    matches = 0.5 * (
+        (context.inputs["left_contact"] == left).astype(F32)
+        + (context.inputs["right_contact"] == right).astype(F32)
+    )
+    _store(context, matches * _gait_gate(context))
+
+
+def _feet_double_stance(context: NumpyTermContext) -> None:
+    stance = np.logical_and(context.inputs["left_contact"], context.inputs["right_contact"])
+    _store(context, stance.astype(F32) * compute_forward_command_mask(context.inputs["commands"]))
+
+
+def _alive(context: NumpyTermContext) -> None:
+    context.output.fill(1.0)
+
+
+def _scaled_copy(context: NumpyTermContext) -> None:
+    np.multiply(
+        next(iter(context.inputs.values())),
+        _parameter(context, "multiplier"),
+        out=context.output,
+    )
+
+
+def _tilt_or_height(context: NumpyTermContext) -> None:
+    tilt = np.arccos(np.clip(context.inputs["gravity"][:, 2], -1.0, 1.0))
+    np.logical_or(
+        tilt > _parameter(context, "max_tilt_rad"),
+        context.inputs["base_height"] < _parameter(context, "min_base_height"),
+        out=context.output,
+    )
+
+
+@dataclass(frozen=True)
+class G1WalkResolvedTermPlan:
+    plan: ResolvedTermPlan
+    reward_outputs: tuple[tuple[str, str], ...]
+    observation_outputs: Mapping[str, tuple[str, ...]]
+    observation_labels: Mapping[str, tuple[str, ...]]
+    termination_outputs: tuple[str, ...]
+
+    @property
+    def observation_dims(self) -> dict[str, int]:
+        return {
+            group: sum(self.plan.output_specs[name].shape[0] for name in names)
+            for group, names in self.observation_outputs.items()
+        }
+
+
+def _build_registry(num_action: int) -> TermRegistry:
+    from . import joystick_numba
+
+    registry = TermRegistry()
+    shapes = {
+        "linvel": (3,),
+        "gyro": (3,),
+        "gravity": (3,),
+        "dof_pos": (num_action,),
+        "dof_vel": (num_action,),
+        "dof_pos_diff": (num_action,),
+        "noisy_gyro": (3,),
+        "noisy_gravity": (3,),
+        "noisy_dof_pos": (num_action,),
+        "noisy_dof_vel": (num_action,),
+        "base_height": (),
+        "commands": (3,),
+        "current_actions": (num_action,),
+        "last_actions": (num_action,),
+        "gait_phase": (2,),
+        "default_angles": (num_action,),
+        "pose_weights": (num_action,),
+        "upper_body_pose_weights": (num_action,),
+        "left_foot_pos": (3,),
+        "right_foot_pos": (3,),
+        "left_foot_quat": (4,),
+        "right_foot_quat": (4,),
+        "left_contact": (),
+        "right_contact": (),
+    }
+
+    def inputs(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(
+            NamedTensorSpec(name, TensorSpec(shapes[name], np.bool_ if "contact" in name else F32))
+            for name in names
+        )
+
+    float_param = lambda name: ParameterSpec(name, ParameterKind.FLOAT)  # noqa: E731
+    definitions = (
+        ("tracking_lin_vel", _tracking_lin_vel, ("linvel", "commands"), ("tracking_sigma",)),
+        ("tracking_ang_vel", _tracking_ang_vel, ("gyro", "commands"), ("tracking_sigma",)),
+        ("forward_progress", _forward_progress, ("linvel", "commands"), ()),
+        ("under_speed", _under_speed, ("linvel", "commands"), ()),
+        ("lin_vel_z", _squared_columns("linvel", slice(2, 3)), ("linvel",), ()),
+        ("orientation", _squared_columns("gravity", slice(0, 2)), ("gravity",), ()),
+        ("ang_vel_xy", _squared_columns("gyro", slice(0, 2)), ("gyro",), ()),
+        ("action_rate", _action_rate, ("current_actions", "last_actions"), ()),
+        ("base_height", _base_height, ("base_height",), ("base_height_target",)),
+        ("pose", _weighted_pose("pose_weights"), ("dof_pos", "default_angles", "pose_weights"), ()),
+        (
+            "upper_body_pose",
+            _weighted_pose("upper_body_pose_weights"),
+            ("dof_pos", "default_angles", "upper_body_pose_weights"),
+            (),
+        ),
+        ("feet_ori", _feet_ori, ("left_foot_quat", "right_foot_quat"), ()),
+        (
+            "feet_phase",
+            _feet_phase,
+            ("linvel", "gait_phase", "left_foot_pos", "right_foot_pos"),
+            ("swing_height", "tracking_sigma", "min_forward_speed"),
+        ),
+        (
+            "feet_phase_contrast",
+            _feet_phase_contrast,
+            ("linvel", "gait_phase", "left_foot_pos", "right_foot_pos"),
+            ("swing_height", "tracking_sigma", "min_forward_speed"),
+        ),
+        (
+            "feet_phase_contact",
+            _feet_phase_contact,
+            ("linvel", "gait_phase", "left_contact", "right_contact"),
+            ("swing_height", "min_forward_speed"),
+        ),
+        (
+            "feet_double_stance",
+            _feet_double_stance,
+            ("commands", "left_contact", "right_contact"),
+            (),
+        ),
+        ("alive", _alive, (), ()),
+    )
+    for name, function, input_names, parameter_names in definitions:
+        registry.register(
+            TermDefinition(
+                f"g1.walk.reward.{name}.v1",
+                TermKind.REWARD,
+                function,
+                TensorSpec((), F32),
+                inputs=inputs(*input_names),
+                parameters=tuple(float_param(p) for p in parameter_names),
+                numba_item_fn=joystick_numba.NUMBA_REWARD_ITEMS.get(name),
+            )
+        )
+
+    for key, (_, _, source, width) in _OBS_META.items():
+        registry.register(
+            TermDefinition(
+                key,
+                TermKind.OBSERVATION,
+                _scaled_copy,
+                TensorSpec((num_action if width == -1 else width,), F32),
+                inputs=inputs(source),
+                parameters=(float_param("multiplier"),),
+                numba_item_fn=joystick_numba.NUMBA_OBSERVATION_ITEM,
+            )
+        )
+    registry.register(
+        TermDefinition(
+            DEFAULT_TERMINATION_TERMS[0],
+            TermKind.TERMINATION,
+            _tilt_or_height,
+            TensorSpec((), np.bool_),
+            inputs=inputs("gravity", "base_height"),
+            parameters=(float_param("max_tilt_rad"), float_param("min_base_height")),
+            numba_item_fn=joystick_numba.NUMBA_TERMINATION_ITEM,
+        )
+    )
+    return registry
+
+
+def _reward_parameters(name: str, cfg: Any) -> dict[str, float]:
+    if name in ("tracking_lin_vel", "tracking_ang_vel"):
+        return {"tracking_sigma": float(cfg.tracking_sigma)}
+    if name == "base_height":
+        return {"base_height_target": float(cfg.base_height_target)}
+    if name in ("feet_phase", "feet_phase_contrast"):
+        return {
+            "swing_height": float(cfg.feet_phase_swing_height),
+            "tracking_sigma": float(cfg.feet_phase_tracking_sigma),
+            "min_forward_speed": float(cfg.min_forward_speed_for_gait_reward),
+        }
+    if name == "feet_phase_contact":
+        return {
+            "swing_height": float(cfg.feet_phase_swing_height),
+            "min_forward_speed": float(cfg.min_forward_speed_for_gait_reward),
+        }
+    return {}
+
+
+def resolve_g1_walk_term_plan(
+    *,
+    num_action: int,
+    reward_cfg: Any,
+    observations: Mapping[str, Sequence[str]],
+    terminations: Sequence[str],
+    walk_profile: bool,
+) -> G1WalkResolvedTermPlan:
+    """Resolve the task config into one reward/observation/termination plan."""
+    registry = _build_registry(num_action)
+    configs: list[TermConfig] = []
+    reward_outputs: list[tuple[str, str]] = []
+    for name, scale in reward_cfg.scales.items():
+        key = REWARD_TERM_KEYS.get(name)
+        if key is None:
+            if scale != 0.0:
+                raise TermPlanError(f"G1 walk has unknown nonzero reward term {name!r}")
+            continue
+        output_name = f"reward.{name}"
+        configs.append(
+            TermConfig(
+                output_name, key, scale=scale, parameters=_reward_parameters(name, reward_cfg)
+            )
+        )
+        reward_outputs.append((name, output_name))
+
+    if set(observations) != {"obs", "critic"}:
+        raise TermPlanError("G1 walk observation layout must define exactly 'obs' and 'critic'")
+    observation_outputs: dict[str, tuple[str, ...]] = {}
+    observation_labels: dict[str, tuple[str, ...]] = {}
+    multipliers = {
+        "actor_gyro": 0.25 if walk_profile else 1.0,
+        "actor_dof_vel": 0.05 if walk_profile else 1.0,
+        "critic_gyro": 0.25 if walk_profile else 1.0,
+        "critic_dof_vel": 0.05 if walk_profile else 1.0,
+        "critic_linvel": 2.0 if walk_profile else 1.0,
+        "actor_gravity": -1.0,
+        "critic_gravity": -1.0,
+    }
+    for group in ("obs", "critic"):
+        keys = observations[group]
+        if not isinstance(keys, (list, tuple)) or not keys:
+            raise TermPlanError(f"G1 walk observation group {group!r} must be a non-empty list")
+        if len(keys) != len(set(keys)):
+            raise TermPlanError(f"G1 walk observation group {group!r} contains duplicate terms")
+        names, labels = [], []
+        for key in keys:
+            meta = _OBS_META.get(key)
+            if meta is None:
+                registry.resolve(key)
+            assert meta is not None
+            declared_group, label, _, _ = meta
+            if declared_group != group:
+                raise TermPlanError(f"observation term {key!r} does not belong to group {group!r}")
+            name = f"observation.{group}.{label}"
+            configs.append(
+                TermConfig(
+                    name,
+                    key,
+                    parameters={"multiplier": multipliers.get(key.rsplit(".", 2)[-2], 1.0)},
+                )
+            )
+            names.append(name)
+            labels.append(label)
+        observation_outputs[group] = tuple(names)
+        observation_labels[group] = tuple(labels)
+
+    if not isinstance(terminations, (list, tuple)) or not terminations:
+        raise TermPlanError("G1 walk termination layout must be a non-empty list")
+    termination_outputs = []
+    for index, key in enumerate(terminations):
+        name = f"termination.term{index}"
+        configs.append(
+            TermConfig(
+                name,
+                key,
+                parameters={
+                    "max_tilt_rad": math.radians(float(reward_cfg.max_tilt_deg)),
+                    "min_base_height": float(reward_cfg.min_base_height),
+                },
+            )
+        )
+        termination_outputs.append(name)
+
+    return G1WalkResolvedTermPlan(
+        plan=resolve_term_plan(registry, configs),
+        reward_outputs=tuple(reward_outputs),
+        observation_outputs=MappingProxyType(observation_outputs),
+        observation_labels=MappingProxyType(observation_labels),
+        termination_outputs=tuple(termination_outputs),
+    )

--- a/src/unilab/envs/motion_tracking/common/config.py
+++ b/src/unilab/envs/motion_tracking/common/config.py
@@ -16,6 +16,7 @@ from unilab.base.scene import SceneCfg
 from unilab.envs.locomotion.g1.base import G1BaseCfg
 
 from .rewards import RewardConfig
+from .terms import DEFAULT_OBSERVATIONS, DEFAULT_TERMINATIONS, PREAMBLE_KEY
 
 
 @dataclass
@@ -40,6 +41,15 @@ class VelocityRandomization:
     roll: tuple[float, float] = (-0.52, 0.52)
     pitch: tuple[float, float] = (-0.52, 0.52)
     yaw: tuple[float, float] = (-0.78, 0.78)
+
+
+@dataclass
+class MotionTermPlanConfig:
+    preambles: list[str] = field(default_factory=lambda: [PREAMBLE_KEY])
+    observations: dict[str, list[str]] = field(
+        default_factory=lambda: {name: list(terms) for name, terms in DEFAULT_OBSERVATIONS.items()}
+    )
+    terminations: list[str] = field(default_factory=lambda: list(DEFAULT_TERMINATIONS))
 
 
 @dataclass
@@ -161,6 +171,7 @@ class MotionTrackingCfg(G1BaseCfg):
     terminate_on_undesired_contacts: bool = False
     numba_acceleration: bool = False
     numba_num_threads: int | None = None
+    term_plan: MotionTermPlanConfig | None = None
 
 
 @dataclass

--- a/src/unilab/envs/motion_tracking/common/numba.py
+++ b/src/unilab/envs/motion_tracking/common/numba.py
@@ -9,52 +9,33 @@ accelerator is not.
 from __future__ import annotations
 
 import math
+import time
 from dataclasses import dataclass
 from typing import Any, Mapping
 
 import numpy as np
 
+from unilab.dtype_config import get_global_dtype
 from unilab.utils.numba_geometry import (
     quat_angle_sq_at,
     quat_gravity_z_at,
-    write_body_pos_relative_to_anchor_at,
-    write_body_quat_relative_6d_to_anchor_at,
     write_relative_anchor_transform_at,
     write_yaw_aligned_body_transforms_at,
 )
 
 try:  # pragma: no cover - exercised in environments with numba installed
-    from numba import get_num_threads, get_thread_id, njit, prange, set_num_threads
+    from numba import get_num_threads, njit, set_num_threads
 
     NUMBA_AVAILABLE = True
 except Exception:  # pragma: no cover - default test env may not install numba
-    get_num_threads = get_thread_id = njit = prange = set_num_threads = None  # type: ignore[assignment]
+    get_num_threads = njit = set_num_threads = None  # type: ignore[assignment]
     NUMBA_AVAILABLE = False
 
 
-TERM_ORDER: tuple[str, ...] = (
-    "motion_global_root_pos",
-    "motion_global_root_ori",
-    "motion_body_pos",
-    "motion_body_ori",
-    "motion_body_lin_vel",
-    "motion_body_ang_vel",
-    "motion_ee_body_pos_z",
-    "motion_joint_pos",
-    "motion_joint_vel",
-    "action_rate_l2",
-    "joint_limit",
-    "undesired_contacts",
-)
-TERM_INDEX = {name: i for i, name in enumerate(TERM_ORDER)}
-SUPPORTED_TERMS = frozenset(TERM_ORDER)
-
-
-@dataclass(frozen=True)
-class G1MotionTrackingNumbaResult:
-    reward: np.ndarray
-    terminated: np.ndarray
-    log: dict[str, float]
+NUMBA_PREAMBLE_ITEM = None
+NUMBA_REWARD_ITEMS: dict[str, Any] = {}
+NUMBA_OBSERVATION_ITEM = None
+NUMBA_TERMINATION_ITEM = None
 
 
 @dataclass(frozen=True)
@@ -71,7 +52,9 @@ def _active_terms(scales: Mapping[str, float]) -> frozenset[str]:
 
 def unsupported_terms(scales: Mapping[str, float]) -> frozenset[str]:
     """Return nonzero reward terms this task-specific kernel cannot compute."""
-    return _active_terms(scales) - SUPPORTED_TERMS
+    from unilab.envs.motion_tracking.common.terms import REWARD_KEYS
+
+    return _active_terms(scales) - REWARD_KEYS.keys()
 
 
 def is_available(scales: Mapping[str, float]) -> bool:
@@ -220,142 +203,6 @@ if NUMBA_AVAILABLE:
                     return True
         return False
 
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_kernel(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
-        anchor,
-        ee_indices,
-        undesired_indices,
-        ctrl_dt,
-        anchor_pos_z_threshold,
-        anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        reward,
-        terminated,
-        log_scratch,
-    ):
-        n = reward.shape[0]
-        n_body = robot_body_pos_w.shape[1]
-        n_action = dof_pos.shape[1]
-        for i in prange(n):
-            tid = get_thread_id()
-            total = 0.0
-
-            w = (
-                motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
-                * scale[0]
-            )
-            total += w
-            log_scratch[tid, 0] += w
-
-            w = (
-                motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
-                * scale[1]
-            )
-            total += w
-            log_scratch[tid, 1] += w
-
-            w = motion_body_pos_i(ref_body_pos_w, robot_body_pos_w, n_body, std[2], i) * scale[2]
-            total += w
-            log_scratch[tid, 2] += w
-
-            w = motion_body_ori_i(ref_body_quat_w, robot_body_quat_w, n_body, std[3], i) * scale[3]
-            total += w
-            log_scratch[tid, 3] += w
-
-            w = (
-                motion_body_lin_vel_i(
-                    motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i
-                )
-                * scale[4]
-            )
-            total += w
-            log_scratch[tid, 4] += w
-
-            w = (
-                motion_body_ang_vel_i(
-                    motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i
-                )
-                * scale[5]
-            )
-            total += w
-            log_scratch[tid, 5] += w
-
-            w = (
-                motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
-                * scale[6]
-            )
-            total += w
-            log_scratch[tid, 6] += w
-
-            w = motion_joint_pos_i(motion_joint_pos, dof_pos, n_action, std[7], i) * scale[7]
-            total += w
-            log_scratch[tid, 7] += w
-
-            w = motion_joint_vel_i(motion_joint_vel, dof_vel, n_action, std[8], i) * scale[8]
-            total += w
-            log_scratch[tid, 8] += w
-
-            w = action_rate_l2_i(current_actions, last_actions, n_action, i) * scale[9]
-            total += w
-            log_scratch[tid, 9] += w
-
-            w = (
-                joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
-                * scale[10]
-            )
-            total += w
-            log_scratch[tid, 10] += w
-
-            w = (
-                undesired_contacts_i(
-                    robot_body_pos_w, undesired_indices, undesired_contact_z_threshold, i
-                )
-                * scale[11]
-            )
-            total += w
-            log_scratch[tid, 11] += w
-
-            reward[i] = total * ctrl_dt
-            terminated[i] = terminated_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                ref_body_pos_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                ee_indices,
-                undesired_indices,
-                anchor_pos_z_threshold,
-                anchor_ori_threshold,
-                ee_body_pos_z_threshold,
-                undesired_contact_z_threshold,
-                terminate_on_undesired_contacts,
-                i,
-            )
-
     @_dev
     def _write_reference_transforms_i(
         motion_body_pos_w,
@@ -402,733 +249,428 @@ if NUMBA_AVAILABLE:
             i,
         )
 
-    @njit(fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_reward_termination_i(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        dof_pos,
-        dof_vel,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
+
+if NUMBA_AVAILABLE:
+
+    @_dev
+    def _write_body_workspace_i(
+        body_pos_w,
+        body_quat_w,
         anchor,
-        ee_indices,
-        undesired_indices,
-        n_body,
-        n_action,
-        ctrl_dt,
-        anchor_pos_z_threshold,
-        anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        log_scratch,
-        reward,
-        terminated,
-        tid,
+        body_pos_b,
+        body_ori_b,
         i,
     ):
-        total = 0.0
+        anchor_px = body_pos_w[i, anchor, 0]
+        anchor_py = body_pos_w[i, anchor, 1]
+        anchor_pz = body_pos_w[i, anchor, 2]
+        aw = body_quat_w[i, anchor, 0]
+        ax = body_quat_w[i, anchor, 1]
+        ay = body_quat_w[i, anchor, 2]
+        az = body_quat_w[i, anchor, 3]
+        for body in range(body_pos_w.shape[1]):
+            vx = body_pos_w[i, body, 0] - anchor_px
+            vy = body_pos_w[i, body, 1] - anchor_py
+            vz = body_pos_w[i, body, 2] - anchor_pz
+            ix, iy, iz = -ax, -ay, -az
+            tx = 2.0 * (iy * vz - iz * vy)
+            ty = 2.0 * (iz * vx - ix * vz)
+            tz = 2.0 * (ix * vy - iy * vx)
+            body_pos_b[i, body, 0] = vx + aw * tx + iy * tz - iz * ty
+            body_pos_b[i, body, 1] = vy + aw * ty + iz * tx - ix * tz
+            body_pos_b[i, body, 2] = vz + aw * tz + ix * ty - iy * tx
 
-        w = (
-            motion_global_root_pos_i(motion_body_pos_w, robot_body_pos_w, anchor, std[0], i)
-            * scale[0]
-        )
-        total += w
-        log_scratch[tid, 0] += w
+            bw = body_quat_w[i, body, 0]
+            bx = body_quat_w[i, body, 1]
+            by = body_quat_w[i, body, 2]
+            bz = body_quat_w[i, body, 3]
+            rw = aw * bw + ax * bx + ay * by + az * bz
+            rx = aw * bx - ax * bw - ay * bz + az * by
+            ry = aw * by + ax * bz - ay * bw - az * bx
+            rz = aw * bz - ax * by + ay * bx - az * bw
+            body_ori_b[i, body, 0] = 1.0 - 2.0 * (ry * ry + rz * rz)
+            body_ori_b[i, body, 1] = 2.0 * (rx * ry - rw * rz)
+            body_ori_b[i, body, 2] = 2.0 * (rx * ry + rw * rz)
+            body_ori_b[i, body, 3] = 1.0 - 2.0 * (rx * rx + rz * rz)
+            body_ori_b[i, body, 4] = 2.0 * (rx * rz - rw * ry)
+            body_ori_b[i, body, 5] = 2.0 * (ry * rz + rw * rx)
 
-        w = (
-            motion_global_root_ori_i(motion_body_quat_w, robot_body_quat_w, anchor, std[1], i)
-            * scale[1]
-        )
-        total += w
-        log_scratch[tid, 1] += w
-
-        w = motion_body_pos_i(ref_body_pos_w, robot_body_pos_w, n_body, std[2], i) * scale[2]
-        total += w
-        log_scratch[tid, 2] += w
-
-        w = motion_body_ori_i(ref_body_quat_w, robot_body_quat_w, n_body, std[3], i) * scale[3]
-        total += w
-        log_scratch[tid, 3] += w
-
-        w = (
-            motion_body_lin_vel_i(motion_body_lin_vel_w, robot_body_lin_vel_w, n_body, std[4], i)
-            * scale[4]
-        )
-        total += w
-        log_scratch[tid, 4] += w
-
-        w = (
-            motion_body_ang_vel_i(motion_body_ang_vel_w, robot_body_ang_vel_w, n_body, std[5], i)
-            * scale[5]
-        )
-        total += w
-        log_scratch[tid, 5] += w
-
-        w = (
-            motion_ee_body_pos_z_i(ref_body_pos_w, robot_body_pos_w, ee_indices, std[6], i)
-            * scale[6]
-        )
-        total += w
-        log_scratch[tid, 6] += w
-
-        w = motion_joint_pos_i(motion_joint_pos, dof_pos, n_action, std[7], i) * scale[7]
-        total += w
-        log_scratch[tid, 7] += w
-
-        w = motion_joint_vel_i(motion_joint_vel, dof_vel, n_action, std[8], i) * scale[8]
-        total += w
-        log_scratch[tid, 8] += w
-
-        w = action_rate_l2_i(current_actions, last_actions, n_action, i) * scale[9]
-        total += w
-        log_scratch[tid, 9] += w
-
-        w = (
-            joint_limit_i(dof_pos, joint_lower, joint_upper, n_action, has_joint_limits, i)
-            * scale[10]
-        )
-        total += w
-        log_scratch[tid, 10] += w
-
-        w = (
-            undesired_contacts_i(
-                robot_body_pos_w, undesired_indices, undesired_contact_z_threshold, i
-            )
-            * scale[11]
-        )
-        total += w
-        log_scratch[tid, 11] += w
-
-        reward[i] = total * ctrl_dt
-        terminated[i] = terminated_i(
+    @_dev
+    def _plan_preamble_i(
+        motion_body_pos_w,
+        motion_body_quat_w,
+        motion_joint_pos,
+        motion_joint_vel,
+        robot_body_pos_w,
+        robot_body_quat_w,
+        dof_pos,
+        effective_default_angles,
+        anchor,
+        delta_pos_w,
+        delta_ori_w,
+        body_vec_error,
+        env_error,
+        term_scratch,
+        ref_body_pos_w,
+        ref_body_quat_w,
+        motion_anchor_pos_b,
+        motion_anchor_ori_b,
+        motion_command,
+        joint_pos_rel,
+        robot_body_pos_b,
+        robot_body_ori_b,
+        i,
+    ):
+        anchor_idx = int(anchor)
+        n_body = robot_body_pos_w.shape[1]
+        _write_reference_transforms_i(
             motion_body_pos_w,
             motion_body_quat_w,
+            robot_body_pos_w,
+            robot_body_quat_w,
+            anchor_idx,
+            n_body,
             ref_body_pos_w,
+            ref_body_quat_w,
+            i,
+        )
+        _write_motion_anchor_i(
+            motion_body_pos_w,
+            motion_body_quat_w,
             robot_body_pos_w,
             robot_body_quat_w,
-            anchor,
-            ee_indices,
-            undesired_indices,
-            anchor_pos_z_threshold,
-            anchor_ori_threshold,
-            ee_body_pos_z_threshold,
-            undesired_contact_z_threshold,
-            terminate_on_undesired_contacts,
-            i,
-        )
-
-    @_dev
-    def _write_joint_pos_rel_i(
-        dof_pos,
-        default_angles,
-        default_dof_pos_bias,
-        has_default_dof_pos_bias,
-        joint_pos_rel,
-        n_action,
-        i,
-    ):
-        for j in range(n_action):
-            default = default_angles[j]
-            if has_default_dof_pos_bias:
-                default += default_dof_pos_bias[i, j]
-            joint_pos_rel[i, j] = dof_pos[i, j] - default
-
-    @_dev
-    def _write_actor_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        actor_noise_linvel,
-        actor_noise_gyro,
-        actor_noise_joint_pos,
-        actor_noise_dof_vel,
-        actor_obs,
-        is_deploy_actor,
-        n_action,
-        i,
-    ):
-        out = 0
-        for j in range(n_action):
-            actor_obs[i, out + j] = motion_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = motion_joint_vel[i, j]
-        out += n_action
-        if not is_deploy_actor:
-            actor_obs[i, out] = motion_anchor_pos_b[i, 0]
-            actor_obs[i, out + 1] = motion_anchor_pos_b[i, 1]
-            actor_obs[i, out + 2] = motion_anchor_pos_b[i, 2]
-            out += 3
-        for k in range(6):
-            actor_obs[i, out + k] = motion_anchor_ori_b[i, k]
-        out += 6
-        if not is_deploy_actor:
-            actor_obs[i, out] = linvel[i, 0] + actor_noise_linvel[i, 0]
-            actor_obs[i, out + 1] = linvel[i, 1] + actor_noise_linvel[i, 1]
-            actor_obs[i, out + 2] = linvel[i, 2] + actor_noise_linvel[i, 2]
-            out += 3
-        actor_obs[i, out] = gyro[i, 0] + actor_noise_gyro[i, 0]
-        actor_obs[i, out + 1] = gyro[i, 1] + actor_noise_gyro[i, 1]
-        actor_obs[i, out + 2] = gyro[i, 2] + actor_noise_gyro[i, 2]
-        out += 3
-        for j in range(n_action):
-            actor_obs[i, out + j] = joint_pos_rel[i, j] + actor_noise_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = dof_vel[i, j] + actor_noise_dof_vel[i, j]
-        out += n_action
-        for j in range(n_action):
-            actor_obs[i, out + j] = current_actions[i, j]
-
-    @_dev
-    def _write_critic_base_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        critic_obs,
-        n_action,
-        i,
-    ):
-        out = 0
-        for j in range(n_action):
-            critic_obs[i, out + j] = motion_joint_pos[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = motion_joint_vel[i, j]
-        out += n_action
-        critic_obs[i, out] = motion_anchor_pos_b[i, 0]
-        critic_obs[i, out + 1] = motion_anchor_pos_b[i, 1]
-        critic_obs[i, out + 2] = motion_anchor_pos_b[i, 2]
-        out += 3
-        for k in range(6):
-            critic_obs[i, out + k] = motion_anchor_ori_b[i, k]
-        out += 6
-        critic_obs[i, out] = linvel[i, 0]
-        critic_obs[i, out + 1] = linvel[i, 1]
-        critic_obs[i, out + 2] = linvel[i, 2]
-        out += 3
-        critic_obs[i, out] = gyro[i, 0]
-        critic_obs[i, out + 1] = gyro[i, 1]
-        critic_obs[i, out + 2] = gyro[i, 2]
-        out += 3
-        for j in range(n_action):
-            critic_obs[i, out + j] = joint_pos_rel[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = dof_vel[i, j]
-        out += n_action
-        for j in range(n_action):
-            critic_obs[i, out + j] = current_actions[i, j]
-
-    @_dev
-    def _write_critic_body_pos_i(
-        robot_body_pos_w,
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        out,
-        i,
-    ):
-        write_body_pos_relative_to_anchor_at(
-            robot_body_pos_w,
-            robot_body_quat_w,
-            anchor,
-            n_body,
-            critic_obs,
-            i,
-            out,
-        )
-
-    @_dev
-    def _write_critic_body_ori_i(
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        out,
-        i,
-    ):
-        write_body_quat_relative_6d_to_anchor_at(
-            robot_body_quat_w,
-            anchor,
-            n_body,
-            critic_obs,
-            i,
-            out,
-        )
-
-    @_dev
-    def _write_critic_linvel_tail_i(linvel, critic_obs, out, i):
-        if critic_obs.shape[1] > out:
-            critic_obs[i, out] = linvel[i, 0]
-            critic_obs[i, out + 1] = linvel[i, 1]
-            critic_obs[i, out + 2] = linvel[i, 2]
-
-    @_dev
-    def _write_critic_obs_i(
-        motion_joint_pos,
-        motion_joint_vel,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        linvel,
-        gyro,
-        dof_vel,
-        current_actions,
-        joint_pos_rel,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        critic_obs,
-        anchor,
-        n_body,
-        n_action,
-        i,
-    ):
-        _write_critic_base_obs_i(
-            motion_joint_pos,
-            motion_joint_vel,
+            anchor_idx,
             motion_anchor_pos_b,
             motion_anchor_ori_b,
-            linvel,
-            gyro,
-            dof_vel,
-            current_actions,
-            joint_pos_rel,
-            critic_obs,
-            n_action,
             i,
         )
-        body_pos_offset = n_action * 5 + 15
-        body_ori_offset = body_pos_offset + n_body * 3
-        tail_offset = body_ori_offset + n_body * 6
-        _write_critic_body_pos_i(
+        for j in range(dof_pos.shape[1]):
+            motion_command[i, j] = motion_joint_pos[i, j]
+            motion_command[i, dof_pos.shape[1] + j] = motion_joint_vel[i, j]
+            joint_pos_rel[i, j] = dof_pos[i, j] - effective_default_angles[i, j]
+        _write_body_workspace_i(
             robot_body_pos_w,
             robot_body_quat_w,
-            critic_obs,
-            anchor,
-            n_body,
-            body_pos_offset,
+            anchor_idx,
+            robot_body_pos_b,
+            robot_body_ori_b,
             i,
         )
-        _write_critic_body_ori_i(
-            robot_body_quat_w,
-            critic_obs,
-            anchor,
-            n_body,
-            body_ori_offset,
-            i,
-        )
-        _write_critic_linvel_tail_i(linvel, critic_obs, tail_offset, i)
 
-    @njit(parallel=True, fastmath=True, cache=True, nogil=True)  # type: ignore[misc]
-    def _compute_update_state_kernel(
-        motion_body_pos_w,
-        motion_body_quat_w,
-        motion_body_lin_vel_w,
-        motion_body_ang_vel_w,
-        motion_joint_pos,
-        motion_joint_vel,
-        robot_body_pos_w,
-        robot_body_quat_w,
-        robot_body_lin_vel_w,
-        robot_body_ang_vel_w,
-        linvel,
-        gyro,
-        dof_pos,
-        dof_vel,
-        default_angles,
-        default_dof_pos_bias,
-        current_actions,
-        last_actions,
-        joint_lower,
-        joint_upper,
-        scale,
-        std,
+    @_dev
+    def _root_pos_plan_i(motion_pos, robot_pos, anchor, std, env_error, i):
+        return motion_global_root_pos_i(motion_pos, robot_pos, int(anchor), std, i)
+
+    @_dev
+    def _root_ori_plan_i(motion_quat, robot_quat, anchor, std, env_error, i):
+        return motion_global_root_ori_i(motion_quat, robot_quat, int(anchor), std, i)
+
+    @_dev
+    def _body_pos_plan_i(robot_pos, std, ref_pos, body_error, env_error, i):
+        return motion_body_pos_i(ref_pos, robot_pos, robot_pos.shape[1], std, i)
+
+    @_dev
+    def _body_ori_plan_i(robot_quat, std, ref_quat, quat_w, quat_x, env_error, i):
+        return motion_body_ori_i(ref_quat, robot_quat, robot_quat.shape[1], std, i)
+
+    @_dev
+    def _body_lin_vel_plan_i(motion_vel, robot_vel, std, body_error, env_error, i):
+        return motion_body_lin_vel_i(motion_vel, robot_vel, robot_vel.shape[1], std, i)
+
+    @_dev
+    def _body_ang_vel_plan_i(motion_vel, robot_vel, std, body_error, env_error, i):
+        return motion_body_ang_vel_i(motion_vel, robot_vel, robot_vel.shape[1], std, i)
+
+    @_dev
+    def _ee_pos_plan_i(robot_pos, indices, std, ref_pos, indexed_error, env_error, i):
+        return motion_ee_body_pos_z_i(ref_pos, robot_pos, indices, std, i)
+
+    @_dev
+    def _joint_pos_plan_i(motion_pos, dof_pos, std, joint_error, env_error, i):
+        return motion_joint_pos_i(motion_pos, dof_pos, dof_pos.shape[1], std, i)
+
+    @_dev
+    def _joint_vel_plan_i(motion_vel, dof_vel, std, joint_error, env_error, i):
+        return motion_joint_vel_i(motion_vel, dof_vel, dof_vel.shape[1], std, i)
+
+    @_dev
+    def _action_rate_plan_i(current, previous, joint_error, env_error, i):
+        return action_rate_l2_i(current, previous, current.shape[1], i)
+
+    @_dev
+    def _joint_limit_plan_i(lower, upper, dof_pos, joint_error, joint_upper, i):
+        acc = 0.0
+        for j in range(dof_pos.shape[1]):
+            low = lower[i, j] - dof_pos[i, j]
+            high = dof_pos[i, j] - upper[i, j]
+            violation = (low if low > 0.0 else 0.0) + (high if high > 0.0 else 0.0)
+            acc += violation * violation
+        return acc
+
+    @_dev
+    def _undesired_plan_i(robot_pos, indices, threshold, indexed_mask, env_error, i):
+        return undesired_contacts_i(robot_pos, indices, threshold, i)
+
+    @_dev
+    def _termination_plan_i(
+        motion_pos,
+        motion_quat,
+        robot_pos,
+        robot_quat,
         anchor,
-        ee_indices,
-        undesired_indices,
-        ctrl_dt,
-        anchor_pos_z_threshold,
+        anchor_pos_threshold,
+        check_anchor_ori,
         anchor_ori_threshold,
-        ee_body_pos_z_threshold,
-        undesired_contact_z_threshold,
-        terminate_on_undesired_contacts,
-        has_joint_limits,
-        has_default_dof_pos_bias,
-        is_deploy_actor,
-        actor_noise_linvel,
-        actor_noise_gyro,
-        actor_noise_joint_pos,
-        actor_noise_dof_vel,
-        ref_body_pos_w,
-        ref_body_quat_w,
-        motion_anchor_pos_b,
-        motion_anchor_ori_b,
-        joint_pos_rel,
-        actor_obs,
-        critic_obs,
-        reward,
-        terminated,
-        log_scratch,
+        ee_indices,
+        ee_threshold,
+        contact_indices,
+        contact_threshold,
+        ref_pos,
+        env_error,
+        indexed_error,
+        indexed_mask,
+        i,
     ):
-        n = reward.shape[0]
-        n_body = robot_body_pos_w.shape[1]
-        n_action = dof_pos.shape[1]
+        anchor_idx = int(anchor)
+        if abs(motion_pos[i, anchor_idx, 2] - robot_pos[i, anchor_idx, 2]) > anchor_pos_threshold:
+            return True
+        if check_anchor_ori != 0.0:
+            motion_gravity_z = quat_gravity_z_at(motion_quat, anchor_idx, i)
+            robot_gravity_z = quat_gravity_z_at(robot_quat, anchor_idx, i)
+            if abs(motion_gravity_z - robot_gravity_z) > anchor_ori_threshold:
+                return True
+        for index in range(ee_indices.shape[0]):
+            body_idx = ee_indices[index]
+            if abs(ref_pos[i, body_idx, 2] - robot_pos[i, body_idx, 2]) > ee_threshold:
+                return True
+        for index in range(contact_indices.shape[0]):
+            if robot_pos[i, contact_indices[index], 2] < contact_threshold:
+                return True
+        return False
 
-        for i in prange(n):
-            _write_reference_transforms_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                n_body,
-                ref_body_pos_w,
-                ref_body_quat_w,
-                i,
-            )
-            _write_motion_anchor_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                anchor,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                i,
-            )
-            _compute_reward_termination_i(
-                motion_body_pos_w,
-                motion_body_quat_w,
-                motion_body_lin_vel_w,
-                motion_body_ang_vel_w,
-                motion_joint_pos,
-                motion_joint_vel,
-                ref_body_pos_w,
-                ref_body_quat_w,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                robot_body_lin_vel_w,
-                robot_body_ang_vel_w,
-                dof_pos,
-                dof_vel,
-                current_actions,
-                last_actions,
-                joint_lower,
-                joint_upper,
-                scale,
-                std,
-                anchor,
-                ee_indices,
-                undesired_indices,
-                n_body,
-                n_action,
-                ctrl_dt,
-                anchor_pos_z_threshold,
-                anchor_ori_threshold,
-                ee_body_pos_z_threshold,
-                undesired_contact_z_threshold,
-                terminate_on_undesired_contacts,
-                has_joint_limits,
-                log_scratch,
-                reward,
-                terminated,
-                get_thread_id(),
-                i,
-            )
-            _write_joint_pos_rel_i(
-                dof_pos,
-                default_angles,
-                default_dof_pos_bias,
-                has_default_dof_pos_bias,
-                joint_pos_rel,
-                n_action,
-                i,
-            )
-            _write_actor_obs_i(
-                motion_joint_pos,
-                motion_joint_vel,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                linvel,
-                gyro,
-                dof_vel,
-                current_actions,
-                joint_pos_rel,
-                actor_noise_linvel,
-                actor_noise_gyro,
-                actor_noise_joint_pos,
-                actor_noise_dof_vel,
-                actor_obs,
-                is_deploy_actor,
-                n_action,
-                i,
-            )
-            _write_critic_obs_i(
-                motion_joint_pos,
-                motion_joint_vel,
-                motion_anchor_pos_b,
-                motion_anchor_ori_b,
-                linvel,
-                gyro,
-                dof_vel,
-                current_actions,
-                joint_pos_rel,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                critic_obs,
-                anchor,
-                n_body,
-                n_action,
-                i,
-            )
+    @_dev
+    def _copy_plan_i(source, output, offset, i):
+        if source.ctypes.data == output.ctypes.data + offset * output.itemsize:
+            return
+        width = source.size // source.shape[0]
+        for j in range(width):
+            output[i, offset + j] = source.flat[i * width + j]
+
+    NUMBA_PREAMBLE_ITEM = _plan_preamble_i
+    NUMBA_REWARD_ITEMS = {
+        "motion_global_root_pos": _root_pos_plan_i,
+        "motion_global_root_ori": _root_ori_plan_i,
+        "motion_body_pos": _body_pos_plan_i,
+        "motion_body_ori": _body_ori_plan_i,
+        "motion_body_lin_vel": _body_lin_vel_plan_i,
+        "motion_body_ang_vel": _body_ang_vel_plan_i,
+        "motion_ee_body_pos_z": _ee_pos_plan_i,
+        "motion_joint_pos": _joint_pos_plan_i,
+        "motion_joint_vel": _joint_vel_plan_i,
+        "action_rate_l2": _action_rate_plan_i,
+        "joint_limit": _joint_limit_plan_i,
+        "undesired_contacts": _undesired_plan_i,
+    }
+    NUMBA_OBSERVATION_ITEM = _copy_plan_i
+    NUMBA_TERMINATION_ITEM = _termination_plan_i
 
 
 class MotionTrackingNumbaAccelerator:
-    """Driver that keeps config-derived arrays and calls the fused kernel."""
+    """Resolved-plan Numba driver for the G1 motion-tracking pilot."""
 
-    def __init__(
-        self,
-        *,
-        num_envs: int,
-        num_action: int,
-        ctrl_dt: float,
-        reward_config: Any,
-        anchor_body_idx: int,
-        ee_body_indices: np.ndarray,
-        undesired_contact_body_indices: np.ndarray,
-        joint_lower: np.ndarray | None,
-        joint_upper: np.ndarray | None,
-        default_angles: np.ndarray,
-        actor_obs_width: int,
-        critic_obs_width: int,
-        is_deploy_actor: bool,
-        anchor_pos_z_threshold: float,
-        anchor_ori_threshold: float,
-        ee_body_pos_z_threshold: float,
-        undesired_contact_z_threshold: float,
-        terminate_on_undesired_contacts: bool,
-        num_threads: int | None = None,
-    ) -> None:
-        self.num_envs = int(num_envs)
-        self.num_action = int(num_action)
-        self.ctrl_dt = float(ctrl_dt)
-        self.anchor_body_idx = int(anchor_body_idx)
-        self.ee_body_indices = np.asarray(ee_body_indices, dtype=np.int32)
-        self.undesired_contact_body_indices = np.asarray(
-            undesired_contact_body_indices, dtype=np.int32
+    def __init__(self, env: Any, *, num_threads: int | None = None) -> None:
+        from unilab.envs.motion_tracking.common.terms import resolve_motion_term_plan
+        from unilab.term.numba import FusedOutputLayout, materialize_numba_plan
+
+        config = env._cfg.term_plan
+        if config is None:
+            raise ValueError(
+                "MotionTracking fused Numba execution requires env.term_plan; disable "
+                "numba_acceleration for profiles that retain the legacy NumPy path"
+            )
+        dtype = np.dtype(get_global_dtype())
+        resolved = resolve_motion_term_plan(
+            cfg=env,
+            n_action=env._num_action,
+            n_body=env._n_motion_bodies,
+            anchor_body_idx=env.anchor_body_idx,
+            ee_indices=env.ee_body_indices,
+            undesired_indices=env.undesired_contact_body_indices,
+            config=config,
+            dtype=dtype,
         )
-        self.anchor_pos_z_threshold = float(anchor_pos_z_threshold)
-        self.anchor_ori_threshold = float(anchor_ori_threshold)
-        self.ee_body_pos_z_threshold = float(ee_body_pos_z_threshold)
-        self.undesired_contact_z_threshold = float(undesired_contact_z_threshold)
-        self.terminate_on_undesired_contacts = bool(terminate_on_undesired_contacts)
-        self.default_angles = np.asarray(default_angles, dtype=np.float64)
-        self.actor_obs_width = int(actor_obs_width)
-        self.critic_obs_width = int(critic_obs_width)
-        self.is_deploy_actor = bool(is_deploy_actor)
+        inputs = {
+            name: np.zeros((env._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (
+            ("joint_lower", env._joint_lower),
+            ("joint_upper", env._joint_upper),
+            ("effective_default_angles", env.default_angles),
+        ):
+            if name in inputs and value is not None:
+                np.copyto(inputs[name], np.broadcast_to(value, inputs[name].shape))
+        observations = {
+            group: np.empty((env._num_envs, width), dtype=dtype)
+            for group, width in resolved.observation_dims.items()
+        }
+        layout = FusedOutputLayout(
+            preambles=resolved.preamble_outputs,
+            rewards=tuple(output for _, output in resolved.reward_outputs),
+            observations=resolved.observation_outputs,
+            terminations=resolved.termination_outputs,
+        )
+        self.runtime = materialize_numba_plan(
+            resolved.plan,
+            layout,
+            num_envs=env._num_envs,
+            inputs=inputs,
+            observations=observations,
+            reward=np.empty((env._num_envs,), dtype=dtype),
+            terminated=np.empty((env._num_envs,), dtype=np.bool_),
+        )
+        self.env = env
+        self.resolved = resolved
+        self.inputs = inputs
+        self._owned_inputs = inputs.copy()
+        self.obs = observations
+        self.num_envs = env._num_envs
         self.num_threads = num_threads
-        self.has_joint_limits = joint_lower is not None and joint_upper is not None
-        if self.has_joint_limits:
-            self.joint_lower = np.asarray(joint_lower, dtype=np.float64)
-            self.joint_upper = np.asarray(joint_upper, dtype=np.float64)
-        else:
-            self.joint_lower = np.zeros((self.num_action,), dtype=np.float64)
-            self.joint_upper = np.zeros((self.num_action,), dtype=np.float64)
-        self.scale = np.zeros((len(TERM_ORDER),), dtype=np.float64)
-        self.std = self._build_std_vector(reward_config)
-        self._zero_actions = np.zeros((self.num_envs, self.num_action), dtype=np.float64)
-        self._zero_default_dof_pos_bias = np.zeros(
-            (self.num_envs, self.num_action), dtype=np.float64
-        )
-        self._zero_linvel_noise = np.zeros((self.num_envs, 3), dtype=np.float64)
-        self._zero_gyro_noise = np.zeros((self.num_envs, 3), dtype=np.float64)
-        self._zero_joint_noise = np.zeros((self.num_envs, self.num_action), dtype=np.float64)
+        self.ctrl_dt = float(env._cfg.ctrl_dt)
+        self.first_jit_ms: float | None = None
+        self._reward_outputs = dict(resolved.reward_outputs)
+        self._scale_snapshot: tuple[float, ...] | None = None
+        self._plan_indices = {term.name: index for index, term in enumerate(resolved.plan.terms)}
+        self._log_scratch: np.ndarray | None = None
+        claimed_workspace = set()
+        for group, names in resolved.observation_outputs.items():
+            offset = 0
+            for term_name in names:
+                term = resolved.plan.terms[self._plan_indices[term_name]]
+                width = resolved.plan.output_specs[term_name].shape[0]
+                if len(term.definition.workspace) == 1:
+                    source = term.definition.workspace[0].name
+                    spec = resolved.plan.workspace_specs[source]
+                    if source not in claimed_workspace:
+                        output = observations[group]
+                        inner_strides = []
+                        stride = output.itemsize
+                        for dimension in reversed(spec.shape):
+                            inner_strides.append(stride)
+                            stride *= dimension
+                        view = np.ndarray(
+                            (env._num_envs, *spec.shape),
+                            dtype=spec.numpy_dtype,
+                            buffer=output,
+                            offset=offset * output.itemsize,
+                            strides=(output.strides[0], *reversed(inner_strides)),
+                        )
+                        self.runtime.bind_workspace(source, view)
+                        claimed_workspace.add(source)
+                offset += width
+        workspace = self.runtime.workspace
+        env.body_pos_relative_w = workspace["ref_body_pos_w"]
+        env.body_quat_relative_w = workspace["ref_body_quat_w"]
+        env._motion_anchor_pos_b = workspace["motion_anchor_pos_b"]
+        env._motion_anchor_ori_b = workspace["motion_anchor_ori_b"]
+        env._motion_command = workspace["motion_command"]
+        env._joint_pos_rel = workspace["joint_pos_rel"]
+
+    @property
+    def compile_info(self):
+        return self.runtime.compile_info
 
     @classmethod
     def from_env(cls, env: Any, num_threads: int | None = None) -> "MotionTrackingNumbaAccelerator":
         if not NUMBA_AVAILABLE:
             raise RuntimeError(
-                "MotionTracking numba_acceleration=True requires numba. Install it or run "
-                "through `uv run --with numba ...`; disable numba_acceleration to use the "
-                "numpy path."
+                "MotionTracking numba_acceleration=True requires numba. Install it or "
+                "disable numba_acceleration to use the NumPy path."
             )
-        unsupported = unsupported_terms(env._cfg.reward_config.scales)
-        if unsupported:
-            raise ValueError(
-                "MotionTracking Numba accelerator does not support active reward terms "
-                f"{sorted(unsupported)}. Disable numba_acceleration or add these terms to "
-                "src/unilab/envs/motion_tracking/common/numba.py."
-            )
-        default_angles = getattr(env, "default_angles", None)
-        if default_angles is None:
-            default_angles = np.zeros((env._num_action,), dtype=np.float64)
-        actor_obs_width = getattr(env, "_actor_obs_width", env._num_action * 5 + 15)
-        critic_obs_width = (
-            env.obs_groups_spec["critic"]
-            if hasattr(env, "obs_groups_spec")
-            else (env._num_action * 5 + 15 + len(env._cfg.body_names) * 9)
-        )
-        return cls(
-            num_envs=env.num_envs,
-            num_action=env._num_action,
-            ctrl_dt=env._cfg.ctrl_dt,
-            reward_config=env._cfg.reward_config,
-            anchor_body_idx=env.anchor_body_idx,
-            ee_body_indices=env.ee_body_indices,
-            undesired_contact_body_indices=env.undesired_contact_body_indices,
-            joint_lower=env._joint_lower,
-            joint_upper=env._joint_upper,
-            default_angles=default_angles,
-            actor_obs_width=actor_obs_width,
-            critic_obs_width=critic_obs_width,
-            is_deploy_actor=actor_obs_width == env._num_action * 5 + 9,
-            anchor_pos_z_threshold=env._cfg.anchor_pos_z_threshold,
-            anchor_ori_threshold=env._cfg.anchor_ori_threshold,
-            ee_body_pos_z_threshold=env._cfg.ee_body_pos_z_threshold,
-            undesired_contact_z_threshold=env._cfg.undesired_contact_z_threshold,
-            terminate_on_undesired_contacts=env._cfg.terminate_on_undesired_contacts,
-            num_threads=num_threads,
-        )
-
-    def _build_std_vector(self, reward_config: Any) -> np.ndarray:
-        per_term = {
-            "motion_global_root_pos": reward_config.std_root_pos,
-            "motion_global_root_ori": reward_config.std_root_ori,
-            "motion_body_pos": reward_config.std_body_pos,
-            "motion_body_ori": reward_config.std_body_ori,
-            "motion_body_lin_vel": reward_config.std_body_lin_vel,
-            "motion_body_ang_vel": reward_config.std_body_ang_vel,
-            "motion_ee_body_pos_z": reward_config.std_body_pos,
-            "motion_joint_pos": reward_config.std_joint_pos,
-            "motion_joint_vel": reward_config.std_joint_vel,
-            "action_rate_l2": 0.0,
-            "joint_limit": 0.0,
-            "undesired_contacts": 0.0,
-        }
-        return np.array([per_term[name] for name in TERM_ORDER], dtype=np.float64)
+        return cls(env, num_threads=num_threads)
 
     def _sync_scales(self, scales: Mapping[str, float]) -> None:
-        unsupported = unsupported_terms(scales)
+        unsupported = _active_terms(scales) - self._reward_outputs.keys()
         if unsupported:
             raise ValueError(
-                "MotionTracking Numba accelerator does not support active reward terms "
-                f"{sorted(unsupported)}. Disable numba_acceleration or add these terms to "
-                "src/unilab/envs/motion_tracking/common/numba.py."
+                f"MotionTracking Numba plan does not support active reward terms {sorted(unsupported)}"
             )
-        self.scale.fill(0.0)
-        for name, value in scales.items():
-            idx = TERM_INDEX.get(name)
-            if idx is not None:
-                self.scale[idx] = float(value)
+        snapshot = tuple(float(scales.get(name, 0.0)) for name in self._reward_outputs)
+        if snapshot == self._scale_snapshot:
+            return
+        for reward_name, output_name in self._reward_outputs.items():
+            configured = scales.get(reward_name, 0.0)
+            scale = configured if self.resolved.reward_available.get(reward_name, True) else 0.0
+            self.runtime.set_scale(output_name, scale)
+        self._scale_snapshot = snapshot
 
-    def compute(
+    def _bind_inputs(
         self,
         *,
         info: dict[str, Any],
         motion_data: Any,
-        ref_body_pos_w: np.ndarray,
-        ref_body_quat_w: np.ndarray,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
         robot_body_pos_w: np.ndarray,
         robot_body_quat_w: np.ndarray,
         robot_body_lin_vel_w: np.ndarray,
         robot_body_ang_vel_w: np.ndarray,
-        dof_pos: np.ndarray,
-        dof_vel: np.ndarray,
-        scales: Mapping[str, float],
-        enable_log: bool,
-    ) -> G1MotionTrackingNumbaResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1MotionTracking Numba accelerator was constructed while numba is "
-                "unavailable; this indicates an invalid accelerator state."
+    ) -> None:
+        def bind(name: str, value: np.ndarray) -> None:
+            if name in self.inputs:
+                self.inputs[name] = np.asarray(value)
+
+        for name, value in (
+            ("motion_body_pos_w", motion_data.body_pos_w),
+            ("motion_body_quat_w", motion_data.body_quat_w),
+            ("motion_body_lin_vel_w", motion_data.body_lin_vel_w),
+            ("motion_body_ang_vel_w", motion_data.body_ang_vel_w),
+            ("motion_joint_pos", motion_data.joint_pos),
+            ("motion_joint_vel", motion_data.joint_vel),
+            ("robot_body_pos_w", robot_body_pos_w),
+            ("robot_body_quat_w", robot_body_quat_w),
+            ("robot_body_lin_vel_w", robot_body_lin_vel_w),
+            ("robot_body_ang_vel_w", robot_body_ang_vel_w),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+            ("linvel", linvel),
+            ("gyro", gyro),
+        ):
+            bind(name, value)
+        zero = self.env._zero_actions
+        current = info.get("current_actions")
+        current = current if isinstance(current, np.ndarray) else zero
+        previous = info.get("last_actions")
+        previous = previous if isinstance(previous, np.ndarray) else zero
+        bind("current_actions", current)
+        bind("last_actions", previous)
+        bind("obs_actions", current)
+
+        effective = self._owned_inputs["effective_default_angles"]
+        bias = info.get("default_dof_pos_bias")
+        if isinstance(bias, np.ndarray):
+            np.add(self.env.default_angles, bias, out=effective)
+        else:
+            np.copyto(effective, np.broadcast_to(self.env.default_angles, effective.shape))
+        bind("effective_default_angles", effective)
+
+        noise = self.env._cfg.noise_config
+        if "noisy_linvel" in self.inputs:
+            bind("noisy_linvel", self.env._obs_noise(linvel, noise.scale_linvel))
+        if "noisy_gyro" in self.inputs:
+            bind("noisy_gyro", self.env._obs_noise(gyro, noise.scale_gyro))
+        if "noisy_joint_pos_rel" in self.inputs:
+            noisy_joint = self._owned_inputs["noisy_joint_pos_rel"]
+            np.subtract(dof_pos, effective, out=noisy_joint)
+            bind(
+                "noisy_joint_pos_rel",
+                self.env._obs_noise(noisy_joint, noise.scale_joint_angle),
             )
-        self._sync_scales(scales)
-        if self.num_threads is not None:
-            set_num_threads(self.num_threads)
-
-        dtype = dof_pos.dtype
-        current_actions = np.asarray(info.get("current_actions", self._zero_actions), dtype=dtype)
-        last_actions = np.asarray(info.get("last_actions", self._zero_actions), dtype=dtype)
-        reward = np.empty((dof_pos.shape[0],), dtype=dtype)
-        terminated = np.empty((dof_pos.shape[0],), dtype=np.bool_)
-        log_scratch = np.zeros((get_num_threads(), len(TERM_ORDER)), dtype=np.float64)
-
-        _compute_reward_termination_kernel(
-            motion_data.body_pos_w,
-            motion_data.body_quat_w,
-            motion_data.body_lin_vel_w,
-            motion_data.body_ang_vel_w,
-            motion_data.joint_pos,
-            motion_data.joint_vel,
-            ref_body_pos_w,
-            ref_body_quat_w,
-            robot_body_pos_w,
-            robot_body_quat_w,
-            robot_body_lin_vel_w,
-            robot_body_ang_vel_w,
-            dof_pos,
-            dof_vel,
-            current_actions,
-            last_actions,
-            self.joint_lower,
-            self.joint_upper,
-            self.scale,
-            self.std,
-            self.anchor_body_idx,
-            self.ee_body_indices,
-            self.undesired_contact_body_indices,
-            self.ctrl_dt,
-            self.anchor_pos_z_threshold,
-            self.anchor_ori_threshold,
-            self.ee_body_pos_z_threshold,
-            self.undesired_contact_z_threshold,
-            self.terminate_on_undesired_contacts,
-            self.has_joint_limits,
-            reward,
-            terminated,
-            log_scratch,
-        )
-
-        step_count = info.get("steps")
-        should_log = enable_log and (
-            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
-        )
-        log = {} if should_log else info.get("log", {})
-        if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / dof_pos.shape[0])
-        return G1MotionTrackingNumbaResult(reward=reward, terminated=terminated, log=log)
+        if "noisy_dof_vel" in self.inputs:
+            bind("noisy_dof_vel", self.env._obs_noise(dof_vel, noise.scale_joint_vel))
+        self.runtime.bind_inputs(self.inputs)
 
     def compute_update_state(
         self,
@@ -1143,131 +685,52 @@ class MotionTrackingNumbaAccelerator:
         robot_body_quat_w: np.ndarray,
         robot_body_lin_vel_w: np.ndarray,
         robot_body_ang_vel_w: np.ndarray,
-        ref_body_pos_w: np.ndarray,
-        ref_body_quat_w: np.ndarray,
-        motion_anchor_pos_b: np.ndarray,
-        motion_anchor_ori_b: np.ndarray,
-        joint_pos_rel: np.ndarray,
         scales: Mapping[str, float],
         enable_log: bool,
-        noise_level: float,
-        noise_scale_linvel: float,
-        noise_scale_gyro: float,
-        noise_scale_joint_angle: float,
-        noise_scale_joint_vel: float,
     ) -> G1MotionTrackingNumbaUpdateStateResult:
-        if not NUMBA_AVAILABLE:
-            raise RuntimeError(
-                "G1MotionTracking Numba accelerator was constructed while numba is "
-                "unavailable; this indicates an invalid accelerator state."
-            )
-        self._sync_scales(scales)
-        if self.num_threads is not None:
-            set_num_threads(self.num_threads)
-
-        dtype = dof_pos.dtype
-        n = dof_pos.shape[0]
-        if n != self.num_envs:
+        if dof_pos.shape[0] != self.num_envs:
             raise ValueError(
                 "G1MotionTracking Numba update_state only supports full-batch updates; "
-                f"got {n} rows for configured num_envs={self.num_envs}."
+                f"got {dof_pos.shape[0]} rows for configured num_envs={self.num_envs}."
             )
-
-        current_actions = np.asarray(info.get("current_actions", self._zero_actions), dtype=dtype)
-        last_actions = np.asarray(info.get("last_actions", self._zero_actions), dtype=dtype)
-        default_dof_pos_bias = info.get("default_dof_pos_bias")
-        has_default_dof_pos_bias = isinstance(default_dof_pos_bias, np.ndarray)
-        if has_default_dof_pos_bias:
-            default_dof_pos_bias_arr = np.asarray(default_dof_pos_bias, dtype=dtype)
-        else:
-            default_dof_pos_bias_arr = self._zero_default_dof_pos_bias.astype(dtype, copy=False)
-
-        noise_level = float(noise_level)
-        if noise_level > 0.0:
-            actor_noise_linvel = np.random.uniform(-1.0, 1.0, linvel.shape).astype(dtype)
-            actor_noise_linvel *= noise_level * float(noise_scale_linvel)
-            actor_noise_gyro = np.random.uniform(-1.0, 1.0, gyro.shape).astype(dtype)
-            actor_noise_gyro *= noise_level * float(noise_scale_gyro)
-            actor_noise_joint_pos = np.random.uniform(-1.0, 1.0, dof_pos.shape).astype(dtype)
-            actor_noise_joint_pos *= noise_level * float(noise_scale_joint_angle)
-            actor_noise_dof_vel = np.random.uniform(-1.0, 1.0, dof_vel.shape).astype(dtype)
-            actor_noise_dof_vel *= noise_level * float(noise_scale_joint_vel)
-        else:
-            actor_noise_linvel = self._zero_linvel_noise.astype(dtype, copy=False)
-            actor_noise_gyro = self._zero_gyro_noise.astype(dtype, copy=False)
-            actor_noise_joint_pos = self._zero_joint_noise.astype(dtype, copy=False)
-            actor_noise_dof_vel = self._zero_joint_noise.astype(dtype, copy=False)
-
-        actor_obs = np.empty((n, self.actor_obs_width), dtype=dtype)
-        critic_obs = np.empty((n, self.critic_obs_width), dtype=dtype)
-        reward = np.empty((n,), dtype=dtype)
-        terminated = np.empty((n,), dtype=np.bool_)
-        log_scratch = np.zeros((get_num_threads(), len(TERM_ORDER)), dtype=np.float64)
-
-        _compute_update_state_kernel(
-            motion_data.body_pos_w,
-            motion_data.body_quat_w,
-            motion_data.body_lin_vel_w,
-            motion_data.body_ang_vel_w,
-            motion_data.joint_pos,
-            motion_data.joint_vel,
-            robot_body_pos_w,
-            robot_body_quat_w,
-            robot_body_lin_vel_w,
-            robot_body_ang_vel_w,
-            linvel,
-            gyro,
-            dof_pos,
-            dof_vel,
-            self.default_angles,
-            default_dof_pos_bias_arr,
-            current_actions,
-            last_actions,
-            self.joint_lower,
-            self.joint_upper,
-            self.scale,
-            self.std,
-            self.anchor_body_idx,
-            self.ee_body_indices,
-            self.undesired_contact_body_indices,
-            self.ctrl_dt,
-            self.anchor_pos_z_threshold,
-            self.anchor_ori_threshold,
-            self.ee_body_pos_z_threshold,
-            self.undesired_contact_z_threshold,
-            self.terminate_on_undesired_contacts,
-            self.has_joint_limits,
-            has_default_dof_pos_bias,
-            self.is_deploy_actor,
-            actor_noise_linvel,
-            actor_noise_gyro,
-            actor_noise_joint_pos,
-            actor_noise_dof_vel,
-            ref_body_pos_w,
-            ref_body_quat_w,
-            motion_anchor_pos_b,
-            motion_anchor_ori_b,
-            joint_pos_rel,
-            actor_obs,
-            critic_obs,
-            reward,
-            terminated,
-            log_scratch,
+        self._sync_scales(scales)
+        self._bind_inputs(
+            info=info,
+            motion_data=motion_data,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
+            robot_body_pos_w=robot_body_pos_w,
+            robot_body_quat_w=robot_body_quat_w,
+            robot_body_lin_vel_w=robot_body_lin_vel_w,
+            robot_body_ang_vel_w=robot_body_ang_vel_w,
         )
+        if self.num_threads is not None:
+            set_num_threads(self.num_threads)
+        nthreads = get_num_threads()
+        if self._log_scratch is None or self._log_scratch.shape[0] != nthreads:
+            self._log_scratch = np.empty((nthreads, len(self.resolved.plan.terms)), np.float64)
+        self._log_scratch.fill(0.0)
+        started = time.perf_counter()
+        self.runtime.execute(reward_multiplier=self.ctrl_dt, log_scratch=self._log_scratch)
+        if self.first_jit_ms is None:
+            self.first_jit_ms = (time.perf_counter() - started) * 1e3
 
-        step_count = info.get("steps")
+        steps = info.get("steps")
         should_log = enable_log and (
-            int(step_count[0]) % 4 == 0 if isinstance(step_count, np.ndarray) else True
+            int(steps[0]) % 4 == 0 if isinstance(steps, np.ndarray) else True
         )
         log = {} if should_log else info.get("log", {})
         if should_log:
-            term_sums = log_scratch.sum(axis=0)
-            for idx, name in enumerate(TERM_ORDER):
-                if self.scale[idx] != 0.0:
-                    log[f"reward/{name}"] = float(term_sums[idx] / n)
+            sums = self._log_scratch.sum(axis=0)
+            for reward_name, output_name in self._reward_outputs.items():
+                if scales.get(reward_name, 0.0) != 0.0:
+                    index = self._plan_indices[output_name]
+                    log[f"reward/{reward_name}"] = float(sums[index] / self.num_envs)
         return G1MotionTrackingNumbaUpdateStateResult(
-            obs={"obs": actor_obs, "critic": critic_obs},
-            reward=reward,
-            terminated=terminated,
+            obs=self.obs,
+            reward=self.runtime.reward,
+            terminated=self.runtime.terminated,
             log=log,
         )

--- a/src/unilab/envs/motion_tracking/common/terms.py
+++ b/src/unilab/envs/motion_tracking/common/terms.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType, SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    ResolvedTermPlan,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistry,
+    resolve_term_plan,
+)
+from unilab.utils.geometry import (
+    np_gravity_z_in_body_from_quat,
+    np_write_relative_anchor_transform_pos_rot6d,
+)
+
+from . import rewards
+from .observations import write_body_ori6_in_anchor_frame, write_body_pos_in_anchor_frame
+from .transforms import write_relative_transforms
+
+PREAMBLE_KEY = "motion.tracking.preamble.transforms.v1"
+REWARD_KEYS = {
+    name: f"motion.tracking.reward.{name}.v1"
+    for name in (
+        "motion_global_root_pos",
+        "motion_global_root_ori",
+        "motion_body_pos",
+        "motion_body_ori",
+        "motion_body_lin_vel",
+        "motion_body_ang_vel",
+        "motion_ee_body_pos_z",
+        "motion_joint_pos",
+        "motion_joint_vel",
+        "action_rate_l2",
+        "joint_limit",
+        "undesired_contacts",
+    )
+}
+DEFAULT_TERMINATIONS = ("motion.tracking.termination.failures.v1",)
+
+_OBS_META = {
+    f"motion.tracking.observation.{key}.v1": (group, label, source, width, workspace)
+    for group, entries in {
+        "obs": (
+            ("actor_command", "command", "motion_command", -2, True),
+            ("actor_anchor_pos", "anchor_pos", "motion_anchor_pos_b", 3, True),
+            ("actor_anchor_ori", "anchor_ori", "motion_anchor_ori_b", 6, True),
+            ("actor_linvel", "linvel", "noisy_linvel", 3, False),
+            ("actor_gyro", "gyro", "noisy_gyro", 3, False),
+            ("actor_joint_pos", "joint_pos", "noisy_joint_pos_rel", -1, False),
+            ("actor_dof_vel", "dof_vel", "noisy_dof_vel", -1, False),
+            ("actor_actions", "actions", "obs_actions", -1, False),
+        ),
+        "critic": (
+            ("critic_command", "command", "motion_command", -2, True),
+            ("critic_anchor_pos", "anchor_pos", "motion_anchor_pos_b", 3, True),
+            ("critic_anchor_ori", "anchor_ori", "motion_anchor_ori_b", 6, True),
+            ("critic_linvel", "linvel", "linvel", 3, False),
+            ("critic_gyro", "gyro", "gyro", 3, False),
+            ("critic_joint_pos", "joint_pos", "joint_pos_rel", -1, True),
+            ("critic_dof_vel", "dof_vel", "dof_vel", -1, False),
+            ("critic_actions", "actions", "obs_actions", -1, False),
+            ("critic_body_pos", "body_pos", "robot_body_pos_b", -3, True),
+            ("critic_body_ori", "body_ori", "robot_body_ori_b", -6, True),
+        ),
+    }.items()
+    for key, label, source, width, workspace in entries
+}
+DEFAULT_OBSERVATIONS = {
+    group: [key for key, meta in _OBS_META.items() if meta[0] == group]
+    for group in ("obs", "critic")
+}
+
+
+def _param(ctx: NumpyTermContext, name: str) -> float:
+    return cast(float, ctx.parameters[name])
+
+
+# fmt: off
+def _preamble(ctx: NumpyTermContext) -> None:
+    inputs, work = ctx.inputs, ctx.workspace
+    i = cast(int, ctx.parameters["anchor_body_idx"])
+    write_relative_transforms(
+        motion_body_pos_w=inputs["motion_body_pos_w"], motion_body_quat_w=inputs["motion_body_quat_w"],
+        robot_body_pos_w=inputs["robot_body_pos_w"], robot_body_quat_w=inputs["robot_body_quat_w"],
+        anchor_body_idx=i, delta_pos_w=work["delta_pos_w"], delta_ori_w=work["delta_ori_w"],
+        body_vec_error=work["body_vec_error"], scalar_scratch=work["env_error"],
+        scalar_scratch2=work["term_scratch"], out_body_pos_w=work["ref_body_pos_w"],
+        out_body_quat_w=work["ref_body_quat_w"],
+    )
+    motion_pos, motion_quat = inputs["motion_body_pos_w"][:, i], inputs["motion_body_quat_w"][:, i]
+    robot_pos, robot_quat = inputs["robot_body_pos_w"][:, i], inputs["robot_body_quat_w"][:, i]
+    np_write_relative_anchor_transform_pos_rot6d(
+        robot_pos, robot_quat, motion_pos, motion_quat,
+        work["motion_anchor_pos_b"], work["motion_anchor_ori_b"],
+    )
+    n = inputs["dof_pos"].shape[1]
+    work["motion_command"][:, :n], work["motion_command"][:, n:] = inputs["motion_joint_pos"], inputs["motion_joint_vel"]
+    np.subtract(inputs["dof_pos"], inputs["effective_default_angles"], out=work["joint_pos_rel"])
+    write_body_pos_in_anchor_frame(
+        robot_pos, robot_quat, inputs["robot_body_pos_w"], work["robot_body_pos_b"],
+        body_vec_error=work["body_vec_error"],
+    )
+    write_body_ori6_in_anchor_frame(robot_quat, inputs["robot_body_quat_w"], work["robot_body_ori_b"])
+    ctx.output.fill(0.0)
+# fmt: on
+
+
+def _copy(ctx: NumpyTermContext) -> None:
+    np.copyto(
+        ctx.output,
+        next(iter((*ctx.inputs.values(), *ctx.workspace.values()))).reshape(ctx.output.shape),
+    )
+
+
+# fmt: off
+class _RewardAdapter:
+    """Cold-bound adapter around the existing vectorized owner term."""
+
+    def __init__(self, fn: Any) -> None:
+        self.fn = fn
+        self.bound: rewards.RewardContext | None = None
+
+    def __call__(self, ctx: NumpyTermContext) -> None:
+        if self.bound is None:
+            get = lambda name: ctx.inputs.get(name)  # noqa: E731
+            work = lambda name: ctx.workspace.get(name)  # noqa: E731
+            std = cast(float, ctx.parameters.get("std", 1.0))
+            std_cfg = SimpleNamespace(**{name: std for name in (
+                "std_root_pos", "std_root_ori", "std_body_pos", "std_body_ori",
+                "std_body_lin_vel", "std_body_ang_vel", "std_joint_pos", "std_joint_vel",
+            )})
+            indices = np.asarray(ctx.parameters.get("indices", ()), dtype=np.intp)
+            env_error, indexed_error, indexed_mask = work("env_error"), work("indexed_error"), work("indexed_mask")
+            direct_fields = (
+                "robot_body_pos_w", "robot_body_quat_w", "robot_body_lin_vel_w",
+                "robot_body_ang_vel_w", "dof_pos", "dof_vel", "joint_lower", "joint_upper",
+            )
+            scratch_fields = (
+                "body_vec_error", "joint_error", "joint_error_upper", "quat_error_w", "quat_error_x",
+            )
+            motion_fields = (
+                "body_pos_w", "body_quat_w", "body_lin_vel_w", "body_ang_vel_w", "joint_pos", "joint_vel",
+            )
+            self.bound = rewards.RewardContext(
+                info={"current_actions": get("current_actions"), "last_actions": get("last_actions")},
+                motion_data=SimpleNamespace(**{name: get(f"motion_{name}") for name in motion_fields}),
+                ref_body_pos_w=work("ref_body_pos_w"), ref_body_quat_w=work("ref_body_quat_w"), reward_config=std_cfg,
+                anchor_body_idx=cast(int, ctx.parameters.get("anchor_body_idx", 0)),
+                ee_body_indices=indices, undesired_contact_body_indices=indices,
+                undesired_contact_z_threshold=cast(float, ctx.parameters.get("threshold", 0.0)),
+                num_envs=ctx.output.shape[0], env_error=env_error if env_error is not None else ctx.output,
+                reward_term=ctx.output,
+                ee_pos_error_z=None if indexed_error is None else indexed_error[:, : len(indices)],
+                undesired_contact_mask=None if indexed_mask is None else indexed_mask[:, : len(indices)],
+                **{name: get(name) for name in direct_fields},
+                **{name: work(name) for name in scratch_fields},
+            )
+        result = self.fn(self.bound)
+        if result is not ctx.output:
+            np.copyto(ctx.output, result)
+# fmt: on
+
+
+# fmt: off
+def _termination(ctx: NumpyTermContext) -> None:
+    i = cast(int, ctx.parameters["anchor_body_idx"])
+    error = ctx.workspace["env_error"]
+    np.subtract(ctx.inputs["motion_body_pos_w"][:, i, 2], ctx.inputs["robot_body_pos_w"][:, i, 2], out=error)
+    np.abs(error, out=error)
+    np.greater(error, _param(ctx, "anchor_pos_z_threshold"), out=ctx.output)
+    if cast(bool, ctx.parameters["check_anchor_ori"]):
+        np.subtract(np_gravity_z_in_body_from_quat(ctx.inputs["motion_body_quat_w"][:, i]),
+                    np_gravity_z_in_body_from_quat(ctx.inputs["robot_body_quat_w"][:, i]), out=error)
+        np.abs(error, out=error)
+        np.logical_or(ctx.output, error > _param(ctx, "anchor_ori_threshold"), out=ctx.output)
+    for prefix, source in (("ee", ctx.workspace["ref_body_pos_w"]), ("contact", None)):
+        indices = cast(tuple[int, ...], ctx.parameters[f"{prefix}_indices"])
+        if not indices:
+            continue
+        mask = ctx.workspace["indexed_mask"][:, : len(indices)]
+        if source is None:
+            np.less(ctx.inputs["robot_body_pos_w"][:, indices, 2], _param(ctx, "contact_threshold"), out=mask)
+        else:
+            indexed_error = ctx.workspace["indexed_error"][:, : len(indices)]
+            np.subtract(source[:, indices, 2], ctx.inputs["robot_body_pos_w"][:, indices, 2], out=indexed_error)
+            np.abs(indexed_error, out=indexed_error)
+            np.greater(indexed_error, _param(ctx, "ee_threshold"), out=mask)
+        np.logical_or.reduce(mask, axis=1, out=error)
+        np.logical_or(ctx.output, error, out=ctx.output)
+# fmt: on
+
+
+@dataclass(frozen=True)
+class MotionResolvedTermPlan:
+    plan: ResolvedTermPlan
+    preamble_outputs: tuple[str, ...]
+    reward_outputs: tuple[tuple[str, str], ...]
+    reward_available: Mapping[str, bool]
+    observation_outputs: Mapping[str, tuple[str, ...]]
+    observation_labels: Mapping[str, tuple[str, ...]]
+    termination_outputs: tuple[str, ...]
+
+    @property
+    def observation_dims(self) -> dict[str, int]:
+        return {
+            group: sum(self.plan.output_specs[name].shape[0] for name in names)
+            for group, names in self.observation_outputs.items()
+        }
+
+
+def _build_registry(*, n_action: int, n_body: int, n_indexed: int, dtype: np.dtype) -> TermRegistry:
+    from . import numba as motion_numba
+
+    registry = TermRegistry()
+    # fmt: off
+    shapes = {
+        "motion_body_pos_w": (n_body, 3), "motion_body_quat_w": (n_body, 4),
+        "motion_body_lin_vel_w": (n_body, 3), "motion_body_ang_vel_w": (n_body, 3),
+        "motion_joint_pos": (n_action,), "motion_joint_vel": (n_action,),
+        "robot_body_pos_w": (n_body, 3), "robot_body_quat_w": (n_body, 4),
+        "robot_body_lin_vel_w": (n_body, 3), "robot_body_ang_vel_w": (n_body, 3),
+        "dof_pos": (n_action,), "dof_vel": (n_action,), "linvel": (3,), "gyro": (3,),
+        "noisy_linvel": (3,), "noisy_gyro": (3,), "noisy_joint_pos_rel": (n_action,),
+        "noisy_dof_vel": (n_action,), "current_actions": (n_action,),
+        "last_actions": (n_action,), "obs_actions": (n_action,),
+        "effective_default_angles": (n_action,), "joint_lower": (n_action,),
+        "joint_upper": (n_action,),
+    }
+    work_shapes = {
+        "delta_pos_w": (3,), "delta_ori_w": (4,), "body_vec_error": (n_body, 3),
+        "env_error": (), "term_scratch": (), "ref_body_pos_w": (n_body, 3),
+        "ref_body_quat_w": (n_body, 4), "motion_anchor_pos_b": (3,),
+        "motion_anchor_ori_b": (6,), "motion_command": (2 * n_action,),
+        "joint_pos_rel": (n_action,), "robot_body_pos_b": (n_body, 3),
+        "robot_body_ori_b": (n_body, 6), "quat_error_w": (n_body,),
+        "quat_error_x": (n_body,), "joint_error": (n_action,),
+        "joint_error_upper": (n_action,), "indexed_error": (n_indexed,),
+        "indexed_mask": (n_indexed,),
+    }
+    # fmt: on
+    # The remaining declarations are a compact registry table.
+    # fmt: off
+    def ins(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(NamedTensorSpec(name, TensorSpec(shapes[name], dtype)) for name in names)
+
+    def work(*names: str) -> tuple[NamedTensorSpec, ...]:
+        return tuple(NamedTensorSpec(name, TensorSpec(work_shapes[name], np.bool_ if name == "indexed_mask" else dtype)) for name in names)
+
+    def register(key: str, kind: TermKind, fn: Any, output: TensorSpec,
+                 inputs: tuple[str, ...] = (), workspace: tuple[str, ...] = (),
+                 parameters: tuple[ParameterSpec, ...] = (), numba_item_fn: Any = None) -> None:
+        registry.register(TermDefinition(key, kind, fn, output, inputs=ins(*inputs),
+                                         workspace=work(*workspace), parameters=parameters,
+                                         numba_item_fn=numba_item_fn))
+
+    scalar = TensorSpec((), dtype)
+
+    def float_param(name: str) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.FLOAT)
+
+    def int_param(name: str, many: bool = False) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.INTEGER, tuple_value=many)
+
+    def bool_param(name: str) -> ParameterSpec:
+        return ParameterSpec(name, ParameterKind.BOOLEAN)
+
+    preamble_inputs = (
+        "motion_body_pos_w", "motion_body_quat_w", "motion_joint_pos", "motion_joint_vel",
+        "robot_body_pos_w", "robot_body_quat_w", "dof_pos", "effective_default_angles",
+    )
+    preamble_work = (
+        "delta_pos_w", "delta_ori_w", "body_vec_error", "env_error", "term_scratch",
+        "ref_body_pos_w", "ref_body_quat_w", "motion_anchor_pos_b", "motion_anchor_ori_b",
+        "motion_command", "joint_pos_rel", "robot_body_pos_b", "robot_body_ori_b",
+    )
+    register(PREAMBLE_KEY, TermKind.OBSERVATION, _preamble, scalar, preamble_inputs,
+             preamble_work, (int_param("anchor_body_idx"),), motion_numba.NUMBA_PREAMBLE_ITEM)
+
+    # (function, inputs, workspace, parameters); kept compact so the paired
+    # authoring surface is auditable as one table.
+    reward_defs = {
+        "motion_global_root_pos": (rewards.motion_global_root_pos, ("motion_body_pos_w", "robot_body_pos_w"), ("env_error",), (int_param("anchor_body_idx"), float_param("std"))),
+        "motion_global_root_ori": (rewards.motion_global_root_ori, ("motion_body_quat_w", "robot_body_quat_w"), ("env_error",), (int_param("anchor_body_idx"), float_param("std"))),
+        "motion_body_pos": (rewards.motion_body_pos, ("robot_body_pos_w",), ("ref_body_pos_w", "body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_body_ori": (rewards.motion_body_ori, ("robot_body_quat_w",), ("ref_body_quat_w", "quat_error_w", "quat_error_x", "env_error"), (float_param("std"),)),
+        "motion_body_lin_vel": (rewards.motion_body_lin_vel, ("motion_body_lin_vel_w", "robot_body_lin_vel_w"), ("body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_body_ang_vel": (rewards.motion_body_ang_vel, ("motion_body_ang_vel_w", "robot_body_ang_vel_w"), ("body_vec_error", "env_error"), (float_param("std"),)),
+        "motion_ee_body_pos_z": (rewards.motion_ee_body_pos_z, ("robot_body_pos_w",), ("ref_body_pos_w", "indexed_error", "env_error"), (int_param("indices", True), float_param("std"))),
+        "motion_joint_pos": (rewards.motion_joint_pos, ("motion_joint_pos", "dof_pos"), ("joint_error", "env_error"), (float_param("std"),)),
+        "motion_joint_vel": (rewards.motion_joint_vel, ("motion_joint_vel", "dof_vel"), ("joint_error", "env_error"), (float_param("std"),)),
+        "action_rate_l2": (rewards.action_rate_l2, ("current_actions", "last_actions"), ("joint_error", "env_error"), ()),
+        "joint_limit": (rewards.joint_limit, ("joint_lower", "joint_upper", "dof_pos"), ("joint_error", "joint_error_upper"), ()),
+        "undesired_contacts": (rewards.undesired_contacts, ("robot_body_pos_w",), ("indexed_mask", "env_error"), (int_param("indices", True), float_param("threshold"))),
+    }
+    for name, (fn, inputs, workspace, params) in reward_defs.items():
+        register(REWARD_KEYS[name], TermKind.REWARD, _RewardAdapter(fn), scalar, inputs, workspace,
+                 params, motion_numba.NUMBA_REWARD_ITEMS.get(name))
+
+    for key, (group, _label, source, width, is_workspace) in _OBS_META.items():
+        resolved_width = {-1: n_action, -2: 2 * n_action, -3: 3 * n_body, -6: 6 * n_body}.get(width, width)
+        register(key, TermKind.OBSERVATION, _copy, TensorSpec((resolved_width,), dtype),
+                 workspace=(source,) if is_workspace else (),
+                 inputs=() if is_workspace else (source,),
+                 numba_item_fn=motion_numba.NUMBA_OBSERVATION_ITEM)
+
+    termination_params = (
+        int_param("anchor_body_idx"), float_param("anchor_pos_z_threshold"),
+        bool_param("check_anchor_ori"), float_param("anchor_ori_threshold"),
+        int_param("ee_indices", True), float_param("ee_threshold"),
+        int_param("contact_indices", True), float_param("contact_threshold"),
+    )
+    register(DEFAULT_TERMINATIONS[0], TermKind.TERMINATION, _termination, TensorSpec((), np.bool_),
+             ("motion_body_pos_w", "motion_body_quat_w", "robot_body_pos_w", "robot_body_quat_w"),
+             ("ref_body_pos_w", "env_error", "indexed_error", "indexed_mask"), termination_params,
+             motion_numba.NUMBA_TERMINATION_ITEM)
+    return registry
+
+
+# fmt: on
+
+
+def resolve_motion_term_plan(
+    *,
+    cfg: Any,
+    n_action: int,
+    n_body: int,
+    anchor_body_idx: int,
+    ee_indices: np.ndarray,
+    undesired_indices: np.ndarray,
+    config: Any,
+    dtype: np.dtype,
+) -> MotionResolvedTermPlan:
+    """Resolve the task-owned motion tracking numeric plan."""
+    n_indexed = max(1, len(ee_indices), len(undesired_indices))
+    registry = _build_registry(n_action=n_action, n_body=n_body, n_indexed=n_indexed, dtype=dtype)
+    configs: list[TermConfig] = []
+    preamble_outputs = []
+    for index, key in enumerate(config.preambles):
+        name = f"preamble.term{index}"
+        configs.append(
+            TermConfig(
+                name,
+                key,
+                parameters={"anchor_body_idx": anchor_body_idx} if key == PREAMBLE_KEY else {},
+            )
+        )
+        preamble_outputs.append(name)
+
+    # fmt: off
+    std_names = {
+        "motion_global_root_pos": "std_root_pos", "motion_global_root_ori": "std_root_ori",
+        "motion_body_pos": "std_body_pos", "motion_body_ori": "std_body_ori",
+        "motion_body_lin_vel": "std_body_lin_vel", "motion_body_ang_vel": "std_body_ang_vel",
+        "motion_ee_body_pos_z": "std_body_pos", "motion_joint_pos": "std_joint_pos",
+        "motion_joint_vel": "std_joint_vel",
+    }
+    # fmt: on
+    available = {
+        "motion_ee_body_pos_z": bool(len(ee_indices)),
+        "joint_limit": cfg._joint_lower is not None,
+        "undesired_contacts": bool(len(undesired_indices)),
+    }
+    reward_outputs = []
+    for name, scale in cfg._cfg.reward_config.scales.items():
+        key = REWARD_KEYS.get(name)
+        if key is None:
+            if scale != 0.0:
+                raise TermPlanError(f"motion tracking has unknown nonzero reward term {name!r}")
+            continue
+        params: dict[str, object] = {}
+        if name in std_names:
+            params["std"] = float(getattr(cfg._cfg.reward_config, std_names[name]))
+        if name in ("motion_global_root_pos", "motion_global_root_ori"):
+            params["anchor_body_idx"] = anchor_body_idx
+        if name == "motion_ee_body_pos_z":
+            params["indices"] = ee_indices.tolist()
+        if name == "undesired_contacts":
+            params.update(
+                indices=undesired_indices.tolist(), threshold=cfg._cfg.undesired_contact_z_threshold
+            )
+        output = f"reward.{name}"
+        configs.append(
+            TermConfig(
+                output, key, scale=scale if available.get(name, True) else 0.0, parameters=params
+            )
+        )
+        reward_outputs.append((name, output))
+
+    termination_outputs = []
+    termination_params = {
+        "anchor_body_idx": anchor_body_idx,
+        "anchor_pos_z_threshold": cfg._cfg.anchor_pos_z_threshold,
+        "check_anchor_ori": cfg._cfg.anchor_ori_threshold < 2.0,
+        "anchor_ori_threshold": cfg._cfg.anchor_ori_threshold,
+        "ee_indices": ee_indices.tolist(),
+        "ee_threshold": cfg._cfg.ee_body_pos_z_threshold,
+        "contact_indices": undesired_indices.tolist()
+        if cfg._cfg.terminate_on_undesired_contacts
+        else [],
+        "contact_threshold": cfg._cfg.undesired_contact_z_threshold,
+    }
+    for index, key in enumerate(config.terminations):
+        name = f"termination.term{index}"
+        configs.append(
+            TermConfig(
+                name, key, parameters=termination_params if key == DEFAULT_TERMINATIONS[0] else {}
+            )
+        )
+        termination_outputs.append(name)
+
+    if set(config.observations) != {"obs", "critic"}:
+        raise TermPlanError("motion observation layout must define exactly 'obs' and 'critic'")
+    observation_outputs, observation_labels = {}, {}
+    for group in ("obs", "critic"):
+        keys = config.observations[group]
+        if not isinstance(keys, (list, tuple)) or not keys or len(keys) != len(set(keys)):
+            raise TermPlanError(
+                f"motion observation group {group!r} must be a non-empty unique list"
+            )
+        names, labels = [], []
+        for index, key in enumerate(keys):
+            meta = _OBS_META.get(key)
+            if meta is None:
+                registry.resolve(key)
+            assert meta is not None
+            if meta[0] != group:
+                raise TermPlanError(f"observation term {key!r} does not belong to group {group!r}")
+            name = f"observation.{group}.term{index}"
+            configs.append(TermConfig(name, key))
+            names.append(name)
+            labels.append(meta[1])
+        observation_outputs[group] = tuple(names)
+        observation_labels[group] = tuple(labels)
+
+    return MotionResolvedTermPlan(
+        plan=resolve_term_plan(registry, configs),
+        preamble_outputs=tuple(preamble_outputs),
+        reward_outputs=tuple(reward_outputs),
+        reward_available=MappingProxyType(available),
+        observation_outputs=MappingProxyType(observation_outputs),
+        observation_labels=MappingProxyType(observation_labels),
+        termination_outputs=tuple(termination_outputs),
+    )

--- a/src/unilab/envs/motion_tracking/common/tracking.py
+++ b/src/unilab/envs/motion_tracking/common/tracking.py
@@ -26,6 +26,7 @@ from .motion_loader import MotionData, MotionLoader, MotionSampler
 from .reset import build_motion_reference_state
 from .rewards import RewardContext, build_reward_functions, compute_reward
 from .terminations import compute_terminations
+from .terms import MotionResolvedTermPlan, resolve_motion_term_plan
 from .transforms import update_relative_transforms
 
 
@@ -171,6 +172,10 @@ class MotionTrackingEnv(G1BaseEnv):
             for name, reward_fn in self._reward_fns.items()
             if self._reward_term_is_active(name)
         }
+        self._resolved_terms: MotionResolvedTermPlan | None = None
+        self._term_runtime: Any = None
+        if cfg.term_plan is not None and not cfg.numba_acceleration:
+            self._init_term_plan(cfg.term_plan)
         self._numba_accelerator = None
         if cfg.numba_acceleration:
             from unilab.envs.motion_tracking.common.numba import MotionTrackingNumbaAccelerator
@@ -279,7 +284,57 @@ class MotionTrackingEnv(G1BaseEnv):
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:
+        resolved = getattr(self, "_resolved_terms", None)
+        if resolved is not None:
+            return dict(resolved.observation_dims)
         return observations.obs_groups_spec(self)
+
+    def _init_term_plan(self, config: Any) -> None:
+        dtype = np.dtype(get_global_dtype())
+        resolved = resolve_motion_term_plan(
+            cfg=self,
+            n_action=self._num_action,
+            n_body=self._n_motion_bodies,
+            anchor_body_idx=self.anchor_body_idx,
+            ee_indices=self.ee_body_indices,
+            undesired_indices=self.undesired_contact_body_indices,
+            config=config,
+            dtype=dtype,
+        )
+        inputs = {
+            name: np.zeros((self._num_envs, *spec.shape), dtype=spec.numpy_dtype)
+            for name, spec in resolved.plan.input_specs.items()
+        }
+        for name, value in (("joint_lower", self._joint_lower), ("joint_upper", self._joint_upper)):
+            if name in inputs and value is not None:
+                np.copyto(inputs[name], value)
+        runtime = resolved.plan.materialize(num_envs=self._num_envs, inputs=inputs)
+        self._resolved_terms = resolved
+        self._term_inputs = inputs
+        self._term_runtime = runtime
+        self._term_obs = {
+            group: np.empty((self._num_envs, width), dtype=dtype)
+            for group, width in resolved.observation_dims.items()
+        }
+        self._term_reward = np.empty((self._num_envs,), dtype=dtype)
+        self._term_terminated = np.empty((self._num_envs,), dtype=np.bool_)
+        self.body_pos_relative_w = runtime.workspace["ref_body_pos_w"]
+        self.body_quat_relative_w = runtime.workspace["ref_body_quat_w"]
+        runtime.execute()  # Bind active owner reward adapters on the cold path.
+        self._sync_term_reward_scales()
+
+    def _sync_term_reward_scales(self) -> None:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        active = []
+        for reward_name, output_name in self._resolved_terms.reward_outputs:
+            configured = self._cfg.reward_config.scales[reward_name]
+            scale = (
+                configured if self._resolved_terms.reward_available.get(reward_name, True) else 0.0
+            )
+            self._term_runtime.set_scale(output_name, scale)
+            if configured != 0.0:
+                active.append((reward_name, output_name))
+        self._active_term_rewards = tuple(active)
 
     def _actor_obs_dim(self, n: int) -> int:
         return observations.actor_obs_dim(n)
@@ -346,7 +401,6 @@ class MotionTrackingEnv(G1BaseEnv):
 
         numba_accelerator = getattr(self, "_numba_accelerator", None)
         if numba_accelerator is not None:
-            noise_cfg = self._cfg.noise_config
             numba_result = numba_accelerator.compute_update_state(
                 info=state.info,
                 motion_data=motion_data,
@@ -358,55 +412,52 @@ class MotionTrackingEnv(G1BaseEnv):
                 robot_body_quat_w=robot_body_quat_w,
                 robot_body_lin_vel_w=robot_body_lin_vel_w,
                 robot_body_ang_vel_w=robot_body_ang_vel_w,
-                ref_body_pos_w=self.body_pos_relative_w,
-                ref_body_quat_w=self.body_quat_relative_w,
-                motion_anchor_pos_b=self._motion_anchor_pos_b,
-                motion_anchor_ori_b=self._motion_anchor_ori_b,
-                joint_pos_rel=self._joint_pos_rel,
                 scales=self._cfg.reward_config.scales,
                 enable_log=self._enable_reward_log,
-                noise_level=noise_cfg.level,
-                noise_scale_linvel=noise_cfg.scale_linvel,
-                noise_scale_gyro=noise_cfg.scale_gyro,
-                noise_scale_joint_angle=noise_cfg.scale_joint_angle,
-                noise_scale_joint_vel=noise_cfg.scale_joint_vel,
             )
             terminated = numba_result.terminated
             reward = numba_result.reward
             obs = numba_result.obs
             state.info["log"] = numba_result.log
         else:
-            # Compute relative body transforms (for observations and rewards)
-            self._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
-
-            # Compute terminations
-            terminated = self._compute_terminations(
-                motion_data, robot_body_pos_w, robot_body_quat_w
-            )
-
-            # Compute reward
-            reward = self._compute_reward(
-                state.info,
-                motion_data,
-                robot_body_pos_w,
-                robot_body_quat_w,
-                robot_body_lin_vel_w,
-                robot_body_ang_vel_w,
-                dof_pos,
-                dof_vel,
-            )
-
-            # Compute observations
-            obs = self._compute_obs(
-                state.info,
-                motion_data,
-                linvel,
-                gyro,
-                dof_pos,
-                dof_vel,
-                robot_body_pos_w,
-                robot_body_quat_w,
-            )
+            if getattr(self, "_term_runtime", None) is not None:
+                obs, reward, terminated = self._compute_term_state(
+                    state.info,
+                    motion_data,
+                    linvel,
+                    gyro,
+                    dof_pos,
+                    dof_vel,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                    robot_body_lin_vel_w,
+                    robot_body_ang_vel_w,
+                )
+            else:
+                self._update_relative_transforms(motion_data, robot_body_pos_w, robot_body_quat_w)
+                terminated = self._compute_terminations(
+                    motion_data, robot_body_pos_w, robot_body_quat_w
+                )
+                reward = self._compute_reward(
+                    state.info,
+                    motion_data,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                    robot_body_lin_vel_w,
+                    robot_body_ang_vel_w,
+                    dof_pos,
+                    dof_vel,
+                )
+                obs = self._compute_obs(
+                    state.info,
+                    motion_data,
+                    linvel,
+                    gyro,
+                    dof_pos,
+                    dof_vel,
+                    robot_body_pos_w,
+                    robot_body_quat_w,
+                )
 
         # Update failure statistics for adaptive sampling
         self.motion_sampler.update_failure_stats(terminated)
@@ -483,7 +534,7 @@ class MotionTrackingEnv(G1BaseEnv):
         robot_body_quat_w: np.ndarray,
     ) -> dict[str, np.ndarray]:
         """Compute observations as dict with actor and critic groups."""
-        return observations.compute_obs(
+        result = observations.compute_obs(
             self,
             info,
             motion_data,
@@ -494,6 +545,164 @@ class MotionTrackingEnv(G1BaseEnv):
             robot_body_pos_w,
             robot_body_quat_w,
         )
+        resolved = getattr(self, "_resolved_terms", None)
+        if resolved is None:
+            return result
+        n = dof_pos.shape[1]
+        layouts = {
+            "obs": (
+                ("command", 2 * n),
+                ("anchor_pos", 3),
+                ("anchor_ori", 6),
+                ("linvel", 3),
+                ("gyro", 3),
+                ("joint_pos", n),
+                ("dof_vel", n),
+                ("actions", n),
+            ),
+            "critic": (
+                ("command", 2 * n),
+                ("anchor_pos", 3),
+                ("anchor_ori", 6),
+                ("linvel", 3),
+                ("gyro", 3),
+                ("joint_pos", n),
+                ("dof_vel", n),
+                ("actions", n),
+                ("body_pos", self._n_motion_bodies * 3),
+                ("body_ori", self._n_motion_bodies * 6),
+            ),
+        }
+        selected = {}
+        for group, layout in layouts.items():
+            start, slices = 0, {}
+            for label, width in layout:
+                slices[label] = slice(start, start + width)
+                start += width
+            selected[group] = np.concatenate(
+                [result[group][:, slices[label]] for label in resolved.observation_labels[group]],
+                axis=1,
+                dtype=get_global_dtype(),
+            )
+        return selected
+
+    @staticmethod
+    def _copy_term_input(inputs: dict[str, np.ndarray], name: str, value: np.ndarray) -> None:
+        if name in inputs:
+            np.copyto(inputs[name], value, casting="same_kind")
+
+    def _populate_term_inputs(
+        self,
+        info: dict,
+        motion_data: Any,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        robot_body_pos_w: np.ndarray,
+        robot_body_quat_w: np.ndarray,
+        robot_body_lin_vel_w: np.ndarray,
+        robot_body_ang_vel_w: np.ndarray,
+    ) -> None:
+        inputs, copy = self._term_inputs, self._copy_term_input
+        for name, value in (
+            ("motion_body_pos_w", motion_data.body_pos_w),
+            ("motion_body_quat_w", motion_data.body_quat_w),
+            ("motion_body_lin_vel_w", motion_data.body_lin_vel_w),
+            ("motion_body_ang_vel_w", motion_data.body_ang_vel_w),
+            ("motion_joint_pos", motion_data.joint_pos),
+            ("motion_joint_vel", motion_data.joint_vel),
+            ("robot_body_pos_w", robot_body_pos_w),
+            ("robot_body_quat_w", robot_body_quat_w),
+            ("robot_body_lin_vel_w", robot_body_lin_vel_w),
+            ("robot_body_ang_vel_w", robot_body_ang_vel_w),
+            ("dof_pos", dof_pos),
+            ("dof_vel", dof_vel),
+            ("linvel", linvel),
+            ("gyro", gyro),
+        ):
+            copy(inputs, name, value)
+        zero = self._zero_actions
+        current = info.get("current_actions")
+        current = current if isinstance(current, np.ndarray) else zero
+        previous = info.get("last_actions")
+        previous = previous if isinstance(previous, np.ndarray) else zero
+        for name, value in (
+            ("current_actions", current),
+            ("last_actions", previous),
+            ("obs_actions", current),
+        ):
+            copy(inputs, name, value)
+        effective_default = self._effective_default_angles()
+        copy(inputs, "effective_default_angles", effective_default)
+
+        noise = self._cfg.noise_config
+        for name, value, scale in (
+            ("noisy_linvel", linvel, noise.scale_linvel),
+            ("noisy_gyro", gyro, noise.scale_gyro),
+        ):
+            if name in inputs:
+                copy(inputs, name, self._obs_noise(value, scale))
+        if "noisy_joint_pos_rel" in inputs:
+            np.subtract(dof_pos, effective_default, out=inputs["noisy_joint_pos_rel"])
+            copy(
+                inputs,
+                "noisy_joint_pos_rel",
+                self._obs_noise(inputs["noisy_joint_pos_rel"], noise.scale_joint_angle),
+            )
+        copy(inputs, "noisy_dof_vel", self._obs_noise(dof_vel, noise.scale_joint_vel))
+
+    def _compute_term_state(
+        self,
+        info: dict,
+        motion_data: Any,
+        linvel: np.ndarray,
+        gyro: np.ndarray,
+        dof_pos: np.ndarray,
+        dof_vel: np.ndarray,
+        robot_body_pos_w: np.ndarray,
+        robot_body_quat_w: np.ndarray,
+        robot_body_lin_vel_w: np.ndarray,
+        robot_body_ang_vel_w: np.ndarray,
+    ) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray]:
+        assert self._resolved_terms is not None and self._term_runtime is not None
+        self._populate_term_inputs(
+            info,
+            motion_data,
+            linvel,
+            gyro,
+            dof_pos,
+            dof_vel,
+            robot_body_pos_w,
+            robot_body_quat_w,
+            robot_body_lin_vel_w,
+            robot_body_ang_vel_w,
+        )
+        outputs = self._term_runtime.execute()
+        for group, names in self._resolved_terms.observation_outputs.items():
+            start = 0
+            for name in names:
+                width = outputs[name].shape[1]
+                np.copyto(self._term_obs[group][:, start : start + width], outputs[name])
+                start += width
+        self._term_reward.fill(0.0)
+        for _, name in self._resolved_terms.reward_outputs:
+            np.add(self._term_reward, outputs[name], out=self._term_reward)
+        self._term_reward *= self._cfg.ctrl_dt
+        self._term_terminated.fill(False)
+        for name in self._resolved_terms.termination_outputs:
+            np.logical_or(self._term_terminated, outputs[name], out=self._term_terminated)
+
+        steps = info.get("steps")
+        should_log = self._enable_reward_log and (
+            int(steps[0]) % 4 == 0 if isinstance(steps, np.ndarray) else True
+        )
+        log = {} if should_log else info.get("log", {})
+        if should_log:
+            for reward_name, name in self._active_term_rewards:
+                log[f"reward/{reward_name}"] = float(np.mean(outputs[name]))
+        info["log"] = log
+        return self._term_obs, self._term_reward, self._term_terminated
 
     def _compute_reward(
         self,

--- a/src/unilab/envs/motion_tracking/common/transforms.py
+++ b/src/unilab/envs/motion_tracking/common/transforms.py
@@ -19,21 +19,51 @@ def update_relative_transforms(
     robot_body_quat_w: np.ndarray,
 ) -> None:
     """Update relative body transforms for tracking."""
+    write_relative_transforms(
+        motion_body_pos_w=motion_data.body_pos_w,
+        motion_body_quat_w=motion_data.body_quat_w,
+        robot_body_pos_w=robot_body_pos_w,
+        robot_body_quat_w=robot_body_quat_w,
+        anchor_body_idx=env.anchor_body_idx,
+        delta_pos_w=env._delta_pos_w,
+        delta_ori_w=env._delta_ori_w,
+        body_vec_error=env._body_vec_error,
+        scalar_scratch=env._env_error,
+        scalar_scratch2=env._reward_term,
+        out_body_pos_w=env.body_pos_relative_w,
+        out_body_quat_w=env.body_quat_relative_w,
+    )
+
+
+def write_relative_transforms(
+    *,
+    motion_body_pos_w: np.ndarray,
+    motion_body_quat_w: np.ndarray,
+    robot_body_pos_w: np.ndarray,
+    robot_body_quat_w: np.ndarray,
+    anchor_body_idx: int,
+    delta_pos_w: np.ndarray,
+    delta_ori_w: np.ndarray,
+    body_vec_error: np.ndarray,
+    scalar_scratch: np.ndarray,
+    scalar_scratch2: np.ndarray,
+    out_body_pos_w: np.ndarray,
+    out_body_quat_w: np.ndarray,
+) -> None:
+    """Write reference transforms using only declared array buffers."""
     # Get anchor states
-    anchor_pos_w = motion_data.body_pos_w[:, env.anchor_body_idx]
-    anchor_quat_w = motion_data.body_quat_w[:, env.anchor_body_idx]
-    robot_anchor_pos_w = robot_body_pos_w[:, env.anchor_body_idx]
-    robot_anchor_quat_w = robot_body_quat_w[:, env.anchor_body_idx]
+    anchor_pos_w = motion_body_pos_w[:, anchor_body_idx]
+    anchor_quat_w = motion_body_quat_w[:, anchor_body_idx]
+    robot_anchor_pos_w = robot_body_pos_w[:, anchor_body_idx]
+    robot_anchor_quat_w = robot_body_quat_w[:, anchor_body_idx]
 
     # Compute delta transform: keep robot's XY position, use motion's Z height
     # and apply yaw-only rotation difference.
-    delta_pos_w = env._delta_pos_w
     delta_pos_w[:] = robot_anchor_pos_w
     delta_pos_w[:, 2] = anchor_pos_w[:, 2]
 
     # Compute yaw-only rotation difference, equivalent to
     # np_yaw_quat(np_quat_mul(robot_anchor_quat_w, np_quat_inv(anchor_quat_w))).
-    delta_ori_w = env._delta_ori_w
     rw, rx, ry, rz = (
         robot_anchor_quat_w[:, 0],
         robot_anchor_quat_w[:, 1],
@@ -59,11 +89,11 @@ def update_relative_transforms(
     dz1 = delta_ori_w[:, 3]
     dw = dw1[:, None]
     dz = dz1[:, None]
-    mw = motion_data.body_quat_w[..., 0]
-    mx = motion_data.body_quat_w[..., 1]
-    my = motion_data.body_quat_w[..., 2]
-    mz = motion_data.body_quat_w[..., 3]
-    out_quat = env.body_quat_relative_w
+    mw = motion_body_quat_w[..., 0]
+    mx = motion_body_quat_w[..., 1]
+    my = motion_body_quat_w[..., 2]
+    mz = motion_body_quat_w[..., 3]
+    out_quat = out_body_quat_w
     out_quat[..., 0] = dw * mw
     out_quat[..., 0] -= dz * mz
     out_quat[..., 1] = dw * mx
@@ -73,16 +103,16 @@ def update_relative_transforms(
     out_quat[..., 3] = dw * mz
     out_quat[..., 3] += dz * mw
 
-    rel_pos = env._body_vec_error
+    rel_pos = body_vec_error
     vx = rel_pos[..., 0]
     vy = rel_pos[..., 1]
     vz = rel_pos[..., 2]
-    np.subtract(motion_data.body_pos_w[..., 0], anchor_pos_w[:, None, 0], out=vx)
-    np.subtract(motion_data.body_pos_w[..., 1], anchor_pos_w[:, None, 1], out=vy)
-    np.subtract(motion_data.body_pos_w[..., 2], anchor_pos_w[:, None, 2], out=vz)
+    np.subtract(motion_body_pos_w[..., 0], anchor_pos_w[:, None, 0], out=vx)
+    np.subtract(motion_body_pos_w[..., 1], anchor_pos_w[:, None, 1], out=vy)
+    np.subtract(motion_body_pos_w[..., 2], anchor_pos_w[:, None, 2], out=vz)
 
-    yaw_cross = env._env_error
-    yaw_z2 = env._reward_term
+    yaw_cross = scalar_scratch
+    yaw_z2 = scalar_scratch2
     np.multiply(dw1, dz1, out=yaw_cross)
     yaw_cross *= 2.0
     np.square(dz1, out=yaw_z2)
@@ -90,7 +120,7 @@ def update_relative_transforms(
     yaw_cross_2d = yaw_cross[:, None]
     yaw_z2_2d = yaw_z2[:, None]
 
-    out_pos = env.body_pos_relative_w
+    out_pos = out_body_pos_w
     out_pos[..., 0] = vx
     out_pos[..., 0] -= yaw_cross_2d * vy
     out_pos[..., 0] -= yaw_z2_2d * vx

--- a/src/unilab/envs/motion_tracking/g1/tracking.py
+++ b/src/unilab/envs/motion_tracking/g1/tracking.py
@@ -18,6 +18,7 @@ from unilab.base.scene import SceneCfg
 from ..common.config import (
     Domain_Rand,
     DomainRand,
+    MotionTermPlanConfig,
     MotionTrackingCfg,
     MotionTrackingDeployEnvCfg,
     PoseRandomization,
@@ -41,7 +42,7 @@ _build_motion_reference_state = build_motion_reference_state
 class G1MotionTrackingEnvCfg(MotionTrackingCfg):
     """Registered configuration for G1 motion tracking."""
 
-    pass
+    term_plan: MotionTermPlanConfig | None = field(default_factory=MotionTermPlanConfig)
 
 
 @registry.envcfg("G1MotionTrackingDeploy")

--- a/src/unilab/term/__init__.py
+++ b/src/unilab/term/__init__.py
@@ -1,0 +1,30 @@
+from .errors import TermBindingError, TermPlanError, TermRegistrationError
+from .plan import ResolvedTermPlan, resolve_term_plan
+from .registry import TermRegistry
+from .spec import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+)
+
+__all__ = [
+    "NamedTensorSpec",
+    "NumpyTermContext",
+    "ParameterKind",
+    "ParameterSpec",
+    "ResolvedTermPlan",
+    "TensorSpec",
+    "TermBindingError",
+    "TermConfig",
+    "TermDefinition",
+    "TermKind",
+    "TermPlanError",
+    "TermRegistrationError",
+    "TermRegistry",
+    "resolve_term_plan",
+]

--- a/src/unilab/term/errors.py
+++ b/src/unilab/term/errors.py
@@ -1,0 +1,17 @@
+"""Stable diagnostics for structured term registration and execution."""
+
+
+class TermContractError(ValueError):
+    """Base class for invalid term definitions, plans, or bound views."""
+
+
+class TermRegistrationError(TermContractError):
+    """Raised when a registry entry violates the definition contract."""
+
+
+class TermPlanError(TermContractError):
+    """Raised when configured terms cannot form one deterministic plan."""
+
+
+class TermBindingError(TermContractError):
+    """Raised when runtime arrays do not satisfy a resolved plan."""

--- a/src/unilab/term/numba.py
+++ b/src/unilab/term/numba.py
@@ -1,0 +1,348 @@
+"""Cold-path assembly and in-process caching for trusted Numba term plans."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from .errors import TermBindingError, TermPlanError
+from .plan import NumpyTermRuntime, ResolvedTermPlan
+from .spec import ParameterKind
+
+try:  # pragma: no cover - optional dependency boundary
+    from numba import njit, prange
+    from numba.np.ufunc.parallel import get_thread_id
+
+    NUMBA_AVAILABLE = True
+except Exception:  # pragma: no cover
+    get_thread_id = njit = prange = None  # type: ignore[assignment]
+    NUMBA_AVAILABLE = False
+
+
+@dataclass(frozen=True)
+class FusedOutputLayout:
+    """Route resolved term instances into fused task-owned outputs."""
+
+    rewards: tuple[str, ...]
+    observations: Mapping[str, tuple[str, ...]]
+    terminations: tuple[str, ...]
+    preambles: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rewards", tuple(self.rewards))
+        object.__setattr__(self, "terminations", tuple(self.terminations))
+        object.__setattr__(self, "preambles", tuple(self.preambles))
+        object.__setattr__(
+            self,
+            "observations",
+            MappingProxyType({name: tuple(terms) for name, terms in self.observations.items()}),
+        )
+
+
+@dataclass(frozen=True)
+class FusedCompileInfo:
+    cache_key: str
+    cache_hit: bool
+    assembly_ms: float
+
+
+class FusedNumbaRuntime:
+    def __init__(
+        self,
+        *,
+        plan: ResolvedTermPlan,
+        numpy_runtime: NumpyTermRuntime,
+        layout: FusedOutputLayout,
+        kernel: Any,
+        compile_info: FusedCompileInfo,
+        parameters: np.ndarray,
+        tuple_parameters: tuple[np.ndarray, ...],
+        inputs: Mapping[str, np.ndarray],
+        observations: Mapping[str, np.ndarray],
+        reward: np.ndarray,
+        terminated: np.ndarray,
+    ) -> None:
+        self.plan = plan
+        self.layout = layout
+        self.compile_info = compile_info
+        self._numpy_runtime = numpy_runtime
+        self._kernel = kernel
+        self._inputs = tuple(inputs[name] for name in plan.input_specs)
+        workspace = dict(numpy_runtime.workspace)
+        self.workspace: Mapping[str, np.ndarray] = MappingProxyType(workspace)
+        self._workspace_views = workspace
+        self._workspace = tuple(workspace[name] for name in plan.workspace_specs)
+        self._observations = tuple(observations[name] for name in layout.observations)
+        self.reward = reward
+        self.terminated = terminated
+        self._indices = {term.name: index for index, term in enumerate(plan.terms)}
+        self.scales = np.asarray([term.scale for term in plan.terms], dtype=np.float64)
+        self.parameters = parameters
+        self._tuple_parameters = tuple_parameters
+
+    def bind_inputs(self, inputs: Mapping[str, np.ndarray]) -> None:
+        """Rebind task-owned views, validating only identities that changed."""
+        views = []
+        for index, (name, spec) in enumerate(self.plan.input_specs.items()):
+            view = inputs.get(name)
+            if not isinstance(view, np.ndarray):
+                raise TermBindingError(f"missing ndarray input {name!r}")
+            if view is not self._inputs[index]:
+                expected = (self.reward.shape[0], *spec.shape)
+                if view.shape != expected or view.dtype != spec.numpy_dtype:
+                    raise TermBindingError(
+                        f"input {name!r} must have shape {expected} and dtype {spec.numpy_dtype}"
+                    )
+            views.append(view)
+        self._inputs = tuple(views)
+
+    def bind_workspace(self, name: str, view: np.ndarray) -> None:
+        """Bind a validated task-owned workspace view on the materialization path."""
+        spec = self.plan.workspace_specs.get(name)
+        if spec is None:
+            raise TermBindingError(f"unknown workspace {name!r}")
+        expected = (self.reward.shape[0], *spec.shape)
+        if view.shape != expected or view.dtype != spec.numpy_dtype:
+            raise TermBindingError(
+                f"workspace {name!r} must have shape {expected} and dtype {spec.numpy_dtype}"
+            )
+        self._workspace_views[name] = view
+        self._workspace = tuple(self._workspace_views[item] for item in self.plan.workspace_specs)
+
+    def set_scale(self, name: str, scale: float) -> None:
+        index = self._indices.get(name)
+        if index is None:
+            raise TermBindingError(f"unknown term instance {name!r}")
+        self._numpy_runtime.set_scale(name, scale)
+        self.scales[index] = float(scale)
+
+    def execute(self, *, reward_multiplier: float, log_scratch: np.ndarray) -> None:
+        self._kernel(
+            self._inputs,
+            self.parameters,
+            self._tuple_parameters,
+            self._workspace,
+            self.scales,
+            self._observations,
+            self.reward,
+            self.terminated,
+            log_scratch,
+            float(reward_multiplier),
+        )
+
+
+_KERNEL_CACHE: dict[str, Any] = {}
+
+
+def clear_numba_plan_cache() -> None:
+    """Test helper for deterministic cache-hit assertions."""
+    _KERNEL_CACHE.clear()
+
+
+def materialize_numba_plan(
+    plan: ResolvedTermPlan,
+    layout: FusedOutputLayout,
+    *,
+    num_envs: int,
+    inputs: Mapping[str, np.ndarray],
+    observations: Mapping[str, np.ndarray],
+    reward: np.ndarray,
+    terminated: np.ndarray,
+) -> FusedNumbaRuntime:
+    if not NUMBA_AVAILABLE:
+        raise RuntimeError("Numba fused term execution requires the optional numba dependency")
+    assert njit is not None
+    _validate_layout(plan, layout, observations, num_envs=num_envs)
+    numpy_runtime = plan.materialize(num_envs=num_envs, inputs=inputs)
+    parameters, tuple_parameters = _pack_parameters(plan)
+    _validate_numba_definitions(plan)
+    _validate_output("reward", reward, (num_envs,), np.floating)
+    _validate_output("terminated", terminated, (num_envs,), np.bool_)
+
+    key = _cache_key(plan, layout)
+    started = time.perf_counter()
+    kernel = _KERNEL_CACHE.get(key)
+    cache_hit = kernel is not None
+    if kernel is None:
+        function, _namespace = _build_kernel(plan, layout)
+        kernel = njit(parallel=True, fastmath=True, nogil=True)(function)
+        _KERNEL_CACHE[key] = kernel
+    info = FusedCompileInfo(key, cache_hit, (time.perf_counter() - started) * 1e3)
+    return FusedNumbaRuntime(
+        plan=plan,
+        numpy_runtime=numpy_runtime,
+        layout=layout,
+        kernel=kernel,
+        compile_info=info,
+        parameters=parameters,
+        tuple_parameters=tuple_parameters,
+        inputs=inputs,
+        observations=observations,
+        reward=reward,
+        terminated=terminated,
+    )
+
+
+def _validate_output(name: str, value: np.ndarray, shape: tuple[int, ...], dtype: Any) -> None:
+    if not isinstance(value, np.ndarray) or value.shape != shape:
+        raise TermBindingError(f"fused output {name!r} must have shape {shape}")
+    if dtype is np.bool_:
+        valid = value.dtype == np.dtype(np.bool_)
+    else:
+        valid = np.issubdtype(value.dtype, dtype)
+    if not valid:
+        raise TermBindingError(f"fused output {name!r} has invalid dtype {value.dtype}")
+
+
+def _validate_layout(
+    plan: ResolvedTermPlan,
+    layout: FusedOutputLayout,
+    observations: Mapping[str, np.ndarray],
+    *,
+    num_envs: int,
+) -> None:
+    routed = [*layout.preambles, *layout.rewards, *layout.terminations]
+    routed.extend(name for names in layout.observations.values() for name in names)
+    expected = [term.name for term in plan.terms]
+    if len(routed) != len(set(routed)) or set(routed) != set(expected):
+        raise TermPlanError("fused output layout must route every resolved term exactly once")
+    if set(observations) != set(layout.observations):
+        raise TermBindingError("fused observation buffers must exactly match the output layout")
+    for group, names in layout.observations.items():
+        width = sum(plan.output_specs[name].shape[0] for name in names)
+        value = observations.get(group)
+        _validate_output(group, value, (num_envs, width), np.floating)  # type: ignore[arg-type]
+
+
+def _pack_parameters(plan: ResolvedTermPlan) -> tuple[np.ndarray, tuple[np.ndarray, ...]]:
+    scalars: list[float] = []
+    tuples: list[np.ndarray] = []
+    for term in plan.terms:
+        for spec in term.definition.parameters:
+            value = term.parameters[spec.name]
+            if spec.tuple_value:
+                if not isinstance(value, tuple) or spec.kind is ParameterKind.STRING:
+                    raise TermPlanError(
+                        f"Numba fused term {term.name!r} requires numeric tuple parameters"
+                    )
+                dtype = {
+                    ParameterKind.BOOLEAN: np.bool_,
+                    ParameterKind.INTEGER: np.int64,
+                    ParameterKind.FLOAT: np.float64,
+                }[spec.kind]
+                tuples.append(np.asarray(value, dtype=dtype))
+            elif isinstance(value, (bool, int, float)):
+                scalars.append(float(value))
+            else:
+                raise TermPlanError(
+                    f"Numba fused term {term.name!r} requires scalar numeric parameters"
+                )
+    return np.asarray(scalars, dtype=np.float64), tuple(tuples)
+
+
+def _validate_numba_definitions(plan: ResolvedTermPlan) -> None:
+    missing = [term.definition.key for term in plan.terms if term.definition.numba_item_fn is None]
+    if missing:
+        raise TermPlanError(f"terms have no Numba item implementation: {missing}")
+
+
+def _cache_key(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> str:
+    def specs(items: Mapping[str, Any]) -> list[tuple[str, tuple[int, ...], str]]:
+        return [(name, spec.shape, spec.dtype) for name, spec in items.items()]
+
+    payload = {
+        "terms": [
+            (
+                term.name,
+                term.definition.key,
+                term.definition.implementation_version,
+                tuple(
+                    (spec.name, spec.kind.value, spec.tuple_value)
+                    for spec in term.definition.parameters
+                ),
+            )
+            for term in plan.terms
+        ],
+        "inputs": specs(plan.input_specs),
+        "workspace": specs(plan.workspace_specs),
+        "outputs": specs(plan.output_specs),
+        "layout": {
+            "preambles": layout.preambles,
+            "rewards": layout.rewards,
+            "observations": list(layout.observations.items()),
+            "terminations": layout.terminations,
+        },
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _build_kernel(plan: ResolvedTermPlan, layout: FusedOutputLayout) -> tuple[Any, dict[str, Any]]:
+    input_indices = {name: index for index, name in enumerate(plan.input_specs)}
+    workspace_indices = {name: index for index, name in enumerate(plan.workspace_specs)}
+    roles = {name: "preamble" for name in layout.preambles}
+    roles.update({name: "reward" for name in layout.rewards})
+    roles.update({name: "termination" for name in layout.terminations})
+    observation_routes = {}
+    for group_index, (group, names) in enumerate(layout.observations.items()):
+        offset = 0
+        for name in names:
+            roles[name] = "observation"
+            observation_routes[name] = (group_index, offset)
+            offset += plan.output_specs[name].shape[0]
+
+    namespace: dict[str, Any] = {"prange": prange, "get_thread_id": get_thread_id}
+    lines = [
+        "def fused(inputs, parameters, tuple_parameters, workspace, scales, observations, reward, terminated, log_scratch, reward_multiplier):",
+        "    n = reward.shape[0]",
+        "    for i in prange(n):",
+        "        tid = get_thread_id()",
+        "        reward[i] = 0.0",
+        "        terminated[i] = False",
+    ]
+    scalar_offset = tuple_offset = 0
+    for index, term in enumerate(plan.terms):
+        definition = term.definition
+        if definition.numba_item_fn is None:
+            raise TermPlanError(f"term {definition.key!r} has no Numba item implementation")
+        fn_name = f"item_{index}"
+        namespace[fn_name] = definition.numba_item_fn
+        args = [f"inputs[{input_indices[item.name]}]" for item in definition.inputs]
+        for spec in definition.parameters:
+            if spec.tuple_value:
+                args.append(f"tuple_parameters[{tuple_offset}]")
+                tuple_offset += 1
+            else:
+                args.append(f"parameters[{scalar_offset}]")
+                scalar_offset += 1
+        args.extend(f"workspace[{workspace_indices[item.name]}]" for item in definition.workspace)
+        joined = ", ".join(args)
+        joined = f"{joined}, " if joined else ""
+        role = roles[term.name]
+        lines.append(f"        if scales[{index}] != 0.0:")
+        if role == "reward":
+            lines.extend(
+                (
+                    f"            value = {fn_name}({joined}i)",
+                    f"            weighted = value * scales[{index}]",
+                    "            reward[i] += weighted",
+                    f"            log_scratch[tid, {index}] += weighted",
+                )
+            )
+        elif role == "termination":
+            lines.append(f"            terminated[i] |= {fn_name}({joined}i)")
+        elif role == "observation":
+            group_index, offset = observation_routes[term.name]
+            lines.append(f"            {fn_name}({joined}observations[{group_index}], {offset}, i)")
+        else:
+            lines.append(f"            {fn_name}({joined}i)")
+    lines.append("        reward[i] *= reward_multiplier")
+    exec("\n".join(lines), namespace)  # noqa: S102 - trusted registry functions only
+    return namespace["fused"], namespace

--- a/src/unilab/term/plan.py
+++ b/src/unilab/term/plan.py
@@ -1,0 +1,221 @@
+"""Cold-path term resolution and pre-bound NumPy Tier 1 execution."""
+
+from __future__ import annotations
+
+import math
+import numbers
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+
+from .errors import TermBindingError, TermContractError, TermPlanError, TermRegistrationError
+from .registry import TermRegistry
+from .spec import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterValue,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedTerm:
+    name: str
+    definition: TermDefinition
+    scale: float
+    parameters: Mapping[str, ParameterValue]
+
+
+@dataclass(frozen=True)
+class ResolvedTermPlan:
+    terms: tuple[ResolvedTerm, ...]
+    input_specs: Mapping[str, TensorSpec]
+    workspace_specs: Mapping[str, TensorSpec]
+    output_specs: Mapping[str, TensorSpec]
+
+    def materialize(self, *, num_envs: int, inputs: Mapping[str, np.ndarray]) -> NumpyTermRuntime:
+        """Validate input views once and allocate all owned buffers."""
+        if isinstance(num_envs, bool) or not isinstance(num_envs, numbers.Integral) or num_envs < 1:
+            raise TermBindingError(f"num_envs must be a positive integer; got {num_envs!r}")
+        count = int(num_envs)
+        bound_inputs: dict[str, np.ndarray] = {}
+        for name, spec in self.input_specs.items():
+            view = inputs.get(name)
+            if not isinstance(view, np.ndarray):
+                raise TermBindingError(f"missing ndarray input {name!r}")
+            expected_shape = (count, *spec.shape)
+            if view.shape != expected_shape:
+                raise TermBindingError(
+                    f"input {name!r} shape mismatch: {expected_shape} != {view.shape}"
+                )
+            if view.dtype != spec.numpy_dtype:
+                raise TermBindingError(
+                    f"input {name!r} dtype mismatch: {spec.numpy_dtype} != {view.dtype}"
+                )
+            bound_inputs[name] = view
+
+        outputs = _allocate(self.output_specs, count)
+        workspace = _allocate(self.workspace_specs, count)
+        bound: list[_BoundTerm] = []
+        for term in self.terms:
+            definition = term.definition
+            context = NumpyTermContext(
+                inputs=_select(definition.inputs, bound_inputs),
+                parameters=term.parameters,
+                output=outputs[term.name],
+                workspace=_select(definition.workspace, workspace),
+            )
+            bound.append(_BoundTerm(term=term, context=context))
+        return NumpyTermRuntime(terms=tuple(bound), outputs=outputs, workspace=workspace)
+
+
+@dataclass(frozen=True)
+class _BoundTerm:
+    term: ResolvedTerm
+    context: NumpyTermContext
+
+
+class NumpyTermRuntime:
+    """Pre-bound, allocation-stable Python dispatcher for vectorized terms."""
+
+    def __init__(
+        self,
+        *,
+        terms: tuple[_BoundTerm, ...],
+        outputs: dict[str, np.ndarray],
+        workspace: dict[str, np.ndarray],
+    ) -> None:
+        self._terms = terms
+        self._indices = {bound.term.name: index for index, bound in enumerate(terms)}
+        self._scales = np.asarray([bound.term.scale for bound in terms], dtype=np.float64)
+        self.outputs: Mapping[str, np.ndarray] = MappingProxyType(outputs)
+        self.workspace: Mapping[str, np.ndarray] = MappingProxyType(workspace)
+
+    def set_scale(self, name: str, scale: float) -> None:
+        """Update one runtime scale without rebuilding the resolved plan."""
+        index = self._indices.get(name)
+        if index is None:
+            raise TermBindingError(f"unknown term instance {name!r}")
+        self._scales[index] = _validate_scale(
+            self._terms[index].term.definition, scale, name=name, error_type=TermBindingError
+        )
+
+    def execute(self) -> Mapping[str, np.ndarray]:
+        """Execute in config order using only pre-bound views and buffers."""
+        for index, bound in enumerate(self._terms):
+            scale = self._scales[index]
+            output = bound.context.output
+            if scale == 0.0:
+                output.fill(0)
+                continue
+            bound.term.definition.numpy_fn(bound.context)
+            if scale != 1.0:
+                np.multiply(output, scale, out=output)
+        return self.outputs
+
+
+def resolve_term_plan(registry: TermRegistry, configs: Sequence[TermConfig]) -> ResolvedTermPlan:
+    """Resolve config declaration order into one immutable execution plan."""
+    terms: list[ResolvedTerm] = []
+    seen_names: set[str] = set()
+    input_specs: dict[str, TensorSpec] = {}
+    workspace_specs: dict[str, TensorSpec] = {}
+    output_specs: dict[str, TensorSpec] = {}
+
+    for config in configs:
+        if config.name in seen_names:
+            raise TermPlanError(f"duplicate term instance name {config.name!r}")
+        seen_names.add(config.name)
+        definition = registry.resolve(config.term_key)
+        parameters = _resolve_parameters(definition, config.parameters)
+        scale = _validate_scale(definition, config.scale, name=config.name)
+        for item in definition.inputs:
+            _merge_tensor_spec(input_specs, item, owner=definition.key, category="input")
+        for item in definition.workspace:
+            _merge_tensor_spec(workspace_specs, item, owner=definition.key, category="workspace")
+        terms.append(ResolvedTerm(config.name, definition, scale, parameters))
+        output_specs[config.name] = definition.output
+
+    namespace_overlap = set(input_specs) & set(workspace_specs)
+    if namespace_overlap:
+        raise TermPlanError(
+            f"plan uses names as both input and workspace: {sorted(namespace_overlap)}"
+        )
+    return ResolvedTermPlan(
+        terms=tuple(terms),
+        input_specs=MappingProxyType(input_specs),
+        workspace_specs=MappingProxyType(workspace_specs),
+        output_specs=MappingProxyType(output_specs),
+    )
+
+
+def _allocate(specs: Mapping[str, TensorSpec], count: int) -> dict[str, np.ndarray]:
+    return {
+        name: np.zeros((count, *spec.shape), dtype=spec.numpy_dtype) for name, spec in specs.items()
+    }
+
+
+def _select(
+    specs: Sequence[NamedTensorSpec], views: Mapping[str, np.ndarray]
+) -> Mapping[str, np.ndarray]:
+    return MappingProxyType({item.name: views[item.name] for item in specs})
+
+
+def _merge_tensor_spec(
+    merged: dict[str, TensorSpec],
+    item: NamedTensorSpec,
+    *,
+    owner: str,
+    category: str,
+) -> None:
+    existing = merged.get(item.name)
+    if existing is not None and existing != item.tensor:
+        raise TermPlanError(
+            f"{category} {item.name!r} has conflicting specs: {existing!r} vs "
+            f"{item.tensor!r} from term {owner!r}"
+        )
+    merged[item.name] = item.tensor
+
+
+def _resolve_parameters(
+    definition: TermDefinition, configured: Mapping[str, object]
+) -> Mapping[str, ParameterValue]:
+    specs = {item.name: item for item in definition.parameters}
+    unknown = set(configured) - set(specs)
+    if unknown:
+        raise TermPlanError(f"term {definition.key!r} has unknown parameters {sorted(unknown)}")
+    resolved: dict[str, ParameterValue] = {}
+    for name, spec in specs.items():
+        if name in configured:
+            value = configured[name]
+        elif spec.required:
+            raise TermPlanError(f"term {definition.key!r} is missing parameter {name!r}")
+        else:
+            value = spec.default
+        try:
+            resolved[name] = spec.normalize(value)
+        except TermRegistrationError as exc:
+            raise TermPlanError(f"term {definition.key!r}: {exc}") from exc
+    return MappingProxyType(resolved)
+
+
+def _validate_scale(
+    definition: TermDefinition,
+    scale: object,
+    *,
+    name: str,
+    error_type: type[TermContractError] = TermPlanError,
+) -> float:
+    if isinstance(scale, bool) or not isinstance(scale, numbers.Real):
+        raise error_type(f"term {name!r} scale must be a finite scalar")
+    normalized = float(scale)
+    if not math.isfinite(normalized):
+        raise error_type(f"term {name!r} scale must be finite")
+    if definition.kind is TermKind.TERMINATION and normalized not in (0.0, 1.0):
+        raise error_type(f"termination term {name!r} scale must be 0.0 or 1.0; got {normalized}")
+    return normalized

--- a/src/unilab/term/registry.py
+++ b/src/unilab/term/registry.py
@@ -1,0 +1,23 @@
+"""Explicit registry for trusted term implementations."""
+
+from __future__ import annotations
+
+from .errors import TermPlanError, TermRegistrationError
+from .spec import TermDefinition
+
+
+class TermRegistry:
+    def __init__(self) -> None:
+        self._definitions: dict[str, TermDefinition] = {}
+
+    def register(self, definition: TermDefinition) -> TermDefinition:
+        if definition.key in self._definitions:
+            raise TermRegistrationError(f"term key {definition.key!r} is already registered")
+        self._definitions[definition.key] = definition
+        return definition
+
+    def resolve(self, key: str) -> TermDefinition:
+        try:
+            return self._definitions[key]
+        except KeyError as exc:
+            raise TermPlanError(f"unknown term key {key!r}") from exc

--- a/src/unilab/term/spec.py
+++ b/src/unilab/term/spec.py
@@ -1,0 +1,233 @@
+"""Data-only contracts for config-resolved numeric terms."""
+
+from __future__ import annotations
+
+import math
+import numbers
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import DTypeLike
+
+from .errors import TermRegistrationError
+
+_NAME = re.compile(r"^[a-z][a-z0-9_.-]*$")
+ParameterValue: TypeAlias = bool | int | float | str | tuple[bool | int | float | str, ...]
+
+
+class TermKind(str, Enum):
+    REWARD = "reward"
+    OBSERVATION = "observation"
+    TERMINATION = "termination"
+
+
+class ParameterKind(str, Enum):
+    FLOAT = "float"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    STRING = "string"
+
+
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+def _valid_name(value: str, label: str) -> None:
+    if not _NAME.fullmatch(value):
+        raise TermRegistrationError(f"{label} must match {_NAME.pattern!r}; got {value!r}")
+
+
+def _scalar(value: object, kind: ParameterKind, label: str) -> bool | int | float | str:
+    if kind is ParameterKind.BOOLEAN and isinstance(value, bool):
+        return value
+    if kind is ParameterKind.STRING and isinstance(value, str):
+        return value
+    if kind is ParameterKind.INTEGER:
+        if not isinstance(value, bool) and isinstance(value, numbers.Integral):
+            return int(value)
+    if kind is ParameterKind.FLOAT:
+        if not isinstance(value, bool) and isinstance(value, numbers.Real):
+            result = float(value)
+            if math.isfinite(result):
+                return result
+    raise TermRegistrationError(f"{label} must be {kind.value}")
+
+
+def _config_value(value: object, label: str) -> ParameterValue:
+    if isinstance(value, (list, tuple)):
+        items = tuple(_config_value(item, label) for item in value)
+        if any(isinstance(item, tuple) for item in items):
+            raise TermRegistrationError(f"{label} must be a flat scalar tuple")
+        return items  # type: ignore[return-value]
+    if isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    if isinstance(value, numbers.Real) and math.isfinite(float(value)):
+        return float(value)
+    raise TermRegistrationError(f"{label} must be a finite scalar or flat scalar tuple")
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    """Batched tensor shape without the leading environment dimension."""
+
+    shape: tuple[int, ...]
+    dtype: DTypeLike
+
+    def __post_init__(self) -> None:
+        shape = tuple(self.shape)
+        if any(
+            isinstance(dim, bool) or not isinstance(dim, numbers.Integral) or dim <= 0
+            for dim in shape
+        ):
+            raise TermRegistrationError(f"tensor dimensions must be positive: {shape!r}")
+        try:
+            dtype = np.dtype(self.dtype)
+        except TypeError as exc:
+            raise TermRegistrationError(f"invalid tensor dtype {self.dtype!r}") from exc
+        if dtype != np.dtype(np.bool_) and not np.issubdtype(dtype, np.number):
+            raise TermRegistrationError(f"tensor dtype must be numeric or bool; got {dtype.name}")
+        object.__setattr__(self, "shape", tuple(int(dim) for dim in shape))
+        object.__setattr__(self, "dtype", dtype.str)
+
+    @property
+    def numpy_dtype(self) -> np.dtype:
+        return np.dtype(self.dtype)
+
+
+@dataclass(frozen=True)
+class NamedTensorSpec:
+    name: str
+    tensor: TensorSpec
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "tensor name")
+
+
+@dataclass(frozen=True)
+class ParameterSpec:
+    name: str
+    kind: ParameterKind
+    tuple_value: bool = False
+    default: ParameterValue | _Missing = _MISSING
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "parameter name")
+        if not isinstance(self.kind, ParameterKind):
+            raise TermRegistrationError(f"invalid parameter kind {self.kind!r}")
+        if not isinstance(self.default, _Missing):
+            object.__setattr__(self, "default", self.normalize(self.default))
+
+    @property
+    def required(self) -> bool:
+        return isinstance(self.default, _Missing)
+
+    def normalize(self, value: object) -> ParameterValue:
+        label = f"parameter {self.name!r}"
+        if not self.tuple_value:
+            return _scalar(value, self.kind, label)
+        if not isinstance(value, (list, tuple)):
+            raise TermRegistrationError(f"{label} must be a tuple of {self.kind.value}")
+        return tuple(_scalar(item, self.kind, label) for item in value)
+
+
+@dataclass(frozen=True)
+class NumpyTermContext:
+    inputs: Mapping[str, np.ndarray]
+    parameters: Mapping[str, ParameterValue]
+    output: np.ndarray
+    workspace: Mapping[str, np.ndarray]
+
+
+NumpyTermFn: TypeAlias = Callable[[NumpyTermContext], None]
+NumbaItemFn: TypeAlias = Callable[..., None]
+
+
+@dataclass(frozen=True)
+class TermDefinition:
+    """Trusted implementation plus cold-path requirements.
+
+    A fused Numba item receives inputs, parameters, workspace, and the row index
+    in declaration order. Reward/termination items return a scalar; observation
+    items additionally receive the destination buffer and column offset. It is
+    metadata in Tier 1.
+    """
+
+    key: str
+    kind: TermKind
+    numpy_fn: NumpyTermFn
+    output: TensorSpec
+    inputs: tuple[NamedTensorSpec, ...] = field(default_factory=tuple)
+    workspace: tuple[NamedTensorSpec, ...] = field(default_factory=tuple)
+    parameters: tuple[ParameterSpec, ...] = field(default_factory=tuple)
+    numba_item_fn: NumbaItemFn | None = None
+    implementation_version: int = 1
+
+    def __post_init__(self) -> None:
+        _valid_name(self.key, "term key")
+        if not isinstance(self.kind, TermKind) or not callable(self.numpy_fn):
+            raise TermRegistrationError(f"term {self.key!r} has an invalid kind or numpy_fn")
+        if self.numba_item_fn is not None and not callable(self.numba_item_fn):
+            raise TermRegistrationError(f"term {self.key!r} numba_item_fn must be callable")
+        if (
+            isinstance(self.implementation_version, bool)
+            or not isinstance(self.implementation_version, numbers.Integral)
+            or self.implementation_version < 1
+        ):
+            raise TermRegistrationError(f"term {self.key!r} version must be a positive integer")
+        object.__setattr__(self, "implementation_version", int(self.implementation_version))
+        object.__setattr__(self, "inputs", tuple(self.inputs))
+        object.__setattr__(self, "workspace", tuple(self.workspace))
+        object.__setattr__(self, "parameters", tuple(self.parameters))
+        for label, items in (
+            ("input", self.inputs),
+            ("workspace", self.workspace),
+            ("parameter", self.parameters),
+        ):
+            names = [item.name for item in items]
+            if len(names) != len(set(names)):
+                raise TermRegistrationError(f"term {self.key!r} declares duplicate {label}")
+        overlap = {item.name for item in self.inputs} & {item.name for item in self.workspace}
+        if overlap:
+            raise TermRegistrationError(f"term {self.key!r} overlaps input/workspace {overlap}")
+        dtype = self.output.numpy_dtype
+        if self.kind is TermKind.TERMINATION and dtype != np.dtype(np.bool_):
+            raise TermRegistrationError(f"termination term {self.key!r} output must use bool dtype")
+        if self.kind is not TermKind.TERMINATION and not np.issubdtype(dtype, np.floating):
+            raise TermRegistrationError(
+                f"{self.kind.value} term {self.key!r} output must use a floating dtype"
+            )
+
+
+@dataclass(frozen=True)
+class TermConfig:
+    name: str
+    term_key: str
+    scale: float = 1.0
+    parameters: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _valid_name(self.name, "term instance name")
+        _valid_name(self.term_key, "term key")
+        if isinstance(self.scale, bool) or not isinstance(self.scale, numbers.Real):
+            raise TermRegistrationError(f"term {self.name!r} scale must be finite")
+        scale = float(self.scale)
+        if not math.isfinite(scale):
+            raise TermRegistrationError(f"term {self.name!r} scale must be finite")
+        parameters = {
+            name: _config_value(value, f"parameter {name!r}")
+            for name, value in self.parameters.items()
+        }
+        for name in parameters:
+            _valid_name(name, "parameter name")
+        object.__setattr__(self, "scale", scale)
+        object.__setattr__(self, "parameters", MappingProxyType(parameters))

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -11,6 +11,8 @@ from omegaconf import OmegaConf
 
 from unilab.base import registry
 from unilab.base.registry import ensure_registries
+from unilab.envs.locomotion.g1 import terms as g1_terms
+from unilab.envs.locomotion.g1.joystick import G1WalkRewardConfig
 from unilab.training.backend_adapter import BackendAdapter
 
 ROOT_DIR = Path(__file__).parents[4]
@@ -263,3 +265,93 @@ def test_g1_walk_tasks_are_registered():
 
     assert registry.contains("G1WalkFlat")
     assert registry.contains("G1WalkRough")
+
+
+def test_g1_flat_term_plan_matches_legacy_numpy_and_reuses_outputs():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    env = cast(
+        Any,
+        registry.make("G1WalkFlat", sim_backend="mujoco", num_envs=2, env_cfg_override=override),
+    )
+    try:
+        env._cfg.noise_config.level = 0.0
+        rng = np.random.default_rng(7)
+        info = {
+            "steps": np.zeros(2, dtype=np.uint32),
+            "commands": rng.normal(size=(2, 3)).astype(np.float32),
+            "current_actions": rng.normal(size=(2, 29)).astype(np.float32),
+            "last_actions": rng.normal(size=(2, 29)).astype(np.float32),
+            "gait_phase": rng.uniform(0, 2 * np.pi, size=(2, 2)).astype(np.float32),
+        }
+        linvel = rng.normal(size=(2, 3)).astype(np.float32)
+        gyro = rng.normal(size=(2, 3)).astype(np.float32)
+        gravity = np.tile(np.array([0.01, -0.02, 0.99], np.float32), (2, 1))
+        dof_pos = rng.normal(size=(2, 29)).astype(np.float32)
+        dof_vel = rng.normal(size=(2, 29)).astype(np.float32)
+
+        expected_reward = env._compute_reward(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        expected_obs = env._compute_legacy_obs(info, linvel, gyro, gravity, dof_pos, dof_vel)
+        expected_terminated = (np.arccos(gravity[:, 2]) > np.deg2rad(25.0)) | (
+            env._backend.get_base_pos()[:, 2] < 0.55
+        )
+        obs, reward, terminated = env._compute_term_state(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        output_ids = (id(obs["obs"]), id(obs["critic"]), id(reward), id(terminated))
+
+        np.testing.assert_allclose(reward, expected_reward, rtol=2e-6, atol=2e-6)
+        np.testing.assert_allclose(obs["obs"], expected_obs["obs"], rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(obs["critic"], expected_obs["critic"], rtol=1e-6, atol=1e-6)
+        np.testing.assert_array_equal(terminated, expected_terminated)
+        repeated = env._compute_term_state(
+            {**info, "log": {}}, linvel, gyro, gravity, dof_pos, dof_vel
+        )
+        assert tuple(id(value) for value in (*repeated[0].values(), *repeated[1:])) == output_ids
+    finally:
+        env.close()
+
+
+def test_g1_flat_term_config_controls_layout_and_reward_scale():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    cfg.env.term_plan.observations.obs = list(reversed(cfg.env.term_plan.observations.obs[:-1]))
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    env = cast(
+        Any,
+        registry.make("G1WalkFlat", sim_backend="mujoco", num_envs=1, env_cfg_override=override),
+    )
+    try:
+        assert env.obs_groups_spec == {"obs": 96, "critic": 101}
+        assert [name for name, _ in env.get_symmetry_obs_layouts()["obs"]] == [
+            "command",
+            "actions",
+            "dof_vel",
+            "dof_pos",
+            "gravity",
+            "gyro",
+        ]
+        assert "feet_phase" in dict(env._active_term_rewards)
+        env._reward_cfg.scales["feet_phase"] = 0.0
+        env._sync_term_reward_scales()
+        assert "feet_phase" not in dict(env._active_term_rewards)
+        env._reward_cfg.scales["feet_phase"] = 1.0
+        env._sync_term_reward_scales()
+        assert "feet_phase" in dict(env._active_term_rewards)
+    finally:
+        env.close()
+
+
+def test_g1_flat_term_plan_rejects_unknown_nonzero_reward():
+    cfg = _compose_cfg("ppo", ["task=g1_walk_flat/mujoco"])
+    reward_cfg = G1WalkRewardConfig(**OmegaConf.to_container(cfg.reward, resolve=True))
+    reward_cfg.scales["custom"] = 1.0
+    with pytest.raises(g1_terms.TermPlanError, match="unknown nonzero reward"):
+        g1_terms.resolve_g1_walk_term_plan(
+            num_action=29,
+            reward_cfg=reward_cfg,
+            observations=g1_terms.DEFAULT_OBSERVATION_TERMS,
+            terminations=g1_terms.DEFAULT_TERMINATION_TERMS,
+            walk_profile=False,
+        )

--- a/tests/envs/locomotion/g1/test_joystick_numba.py
+++ b/tests/envs/locomotion/g1/test_joystick_numba.py
@@ -50,6 +50,7 @@ class _Backend:
 class _Cfg:
     ctrl_dt = 0.02
     noise_config = None
+    term_plan = None
 
 
 class _NoiseCfg:
@@ -61,6 +62,31 @@ class _NoiseCfg:
 
 
 class _RewardCfg:
+    scales = {
+        name: 0.0
+        for name in (
+            "tracking_lin_vel",
+            "tracking_ang_vel",
+            "forward_progress",
+            "under_speed",
+            "lin_vel_z",
+            "orientation",
+            "penalty_orientation",
+            "ang_vel_xy",
+            "penalty_ang_vel_xy",
+            "action_rate",
+            "penalty_action_rate",
+            "base_height",
+            "pose",
+            "upper_body_pose",
+            "penalty_feet_ori",
+            "feet_phase",
+            "feet_phase_contrast",
+            "feet_phase_contact",
+            "feet_double_stance",
+            "alive",
+        )
+    }
     tracking_sigma = 0.25
     base_height_target = 0.754
     min_base_height = 0.3
@@ -73,17 +99,25 @@ class _RewardCfg:
 
 class _Env:
     def __init__(self, n: int, n_action: int):
+        from unilab.envs.locomotion.g1.joystick import G1WalkEnv, G1WalkTermPlanConfig
+
         self.num_envs = n
         self._num_envs = n
         self._num_action = n_action
         self._cfg = _Cfg()
         self._cfg.noise_config = _NoiseCfg()
+        self._cfg.term_plan = G1WalkTermPlanConfig()
         self._reward_cfg = _RewardCfg()
         self._enable_reward_log = True
         self.default_angles = np.zeros((n_action,), dtype=np.float32)
         self._pose_weights = np.ones((n_action,), dtype=np.float32)
         self._upper_body_pose_weights = np.ones((n_action,), dtype=np.float32)
         self._backend = _Backend(n)
+        self._copy_term_input = G1WalkEnv._copy_term_input
+        self._populate_term_inputs = G1WalkEnv._populate_term_inputs.__get__(self, G1WalkEnv)
+        self._obs_noise = lambda data, scale: np.asarray(
+            data + self._cfg.noise_config.level * scale, dtype=data.dtype
+        )
 
     @property
     def obs_groups_spec(self):
@@ -276,7 +310,7 @@ def test_g1_walk_numba_update_state_parity_without_noise():
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
-def test_g1_walk_numba_update_state_rejects_noise():
+def test_g1_walk_numba_update_state_supports_owner_generated_noise():
     env = _Env(8, 29)
     accel = G1WalkNumbaAccelerator.from_env(env, num_threads=1)
     arrays = {
@@ -286,18 +320,36 @@ def test_g1_walk_numba_update_state_rejects_noise():
         "dof_pos": np.zeros((8, 29), dtype=np.float32),
         "dof_vel": np.zeros((8, 29), dtype=np.float32),
     }
-    with pytest.raises(RuntimeError, match="does not support observation noise"):
-        accel.compute_update_state(
-            env=env,
-            info={
-                "steps": np.zeros((8,), dtype=np.uint32),
-                "commands": np.zeros((8, 3), dtype=np.float32),
-            },
-            scales={"tracking_lin_vel": 1.0},
-            enable_log=False,
-            noise_level=1.0,
-            **arrays,
-        )
+    env._cfg.noise_config.level = 1.0
+    out = accel.compute_update_state(
+        env=env,
+        info={
+            "steps": np.zeros((8,), dtype=np.uint32),
+            "commands": np.zeros((8, 3), dtype=np.float32),
+        },
+        scales={"tracking_lin_vel": 1.0},
+        enable_log=False,
+        noise_level=1.0,
+        **arrays,
+    )
+    np.testing.assert_allclose(out.obs["obs"][:, :3], 0.025)
+    np.testing.assert_array_equal(out.obs["critic"][:, :3], 0.0)
+    reward_id = id(out.reward)
+    obs_ids = {name: id(value) for name, value in out.obs.items()}
+    again = accel.compute_update_state(
+        env=env,
+        info={
+            "steps": np.zeros((8,), dtype=np.uint32),
+            "commands": np.zeros((8, 3), dtype=np.float32),
+        },
+        scales={"tracking_lin_vel": 1.0},
+        enable_log=False,
+        noise_level=1.0,
+        **arrays,
+    )
+    assert accel.first_jit_ms is not None
+    assert id(again.reward) == reward_id
+    assert {name: id(value) for name, value in again.obs.items()} == obs_ids
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
@@ -314,8 +366,8 @@ def test_g1_walk_numba_term_py_funcs_match_numpy_math():
     dof_pos = rng.normal(size=(n, n_action)).astype(np.float32)
     current_actions = rng.normal(size=(n, n_action)).astype(np.float32)
     last_actions = rng.normal(size=(n, n_action)).astype(np.float32)
-    default_angles = rng.normal(size=(n_action,)).astype(np.float32)
-    weights = rng.uniform(0.1, 2.0, size=(n_action,)).astype(np.float32)
+    default_angles = rng.normal(size=(n, n_action)).astype(np.float32)
+    weights = rng.uniform(0.1, 2.0, size=(n, n_action)).astype(np.float32)
     base_height = rng.uniform(0.4, 0.9, size=(n,)).astype(np.float32)
     gait_phase = rng.uniform(0.0, 2 * np.pi, size=(n, 2)).astype(np.float32)
     left_foot_pos = rng.normal(size=(n, 3)).astype(np.float32)
@@ -324,7 +376,6 @@ def test_g1_walk_numba_term_py_funcs_match_numpy_math():
     right_foot_quat = rng.normal(size=(n, 4)).astype(np.float32)
     left_contact = np.array([True, False, True])
     right_contact = np.array([True, True, False])
-    feet_air_time = rng.uniform(0.0, 0.8, size=(n, 2)).astype(np.float32)
 
     i = 1
     tracking_sigma = 0.25
@@ -332,7 +383,6 @@ def test_g1_walk_numba_term_py_funcs_match_numpy_math():
     swing_height = 0.09
     feet_sigma = 0.04
     min_forward_speed = 0.0
-    close_feet_threshold = 0.15
 
     np.testing.assert_allclose(
         T.tracking_lin_vel_i.py_func(linvel, commands, tracking_sigma, i),
@@ -356,33 +406,24 @@ def test_g1_walk_numba_term_py_funcs_match_numpy_math():
     )
     assert T.ang_vel_xy_i.py_func(gyro, i) == pytest.approx(gyro[i, 0] ** 2 + gyro[i, 1] ** 2)
     np.testing.assert_allclose(
-        T.action_rate_i.py_func(current_actions, last_actions, n_action, i),
+        T.action_rate_plan_i.py_func(current_actions, last_actions, i),
         np.sum((current_actions[i] - last_actions[i]) ** 2),
     )
     np.testing.assert_allclose(
-        T.weighted_pose_i.py_func(dof_pos, default_angles, weights, n_action, i),
-        np.sum(weights * (dof_pos[i] - default_angles) ** 2),
+        T.weighted_pose_plan_i.py_func(dof_pos, default_angles, weights, i),
+        np.sum(weights[i] * (dof_pos[i] - default_angles[i]) ** 2),
+        rtol=2e-6,
     )
     assert T.base_height_i.py_func(base_height, base_height_target, i) == pytest.approx(
         (base_height[i] - base_height_target) ** 2
     )
 
-    feet_dist = np.linalg.norm(left_foot_pos[i, :2] - right_foot_pos[i, :2])
-    close_feet = (
-        (feet_dist - close_feet_threshold) ** 2 if feet_dist < close_feet_threshold else 0.0
-    )
-    assert T.close_feet_xy_i.py_func(
-        left_foot_pos, right_foot_pos, close_feet_threshold, i
-    ) == pytest.approx(close_feet)
     np.testing.assert_allclose(
         T.feet_ori_i.py_func(left_foot_quat, right_foot_quat, i),
         left_foot_quat[i, 1] ** 2
         + left_foot_quat[i, 2] ** 2
         + right_foot_quat[i, 1] ** 2
         + right_foot_quat[i, 2] ** 2,
-    )
-    assert T.feet_air_time_i.py_func(feet_air_time, i) == pytest.approx(
-        np.sum((feet_air_time[i] > 0.05) & (feet_air_time[i] < 0.5))
     )
     assert T.terminated_i.py_func(gravity, base_height, np.deg2rad(65.0), 0.3, i) == pytest.approx(
         np.arccos(np.clip(gravity[i, 2], -1.0, 1.0)) > np.deg2rad(65.0) or base_height[i] < 0.3

--- a/tests/envs/test_g1_motion_tracking_numba.py
+++ b/tests/envs/test_g1_motion_tracking_numba.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
+from unilab.envs.motion_tracking.common import observations
+from unilab.envs.motion_tracking.common.config import MotionTermPlanConfig
 from unilab.envs.motion_tracking.common.numba import (
     NUMBA_AVAILABLE,
     MotionTrackingNumbaAccelerator,
@@ -35,8 +37,72 @@ def test_numba_accelerator_rejects_unsupported_active_reward_terms():
     env = _make_env(8, include_undesired=False)
     env._cfg.reward_config.scales = {"motion_body_pos": 1.0, "custom": 1.0}
     if NUMBA_AVAILABLE:
-        with pytest.raises(ValueError, match="does not support active reward terms"):
+        with pytest.raises(ValueError, match="unknown nonzero reward term"):
             MotionTrackingNumbaAccelerator.from_env(env)
+
+
+def test_motion_term_plan_matches_legacy_numpy_and_reuses_workspace():
+    n = 8
+    env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
+    env._cfg.noise_config.level = 1.0
+
+    motion_data, robot_state, info = _make_batch(n, seed=11)
+    body_pos, body_quat, body_linvel, body_angvel, dof_pos, dof_vel = robot_state
+    rng = np.random.default_rng(12)
+    linvel = rng.normal(size=(n, 3)).astype(np.float32)
+    gyro = rng.normal(size=(n, 3)).astype(np.float32)
+    env._update_relative_transforms(motion_data, body_pos, body_quat)
+    expected_termination = env._compute_terminations(motion_data, body_pos, body_quat).copy()
+    expected_reward = env._compute_reward(
+        {**info, "log": {}},
+        motion_data,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+        dof_pos,
+        dof_vel,
+    ).copy()
+    np.random.seed(13)
+    expected_obs = observations.compute_obs(
+        env, info, motion_data, linvel, gyro, dof_pos, dof_vel, body_pos, body_quat
+    )
+    expected_obs = {name: value.copy() for name, value in expected_obs.items()}
+
+    env._init_term_plan(MotionTermPlanConfig())
+    np.random.seed(13)
+    actual = env._compute_term_state(
+        {**info, "log": {}},
+        motion_data,
+        linvel,
+        gyro,
+        dof_pos,
+        dof_vel,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+    )
+    workspace_ids = tuple(id(value) for value in env._term_runtime.workspace.values())
+
+    np.testing.assert_allclose(actual[0]["obs"], expected_obs["obs"], rtol=2e-5, atol=2e-5)
+    np.testing.assert_allclose(actual[0]["critic"], expected_obs["critic"], rtol=2e-5, atol=2e-5)
+    np.testing.assert_allclose(actual[1], expected_reward, rtol=2e-5, atol=2e-5)
+    np.testing.assert_array_equal(actual[2], expected_termination)
+    env._compute_term_state(
+        {**info, "log": {}},
+        motion_data,
+        linvel,
+        gyro,
+        dof_pos,
+        dof_vel,
+        body_pos,
+        body_quat,
+        body_linvel,
+        body_angvel,
+    )
+    assert tuple(id(value) for value in env._term_runtime.workspace.values()) == workspace_ids
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
@@ -44,6 +110,7 @@ def test_numba_accelerator_rejects_unsupported_active_reward_terms():
 def test_g1_motion_tracking_numba_reward_termination_parity():
     n = 512
     env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
     motion_data, robot_state, info = _make_batch(n, seed=0)
     (
         robot_body_pos_w,
@@ -69,15 +136,15 @@ def test_g1_motion_tracking_numba_reward_termination_parity():
     log_np = dict(info["log"])
 
     accel = MotionTrackingNumbaAccelerator.from_env(env, num_threads=2)
-    out = accel.compute(
+    out = accel.compute_update_state(
         info={
             "steps": np.zeros((n,), dtype=np.uint32),
             "current_actions": info["current_actions"],
             "last_actions": info["last_actions"],
         },
         motion_data=motion_data,
-        ref_body_pos_w=env.body_pos_relative_w,
-        ref_body_quat_w=env.body_quat_relative_w,
+        linvel=np.zeros((n, 3), dtype=np.float32),
+        gyro=np.zeros((n, 3), dtype=np.float32),
         robot_body_pos_w=robot_body_pos_w,
         robot_body_quat_w=robot_body_quat_w,
         robot_body_lin_vel_w=robot_body_lin_vel_w,
@@ -100,17 +167,7 @@ def test_g1_motion_tracking_numba_reward_termination_parity():
 def test_g1_motion_tracking_numba_update_state_parity_without_noise():
     n = 512
     env = _make_env(n, include_undesired=True)
-    env.default_angles = np.linspace(-0.2, 0.2, env._num_action).astype(np.float32)
-    env._actor_obs_width = env._actor_obs_dim(env._num_action)
-    env._critic_base_obs_width = env._critic_base_obs_dim(env._num_action)
-    env._critic_obs_width = env._critic_base_obs_width + env._n_motion_bodies * 9
-    env._motion_anchor_pos_b = np.empty((n, 3), dtype=np.float32)
-    env._motion_anchor_ori_b = np.empty((n, 6), dtype=np.float32)
-    env._joint_pos_rel = np.empty((n, env._num_action), dtype=np.float32)
-    env._motion_command = np.empty((n, env._num_action * 2), dtype=np.float32)
-    env._zero_actions = np.zeros((n, env._num_action), dtype=np.float32)
-    env._body_vec_tmp = np.empty((n, env._n_motion_bodies, 3), dtype=np.float32)
-    env._cfg.noise_config = _NoiseCfg()
+    _prepare_observation_buffers(env, n)
 
     motion_data, robot_state, info = _make_batch(n, seed=2)
     (
@@ -160,24 +217,64 @@ def test_g1_motion_tracking_numba_update_state_parity_without_noise():
         robot_body_quat_w=robot_body_quat_w,
         robot_body_lin_vel_w=robot_body_lin_vel_w,
         robot_body_ang_vel_w=robot_body_ang_vel_w,
-        ref_body_pos_w=env.body_pos_relative_w,
-        ref_body_quat_w=env.body_quat_relative_w,
-        motion_anchor_pos_b=env._motion_anchor_pos_b,
-        motion_anchor_ori_b=env._motion_anchor_ori_b,
-        joint_pos_rel=env._joint_pos_rel,
         scales=env._cfg.reward_config.scales,
         enable_log=True,
-        noise_level=0.0,
-        noise_scale_linvel=0.0,
-        noise_scale_gyro=0.0,
-        noise_scale_joint_angle=0.0,
-        noise_scale_joint_vel=0.0,
     )
 
     np.testing.assert_allclose(out.reward, reward_np, rtol=1e-4, atol=1e-5)
     np.testing.assert_array_equal(out.terminated, terminated_np)
     np.testing.assert_allclose(out.obs["obs"], obs_np["obs"], rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(out.obs["critic"], obs_np["critic"], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
+def test_g1_motion_tracking_numba_uses_owner_noise_and_reuses_outputs(monkeypatch):
+    n = 8
+    env = _make_env(n, include_undesired=True)
+    _prepare_observation_buffers(env, n)
+    env._cfg.noise_config.level = 1.0
+    monkeypatch.setattr(
+        env,
+        "_obs_noise",
+        lambda data, scale: np.asarray(data + 0.025, dtype=np.float32),
+    )
+    motion_data, robot_state, info = _make_batch(n, seed=23)
+    body_pos, body_quat, body_linvel, body_angvel, dof_pos, dof_vel = robot_state
+    linvel = np.zeros((n, 3), dtype=np.float32)
+    gyro = np.zeros((n, 3), dtype=np.float32)
+    accel = MotionTrackingNumbaAccelerator.from_env(env, num_threads=2)
+
+    def compute():
+        return accel.compute_update_state(
+            info=info,
+            motion_data=motion_data,
+            linvel=linvel,
+            gyro=gyro,
+            dof_pos=dof_pos,
+            dof_vel=dof_vel,
+            robot_body_pos_w=body_pos,
+            robot_body_quat_w=body_quat,
+            robot_body_lin_vel_w=body_linvel,
+            robot_body_ang_vel_w=body_angvel,
+            scales=env._cfg.reward_config.scales,
+            enable_log=False,
+        )
+
+    out = compute()
+    sensor_offset = env._num_action * 2 + 3 + 6
+    np.testing.assert_allclose(
+        out.obs["obs"][:, sensor_offset : sensor_offset + 3],
+        out.obs["critic"][:, sensor_offset : sensor_offset + 3] + 0.025,
+    )
+    output_ids = tuple(id(value) for value in (*out.obs.values(), out.reward, out.terminated))
+
+    repeated = compute()
+
+    assert accel.first_jit_ms is not None
+    assert (
+        tuple(id(value) for value in (*repeated.obs.values(), repeated.reward, repeated.terminated))
+        == output_ids
+    )
 
 
 @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba is optional")
@@ -254,6 +351,7 @@ class _Cfg:
     ee_body_names: tuple[str, ...] = G1MotionTrackingCfg.ee_body_names
     undesired_contact_z_threshold: float = G1MotionTrackingCfg.undesired_contact_z_threshold
     terminate_on_undesired_contacts: bool = False
+    term_plan: MotionTermPlanConfig = field(default_factory=MotionTermPlanConfig)
 
 
 @dataclass
@@ -263,6 +361,20 @@ class _NoiseCfg:
     scale_gyro: float = 0.1
     scale_joint_angle: float = 0.02
     scale_joint_vel: float = 0.3
+
+
+def _prepare_observation_buffers(env: Any, n: int) -> None:
+    env.default_angles = np.linspace(-0.2, 0.2, env._num_action).astype(np.float32)
+    env._actor_obs_width = env._actor_obs_dim(env._num_action)
+    env._critic_base_obs_width = env._critic_base_obs_dim(env._num_action)
+    env._critic_obs_width = env._critic_base_obs_width + env._n_motion_bodies * 9
+    env._motion_anchor_pos_b = np.empty((n, 3), dtype=np.float32)
+    env._motion_anchor_ori_b = np.empty((n, 6), dtype=np.float32)
+    env._joint_pos_rel = np.empty((n, env._num_action), dtype=np.float32)
+    env._motion_command = np.empty((n, env._num_action * 2), dtype=np.float32)
+    env._zero_actions = np.zeros((n, env._num_action), dtype=np.float32)
+    env._body_vec_tmp = np.empty((n, env._n_motion_bodies, 3), dtype=np.float32)
+    env._cfg.noise_config = _NoiseCfg()
 
 
 def _make_env(n: int, *, include_undesired: bool) -> Any:
@@ -352,12 +464,22 @@ def _make_batch(n: int, seed: int):
     target_joint_vel = rng.uniform(-2.0, 2.0, (n, na)).astype(np.float32)
 
     motion_data = _MotionData(
-        body_pos_w=np.ascontiguousarray(target_pos + 0.03 * rng.standard_normal((n, nb, 3))),
+        body_pos_w=np.ascontiguousarray(
+            target_pos + 0.03 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
         body_quat_w=np.ascontiguousarray(_perturb_quats(rng, target_quat, 0.02)),
-        body_lin_vel_w=np.ascontiguousarray(target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3))),
-        body_ang_vel_w=np.ascontiguousarray(target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3))),
-        joint_pos=np.ascontiguousarray(target_joint_pos + 0.03 * rng.standard_normal((n, na))),
-        joint_vel=np.ascontiguousarray(target_joint_vel + 0.05 * rng.standard_normal((n, na))),
+        body_lin_vel_w=np.ascontiguousarray(
+            target_lin_vel + 0.1 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
+        body_ang_vel_w=np.ascontiguousarray(
+            target_ang_vel + 0.1 * rng.standard_normal((n, nb, 3)), dtype=np.float32
+        ),
+        joint_pos=np.ascontiguousarray(
+            target_joint_pos + 0.03 * rng.standard_normal((n, na)), dtype=np.float32
+        ),
+        joint_vel=np.ascontiguousarray(
+            target_joint_vel + 0.05 * rng.standard_normal((n, na)), dtype=np.float32
+        ),
     )
     robot_body_pos_w = np.ascontiguousarray(
         target_pos + 0.05 * rng.standard_normal((n, nb, 3)), dtype=np.float32

--- a/tests/envs/test_motion_tracking_rewards.py
+++ b/tests/envs/test_motion_tracking_rewards.py
@@ -14,6 +14,7 @@ import numpy as np
 from unilab.envs.motion_tracking.common import numba as numba_mod
 from unilab.envs.motion_tracking.common import rewards
 from unilab.envs.motion_tracking.common.rewards import RewardConfig, RewardContext
+from unilab.envs.motion_tracking.common.terms import REWARD_KEYS
 
 
 def _make_ctx(*, scales: dict[str, float] | None = None) -> RewardContext:
@@ -85,8 +86,11 @@ def _make_ctx(*, scales: dict[str, float] | None = None) -> RewardContext:
     )
 
 
-def test_build_reward_functions_matches_numba_term_order():
-    assert set(rewards.build_reward_functions()) == set(numba_mod.TERM_ORDER)
+def test_build_reward_functions_matches_registered_reward_terms():
+    expected = set(rewards.build_reward_functions())
+    assert expected == set(REWARD_KEYS)
+    if numba_mod.NUMBA_AVAILABLE:
+        assert expected == set(numba_mod.NUMBA_REWARD_ITEMS)
 
 
 def test_motion_joint_pos_term_matches_hand_computed():

--- a/tests/term/test_import_boundary.py
+++ b/tests/term/test_import_boundary.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).parents[2] / "src" / "unilab" / "term"
+BANNED_PREFIXES = (
+    "hydra",
+    "omegaconf",
+    "unilab.algos",
+    "unilab.base",
+    "unilab.envs",
+    "unilab.ipc",
+    "unilab.training",
+)
+
+
+def test_term_package_does_not_import_owner_or_runtime_layers() -> None:
+    violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported = [node.module]
+            else:
+                continue
+            for module in imported:
+                if module.startswith(BANNED_PREFIXES):
+                    violations.append(f"{path.name}:{node.lineno}: {module}")
+
+    assert violations == []

--- a/tests/term/test_numba.py
+++ b/tests/term/test_numba.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+
+numba = pytest.importorskip("numba")
+
+from unilab.term import (  # noqa: E402
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    TensorSpec,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistry,
+    resolve_term_plan,
+)
+from unilab.term.numba import (  # noqa: E402
+    FusedOutputLayout,
+    clear_numba_plan_cache,
+    materialize_numba_plan,
+)
+
+
+@numba.njit(inline="always", fastmath=True, nogil=True)
+def _reward_item(state, gain, scratch, index):
+    scratch[index, 0] = state[index, 0] + state[index, 1]
+    return scratch[index, 0] * gain
+
+
+def _reward_numpy(context: NumpyTermContext) -> None:
+    np.sum(context.inputs["state"], axis=1, out=context.workspace["scratch"][:, 0])
+    np.multiply(context.workspace["scratch"][:, 0], context.parameters["gain"], out=context.output)
+
+
+@numba.njit(inline="always", fastmath=True, nogil=True)
+def _typed_parameter_item(state, enabled, offset, indices, index):
+    value = 0.0
+    if enabled:
+        for column in indices:
+            value += state[index, column]
+    return value + offset
+
+
+def _typed_parameter_numpy(context: NumpyTermContext) -> None:
+    context.output.fill(float(context.parameters["offset"]))
+    if context.parameters["enabled"]:
+        context.output += context.inputs["state"][:, context.parameters["indices"]].sum(axis=1)
+
+
+def _plan(
+    *,
+    dtype: type[np.floating] = np.float32,
+    workspace_width: int = 1,
+    version: int = 1,
+    order: Sequence[str] = ("a",),
+    item_fn=_reward_item,
+):
+    registry = TermRegistry()
+    for label in ("a", "b"):
+        registry.register(
+            TermDefinition(
+                f"synthetic.reward.{label}.v1",
+                TermKind.REWARD,
+                _reward_numpy,
+                TensorSpec((), dtype),
+                inputs=(NamedTensorSpec("state", TensorSpec((2,), dtype)),),
+                workspace=(NamedTensorSpec("scratch", TensorSpec((workspace_width,), dtype)),),
+                parameters=(ParameterSpec("gain", ParameterKind.FLOAT),),
+                numba_item_fn=item_fn,
+                implementation_version=version,
+            )
+        )
+    return resolve_term_plan(
+        registry,
+        tuple(
+            TermConfig(label, f"synthetic.reward.{label}.v1", parameters={"gain": 0.25})
+            for label in order
+        ),
+    )
+
+
+def _materialize(plan, layout: FusedOutputLayout | None = None):
+    count = 8
+    dtype = plan.input_specs["state"].numpy_dtype
+    inputs = {"state": np.arange(count * 2, dtype=dtype).reshape(count, 2)}
+    reward = np.empty((count,), dtype=dtype)
+    terminated = np.empty((count,), dtype=np.bool_)
+    runtime = materialize_numba_plan(
+        plan,
+        layout
+        or FusedOutputLayout(
+            rewards=tuple(term.name for term in plan.terms), observations={}, terminations=()
+        ),
+        num_envs=count,
+        inputs=inputs,
+        observations={},
+        reward=reward,
+        terminated=terminated,
+    )
+    return runtime, inputs
+
+
+def test_fused_plan_cache_reuses_callable_and_runtime_buffers() -> None:
+    clear_numba_plan_cache()
+    plan = _plan()
+    first, inputs = _materialize(plan)
+    second, _ = _materialize(plan)
+
+    assert not first.compile_info.cache_hit
+    assert second.compile_info.cache_hit
+    assert first.compile_info.cache_key == second.compile_info.cache_key
+    assert first._kernel is second._kernel
+
+    reward_id = id(first.reward)
+    scratch = np.zeros((numba.get_num_threads(), len(plan.terms)), dtype=np.float64)
+    first.execute(reward_multiplier=2.0, log_scratch=scratch)
+    expected = inputs["state"].sum(axis=1) * 0.5
+    np.testing.assert_allclose(first.reward, expected)
+
+    first.parameters[0] = 0.5
+    first.execute(reward_multiplier=2.0, log_scratch=scratch)
+    np.testing.assert_allclose(first.reward, expected * 2.0)
+    first.set_scale("a", 0.0)
+    first.execute(reward_multiplier=2.0, log_scratch=scratch)
+    np.testing.assert_array_equal(first.reward, 0.0)
+    assert id(first.reward) == reward_id
+
+
+def test_fused_cache_key_covers_plan_structure_dtype_and_version() -> None:
+    clear_numba_plan_cache()
+    base, _ = _materialize(_plan(order=("a", "b")))
+    variants = (
+        _materialize(_plan(order=("b", "a")))[0],
+        _materialize(_plan(workspace_width=2, order=("a", "b")))[0],
+        _materialize(_plan(dtype=np.float64, order=("a", "b")))[0],
+        _materialize(_plan(version=2, order=("a", "b")))[0],
+        _materialize(
+            _plan(order=("a", "b")),
+            FusedOutputLayout(rewards=(), observations={}, terminations=(), preambles=("a", "b")),
+        )[0],
+    )
+    keys = {runtime.compile_info.cache_key for runtime in variants}
+    assert base.compile_info.cache_key not in keys
+    assert len(keys) == 5
+    assert all(not runtime.compile_info.cache_hit for runtime in variants)
+
+
+def test_fused_materialization_fails_closed_without_numba_item() -> None:
+    clear_numba_plan_cache()
+    with pytest.raises(TermPlanError, match="no Numba item implementation"):
+        _materialize(_plan(item_fn=None))
+
+
+def test_fused_plan_executes_bool_int_and_typed_tuple_parameters() -> None:
+    registry = TermRegistry()
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.typed.v1",
+            TermKind.REWARD,
+            _typed_parameter_numpy,
+            TensorSpec((), np.float32),
+            inputs=(NamedTensorSpec("state", TensorSpec((2,), np.float32)),),
+            parameters=(
+                ParameterSpec("enabled", ParameterKind.BOOLEAN),
+                ParameterSpec("offset", ParameterKind.INTEGER),
+                ParameterSpec("indices", ParameterKind.INTEGER, tuple_value=True),
+            ),
+            numba_item_fn=_typed_parameter_item,
+        )
+    )
+    plan = resolve_term_plan(
+        registry,
+        (
+            TermConfig(
+                "typed",
+                "synthetic.reward.typed.v1",
+                parameters={"enabled": True, "offset": 3, "indices": (0, 1)},
+            ),
+        ),
+    )
+    runtime, inputs = _materialize(plan)
+    scratch = np.zeros((numba.get_num_threads(), 1), dtype=np.float64)
+
+    runtime.execute(reward_multiplier=1.0, log_scratch=scratch)
+
+    np.testing.assert_allclose(runtime.reward, inputs["state"].sum(axis=1) + 3.0)

--- a/tests/term/test_plan.py
+++ b/tests/term/test_plan.py
@@ -1,0 +1,197 @@
+from typing import cast
+
+import numpy as np
+import pytest
+
+from unilab.term import (
+    NamedTensorSpec,
+    NumpyTermContext,
+    ParameterKind,
+    ParameterSpec,
+    TensorSpec,
+    TermBindingError,
+    TermConfig,
+    TermDefinition,
+    TermKind,
+    TermPlanError,
+    TermRegistrationError,
+    TermRegistry,
+    resolve_term_plan,
+)
+
+STATE = NamedTensorSpec("state", TensorSpec((2,), np.float32))
+SCRATCH = NamedTensorSpec("scratch", TensorSpec((), np.float32))
+
+
+def _registry(calls: list[str] | None = None) -> TermRegistry:
+    registry = TermRegistry()
+
+    def reward(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("reward")
+        np.sum(context.inputs["state"], axis=1, out=context.workspace["scratch"])
+        np.multiply(
+            context.workspace["scratch"],
+            cast(float, context.parameters["gain"]),
+            out=context.output,
+        )
+
+    def item(state, gain, output, scratch, index) -> None:
+        scratch[index] = state[index, 0] + state[index, 1]
+        output[index] = scratch[index] * gain
+
+    def observation(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("observation")
+        np.add(
+            context.inputs["state"],
+            cast(tuple[float, ...], context.parameters["offsets"]),
+            out=context.output,
+        )
+
+    def termination(context: NumpyTermContext) -> None:
+        calls is not None and calls.append("termination")
+        np.greater(
+            context.inputs["state"][:, 0],
+            cast(float, context.parameters["threshold"]),
+            out=context.output,
+        )
+
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.sum.v1",
+            TermKind.REWARD,
+            reward,
+            TensorSpec((), np.float32),
+            inputs=(STATE,),
+            workspace=(SCRATCH,),
+            parameters=(ParameterSpec("gain", ParameterKind.FLOAT),),
+            numba_item_fn=item,
+        )
+    )
+    registry.register(
+        TermDefinition(
+            "synthetic.observation.offset.v1",
+            TermKind.OBSERVATION,
+            observation,
+            TensorSpec((2,), np.float32),
+            inputs=(STATE,),
+            workspace=(SCRATCH,),
+            parameters=(
+                ParameterSpec("offsets", ParameterKind.FLOAT, tuple_value=True, default=(0.0, 0.0)),
+            ),
+        )
+    )
+    registry.register(
+        TermDefinition(
+            "synthetic.termination.threshold.v1",
+            TermKind.TERMINATION,
+            termination,
+            TensorSpec((), np.bool_),
+            inputs=(STATE,),
+            parameters=(ParameterSpec("threshold", ParameterKind.FLOAT, default=0.0),),
+        )
+    )
+    return registry
+
+
+def _configs() -> tuple[TermConfig, ...]:
+    return (
+        TermConfig(
+            "actor_offset",
+            "synthetic.observation.offset.v1",
+            parameters={"offsets": [0.5, -0.5]},
+        ),
+        TermConfig(
+            "tracking_reward",
+            "synthetic.reward.sum.v1",
+            scale=2.0,
+            parameters={"gain": 0.25},
+        ),
+        TermConfig("fell", "synthetic.termination.threshold.v1", parameters={"threshold": 2.0}),
+    )
+
+
+def test_plan_executes_in_config_order_and_reuses_buffers() -> None:
+    calls: list[str] = []
+    state = np.array([[1.0, 3.0], [4.0, -2.0]], dtype=np.float32)
+    runtime = resolve_term_plan(_registry(calls), _configs()).materialize(
+        num_envs=2, inputs={"state": state}
+    )
+    outputs = runtime.execute()
+    ids = [id(value) for value in (*outputs.values(), *runtime.workspace.values())]
+
+    assert calls == ["observation", "reward", "termination"]
+    assert tuple(outputs) == ("actor_offset", "tracking_reward", "fell")
+    np.testing.assert_array_equal(outputs["actor_offset"], [[1.5, 2.5], [4.5, -2.5]])
+    np.testing.assert_array_equal(outputs["tracking_reward"], [2.0, 1.0])
+    np.testing.assert_array_equal(outputs["fell"], [False, True])
+    definition = _registry().resolve("synthetic.reward.sum.v1")
+    item_output, item_scratch = np.empty(2, np.float32), np.empty(2, np.float32)
+    assert definition.numba_item_fn is not None
+    for index in range(2):
+        definition.numba_item_fn(state, 0.25, item_output, item_scratch, index)
+    np.testing.assert_array_equal(item_output, outputs["tracking_reward"] / 2.0)
+
+    calls.clear()
+    runtime.set_scale("tracking_reward", 0.0)
+    state += 1.0
+    assert runtime.execute() is outputs
+    assert calls == ["observation", "termination"]
+    assert [id(value) for value in (*outputs.values(), *runtime.workspace.values())] == ids
+    np.testing.assert_array_equal(outputs["tracking_reward"], 0.0)
+
+
+@pytest.mark.parametrize(
+    ("configs", "message"),
+    [
+        ((TermConfig("x", "synthetic.reward.unknown.v1"),), "unknown term key"),
+        ((TermConfig("x", "synthetic.reward.sum.v1"),), "missing parameter"),
+        (
+            (TermConfig("x", "synthetic.reward.sum.v1", parameters={"gain": "fast"}),),
+            "must be float",
+        ),
+        ((TermConfig("x", "synthetic.termination.threshold.v1", scale=0.5),), "0.0 or 1.0"),
+    ],
+)
+def test_plan_rejects_invalid_config(configs, message: str) -> None:
+    with pytest.raises(TermPlanError, match=message):
+        resolve_term_plan(_registry(), configs)
+
+
+def test_plan_rejects_conflicting_workspace_specs() -> None:
+    registry = _registry()
+
+    registry.register(
+        TermDefinition(
+            "synthetic.reward.conflict.v1",
+            TermKind.REWARD,
+            lambda context: context.output.fill(0),
+            TensorSpec((), np.float32),
+            inputs=(STATE,),
+            workspace=(NamedTensorSpec("scratch", TensorSpec((2,), np.float64)),),
+        )
+    )
+    configs = (
+        TermConfig("obs", "synthetic.observation.offset.v1"),
+        TermConfig("conflict", "synthetic.reward.conflict.v1"),
+    )
+    with pytest.raises(TermPlanError, match="workspace 'scratch' has conflicting specs"):
+        resolve_term_plan(registry, configs)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "message"),
+    [
+        ({"state": np.zeros((3, 2), np.float32)}, "shape mismatch"),
+        ({"state": np.zeros((2, 2), np.float64)}, "dtype mismatch"),
+    ],
+)
+def test_materialize_rejects_invalid_bound_views(inputs, message: str) -> None:
+    plan = resolve_term_plan(_registry(), _configs())
+    with pytest.raises(TermBindingError, match=message):
+        plan.materialize(num_envs=2, inputs=inputs)
+
+
+def test_registry_rejects_duplicate_key() -> None:
+    registry = _registry()
+    with pytest.raises(TermRegistrationError, match="already registered"):
+        registry.register(registry.resolve("synthetic.reward.sum.v1"))


### PR DESCRIPTION
Relates to #918

## Purpose

This PR repackages the complete #918 Numba roadmap as one independently reviewable change. It is intentionally not merged automatically; maintainers should review and manually merge it into `refactor/issue-902-mjwarp-squashed-delivery`.

## Branch / history separation

- source branch: `feat/issue-918-numba-independent`
- source point: `b8ecb79e`, the refactor branch state before #918 started
- base branch: `refactor/issue-902-mjwarp-squashed-delivery`
- the base branch currently has five explicit revert commits for historical roadmap merges #924–#928, with a net file tree equal to `b8ecb79e`
- the original mjwarp commits remain in the base and are not part of this PR
- this PR is one squashed commit: `09702431`

After manual merge, the refactor branch will contain the mjwarp baseline plus this independently reviewable Numba roadmap.

## Included roadmap work

- #919: structured term contract, resolved plan, NumPy Tier 1 runtime
- #920: G1WalkFlat config-driven term plan
- #921: motion tracking NumPy term plan
- #922: automatic Numba fusion for G1WalkFlat
- #923: automatic Numba fusion for motion tracking with shared preamble/workspace and owner-managed noise

The PR does not add backend, runner, `NpEnv` lifecycle, training ABI, checkpoint, sim2sim, or regular CI changes, and does not expand beyond the two pilot task families.

## Validation

- `make test-all`
  - 1667 passed, 37 skipped, 280 deselected, 1 xfailed
  - Ruff, mypy, Pyright, and benchmark smoke passed
- the 9-file motion pilot acceptance and benchmark evidence from #923 is included in this squashed package
- performance evidence retained from the child PRs:
  - G1 walk, 8 threads: N=2048 25.54M env/s (116.7% baseline), N=8192 29.80M env/s (275.0% baseline)
  - motion tracking, 8 threads: N=2048 10.43M env/s (97.3% baseline), N=8192 12.24M env/s (105.5% baseline)

## Scope

- 29 files
- +3841 / -2002 lines
- no mjwarp implementation changes are included in the diff; those remain in the refactor base branch
