### PR TITLE
conf(offpolicy): default collector inference to the accelerator for sac/flashsac

### DIFF
--- a/conf/offpolicy/algo/flashsac.yaml
+++ b/conf/offpolicy/algo/flashsac.yaml
@@ -1,48 +1,55 @@
-# @package algo
-algo: flashsac
-algo_log_name: flash_sac
-load_run: "-1"
-seed: 1
-num_envs: 1024
-batch_size: 2048
-replay_buffer_n: 512
-updates_per_step: 2
-learning_starts: 98
-policy_frequency: 2
-env_steps_per_sync: 1
-max_iterations: 5000
-save_interval: 1000
-gamma: 0.97
-tau: 0.01
-actor_lr: 3.0e-4
-critic_lr: 3.0e-4
-actor_hidden_dim: 128
-critic_hidden_dim: 256
-num_atoms: 101
-obs_normalization: false
-use_layer_norm: false
-algo_params:
-  normalize_reward: true
-  normalized_g_max: 5.0
-  actor_num_blocks: 2
-  critic_num_blocks: 2
-  actor_bc_alpha: 0.0
-  actor_noise_zeta_mu: 2.0
-  actor_noise_zeta_max: 16
-  critic_min_v: -5.0
-  critic_max_v: 5.0
-  temp_initial_value: 0.01
-  temp_target_sigma: 0.15
-  temp_target_entropy: null
-  learning_rate_init: 3.0e-4
-  learning_rate_peak: 3.0e-4
-  learning_rate_end: 1.5e-4
-  learning_rate_warmup_steps: 0
-  learning_rate_decay_steps: 500000
-  n_step: 1
-  amp_dtype: auto
-  use_compile: true
-  use_cuda_graph_critic: false
-  use_cuda_graph_actor: false
-  use_cuda_graph_critic_packed_staging: false
-  use_cuda_graph_actor_packed_staging: false
+# @package _global_
+training:
+  # "gpu" is a cross-platform accelerator alias resolved by
+  # resolve_torch_device_alias: cuda (including ROCm/AMD), then xpu, then mps
+  # (macOS); it fails fast when no accelerator is available, which matches the
+  # off-policy learner device requirement (CUDA or MPS only).
+  collector_infer_device: gpu
+algo:
+  algo: flashsac
+  algo_log_name: flash_sac
+  load_run: "-1"
+  seed: 1
+  num_envs: 1024
+  batch_size: 2048
+  replay_buffer_n: 512
+  updates_per_step: 2
+  learning_starts: 98
+  policy_frequency: 2
+  env_steps_per_sync: 1
+  max_iterations: 5000
+  save_interval: 1000
+  gamma: 0.97
+  tau: 0.01
+  actor_lr: 3.0e-4
+  critic_lr: 3.0e-4
+  actor_hidden_dim: 128
+  critic_hidden_dim: 256
+  num_atoms: 101
+  obs_normalization: false
+  use_layer_norm: false
+  algo_params:
+    normalize_reward: true
+    normalized_g_max: 5.0
+    actor_num_blocks: 2
+    critic_num_blocks: 2
+    actor_bc_alpha: 0.0
+    actor_noise_zeta_mu: 2.0
+    actor_noise_zeta_max: 16
+    critic_min_v: -5.0
+    critic_max_v: 5.0
+    temp_initial_value: 0.01
+    temp_target_sigma: 0.15
+    temp_target_entropy: null
+    learning_rate_init: 3.0e-4
+    learning_rate_peak: 3.0e-4
+    learning_rate_end: 1.5e-4
+    learning_rate_warmup_steps: 0
+    learning_rate_decay_steps: 500000
+    n_step: 1
+    amp_dtype: auto
+    use_compile: true
+    use_cuda_graph_critic: false
+    use_cuda_graph_actor: false
+    use_cuda_graph_critic_packed_staging: false
+    use_cuda_graph_actor_packed_staging: false

--- a/conf/offpolicy/algo/sac.yaml
+++ b/conf/offpolicy/algo/sac.yaml
@@ -1,40 +1,47 @@
-# @package algo
-algo: sac
-algo_log_name: fast_sac
-runtime_impl: null
-runtime_resolver: null
-load_run: "-1"
-seed: 1
-num_envs: 4096
-# Learner batch size for one SAC update. Symmetry may sample fewer replay rows
-# and expand them inside the learner.
-batch_size: 8192
-replay_buffer_n: 512
-updates_per_step: 4
-learning_starts: 1
-policy_frequency: 4
-env_steps_per_sync: 1
-max_iterations: 500
-save_interval: 500
-gamma: 0.97
-tau: 0.125
-actor_lr: 3.0e-4
-critic_lr: 3.0e-4
-actor_hidden_dim: 512
-critic_hidden_dim: 768
-num_atoms: 101
-obs_normalization: false
-use_layer_norm: true
-use_symmetry: false
-actor: {}
-algo_params:
-  alpha_lr: 3.0e-4
-  alpha_init: 0.01
-  target_entropy_ratio: 0.0
-  max_grad_norm: 0.0
-  amp_dtype: auto
-  use_compile: true
-  use_cuda_graph_critic: false
-  use_cuda_graph_actor: false
-  use_cuda_graph_critic_packed_staging: false
-  use_cuda_graph_actor_packed_staging: false
+# @package _global_
+training:
+  # "gpu" is a cross-platform accelerator alias resolved by
+  # resolve_torch_device_alias: cuda (including ROCm/AMD), then xpu, then mps
+  # (macOS); it fails fast when no accelerator is available, which matches the
+  # off-policy learner device requirement (CUDA or MPS only).
+  collector_infer_device: gpu
+algo:
+  algo: sac
+  algo_log_name: fast_sac
+  runtime_impl: null
+  runtime_resolver: null
+  load_run: "-1"
+  seed: 1
+  num_envs: 4096
+  # Learner batch size for one SAC update. Symmetry may sample fewer replay rows
+  # and expand them inside the learner.
+  batch_size: 8192
+  replay_buffer_n: 512
+  updates_per_step: 4
+  learning_starts: 1
+  policy_frequency: 4
+  env_steps_per_sync: 1
+  max_iterations: 500
+  save_interval: 500
+  gamma: 0.97
+  tau: 0.125
+  actor_lr: 3.0e-4
+  critic_lr: 3.0e-4
+  actor_hidden_dim: 512
+  critic_hidden_dim: 768
+  num_atoms: 101
+  obs_normalization: false
+  use_layer_norm: true
+  use_symmetry: false
+  actor: {}
+  algo_params:
+    alpha_lr: 3.0e-4
+    alpha_init: 0.01
+    target_entropy_ratio: 0.0
+    max_grad_norm: 0.0
+    amp_dtype: auto
+    use_compile: true
+    use_cuda_graph_critic: false
+    use_cuda_graph_actor: false
+    use_cuda_graph_critic_packed_staging: false
+    use_cuda_graph_actor_packed_staging: false


### PR DESCRIPTION
## Summary

SAC 与 FlashSAC 的 `training.collector_infer_device` 默认值从 `cpu` 改为 `gpu`，配合 #947 的 GPU collector weight sync，collector 推理默认落在加速器上。

- `gpu` 是 `resolve_torch_device_alias` 已有的跨平台别名：ROCm/AMD 上 `torch.cuda.is_available()` 为 True → 解析为 `cuda`；macOS → `mps`；无加速器时 fail fast（off-policy 本就要求 CUDA/MPS learner device，行为一致）。
- 实现方式：`conf/offpolicy/algo/sac.yaml` 与 `flashsac.yaml` 从 `# @package algo` 改为 `# @package _global_`（与仓库全部 task owner yaml 同一写法），在 `training:` 段声明默认值。
- TD3 保持 `cpu` 默认不变；用户可用 `training.collector_infer_device=cpu` 覆盖。

## Validation

- Hydra compose 前后对比：sac / flashsac 仅 `training.collector_infer_device` 由 `cpu` → `gpu`，其余字段逐一相同；td3 完全一致。
- `make test-all` 通过：ruff / mypy / pyright 干净，pytest 1508 passed, 36 skipped, 269 deselected, 1 xfailed。