### PR TITLE
perf(offpolicy): 降低 GPU collector 的 CPU-staged weight sync 延迟

### DIFF
--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -297,11 +297,19 @@ def _run_collector(
     replay_buffer.trace_thread_time = trace_thread_time
     replay_buffer.attach_stop_event(stop_event)
 
-    # Load initial weights
-    sd = dict(actor.state_dict())
-    weight_sync.read_weights_into(sd)
-    actor.load_state_dict(sd)
-    local_weight_version = weight_sync.version
+    # Load initial weights. read_weights_into / the device applier copy
+    # directly into the actor's own state-dict storage, so no follow-up
+    # actor.load_state_dict(sd) is needed (it would be a redundant self-copy).
+    collector_device = torch.device(collector_infer_device)
+    weight_applier = None
+    if collector_device.type == "cuda":
+        # CUDA collectors take the flat-snapshot fast path (single H2D +
+        # on-device apply). CPU and other accelerators keep the reference path.
+        weight_applier = weight_sync.create_device_applier(actor.state_dict(), collector_device)
+        local_weight_version = weight_applier.apply()
+    else:
+        sd = dict(actor.state_dict())
+        local_weight_version = weight_sync.read_weights_into(sd)
 
     total_steps = 0
     ep_rewards = []
@@ -340,9 +348,11 @@ def _run_collector(
             # Check for weight updates
             if weight_sync.version > local_weight_version:
                 _wt_ns = _time.perf_counter_ns()
-                sd = dict(actor.state_dict())
-                local_weight_version = weight_sync.read_weights_into(sd)
-                actor.load_state_dict(sd)
+                if weight_applier is not None:
+                    local_weight_version = weight_applier.apply()
+                else:
+                    sd = dict(actor.state_dict())
+                    local_weight_version = weight_sync.read_weights_into(sd)
                 if trace_recorder:
                     trace_recorder.add_slice(
                         "collector/check_weight_update",

--- a/src/unilab/ipc/__init__.py
+++ b/src/unilab/ipc/__init__.py
@@ -4,10 +4,11 @@ from unilab.ipc.async_runner import AsyncRunner
 from unilab.ipc.replay_buffer import ReplayBuffer
 from unilab.ipc.rollout_ring_buffer import RolloutRingBuffer
 from unilab.ipc.shared_obs_stats import SharedObsNormStats
-from unilab.ipc.weight_sync import SharedWeightSync
+from unilab.ipc.weight_sync import DeviceWeightApplier, SharedWeightSync
 
 __all__ = [
     "SharedWeightSync",
+    "DeviceWeightApplier",
     "RolloutRingBuffer",
     "AsyncRunner",
     "SharedObsNormStats",

--- a/src/unilab/ipc/weight_sync.py
+++ b/src/unilab/ipc/weight_sync.py
@@ -140,6 +140,10 @@ class SharedWeightSync:
                 )
         return version
 
+    def create_device_applier(self, state_dict, device) -> DeviceWeightApplier:
+        """Build a DeviceWeightApplier bound to this sync's layout."""
+        return DeviceWeightApplier(self, state_dict, device)
+
     def cleanup(self) -> None:
         try:
             self._shm.close()
@@ -152,3 +156,93 @@ class SharedWeightSync:
             self._shm.close()
         except Exception:
             pass
+
+
+class DeviceWeightApplier:
+    """Device-side fast apply path for one SharedWeightSync snapshot layout.
+
+    One refresh is a single flat host snapshot copy under the lock, one flat
+    H2D copy into persistent device staging, then on-device copies into the
+    target tensors. Host/device staging and the layout are computed once and
+    reused, so steady-state refreshes do not allocate or rebuild host arrays.
+
+    The shared-memory snapshot, version and lock semantics are unchanged: the
+    host copy runs entirely under the existing lock, so a refresh never sees a
+    partially published state.
+    """
+
+    def __init__(self, weight_sync: SharedWeightSync, state_dict, device) -> None:
+        import torch
+
+        self._sync = weight_sync
+        self._device = torch.device(device)
+
+        names = weight_sync._param_names
+        shapes = weight_sync._param_shapes
+        self._dst_views = []
+        self._offsets: list[tuple[int, int]] = []
+        offset = 0
+        for name in names:
+            tensor = state_dict[name]
+            if tuple(tensor.shape) != tuple(shapes[name]):
+                raise ValueError(
+                    f"DeviceWeightApplier shape mismatch for '{name}': "
+                    f"{tuple(tensor.shape)} != {tuple(shapes[name])}"
+                )
+            n = tensor.numel()
+            self._offsets.append((offset, n))
+            self._dst_views.append(tensor.data.view(-1))
+            offset += n
+
+        total_numel = offset
+        if total_numel != weight_sync._buffer.size:
+            raise ValueError(
+                "DeviceWeightApplier layout mismatch: state_dict total numel "
+                f"{total_numel} != snapshot numel {weight_sync._buffer.size}"
+            )
+
+        self._host = torch.empty(
+            total_numel, dtype=torch.float32, pin_memory=self._device.type == "cuda"
+        )
+        self._host_np = self._host.numpy()
+        self._dev = torch.empty(total_numel, dtype=torch.float32, device=self._device)
+        # Guards reuse of the (pinned) host staging buffer: the previous async
+        # H2D must be finished before apply() overwrites the host buffer again.
+        self._h2d_done: Any | None = torch.cuda.Event() if self._device.type == "cuda" else None
+
+    def apply(self) -> int:
+        """Apply the latest published snapshot to the bound tensors; return its version."""
+        _trace_ns = time.perf_counter_ns()
+        _thread_ns = time.thread_time_ns() if self._sync.trace_thread_time else None
+        if self._h2d_done is not None:
+            self._h2d_done.synchronize()
+
+        if self._sync._lock is not None:
+            with self._sync._lock:
+                np.copyto(self._host_np, self._sync._buffer)
+                version = int(self._sync._version_arr[0])
+        else:
+            np.copyto(self._host_np, self._sync._buffer)
+            version = int(self._sync._version_arr[0])
+
+        self._dev.copy_(self._host, non_blocking=True)
+        if self._h2d_done is not None:
+            self._h2d_done.record()
+        for (offset, n), dst in zip(self._offsets, self._dst_views, strict=True):
+            dst.copy_(self._dev[offset : offset + n])
+
+        if self._sync.trace_recorder is not None:
+            self._sync.trace_recorder.add_slice(
+                "weight_sync/read_weights_into_device_actor",
+                category="weight_sync",
+                start_ns=_trace_ns,
+                end_ns=time.perf_counter_ns(),
+                args={"version": version, "device": self._device.type},
+            )
+            if _thread_ns is not None:
+                self._sync.trace_recorder.add_counter(
+                    "weight_sync/read_thread_cpu_us",
+                    (time.thread_time_ns() - _thread_ns) / 1000.0,
+                    category="weight_sync",
+                )
+        return version

--- a/tests/ipc/test_shared_weight_sync.py
+++ b/tests/ipc/test_shared_weight_sync.py
@@ -14,6 +14,25 @@ from unilab.ipc.weight_sync import SharedWeightSync
 _SPAWN_CTX = mp.get_context("spawn")
 
 
+class _Actor31(torch.nn.Module):
+    """Small actor-shaped module: 20 parameters + 11 persistent buffers = 31 state entries."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = torch.nn.Linear(8, 16)
+        self.ln1 = torch.nn.LayerNorm(16)
+        self.fc2 = torch.nn.Linear(16, 16)
+        self.ln2 = torch.nn.LayerNorm(16)
+        self.fc3 = torch.nn.Linear(16, 16)
+        self.ln3 = torch.nn.LayerNorm(16)
+        self.fc4 = torch.nn.Linear(16, 16)
+        self.ln4 = torch.nn.LayerNorm(16)
+        self.fc5 = torch.nn.Linear(16, 3)
+        self.ln5 = torch.nn.LayerNorm(3)
+        for i in range(11):
+            self.register_buffer(f"buf{i}", torch.zeros(4), persistent=True)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -175,5 +194,171 @@ def test_multiprocess_write_then_read(tiny_weight_shapes):
 
     for name in tiny_weight_shapes:
         assert torch.allclose(written_sd[name].float(), read_sd[name].float(), atol=1e-6)
+
+    ws.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# DeviceWeightApplier tests
+# ---------------------------------------------------------------------------
+
+
+def _make_31entry_state_dict(seed: int) -> dict:
+    module = _Actor31()
+    torch.manual_seed(seed)
+    return {name: torch.randn_like(t) for name, t in module.state_dict().items()}
+
+
+def _assert_state_dict_matches(target_sd: dict, expected_sd: dict) -> None:
+    for name, expected in expected_sd.items():
+        actual = target_sd[name].detach().cpu()
+        assert torch.allclose(actual, expected.float().cpu(), atol=1e-6), f"Mismatch for {name}"
+
+
+def test_device_applier_cpu_roundtrip(tiny_weight_shapes):
+    """Applier on CPU device copies the snapshot into the bound tensors."""
+    state_dict = _make_state_dict(tiny_weight_shapes)
+    ws = SharedWeightSync.from_state_dict(state_dict, create=True)
+
+    target = {name: torch.zeros(shape) for name, shape in tiny_weight_shapes.items()}
+    applier = ws.create_device_applier(target, torch.device("cpu"))
+    version = applier.apply()
+
+    assert version == ws.version
+    for name in tiny_weight_shapes:
+        assert torch.allclose(state_dict[name].float(), target[name].float(), atol=1e-6)
+
+    ws.cleanup()
+
+
+def test_device_applier_consecutive_versions(tiny_weight_shapes):
+    """Back-to-back version publishes each apply completely and return the new version."""
+    ws = SharedWeightSync(tiny_weight_shapes, create=True)
+    target = {name: torch.zeros(shape) for name, shape in tiny_weight_shapes.items()}
+    applier = ws.create_device_applier(target, torch.device("cpu"))
+
+    versions = []
+    for seed in range(3):
+        sd = {
+            name: torch.full(shape, float(seed + 1)) for name, shape in tiny_weight_shapes.items()
+        }
+        ws.write_weights(sd)
+        versions.append(applier.apply())
+        for name in tiny_weight_shapes:
+            assert torch.allclose(target[name], sd[name], atol=1e-6)
+
+    assert versions == [1, 2, 3]
+
+    ws.cleanup()
+
+
+def test_device_applier_shape_mismatch_raises(tiny_weight_shapes):
+    """Applier construction fails closed on shape/layout mismatch."""
+    ws = SharedWeightSync(tiny_weight_shapes, create=True)
+    bad = {name: torch.zeros(tuple(shape) + (1,)) for name, shape in tiny_weight_shapes.items()}
+    with pytest.raises(ValueError, match="shape mismatch"):
+        ws.create_device_applier(bad, torch.device("cpu"))
+    ws.cleanup()
+
+
+def test_device_applier_no_version_bump_without_write(tiny_weight_shapes):
+    """Without a new publish, apply() keeps returning the same version (no-op upstream)."""
+    state_dict = _make_state_dict(tiny_weight_shapes)
+    ws = SharedWeightSync.from_state_dict(state_dict, create=True)
+    target = {name: torch.zeros(shape) for name, shape in tiny_weight_shapes.items()}
+    applier = ws.create_device_applier(target, torch.device("cpu"))
+
+    v1 = applier.apply()
+    v2 = applier.apply()
+    assert v1 == v2 == ws.version
+
+    ws.cleanup()
+
+
+def test_device_applier_31entry_param_buffer_completeness():
+    """31-entry (20 params + 11 persistent buffers) snapshot applies every entry."""
+    source_sd = _make_31entry_state_dict(seed=0)
+    assert len(source_sd) == 31
+
+    ws = SharedWeightSync.from_state_dict(source_sd, create=True)
+
+    target_module = _Actor31()
+    with torch.no_grad():
+        for t in target_module.state_dict().values():
+            t.zero_()
+    target_sd = dict(target_module.state_dict())
+
+    applier = ws.create_device_applier(target_module.state_dict(), torch.device("cpu"))
+    version = applier.apply()
+
+    assert version == ws.version
+    # The bound state_dict storage must have been updated in place.
+    _assert_state_dict_matches(target_sd, source_sd)
+    # And the module itself observes the new values (same storage).
+    _assert_state_dict_matches(dict(target_module.state_dict()), source_sd)
+
+    ws.cleanup()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_device_applier_cuda_roundtrip():
+    """CUDA applier: 31-entry snapshot lands on the on-device actor tensors."""
+    source_sd = _make_31entry_state_dict(seed=1)
+    ws = SharedWeightSync.from_state_dict(source_sd, create=True)
+
+    target_module = _Actor31().cuda()
+    target_sd = dict(target_module.state_dict())
+
+    applier = ws.create_device_applier(target_module.state_dict(), torch.device("cuda"))
+    version = applier.apply()
+    torch.cuda.synchronize()
+
+    assert version == ws.version
+    _assert_state_dict_matches(target_sd, source_sd)
+
+    # A second publish must also apply cleanly over the reused staging buffers.
+    source_sd2 = _make_31entry_state_dict(seed=2)
+    ws.write_weights(source_sd2)
+    version2 = applier.apply()
+    torch.cuda.synchronize()
+
+    assert version2 == version + 1
+    _assert_state_dict_matches(dict(target_module.state_dict()), source_sd2)
+
+    ws.cleanup()
+
+
+def _constant_writer_fn(shm_name: str, lock, shapes: dict, iterations: int) -> None:
+    """Subprocess: alternate publishing all-ones and all-twos snapshots."""
+    ws = SharedWeightSync(shapes, create=False, shm_name=shm_name, lock=lock)
+    sd_one = {name: torch.ones(shape) for name, shape in shapes.items()}
+    sd_two = {name: torch.full(shape, 2.0) for name, shape in shapes.items()}
+    for i in range(iterations):
+        ws.write_weights(sd_one if i % 2 == 0 else sd_two)
+    ws.close()
+
+
+def test_device_applier_concurrent_publish_no_torn_snapshot(tiny_weight_shapes):
+    """Concurrent publish/apply must never surface a partially published state."""
+    ws = SharedWeightSync(tiny_weight_shapes, create=True)
+    target = {name: torch.zeros(shape) for name, shape in tiny_weight_shapes.items()}
+    applier = ws.create_device_applier(target, torch.device("cpu"))
+
+    p = _SPAWN_CTX.Process(
+        target=_constant_writer_fn,
+        args=(ws.name, ws._lock, tiny_weight_shapes, 50),
+    )
+    p.start()
+    while p.is_alive():
+        version = applier.apply()
+        if version == 0:
+            continue  # initial all-zero snapshot, writer has not published yet
+        for name in tiny_weight_shapes:
+            values = target[name]
+            assert torch.allclose(values, torch.ones_like(values), atol=1e-6) or torch.allclose(
+                values, torch.full_like(values, 2.0), atol=1e-6
+            ), f"Torn snapshot for {name}"
+    p.join(timeout=30)
+    assert p.exitcode == 0
 
     ws.cleanup()


### PR DESCRIPTION
## 改了什么

在保留现有 CPU shared-memory snapshot / version / lock 协议的前提下，为 CUDA collector 提供 device-aware 的 weight apply 快速路径。共 4 个文件，净增约 290 行：

- **`src/unilab/ipc/weight_sync.py`** — 新增 `DeviceWeightApplier`：
  - 构造时预计算 flat layout（name → offset/numel），校验 shape/总 numel，不匹配即 fail-closed；
  - 复用持久 staging：一块 pinned host buffer + 一块 device flat buffer，稳态 refresh 不再分配或重建 31 个临时 host array；
  - 一次 refresh = 锁内单次 `np.copyto` flat snapshot 拷贝（version 仍在锁内读取，snapshot/version/lock 语义完全不变）→ 单次异步 pinned H2D → device 侧 31 次 D2D `copy_` 写入 actor 各 parameter/buffer；
  - 用 CUDA event 保护 host staging 复用（上一次异步 H2D 完成后才允许下次覆写）；
  - 新增 trace 事件 `weight_sync/read_weights_into_device_actor`，CPU 路径的 `weight_sync/read_weights_into_cpu_actor` 保持不变。
- **`src/unilab/algos/torch/offpolicy/worker.py`** — CUDA collector 使用 applier 快速路径；同时移除 `read_weights_into(sd)` 之后冗余的 `actor.load_state_dict(sd)`（`sd` 与 actor 共享 storage，`read_weights_into` 已原地写入，`load_state_dict` 是纯自拷贝）。CPU / MPS / XPU 保持原参考路径，不新增未经验证的 support claim。
- **`src/unilab/ipc/__init__.py`** — 导出 `DeviceWeightApplier`。
- **`tests/ipc/test_shared_weight_sync.py`** — 新增 7 个测试：CPU/CUDA roundtrip、31-entry（20 parameters + 11 persistent buffers）完整性、连续 version 更新、shape mismatch fail-closed、无新 publish 时 version 不变、多进程并发 publish/apply 不产生 torn snapshot。

未引入 CUDA IPC / 共享 CUDA tensor / NCCL / 双缓冲，未新增 queue / ack / runner lifecycle，未改变 learner update 次数、publish 频率与训练数学语义。

## 结果报告

环境：NVIDIA GeForce RTX 4090，PyTorch 2.7.0+cu128。Workload（与 issue baseline 一致）：

```bash
uv run train --algo flashsac --task g1_walk_flat --sim motrix \
  training.collector_infer_device=gpu \
  algo.learning_starts=1 algo.max_iterations=30 \
  training.trace_enabled=true training.trace_cuda_events=false
```

同机 paired 各 5 轮（baseline=main，candidate=本分支），只统计 version 实际变化的稳态 refresh 事件（`collector/check_weight_update`，n=27/轮，不含 startup initial load 与 no-op version check）：

| 指标 | baseline 5 轮 (ms) | candidate 5 轮 (ms) | DoD 门槛 | 结论 |
|---|---|---|---|---|
| refresh median | 9.563 / 14.275 / 14.501 / 14.540 / 9.646 | 0.370 / 0.344 / 0.356 / 0.350 / 0.343 | ≤3ms 且降幅 ≥70% | 降幅 ≥96% ✅ |
| refresh p95 | 16.316 – 21.837 | 0.419 – 0.476 | ≤5ms | ✅ |

成本未转移到其他 timing bucket（5 轮均值）：

| 指标 | baseline | candidate |
|---|---|---|
| `learner/weight_sync_write` | ~0.49ms | ~0.49ms（不变） |
| `collector/env_step` | ~36.3ms | ~36.0ms（不变） |
| `collector/wait_trainer_done` | ~0.53ms | ~0.53ms（不变） |
| `collector/actor_infer` median | ~3.0ms | ~5.3ms（weight apply 的 device 侧拷贝按流顺序计入下一次推理，+2.3ms，相对 refresh 节省的 ~12ms 为净收益） |
| cycle Steps/s | 28,009–28,391 | 28,140–28,684（无退化，未靠串行化换取局部指标） |

CPU collector no-regression（相同协议单次对照）：`check_weight_update` median 0.672ms → 0.393ms（**-42%**，来自移除冗余 `load_state_dict` 自拷贝；门槛为回退 ≤+10%）✅。

paired raw data 与 trace 保留在 `logs/issue946/{gpu,cpu}/{baseline,candidate}/run*/perfetto_offpolicy_timeline.json`。

## Validation

- 定向测试通过（31 个，含新增 7 个）：

  ```bash
  uv run pytest -q tests/ipc/test_shared_weight_sync.py \
    tests/algos/test_offpolicy_worker.py tests/algos/test_offpolicy_logger.py
  ```

- 目标 Motrix FlashSAC 命令 5 轮 smoke run 完成，loss/reward/step 推进正常。
- `make test-all` 已通过：ruff 无告警、mypy 0 errors、pytest 1508 passed（36 skipped / 1 xfailed）、benchmark module-mode 31/32 与 script-mode 32/33（唯一 skip 为平台可选 mlx）。

Fixes #946
