### PR TITLE
chore: remove wallflip2 demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ make setup
 uv run demo dance
 ```
 
-Available demo names: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
+Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
 
 > Mainland China users: motions, scenes, robot meshes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
 >

--- a/README_zh.md
+++ b/README_zh.md
@@ -119,7 +119,7 @@ make setup
 uv run demo dance
 ```
 
-可用的 demo 名称：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
 完整的命令与参数请参阅 [统一 CLI](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/1-cli_reference.html) 页面。
 
 > 中国大陆用户：动作、场景、机器人网格和 demo checkpoint 首次运行时会从 Hugging Face 拉取。如果 `huggingface.co`

--- a/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/en/1-getting_started/1-quick_demo.md
@@ -56,7 +56,7 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
 uv run demo dance
 ```
 
-Available demo names: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`.
+Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
 
 Mainland China users: motions, scenes, robot meshes, and demo checkpoints come
 from Hugging Face on first run. If `huggingface.co` is unreachable, switch to the

--- a/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
@@ -95,14 +95,13 @@ Supported render modes are `auto`, `interactive`, `record`, and `none`.
 ```bash
 uv run demo dance
 uv run demo wallflip
-uv run demo wallflip2
 uv run demo boxtracking
 uv run demo locomani
 uv run demo inhandgrasp
 uv run demo dance --refresh --device cpu
 ```
 
-Available demos: `teaser`, `dance`, `wallflip`, `wallflip2`, `boxtracking`, `locomani`, `inhandgrasp`.
+Available demos: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`.
 Each demo fetches a pre-trained checkpoint from the
 `unilabsim/unilab-checkpoints` Hugging Face dataset on first run and caches it
 under `src/unilab/assets/checkpoints/<demo>/model_0.pt`. Pass `--refresh` to

--- a/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/1-quick_demo.md
@@ -41,7 +41,7 @@ make setup-motrix
 uv run demo dance
 ```
 
-可用的 demo 名称：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo 名称：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
 
 中国大陆用户：运动、场景、机器人网格和 demo 检查点在首次运行时从 Hugging Face 拉取。如果
 `huggingface.co` 无法访问，请在运行训练、评估或 demo 命令前切到社区镜像：

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
@@ -92,14 +92,13 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1 \
 ```bash
 uv run demo dance
 uv run demo wallflip
-uv run demo wallflip2
 uv run demo boxtracking
 uv run demo locomani
 uv run demo inhandgrasp
 uv run demo dance --refresh --device cpu
 ```
 
-可用的 demo：`teaser`、`dance`、`wallflip`、`wallflip2`、`boxtracking`、`locomani`、`inhandgrasp`。
+可用的 demo：`teaser`、`dance`、`wallflip`、`boxtracking`、`locomani`、`inhandgrasp`。
 每个 demo 在首次运行时会从 `unilabsim/unilab-checkpoints` 这个 Hugging Face
 数据集拉取预训练检查点，并缓存到 `src/unilab/assets/checkpoints/<demo>/model_0.pt`。
 传入 `--refresh` 可重新下载。

--- a/src/unilab/demo.py
+++ b/src/unilab/demo.py
@@ -27,9 +27,6 @@ class DemoSpec:
 DEMO_REGISTRY: dict[str, DemoSpec] = {
     "dance": DemoSpec(algo="ppo", task="g1_motion_tracking", sim="motrix", entry="eval"),
     "wallflip": DemoSpec(algo="ppo", task="g1_wall_flip_tracking", sim="motrix", entry="eval"),
-    "wallflip2": DemoSpec(
-        algo="ppo", task="x2_wall_flip_tracking", sim="mujoco", entry="play_interactive"
-    ),
     "boxtracking": DemoSpec(algo="ppo", task="g1_box_tracking", sim="motrix", entry="eval"),
     "locomani": DemoSpec(
         algo="ppo", task="go2_arm_manip_loco", sim="mujoco", entry="play_interactive"

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -630,7 +630,7 @@ def test_ppo_x2_wall_flip_tracking():
     assert cfg.algo.obs_groups.critic == ["critic"]
     assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
     assert cfg.algo.algorithm.desired_kl == pytest.approx(0.01)
-    # The `wallflip2` demo relies on the owner config defaulting to policy playback.
+    # Interactive playback defaults to policy mode for this task.
     assert cfg.interactive.action_mode == "policy"
     assert cfg.env.sampling_mode == "start"
     assert cfg.env.truncate_on_clip_end is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,7 +274,6 @@ def test_demo_registry_contains_expected_entries() -> None:
     assert set(demo.DEMO_REGISTRY) == {
         "dance",
         "wallflip",
-        "wallflip2",
         "boxtracking",
         "locomani",
         "sharpa_appo_student",
@@ -283,12 +282,6 @@ def test_demo_registry_contains_expected_entries() -> None:
     }
     assert demo.DEMO_REGISTRY["locomani"].entry == "play_interactive"
     assert demo.DEMO_REGISTRY["locomani"].sim == "mujoco"
-    assert demo.DEMO_REGISTRY["wallflip2"] == demo.DemoSpec(
-        algo="ppo",
-        task="x2_wall_flip_tracking",
-        sim="mujoco",
-        entry="play_interactive",
-    )
     assert demo.DEMO_REGISTRY["inhandgrasp"] == demo.DemoSpec(
         algo="hora_distill",
         task="sharpa_inhand",
@@ -343,24 +336,6 @@ def test_demo_play_interactive_entry_assembles_locomani_command(
     assert f"algo.load_run={abs_pt}" in command
     assert "training.device=cpu" in command
     assert "interactive.camera_follow_body=false" in command
-
-
-def test_demo_play_interactive_entry_assembles_wallflip2_command(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _make_demo_checkout(tmp_path, demo_name="wallflip2")
-    monkeypatch.setattr(demo.platform, "system", lambda: "Linux")
-    abs_pt = str(tmp_path / "fake" / "model_0.pt")
-    command = demo.build_demo_command(
-        demo_name="wallflip2", checkpoint_path=abs_pt, device="cpu", root=tmp_path
-    )
-
-    assert command[0] == sys.executable
-    assert command[1] == str(tmp_path / "scripts" / "play_interactive.py")
-    assert command[2:4] == ["--algo", "ppo"]
-    assert command[4:8] == ["--task", "x2_wall_flip_tracking", "--sim", "mujoco"]
-    assert f"algo.load_run={abs_pt}" in command
-    assert "training.device=cpu" in command
 
 
 def test_demo_play_interactive_entry_assembles_inhandgrasp_command(

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -295,7 +295,6 @@ def test_demo_positional_completes_all_demo_names(tmp_path: Path) -> None:
         "sharpa_appo_student",
         "teaser",
         "wallflip",
-        "wallflip2",
     ]
 
 


### PR DESCRIPTION
## Summary

- Remove the `wallflip2` demo entry (`x2_wall_flip_tracking` interactive playback) from `DEMO_REGISTRY` in `src/unilab/demo.py` — shell completion follows the registry automatically.
- Remove `wallflip2` from README (en/zh) and Sphinx docs (quick demo + CLI reference, en/zh).
- Remove wallflip2-specific tests (`tests/test_cli.py`, `tests/test_completion.py`) and update the stale comment in `tests/config/test_locomotion_params.py`.

The `x2_wall_flip_tracking` task itself and its owner configs are unchanged.

## Follow-up (remote)

The remote checkpoint `checkpoints/wallflip2/model_0.pt` in the `unilabsim/unilab-checkpoints` HF dataset still needs to be deleted (requires repo write access).

## Validation

- `make test-all` completed: 1488 passed, 39 skipped, 1 xfailed; benchmark module-mode 32/32, script-mode 33/33.