### PR TITLE
feat(ppo): add single-node RSL-RL multi-GPU training

### DIFF
--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -56,6 +56,10 @@ algo:
 
 training:
   task_name: Go1JoystickFlat
+  # list[int] | null; null/[] keeps single-device behavior, [d] selects one
+  # CUDA device, and [d0..dN-1] launches one RSL-RL worker per device.
+  # algo.num_envs is per rank; do not set this together with training.device.
+  devices: null
   device: null
   logger: tensorboard
   wandb_project: unilab

--- a/docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md
+++ b/docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md
@@ -6,6 +6,7 @@ orphan: true
 
 - Status: Accepted
 - Date: 2026-04-11
+- Last updated: 2026-08-15
 - Owners: Infra / Training maintainers
 - Supersedes: None
 - Superseded by: None
@@ -22,6 +23,9 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 2. 分层依赖单向: `backend -> env -> config/registry -> algo/ipc -> scripts`。
 3. `scripts/` 只做装配，不承载长期业务规则。
 4. 变更评审优先检查 contract 是否被破坏，而不是只看 smoke run 是否通过。
+5. 同步 PPO 默认单进程；单机多卡时按一卡一进程复制 env、policy 与 rollout，复用
+   RSL-RL 的 startup model broadcast 和 per-mini-batch gradient averaging，不在
+   UniLab 另建 PPO 同步协议。
 
 ## Stable Contracts
 
@@ -29,17 +33,27 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 - `NpEnvState.obs` 必须是 `dict`，`reset()` 返回 `(obs_dict, info_dict)`。
 - `SimBackend` 是 backend 抽象边界；算法与脚本不应依赖后端私有实现。
 - 异步路径统一复用 `AsyncRunner` 生命周期与 shared resource cleanup。
+- PPO 的 `algo.num_envs` 是 per-rank 数量；全局每轮新样本数为
+  `world_size * num_envs * num_steps_per_env`。
+- PPO 多卡只有 rank 0 持久化日志/checkpoint；rollout、GAE、normalizer buffer、
+  curriculum 与 episode statistics 不做隐式全局聚合。
 
 ## Consequences
 
 - 跨层问题必须在 owner layer 修复。
 - 新功能必须先确定 contract 归属，再决定具体落点。
 - 文档和评审用语应区分“稳定 contract”与“阶段性能力”。
+- PPO launcher 只维护单机 device/rank 与 worker lifecycle；算法 collective 的版本
+  兼容性继续由锁定的 RSL-RL 依赖负责。
 
 ## Alternatives Considered
 
 - 保持脚本层按训练入口各自处理 backend/env/algo 差异。拒绝原因：会把 contract 漏洞扩散到 `scripts/`，并让 smoke run 掩盖 owner layer 问题。
 - 只用顶层训练脚本定义 runtime contract。拒绝原因：无法约束 env、backend、runner 和 IPC 的长期边界。
+- 要求用户手工调用 `torchrun`。拒绝原因：无法稳定提供 Hydra device list、共享运行
+  目录、rank seed 与顶层 CLI 的失败传播语义。
+- 在 UniLab 自行实现 PPO gradient collective。拒绝原因：会与 RSL-RL 已有的广播、
+  adaptive-KL 和 mini-batch 同步周期形成第二套协议。
 
 ## Evidence In Repo
 
@@ -48,6 +62,10 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 - Env contract: `src/unilab/base/np_env.py`
 - Registry 入口: `src/unilab/base/registry.py`
 - Async runner: `src/unilab/ipc/async_runner.py`
+- PPO distributed adapter: `src/unilab/ipc/dp_launcher.py`,
+  `src/unilab/training/rsl_rl.py`, `scripts/train_rsl_rl.py`
+- PPO distributed tests: `tests/ipc/test_dp_launcher.py`,
+  `tests/algos/test_rsl_rl_ppo.py`, `tests/scripts/test_train_script_configs.py`
 
 ## Related Documents
 

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
@@ -29,3 +29,57 @@ uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
 
 Logs are grouped by `algo.algo_log_name`; the default in `conf/ppo/config.yaml`
 is `rsl_rl_ppo`.
+
+## Single-node multi-GPU training
+
+`training.devices` enables RSL-RL's synchronous data-parallel PPO path:
+
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+
+uv run train --algo ppo --task g1_motion_tracking --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+```
+
+`null` or `[]` keeps automatic single-device selection, `[d]` selects one
+CUDA device, and two or more entries launch one local process per listed
+device. Do not set `training.device` and `training.devices` together. The
+configured order is preserved, including when the parent already has
+`CUDA_VISIBLE_DEVICES` set.
+
+`algo.num_envs` is a **per-rank** count, not a global budget. For `W` ranks,
+`N` configured envs, and rollout length `T`:
+
+```text
+local samples / iteration  = N * T
+global samples / iteration = W * N * T
+```
+
+Each rank owns an independent env, policy copy, and rollout storage. Rollouts,
+GAE, advantage normalization, and mini-batch shuffling stay rank-local.
+RSL-RL broadcasts rank 0's model state at startup and averages gradients after
+every PPO mini-batch backward pass. Rank `i` uses `algo.seed + i`.
+`training.num_timesteps` is interpreted as a global sample budget and therefore
+uses `W * N * T` when deriving the iteration count.
+
+Only rank 0 writes TensorBoard/W&B data, checkpoints, `run_config.json`, and
+`run_summary.json`, then optionally enters playback after all ranks have closed
+their process group. `run_summary.json` records `world_size`, per-rank/global
+env counts, samples per iteration, and aggregate training throughput. RSL-RL's
+`Perf/total_fps` is also an aggregate global samples/s metric; reward and episode
+statistics remain rank-0-local.
+
+RSL-RL does not synchronize observation-normalizer buffers or environment
+curriculum state after startup. Consequently, tasks with empirical
+normalization (including the current Go2 flat owner) keep rank-local statistics,
+and the checkpoint contains rank 0's copy. This is the upstream RSL-RL
+distributed semantic, not global-rollout PPO.
+
+The integrated launcher is single-node only. The repository has two-GPU MuJoCo
+smoke coverage for `go2_joystick_flat` and `g1_motion_tracking`; this does not
+claim multi-node or Motrix multi-GPU support. On the currently validated RTX
+6000D host, the launcher inherits the production NCCL compatibility defaults
+`NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1`; explicit environment values win.

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
@@ -28,3 +28,52 @@ uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
 
 日志按 `algo.algo_log_name` 分组；`conf/ppo/config.yaml` 中的默认值为
 `rsl_rl_ppo`。
+
+## 单机多卡训练
+
+`training.devices` 打开 RSL-RL 的同步数据并行 PPO：
+
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+
+uv run train --algo ppo --task g1_motion_tracking --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+```
+
+`null` 或 `[]` 保持自动选择单个 device；`[d]` 显式选择一张 CUDA 卡；两个以上
+索引会按列表顺序在本机为每张卡启动一个进程。不能同时设置 `training.device` 与
+`training.devices`。父进程已有 `CUDA_VISIBLE_DEVICES` 时，配置索引仍按父进程可见
+设备解释，并保留用户给定顺序。
+
+`algo.num_envs` 是**每个 rank** 的环境数，不是全局预算。设 rank 数为 `W`、配置
+环境数为 `N`、rollout 长度为 `T`：
+
+```text
+每 rank 每轮样本数 = N * T
+全局每轮样本数     = W * N * T
+```
+
+每个 rank 独立持有 env、policy copy 和 rollout storage；rollout、GAE、advantage
+normalization 与 mini-batch shuffle 都留在本地。RSL-RL 在启动时广播 rank 0 的模型
+状态，并在每个 PPO mini-batch backward 后平均梯度。rank `i` 使用
+`algo.seed + i`。`training.num_timesteps` 按全局样本预算解释，因此推导 iteration
+数时使用 `W * N * T`。
+
+只有 rank 0 写 TensorBoard/W&B、checkpoint、`run_config.json` 与
+`run_summary.json`；所有 rank 销毁 process group 后，才由 rank 0 可选进入
+playback。`run_summary.json` 记录 world size、每 rank/全局环境数、每轮样本数和
+聚合训练吞吐率。RSL-RL 的 `Perf/total_fps` 同样是全局 samples/s；reward 与
+episode 统计仍是 rank 0 的本地视角。
+
+RSL-RL 启动后不会同步 observation normalizer buffer 或环境 curriculum 状态。因此，
+启用 empirical normalization 的 task（包括当前 Go2 flat owner）保留 rank-local
+统计，checkpoint 保存 rank 0 的副本。这是上游 RSL-RL 的分布式语义，不是先拼接
+全局 rollout 再训练的 PPO。
+
+集成 launcher 只覆盖单机。仓库已有 `go2_joystick_flat` 与
+`g1_motion_tracking` 的双卡 MuJoCo smoke；这不构成多机或 Motrix 多卡 support
+声明。当前验证的 RTX 6000D 主机沿用 production NCCL 兼容默认值
+`NCCL_P2P_DISABLE=1`、`NCCL_SHM_DISABLE=1`，用户显式环境变量优先。

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
@@ -12,8 +12,10 @@ CPU physics backend -> collector / IPC -> learner
 MuJoCo or Motrix      shared memory       torch
 ```
 
-PPO 是同步的单进程路径。APPO 与 off-policy 算法则使用异步 runner、
-共享缓冲区，以及位于 `src/unilab/ipc/` 与 `src/unilab/algos/` 下的权重同步原语。
+PPO 是同步路径：默认单进程，也可在单机上按一卡一进程运行 RSL-RL 数据并行；
+每个 rank 独立持有 env/rollout，RSL-RL 在每个 mini-batch 后平均梯度。APPO 与
+off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `src/unilab/ipc/` 与
+`src/unilab/algos/` 下的权重同步原语。
 
 ## 分层边界
 

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
@@ -11,7 +11,15 @@
 
 `scripts/train_rsl_rl.py` 会 compose Hydra config、
 调用 registry bootstrap、通过 `registry.make(...)` 构造 env，并在同一进程内运行
-learner。RSL-RL 路径通过 `src/unilab/training/rsl_rl.py` 适配 `NpEnv`。
+learner。默认配置保持单进程；`training.devices` 指定多张卡时，父进程通过 PyTorch
+elastic launcher 启动本机 worker，worker 再进入同一脚本完成上述构造。RSL-RL 路径
+通过 `src/unilab/training/rsl_rl.py` 适配 `NpEnv`。
+
+多卡时每个 rank 按配置创建完整的 `algo.num_envs`、policy copy 与 rollout storage，
+数据和 GAE 不跨 rank 交换。RSL-RL 负责 startup model broadcast、adaptive-KL 标量
+同步，以及每个 PPO mini-batch 的梯度平均。UniLab 的 launcher 只负责 device/rank、
+共享 log dir、seed offset 与进程失败联动，不另建 PPO 同步协议。只有 rank 0 写日志与
+checkpoint；normalizer buffer、curriculum 和 episode 统计保持 rank-local。
 
 ### 异步 APPO 与 off-policy 路径
 
@@ -36,6 +44,8 @@ CPU physics env loop -> shared IPC buffer -> learner
 - GPU tensor 与 optimizer 状态属于 learner 代码，而非 env 代码。
 - Collector/learner 协议必须复用现有的 IPC 原语，而不是在 scripts 中另起临时的
   并行协议。
+- PPO 多卡必须复用 RSL-RL 的 distributed contract；`algo.num_envs` 是 per-rank
+  语义，不能在脚本中静默除以 world size。
 
 ## 仓库中的证据
 

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import statistics
 import sys
 import time
@@ -18,6 +19,15 @@ if str(ROOT_DIR) not in sys.path:
 
 from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_LOG_DIR,
+    current_torch_distributed_local_rank,
+    current_torch_distributed_rank,
+    current_torch_distributed_world_size,
+    launch_torchrun_workers,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
 from unilab.training import (
     BackendAdapter,
     apply_configured_training_seed,
@@ -35,7 +45,15 @@ from unilab.training.experiment import (
     patch_rsl_rl_resume_state,
     patch_rsl_rl_wandb_writer,
 )
-from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
+from unilab.training.rsl_rl import (
+    RslRlVecEnvWrapper,
+    apply_rsl_rl_rank_seed,
+    finish_rsl_rl_distributed,
+    normalize_ppo_train_cfg,
+    ppo_samples_per_iteration,
+    resolve_rsl_rl_device,
+    rsl_rl_single_process_topology,
+)
 from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
 from unilab.utils.device import get_default_device
 
@@ -101,6 +119,36 @@ def run_motrix_rsl_play_loop(
 
 def _get_log_root(cfg: DictConfig) -> str:
     return str(get_log_root(ROOT_DIR, cfg))
+
+
+def build_ppo_run_dir_name(timestamp: str, sim_backend: str, *, world_size: int = 1) -> str:
+    gpu_suffix = f"_gpux{world_size}" if world_size > 1 else ""
+    return f"{timestamp}_{sim_backend}{gpu_suffix}"
+
+
+def resolve_ppo_log_dir(
+    cfg: DictConfig,
+    *,
+    world_size: int,
+    timestamp: str | None = None,
+) -> str:
+    """Resolve one canonical run directory shared by all distributed ranks."""
+    distributed_log_dir = os.environ.get(UNILAB_DP_LOG_DIR)
+    if distributed_log_dir:
+        return distributed_log_dir
+    configured_log_dir = OmegaConf.select(cfg, "training.log_dir", default=None)
+    if configured_log_dir:
+        return str(configured_log_dir)
+    timestamp = timestamp or datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    return str(
+        Path(_get_log_root(cfg))
+        / str(cfg.training.task_name)
+        / build_ppo_run_dir_name(
+            timestamp,
+            str(cfg.training.sim_backend),
+            world_size=world_size,
+        )
+    )
 
 
 def _algo_config_dict(cfg: DictConfig) -> dict[str, Any]:
@@ -296,18 +344,70 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
 
 @hydra.main(version_base="1.3", config_path="../conf/ppo", config_name="config")
 def main(cfg: DictConfig) -> None:
-    ensure_registries()
+    devices = resolve_dp_topology(cfg.training.devices)
+    rank = current_torch_distributed_rank()
+    local_rank = current_torch_distributed_local_rank()
+    world_size = current_torch_distributed_world_size()
+    configured_device = OmegaConf.select(cfg, "training.device", default=None)
 
+    if configured_device is not None and devices is not None:
+        raise ValueError("Set either training.device or training.devices, not both")
+    if rank < 0 or rank >= world_size:
+        raise ValueError(f"RANK={rank} is out of range for WORLD_SIZE={world_size}")
+    if cfg.training.play_only and world_size > 1:
+        raise ValueError(
+            "Distributed play-only execution is not supported; launch eval normally and "
+            "select one device"
+        )
+
+    # The parent only composes config and invokes torchrun. CUDA, registry,
+    # env, tracker, and runner construction all happen inside workers.
+    if devices is not None and len(devices) > 1 and world_size == 1:
+        if not cfg.training.play_only:
+            log_dir = resolve_ppo_log_dir(cfg, world_size=len(devices))
+            launch_torchrun_workers(
+                devices,
+                script_path=Path(__file__),
+                argv=sys.argv[1:],
+                log_dir=log_dir,
+            )
+            return
+        validate_dp_launchable(devices)
+    elif devices is not None and world_size == 1:
+        validate_dp_launchable(devices)
+
+    if (
+        world_size > 1
+        and os.environ.get(UNILAB_DP_LOG_DIR) is None
+        and OmegaConf.select(cfg, "training.log_dir", default=None) is None
+    ):
+        raise ValueError(
+            "Distributed RSL-RL workers require one shared run directory; use "
+            "training.devices or set training.log_dir explicitly"
+        )
+
+    ensure_registries()
+    apply_rsl_rl_rank_seed(cfg, rank)
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     env_cfg_override = build_ppo_env_cfg_override(cfg)
 
-    device = get_default_device()
-    print(f"Using device: {device}")
+    device = resolve_rsl_rl_device(
+        configured_device=str(configured_device) if configured_device is not None else None,
+        devices=devices,
+        world_size=world_size,
+        local_rank=local_rank,
+        default_device=get_default_device(),
+    )
+    print(f"[rank {rank}/{world_size}] Using device: {device}")
 
     # Compute effective max_iterations (supports num_timesteps override)
     max_iterations = cfg.algo.max_iterations
     if cfg.training.num_timesteps:
-        n_steps_per_iter = cfg.algo.num_steps_per_env * cfg.algo.num_envs
+        n_steps_per_iter = ppo_samples_per_iteration(
+            num_envs=cfg.algo.num_envs,
+            num_steps_per_env=cfg.algo.num_steps_per_env,
+            world_size=world_size,
+        )
         max_iterations = max(1, int(cfg.training.num_timesteps / n_steps_per_iter))
         print(
             f"Overriding max_iterations to {max_iterations} based on "
@@ -315,16 +415,12 @@ def main(cfg: DictConfig) -> None:
         )
 
     if not cfg.training.play_only:
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_root = _get_log_root(cfg)
-        log_dir = str(
-            Path(log_root) / cfg.training.task_name / f"{timestamp}_{cfg.training.sim_backend}"
-        )
+        log_dir = resolve_ppo_log_dir(cfg, world_size=world_size)
     else:
         log_dir = None
 
     tracker = None
-    if not cfg.training.play_only and log_dir is not None:
+    if not cfg.training.play_only and log_dir is not None and rank == 0:
         tracker = ExperimentTracker(
             root_dir=ROOT_DIR,
             log_dir=log_dir,
@@ -338,6 +434,7 @@ def main(cfg: DictConfig) -> None:
         )
         tracker.start()
 
+    training_succeeded = False
     try:
         if not cfg.training.play_only:
             env = create_env(
@@ -400,48 +497,79 @@ def main(cfg: DictConfig) -> None:
                 resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
                 if resume_path:
                     print(f"Resuming from {resume_path}")
-                    runner.load(str(resume_path))
+                    runner.load(str(resume_path), map_location=device)
 
+            initial_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+            initial_training_time = float(getattr(runner.logger, "tot_time", 0.0))
             train_start_wall = time.time()
             runner.learn(num_learning_iterations=max_iterations, init_at_random_ep_len=True)
-            assert log_dir is not None
-            train_summary = {
-                "status": "completed",
-                "completed_iterations": int(runner.current_learning_iteration),
-                "total_env_steps": int(getattr(runner.logger, "tot_timesteps", 0)),
-                "final_mean_reward": (
-                    float(statistics.mean(runner.logger.rewbuffer))
-                    if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                    else None
-                ),
-                "best_mean_reward": (
-                    float(max(runner.logger.rewbuffer))
-                    if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                    else None
-                ),
-                "mean_episode_length": (
-                    float(statistics.mean(runner.logger.lenbuffer))
-                    if len(getattr(runner.logger, "lenbuffer", [])) > 0
-                    else None
-                ),
-                "last_checkpoint": str(
-                    Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
-                ),
-                "training_wall_time_sec": time.time() - train_start_wall,
-            }
-            if tracker is not None:
-                tracker.update_summary(train_summary)
+            training_succeeded = True
+            if rank == 0:
+                assert log_dir is not None
+                total_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+                total_training_time = float(getattr(runner.logger, "tot_time", 0.0))
+                run_timesteps = total_timesteps - initial_timesteps
+                run_training_time = total_training_time - initial_training_time
+                train_summary = {
+                    "status": "completed",
+                    "completed_iterations": int(runner.current_learning_iteration),
+                    "total_env_steps": total_timesteps,
+                    "run_env_steps": run_timesteps,
+                    "world_size": world_size,
+                    "num_envs_per_rank": int(cfg.algo.num_envs),
+                    "global_num_envs": int(cfg.algo.num_envs) * world_size,
+                    "samples_per_iteration": ppo_samples_per_iteration(
+                        num_envs=cfg.algo.num_envs,
+                        num_steps_per_env=cfg.algo.num_steps_per_env,
+                        world_size=world_size,
+                    ),
+                    "training_throughput_env_steps_per_sec": (
+                        run_timesteps / run_training_time if run_training_time > 0.0 else None
+                    ),
+                    "final_mean_reward": (
+                        float(statistics.mean(runner.logger.rewbuffer))
+                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                        else None
+                    ),
+                    "best_mean_reward": (
+                        float(max(runner.logger.rewbuffer))
+                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                        else None
+                    ),
+                    "mean_episode_length": (
+                        float(statistics.mean(runner.logger.lenbuffer))
+                        if len(getattr(runner.logger, "lenbuffer", [])) > 0
+                        else None
+                    ),
+                    "last_checkpoint": str(
+                        Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
+                    ),
+                    "training_wall_time_sec": time.time() - train_start_wall,
+                }
+                if tracker is not None:
+                    tracker.update_summary(train_summary)
             env.close()
 
-        if should_run_playback(
+            # Keep non-main ranks alive until rank 0 has persisted its final
+            # checkpoint and summary, then release NCCL before playback.
+            finish_rsl_rl_distributed(training_succeeded=training_succeeded)
+
+        if rank == 0 and should_run_playback(
             play_only=cfg.training.play_only,
             no_play=cfg.training.no_play,
             play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
         ):
-            play_video_path = play_rsl_rl(cfg, device)
+            # torchrun rank variables outlive the training process group. Mask
+            # them while playback constructs a new runner so rank 0 does not
+            # initialize a second NCCL group after sibling workers have exited.
+            with rsl_rl_single_process_topology():
+                play_video_path = play_rsl_rl(cfg, device)
             if tracker is not None:
                 tracker.log_video(play_video_path)
     finally:
+        # On failure, release an initialized group without a peer barrier;
+        # torchrun owns sibling termination and error propagation.
+        finish_rsl_rl_distributed(training_succeeded=training_succeeded)
         if tracker is not None:
             tracker.finish()
 

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -1,9 +1,10 @@
-"""Multi-GPU data-parallel rank topology for off-policy training.
+"""Single-node multi-GPU data-parallel launch and rank topology helpers.
 
 Topology rules (config parsing, rank/device mapping, subprocess supervision)
-live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
-This module covers topology only; the parameter-sync collectives between
-ranks live in ``dp_sync.py``.
+live here so training scripts only assemble their flows. The off-policy path
+uses :class:`DpRankSupervisor`; RSL-RL PPO uses PyTorch's elastic launcher and
+standard ``WORLD_SIZE`` / ``RANK`` / ``LOCAL_RANK`` variables. Algorithm-level
+collectives remain owned by their respective learner implementations.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 UNILAB_DP_RANK = "UNILAB_DP_RANK"
 UNILAB_DP_WORLD_SIZE = "UNILAB_DP_WORLD_SIZE"
@@ -66,6 +67,21 @@ def current_dp_rank() -> int:
 def current_dp_world_size() -> int:
     """Data-parallel world size of this process (1 when not spawned as a rank)."""
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def current_torch_distributed_rank() -> int:
+    """Global torch-distributed rank of this process (0 outside torchrun)."""
+    return int(os.environ.get("RANK", "0"))
+
+
+def current_torch_distributed_local_rank() -> int:
+    """Node-local torch-distributed rank of this process (0 outside torchrun)."""
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+
+def current_torch_distributed_world_size() -> int:
+    """Torch-distributed world size of this process (1 outside torchrun)."""
+    return int(os.environ.get("WORLD_SIZE", "1"))
 
 
 def resolve_dp_rendezvous_path(log_dir: str, *, rank: int) -> str:
@@ -161,6 +177,83 @@ def validate_dp_launchable(devices: tuple[int, ...]) -> None:
             f"training.devices={list(devices)} requires CUDA device index(es) {missing}, "
             f"but torch.cuda.device_count()={device_count}"
         )
+
+
+def resolve_cuda_visible_devices(
+    devices: tuple[int, ...],
+    *,
+    current_visible_devices: str | None = None,
+) -> str:
+    """Map configured logical CUDA indices to a child ``CUDA_VISIBLE_DEVICES`` value.
+
+    ``training.devices`` indexes the CUDA devices visible to the parent process.
+    When the parent already has ``CUDA_VISIBLE_DEVICES`` set, preserve that
+    mapping (including UUID entries) instead of accidentally switching back to
+    host-global device indices.
+    """
+    if current_visible_devices is None:
+        return ",".join(str(index) for index in devices)
+
+    visible_entries = [
+        entry.strip() for entry in current_visible_devices.split(",") if entry.strip()
+    ]
+    missing = [index for index in devices if index >= len(visible_entries)]
+    if missing:
+        raise ValueError(
+            f"training.devices={list(devices)} requires visible CUDA index(es) {missing}, "
+            f"but CUDA_VISIBLE_DEVICES={current_visible_devices!r} exposes "
+            f"{len(visible_entries)} device(s)"
+        )
+    return ",".join(visible_entries[index] for index in devices)
+
+
+def launch_torchrun_workers(
+    devices: tuple[int, ...],
+    *,
+    script_path: str | os.PathLike[str],
+    argv: Sequence[str],
+    log_dir: str,
+) -> None:
+    """Launch one local torchrun worker per configured CUDA device.
+
+    PyTorch elastic owns worker supervision and failure propagation. Each
+    worker re-enters the regular training script with the original Hydra
+    arguments, while ``UNILAB_DP_LOG_DIR`` supplies one canonical rank-0-owned
+    run directory.
+    """
+    if len(devices) < 2:
+        raise ValueError("launch_torchrun_workers requires at least two CUDA devices")
+    validate_dp_launchable(devices)
+
+    launch_env = os.environ.copy()
+    launch_env["CUDA_VISIBLE_DEVICES"] = resolve_cuda_visible_devices(
+        devices,
+        current_visible_devices=os.environ.get("CUDA_VISIBLE_DEVICES"),
+    )
+    # Keep the production transport defaults already used by DpParameterSync:
+    # current RTX 6000D hosts hang with NCCL P2P and can fault with SHM. An
+    # explicit user environment still wins over these compatibility defaults.
+    launch_env.setdefault("NCCL_P2P_DISABLE", "1")
+    launch_env.setdefault("NCCL_SHM_DISABLE", "1")
+    launch_env[UNILAB_DP_LOG_DIR] = str(log_dir)
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        "--nnodes=1",
+        f"--nproc_per_node={len(devices)}",
+        str(Path(script_path).resolve()),
+        *argv,
+    ]
+    print(
+        f"Launching RSL-RL data parallel training on CUDA devices {list(devices)} "
+        f"with {len(devices)} workers.",
+        flush=True,
+    )
+    completed = subprocess.run(command, env=launch_env, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(f"torchrun workers failed with exit code {completed.returncode}")
 
 
 def resolve_dp_rank_device(devices: tuple[int, ...] | None, rank: int) -> str | None:

--- a/src/unilab/training/rsl_rl.py
+++ b/src/unilab/training/rsl_rl.py
@@ -2,16 +2,109 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any
 
 import numpy as np
 import torch
+from omegaconf import open_dict
 from tensordict import TensorDict
 
 from unilab.base.final_observation import resolve_terminal_observation_contract
 from unilab.base.np_env import NpEnvState
 from unilab.utils.tensor import to_numpy, to_torch
+
+
+def apply_rsl_rl_rank_seed(cfg: Any, rank: int) -> int:
+    """Apply RSL-RL's ``base seed + global rank`` data-parallel contract."""
+    if rank < 0:
+        raise ValueError(f"rank must be non-negative, got {rank}")
+    base_seed = int(cfg.algo.seed)
+    with open_dict(cfg):
+        cfg.algo.seed = base_seed + int(rank)
+    return int(cfg.algo.seed)
+
+
+def resolve_rsl_rl_device(
+    *,
+    configured_device: str | None,
+    devices: tuple[int, ...] | None,
+    world_size: int,
+    local_rank: int,
+    default_device: str,
+) -> str:
+    """Resolve the exact device string expected by RSL-RL's runner.
+
+    Integrated multi-GPU workers see the selected physical devices through a
+    remapped ``CUDA_VISIBLE_DEVICES`` list, so RSL-RL must receive
+    ``cuda:LOCAL_RANK`` rather than the original host-global device index.
+    """
+    if configured_device is not None and devices is not None:
+        raise ValueError("Set either training.device or training.devices, not both")
+    if world_size < 1:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    if local_rank < 0 or local_rank >= world_size:
+        raise ValueError(f"local_rank={local_rank} is out of range for world_size={world_size}")
+    if world_size > 1:
+        if configured_device is not None:
+            raise ValueError(
+                "training.device cannot select one device in a distributed run; "
+                "use training.devices"
+            )
+        if devices is not None and len(devices) != world_size:
+            raise ValueError(
+                f"training.devices has {len(devices)} entries but WORLD_SIZE={world_size}"
+            )
+        return f"cuda:{local_rank}"
+    if devices is not None:
+        return f"cuda:{devices[0]}"
+    return configured_device or default_device
+
+
+def ppo_samples_per_iteration(*, num_envs: int, num_steps_per_env: int, world_size: int) -> int:
+    """Return the global fresh rollout sample count for one PPO iteration."""
+    return int(num_envs) * int(num_steps_per_env) * int(world_size)
+
+
+def finish_rsl_rl_distributed(*, training_succeeded: bool) -> None:
+    """Synchronize successful ranks and release RSL-RL's process group."""
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return
+    try:
+        if training_succeeded:
+            torch.distributed.barrier()
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@contextmanager
+def rsl_rl_single_process_topology() -> Iterator[None]:
+    """Temporarily hide torchrun's worker topology from rank-0-only work.
+
+    Destroying a process group does not clear ``WORLD_SIZE`` / ``RANK`` /
+    ``LOCAL_RANK``. RSL-RL would therefore initialize a second distributed
+    group when rank 0 constructs a fresh runner for post-training playback,
+    even though every other rank has already exited. Present the playback
+    scope as a single-process runtime, then restore launcher-owned variables.
+    """
+    single_process_topology = {
+        "WORLD_SIZE": "1",
+        "RANK": "0",
+        "LOCAL_RANK": "0",
+    }
+    previous = {name: os.environ.get(name) for name in single_process_topology}
+    os.environ.update(single_process_topology)
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def get_policy_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:

--- a/tests/algos/test_rsl_rl_ppo.py
+++ b/tests/algos/test_rsl_rl_ppo.py
@@ -1,13 +1,111 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from typing import Any
 
+import pytest
 import torch
+from omegaconf import OmegaConf
 from tensordict import TensorDict
 
 from unilab.algos.torch.rsl_rl_ppo import FinalObservationAwarePPO
-from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
+from unilab.training.rsl_rl import (
+    RslRlVecEnvWrapper,
+    apply_rsl_rl_rank_seed,
+    finish_rsl_rl_distributed,
+    normalize_ppo_train_cfg,
+    ppo_samples_per_iteration,
+    resolve_rsl_rl_device,
+    rsl_rl_single_process_topology,
+)
+
+
+def test_rsl_rl_rank_seed_uses_base_seed_plus_global_rank() -> None:
+    cfg = OmegaConf.create({"algo": {"seed": 41}})
+
+    assert apply_rsl_rl_rank_seed(cfg, rank=3) == 44
+    assert cfg.algo.seed == 44
+
+
+def test_rsl_rl_device_uses_local_rank_after_cuda_visibility_remap() -> None:
+    assert (
+        resolve_rsl_rl_device(
+            configured_device=None,
+            devices=(3, 1),
+            world_size=2,
+            local_rank=1,
+            default_device="cuda",
+        )
+        == "cuda:1"
+    )
+
+
+def test_rsl_rl_device_supports_explicit_single_device() -> None:
+    assert (
+        resolve_rsl_rl_device(
+            configured_device=None,
+            devices=(2,),
+            world_size=1,
+            local_rank=0,
+            default_device="cuda",
+        )
+        == "cuda:2"
+    )
+
+
+def test_rsl_rl_device_rejects_singular_and_plural_config() -> None:
+    with pytest.raises(ValueError, match="either training.device or training.devices"):
+        resolve_rsl_rl_device(
+            configured_device="cuda:0",
+            devices=(0, 1),
+            world_size=2,
+            local_rank=0,
+            default_device="cuda",
+        )
+
+
+def test_ppo_samples_per_iteration_uses_per_rank_num_envs() -> None:
+    assert ppo_samples_per_iteration(num_envs=1024, num_steps_per_env=24, world_size=2) == 49152
+
+
+def test_finish_rsl_rl_distributed_barriers_only_after_success(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: calls.append("barrier"))
+    monkeypatch.setattr(torch.distributed, "destroy_process_group", lambda: calls.append("destroy"))
+
+    finish_rsl_rl_distributed(training_succeeded=True)
+
+    assert calls == ["barrier", "destroy"]
+
+
+def test_finish_rsl_rl_distributed_failure_skips_barrier(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: calls.append("barrier"))
+    monkeypatch.setattr(torch.distributed, "destroy_process_group", lambda: calls.append("destroy"))
+
+    finish_rsl_rl_distributed(training_succeeded=False)
+
+    assert calls == ["destroy"]
+
+
+def test_rsl_rl_single_process_topology_masks_and_restores_torchrun_env(monkeypatch) -> None:
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    with rsl_rl_single_process_topology():
+        assert os.environ["WORLD_SIZE"] == "1"
+        assert os.environ["RANK"] == "0"
+        assert os.environ["LOCAL_RANK"] == "0"
+
+    assert os.environ["WORLD_SIZE"] == "2"
+    assert os.environ["RANK"] == "0"
+    assert os.environ["LOCAL_RANK"] == "0"
 
 
 class _FakeActor:

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -25,7 +25,12 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     current_dp_world_size,
+    current_torch_distributed_local_rank,
+    current_torch_distributed_rank,
+    current_torch_distributed_world_size,
+    launch_torchrun_workers,
     resolve_collector_cpu_ids,
+    resolve_cuda_visible_devices,
     resolve_dp_rank_device,
     resolve_dp_topology,
     validate_dp_launchable,
@@ -153,6 +158,122 @@ def test_current_dp_rank_reads_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "4")
     assert current_dp_rank() == 2
     assert current_dp_world_size() == 4
+
+
+def test_current_torch_distributed_rank_defaults(monkeypatch: pytest.MonkeyPatch):
+    for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE"):
+        monkeypatch.delenv(name, raising=False)
+    assert current_torch_distributed_rank() == 0
+    assert current_torch_distributed_local_rank() == 0
+    assert current_torch_distributed_world_size() == 1
+
+
+def test_current_torch_distributed_rank_reads_torchrun_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    assert current_torch_distributed_rank() == 3
+    assert current_torch_distributed_local_rank() == 1
+    assert current_torch_distributed_world_size() == 4
+
+
+def test_resolve_cuda_visible_devices_preserves_parent_mapping():
+    assert resolve_cuda_visible_devices((2, 0)) == "2,0"
+    assert (
+        resolve_cuda_visible_devices(
+            (1, 0),
+            current_visible_devices="GPU-parent-0,GPU-parent-1",
+        )
+        == "GPU-parent-1,GPU-parent-0"
+    )
+
+
+def test_resolve_cuda_visible_devices_rejects_hidden_index():
+    with pytest.raises(ValueError, match="CUDA_VISIBLE_DEVICES"):
+        resolve_cuda_visible_devices((0, 2), current_visible_devices="4,7")
+
+
+def test_launch_torchrun_workers_builds_standard_single_node_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    captured: dict[str, object] = {}
+
+    def fake_run(command, *, env, check):
+        captured.update(command=list(command), env=dict(env), check=check)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(dp_launcher.subprocess, "run", fake_run)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-a,GPU-b,GPU-c")
+    monkeypatch.delenv("NCCL_P2P_DISABLE", raising=False)
+    monkeypatch.delenv("NCCL_SHM_DISABLE", raising=False)
+    script = tmp_path / "train_rsl_rl.py"
+
+    launch_torchrun_workers(
+        (2, 0),
+        script_path=script,
+        argv=["task=go2_joystick_flat/mujoco", "training.devices=[2,0]"],
+        log_dir="/tmp/ppo_gpux2",
+    )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[:3] == [sys.executable, "-m", "torch.distributed.run"]
+    assert "--standalone" in command
+    assert "--nnodes=1" in command
+    assert "--nproc_per_node=2" in command
+    assert command[-2:] == ["task=go2_joystick_flat/mujoco", "training.devices=[2,0]"]
+    launch_env = captured["env"]
+    assert isinstance(launch_env, dict)
+    assert launch_env["CUDA_VISIBLE_DEVICES"] == "GPU-c,GPU-a"
+    assert launch_env["NCCL_P2P_DISABLE"] == "1"
+    assert launch_env["NCCL_SHM_DISABLE"] == "1"
+    assert launch_env[UNILAB_DP_LOG_DIR] == "/tmp/ppo_gpux2"
+    assert captured["check"] is False
+
+
+def test_launch_torchrun_workers_propagates_failure(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(
+        dp_launcher.subprocess,
+        "run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 7})(),
+    )
+
+    with pytest.raises(RuntimeError, match="exit code 7"):
+        launch_torchrun_workers(
+            (0, 1),
+            script_path="scripts/train_rsl_rl.py",
+            argv=[],
+            log_dir="/tmp/ppo_gpux2",
+        )
+
+
+def test_launch_torchrun_workers_preserves_explicit_nccl_transport(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, str] = {}
+
+    def fake_run(*args, env, **kwargs):
+        del args, kwargs
+        captured.update(env)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(dp_launcher.subprocess, "run", fake_run)
+    monkeypatch.setenv("NCCL_P2P_DISABLE", "0")
+    monkeypatch.setenv("NCCL_SHM_DISABLE", "0")
+
+    launch_torchrun_workers(
+        (0, 1),
+        script_path="scripts/train_rsl_rl.py",
+        argv=[],
+        log_dir="/tmp/ppo_gpux2",
+    )
+
+    assert captured["NCCL_P2P_DISABLE"] == "0"
+    assert captured["NCCL_SHM_DISABLE"] == "0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_train_script_configs.py
+++ b/tests/scripts/test_train_script_configs.py
@@ -5,12 +5,14 @@ These tests verify that Hydra configs are complete and scripts don't crash on st
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 
 pytest.importorskip("mujoco")
 
@@ -170,3 +172,59 @@ def test_ppo_sharpa_motrix_one_iteration_training_smoke(tmp_path):
     )
     assert "Learning iteration 0/1" in result.stdout
     assert "reward/total" in result.stdout
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires >=2 CUDA devices")
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("task", "task_name"),
+    [
+        ("go2_joystick_flat/mujoco", "Go2JoystickFlat"),
+        ("g1_motion_tracking/mujoco", "G1MotionTracking"),
+    ],
+)
+def test_ppo_two_gpu_rsl_rl_training_smoke(task: str, task_name: str, tmp_path: Path) -> None:
+    """RSL-RL PPO uses one env/storage replica per rank and rank-0 artifacts."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/train_rsl_rl.py",
+            f"task={task}",
+            "training.devices=[0,1]",
+            "training.play_render_mode=record",
+            "training.play_steps=2",
+            "training.play_env_num=2",
+            "training.nan_guard.enabled=false",
+            f"training.log_root={tmp_path}",
+            "algo.num_envs=64",
+            "algo.num_steps_per_env=4",
+            "algo.max_iterations=1",
+            "algo.save_interval=100",
+            "algo.algorithm.num_learning_epochs=1",
+            "algo.algorithm.num_mini_batches=2",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, (
+        f"PPO two-GPU smoke failed for {task}:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "Synchronizing parameters for rank 0" in result.stdout
+    assert "Synchronizing parameters for rank 1" in result.stdout
+    assert "Done." in result.stdout
+    assert "device used by this process is currently unknown" not in result.stderr
+
+    run_dirs = list((tmp_path / task_name).glob("*_mujoco_gpux2"))
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    assert len(list(run_dir.glob("events.out.tfevents.*"))) == 1
+    assert len(list(run_dir.glob("model_*.pt"))) == 1
+    assert (run_dir / "play_video.mp4").is_file()
+    summary = json.loads((run_dir / "run_summary.json").read_text(encoding="utf-8"))
+    assert summary["world_size"] == 2
+    assert summary["num_envs_per_rank"] == 64
+    assert summary["global_num_envs"] == 128
+    assert summary["samples_per_iteration"] == 512
+    assert summary["run_env_steps"] == 512


### PR DESCRIPTION
## Summary

- Add integrated single-node RSL-RL PPO launch through `training.devices=[...]`, with one torchrun worker, environment replica, policy, and rollout storage per GPU.
- Preserve parent `CUDA_VISIBLE_DEVICES` mapping and device order; reject simultaneous `training.device` and `training.devices`.
- Keep the RSL-RL contract from Discussion #976: `algo.num_envs` is per rank, global samples per iteration are `world_size * num_envs * num_steps_per_env`, `training.num_timesteps` is global, and rank seed is `algo.seed + global_rank`.
- Leave startup model broadcast, adaptive-KL communication, and per-mini-batch gradient averaging owned by upstream RSL-RL.
- Make rank 0 the sole tracker, log, checkpoint, summary, and playback owner. Post-training playback is temporarily presented as a single-process topology so it cannot initialize a second NCCL group after sibling ranks exit.
- Record aggregate throughput and topology in `run_summary.json`, and document rank-local normalization/curriculum semantics and the tested support boundary.

## Linked Work

- Driving discussion: https://github.com/unilabsim/UniLab/discussions/976
- Runtime ADR: `docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md`
- Stacked base: `fix/issue-978-nccl-cuda-graph-capture` (the branch requested as the implementation base)
- Milestone: none

## Validation

- [x] `make check` (included in `make test-all`)
- [x] `uv run pytest -m "not slow"` with coverage (included in `make test-all`)
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
make test-all

uv run pytest -q -m slow   tests/scripts/test_train_script_configs.py::test_ppo_two_gpu_rsl_rl_training_smoke

timeout 180s uv run train --algo ppo --task go2_joystick_flat --sim mujoco   'training.devices=[0,1]'   training.log_root=/tmp/unilab-ppo-play-exit.ldVrRS   training.nan_guard.enabled=false   training.play_render_mode=record   training.play_steps=4   training.play_env_num=4   algo.num_envs=64   algo.num_steps_per_env=4   algo.max_iterations=1   algo.save_interval=100   algo.algorithm.num_learning_epochs=1   algo.algorithm.num_mini_batches=2
```

Results:

- `make test-all`: 1657 passed, 24 skipped, 1 xfailed; total coverage 72%; benchmark import smoke passed.
- Two-GPU slow smoke: Go2 joystick flat and G1 motion tracking both passed, including short rank-0 playback, video creation, and natural process exit.
- Direct Go2 train-to-playback regression: exit code 0 after `Done.`; no second `ProcessGroupNCCL PG ID 1` warning.
- Earlier single-GPU Go2 smoke and two-GPU Go2/G1 training smoke passed.

## Throughput

Hardware: 2 x NVIDIA RTX 6000D. Each rank used 1024 environments, rollout length 24, and the owner PPO defaults of 5 epochs x 4 mini-batches. Each run used 12 iterations; the first 2 were discarded and statistics cover the remaining 10.

| Task | GPUs | Mean samples/s | Median | Population stddev | Mean iteration |
|---|---:|---:|---:|---:|---:|
| Go2 joystick flat | 1 | 134,258.5 | 134,469.0 | 3,808.0 | 0.1832 s |
| Go2 joystick flat | 2 | 218,351.9 | 220,357.5 | 6,569.4 | 0.2253 s |
| G1 motion tracking | 1 | 67,999.5 | 67,921.5 | 888.4 | 0.3615 s |
| G1 motion tracking | 2 | 117,617.4 | 118,010.5 | 1,991.0 | 0.4180 s |

This is weak scaling: global samples per iteration increase from 24,576 to 49,152.

- Go2 scaling: 1.626x; two-GPU efficiency 81.3%.
- G1 motion tracking scaling: 1.730x; two-GPU efficiency 86.5%.

## Impact

- Backend impact: MuJoCo multi-GPU validated; Motrix behavior is unchanged and no Motrix multi-GPU support claim is made.
- Platform impact: Linux, single node.
- Training effect expected: yes. Multiple GPUs increase global rollout size because `algo.num_envs` remains a per-rank value.
- Model quality: intentionally not evaluated; acceptance is semantic correctness and throughput reporting.
- RSL-RL observation normalizers, GAE/advantage preprocessing, curriculum, and episode statistics remain rank-local. Rank 0 checkpoint/log state is authoritative.
- Launcher defaults `NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1` on the validated RTX 6000D setup; explicit user environment values still win.

## Artifacts

- W&B: none
- Benchmark result: table above; raw local artifacts at `/tmp/unilab-ppo-dp-benchmark.uXvsc0`
- Playback regression video: `/tmp/unilab-ppo-play-exit.ldVrRS/.../play_video.mp4`
- ONNX/checkpoint: generated only as local smoke artifacts; no model metric claim

## Checklist

- [x] Added or updated tests where needed
- [x] Updated English/Chinese user docs and runtime architecture documentation
- [x] Linked the driving Discussion #976 (no separate implementation issue exists)
- [x] Noted single-node/MuJoCo-only validation and rank-local state limitations explicitly
