### PR TITLE
feat: make single-GPU replay device-authoritative

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -48,7 +48,7 @@ training:
   replay_prefetch_mode: one_tick
   # Replay batch source for single-GPU off-policy runners:
   # cpu_pinned_double_buffer (collector CPU pack + batch H2D) or
-  # gpu_resident (learner-side CUDA/MPS mirror with device-side sampling).
+  # gpu_resident (bounded collector ingress + authoritative CUDA/MPS replay).
   replay_pipeline: cpu_pinned_double_buffer
   verbose_metrics: false
   torch_threads:

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/3-sac.md
@@ -12,11 +12,15 @@ memory: a collector subprocess fills a CPU-resident replay buffer while the
 learner trains on the GPU.
 
 Single-GPU CUDA and Apple MPS runs may select
-`training.replay_pipeline=gpu_resident`. The CPU replay remains authoritative,
-while the learner maintains a full device mirror and samples on the device.
-This consumes one additional full replay allocation on the device; the default
-remains `cpu_pinned_double_buffer`. On MPS, the learner thread submits mirror
-copies and gathers, avoiding background Metal command submission.
+`training.replay_pipeline=gpu_resident`. In this single-device path, the full
+replay ring is authoritative on the learner device. The collector publishes
+packed transitions through two bounded shared-memory ingress slots, so host
+replay allocation does not grow with replay capacity; `ptr` and `size` advance
+only after a slot's device copy completes. The default remains
+`cpu_pinned_double_buffer`. CUDA commits on a side stream, while MPS device work
+is submitted only by the learner thread to avoid background Metal submission.
+The multi-GPU `gpu_resident` migration is separate and still uses its existing
+CPU-authoritative mirror path.
 
 The default FastSAC learner is also the currently validated replay-buffer
 multi-GPU SAC implementation. Enable it with `training.num_gpus > 1`; the host

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -10,10 +10,13 @@ off-policy runner 通过 shared memory 把 CPU 仿真与 GPU 学习解耦：coll
 填充驻留在 CPU 上的 replay buffer，learner 在 GPU 上训练。
 
 单 GPU CUDA 或 Apple MPS 训练可选择
-`training.replay_pipeline=gpu_resident`：CPU replay buffer 仍是权威数据源，learner
-另外维护完整的 device mirror 并在 device 上随机采样。该模式会额外占用一份完整
-replay 的 device 内存；默认仍是 `cpu_pinned_double_buffer`。MPS 路径由 learner
-线程提交 mirror copy 和采样，不使用后台 Metal command submission。
+`training.replay_pipeline=gpu_resident`：这条单 device 路径只在 learner device 上
+保留完整 replay ring。collector 通过两个固定深度的 shared-memory packed ingress
+slot 发布 transition，因此 host replay 分配不随 replay capacity 增长；slot 的 device
+copy 完成后才推进 `ptr` 与 `size`。默认仍是 `cpu_pinned_double_buffer`。CUDA 通过
+side stream 提交和 commit，MPS 的 device work 只由 learner 线程提交，不使用后台
+Metal submission。多 GPU `gpu_resident` 的迁移属于后续工作，目前仍保留原有的
+CPU-authoritative mirror 路径。
 
 默认 FastSAC learner 也是当前已验证的 replay-buffer 多 GPU SAC 实现。多卡模式通过
 `training.num_gpus > 1` 打开，host 侧并行打包并分发 batch，多张 GPU 上的 learner

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -27,7 +27,7 @@ from unilab.algos.torch.offpolicy.thread_budget import (
 from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
 from unilab.ipc import SharedObsNormStats, SharedWeightSync
 from unilab.ipc.async_runner import _SPAWN_CTX
-from unilab.ipc.replay_buffer import ReplayBuffer
+from unilab.ipc.replay_buffer import DEFAULT_REPLAY_INGRESS_DEPTH, ReplayBuffer
 from unilab.ipc.replay_pipelines.base import ReplayPipeline
 from unilab.ipc.replay_pipelines.cpu_pinned_double_buffer import (
     CPUPinnedDoubleBufferReplayPipeline,
@@ -219,6 +219,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             if use_critic_graph_packed_source
             else 0
         )
+        use_gpu_resident_pipeline = self.replay_pipeline_impl == "gpu_resident"
         mem_est = estimate_offpolicy_bytes(
             num_envs=self.num_envs,
             replay_buffer_n=self.replay_buffer_n,
@@ -228,12 +229,22 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             batch_size=self.batch_size,
             updates_per_step=self.updates_per_step,
             critic_graph_staging_width=critic_graph_staging_width,
+            replay_pipeline=self.replay_pipeline_impl,
+            ingress_depth=DEFAULT_REPLAY_INGRESS_DEPTH,
         )
         warn_if_over_budget(mem_est, label=f"Off-policy ({self.algo_type})")
         raise_if_shared_memory_over_budget(mem_est, label=f"Off-policy ({self.algo_type})")
 
         # --- replay buffer (packed CPU shared storage) ---
         buffer_capacity = self.replay_buffer_n * self.num_envs
+        replay_storage_kwargs = (
+            {
+                "ingress_slot_rows": self.num_envs,
+                "ingress_depth": DEFAULT_REPLAY_INGRESS_DEPTH,
+            }
+            if use_gpu_resident_pipeline
+            else {}
+        )
         replay_buffer = ReplayBuffer(
             capacity=buffer_capacity,
             obs_dim=self.obs_dim,
@@ -242,6 +253,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             defer_gpu=True,
             critic_dim=self.critic_obs_dim,
             packed_cpu_storage=self.replay_pack_layout == "packed",
+            **replay_storage_kwargs,
         )
         self._shared_resources.append(replay_buffer)
         replay_buffer.trace_recorder = trace_recorder
@@ -250,7 +262,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
         # --- replay pipeline (double buffer) ---
         sample_count = self.batch_size * self.updates_per_step
-        use_gpu_resident_pipeline = self.replay_pipeline_impl == "gpu_resident"
         collector_pack_request_queue = None
         collector_pack_ready_queue = None
         collector_pack_shared_slots = None
@@ -456,6 +467,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                         try:
                             collection_ready_queue.get(timeout=1.0)
                         except queue.Empty:
+                            replay_pipeline.progress(wait=True)
                             if not self._check_collector_alive():
                                 self._drain_metrics(
                                     metrics_queue,
@@ -481,6 +493,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                             logger,
                             trace_recorder,
                         )
+                        replay_pipeline.progress(wait=True)
                         cur_size = int(replay_buffer.size[0])
                         if replay_buffer_ready_for_learning(
                             cur_size,
@@ -504,12 +517,15 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                             sync_coordination_time += _coord_d
                             collector_wait_overhead += _coord_d
                 else:
-                    while not replay_buffer_ready_for_learning(
-                        int(replay_buffer.size[0]),
-                        batch_size=self.batch_size,
-                        learning_starts=self.learning_starts,
-                        num_envs=self.num_envs,
-                    ):
+                    while True:
+                        replay_pipeline.progress(wait=True)
+                        if replay_buffer_ready_for_learning(
+                            int(replay_buffer.size[0]),
+                            batch_size=self.batch_size,
+                            learning_starts=self.learning_starts,
+                            num_envs=self.num_envs,
+                        ):
+                            break
                         if not self._check_collector_alive():
                             self._drain_metrics(
                                 metrics_queue,
@@ -565,6 +581,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     replay_buffer,
                     reward_stats_ptr,
                     int(replay_buffer.ptr[0]),
+                    replay_source=replay_pipeline,
                 )
                 if trace_recorder:
                     trace_recorder.add_slice(
@@ -707,6 +724,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
                         _target_ns = time.perf_counter_ns()
                         learner.soft_update_target()
+                        replay_pipeline.progress()
                         if trace_recorder:
                             trace_recorder.add_slice(
                                 "learner/soft_update_target",

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -123,11 +123,19 @@ def update_reward_stats_from_replay(
     start_ptr: int,
     end_ptr: int,
     num_envs: int,
+    replay_source: Any | None = None,
 ) -> int:
     if not hasattr(learner, "update_reward_stats"):
         return end_ptr
     if getattr(learner, "reward_normalizer", None) is None:
         return end_ptr
+
+    committed_fields: dict[str, torch.Tensor] | None = None
+    if replay_source is not None:
+        end_ptr, committed_fields = replay_source.read_committed_fields(
+            ("rewards", "dones"),
+            start_ptr=start_ptr,
+        )
 
     count = end_ptr - start_ptr
     if count <= 0:
@@ -141,8 +149,12 @@ def update_reward_stats_from_replay(
     if count <= 0:
         return end_ptr
 
-    rewards = read_recent_replay_field(replay_buffer, "rewards", start_ptr, count)
-    dones = read_recent_replay_field(replay_buffer, "dones", start_ptr, count)
+    if committed_fields is None:
+        rewards = read_recent_replay_field(replay_buffer, "rewards", start_ptr, count)
+        dones = read_recent_replay_field(replay_buffer, "dones", start_ptr, count)
+    else:
+        rewards = committed_fields["rewards"][-count:]
+        dones = committed_fields["dones"][-count:]
     num_steps = count // num_envs
     learner.update_reward_stats(
         rewards.view(num_steps, num_envs),
@@ -253,13 +265,20 @@ class OffPolicyRunner(AsyncRunner):
     ) -> torch.Tensor:
         return read_recent_replay_field(replay_buffer, field_name, start_ptr, count)
 
-    def _update_reward_stats_from_replay(self, replay_buffer, start_ptr: int, end_ptr: int) -> int:
+    def _update_reward_stats_from_replay(
+        self,
+        replay_buffer,
+        start_ptr: int,
+        end_ptr: int,
+        replay_source: Any | None = None,
+    ) -> int:
         return update_reward_stats_from_replay(
             self.learner,
             replay_buffer,
             start_ptr=start_ptr,
             end_ptr=end_ptr,
             num_envs=self.num_envs,
+            replay_source=replay_source,
         )
 
     def learn(

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -671,6 +671,7 @@ def _run_collector(
     actor.eval()
     replay_buffer.trace_recorder = trace_recorder
     replay_buffer.trace_thread_time = trace_thread_time
+    replay_buffer.attach_stop_event(stop_event)
 
     # Load initial weights
     sd = dict(actor.state_dict())

--- a/src/unilab/ipc/memory_budget.py
+++ b/src/unilab/ipc/memory_budget.py
@@ -20,25 +20,33 @@ def estimate_offpolicy_bytes(
     batch_size: int,
     updates_per_step: int,
     critic_graph_staging_width: int = 0,
+    replay_pipeline: str = "cpu_pinned_double_buffer",
+    ingress_depth: int = 2,
 ) -> dict[str, int | str]:
-    """Estimate memory for off-policy replay buffer + double-buffer slots."""
+    """Estimate host memory for off-policy replay and staging slots."""
     row_width = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
     capacity = replay_buffer_n * num_envs
-    replay_bytes = capacity * row_width * 4
-
     sample_count = batch_size * updates_per_step
-    slot_bytes = sample_count * row_width * 4 * 2
-    critic_graph_staging_bytes = sample_count * int(critic_graph_staging_width) * 4 * 2
+    device_authoritative = replay_pipeline == "gpu_resident"
+    replay_bytes = 0 if device_authoritative else capacity * row_width * 4
+    ingress_bytes = int(ingress_depth) * num_envs * row_width * 4 if device_authoritative else 0
+    slot_bytes = 0 if device_authoritative else sample_count * row_width * 4 * 2
+    critic_graph_staging_bytes = (
+        0 if device_authoritative else sample_count * int(critic_graph_staging_width) * 4 * 2
+    )
 
-    total = replay_bytes + slot_bytes + critic_graph_staging_bytes
+    total = replay_bytes + ingress_bytes + slot_bytes + critic_graph_staging_bytes
     return {
         "replay_buffer": replay_bytes,
+        "bounded_ingress_slots": ingress_bytes,
         "double_buffer_slots": slot_bytes,
         "critic_graph_staging_slots": critic_graph_staging_bytes,
         "total": total,
         "breakdown": (
             f"Replay: {replay_bytes / 1024**2:.0f} MB "
             f"({num_envs} envs × {replay_buffer_n} steps × {row_width} cols × 4B)\n"
+            f"  Bounded ingress: {ingress_bytes / 1024**2:.0f} MB "
+            f"({int(ingress_depth)} slots × {num_envs} rows × {row_width} cols × 4B)\n"
             f"  Double-buffer: {slot_bytes / 1024**2:.0f} MB "
             f"({sample_count} samples × {row_width} cols × 4B × 2 slots)\n"
             f"  Critic graph staging: {critic_graph_staging_bytes / 1024**2:.0f} MB "

--- a/src/unilab/ipc/replay_buffer.py
+++ b/src/unilab/ipc/replay_buffer.py
@@ -1,20 +1,25 @@
-"""Packed shared-memory replay buffer for off-policy RL."""
+"""Packed replay storage and bounded collector ingress for off-policy RL."""
 
+import multiprocessing as mp
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import torch
 
 from unilab.ipc.shared_buffer import SharedBufferBase
 
+DEFAULT_REPLAY_INGRESS_DEPTH = 2
+
 
 class ReplayBuffer(SharedBufferBase):
-    """Shared replay buffer backed by authoritative packed CPU storage.
+    """Packed replay owner for CPU-authoritative and device-authoritative modes.
 
-    Device transfer is owned by replay pipeline transfer backends.  The
-    fallback sample() path copies a sampled packed batch to ``self.device`` and
-    keeps no per-device replay cache.
+    The default mode owns a full shared-memory CPU ring. Device-authoritative
+    replay instead owns only fixed-depth shared ingress slots; its replay
+    pipeline commits ``ptr`` and ``size`` after the device copy completes.
     """
+
+    DEFAULT_INGRESS_DEPTH = DEFAULT_REPLAY_INGRESS_DEPTH
 
     def __init__(
         self,
@@ -25,6 +30,8 @@ class ReplayBuffer(SharedBufferBase):
         defer_gpu: bool = False,
         critic_dim: int = 0,
         packed_cpu_storage: bool = False,
+        ingress_slot_rows: int | None = None,
+        ingress_depth: int = DEFAULT_INGRESS_DEPTH,
     ):
         super().__init__(capacity, device, defer_gpu=defer_gpu)
         del packed_cpu_storage
@@ -36,15 +43,22 @@ class ReplayBuffer(SharedBufferBase):
         self.trace_recorder: Any | None = None
         self.trace_thread_time = False
         self.trace_cuda_events = True
+        self._stop_event: Any | None = None
 
         self.size = torch.zeros(1, dtype=torch.int64).share_memory_()
-        self._init_packed_storage(capacity, obs_dim, action_dim, critic_dim)
+        self._init_packed_layout(obs_dim, action_dim, critic_dim)
+        self._device_authoritative = ingress_slot_rows is not None
+        self._ingress_slots: list[torch.Tensor] = []
+        if ingress_slot_rows is not None:
+            self._init_bounded_ingress(
+                slot_rows=ingress_slot_rows,
+                depth=int(ingress_depth),
+            )
+        else:
+            self._storage = torch.zeros(capacity, self._storage_width).share_memory_()
 
-    def _init_packed_storage(
-        self, capacity: int, obs_dim: int, action_dim: int, critic_dim: int
-    ) -> None:
-        total_dim = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
-        self._storage = torch.zeros(capacity, total_dim).share_memory_()
+    def _init_packed_layout(self, obs_dim: int, action_dim: int, critic_dim: int) -> None:
+        self._storage_width = 2 * obs_dim + action_dim + 3 + 2 * critic_dim
 
         c = 0
         self._obs_sl = slice(c, c + obs_dim)
@@ -66,6 +80,88 @@ class ReplayBuffer(SharedBufferBase):
             self._ncritic_sl = slice(c, c + critic_dim)
             c += critic_dim
 
+    def _init_bounded_ingress(self, *, slot_rows: int, depth: int) -> None:
+        if slot_rows <= 0:
+            raise ValueError("ingress_slot_rows must be positive")
+        if slot_rows > self.capacity:
+            raise ValueError("ingress_slot_rows cannot exceed replay capacity")
+        if depth <= 0:
+            raise ValueError("ingress_depth must be positive")
+        self._ingress_slot_rows = slot_rows
+        self._ingress_depth = depth
+        self._ingress_slots = [
+            torch.empty((slot_rows, self._storage_width), dtype=torch.float32).share_memory_()
+            for _ in range(depth)
+        ]
+        self._ingress_starts = torch.zeros(depth, dtype=torch.int64).share_memory_()
+        self._ingress_counts = torch.zeros(depth, dtype=torch.int64).share_memory_()
+        self._published_ptr = torch.zeros(1, dtype=torch.int64).share_memory_()
+        self._ingress_publish_seq = torch.zeros(1, dtype=torch.int64).share_memory_()
+        self._ingress_closed = torch.zeros(1, dtype=torch.bool).share_memory_()
+        spawn_context = mp.get_context("spawn")
+        self._ingress_free = spawn_context.Semaphore(depth)
+        self._ingress_ready = spawn_context.Semaphore(0)
+        self._ingress_consume_seq = 0
+        self._ingress_release_seq = 0
+
+    @property
+    def device_authoritative(self) -> bool:
+        return self._device_authoritative
+
+    @property
+    def storage_width(self) -> int:
+        return self._storage_width
+
+    @property
+    def host_storage_bytes(self) -> int:
+        if self._device_authoritative:
+            return sum(slot.numel() * slot.element_size() for slot in self._ingress_slots)
+        return int(self._storage.numel() * self._storage.element_size())
+
+    @property
+    def published_ptr(self) -> int:
+        if self._device_authoritative:
+            return int(self._published_ptr[0])
+        return int(self.ptr[0])
+
+    def attach_stop_event(self, stop_event: Any) -> None:
+        self._stop_event = stop_event
+
+    def take_published_ingress(self) -> tuple[int, int, int, torch.Tensor] | None:
+        if not self._device_authoritative:
+            raise RuntimeError("Full CPU replay does not expose bounded ingress slots")
+        if not self._ingress_ready.acquire(block=False):
+            return None
+        slot = self._ingress_consume_seq % self._ingress_depth
+        self._ingress_consume_seq += 1
+        start = int(self._ingress_starts[slot])
+        count = int(self._ingress_counts[slot])
+        return slot, start, count, self._ingress_slots[slot][:count]
+
+    def commit_ingress(self, *, slot: int, start: int, count: int) -> None:
+        if not self._device_authoritative:
+            raise RuntimeError("Full CPU replay has no bounded ingress commit")
+        expected_slot = self._ingress_release_seq % self._ingress_depth
+        if slot != expected_slot:
+            raise RuntimeError(
+                f"Ingress slots must commit in publication order: expected {expected_slot}, got {slot}"
+            )
+        if start != int(self.ptr[0]):
+            raise RuntimeError(
+                f"Ingress commit is not contiguous: committed ptr {int(self.ptr[0])}, start {start}"
+            )
+        self.ptr[0] = start + count
+        self.size[0] = min(start + count, self.capacity)
+        self._ingress_release_seq += 1
+        self._ingress_free.release()
+
+    def close(self) -> None:
+        if not self._device_authoritative:
+            return
+        self._ingress_closed[0] = True
+        for _ in range(self._ingress_depth):
+            self._ingress_free.release()
+
     def critic_graph_packed_width(self) -> int:
         """Return graph-order packed width for FastSAC critic graph inputs."""
         if self._critic_dim <= 0:
@@ -76,7 +172,7 @@ class ReplayBuffer(SharedBufferBase):
         """Return graph-union packed width for one-H2D FastSAC graph staging."""
         if self._critic_dim <= 0:
             raise RuntimeError("sac_graph_packed_source requires critic replay storage")
-        return int(self._storage.shape[1])
+        return self._storage_width
 
     def pack_critic_graph_source(
         self,
@@ -144,12 +240,13 @@ class ReplayBuffer(SharedBufferBase):
     def __getstate__(self) -> dict:
         """Custom pickle support.
 
-        The collector subprocess only calls add(), which writes to the CPU
-        shared-memory tensor.  The original object in the learner process is
-        unaffected.
+        The collector subprocess only calls ``add()``. Trace and stop-event
+        handles are process-local; replay storage, ingress metadata, and
+        semaphores remain shared.
         """
         state = self.__dict__.copy()
         state["trace_recorder"] = None
+        state["_stop_event"] = None
         return state
 
     def add(
@@ -174,6 +271,22 @@ class ReplayBuffer(SharedBufferBase):
         """
         _trace_ns = time.perf_counter_ns() if self.trace_recorder is not None else 0
         n = obs.shape[0]
+        if self._device_authoritative:
+            self._add_to_ingress(
+                obs,
+                actions,
+                rewards,
+                next_obs,
+                dones,
+                truncated,
+                terminal_mask,
+                terminal_next_obs,
+                critic,
+                next_critic,
+                terminal_next_critic,
+                trace_start_ns=_trace_ns,
+            )
+            return
         idx = int(self.ptr[0]) % self.capacity
         has_critic = self._critic_dim > 0 and critic is not None
         if self._critic_dim > 0 and (critic is None or next_critic is None):
@@ -254,6 +367,97 @@ class ReplayBuffer(SharedBufferBase):
                 args={"batch_size": int(n), "device": self.device},
             )
 
+    def _add_to_ingress(
+        self,
+        obs,
+        actions,
+        rewards,
+        next_obs,
+        dones,
+        truncated,
+        terminal_mask,
+        terminal_next_obs,
+        critic,
+        next_critic,
+        terminal_next_critic,
+        *,
+        trace_start_ns: int,
+    ) -> None:
+        count = int(obs.shape[0])
+        if count > self._ingress_slot_rows:
+            raise ValueError(
+                f"Transition batch has {count} rows but bounded ingress slots hold "
+                f"{self._ingress_slot_rows}"
+            )
+        has_critic = self._critic_dim > 0 and critic is not None
+        if self._critic_dim > 0 and (critic is None or next_critic is None):
+            raise ValueError("ReplayBuffer with critic_dim > 0 requires critic and next_critic")
+
+        wait_start_ns = time.perf_counter_ns()
+        while not self._ingress_free.acquire(timeout=0.05):
+            if bool(self._ingress_closed[0]):
+                return
+            if self._stop_event is not None and self._stop_event.is_set():
+                return
+        wait_end_ns = time.perf_counter_ns()
+        if bool(self._ingress_closed[0]):
+            return
+
+        sequence = int(self._ingress_publish_seq[0])
+        slot = sequence % self._ingress_depth
+        target = self._ingress_slots[slot][:count]
+        try:
+            self._write_transition_rows(
+                target,
+                obs,
+                actions,
+                rewards,
+                next_obs,
+                dones,
+                truncated,
+                critic,
+                next_critic,
+                has_critic=has_critic,
+            )
+            self._patch_terminal_next_observations(
+                target[:, self._nobs_sl],
+                terminal_mask,
+                terminal_next_obs,
+                target[:, self._ncritic_sl] if has_critic else None,
+                terminal_next_critic,
+            )
+            start = int(self._published_ptr[0])
+            self._ingress_starts[slot] = start
+            self._ingress_counts[slot] = count
+            self._published_ptr[0] = start + count
+            self._ingress_publish_seq[0] = sequence + 1
+            self._ingress_ready.release()
+        except BaseException:
+            self._ingress_free.release()
+            raise
+
+        if self.trace_recorder is not None:
+            end_ns = time.perf_counter_ns()
+            self.trace_recorder.add_slice(
+                "replay/ingress_backpressure",
+                category="replay",
+                start_ns=wait_start_ns,
+                end_ns=wait_end_ns,
+                args={"batch_size": count, "slot": slot, "depth": self._ingress_depth},
+            )
+            self.trace_recorder.add_slice(
+                "replay/add",
+                category="replay",
+                start_ns=trace_start_ns,
+                end_ns=end_ns,
+                args={
+                    "batch_size": count,
+                    "device": self.device,
+                    "ingress_slot": slot,
+                    "published_ptr": start + count,
+                },
+            )
+
     def _write_transition_rows(
         self,
         target,
@@ -302,6 +506,8 @@ class ReplayBuffer(SharedBufferBase):
 
     def sample(self, batch_size: int) -> Dict[str, torch.Tensor]:
         """Sample batch (called by learner)."""
+        if self._device_authoritative:
+            raise RuntimeError("Device-authoritative replay must be sampled through its pipeline")
         self.last_incremental_h2d_time_s = 0.0
         _trace_ns = time.perf_counter_ns() if self.trace_recorder is not None else 0
         size = int(self.size[0])
@@ -337,3 +543,40 @@ class ReplayBuffer(SharedBufferBase):
                 args={"batch_size": int(batch_size), "device": self.device},
             )
         return batch
+
+    def field_view(self, packed: torch.Tensor, field_name: str) -> torch.Tensor:
+        field = {
+            "obs": self._obs_sl,
+            "next_obs": self._nobs_sl,
+            "actions": self._act_sl,
+            "rewards": self._rew_col,
+            "dones": self._done_col,
+            "truncated": self._trunc_col,
+            "critic": getattr(self, "_critic_sl", None),
+            "next_critic": getattr(self, "_ncritic_sl", None),
+        }.get(field_name)
+        if field is None:
+            raise KeyError(f"Replay field {field_name!r} is unavailable")
+        return packed[:, field]
+
+    def read_recent_fields(
+        self,
+        field_names: Iterable[str],
+        start_ptr: int,
+        count: int,
+    ) -> dict[str, torch.Tensor]:
+        if self._device_authoritative:
+            raise RuntimeError("Device-authoritative fields are owned by the replay pipeline")
+        index = start_ptr % self.capacity
+        fields: dict[str, torch.Tensor] = {}
+        for field_name in field_names:
+            source = self.field_view(self._storage, field_name)
+            if index + count <= self.capacity:
+                fields[field_name] = source[index : index + count].clone()
+                continue
+            split = self.capacity - index
+            fields[field_name] = torch.cat(
+                [source[index:], source[: count - split]],
+                dim=0,
+            ).clone()
+        return fields

--- a/src/unilab/ipc/replay_pipelines/base.py
+++ b/src/unilab/ipc/replay_pipelines/base.py
@@ -21,6 +21,13 @@ class ReplayTickMetadata:
 
 @runtime_checkable
 class ReplayPipeline(Protocol):
+    def progress(self, *, wait: bool = False) -> bool: ...
+    def read_committed_fields(
+        self,
+        field_names: tuple[str, ...],
+        *,
+        start_ptr: int,
+    ) -> tuple[int, dict[str, torch.Tensor]]: ...
     def start_prepare(
         self,
         tick_id: int,

--- a/src/unilab/ipc/replay_pipelines/cpu_pinned_double_buffer.py
+++ b/src/unilab/ipc/replay_pipelines/cpu_pinned_double_buffer.py
@@ -399,6 +399,25 @@ class CPUPinnedDoubleBufferReplayPipeline:
 
     # -- public API -----------------------------------------------------------
 
+    def progress(self, *, wait: bool = False) -> bool:
+        del wait
+        return False
+
+    def read_committed_fields(
+        self,
+        field_names: tuple[str, ...],
+        *,
+        start_ptr: int,
+    ) -> tuple[int, dict[str, torch.Tensor]]:
+        end_ptr = int(self._replay_buffer.ptr[0])
+        count = min(max(end_ptr - start_ptr, 0), int(self._replay_buffer.capacity))
+        field_start = end_ptr - count
+        return end_ptr, self._replay_buffer.read_recent_fields(
+            field_names,
+            field_start,
+            count,
+        )
+
     def _validate_sample_count(self, sample_count: int) -> None:
         if int(sample_count) != int(self._sample_count):
             raise ValueError("sample_count must match the value used to allocate the double buffer")

--- a/src/unilab/ipc/replay_pipelines/gpu_resident.py
+++ b/src/unilab/ipc/replay_pipelines/gpu_resident.py
@@ -1,12 +1,10 @@
-"""GPU-resident replay mirror pipeline for one CUDA or MPS learner.
+"""GPU-resident replay pipeline for one CUDA or MPS learner.
 
-The packed CPU :class:`ReplayBuffer` stays authoritative: the collector's
-``add()`` path is unchanged and does zero extra CPU work. CUDA uses a
-learner-side daemon and side stream to maintain the mirror. MPS has no public
-stream API and device submission from a background thread is unsafe, so its
-existing learner-thread pipeline calls drive mirror copies and device-side
-sampling (``randint`` + ``index_select``). There is no collector pack request,
-no pinned batch staging, and no per-tick full-batch H2D.
+Single-device training consumes fixed-depth packed ingress slots and keeps the
+full replay ring authoritative on device. CUDA uses a learner-side daemon and
+side stream. MPS has no public stream API, so existing learner-thread calls
+submit copies and device-side sampling. The legacy CPU-ring mirror remains only
+for the multi-GPU migration path.
 
 Consistency model:
 
@@ -15,8 +13,8 @@ Consistency model:
 - Span copies and batch gathers are totally ordered on the CUDA side stream or
   the MPS learner-thread command queue. A gather therefore observes every
   completed span before it and none submitted after it.
-- Ring-overwrite races against concurrent collector CPU writes are the same
-  class the CPU pack path already accepts (single writer / snapshot reader).
+- An ingress slot is not reusable and ``ptr``/``size`` do not advance until its
+  device-copy completion event is observed.
 """
 
 from __future__ import annotations
@@ -90,7 +88,7 @@ def _validate_device_memory_budget(
 
 
 class GPUResidentReplayPipeline:
-    """ReplayPipeline backed by a GPU-resident mirror of the packed CPU storage."""
+    """ReplayPipeline backed by an authoritative packed device ring."""
 
     _POLL_INTERVAL_S = 0.0005
     _MEMORY_HEADROOM = 0.8
@@ -130,7 +128,8 @@ class GPUResidentReplayPipeline:
         self._base_seed = int(base_seed)
         self._trace_recorder = trace_recorder
         self._capacity = int(replay_buffer.capacity)
-        self._storage_width = int(replay_buffer._storage.shape[1])
+        self._device_authoritative = bool(replay_buffer.device_authoritative)
+        self._storage_width = int(replay_buffer.storage_width)
         self._packed_width = (
             int(replay_buffer.sac_graph_packed_width())
             if self._pack_layout == "sac_graph"
@@ -167,8 +166,11 @@ class GPUResidentReplayPipeline:
         )
         self._device_family = self._transfer_backend.device_family
         self._host_pinned = False
+        host_slots = (
+            replay_buffer._ingress_slots if self._device_authoritative else [replay_buffer._storage]
+        )
         try:
-            self._transfer_backend.register_host_slots([replay_buffer._storage])
+            self._transfer_backend.register_host_slots(host_slots)
             self._host_pinned = bool(self._transfer_backend.host_pinned)
         except RuntimeError as exc:
             print(
@@ -211,7 +213,8 @@ class GPUResidentReplayPipeline:
             self._slot_events: list[Any] = [torch.cuda.Event() for _ in range(2)]
         else:
             self._slot_events = [torch.mps.Event() for _ in range(2)]
-        self._span_events: deque[tuple[int, Any]] = deque()
+        self._span_events: deque[tuple[int, Any, int | None, int, int]] = deque()
+        self._submission_lock = threading.Lock()
         self._submitted_ptr = 0
         self._visible_ptr = 0
         self._wrap_skip_warned = False
@@ -240,8 +243,12 @@ class GPUResidentReplayPipeline:
     @property
     def h2d_submitter(self) -> str:
         if self._main_thread_submission:
-            return "gpu_resident_mirror_main_thread"
-        return "gpu_resident_mirror"
+            return (
+                "gpu_resident_ingress_main_thread"
+                if self._device_authoritative
+                else "gpu_resident_mirror_main_thread"
+            )
+        return "gpu_resident_ingress" if self._device_authoritative else "gpu_resident_mirror"
 
     @property
     def transfer_manifest(self) -> dict[str, object]:
@@ -250,6 +257,7 @@ class GPUResidentReplayPipeline:
             "device": str(self._device),
             "device_family": self._device_family,
             "pipeline": "gpu_resident",
+            "storage_owner": "device" if self._device_authoritative else "cpu_mirror",
             "host_memory_kind": (
                 self._transfer_backend.host_memory_kind if self._host_pinned else "pageable_shared"
             ),
@@ -257,6 +265,10 @@ class GPUResidentReplayPipeline:
             "storage_rows": self._capacity,
             "storage_width": self._storage_width,
             "storage_bytes": int(self._gpu_storage.numel() * self._gpu_storage.element_size()),
+            "host_storage_bytes": self._replay_buffer.host_storage_bytes,
+            "ingress_depth": (
+                self._replay_buffer._ingress_depth if self._device_authoritative else None
+            ),
             "h2d_submitter": self.h2d_submitter,
             "device_submission_thread": "learner" if self._main_thread_submission else "daemon",
             "ring_depth": 2,
@@ -321,21 +333,23 @@ class GPUResidentReplayPipeline:
                 "MPS gpu_resident replay device work must be submitted from the learner thread"
             )
 
-    def _drive_mps_learner_thread(self) -> bool:
-        """Advance MPS mirror and gather work from an existing learner call."""
+    def _drive_mps_learner_thread(self, *, wait: bool = False) -> bool:
+        """Advance MPS ingress and gather work from an existing learner call."""
         if not self._main_thread_submission:
             return False
         self._assert_mps_learner_thread()
         try:
-            did_work = self._submit_new_spans()
-            # MPS exposes events but no side streams. Waiting for just the
-            # mirror events submitted by this pipeline avoids an extra runner
-            # polling interval without globally synchronizing unrelated work.
-            for _, event in self._span_events:
-                event.synchronize()
-            did_work |= self._drain_completed_spans()
-            did_work |= self._service_pending_prepare()
-            if self._prepared_metadata is not None:
+            if wait:
+                did_work = self._submit_new_spans()
+                for _, event, _, _, _ in self._span_events:
+                    event.synchronize()
+                did_work |= self._drain_completed_spans()
+                did_work |= self._service_pending_prepare()
+            else:
+                did_work = self._drain_completed_spans()
+                did_work |= self._service_pending_prepare()
+                did_work |= self._submit_new_spans()
+            if wait and self._prepared_metadata is not None:
                 slot = self._prepared_metadata.batch_gpu_slot
                 if slot is not None:
                     self._slot_events[slot].synchronize()
@@ -354,9 +368,14 @@ class GPUResidentReplayPipeline:
             if self._closed:
                 return
             try:
-                did_work = self._submit_new_spans()
-                did_work |= self._drain_completed_spans()
-                did_work |= self._service_pending_prepare()
+                if self._device_authoritative:
+                    did_work = self._drain_completed_spans()
+                    did_work |= self._service_pending_prepare()
+                    did_work |= self._submit_new_spans()
+                else:
+                    did_work = self._submit_new_spans()
+                    did_work |= self._drain_completed_spans()
+                    did_work |= self._service_pending_prepare()
             except BaseException as exc:
                 with self._prepare_condition:
                     self._prepare_error = exc
@@ -368,49 +387,91 @@ class GPUResidentReplayPipeline:
     def _submit_new_spans(self) -> bool:
         if self._main_thread_submission:
             self._assert_mps_learner_thread()
-        ptr = int(self._replay_buffer.ptr[0])
-        if ptr <= self._submitted_ptr:
-            return False
-        if ptr - self._submitted_ptr > self._capacity:
-            skipped = ptr - self._capacity
-            if not self._wrap_skip_warned:
-                print(
-                    "[GPUResidentReplay] mirror fell behind by more than one "
-                    f"capacity; skipping to absolute row {skipped}",
-                    flush=True,
-                )
-                self._wrap_skip_warned = True
-            self._submitted_ptr = skipped
-        start = self._submitted_ptr
-        end = ptr
+        with self._submission_lock:
+            if self._device_authoritative:
+                submitted = False
+                while True:
+                    ingress = self._replay_buffer.take_published_ingress()
+                    if ingress is None:
+                        return submitted
+                    slot, start, count, source = ingress
+                    if start != self._submitted_ptr:
+                        raise RuntimeError(
+                            "Bounded replay ingress publication is not contiguous: "
+                            f"submitted ptr {self._submitted_ptr}, slot start {start}"
+                        )
+                    self._submit_span_copy(
+                        start=start,
+                        end=start + count,
+                        source=source,
+                        ingress_slot=slot,
+                    )
+                    submitted = True
+
+            ptr = int(self._replay_buffer.ptr[0])
+            if ptr <= self._submitted_ptr:
+                return False
+            if ptr - self._submitted_ptr > self._capacity:
+                skipped = ptr - self._capacity
+                if not self._wrap_skip_warned:
+                    print(
+                        "[GPUResidentReplay] mirror fell behind by more than one "
+                        f"capacity; skipping to absolute row {skipped}",
+                        flush=True,
+                    )
+                    self._wrap_skip_warned = True
+                self._submitted_ptr = skipped
+            self._submit_span_copy(
+                start=self._submitted_ptr,
+                end=ptr,
+                source=self._replay_buffer._storage,
+                ingress_slot=None,
+            )
+            return True
+
+    def _submit_span_copy(
+        self,
+        *,
+        start: int,
+        end: int,
+        source: torch.Tensor,
+        ingress_slot: int | None,
+    ) -> None:
         h2d_begin_ns = time.perf_counter_ns()
         start_event = None
         end_event = None
         record_cuda = self._trace_recorder is not None and self._trace_cuda_events
+
+        def copy_spans(*, non_blocking: bool) -> None:
+            source_offset = 0
+            for offset, length in _ring_spans(start, end, self._capacity):
+                source_span = (
+                    source[source_offset : source_offset + length]
+                    if ingress_slot is not None
+                    else source[offset : offset + length]
+                )
+                self._gpu_storage[offset : offset + length].copy_(
+                    source_span,
+                    non_blocking=non_blocking,
+                )
+                source_offset += length
+
         if self._device.type == "cuda":
             with torch.cuda.device(self._device), torch.cuda.stream(self._sync_stream):
                 if record_cuda:
                     start_event = cast(Any, torch.cuda.Event(enable_timing=True))
                     end_event = cast(Any, torch.cuda.Event(enable_timing=True))
                     start_event.record()
-                for offset, length in _ring_spans(start, end, self._capacity):
-                    self._gpu_storage[offset : offset + length].copy_(
-                        self._replay_buffer._storage[offset : offset + length],
-                        non_blocking=True,
-                    )
+                copy_spans(non_blocking=True)
                 if end_event is not None:
                     end_event.record()
                 done_event = cast(Any, torch.cuda.Event())
                 done_event.record(self._sync_stream)
         else:
-            for offset, length in _ring_spans(start, end, self._capacity):
-                self._gpu_storage[offset : offset + length].copy_(
-                    self._replay_buffer._storage[offset : offset + length],
-                    non_blocking=False,
-                )
+            copy_spans(non_blocking=False)
             done_event = cast(Any, torch.mps.Event())
             done_event.record()
-        self._span_events.append((end, done_event))
+        self._span_events.append((end, done_event, ingress_slot, start, end - start))
         self._submitted_ptr = end
         self.last_incremental_h2d_time_s = (time.perf_counter_ns() - h2d_begin_ns) / 1e9
         if self._trace_recorder is not None and start_event is not None and end_event is not None:
@@ -425,17 +486,42 @@ class GPUResidentReplayPipeline:
                     "rows": end - start,
                     "span_start": start,
                     "span_end": end,
+                    "ingress_slot": ingress_slot,
                     "pinned_memory": self._host_pinned,
                     "pipeline": "gpu_resident",
+                    "storage_owner": "device" if self._device_authoritative else "cpu_mirror",
                 },
             )
-        return True
 
     def _drain_completed_spans(self) -> bool:
+        with self._submission_lock:
+            return self._drain_completed_spans_locked()
+
+    def _drain_completed_spans_locked(self) -> bool:
         drained = False
         while self._span_events and self._span_events[0][1].query():
-            self._visible_ptr = self._span_events[0][0]
-            self._span_events.popleft()
+            end, _, ingress_slot, start, count = self._span_events.popleft()
+            if ingress_slot is not None:
+                commit_ns = time.perf_counter_ns()
+                self._replay_buffer.commit_ingress(
+                    slot=ingress_slot,
+                    start=start,
+                    count=count,
+                )
+                if self._trace_recorder is not None:
+                    self._trace_recorder.add_slice(
+                        "replay_pipeline/ingress_commit",
+                        category="replay_pipeline",
+                        start_ns=commit_ns,
+                        end_ns=time.perf_counter_ns(),
+                        args={
+                            "ingress_slot": ingress_slot,
+                            "committed_ptr": end,
+                            "rows": count,
+                            "pipeline": "gpu_resident",
+                        },
+                    )
+            self._visible_ptr = end
             drained = True
         if drained:
             with self._prepare_condition:
@@ -466,6 +552,10 @@ class GPUResidentReplayPipeline:
     def _service_pending_prepare(self) -> bool:
         if self._main_thread_submission:
             self._assert_mps_learner_thread()
+        if self._device_authoritative:
+            with self._submission_lock:
+                if self._span_events:
+                    return False
         with self._prepare_condition:
             if self._prepare_state != "preparing" or self._prepare_tick_id is None:
                 return False
@@ -556,6 +646,67 @@ class GPUResidentReplayPipeline:
             slot = self._prepared_metadata.batch_gpu_slot
             if slot is not None and self._slot_events[slot].query():
                 self._prepare_state = "ready"
+
+    def progress(self, *, wait: bool = False) -> bool:
+        """Advance ingress work without changing replay lifecycle state."""
+        if self._main_thread_submission:
+            return self._drive_mps_learner_thread(wait=wait)
+        if not wait:
+            return False
+        did_work = self._submit_new_spans()
+        with self._submission_lock:
+            for _, event, _, _, _ in self._span_events:
+                event.synchronize()
+            did_work |= self._drain_completed_spans_locked()
+        return did_work
+
+    def read_committed_fields(
+        self,
+        field_names: tuple[str, ...],
+        *,
+        start_ptr: int,
+    ) -> tuple[int, dict[str, torch.Tensor]]:
+        """Return a stable ordered field snapshot through the committed pointer."""
+        if not self._device_authoritative:
+            end_ptr = int(self._replay_buffer.ptr[0])
+            count = min(max(end_ptr - start_ptr, 0), self._capacity)
+            field_start = end_ptr - count
+            return end_ptr, self._replay_buffer.read_recent_fields(
+                field_names,
+                field_start,
+                count,
+            )
+
+        published_snapshot = self._replay_buffer.published_ptr
+        while self._submitted_ptr < published_snapshot:
+            if not self._submit_new_spans():
+                time.sleep(self._POLL_INTERVAL_S)
+
+        with self._submission_lock:
+            for _, event, _, _, _ in self._span_events:
+                event.synchronize()
+            self._drain_completed_spans_locked()
+            end_ptr = self._visible_ptr
+            count = min(max(end_ptr - start_ptr, 0), self._capacity)
+            field_start = end_ptr - count
+            index = field_start % self._capacity
+            fields: dict[str, torch.Tensor] = {}
+            for field_name in field_names:
+                source = self._replay_buffer.field_view(self._gpu_storage, field_name)
+                if index + count <= self._capacity:
+                    fields[field_name] = source[index : index + count].clone()
+                    continue
+                split = self._capacity - index
+                fields[field_name] = torch.cat(
+                    [source[index:], source[: count - split]],
+                    dim=0,
+                ).clone()
+            if self._device.type == "cuda":
+                snapshot_event = cast(Any, torch.cuda.Event())
+                snapshot_event.record(torch.cuda.current_stream(self._device))
+                assert self._sync_stream is not None
+                self._sync_stream.wait_event(snapshot_event)
+            return end_ptr, fields
 
     def start_prepare(
         self,
@@ -648,7 +799,7 @@ class GPUResidentReplayPipeline:
                 self.start_prepare(tick_id, self._sample_count)
             if self._main_thread_submission:
                 while self._prepared_metadata is None and self._prepare_error is None:
-                    did_work = self._drive_mps_learner_thread()
+                    did_work = self._drive_mps_learner_thread(wait=True)
                     if not did_work:
                         time.sleep(self._POLL_INTERVAL_S)
             else:
@@ -740,12 +891,14 @@ class GPUResidentReplayPipeline:
             self._prepare_condition.notify_all()
         if self._sync_thread is not None:
             self._sync_thread.join(timeout=2.0)
-        while self._span_events:
-            _, event = self._span_events.popleft()
-            try:
-                event.synchronize()
-            except Exception:
-                pass
+        try:
+            self._submit_new_spans()
+            with self._submission_lock:
+                for _, event, _, _, _ in self._span_events:
+                    event.synchronize()
+                self._drain_completed_spans_locked()
+        except Exception:
+            pass
         for event in self._slot_events:
             try:
                 event.synchronize()

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -17,6 +17,7 @@ from unilab.algos.torch.offpolicy.runner import (
     build_offpolicy_sample_info,
     compute_train_start_threshold,
     replay_buffer_ready_for_learning,
+    update_reward_stats_from_replay,
 )
 from unilab.ipc.replay_buffer import ReplayBuffer
 
@@ -362,6 +363,45 @@ def test_compute_train_start_threshold(
     batch_size: int, learning_starts: int, num_envs: int, expected: int
 ) -> None:
     assert compute_train_start_threshold(batch_size, learning_starts, num_envs) == expected
+
+
+def test_reward_stats_use_pipeline_committed_metadata() -> None:
+    class _Learner:
+        reward_normalizer = object()
+
+        def __init__(self) -> None:
+            self.rewards = None
+            self.dones = None
+
+        def update_reward_stats(self, rewards: torch.Tensor, dones: torch.Tensor) -> None:
+            self.rewards = rewards
+            self.dones = dones
+
+    class _Replay:
+        capacity = 8
+
+    class _Pipeline:
+        def read_committed_fields(self, field_names, *, start_ptr):
+            assert field_names == ("rewards", "dones")
+            assert start_ptr == 0
+            return 8, {
+                "rewards": torch.arange(8, dtype=torch.float32),
+                "dones": torch.tensor([0, 0, 1, 0, 0, 1, 0, 0], dtype=torch.float32),
+            }
+
+    learner = _Learner()
+    end_ptr = update_reward_stats_from_replay(
+        learner,
+        _Replay(),
+        start_ptr=0,
+        end_ptr=0,
+        num_envs=2,
+        replay_source=_Pipeline(),
+    )
+
+    assert end_ptr == 8
+    torch.testing.assert_close(learner.rewards, torch.arange(8, dtype=torch.float32).view(4, 2))
+    assert learner.dones.shape == (4, 2)
 
 
 @pytest.mark.parametrize(
@@ -972,6 +1012,10 @@ class _FakeDoubleBufferPipeline:
         self.trace_recorder = trace_recorder
         self.close_calls = 0
         self.ready_ticks: set[int] = set()
+
+    def progress(self, *, wait: bool = False) -> bool:
+        del wait
+        return False
 
     def start_prepare(self, tick_id: int, sample_count: int, min_snapshot_ptr=None) -> bool:
         del min_snapshot_ptr

--- a/tests/ipc/test_memory_budget.py
+++ b/tests/ipc/test_memory_budget.py
@@ -44,6 +44,27 @@ def test_offpolicy_memory_budget_includes_opt_in_critic_graph_staging() -> None:
     assert "Critic graph staging" in str(estimate["breakdown"])
 
 
+def test_gpu_resident_host_budget_is_independent_of_replay_capacity() -> None:
+    estimates = [
+        estimate_offpolicy_bytes(
+            num_envs=10,
+            replay_buffer_n=replay_buffer_n,
+            obs_dim=2,
+            action_dim=1,
+            critic_dim=3,
+            batch_size=5,
+            updates_per_step=2,
+            replay_pipeline="gpu_resident",
+            ingress_depth=2,
+        )
+        for replay_buffer_n in (4, 4000)
+    ]
+
+    assert estimates[0]["replay_buffer"] == 0
+    assert estimates[0]["bounded_ingress_slots"] > 0
+    assert estimates[0]["total"] == estimates[1]["total"]
+
+
 def test_shared_memory_budget_unknown_available_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(shutil, "disk_usage", lambda path: (_ for _ in ()).throw(OSError()))
     estimate = {"total": 1024, "breakdown": "test"}

--- a/tests/ipc/test_replay_buffer.py
+++ b/tests/ipc/test_replay_buffer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import threading
 
 import numpy as np
 import pytest
@@ -220,6 +221,118 @@ def test_add_writes_packed_columns_without_cat(monkeypatch: pytest.MonkeyPatch):
     torch.testing.assert_close(buf._storage[:4, buf._obs_sl], obs)
     torch.testing.assert_close(buf._storage[:4, buf._act_sl], act)
     torch.testing.assert_close(buf._storage[:4, buf._critic_sl], critic)
+
+
+def test_bounded_ingress_host_allocation_is_capacity_independent_and_committed_late():
+    buffers = [
+        ReplayBuffer(
+            capacity=capacity,
+            obs_dim=_OBS_DIM,
+            action_dim=_ACTION_DIM,
+            device="cuda",
+            ingress_slot_rows=4,
+        )
+        for capacity in (32, 3200)
+    ]
+    small, large = buffers
+    assert small.host_storage_bytes == large.host_storage_bytes
+    assert not hasattr(small, "_storage")
+
+    obs, act, rew, nobs, done, trunc = _random_batch(4)
+    small.add(obs, act, rew, nobs, done, trunc)
+    assert small.published_ptr == 4
+    assert int(small.ptr[0]) == 0
+    assert int(small.size[0]) == 0
+
+    ingress = small.take_published_ingress()
+    assert ingress is not None
+    slot, start, count, packed = ingress
+    torch.testing.assert_close(packed[:, small._obs_sl], obs)
+    small.commit_ingress(slot=slot, start=start, count=count)
+    assert int(small.ptr[0]) == 4
+    assert int(small.size[0]) == 4
+    for buffer in buffers:
+        buffer.close()
+
+
+def test_bounded_ingress_patches_terminal_rows_before_publication():
+    buf = ReplayBuffer(
+        capacity=16,
+        obs_dim=_OBS_DIM,
+        action_dim=_ACTION_DIM,
+        critic_dim=3,
+        device="cuda",
+        ingress_slot_rows=4,
+    )
+    terminal_mask = torch.tensor([False, True, False, True])
+    terminal_obs = torch.full((4, _OBS_DIM), 17.0)
+    terminal_critic = torch.full((4, 3), 23.0)
+    obs, act, rew, nobs, done, trunc = _random_batch(4)
+    critic = torch.zeros(4, 3)
+    next_critic = torch.ones(4, 3)
+
+    buf.add(
+        obs,
+        act,
+        rew,
+        nobs,
+        done,
+        trunc,
+        terminal_mask=terminal_mask,
+        terminal_next_obs=terminal_obs,
+        critic=critic,
+        next_critic=next_critic,
+        terminal_next_critic=terminal_critic,
+    )
+
+    ingress = buf.take_published_ingress()
+    assert ingress is not None
+    slot, start, count, packed = ingress
+    torch.testing.assert_close(packed[terminal_mask, buf._nobs_sl], terminal_obs[terminal_mask])
+    torch.testing.assert_close(
+        packed[terminal_mask, buf._ncritic_sl], terminal_critic[terminal_mask]
+    )
+    buf.commit_ingress(slot=slot, start=start, count=count)
+    buf.close()
+
+
+def test_bounded_ingress_backpressures_until_completed_slot_is_released():
+    buf = ReplayBuffer(
+        capacity=16,
+        obs_dim=_OBS_DIM,
+        action_dim=_ACTION_DIM,
+        device="cuda",
+        ingress_slot_rows=4,
+        ingress_depth=1,
+    )
+    first = _random_batch(4)
+    second = _random_batch(4)
+    buf.add(*first)
+    add_started = threading.Event()
+    add_finished = threading.Event()
+
+    def add_second() -> None:
+        add_started.set()
+        buf.add(*second)
+        add_finished.set()
+
+    thread = threading.Thread(target=add_second)
+    thread.start()
+    assert add_started.wait(timeout=1.0)
+    assert not add_finished.wait(timeout=0.05)
+
+    ingress = buf.take_published_ingress()
+    assert ingress is not None
+    slot, start, count, _ = ingress
+    buf.commit_ingress(slot=slot, start=start, count=count)
+    assert add_finished.wait(timeout=1.0)
+    thread.join(timeout=1.0)
+
+    ingress = buf.take_published_ingress()
+    assert ingress is not None
+    slot, start, count, _ = ingress
+    buf.commit_ingress(slot=slot, start=start, count=count)
+    buf.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ipc/test_replay_pipeline_gpu_resident.py
+++ b/tests/ipc/test_replay_pipeline_gpu_resident.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import multiprocessing as mp
 import threading
 import time
 
@@ -44,6 +45,24 @@ def _make_replay(
     )
 
 
+def _make_bounded_replay(
+    *,
+    capacity: int = 128,
+    slot_rows: int = 16,
+    device: str = "cuda",
+) -> ReplayBuffer:
+    return ReplayBuffer(
+        capacity=capacity,
+        obs_dim=_OBS_DIM,
+        action_dim=_ACTION_DIM,
+        device=device,
+        critic_dim=_CRITIC_DIM,
+        defer_gpu=True,
+        packed_cpu_storage=True,
+        ingress_slot_rows=slot_rows,
+    )
+
+
 def _pattern_add(rb: ReplayBuffer, start_row: int, n: int) -> None:
     """Add rows whose fields are exact float32 functions of the absolute row id."""
     obs_dim, action_dim, critic_dim = rb._obs_dim, rb._action_dim, rb._critic_dim
@@ -63,6 +82,11 @@ def _pattern_add(rb: ReplayBuffer, start_row: int, n: int) -> None:
         critic=critic,
         next_critic=next_critic,
     )
+
+
+def _pattern_add_chunks(rb: ReplayBuffer, chunk_rows: int, chunks: int) -> None:
+    for chunk in range(chunks):
+        _pattern_add(rb, chunk * chunk_rows, chunk_rows)
 
 
 def _expected_pattern(rb: ReplayBuffer, rewards: torch.Tensor) -> dict[str, torch.Tensor]:
@@ -189,6 +213,102 @@ class TestGPUResidentPipeline:
         assert manifest["pipeline"] == "gpu_resident"
         assert manifest["storage_rows"] == 64
         assert manifest["host_pinned"] is True
+
+    def test_bounded_ingress_owns_no_full_host_ring_and_commits_after_h2d(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=64, slot_rows=16)
+        _pattern_add(rb, 0, 16)
+        assert not hasattr(rb, "_storage")
+        assert int(rb.ptr[0]) == 0
+        assert rb.published_ptr == 16
+
+        pipeline = pipeline_factory(rb, sample_count=8)
+        _wait_visible(pipeline, 16)
+
+        assert int(rb.ptr[0]) == 16
+        assert int(rb.size[0]) == 16
+        assert pipeline._gpu_storage.shape == (64, rb.storage_width)
+        assert pipeline.transfer_manifest["storage_owner"] == "device"
+        assert pipeline.transfer_manifest["host_storage_bytes"] == rb.host_storage_bytes
+        assert pipeline.transfer_manifest["ingress_depth"] == 2
+
+    def test_bounded_ingress_ring_wrap_and_committed_field_order(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=32, slot_rows=8)
+        _pattern_add(rb, 0, 8)
+        _pattern_add(rb, 8, 8)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        _wait_visible(pipeline, 16)
+        for start in (16, 24, 32):
+            _pattern_add(rb, start, 8)
+        _wait_visible(pipeline, 40)
+
+        end_ptr, fields = pipeline.read_committed_fields(
+            ("rewards", "dones"),
+            start_ptr=0,
+        )
+
+        assert end_ptr == 40
+        torch.testing.assert_close(
+            fields["rewards"].cpu(),
+            torch.arange(8, 40, dtype=torch.float32),
+        )
+        assert (fields["dones"].cpu() == 0).all()
+
+    def test_bounded_ingress_samples_only_committed_rows(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=64, slot_rows=16)
+        _pattern_add(rb, 0, 16)
+        with pytest.raises(RuntimeError, match="sampled through its pipeline"):
+            rb.sample(4)
+        pipeline = pipeline_factory(rb, sample_count=16, base_seed=41)
+
+        batch = pipeline.sample_large_batch(3, 16)
+        rewards = batch["rewards"].cpu()
+
+        assert rewards.min() >= 0
+        assert rewards.max() < 16
+        expected = _expected_pattern(rb, rewards)
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)
+
+    def test_bounded_ingress_pending_overwrite_cannot_prepare_batch(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=32, slot_rows=8)
+        _pattern_add(rb, 0, 8)
+        _pattern_add(rb, 8, 8)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        _wait_visible(pipeline, 16)
+        _pattern_add(rb, 16, 8)
+        _pattern_add(rb, 24, 8)
+        _wait_visible(pipeline, 32)
+        pipeline._closed = True
+        assert pipeline._sync_thread is not None
+        pipeline._sync_thread.join(timeout=2.0)
+        pipeline._closed = False
+
+        _pattern_add(rb, 32, 8)
+        assert pipeline._submit_new_spans() is True
+        assert int(rb.ptr[0]) == 32
+        assert pipeline.start_prepare(2, 8, min_snapshot_ptr=32) is True
+        assert pipeline._service_pending_prepare() is False
+        assert pipeline._prepared_metadata is None
+
+        pipeline.progress(wait=True)
+        assert int(rb.ptr[0]) == 40
+        assert pipeline._service_pending_prepare() is True
+
+    def test_bounded_ingress_consumes_spawned_collector_chunks(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=64, slot_rows=8)
+        pipeline = pipeline_factory(rb, sample_count=8)
+        process = mp.get_context("spawn").Process(
+            target=_pattern_add_chunks,
+            args=(rb, 8, 5),
+        )
+
+        process.start()
+        process.join(timeout=15)
+        assert process.exitcode == 0
+        _wait_visible(pipeline, 40)
+
+        assert int(rb.ptr[0]) == 40
+        assert int(rb.size[0]) == 40
 
     def test_mirror_syncs_rows_incrementally(self, pipeline_factory):
         rb = _make_replay(capacity=128)
@@ -360,6 +480,22 @@ class TestMPSGPUResidentPipeline:
         assert pipeline.h2d_submitter == "gpu_resident_mirror_main_thread"
         assert pipeline.transfer_manifest["device_submission_thread"] == "learner"
         assert all(value.device.type == "mps" for value in batch.values())
+        rewards = batch["rewards"].cpu()
+        expected = _expected_pattern(rb, rewards)
+        for key, want in expected.items():
+            torch.testing.assert_close(batch[key].cpu(), want)
+
+    def test_bounded_ingress_commits_and_samples_on_learner_thread(self, pipeline_factory):
+        rb = _make_bounded_replay(capacity=64, slot_rows=16, device="mps")
+        _pattern_add(rb, 0, 16)
+        assert int(rb.ptr[0]) == 0
+        pipeline = pipeline_factory(rb, sample_count=8)
+
+        batch = pipeline.sample_large_batch(1, 8)
+
+        assert int(rb.ptr[0]) == 16
+        assert pipeline.transfer_manifest["storage_owner"] == "device"
+        assert pipeline.h2d_submitter == "gpu_resident_ingress_main_thread"
         rewards = batch["rewards"].cpu()
         expected = _expected_pattern(rb, rewards)
         for key, want in expected.items():


### PR DESCRIPTION
Closes #934
Parent roadmap: #933

## Summary

- Replace the single-device gpu_resident full host replay ring with a fixed two-slot shared ingress and one authoritative device ring.
- Publish collector transitions only after terminal next-observation/critic patching; advance committed ptr/size only after device-copy completion and release slots with bounded backpressure.
- Preserve sync and no-sync collection, ring wrap, freshness, deterministic sampling seeds, hot/cold batches, graph-packed layouts, reward normalization and trace/logger diagnostics.
- Keep CUDA submission on the existing daemon/side stream and MPS device submission on the learner thread.
- Update host/device memory budgeting, focused tests and SAC documentation.
- Keep the legacy CPU-authoritative pipeline temporarily; roadmap #933 now removes off-policy multi-GPU via #937/#938 and removes the remaining CPU fallback via #936.

## Scope

- 15 files
- 898 insertions, 109 deletions
- 789 net lines
- No multi-GPU migration, runner lifecycle, checkpoint or learner schema changes

## Validation

### Linux / CUDA

Hardware: NVIDIA RTX 6000 Ada 48 GB.

- make test-all passed on the final commit: ruff format/check, mypy, pyright, 1647 passed, 35 skipped, 1 xfailed, 276 deselected; benchmark import smoke passed with only platform-optional MLX entries skipped.
- Focused replay/runner/docs suite: 154 passed, 8 skipped, 1 deselected; docs checks: 20 passed.
- Real spawned CUDA collector coverage included bounded allocation, backpressure, terminal patch, ring wrap, uncommitted-row exclusion, committed reward fields, sync collection and no-sync collection.
- Five paired, order-reversed SAC/G1WalkFlat/MuJoCo runs, seed 1, 512 envs, batch 1024, replay_buffer_n 8, 30 iterations, last 20 iterations per-run median:
  - Steps/s median/IQR: baseline 18828.395 / 504.437; candidate 18852.566 / 857.389.
  - Iteration ms median/IQR: baseline 27.193 / 0.727; candidate 27.159 / 1.244.
  - Replay boundary wait ms median/IQR: baseline 0.008264 / 0.000722; candidate 0.008281 / 0.000500.
- Final Perfetto trace verified steady ticks 3–9 in add → H2D → commit → gather order, all inside the preceding learner update window; maximum steady replay boundary wait was 0.853 microseconds.

### Real Mac / MPS

Evidence: https://github.com/unilabsim/UniLab/issues/934#issuecomment-5231957021

Hardware: Apple M5 Max, 128 GB, macOS 26.5.2, PyTorch 2.7.0; MPS built and available.

- Candidate make test-all passed: 1634 passed, 65 skipped, 1 xfailed; benchmark import smoke 32/32 modules and 33/33 scripts.
- Additional real-MPS owner tests: 28 passed, including 8 MPS-specific tests.
- Sync and training.no_sync_collection=true lifecycle smoke runs both exited successfully.
- Five runs × 30 ticks of fixed-seed pure replay IPC, each crossing ring wrap three times:
  - Serial total IPC ms median/IQR: baseline 0.82781 / 0.06638; candidate 0.77238 / 0.14569.
  - One-tick prefetch boundary ms median/IQR: baseline 1.92271 / 0.09760; candidate 0.00708 / 0.00162.
  - All candidate steady ticks were immediately ready with committed_ptr equal to visible_ptr.
- Perfetto showed 29/29 steady add operations overlapping learner update windows, 29/29 post-warmup commits and gathers on the learner/main thread inside update windows, and no background Metal submission.
- Host storage at capacity 4096 decreased from 7045120 to 1761280 bytes; candidate host storage remained 1761280 bytes when capacity doubled to 8192.

The MPS result intentionally claims the owner-layer replay IPC gate, not collector-dominated end-to-end Steps/s. The initially suggested full-training setup was invalid because learning_starts required 5120 rows while replay capacity was 4096; that run was excluded rather than used as evidence.

## Follow-up

- #935 is canceled as not planned.
- #937 removes the existing off-policy multi-GPU production path.
- #938 removes distributed learner hooks and metrics after their consumers are gone.
- #936 removes the remaining single-device CPU replay fallback and replay_pipeline branch.
