### PR TITLE
perf(offpolicy): 多卡数据并行 scaling benchmark 与验收

### DIFF
--- a/benchmark/rl/benchmark_offpolicy_dp_scaling.py
+++ b/benchmark/rl/benchmark_offpolicy_dp_scaling.py
@@ -1,0 +1,473 @@
+"""Off-policy multi-GPU data-parallel scaling benchmark (issue #968).
+
+Runs real ``scripts/train_offpolicy.py`` training via subprocess (same Hydra
+overrides as the production CLI entry, never importing training internals) and
+compares single-device N=1 (no ``training.devices``) against N-way data
+parallel (``training.devices=[d0..dN-1]``, default ``[0,1]``). Every config
+keeps the owner YAML production defaults (sac / g1_walk_flat / mujoco) except
+``algo.max_iterations``, ``training.no_play=true`` and ``training.log_dir``
+pointing into this benchmark's own work directory. Runs execute sequentially
+to avoid resource contention.
+
+Measurement conventions:
+
+- Steady-state throughput: mean of the last 50% of ``perf/steps_per_sec``
+  tfevents samples (ceil(n/2) tail points; with n samples the tail is
+  ``n - n//2``). This skips collector warm-up and replay prefill.
+- N-way aggregate throughput: sum of per-rank steady-state steps/s. Rank 0
+  artifacts live in the run directory itself (``run_summary.json`` +
+  tfevents); rank i>0 tfevents live in the ``rank{i}/`` subdirectory. A rank
+  missing its tfevents is a hard error, never silently skipped.
+- Scaling ratio: N-way aggregate / N=1 steady-state steps/s. The verdict is
+  ``pass`` when ratio >= 1.7 (``SCALING_PASS_THRESHOLD``), otherwise
+  ``below threshold``. The verdict is data only: it does not affect the
+  exit code.
+- Exit code is non-zero only when a run itself failed (subprocess error,
+  non-completed summary, or missing artifacts).
+
+Run:
+    uv run benchmark/rl/benchmark_offpolicy_dp_scaling.py
+
+    # tuning / passthrough overrides:
+    uv run benchmark/rl/benchmark_offpolicy_dp_scaling.py \
+        --iterations 300 --sync-interval 8 --devices 0,1 \
+        --extra-overrides algo.num_envs=2048 \
+        --out-json benchmark/outputs/offpolicy_dp_scaling/results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from benchmark.core.device_info import get_device_info_dict, get_device_info_line
+from benchmark.core.output import print_table, save_json
+
+DEFAULT_OUTPUT_JSON = ROOT_DIR / "benchmark" / "outputs" / "offpolicy_dp_scaling" / "results.json"
+DEFAULT_RUNS_ROOT = ROOT_DIR / "benchmark" / "outputs" / "offpolicy_dp_scaling" / "runs"
+
+TRAIN_SCRIPT = ROOT_DIR / "scripts" / "train_offpolicy.py"
+
+# Route overrides equivalent to `uv run train --algo sac --task g1_walk_flat
+# --sim mujoco` (see src/unilab/cli.py build_route for off-policy algos).
+ROUTE_OVERRIDES = ("algo=sac", "task=sac/g1_walk_flat/mujoco")
+
+STEPS_PER_SEC_TAG = "perf/steps_per_sec"
+REWARD_TAG = "reward/mean"
+DP_SYNC_TIME_TAG = "train/dp_sync_time"
+
+DEFAULT_ITERATIONS = 300
+DEFAULT_SYNC_INTERVAL = 8
+DEFAULT_DEVICES = "0,1"
+
+# Roadmap #964 acceptance target for 2-way data-parallel aggregate throughput.
+SCALING_PASS_THRESHOLD = 1.7
+
+STEADY_STATE_TAIL_FRACTION = 0.5
+
+
+class RunParseError(RuntimeError):
+    """A finished run directory is missing required artifacts or is invalid."""
+
+
+# =====================================================================
+# Pure helpers (unit-tested in tests/benchmark/)
+# =====================================================================
+
+
+def steady_state_mean(
+    values: Sequence[float], tail_fraction: float = STEADY_STATE_TAIL_FRACTION
+) -> float:
+    """Mean of the last ``tail_fraction`` of samples (ceil tail size, min 1)."""
+    if not values:
+        raise ValueError("steady_state_mean requires at least one sample")
+    if not 0 < tail_fraction <= 1:
+        raise ValueError(f"tail_fraction must be in (0, 1], got {tail_fraction}")
+    n = len(values)
+    tail = max(1, n - int(n * (1 - tail_fraction)))
+    window = [float(v) for v in values[n - tail :]]
+    return sum(window) / len(window)
+
+
+def verdict_for_ratio(ratio: float | None, threshold: float = SCALING_PASS_THRESHOLD) -> str | None:
+    """Map a scaling ratio to its verdict string; None stays None (baseline)."""
+    if ratio is None:
+        return None
+    return "pass" if ratio >= threshold else "below threshold"
+
+
+def find_event_files(rank_dir: Path) -> list[Path]:
+    """All tfevents files directly under one rank's log directory."""
+    rank_dir = Path(rank_dir)
+    if not rank_dir.is_dir():
+        raise RunParseError(f"rank log directory does not exist: {rank_dir}")
+    return sorted(rank_dir.glob("events.out.tfevents.*"))
+
+
+def read_scalar_series(rank_dir: Path, tag: str) -> list[float]:
+    """Scalar values of ``tag`` from a rank's tfevents (in event order).
+
+    An absent tag yields ``[]``; a rank directory without any tfevents file
+    raises ``RunParseError`` so missing rank data is never silent.
+    """
+    event_files = find_event_files(rank_dir)
+    if not event_files:
+        raise RunParseError(f"no tfevents file found under {rank_dir}")
+    if len(event_files) > 1:
+        raise RunParseError(
+            f"expected exactly one tfevents file under {rank_dir}, got {len(event_files)}"
+        )
+    from tensorboard.backend.event_processing import event_accumulator
+
+    accumulator = event_accumulator.EventAccumulator(str(event_files[0]))
+    accumulator.Reload()
+    if tag not in accumulator.Tags()["scalars"]:
+        return []
+    return [float(event.value) for event in accumulator.Scalars(tag)]
+
+
+def rank_dir_for(run_dir: Path, rank: int) -> Path:
+    """Rank i>0 logs into the ``rank{i}`` subdirectory of rank 0's run dir."""
+    run_dir = Path(run_dir)
+    return run_dir if rank == 0 else run_dir / f"rank{rank}"
+
+
+def parse_run(run_dir: Path, world_size: int) -> dict[str, Any]:
+    """Parse one finished run directory into a metrics record.
+
+    Rank 0 must carry a ``run_summary.json`` with ``status == "completed"``
+    and a tfevents file; ranks 1..N-1 must each carry their own tfevents.
+    """
+    run_dir = Path(run_dir)
+    if world_size < 1:
+        raise ValueError(f"world_size must be >= 1, got {world_size}")
+
+    summary_path = run_dir / "run_summary.json"
+    if not summary_path.is_file():
+        raise RunParseError(f"missing run summary: {summary_path}")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    status = summary.get("status")
+    if status != "completed":
+        raise RunParseError(
+            f"run {run_dir} did not complete: status={status!r} error={summary.get('error')!r}"
+        )
+
+    ranks: list[dict[str, Any]] = []
+    dp_sync_samples: list[float] = []
+    for rank in range(world_size):
+        rank_dir = rank_dir_for(run_dir, rank)
+        series = read_scalar_series(rank_dir, STEPS_PER_SEC_TAG)
+        if not series:
+            raise RunParseError(
+                f"rank {rank} has no {STEPS_PER_SEC_TAG!r} samples under {rank_dir}"
+            )
+        ranks.append(
+            {
+                "rank": rank,
+                "log_dir": str(rank_dir),
+                "num_throughput_samples": len(series),
+                "steady_state_env_steps_per_s": steady_state_mean(series),
+            }
+        )
+        dp_sync_samples.extend(read_scalar_series(rank_dir, DP_SYNC_TIME_TAG))
+
+    reward_series = read_scalar_series(run_dir, REWARD_TAG)
+    aggregate = sum(r["steady_state_env_steps_per_s"] for r in ranks)
+    return {
+        "run_dir": str(run_dir),
+        "world_size": world_size,
+        "completed_iterations": summary.get("completed_iterations"),
+        "total_env_steps": summary.get("total_env_steps"),
+        "training_wall_time_sec": summary.get("training_wall_time_sec"),
+        "ranks": ranks,
+        "aggregate_env_steps_per_s": aggregate,
+        "final_mean_reward": reward_series[-1] if reward_series else None,
+        "mean_dp_sync_time_sec": (
+            sum(dp_sync_samples) / len(dp_sync_samples) if dp_sync_samples else None
+        ),
+    }
+
+
+def build_train_command(
+    run_dir: Path,
+    *,
+    iterations: int,
+    devices: Sequence[int] | None = None,
+    sync_interval: int = DEFAULT_SYNC_INTERVAL,
+    extra_overrides: Sequence[str] = (),
+) -> list[str]:
+    """Subprocess argv matching the production off-policy CLI overrides.
+
+    ``devices=None`` is the N=1 baseline and intentionally carries no
+    ``training.devices`` override at all.
+    """
+    command = [
+        sys.executable,
+        str(TRAIN_SCRIPT),
+        *ROUTE_OVERRIDES,
+        "training.no_play=true",
+        f"algo.max_iterations={iterations}",
+        f"training.log_dir={Path(run_dir)}",
+    ]
+    if devices is not None:
+        command.append(f"training.devices=[{','.join(str(d) for d in devices)}]")
+        command.append(f"training.dp_sync_interval={sync_interval}")
+    command.extend(extra_overrides)
+    return command
+
+
+def attach_scaling(
+    records: list[dict[str, Any]], threshold: float = SCALING_PASS_THRESHOLD
+) -> list[dict[str, Any]]:
+    """Fill ``scaling_vs_n1``/``verdict`` on DP configs against the N=1 record."""
+    baseline = next(
+        (
+            r
+            for r in records
+            if r["config"] == "n1" and r["status"] == "ok" and r["metrics"] is not None
+        ),
+        None,
+    )
+    baseline_throughput = (
+        float(baseline["metrics"]["aggregate_env_steps_per_s"]) if baseline else None
+    )
+    for record in records:
+        record["scaling_vs_n1"] = None
+        record["verdict"] = None
+        if record["config"] == "n1" or record["status"] != "ok" or record["metrics"] is None:
+            continue
+        if baseline_throughput:
+            ratio = float(record["metrics"]["aggregate_env_steps_per_s"]) / baseline_throughput
+            record["scaling_vs_n1"] = ratio
+            record["verdict"] = verdict_for_ratio(ratio, threshold)
+    return records
+
+
+def git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(ROOT_DIR), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except Exception:
+        return "unknown"
+
+
+def _parse_int_list(text: str, name: str) -> list[int]:
+    values = [int(v) for v in text.split(",") if v.strip()]
+    if not values:
+        raise ValueError(f"{name} must not be empty")
+    return values
+
+
+# =====================================================================
+# Subprocess execution
+# =====================================================================
+
+
+def execute_run(command: list[str], run_dir: Path) -> None:
+    """Run one training config to completion; raise on subprocess failure."""
+    run_dir = Path(run_dir)
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True)
+    completed = subprocess.run(command, cwd=ROOT_DIR)  # noqa: S603 - fixed argv, no shell
+    if completed.returncode != 0:
+        raise RunParseError(
+            f"training subprocess exited with code {completed.returncode}: {' '.join(command)}"
+        )
+
+
+def run_config(
+    name: str,
+    devices: Sequence[int] | None,
+    *,
+    iterations: int,
+    sync_interval: int,
+    extra_overrides: Sequence[str],
+    runs_root: Path,
+) -> dict[str, Any]:
+    """Execute and parse one benchmark config; failures are recorded, not raised."""
+    world_size = len(devices) if devices is not None else 1
+    run_dir = runs_root / name
+    record: dict[str, Any] = {
+        "config": name,
+        "world_size": world_size,
+        "devices": list(devices) if devices is not None else None,
+        "status": "ok",
+        "error": None,
+        "metrics": None,
+        "scaling_vs_n1": None,
+        "verdict": None,
+    }
+    try:
+        command = build_train_command(
+            run_dir,
+            iterations=iterations,
+            devices=devices,
+            sync_interval=sync_interval,
+            extra_overrides=extra_overrides,
+        )
+        print(f"[{name}] launching: {' '.join(command)}", flush=True)
+        execute_run(command, run_dir)
+        record["metrics"] = parse_run(run_dir, world_size)
+    except (RunParseError, ValueError) as exc:
+        record["status"] = "failed"
+        record["error"] = str(exc)
+    print(
+        f"[{name}] {record['status']}"
+        + (
+            f"  aggregate={record['metrics']['aggregate_env_steps_per_s']:,.0f} env-steps/s"
+            if record["metrics"]
+            else f"  error={record['error']}"
+        ),
+        flush=True,
+    )
+    return record
+
+
+# =====================================================================
+# CLI
+# =====================================================================
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Off-policy multi-GPU data-parallel scaling benchmark (issue #968)."
+    )
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--sync-interval", type=int, default=DEFAULT_SYNC_INTERVAL)
+    parser.add_argument(
+        "--devices",
+        default=DEFAULT_DEVICES,
+        help="comma-separated CUDA indices for the data-parallel config "
+        "(length 1 skips the DP config)",
+    )
+    parser.add_argument(
+        "--extra-overrides",
+        nargs="*",
+        default=(),
+        help="extra Hydra overrides appended verbatim to every config "
+        "(e.g. algo.num_envs=2048); owner YAML defaults are used otherwise",
+    )
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    parser.add_argument(
+        "--keep-runs",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="keep per-config training run directories under the output root",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    devices = _parse_int_list(args.devices, "--devices")
+
+    print(f"Device: {get_device_info_line()}")
+    print(f"commit: {git_commit()}")
+
+    configs: list[tuple[str, list[int] | None]] = [("n1", None)]
+    if len(devices) > 1:
+        configs.append((f"n{len(devices)}", devices))
+    else:
+        print(
+            f"--devices={args.devices!r} has length {len(devices)}; "
+            "skipping the data-parallel config (need >= 2 devices)."
+        )
+
+    records = [
+        run_config(
+            name,
+            config_devices,
+            iterations=args.iterations,
+            sync_interval=args.sync_interval,
+            extra_overrides=tuple(args.extra_overrides),
+            runs_root=DEFAULT_RUNS_ROOT,
+        )
+        for name, config_devices in configs
+    ]
+    attach_scaling(records)
+
+    if not args.keep_runs:
+        shutil.rmtree(DEFAULT_RUNS_ROOT, ignore_errors=True)
+
+    print()
+    print_table(
+        [
+            {
+                "config": r["config"],
+                "devices": ",".join(str(d) for d in r["devices"]) if r["devices"] else "-",
+                "aggregate env-steps/s": (
+                    f"{r['metrics']['aggregate_env_steps_per_s']:,.0f}" if r["metrics"] else "-"
+                ),
+                "final reward": (
+                    f"{r['metrics']['final_mean_reward']:.2f}"
+                    if r["metrics"] and r["metrics"]["final_mean_reward"] is not None
+                    else "-"
+                ),
+                "dp_sync mean (s)": (
+                    f"{r['metrics']['mean_dp_sync_time_sec']:.4f}"
+                    if r["metrics"] and r["metrics"]["mean_dp_sync_time_sec"] is not None
+                    else "-"
+                ),
+                "scaling vs n1": (
+                    f"{r['scaling_vs_n1']:.2f}x" if r["scaling_vs_n1"] is not None else "-"
+                ),
+                "verdict": r["verdict"] or "-",
+                "status": r["status"],
+            }
+            for r in records
+        ],
+        [
+            "config",
+            "devices",
+            "aggregate env-steps/s",
+            "final reward",
+            "dp_sync mean (s)",
+            "scaling vs n1",
+            "verdict",
+            "status",
+        ],
+    )
+
+    save_json(
+        args.out_json,
+        records,
+        {
+            "benchmark": "offpolicy_dp_scaling",
+            "issue": 968,
+            "commit": git_commit(),
+            "device": get_device_info_dict(),
+            "params": {
+                "route_overrides": list(ROUTE_OVERRIDES),
+                "iterations": args.iterations,
+                "sync_interval": args.sync_interval,
+                "devices": devices,
+                "extra_overrides": list(args.extra_overrides),
+                "scaling_pass_threshold": SCALING_PASS_THRESHOLD,
+                "steady_state_tail_fraction": STEADY_STATE_TAIL_FRACTION,
+                "throughput_tag": STEPS_PER_SEC_TAG,
+            },
+        },
+    )
+    failures = [r["config"] for r in records if r["status"] != "ok"]
+    if failures:
+        print(f"failed configs: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -41,3 +41,34 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
   algo.max_iterations=1000 \
   training.no_play=true
 ```
+
+## 多卡数据并行
+
+`training.devices` 打开单节点多卡数据并行（data parallel）：rank i 在
+`cuda:devices[i]` 上各跑一套独立的 learner+collector，rank 0 负责 spawn 其余
+rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参数，之后每
+`training.dp_sync_interval`（默认 8）个 learner iteration 对 actor+critic 参数做
+一次 all-reduce 平均；梯度不交换，各 rank 保留自己的 optimizer 状态。
+
+```bash
+uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.devices=[0,1] \
+  training.dp_sync_interval=8
+```
+
+每个 rank 的日志落在同一 run 目录下：rank 0 直接在 run 目录（含
+`run_summary.json` 与 tfevents），rank i>0 在 `rank{i}/` 子目录（仅 tfevents）。
+collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段），可用
+`training.dp_collector_cpu_ids` 显式指定。
+
+当前限制：
+
+- 仅 SAC：TD3 / FlashSAC 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
+- 仅验证过 `mujoco` backend；`training.devices` 与 `training.device` 互斥。
+- 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
+  loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置
+  时优先）——部分机型（如 RTX 6000D）的 NCCL P2P/SHM peer transport 不可靠，
+  TCP loopback 是唯一稳定传输。
+
+2 卡聚合吞吐相对单卡的 scaling 验收基准见
+`benchmark/rl/benchmark_offpolicy_dp_scaling.py`（issue #968，真实运行不进 CI）。

--- a/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
+++ b/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from benchmark.rl import benchmark_offpolicy_dp_scaling as bench
+
+torch = pytest.importorskip("torch")
+from torch.utils.tensorboard import SummaryWriter  # noqa: E402
+
+
+def _write_tfevents(log_dir: Path, series: dict[str, list[float]]) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    writer = SummaryWriter(log_dir=str(log_dir))
+    try:
+        for tag, values in series.items():
+            for step, value in enumerate(values):
+                writer.add_scalar(tag, value, step)
+    finally:
+        writer.close()
+
+
+def _write_run_summary(run_dir: Path, **overrides: object) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "status": "completed",
+        "completed_iterations": 300,
+        "total_env_steps": 1_200_000,
+        "training_wall_time_sec": 600.0,
+        **overrides,
+    }
+    (run_dir / "run_summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+
+def _make_run_dir(
+    run_dir: Path,
+    *,
+    world_size: int,
+    steps_per_sec: list[float] | None = None,
+    rank_steps_per_sec: list[list[float]] | None = None,
+    reward: list[float] | None = None,
+    dp_sync_time: list[float] | None = None,
+) -> None:
+    _write_run_summary(run_dir)
+    rank0_series = {bench.STEPS_PER_SEC_TAG: steps_per_sec or []}
+    if reward is not None:
+        rank0_series[bench.REWARD_TAG] = reward
+    if dp_sync_time is not None:
+        rank0_series[bench.DP_SYNC_TIME_TAG] = dp_sync_time
+    _write_tfevents(run_dir, rank0_series)
+    for rank, series in enumerate(rank_steps_per_sec or [], start=1):
+        _write_tfevents(bench.rank_dir_for(run_dir, rank), {bench.STEPS_PER_SEC_TAG: series})
+    assert world_size == 1 + len(rank_steps_per_sec or [])
+
+
+def test_steady_state_mean_uses_tail_half() -> None:
+    # ceil(3/2)=2 tail points: (30+40)/2; warm-up prefix 10 is excluded.
+    assert bench.steady_state_mean([10.0, 30.0, 40.0]) == pytest.approx(35.0)
+    assert bench.steady_state_mean([1.0, 2.0, 3.0, 4.0]) == pytest.approx(3.5)
+    assert bench.steady_state_mean([7.0]) == pytest.approx(7.0)
+    assert bench.steady_state_mean([0.0, 100.0], tail_fraction=1.0) == pytest.approx(50.0)
+    with pytest.raises(ValueError, match="at least one sample"):
+        bench.steady_state_mean([])
+
+
+def test_verdict_for_ratio() -> None:
+    assert bench.verdict_for_ratio(1.7) == "pass"
+    assert bench.verdict_for_ratio(2.0) == "pass"
+    assert bench.verdict_for_ratio(1.69) == "below threshold"
+    assert bench.verdict_for_ratio(None) is None
+
+
+def test_build_train_command_matches_production_overrides(tmp_path: Path) -> None:
+    command = bench.build_train_command(tmp_path / "runs" / "n1", iterations=300, devices=None)
+    assert command[0] == sys.executable
+    assert command[1].endswith("scripts/train_offpolicy.py")
+    assert "algo=sac" in command
+    assert "task=sac/g1_walk_flat/mujoco" in command
+    assert "training.no_play=true" in command
+    assert "algo.max_iterations=300" in command
+    assert any(arg.startswith("training.log_dir=") for arg in command)
+    # N=1 baseline must not carry training.devices at all.
+    assert not any(arg.startswith("training.devices") for arg in command)
+    assert not any(arg.startswith("training.dp_sync_interval") for arg in command)
+
+    command_dp = bench.build_train_command(
+        tmp_path / "runs" / "n2",
+        iterations=300,
+        devices=[0, 1],
+        sync_interval=4,
+        extra_overrides=("algo.num_envs=2048",),
+    )
+    assert "training.devices=[0,1]" in command_dp
+    assert "training.dp_sync_interval=4" in command_dp
+    assert "algo.num_envs=2048" in command_dp
+
+
+def test_parse_run_single_rank(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n1"
+    _make_run_dir(
+        run_dir,
+        world_size=1,
+        steps_per_sec=[100.0, 200.0, 300.0, 400.0],
+        reward=[0.5, 1.5],
+    )
+    metrics = bench.parse_run(run_dir, world_size=1)
+    assert metrics["completed_iterations"] == 300
+    assert metrics["total_env_steps"] == 1_200_000
+    assert metrics["training_wall_time_sec"] == pytest.approx(600.0)
+    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(350.0)
+    assert metrics["final_mean_reward"] == pytest.approx(1.5)
+    assert metrics["mean_dp_sync_time_sec"] is None
+    assert len(metrics["ranks"]) == 1
+    assert metrics["ranks"][0]["steady_state_env_steps_per_s"] == pytest.approx(350.0)
+
+
+def test_parse_run_two_ranks_aggregates_and_reads_rank1_subdir(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n2"
+    _make_run_dir(
+        run_dir,
+        world_size=2,
+        steps_per_sec=[100.0, 200.0],
+        rank_steps_per_sec=[[150.0, 250.0]],
+        dp_sync_time=[0.02, 0.04],
+    )
+    metrics = bench.parse_run(run_dir, world_size=2)
+    assert metrics["world_size"] == 2
+    # Aggregate = rank0 steady state + rank1 steady state.
+    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(200.0 + 250.0)
+    assert metrics["ranks"][1]["log_dir"].endswith("rank1")
+    assert metrics["mean_dp_sync_time_sec"] == pytest.approx(0.03)
+
+
+def test_parse_run_missing_rank1_data_is_a_hard_error(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n2"
+    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0, 200.0])
+    with pytest.raises(bench.RunParseError, match="rank1"):
+        bench.parse_run(run_dir, world_size=2)
+
+    # rank1 directory exists but has no tfevents file.
+    bench.rank_dir_for(run_dir, 1).mkdir(parents=True)
+    with pytest.raises(bench.RunParseError, match="no tfevents"):
+        bench.parse_run(run_dir, world_size=2)
+
+
+def test_parse_run_rejects_non_completed_status(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n1"
+    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0])
+    _write_run_summary(run_dir, status="failed", error="boom")
+    with pytest.raises(bench.RunParseError, match="did not complete"):
+        bench.parse_run(run_dir, world_size=1)
+
+    (run_dir / "run_summary.json").unlink()
+    with pytest.raises(bench.RunParseError, match="missing run summary"):
+        bench.parse_run(run_dir, world_size=1)
+
+
+def _record(config: str, aggregate: float | None, status: str = "ok") -> dict[str, object]:
+    return {
+        "config": config,
+        "status": status,
+        "error": None if status == "ok" else "boom",
+        "metrics": (
+            {"aggregate_env_steps_per_s": aggregate}
+            if status == "ok" and aggregate is not None
+            else None
+        ),
+    }
+
+
+def test_attach_scaling_computes_ratio_and_verdict() -> None:
+    records = [
+        _record("n1", 100_000.0),
+        _record("n2", 180_000.0),
+        _record("n2", None, status="failed"),
+    ]
+    bench.attach_scaling(records)
+    assert records[0]["scaling_vs_n1"] is None
+    assert records[0]["verdict"] is None
+    assert records[1]["scaling_vs_n1"] == pytest.approx(1.8)
+    assert records[1]["verdict"] == "pass"
+    assert records[2]["scaling_vs_n1"] is None
+    assert records[2]["verdict"] is None
+
+
+def test_attach_scaling_below_threshold_verdict() -> None:
+    records = [_record("n1", 100_000.0), _record("n2", 120_000.0)]
+    bench.attach_scaling(records)
+    assert records[1]["scaling_vs_n1"] == pytest.approx(1.2)
+    assert records[1]["verdict"] == "below threshold"
+
+
+def test_parse_args_skips_dp_config_with_single_device() -> None:
+    args = bench.parse_args(["--devices", "0"])
+    assert args.devices == "0"
+    assert args.keep_runs is True
+    args = bench.parse_args(["--no-keep-runs"])
+    assert args.keep_runs is False


### PR DESCRIPTION
Closes #968. Parent roadmap: #964.

## 内容

- `benchmark/rl/benchmark_offpolicy_dp_scaling.py`：subprocess 跑生产入口（等价 `uv run train --algo sac --task g1_walk_flat --sim mujoco`），顺序执行 N=1 与 N=2（`training.devices=[0,1]`），解析 run_summary + tfevents，输出 scaling 表与 `benchmark/outputs/offpolicy_dp_scaling/results.json`（gitignored，随 issue 存档）。口径：稳态 env steps/s = `perf/steps_per_sec` 后 50% 采样点均值；N=2 聚合 = rank 求和；rank 缺数据即报错。
- 定向测试 10 例（假 tfevents/summary 覆盖解析、聚合、报错、verdict），不起真实训练。
- 文档：`docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md` 新增"多卡数据并行"小节（用法、`dp_sync_interval`、限制、NCCL TCP loopback 说明）。支持矩阵生成器结构无法表达多卡维度，未改。

## Validation（真实 2× RTX 6000D, Threadripper 9980X）

- `make test-all` 通过（exit=0）。
- 真实 benchmark（300 iterations，生产 owner YAML 配置）：
  - N=1：稳态 **64,242 env steps/s**，final reward 7.96
  - N=2：聚合 **110,804 env steps/s**，**1.72×**（≥1.7× 阈值，verdict=pass），final reward 7.93，`dp_sync_time` 均值 0.156s/次
  - 训练曲线不退化（final reward 7.96 vs 7.93）
- 数据存档：`benchmark/outputs/offpolicy_dp_scaling/results.json`（含 commit/device/params 元信息），结论同步写入 #964。
