### PR TITLE
feat(offpolicy): 多卡数据并行扩展到 flashsac

### DIFF
--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -47,8 +47,9 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
 `training.devices` 打开单节点多卡数据并行（data parallel）：rank i 在
 `cuda:devices[i]` 上各跑一套独立的 learner+collector，rank 0 负责 spawn 其余
 rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参数，之后每
-`training.dp_sync_interval`（默认 8）个 learner iteration 对 actor+critic 参数做
-一次 all-reduce 平均；梯度不交换，各 rank 保留自己的 optimizer 状态。
+`training.dp_sync_interval`（默认 8）个 learner iteration 对 learner 可学习参数
+（actor / critic / 温度系数）做一次 all-reduce 平均；梯度不交换，各 rank 保留自己的
+optimizer 状态。
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
@@ -63,7 +64,7 @@ collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段
 
 当前限制：
 
-- 仅 SAC：TD3 / FlashSAC 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
+- 仅 SAC 与 FlashSAC：TD3 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
 - 仅验证过 `mujoco` backend；`training.devices` 与 `training.device` 互斥。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
@@ -33,3 +33,16 @@ FlashSAC 要求同步采集，并与 SAC、TD3 共用唯一 replay 路径：有�
 training 不受支持。
 
 日志根目录为 `logs/flash_sac/<task>/`。
+
+## 多卡数据并行
+
+FlashSAC 与 SAC 共用同一套多卡数据并行机制：`training.devices` 下每个 rank 各跑一
+套独立的 learner+collector，`FlashSACLearner.dp_sync_tensors()` 同步 actor / critic /
+target critic / temperature 参数。用法与限制见
+{doc}`/zh_CN/2-user_guide/2-algorithms/3-sac` 的"多卡数据并行"小节。
+
+```bash
+uv run train --algo flashsac --task g1_walk_flat --sim mujoco \
+  training.devices=[0,1] \
+  training.dp_sync_interval=8
+```

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -452,6 +452,9 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             device=replay_device,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     raise ValueError(f"Unsupported algo: {algo_name}")

--- a/src/unilab/algos/torch/flash_sac/double_buffer.py
+++ b/src/unilab/algos/torch/flash_sac/double_buffer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from omegaconf import DictConfig
 
@@ -13,6 +13,9 @@ from unilab.training import create_env, ensure_registries
 from unilab.training.seed import apply_training_seed
 from unilab.utils.device import get_default_device
 from unilab.utils.nan_guard import NanGuardCfg
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
 
 
 def _validate_flashsac_double_buffer_runtime(
@@ -34,6 +37,9 @@ def build_flashsac_double_buffer_runner(
     device: str | None = None,
     nan_guard_cfg: NanGuardCfg | None = None,
     torch_thread_runtime: dict[str, Any] | None = None,
+    collector_cpu_ids: list[int] | None = None,
+    dp_sync: DpParameterSync | None = None,
+    dp_sync_interval: int = 8,
 ) -> Any:
     """Build FlashSAC with the bounded-ingress device replay pipeline."""
     from unilab.base.observations import get_obs_dims
@@ -122,4 +128,7 @@ def build_flashsac_double_buffer_runner(
         replay_prefetch_mode=replay_prefetch_mode,
         nan_guard_cfg=nan_guard_cfg,
         torch_thread_runtime=torch_thread_runtime,
+        collector_cpu_ids=collector_cpu_ids,
+        dp_sync=dp_sync,
+        dp_sync_interval=dp_sync_interval,
     )

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -1052,6 +1052,29 @@ class FlashSACLearner:
             ):
                 target_param.data.mul_(1.0 - self.tau).add_(param.data, alpha=self.tau)
 
+    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Tensors synchronized across data-parallel ranks, as live references.
+
+        The values alias the parameter/buffer storage of ``actor``, ``critic``,
+        ``target_critic`` and ``temperature`` rather than copies, so the DP
+        collectives (``unilab.ipc.dp_sync.DpParameterSync``) update the model
+        in place — required because CUDA-graph capture pins parameter
+        addresses. Optimizer state (Adam moments) and the observation/reward
+        normalizers' running statistics are deliberately excluded: sync is
+        parameter-level, each rank keeps its own optimizer state and running
+        statistics, and they diverge across ranks by design.
+        """
+        tensors: dict[str, torch.Tensor] = {}
+        for prefix, module in (
+            ("actor", self.actor),
+            ("critic", self.critic),
+            ("target_critic", self.target_critic),
+            ("temperature", self.temperature),
+        ):
+            for key, value in module.state_dict().items():
+                tensors[f"{prefix}.{key}"] = value
+        return tensors
+
     def get_state_dict(self) -> dict[str, Any]:
         return {
             "actor": self.actor.state_dict(),

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -262,3 +262,124 @@ def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.Monke
     monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
     with pytest.raises(ValueError, match="log_dir"):
         module.build_runner("sac", cfg)
+
+
+# ---- FlashSACLearner.dp_sync_tensors contract ----
+
+
+def test_flash_sac_dp_sync_tensors_returns_live_references():
+    from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+
+    learner = FlashSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=6,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        actor_num_blocks=1,
+        critic_num_blocks=1,
+        num_atoms=3,
+    )
+    tensors = learner.dp_sync_tensors()
+
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("critic", learner.critic),
+        ("target_critic", learner.target_critic),
+        ("temperature", learner.temperature),
+    ):
+        state = module.state_dict()
+        assert state, prefix
+        for key, value in state.items():
+            full_key = f"{prefix}.{key}"
+            assert full_key in tensors
+            # Live references, not copies: same storage as the module state.
+            assert tensors[full_key].data_ptr() == value.data_ptr()
+
+    # Every optimizer-updated tensor is covered by the sync set.
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("critic", learner.critic),
+        ("target_critic", learner.target_critic),
+        ("temperature", learner.temperature),
+    ):
+        for key, param in module.named_parameters():
+            assert f"{prefix}.{key}" in tensors
+
+    # In-place collective semantics propagate into the module parameters.
+    probe_key = next(key for key in tensors if key.startswith("actor."))
+    with torch.no_grad():
+        tensors[probe_key].mul_(0.0)
+    assert torch.all(tensors[probe_key] == 0.0)
+
+
+# ---- flashsac build_runner assembly ----
+
+
+def _build_flashsac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: list[str]):
+    """build_runner("flashsac", ...) with learner/env/runner fakes; returns runner kwargs."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
+
+    import unilab.algos.torch.flash_sac.double_buffer as flash_module
+
+    monkeypatch.setattr(flash_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(flash_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+
+    class _Learner:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    monkeypatch.setattr(flash_module, "FlashSACLearner", _Learner)
+    monkeypatch.setattr(flash_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    runner = module.build_runner("flashsac", cfg, log_dir="/tmp/dp_sync_test_run")
+    return runner.kwargs
+
+
+def test_build_runner_single_rank_flashsac_keeps_dp_sync_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    kwargs = _build_flashsac_runner_with_dp_fakes(monkeypatch, ["algo=flashsac"])
+    assert kwargs["dp_sync"] is None
+    assert kwargs["dp_sync_interval"] == 8
+    assert kwargs["collector_cpu_ids"] is None
+
+
+def test_build_runner_multi_gpu_constructs_dp_sync_for_flashsac_rank0(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    kwargs = _build_flashsac_runner_with_dp_fakes(
+        monkeypatch,
+        [
+            "algo=flashsac",
+            "training.devices=[0,1]",
+            "training.dp_sync_interval=4",
+        ],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.world_size == 2
+    assert dp_sync.rank == 0
+    assert dp_sync.backend == "nccl"
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
+    assert kwargs["dp_sync_interval"] == 4
+    # Rank 0 collector owns the first contiguous CPU block.
+    assert kwargs["collector_cpu_ids"] == list(range(64))
+
+
+def test_build_runner_multi_gpu_flashsac_spawned_rank(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/dp_sync_shared_root")
+    kwargs = _build_flashsac_runner_with_dp_fakes(
+        monkeypatch,
+        ["algo=flashsac", "training.devices=[0,1]"],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.rank == 1
+    # Spawned ranks rendezvous on rank 0's run root, not their rank sub-dir.
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_shared_root/.dp_rendezvous"
+    assert kwargs["collector_cpu_ids"] == list(range(64, 128))


### PR DESCRIPTION
Closes #969. Parent roadmap: #964.

## 内容

- `FlashSACLearner.dp_sync_tensors()`：actor/critic/target_critic/temperature（`log_temp`）state_dict 活引用；optimizer/scheduler state 与 obs/reward normalizer 运行统计不同步（per-rank 统计，与 FastSAC 口径一致）。
- flashsac 分支接线：`build_flashsac_double_buffer_runner` 透传 `dp_sync`/`dp_sync_interval`/`collector_cpu_ids`；runner/dp_sync/dp_launcher 机制代码零改动，sac 路径未动。
- 测试：FlashSACLearner 活引用契约 + named_parameters 全覆盖、单卡 None、2 卡 rank0/rank1 接线（rendezvous 路径、cpu 分区）。
- 文档：sac 页多卡小节算法范围更新为 SAC + FlashSAC；flashsac 页新增等价小节并互链。

## Validation

- `make test-all` 通过（exit=0）。
- 2 卡 flashsac K=1 验收（30 iterations）：rank0/rank1 checkpoint **90 个张量逐位一致**，exit=0。
- sac 2 卡回归 smoke 通过（exit=0，双 rank checkpoint 正常）。
