### PR TITLE
fix(offpolicy): stabilize multi-GPU graphs and logging

### DIFF
--- a/benchmark/rl/reproduce_nccl_cuda_graph_capture.py
+++ b/benchmark/rl/reproduce_nccl_cuda_graph_capture.py
@@ -1,0 +1,126 @@
+"""Bounded two-rank reproducer for NCCL CUDA Graph capture (issue #978).
+
+Verified on 2 x RTX 6000D, PyTorch 2.7.0+cu128, CUDA 12.8 and NCCL
+2.26.2 with P2P/SHM disabled (TCP loopback):
+
+- no warmup: capture fails with ``operation not permitted when stream is capturing``;
+- eager all-reduce warmup: synchronous capture and replay pass;
+- ``async_op=True`` with captured ``Work.wait()`` also passes;
+- both collective modes pass on the default and a side stream.
+
+Every invocation has a parent-enforced timeout, including the intentionally
+hanging/error variants. The production FastSAC/FlashSAC path keeps synchronous
+all-reduce and performs the required eager warmup before its first capture.
+
+Run:
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py --warmup
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py --warmup --async-op
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py \
+        --warmup --async-op --side-stream
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker(
+    rank: int,
+    rendezvous_path: str,
+    warmup: bool,
+    side_stream: bool,
+    async_op: bool,
+) -> None:
+    os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+    os.environ.setdefault("NCCL_SHM_DISABLE", "1")
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_path}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        if warmup:
+            warmup_tensor = torch.ones(1, device=device)
+            dist.all_reduce(warmup_tensor)
+            torch.cuda.synchronize(device)
+            print(f"rank={rank} warmup complete", flush=True)
+
+        tensor = torch.full((1024,), rank + 1, dtype=torch.float32, device=device)
+        graph = torch.cuda.CUDAGraph()
+        if side_stream:
+            capture_stream = torch.cuda.Stream(device=device)
+            capture_stream.wait_stream(torch.cuda.current_stream(device))
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                work = dist.all_reduce(tensor, async_op=async_op)
+                if work is not None:
+                    work.wait()
+            torch.cuda.current_stream(device).wait_stream(capture_stream)
+        else:
+            with torch.cuda.graph(graph):
+                work = dist.all_reduce(tensor, async_op=async_op)
+                if work is not None:
+                    work.wait()
+        print(f"rank={rank} capture complete", flush=True)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(tensor, torch.full_like(tensor, 3.0))
+        print(f"rank={rank} replay complete", flush=True)
+        graph.reset()
+        torch.cuda.synchronize(device)
+    finally:
+        dist.destroy_process_group()
+
+
+def _terminate_processes(processes: list[mp.Process]) -> None:
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    for process in processes:
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", action="store_true")
+    parser.add_argument("--side-stream", action="store_true")
+    parser.add_argument("--async-op", action="store_true")
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be positive")
+    if torch.cuda.device_count() < 2:
+        parser.error("the NCCL capture reproducer requires at least two CUDA devices")
+
+    with tempfile.TemporaryDirectory(prefix="issue978-nccl-") as temp_dir:
+        rendezvous_path = os.path.join(temp_dir, "store")
+        context = mp.spawn(
+            _worker,
+            args=(rendezvous_path, args.warmup, args.side_stream, args.async_op),
+            nprocs=2,
+            join=False,
+        )
+        deadline = time.monotonic() + args.timeout_seconds
+        while not context.join(timeout=max(0.0, deadline - time.monotonic())):
+            if time.monotonic() >= deadline:
+                _terminate_processes(context.processes)
+                raise TimeoutError(
+                    f"NCCL graph capture did not finish within {args.timeout_seconds:g}s"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
@@ -2,8 +2,9 @@
 
 The terminal panel and TensorBoard / W&B are not separate logging systems. An
 algorithm runner submits each metric once to the same training logger. The terminal
-is a live view of the latest values; `training.logger=tensorboard` (the default) or
-`training.logger=wandb` selects the persistent backend for the same canonical keys.
+refreshes on a fixed 2 Hz clock and shows a two-second sliding average;
+`training.logger=tensorboard` (the default) or `training.logger=wandb` selects the
+persistent backend, which keeps each unsmoothed iteration value.
 
 This page first covers the log directory shared by all algorithms, then documents the
 off-policy terminal used by SAC / TD3 / FlashSAC and APPO. Every terminal field in the
@@ -54,7 +55,16 @@ The bottom of the terminal has three columns:
   `Iter Wall` as its denominator.
 - `Collector (own clock)` is measured in the collector subprocess and runs in
   parallel with the learner.
-- `System` contains non-timing state such as buffer, batch, and done rates.
+- `System` contains the buffer size, timeout rate, environment count, and per-rank
+  batch size.
+
+The panel-border title reports `GPUs N`. In multi-GPU training, only rank 0 owns the
+terminal and persistent logger. Learner metrics and timings are averaged across
+ranks first and then across the terminal's two-second window. `Steps/s` and
+`Samples/s` are exceptions to the rank average: per-rank collector step rates and
+learner sample rates are summed, so both fields are total job throughput. The
+`Avg 2s (n=...)` header field gives the number of already rank-reduced learner
+samples in the current time window.
 
 Do not add times across the learner and collector columns. Only the learner rows from
 `Collector Wait` through `Other` are mutually exclusive main-thread phases. The
@@ -118,7 +128,6 @@ tags below, while an existing run continues to show its old names:
 | `timing/learner_incremental_h2d_ms` (SAC-like) | `timing/replay_ingress_h2d_submit_ms` | Identify a potentially parallel submit diagnostic rather than a learner main phase |
 | `timing/learner_incremental_h2d_ms` (APPO) | `timing/learner_replay_stage_ms` | Identify synchronous staging that is part of `Iter Wall` |
 | `timing/collector_inference_wait_ms` | `timing/collector_learner_action_wait_ms` | The wait can include the remaining learner update, not only inference latency |
-| `timing/collector_sync_idle_ms` | `timing/collector_bookkeeping_ms` | The measured work is episode / metrics bookkeeping, not synchronization idle time |
 
 `perf/learner_pipeline_ms` was removed because it mixed exclusive main phases with a
 background H2D submission. Use `perf/iter_ms` for the main timeline and reconcile it
@@ -126,8 +135,9 @@ with `perf/learner_accounted_pct` plus `perf/learner_other_pct`.
 
 ### Collector Timeline
 
-SAC / TD3 / FlashSAC record five mutually exclusive phases per vectorized env tick.
-Terminal percentages use `perf/collector_cycle_ms`, the sum of these five phases:
+SAC / TD3 / FlashSAC record four mutually exclusive hot-path phases per vectorized
+env tick. Terminal percentages use `perf/collector_cycle_ms`, the sum of these four
+phases:
 
 | Terminal field | TensorBoard / W&B key | Meaning |
 | --- | --- | --- |
@@ -135,7 +145,6 @@ Terminal percentages use `perf/collector_cycle_ms`, the sum of these five phases
 | Learner Action Wait | `timing/collector_learner_action_wait_ms` | Barrier wall time from request publication until the learner publishes this tick's action |
 | Env Step | `timing/collector_env_step_ms` | `env.step()` wall time |
 | Replay Write | `timing/collector_replay_write_ms` | Transition post-processing, packing, and bounded-ingress write |
-| Bookkeeping | `timing/collector_bookkeeping_ms` | Episode statistics, metrics reporting, and remaining per-step bookkeeping |
 
 `Learner Action Wait` is deliberately not named “Inference Wait”: it is not pure
 inference latency. If the collector finishes `Env Step + Replay Write` and submits its
@@ -144,11 +153,13 @@ update, a small scheduling part of the next learner `Collector Wait`, and the ne
 `Inference + Collector Release`. A long value therefore agrees with parallel
 execution: it means the collector reached the next barrier before the learner.
 
-`Collector/s` is active collector throughput, calculated as
+The persistent `perf/collector_active_steps_per_sec` diagnostic is calculated as
 `num_envs / (Inference Request + Env Step + Replay Write)`. It intentionally excludes
-`Learner Action Wait` and `Bookkeeping`. The indented Backend Step / Update State /
-Reset Done rows are nested `Env Step` details. They do not enter the cycle sum, though
-their displayed percentages use the same collector-cycle denominator.
+`Learner Action Wait`; low-value sub-millisecond episode / metrics bookkeeping is no
+longer timed separately. The terminal `Steps/s` field instead reports total
+synchronized collector throughput. The indented Backend Step / Update State / Reset
+Done rows are nested `Env Step` details. They do not enter the cycle sum, though their
+displayed percentages use the same collector-cycle denominator.
 
 APPO has a different collection contract and reports:
 
@@ -159,8 +170,8 @@ APPO has a different collection contract and reports:
 | Rollout Wall | `timing/collector_rollout_ms` | Whole `steps_per_env` rollout wall-time EMA |
 
 These are not one percentage breakdown: the first two are per-step EMAs and `Rollout
-Wall` is a whole-rollout total, so the terminal shows milliseconds only.
-`Collector/s = (num_envs * steps_per_env) / Rollout Wall`.
+Wall` is a whole-rollout total, so the terminal shows milliseconds only. The backend
+active-throughput diagnostic is `(num_envs * steps_per_env) / Rollout Wall`.
 
 ## FastSAC Dual Timeline
 
@@ -189,7 +200,6 @@ sequenceDiagram
     par Collector tick t
         C->>C: Env Step(t)
         C->>D: Replay Write(t)
-        C->>C: Bookkeeping(t)
         C->>I: Inference Request(t+1)
         Note over C,I: Learner Action Wait(t+1) starts here
     and Learner iteration k

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
@@ -1,8 +1,9 @@
 # 日志
 
 训练时看到的终端面板与 TensorBoard / W&B 不是两套 logger：算法 runner 只向同一个
-training logger 提交一次指标。终端面板是当前值的实时视图；`training.logger=tensorboard`
-（默认）或 `training.logger=wandb` 决定把同一批 canonical key 持久化到哪个 backend。
+training logger 提交一次指标。终端面板按固定 2 Hz 时钟刷新，并显示两秒时间滑动平均；
+`training.logger=tensorboard`（默认）或 `training.logger=wandb` 决定持久化 backend，
+backend 保留每个 iteration 未经时间平滑的值。
 
 本文先说明所有算法共用的日志目录，再详细说明 SAC / TD3 / FlashSAC 与 APPO 共用的
 off-policy 终端视图。表中的“终端字段”与 backend key 一一对应；后缀 `_ms` 均为毫秒。
@@ -50,7 +51,13 @@ RSL-RL writer。MuJoCo run 若产生 `play_video.mp4`，该视频会上传至 W&
 
 - `Learner (Iter Wall)`：learner 主线程的一圈；所有行使用 `Iter Wall` 作分母。
 - `Collector (own clock)`：collector 子进程自己的采集时钟，与 learner 并行。
-- `System`：buffer、batch、done rate 等非计时状态。
+- `System`：buffer 大小、timeout rate、env 数和每 rank batch 大小。
+
+面板边框标题显示 `GPUs N`。多卡训练中只有 rank 0 持有终端与持久化 logger；learner
+指标和计时先在 rank 间取平均，再进入终端的两秒时间窗口。`Steps/s` 与 `Samples/s`
+不取 rank 平均：前者把各 rank collector step rate 求和，后者把各 rank learner sample
+rate 求和，因此两者都是整个训练任务的总吞吐。标题中的 `Avg 2s (n=...)` 表示当前窗口
+包含多少个已经完成 rank 聚合的 learner 样本。
 
 两列时间不能横向相加。只有 learner 列从 `Collector Wait` 到 `Other` 的行是互斥主线程
 阶段；实现以 `Other = max(Iter Wall - accounted, 0)` 补齐未命名区间。正常情况下它们合计
@@ -109,7 +116,6 @@ backend 还记录 `perf/learner_train_pct`、`perf/learner_accounted_pct` 与
 | `timing/learner_incremental_h2d_ms`（SAC 类） | `timing/replay_ingress_h2d_submit_ms` | 明确它是可能并行的 submit 诊断，不是 learner 主阶段 |
 | `timing/learner_incremental_h2d_ms`（APPO） | `timing/learner_replay_stage_ms` | 明确它是可计入 `Iter Wall` 的同步 staging 阶段 |
 | `timing/collector_inference_wait_ms` | `timing/collector_learner_action_wait_ms` | 等待范围还包含剩余 learner update，不等于 inference latency |
-| `timing/collector_sync_idle_ms` | `timing/collector_bookkeeping_ms` | 实际内容是 episode / metrics bookkeeping，并非同步 idle |
 
 `perf/learner_pipeline_ms` 已移除：它曾把互斥主阶段与后台 H2D submit 混加。主时间线请使用
 `perf/iter_ms`，完整性请对照 `perf/learner_accounted_pct` 与
@@ -117,8 +123,8 @@ backend 还记录 `perf/learner_train_pct`、`perf/learner_accounted_pct` 与
 
 ### Collector 自有时间线
 
-SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终端百分比使用
-`perf/collector_cycle_ms`（这五项之和）作分母：
+SAC / TD3 / FlashSAC 每个 vectorized env tick 记录四个热路径互斥阶段，终端百分比使用
+`perf/collector_cycle_ms`（这四项之和）作分母：
 
 | 终端字段 | TensorBoard / W&B key | 含义 |
 | --- | --- | --- |
@@ -126,7 +132,6 @@ SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终�
 | Learner Action Wait | `timing/collector_learner_action_wait_ms` | request 发出后，等 learner 发布当前 tick action 的屏障墙钟 |
 | Env Step | `timing/collector_env_step_ms` | `env.step()` 墙钟 |
 | Replay Write | `timing/collector_replay_write_ms` | transition 后处理、打包并写入 bounded ingress |
-| Bookkeeping | `timing/collector_bookkeeping_ms` | episode 统计、metrics 上报及其余单步 bookkeeping |
 
 `Learner Action Wait` 特意不叫 “Inference Wait”：它不是纯 inference latency。如果 collector
 在 learner update 期间先完成 `Env Step + Replay Write` 并提交下一 request，这一项会包含
@@ -134,10 +139,12 @@ SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终�
 Collector Release`。所以它很长并不与“两侧并行”矛盾，反而说明 collector 比 learner
 update 更早到达下一屏障。
 
-`Collector/s` 是 collector 活跃路径吞吐，按
+持久化指标 `perf/collector_active_steps_per_sec` 按 collector 活跃路径计算：
 `num_envs / (Inference Request + Env Step + Replay Write)` 计算；它有意排除
-`Learner Action Wait` 与 `Bookkeeping`。`Env Step` 下缩进的 Backend Step / Update State /
-Reset Done 是父项的嵌套明细，不参与 cycle 求和，但百分比仍使用同一 collector cycle 分母。
+`Learner Action Wait`；诊断价值较低的亚毫秒 episode / metrics bookkeeping 不再单独计时。
+终端 `Steps/s` 则报告同步 collector 的总吞吐。`Env Step` 下缩进的 Backend Step /
+Update State / Reset Done 是父项的嵌套明细，不参与 cycle 求和，但百分比仍使用同一
+collector cycle 分母。
 
 APPO 使用不同的采集 contract，因此 collector 只上报：
 
@@ -148,7 +155,8 @@ APPO 使用不同的采集 contract，因此 collector 只上报：
 | Rollout Wall | `timing/collector_rollout_ms` | 完整 `steps_per_env` 步 rollout 的墙钟 EMA |
 
 APPO 的三个值不是一组百分比分解：前两个是单步 EMA，`Rollout Wall` 是整条 rollout 总量，
-所以终端只显示 ms。`Collector/s = (num_envs * steps_per_env) / Rollout Wall`。
+所以终端只显示 ms。backend 的活跃吞吐诊断按
+`(num_envs * steps_per_env) / Rollout Wall` 计算。
 
 ## FastSAC 双时间线
 
@@ -176,7 +184,6 @@ sequenceDiagram
     par Collector tick t
         C->>C: Env Step(t)
         C->>D: Replay Write(t)
-        C->>C: Bookkeeping(t)
         C->>I: Inference Request(t+1)
         Note over C,I: Learner Action Wait(t+1) 从这里开始
     and Learner iteration k

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -76,9 +76,16 @@ collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段
 
 - 仅 SAC 与 FlashSAC：TD3 learner 未实现 optimizer-boundary gradient sync contract，
   多卡启动即报错。
-- NCCL gradient collective 不捕获进 optimizer CUDA Graph；若多卡配置请求 actor/critic
-  graph capture，learner 会自动切换到 eager optimizer update 并继续同步梯度，单卡行为不变。
-  runtime manifest 的 `dp_sync.cuda_graph_optimizer_capture=eager_fallback` 会记录该回退。
+- 多卡 actor/critic optimizer CUDA Graph 支持捕获 NCCL gradient all-reduce。首次 capture
+  前，DP owner 会先执行一次 eager all-reduce 并同步设备，完成 NCCL collective lazy
+  initialization；flat-gradient buffer 在 graph 生命周期内保持固定地址。runtime manifest
+  记录 `dp_sync.cuda_graph_optimizer_capture=enabled_after_collective_warmup` 和
+  `cuda_graph_collective_warmup=true`。销毁 process group 前会先释放 graph 中的 NCCL 节点。
+  Issue #978 的验证环境为 PyTorch 2.7.0+cu128、CUDA 12.8、NCCL 2.26.2、2 × RTX
+  6000D；TCP loopback 下同步 all-reduce 和 `async_op=True` + `Work.wait()` 均可 capture/replay，
+  默认 stream 与 side stream 均通过；跳过 warmup 时首个 all-reduce 会在 capture 中报
+  `operation not permitted when stream is capturing`。有限超时的最小复现见
+  `benchmark/rl/reproduce_nccl_cuda_graph_capture.py`。
 - 仅验证过 `mujoco` backend。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -308,7 +308,6 @@ class APPORunner(AsyncRunner):
             log_backend=logger_type,
             timing_profile="appo",
         )
-        logger.set_collection_sync(True, env_steps_per_sync)
         logger.log_status(
             f"Waiting for first rollout... "
             f"(staging_pool={self.staging_pool_size}, "
@@ -480,11 +479,8 @@ class APPORunner(AsyncRunner):
                         float(collector_active_steps_per_sec)
                     )
 
-                if "timeout_rate" in m or "terminated_rate" in m:
-                    logger.update_done_rates(
-                        timeout_rate=float(m.get("timeout_rate", 0.0)),
-                        terminated_rate=float(m.get("terminated_rate", 0.0)),
-                    )
+                if "timeout_rate" in m:
+                    logger.update_timeout_rate(float(m["timeout_rate"]))
 
                 if "total_steps" in m:
                     logger.log_collector(

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -241,9 +241,9 @@ def appo_collector_fn(
     current_ep_lengths = np.zeros(num_envs, dtype=np.int32)
     ep_reward_components = defaultdict(list)
 
-    # Episode completion mode counters (reset after each metrics report)
+    # Episode completion counters (reset after each metrics report)
     ep_timeouts = 0
-    ep_terminates = 0
+    ep_completions = 0
 
     # Collector timing EMA (milliseconds, α=0.1 → slow-moving average)
     _EMA = 0.1
@@ -345,9 +345,8 @@ def appo_collector_fn(
                     ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
                     current_ep_rewards[reset_indices] = 0.0
                     current_ep_lengths[reset_indices] = 0
-                    # Count episode completion modes for timeout/terminated rates
+                    ep_completions += len(reset_indices)
                     ep_timeouts += int(np.sum(truncated_raw[reset_indices] > 0.5))
-                    ep_terminates += int(np.sum(truncated_raw[reset_indices] <= 0.5))
 
                 log_info = state.info.get("log", {})
                 for k, v in log_info.items():
@@ -364,13 +363,10 @@ def appo_collector_fn(
                             msg["mean_ep_length"] = (
                                 statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
                             )
-                        # Episode completion mode rates
-                        total_ep = ep_timeouts + ep_terminates
-                        if total_ep > 0:
-                            msg["timeout_rate"] = ep_timeouts / total_ep
-                            msg["terminated_rate"] = ep_terminates / total_ep
+                        if ep_completions > 0:
+                            msg["timeout_rate"] = ep_timeouts / ep_completions
                             ep_timeouts = 0
-                            ep_terminates = 0
+                            ep_completions = 0
                         # Collector-side timing breakdown
                         msg["collector_timing_ms"] = {
                             "rollout_ms": ema_rollout_ms,

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -445,7 +445,9 @@ class FastSACLearner:
         requested_cuda_graph_actor_packed_staging = bool(use_cuda_graph_actor_packed_staging)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor) and self._device_type == "cuda"
         self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
-        self.dp_cuda_graph_fallback = False
+        self._gradient_sync_graph_replay_recorder: Callable[[int], None] | None = None
+        self.dp_cuda_graph_gradient_sync = False
+        self._active_cuda_graph_gradient_sync_calls: list[int] | None = None
         self.nvtx_profile_ranges = bool(nvtx_profile_ranges) and self._device_type == "cuda"
         self.amp_dtype = amp_dtype
         self._amp_dtype = self._resolve_amp_dtype(amp_dtype, self._device_type)
@@ -575,6 +577,7 @@ class FastSACLearner:
             | None
         ) = None
         self._cuda_graph_critic_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
         self._cuda_graph_actor: torch.cuda.CUDAGraph | None = None
         self._cuda_graph_actor_static_inputs: dict[str, torch.Tensor] | None = None
         self._cuda_graph_actor_static_packed_input: torch.Tensor | None = None
@@ -589,6 +592,7 @@ class FastSACLearner:
             | None
         ) = None
         self._cuda_graph_actor_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
         if self.use_compile:
             self._compile_training_methods()
 
@@ -768,6 +772,7 @@ class FastSACLearner:
             self.scaler.update()
         else:
             actor_loss.backward()
+            self._sync_gradients(self.actor.parameters())
             if self.max_grad_norm > 0:
                 actor_grad_norm = torch.nn.utils.clip_grad_norm_(
                     self.actor.parameters(), max_norm=self.max_grad_norm
@@ -813,6 +818,7 @@ class FastSACLearner:
             self.scaler.update()
         else:
             qf_loss.backward()
+            self._sync_gradients(self.qnet.parameters())
             if self.max_grad_norm > 0:
                 critic_grad_norm = torch.nn.utils.clip_grad_norm_(
                     self.qnet.parameters(), max_norm=self.max_grad_norm
@@ -826,6 +832,7 @@ class FastSACLearner:
             self.alpha_optimizer.zero_grad(set_to_none=True)
             alpha_loss = self._alpha_loss_tensor(next_log_probs)
             alpha_loss.backward()
+            self._sync_gradients((self.log_alpha,))
             self.alpha_optimizer.step()
 
         return (
@@ -1065,7 +1072,10 @@ class FastSACLearner:
                         tensor.zero_()
 
     def _reset_critic_cuda_graph(self) -> None:
+        graph = self._cuda_graph_critic
         self._cuda_graph_critic = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_critic_static_inputs = None
         self._cuda_graph_critic_static_packed_input = None
         self._cuda_graph_sac_static_packed_input = None
@@ -1073,6 +1083,7 @@ class FastSACLearner:
         self._cuda_graph_critic_action_noise = None
         self._cuda_graph_critic_outputs = None
         self._cuda_graph_critic_shapes = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
 
     def _materialize_capturable_actor_optimizer_state(
         self,
@@ -1118,12 +1129,16 @@ class FastSACLearner:
                     tensor.zero_()
 
     def _reset_actor_cuda_graph(self) -> None:
+        graph = self._cuda_graph_actor
         self._cuda_graph_actor = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_actor_static_inputs = None
         self._cuda_graph_actor_static_packed_input = None
         self._cuda_graph_actor_action_noise = None
         self._cuda_graph_actor_outputs = None
         self._cuda_graph_actor_shapes = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
     def _capture_actor_cuda_graph(self, batch: Dict[str, torch.Tensor]) -> None:
         if not self.use_cuda_graph_actor:
@@ -1164,14 +1179,20 @@ class FastSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
-                self._cuda_graph_actor_static_inputs["obs"],
-                self._cuda_graph_actor_static_inputs["critic"],
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
+                    self._cuda_graph_actor_static_inputs["obs"],
+                    self._cuda_graph_actor_static_inputs["critic"],
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_actor = graph
+        self._cuda_graph_actor_gradient_sync_calls = sync_calls[0]
 
     def _actor_graph_output_metrics(self, *, read_items: bool = True) -> Dict[str, float]:
         if not read_items:
@@ -1229,19 +1250,25 @@ class FastSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
-                self._cuda_graph_critic_static_inputs["critic"],
-                self._cuda_graph_critic_static_inputs["actions"],
-                self._cuda_graph_critic_static_inputs["rewards"],
-                self._cuda_graph_critic_static_inputs["next_obs"],
-                self._cuda_graph_critic_static_inputs["next_critic"],
-                self._cuda_graph_critic_static_inputs["dones"],
-                self._cuda_graph_critic_static_inputs["truncated"],
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
+                    self._cuda_graph_critic_static_inputs["critic"],
+                    self._cuda_graph_critic_static_inputs["actions"],
+                    self._cuda_graph_critic_static_inputs["rewards"],
+                    self._cuda_graph_critic_static_inputs["next_obs"],
+                    self._cuda_graph_critic_static_inputs["next_critic"],
+                    self._cuda_graph_critic_static_inputs["dones"],
+                    self._cuda_graph_critic_static_inputs["truncated"],
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_critic = graph
+        self._cuda_graph_critic_gradient_sync_calls = sync_calls[0]
 
     def _critic_graph_output_metrics(self, *, read_items: bool = True) -> Dict[str, float]:
         if not read_items:
@@ -1285,6 +1312,7 @@ class FastSACLearner:
             self._copy_critic_graph_inputs(batch)
         with _cuda_nvtx_range("critic_graph/replay", self.nvtx_profile_ranges):
             self._cuda_graph_critic.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_critic_gradient_sync_calls)
         with _cuda_nvtx_range("critic_graph/output_metrics_item", self.nvtx_profile_ranges):
             return self._critic_graph_output_metrics(read_items=read_metrics)
 
@@ -1314,6 +1342,7 @@ class FastSACLearner:
             self._copy_actor_graph_inputs(batch)
         with _cuda_nvtx_range("actor_graph/replay", self.nvtx_profile_ranges):
             self._cuda_graph_actor.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_actor_gradient_sync_calls)
         with _cuda_nvtx_range("actor_graph/output_metrics_item", self.nvtx_profile_ranges):
             return self._actor_graph_output_metrics(read_items=read_metrics)
 
@@ -1507,23 +1536,39 @@ class FastSACLearner:
     def set_gradient_sync(
         self,
         sync: Callable[[Iterable[torch.Tensor]], None] | None,
+        *,
+        graph_replay_recorder: Callable[[int], None] | None = None,
     ) -> None:
         """Attach the per-optimizer gradient collective used by multi-GPU DP."""
-        self.dp_cuda_graph_fallback = bool(
-            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
-        )
-        if self.dp_cuda_graph_fallback:
-            self.use_cuda_graph_critic = False
-            self.use_cuda_graph_actor = False
-            self.use_cuda_graph_critic_packed_staging = False
-            self.use_cuda_graph_actor_packed_staging = False
+        if sync is None and graph_replay_recorder is not None:
+            raise ValueError("graph_replay_recorder requires a gradient sync callback")
+        if sync != self._gradient_sync:
             self._reset_critic_cuda_graph()
             self._reset_actor_cuda_graph()
         self._gradient_sync = sync
+        self._gradient_sync_graph_replay_recorder = graph_replay_recorder
+        self.dp_cuda_graph_gradient_sync = bool(
+            sync is not None
+            and (
+                (self.use_cuda_graph_critic and self.scaler is None)
+                or (self.use_cuda_graph_actor and self.scaler is None and not self.use_symmetry)
+            )
+        )
 
     def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         if self._gradient_sync is not None:
             self._gradient_sync(parameters)
+            if self._active_cuda_graph_gradient_sync_calls is not None:
+                self._active_cuda_graph_gradient_sync_calls[0] += 1
+
+    def _record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        if self._gradient_sync_graph_replay_recorder is not None and collective_calls > 0:
+            self._gradient_sync_graph_replay_recorder(collective_calls)
+
+    def release_cuda_graphs(self) -> None:
+        """Release captured NCCL nodes before the process group is destroyed."""
+        self._reset_critic_cuda_graph()
+        self._reset_actor_cuda_graph()
 
     def dp_initial_sync_tensors(self) -> Dict[str, torch.Tensor]:
         """Model state broadcast once from rank 0 before collection starts.

--- a/src/unilab/algos/torch/flash_sac/layers.py
+++ b/src/unilab/algos/torch/flash_sac/layers.py
@@ -141,7 +141,10 @@ class NormalTanhPolicy(nn.Module):
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         mean, std = self.get_mean_and_std(x)
-        dist = torch.distributions.Normal(mean, std)
+        # ``std`` is positive by construction (exp of bounded log_std). The
+        # distribution's generic validation performs a GPU-to-host truth check,
+        # which CUDA forbids while this actor is captured into an optimizer graph.
+        dist = torch.distributions.Normal(mean, std, validate_args=False)
         raw_action = dist.rsample()
         tanh_action = torch.tanh(raw_action)
         log_prob = dist.log_prob(raw_action)

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -195,7 +195,9 @@ class FlashSACLearner:
         self.use_cuda_graph_critic = bool(use_cuda_graph_critic)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor)
         self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
-        self.dp_cuda_graph_fallback = False
+        self._gradient_sync_graph_replay_recorder: Callable[[int], None] | None = None
+        self.dp_cuda_graph_gradient_sync = False
+        self._active_cuda_graph_gradient_sync_calls: list[int] | None = None
         self.use_cuda_graph_critic_packed_staging = bool(
             use_cuda_graph_critic_packed_staging and self.use_cuda_graph_critic
         )
@@ -263,6 +265,7 @@ class FlashSACLearner:
         self._cuda_graph_sac_static_source_ptr: int | None = None
         self._cuda_graph_critic_outputs: tuple[torch.Tensor, torch.Tensor] | None = None
         self._cuda_graph_critic_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
         self._cuda_graph_actor: torch.cuda.CUDAGraph | None = None
         self._cuda_graph_actor_static_inputs: dict[str, torch.Tensor] | None = None
         self._cuda_graph_actor_static_packed_input: torch.Tensor | None = None
@@ -270,6 +273,7 @@ class FlashSACLearner:
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
         ) = None
         self._cuda_graph_actor_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
         scheduler_fn = build_lr_lambda(
             init_lr=learning_rate_init,
@@ -591,6 +595,7 @@ class FlashSACLearner:
 
         self.critic_optimizer.zero_grad(set_to_none=True)
         critic_loss.backward()
+        self._sync_gradients(self.critic.parameters())
         self.critic_optimizer.step()
         reward_scale_std = (
             torch.sqrt(self.reward_normalizer.rms.var)
@@ -600,12 +605,16 @@ class FlashSACLearner:
         return critic_loss, reward_scale_std
 
     def _reset_critic_cuda_graph(self) -> None:
+        graph = self._cuda_graph_critic
         self._cuda_graph_critic = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_critic_static_inputs = None
         self._cuda_graph_sac_static_packed_input = None
         self._cuda_graph_sac_static_source_ptr = None
         self._cuda_graph_critic_outputs = None
         self._cuda_graph_critic_shapes = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
 
     def _materialize_capturable_critic_optimizer_state(
         self,
@@ -668,13 +677,19 @@ class FlashSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
-                self._cuda_graph_critic_static_inputs
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
+                    self._cuda_graph_critic_static_inputs
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_critic = graph
+        self._cuda_graph_critic_gradient_sync_calls = sync_calls[0]
 
     def _critic_graph_output_metrics(self, *, read_items: bool = True) -> dict[str, float]:
         if not read_items:
@@ -713,6 +728,7 @@ class FlashSACLearner:
         assert self._cuda_graph_critic is not None
         self._copy_critic_graph_inputs(inputs)
         self._cuda_graph_critic.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_critic_gradient_sync_calls)
         self.critic_scheduler.step()
         self.critic.normalize_parameters()
         return self._critic_graph_output_metrics(read_items=read_metrics)
@@ -787,20 +803,26 @@ class FlashSACLearner:
 
         self.actor_optimizer.zero_grad(set_to_none=True)
         actor_loss.backward()
+        self._sync_gradients(self.actor.parameters())
         self.actor_optimizer.step()
 
         temp_loss = temp_value * (entropy - self.target_entropy)
         self.temperature_optimizer.zero_grad(set_to_none=True)
         temp_loss.backward()
+        self._sync_gradients(self.temperature.parameters())
         self.temperature_optimizer.step()
         return actor_loss, entropy, temp_value, temp_loss
 
     def _reset_actor_cuda_graph(self) -> None:
+        graph = self._cuda_graph_actor
         self._cuda_graph_actor = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_actor_static_inputs = None
         self._cuda_graph_actor_static_packed_input = None
         self._cuda_graph_actor_outputs = None
         self._cuda_graph_actor_shapes = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
     def _materialize_capturable_actor_optimizer_state(
         self,
@@ -880,13 +902,19 @@ class FlashSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
-                self._cuda_graph_actor_static_inputs
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
+                    self._cuda_graph_actor_static_inputs
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_actor = graph
+        self._cuda_graph_actor_gradient_sync_calls = sync_calls[0]
 
     def _actor_graph_output_metrics(self, *, read_items: bool = True) -> dict[str, float]:
         if not read_items:
@@ -928,6 +956,7 @@ class FlashSACLearner:
         assert self._cuda_graph_actor is not None
         self._copy_actor_graph_inputs(inputs)
         self._cuda_graph_actor.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_actor_gradient_sync_calls)
         self.actor_scheduler.step()
         self.temperature_scheduler.step()
         self.actor.normalize_parameters()
@@ -1063,23 +1092,38 @@ class FlashSACLearner:
     def set_gradient_sync(
         self,
         sync: Callable[[Iterable[torch.Tensor]], None] | None,
+        *,
+        graph_replay_recorder: Callable[[int], None] | None = None,
     ) -> None:
         """Attach the per-optimizer gradient collective used by multi-GPU DP."""
-        self.dp_cuda_graph_fallback = bool(
-            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
-        )
-        if self.dp_cuda_graph_fallback:
-            self.use_cuda_graph_critic = False
-            self.use_cuda_graph_actor = False
-            self.use_cuda_graph_critic_packed_staging = False
-            self.use_cuda_graph_actor_packed_staging = False
+        if sync is None and graph_replay_recorder is not None:
+            raise ValueError("graph_replay_recorder requires a gradient sync callback")
+        if sync != self._gradient_sync:
             self._reset_critic_cuda_graph()
             self._reset_actor_cuda_graph()
         self._gradient_sync = sync
+        self._gradient_sync_graph_replay_recorder = graph_replay_recorder
+        self.dp_cuda_graph_gradient_sync = bool(
+            sync is not None
+            and self.scaler is None
+            and isinstance(self.obs_normalizer, nn.Identity)
+            and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
+        )
 
     def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         if self._gradient_sync is not None:
             self._gradient_sync(parameters)
+            if self._active_cuda_graph_gradient_sync_calls is not None:
+                self._active_cuda_graph_gradient_sync_calls[0] += 1
+
+    def _record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        if self._gradient_sync_graph_replay_recorder is not None and collective_calls > 0:
+            self._gradient_sync_graph_replay_recorder(collective_calls)
+
+    def release_cuda_graphs(self) -> None:
+        """Release captured NCCL nodes before the process group is destroyed."""
+        self._reset_critic_cuda_graph()
+        self._reset_actor_cuda_graph()
 
     def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         """Model state broadcast once from rank 0 before collection starts.

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -299,7 +299,6 @@ class HoraAPPORunner(APPORunner):
             log_backend=logger_type,
             timing_profile="appo",
         )
-        logger.set_collection_sync(True, env_steps_per_sync)
         logger.start()
         logger.log_status(
             f"Waiting for first rollout... "

--- a/src/unilab/algos/torch/hora/appo_worker.py
+++ b/src/unilab/algos/torch/hora/appo_worker.py
@@ -233,7 +233,7 @@ def hora_appo_collector_fn(
     current_ep_lengths = np.zeros(num_envs, dtype=np.int32)
     ep_reward_components = defaultdict(list)
     ep_timeouts = 0
-    ep_terminates = 0
+    ep_completions = 0
 
     _EMA = 0.1
     ema_mlp_infer_ms = 0.0
@@ -357,8 +357,8 @@ def hora_appo_collector_fn(
                     ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
                     current_ep_rewards[reset_indices] = 0.0
                     current_ep_lengths[reset_indices] = 0
+                    ep_completions += len(reset_indices)
                     ep_timeouts += int(np.sum(truncated_raw[reset_indices] > 0.5))
-                    ep_terminates += int(np.sum(truncated_raw[reset_indices] <= 0.5))
 
                 log_info = state.info.get("log", {})
                 for k, v in log_info.items():
@@ -375,12 +375,10 @@ def hora_appo_collector_fn(
                             msg["mean_ep_length"] = (
                                 statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
                             )
-                        total_ep = ep_timeouts + ep_terminates
-                        if total_ep > 0:
-                            msg["timeout_rate"] = ep_timeouts / total_ep
-                            msg["terminated_rate"] = ep_terminates / total_ep
+                        if ep_completions > 0:
+                            msg["timeout_rate"] = ep_timeouts / ep_completions
                             ep_timeouts = 0
-                            ep_terminates = 0
+                            ep_completions = 0
                         msg["collector_timing_ms"] = {
                             "rollout_ms": ema_rollout_ms,
                             "mlp_infer_ms": ema_mlp_infer_ms,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -79,7 +79,6 @@ class _LocalLoggerStatistics(TypedDict):
     collector_active_steps_per_sec: float | None
     mean_ep_length: float
     timeout_rate: float
-    terminated_rate: float
     buffer_utilization: float
     collector_timing: dict[str, float]
     staging_pool_len: int
@@ -191,15 +190,17 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "logger_cross_rank_aggregation": self.dp_sync is not None,
         }
         if self.dp_sync is not None:
+            captures_gradient_sync = bool(
+                getattr(self.learner, "dp_cuda_graph_gradient_sync", False)
+            )
             self.runtime_manifest["dp_sync"] = {
                 "world_size": self.dp_sync.world_size,
                 "backend": self.dp_sync.backend,
                 "mode": "gradient_mean_per_optimizer_step",
                 "cuda_graph_optimizer_capture": (
-                    "eager_fallback"
-                    if bool(getattr(self.learner, "dp_cuda_graph_fallback", False))
-                    else "not_requested"
+                    "enabled_after_collective_warmup" if captures_gradient_sync else "not_requested"
                 ),
+                "cuda_graph_collective_warmup": captures_gradient_sync,
             }
 
     def _attach_dp_gradient_sync(self) -> None:
@@ -211,7 +212,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 f"{type(self.learner).__name__} must implement set_gradient_sync() "
                 "for multi-GPU data parallelism"
             )
-        setter(self.dp_sync.allreduce_gradients)
+        setter(
+            self.dp_sync.allreduce_gradients,
+            graph_replay_recorder=self.dp_sync.record_cuda_graph_gradient_replay,
+        )
 
     def _dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         """Live model-state references broadcast once before collection."""
@@ -233,6 +237,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             return
         self.dp_sync.start()
         self.dp_sync.broadcast_from_rank0(self._dp_initial_sync_tensors())
+        if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
+            self.dp_sync.prepare_cuda_graph_collectives()
 
     def _collect_dp_sync_metrics(self, iter_metrics: defaultdict[str, list]) -> None:
         """Move per-optimizer collective timing into this iteration's metrics."""
@@ -304,7 +310,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_active_steps_per_sec": logger._collector_active_steps_per_sec,
             "mean_ep_length": logger._mean_ep_length,
             "timeout_rate": logger._timeout_rate,
-            "terminated_rate": logger._terminated_rate,
             "buffer_utilization": logger._buffer_utilization,
             "collector_timing": dict(logger._collector_timing),
             "staging_pool_len": logger._staging_pool_len,
@@ -333,7 +338,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "timing::inference_time": inference_time,
             "timing::iteration_time": iteration_time,
             "logger::timeout_rate": float(logger._timeout_rate),
-            "logger::terminated_rate": float(logger._terminated_rate),
             "logger::buffer_utilization": float(logger._buffer_utilization),
             "extra::batch_size_per_rank": float(extra_info.get("batch_size_per_rank", 0) or 0),
         }
@@ -378,7 +382,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         logger._staging_pool_len = int(round(aggregated["logger::staging_pool_len"]))
         logger._staging_pool_max = int(round(aggregated["logger::staging_pool_max"]))
         logger._timeout_rate = aggregated["logger::timeout_rate"]
-        logger._terminated_rate = aggregated["logger::terminated_rate"]
         logger._buffer_utilization = aggregated["logger::buffer_utilization"]
         if "logger::mean_ep_length" in aggregated:
             logger._mean_ep_length = aggregated["logger::mean_ep_length"]
@@ -443,7 +446,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         logger._collector_active_steps_per_sec = None if active_rate is None else float(active_rate)
         logger._mean_ep_length = float(state["mean_ep_length"])
         logger._timeout_rate = float(state["timeout_rate"])
-        logger._terminated_rate = float(state["terminated_rate"])
         logger._buffer_utilization = float(state["buffer_utilization"])
         logger._collector_timing = dict(state["collector_timing"])
         logger._staging_pool_len = int(state["staging_pool_len"])
@@ -476,6 +478,14 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
     def close(self) -> None:
         if self.dp_sync is not None:
+            if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
+                release_cuda_graphs = getattr(self.learner, "release_cuda_graphs", None)
+                if not callable(release_cuda_graphs):
+                    raise TypeError(
+                        f"{type(self.learner).__name__} must implement release_cuda_graphs() "
+                        "before an NCCL process group with captured collectives is destroyed"
+                    )
+                release_cuda_graphs()
             self.dp_sync.close()
         super().close()
 
@@ -884,10 +894,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             env_name=self.env_name,
             obs_dim=self.obs_dim,
             action_dim=self.action_dim,
+            num_gpus=(self.dp_sync.world_size if self.dp_sync is not None else 1),
             log_dir=log_dir,
             log_backend=self._logger_backend(logger_type),
         )
-        logger.set_collection_sync(True, self.env_steps_per_sync)
         logger.update_runtime_manifest(self.runtime_manifest)
         if hasattr(self.learner, "use_symmetry") and self.learner.use_symmetry:
             logger.log_status("Symmetry augmentation: enabled")
@@ -912,10 +922,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             # --- inference coordination queues ---
             inference_request_queue = _SPAWN_CTX.Queue(maxsize=1)
             inference_response_queue = _SPAWN_CTX.Queue(maxsize=1)
-            print(
-                f"[DoubleBufferRunner] Collection sync enabled: "
-                f"env_steps_per_sync={self.env_steps_per_sync}"
-            )
 
             metrics_queue = _SPAWN_CTX.Queue(maxsize=100)
 
@@ -948,11 +954,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 )
 
             time.sleep(0.5)
-            if self._collector_process:
-                print(
-                    f"[DoubleBufferRunner] Collector process alive: "
-                    f"{self._collector_process.is_alive()}"
-                )
 
             reward_history: deque = deque(maxlen=100)
             latest_reward_components: dict[str, float] = {}

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -264,11 +264,8 @@ class OffPolicyRunner(AsyncRunner):
                 active_steps_per_sec = metrics.get("collector_active_steps_per_sec")
                 if active_steps_per_sec is not None:
                     logger.update_collector_active_steps_per_sec(float(active_steps_per_sec))
-                if "timeout_rate" in metrics or "terminated_rate" in metrics:
-                    logger.update_done_rates(
-                        timeout_rate=float(metrics.get("timeout_rate", 0.0)),
-                        terminated_rate=float(metrics.get("terminated_rate", 0.0)),
-                    )
+                if "timeout_rate" in metrics:
+                    logger.update_timeout_rate(float(metrics["timeout_rate"]))
                 if "total_steps" in metrics and "buffer_size" in metrics:
                     logger.log_collector(
                         metrics["total_steps"],

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -19,16 +19,14 @@ from unilab.training.seed import apply_training_seed
 # Every key is recorded once per iteration so the reported averages share one
 # denominator and can be summed without double counting.
 # - replay_write_ms: pack transitions and write them into the bounded ingress
-# - bookkeeping_ms: per-cycle episode bookkeeping and metrics reporting
 COLLECTOR_TIMING_KEYS = (
     "inference_request_ms",
     "learner_action_wait_ms",
     "env_step_ms",
     "replay_write_ms",
-    "bookkeeping_ms",
 )
 COLLECTOR_ACTIVE_TIMING_KEYS = tuple(
-    key for key in COLLECTOR_TIMING_KEYS if key not in {"learner_action_wait_ms", "bookkeeping_ms"}
+    key for key in COLLECTOR_TIMING_KEYS if key != "learner_action_wait_ms"
 )
 
 
@@ -170,7 +168,6 @@ def off_policy_collector_fn(
     Error handling is provided by ``_collector_entry_wrapper`` in
     ``async_runner.py``.
     """
-    print("[Collector] Entry point called", file=sys.stderr, flush=True)
     _run_collector(
         stop_event=stop_event,
         env_name=env_name,
@@ -253,7 +250,6 @@ def _run_collector(
     timing_counts: defaultdict[str, int] = defaultdict(int)
     done_count_window = 0
     timeout_count_window = 0
-    terminated_count_window = 0
 
     state = env.state
     assert state is not None
@@ -263,8 +259,6 @@ def _run_collector(
     info_dict = state.info
     prev_dones_np = np.zeros(num_envs, dtype=np.float32)
     import time as _time
-
-    _last_log_time = _time.time()
 
     runtime_manifest = {
         "inference_owner": "learner",
@@ -376,7 +370,6 @@ def _run_collector(
             next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
             rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
 
-            terminated_np = state.terminated.astype(np.float32, copy=False).ravel()
             truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
             combined_dones = (
                 (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
@@ -384,11 +377,9 @@ def _run_collector(
             prev_dones_np = combined_dones
             done_mask_np = combined_dones > 0.5
             timeout_mask_np = truncated_np > 0.5
-            terminated_mask_np = np.logical_and(terminated_np > 0.5, ~timeout_mask_np)
 
             done_count_window += int(np.count_nonzero(done_mask_np))
             timeout_count_window += int(np.count_nonzero(timeout_mask_np))
-            terminated_count_window += int(np.count_nonzero(terminated_mask_np))
 
             terminal_contract = resolve_terminal_observation_contract(
                 next_obs_batch_size=next_obs_np.shape[0],
@@ -448,12 +439,6 @@ def _run_collector(
             critic_np = next_critic_np
             info_dict = state.info
             total_steps += num_envs
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "bookkeeping_ms", phase_start_ns)
-
-            # Progress log every 2 seconds
-            now = _time.time()
-            if now - _last_log_time > 2.0:
-                _last_log_time = now
 
             # Extract reward components from env info
             log_info = state.info.get("log", {})
@@ -500,10 +485,8 @@ def _run_collector(
 
                     if done_count_window > 0:
                         msg["timeout_rate"] = timeout_count_window / done_count_window
-                        msg["terminated_rate"] = terminated_count_window / done_count_window
                         done_count_window = 0
                         timeout_count_window = 0
-                        terminated_count_window = 0
 
                     if trace_recorder:
                         msg["trace_events"] = trace_recorder.drain_events()
@@ -514,8 +497,6 @@ def _run_collector(
                         timing_counts.clear()
                 except Exception as e:
                     print(f"[OffPolicyWorker] metrics enqueue error: {e}", file=sys.stderr)
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "bookkeeping_ms", phase_start_ns)
-
             for key, value in cycle_timing_ms.items():
                 _record_timing_ms(timing_accum_ms, timing_counts, key, value)
 

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -57,6 +57,8 @@ class DpParameterSync:
         self._statistics_schema: dict[str, str] = {}
         self._gradient_sync_time_sec = 0.0
         self._gradient_sync_calls = 0
+        self._gradient_buffers: dict[tuple[int, ...], torch.Tensor] = {}
+        self._cuda_graph_collective_ready = False
         self._started = False
 
     def start(self) -> None:
@@ -101,6 +103,30 @@ class DpParameterSync:
             for key in self._ordered_keys(tensors):
                 dist.broadcast(tensors[key], src=0)
 
+    def prepare_cuda_graph_collectives(self) -> None:
+        """Warm up NCCL before the first graph-captured gradient collective.
+
+        NCCL communicator and collective-specific lazy initialization must run
+        eagerly. Capturing the first all-reduce either fails at capture time or
+        produces a graph that hangs on replay with the supported TCP-loopback
+        transport. This mirrors PyTorch's c10d CUDA Graph tests: one eager
+        all-reduce followed by a device synchronize before capture.
+        """
+        if self._cuda_graph_collective_ready:
+            return
+        if not self._started:
+            raise RuntimeError("start() must run before CUDA Graph collective warmup")
+        if self.backend != "nccl" or self.device is None or self.device.type != "cuda":
+            raise RuntimeError(
+                "optimizer CUDA Graph gradient synchronization requires "
+                "an NCCL process group with an explicit CUDA device"
+            )
+
+        warmup = torch.ones(1, device=self.device)
+        dist.all_reduce(warmup, op=dist.ReduceOp.SUM)
+        torch.cuda.synchronize(self.device)
+        self._cuda_graph_collective_ready = True
+
     def allreduce_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         """Average one optimizer's gradients with one flat all-reduce.
 
@@ -126,7 +152,16 @@ class DpParameterSync:
                 )
 
         gradient_numel = sum(parameter.numel() for parameter in params)
-        packed = torch.empty(gradient_numel, device=device, dtype=dtype)
+        buffer_key = tuple(id(parameter) for parameter in params)
+        packed = self._gradient_buffers.get(buffer_key)
+        if (
+            packed is None
+            or packed.numel() != gradient_numel
+            or packed.device != device
+            or packed.dtype != dtype
+        ):
+            packed = torch.empty(gradient_numel, device=device, dtype=dtype)
+            self._gradient_buffers[buffer_key] = packed
         offset = 0
         for parameter in params:
             width = parameter.numel()
@@ -135,6 +170,11 @@ class DpParameterSync:
             packed[offset : offset + width].copy_(gradient.detach().reshape(-1))
             offset += width
 
+        capturing = device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+        if capturing and not self._cuda_graph_collective_ready:
+            raise RuntimeError(
+                "NCCL gradient capture requires prepare_cuda_graph_collectives() first"
+            )
         dist.all_reduce(packed, op=dist.ReduceOp.SUM)
         packed.div_(self.world_size)
 
@@ -146,8 +186,18 @@ class DpParameterSync:
             gradient.copy_(packed[offset : offset + width].view_as(parameter))
             offset += width
 
-        self._gradient_sync_time_sec += time.perf_counter() - sync_start
-        self._gradient_sync_calls += 1
+        # Python executes once while a CUDA Graph is captured, not on replay.
+        # Learners report replayed collectives separately so this metric counts
+        # actual executions rather than graph construction.
+        if not capturing:
+            self._gradient_sync_time_sec += time.perf_counter() - sync_start
+            self._gradient_sync_calls += 1
+
+    def record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        """Account for collectives executed by one optimizer graph replay."""
+        if collective_calls < 0:
+            raise ValueError(f"collective_calls must be >= 0, got {collective_calls}")
+        self._gradient_sync_calls += int(collective_calls)
 
     def take_gradient_sync_metrics(self) -> tuple[float, int]:
         """Return and reset this rank's gradient-sync time and call count."""
@@ -280,6 +330,8 @@ class DpParameterSync:
             return
         if dist.is_available() and dist.is_initialized():
             dist.destroy_process_group()
+        self._gradient_buffers.clear()
+        self._cuda_graph_collective_ready = False
         self._started = False
 
     def _ordered_keys(self, tensors: dict[str, torch.Tensor]) -> tuple[str, ...]:

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -76,6 +76,7 @@ class BaseTrainingLogger:
         wandb_tags: list[str] | None,
         wandb_notes: str | None,
         refresh_per_second: int = 4,
+        fixed_terminal_refresh: bool = False,
         tensorboard_subdir: str | None = "tb",
         wandb_config: dict[str, Any] | None = None,
     ):
@@ -91,6 +92,7 @@ class BaseTrainingLogger:
         self._console = Console(force_terminal=False if not self._unicode_console else None)
         self._live: Live | None = None
         self._refresh_rate = refresh_per_second
+        self._fixed_terminal_refresh = fixed_terminal_refresh
         self._last_live_refresh_time: float | None = None
 
         self._start_time: float = 0.0
@@ -211,9 +213,10 @@ class BaseTrainingLogger:
             self._live = Live(
                 self._build_display(),
                 console=self._console,
-                auto_refresh=False,
+                auto_refresh=self._fixed_terminal_refresh,
                 refresh_per_second=self._refresh_rate,
                 transient=False,
+                get_renderable=(self._build_display if self._fixed_terminal_refresh else None),
             )
             self._live.start(refresh=False)
 
@@ -277,6 +280,8 @@ class BaseTrainingLogger:
     def _refresh(self, *, force: bool = False):
         if self._live is None:
             return
+        if self._fixed_terminal_refresh and not force:
+            return
         now = time.time()
         if not force and self._refresh_rate > 0 and self._last_live_refresh_time is not None:
             min_interval_s = 1.0 / self._refresh_rate
@@ -285,12 +290,13 @@ class BaseTrainingLogger:
         self._last_live_refresh_time = now
         self._live.update(self._build_display(), refresh=True)
 
-    def _estimate_eta(self) -> str:
-        if self._iteration <= 0:
+    def _estimate_eta(self, *, iteration: int | None = None) -> str:
+        current_iteration = self._iteration if iteration is None else iteration
+        if current_iteration <= 0:
             return ""
         elapsed = time.time() - self._start_time
-        remaining = self.max_iterations - self._iteration
-        avg_iter = elapsed / self._iteration
+        remaining = self.max_iterations - current_iteration
+        avg_iter = elapsed / current_iteration
         eta_s = remaining * avg_iter
         return _fmt_time(eta_s)
 
@@ -324,8 +330,27 @@ class BaseTrainingLogger:
         include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
+        return self._build_compact_header_state(
+            include_status=include_status,
+            include_identity=include_identity,
+            include_iteration=include_iteration,
+            extra_fields=extra_fields,
+            ep_length=self._mean_ep_length,
+            current_iteration=self._iteration,
+        )
+
+    def _build_compact_header_state(
+        self,
+        *,
+        include_status: bool,
+        include_identity: bool,
+        include_iteration: bool,
+        extra_fields: list[tuple[str, str]] | None,
+        ep_length: float,
+        current_iteration: int,
+    ) -> Text:
         elapsed = time.time() - self._start_time if self._start_time else 0
-        eta = self._estimate_eta()
+        eta = self._estimate_eta(iteration=current_iteration)
         fields: list[tuple[str, str]] = []
         if include_identity:
             fields.extend(
@@ -335,7 +360,7 @@ class BaseTrainingLogger:
                 ]
             )
         if include_iteration:
-            fields.append((f"iter {self._iteration}/{self.max_iterations}", "yellow"))
+            fields.append((f"iter {current_iteration}/{self.max_iterations}", "yellow"))
         fields.append(
             (
                 f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}",
@@ -344,8 +369,8 @@ class BaseTrainingLogger:
         )
         if eta:
             fields.append((f"ETA {eta}", "bold magenta"))
-        if self._mean_ep_length > 0:
-            fields.append((f"Ep Len {self._mean_ep_length:.1f}", "yellow"))
+        if ep_length > 0:
+            fields.append((f"Ep Len {ep_length:.1f}", "yellow"))
         if extra_fields:
             fields.extend(extra_fields)
         if include_status and self._status:
@@ -363,6 +388,9 @@ class BaseTrainingLogger:
         *,
         wait_message: str,
         include_ep_length: bool = True,
+        reward_history: tuple[float, ...] | None = None,
+        reward_components: dict[str, float] | None = None,
+        mean_reward: float | None = None,
     ) -> Table:
         table = Table(
             box=box.SIMPLE_HEAVY,
@@ -375,9 +403,13 @@ class BaseTrainingLogger:
         table.add_column("Rewards", style="white", width=21, no_wrap=True)
         table.add_column("Value", justify="right", ratio=2, no_wrap=True)
 
-        if self._reward_history:
-            recent = list(self._reward_history)
-            mean_rew = sum(recent[-50:]) / max(len(recent[-50:]), 1)
+        recent = list(self._reward_history if reward_history is None else reward_history)
+        if recent:
+            mean_rew = (
+                mean_reward
+                if mean_reward is not None
+                else sum(recent[-50:]) / max(len(recent[-50:]), 1)
+            )
             peak_rew = max(recent) if recent else 0
 
             if len(recent) >= 10:
@@ -403,8 +435,11 @@ class BaseTrainingLogger:
         else:
             table.add_row(wait_message, "")
 
-        if self._latest_reward_components:
-            for name, val in sorted(self._latest_reward_components.items()):
+        components = (
+            self._latest_reward_components if reward_components is None else reward_components
+        )
+        if components:
+            for name, val in sorted(components.items()):
                 display = name.replace("reward/", "").replace("_", " ")
                 color = "green" if val > 0 else "red" if val < 0 else "dim"
                 table.add_row(f"  {display}", f"[{color}]{val:+.4f}[/]")

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import time
+from collections import deque
+from dataclasses import dataclass
 from typing import Any
 
 from rich import box
@@ -96,7 +98,6 @@ _COLLECTOR_TIMING_SPECS = {
     "env_step_update_state_ms": (2.2, "  Update State", "env_step_detail"),
     "env_step_reset_done_ms": (2.3, "  Reset Done", "env_step_detail"),
     "replay_write_ms": (3.0, "Replay Write", "cycle_phase"),
-    "bookkeeping_ms": (4.0, "Bookkeeping", "cycle_phase"),
     "rollout_ms": (9.0, "Rollout Wall", "rollout_total"),
 }
 
@@ -109,6 +110,31 @@ OFFPOLICY_ENV_STEP_DETAIL_KEYS = (
 _OFFPOLICY_COLLECTOR_CYCLE_KEYS = tuple(
     key for key, (_, _, role) in _COLLECTOR_TIMING_SPECS.items() if role == "cycle_phase"
 )
+
+_TERMINAL_AVERAGE_WINDOW_SEC = 2.0
+_TERMINAL_AVERAGE_MAX_SAMPLES = 512
+
+
+@dataclass(frozen=True)
+class _TerminalSample:
+    timestamp: float
+    scalars: dict[str, float]
+    metrics: dict[str, float]
+    reward_components: dict[str, float]
+    collector_timing: dict[str, float]
+
+
+@dataclass(frozen=True)
+class _TerminalSnapshot:
+    iteration: int
+    sample_count: int
+    scalars: dict[str, float]
+    metrics: dict[str, float]
+    reward_components: dict[str, float]
+    collector_timing: dict[str, float]
+    reward_history: tuple[float, ...]
+    buffer_size: int
+    batch_size_per_rank: int
 
 
 def _metric_backend_key(key: str) -> str:
@@ -149,7 +175,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         env_name: str = "",
         obs_dim: int = 0,
         action_dim: int = 0,
-        refresh_per_second: int = 4,
+        num_gpus: int = 1,
+        refresh_per_second: int = 2,
         log_dir: str = "",
         log_backend: str = "tensorboard",
         wandb_project: str = "unilab",
@@ -176,6 +203,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             wandb_tags=wandb_tags,
             wandb_notes=wandb_notes,
             refresh_per_second=refresh_per_second,
+            fixed_terminal_refresh=True,
             tensorboard_subdir=None,
             wandb_config={
                 "obs_dim": obs_dim,
@@ -185,6 +213,9 @@ class OffPolicyLogger(BaseTrainingLogger):
         )
         self.obs_dim = obs_dim
         self.action_dim = action_dim
+        if int(num_gpus) < 1:
+            raise ValueError("num_gpus must be >= 1")
+        self.num_gpus = int(num_gpus)
         self._total_steps: int = 0
         self._buffer_size: int = 0
         self._buffer_target: int = 0
@@ -214,16 +245,14 @@ class OffPolicyLogger(BaseTrainingLogger):
             raise ValueError("timing_profile must be 'sac_family' or 'appo'")
         self._timing_profile = timing_profile
         self._timeout_rate: float = 0.0
-        self._terminated_rate: float = 0.0
         self._buffer_utilization: float = 0.0
-        self._sync_collection: bool = False
-        self._env_steps_per_sync: int = 0
         self._runtime_manifest: dict[str, Any] = {}
         self._staging_pool_len: int = 0
         self._staging_pool_max: int = 0
         self._status: str = "Initializing..."
-        self._terminal_refresh_started: bool = False
         self._training_timer_started: bool = False
+        self._terminal_samples: deque[_TerminalSample] = deque(maxlen=_TERMINAL_AVERAGE_MAX_SAMPLES)
+        self._terminal_snapshot: _TerminalSnapshot | None = None
 
     def _format_tensorboard_message(self, tb_dir: str) -> str:
         return f"[dim]TensorBoard logging to: {tb_dir}[/]"
@@ -252,8 +281,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_target = target
         pct = current / max(target, 1) * 100
         self._status = f"Buffer fill: {current:,}/{target:,} ({pct:.0f}%)"
-        if self._terminal_refresh_started:
-            self._refresh()
 
     def _get_iter_steps_per_sec(self) -> float | None:
         if self._steps_per_sec_override is not None:
@@ -310,12 +337,16 @@ class OffPolicyLogger(BaseTrainingLogger):
             return self._iteration_time
         return self._get_learner_accounted_time()
 
-    def _get_collector_cycle_ms(self) -> float | None:
+    def _get_collector_cycle_ms(
+        self,
+        collector_timing: dict[str, float] | None = None,
+    ) -> float | None:
         if self._timing_profile != "sac_family":
             return None
-        if not all(key in self._collector_timing for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS):
+        timing = self._collector_timing if collector_timing is None else collector_timing
+        if not all(key in timing for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS):
             return None
-        return sum(self._collector_timing.get(key, 0.0) for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS)
+        return sum(timing.get(key, 0.0) for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS)
 
     def _build_compact_header(
         self,
@@ -324,21 +355,115 @@ class OffPolicyLogger(BaseTrainingLogger):
         include_identity: bool = True,
         include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
+        terminal_snapshot: _TerminalSnapshot | None = None,
     ) -> Text:
-        iter_steps_per_sec = self._get_iter_steps_per_sec()
-        effective_samples_per_sec = self._get_effective_samples_per_sec()
+        snapshot = terminal_snapshot or self._terminal_snapshot
+        iter_steps_per_sec = (
+            snapshot.scalars.get("steps_per_sec")
+            if snapshot is not None
+            else self._get_iter_steps_per_sec()
+        )
+        effective_samples_per_sec = (
+            snapshot.scalars.get("samples_per_sec")
+            if snapshot is not None
+            else self._get_effective_samples_per_sec()
+        )
         header_extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
             header_extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
         if effective_samples_per_sec is not None:
             header_extra_fields.append((f"Samples/s {effective_samples_per_sec:,.0f}", "bold cyan"))
+        if snapshot is not None:
+            header_extra_fields.append(
+                (
+                    f"Avg {_TERMINAL_AVERAGE_WINDOW_SEC:g}s (n={snapshot.sample_count})",
+                    "dim",
+                )
+            )
         if extra_fields:
             header_extra_fields.extend(extra_fields)
-        return super()._build_compact_header(
+        return self._build_compact_header_state(
             include_status=include_status,
             include_identity=include_identity,
             include_iteration=include_iteration,
             extra_fields=header_extra_fields,
+            ep_length=(
+                snapshot.scalars.get("mean_ep_length", 0.0)
+                if snapshot is not None
+                else self._mean_ep_length
+            ),
+            current_iteration=(snapshot.iteration if snapshot is not None else self._iteration),
+        )
+
+    @staticmethod
+    def _mean_sample_maps(
+        samples: tuple[_TerminalSample, ...],
+        attribute: str,
+    ) -> dict[str, float]:
+        totals: dict[str, float] = {}
+        counts: dict[str, int] = {}
+        for sample in samples:
+            values = getattr(sample, attribute)
+            for key, value in values.items():
+                totals[key] = totals.get(key, 0.0) + float(value)
+                counts[key] = counts.get(key, 0) + 1
+        return {key: total / counts[key] for key, total in totals.items()}
+
+    def _record_terminal_sample(
+        self,
+        *,
+        metrics: dict[str, float] | None,
+        reward: float | None,
+        reward_components: dict[str, float] | None,
+    ) -> None:
+        """Publish one immutable, time-smoothed terminal-only state snapshot."""
+        scalars = {
+            attribute: float(getattr(self, attribute))
+            for _, _, attribute in self._learner_timing_specs()
+        }
+        scalars.update(
+            {
+                "iter_wall_time": self._get_iter_wall_time(),
+                "learner_other_time": self._get_learner_other_time(),
+                "timeout_rate": self._timeout_rate,
+            }
+        )
+        if self._mean_ep_length > 0.0:
+            scalars["mean_ep_length"] = self._mean_ep_length
+        if reward is not None:
+            scalars["reward"] = float(reward)
+        steps_per_sec = self._get_iter_steps_per_sec()
+        if steps_per_sec is not None:
+            scalars["steps_per_sec"] = steps_per_sec
+        samples_per_sec = self._get_effective_samples_per_sec()
+        if samples_per_sec is not None:
+            scalars["samples_per_sec"] = samples_per_sec
+
+        now = time.monotonic()
+        self._terminal_samples.append(
+            _TerminalSample(
+                timestamp=now,
+                scalars=scalars,
+                metrics=dict(metrics or {}),
+                reward_components=dict(reward_components or {}),
+                collector_timing=dict(self._collector_timing),
+            )
+        )
+        cutoff = now - _TERMINAL_AVERAGE_WINDOW_SEC
+        while self._terminal_samples and self._terminal_samples[0].timestamp < cutoff:
+            self._terminal_samples.popleft()
+
+        samples = tuple(self._terminal_samples)
+        self._terminal_snapshot = _TerminalSnapshot(
+            iteration=self._iteration,
+            sample_count=len(samples),
+            scalars=self._mean_sample_maps(samples, "scalars"),
+            metrics=self._mean_sample_maps(samples, "metrics"),
+            reward_components=self._mean_sample_maps(samples, "reward_components"),
+            collector_timing=self._mean_sample_maps(samples, "collector_timing"),
+            reward_history=tuple(self._reward_history),
+            buffer_size=self._buffer_size,
+            batch_size_per_rank=self._batch_size_per_rank,
         )
 
     def update_collector_timing(self, timing_ms: dict[str, float]):
@@ -346,17 +471,15 @@ class OffPolicyLogger(BaseTrainingLogger):
         legacy_action_wait = normalized.pop("inference_wait_ms", None)
         if "learner_action_wait_ms" not in normalized and legacy_action_wait is not None:
             normalized["learner_action_wait_ms"] = legacy_action_wait
-        legacy_bookkeeping = normalized.pop("sync_idle_ms", None)
-        if "bookkeeping_ms" not in normalized and legacy_bookkeeping is not None:
-            normalized["bookkeeping_ms"] = legacy_bookkeeping
+        normalized.pop("sync_idle_ms", None)
+        normalized.pop("bookkeeping_ms", None)
         self._collector_timing.update(normalized)
 
     def update_collector_active_steps_per_sec(self, steps_per_sec: float):
         self._collector_active_steps_per_sec = float(steps_per_sec)
 
-    def update_done_rates(self, timeout_rate: float, terminated_rate: float):
+    def update_timeout_rate(self, timeout_rate: float):
         self._timeout_rate = float(timeout_rate)
-        self._terminated_rate = float(terminated_rate)
 
     def update_buffer_utilization(self, utilization: float):
         self._buffer_utilization = float(utilization)
@@ -367,10 +490,6 @@ class OffPolicyLogger(BaseTrainingLogger):
     def update_staging_pool(self, current_len: int, max_size: int):
         self._staging_pool_len = current_len
         self._staging_pool_max = max_size
-
-    def set_collection_sync(self, enabled: bool, env_steps_per_sync: int = 0):
-        self._sync_collection = enabled
-        self._env_steps_per_sync = env_steps_per_sync
 
     def update_runtime_manifest(self, manifest: dict[str, Any]) -> None:
         self._runtime_manifest.update(manifest)
@@ -461,8 +580,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         if reward_components:
             self._latest_reward_components = reward_components
         self._status = "Training"
-        self._terminal_refresh_started = True
-        self._refresh()
         self._backend_log_step(
             iteration,
             metrics,
@@ -470,6 +587,11 @@ class OffPolicyLogger(BaseTrainingLogger):
             reward_metrics,
             reward_components,
             train_time,
+        )
+        self._record_terminal_sample(
+            metrics=metrics,
+            reward=reward,
+            reward_components=reward_components,
         )
 
     def _backend_log_step(
@@ -512,7 +634,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             if self._mean_ep_length > 0:
                 writer.add_scalar("episode/length", self._mean_ep_length, global_step)
             writer.add_scalar("episode/timeout_rate", self._timeout_rate, global_step)
-            writer.add_scalar("episode/terminated_rate", self._terminated_rate, global_step)
             for key, value_ms in learner_timing_ms.items():
                 writer.add_scalar(key, value_ms, global_step)
             for key, value in self._collector_timing.items():
@@ -565,7 +686,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             if self._mean_ep_length > 0:
                 log_dict["episode/length"] = self._mean_ep_length
             log_dict["episode/timeout_rate"] = self._timeout_rate
-            log_dict["episode/terminated_rate"] = self._terminated_rate
             log_dict.update(learner_timing_ms)
             for key, value in self._collector_timing.items():
                 log_dict[f"timing/collector_{key}"] = value
@@ -589,18 +709,18 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._status = status
         if "[red]" in status or "ERROR" in status:
             self._refresh(force=True)
-        elif self._terminal_refresh_started:
-            self._refresh()
 
     def _build_display(self) -> Panel:
+        snapshot = self._terminal_snapshot
         header = self._build_compact_header(
             include_status=self._status != "Training",
             include_identity=False,
             include_iteration=False,
+            terminal_snapshot=snapshot,
         )
-        left = self._build_metrics_table()
-        right = self._build_reward_table()
-        bottom = self._build_timing_table()
+        left = self._build_metrics_table(snapshot)
+        right = self._build_reward_table(snapshot)
+        bottom = self._build_timing_table(snapshot)
         grid = Table.grid(expand=True)
         grid.add_column(ratio=1)
         grid.add_column(width=2)
@@ -615,7 +735,10 @@ class OffPolicyLogger(BaseTrainingLogger):
         title.append("|", style="dim")
         title.append(f" {self.env_name} ", style="bold white")
         title.append("|", style="dim")
-        title.append(f" iter {self._iteration}/{self.max_iterations} ", style="yellow")
+        title.append(f" GPUs {self.num_gpus} ", style="bold magenta")
+        title.append("|", style="dim")
+        iteration = snapshot.iteration if snapshot is not None else self._iteration
+        title.append(f" iter {iteration}/{self.max_iterations} ", style="yellow")
         return Panel(
             Group(header, Text(""), grid, Text(""), bottom),
             title=title,
@@ -623,7 +746,8 @@ class OffPolicyLogger(BaseTrainingLogger):
             padding=(0, 1),
         )
 
-    def _build_metrics_table(self) -> Table:
+    def _build_metrics_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         table = Table(
             box=box.SIMPLE_HEAVY,
             show_header=True,
@@ -634,27 +758,33 @@ class OffPolicyLogger(BaseTrainingLogger):
         )
         table.add_column("Losses & Metrics", style="white", ratio=2)
         table.add_column("Value", style="yellow", justify="right", ratio=1)
-        if not self._latest_metrics:
+        metrics = snapshot.metrics if snapshot is not None else self._latest_metrics
+        if not metrics:
             table.add_row("[dim]Waiting for data...[/]", "")
         else:
-            loss_keys = sorted([key for key in self._latest_metrics if "loss" in key.lower()])
-            other_keys = sorted([key for key in self._latest_metrics if "loss" not in key.lower()])
+            loss_keys = sorted([key for key in metrics if "loss" in key.lower()])
+            other_keys = sorted([key for key in metrics if "loss" not in key.lower()])
             for key in loss_keys:
-                value = self._latest_metrics[key]
+                value = metrics[key]
                 style = "red" if value > 10 else "yellow"
                 table.add_row(key.replace("_", " ").title(), f"[{style}]{_fmt_number(value)}[/]")
             for key in other_keys:
-                value = self._latest_metrics[key]
+                value = metrics[key]
                 table.add_row(f"  {key.replace('_', ' ').title()}", _fmt_number(value))
         return table
 
-    def _build_reward_table(self) -> Table:
+    def _build_reward_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         return self._build_reward_table_common(
             wait_message="[dim]Waiting for data...[/]",
             include_ep_length=False,
+            reward_history=(snapshot.reward_history if snapshot is not None else None),
+            reward_components=(snapshot.reward_components if snapshot is not None else None),
+            mean_reward=(snapshot.scalars.get("reward") if snapshot is not None else None),
         )
 
-    def _build_timing_table(self) -> Table:
+    def _build_timing_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         table = Table(
             box=box.SIMPLE_HEAVY,
             show_header=True,
@@ -670,13 +800,24 @@ class OffPolicyLogger(BaseTrainingLogger):
         table.add_column("System", style="white", ratio=4, no_wrap=True)
         table.add_column("Value", style="yellow", justify="right", width=12, no_wrap=True)
 
+        iter_wall_time = (
+            snapshot.scalars.get("iter_wall_time", self._get_iter_wall_time())
+            if snapshot is not None
+            else self._get_iter_wall_time()
+        )
+
+        def _scalar(attribute: str, fallback: float) -> float:
+            if snapshot is None:
+                return fallback
+            return snapshot.scalars.get(attribute, fallback)
+
         def _fmt_phase(seconds: float, *, color: str | None = None) -> str:
             ms = seconds * 1000
-            pct = self._get_iter_pct(seconds)
+            pct = seconds / iter_wall_time * 100.0 if iter_wall_time > 0.0 else 0.0
             text = f"{ms:>7.1f}ms  {pct:>3.0f}%"
             return f"[{color}]{text}[/]" if color else text
 
-        collector_wait_ms = self._collector_wait_time * 1000
+        collector_wait_ms = _scalar("_collector_wait_time", self._collector_wait_time) * 1000
         wait_color = "red" if collector_wait_ms > 1.0 else "yellow"
         phase_colors = {
             "Collector Wait": wait_color,
@@ -686,7 +827,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             (
                 label,
                 _fmt_phase(
-                    float(getattr(self, attribute)),
+                    _scalar(attribute, float(getattr(self, attribute))),
                     color=phase_colors.get(label),
                 ),
             )
@@ -695,17 +836,20 @@ class OffPolicyLogger(BaseTrainingLogger):
         learner_items.append(
             (
                 _LEARNER_OTHER_TIMING_SPEC[1],
-                _fmt_phase(self._get_learner_other_time()),
+                _fmt_phase(_scalar("learner_other_time", self._get_learner_other_time())),
             )
         )
         learner_items.append(
             (
                 _ITER_WALL_TIMING_SPEC[1],
-                f"{self._get_iter_wall_time() * 1000:>7.1f}ms  100%",
+                f"{iter_wall_time * 1000:>7.1f}ms  100%",
             )
         )
+        collector_timing = (
+            snapshot.collector_timing if snapshot is not None else self._collector_timing
+        )
         sorted_collector_timing = sorted(
-            self._collector_timing.items(),
+            collector_timing.items(),
             key=lambda item: (
                 _COLLECTOR_TIMING_SPECS.get(item[0], (float("inf"), "", ""))[0],
                 item[0],
@@ -715,7 +859,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             key for key, _ in sorted_collector_timing if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS
         ]
         last_env_step_detail_key = env_step_detail_keys[-1] if env_step_detail_keys else None
-        cycle_total_ms = self._get_collector_cycle_ms() or 0.0
+        cycle_total_ms = self._get_collector_cycle_ms(collector_timing) or 0.0
         collector_items: list[tuple[str, str]] = []
         for key, value in sorted_collector_timing:
             _, label, role = _COLLECTOR_TIMING_SPECS.get(
@@ -742,44 +886,18 @@ class OffPolicyLogger(BaseTrainingLogger):
                 pct = value / cycle_total_ms * 100.0
                 value_text = f"{value:>7.1f}ms  {pct:>3.0f}%"
             collector_items.append((label, value_text))
+        buffer_size = snapshot.buffer_size if snapshot is not None else self._buffer_size
+        timeout_rate = _scalar("timeout_rate", self._timeout_rate)
+        batch_size_per_rank = (
+            snapshot.batch_size_per_rank if snapshot is not None else self._batch_size_per_rank
+        )
         system_items = [
-            ("Buffer", f"{self._buffer_size:,}"),
+            ("Buffer", f"{buffer_size:,}"),
+            ("Timeout Rate", f"{timeout_rate * 100:.1f}%"),
         ]
-        system_items.extend(
-            [
-                ("Timeout Rate", f"{self._timeout_rate * 100:.1f}%"),
-                ("Terminated Rate", f"{self._terminated_rate * 100:.1f}%"),
-            ]
-        )
         system_items.append(("Envs", f"{self.num_envs:,}"))
-        if self._batch_size_per_rank > 0:
-            system_items.append(("Batch/Rank", f"{self._batch_size_per_rank:,}"))
-        if (
-            self._effective_batch_size > 0
-            and self._effective_batch_size != self._batch_size_per_rank
-        ):
-            system_items.append(("Batch/Update", f"{self._effective_batch_size:,}"))
-        if (
-            self._replay_samples_per_iter > 0
-            and self._replay_samples_per_iter != self._learner_samples_per_iter
-        ):
-            system_items.append(("Replay/Iter", f"{self._replay_samples_per_iter:,}"))
-        if self._learner_samples_per_iter > 0:
-            system_items.append(("Samples/Iter", f"{self._learner_samples_per_iter:,}"))
-        yes_mark = "✓" if self._unicode_console else "yes"
-        no_mark = "✗" if self._unicode_console else "no"
-        sync_collect = (
-            f"{yes_mark} ({self._env_steps_per_sync})" if self._sync_collection else no_mark
-        )
-        system_items.append(("Sync Collect", sync_collect))
-        if self._staging_pool_max > 0:
-            staging_color = "green" if self._staging_pool_len < self._staging_pool_max else "yellow"
-            system_items.append(
-                (
-                    "Staging Pool",
-                    f"[{staging_color}]{self._staging_pool_len}/{self._staging_pool_max}[/]",
-                )
-            )
+        if batch_size_per_rank > 0:
+            system_items.append(("Batch/Rank", f"{batch_size_per_rank:,}"))
         row_count = max(len(learner_items), len(collector_items), len(system_items))
         for index in range(row_count):
             row: list[str] = []

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -31,9 +31,12 @@ class _SyncLearner:
             "qnet.w": torch.full((2,), 2.0),
         }
         self.gradient_sync = None
+        self.graph_replay_recorder = None
+        self.dp_cuda_graph_gradient_sync = False
 
-    def set_gradient_sync(self, sync) -> None:
+    def set_gradient_sync(self, sync, *, graph_replay_recorder=None) -> None:
         self.gradient_sync = sync
+        self.graph_replay_recorder = graph_replay_recorder
 
     def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         return self.tensors
@@ -58,6 +61,12 @@ class _FakeDpSync:
 
     def allreduce_gradients(self, parameters) -> None:
         self.calls.append(("allreduce_gradients", tuple(parameters)))
+
+    def record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        self.calls.append(("record_cuda_graph_gradient_replay", collective_calls))
+
+    def prepare_cuda_graph_collectives(self) -> None:
+        self.calls.append(("prepare_cuda_graph_collectives", None))
 
     def take_gradient_sync_metrics(self):
         self.calls.append(("take_gradient_sync_metrics", None))
@@ -92,6 +101,9 @@ def test_runner_attaches_per_optimizer_gradient_collective():
     parameter.grad = torch.full_like(parameter, 2.0)
     learner.gradient_sync((parameter,))
     assert dp_sync.calls == [("allreduce_gradients", (parameter,))]
+    assert learner.graph_replay_recorder is not None
+    learner.graph_replay_recorder(2)
+    assert dp_sync.calls[-1] == ("record_cuda_graph_gradient_replay", 2)
 
 
 def test_runner_collects_per_iteration_gradient_sync_metrics():
@@ -114,6 +126,19 @@ def test_dp_init_broadcast_starts_group_then_broadcasts():
     runner._dp_init_broadcast()
     assert [name for name, _ in dp_sync.calls] == ["start", "broadcast_from_rank0"]
     assert dp_sync.calls[1][1] is learner.tensors
+
+
+def test_dp_init_warms_nccl_collective_when_optimizer_graph_is_enabled():
+    learner = _SyncLearner()
+    learner.dp_cuda_graph_gradient_sync = True
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync)
+    runner._dp_init_broadcast()
+    assert [name for name, _ in dp_sync.calls] == [
+        "start",
+        "broadcast_from_rank0",
+        "prepare_cuda_graph_collectives",
+    ]
 
 
 def test_dp_init_broadcast_is_a_noop_without_dp_sync():
@@ -141,7 +166,7 @@ def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
 
     dp_sync = _FakeDpSync()
     runner = _runner_with(_SyncLearner(), dp_sync)
-    logger = OffPolicyLogger(log_backend="none")
+    logger = OffPolicyLogger(log_backend="none", num_gpus=dp_sync.world_size)
     logger._total_steps = 100
     logger._buffer_size = 50
     logger._buffer_target = 200
@@ -196,6 +221,7 @@ def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
     assert "Steps/s 400" in header
     assert "Samples/s 1,024" in header
     assert "Collector/s" not in header
+    assert "GPUs 2" in logger._build_display().title.plain
     runner._restore_local_logger_statistics(logger)
     assert logger._total_steps == 100
     assert logger._buffer_size == 50
@@ -362,8 +388,24 @@ def test_fast_sac_syncs_each_optimizer_gradient_before_step():
     assert len(calls) == 3  # critic, alpha, actor
     assert calls[1] == (1,)
 
+    calls.clear()
+    learner._cuda_graph_critic_action_noise = torch.zeros_like(batch["actions"])
+    learner._update_critic_capture_candidate(
+        batch["critic"],
+        batch["actions"],
+        batch["rewards"],
+        batch["next_obs"],
+        batch["next_critic"],
+        batch["dones"],
+        batch["truncated"],
+    )
+    learner._cuda_graph_actor_action_noise = torch.zeros_like(batch["actions"])
+    learner._update_actor_capture_candidate(batch["obs"], batch["critic"])
+    assert len(calls) == 3  # captured critic, alpha, actor collectives
+    assert calls[1] == (1,)
 
-def test_fast_sac_gradient_sync_disables_cuda_graph_capture():
+
+def test_fast_sac_gradient_sync_preserves_cuda_graph_capture():
     from unilab.algos.torch.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
@@ -384,11 +426,11 @@ def test_fast_sac_gradient_sync_disables_cuda_graph_capture():
 
     learner.set_gradient_sync(lambda parameters: None)
 
-    assert learner.dp_cuda_graph_fallback is True
-    assert learner.use_cuda_graph_critic is False
-    assert learner.use_cuda_graph_actor is False
-    assert learner.use_cuda_graph_critic_packed_staging is False
-    assert learner.use_cuda_graph_actor_packed_staging is False
+    assert learner.dp_cuda_graph_gradient_sync is True
+    assert learner.use_cuda_graph_critic is True
+    assert learner.use_cuda_graph_actor is True
+    assert learner.use_cuda_graph_critic_packed_staging is True
+    assert learner.use_cuda_graph_actor_packed_staging is True
 
 
 # ---- build_runner assembly ----
@@ -560,8 +602,14 @@ def test_flash_sac_syncs_each_optimizer_gradient_before_step():
     assert len(calls) == 3  # critic, actor, temperature
     assert calls[-1] == (1,)
 
+    calls.clear()
+    learner._update_critic_capture_candidate(learner._prepare_critic_graph_inputs(batch))
+    learner._update_actor_capture_candidate(learner._prepare_actor_graph_inputs(batch))
+    assert len(calls) == 3  # captured critic, actor, temperature collectives
+    assert calls[-1] == (1,)
 
-def test_gradient_sync_falls_back_from_cuda_graph_to_eager_updates():
+
+def test_flash_sac_gradient_sync_preserves_cuda_graph_and_cpu_fallback_updates():
     from unilab.algos.torch.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
@@ -587,11 +635,11 @@ def test_gradient_sync_falls_back_from_cuda_graph_to_eager_updates():
         calls.append(tuple(parameter.numel() for parameter in params))
 
     learner.set_gradient_sync(record_gradients)
-    assert learner.dp_cuda_graph_fallback is True
-    assert learner.use_cuda_graph_critic is False
-    assert learner.use_cuda_graph_actor is False
-    assert learner.use_cuda_graph_critic_packed_staging is False
-    assert learner.use_cuda_graph_actor_packed_staging is False
+    assert learner.dp_cuda_graph_gradient_sync is True
+    assert learner.use_cuda_graph_critic is True
+    assert learner.use_cuda_graph_actor is True
+    assert learner.use_cuda_graph_critic_packed_staging is True
+    assert learner.use_cuda_graph_actor_packed_staging is True
     batch_size = 4
     batch = {
         "obs": torch.randn(batch_size, 4),

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -6,10 +6,11 @@ import pytest
 from rich.console import Console
 
 import unilab.logging.common as common_logger_module
+import unilab.logging.offpolicy as offpolicy_logger_module
 from unilab.logging.offpolicy import OffPolicyLogger
 
 
-def test_offpolicy_logger_defers_warmup_refresh_until_training_step(monkeypatch) -> None:
+def test_offpolicy_logger_only_forces_refresh_for_errors(monkeypatch) -> None:
     logger = OffPolicyLogger(
         algo_name="SAC",
         max_iterations=2,
@@ -44,7 +45,7 @@ def test_offpolicy_logger_defers_warmup_refresh_until_training_step(monkeypatch)
     logger.log_status("Training")
     logger.log_buffer_fill(64, 64)
 
-    assert refresh_calls == [False, False, False]
+    assert refresh_calls == []
 
 
 def test_offpolicy_logger_stop_live_lets_rich_do_final_refresh() -> None:
@@ -97,7 +98,6 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
             "env_step_update_state_ms": 1.0,
             "env_step_reset_done_ms": 0.5,
             "replay_write_ms": 0.3,
-            "bookkeeping_ms": 0.0,
         }
     )
 
@@ -137,7 +137,7 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
     assert len(set(connector_columns)) == 1
 
 
-def test_offpolicy_logger_normalizes_pre_contract_collector_timing_names() -> None:
+def test_offpolicy_logger_discards_retired_collector_timing_names() -> None:
     logger = OffPolicyLogger(log_backend="none")
 
     logger.update_collector_timing(
@@ -148,10 +148,7 @@ def test_offpolicy_logger_normalizes_pre_contract_collector_timing_names() -> No
         }
     )
 
-    assert logger._collector_timing == {
-        "learner_action_wait_ms": 4.0,
-        "bookkeeping_ms": 3.0,
-    }
+    assert logger._collector_timing == {"learner_action_wait_ms": 4.0}
 
 
 def test_offpolicy_logger_waits_for_complete_collector_cycle_before_percentages() -> None:
@@ -369,9 +366,102 @@ def test_offpolicy_logger_moves_identity_and_iteration_to_panel_title() -> None:
 
     assert isinstance(display.title, type(header))
     assert display.title.plain == (
-        " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | iter 5000/5000 "
+        " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | GPUs 1 | iter 5000/5000 "
     )
     assert "FastSAC" not in header.plain
     assert "G1WalkFlat" not in header.plain
     assert "iter 5000/5000" not in header.plain
     assert "Training" not in header.plain
+
+
+def test_offpolicy_terminal_averages_aggregated_samples_over_two_seconds(
+    monkeypatch,
+) -> None:
+    now = 100.0
+    monkeypatch.setattr(offpolicy_logger_module.time, "monotonic", lambda: now)
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.scalars: list[tuple[str, float, int]] = []
+
+        def add_scalar(self, tag: str, value: float, step: int) -> None:
+            self.scalars.append((tag, value, step))
+
+    logger = OffPolicyLogger(log_backend="none", num_gpus=2)
+    writer = _Writer()
+    logger._tb_writer = writer
+
+    logger.update_timeout_rate(0.2)
+    logger.update_collector_timing(
+        {
+            "inference_request_ms": 1.0,
+            "learner_action_wait_ms": 2.0,
+            "env_step_ms": 3.0,
+            "replay_write_ms": 4.0,
+        }
+    )
+    logger.log_step(
+        iteration=1,
+        metrics={"critic_loss": 2.0},
+        train_time=0.2,
+        iteration_time=0.5,
+        extra_info={
+            "steps_per_sec": 400.0,
+            "learner_samples_per_sec": 1_000.0,
+        },
+    )
+
+    now = 101.0
+    logger.update_timeout_rate(0.4)
+    logger.update_collector_timing(
+        {
+            "inference_request_ms": 3.0,
+            "learner_action_wait_ms": 4.0,
+            "env_step_ms": 5.0,
+            "replay_write_ms": 6.0,
+        }
+    )
+    logger.log_step(
+        iteration=2,
+        metrics={"critic_loss": 4.0},
+        train_time=0.4,
+        iteration_time=1.0,
+        extra_info={
+            "steps_per_sec": 800.0,
+            "learner_samples_per_sec": 3_000.0,
+        },
+    )
+
+    snapshot = logger._terminal_snapshot
+    assert snapshot is not None
+    assert snapshot.sample_count == 2
+    assert snapshot.metrics["critic_loss"] == pytest.approx(3.0)
+    assert snapshot.scalars["_train_time"] == pytest.approx(0.3)
+    assert snapshot.scalars["timeout_rate"] == pytest.approx(0.3)
+    assert snapshot.scalars["steps_per_sec"] == pytest.approx(600.0)
+    assert snapshot.scalars["samples_per_sec"] == pytest.approx(2_000.0)
+    assert snapshot.collector_timing["env_step_ms"] == pytest.approx(4.0)
+    collector_values = list(logger._build_timing_table().columns[3].cells)
+    assert "    4.0ms   29%" in collector_values
+    assert "Avg 2s (n=2)" in logger._build_compact_header(include_status=False).plain
+    assert "GPUs 2" in logger._build_display().title.plain
+
+    latest_backend_values = {tag: value for tag, value, _ in writer.scalars}
+    assert latest_backend_values["train/critic_loss"] == pytest.approx(4.0)
+    assert latest_backend_values["perf/steps_per_sec"] == pytest.approx(800.0)
+
+    now = 103.1
+    logger.log_step(
+        iteration=3,
+        metrics={"critic_loss": 10.0},
+        train_time=1.0,
+        iteration_time=2.0,
+        extra_info={
+            "steps_per_sec": 1_200.0,
+            "learner_samples_per_sec": 5_000.0,
+        },
+    )
+    snapshot = logger._terminal_snapshot
+    assert snapshot is not None
+    assert snapshot.sample_count == 1
+    assert snapshot.metrics["critic_loss"] == pytest.approx(10.0)

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -175,6 +175,30 @@ def test_close_without_start_is_idempotent(tmp_path: Path):
     sync.close()
 
 
+def test_cuda_graph_collective_warmup_requires_started_nccl_cuda_group(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused_graph_warmup"),
+        backend="gloo",
+    )
+    with pytest.raises(RuntimeError, match=r"start\(\) must run"):
+        sync.prepare_cuda_graph_collectives()
+
+
+def test_cuda_graph_replay_metrics_count_actual_collectives(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused_graph_metrics"),
+        backend="gloo",
+    )
+    sync.record_cuda_graph_gradient_replay(3)
+    assert sync.take_gradient_sync_metrics() == (0.0, 3)
+    with pytest.raises(ValueError, match=">= 0"):
+        sync.record_cuda_graph_gradient_replay(-1)
+
+
 def test_invalid_world_size_and_rank_are_rejected(tmp_path: Path):
     path = str(tmp_path / "unused")
     with pytest.raises(ValueError, match="world_size >= 2"):
@@ -237,5 +261,17 @@ def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
         total={"steps_per_sec": float(100 * (rank + 1))},
     )
     assert statistics == pytest.approx({"loss": 1.5, "steps_per_sec": 300.0})
+    sync.prepare_cuda_graph_collectives()
+    tensor.grad = torch.full_like(tensor, float(rank + 1))
+    graph = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+        sync.allreduce_gradients((tensor,))
+    torch.cuda.current_stream(device).wait_stream(capture_stream)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.allclose(tensor.grad, torch.full((8,), 1.5, device=device))
+    graph.reset()
     sync.close()
     result_queue.put(rank)

--- a/tests/nan_injection/stage3_nan_inject.py
+++ b/tests/nan_injection/stage3_nan_inject.py
@@ -106,9 +106,6 @@ class _FakeLogger:
         self._buffer_size = 0
         self._mean_ep_length = 0.0
 
-    def set_collection_sync(self, enabled, env_steps_per_sync):
-        del enabled, env_steps_per_sync
-
     def start(self, **kwargs):
         del kwargs
 
@@ -133,8 +130,8 @@ class _FakeLogger:
     def update_collector_timing(self, timing_ms):
         del timing_ms
 
-    def update_done_rates(self, timeout_rate, terminated_rate):
-        del timeout_rate, terminated_rate
+    def update_timeout_rate(self, timeout_rate):
+        del timeout_rate
 
     def update_replay_queue(self, current_len, max_size):
         del current_len, max_size

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -70,10 +70,12 @@ class _FakeTensorBoardWriter:
 
 def test_training_logger_defers_initial_live_render(monkeypatch):
     start_refresh_values: list[bool] = []
+    live_kwargs: list[dict[str, Any]] = []
 
     class _FakeLive:
         def __init__(self, *args, **kwargs):
-            del args, kwargs
+            del args
+            live_kwargs.append(kwargs)
 
         def start(self, *, refresh: bool = False) -> None:
             start_refresh_values.append(refresh)
@@ -91,9 +93,12 @@ def test_training_logger_defers_initial_live_render(monkeypatch):
     logger.close()
 
     assert start_refresh_values == [False]
+    assert live_kwargs[0]["auto_refresh"] is True
+    assert live_kwargs[0]["refresh_per_second"] == 2
+    assert callable(live_kwargs[0]["get_renderable"])
 
 
-def test_offpolicy_training_terminal_refresh_uses_single_low_frequency_trigger(monkeypatch):
+def test_offpolicy_training_terminal_uses_fixed_clock_and_only_forces_errors(monkeypatch):
     update_refresh_values: list[bool | None] = []
     now = 100.0
 
@@ -120,19 +125,19 @@ def test_offpolicy_training_terminal_refresh_uses_single_low_frequency_trigger(m
     logger = OffPolicyLogger(log_backend="none", refresh_per_second=4)
     logger.start()
     logger.log_step(iteration=1, train_time=0.01, collector_wait_time=0.0)
-    assert update_refresh_values == [True]
+    assert update_refresh_values == []
 
     logger.log_collector(total_steps=128, buffer_size=128, mean_reward=2.0)
     logger.log_status("Collector metrics updated")
     logger.log_save("/tmp/model_2.pt")
-    assert update_refresh_values == [True]
+    assert update_refresh_values == []
 
     now += 0.3
     logger.log_step(iteration=2, train_time=0.01, collector_wait_time=0.0)
-    assert update_refresh_values == [True, True]
+    assert update_refresh_values == []
 
     logger.log_status("[red]ERROR: Collector died[/]")
-    assert update_refresh_values == [True, True, True]
+    assert update_refresh_values == [True]
 
     logger.close()
 
@@ -227,12 +232,15 @@ def test_offpolicy_logger_terminal_keeps_core_bottleneck_timing_rows():
     assert "Param Sync" not in output
     assert "Unaccounted" not in output
     assert "Other Loop" not in output
-    assert "GPUs" not in output
+    assert "GPUs 1" in output
     assert "Sync Mode" not in output
     assert "Sync Interval" not in output
+    assert "Sync Collect" not in output
+    assert "Terminated Rate" not in output
+    assert "Staging Pool" not in output
     assert "Batch/Rank" in output
     assert "Batch/Update" not in output
-    assert "Samples/Iter" in output
+    assert "Samples/Iter" not in output
     assert "Samples/s" in output
 
     logger.close()
@@ -296,8 +304,8 @@ def test_offpolicy_logger_terminal_shows_replay_rows_when_symmetry_expands_batch
     output = console.export_text()
 
     assert "Batch/Rank" in output
-    assert "Replay/Iter" in output
-    assert "Samples/Iter" in output
+    assert "Replay/Iter" not in output
+    assert "Samples/Iter" not in output
     assert "Samples/s" in output
     assert "Rank Barrier" not in output
     assert "Param Sync" not in output
@@ -631,7 +639,6 @@ def test_offpolicy_logger_uses_same_canonical_timing_names_in_terminal_and_backe
             "learner_action_wait_ms": 2.0,
             "env_step_ms": 3.0,
             "replay_write_ms": 4.0,
-            "bookkeeping_ms": 5.0,
         }
     )
     logger.log_step(
@@ -674,23 +681,22 @@ def test_offpolicy_logger_uses_same_canonical_timing_names_in_terminal_and_backe
         assert key in payload
     assert "timing/learner_replay_stage_ms" not in payload
     assert "timing/learner_weight_publish_ms" not in payload
-    assert collector_labels[:5] == [
+    assert collector_labels[:4] == [
         "Inference Request",
         "Learner Action Wait",
         "Env Step",
         "Replay Write",
-        "Bookkeeping",
     ]
     for key in (
         "timing/collector_inference_request_ms",
         "timing/collector_learner_action_wait_ms",
         "timing/collector_env_step_ms",
         "timing/collector_replay_write_ms",
-        "timing/collector_bookkeeping_ms",
         "perf/collector_cycle_ms",
     ):
         assert key in payload
-    assert payload["perf/collector_cycle_ms"] == pytest.approx(15.0)
+    assert "timing/collector_bookkeeping_ms" not in payload
+    assert payload["perf/collector_cycle_ms"] == pytest.approx(10.0)
     logger.finish()
 
 
@@ -748,6 +754,8 @@ def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_scalars():
     assert scalars["perf/learner_other_pct"] == pytest.approx(0.16 / 2.15 * 100)
     assert scalars["perf/collector_active_steps_per_sec"] == pytest.approx(4321.0)
     assert scalars["perf/effective_samples_per_sec"] == pytest.approx(64.0 / 2.15)
+    assert scalars["episode/timeout_rate"] == pytest.approx(0.0)
+    assert "episode/terminated_rate" not in scalars
     for key in ("axis/iteration", "axis/env_steps_total"):
         assert key not in scalars
     assert not any(key.startswith("distributed/") for key in scalars)


### PR DESCRIPTION
## Summary

- warm up NCCL collectives before CUDA Graph capture and keep stable flat-gradient buffers across replay
- capture FastSAC and FlashSAC gradient synchronization safely, with graph teardown before process-group destruction
- make rank 0 the only terminal/backend logger owner, use fixed-rate rolling terminal statistics, and report aggregate job throughput
- remove retired non-sync collector presentation paths and redundant collector telemetry
- add an NCCL CUDA Graph reproducer, regression coverage, and logging documentation

## Validation

- `make test-all` — 1611 passed, 49 skipped, 1 xfailed
- real 2-GPU SAC smoke — 4 iterations completed with one `GPUs 2` terminal and one checkpoint copy
- Sphinx HTML build with nitpicky mode — passed

Addresses #978