### PR TITLE
refactor(offpolicy): clarify learner/collector timing metric semantics post-#945

### DIFF
--- a/benchmark/rl/extract_offpolicy_metrics.py
+++ b/benchmark/rl/extract_offpolicy_metrics.py
@@ -13,13 +13,12 @@ TAGS = {
     "iter_ms": "perf/iter_ms",
     "steps_per_sec": "perf/steps_per_sec",
     "collector_active_steps_per_sec": "perf/collector_active_steps_per_sec",
-    "collector_replay_ms": "timing/collector_replay_ms",
+    "collector_replay_write_ms": "timing/collector_replay_write_ms",
     "learner_collector_wait_ms": "timing/learner_collector_wait_ms",
     "learner_replay_batch_wait_ms": "timing/learner_replay_batch_wait_ms",
     "learner_replay_sample_ms": "timing/learner_replay_sample_ms",
-    "learner_rank_barrier_ms": "timing/learner_rank_barrier_ms",
     "learner_incremental_h2d_ms": "timing/learner_incremental_h2d_ms",
-    "learner_sync_coordination_ms": "timing/learner_sync_coordination_ms",
+    "learner_collector_release_ms": "timing/learner_collector_release_ms",
     "learner_train_ms": "timing/learner_train_ms",
 }
 

--- a/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
@@ -81,36 +81,58 @@ instead of being compared only against wait metrics.
 
 | Terminal field | TensorBoard / W&B key | Meaning |
 | --- | --- | --- |
-| Collector Wait | `timing/learner_collector_wait_ms` | Waiting for the collector to produce trainable data |
-| Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | Device-replay prefetch miss waiting for committed ingress and the device gather; ~0 on a prefetch hit |
-| Replay Sample | `timing/learner_replay_sample_ms` | Consuming the already gathered hot device batch after the wait is over |
-| Sync Coordination | `timing/learner_sync_coordination_ms` | Synchronous-collection handshake; 0 when not in sync collection |
-| H2D Copy | `timing/learner_incremental_h2d_ms` | Incremental bounded-ingress copy into the authoritative device ring |
+| Collector Wait | `timing/learner_collector_wait_ms` | Waiting for the collector to produce trainable data; in async collection it is ≈0 in steady state (only warm-up buffer fill), in sync collection each iteration waits for one collection chunk |
+| Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | Waiting for the device batch prefetched at the end of the previous iteration (ingress commit + side-stream gather); ~0 on a prefetch hit, non-zero means the device replay pipeline is not keeping up with the learner |
+| Replay Sample | `timing/learner_replay_sample_ms` | Consuming the already gathered hot device batch (hot/cold slot swap + view); ≈0 on CUDA, on MPS it includes the slot-event synchronization |
+| Collector Release | `timing/learner_collector_release_ms` | Sync collection only: the learner sending the release token to the collector; blocking here means the collector has not consumed the previous release (collection side is behind); 0 when not in sync collection |
+| H2D Copy | `timing/learner_incremental_h2d_ms` | Submission cost of the incremental bounded-ingress copy into the authoritative device ring (CUDA: non-blocking submit on a daemon thread; MPS: blocking copy on the learner thread); on CUDA this work overlaps Train or already happens inside Collector Wait / Replay Batch Wait, so treat this row as a diagnostic that is not strictly additive with the other learner rows |
 | Train | `timing/learner_train_ms` | Pure SGD compute |
-| Weight Sync | `timing/learner_weight_sync_ms` | Publishing new weights to the collector |
+| Weight Publish | `timing/learner_weight_publish_ms` | Publishing new actor weights to shared memory for the collector (write side of the weight channel) |
 | Iter Wall | `perf/iter_ms` | Whole-iteration wall time, not the sum of the components |
 
 The terminal shows every learner row as right-aligned `ms` plus `% of Iter Wall`.
 Backend logs include `perf/learner_train_pct`, `perf/learner_accounted_pct`,
 `perf/learner_other_pct` and `timing/learner_other_ms`; the latter two are residual
 diagnostics and are not shown as terminal rows. `perf/learner_pipeline_ms` = H2D +
-Train + Weight Sync. The former `timing/learner_wait_ms` was renamed to
-`timing/learner_collector_wait_ms`.
+Train + Weight Publish. The former `timing/learner_wait_ms` was renamed to
+`timing/learner_collector_wait_ms`; the former `timing/learner_sync_coordination_ms`
+and `timing/learner_weight_sync_ms` were renamed to
+`timing/learner_collector_release_ms` and `timing/learner_weight_publish_ms`.
 
 The collector process reports per-phase timings in the terminal Collector column and
-TensorBoard `timing/collector_*`. SAC / TD3:
+TensorBoard `timing/collector_*`; each terminal row also shows the share of one
+collection cycle (the sum of the rows below). SAC / TD3:
 
 | Terminal field | TensorBoard / W&B key | Meaning |
 | --- | --- | --- |
-| Weight Sync | `timing/collector_weight_sync_ms` | Pulling and loading new learner weights |
-| Action Select | `timing/collector_action_select_ms` | Actor inference |
+| Weight Apply | `timing/collector_weight_apply_ms` | Checking for and loading newly published learner weights (read side of the same channel as the learner's Weight Publish — not a duplicate) |
+| Policy Infer | `timing/collector_policy_infer_ms` | Actor forward inference (including exploration sampling); the terminal row reads `Policy Infer(<device>)` with the collector inference device |
 | Env Step | `timing/collector_env_step_ms` | Environment step |
-| Replay | `timing/collector_replay_ms` | Packing transitions into the bounded replay ingress |
-| Sync Coordination | `timing/collector_sync_coordination_ms` | Synchronous-collection handshake (signal learner, wait for learner) |
+| Replay Write | `timing/collector_replay_write_ms` | Packing transitions and writing them into the bounded replay ingress |
+| Sync Idle | `timing/collector_sync_idle_ms` | Per-step bookkeeping and metrics reporting; in sync collection it is dominated by waiting for the learner release, making it the collector idle indicator; excluded from `Collector/s` |
 
 `Collector/s` is collector active throughput. For SAC / TD3 it uses
-`num_envs / (Weight Sync + Action Select + Env Step + Replay)` and excludes
-`Sync Coordination`.
+`num_envs / (Weight Apply + Policy Infer + Env Step + Replay Write)` and excludes
+`Sync Idle`. The three indented child rows under Env Step (Backend Step / Update
+State / Reset Done) are marked with tree connectors and share the same percentage
+base as the other rows (one collection cycle). The former `timing/collector_weight_sync_ms`,
+`timing/collector_action_select_ms`, `timing/collector_replay_ms`, and
+`timing/collector_sync_coordination_ms` were renamed to
+`timing/collector_weight_apply_ms`, `timing/collector_policy_infer_ms`,
+`timing/collector_replay_write_ms`, and `timing/collector_sync_idle_ms`.
+
+### Reading CPU vs GPU load
+
+The two sides of the pipeline expose matching wait signals; use them to tell which
+side is the bottleneck:
+
+| Observation | Meaning | Where to look |
+| --- | --- | --- |
+| Learner Collector Wait % is high | Learner starved for data: collection (CPU env step + inference) cannot keep up | Scale `num_envs`, cut collector cost, or move collector inference to GPU |
+| Learner Replay Batch Wait is high | The device replay pipeline (ingress commit + gather) is not keeping up with learner consumption | GPU is saturated or the side stream is queued behind training kernels |
+| Collector Sync Idle is high (sync collection) | Collector waits for the learner: GPU training is the bottleneck | Reduce `updates_per_step` / batch size, or disable sync collection |
+| Collector Replay Write grows | Writing into the bounded ingress slows down, e.g. slots exhausted waiting for device commits | Same direction as Replay Batch Wait: the device consumption side is behind |
+| Collector Weight Apply is high | Loading published weights costs too much per step | Weight publish frequency and collector inference device |
 
 APPO uses a ring buffer; the collector reports two **per-step** EMAs plus one **whole-rollout** total:
 
@@ -147,14 +169,14 @@ gantt
     Collector Wait (≈0 when buffer full)  :done,   l0, 12000, 13000
     H2D Copy (ring → staging)             :        l1, 13000, 16000
     Train (V-trace + PPO SGD)             :active, l2, 16000, 28000
-    Weight Sync → collector               :crit,   l3, 28000, 30000
+    Weight Publish → collector            :crit,   l3, 28000, 30000
 
     section Iter Wall
     perf/iter_ms (learner loop only)      :        l4, 12000, 30000
 ```
 
-> The axis is schematic (relative, not real-ms). The collector subprocess produces rollouts through the 4-slot ring buffer in parallel with the learner, so **Collector Wait ≈ 0** in steady state. `perf/iter_ms` counts only this learner loop (it includes Collector Wait but not the collector's parallel rollout compute); the red Weight Sync marks the end of the iteration when fresh weights are published to the collector.
+> The axis is schematic (relative, not real-ms). The collector subprocess produces rollouts through the 4-slot ring buffer in parallel with the learner, so **Collector Wait ≈ 0** in steady state. `perf/iter_ms` counts only this learner loop (it includes Collector Wait but not the collector's parallel rollout compute); the red Weight Publish marks the end of the iteration when fresh weights are published to the collector.
 
 All off-policy terminal views use the same value formatting. Replay Batch Wait is
-shown only when a single-device/double-buffer prefetch miss is non-zero. Sync
-Coordination is shown only with synchronous collection.
+shown only when a single-device/double-buffer prefetch miss is non-zero. Collector
+Release is shown only with synchronous collection.

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/2-appo.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/2-appo.md
@@ -56,13 +56,13 @@ gantt
     Collector Wait (≈0 when buffer full)  :done,   l0, 12000, 13000
     H2D Copy (ring → staging)             :        l1, 13000, 16000
     Train (V-trace + PPO SGD)             :active, l2, 16000, 28000
-    Weight Sync → collector               :crit,   l3, 28000, 30000
+    Weight Publish → collector            :crit,   l3, 28000, 30000
 
     section Iter Wall
     perf/iter_ms (learner loop only)      :        l4, 12000, 30000
 ```
 
-> The axis is schematic (relative, not real-ms). The collector subprocess produces rollouts through the 4-slot ring buffer in parallel with the learner, so **Collector Wait ≈ 0** in steady state. `perf/iter_ms` counts only this learner loop (it includes Collector Wait but not the collector's parallel rollout compute); the red Weight Sync marks the end of the iteration when fresh weights are published to the collector. Field meanings are on the [logging page](../1-training/3-logging.md).
+> The axis is schematic (relative, not real-ms). The collector subprocess produces rollouts through the 4-slot ring buffer in parallel with the learner, so **Collector Wait ≈ 0** in steady state. `perf/iter_ms` counts only this learner loop (it includes Collector Wait but not the collector's parallel rollout compute); the red Weight Publish marks the end of the iteration when fresh weights are published to the collector. Field meanings are on the [logging page](../1-training/3-logging.md).
 
 ## Key Fields
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
@@ -77,30 +77,42 @@ off-policy（SAC / TD3 / FlashSAC 与 APPO）把 learner loop 记录为已命名
 
 | 终端字段 | TensorBoard / W&B key | 含义 |
 | --- | --- | --- |
-| Collector Wait | `timing/learner_collector_wait_ms` | 等待 collector 产出可训练数据 |
-| Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | device replay 预取 miss 时等待 ingress commit 与 device gather；预取命中时约为 0 |
-| Replay Sample | `timing/learner_replay_sample_ms` | wait 结束后消费已经 gather 完成的 hot device batch |
-| Sync Coordination | `timing/learner_sync_coordination_ms` | 同步采集握手耗时；非同步采集时为 0 |
-| H2D Copy | `timing/learner_incremental_h2d_ms` | bounded ingress 增量拷入 authoritative device ring 的耗时 |
+| Collector Wait | `timing/learner_collector_wait_ms` | 等待 collector 产出可训练数据；async 采集下稳态 ≈0（仅 warm-up 填 buffer），sync 采集下每个 iter 等一个 collection chunk |
+| Replay Batch Wait | `timing/learner_replay_batch_wait_ms` | 等上一轮末尾 prefetch 的 device batch 就绪（ingress commit + side-stream gather）；预取命中 ≈0，非零说明 device replay 流水线跟不上 learner 的消费速度 |
+| Replay Sample | `timing/learner_replay_sample_ms` | 消费已 gather 完成的 hot device batch（hot/cold 槽交换 + view）；CUDA 下 ≈0，MPS 下含 slot event 同步 |
+| Collector Release | `timing/learner_collector_release_ms` | 仅 sync 采集：learner 向 collector 发送 release token 的耗时；阻塞说明 collector 还没消费上一个 release（采集侧落后）；非 sync 采集为 0 |
+| H2D Copy | `timing/learner_incremental_h2d_ms` | bounded ingress 增量拷入 authoritative device ring 的提交耗时（CUDA：后台线程 non_blocking 提交；MPS：learner 线程阻塞拷贝）；这部分工作在 CUDA 下与 Train 并行、或已发生在 Collector Wait / Replay Batch Wait 内，因此该行是诊断项，与其他 learner 行不严格可加 |
 | Train | `timing/learner_train_ms` | 纯 SGD 计算耗时 |
-| Weight Sync | `timing/learner_weight_sync_ms` | 向 collector 发布新权重的耗时 |
+| Weight Publish | `timing/learner_weight_publish_ms` | 发布方：把 actor 新权重写入共享内存给 collector（权重通道的写端） |
 | Iter Wall | `perf/iter_ms` | 整圈迭代墙钟，非各分量之和 |
 
-终端所有 learner 行都显示右对齐的 `ms` 与占 `Iter Wall` 百分比。后端额外记录 `perf/learner_train_pct`、`perf/learner_accounted_pct`、`perf/learner_other_pct` 和 `timing/learner_other_ms`；后两者是 residual 诊断，不占终端行。另有 `perf/learner_pipeline_ms` = H2D + Train + Weight Sync。原 `timing/learner_wait_ms` 已更名为 `timing/learner_collector_wait_ms`。
+终端所有 learner 行都显示右对齐的 `ms` 与占 `Iter Wall` 百分比。后端额外记录 `perf/learner_train_pct`、`perf/learner_accounted_pct`、`perf/learner_other_pct` 和 `timing/learner_other_ms`；后两者是 residual 诊断，不占终端行。另有 `perf/learner_pipeline_ms` = H2D + Train + Weight Publish。原 `timing/learner_wait_ms` 已更名为 `timing/learner_collector_wait_ms`；原 `timing/learner_sync_coordination_ms`、`timing/learner_weight_sync_ms` 已更名为 `timing/learner_collector_release_ms`、`timing/learner_weight_publish_ms`。
 
-collector 进程在终端 Collector 列、TensorBoard `timing/collector_*` 上报各阶段耗时。SAC / TD3：
+collector 进程在终端 Collector 列、TensorBoard `timing/collector_*` 上报各阶段耗时；终端每行同时显示占单步采集周期（下列各行之和）的百分比。SAC / TD3：
 
 | 终端字段 | TensorBoard / W&B key | 含义 |
 | --- | --- | --- |
-| Weight Sync | `timing/collector_weight_sync_ms` | 拉取并加载 learner 新权重 |
-| Action Select | `timing/collector_action_select_ms` | actor 推理选动作 |
+| Weight Apply | `timing/collector_weight_apply_ms` | 消费方：检查并加载 learner 发布的新权重（与 learner 的 Weight Publish 是同一通道的读端，不是重复统计） |
+| Policy Infer | `timing/collector_policy_infer_ms` | actor 前向推理（含探索采样）；终端行以 `Policy Infer(<device>)` 标注 collector 推理设备 |
 | Env Step | `timing/collector_env_step_ms` | 环境 step |
-| Replay | `timing/collector_replay_ms` | 将 transition 打包写入 bounded replay ingress |
-| Sync Coordination | `timing/collector_sync_coordination_ms` | 同步采集握手（通知 learner、等待 learner 完成） |
+| Replay Write | `timing/collector_replay_write_ms` | 将 transition 打包并写入 bounded replay ingress 槽 |
+| Sync Idle | `timing/collector_sync_idle_ms` | 每步的 episode 簿记与 metrics 上报；sync 采集下同时包含等 learner release 的空转，即 collector 空转指标；不计入 `Collector/s` |
 
 `Collector/s` 表示 collector 活跃采集吞吐。SAC / TD3 使用
-`num_envs / (Weight Sync + Action Select + Env Step + Replay)`，并排除
-`Sync Coordination`。
+`num_envs / (Weight Apply + Policy Infer + Env Step + Replay Write)`，并排除
+`Sync Idle`。Env Step 下的三个缩进子项（Backend Step / Update State / Reset Done）以树形连接线标注，其百分比与其他行使用同一分母（单步采集周期总和）。原 `timing/collector_weight_sync_ms`、`timing/collector_action_select_ms`、`timing/collector_replay_ms`、`timing/collector_sync_coordination_ms` 已更名为 `timing/collector_weight_apply_ms`、`timing/collector_policy_infer_ms`、`timing/collector_replay_write_ms`、`timing/collector_sync_idle_ms`。
+
+### 判读 CPU 与 GPU 的相对负载
+
+流水线两侧暴露了相互对应的等待信号，可以据此判断瓶颈在哪一侧：
+
+| 现象 | 含义 | 优化方向 |
+| --- | --- | --- |
+| learner Collector Wait 占比高 | learner 等数据：采集侧（CPU 环境 step + 推理）跟不上 | 提高 `num_envs`、降低 collector 开销，或把 collector 推理放到 GPU |
+| learner Replay Batch Wait 高 | device replay 流水线（ingress commit + gather）跟不上 learner 消费 | GPU 已被训练占满，或 side stream 排在训练 kernel 之后 |
+| collector Sync Idle 高（sync 采集） | collector 等 learner：GPU 训练是瓶颈 | 降低 `updates_per_step` / batch size，或关闭 sync 采集 |
+| collector Replay Write 升高 | 写 bounded ingress 变慢，例如 ingress 槽耗尽、在等设备端 commit 释放槽位 | 与 Replay Batch Wait 同向：device 消费侧落后 |
+| collector Weight Apply 高 | 每步加载发布权重的成本过高 | 关注权重发布频率与 collector 推理设备 |
 
 APPO 沿用 ring buffer，collector 上报两个**单步** EMA 和一个**整条 rollout** 的总时间：
 
@@ -136,12 +148,12 @@ gantt
     Collector Wait（缓冲满则约 0）    :done,   l0, 12000, 13000
     H2D Copy（ring 进 staging）       :        l1, 13000, 16000
     Train（V-trace + PPO SGD）        :active, l2, 16000, 28000
-    Weight Sync 写回 collector        :crit,   l3, 28000, 30000
+    Weight Publish 写回 collector     :crit,   l3, 28000, 30000
 
     section Iter Wall
     perf/iter_ms（仅 learner 这圈）   :        l4, 12000, 30000
 ```
 
-> 横轴为示意相对时长（非真实 ms 比例）。collector 子进程经 4 槽 ring buffer 与 learner 并行产出 rollout，稳态下 **Collector Wait ≈ 0**。`perf/iter_ms` 仅计 learner 这一圈（含 Collector Wait，但不含 collector 的并行采集计算）；红色 Weight Sync 标志该轮迭代结束、向 collector 发布新权重。
+> 横轴为示意相对时长（非真实 ms 比例）。collector 子进程经 4 槽 ring buffer 与 learner 并行产出 rollout，稳态下 **Collector Wait ≈ 0**。`perf/iter_ms` 仅计 learner 这一圈（含 Collector Wait，但不含 collector 的并行采集计算）；红色 Weight Publish 标志该轮迭代结束、向 collector 发布新权重。
 
-所有 off-policy 终端视图都使用同一套数值格式。Replay Batch Wait 只在单 device / double-buffer 预取 miss 非零时显示；Sync Coordination 只在同步采集时显示。
+所有 off-policy 终端视图都使用同一套数值格式。Replay Batch Wait 只在单 device / double-buffer 预取 miss 非零时显示；Collector Release 只在同步采集时显示。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/2-appo.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/2-appo.md
@@ -54,13 +54,13 @@ gantt
     Collector Wait（缓冲满则约 0）    :done,   l0, 12000, 13000
     H2D Copy（ring 进 staging）       :        l1, 13000, 16000
     Train（V-trace + PPO SGD）        :active, l2, 16000, 28000
-    Weight Sync 写回 collector        :crit,   l3, 28000, 30000
+    Weight Publish 写回 collector     :crit,   l3, 28000, 30000
 
     section Iter Wall
     perf/iter_ms（仅 learner 这圈）   :        l4, 12000, 30000
 ```
 
-> 横轴为示意相对时长（非真实 ms 比例）。collector 子进程经 4 槽 ring buffer 与 learner 并行产出 rollout，稳态下 **Collector Wait ≈ 0**。`perf/iter_ms` 仅计 learner 这一圈（含 Collector Wait，但不含 collector 的并行采集计算）；红色 Weight Sync 标志该轮迭代结束、向 collector 发布新权重。各字段含义见[日志页](../1-training/3-logging.md)。
+> 横轴为示意相对时长（非真实 ms 比例）。collector 子进程经 4 槽 ring buffer 与 learner 并行产出 rollout，稳态下 **Collector Wait ≈ 0**。`perf/iter_ms` 仅计 learner 这一圈（含 Collector Wait，但不含 collector 的并行采集计算）；红色 Weight Publish 标志该轮迭代结束、向 collector 发布新权重。各字段含义见[日志页](../1-training/3-logging.md)。
 
 ## 关键字段
 

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -267,6 +267,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             log_backend=logger_type,
         )
         logger.set_collection_sync(self.sync_collection, self.env_steps_per_sync)
+        logger.set_collector_infer_device(self.collector_infer_device)
         if hasattr(self.learner, "use_symmetry") and self.learner.use_symmetry:
             logger.log_status("Symmetry augmentation: enabled")
         logger.log_status(format_torch_thread_runtime(self.torch_thread_runtime))

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -23,16 +23,19 @@ from unilab.training.seed import apply_training_seed
 # Exclusive phases for one collector loop iteration (one vectorized env.step).
 # Every key is recorded once per iteration so the reported averages share one
 # denominator and can be summed without double counting.
+# - weight_apply_ms: check for and apply newly published learner weights
+# - replay_write_ms: pack transitions and write them into the bounded ingress
+# - sync_idle_ms: per-cycle bookkeeping and metrics reporting; in sync
+#   collection mode it is dominated by waiting for the learner release token,
+#   so it doubles as the collector idle indicator (excluded from Collector/s)
 COLLECTOR_TIMING_KEYS = (
-    "weight_sync_ms",
-    "action_select_ms",
+    "weight_apply_ms",
+    "policy_infer_ms",
     "env_step_ms",
-    "replay_ms",
-    "sync_coordination_ms",
+    "replay_write_ms",
+    "sync_idle_ms",
 )
-COLLECTOR_ACTIVE_TIMING_KEYS = tuple(
-    key for key in COLLECTOR_TIMING_KEYS if key != "sync_coordination_ms"
-)
+COLLECTOR_ACTIVE_TIMING_KEYS = tuple(key for key in COLLECTOR_TIMING_KEYS if key != "sync_idle_ms")
 
 
 def resolve_collector_actor_dims(
@@ -367,7 +370,7 @@ def _run_collector(
                     if stats is not None:
                         # Apply stats to a local normalizer if needed, or directly to actor
                         pass  # Handled by EmpiricalNormalization in learner if actor possesses it. We need a local normalizer.
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "weight_sync_ms", phase_start_ns)
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "weight_apply_ms", phase_start_ns)
 
             # Normalize obs_np
             obs_np_input = obs_np
@@ -412,7 +415,7 @@ def _run_collector(
                             "collector_infer_device": collector_infer_device,
                         },
                     )
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "action_select_ms", phase_start_ns)
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "policy_infer_ms", phase_start_ns)
 
             # Step environment
             _env_ns = _time.perf_counter_ns()
@@ -455,7 +458,7 @@ def _run_collector(
                 info=state.info,
                 truncated=truncated_np,
             )
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_write_ms", phase_start_ns)
 
             # ReplayBuffer `dones` follows the UniLab env lifecycle contract:
             # done = terminated | truncated. Learners use `truncated` to keep
@@ -489,7 +492,7 @@ def _run_collector(
                     start_ns=_rb_ns,
                     end_ns=_time.perf_counter_ns(),
                 )
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_ms", phase_start_ns)
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "replay_write_ms", phase_start_ns)
 
             # Track episode rewards - vectorized
             current_ep_rewards += rewards_np
@@ -507,9 +510,7 @@ def _run_collector(
             info_dict = state.info
             total_steps += num_envs
             env_steps_since_sync += 1
-            phase_start_ns = _record_phase_ms(
-                cycle_timing_ms, "sync_coordination_ms", phase_start_ns
-            )
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_idle_ms", phase_start_ns)
 
             # Signal the learner once this collection chunk is ready.
             if (
@@ -528,19 +529,19 @@ def _run_collector(
                             end_ns=_time.perf_counter_ns(),
                         )
                     phase_start_ns = _record_phase_ms(
-                        cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                        cycle_timing_ms, "sync_idle_ms", phase_start_ns
                     )
                     _wait_ns = _time.perf_counter_ns()
                     while not stop_event.is_set():
                         try:
                             trainer_done_queue.get(timeout=0.001)
                             phase_start_ns = _record_phase_ms(
-                                cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                                cycle_timing_ms, "sync_idle_ms", phase_start_ns
                             )
                             break
                         except queue.Empty:
                             phase_start_ns = _record_phase_ms(
-                                cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                                cycle_timing_ms, "sync_idle_ms", phase_start_ns
                             )
                             continue
                     if trace_recorder:
@@ -558,14 +559,12 @@ def _run_collector(
                             except Exception:
                                 pass
                         phase_start_ns = _record_phase_ms(
-                            cycle_timing_ms, "sync_coordination_ms", phase_start_ns
+                            cycle_timing_ms, "sync_idle_ms", phase_start_ns
                         )
                     env_steps_since_sync = 0
             elif env_steps_since_sync >= env_steps_per_sync:
                 env_steps_since_sync = 0
-            phase_start_ns = _record_phase_ms(
-                cycle_timing_ms, "sync_coordination_ms", phase_start_ns
-            )
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_idle_ms", phase_start_ns)
 
             # Progress log every 2 seconds
             now = _time.time()
@@ -631,9 +630,7 @@ def _run_collector(
                         timing_counts.clear()
                 except Exception as e:
                     print(f"[OffPolicyWorker] metrics enqueue error: {e}", file=sys.stderr)
-            phase_start_ns = _record_phase_ms(
-                cycle_timing_ms, "sync_coordination_ms", phase_start_ns
-            )
+            phase_start_ns = _record_phase_ms(cycle_timing_ms, "sync_idle_ms", phase_start_ns)
 
             for key, value in cycle_timing_ms.items():
                 _record_timing_ms(timing_accum_ms, timing_counts, key, value)

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -351,7 +351,7 @@ class BaseTrainingLogger:
         if include_status and self._status:
             fields.append((self._status, "dim italic"))
 
-        header_text = Text(no_wrap=True, overflow="ellipsis")
+        header_text = Text(no_wrap=True, overflow="ellipsis", justify="center")
         for index, (text, style) in enumerate(fields):
             if index > 0:
                 header_text.append(" | ", style="dim")

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -14,35 +14,44 @@ from rich.text import Text
 from unilab.logging.common import BaseTrainingLogger, _fmt_number, _load_wandb
 
 OFFPOLICY_COLLECTOR_TIMING_ORDER = {
-    "weight_sync_ms": 0,
+    "weight_apply_ms": 0,
     "mlp_infer_ms": 1,
-    "action_select_ms": 1,
+    "policy_infer_ms": 1,
     "env_step_ms": 2,
     "env_step_backend_ms": 2.1,
     "env_step_update_state_ms": 2.2,
     "env_step_reset_done_ms": 2.3,
-    "replay_ms": 3,
-    "sync_coordination_ms": 4,
+    "replay_write_ms": 3,
+    "sync_idle_ms": 4,
     "rollout_ms": 9,
 }
 
 OFFPOLICY_COLLECTOR_TIMING_LABELS = {
     "rollout_ms": "Rollout",
-    "weight_sync_ms": "Weight Sync",
+    "weight_apply_ms": "Weight Apply",
     "mlp_infer_ms": "MLP Infer",
-    "action_select_ms": "Action Select",
+    "policy_infer_ms": "Policy Infer",
     "env_step_ms": "Env Step",
     "env_step_backend_ms": "  Backend Step",
     "env_step_update_state_ms": "  Update State",
     "env_step_reset_done_ms": "  Reset Done",
-    "replay_ms": "Replay",
-    "sync_coordination_ms": "Sync Coordination",
+    "replay_write_ms": "Replay Write",
+    "sync_idle_ms": "Sync Idle",
 }
 
 OFFPOLICY_ENV_STEP_DETAIL_KEYS = (
     "env_step_backend_ms",
     "env_step_update_state_ms",
     "env_step_reset_done_ms",
+)
+
+# Collector rows that make up one collection cycle. Env-step detail rows are
+# children of env_step_ms and rollout_ms is a whole-rollout total (APPO), so
+# neither is part of the per-cycle percentage base.
+_OFFPOLICY_COLLECTOR_CYCLE_KEYS = tuple(
+    key
+    for key in OFFPOLICY_COLLECTOR_TIMING_ORDER
+    if key not in OFFPOLICY_ENV_STEP_DETAIL_KEYS and key != "rollout_ms"
 )
 
 
@@ -142,6 +151,7 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_utilization: float = 0.0
         self._sync_collection: bool = False
         self._env_steps_per_sync: int = 0
+        self._collector_infer_device: str = ""
         self._staging_pool_len: int = 0
         self._staging_pool_max: int = 0
         self._status: str = "Initializing..."
@@ -278,6 +288,10 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._sync_collection = enabled
         self._env_steps_per_sync = env_steps_per_sync
 
+    def set_collector_infer_device(self, device: str):
+        """Record the collector inference device for the Policy Infer row label."""
+        self._collector_infer_device = str(device)
+
     def log_collector(self, total_steps: int, buffer_size: int, mean_reward: float = 0.0):
         self._total_steps = total_steps
         self._buffer_size = buffer_size
@@ -404,7 +418,7 @@ class OffPolicyLogger(BaseTrainingLogger):
                 global_step,
             )
             writer.add_scalar(
-                "timing/learner_sync_coordination_ms",
+                "timing/learner_collector_release_ms",
                 self._sync_coordination_time * 1000,
                 global_step,
             )
@@ -415,7 +429,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             )
             writer.add_scalar("timing/learner_train_ms", train_time * 1000, global_step)
             writer.add_scalar(
-                "timing/learner_weight_sync_ms",
+                "timing/learner_weight_publish_ms",
                 self._weight_sync_time * 1000,
                 global_step,
             )
@@ -481,12 +495,12 @@ class OffPolicyLogger(BaseTrainingLogger):
             log_dict["timing/learner_collector_wait_ms"] = self._collector_wait_time * 1000
             log_dict["timing/learner_replay_batch_wait_ms"] = self._replay_batch_wait_time * 1000
             log_dict["timing/learner_replay_sample_ms"] = self._learner_replay_sample_time * 1000
-            log_dict["timing/learner_sync_coordination_ms"] = self._sync_coordination_time * 1000
+            log_dict["timing/learner_collector_release_ms"] = self._sync_coordination_time * 1000
             log_dict["timing/learner_incremental_h2d_ms"] = (
                 self._learner_incremental_h2d_time * 1000
             )
             log_dict["timing/learner_train_ms"] = train_time * 1000
-            log_dict["timing/learner_weight_sync_ms"] = self._weight_sync_time * 1000
+            log_dict["timing/learner_weight_publish_ms"] = self._weight_sync_time * 1000
             log_dict["timing/learner_other_ms"] = learner_other_time * 1000
             for key, value in self._collector_timing.items():
                 log_dict[f"timing/collector_{key}"] = value
@@ -583,12 +597,12 @@ class OffPolicyLogger(BaseTrainingLogger):
             expand=True,
             pad_edge=False,
         )
-        table.add_column("Learner", style="white", ratio=2, no_wrap=True)
+        table.add_column("Learner", style="white", ratio=5, no_wrap=True)
         table.add_column("Value", style="yellow", justify="right", width=16, no_wrap=True)
-        table.add_column("Collector", style="white", ratio=2, no_wrap=True)
+        table.add_column("Collector", style="white", ratio=6, no_wrap=True)
         table.add_column("Value", style="yellow", justify="right", width=16, no_wrap=True)
-        table.add_column("System", style="white", ratio=2, no_wrap=True)
-        table.add_column("Value", style="yellow", justify="right", width=16, no_wrap=True)
+        table.add_column("System", style="white", ratio=4, no_wrap=True)
+        table.add_column("Value", style="yellow", justify="right", width=12, no_wrap=True)
 
         def _fmt_phase(seconds: float, *, color: str | None = None) -> str:
             ms = seconds * 1000
@@ -605,14 +619,14 @@ class OffPolicyLogger(BaseTrainingLogger):
             learner_items.append(("Replay Batch Wait", _fmt_phase(self._replay_batch_wait_time)))
         learner_items.append(("Replay Sample", _fmt_phase(self._learner_replay_sample_time)))
         if self._sync_coordination_time > 0.0:
-            learner_items.append(("Sync Coordination", _fmt_phase(self._sync_coordination_time)))
+            learner_items.append(("Collector Release", _fmt_phase(self._sync_coordination_time)))
         learner_items.extend(
             [
                 ("H2D Copy", _fmt_phase(self._learner_incremental_h2d_time)),
                 ("Train", _fmt_phase(self._train_time, color="green")),
             ]
         )
-        learner_items.append(("Weight Sync", _fmt_phase(self._weight_sync_time)))
+        learner_items.append(("Weight Publish", _fmt_phase(self._weight_sync_time)))
         learner_items.append(("Iter Wall", f"{self._get_iter_wall_time() * 1000:>7.1f}ms  100%"))
         sorted_collector_timing = sorted(
             self._collector_timing.items(),
@@ -627,9 +641,14 @@ class OffPolicyLogger(BaseTrainingLogger):
             key for key, _ in sorted_collector_timing if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS
         ]
         last_env_step_detail_key = env_step_detail_keys[-1] if env_step_detail_keys else None
+        cycle_total_ms = sum(
+            self._collector_timing.get(key, 0.0) for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS
+        )
         collector_items: list[tuple[str, str]] = []
         for key, value in sorted_collector_timing:
             label = OFFPOLICY_COLLECTOR_TIMING_LABELS.get(key, key)
+            if key == "policy_infer_ms" and self._collector_infer_device:
+                label = f"{label}({self._collector_infer_device})"
             value_text = f"{value:.1f}ms"
             if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS:
                 if self._unicode_console:
@@ -637,7 +656,14 @@ class OffPolicyLogger(BaseTrainingLogger):
                 else:
                     connector = "-'" if key == last_env_step_detail_key else "-+"
                 label = f"[dim]{label}[/]"
-                value_text = f"[dim cyan]{value_text} {connector}[/]"
+                if cycle_total_ms > 0.0:
+                    pct = value / cycle_total_ms * 100.0
+                    value_text = f"[dim cyan]{value:>7.1f}ms {pct:>3.0f}%{connector}[/]"
+                else:
+                    value_text = f"[dim cyan]{value:>7.1f}ms {connector}[/]"
+            elif key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS and cycle_total_ms > 0.0:
+                pct = value / cycle_total_ms * 100.0
+                value_text = f"{value:>7.1f}ms  {pct:>3.0f}%"
             collector_items.append((label, value_text))
         system_items = [
             ("Buffer", f"{self._buffer_size:,}"),

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -87,15 +87,16 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
         env_name="Dummy",
         log_backend="none",
     )
+    logger.set_collector_infer_device("cpu")
     logger.update_collector_timing(
         {
-            "weight_sync_ms": 0.1,
-            "action_select_ms": 0.2,
+            "weight_apply_ms": 0.1,
+            "policy_infer_ms": 0.2,
             "env_step_ms": 14.0,
             "env_step_backend_ms": 12.5,
             "env_step_update_state_ms": 1.0,
             "env_step_reset_done_ms": 0.5,
-            "replay_ms": 0.3,
+            "replay_write_ms": 0.3,
         }
     )
 
@@ -104,22 +105,22 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
     collector_value_cells = list(table.columns[3].cells)
 
     assert collector_cells == [
-        "Weight Sync",
-        "Action Select",
+        "Weight Apply",
+        "Policy Infer(cpu)",
         "Env Step",
         "[dim]  Backend Step[/]",
         "[dim]  Update State[/]",
         "[dim]  Reset Done[/]",
-        "Replay",
+        "Replay Write",
     ]
     assert collector_value_cells == [
-        "0.1ms",
-        "0.2ms",
-        "14.0ms",
-        "[dim cyan]12.5ms ─┤[/]",
-        "[dim cyan]1.0ms ─┤[/]",
-        "[dim cyan]0.5ms ─┘[/]",
-        "0.3ms",
+        "    0.1ms    1%",
+        "    0.2ms    1%",
+        "   14.0ms   96%",
+        "[dim cyan]   12.5ms  86%─┤[/]",
+        "[dim cyan]    1.0ms   7%─┤[/]",
+        "[dim cyan]    0.5ms   3%─┘[/]",
+        "    0.3ms    2%",
     ]
 
     console = Console(width=100, record=True, force_terminal=False)

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -190,6 +190,9 @@ class _FakeLogger:
     def set_collection_sync(self, *args):
         del args
 
+    def set_collector_infer_device(self, *args):
+        del args
+
     def log_status(self, value):
         self.statuses.append(value)
 

--- a/tests/algos/test_offpolicy_worker.py
+++ b/tests/algos/test_offpolicy_worker.py
@@ -29,11 +29,11 @@ class _DummyActor:
 def test_compute_collector_active_steps_per_sec_includes_active_phases_only() -> None:
     steps_per_sec = compute_collector_active_steps_per_sec(
         {
-            "weight_sync_ms": 1.0,
-            "action_select_ms": 2.0,
+            "weight_apply_ms": 1.0,
+            "policy_infer_ms": 2.0,
             "env_step_ms": 10.0,
-            "replay_ms": 3.0,
-            "sync_coordination_ms": 100.0,
+            "replay_write_ms": 3.0,
+            "sync_idle_ms": 100.0,
         },
         num_envs=32,
     )
@@ -63,7 +63,7 @@ def test_extract_env_step_breakdown_timing_ms_maps_env_owned_keys_only() -> None
 def test_compute_collector_active_steps_per_sec_returns_none_without_active_time() -> None:
     assert (
         compute_collector_active_steps_per_sec(
-            {"sync_coordination_ms": 100.0},
+            {"sync_idle_ms": 100.0},
             num_envs=32,
         )
         is None

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -505,7 +505,7 @@ def test_offpolicy_logger_logs_wait_and_iter_throughput(monkeypatch):
     assert payload["timing/learner_replay_sample_ms"] == 0.0
     assert payload["timing/learner_train_ms"] == 750.0
     assert "timing/learner_param_sync_ms" not in payload
-    assert payload["timing/learner_weight_sync_ms"] == 50.0
+    assert payload["timing/learner_weight_publish_ms"] == 50.0
     assert payload["timing/learner_other_ms"] == pytest.approx(80.0)
     assert payload["perf/learner_pipeline_ms"] == pytest.approx(820.0)
     assert payload["perf/iter_ms"] == pytest.approx(10_900.0)
@@ -534,11 +534,11 @@ def test_offpolicy_logger_logs_collector_phase_timing_to_backends(monkeypatch):
         env_name="Go2JoystickFlat",
         log_backend="wandb",
     )
-    wandb_logger.update_collector_timing({"replay_ms": 1.25})
+    wandb_logger.update_collector_timing({"replay_write_ms": 1.25})
     wandb_logger.log_step(iteration=3, metrics={}, train_time=0.1)
 
     payload, _ = fake_wandb.log_calls[-1]
-    assert payload["timing/collector_replay_ms"] == pytest.approx(1.25)
+    assert payload["timing/collector_replay_write_ms"] == pytest.approx(1.25)
     wandb_logger.finish()
 
     tb_writer = _FakeTensorBoardWriter()
@@ -548,10 +548,10 @@ def test_offpolicy_logger_logs_collector_phase_timing_to_backends(monkeypatch):
         log_backend="none",
     )
     tb_logger._tb_writer = tb_writer
-    tb_logger.update_collector_timing({"replay_ms": 2.5})
+    tb_logger.update_collector_timing({"replay_write_ms": 2.5})
     tb_logger.log_step(iteration=4, metrics={}, train_time=0.1)
 
-    assert ("timing/collector_replay_ms", 2.5, 4) in tb_writer.scalars
+    assert ("timing/collector_replay_write_ms", 2.5, 4) in tb_writer.scalars
     tb_logger.finish()
 
 


### PR DESCRIPTION
## Summary

PR#945 把 replay 改为 device-authoritative bounded ingress 之后，off-policy 的统计口径没有同步澄清：learner / collector 两侧同名的 `Weight Sync`、`Sync Coordination` 含义完全不同，`Replay Batch Wait` 语义已变，collector `Replay` 含义也变了。本 PR 统一重命名终端 label 与 TensorBoard/W&B key，并让终端直接暴露 CPU/GPU 相对负载信号。

### Key 更名（终端 label 与 TB/W&B key 同步）

| 旧 | 新 | 含义 |
| --- | --- | --- |
| `timing/learner_weight_sync_ms` | `timing/learner_weight_publish_ms` | 发布方：actor 权重写入共享内存 |
| `timing/learner_sync_coordination_ms` | `timing/learner_collector_release_ms` | 仅 sync 采集：learner 发 release token，阻塞 = collector 落后 |
| `timing/collector_weight_sync_ms` | `timing/collector_weight_apply_ms` | 消费方：检查并加载新权重（与 Weight Publish 是同一通道两端，非重复） |
| `timing/collector_action_select_ms` | `timing/collector_policy_infer_ms` | actor 前向推理（含探索采样）；终端行标注推理设备 `Policy Infer(cuda:0)` |
| `timing/collector_replay_ms` | `timing/collector_replay_write_ms` | 打包 transition 并写入 bounded ingress 槽 |
| `timing/collector_sync_coordination_ms` | `timing/collector_sync_idle_ms` | 簿记 + metrics 上报；sync 采集下含等 learner 的空转，即 collector 空转指标 |

注意：TB key 更名对旧 run 的历史曲线是断档的；`benchmark/rl/extract_offpolicy_metrics.py` 已同步，并删除 #945 移除多 GPU 后的死 key `learner_rank_barrier_ms`。

### 终端显示

- Collector 列每行新增占单步采集周期的百分比；Env Step 三个子项 ms 与父行对齐、共享同一分母、保留树形连接线（dim cyan）。
- 状态栏 header 行居中（`logging/common.py`，on/off-policy 一致）。
- 时序表列宽重新分配（Learner/Collector/System = 5:6:4），`Policy Infer(<device>)` 在宽度 ≥110 时完整显示。

### 文档

- en/zh_CN `3-logging.md`：重写 off-policy 计时表，逐项写明 #945 后的真实口径（含 H2D Copy 在 CUDA 下为后台线程提交耗时、与其他 learner 行不严格可加的说明），并新增「判读 CPU 与 GPU 的相对负载」一节（Collector Wait 高 = 采集侧瓶颈；Replay Batch Wait 高 = device replay 流水线落后；collector Sync Idle 高 = GPU 训练瓶颈）。
- 两处 `2-appo.md` 图注同步 Weight Publish 名称。

不改任何训练行为；APPO/HORA 共享 `OffPolicyLogger`，其 learner TB key 随之更名（`log_step` Python kwargs 保持不变）。

## Validation

- `make test-all` 通过：ruff / mypy / pyright 干净，pytest 1508 passed, 36 skipped, 269 deselected, 1 xfailed；benchmark import smoke 通过。
- 新增/更新测试覆盖：collector 表格 label、百分比、device 后缀、连接器对齐（`test_offpolicy_logger.py`），活跃吞吐口径（`test_offpolicy_worker.py`），TB/W&B key（`test_experiment_tracking.py`）。
- Sphinx 全量构建成功（仅 1 条与本次无关的既有警告）。