### PR TITLE
feat(offpolicy): learner 间周期性参数平均同步（NCCL）

### DIFF
--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -12,6 +12,10 @@ training:
   # list[list[int]] | null; one CPU-id segment per rank for the collector's
   # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.
   dp_collector_cpu_ids: null
+  # int >= 1; every K learner iterations, ranks all-reduce the actor+critic
+  # parameter mean (K=1 = every iteration). Only takes effect with multi-GPU
+  # training.devices.
+  dp_sync_interval: 8
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -21,6 +21,7 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     resolve_collector_cpu_ids,
+    resolve_dp_rendezvous_path,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -161,7 +162,7 @@ def build_offpolicy_env_cfg_override(algo_name: str, cfg: DictConfig) -> dict[st
     )
 
 
-def build_runner(algo_name: str, cfg: DictConfig):
+def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
     """Build algorithm runner from unified Hydra config."""
     env_cfg_override = build_offpolicy_env_cfg_override(algo_name, cfg)
     from unilab.algos.torch.offpolicy.thread_budget import (
@@ -177,16 +178,38 @@ def build_runner(algo_name: str, cfg: DictConfig):
     # only spawned ranks carry it), rank from the env (0 for rank 0).
     dp_devices = resolve_dp_topology(cfg.training.devices)
     dp_world_size = len(dp_devices) if dp_devices is not None else 1
+    dp_rank = current_dp_rank()
     host_cpu_count = os.cpu_count() or 1
     explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
     if explicit_cpu_ids is not None:
         explicit_cpu_ids = cast(list, OmegaConf.to_container(explicit_cpu_ids, resolve=True))
     collector_cpu_ids = resolve_collector_cpu_ids(
         dp_world_size,
-        current_dp_rank(),
+        dp_rank,
         host_cpu_count,
         explicit=explicit_cpu_ids,
     )
+
+    # Cold-path DP parameter sync: ranks average actor+critic parameters at
+    # the update boundary. world_size == 1 keeps dp_sync=None (bit-identical
+    # single-rank path, no process group is created).
+    dp_sync_interval = int(getattr(cfg.training, "dp_sync_interval", 8))
+    if dp_sync_interval < 1:
+        raise ValueError(f"training.dp_sync_interval must be >= 1, got {dp_sync_interval}")
+    dp_sync = None
+    if dp_world_size > 1:
+        if dp_rank == 0 and log_dir is None:
+            raise ValueError(
+                "build_runner requires log_dir for multi-GPU data-parallel rank 0 "
+                "(it anchors the DP rendezvous FileStore)"
+            )
+        from unilab.ipc.dp_sync import DpParameterSync
+
+        dp_sync = DpParameterSync(
+            world_size=dp_world_size,
+            rank=dp_rank,
+            rendezvous_path=resolve_dp_rendezvous_path(cast(str, log_dir), rank=dp_rank),
+        )
 
     torch_thread_runtime = resolve_torch_thread_runtime(
         getattr(cfg.training, "torch_threads", None),
@@ -345,6 +368,8 @@ def build_runner(algo_name: str, cfg: DictConfig):
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "td3":
@@ -410,6 +435,8 @@ def build_runner(algo_name: str, cfg: DictConfig):
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "flashsac":
@@ -749,7 +776,7 @@ def main(cfg: DictConfig) -> None:
             if not cfg.training.play_only:
                 runner = None
                 try:
-                    runner = build_runner(algo_name, cfg)
+                    runner = build_runner(algo_name, cfg, log_dir=log_dir)
                     runner.learn(
                         max_iterations=cfg.algo.max_iterations,
                         save_interval=cfg.algo.save_interval,

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -209,6 +209,7 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             world_size=dp_world_size,
             rank=dp_rank,
             rendezvous_path=resolve_dp_rendezvous_path(cast(str, log_dir), rank=dp_rank),
+            device=cfg.training.device,
         )
 
     torch_thread_runtime = resolve_torch_thread_runtime(

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -1497,6 +1497,28 @@ class FastSACLearner:
                     for tgt, src in zip(target_params, source_params):
                         tgt.mul_(1.0 - self.tau).add_(src, alpha=self.tau)
 
+    def dp_sync_tensors(self) -> Dict[str, torch.Tensor]:
+        """Tensors synchronized across data-parallel ranks, as live references.
+
+        The values alias the parameter/buffer storage of ``actor``, ``qnet``
+        and ``qnet_target`` (plus the ``log_alpha`` leaf) rather than copies,
+        so the DP collectives (``unilab.ipc.dp_sync.DpParameterSync``) update
+        the model in place — required because CUDA-graph capture pins
+        parameter addresses. Optimizer state (AdamW moments) is deliberately
+        excluded: sync is parameter-level, each rank keeps its own optimizer
+        state, and the moments diverge across ranks by design.
+        """
+        tensors: Dict[str, torch.Tensor] = {}
+        for prefix, module in (
+            ("actor", self.actor),
+            ("qnet", self.qnet),
+            ("qnet_target", self.qnet_target),
+        ):
+            for key, value in module.state_dict().items():
+                tensors[f"{prefix}.{key}"] = value
+        tensors["log_alpha"] = self.log_alpha
+        return tensors
+
     def get_state_dict(self) -> Dict[str, Any]:
         """Save all components."""
         return {

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -10,8 +10,12 @@ import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import torch
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
 
 from unilab.algos.torch.offpolicy.runner import (
     OffPolicyRunner,
@@ -116,6 +120,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         *,
         replay_prefetch_mode: str = "one_tick",
         collector_cpu_ids: list[int] | None = None,
+        dp_sync: DpParameterSync | None = None,
+        dp_sync_interval: int = 8,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -128,6 +134,14 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
         # merged into the collector-only env override at collector startup.
         self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
+        # Multi-GPU data-parallel parameter sync (None = single-rank default,
+        # bit-identical to the pre-DP behavior). Sync happens only at learner
+        # update boundaries — init broadcast before the collector starts, then
+        # an in-place all-reduce mean every dp_sync_interval iterations.
+        self.dp_sync = dp_sync
+        self.dp_sync_interval = int(dp_sync_interval)
+        if self.dp_sync is not None and self.dp_sync_interval < 1:
+            raise ValueError(f"dp_sync_interval must be >= 1, got {dp_sync_interval}")
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -139,6 +153,46 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_torch_inference": False,
             "learner_actor_reused": True,
         }
+        if self.dp_sync is not None:
+            self.runtime_manifest["dp_sync"] = {
+                "world_size": self.dp_sync.world_size,
+                "interval": self.dp_sync_interval,
+                "backend": self.dp_sync.backend,
+            }
+
+    def _dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Live parameter references handed to the DP collectives."""
+        dp_sync_tensors = getattr(self.learner, "dp_sync_tensors", None)
+        if not callable(dp_sync_tensors):
+            raise TypeError(
+                f"{type(self.learner).__name__} must implement dp_sync_tensors() "
+                "for multi-GPU data-parallel parameter sync"
+            )
+        return cast(dict[str, torch.Tensor], dp_sync_tensors())
+
+    def _dp_init_broadcast(self) -> None:
+        """Align initial parameters from rank 0 before the collector starts.
+
+        Ranks train with per-rank seeds, so without this broadcast each
+        rank's actor would serve different inference from the first tick.
+        """
+        if self.dp_sync is None:
+            return
+        self.dp_sync.start()
+        self.dp_sync.broadcast_from_rank0(self._dp_sync_tensors())
+
+    def _maybe_dp_sync(self, iteration: int, iter_metrics: defaultdict[str, list]) -> None:
+        """All-reduce parameter means at the configured update boundary."""
+        if self.dp_sync is None or iteration % self.dp_sync_interval != 0:
+            return
+        sync_start = time.perf_counter()
+        self.dp_sync.allreduce_mean(self._dp_sync_tensors())
+        iter_metrics["dp_sync_time"].append(time.perf_counter() - sync_start)
+
+    def close(self) -> None:
+        if self.dp_sync is not None:
+            self.dp_sync.close()
+        super().close()
 
     def _collector_env_cfg_override(self) -> dict | None:
         """Env override copy for the collector process, with per-rank CPU ids.
@@ -577,6 +631,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
             metrics_queue = _SPAWN_CTX.Queue(maxsize=100)
 
+            # --- DP init broadcast must land before the collector's first ---
+            # --- inference request reaches learner.actor ---
+            self._dp_init_broadcast()
+
             # --- start collector ---
             collector_kwargs = {
                 "env_name": self.env_name,
@@ -908,6 +966,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 train_time = time.perf_counter() - train_start
                 self.learner.update_count += 1
                 inference_scheduler.finish_update()
+                # DP parameter averaging sits at the update boundary: the
+                # update phase is done and the next iteration's inference
+                # tick has not started (strict learner/inference time-share).
+                self._maybe_dp_sync(iteration, iter_metrics)
                 if trace_recorder:
                     trace_recorder.add_counter(
                         "replay_size",

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -2,8 +2,8 @@
 
 Topology rules (config parsing, rank/device mapping, subprocess supervision)
 live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
-This module covers topology only; parameter sync between ranks is out of
-scope for this stage.
+This module covers topology only; the parameter-sync collectives between
+ranks live in ``dp_sync.py``.
 """
 
 from __future__ import annotations
@@ -64,6 +64,27 @@ def current_dp_rank() -> int:
 def current_dp_world_size() -> int:
     """Data-parallel world size of this process (1 when not spawned as a rank)."""
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def resolve_dp_rendezvous_path(log_dir: str, *, rank: int) -> str:
+    """Shared FileStore rendezvous path for the DP parameter-sync group.
+
+    Rank 0 anchors the store in its own run directory; spawned ranks point at
+    the same run root via ``UNILAB_DP_LOG_DIR`` (their own log_dir is a
+    per-rank subdirectory). The run directory is unique per run, which keeps
+    stale FileStore state from a previous run out of the rendezvous.
+
+    Cold path only: call at runner construction.
+    """
+    if int(rank) > 0:
+        root = os.environ.get(UNILAB_DP_LOG_DIR)
+        if root is None:
+            raise ValueError(
+                f"{UNILAB_DP_LOG_DIR} must be set for spawned data-parallel rank {rank}"
+            )
+    else:
+        root = str(log_dir)
+    return os.path.join(root, ".dp_rendezvous")
 
 
 def resolve_collector_cpu_ids(

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -1,0 +1,108 @@
+"""Periodic parameter averaging across data-parallel ranks (torch.distributed).
+
+Multi-GPU data-parallel off-policy training runs one independent
+learner+collector pair per rank (see ``dp_launcher.py``). Ranks start from
+different initial parameters (seed = cfg.algo.seed + rank), so the runner
+broadcasts rank 0's parameters before the collector starts, then averages
+actor/critic parameters every ``dp_sync_interval`` learner iterations at the
+update boundary (never overlapping an inference tick).
+
+This module owns only the process-group lifecycle and the two collectives;
+the runner decides when to call them. Synchronization is parameter-level by
+design: gradients are never exchanged and each rank keeps its own optimizer
+state (AdamW moments diverge across ranks — see
+``FastSACLearner.dp_sync_tensors``).
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import torch
+import torch.distributed as dist
+
+
+class DpParameterSync:
+    """torch.distributed process group for DP parameter broadcast/averaging.
+
+    Both collectives mutate the given tensors **in place**: CUDA-graph capture
+    pins parameter addresses and AMP master weights stay fp32, so after an
+    in-place all-reduce every rank already holds the mean with no write-back.
+
+    The synchronization key order is frozen on the first collective
+    (``sorted(keys)``) so every rank walks the identical sequence without
+    re-sorting per call; a later call with a different key set is a bug and
+    raises ValueError.
+    """
+
+    def __init__(
+        self,
+        *,
+        world_size: int,
+        rank: int,
+        rendezvous_path: str,
+        backend: str = "nccl",
+        timeout_s: int = 120,
+    ) -> None:
+        if int(world_size) < 2:
+            raise ValueError(f"DpParameterSync requires world_size >= 2, got {world_size}")
+        if not (0 <= int(rank) < int(world_size)):
+            raise ValueError(f"rank {rank} is out of range for world_size={world_size}")
+        self.world_size = int(world_size)
+        self.rank = int(rank)
+        self.rendezvous_path = str(rendezvous_path)
+        self.backend = str(backend)
+        self.timeout_s = int(timeout_s)
+        self._key_order: tuple[str, ...] | None = None
+        self._started = False
+
+    def start(self) -> None:
+        """Init the process group over a shared-file rendezvous.
+
+        The rendezvous path must be unique per run (the caller derives it
+        from the per-run log directory), so no stale FileStore state from a
+        previous run can leak in and no pre-clean is needed.
+        """
+        if self._started:
+            return
+        dist.init_process_group(
+            backend=self.backend,
+            init_method=f"file://{self.rendezvous_path}",
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=datetime.timedelta(seconds=self.timeout_s),
+        )
+        self._started = True
+
+    def broadcast_from_rank0(self, tensors: dict[str, torch.Tensor]) -> None:
+        """Overwrite every rank's tensors with rank 0's values, in place."""
+        with torch.no_grad():
+            for key in self._ordered_keys(tensors):
+                dist.broadcast(tensors[key], src=0)
+
+    def allreduce_mean(self, tensors: dict[str, torch.Tensor]) -> None:
+        """Replace every tensor with the cross-rank mean, in place."""
+        with torch.no_grad():
+            for key in self._ordered_keys(tensors):
+                tensor = tensors[key]
+                dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+                tensor.div_(self.world_size)
+
+    def close(self) -> None:
+        """Destroy the process group; idempotent and safe before start()."""
+        if not self._started:
+            return
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+        self._started = False
+
+    def _ordered_keys(self, tensors: dict[str, torch.Tensor]) -> tuple[str, ...]:
+        if self._key_order is None:
+            self._key_order = tuple(sorted(tensors))
+            return self._key_order
+        if set(tensors) != set(self._key_order):
+            raise ValueError(
+                "DpParameterSync tensor keys changed between collectives: "
+                f"expected {sorted(self._key_order)}, got {sorted(tensors)}"
+            )
+        return self._key_order

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -83,11 +83,7 @@ class DpParameterSync:
 
             os.environ.setdefault("NCCL_P2P_DISABLE", "1")
             os.environ.setdefault("NCCL_SHM_DISABLE", "1")
-        if (
-            self.backend == "nccl"
-            and self.device is not None
-            and self.device.type == "cuda"
-        ):
+        if self.backend == "nccl" and self.device is not None and self.device.type == "cuda":
             torch.cuda.set_device(self.device)
         dist.init_process_group(
             backend=self.backend,

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -42,6 +42,7 @@ class DpParameterSync:
         rank: int,
         rendezvous_path: str,
         backend: str = "nccl",
+        device: str | None = None,
         timeout_s: int = 120,
     ) -> None:
         if int(world_size) < 2:
@@ -52,6 +53,7 @@ class DpParameterSync:
         self.rank = int(rank)
         self.rendezvous_path = str(rendezvous_path)
         self.backend = str(backend)
+        self.device = None if device is None else torch.device(device)
         self.timeout_s = int(timeout_s)
         self._key_order: tuple[str, ...] | None = None
         self._started = False
@@ -62,9 +64,31 @@ class DpParameterSync:
         The rendezvous path must be unique per run (the caller derives it
         from the per-run log directory), so no stale FileStore state from a
         previous run can leak in and no pre-clean is needed.
+
+        For NCCL the current CUDA device is pinned to this rank's device
+        first: ProcessGroupNCCL binds communicators to the current device,
+        and without the pin every rank defaults to cuda:0, which hangs the
+        first collective on any rank whose learner lives on another GPU.
+
+        ``NCCL_P2P_DISABLE``/``NCCL_SHM_DISABLE`` default to 1 (env override
+        wins): on hosts with broken NCCL peer transport (e.g. RTX 6000D on
+        current drivers, where P2P hangs and SHM triggers CUDA illegal
+        memory access) the TCP loopback transport is the only reliable
+        path, and it is fast enough for periodic parameter averaging.
         """
         if self._started:
             return
+        if self.backend == "nccl":
+            import os
+
+            os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+            os.environ.setdefault("NCCL_SHM_DISABLE", "1")
+        if (
+            self.backend == "nccl"
+            and self.device is not None
+            and self.device.type == "cuda"
+        ):
+            torch.cuda.set_device(self.device)
         dist.init_process_group(
             backend=self.backend,
             init_method=f"file://{self.rendezvous_path}",

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -13,7 +13,7 @@ from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from hydra.errors import ConfigCompositionException
 
-from unilab.ipc.dp_launcher import UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
+from unilab.ipc.dp_launcher import UNILAB_DP_LOG_DIR, UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
 
 _ROOT = Path(__file__).parent.parent.parent
 _CONF_DIR = _ROOT / "conf"
@@ -267,13 +267,14 @@ def _build_sac_runner_with_fakes(
     monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
     monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
 
-    runner = module.build_runner("sac", cfg)
+    runner = module.build_runner("sac", cfg, log_dir="/tmp/offpolicy_test_run")
     return runner, probe_env_calls
 
 
 def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.MonkeyPatch):
     # Spawned rank: rank comes from the env, world_size from training.devices.
     monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/offpolicy_test_run")
     runner, probe_env_calls = _build_sac_runner_with_fakes(
         monkeypatch,
         ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -1,0 +1,264 @@
+"""Runner/build_runner integration tests for DP parameter sync (CPU-only)."""
+
+from __future__ import annotations
+
+import inspect
+from collections import defaultdict
+
+import pytest
+import torch
+
+from tests.algos.test_offpolicy_double_buffer_runner import (
+    _FakeEnv,
+    _FakeRunner,
+    _offpolicy,
+    _offpolicy_cfg,
+)
+from unilab.ipc.dp_launcher import UNILAB_DP_LOG_DIR, UNILAB_DP_RANK
+from unilab.ipc.dp_sync import DpParameterSync
+
+
+def _bare_runner():
+    from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+
+    return object.__new__(DoubleBufferOffPolicyRunner)
+
+
+class _SyncLearner:
+    def __init__(self) -> None:
+        self.tensors = {
+            "actor.w": torch.ones(2),
+            "qnet.w": torch.full((2,), 2.0),
+        }
+
+    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        return self.tensors
+
+
+class _NoSyncLearner:
+    pass
+
+
+class _FakeDpSync:
+    def __init__(self) -> None:
+        self.world_size = 2
+        self.backend = "gloo"
+        self.calls: list[tuple[str, object]] = []
+
+    def start(self) -> None:
+        self.calls.append(("start", None))
+
+    def broadcast_from_rank0(self, tensors) -> None:
+        self.calls.append(("broadcast_from_rank0", tensors))
+
+    def allreduce_mean(self, tensors) -> None:
+        self.calls.append(("allreduce_mean", tensors))
+
+    def close(self) -> None:
+        self.calls.append(("close", None))
+
+
+def _runner_with(learner, dp_sync, interval: int = 2):
+    runner = _bare_runner()
+    runner.learner = learner
+    runner.dp_sync = dp_sync
+    runner.dp_sync_interval = interval
+    return runner
+
+
+def test_maybe_dp_sync_allreduces_on_interval_boundary():
+    learner = _SyncLearner()
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync, interval=2)
+    metrics = defaultdict(list)
+
+    runner._maybe_dp_sync(1, metrics)
+    assert dp_sync.calls == []
+    assert "dp_sync_time" not in metrics
+
+    runner._maybe_dp_sync(2, metrics)
+    assert [name for name, _ in dp_sync.calls] == ["allreduce_mean"]
+    # The collectives receive the learner's live tensor references.
+    assert dp_sync.calls[0][1] is learner.tensors
+    assert len(metrics["dp_sync_time"]) == 1
+    assert metrics["dp_sync_time"][0] >= 0.0
+
+
+def test_maybe_dp_sync_skips_everything_without_dp_sync():
+    runner = _runner_with(_SyncLearner(), None, interval=1)
+    metrics = defaultdict(list)
+    runner._maybe_dp_sync(4, metrics)
+    assert metrics == {}
+
+
+def test_dp_init_broadcast_starts_group_then_broadcasts():
+    learner = _SyncLearner()
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync)
+    runner._dp_init_broadcast()
+    assert [name for name, _ in dp_sync.calls] == ["start", "broadcast_from_rank0"]
+    assert dp_sync.calls[1][1] is learner.tensors
+
+
+def test_dp_init_broadcast_is_a_noop_without_dp_sync():
+    runner = _runner_with(_SyncLearner(), None)
+    runner._dp_init_broadcast()  # must not touch the learner
+
+
+def test_learner_without_dp_sync_tensors_fails_with_type_error():
+    runner = _runner_with(_NoSyncLearner(), _FakeDpSync())
+    with pytest.raises(TypeError, match="dp_sync_tensors"):
+        runner._dp_init_broadcast()
+
+
+def test_close_closes_dp_sync_idempotently():
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(_SyncLearner(), dp_sync)
+    # Avoid the full AsyncRunner.close(); only the dp_sync branch is under test.
+    runner.dp_sync.close()
+    runner.dp_sync.close()
+    assert [name for name, _ in dp_sync.calls] == ["close", "close"]
+
+
+def test_learn_source_orders_sync_around_collector_and_logging():
+    """Structural contract: init broadcast precedes collector startup, and the
+    periodic all-reduce sits at the update boundary before log_step."""
+    from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+
+    source = inspect.getsource(DoubleBufferOffPolicyRunner.learn)
+    assert source.index("self._dp_init_broadcast()") < source.index("self._start_collector(")
+    assert (
+        source.index("inference_scheduler.finish_update()")
+        < source.index("self._maybe_dp_sync(iteration, iter_metrics)")
+        < source.index("logger.log_step(")
+    )
+
+
+# ---- FastSACLearner.dp_sync_tensors contract ----
+
+
+def test_fast_sac_dp_sync_tensors_returns_live_references():
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+        max_grad_norm=0.0,
+    )
+    tensors = learner.dp_sync_tensors()
+
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("qnet", learner.qnet),
+        ("qnet_target", learner.qnet_target),
+    ):
+        state = module.state_dict()
+        assert state, prefix
+        for key, value in state.items():
+            full_key = f"{prefix}.{key}"
+            assert full_key in tensors
+            # Live references, not copies: same storage as the module state.
+            assert tensors[full_key].data_ptr() == value.data_ptr()
+    assert tensors["log_alpha"] is learner.log_alpha
+
+    # In-place collective semantics propagate into the module parameters.
+    probe_key = next(key for key in tensors if key.startswith("actor."))
+    with torch.no_grad():
+        tensors[probe_key].mul_(0.0)
+    assert torch.all(tensors[probe_key] == 0.0)
+
+
+# ---- build_runner assembly ----
+
+
+def _build_sac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: list[str]):
+    """build_runner("sac", ...) with learner/env/runner fakes; returns runner kwargs."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
+
+    import unilab.algos.torch.fast_sac.learner as learner_module
+    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+
+    class _Learner:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    monkeypatch.setattr(learner_module, "FastSACLearner", _Learner)
+    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    runner = module.build_runner("sac", cfg, log_dir="/tmp/dp_sync_test_run")
+    return runner.kwargs
+
+
+def test_offpolicy_config_dp_sync_interval_defaults_to_eight():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.dp_sync_interval == 8
+
+
+def test_build_runner_rejects_invalid_dp_sync_interval():
+    cfg = _offpolicy_cfg(["algo=sac", "training.dp_sync_interval=0"])
+    with pytest.raises(ValueError, match="dp_sync_interval"):
+        _offpolicy().build_runner("sac", cfg)
+
+
+def test_build_runner_single_rank_keeps_dp_sync_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    kwargs = _build_sac_runner_with_dp_fakes(monkeypatch, ["algo=sac", "algo.use_symmetry=false"])
+    assert kwargs["dp_sync"] is None
+    assert kwargs["dp_sync_interval"] == 8
+
+
+def test_build_runner_multi_gpu_constructs_dp_sync_for_rank0(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    kwargs = _build_sac_runner_with_dp_fakes(
+        monkeypatch,
+        [
+            "algo=sac",
+            "algo.use_symmetry=false",
+            "training.devices=[0,1]",
+            "training.dp_sync_interval=4",
+        ],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.world_size == 2
+    assert dp_sync.rank == 0
+    assert dp_sync.backend == "nccl"
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
+    assert kwargs["dp_sync_interval"] == 4
+
+
+def test_build_runner_spawned_rank_uses_shared_run_root(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/dp_sync_shared_root")
+    kwargs = _build_sac_runner_with_dp_fakes(
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.rank == 1
+    # Spawned ranks rendezvous on rank 0's run root, not their rank sub-dir.
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_shared_root/.dp_rendezvous"
+
+
+def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.MonkeyPatch):
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"])
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    with pytest.raises(ValueError, match="log_dir"):
+        module.build_runner("sac", cfg)

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -193,6 +193,7 @@ def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
         rank=rank,
         rendezvous_path=rendezvous_path,
         backend="nccl",
+        device=str(device),
         timeout_s=120,
     )
     sync.start()

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -1,0 +1,205 @@
+"""Two-process gloo tests for DpParameterSync (CPU-only)."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+import torch
+
+from unilab.ipc.dp_launcher import resolve_dp_rendezvous_path
+from unilab.ipc.dp_sync import DpParameterSync
+
+_SPAWN_CTX = mp.get_context("spawn")
+
+
+def _make_tensors(rank: int, *, reversed_order: bool = False) -> dict[str, torch.Tensor]:
+    """Deterministic per-rank tensors; distinct values and shapes per key."""
+    entries = [
+        ("actor.net.weight", torch.full((4, 3), 1.0 + rank)),
+        ("qnet.head.bias", torch.full((2,), 10.0 + rank)),
+        ("log_alpha", torch.full((1,), -0.5 + rank, requires_grad=True)),
+    ]
+    if reversed_order:
+        entries.reverse()
+    return dict(entries)
+
+
+def _broadcast_and_allreduce_worker(
+    rank: int, rendezvous_path: str, reversed_order: bool, result_queue
+) -> None:
+    tensors = _make_tensors(rank, reversed_order=reversed_order)
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="gloo",
+        timeout_s=60,
+    )
+    sync.start()
+
+    # Init broadcast: every rank ends up with rank 0's values, bit-exact.
+    sync.broadcast_from_rank0(tensors)
+    expected = _make_tensors(0)
+    for key, tensor in tensors.items():
+        assert torch.equal(tensor.detach(), expected[key].detach()), (
+            f"rank {rank} broadcast mismatch on {key}"
+        )
+
+    # In-place semantics: allreduce_mean must not rebind the storage.
+    ptrs_before = {key: tensor.data_ptr() for key, tensor in tensors.items()}
+
+    # Per-rank perturbation -> allreduce_mean lands on the cross-rank mean.
+    for key, tensor in tensors.items():
+        with torch.no_grad():
+            tensor.add_(float(rank + 1))
+    sync.allreduce_mean(tensors)
+    for key, tensor in tensors.items():
+        base = expected[key].detach()
+        assert torch.allclose(tensor.detach(), base + 1.5), (
+            f"rank {rank} allreduce mismatch on {key}"
+        )
+        assert tensor.data_ptr() == ptrs_before[key], f"{key} was not updated in place"
+
+    sync.close()
+    sync.close()  # idempotent
+    result_queue.put((rank, sorted(tensors)))
+
+
+def test_broadcast_then_allreduce_mean_two_ranks(tmp_path: Path):
+    rendezvous = str(tmp_path / "rendezvous")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(
+            target=_broadcast_and_allreduce_worker,
+            args=(rank, rendezvous, False, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+    results = sorted(result_queue.get(timeout=10) for _ in procs)
+    for proc in procs:
+        assert proc.exitcode == 0
+    # Both ranks walked the same (sorted) key order.
+    assert results[0][1] == results[1][1]
+
+
+def _key_order_worker(rank: int, rendezvous_path: str, result_queue) -> None:
+    # Insertion order differs per rank; the collective order must not.
+    tensors = _make_tensors(rank, reversed_order=bool(rank))
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="gloo",
+        timeout_s=60,
+    )
+    sync.start()
+    sync.allreduce_mean(tensors)
+    for key, tensor in tensors.items():
+        mean = (_make_tensors(0)[key].detach() + _make_tensors(1)[key].detach()) / 2
+        assert torch.allclose(tensor.detach(), mean), f"rank {rank} key-order mismatch on {key}"
+    sync.close()
+    result_queue.put(rank)
+
+
+def test_collective_key_order_is_insertion_order_independent(tmp_path: Path):
+    rendezvous = str(tmp_path / "rendezvous_key_order")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(target=_key_order_worker, args=(rank, rendezvous, result_queue))
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+    for proc in procs:
+        assert proc.exitcode == 0
+
+
+def test_key_set_change_between_collectives_is_rejected(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused"),
+        backend="gloo",
+    )
+    first = {"a": torch.zeros(1), "b": torch.zeros(1)}
+    sync._ordered_keys(first)
+    with pytest.raises(ValueError, match="tensor keys changed"):
+        sync._ordered_keys({"a": torch.zeros(1), "c": torch.zeros(1)})
+
+
+def test_close_without_start_is_idempotent(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused"),
+        backend="gloo",
+    )
+    sync.close()
+    sync.close()
+
+
+def test_invalid_world_size_and_rank_are_rejected(tmp_path: Path):
+    path = str(tmp_path / "unused")
+    with pytest.raises(ValueError, match="world_size >= 2"):
+        DpParameterSync(world_size=1, rank=0, rendezvous_path=path)
+    with pytest.raises(ValueError, match="out of range"):
+        DpParameterSync(world_size=2, rank=2, rendezvous_path=path)
+
+
+def test_resolve_dp_rendezvous_path_anchors_on_run_root(tmp_path: Path, monkeypatch):
+    # Rank 0 anchors in its own log_dir; spawned ranks use the shared run root.
+    monkeypatch.delenv("UNILAB_DP_LOG_DIR", raising=False)
+    rank0 = resolve_dp_rendezvous_path(str(tmp_path / "run"), rank=0)
+    assert rank0 == str(tmp_path / "run" / ".dp_rendezvous")
+    monkeypatch.setenv("UNILAB_DP_LOG_DIR", str(tmp_path / "run"))
+    rank1 = resolve_dp_rendezvous_path(str(tmp_path / "run" / "rank1"), rank=1)
+    assert rank1 == rank0
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 CUDA devices")
+def test_nccl_two_gpu_smoke(tmp_path: Path):
+    """Real NCCL smoke: init + broadcast + allreduce across cuda:0/cuda:1."""
+    rendezvous = str(tmp_path / "rendezvous_nccl")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(
+            target=_nccl_smoke_worker,
+            args=(rank, rendezvous, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=180)
+    for proc in procs:
+        assert proc.exitcode == 0
+
+
+def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
+    device = torch.device(f"cuda:{rank}")
+    tensor = torch.full((8,), float(rank + 1), device=device)
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="nccl",
+        timeout_s=120,
+    )
+    sync.start()
+    tensors = {"w": tensor}
+    sync.broadcast_from_rank0(tensors)
+    assert torch.equal(tensor, torch.ones(8, device=device))
+    sync.allreduce_mean(tensors)
+    assert torch.allclose(tensor, torch.full((8,), 0.5 + 0.5, device=device))
+    sync.close()
+    result_queue.put(rank)

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1464,7 +1464,7 @@ def test_offpolicy_main_failure_summary_and_skips_playback(
         mod, "assert_offpolicy_task_choice_matches_algo", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(mod, "ExperimentTracker", FakeTracker)
-    monkeypatch.setattr(mod, "build_runner", lambda algo_name, cfg: FakeRunner())
+    monkeypatch.setattr(mod, "build_runner", lambda algo_name, cfg, log_dir=None: FakeRunner())
     monkeypatch.setattr(
         mod,
         "play_offpolicy",


### PR DESCRIPTION
Closes #967. Parent roadmap: #964.

## 内容

- 新模块 `src/unilab/ipc/dp_sync.py`：`DpParameterSync`（FileStore rendezvous + NCCL），`broadcast_from_rank0` / `allreduce_mean` 均为原地集合通信（key 序首次固定，变更即报错）；`close()` 幂等。
- `FastSACLearner.dp_sync_tensors()`：actor/qnet/qnet_target state_dict 活引用 + log_alpha；optimizer state 不同步（moments 发散为设计，docstring 写明）。
- runner：init broadcast 在 collector 启动前；周期同步挂在 update 边界（`update_count+=1` + `finish_update()` 后、`log_step` 前），`iteration % dp_sync_interval == 0` 时 all-reduce，`dp_sync_time` 进 metrics；`close()` 级联；manifest 记录 dp_sync 配置。
- 配置：`training.dp_sync_interval`（默认 8，<1 报错）；world_size=1 不建 process group，行为逐位等价。

## 验收中修复的两个 NCCL 缺陷（918885ce）

1. rank>0 的 current CUDA device 默认 cuda:0 而 learner 在 cuda:1，首个集合通信挂死 120s 超时——`start()` 按 rank 设备 `torch.cuda.set_device`。
2. 本机（2× RTX 6000D）NCCL 的 P2P 传输挂死、SHM 传输在多张量 all_reduce 触发 CUDA illegal memory access（repo-free 最小复现证实）——`NCCL_P2P_DISABLE`/`NCCL_SHM_DISABLE` 默认置 1（env 可覆盖），走 TCP loopback。

## Validation

- `make test-all` 通过（exit=0；最终提交另含一处 ruff 格式化）。
- 单测：gloo 双进程正确性（broadcast 一致/均值/原地 data_ptr 不变/乱序 dict 一致/幂等 close）、runner 集成（边界调用时序、指标注入、TypeError fail-fast）、NCCL 双卡冒烟（修复后 3s 通过）。
- 真实 2 卡验收（K=1, 30 iterations）：rank0/rank1 checkpoint **77 个同步张量逐位一致**；`train/dp_sync_time` 30 点均值 ~1.8ms/次；exit=0 无进程泄漏。
