### PR TITLE
fix(offpolicy): correct algo display names in training panel

### DIFF
--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -35,6 +35,18 @@ from unilab.ipc.replay_pipelines.gpu_resident import (
 from unilab.logging import OffPolicyLogger, TraceRecorder
 from unilab.training.seed import derive_worker_seed
 
+# Terminal/W&B display names for the off-policy algo types. Keep these
+# user-facing (no internal "Fast*" implementation prefixes).
+_ALGO_DISPLAY_NAMES = {
+    "sac": "SAC",
+    "td3": "TD3",
+    "flashsac": "FlashSAC",
+}
+
+
+def algo_display_name(algo_type: str) -> str:
+    return _ALGO_DISPLAY_NAMES.get(algo_type, algo_type.upper())
+
 
 class _CollectorDiedError(RuntimeError):
     """Raised by _safe_put_trainer_done when collector death is detected.
@@ -257,7 +269,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
         # --- logger ---
         logger = OffPolicyLogger(
-            algo_name=f"Fast{self.algo_type.upper()}",
+            algo_name=algo_display_name(self.algo_type),
             max_iterations=max_iterations,
             num_envs=self.num_envs,
             env_name=self.env_name,

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -10,12 +10,21 @@ import torch
 
 import unilab.algos.torch.offpolicy.double_buffer_runner as device_runner_module
 import unilab.algos.torch.offpolicy.runner as runner_module
+from unilab.algos.torch.offpolicy.double_buffer_runner import algo_display_name
 from unilab.algos.torch.offpolicy.runner import (
     build_offpolicy_sample_info,
     compute_train_start_threshold,
     replay_buffer_ready_for_learning,
     update_reward_stats_from_replay,
 )
+
+
+@pytest.mark.parametrize(
+    ("algo_type", "expected"),
+    [("sac", "SAC"), ("td3", "TD3"), ("flashsac", "FlashSAC"), ("hora_sac", "HORA_SAC")],
+)
+def test_algo_display_name(algo_type, expected):
+    assert algo_display_name(algo_type) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

#948 之后发现训练面板算法名显示 bug：logger 名字由 `f"Fast{algo_type.upper()}"` 拼接，FlashSAC 的 run 显示为 `FastFLASHSAC`。

改为显式显示名映射（`algo_display_name()`）：

- `sac` → `SAC`（不再显示 FastSAC）
- `td3` → `TD3`
- `flashsac` → `FlashSAC`
- 未知类型回退 `upper()`

内部的 `FastSACLearner` / `FastTD3Learner` 类名是实现细节，不作为用户可见的算法名。

## Validation

- `make test-all` 通过：ruff / mypy / pyright 干净，pytest 1512 passed, 36 skipped, 269 deselected, 1 xfailed（含新增的 `test_algo_display_name` 参数化单测）。