### PR TITLE
bench: 新增 collector update_state/reset_done 的 NumPy vs Torch 对比测评

### DIFF
--- a/benchmark/torch_env/__init__.py
+++ b/benchmark/torch_env/__init__.py
@@ -1,0 +1,1 @@
+"""Torch-vs-NumPy benchmarks for collector-timed env computation."""

--- a/benchmark/torch_env/motion_tracking.py
+++ b/benchmark/torch_env/motion_tracking.py
@@ -1,0 +1,602 @@
+"""G1MotionTrackingSAC (SAC/mujoco) update_state / reset_done workload.
+
+Faithful xp-port of the NumPy computation in the collector-timed sections of
+`uv run train --algo sac --task g1_motion_tracking --sim mujoco`
+(num_envs=2048, 29-dof, 14 tracked bodies):
+
+- `MotionTrackingEnv.update_state`
+  (src/unilab/envs/motion_tracking/common/tracking.py):
+  motion gather, relative transforms (transforms.py), terminations
+  (terminations.py), 9 active reward terms (rewards.py, incl. per-term logging
+  every 4 steps), observation build (observations.py, actor 160 / critic 289
+  with the SAC +3 linvel tail), adaptive motion-sampler bookkeeping
+  (motion_loader.py).
+- `MotionTrackingDomainRandomizationProvider.build_reset_plan` /
+  `build_reset_observation` + `build_motion_reference_state` (reset.py).
+- `NpEnv._reset_done_envs` scatter/gather.
+
+Excluded (identical across variants, not NumPy/Torch env math):
+`backend.step` physics, `backend.set_state`, sensor/body-state reads (replaced
+by persistent arrays), and the adaptive-sampler entropy metrics (3 scalar
+reductions per reset).
+
+The real `build_motion_reference_state` samples pose/velocity randomization
+with a per-element Python loop (num_reset x 6 draws, twice). The NumPy
+workload reproduces that faithfully; pass ``vectorized_reset_rng=True`` for a
+column-wise vectorized NumPy draw (used for cross-backend RNG replay during
+validation, which is also the only mode Torch implements).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+N_ENVS = 2048
+N_ACTION = 29
+N_BODY = 14
+NQ = 36
+NV = 35
+OBS_DIM = 160
+CRITIC_DIM = 289
+N_FRAMES = 870
+CLIP_END_FRAME = 869
+N_BINS = 18
+ANCHOR_IDX = 7
+EE_INDICES = (3, 6, 10, 13)
+UNDESIRED_INDICES = (0, 1, 2, 4, 5, 7, 8, 9, 11, 12)
+
+ANCHOR_POS_Z_THRESHOLD = 0.5
+ANCHOR_ORI_THRESHOLD = 0.8
+EE_BODY_POS_Z_THRESHOLD = 0.5
+UNDESIRED_CONTACT_Z_THRESHOLD = 0.05
+CTRL_DT = 0.02
+SAMPLER_UNIFORM_RATIO = 0.1
+SAMPLER_ALPHA = 0.001
+JOINT_POSITION_RANGE = (-0.1, 0.1)
+POSE_RANGES = ((-0.05, 0.05), (-0.05, 0.05), (-0.01, 0.01), (-0.1, 0.1), (-0.1, 0.1), (-0.2, 0.2))
+VEL_RANGES = ((-0.5, 0.5), (-0.5, 0.5), (-0.2, 0.2), (-0.52, 0.52), (-0.52, 0.52), (-0.78, 0.78))
+NOISE_LEVEL = 1.0
+NOISE_SCALES = {"linvel": 0.1, "gyro": 0.2, "joint_angle": 0.01, "joint_vel": 1.5}
+
+# (name, scale, 1/std^2) in YAML dispatch order; scale==0 terms are skipped by
+# the real dispatcher and therefore absent here.
+REWARD_TERMS = (
+    ("motion_global_root_pos", 1.0, 1.0 / 0.3**2),
+    ("motion_global_root_ori", 0.5, 1.0 / 0.4**2),
+    ("motion_body_pos", 2.0, 1.0 / 0.3**2),
+    ("motion_body_ori", 1.0, 1.0 / 0.4**2),
+    ("motion_body_lin_vel", 1.0, 1.0 / 1.0**2),
+    ("motion_body_ang_vel", 1.0, 1.0 / 3.14**2),
+)
+
+
+def _quat_mul(b, q1, q2):
+    """Hamilton product, w-first, broadcasting over leading dims."""
+    w1, x1, y1, z1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    w2, x2, y2, z2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
+    return b.stack(
+        [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        ],
+        axis=-1,
+    )
+
+
+def _quat_from_euler_xyz(b, roll, pitch, yaw):
+    cr, sr = b.cos(roll * 0.5), b.sin(roll * 0.5)
+    cp, sp = b.cos(pitch * 0.5), b.sin(pitch * 0.5)
+    cy, sy = b.cos(yaw * 0.5), b.sin(yaw * 0.5)
+    return b.stack(
+        [
+            cr * cp * cy + sr * sp * sy,
+            sr * cp * cy - cr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+        ],
+        axis=-1,
+    )
+
+
+def _quat_apply(b, q, v):
+    """Rotate vectors v (..., 3) by quaternions q (..., 4), w-first."""
+    qw = q[..., 0:1]
+    qv = q[..., 1:4]
+    # t = 2 * cross(qv, v)
+    tx = 2 * (qv[..., 1:2] * v[..., 2:3] - qv[..., 2:3] * v[..., 1:2])
+    ty = 2 * (qv[..., 2:3] * v[..., 0:1] - qv[..., 0:1] * v[..., 2:3])
+    tz = 2 * (qv[..., 0:1] * v[..., 1:2] - qv[..., 1:2] * v[..., 0:1])
+    # v + qw * t + cross(qv, t)
+    return b.concat(
+        [
+            v[..., 0:1] + qw * tx + qv[..., 1:2] * tz - qv[..., 2:3] * ty,
+            v[..., 1:2] + qw * ty + qv[..., 2:3] * tx - qv[..., 0:1] * tz,
+            v[..., 2:3] + qw * tz + qv[..., 0:1] * ty - qv[..., 1:2] * tx,
+        ],
+        axis=-1,
+    )
+
+
+def _quat_inv(b, q):
+    return b.concat([q[..., 0:1], -q[..., 1:4]], axis=-1)
+
+
+def _gravity_z_in_body(q):
+    return 2 * (q[..., 1] * q[..., 1] + q[..., 2] * q[..., 2]) - 1
+
+
+class MotionTrackingWorkload:
+    def __init__(
+        self, b, rng, seed: int = 0, vectorized_reset_rng: bool = False, num_envs: int = N_ENVS
+    ):
+        self.b = b
+        self.rng = rng
+        self.vectorized_reset_rng = vectorized_reset_rng
+        self.n_envs = num_envs
+        rs = np.random.RandomState(seed)
+
+        def f32(*shape):
+            return rs.standard_normal(shape).astype(np.float32)
+
+        def rand_quat(*shape):
+            q = f32(*shape)
+            q /= np.linalg.norm(q, axis=-1, keepdims=True)
+            return q.astype(np.float32)
+
+        n = num_envs
+        self.default_angles = b.convert(rs.uniform(-0.5, 0.5, N_ACTION).astype(np.float32))
+        da = b.to_numpy(self.default_angles)
+        self.joint_lower = b.convert(da - 1.0)
+        self.joint_upper = b.convert(da + 1.0)
+
+        # Motion store (one clip, 870 frames @ fps 50).
+        self.m_joint_pos = b.convert(f32(N_FRAMES, N_ACTION) * 0.3)
+        self.m_joint_vel = b.convert(f32(N_FRAMES, N_ACTION))
+        body_pos = f32(N_FRAMES, N_BODY, 3) * 0.2
+        body_pos[..., 2] = np.abs(body_pos[..., 2]) + 0.15
+        self.m_body_pos = b.convert(body_pos)
+        self.m_body_quat = b.convert(rand_quat(N_FRAMES, N_BODY, 4))
+        self.m_body_lin_vel = b.convert(f32(N_FRAMES, N_BODY, 3) * 0.5)
+        self.m_body_ang_vel = b.convert(f32(N_FRAMES, N_BODY, 3))
+
+        # Robot state (backend reads replaced by persistent arrays).
+        self.body_pos = b.convert(b.to_numpy(self.m_body_pos)[0:1] + f32(n, N_BODY, 3) * 0.02)
+        self.body_quat = b.convert(rand_quat(n, N_BODY, 4))
+        self.body_lin_vel = b.convert(f32(n, N_BODY, 3) * 0.5)
+        self.body_ang_vel = b.convert(f32(n, N_BODY, 3))
+        # Force a few anchor-z mismatches so the terminated branch stays live.
+        forced = b.to_numpy(self.body_pos)
+        forced[:8, ANCHOR_IDX, 2] += 1.0
+        self.body_pos = b.convert(forced)
+        self.linvel = b.convert(f32(n, 3) * 0.5)
+        self.gyro = b.convert(f32(n, 3) * 0.5)
+        self.dof_pos = b.convert(da[None, :] + f32(n, N_ACTION) * 0.1)
+        self.dof_vel = b.convert(f32(n, N_ACTION))
+
+        # info / sampler state.
+        self.current_actions = b.convert(f32(n, N_ACTION) * 0.3)
+        self.last_actions = b.convert(f32(n, N_ACTION) * 0.3)
+        self.steps = b.index(rs.randint(0, 500, n))
+        self.current_frames = b.index(rs.randint(0, 200, n))
+        self.bin_failed_count = b.convert(np.full(N_BINS, 0.05, dtype=np.float32))
+        self.clip_end_truncated = b.zeros((n,)) > 0.0  # bool array
+
+        # Reset plan constants (keyframe "stand").
+        init_qpos = np.zeros(NQ, dtype=np.float32)
+        init_qpos[2] = 0.754
+        init_qpos[3] = 1.0
+        init_qpos[7:] = da
+        self.init_qpos = b.convert(init_qpos)
+
+        # Step outputs kept across calls for the reset scatter/gather path.
+        self.obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+        self.final_obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+        self.compat_final_obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+
+    # ------------------------------------------------------------- gathers --
+    def _motion_at_frames(self, frames):
+        b = self.b
+        return (
+            b.take(self.m_joint_pos, frames),
+            b.take(self.m_joint_vel, frames),
+            b.take(self.m_body_pos, frames),
+            b.take(self.m_body_quat, frames),
+            b.take(self.m_body_lin_vel, frames),
+            b.take(self.m_body_ang_vel, frames),
+        )
+
+    # ----------------------------------------------------------- transforms --
+    def _update_relative_transforms(self, m_body_pos, m_body_quat):
+        b = self.b
+        anchor_pos = m_body_pos[:, ANCHOR_IDX]
+        anchor_quat = m_body_quat[:, ANCHOR_IDX]
+        r_anchor_pos = self.body_pos[:, ANCHOR_IDX]
+        r_anchor_quat = self.body_quat[:, ANCHOR_IDX]
+
+        delta_pos_z = anchor_pos[:, 2]
+        delta_pos = b.stack([r_anchor_pos[:, 0], r_anchor_pos[:, 1], delta_pos_z], axis=1)
+
+        # yaw-only relative rotation: yaw_quat(r_quat x conj(anchor_quat)).
+        rw, rx, ry, rz = (r_anchor_quat[:, i] for i in range(4))
+        aw, ax, ay, az = (anchor_quat[:, i] for i in range(4))
+        qw = rw * aw + rx * ax + ry * ay + rz * az
+        qx = -rw * ax + rx * aw - ry * az + rz * ay
+        qy = -rw * ay + rx * az + ry * aw - rz * ax
+        qz = -rw * az - rx * ay + ry * ax + rz * aw
+        half_yaw = 0.5 * b.atan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz))
+        dw = b.cos(half_yaw)
+        dz = b.sin(half_yaw)
+
+        mw = m_body_quat[..., 0]
+        mx = m_body_quat[..., 1]
+        my = m_body_quat[..., 2]
+        mz = m_body_quat[..., 3]
+        dw_c = dw[:, None]
+        dz_c = dz[:, None]
+        body_quat_relative = b.stack(
+            [
+                dw_c * mw - dz_c * mz,
+                dw_c * mx - dz_c * my,
+                dw_c * my + dz_c * mx,
+                dw_c * mz + dz_c * mw,
+            ],
+            axis=-1,
+        )
+
+        rel = m_body_pos - anchor_pos[:, None, :]
+        yc = (2 * dw * dz)[:, None]
+        yz2 = (2 * dz * dz)[:, None]
+        vx, vy, vz = rel[..., 0], rel[..., 1], rel[..., 2]
+        body_pos_relative = b.stack(
+            [
+                vx - yc * vy - yz2 * vx + delta_pos[:, 0:1],
+                vy + yc * vx - yz2 * vy + delta_pos[:, 1:2],
+                vz + delta_pos[:, 2:3],
+            ],
+            axis=-1,
+        )
+        return body_pos_relative, body_quat_relative
+
+    # ---------------------------------------------------------- terminations --
+    def _compute_terminations(self, m_body_pos, m_body_quat, body_pos_relative):
+        b = self.b
+        anchor_pos = m_body_pos[:, ANCHOR_IDX]
+        anchor_quat = m_body_quat[:, ANCHOR_IDX]
+        r_anchor_pos = self.body_pos[:, ANCHOR_IDX]
+        r_anchor_quat = self.body_quat[:, ANCHOR_IDX]
+
+        terminated = b.abs(anchor_pos[:, 2] - r_anchor_pos[:, 2]) > ANCHOR_POS_Z_THRESHOLD
+        ori_err = b.abs(_gravity_z_in_body(anchor_quat) - _gravity_z_in_body(r_anchor_quat))
+        terminated = b.logical_or(terminated, ori_err > ANCHOR_ORI_THRESHOLD)
+        ee = list(EE_INDICES)
+        ee_err = b.abs(body_pos_relative[:, ee, 2] - self.body_pos[:, ee, 2])
+        terminated = b.logical_or(terminated, b.any(ee_err > EE_BODY_POS_Z_THRESHOLD, axis=1))
+        return terminated
+
+    # --------------------------------------------------------------- reward --
+    def _compute_reward(
+        self,
+        should_log,
+        m_body_pos,
+        m_body_quat,
+        m_body_lin_vel,
+        m_body_ang_vel,
+        body_pos_relative,
+        body_quat_relative,
+    ):
+        b = self.b
+        terms = {}
+
+        anchor_err = b.sum(
+            b.square(m_body_pos[:, ANCHOR_IDX] - self.body_pos[:, ANCHOR_IDX]), axis=1
+        )
+        terms["motion_global_root_pos"] = anchor_err
+
+        aq = m_body_quat[:, ANCHOR_IDX]
+        rq = self.body_quat[:, ANCHOR_IDX]
+        d = b.clip(b.abs(b.sum(aq * rq, axis=1)), 0.0, 1.0)
+        terms["motion_global_root_ori"] = b.square(2 * b.arccos(d))
+
+        pos_err = b.square(body_pos_relative - self.body_pos)
+        terms["motion_body_pos"] = b.sum(pos_err, axis=(1, 2)) / N_BODY
+
+        d_all = b.clip(b.abs(b.sum(body_quat_relative * self.body_quat, axis=-1)), 0.0, 1.0)
+        ori_err_all = b.square(2 * b.arccos(d_all))
+        terms["motion_body_ori"] = b.sum(ori_err_all, axis=1) / N_BODY
+
+        lin_err = b.square(m_body_lin_vel - self.body_lin_vel)
+        terms["motion_body_lin_vel"] = b.sum(lin_err, axis=(1, 2)) / N_BODY
+        ang_err = b.square(m_body_ang_vel - self.body_ang_vel)
+        terms["motion_body_ang_vel"] = b.sum(ang_err, axis=(1, 2)) / N_BODY
+
+        reward = b.zeros((self.body_pos.shape[0],))
+        log = {}
+        for name, scale, inv_var in REWARD_TERMS:
+            weighted = b.exp(terms[name] * (-inv_var)) * scale
+            reward = reward + weighted
+            if should_log:
+                log[f"reward/{name}"] = b.scalar(b.mean(weighted))
+
+        ar = b.sum(b.square(self.current_actions - self.last_actions), axis=1)
+        weighted = ar * -0.1
+        reward = reward + weighted
+        if should_log:
+            log["reward/action_rate_l2"] = b.scalar(b.mean(weighted))
+
+        viol = b.maximum(self.joint_lower - self.dof_pos, 0.0) + b.maximum(
+            self.dof_pos - self.joint_upper, 0.0
+        )
+        weighted = b.sum(b.square(viol), axis=1) * -2.0
+        reward = reward + weighted
+        if should_log:
+            log["reward/joint_limit"] = b.scalar(b.mean(weighted))
+
+        undesired = list(UNDESIRED_INDICES)
+        contacts = self.body_pos[:, undesired, 2] < UNDESIRED_CONTACT_Z_THRESHOLD
+        weighted = b.float_(b.sum(contacts, axis=1)) * -0.1
+        reward = reward + weighted
+        if should_log:
+            log["reward/undesired_contacts"] = b.scalar(b.mean(weighted))
+
+        self._last_log = log
+        return reward * CTRL_DT
+
+    # ------------------------------------------------------------------ obs --
+    def _obs_noise(self, data, scale):
+        noise = self.b.float_(self.rng.uniform(-1.0, 1.0, tuple(data.shape)))
+        return data + noise * NOISE_LEVEL * scale
+
+    def _compute_obs(
+        self, motion, linvel, gyro, dof_pos, dof_vel, body_pos, body_quat, last_actions
+    ):
+        b = self.b
+        m_joint_pos, m_joint_vel, m_body_pos, m_body_quat = motion[:4]
+        m = linvel.shape[0]
+
+        anchor_pos = m_body_pos[:, ANCHOR_IDX]
+        anchor_quat = m_body_quat[:, ANCHOR_IDX]
+        r_anchor_pos = body_pos[:, ANCHOR_IDX]
+        r_anchor_quat = body_quat[:, ANCHOR_IDX]
+
+        # Motion anchor pose in robot anchor frame (np_write_relative_anchor_
+        # transform_pos_rot6d, geometry.py).
+        aw, ax, ay, az = (r_anchor_quat[:, i] for i in range(4))
+        vx = anchor_pos[:, 0] - r_anchor_pos[:, 0]
+        vy = anchor_pos[:, 1] - r_anchor_pos[:, 1]
+        vz = anchor_pos[:, 2] - r_anchor_pos[:, 2]
+        qx, qy, qz = -ax, -ay, -az
+        tx = 2 * (qy * vz - qz * vy)
+        ty = 2 * (qz * vx - qx * vz)
+        tz = 2 * (qx * vy - qy * vx)
+        pos_b = b.stack(
+            [
+                vx + aw * tx + qy * tz - qz * ty,
+                vy + aw * ty + qz * tx - qx * tz,
+                vz + aw * tz + qx * ty - qy * tx,
+            ],
+            axis=1,
+        )
+        bw, bx, by, bz = (anchor_quat[:, i] for i in range(4))
+        rw = aw * bw + ax * bx + ay * by + az * bz
+        rx = aw * bx - ax * bw - ay * bz + az * by
+        ry = aw * by + ax * bz - ay * bw - az * bx
+        rz = aw * bz - ax * by + ay * bx - az * bw
+        ori6 = b.stack(
+            [
+                1 - 2 * (ry * ry + rz * rz),
+                2 * (rx * ry - rw * rz),
+                2 * (rx * ry + rw * rz),
+                1 - 2 * (rx * rx + rz * rz),
+                2 * (rx * rz - rw * ry),
+                2 * (ry * rz + rw * rx),
+            ],
+            axis=1,
+        )
+
+        joint_pos_rel = dof_pos - self.default_angles
+        command = b.concat([m_joint_pos, m_joint_vel], axis=1)
+
+        noisy_linvel = self._obs_noise(linvel, NOISE_SCALES["linvel"])
+        noisy_gyro = self._obs_noise(gyro, NOISE_SCALES["gyro"])
+        noisy_jpr = self._obs_noise(joint_pos_rel, NOISE_SCALES["joint_angle"])
+        noisy_dv = self._obs_noise(dof_vel, NOISE_SCALES["joint_vel"])
+
+        actor = b.concat(
+            [command, pos_b, ori6, noisy_linvel, noisy_gyro, noisy_jpr, noisy_dv, last_actions],
+            axis=1,
+        )
+
+        # Critic: clean channels + privileged body transforms in anchor frame.
+        # Matches observations.write_body_pos_in_anchor_frame exactly.
+        aqw = r_anchor_quat[:, None, 0:1]
+        aqv = r_anchor_quat[:, None, 1:4]
+        rel = body_pos - r_anchor_pos[:, None, :]
+        txx = 2 * (aqv[..., 2:3] * rel[..., 1:2] - aqv[..., 1:2] * rel[..., 2:3])
+        tyy = 2 * (aqv[..., 0:1] * rel[..., 2:3] - aqv[..., 2:3] * rel[..., 0:1])
+        tzz = 2 * (aqv[..., 1:2] * rel[..., 0:1] - aqv[..., 0:1] * rel[..., 1:2])
+        body_pos_b = b.concat(
+            [
+                rel[..., 0:1] + aqw * txx + aqv[..., 2:3] * tyy - aqv[..., 1:2] * tzz,
+                rel[..., 1:2] + aqw * tyy + aqv[..., 0:1] * tzz - aqv[..., 2:3] * txx,
+                rel[..., 2:3] + aqw * tzz + aqv[..., 1:2] * txx - aqv[..., 0:1] * tyy,
+            ],
+            axis=-1,
+        )
+        rel_quat = _quat_mul(b, _quat_inv(b, r_anchor_quat[:, None, :]), body_quat)
+        rw2 = rel_quat[..., 0]
+        rx2 = rel_quat[..., 1]
+        ry2 = rel_quat[..., 2]
+        rz2 = rel_quat[..., 3]
+        body_ori6_b = b.stack(
+            [
+                1 - 2 * (ry2 * ry2 + rz2 * rz2),
+                2 * (rx2 * ry2 - rw2 * rz2),
+                2 * (rx2 * ry2 + rw2 * rz2),
+                1 - 2 * (rx2 * rx2 + rz2 * rz2),
+                2 * (rx2 * rz2 - rw2 * ry2),
+                2 * (ry2 * rz2 + rw2 * rx2),
+            ],
+            axis=-1,
+        )
+        critic = b.concat(
+            [
+                command,
+                pos_b,
+                ori6,
+                linvel,
+                gyro,
+                joint_pos_rel,
+                dof_vel,
+                last_actions,
+                body_pos_b.reshape(m, N_BODY * 3),
+                body_ori6_b.reshape(m, N_BODY * 6),
+                linvel,  # SAC critic tail (+3)
+            ],
+            axis=1,
+        )
+        return {"obs": actor, "critic": critic}
+
+    # --------------------------------------------------------- update_state --
+    def update_state(self, should_log: bool):
+        b = self.b
+        motion = self._motion_at_frames(self.current_frames)
+        m_body_pos, m_body_quat, m_lin, m_ang = motion[2], motion[3], motion[4], motion[5]
+
+        body_pos_relative, body_quat_relative = self._update_relative_transforms(
+            m_body_pos, m_body_quat
+        )
+        terminated = self._compute_terminations(m_body_pos, m_body_quat, body_pos_relative)
+        reward = self._compute_reward(
+            should_log,
+            m_body_pos,
+            m_body_quat,
+            m_lin,
+            m_ang,
+            body_pos_relative,
+            body_quat_relative,
+        )
+        obs = self._compute_obs(
+            motion,
+            self.linvel,
+            self.gyro,
+            self.dof_pos,
+            self.dof_vel,
+            self.body_pos,
+            self.body_quat,
+            self.current_actions,
+        )
+        self.obs = obs
+
+        # MotionSampler.update_failure_stats (adaptive mode).
+        if b.any_scalar(terminated):
+            bin_idx = b.clip((self.current_frames * N_BINS) // N_FRAMES, 0, N_BINS - 1)
+            failed = bin_idx[terminated]
+            counts = b.float_(b.bincount(failed, N_BINS))
+            self.bin_failed_count = (
+                SAMPLER_ALPHA * counts + (1.0 - SAMPLER_ALPHA) * self.bin_failed_count
+            )
+
+        # MotionSampler.step + truncate_on_clip_end=True branch.
+        self.current_frames = self.current_frames + 1
+        clip_done = self.current_frames > CLIP_END_FRAME
+        if b.any_scalar(clip_done):
+            self.clip_end_truncated[b.nonzero(clip_done)] = True
+        return obs, reward, terminated
+
+    # ----------------------------------------------------------- reset_done --
+    def _sample_pose_vel(self, ranges, n):
+        """Per-element Python loop (faithful) or column-wise vectorized draw."""
+        b = self.b
+        if self.vectorized_reset_rng or b.is_torch:
+            cols = [b.float_(self.rng.uniform(lo, hi, (n,))) for lo, hi in ranges]
+            return b.stack(cols, axis=1)
+        samples = np.array(
+            [[self.rng.uniform(lo, hi, ()) for lo, hi in ranges] for _ in range(n)],
+            dtype=np.float32,
+        )
+        return b.convert(samples)
+
+    def reset_done(self, env_ids):
+        b = self.b
+        n = int(env_ids.shape[0])
+
+        # NpEnv._reset_done_envs: steps reset + terminal-obs double copy.
+        self.steps[env_ids] = 0
+        for key in ("obs", "critic"):
+            self.final_obs[key][env_ids] = self.obs[key][env_ids]
+            self.compat_final_obs[key][env_ids] = self.final_obs[key][env_ids]
+
+        # MotionSampler.sample_frames (adaptive).
+        p = self.bin_failed_count + SAMPLER_UNIFORM_RATIO / N_BINS
+        p = p / b.sum(p)
+        bins = b.float_(self.rng.choice(N_BINS, n, p))
+        off = b.float_(self.rng.uniform(0.0, 1.0, (n,)))
+        frames = b.long((bins + off) / N_BINS * CLIP_END_FRAME)
+        self.current_frames[env_ids] = frames
+
+        motion = self._motion_at_frames(frames)
+        m_joint_pos, m_joint_vel, m_body_pos, m_body_quat = motion[:4]
+
+        # build_motion_reference_state (reset.py).
+        root_pos = b.copy(m_body_pos[:, 0])
+        root_ori = b.copy(m_body_quat[:, 0])
+        root_lin_vel = b.copy(motion[4][:, 0])
+        root_ang_vel = b.copy(motion[5][:, 0])
+        joint_pos = b.copy(m_joint_pos)
+        joint_vel = b.copy(m_joint_vel)
+
+        pose = self._sample_pose_vel(POSE_RANGES, n)
+        root_pos = root_pos + pose[:, 0:3]
+        root_ori = _quat_mul(
+            b, _quat_from_euler_xyz(b, pose[:, 3], pose[:, 4], pose[:, 5]), root_ori
+        )
+        vel = self._sample_pose_vel(VEL_RANGES, n)
+        root_lin_vel = root_lin_vel + vel[:, 0:3]
+        root_ang_vel = root_ang_vel + vel[:, 3:6]
+        joint_pos = joint_pos + b.float_(
+            self.rng.uniform(JOINT_POSITION_RANGE[0], JOINT_POSITION_RANGE[1], (n, N_ACTION))
+        )
+        joint_pos = b.clip(joint_pos, self.joint_lower, self.joint_upper)
+
+        qpos = b.tile_batch(self.init_qpos, n)
+        qpos[:, 0:3] = root_pos
+        qpos[:, 3:7] = root_ori
+        qpos[:, 7:] = joint_pos
+        qvel = b.zeros((n, NV))
+        qvel[:, 0:3] = root_lin_vel
+        qvel[:, 3:6] = _quat_apply(b, _quat_inv(b, root_ori), root_ang_vel)
+        qvel[:, 6:] = joint_vel
+
+        new_actions = b.zeros((n, N_ACTION))
+
+        # build_reset_observation: row gather + same obs math at batch n.
+        obs_r = self._compute_obs(
+            motion,
+            self.linvel[env_ids],
+            self.gyro[env_ids],
+            self.dof_pos[env_ids],
+            self.dof_vel[env_ids],
+            self.body_pos[env_ids],
+            self.body_quat[env_ids],
+            new_actions,
+        )
+
+        # NpEnv._reset_done_envs: obs/info scatter.
+        for key in ("obs", "critic"):
+            self.obs[key][env_ids] = obs_r[key]
+        self.current_actions[env_ids] = new_actions
+        self.last_actions[env_ids] = new_actions
+
+        info_updates = {"current_actions": new_actions, "last_actions": new_actions}
+        return qpos, qvel, obs_r, info_updates

--- a/benchmark/torch_env/run_benchmark.py
+++ b/benchmark/torch_env/run_benchmark.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""NumPy vs Torch comparison for the collector-timed env computation.
+
+Reproduces the `update_state` and `reset_done` sections of `NpEnv.step` (the
+`env_step_update_state_ms` / `env_step_reset_done_ms` collector metrics) for the
+two SAC/mujoco tasks, at identical scale and computation items:
+
+- g1_walk_flat       (num_envs=2048, 29-dof, obs 98 / critic 101)
+- g1_motion_tracking (num_envs=2048, 29-dof, 14 bodies, obs 160 / critic 289)
+
+Variants:
+    numpy               single-process NumPy (the production code path)
+    torch-cpu           same kernels on torch CPU tensors
+    torch-cuda          same kernels on torch CUDA tensors (state stays on GPU)
+    torch-cuda-compile  torch.compile'd CUDA kernels (dynamic=False)
+    torch-mps(-compile) only when MPS is available (not on Linux)
+
+Usage:
+    uv run benchmark/torch_env/run_benchmark.py
+    uv run benchmark/torch_env/run_benchmark.py --iters 300 --warmup 50
+    uv run benchmark/torch_env/run_benchmark.py --variants numpy,torch-cpu
+    uv run benchmark/torch_env/run_benchmark.py --tasks walk
+    uv run benchmark/torch_env/run_benchmark.py --num-envs 2048,8192,32768
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from statistics import mean, median, pstdev
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from benchmark.core.device_info import get_device_info_dict
+from benchmark.torch_env import motion_tracking, walk_flat
+from benchmark.torch_env.xp import (
+    NumpyBackend,
+    NumpyRng,
+    RecordingRng,
+    ReplayRng,
+    TorchBackend,
+    TorchRng,
+)
+
+DEFAULT_OUTPUT_JSON = ROOT_DIR / "benchmark" / "outputs" / "torch_env" / "results.json"
+RESET_SIZES = (16, 256, 2048)
+TASKS = ("walk", "tracking")
+
+
+def build_workload(
+    task: str,
+    variant: str,
+    seed: int = 0,
+    vectorized_reset_rng: bool = False,
+    num_envs: int = walk_flat.N_ENVS,
+):
+    """Build (workload, backend) for a task/variant pair."""
+    compile_requested = variant.endswith("-compile")
+    device = variant[: -len("-compile")] if compile_requested else variant
+    if device == "numpy":
+        backend = NumpyBackend()
+        rng = NumpyRng()
+    else:
+        torch_device = device[len("torch-") :]
+        backend = TorchBackend(torch_device)
+        rng = TorchRng(torch_device)
+    cls = {
+        "walk": walk_flat.WalkFlatWorkload,
+        "tracking": motion_tracking.MotionTrackingWorkload,
+    }[task]
+    if task == "tracking":
+        workload = cls(
+            backend, rng, seed=seed, vectorized_reset_rng=vectorized_reset_rng, num_envs=num_envs
+        )
+    else:
+        workload = cls(backend, rng, seed=seed, num_envs=num_envs)
+    if compile_requested:
+        import torch
+
+        # The xp shim helpers are shared across many call sites with distinct
+        # static shapes; raise the specialization ceiling so later sites do not
+        # silently fall back to eager.
+        torch._dynamo.config.recompile_limit = 64
+        torch._dynamo.config.accumulated_recompile_limit = 512
+        workload.update_state = torch.compile(workload.update_state, dynamic=False)
+        workload.reset_done = torch.compile(workload.reset_done, dynamic=False)
+    return workload, backend
+
+
+def available_variants() -> list[str]:
+    variants = ["numpy", "torch-cpu"]
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            variants += ["torch-cuda", "torch-cuda-compile"]
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            variants += ["torch-mps", "torch-mps-compile"]
+    except ImportError:
+        pass
+    return variants
+
+
+def time_call(fn, sync, warmup: int, iters: int) -> dict[str, float]:
+    for _ in range(warmup):
+        fn()
+    sync()
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        sync()
+        samples.append((time.perf_counter() - t0) * 1000.0)
+    return {
+        "mean_ms": mean(samples),
+        "std_ms": pstdev(samples),
+        "p50_ms": median(samples),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+        "iters": iters,
+    }
+
+
+def _to_numpy_tree(b, value):
+    if isinstance(value, dict):
+        return {k: _to_numpy_tree(b, v) for k, v in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_to_numpy_tree(b, v) for v in value]
+    return b.to_numpy(value)
+
+
+def _assert_close(name, ref, got, rtol=2e-4, atol=1e-5):
+    if ref.dtype == bool:
+        assert (ref == got).all(), f"{name}: bool mismatch"
+        return
+    if not np.allclose(ref, got, rtol=rtol, atol=atol):
+        diff = np.abs(ref.astype(np.float64) - got.astype(np.float64))
+        raise AssertionError(f"{name}: max abs diff {diff.max():.3e}")
+
+
+def validate_task(task: str, variants: list[str], num_envs: int) -> dict[str, str]:
+    """Replay identical RNG draws on every variant and compare outputs."""
+    # Reference: numpy with vectorized reset RNG so the draw sequence matches
+    # the (vectorized) torch implementations.
+    workload, b = build_workload(task, "numpy", vectorized_reset_rng=True, num_envs=num_envs)
+    recording = RecordingRng()
+    workload.rng = recording
+    rs = np.random.RandomState(1)
+    env_ids = np.sort(rs.choice(num_envs, 64, replace=False)).astype(np.int64)
+
+    ref_obs, ref_reward, ref_terminated = workload.update_state(should_log=True)
+    ref_reset = workload.reset_done(b.index(env_ids))
+    ref = {
+        "obs": _to_numpy_tree(b, ref_obs),
+        "reward": b.to_numpy(ref_reward),
+        "terminated": b.to_numpy(ref_terminated),
+        "reset": _to_numpy_tree(b, ref_reset),
+    }
+
+    results = {}
+    for variant in variants:
+        if variant == "numpy" or variant.endswith("-compile"):
+            continue
+        workload, b = build_workload(task, variant, vectorized_reset_rng=True, num_envs=num_envs)
+        workload.rng = ReplayRng(b, recording.calls)
+        obs, reward, terminated = workload.update_state(should_log=True)
+        reset = workload.reset_done(b.index(env_ids))
+        try:
+            for key in ("obs", "critic"):
+                _assert_close(f"obs[{key}]", ref["obs"][key], b.to_numpy(obs[key]))
+            _assert_close("reward", ref["reward"], b.to_numpy(reward))
+            _assert_close("terminated", ref["terminated"], b.to_numpy(terminated))
+            _assert_close("reset.qpos", ref["reset"][0], b.to_numpy(reset[0]))
+            _assert_close("reset.qvel", ref["reset"][1], b.to_numpy(reset[1]))
+            for key in ("obs", "critic"):
+                _assert_close(f"reset.obs[{key}]", ref["reset"][2][key], b.to_numpy(reset[2][key]))
+            results[variant] = "ok"
+        except AssertionError as exc:
+            results[variant] = f"FAILED: {exc}"
+    return results
+
+
+def benchmark_task(
+    task: str,
+    variants: list[str],
+    warmup: int,
+    iters: int,
+    reset_iters: int,
+    num_envs_list: list[int],
+):
+    task_result = {"update_state": {}, "reset_done": {}, "validation": {}}
+    for variant in variants:
+        for num_envs in num_envs_list:
+            workload, b = build_workload(task, variant, num_envs=num_envs)
+            step = {"count": 0}
+
+            def run_update_state():
+                step["count"] += 1
+                workload.update_state(step["count"] % 4 == 0)
+
+            task_result["update_state"].setdefault(variant, {})[f"n={num_envs}"] = time_call(
+                run_update_state, b.sync, warmup, iters
+            )
+
+        # reset_done is measured at the base (training) scale only.
+        base_envs = num_envs_list[0]
+        workload, b = build_workload(task, variant, num_envs=base_envs)
+        rs = np.random.RandomState(2)
+        for n_reset in RESET_SIZES:
+            env_ids = b.index(np.sort(rs.choice(base_envs, n_reset, replace=False)))
+
+            def run_reset():
+                workload.reset_done(env_ids)
+
+            task_result["reset_done"].setdefault(variant, {})[f"n={n_reset}"] = time_call(
+                run_reset, b.sync, max(5, warmup // 2), reset_iters
+            )
+    return task_result
+
+
+def fmt(stats):
+    return f"{stats['mean_ms']:8.3f} ± {stats['std_ms']:6.3f}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tasks", type=str, default=",".join(TASKS))
+    parser.add_argument("--variants", type=str, default=None)
+    parser.add_argument("--warmup", type=int, default=50)
+    parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--reset-iters", type=int, default=100)
+    parser.add_argument(
+        "--num-envs",
+        type=str,
+        default="2048",
+        help="Comma-separated num_envs scales for update_state (reset_done uses the first).",
+    )
+    parser.add_argument("--out-json", type=str, default=str(DEFAULT_OUTPUT_JSON))
+    parser.add_argument("--skip-validation", action="store_true")
+    args = parser.parse_args()
+
+    tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+    num_envs_list = [int(v) for v in args.num_envs.split(",") if v.strip()]
+    all_variants = available_variants()
+    if args.variants:
+        requested = [v.strip() for v in args.variants.split(",") if v.strip()]
+        variants = [v for v in requested if v in all_variants]
+        skipped = sorted(set(requested) - set(variants))
+    else:
+        variants = all_variants
+        skipped = []
+    for wanted in ("torch-mps", "torch-mps-compile"):
+        if wanted not in all_variants and (not args.variants or wanted in args.variants):
+            skipped.append(wanted)
+
+    import torch
+
+    print(f"tasks: {tasks}")
+    print(f"variants: {variants} (skipped/unavailable: {skipped or 'none'})")
+    print(f"torch {torch.__version__}, cpu threads: {torch.get_num_threads()}")
+
+    report = {
+        "device_info": get_device_info_dict(),
+        "torch_version": torch.__version__,
+        "torch_num_threads": torch.get_num_threads(),
+        "variants": variants,
+        "skipped_variants": skipped,
+        "params": {
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "reset_iters": args.reset_iters,
+            "reset_sizes": list(RESET_SIZES),
+            "num_envs_list": num_envs_list,
+        },
+        "tasks": {},
+    }
+
+    for task in tasks:
+        print(f"\n=== task: {task} ===")
+        if not args.skip_validation:
+            validation = validate_task(task, variants, num_envs_list[0])
+        else:
+            validation = {}
+        result = benchmark_task(
+            task, variants, args.warmup, args.iters, args.reset_iters, num_envs_list
+        )
+        result["validation"] = validation
+        report["tasks"][task] = result
+        for variant, status in validation.items():
+            print(f"  validation[{variant}]: {status}")
+
+        base = result["update_state"].get("numpy", {})
+        print("\n  update_state (ms per call):")
+        for variant, by_size in result["update_state"].items():
+            for size_key, stats in by_size.items():
+                base_stats = base.get(size_key)
+                speedup = base_stats["mean_ms"] / stats["mean_ms"] if base_stats else float("nan")
+                print(
+                    f"    {variant:22s} {size_key:9s} {fmt(stats)}"
+                    f"   speedup vs numpy: {speedup:6.2f}x"
+                )
+        print("  reset_done (ms per call):")
+        for n_reset in RESET_SIZES:
+            print(f"    n_reset={n_reset}:")
+            for variant, by_size in result["reset_done"].items():
+                stats = by_size[f"n={n_reset}"]
+                base_stats = result["reset_done"].get("numpy", {}).get(f"n={n_reset}")
+                speedup = base_stats["mean_ms"] / stats["mean_ms"] if base_stats else float("nan")
+                print(f"      {variant:22s} {fmt(stats)}   speedup vs numpy: {speedup:6.2f}x")
+
+    out_path = Path(args.out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2))
+    print(f"\nresults written to {out_path}")
+
+    failures = {
+        task: {v: s for v, s in r["validation"].items() if s != "ok"}
+        for task, r in report["tasks"].items()
+    }
+    failures = {t: f for t, f in failures.items() if f}
+    if failures:
+        print(f"VALIDATION FAILURES: {failures}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/torch_env/walk_flat.py
+++ b/benchmark/torch_env/walk_flat.py
@@ -1,0 +1,346 @@
+"""G1WalkFlat (SAC/mujoco) update_state / reset_done workload.
+
+Faithful xp-port of the NumPy computation in the collector-timed sections of
+`uv run train --algo sac --task g1_walk_flat --sim mujoco` (num_envs=2048):
+
+- `G1WalkEnv.update_state` (src/unilab/envs/locomotion/g1/joystick.py):
+  termination, `_compute_reward` (9 active terms under the SAC scales incl.
+  per-term logging every 4 steps), `_compute_obs` (noise + concat, walk
+  profile), and the done-triggered curriculum bookkeeping.
+- `G1WalkDomainRandomizationProvider.build_reset_plan` /
+  `build_reset_observation` (qpos/qvel sampling, commands, gait phase, kp/kd
+  payload, obs rebuild at batch n_reset).
+- `NpEnv._reset_done_envs` scatter/gather (terminal-obs double copy, obs/info
+  scatter).
+
+Excluded (identical across variants, not NumPy/Torch env math):
+`backend.step` physics, `backend.set_state`, sensor reads (replaced by
+persistent state arrays), and the flat-terrain spawn add of zeros.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+N_ENVS = 2048
+N_ACTION = 29
+NQ = 36
+NV = 35
+OBS_DIM = 98
+CRITIC_DIM = 101
+
+MAX_TILT_RAD = math.radians(65.0)
+MIN_BASE_HEIGHT = 0.3
+TRACKING_SIGMA = 0.25
+FEET_PHASE_SIGMA = 0.04
+SWING_HEIGHT = 0.09
+CTRL_DT = 0.02
+COMMAND_LOW = (-0.6, -0.4, -0.8)
+COMMAND_HIGH = (1.0, 0.4, 0.8)
+ZERO_SMALL_XY_THRESHOLD = 0.2
+RESET_BASE_QVEL_LIMIT = 0.5
+EPISODE_WINDOW = 500  # EpisodeLengthTracker: 1000 * 2048 / 4096
+CURRICULUM_DEGREE = 0.001
+CURRICULUM_MIN_SCALE = 0.5
+CURRICULUM_MAX_SCALE = 1.0
+CURRICULUM_LEVEL_DOWN = 150.0
+CURRICULUM_LEVEL_UP = 750.0
+NOISE_LEVEL = 1.0
+NOISE_SCALE_JOINT_ANGLE = 0.01
+NOISE_SCALE_JOINT_VEL = 0.1
+
+# conf/offpolicy/task/sac/g1_walk_flat/mujoco.yaml pose_weights (29-dof)
+POSE_WEIGHTS = [0.01, 1.0, 5.0, 0.01, 5.0, 5.0] * 2 + [50.0] * 17
+
+# Reward scales from the SAC owner YAML; penalty terms are multiplied by the
+# curriculum penalty scale (initial_scale=0.5).
+REWARD_SCALES = (
+    ("tracking_lin_vel", 2.0, False),
+    ("tracking_ang_vel", 1.5, False),
+    ("penalty_ang_vel_xy", -1.0, True),
+    ("penalty_orientation", -10.0, True),
+    ("penalty_action_rate", -4.0, True),
+    ("pose", -0.5, True),
+    ("penalty_feet_ori", -20.0, True),
+    ("feet_phase", 5.0, False),
+    ("alive", 10.0, False),
+)
+
+
+def _quat_mul(b, q1, q2):
+    """Hamilton product, w-first, broadcasting over leading dims."""
+    w1, x1, y1, z1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    w2, x2, y2, z2 = q2[..., 0], q2[..., 1], q2[..., 2], q2[..., 3]
+    return b.stack(
+        [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        ],
+        axis=-1,
+    )
+
+
+class WalkFlatWorkload:
+    def __init__(self, b, rng, seed: int = 0, num_envs: int = N_ENVS):
+        self.b = b
+        self.rng = rng
+        self.n_envs = num_envs
+        rs = np.random.RandomState(seed)
+
+        def f32(*shape):
+            return rs.standard_normal(shape).astype(np.float32)
+
+        n = num_envs
+        default_angles_np = rs.uniform(-0.5, 0.5, N_ACTION).astype(np.float32)
+        self.default_angles = b.convert(default_angles_np)
+        self.pose_weights = b.convert(np.array(POSE_WEIGHTS, dtype=np.float32))
+        self.base_kp = b.convert(rs.uniform(50.0, 150.0, N_ACTION).astype(np.float32))
+        self.base_kd = b.convert(rs.uniform(1.0, 5.0, N_ACTION).astype(np.float32))
+
+        # Backend-owned state (sensor reads replaced by persistent arrays).
+        self.linvel = b.convert(f32(n, 3) * 0.5)
+        self.gyro = b.convert(f32(n, 3) * 0.5)
+        gravity = f32(n, 3) * 0.05
+        gravity[:, 2] += 1.0
+        gravity /= np.linalg.norm(gravity, axis=1, keepdims=True)
+        self.gravity = b.convert(gravity.astype(np.float32))
+        self.dof_pos = b.convert(default_angles_np[None, :] + f32(n, N_ACTION) * 0.1)
+        self.dof_vel = b.convert(f32(n, N_ACTION))
+        base_z = 0.754 + f32(n) * 0.01
+        base_z[:8] = 0.1  # force a few terminations -> done branch stays live
+        self.base_z = b.convert(base_z.astype(np.float32))
+        self.left_foot_pos = b.convert(np.abs(f32(n, 3)) * 0.05)
+        self.right_foot_pos = b.convert(np.abs(f32(n, 3)) * 0.05)
+        lq = f32(n, 4)
+        lq /= np.linalg.norm(lq, axis=1, keepdims=True)
+        rq = f32(n, 4)
+        rq /= np.linalg.norm(rq, axis=1, keepdims=True)
+        self.left_foot_quat = b.convert(lq.astype(np.float32))
+        self.right_foot_quat = b.convert(rq.astype(np.float32))
+
+        # info state.
+        self.commands = b.convert(rs.uniform(COMMAND_LOW, COMMAND_HIGH, (n, 3)).astype(np.float32))
+        self.current_actions = b.convert(f32(n, N_ACTION) * 0.3)
+        self.last_actions = b.convert(f32(n, N_ACTION) * 0.3)
+        self.gait_phase = b.convert(rs.uniform(0.0, 2 * np.pi, (n, 2)).astype(np.float32))
+        self.steps = b.index(rs.randint(0, 1000, n))
+
+        # Reset plan constants (keyframe "stand").
+        init_qpos = np.zeros(NQ, dtype=np.float32)
+        init_qpos[2] = 0.754
+        init_qpos[3] = 1.0
+        init_qpos[7:] = b.to_numpy(self.default_angles)
+        self.init_qpos = b.convert(init_qpos)
+
+        # Step outputs kept across calls for the reset scatter/gather path.
+        self.obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+        self.final_obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+        self.compat_final_obs = {
+            "obs": b.zeros((n, OBS_DIM)),
+            "critic": b.zeros((n, CRITIC_DIM)),
+        }
+
+        # Curriculum bookkeeping state (scalar floats, as in the real code).
+        self._ep_avg = 0.0
+        self._penalty_scale = CURRICULUM_MIN_SCALE
+
+    # ------------------------------------------------------------------ obs --
+    def _obs_noise(self, data, scale):
+        # G1BaseEnv._obs_noise with level=1.0, seed=None: full-size uniform draw
+        # (float64 -> astype float32 on numpy) even when scale == 0.
+        noise = self.b.float_(self.rng.uniform(-1.0, 1.0, tuple(data.shape)))
+        return data + noise * NOISE_LEVEL * scale
+
+    def _compute_obs(
+        self, commands, last_actions, gait_phase, linvel, gyro, gravity, dof_pos, dof_vel
+    ):
+        b = self.b
+        diff = dof_pos - self.default_angles
+        noisy_gyro = self._obs_noise(gyro, 0.0)
+        noisy_gravity = self._obs_noise(gravity, 0.0)
+        noisy_diff = self._obs_noise(diff, NOISE_SCALE_JOINT_ANGLE)
+        noisy_dof_vel = self._obs_noise(dof_vel, NOISE_SCALE_JOINT_VEL)
+        actor = b.concat(
+            [
+                noisy_gyro * 0.25,
+                -noisy_gravity,
+                noisy_diff,
+                noisy_dof_vel * 0.05,
+                last_actions,
+                commands,
+                gait_phase,
+            ],
+            axis=1,
+        )
+        critic_base = b.concat(
+            [
+                gyro * 0.25,
+                -gravity,
+                diff,
+                dof_vel * 0.05,
+                last_actions,
+                commands,
+                gait_phase,
+            ],
+            axis=1,
+        )
+        critic = b.concat([critic_base, linvel * 2.0], axis=1)
+        return {"obs": actor, "critic": critic}
+
+    # --------------------------------------------------------------- reward --
+    def _feet_phase_height_target(self, phi):
+        b = self.b
+        phi_normalized = b.fmod(phi + np.pi, 2 * np.pi) - np.pi
+        x = (phi_normalized + np.pi) / (2 * np.pi)
+
+        def bezier(y_start, y_end, t):
+            return y_start + (y_end - y_start) * (t**3 + 3 * (t**2 * (1 - t)))
+
+        stance = bezier(0.0, SWING_HEIGHT, 2 * x)
+        swing = bezier(SWING_HEIGHT, 0.0, 2 * x - 1)
+        return b.where(x <= 0.5, stance, swing)
+
+    def _compute_reward(self, should_log: bool):
+        b = self.b
+        ps = self._penalty_scale
+        cmd, linvel, gyro, g = self.commands, self.linvel, self.gyro, self.gravity
+        q = self.dof_pos
+        act, prev = self.current_actions, self.last_actions
+
+        terms = {}
+        err = b.sum(b.square(cmd[:, :2] - linvel[:, :2]), axis=1)
+        terms["tracking_lin_vel"] = b.exp(-err / TRACKING_SIGMA)
+        terms["tracking_ang_vel"] = b.exp(-b.square(cmd[:, 2] - gyro[:, 2]) / TRACKING_SIGMA)
+        terms["penalty_ang_vel_xy"] = b.sum(b.square(gyro[:, :2]), axis=1)
+        terms["penalty_orientation"] = b.square(g[:, 0]) + b.square(g[:, 1])
+        terms["penalty_action_rate"] = b.sum(b.square(act - prev), axis=1)
+        terms["pose"] = b.sum(self.pose_weights * b.square(q - self.default_angles), axis=1)
+        lq, rq = self.left_foot_quat, self.right_foot_quat
+        terms["penalty_feet_ori"] = (
+            b.square(lq[:, 1]) + b.square(lq[:, 2]) + b.square(rq[:, 1]) + b.square(rq[:, 2])
+        )
+        left_target = self._feet_phase_height_target(self.gait_phase[:, 0])
+        right_target = self._feet_phase_height_target(self.gait_phase[:, 1])
+        feet_err = b.square(self.left_foot_pos[:, 2] - left_target) + b.square(
+            self.right_foot_pos[:, 2] - right_target
+        )
+        gate = b.float_(b.maximum(linvel[:, 0], 0.0) >= 0.0)
+        terms["feet_phase"] = b.exp(-feet_err / FEET_PHASE_SIGMA) * gate
+        terms["alive"] = b.ones((self.n_envs,))
+
+        reward = b.zeros((self.n_envs,))
+        log = {}
+        for name, scale, is_penalty in REWARD_SCALES:
+            weighted = terms[name] * (scale * ps if is_penalty else scale)
+            reward = reward + weighted
+            if should_log:
+                log[f"reward/{name}"] = b.scalar(b.mean(weighted))
+        self._last_log = log
+        return reward * CTRL_DT
+
+    # --------------------------------------------------------- update_state --
+    def update_state(self, should_log: bool):
+        b = self.b
+        tilt = b.arccos(b.clip(self.gravity[:, 2], -1.0, 1.0))
+        terminated = b.logical_or(tilt > MAX_TILT_RAD, self.base_z < MIN_BASE_HEIGHT)
+        reward = self._compute_reward(should_log)
+        obs = self._compute_obs(
+            self.commands,
+            self.current_actions,
+            self.gait_phase,
+            self.linvel,
+            self.gyro,
+            self.gravity,
+            self.dof_pos,
+            self.dof_vel,
+        )
+        self.obs = obs
+
+        # Done-triggered curriculum bookkeeping (truncated is NpEnv-side and
+        # excluded; done == terminated here).
+        if b.any_scalar(terminated):
+            done_idx = b.nonzero(terminated)
+            ep_len = b.float_(self.steps[done_idx]) + 1.0
+            avg = b.scalar(b.mean(ep_len))
+            w = min(float(done_idx.shape[0]) / EPISODE_WINDOW, 1.0)
+            self._ep_avg = self._ep_avg * (1.0 - w) + avg * w
+            if self._ep_avg > CURRICULUM_LEVEL_UP:
+                self._penalty_scale *= 1.0 + CURRICULUM_DEGREE
+            elif self._ep_avg < CURRICULUM_LEVEL_DOWN:
+                self._penalty_scale *= 1.0 - CURRICULUM_DEGREE
+            self._penalty_scale = min(
+                max(self._penalty_scale, CURRICULUM_MIN_SCALE), CURRICULUM_MAX_SCALE
+            )
+        return obs, reward, terminated
+
+    # ----------------------------------------------------------- reset_done --
+    def reset_done(self, env_ids):
+        b = self.b
+        n = int(env_ids.shape[0])
+
+        # NpEnv._reset_done_envs: steps reset + terminal-obs double copy.
+        self.steps[env_ids] = 0
+        for key in ("obs", "critic"):
+            self.final_obs[key][env_ids] = self.obs[key][env_ids]
+            self.compat_final_obs[key][env_ids] = self.final_obs[key][env_ids]
+
+        # build_reset_plan: qpos/qvel sampling.
+        qpos = b.tile_batch(self.init_qpos, n)
+        qpos[:, 0:2] += b.float_(self.rng.uniform(-0.5, 0.5, (n, 2)))
+        yaw = b.float_(self.rng.uniform(-np.pi, np.pi, (n,)))
+        zeros_n = b.zeros((n,))
+        yaw_quat = b.stack([b.cos(yaw * 0.5), zeros_n, zeros_n, b.sin(yaw * 0.5)], axis=1)
+        qpos[:, 3:7] = _quat_mul(b, qpos[:, 3:7], yaw_quat)
+        qvel = b.zeros((n, NV))
+        qvel[:, 0:6] = b.float_(
+            self.rng.uniform(-RESET_BASE_QVEL_LIMIT, RESET_BASE_QVEL_LIMIT, (n, 6))
+        )
+
+        # info_updates.
+        commands = b.float_(self.rng.uniform(COMMAND_LOW, COMMAND_HIGH, (n, 3)))
+        moving = b.sqrt(b.sum(b.square(commands[:, :2]), axis=1)) > ZERO_SMALL_XY_THRESHOLD
+        commands[:, :2] = commands[:, :2] * b.float_(moving)[:, None]
+        phi = b.float_(self.rng.uniform(0.0, 2 * np.pi, (n,)))
+        gait_phase = b.stack([phi, phi + np.pi], axis=1)
+        new_actions = b.zeros((n, N_ACTION))
+        # DR payload consumed by backend.set_state (computed env-side).
+        kp = self.base_kp * b.float_(self.rng.uniform(0.9, 1.1, (n, 1)))
+        kd = self.base_kd * b.float_(self.rng.uniform(0.9, 1.1, (n, 1)))
+
+        # build_reset_observation: row gather + same obs math at batch n.
+        obs_r = self._compute_obs(
+            commands,
+            new_actions,
+            gait_phase,
+            self.linvel[env_ids],
+            self.gyro[env_ids],
+            self.gravity[env_ids],
+            self.dof_pos[env_ids],
+            self.dof_vel[env_ids],
+        )
+
+        # NpEnv._reset_done_envs: obs/info scatter.
+        for key in ("obs", "critic"):
+            self.obs[key][env_ids] = obs_r[key]
+        self.commands[env_ids] = commands
+        self.current_actions[env_ids] = new_actions
+        self.last_actions[env_ids] = new_actions
+        self.gait_phase[env_ids] = gait_phase
+
+        info_updates = {
+            "commands": commands,
+            "current_actions": new_actions,
+            "last_actions": new_actions,
+            "gait_phase": gait_phase,
+        }
+        return qpos, qvel, obs_r, info_updates, (kp, kd)

--- a/benchmark/torch_env/xp.py
+++ b/benchmark/torch_env/xp.py
@@ -1,0 +1,358 @@
+"""Array-backend shim shared by the torch_env benchmarks.
+
+The workload kernels in this directory are written once against this shim and
+executed with either NumPy or Torch (cpu / cuda / mps) arrays, so every variant
+runs the same sequence of math ops on identically shaped float32 tensors as the
+real env code (`NpEnv.update_state` / `NpEnv._reset_done_envs` paths).
+
+Scope notes:
+- Backend physics (`backend.step`, `backend.set_state`) is excluded: it is not
+  NumPy/Torch-level env computation and is identical across variants.
+- NumPy RNG follows the real code (`np.random.uniform`, float64 draw + astype
+  float32 where the real code does so). Torch draws float32 directly, which is
+  the idiomatic torch equivalent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class NumpyBackend:
+    name = "numpy"
+    device = "cpu"
+    is_torch = False
+
+    # --- creation / conversion -------------------------------------------------
+    def convert(self, x):
+        return np.asarray(x)
+
+    def to_numpy(self, x):
+        return np.asarray(x)
+
+    def index(self, x):
+        return np.asarray(x, dtype=np.int64)
+
+    def zeros(self, shape):
+        return np.zeros(shape, dtype=np.float32)
+
+    def ones(self, shape):
+        return np.ones(shape, dtype=np.float32)
+
+    def empty(self, shape):
+        return np.empty(shape, dtype=np.float32)
+
+    def zeros_like(self, x):
+        return np.zeros_like(x)
+
+    def copy(self, x):
+        return x.copy()
+
+    def float_(self, x):
+        return np.asarray(x, dtype=np.float32)
+
+    def long(self, x):
+        return np.asarray(x).astype(np.int64)
+
+    # --- elementwise -----------------------------------------------------------
+    def exp(self, x):
+        return np.exp(x)
+
+    def square(self, x):
+        return np.square(x)
+
+    def sqrt(self, x):
+        return np.sqrt(x)
+
+    def cos(self, x):
+        return np.cos(x)
+
+    def sin(self, x):
+        return np.sin(x)
+
+    def arccos(self, x):
+        return np.arccos(x)
+
+    def atan2(self, y, x):
+        return np.arctan2(y, x)
+
+    def fmod(self, x, y):
+        return np.fmod(x, y)
+
+    def clip(self, x, lo, hi):
+        return np.clip(x, lo, hi)
+
+    def abs(self, x):
+        return np.abs(x)
+
+    def maximum(self, a, b):
+        return np.maximum(a, b)
+
+    def minimum(self, a, b):
+        return np.minimum(a, b)
+
+    def where(self, c, a, b):
+        return np.where(c, a, b)
+
+    def logical_or(self, a, b):
+        return np.logical_or(a, b)
+
+    def logical_and(self, a, b):
+        return np.logical_and(a, b)
+
+    def logical_not(self, a):
+        return np.logical_not(a)
+
+    # --- reductions / joins ----------------------------------------------------
+    def sum(self, x, axis=None):
+        return np.sum(x, axis=axis)
+
+    def mean(self, x, axis=None):
+        return np.mean(x, axis=axis)
+
+    def any(self, x, axis=None):
+        return np.any(x, axis=axis)
+
+    def concat(self, xs, axis=1):
+        return np.concatenate(xs, axis=axis)
+
+    def stack(self, xs, axis=-1):
+        return np.stack(xs, axis=axis)
+
+    def tile_batch(self, x, n):
+        return np.tile(x, (n, 1))
+
+    def take(self, x, idx):
+        return np.take(x, idx, axis=0)
+
+    def bincount(self, x, minlength):
+        return np.bincount(x, minlength=minlength)
+
+    def nonzero(self, x):
+        return np.flatnonzero(x)
+
+    def any_scalar(self, x) -> bool:
+        return bool(np.any(x))
+
+    def scalar(self, x) -> float:
+        return float(x)
+
+    def sync(self):
+        pass
+
+
+class TorchBackend:
+    is_torch = True
+
+    def __init__(self, device: str):
+        import torch
+
+        self.torch = torch
+        self.device = device
+        self.name = f"torch-{device}"
+
+    # --- creation / conversion -------------------------------------------------
+    def convert(self, x):
+        return self.torch.as_tensor(np.asarray(x), device=self.device)
+
+    def to_numpy(self, x):
+        return x.detach().cpu().numpy()
+
+    def index(self, x):
+        return self.torch.as_tensor(np.asarray(x), dtype=self.torch.long, device=self.device)
+
+    def zeros(self, shape):
+        return self.torch.zeros(shape, device=self.device, dtype=self.torch.float32)
+
+    def ones(self, shape):
+        return self.torch.ones(shape, device=self.device, dtype=self.torch.float32)
+
+    def empty(self, shape):
+        return self.torch.empty(shape, device=self.device, dtype=self.torch.float32)
+
+    def zeros_like(self, x):
+        return self.torch.zeros_like(x)
+
+    def copy(self, x):
+        return x.clone()
+
+    def float_(self, x):
+        return x.to(self.torch.float32)
+
+    def long(self, x):
+        return x.to(self.torch.long)
+
+    # --- elementwise -----------------------------------------------------------
+    def exp(self, x):
+        return self.torch.exp(x)
+
+    def square(self, x):
+        return self.torch.square(x)
+
+    def sqrt(self, x):
+        return self.torch.sqrt(x)
+
+    def cos(self, x):
+        return self.torch.cos(x)
+
+    def sin(self, x):
+        return self.torch.sin(x)
+
+    def arccos(self, x):
+        return self.torch.acos(x)
+
+    def atan2(self, y, x):
+        return self.torch.atan2(y, x)
+
+    def fmod(self, x, y):
+        return self.torch.fmod(x, y)
+
+    def clip(self, x, lo, hi):
+        return self.torch.clamp(x, lo, hi)
+
+    def abs(self, x):
+        return self.torch.abs(x)
+
+    def maximum(self, a, b):
+        if not self.torch.is_tensor(a):
+            a = self.torch.as_tensor(a, device=self.device, dtype=self.torch.float32)
+        if not self.torch.is_tensor(b):
+            b = self.torch.as_tensor(b, device=self.device, dtype=self.torch.float32)
+        return self.torch.maximum(a, b)
+
+    def minimum(self, a, b):
+        if not self.torch.is_tensor(a):
+            a = self.torch.as_tensor(a, device=self.device, dtype=self.torch.float32)
+        if not self.torch.is_tensor(b):
+            b = self.torch.as_tensor(b, device=self.device, dtype=self.torch.float32)
+        return self.torch.minimum(a, b)
+
+    def where(self, c, a, b):
+        return self.torch.where(c, a, b)
+
+    def logical_or(self, a, b):
+        return self.torch.logical_or(a, b)
+
+    def logical_and(self, a, b):
+        return self.torch.logical_and(a, b)
+
+    def logical_not(self, a):
+        return self.torch.logical_not(a)
+
+    # --- reductions / joins ----------------------------------------------------
+    def sum(self, x, axis=None):
+        return self.torch.sum(x, dim=axis)
+
+    def mean(self, x, axis=None):
+        return self.torch.mean(x, dim=axis)
+
+    def any(self, x, axis=None):
+        return self.torch.any(x, dim=axis)
+
+    def concat(self, xs, axis=1):
+        return self.torch.cat(list(xs), dim=axis)
+
+    def stack(self, xs, axis=-1):
+        return self.torch.stack(list(xs), dim=axis)
+
+    def tile_batch(self, x, n):
+        return x.unsqueeze(0).repeat(n, 1)
+
+    def take(self, x, idx):
+        return x.index_select(0, idx)
+
+    def bincount(self, x, minlength):
+        return self.torch.bincount(x, minlength=minlength)
+
+    def nonzero(self, x):
+        return self.torch.nonzero(x, as_tuple=False).flatten()
+
+    def any_scalar(self, x) -> bool:
+        return bool(x.any())
+
+    def scalar(self, x) -> float:
+        return float(x)
+
+    def sync(self):
+        if self.device == "cuda":
+            self.torch.cuda.synchronize()
+        elif self.device == "mps":
+            self.torch.mps.synchronize()
+
+
+class NumpyRng:
+    """Mirrors the real env code: np.random.uniform / np.random.choice."""
+
+    def uniform(self, low, high, shape):
+        return np.random.uniform(low, high, size=shape)
+
+    def choice(self, a, size, p):
+        # Normalize in float64 so np.random.choice's sum-to-1 check is stable
+        # even when the kernel produced float32 probabilities.
+        p64 = np.asarray(p, dtype=np.float64)
+        p64 /= p64.sum()
+        return np.random.choice(a, size=size, p=p64)
+
+
+class TorchRng:
+    """Idiomatic torch equivalent: float32 draws directly on device."""
+
+    def __init__(self, device: str):
+        import torch
+
+        self.torch = torch
+        self.device = device
+
+    def uniform(self, low, high, shape):
+        t = self.torch.rand(shape, device=self.device, dtype=self.torch.float32)
+        if np.isscalar(low) and np.isscalar(high):
+            return t * float(high - low) + float(low)
+        low_t = self.torch.as_tensor(np.asarray(low), device=self.device)
+        high_t = self.torch.as_tensor(np.asarray(high), device=self.device)
+        return t * (high_t - low_t) + low_t
+
+    def choice(self, a, size, p):
+        return self.torch.multinomial(p, size, replacement=True)
+
+
+class RecordingRng:
+    """Records every draw as float32 numpy so torch variants can replay them."""
+
+    def __init__(self):
+        self.calls: list[np.ndarray] = []
+
+    def uniform(self, low, high, shape):
+        value = np.random.uniform(low, high, size=shape).astype(np.float32)
+        self.calls.append(value)
+        return value
+
+    def choice(self, a, size, p):
+        p64 = np.asarray(p, dtype=np.float64)
+        p64 /= p64.sum()
+        value = np.random.choice(a, size=size, p=p64)
+        self.calls.append(value)
+        return value
+
+
+class ReplayRng:
+    """Replays RecordingRng draws on any backend for cross-backend validation."""
+
+    def __init__(self, backend, calls):
+        self._b = backend
+        self._calls = list(calls)
+        self._i = 0
+
+    def _next(self):
+        value = self._calls[self._i]
+        self._i += 1
+        return self._b.convert(value)
+
+    def uniform(self, low, high, shape):
+        value = self._next()
+        assert tuple(value.shape) == tuple(shape), (value.shape, shape)
+        return value
+
+    def choice(self, a, size, p):
+        value = self._next()
+        assert tuple(value.shape) == (size,), (value.shape, size)
+        return self._b.index(self._b.to_numpy(value))


### PR DESCRIPTION
## Summary

新增 `benchmark/torch_env/`：针对 collector 统计用时中的 `update_state`（`env_step_update_state_ms`）和 `reset_done`（`env_step_reset_done_ms`）两段 env 计算，以两个真实 SAC/mujoco 任务为基准做 NumPy vs Torch 对比测评：

- `g1_walk_flat`（num_envs=2048，29dof，obs 98 / critic 101）
- `g1_motion_tracking`（num_envs=2048，29dof，14 bodies，obs 160 / critic 289）

设计要点：

- 计算内核基于 `xp.py` 的 array-backend shim 只写一遍，numpy / torch-cpu / torch-cuda / torch-cuda-compile（mps 自动探测）跑的是**同一 op 序列、同一 shape**，保证"计算项与真实任务完全一致"；reward/obs/termination/transform/reset 数学逐行对齐 `joystick.py`、`motion_tracking/common/*` 与 `np_env.py`。
- torch 变体通过 RNG replay 与 numpy 参考输出做 allclose 校验（obs/reward/terminated/qpos/qvel/reset obs），本机全部通过。
- 排除各变体间相同且非 NumPy/Torch 层面的部分：`backend.step` 物理、`backend.set_state`、传感器读取（以持久数组替代）。
- `update_state` 支持 `--num-envs 2048,8192,32768` 多档规模；`reset_done` 支持 n_reset=16/256/2048。
- 结果写入 `benchmark/outputs/torch_env/results.json`（gitignored）。

用法：

```
uv run benchmark/torch_env/run_benchmark.py
uv run benchmark/torch_env/run_benchmark.py --num-envs 2048,8192,32768
```

## Validation

- `make test-all` 已通过（1479 passed, 49 skipped, 1 xfailed；benchmark smoke 31/32，mlx 平台跳过 1 个）。
- benchmark 内置跨后端数值校验本机全部 ok。
- 本机测评结果（含硬件信息与结论）见 PR 评论。
