### PR TITLE
refactor(offpolicy): remove distributed logger metrics

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
@@ -81,23 +81,20 @@ instead of being compared only against wait metrics.
 
 | Terminal field | TensorBoard / W&B key | Meaning |
 | --- | --- | --- |
-| Collector Wait | `timing/learner_collector_wait_ms` | Waiting for the collector to produce trainable data; in multi-GPU sync collection this also includes waiting for the rank batch to become ready before the initial barrier |
+| Collector Wait | `timing/learner_collector_wait_ms` | Waiting for the collector to produce trainable data |
 | Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | Single-GPU/double-buffer prefetch miss waiting for a replay pack / H2D batch to become ready; ~0 on a prefetch hit |
 | Replay Sample | `timing/learner_replay_sample_ms` | Learner-side replay sampling / ready-batch materialization after the wait is over |
-| Rank Barrier | `timing/learner_rank_barrier_ms` | Multi-GPU `dist.barrier()` (initial + final) total |
 | Sync Coordination | `timing/learner_sync_coordination_ms` | Synchronous-collection handshake; 0 when not in sync collection |
 | H2D Copy | `timing/learner_incremental_h2d_ms` | Host-to-device batch copy |
-| Train | `timing/learner_train_ms` | Pure SGD compute, excluding param sync and barrier |
-| Param Sync | `timing/learner_param_sync_ms` | Multi-GPU local-SGD parameter averaging |
+| Train | `timing/learner_train_ms` | Pure SGD compute |
 | Weight Sync | `timing/learner_weight_sync_ms` | Publishing new weights to the collector |
 | Iter Wall | `perf/iter_ms` | Whole-iteration wall time, not the sum of the components |
 
 The terminal shows every learner row as right-aligned `ms` plus `% of Iter Wall`.
-Distributed-only rows are hidden on single GPU unless they are non-zero. Backend
-logs include `perf/learner_train_pct`, `perf/learner_accounted_pct`,
+Backend logs include `perf/learner_train_pct`, `perf/learner_accounted_pct`,
 `perf/learner_other_pct` and `timing/learner_other_ms`; the latter two are residual
 diagnostics and are not shown as terminal rows. `perf/learner_pipeline_ms` = H2D +
-Train + Param Sync + Weight Sync. The former `timing/learner_wait_ms` was renamed to
+Train + Weight Sync. The former `timing/learner_wait_ms` was renamed to
 `timing/learner_collector_wait_ms`.
 
 The collector process reports per-phase timings in the terminal Collector column and
@@ -159,7 +156,5 @@ gantt
 > The axis is schematic (relative, not real-ms). The collector subprocess produces rollouts through the 4-slot ring buffer in parallel with the learner, so **Collector Wait ≈ 0** in steady state. `perf/iter_ms` counts only this learner loop (it includes Collector Wait but not the collector's parallel rollout compute); the red Weight Sync marks the end of the iteration when fresh weights are published to the collector.
 
 All off-policy terminal views use the same value formatting. Replay Batch Wait is
-shown only when a single-GPU/double-buffer prefetch miss is non-zero; multi-GPU
-synchronized batch readiness is folded into Collector Wait before the initial rank
-barrier. Rank Barrier and Param Sync are shown only on multi-GPU paths or when
-non-zero. Sync Coordination is shown only with synchronous collection.
+shown only when a single-device/double-buffer prefetch miss is non-zero. Sync
+Coordination is shown only with synchronous collection.

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
@@ -77,18 +77,16 @@ off-policy（SAC / TD3 / FlashSAC 与 APPO）把 learner loop 记录为已命名
 
 | 终端字段 | TensorBoard / W&B key | 含义 |
 | --- | --- | --- |
-| Collector Wait | `timing/learner_collector_wait_ms` | 等待 collector 产出可训练数据；多卡同步采集下也包含 initial barrier 前等待 rank batch 就绪的时间 |
+| Collector Wait | `timing/learner_collector_wait_ms` | 等待 collector 产出可训练数据 |
 | Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | 单卡 / double-buffer 预取 miss 时等待 replay pack / H2D batch 就绪；预取命中时约为 0 |
 | Replay Sample | `timing/learner_replay_sample_ms` | wait 结束后，learner 侧 replay 采样 / ready batch 物化耗时 |
-| Rank Barrier | `timing/learner_rank_barrier_ms` | 多卡 `dist.barrier()`（初始 + 最终）耗时之和 |
 | Sync Coordination | `timing/learner_sync_coordination_ms` | 同步采集握手耗时；非同步采集时为 0 |
 | H2D Copy | `timing/learner_incremental_h2d_ms` | host→device 批次拷贝耗时 |
-| Train | `timing/learner_train_ms` | 纯 SGD 计算，不含 param sync 与 barrier |
-| Param Sync | `timing/learner_param_sync_ms` | 多卡 local-SGD 参数平均耗时 |
+| Train | `timing/learner_train_ms` | 纯 SGD 计算耗时 |
 | Weight Sync | `timing/learner_weight_sync_ms` | 向 collector 发布新权重的耗时 |
 | Iter Wall | `perf/iter_ms` | 整圈迭代墙钟，非各分量之和 |
 
-终端所有 learner 行都显示右对齐的 `ms` 与占 `Iter Wall` 百分比。多卡专有行在单 GPU 上隐藏，除非对应计时非零。后端额外记录 `perf/learner_train_pct`、`perf/learner_accounted_pct`、`perf/learner_other_pct` 和 `timing/learner_other_ms`；后两者是 residual 诊断，不占终端行。另有 `perf/learner_pipeline_ms` = H2D + Train + Param Sync + Weight Sync。原 `timing/learner_wait_ms` 已更名为 `timing/learner_collector_wait_ms`。
+终端所有 learner 行都显示右对齐的 `ms` 与占 `Iter Wall` 百分比。后端额外记录 `perf/learner_train_pct`、`perf/learner_accounted_pct`、`perf/learner_other_pct` 和 `timing/learner_other_ms`；后两者是 residual 诊断，不占终端行。另有 `perf/learner_pipeline_ms` = H2D + Train + Weight Sync。原 `timing/learner_wait_ms` 已更名为 `timing/learner_collector_wait_ms`。
 
 collector 进程在终端 Collector 列、TensorBoard `timing/collector_*` 上报各阶段耗时。SAC / TD3：
 
@@ -146,4 +144,4 @@ gantt
 
 > 横轴为示意相对时长（非真实 ms 比例）。collector 子进程经 4 槽 ring buffer 与 learner 并行产出 rollout，稳态下 **Collector Wait ≈ 0**。`perf/iter_ms` 仅计 learner 这一圈（含 Collector Wait，但不含 collector 的并行采集计算）；红色 Weight Sync 标志该轮迭代结束、向 collector 发布新权重。
 
-所有 off-policy 终端视图都使用同一套数值格式。Replay Batch Wait 只在单卡 / double-buffer 预取 miss 非零时显示；多卡同步 batch ready 等待会在 initial barrier 前归入 Collector Wait。Rank Barrier 和 Param Sync 只在多卡路径或非零时显示；Sync Coordination 只在同步采集时显示。
+所有 off-policy 终端视图都使用同一套数值格式。Replay Batch Wait 只在单 device / double-buffer 预取 miss 非零时显示；Sync Coordination 只在同步采集时显示。

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -795,7 +795,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     collector_wait_time=collector_wait_time,
                     replay_batch_wait_time=replay_batch_wait_time,
                     learner_replay_sample_time=learner_replay_sample_time,
-                    rank_barrier_time=0.0,
                     sync_coordination_time=sync_coordination_time,
                     learner_incremental_h2d_time=learner_incremental_h2d_time,
                     weight_sync_time=weight_sync_time,

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -59,24 +59,22 @@ def build_offpolicy_sample_info(
     replay_batch_size_per_rank: int,
     updates_per_step: int,
     learner: Any,
-    world_size: int = 1,
 ) -> dict[str, int]:
     """Describe replay rows and effective learner samples for logging.
 
-    ``algo.batch_size`` is defined as a per-rank learner batch per update. When
+    ``algo.batch_size`` is the learner batch per update. When
     symmetry is enabled, the runner samples fewer replay rows and the learner
-    expands them back to the configured per-rank batch.
+    expands them back to the configured batch.
     """
-    world_size = max(int(world_size), 1)
     updates_per_step = max(int(updates_per_step), 0)
     replay_batch_size_per_rank = max(int(replay_batch_size_per_rank), 0)
     batch_multiplier = get_learner_batch_multiplier(learner)
     batch_size_per_rank = replay_batch_size_per_rank * batch_multiplier
     return {
         "batch_size_per_rank": batch_size_per_rank,
-        "effective_batch_size": batch_size_per_rank * world_size,
-        "replay_samples_per_iter": replay_batch_size_per_rank * updates_per_step * world_size,
-        "learner_samples_per_iter": batch_size_per_rank * updates_per_step * world_size,
+        "effective_batch_size": batch_size_per_rank,
+        "replay_samples_per_iter": replay_batch_size_per_rank * updates_per_step,
+        "learner_samples_per_iter": batch_size_per_rank * updates_per_step,
     }
 
 
@@ -700,7 +698,6 @@ class OffPolicyRunner(AsyncRunner):
                 collector_wait_time=collector_wait_time,
                 replay_batch_wait_time=0.0,
                 learner_replay_sample_time=learner_replay_sample_time,
-                rank_barrier_time=0.0,
                 sync_coordination_time=sync_coordination_time,
                 learner_incremental_h2d_time=learner_incremental_h2d_time,
                 weight_sync_time=weight_sync_time,

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -125,17 +125,12 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._collector_wait_time: float = 0.0
         self._replay_batch_wait_time: float = 0.0
         self._learner_replay_sample_time: float = 0.0
-        self._rank_barrier_time: float = 0.0
         self._sync_coordination_time: float = 0.0
         self._learner_incremental_h2d_time: float = 0.0
-        self._learner_param_sync_time: float = 0.0
         self._weight_sync_time: float = 0.0
         self._iteration_time: float | None = None
         self._throughput_steps: int = 0
         self._collector_active_steps_per_sec: float | None = None
-        self._world_size: int = 1
-        self._multi_gpu_sync_mode: str = ""
-        self._multi_gpu_sync_interval: int = 0
         self._batch_size_per_rank: int = 0
         self._effective_batch_size: int = 0
         self._replay_samples_per_iter: int = 0
@@ -200,19 +195,13 @@ class OffPolicyLogger(BaseTrainingLogger):
         return self._learner_samples_per_iter / iter_time
 
     def _get_learner_pipeline_time(self) -> float:
-        return (
-            self._learner_incremental_h2d_time
-            + self._train_time
-            + self._learner_param_sync_time
-            + self._weight_sync_time
-        )
+        return self._learner_incremental_h2d_time + self._train_time + self._weight_sync_time
 
     def _get_learner_accounted_time(self) -> float:
         return (
             self._collector_wait_time
             + self._replay_batch_wait_time
             + self._learner_replay_sample_time
-            + self._rank_barrier_time
             + self._sync_coordination_time
             + self._get_learner_pipeline_time()
         )
@@ -233,7 +222,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             self._collector_wait_time
             + self._replay_batch_wait_time
             + self._learner_replay_sample_time
-            + self._rank_barrier_time
             + self._sync_coordination_time
             + self._get_learner_pipeline_time()
         )
@@ -307,10 +295,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         collector_wait_time: float = 0.0,
         replay_batch_wait_time: float = 0.0,
         learner_replay_sample_time: float = 0.0,
-        rank_barrier_time: float = 0.0,
         sync_coordination_time: float = 0.0,
         learner_incremental_h2d_time: float = 0.0,
-        learner_param_sync_time: float = 0.0,
         weight_sync_time: float = 0.0,
         iteration_time: float | None = None,
         extra_info: dict | None = None,
@@ -321,10 +307,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._collector_wait_time = collector_wait_time
         self._replay_batch_wait_time = replay_batch_wait_time
         self._learner_replay_sample_time = learner_replay_sample_time
-        self._rank_barrier_time = rank_barrier_time
         self._sync_coordination_time = sync_coordination_time
         self._learner_incremental_h2d_time = learner_incremental_h2d_time
-        self._learner_param_sync_time = learner_param_sync_time
         self._weight_sync_time = weight_sync_time
         self._iteration_time = iteration_time
         self._has_iteration_extra_info = extra_info is not None
@@ -336,15 +320,12 @@ class OffPolicyLogger(BaseTrainingLogger):
                 if collector_active_steps_per_sec is not None
                 else None
             )
-            self._world_size = int(extra_info.get("world_size", 1))
-            self._multi_gpu_sync_mode = str(extra_info.get("multi_gpu_sync_mode", ""))
-            self._multi_gpu_sync_interval = int(extra_info.get("multi_gpu_sync_interval", 0))
             self._batch_size_per_rank = int(extra_info.get("batch_size_per_rank", 0))
             self._effective_batch_size = int(extra_info.get("effective_batch_size", 0))
             if self._effective_batch_size <= 0:
-                self._effective_batch_size = self._batch_size_per_rank * self._world_size
+                self._effective_batch_size = self._batch_size_per_rank
             if self._batch_size_per_rank <= 0 and self._effective_batch_size > 0:
-                self._batch_size_per_rank = self._effective_batch_size // max(self._world_size, 1)
+                self._batch_size_per_rank = self._effective_batch_size
             self._replay_samples_per_iter = int(extra_info.get("replay_samples_per_iter", 0))
             self._learner_samples_per_iter = int(extra_info.get("learner_samples_per_iter", 0))
             if self._replay_samples_per_iter <= 0:
@@ -352,9 +333,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         else:
             self._throughput_steps = 0
             self._collector_active_steps_per_sec = None
-            self._world_size = 1
-            self._multi_gpu_sync_mode = ""
-            self._multi_gpu_sync_interval = 0
             self._batch_size_per_rank = 0
             self._effective_batch_size = 0
             self._replay_samples_per_iter = 0
@@ -426,11 +404,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 global_step,
             )
             writer.add_scalar(
-                "timing/learner_rank_barrier_ms",
-                self._rank_barrier_time * 1000,
-                global_step,
-            )
-            writer.add_scalar(
                 "timing/learner_sync_coordination_ms",
                 self._sync_coordination_time * 1000,
                 global_step,
@@ -441,12 +414,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 global_step,
             )
             writer.add_scalar("timing/learner_train_ms", train_time * 1000, global_step)
-            if self._world_size > 1 or self._learner_param_sync_time > 0.0:
-                writer.add_scalar(
-                    "timing/learner_param_sync_ms",
-                    self._learner_param_sync_time * 1000,
-                    global_step,
-                )
             writer.add_scalar(
                 "timing/learner_weight_sync_ms",
                 self._weight_sync_time * 1000,
@@ -514,14 +481,11 @@ class OffPolicyLogger(BaseTrainingLogger):
             log_dict["timing/learner_collector_wait_ms"] = self._collector_wait_time * 1000
             log_dict["timing/learner_replay_batch_wait_ms"] = self._replay_batch_wait_time * 1000
             log_dict["timing/learner_replay_sample_ms"] = self._learner_replay_sample_time * 1000
-            log_dict["timing/learner_rank_barrier_ms"] = self._rank_barrier_time * 1000
             log_dict["timing/learner_sync_coordination_ms"] = self._sync_coordination_time * 1000
             log_dict["timing/learner_incremental_h2d_ms"] = (
                 self._learner_incremental_h2d_time * 1000
             )
             log_dict["timing/learner_train_ms"] = train_time * 1000
-            if self._world_size > 1 or self._learner_param_sync_time > 0.0:
-                log_dict["timing/learner_param_sync_ms"] = self._learner_param_sync_time * 1000
             log_dict["timing/learner_weight_sync_ms"] = self._weight_sync_time * 1000
             log_dict["timing/learner_other_ms"] = learner_other_time * 1000
             for key, value in self._collector_timing.items():
@@ -640,9 +604,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         if self._replay_batch_wait_time > 0.0:
             learner_items.append(("Replay Batch Wait", _fmt_phase(self._replay_batch_wait_time)))
         learner_items.append(("Replay Sample", _fmt_phase(self._learner_replay_sample_time)))
-        if self._world_size > 1 or self._rank_barrier_time > 0.0:
-            learner_items.append(("Rank Barrier", _fmt_phase(self._rank_barrier_time)))
-        if self._world_size > 1 or self._sync_coordination_time > 0.0:
+        if self._sync_coordination_time > 0.0:
             learner_items.append(("Sync Coordination", _fmt_phase(self._sync_coordination_time)))
         learner_items.extend(
             [
@@ -650,8 +612,6 @@ class OffPolicyLogger(BaseTrainingLogger):
                 ("Train", _fmt_phase(self._train_time, color="green")),
             ]
         )
-        if self._world_size > 1 or self._learner_param_sync_time > 0.0:
-            learner_items.append(("Param Sync", _fmt_phase(self._learner_param_sync_time)))
         learner_items.append(("Weight Sync", _fmt_phase(self._weight_sync_time)))
         learner_items.append(("Iter Wall", f"{self._get_iter_wall_time() * 1000:>7.1f}ms  100%"))
         sorted_collector_timing = sorted(
@@ -689,12 +649,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             ]
         )
         system_items.append(("Envs", f"{self.num_envs:,}"))
-        if self._world_size > 1:
-            system_items.append(("GPUs", f"{self._world_size:,}"))
-            if self._multi_gpu_sync_mode:
-                system_items.append(("Sync Mode", self._multi_gpu_sync_mode))
-            if self._multi_gpu_sync_interval > 0:
-                system_items.append(("Sync Interval", f"{self._multi_gpu_sync_interval:,}"))
         if self._batch_size_per_rank > 0:
             system_items.append(("Batch/Rank", f"{self._batch_size_per_rank:,}"))
         if (

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -411,19 +411,18 @@ def test_replay_buffer_ready_for_learning(
     )
 
 
-def test_build_offpolicy_sample_info_uses_per_rank_batch_contract() -> None:
+def test_build_offpolicy_sample_info_uses_single_device_batch_contract() -> None:
     learner = _FakeLearner()
 
     assert build_offpolicy_sample_info(
         replay_batch_size_per_rank=8,
         updates_per_step=2,
         learner=learner,
-        world_size=2,
     ) == {
         "batch_size_per_rank": 8,
-        "effective_batch_size": 16,
-        "replay_samples_per_iter": 32,
-        "learner_samples_per_iter": 32,
+        "effective_batch_size": 8,
+        "replay_samples_per_iter": 16,
+        "learner_samples_per_iter": 16,
     }
 
 
@@ -685,7 +684,7 @@ def test_offpolicy_async_collector_wait_isolates_wait_components(
     assert "wait_time" not in step
     assert step["collector_wait_time"] >= 0.0
     assert step["replay_batch_wait_time"] == 0.0
-    assert step["rank_barrier_time"] == 0.0
+    assert "rank_barrier_time" not in step
     assert step["sync_coordination_time"] == 0.0
 
 
@@ -702,7 +701,6 @@ def test_offpolicy_logger_emits_four_independent_wait_components() -> None:
     logger = OffPolicyLogger(algo_name="SAC", max_iterations=10, num_envs=8, log_backend="none")
     logger._tb_writer = _FakeWriter()
     logger._wandb_run = None
-    logger._world_size = 2
 
     logger.log_step(
         iteration=1,
@@ -712,13 +710,11 @@ def test_offpolicy_logger_emits_four_independent_wait_components() -> None:
         collector_wait_time=0.30,
         replay_batch_wait_time=0.05,
         learner_replay_sample_time=0.08,
-        rank_barrier_time=0.02,
         sync_coordination_time=0.01,
         learner_incremental_h2d_time=0.10,
-        learner_param_sync_time=0.04,
         weight_sync_time=0.03,
-        iteration_time=1.83,
-        extra_info={"throughput_steps": 1000, "world_size": 2},
+        iteration_time=1.77,
+        extra_info={"throughput_steps": 1000},
     )
 
     scalars = cast("dict[str, float]", logger._tb_writer.scalars)
@@ -726,12 +722,13 @@ def test_offpolicy_logger_emits_four_independent_wait_components() -> None:
     assert scalars["timing/learner_collector_wait_ms"] == pytest.approx(300.0)
     assert scalars["timing/learner_replay_batch_wait_ms"] == pytest.approx(50.0)
     assert scalars["timing/learner_replay_sample_ms"] == pytest.approx(80.0)
-    assert scalars["timing/learner_rank_barrier_ms"] == pytest.approx(20.0)
+    assert "timing/learner_rank_barrier_ms" not in scalars
+    assert "timing/learner_param_sync_ms" not in scalars
     assert scalars["timing/learner_sync_coordination_ms"] == pytest.approx(10.0)
     assert scalars["timing/learner_other_ms"] == pytest.approx(0.0)
-    assert scalars["perf/learner_pipeline_ms"] == pytest.approx((0.10 + 1.2 + 0.04 + 0.03) * 1000)
-    assert scalars["perf/iter_ms"] == pytest.approx(1830.0)
-    assert scalars["perf/learner_train_pct"] == pytest.approx(1.2 / 1.83 * 100)
+    assert scalars["perf/learner_pipeline_ms"] == pytest.approx((0.10 + 1.2 + 0.03) * 1000)
+    assert scalars["perf/iter_ms"] == pytest.approx(1770.0)
+    assert scalars["perf/learner_train_pct"] == pytest.approx(1.2 / 1.77 * 100)
     assert scalars["perf/learner_accounted_pct"] == pytest.approx(100.0)
     assert scalars["perf/learner_other_pct"] == pytest.approx(0.0)
 

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -173,9 +173,9 @@ def test_onpolicy_logger_uses_offpolicy_terminal_layout():
     logger.close()
 
 
-def test_offpolicy_logger_terminal_timing_labels_include_wall_clock_and_distributed_context():
+def test_offpolicy_logger_terminal_timing_labels_include_wall_clock_context():
     logger = OffPolicyLogger(
-        algo_name="FastSAC_x2GPU",
+        algo_name="FastSAC",
         env_name="G1WalkFlat",
         max_iterations=10,
         num_envs=4,
@@ -192,11 +192,8 @@ def test_offpolicy_logger_terminal_timing_labels_include_wall_clock_and_distribu
         iteration_time=1.6,
         extra_info={
             "throughput_steps": 8,
-            "world_size": 2,
-            "multi_gpu_sync_mode": "local_sgd",
-            "multi_gpu_sync_interval": 1,
             "batch_size_per_rank": 8,
-            "effective_batch_size": 16,
+            "effective_batch_size": 8,
             "replay_samples_per_iter": 64,
             "learner_samples_per_iter": 64,
         },
@@ -210,16 +207,16 @@ def test_offpolicy_logger_terminal_timing_labels_include_wall_clock_and_distribu
     assert "H2D Copy" in output
     assert "Replay Batch Wait" not in output
     assert "Replay Sample" in output
-    assert "Param Sync" in output
+    assert "Rank Barrier" not in output
+    assert "Param Sync" not in output
     assert "Iter Wall" in output
     assert "Unaccounted" not in output
     assert "Other Loop" not in output
-    assert "GPUs" in output
-    assert "Sync Mode" in output
-    assert "local_sgd" in output
-    assert "Sync Interval" in output
+    assert "GPUs" not in output
+    assert "Sync Mode" not in output
+    assert "Sync Interval" not in output
     assert "Batch/Rank" in output
-    assert "Batch/Update" in output
+    assert "Batch/Update" not in output
     assert "Samples/Iter" in output
     assert "Samples/s" in output
 
@@ -487,15 +484,13 @@ def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
         train_time=0.75,
         collector_wait_time=10.0,
         learner_incremental_h2d_time=0.02,
-        learner_param_sync_time=0.04,
         weight_sync_time=0.05,
         iteration_time=10.9,
         extra_info={
             "throughput_steps": 8,
             "collector_active_steps_per_sec": 1234.5,
-            "world_size": 2,
             "batch_size_per_rank": 8,
-            "effective_batch_size": 16,
+            "effective_batch_size": 8,
             "replay_samples_per_iter": 32,
             "learner_samples_per_iter": 32,
         },
@@ -509,28 +504,21 @@ def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
     assert payload["timing/learner_incremental_h2d_ms"] == 20.0
     assert payload["timing/learner_replay_sample_ms"] == 0.0
     assert payload["timing/learner_train_ms"] == 750.0
-    assert payload["timing/learner_param_sync_ms"] == 40.0
+    assert "timing/learner_param_sync_ms" not in payload
     assert payload["timing/learner_weight_sync_ms"] == 50.0
-    assert payload["timing/learner_other_ms"] == pytest.approx(40.0)
-    assert payload["perf/learner_pipeline_ms"] == pytest.approx(860.0)
+    assert payload["timing/learner_other_ms"] == pytest.approx(80.0)
+    assert payload["perf/learner_pipeline_ms"] == pytest.approx(820.0)
     assert payload["perf/iter_ms"] == pytest.approx(10_900.0)
     assert "perf/iter_unaccounted_ms" not in payload
     assert payload["perf/learner_train_pct"] == pytest.approx(0.75 / 10.9 * 100)
-    assert payload["perf/learner_other_pct"] == pytest.approx(0.04 / 10.9 * 100)
-    assert payload["perf/learner_accounted_pct"] == pytest.approx(10.86 / 10.9 * 100)
+    assert payload["perf/learner_other_pct"] == pytest.approx(0.08 / 10.9 * 100)
+    assert payload["perf/learner_accounted_pct"] == pytest.approx(10.82 / 10.9 * 100)
     assert payload["perf/steps_per_sec"] == pytest.approx(8.0 / 10.9)
     assert payload["perf/collector_active_steps_per_sec"] == pytest.approx(1234.5)
     assert payload["perf/effective_samples_per_sec"] == pytest.approx(32.0 / 10.9)
-    for key in (
-        "axis/iteration",
-        "axis/env_steps_total",
-        "distributed/world_size",
-        "distributed/batch_size_per_rank",
-        "distributed/effective_batch_size",
-        "distributed/replay_samples_per_iter",
-        "distributed/learner_samples_per_iter",
-    ):
+    for key in ("axis/iteration", "axis/env_steps_total"):
         assert key not in payload
+    assert not any(key.startswith("distributed/") for key in payload)
     assert "perf/effective_samples_per_sec_smoothed" not in payload
     assert "perf/collect_train_ratio" not in payload
 
@@ -567,62 +555,7 @@ def test_offpolicy_logger_logs_collector_phase_timing_to_backends(monkeypatch):
     tb_logger.finish()
 
 
-def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_or_distributed_scalars():
-    tb_writer = _FakeTensorBoardWriter()
-    logger = OffPolicyLogger(
-        algo_name="FastSAC_x2GPU",
-        env_name="G1WalkFlat",
-        log_backend="none",
-    )
-    logger._tb_writer = tb_writer
-    logger.log_step(
-        iteration=5,
-        metrics={},
-        train_time=0.7,
-        collector_wait_time=1.0,
-        learner_incremental_h2d_time=0.05,
-        learner_param_sync_time=0.02,
-        weight_sync_time=0.1,
-        iteration_time=1.95,
-        extra_info={
-            "throughput_steps": 16,
-            "collector_active_steps_per_sec": 4321.0,
-            "world_size": 2,
-            "batch_size_per_rank": 16,
-            "effective_batch_size": 32,
-            "replay_samples_per_iter": 64,
-            "learner_samples_per_iter": 64,
-        },
-    )
-
-    scalars = {tag: value for tag, value, _ in tb_writer.scalars}
-    assert scalars["timing/learner_collector_wait_ms"] == pytest.approx(1_000.0)
-    assert "timing/learner_replay_wait_ms" not in scalars
-    assert scalars["timing/learner_incremental_h2d_ms"] == pytest.approx(50.0)
-    assert scalars["timing/learner_replay_sample_ms"] == pytest.approx(0.0)
-    assert scalars["timing/learner_param_sync_ms"] == pytest.approx(20.0)
-    assert scalars["timing/learner_other_ms"] == pytest.approx(80.0)
-    assert scalars["perf/learner_pipeline_ms"] == pytest.approx(870.0)
-    assert scalars["perf/iter_ms"] == pytest.approx(1_950.0)
-    assert scalars["perf/learner_train_pct"] == pytest.approx(0.7 / 1.95 * 100)
-    assert scalars["perf/learner_other_pct"] == pytest.approx(0.08 / 1.95 * 100)
-    assert scalars["perf/collector_active_steps_per_sec"] == pytest.approx(4321.0)
-    assert scalars["perf/effective_samples_per_sec"] == pytest.approx(64.0 / 1.95)
-    for key in (
-        "axis/iteration",
-        "axis/env_steps_total",
-        "distributed/world_size",
-        "distributed/batch_size_per_rank",
-        "distributed/effective_batch_size",
-        "distributed/replay_samples_per_iter",
-        "distributed/learner_samples_per_iter",
-    ):
-        assert key not in scalars
-    assert "perf/effective_samples_per_sec_smoothed" not in scalars
-    logger.finish()
-
-
-def test_offpolicy_logger_omits_param_sync_scalar_for_single_gpu_without_sync():
+def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_scalars():
     tb_writer = _FakeTensorBoardWriter()
     logger = OffPolicyLogger(
         algo_name="FastSAC",
@@ -634,21 +567,37 @@ def test_offpolicy_logger_omits_param_sync_scalar_for_single_gpu_without_sync():
         iteration=5,
         metrics={},
         train_time=0.7,
-        collector_wait_time=0.1,
-        learner_param_sync_time=0.0,
-        iteration_time=0.9,
+        collector_wait_time=1.0,
+        learner_incremental_h2d_time=0.05,
+        weight_sync_time=0.1,
+        iteration_time=1.95,
         extra_info={
             "throughput_steps": 16,
-            "world_size": 1,
+            "collector_active_steps_per_sec": 4321.0,
             "batch_size_per_rank": 16,
             "effective_batch_size": 16,
-            "replay_samples_per_iter": 16,
-            "learner_samples_per_iter": 16,
+            "replay_samples_per_iter": 64,
+            "learner_samples_per_iter": 64,
         },
     )
 
-    scalars = {tag for tag, _, _ in tb_writer.scalars}
+    scalars = {tag: value for tag, value, _ in tb_writer.scalars}
+    assert scalars["timing/learner_collector_wait_ms"] == pytest.approx(1_000.0)
+    assert "timing/learner_replay_wait_ms" not in scalars
+    assert scalars["timing/learner_incremental_h2d_ms"] == pytest.approx(50.0)
+    assert scalars["timing/learner_replay_sample_ms"] == pytest.approx(0.0)
     assert "timing/learner_param_sync_ms" not in scalars
+    assert scalars["timing/learner_other_ms"] == pytest.approx(100.0)
+    assert scalars["perf/learner_pipeline_ms"] == pytest.approx(850.0)
+    assert scalars["perf/iter_ms"] == pytest.approx(1_950.0)
+    assert scalars["perf/learner_train_pct"] == pytest.approx(0.7 / 1.95 * 100)
+    assert scalars["perf/learner_other_pct"] == pytest.approx(0.1 / 1.95 * 100)
+    assert scalars["perf/collector_active_steps_per_sec"] == pytest.approx(4321.0)
+    assert scalars["perf/effective_samples_per_sec"] == pytest.approx(64.0 / 1.95)
+    for key in ("axis/iteration", "axis/env_steps_total"):
+        assert key not in scalars
+    assert not any(key.startswith("distributed/") for key in scalars)
+    assert "perf/effective_samples_per_sec_smoothed" not in scalars
     logger.finish()
 
 


### PR DESCRIPTION
## Summary

- remove obsolete rank-barrier, learner parameter-sync, world-size, and multi-GPU sync fields from the off-policy logger
- make sample accounting single-device while preserving collector/replay/H2D/train/weight-sync and throughput semantics
- update focused tests and bilingual logging documentation

Implements #941.
Parent roadmap: #933.

## Scope

This PR only removes logger-owned distributed fields after #938 removed learner hooks. It does not change learner updates, replay scheduling, or the CPU replay fallback covered by #936.

## Validation

- `uv run pytest -q tests/algos/test_offpolicy_runner_unit.py tests/utils/test_experiment_tracking.py tests/scripts/test_check_docs.py` (66 passed)
- offline Sphinx strict build: 216 pages, `-W --keep-going -n` passed; external inventories disabled and one pre-existing `ref.doc` warning suppressed
- `make test-all` (1603 passed, 35 skipped, 1 xfailed; mypy/pyright and benchmark smoke passed)