### PR TITLE
feat(offpolicy): 多卡数据并行拓扑与配置面（training.devices + rank launcher）

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -6,6 +6,9 @@ defaults:
 training:
   task_name: G1WalkFlat
   device: null
+  # list[int] | null; null/[] = current single-device behavior;
+  # [d0..dN-1] = N-way data parallel, rank i trains on cuda:devices[i].
+  devices: null
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import os
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,6 +15,14 @@ from omegaconf import DictConfig, OmegaConf
 ROOT_DIR = Path(__file__).parent.parent
 sys.path.append(str(ROOT_DIR))
 
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_LOG_DIR,
+    DpRankSupervisor,
+    apply_dp_rank_config,
+    current_dp_rank,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
 from unilab.training import (
     BackendAdapter,
     apply_configured_training_seed,
@@ -670,6 +679,10 @@ def main(cfg: DictConfig) -> None:
     enable_faulthandler()
     ensure_registries()
 
+    devices = resolve_dp_topology(cfg.training.devices)
+    rank = current_dp_rank()
+    apply_dp_rank_config(cfg, devices, rank)
+
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     algo_name = cfg.algo.algo
     task_name = cfg.training.task_name
@@ -681,11 +694,20 @@ def main(cfg: DictConfig) -> None:
         log_dir = str(get_log_root(ROOT_DIR, cfg) / task_name / run_dir_name)
     else:
         log_dir = cfg.training.log_dir
+    if rank > 0:
+        # Spawned ranks reuse rank 0's run directory via a rank sub-directory;
+        # rank 0 owns the canonical checkpoints and the ExperimentTracker.
+        log_dir = os.path.join(os.environ[UNILAB_DP_LOG_DIR], f"rank{rank}")
+
+    supervisor: DpRankSupervisor | None = None
+    if devices is not None and rank == 0 and len(devices) > 1:
+        validate_dp_launchable(devices)
+        supervisor = DpRankSupervisor(devices, log_dir)
 
     import torch
 
     tracker = None
-    if not cfg.training.play_only:
+    if not cfg.training.play_only and rank == 0:
         tracker = ExperimentTracker(
             root_dir=ROOT_DIR,
             log_dir=log_dir,
@@ -700,45 +722,46 @@ def main(cfg: DictConfig) -> None:
         tracker.start()
 
     try:
-        if not cfg.training.play_only:
-            runner = None
-            try:
-                runner = build_runner(algo_name, cfg)
-                runner.learn(
-                    max_iterations=cfg.algo.max_iterations,
-                    save_interval=cfg.algo.save_interval,
-                    log_dir=log_dir,
-                    logger_type=cfg.training.logger,
-                )
-                run_summary = getattr(runner, "last_run_summary", None)
-                if isinstance(run_summary, dict) and run_summary.get("status") not in (
-                    None,
-                    "completed",
-                ):
-                    raise RuntimeError(
-                        f"Off-policy training ended with status={run_summary.get('status')!r}"
+        with supervisor if supervisor is not None else nullcontext():
+            if not cfg.training.play_only:
+                runner = None
+                try:
+                    runner = build_runner(algo_name, cfg)
+                    runner.learn(
+                        max_iterations=cfg.algo.max_iterations,
+                        save_interval=cfg.algo.save_interval,
+                        log_dir=log_dir,
+                        logger_type=cfg.training.logger,
                     )
-                if tracker is not None:
-                    tracker.update_summary(run_summary)
-            except BaseException as exc:
-                if tracker is not None:
-                    tracker.update_summary(
-                        build_failure_summary(exc, getattr(runner, "last_run_summary", None))
-                    )
-                raise
-            finally:
-                if runner is not None:
-                    runner.close()
+                    run_summary = getattr(runner, "last_run_summary", None)
+                    if isinstance(run_summary, dict) and run_summary.get("status") not in (
+                        None,
+                        "completed",
+                    ):
+                        raise RuntimeError(
+                            f"Off-policy training ended with status={run_summary.get('status')!r}"
+                        )
+                    if tracker is not None:
+                        tracker.update_summary(run_summary)
+                except BaseException as exc:
+                    if tracker is not None:
+                        tracker.update_summary(
+                            build_failure_summary(exc, getattr(runner, "last_run_summary", None))
+                        )
+                    raise
+                finally:
+                    if runner is not None:
+                        runner.close()
 
-        if should_run_playback(
-            play_only=cfg.training.play_only,
-            no_play=cfg.training.no_play,
-            play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
-        ):
-            print("@" * 50)
-            play_video_path = play_offpolicy(algo_name, cfg)
-            if tracker is not None:
-                tracker.log_video(play_video_path)
+            if rank == 0 and should_run_playback(
+                play_only=cfg.training.play_only,
+                no_play=cfg.training.no_play,
+                play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
+            ):
+                print("@" * 50)
+                play_video_path = play_offpolicy(algo_name, cfg)
+                if tracker is not None:
+                    tracker.log_video(play_video_path)
     finally:
         if tracker is not None:
             tracker.finish()

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -25,6 +25,10 @@ _OFFPOLICY_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "train_off
 
 _WATCHDOG_INTERVAL_S = 0.5
 _TERMINATE_TIMEOUT_S = 10.0
+# Grace window for sibling ranks to finish their own runs once rank 0
+# completed normally. Ranks run the same config, so they should land within
+# startup skew of each other; exceeding the grace is treated as a failure.
+_NORMAL_EXIT_GRACE_S = 600.0
 
 
 def resolve_dp_topology(devices_cfg: Any) -> tuple[int, ...] | None:
@@ -166,11 +170,29 @@ class DpRankSupervisor:
 
         # Ranks that already exited on their own keep their exit code;
         # non-zero means the data-parallel run failed even if rank 0 is fine.
-        failed = [
+        failed: list[tuple[int, object]] = [
             (rank, child.returncode)
             for rank, child in enumerate(self._children, start=1)
             if child.returncode is not None and child.returncode != 0
         ]
+        if exc_type is None and not failed:
+            # Normal rank-0 completion: give sibling ranks a grace window to
+            # finish their own runs instead of cutting them short.
+            for rank, child in enumerate(self._children, start=1):
+                if child.returncode is not None:
+                    continue
+                try:
+                    child.wait(timeout=_NORMAL_EXIT_GRACE_S)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[dp_launcher] rank {rank} subprocess pid={child.pid} did not "
+                        f"exit within {_NORMAL_EXIT_GRACE_S}s of rank 0 completion",
+                        file=sys.stderr,
+                    )
+                if child.returncode != 0:
+                    failed.append(
+                        (rank, child.returncode if child.returncode is not None else "timeout")
+                    )
         self._terminate_children()
         if failed:
             message = (

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 UNILAB_DP_RANK = "UNILAB_DP_RANK"
 UNILAB_DP_WORLD_SIZE = "UNILAB_DP_WORLD_SIZE"
@@ -159,7 +159,7 @@ class DpRankSupervisor:
         self._watchdog.start()
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
         self._watchdog_stop.set()
         if self._watchdog is not None:
             self._watchdog.join(timeout=_TERMINATE_TIMEOUT_S)
@@ -195,9 +195,8 @@ class DpRankSupervisor:
                     )
         self._terminate_children()
         if failed:
-            message = (
-                "data-parallel rank subprocess(es) failed: "
-                + ", ".join(f"rank {rank} exit code {code}" for rank, code in failed)
+            message = "data-parallel rank subprocess(es) failed: " + ", ".join(
+                f"rank {rank} exit code {code}" for rank, code in failed
             )
             if exc_type is None:
                 raise RuntimeError(message)

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -1,0 +1,212 @@
+"""Multi-GPU data-parallel rank topology for off-policy training.
+
+Topology rules (config parsing, rank/device mapping, subprocess supervision)
+live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
+This module covers topology only; parameter sync between ranks is out of
+scope for this stage.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+UNILAB_DP_RANK = "UNILAB_DP_RANK"
+UNILAB_DP_WORLD_SIZE = "UNILAB_DP_WORLD_SIZE"
+UNILAB_DP_DEVICES = "UNILAB_DP_DEVICES"
+UNILAB_DP_LOG_DIR = "UNILAB_DP_LOG_DIR"
+
+_OFFPOLICY_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "train_offpolicy.py"
+
+_WATCHDOG_INTERVAL_S = 0.5
+_TERMINATE_TIMEOUT_S = 10.0
+
+
+def resolve_dp_topology(devices_cfg: Any) -> tuple[int, ...] | None:
+    """Normalize ``training.devices`` into an ordered CUDA-index tuple.
+
+    Returns None for the single-card default (null / empty list). The user
+    given order is preserved: rank i maps to ``cuda:{devices[i]}``.
+    """
+    if devices_cfg is None:
+        return None
+    devices = list(devices_cfg)
+    if len(devices) == 0:
+        return None
+    normalized: list[int] = []
+    for entry in devices:
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            raise ValueError(
+                f"training.devices entries must be integer CUDA indices, got {entry!r}"
+            )
+        if entry < 0:
+            raise ValueError(f"training.devices entries must be non-negative, got {entry}")
+        normalized.append(int(entry))
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"training.devices must not contain duplicates, got {normalized}")
+    return tuple(normalized)
+
+
+def current_dp_rank() -> int:
+    """Data-parallel rank of this process (0 when not spawned as a rank)."""
+    return int(os.environ.get(UNILAB_DP_RANK, "0"))
+
+
+def current_dp_world_size() -> int:
+    """Data-parallel world size of this process (1 when not spawned as a rank)."""
+    return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def validate_dp_launchable(devices: tuple[int, ...]) -> None:
+    """Fail fast at launch time when the host lacks any requested CUDA device."""
+    import torch
+
+    device_count = torch.cuda.device_count()
+    missing = [index for index in devices if index >= device_count]
+    if missing:
+        raise ValueError(
+            f"training.devices={list(devices)} requires CUDA device index(es) {missing}, "
+            f"but torch.cuda.device_count()={device_count}"
+        )
+
+
+def apply_dp_rank_config(cfg: Any, devices: tuple[int, ...] | None, rank: int) -> None:
+    """Rewrite per-rank device and seed into the composed Hydra config.
+
+    Rank 0 keeps the configured seed; rank i>0 trains with ``seed + i`` until
+    init broadcast lands in a later stage.
+    """
+    if devices is None:
+        return
+    if cfg.training.device is not None:
+        raise ValueError(
+            "training.device and training.devices are mutually exclusive; "
+            "use training.devices for multi-GPU data-parallel training and leave "
+            "training.device null"
+        )
+    if rank < 0 or rank >= len(devices):
+        raise ValueError(
+            f"data-parallel rank {rank} is out of range for training.devices={list(devices)}"
+        )
+    from omegaconf import open_dict
+
+    with open_dict(cfg):
+        cfg.training.device = f"cuda:{devices[rank]}"
+        cfg.algo.seed = int(cfg.algo.seed) + rank
+
+
+def _sigterm_system_exit(signum: int, _frame: Any) -> None:
+    raise SystemExit(f"data-parallel rank 0 received signal {signum}")
+
+
+class DpRankSupervisor:
+    """Rank-0 supervisor that spawns and watches data-parallel rank subprocesses.
+
+    Ranks 1..N-1 re-run ``scripts/train_offpolicy.py`` with the same Hydra
+    argv plus the ``UNILAB_DP_*`` environment; each spawned rank builds its
+    own learner+collector pair through the regular runner path. If any rank
+    subprocess dies with a non-zero exit code while active, the supervisor
+    delivers SIGTERM to rank 0 so the runner lifecycle unwinds through the
+    normal try/finally (``runner.close()``), and ``__exit__`` tears down the
+    remaining ranks.
+    """
+
+    def __init__(self, devices: tuple[int, ...], log_dir: str) -> None:
+        self._devices = tuple(devices)
+        self._log_dir = log_dir
+        self._world_size = len(self._devices)
+        self._children: list[subprocess.Popen] = []
+        self._watchdog_stop = threading.Event()
+        self._watchdog: threading.Thread | None = None
+        self._previous_sigterm_handler: Any = None
+
+    def __enter__(self) -> DpRankSupervisor:
+        if self._world_size <= 1:
+            # Single-device degenerate case: nothing to spawn or watch.
+            return self
+        base_env = os.environ | {
+            UNILAB_DP_WORLD_SIZE: str(self._world_size),
+            UNILAB_DP_DEVICES: ",".join(str(index) for index in self._devices),
+            UNILAB_DP_LOG_DIR: self._log_dir,
+        }
+        try:
+            for rank in range(1, self._world_size):
+                env = base_env | {UNILAB_DP_RANK: str(rank)}
+                self._children.append(
+                    subprocess.Popen(
+                        [sys.executable, str(_OFFPOLICY_SCRIPT), *sys.argv[1:]],
+                        env=env,
+                    )
+                )
+        except BaseException:
+            self._terminate_children()
+            raise
+        self._previous_sigterm_handler = signal.signal(signal.SIGTERM, _sigterm_system_exit)
+        self._watchdog = threading.Thread(
+            target=self._watchdog_loop,
+            name="dp-rank-watchdog",
+            daemon=True,
+        )
+        self._watchdog.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        self._watchdog_stop.set()
+        if self._watchdog is not None:
+            self._watchdog.join(timeout=_TERMINATE_TIMEOUT_S)
+            self._watchdog = None
+        if self._previous_sigterm_handler is not None:
+            signal.signal(signal.SIGTERM, self._previous_sigterm_handler)
+            self._previous_sigterm_handler = None
+
+        # Ranks that already exited on their own keep their exit code;
+        # non-zero means the data-parallel run failed even if rank 0 is fine.
+        failed = [
+            (rank, child.returncode)
+            for rank, child in enumerate(self._children, start=1)
+            if child.returncode is not None and child.returncode != 0
+        ]
+        self._terminate_children()
+        if failed:
+            message = (
+                "data-parallel rank subprocess(es) failed: "
+                + ", ".join(f"rank {rank} exit code {code}" for rank, code in failed)
+            )
+            if exc_type is None:
+                raise RuntimeError(message)
+            print(f"[dp_launcher] {message}", file=sys.stderr)
+        return False
+
+    def _terminate_children(self) -> None:
+        alive = [child for child in self._children if child.poll() is None]
+        for child in alive:
+            child.terminate()
+        for child in alive:
+            try:
+                child.wait(timeout=_TERMINATE_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+
+    def _watchdog_loop(self) -> None:
+        while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL_S):
+            for rank, child in enumerate(self._children, start=1):
+                exit_code = child.poll()
+                if exit_code is None:
+                    continue
+                if exit_code == 0:
+                    # A rank that finishes cleanly (e.g. while rank 0 is still
+                    # in playback) is not a failure; keep watching the rest.
+                    continue
+                print(
+                    f"[dp_launcher] rank {rank} subprocess pid={child.pid} exited "
+                    f"unexpectedly with code {exit_code}; shutting down rank 0",
+                    file=sys.stderr,
+                )
+                os.kill(os.getpid(), signal.SIGTERM)
+                return

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -45,6 +45,9 @@ class _FakePopen:
     """Minimal subprocess.Popen stand-in with a scriptable exit code."""
 
     instances: list["_FakePopen"] = []
+    # When True, wait() on a still-running child makes it exit cleanly
+    # (simulates a rank that finishes during the normal-exit grace window).
+    wait_completes: bool = False
 
     def __init__(self, argv, env=None, **kwargs):
         del kwargs
@@ -69,8 +72,10 @@ class _FakePopen:
         self.returncode = -signal.SIGKILL
 
     def wait(self, timeout=None):
-        del timeout
         if self.returncode is None:
+            if _FakePopen.wait_completes:
+                self.returncode = 0
+                return 0
             raise subprocess.TimeoutExpired(cmd=self.argv, timeout=timeout)
         return self.returncode
 
@@ -78,6 +83,7 @@ class _FakePopen:
 @pytest.fixture()
 def fake_popen(monkeypatch: pytest.MonkeyPatch):
     _FakePopen.instances = []
+    _FakePopen.wait_completes = False
     monkeypatch.setattr(dp_launcher.subprocess, "Popen", _FakePopen)
     return _FakePopen
 
@@ -201,8 +207,28 @@ def test_supervisor_spawn_argv_and_env(fake_popen, monkeypatch: pytest.MonkeyPat
             assert child.env[UNILAB_DP_LOG_DIR] == "/tmp/dp_test_log"
         # Rank 0's own environment stays untouched.
         assert os.environ.get(UNILAB_DP_RANK) is None
+        for child in fake_popen.instances:
+            child.returncode = 0
     for child in fake_popen.instances:
-        assert child.terminated
+        assert not child.terminated
+
+
+def test_supervisor_normal_exit_waits_for_children(fake_popen):
+    _FakePopen.wait_completes = True
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        pass
+    child = fake_popen.instances[0]
+    assert child.returncode == 0
+    assert not child.terminated
+
+
+def test_supervisor_grace_timeout_is_a_failure(fake_popen):
+    with pytest.raises(RuntimeError, match="rank 1 exit code timeout"):
+        with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+            pass
+    child = fake_popen.instances[0]
+    assert child.terminated
+    assert child.returncode == -signal.SIGTERM
 
 
 def test_supervisor_clean_child_exit_is_not_a_failure(fake_popen):
@@ -222,9 +248,10 @@ def test_supervisor_failed_child_makes_rank_zero_fail(
         supervisor.__exit__(None, None, None)
 
 
-def test_supervisor_exit_terminates_live_children(fake_popen):
-    with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
-        pass
+def test_supervisor_error_exit_terminates_live_children(fake_popen):
+    with pytest.raises(ValueError, match="boom"):
+        with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
+            raise ValueError("boom")
     assert all(child.terminated for child in fake_popen.instances)
     assert all(child.returncode == -signal.SIGTERM for child in fake_popen.instances)
 
@@ -248,6 +275,7 @@ def test_supervisor_restores_sigterm_handler(fake_popen):
     previous = signal.getsignal(signal.SIGTERM)
     with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
         assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
+        fake_popen.instances[0].returncode = 0
     assert signal.getsignal(signal.SIGTERM) == previous
 
 

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -1,0 +1,264 @@
+"""Tests for the off-policy multi-GPU data-parallel rank topology."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+import unilab.ipc.dp_launcher as dp_launcher
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_DEVICES,
+    UNILAB_DP_LOG_DIR,
+    UNILAB_DP_RANK,
+    UNILAB_DP_WORLD_SIZE,
+    DpRankSupervisor,
+    apply_dp_rank_config,
+    current_dp_rank,
+    current_dp_world_size,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
+
+_ROOT = Path(__file__).parent.parent.parent
+_CONF_DIR = _ROOT / "conf"
+
+
+def _offpolicy_cfg(overrides: list[str] | None = None):
+    GlobalHydra.instance().clear()
+    normalized = list(overrides or [])
+    if not any(override.startswith("task=") for override in normalized):
+        normalized.append("task=sac/g1_walk_flat/mujoco")
+    with initialize_config_dir(config_dir=str(_CONF_DIR / "offpolicy"), version_base="1.3"):
+        return compose("config", overrides=normalized)
+
+
+class _FakePopen:
+    """Minimal subprocess.Popen stand-in with a scriptable exit code."""
+
+    instances: list["_FakePopen"] = []
+
+    def __init__(self, argv, env=None, **kwargs):
+        del kwargs
+        self.argv = list(argv)
+        self.env = dict(env or {})
+        self.pid = 10_000 + len(_FakePopen.instances)
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+        _FakePopen.instances.append(self)
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        if self.returncode is None:
+            self.returncode = -signal.SIGTERM
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -signal.SIGKILL
+
+    def wait(self, timeout=None):
+        del timeout
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired(cmd=self.argv, timeout=timeout)
+        return self.returncode
+
+
+@pytest.fixture()
+def fake_popen(monkeypatch: pytest.MonkeyPatch):
+    _FakePopen.instances = []
+    monkeypatch.setattr(dp_launcher.subprocess, "Popen", _FakePopen)
+    return _FakePopen
+
+
+# ---------------------------------------------------------------------------
+# resolve_dp_topology
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("devices_cfg", [None, []])
+def test_resolve_dp_topology_single_device_default(devices_cfg):
+    assert resolve_dp_topology(devices_cfg) is None
+
+
+def test_resolve_dp_topology_preserves_user_order():
+    assert resolve_dp_topology([0, 1]) == (0, 1)
+    assert resolve_dp_topology([2, 0]) == (2, 0)
+
+
+@pytest.mark.parametrize(
+    "devices_cfg",
+    [[0, 0], [-1], [0, "1"], [True], [0.5]],
+)
+def test_resolve_dp_topology_rejects_invalid_entries(devices_cfg):
+    with pytest.raises(ValueError, match="training.devices"):
+        resolve_dp_topology(devices_cfg)
+
+
+# ---------------------------------------------------------------------------
+# rank / world-size environment
+# ---------------------------------------------------------------------------
+
+
+def test_current_dp_rank_defaults(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    assert current_dp_rank() == 0
+    assert current_dp_world_size() == 1
+
+
+def test_current_dp_rank_reads_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "2")
+    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "4")
+    assert current_dp_rank() == 2
+    assert current_dp_world_size() == 4
+
+
+# ---------------------------------------------------------------------------
+# Hydra compose surface
+# ---------------------------------------------------------------------------
+
+
+def test_offpolicy_config_devices_defaults_to_null():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.devices is None
+    assert resolve_dp_topology(cfg.training.devices) is None
+
+
+def test_offpolicy_config_devices_compose():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null"])
+    assert resolve_dp_topology(cfg.training.devices) == (0, 1)
+
+
+def test_training_device_and_devices_are_mutually_exclusive():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=cuda"])
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        apply_dp_rank_config(cfg, resolve_dp_topology(cfg.training.devices), rank=0)
+
+
+# ---------------------------------------------------------------------------
+# apply_dp_rank_config / N=1 equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_apply_dp_rank_config_maps_rank_to_device_and_seed():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
+    base_seed = int(cfg.algo.seed)
+    apply_dp_rank_config(cfg, (0, 1), rank=1)
+    assert cfg.training.device == "cuda:1"
+    assert int(cfg.algo.seed) == base_seed + 1
+
+
+def test_apply_dp_rank_config_rank_zero_keeps_seed():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
+    apply_dp_rank_config(cfg, (0, 1), rank=0)
+    assert cfg.training.device == "cuda:0"
+    assert int(cfg.algo.seed) == 42
+
+
+def test_single_device_topology_spawns_no_children(
+    fake_popen, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    cfg = _offpolicy_cfg(["training.devices=[0]", "training.device=null"])
+    devices = resolve_dp_topology(cfg.training.devices)
+    assert devices == (0,)
+    apply_dp_rank_config(cfg, devices, rank=0)
+    assert cfg.training.device == "cuda:0"
+    with DpRankSupervisor(devices, log_dir="/tmp/dp_test_log"):
+        assert fake_popen.instances == []
+    assert os.environ.get(UNILAB_DP_RANK) is None
+
+
+# ---------------------------------------------------------------------------
+# DpRankSupervisor
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_spawn_argv_and_env(fake_popen, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.setattr(sys, "argv", ["train_offpolicy.py", "algo=sac", "training.devices=[0,1,2]"])
+    with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
+        assert len(fake_popen.instances) == 2
+        for rank, child in enumerate(fake_popen.instances, start=1):
+            assert child.argv[0] == sys.executable
+            assert child.argv[1].endswith("scripts/train_offpolicy.py")
+            assert child.argv[2:] == ["algo=sac", "training.devices=[0,1,2]"]
+            assert child.env[UNILAB_DP_RANK] == str(rank)
+            assert child.env[UNILAB_DP_WORLD_SIZE] == "3"
+            assert child.env[UNILAB_DP_DEVICES] == "0,1,2"
+            assert child.env[UNILAB_DP_LOG_DIR] == "/tmp/dp_test_log"
+        # Rank 0's own environment stays untouched.
+        assert os.environ.get(UNILAB_DP_RANK) is None
+    for child in fake_popen.instances:
+        assert child.terminated
+
+
+def test_supervisor_clean_child_exit_is_not_a_failure(fake_popen):
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        fake_popen.instances[0].returncode = 0
+
+
+def test_supervisor_failed_child_makes_rank_zero_fail(
+    fake_popen, monkeypatch: pytest.MonkeyPatch
+):
+    # Keep the watchdog from polling so __exit__ observes the exit code first.
+    monkeypatch.setattr(dp_launcher, "_WATCHDOG_INTERVAL_S", 60.0)
+    supervisor = DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log")
+    supervisor.__enter__()
+    fake_popen.instances[0].returncode = 3
+    with pytest.raises(RuntimeError, match="rank 1 exit code 3"):
+        supervisor.__exit__(None, None, None)
+
+
+def test_supervisor_exit_terminates_live_children(fake_popen):
+    with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
+        pass
+    assert all(child.terminated for child in fake_popen.instances)
+    assert all(child.returncode == -signal.SIGTERM for child in fake_popen.instances)
+
+
+def test_supervisor_watchdog_sigterms_rank_zero_on_child_death(
+    fake_popen, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(dp_launcher, "_WATCHDOG_INTERVAL_S", 0.01)
+    killed: list[int] = []
+    monkeypatch.setattr(dp_launcher.os, "kill", lambda pid, sig: killed.append(sig))
+    with pytest.raises(RuntimeError, match="exit code 1"):
+        with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+            fake_popen.instances[0].returncode = 1
+            deadline = time.monotonic() + 5.0
+            while not killed and time.monotonic() < deadline:
+                time.sleep(0.01)
+    assert killed == [signal.SIGTERM]
+
+
+def test_supervisor_restores_sigterm_handler(fake_popen):
+    previous = signal.getsignal(signal.SIGTERM)
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
+    assert signal.getsignal(signal.SIGTERM) == previous
+
+
+# ---------------------------------------------------------------------------
+# Hardware-gated smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires >=2 CUDA devices")
+@pytest.mark.slow
+def test_dp_topology_validates_on_two_gpu_host():
+    devices = resolve_dp_topology([0, 1])
+    assert devices == (0, 1)
+    validate_dp_launchable(devices)

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -173,9 +173,7 @@ def test_apply_dp_rank_config_rank_zero_keeps_seed():
     assert int(cfg.algo.seed) == 42
 
 
-def test_single_device_topology_spawns_no_children(
-    fake_popen, monkeypatch: pytest.MonkeyPatch
-):
+def test_single_device_topology_spawns_no_children(fake_popen, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
     cfg = _offpolicy_cfg(["training.devices=[0]", "training.device=null"])
     devices = resolve_dp_topology(cfg.training.devices)
@@ -236,9 +234,7 @@ def test_supervisor_clean_child_exit_is_not_a_failure(fake_popen):
         fake_popen.instances[0].returncode = 0
 
 
-def test_supervisor_failed_child_makes_rank_zero_fail(
-    fake_popen, monkeypatch: pytest.MonkeyPatch
-):
+def test_supervisor_failed_child_makes_rank_zero_fail(fake_popen, monkeypatch: pytest.MonkeyPatch):
     # Keep the watchdog from polling so __exit__ observes the exit code first.
     monkeypatch.setattr(dp_launcher, "_WATCHDOG_INTERVAL_S", 60.0)
     supervisor = DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log")


### PR DESCRIPTION
Closes #965. Parent roadmap: #964.

## 内容

- `training.devices: list[int] | null`（默认 null = 现状单卡）进入 `conf/offpolicy/config.yaml`；CLI 经 passthrough 生效：`uv run train --algo sac --task g1_walk_flat --sim mujoco training.devices=[0,1]`。
- 新模块 `src/unilab/ipc/dp_launcher.py`：拓扑解析/校验、rank→device 映射、rank seed 偏移、`DpRankSupervisor`（spawn N-1 个 rank 子进程，watchdog 失败传播 SIGTERM → 沿 runner lifecycle 展开，正常退出给 sibling ranks 宽限期完成各自训练，宽限超时/非零退出判失败）。
- `scripts/train_offpolicy.py` 只做组装：rank>0 用 `{log_dir}/rank{i}`、tracker 禁用、playback 跳过；`training.device` 与 `training.devices` 互斥。
- tombstone 测试（`training.num_gpus` 等 #937 移除 key）保持不变，仍 compose 失败；新增 `training.devices` 合法 compose 覆盖。
- N=1（null/[]/[0]）不 spawn、不装 handler、不起 watchdog，行为与现状等价。

## Validation

- `make test-all` 通过（exit=0，本分支最终提交）。
- `tests/ipc/test_dp_launcher.py` 24 用例 + tombstone 回归全绿。
- 真实 2 卡 smoke（2× RTX 6000D）：`training.devices=[0,1]`，30 iterations，rank0/rank1 均完整训练并各自产出 `model_30.pt` 与 metrics，exit=0，无进程泄漏。
- 修复了一个 smoke 中发现的语义缺陷：rank0 正常结束后会立即 terminate sibling ranks（b0fe2ac5）。

## 备注

- 调查过程中确认此前"启动卡 10+ 分钟"是我自建 smoke 的 replay 容量配置错误（capacity < batch_size 时 learner 无限等数据），main 无此问题；该场景下缺 fail-fast 校验，建议后续单独立项（不属本 PR 范围）。
- 参数同步（NCCL）在 child 3（#967）；CPU 均分在 child 2（#966）。
