### PR TITLE
bench: fix TorchRng.uniform float64 conversion on MPS

### DIFF
--- a/benchmark/torch_env/xp.py
+++ b/benchmark/torch_env/xp.py
@@ -307,8 +307,10 @@ class TorchRng:
         t = self.torch.rand(shape, device=self.device, dtype=self.torch.float32)
         if np.isscalar(low) and np.isscalar(high):
             return t * float(high - low) + float(low)
-        low_t = self.torch.as_tensor(np.asarray(low), device=self.device)
-        high_t = self.torch.as_tensor(np.asarray(high), device=self.device)
+        low_t = self.torch.as_tensor(np.asarray(low), dtype=self.torch.float32, device=self.device)
+        high_t = self.torch.as_tensor(
+            np.asarray(high), dtype=self.torch.float32, device=self.device
+        )
         return t * (high_t - low_t) + low_t
 
     def choice(self, a, size, p):


### PR DESCRIPTION
## Summary

`benchmark/torch_env` 的 `TorchRng.uniform` 数组边界路径把 `np.asarray(low/high)`（float64）直接 `torch.as_tensor(..., device=...)`，在 MPS 上抛 `TypeError: Cannot convert a MPS Tensor to float64 dtype`（MPS 不支持 float64），导致 eager `torch-mps` 的 `reset_done` 无法运行。

修复为显式 `dtype=torch.float32`，与该 shim "float32 draws directly on device" 的约定一致。CPU / CUDA 行为不受影响（原路径在 f64 下计算后也随即由调用方 `b.float_()` 转回 float32），实测 torch-cpu 数值校验通过。

在 Apple M5 Max 上运行 #953 的 benchmark 时发现；M5 Max 完整结果见 https://github.com/unilabsim/UniLab/pull/953#issuecomment-5252169371 。

## Validation

- `make check` 通过（format + mypy + pyright）。
- `make test-all` 通过（exit 0；benchmark smoke module-mode 32/32、script-mode 33/33）。
- M5 Max 实测：修复后两任务（walk / tracking）的 `numpy` / `torch-cpu` / `torch-mps` 变体全部跑通，RNG replay allclose 校验（obs/reward/terminated/qpos/qvel/reset obs）全部 ok。
