### PR TITLE
feat(offpolicy): 多 collector CPU 核区自动均分（EnvCfg.cpu_ids 接入）

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -9,6 +9,9 @@ training:
   # list[int] | null; null/[] = current single-device behavior;
   # [d0..dN-1] = N-way data parallel, rank i trains on cuda:devices[i].
   devices: null
+  # list[list[int]] | null; one CPU-id segment per rank for the collector's
+  # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.
+  dp_collector_cpu_ids: null
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -20,7 +20,6 @@ from unilab.ipc.dp_launcher import (
     DpRankSupervisor,
     apply_dp_rank_config,
     current_dp_rank,
-    current_dp_world_size,
     resolve_collector_cpu_ids,
     resolve_dp_topology,
     validate_dp_launchable,
@@ -174,7 +173,10 @@ def build_runner(algo_name: str, cfg: DictConfig):
     # CPU block (single rank keeps the legacy unset behavior). The ids only
     # reach the collector env override — never the num_envs=1 probe envs,
     # whose MuJoCo pool would size itself from len(cpu_ids).
-    dp_world_size = current_dp_world_size()
+    # world_size comes from training.devices (rank 0 has no UNILAB_DP_* env;
+    # only spawned ranks carry it), rank from the env (0 for rank 0).
+    dp_devices = resolve_dp_topology(cfg.training.devices)
+    dp_world_size = len(dp_devices) if dp_devices is not None else 1
     host_cpu_count = os.cpu_count() or 1
     explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
     if explicit_cpu_ids is not None:

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -20,6 +20,8 @@ from unilab.ipc.dp_launcher import (
     DpRankSupervisor,
     apply_dp_rank_config,
     current_dp_rank,
+    current_dp_world_size,
+    resolve_collector_cpu_ids,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -168,8 +170,25 @@ def build_runner(algo_name: str, cfg: DictConfig):
         resolve_torch_thread_runtime,
     )
 
+    # Cold-path DP CPU partition: each rank's collector owns one contiguous
+    # CPU block (single rank keeps the legacy unset behavior). The ids only
+    # reach the collector env override — never the num_envs=1 probe envs,
+    # whose MuJoCo pool would size itself from len(cpu_ids).
+    dp_world_size = current_dp_world_size()
+    host_cpu_count = os.cpu_count() or 1
+    explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
+    if explicit_cpu_ids is not None:
+        explicit_cpu_ids = cast(list, OmegaConf.to_container(explicit_cpu_ids, resolve=True))
+    collector_cpu_ids = resolve_collector_cpu_ids(
+        dp_world_size,
+        current_dp_rank(),
+        host_cpu_count,
+        explicit=explicit_cpu_ids,
+    )
+
     torch_thread_runtime = resolve_torch_thread_runtime(
-        getattr(cfg.training, "torch_threads", None)
+        getattr(cfg.training, "torch_threads", None),
+        cpu_count=host_cpu_count // dp_world_size if dp_world_size > 1 else None,
     )
     apply_torch_thread_runtime(torch_thread_runtime, role="learner")
 
@@ -323,6 +342,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             seed=cfg.algo.seed,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
         )
 
     if algo_name == "td3":
@@ -387,6 +407,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             replay_prefetch_mode=replay_prefetch_mode,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
         )
 
     if algo_name == "flashsac":

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -115,6 +115,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         self,
         *,
         replay_prefetch_mode: str = "one_tick",
+        collector_cpu_ids: list[int] | None = None,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -124,6 +125,11 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "DoubleBufferOffPolicyRunner only supports replay_prefetch_mode='one_tick'"
             )
         self.replay_prefetch_mode = replay_prefetch_mode
+        # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
+        # merged into the collector-only env override at collector startup.
+        self.collector_cpu_ids = (
+            list(collector_cpu_ids) if collector_cpu_ids is not None else None
+        )
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -135,6 +141,17 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_torch_inference": False,
             "learner_actor_reused": True,
         }
+
+    def _collector_env_cfg_override(self) -> dict | None:
+        """Env override copy for the collector process, with per-rank CPU ids.
+
+        MuJoCo sizes its BatchEnvPool worker count from ``len(cpu_ids)``, so
+        the affinity list must only reach the collector's copy — never the
+        learner-side probe envs, which keep the base override untouched.
+        """
+        if self.collector_cpu_ids is None:
+            return self.env_cfg_override
+        return {**(self.env_cfg_override or {}), "cpu_ids": list(self.collector_cpu_ids)}
 
     def _wait_for_inference_request(
         self,
@@ -572,7 +589,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "inference_request_queue": inference_request_queue,
                 "inference_response_queue": inference_response_queue,
                 "sim_backend": self.sim_backend,
-                "env_cfg_override": self.env_cfg_override,
+                "env_cfg_override": self._collector_env_cfg_override(),
                 "inference_slot": inference_slot,
                 "seed": derive_worker_seed(self.seed, worker_index=0),
                 "trace_enabled": self.trace_enabled,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -127,9 +127,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         self.replay_prefetch_mode = replay_prefetch_mode
         # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
         # merged into the collector-only env override at collector startup.
-        self.collector_cpu_ids = (
-            list(collector_cpu_ids) if collector_cpu_ids is not None else None
-        )
+        self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"

--- a/src/unilab/algos/torch/offpolicy/thread_budget.py
+++ b/src/unilab/algos/torch/offpolicy/thread_budget.py
@@ -1,8 +1,9 @@
 """Torch CPU thread budget helpers for off-policy training.
 
-Off-policy training runs Torch in multiple processes: the learner, the CPU
-collector, and optional multi-GPU learner workers. PyTorch defaults each process
-to a host-sized thread pool, so every role needs an explicit budget.
+Off-policy training runs Torch in multiple processes: the learner and the CPU
+collector of each rank (multi-GPU data parallel runs one learner+collector
+pair per rank). PyTorch defaults each process to a host-sized thread pool, so
+every role needs an explicit budget.
 """
 
 from __future__ import annotations

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -91,9 +91,7 @@ def resolve_collector_cpu_ids(
         return None
     rank = int(rank)
     if rank < 0 or rank >= world_size:
-        raise ValueError(
-            f"data-parallel rank {rank} is out of range for world_size={world_size}"
-        )
+        raise ValueError(f"data-parallel rank {rank} is out of range for world_size={world_size}")
     cpu_count = int(cpu_count)
     if cpu_count < world_size:
         raise ValueError(
@@ -111,8 +109,7 @@ def resolve_collector_cpu_ids(
         for segment in segments:
             if not segment:
                 raise ValueError(
-                    "training.dp_collector_cpu_ids segments must be non-empty, "
-                    f"got {segments!r}"
+                    f"training.dp_collector_cpu_ids segments must be non-empty, got {segments!r}"
                 )
             for cpu_id in segment:
                 if isinstance(cpu_id, bool) or not isinstance(cpu_id, int) or cpu_id < 0:

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -66,6 +66,70 @@ def current_dp_world_size() -> int:
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
 
 
+def resolve_collector_cpu_ids(
+    world_size: int,
+    rank: int,
+    cpu_count: int,
+    explicit: Any = None,
+) -> list[int] | None:
+    """Resolve the CPU ids exclusively owned by this rank's collector.
+
+    Returns None for the single-rank default (``world_size <= 1``) so the
+    single-card path stays bit-identical to the pre-partition behavior.
+    Otherwise the host CPUs are split into ``world_size`` contiguous blocks of
+    ``cpu_count // world_size``: rank i owns ``[i*size, (i+1)*size)`` and any
+    remainder CPUs stay on default OS scheduling. ``explicit`` (config
+    ``training.dp_collector_cpu_ids``, one segment per rank) overrides the
+    automatic partition; the segments must number exactly ``world_size``, be
+    non-empty, contain non-negative ints, and not overlap. An empty
+    ``explicit`` falls back to the automatic partition.
+
+    Cold path only: call at runner construction, never from the collect loop.
+    """
+    world_size = int(world_size)
+    if world_size <= 1:
+        return None
+    rank = int(rank)
+    if rank < 0 or rank >= world_size:
+        raise ValueError(
+            f"data-parallel rank {rank} is out of range for world_size={world_size}"
+        )
+    cpu_count = int(cpu_count)
+    if cpu_count < world_size:
+        raise ValueError(
+            f"cpu_count={cpu_count} cannot give each data-parallel rank its own CPU "
+            f"(world_size={world_size})"
+        )
+    if explicit is not None and len(explicit) > 0:
+        segments: list[list[int]] = [list(segment) for segment in explicit]
+        if len(segments) != world_size:
+            raise ValueError(
+                f"training.dp_collector_cpu_ids must provide exactly world_size={world_size} "
+                f"segments, got {len(segments)}"
+            )
+        seen: set[int] = set()
+        for segment in segments:
+            if not segment:
+                raise ValueError(
+                    "training.dp_collector_cpu_ids segments must be non-empty, "
+                    f"got {segments!r}"
+                )
+            for cpu_id in segment:
+                if isinstance(cpu_id, bool) or not isinstance(cpu_id, int) or cpu_id < 0:
+                    raise ValueError(
+                        "training.dp_collector_cpu_ids entries must be non-negative "
+                        f"integers, got {cpu_id!r}"
+                    )
+                if cpu_id in seen:
+                    raise ValueError(
+                        f"training.dp_collector_cpu_ids segments overlap on CPU {cpu_id}"
+                    )
+                seen.add(cpu_id)
+        return segments[rank]
+    size = cpu_count // world_size
+    return list(range(rank * size, rank * size + size))
+
+
 def validate_dp_launchable(devices: tuple[int, ...]) -> None:
     """Fail fast at launch time when the host lacks any requested CUDA device."""
     import torch

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -13,6 +13,8 @@ from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from hydra.errors import ConfigCompositionException
 
+from unilab.ipc.dp_launcher import UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
+
 _ROOT = Path(__file__).parent.parent.parent
 _CONF_DIR = _ROOT / "conf"
 
@@ -237,3 +239,102 @@ def test_inference_response_detects_dead_collector():
 
     with pytest.raises(RuntimeError, match="collector dead"):
         runner._publish_inference_response(full_queue, timeout=0.01)
+
+
+def _build_sac_runner_with_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: list[str],
+    *,
+    cpu_count: int = 128,
+):
+    """build_runner("sac", ...) with learner/env/runner fakes; returns captured state."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    probe_env_calls: list[dict] = []
+
+    def fake_create_env(*args, **kwargs):
+        del args
+        probe_env_calls.append(kwargs)
+        return _FakeEnv()
+
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", fake_create_env)
+    monkeypatch.setattr(module.os, "cpu_count", lambda: cpu_count)
+
+    import unilab.algos.torch.fast_sac.learner as learner_module
+    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+
+    monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+
+    runner = module.build_runner("sac", cfg)
+    return runner, probe_env_calls
+
+
+def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "2")
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch, ["algo=sac", "algo.use_symmetry=false"], cpu_count=128
+    )
+    assert runner.kwargs["collector_cpu_ids"] == list(range(64, 128))
+    # The thread budget is resolved against the rank's CPU share, not the host.
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 64
+    # The num_envs=1 probe env must never see cpu_ids (it would size its
+    # MuJoCo BatchEnvPool worker count from len(cpu_ids)).
+    assert probe_env_calls
+    for call in probe_env_calls:
+        override = call.get("env_cfg_override") or {}
+        assert "cpu_ids" not in override
+
+
+def test_build_runner_single_rank_keeps_collector_cpus_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch, ["algo=sac", "algo.use_symmetry=false"], cpu_count=128
+    )
+    assert runner.kwargs["collector_cpu_ids"] is None
+    # Single-rank thread budget still resolves against the full host.
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 128
+    override = runner.kwargs["env_cfg_override"] or {}
+    assert "cpu_ids" not in override
+    for call in probe_env_calls:
+        assert "cpu_ids" not in (call.get("env_cfg_override") or {})
+
+
+def test_build_runner_explicit_dp_collector_cpu_ids(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "0")
+    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "2")
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.dp_collector_cpu_ids=[[0,1],[2,3]]"],
+        cpu_count=128,
+    )
+    assert runner.kwargs["collector_cpu_ids"] == [0, 1]
+    for call in probe_env_calls:
+        assert "cpu_ids" not in (call.get("env_cfg_override") or {})
+
+
+def test_collector_env_cfg_override_merges_cpu_ids_without_mutating_base():
+    runner = _bare_runner()
+    base = {"reward_config": {"x": 1}}
+    runner.env_cfg_override = base
+    runner.collector_cpu_ids = [0, 1]
+    merged = runner._collector_env_cfg_override()
+    assert merged == {"reward_config": {"x": 1}, "cpu_ids": [0, 1]}
+    assert "cpu_ids" not in base
+
+
+def test_collector_env_cfg_override_without_cpu_ids_passes_through():
+    runner = _bare_runner()
+    runner.env_cfg_override = {"a": 1}
+    runner.collector_cpu_ids = None
+    assert runner._collector_env_cfg_override() is runner.env_cfg_override
+
+
+def test_collector_env_cfg_override_from_none_base():
+    runner = _bare_runner()
+    runner.env_cfg_override = None
+    runner.collector_cpu_ids = [4, 5]
+    assert runner._collector_env_cfg_override() == {"cpu_ids": [4, 5]}

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -272,10 +272,11 @@ def _build_sac_runner_with_fakes(
 
 
 def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.MonkeyPatch):
+    # Spawned rank: rank comes from the env, world_size from training.devices.
     monkeypatch.setenv(UNILAB_DP_RANK, "1")
-    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "2")
     runner, probe_env_calls = _build_sac_runner_with_fakes(
-        monkeypatch, ["algo=sac", "algo.use_symmetry=false"], cpu_count=128
+        monkeypatch, ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        cpu_count=128,
     )
     assert runner.kwargs["collector_cpu_ids"] == list(range(64, 128))
     # The thread budget is resolved against the rank's CPU share, not the host.
@@ -286,6 +287,18 @@ def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.Mon
     for call in probe_env_calls:
         override = call.get("env_cfg_override") or {}
         assert "cpu_ids" not in override
+
+
+def test_build_runner_rank_zero_partitions_without_dp_env(monkeypatch: pytest.MonkeyPatch):
+    # Rank 0 carries no UNILAB_DP_* env; world_size must come from the config.
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    runner, _ = _build_sac_runner_with_fakes(
+        monkeypatch, ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        cpu_count=128,
+    )
+    assert runner.kwargs["collector_cpu_ids"] == list(range(0, 64))
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 64
 
 
 def test_build_runner_single_rank_keeps_collector_cpus_unset(monkeypatch: pytest.MonkeyPatch):
@@ -305,10 +318,14 @@ def test_build_runner_single_rank_keeps_collector_cpus_unset(monkeypatch: pytest
 
 def test_build_runner_explicit_dp_collector_cpu_ids(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(UNILAB_DP_RANK, "0")
-    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "2")
     runner, probe_env_calls = _build_sac_runner_with_fakes(
         monkeypatch,
-        ["algo=sac", "algo.use_symmetry=false", "training.dp_collector_cpu_ids=[[0,1],[2,3]]"],
+        [
+            "algo=sac",
+            "algo.use_symmetry=false",
+            "training.devices=[0,1]",
+            "training.dp_collector_cpu_ids=[[0,1],[2,3]]",
+        ],
         cpu_count=128,
     )
     assert runner.kwargs["collector_cpu_ids"] == [0, 1]

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -275,7 +275,8 @@ def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.Mon
     # Spawned rank: rank comes from the env, world_size from training.devices.
     monkeypatch.setenv(UNILAB_DP_RANK, "1")
     runner, probe_env_calls = _build_sac_runner_with_fakes(
-        monkeypatch, ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
         cpu_count=128,
     )
     assert runner.kwargs["collector_cpu_ids"] == list(range(64, 128))
@@ -294,7 +295,8 @@ def test_build_runner_rank_zero_partitions_without_dp_env(monkeypatch: pytest.Mo
     monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
     monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
     runner, _ = _build_sac_runner_with_fakes(
-        monkeypatch, ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
         cpu_count=128,
     )
     assert runner.kwargs["collector_cpu_ids"] == list(range(0, 64))

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
 
 import unilab.ipc.dp_launcher as dp_launcher
 from unilab.ipc.dp_launcher import (
@@ -24,6 +25,7 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     current_dp_world_size,
+    resolve_collector_cpu_ids,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -273,6 +275,78 @@ def test_supervisor_restores_sigterm_handler(fake_popen):
         assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
         fake_popen.instances[0].returncode = 0
     assert signal.getsignal(signal.SIGTERM) == previous
+
+
+# ---------------------------------------------------------------------------
+# resolve_collector_cpu_ids
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_collector_cpu_ids_single_rank_returns_none():
+    assert resolve_collector_cpu_ids(1, 0, 128) is None
+    assert resolve_collector_cpu_ids(0, 0, 128) is None
+
+
+def test_resolve_collector_cpu_ids_even_partition():
+    assert resolve_collector_cpu_ids(2, 0, 128) == list(range(0, 64))
+    assert resolve_collector_cpu_ids(2, 1, 128) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_remainder_stays_unassigned():
+    # 129 CPUs / 2 ranks -> 64+64; CPU 128 keeps default OS scheduling.
+    assert resolve_collector_cpu_ids(2, 0, 129) == list(range(0, 64))
+    assert resolve_collector_cpu_ids(2, 1, 129) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_requires_one_cpu_per_rank():
+    with pytest.raises(ValueError, match="cpu_count"):
+        resolve_collector_cpu_ids(4, 0, 3)
+
+
+def test_resolve_collector_cpu_ids_rank_out_of_range():
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_collector_cpu_ids(2, 2, 128)
+
+
+def test_resolve_collector_cpu_ids_explicit_valid():
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=[[0, 1], [2, 3]]) == [2, 3]
+
+
+def test_resolve_collector_cpu_ids_empty_explicit_falls_back_to_auto():
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=[]) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_segment_count_mismatch():
+    with pytest.raises(ValueError, match="world_size"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0], [1], [2]])
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_overlapping_segments():
+    with pytest.raises(ValueError, match="overlap"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, 1], [1, 2]])
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_empty_segment():
+    with pytest.raises(ValueError, match="non-empty"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, 1], []])
+
+
+@pytest.mark.parametrize("bad_id", [-1, True, "2"])
+def test_resolve_collector_cpu_ids_explicit_rejects_invalid_ids(bad_id):
+    with pytest.raises(ValueError, match="non-negative integers"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, bad_id], [2, 3]])
+
+
+def test_offpolicy_config_dp_collector_cpu_ids_defaults_to_null():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.dp_collector_cpu_ids is None
+
+
+def test_offpolicy_config_dp_collector_cpu_ids_compose():
+    cfg = _offpolicy_cfg(["training.dp_collector_cpu_ids=[[0,1],[2,3]]"])
+    explicit = OmegaConf.to_container(cfg.training.dp_collector_cpu_ids, resolve=True)
+    assert explicit == [[0, 1], [2, 3]]
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=explicit) == [2, 3]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #966. Parent roadmap: #964.

## 内容

- `dp_launcher.resolve_collector_cpu_ids(world_size, rank, cpu_count, explicit)`：world_size>1 时按 `cpu_count // world_size` 连续分块（余数核留 OS 默认调度）；支持 `training.dp_collector_cpu_ids`（每 rank 一段）显式覆盖，校验段数/非空/非负 int/不重叠。world_size<=1 返回 None（单卡逐位等价）。
- 注入点：`DoubleBufferOffPolicyRunner` 新可选参数 `collector_cpu_ids`，仅在组 collector kwargs 时合入 env_cfg_override **拷贝**；num_envs=1 探测 env 不受影响（否则 MuJoCo pool 按 len(cpu_ids) 建 worker 数）。
- 线程预算配套：world_size>1 时 `resolve_torch_thread_runtime(cpu_count=host//world_size)`，learner/collector 全覆盖。
- `thread_budget.py` 过时 docstring 修正。

## 验收中发现的缺陷（已修，d2222065）

rank 0 不带 `UNILAB_DP_*` env（supervisor 只给 spawn 的 rank 设置），导致 rank 0 的 world_size 解析为 1，其 collector 未获分区、线程预算也未缩减。world_size 改由 `training.devices` 推导，rank 仍取 env。新增回归测试 `test_build_runner_rank_zero_partitions_without_dp_env`。

## Validation

- `make test-all` 通过（exit=0，最终提交）。
- 新增/更新测试：`tests/ipc/test_dp_launcher.py` 分区用例、`tests/algos/test_offpolicy_double_buffer_runner.py` 接线用例（含 rank0 无 env 回归、探测 env 隔离、N=1 不变）。
- 2 卡真机验证（2× RTX 6000D，128 线程主机）：`training.devices=[0,1]` 训练运行中 /proc 证据——rank0 collector BatchEnvPool worker 绑定 CPU 0-63，rank1 绑定 64-127，互不重叠；N=1 路径不设置 cpu_ids。
