### PR TITLE
feat(multi-gpu): integrate single-node off-policy and PPO data parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
 
   test:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-slim]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ gh pr view
 2. 最终提交已经通过 `make test-all`。
 3. 如果用户明确说明已经跑过 `make test-all`，不要重复跑；但必须在 PR body 的 Validation 里记录 `make test-all` 已完成。
 4. 如果 `make test-all` 未通过且用户没有明确 override，不要创建或更新 PR。
+5. 创建或更新 PR 后，必须按当前 head SHA 等待远程 CI 全部结束并通过后才能报告完成；`pending` / `in_progress`、旧 head 的成功结果或挂起 job 都不算通过。失败或挂起时必须查看对应 job 日志并修复，除非用户明确 override。
 
 ### CI 工作流查看
 ```bash

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ uv run train --algo ppo --task go2_arm_manip_loco --sim motrix
 uv run eval --algo ppo --task go2_arm_manip_loco --sim motrix --load-run -1
 ```
 
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco 'training.devices=[0,1]'
+uv run train --algo flashsac --task g1_walk_flat --sim mujoco training.devices="[0,1,2,3]"
+uv run train --algo sac --task g1_motion_tracking --sim mujoco training.devices="[0,1,2,3,4,5,6,7]"
+```
+
 Use `uv run train` for training, `uv run eval` for checkpoint playback, and `uv run demo` for the local demo preset. These commands keep algorithm, task, and backend selection explicit.
 
 More training commands, script-level entrypoints, algorithm matrix, resume flow, and W&B details are in the [Training Guide](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/0-index.html).

--- a/README_zh.md
+++ b/README_zh.md
@@ -169,6 +169,12 @@ uv run train --algo ppo --task go2_arm_manip_loco --sim motrix
 uv run eval --algo ppo --task go2_arm_manip_loco --sim motrix --load-run -1
 ```
 
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco 'training.devices=[0,1]'
+uv run train --algo flashsac --task g1_walk_flat --sim mujoco training.devices="[0,1,2,3]"
+uv run train --algo sac --task g1_motion_tracking --sim mujoco training.devices="[0,1,2,3,4,5,6,7]"
+```
+
 使用 `uv run train` 进行训练，使用 `uv run eval` 进行检查点回放，`uv run demo` 用于本地 demo 预设。这些命令可以明确指定算法、任务和后端。
 
 更多训练命令、脚本级入口、算法矩阵、续训流程以及 W&B 细节请参阅 [训练指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)。

--- a/benchmark/rl/benchmark_offpolicy_dp_scaling.py
+++ b/benchmark/rl/benchmark_offpolicy_dp_scaling.py
@@ -32,7 +32,7 @@ Run:
 
     # tuning / passthrough overrides:
     uv run benchmark/rl/benchmark_offpolicy_dp_scaling.py \
-        --iterations 300 --sync-interval 8 --devices 0,1 \
+        --iterations 300 --devices 0,1 \
         --extra-overrides algo.num_envs=2048 \
         --out-json benchmark/outputs/offpolicy_dp_scaling/results.json
 """
@@ -69,7 +69,6 @@ REWARD_TAG = "reward/mean"
 DP_SYNC_TIME_TAG = "train/dp_sync_time"
 
 DEFAULT_ITERATIONS = 300
-DEFAULT_SYNC_INTERVAL = 8
 DEFAULT_DEVICES = "0,1"
 
 # Roadmap #964 acceptance target for 2-way data-parallel aggregate throughput.
@@ -189,7 +188,6 @@ def build_train_command(
     *,
     iterations: int,
     devices: Sequence[int] | None = None,
-    sync_interval: int = DEFAULT_SYNC_INTERVAL,
     extra_overrides: Sequence[str] = (),
 ) -> list[str]:
     """Subprocess argv matching the production off-policy CLI overrides.
@@ -207,7 +205,6 @@ def build_train_command(
     ]
     if devices is not None:
         command.append(f"training.devices=[{','.join(str(d) for d in devices)}]")
-        command.append(f"training.dp_sync_interval={sync_interval}")
     command.extend(extra_overrides)
     return command
 
@@ -291,7 +288,6 @@ def run_config(
     devices: Sequence[int] | None,
     *,
     iterations: int,
-    sync_interval: int,
     extra_overrides: Sequence[str],
     runs_root: Path,
 ) -> dict[str, Any]:
@@ -314,7 +310,6 @@ def run_config(
             run_dir,
             iterations=iterations,
             devices=devices,
-            sync_interval=sync_interval,
             extra_overrides=extra_overrides,
         )
         print(f"[{name}] launching: {' '.join(command)}", flush=True)
@@ -346,7 +341,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Off-policy multi-GPU data-parallel scaling benchmark (issue #968)."
     )
     parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
-    parser.add_argument("--sync-interval", type=int, default=DEFAULT_SYNC_INTERVAL)
     parser.add_argument(
         "--devices",
         default=DEFAULT_DEVICES,
@@ -391,7 +385,6 @@ def main(argv: list[str] | None = None) -> int:
             name,
             config_devices,
             iterations=args.iterations,
-            sync_interval=args.sync_interval,
             extra_overrides=tuple(args.extra_overrides),
             runs_root=DEFAULT_RUNS_ROOT,
         )
@@ -468,7 +461,6 @@ def main(argv: list[str] | None = None) -> int:
             "params": {
                 "route_overrides": list(ROUTE_OVERRIDES),
                 "iterations": args.iterations,
-                "sync_interval": args.sync_interval,
                 "devices": devices,
                 "extra_overrides": list(args.extra_overrides),
                 "scaling_pass_threshold": SCALING_PASS_THRESHOLD,

--- a/benchmark/rl/benchmark_offpolicy_dp_scaling.py
+++ b/benchmark/rl/benchmark_offpolicy_dp_scaling.py
@@ -1,0 +1,473 @@
+"""Off-policy multi-GPU data-parallel scaling benchmark (issue #968).
+
+Runs real ``scripts/train_offpolicy.py`` training via subprocess (same Hydra
+overrides as the production CLI entry, never importing training internals) and
+compares single-device N=1 (no ``training.devices``) against N-way data
+parallel (``training.devices=[d0..dN-1]``, default ``[0,1]``). Every config
+keeps the owner YAML production defaults (sac / g1_walk_flat / mujoco) except
+``algo.max_iterations``, ``training.no_play=true`` and ``training.log_dir``
+pointing into this benchmark's own work directory. Runs execute sequentially
+to avoid resource contention.
+
+Measurement conventions:
+
+- Steady-state throughput: mean of the last 50% of ``perf/steps_per_sec``
+  tfevents samples (ceil(n/2) tail points; with n samples the tail is
+  ``n - n//2``). This skips collector warm-up and replay prefill.
+- N-way aggregate throughput: sum of per-rank steady-state steps/s. Rank 0
+  artifacts live in the run directory itself (``run_summary.json`` +
+  tfevents); rank i>0 tfevents live in the ``rank{i}/`` subdirectory. A rank
+  missing its tfevents is a hard error, never silently skipped.
+- Scaling ratio: N-way aggregate / N=1 steady-state steps/s. The verdict is
+  ``pass`` when ratio >= 1.7 (``SCALING_PASS_THRESHOLD``), otherwise
+  ``below threshold``. The verdict is data only: it does not affect the
+  exit code.
+- Exit code is non-zero only when a run itself failed (subprocess error,
+  non-completed summary, or missing artifacts).
+
+Run:
+    uv run benchmark/rl/benchmark_offpolicy_dp_scaling.py
+
+    # tuning / passthrough overrides:
+    uv run benchmark/rl/benchmark_offpolicy_dp_scaling.py \
+        --iterations 300 --sync-interval 8 --devices 0,1 \
+        --extra-overrides algo.num_envs=2048 \
+        --out-json benchmark/outputs/offpolicy_dp_scaling/results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from benchmark.core.device_info import get_device_info_dict, get_device_info_line
+from benchmark.core.output import print_table, save_json
+
+DEFAULT_OUTPUT_JSON = ROOT_DIR / "benchmark" / "outputs" / "offpolicy_dp_scaling" / "results.json"
+DEFAULT_RUNS_ROOT = ROOT_DIR / "benchmark" / "outputs" / "offpolicy_dp_scaling" / "runs"
+
+TRAIN_SCRIPT = ROOT_DIR / "scripts" / "train_offpolicy.py"
+
+# Route overrides equivalent to `uv run train --algo sac --task g1_walk_flat
+# --sim mujoco` (see src/unilab/cli.py build_route for off-policy algos).
+ROUTE_OVERRIDES = ("algo=sac", "task=sac/g1_walk_flat/mujoco")
+
+STEPS_PER_SEC_TAG = "perf/steps_per_sec"
+REWARD_TAG = "reward/mean"
+DP_SYNC_TIME_TAG = "train/dp_sync_time"
+
+DEFAULT_ITERATIONS = 300
+DEFAULT_SYNC_INTERVAL = 8
+DEFAULT_DEVICES = "0,1"
+
+# Roadmap #964 acceptance target for 2-way data-parallel aggregate throughput.
+SCALING_PASS_THRESHOLD = 1.7
+
+STEADY_STATE_TAIL_FRACTION = 0.5
+
+
+class RunParseError(RuntimeError):
+    """A finished run directory is missing required artifacts or is invalid."""
+
+
+# =====================================================================
+# Pure helpers (unit-tested in tests/benchmark/)
+# =====================================================================
+
+
+def steady_state_mean(
+    values: Sequence[float], tail_fraction: float = STEADY_STATE_TAIL_FRACTION
+) -> float:
+    """Mean of the last ``tail_fraction`` of samples (ceil tail size, min 1)."""
+    if not values:
+        raise ValueError("steady_state_mean requires at least one sample")
+    if not 0 < tail_fraction <= 1:
+        raise ValueError(f"tail_fraction must be in (0, 1], got {tail_fraction}")
+    n = len(values)
+    tail = max(1, n - int(n * (1 - tail_fraction)))
+    window = [float(v) for v in values[n - tail :]]
+    return sum(window) / len(window)
+
+
+def verdict_for_ratio(ratio: float | None, threshold: float = SCALING_PASS_THRESHOLD) -> str | None:
+    """Map a scaling ratio to its verdict string; None stays None (baseline)."""
+    if ratio is None:
+        return None
+    return "pass" if ratio >= threshold else "below threshold"
+
+
+def find_event_files(rank_dir: Path) -> list[Path]:
+    """All tfevents files directly under one rank's log directory."""
+    rank_dir = Path(rank_dir)
+    if not rank_dir.is_dir():
+        raise RunParseError(f"rank log directory does not exist: {rank_dir}")
+    return sorted(rank_dir.glob("events.out.tfevents.*"))
+
+
+def read_scalar_series(rank_dir: Path, tag: str) -> list[float]:
+    """Scalar values of ``tag`` from a rank's tfevents (in event order).
+
+    An absent tag yields ``[]``; a rank directory without any tfevents file
+    raises ``RunParseError`` so missing rank data is never silent.
+    """
+    event_files = find_event_files(rank_dir)
+    if not event_files:
+        raise RunParseError(f"no tfevents file found under {rank_dir}")
+    if len(event_files) > 1:
+        raise RunParseError(
+            f"expected exactly one tfevents file under {rank_dir}, got {len(event_files)}"
+        )
+    from tensorboard.backend.event_processing import event_accumulator
+
+    accumulator = event_accumulator.EventAccumulator(str(event_files[0]))
+    accumulator.Reload()
+    if tag not in accumulator.Tags()["scalars"]:
+        return []
+    return [float(event.value) for event in accumulator.Scalars(tag)]
+
+
+def rank_dir_for(run_dir: Path, rank: int) -> Path:
+    """Rank i>0 logs into the ``rank{i}`` subdirectory of rank 0's run dir."""
+    run_dir = Path(run_dir)
+    return run_dir if rank == 0 else run_dir / f"rank{rank}"
+
+
+def parse_run(run_dir: Path, world_size: int) -> dict[str, Any]:
+    """Parse one finished run directory into a metrics record.
+
+    Rank 0 must carry a ``run_summary.json`` with ``status == "completed"``
+    and a tfevents file; ranks 1..N-1 must each carry their own tfevents.
+    """
+    run_dir = Path(run_dir)
+    if world_size < 1:
+        raise ValueError(f"world_size must be >= 1, got {world_size}")
+
+    summary_path = run_dir / "run_summary.json"
+    if not summary_path.is_file():
+        raise RunParseError(f"missing run summary: {summary_path}")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    status = summary.get("status")
+    if status != "completed":
+        raise RunParseError(
+            f"run {run_dir} did not complete: status={status!r} error={summary.get('error')!r}"
+        )
+
+    ranks: list[dict[str, Any]] = []
+    dp_sync_samples: list[float] = []
+    for rank in range(world_size):
+        rank_dir = rank_dir_for(run_dir, rank)
+        series = read_scalar_series(rank_dir, STEPS_PER_SEC_TAG)
+        if not series:
+            raise RunParseError(
+                f"rank {rank} has no {STEPS_PER_SEC_TAG!r} samples under {rank_dir}"
+            )
+        ranks.append(
+            {
+                "rank": rank,
+                "log_dir": str(rank_dir),
+                "num_throughput_samples": len(series),
+                "steady_state_env_steps_per_s": steady_state_mean(series),
+            }
+        )
+        dp_sync_samples.extend(read_scalar_series(rank_dir, DP_SYNC_TIME_TAG))
+
+    reward_series = read_scalar_series(run_dir, REWARD_TAG)
+    aggregate = sum(r["steady_state_env_steps_per_s"] for r in ranks)
+    return {
+        "run_dir": str(run_dir),
+        "world_size": world_size,
+        "completed_iterations": summary.get("completed_iterations"),
+        "total_env_steps": summary.get("total_env_steps"),
+        "training_wall_time_sec": summary.get("training_wall_time_sec"),
+        "ranks": ranks,
+        "aggregate_env_steps_per_s": aggregate,
+        "final_mean_reward": reward_series[-1] if reward_series else None,
+        "mean_dp_sync_time_sec": (
+            sum(dp_sync_samples) / len(dp_sync_samples) if dp_sync_samples else None
+        ),
+    }
+
+
+def build_train_command(
+    run_dir: Path,
+    *,
+    iterations: int,
+    devices: Sequence[int] | None = None,
+    sync_interval: int = DEFAULT_SYNC_INTERVAL,
+    extra_overrides: Sequence[str] = (),
+) -> list[str]:
+    """Subprocess argv matching the production off-policy CLI overrides.
+
+    ``devices=None`` is the N=1 baseline and intentionally carries no
+    ``training.devices`` override at all.
+    """
+    command = [
+        sys.executable,
+        str(TRAIN_SCRIPT),
+        *ROUTE_OVERRIDES,
+        "training.no_play=true",
+        f"algo.max_iterations={iterations}",
+        f"training.log_dir={Path(run_dir)}",
+    ]
+    if devices is not None:
+        command.append(f"training.devices=[{','.join(str(d) for d in devices)}]")
+        command.append(f"training.dp_sync_interval={sync_interval}")
+    command.extend(extra_overrides)
+    return command
+
+
+def attach_scaling(
+    records: list[dict[str, Any]], threshold: float = SCALING_PASS_THRESHOLD
+) -> list[dict[str, Any]]:
+    """Fill ``scaling_vs_n1``/``verdict`` on DP configs against the N=1 record."""
+    baseline = next(
+        (
+            r
+            for r in records
+            if r["config"] == "n1" and r["status"] == "ok" and r["metrics"] is not None
+        ),
+        None,
+    )
+    baseline_throughput = (
+        float(baseline["metrics"]["aggregate_env_steps_per_s"]) if baseline else None
+    )
+    for record in records:
+        record["scaling_vs_n1"] = None
+        record["verdict"] = None
+        if record["config"] == "n1" or record["status"] != "ok" or record["metrics"] is None:
+            continue
+        if baseline_throughput:
+            ratio = float(record["metrics"]["aggregate_env_steps_per_s"]) / baseline_throughput
+            record["scaling_vs_n1"] = ratio
+            record["verdict"] = verdict_for_ratio(ratio, threshold)
+    return records
+
+
+def git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(ROOT_DIR), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except Exception:
+        return "unknown"
+
+
+def _parse_int_list(text: str, name: str) -> list[int]:
+    values = [int(v) for v in text.split(",") if v.strip()]
+    if not values:
+        raise ValueError(f"{name} must not be empty")
+    return values
+
+
+# =====================================================================
+# Subprocess execution
+# =====================================================================
+
+
+def execute_run(command: list[str], run_dir: Path) -> None:
+    """Run one training config to completion; raise on subprocess failure."""
+    run_dir = Path(run_dir)
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True)
+    completed = subprocess.run(command, cwd=ROOT_DIR)  # noqa: S603 - fixed argv, no shell
+    if completed.returncode != 0:
+        raise RunParseError(
+            f"training subprocess exited with code {completed.returncode}: {' '.join(command)}"
+        )
+
+
+def run_config(
+    name: str,
+    devices: Sequence[int] | None,
+    *,
+    iterations: int,
+    sync_interval: int,
+    extra_overrides: Sequence[str],
+    runs_root: Path,
+) -> dict[str, Any]:
+    """Execute and parse one benchmark config; failures are recorded, not raised."""
+    world_size = len(devices) if devices is not None else 1
+    run_dir = runs_root / name
+    record: dict[str, Any] = {
+        "config": name,
+        "world_size": world_size,
+        "devices": list(devices) if devices is not None else None,
+        "status": "ok",
+        "error": None,
+        "metrics": None,
+        "scaling_vs_n1": None,
+        "verdict": None,
+    }
+    try:
+        command = build_train_command(
+            run_dir,
+            iterations=iterations,
+            devices=devices,
+            sync_interval=sync_interval,
+            extra_overrides=extra_overrides,
+        )
+        print(f"[{name}] launching: {' '.join(command)}", flush=True)
+        execute_run(command, run_dir)
+        record["metrics"] = parse_run(run_dir, world_size)
+    except (RunParseError, ValueError) as exc:
+        record["status"] = "failed"
+        record["error"] = str(exc)
+    print(
+        f"[{name}] {record['status']}"
+        + (
+            f"  aggregate={record['metrics']['aggregate_env_steps_per_s']:,.0f} env-steps/s"
+            if record["metrics"]
+            else f"  error={record['error']}"
+        ),
+        flush=True,
+    )
+    return record
+
+
+# =====================================================================
+# CLI
+# =====================================================================
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Off-policy multi-GPU data-parallel scaling benchmark (issue #968)."
+    )
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--sync-interval", type=int, default=DEFAULT_SYNC_INTERVAL)
+    parser.add_argument(
+        "--devices",
+        default=DEFAULT_DEVICES,
+        help="comma-separated CUDA indices for the data-parallel config "
+        "(length 1 skips the DP config)",
+    )
+    parser.add_argument(
+        "--extra-overrides",
+        nargs="*",
+        default=(),
+        help="extra Hydra overrides appended verbatim to every config "
+        "(e.g. algo.num_envs=2048); owner YAML defaults are used otherwise",
+    )
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    parser.add_argument(
+        "--keep-runs",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="keep per-config training run directories under the output root",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    devices = _parse_int_list(args.devices, "--devices")
+
+    print(f"Device: {get_device_info_line()}")
+    print(f"commit: {git_commit()}")
+
+    configs: list[tuple[str, list[int] | None]] = [("n1", None)]
+    if len(devices) > 1:
+        configs.append((f"n{len(devices)}", devices))
+    else:
+        print(
+            f"--devices={args.devices!r} has length {len(devices)}; "
+            "skipping the data-parallel config (need >= 2 devices)."
+        )
+
+    records = [
+        run_config(
+            name,
+            config_devices,
+            iterations=args.iterations,
+            sync_interval=args.sync_interval,
+            extra_overrides=tuple(args.extra_overrides),
+            runs_root=DEFAULT_RUNS_ROOT,
+        )
+        for name, config_devices in configs
+    ]
+    attach_scaling(records)
+
+    if not args.keep_runs:
+        shutil.rmtree(DEFAULT_RUNS_ROOT, ignore_errors=True)
+
+    print()
+    print_table(
+        [
+            {
+                "config": r["config"],
+                "devices": ",".join(str(d) for d in r["devices"]) if r["devices"] else "-",
+                "aggregate env-steps/s": (
+                    f"{r['metrics']['aggregate_env_steps_per_s']:,.0f}" if r["metrics"] else "-"
+                ),
+                "final reward": (
+                    f"{r['metrics']['final_mean_reward']:.2f}"
+                    if r["metrics"] and r["metrics"]["final_mean_reward"] is not None
+                    else "-"
+                ),
+                "dp_sync mean (s)": (
+                    f"{r['metrics']['mean_dp_sync_time_sec']:.4f}"
+                    if r["metrics"] and r["metrics"]["mean_dp_sync_time_sec"] is not None
+                    else "-"
+                ),
+                "scaling vs n1": (
+                    f"{r['scaling_vs_n1']:.2f}x" if r["scaling_vs_n1"] is not None else "-"
+                ),
+                "verdict": r["verdict"] or "-",
+                "status": r["status"],
+            }
+            for r in records
+        ],
+        [
+            "config",
+            "devices",
+            "aggregate env-steps/s",
+            "final reward",
+            "dp_sync mean (s)",
+            "scaling vs n1",
+            "verdict",
+            "status",
+        ],
+    )
+
+    save_json(
+        args.out_json,
+        records,
+        {
+            "benchmark": "offpolicy_dp_scaling",
+            "issue": 968,
+            "commit": git_commit(),
+            "device": get_device_info_dict(),
+            "params": {
+                "route_overrides": list(ROUTE_OVERRIDES),
+                "iterations": args.iterations,
+                "sync_interval": args.sync_interval,
+                "devices": devices,
+                "extra_overrides": list(args.extra_overrides),
+                "scaling_pass_threshold": SCALING_PASS_THRESHOLD,
+                "steady_state_tail_fraction": STEADY_STATE_TAIL_FRACTION,
+                "throughput_tag": STEPS_PER_SEC_TAG,
+            },
+        },
+    )
+    failures = [r["config"] for r in records if r["status"] != "ok"]
+    if failures:
+        print(f"failed configs: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/rl/benchmark_offpolicy_dp_scaling.py
+++ b/benchmark/rl/benchmark_offpolicy_dp_scaling.py
@@ -11,17 +11,19 @@ to avoid resource contention.
 
 Measurement conventions:
 
-- Steady-state throughput: mean of the last 50% of ``perf/steps_per_sec``
-  tfevents samples (ceil(n/2) tail points; with n samples the tail is
-  ``n - n//2``). This skips collector warm-up and replay prefill.
-- N-way aggregate throughput: sum of per-rank steady-state steps/s. Rank 0
-  artifacts live in the run directory itself (``run_summary.json`` +
-  tfevents); rank i>0 tfevents live in the ``rank{i}/`` subdirectory. A rank
-  missing its tfevents is a hard error, never silently skipped.
-- Scaling ratio: N-way aggregate / N=1 steady-state steps/s. The verdict is
-  ``pass`` when ratio >= 1.7 (``SCALING_PASS_THRESHOLD``), otherwise
-  ``below threshold``. The verdict is data only: it does not affect the
-  exit code.
+- Collector throughput (Steps/s): mean of the last 50% of canonical rank-0
+  ``perf/steps_per_sec`` samples. In DP runs the runner already sums the
+  per-rank collector rates before logging.
+- Learner throughput (Samples/s): the same tail mean over
+  ``perf/effective_samples_per_sec``. This counts effective learner samples
+  (including configured sample multipliers), summed across ranks.
+- Both fields report their own N-way / N=1 scaling ratio. The roadmap verdict
+  remains attached to collector Steps/s: ``pass`` at >= 1.7
+  (``SCALING_PASS_THRESHOLD``), otherwise ``below threshold``. The verdict is
+  data only and does not affect the exit code.
+- The tail uses ceil(n/2) points (with n samples, ``n - n//2``), skipping
+  collector warm-up and replay prefill. Missing either throughput tag is a
+  hard error, never silently skipped.
 - Exit code is non-zero only when a run itself failed (subprocess error,
   non-completed summary, or missing artifacts).
 
@@ -62,6 +64,7 @@ TRAIN_SCRIPT = ROOT_DIR / "scripts" / "train_offpolicy.py"
 ROUTE_OVERRIDES = ("algo=sac", "task=sac/g1_walk_flat/mujoco")
 
 STEPS_PER_SEC_TAG = "perf/steps_per_sec"
+SAMPLES_PER_SEC_TAG = "perf/effective_samples_per_sec"
 REWARD_TAG = "reward/mean"
 DP_SYNC_TIME_TAG = "train/dp_sync_time"
 
@@ -135,17 +138,12 @@ def read_scalar_series(rank_dir: Path, tag: str) -> list[float]:
     return [float(event.value) for event in accumulator.Scalars(tag)]
 
 
-def rank_dir_for(run_dir: Path, rank: int) -> Path:
-    """Rank i>0 logs into the ``rank{i}`` subdirectory of rank 0's run dir."""
-    run_dir = Path(run_dir)
-    return run_dir if rank == 0 else run_dir / f"rank{rank}"
-
-
 def parse_run(run_dir: Path, world_size: int) -> dict[str, Any]:
     """Parse one finished run directory into a metrics record.
 
     Rank 0 must carry a ``run_summary.json`` with ``status == "completed"``
-    and a tfevents file; ranks 1..N-1 must each carry their own tfevents.
+    and the canonical aggregate tfevents file. Non-owner ranks intentionally
+    create no TensorBoard writer.
     """
     run_dir = Path(run_dir)
     if world_size < 1:
@@ -161,35 +159,24 @@ def parse_run(run_dir: Path, world_size: int) -> dict[str, Any]:
             f"run {run_dir} did not complete: status={status!r} error={summary.get('error')!r}"
         )
 
-    ranks: list[dict[str, Any]] = []
-    dp_sync_samples: list[float] = []
-    for rank in range(world_size):
-        rank_dir = rank_dir_for(run_dir, rank)
-        series = read_scalar_series(rank_dir, STEPS_PER_SEC_TAG)
-        if not series:
-            raise RunParseError(
-                f"rank {rank} has no {STEPS_PER_SEC_TAG!r} samples under {rank_dir}"
-            )
-        ranks.append(
-            {
-                "rank": rank,
-                "log_dir": str(rank_dir),
-                "num_throughput_samples": len(series),
-                "steady_state_env_steps_per_s": steady_state_mean(series),
-            }
-        )
-        dp_sync_samples.extend(read_scalar_series(rank_dir, DP_SYNC_TIME_TAG))
-
+    collector_series = read_scalar_series(run_dir, STEPS_PER_SEC_TAG)
+    if not collector_series:
+        raise RunParseError(f"run has no {STEPS_PER_SEC_TAG!r} samples under {run_dir}")
+    learner_series = read_scalar_series(run_dir, SAMPLES_PER_SEC_TAG)
+    if not learner_series:
+        raise RunParseError(f"run has no {SAMPLES_PER_SEC_TAG!r} samples under {run_dir}")
+    dp_sync_samples = read_scalar_series(run_dir, DP_SYNC_TIME_TAG)
     reward_series = read_scalar_series(run_dir, REWARD_TAG)
-    aggregate = sum(r["steady_state_env_steps_per_s"] for r in ranks)
     return {
         "run_dir": str(run_dir),
         "world_size": world_size,
         "completed_iterations": summary.get("completed_iterations"),
         "total_env_steps": summary.get("total_env_steps"),
         "training_wall_time_sec": summary.get("training_wall_time_sec"),
-        "ranks": ranks,
-        "aggregate_env_steps_per_s": aggregate,
+        "num_collector_throughput_samples": len(collector_series),
+        "num_learner_throughput_samples": len(learner_series),
+        "steady_state_collector_steps_per_s": steady_state_mean(collector_series),
+        "steady_state_learner_samples_per_s": steady_state_mean(learner_series),
         "final_mean_reward": reward_series[-1] if reward_series else None,
         "mean_dp_sync_time_sec": (
             sum(dp_sync_samples) / len(dp_sync_samples) if dp_sync_samples else None
@@ -228,7 +215,7 @@ def build_train_command(
 def attach_scaling(
     records: list[dict[str, Any]], threshold: float = SCALING_PASS_THRESHOLD
 ) -> list[dict[str, Any]]:
-    """Fill ``scaling_vs_n1``/``verdict`` on DP configs against the N=1 record."""
+    """Attach separate collector and learner scaling ratios against N=1."""
     baseline = next(
         (
             r
@@ -237,18 +224,28 @@ def attach_scaling(
         ),
         None,
     )
-    baseline_throughput = (
-        float(baseline["metrics"]["aggregate_env_steps_per_s"]) if baseline else None
+    baseline_collector = (
+        float(baseline["metrics"]["steady_state_collector_steps_per_s"]) if baseline else None
+    )
+    baseline_learner = (
+        float(baseline["metrics"]["steady_state_learner_samples_per_s"]) if baseline else None
     )
     for record in records:
-        record["scaling_vs_n1"] = None
+        record["collector_scaling_vs_n1"] = None
+        record["learner_scaling_vs_n1"] = None
         record["verdict"] = None
         if record["config"] == "n1" or record["status"] != "ok" or record["metrics"] is None:
             continue
-        if baseline_throughput:
-            ratio = float(record["metrics"]["aggregate_env_steps_per_s"]) / baseline_throughput
-            record["scaling_vs_n1"] = ratio
+        if baseline_collector:
+            ratio = (
+                float(record["metrics"]["steady_state_collector_steps_per_s"]) / baseline_collector
+            )
+            record["collector_scaling_vs_n1"] = ratio
             record["verdict"] = verdict_for_ratio(ratio, threshold)
+        if baseline_learner:
+            record["learner_scaling_vs_n1"] = (
+                float(record["metrics"]["steady_state_learner_samples_per_s"]) / baseline_learner
+            )
     return records
 
 
@@ -308,7 +305,8 @@ def run_config(
         "status": "ok",
         "error": None,
         "metrics": None,
-        "scaling_vs_n1": None,
+        "collector_scaling_vs_n1": None,
+        "learner_scaling_vs_n1": None,
         "verdict": None,
     }
     try:
@@ -328,7 +326,8 @@ def run_config(
     print(
         f"[{name}] {record['status']}"
         + (
-            f"  aggregate={record['metrics']['aggregate_env_steps_per_s']:,.0f} env-steps/s"
+            f"  collector={record['metrics']['steady_state_collector_steps_per_s']:,.0f} Steps/s"
+            f"  learner={record['metrics']['steady_state_learner_samples_per_s']:,.0f} Samples/s"
             if record["metrics"]
             else f"  error={record['error']}"
         ),
@@ -409,8 +408,15 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "config": r["config"],
                 "devices": ",".join(str(d) for d in r["devices"]) if r["devices"] else "-",
-                "aggregate env-steps/s": (
-                    f"{r['metrics']['aggregate_env_steps_per_s']:,.0f}" if r["metrics"] else "-"
+                "collector Steps/s": (
+                    f"{r['metrics']['steady_state_collector_steps_per_s']:,.0f}"
+                    if r["metrics"]
+                    else "-"
+                ),
+                "learner Samples/s": (
+                    f"{r['metrics']['steady_state_learner_samples_per_s']:,.0f}"
+                    if r["metrics"]
+                    else "-"
                 ),
                 "final reward": (
                     f"{r['metrics']['final_mean_reward']:.2f}"
@@ -422,8 +428,15 @@ def main(argv: list[str] | None = None) -> int:
                     if r["metrics"] and r["metrics"]["mean_dp_sync_time_sec"] is not None
                     else "-"
                 ),
-                "scaling vs n1": (
-                    f"{r['scaling_vs_n1']:.2f}x" if r["scaling_vs_n1"] is not None else "-"
+                "collector scaling": (
+                    f"{r['collector_scaling_vs_n1']:.2f}x"
+                    if r["collector_scaling_vs_n1"] is not None
+                    else "-"
+                ),
+                "learner scaling": (
+                    f"{r['learner_scaling_vs_n1']:.2f}x"
+                    if r["learner_scaling_vs_n1"] is not None
+                    else "-"
                 ),
                 "verdict": r["verdict"] or "-",
                 "status": r["status"],
@@ -433,10 +446,12 @@ def main(argv: list[str] | None = None) -> int:
         [
             "config",
             "devices",
-            "aggregate env-steps/s",
+            "collector Steps/s",
+            "learner Samples/s",
             "final reward",
             "dp_sync mean (s)",
-            "scaling vs n1",
+            "collector scaling",
+            "learner scaling",
             "verdict",
             "status",
         ],
@@ -458,7 +473,10 @@ def main(argv: list[str] | None = None) -> int:
                 "extra_overrides": list(args.extra_overrides),
                 "scaling_pass_threshold": SCALING_PASS_THRESHOLD,
                 "steady_state_tail_fraction": STEADY_STATE_TAIL_FRACTION,
-                "throughput_tag": STEPS_PER_SEC_TAG,
+                "throughput_tags": {
+                    "collector_steps_per_sec": STEPS_PER_SEC_TAG,
+                    "learner_samples_per_sec": SAMPLES_PER_SEC_TAG,
+                },
             },
         },
     )

--- a/benchmark/rl/reproduce_nccl_cuda_graph_capture.py
+++ b/benchmark/rl/reproduce_nccl_cuda_graph_capture.py
@@ -1,0 +1,126 @@
+"""Bounded two-rank reproducer for NCCL CUDA Graph capture (issue #978).
+
+Verified on 2 x RTX 6000D, PyTorch 2.7.0+cu128, CUDA 12.8 and NCCL
+2.26.2 with P2P/SHM disabled (TCP loopback):
+
+- no warmup: capture fails with ``operation not permitted when stream is capturing``;
+- eager all-reduce warmup: synchronous capture and replay pass;
+- ``async_op=True`` with captured ``Work.wait()`` also passes;
+- both collective modes pass on the default and a side stream.
+
+Every invocation has a parent-enforced timeout, including the intentionally
+hanging/error variants. The production FastSAC/FlashSAC path keeps synchronous
+all-reduce and performs the required eager warmup before its first capture.
+
+Run:
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py --warmup
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py --warmup --async-op
+    uv run benchmark/rl/reproduce_nccl_cuda_graph_capture.py \
+        --warmup --async-op --side-stream
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker(
+    rank: int,
+    rendezvous_path: str,
+    warmup: bool,
+    side_stream: bool,
+    async_op: bool,
+) -> None:
+    os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+    os.environ.setdefault("NCCL_SHM_DISABLE", "1")
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_path}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        if warmup:
+            warmup_tensor = torch.ones(1, device=device)
+            dist.all_reduce(warmup_tensor)
+            torch.cuda.synchronize(device)
+            print(f"rank={rank} warmup complete", flush=True)
+
+        tensor = torch.full((1024,), rank + 1, dtype=torch.float32, device=device)
+        graph = torch.cuda.CUDAGraph()
+        if side_stream:
+            capture_stream = torch.cuda.Stream(device=device)
+            capture_stream.wait_stream(torch.cuda.current_stream(device))
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                work = dist.all_reduce(tensor, async_op=async_op)
+                if work is not None:
+                    work.wait()
+            torch.cuda.current_stream(device).wait_stream(capture_stream)
+        else:
+            with torch.cuda.graph(graph):
+                work = dist.all_reduce(tensor, async_op=async_op)
+                if work is not None:
+                    work.wait()
+        print(f"rank={rank} capture complete", flush=True)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(tensor, torch.full_like(tensor, 3.0))
+        print(f"rank={rank} replay complete", flush=True)
+        graph.reset()
+        torch.cuda.synchronize(device)
+    finally:
+        dist.destroy_process_group()
+
+
+def _terminate_processes(processes: list[mp.Process]) -> None:
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    for process in processes:
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", action="store_true")
+    parser.add_argument("--side-stream", action="store_true")
+    parser.add_argument("--async-op", action="store_true")
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be positive")
+    if torch.cuda.device_count() < 2:
+        parser.error("the NCCL capture reproducer requires at least two CUDA devices")
+
+    with tempfile.TemporaryDirectory(prefix="issue978-nccl-") as temp_dir:
+        rendezvous_path = os.path.join(temp_dir, "store")
+        context = mp.spawn(
+            _worker,
+            args=(rendezvous_path, args.warmup, args.side_stream, args.async_op),
+            nprocs=2,
+            join=False,
+        )
+        deadline = time.monotonic() + args.timeout_seconds
+        while not context.join(timeout=max(0.0, deadline - time.monotonic())):
+            if time.monotonic() >= deadline:
+                _terminate_processes(context.processes)
+                raise TimeoutError(
+                    f"NCCL graph capture did not finish within {args.timeout_seconds:g}s"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -12,10 +12,6 @@ training:
   # list[list[int]] | null; one CPU-id segment per rank for the collector's
   # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.
   dp_collector_cpu_ids: null
-  # int >= 1; every K learner iterations, ranks all-reduce the actor+critic
-  # parameter mean (K=1 = every iteration). Only takes effect with multi-GPU
-  # training.devices.
-  dp_sync_interval: 8
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -12,6 +12,10 @@ training:
   # list[list[int]] | null; one CPU-id segment per rank for the collector's
   # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.
   dp_collector_cpu_ids: null
+  # int >= 1; every K learner iterations, ranks all-reduce the actor+critic
+  # parameter mean (K=1 = every iteration). Only takes effect with multi-GPU
+  # training.devices.
+  dp_sync_interval: 8
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -6,6 +6,9 @@ defaults:
 training:
   task_name: G1WalkFlat
   device: null
+  # list[int] | null; null/[] = current single-device behavior;
+  # [d0..dN-1] = N-way data parallel, rank i trains on cuda:devices[i].
+  devices: null
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -9,6 +9,9 @@ training:
   # list[int] | null; null/[] = current single-device behavior;
   # [d0..dN-1] = N-way data parallel, rank i trains on cuda:devices[i].
   devices: null
+  # list[list[int]] | null; one CPU-id segment per rank for the collector's
+  # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.
+  dp_collector_cpu_ids: null
   logger: tensorboard
   wandb_project: unilab
   wandb_entity: null

--- a/conf/offpolicy/config.yaml
+++ b/conf/offpolicy/config.yaml
@@ -5,9 +5,9 @@ defaults:
 
 training:
   task_name: G1WalkFlat
-  device: null
-  # list[int] | null; null/[] = current single-device behavior;
-  # [d0..dN-1] = N-way data parallel, rank i trains on cuda:devices[i].
+  # list[int] | null; null/[] = auto-selected single-device behavior;
+  # [d0] = explicit single CUDA device; [d0..dN-1] = N-way data parallel,
+  # rank i trains on cuda:devices[i].
   devices: null
   # list[list[int]] | null; one CPU-id segment per rank for the collector's
   # MuJoCo pool; null = auto partition of cpu_count // world_size per rank.

--- a/conf/ppo/config.yaml
+++ b/conf/ppo/config.yaml
@@ -56,6 +56,10 @@ algo:
 
 training:
   task_name: Go1JoystickFlat
+  # list[int] | null; null/[] keeps single-device behavior, [d] selects one
+  # CUDA device, and [d0..dN-1] launches one RSL-RL worker per device.
+  # algo.num_envs is per rank; do not set this together with training.device.
+  devices: null
   device: null
   logger: tensorboard
   wandb_project: unilab

--- a/docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md
+++ b/docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md
@@ -6,6 +6,7 @@ orphan: true
 
 - Status: Accepted
 - Date: 2026-04-11
+- Last updated: 2026-08-15
 - Owners: Infra / Training maintainers
 - Supersedes: None
 - Superseded by: None
@@ -22,6 +23,9 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 2. 分层依赖单向: `backend -> env -> config/registry -> algo/ipc -> scripts`。
 3. `scripts/` 只做装配，不承载长期业务规则。
 4. 变更评审优先检查 contract 是否被破坏，而不是只看 smoke run 是否通过。
+5. 同步 PPO 默认单进程；单机多卡时按一卡一进程复制 env、policy 与 rollout，复用
+   RSL-RL 的 startup model broadcast 和 per-mini-batch gradient averaging，不在
+   UniLab 另建 PPO 同步协议。
 
 ## Stable Contracts
 
@@ -29,17 +33,27 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 - `NpEnvState.obs` 必须是 `dict`，`reset()` 返回 `(obs_dict, info_dict)`。
 - `SimBackend` 是 backend 抽象边界；算法与脚本不应依赖后端私有实现。
 - 异步路径统一复用 `AsyncRunner` 生命周期与 shared resource cleanup。
+- PPO 的 `algo.num_envs` 是 per-rank 数量；全局每轮新样本数为
+  `world_size * num_envs * num_steps_per_env`。
+- PPO 多卡只有 rank 0 持久化日志/checkpoint；rollout、GAE、normalizer buffer、
+  curriculum 与 episode statistics 不做隐式全局聚合。
 
 ## Consequences
 
 - 跨层问题必须在 owner layer 修复。
 - 新功能必须先确定 contract 归属，再决定具体落点。
 - 文档和评审用语应区分“稳定 contract”与“阶段性能力”。
+- PPO launcher 只维护单机 device/rank 与 worker lifecycle；算法 collective 的版本
+  兼容性继续由锁定的 RSL-RL 依赖负责。
 
 ## Alternatives Considered
 
 - 保持脚本层按训练入口各自处理 backend/env/algo 差异。拒绝原因：会把 contract 漏洞扩散到 `scripts/`，并让 smoke run 掩盖 owner layer 问题。
 - 只用顶层训练脚本定义 runtime contract。拒绝原因：无法约束 env、backend、runner 和 IPC 的长期边界。
+- 要求用户手工调用 `torchrun`。拒绝原因：无法稳定提供 Hydra device list、共享运行
+  目录、rank seed 与顶层 CLI 的失败传播语义。
+- 在 UniLab 自行实现 PPO gradient collective。拒绝原因：会与 RSL-RL 已有的广播、
+  adaptive-KL 和 mini-batch 同步周期形成第二套协议。
 
 ## Evidence In Repo
 
@@ -48,6 +62,10 @@ UniLab 同时支持多种算法入口和两种仿真后端。没有统一 runtim
 - Env contract: `src/unilab/base/np_env.py`
 - Registry 入口: `src/unilab/base/registry.py`
 - Async runner: `src/unilab/ipc/async_runner.py`
+- PPO distributed adapter: `src/unilab/ipc/dp_launcher.py`,
+  `src/unilab/training/rsl_rl.py`, `scripts/train_rsl_rl.py`
+- PPO distributed tests: `tests/ipc/test_dp_launcher.py`,
+  `tests/algos/test_rsl_rl_ppo.py`, `tests/scripts/test_train_script_configs.py`
 
 ## Related Documents
 

--- a/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/3-logging.md
@@ -2,8 +2,9 @@
 
 The terminal panel and TensorBoard / W&B are not separate logging systems. An
 algorithm runner submits each metric once to the same training logger. The terminal
-is a live view of the latest values; `training.logger=tensorboard` (the default) or
-`training.logger=wandb` selects the persistent backend for the same canonical keys.
+refreshes on a fixed 2 Hz clock and shows a two-second sliding average;
+`training.logger=tensorboard` (the default) or `training.logger=wandb` selects the
+persistent backend, which keeps each unsmoothed iteration value.
 
 This page first covers the log directory shared by all algorithms, then documents the
 off-policy terminal used by SAC / TD3 / FlashSAC and APPO. Every terminal field in the
@@ -54,7 +55,16 @@ The bottom of the terminal has three columns:
   `Iter Wall` as its denominator.
 - `Collector (own clock)` is measured in the collector subprocess and runs in
   parallel with the learner.
-- `System` contains non-timing state such as buffer, batch, and done rates.
+- `System` contains the buffer size, timeout rate, environment count, and per-rank
+  batch size.
+
+The panel-border title reports `GPUs N`. In multi-GPU training, only rank 0 owns the
+terminal and persistent logger. Learner metrics and timings are averaged across
+ranks first and then across the terminal's two-second window. `Steps/s` and
+`Samples/s` are exceptions to the rank average: per-rank collector step rates and
+learner sample rates are summed, so both fields are total job throughput. The
+`Avg 2s (n=...)` header field gives the number of already rank-reduced learner
+samples in the current time window.
 
 Do not add times across the learner and collector columns. Only the learner rows from
 `Collector Wait` through `Other` are mutually exclusive main-thread phases. The
@@ -118,7 +128,6 @@ tags below, while an existing run continues to show its old names:
 | `timing/learner_incremental_h2d_ms` (SAC-like) | `timing/replay_ingress_h2d_submit_ms` | Identify a potentially parallel submit diagnostic rather than a learner main phase |
 | `timing/learner_incremental_h2d_ms` (APPO) | `timing/learner_replay_stage_ms` | Identify synchronous staging that is part of `Iter Wall` |
 | `timing/collector_inference_wait_ms` | `timing/collector_learner_action_wait_ms` | The wait can include the remaining learner update, not only inference latency |
-| `timing/collector_sync_idle_ms` | `timing/collector_bookkeeping_ms` | The measured work is episode / metrics bookkeeping, not synchronization idle time |
 
 `perf/learner_pipeline_ms` was removed because it mixed exclusive main phases with a
 background H2D submission. Use `perf/iter_ms` for the main timeline and reconcile it
@@ -126,8 +135,9 @@ with `perf/learner_accounted_pct` plus `perf/learner_other_pct`.
 
 ### Collector Timeline
 
-SAC / TD3 / FlashSAC record five mutually exclusive phases per vectorized env tick.
-Terminal percentages use `perf/collector_cycle_ms`, the sum of these five phases:
+SAC / TD3 / FlashSAC record four mutually exclusive hot-path phases per vectorized
+env tick. Terminal percentages use `perf/collector_cycle_ms`, the sum of these four
+phases:
 
 | Terminal field | TensorBoard / W&B key | Meaning |
 | --- | --- | --- |
@@ -135,7 +145,6 @@ Terminal percentages use `perf/collector_cycle_ms`, the sum of these five phases
 | Learner Action Wait | `timing/collector_learner_action_wait_ms` | Barrier wall time from request publication until the learner publishes this tick's action |
 | Env Step | `timing/collector_env_step_ms` | `env.step()` wall time |
 | Replay Write | `timing/collector_replay_write_ms` | Transition post-processing, packing, and bounded-ingress write |
-| Bookkeeping | `timing/collector_bookkeeping_ms` | Episode statistics, metrics reporting, and remaining per-step bookkeeping |
 
 `Learner Action Wait` is deliberately not named “Inference Wait”: it is not pure
 inference latency. If the collector finishes `Env Step + Replay Write` and submits its
@@ -144,11 +153,13 @@ update, a small scheduling part of the next learner `Collector Wait`, and the ne
 `Inference + Collector Release`. A long value therefore agrees with parallel
 execution: it means the collector reached the next barrier before the learner.
 
-`Collector/s` is active collector throughput, calculated as
+The persistent `perf/collector_active_steps_per_sec` diagnostic is calculated as
 `num_envs / (Inference Request + Env Step + Replay Write)`. It intentionally excludes
-`Learner Action Wait` and `Bookkeeping`. The indented Backend Step / Update State /
-Reset Done rows are nested `Env Step` details. They do not enter the cycle sum, though
-their displayed percentages use the same collector-cycle denominator.
+`Learner Action Wait`; low-value sub-millisecond episode / metrics bookkeeping is no
+longer timed separately. The terminal `Steps/s` field instead reports total
+synchronized collector throughput. The indented Backend Step / Update State / Reset
+Done rows are nested `Env Step` details. They do not enter the cycle sum, though their
+displayed percentages use the same collector-cycle denominator.
 
 APPO has a different collection contract and reports:
 
@@ -159,8 +170,8 @@ APPO has a different collection contract and reports:
 | Rollout Wall | `timing/collector_rollout_ms` | Whole `steps_per_env` rollout wall-time EMA |
 
 These are not one percentage breakdown: the first two are per-step EMAs and `Rollout
-Wall` is a whole-rollout total, so the terminal shows milliseconds only.
-`Collector/s = (num_envs * steps_per_env) / Rollout Wall`.
+Wall` is a whole-rollout total, so the terminal shows milliseconds only. The backend
+active-throughput diagnostic is `(num_envs * steps_per_env) / Rollout Wall`.
 
 ## FastSAC Dual Timeline
 
@@ -189,7 +200,6 @@ sequenceDiagram
     par Collector tick t
         C->>C: Env Step(t)
         C->>D: Replay Write(t)
-        C->>C: Bookkeeping(t)
         C->>I: Inference Request(t+1)
         Note over C,I: Learner Action Wait(t+1) starts here
     and Learner iteration k

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
@@ -29,3 +29,57 @@ uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
 
 Logs are grouped by `algo.algo_log_name`; the default in `conf/ppo/config.yaml`
 is `rsl_rl_ppo`.
+
+## Single-node multi-GPU training
+
+`training.devices` enables RSL-RL's synchronous data-parallel PPO path:
+
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+
+uv run train --algo ppo --task g1_motion_tracking --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+```
+
+`null` or `[]` keeps automatic single-device selection, `[d]` selects one
+CUDA device, and two or more entries launch one local process per listed
+device. Do not set `training.device` and `training.devices` together. The
+configured order is preserved, including when the parent already has
+`CUDA_VISIBLE_DEVICES` set.
+
+`algo.num_envs` is a **per-rank** count, not a global budget. For `W` ranks,
+`N` configured envs, and rollout length `T`:
+
+```text
+local samples / iteration  = N * T
+global samples / iteration = W * N * T
+```
+
+Each rank owns an independent env, policy copy, and rollout storage. Rollouts,
+GAE, advantage normalization, and mini-batch shuffling stay rank-local.
+RSL-RL broadcasts rank 0's model state at startup and averages gradients after
+every PPO mini-batch backward pass. Rank `i` uses `algo.seed + i`.
+`training.num_timesteps` is interpreted as a global sample budget and therefore
+uses `W * N * T` when deriving the iteration count.
+
+Only rank 0 writes TensorBoard/W&B data, checkpoints, `run_config.json`, and
+`run_summary.json`, then optionally enters playback after all ranks have closed
+their process group. `run_summary.json` records `world_size`, per-rank/global
+env counts, samples per iteration, and aggregate training throughput. RSL-RL's
+`Perf/total_fps` is also an aggregate global samples/s metric; reward and episode
+statistics remain rank-0-local.
+
+RSL-RL does not synchronize observation-normalizer buffers or environment
+curriculum state after startup. Consequently, tasks with empirical
+normalization (including the current Go2 flat owner) keep rank-local statistics,
+and the checkpoint contains rank 0's copy. This is the upstream RSL-RL
+distributed semantic, not global-rollout PPO.
+
+The integrated launcher is single-node only. The repository has two-GPU MuJoCo
+smoke coverage for `go2_joystick_flat` and `g1_motion_tracking`; this does not
+claim multi-node or Motrix multi-GPU support. On the currently validated RTX
+6000D host, the launcher inherits the production NCCL compatibility defaults
+`NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1`; explicit environment values win.

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/3-logging.md
@@ -1,8 +1,9 @@
 # 日志
 
 训练时看到的终端面板与 TensorBoard / W&B 不是两套 logger：算法 runner 只向同一个
-training logger 提交一次指标。终端面板是当前值的实时视图；`training.logger=tensorboard`
-（默认）或 `training.logger=wandb` 决定把同一批 canonical key 持久化到哪个 backend。
+training logger 提交一次指标。终端面板按固定 2 Hz 时钟刷新，并显示两秒时间滑动平均；
+`training.logger=tensorboard`（默认）或 `training.logger=wandb` 决定持久化 backend，
+backend 保留每个 iteration 未经时间平滑的值。
 
 本文先说明所有算法共用的日志目录，再详细说明 SAC / TD3 / FlashSAC 与 APPO 共用的
 off-policy 终端视图。表中的“终端字段”与 backend key 一一对应；后缀 `_ms` 均为毫秒。
@@ -50,7 +51,13 @@ RSL-RL writer。MuJoCo run 若产生 `play_video.mp4`，该视频会上传至 W&
 
 - `Learner (Iter Wall)`：learner 主线程的一圈；所有行使用 `Iter Wall` 作分母。
 - `Collector (own clock)`：collector 子进程自己的采集时钟，与 learner 并行。
-- `System`：buffer、batch、done rate 等非计时状态。
+- `System`：buffer 大小、timeout rate、env 数和每 rank batch 大小。
+
+面板边框标题显示 `GPUs N`。多卡训练中只有 rank 0 持有终端与持久化 logger；learner
+指标和计时先在 rank 间取平均，再进入终端的两秒时间窗口。`Steps/s` 与 `Samples/s`
+不取 rank 平均：前者把各 rank collector step rate 求和，后者把各 rank learner sample
+rate 求和，因此两者都是整个训练任务的总吞吐。标题中的 `Avg 2s (n=...)` 表示当前窗口
+包含多少个已经完成 rank 聚合的 learner 样本。
 
 两列时间不能横向相加。只有 learner 列从 `Collector Wait` 到 `Other` 的行是互斥主线程
 阶段；实现以 `Other = max(Iter Wall - accounted, 0)` 补齐未命名区间。正常情况下它们合计
@@ -109,7 +116,6 @@ backend 还记录 `perf/learner_train_pct`、`perf/learner_accounted_pct` 与
 | `timing/learner_incremental_h2d_ms`（SAC 类） | `timing/replay_ingress_h2d_submit_ms` | 明确它是可能并行的 submit 诊断，不是 learner 主阶段 |
 | `timing/learner_incremental_h2d_ms`（APPO） | `timing/learner_replay_stage_ms` | 明确它是可计入 `Iter Wall` 的同步 staging 阶段 |
 | `timing/collector_inference_wait_ms` | `timing/collector_learner_action_wait_ms` | 等待范围还包含剩余 learner update，不等于 inference latency |
-| `timing/collector_sync_idle_ms` | `timing/collector_bookkeeping_ms` | 实际内容是 episode / metrics bookkeeping，并非同步 idle |
 
 `perf/learner_pipeline_ms` 已移除：它曾把互斥主阶段与后台 H2D submit 混加。主时间线请使用
 `perf/iter_ms`，完整性请对照 `perf/learner_accounted_pct` 与
@@ -117,8 +123,8 @@ backend 还记录 `perf/learner_train_pct`、`perf/learner_accounted_pct` 与
 
 ### Collector 自有时间线
 
-SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终端百分比使用
-`perf/collector_cycle_ms`（这五项之和）作分母：
+SAC / TD3 / FlashSAC 每个 vectorized env tick 记录四个热路径互斥阶段，终端百分比使用
+`perf/collector_cycle_ms`（这四项之和）作分母：
 
 | 终端字段 | TensorBoard / W&B key | 含义 |
 | --- | --- | --- |
@@ -126,7 +132,6 @@ SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终�
 | Learner Action Wait | `timing/collector_learner_action_wait_ms` | request 发出后，等 learner 发布当前 tick action 的屏障墙钟 |
 | Env Step | `timing/collector_env_step_ms` | `env.step()` 墙钟 |
 | Replay Write | `timing/collector_replay_write_ms` | transition 后处理、打包并写入 bounded ingress |
-| Bookkeeping | `timing/collector_bookkeeping_ms` | episode 统计、metrics 上报及其余单步 bookkeeping |
 
 `Learner Action Wait` 特意不叫 “Inference Wait”：它不是纯 inference latency。如果 collector
 在 learner update 期间先完成 `Env Step + Replay Write` 并提交下一 request，这一项会包含
@@ -134,10 +139,12 @@ SAC / TD3 / FlashSAC 每个 vectorized env tick 记录五个互斥阶段，终�
 Collector Release`。所以它很长并不与“两侧并行”矛盾，反而说明 collector 比 learner
 update 更早到达下一屏障。
 
-`Collector/s` 是 collector 活跃路径吞吐，按
+持久化指标 `perf/collector_active_steps_per_sec` 按 collector 活跃路径计算：
 `num_envs / (Inference Request + Env Step + Replay Write)` 计算；它有意排除
-`Learner Action Wait` 与 `Bookkeeping`。`Env Step` 下缩进的 Backend Step / Update State /
-Reset Done 是父项的嵌套明细，不参与 cycle 求和，但百分比仍使用同一 collector cycle 分母。
+`Learner Action Wait`；诊断价值较低的亚毫秒 episode / metrics bookkeeping 不再单独计时。
+终端 `Steps/s` 则报告同步 collector 的总吞吐。`Env Step` 下缩进的 Backend Step /
+Update State / Reset Done 是父项的嵌套明细，不参与 cycle 求和，但百分比仍使用同一
+collector cycle 分母。
 
 APPO 使用不同的采集 contract，因此 collector 只上报：
 
@@ -148,7 +155,8 @@ APPO 使用不同的采集 contract，因此 collector 只上报：
 | Rollout Wall | `timing/collector_rollout_ms` | 完整 `steps_per_env` 步 rollout 的墙钟 EMA |
 
 APPO 的三个值不是一组百分比分解：前两个是单步 EMA，`Rollout Wall` 是整条 rollout 总量，
-所以终端只显示 ms。`Collector/s = (num_envs * steps_per_env) / Rollout Wall`。
+所以终端只显示 ms。backend 的活跃吞吐诊断按
+`(num_envs * steps_per_env) / Rollout Wall` 计算。
 
 ## FastSAC 双时间线
 
@@ -176,7 +184,6 @@ sequenceDiagram
     par Collector tick t
         C->>C: Env Step(t)
         C->>D: Replay Write(t)
-        C->>C: Bookkeeping(t)
         C->>I: Inference Request(t+1)
         Note over C,I: Learner Action Wait(t+1) 从这里开始
     and Learner iteration k

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
@@ -28,3 +28,52 @@ uv run eval --algo ppo --task go2_joystick_flat --sim mujoco --load-run -1
 
 日志按 `algo.algo_log_name` 分组；`conf/ppo/config.yaml` 中的默认值为
 `rsl_rl_ppo`。
+
+## 单机多卡训练
+
+`training.devices` 打开 RSL-RL 的同步数据并行 PPO：
+
+```bash
+uv run train --algo ppo --task go2_joystick_flat --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+
+uv run train --algo ppo --task g1_motion_tracking --sim mujoco \
+  'training.devices=[0,1]' \
+  training.no_play=true
+```
+
+`null` 或 `[]` 保持自动选择单个 device；`[d]` 显式选择一张 CUDA 卡；两个以上
+索引会按列表顺序在本机为每张卡启动一个进程。不能同时设置 `training.device` 与
+`training.devices`。父进程已有 `CUDA_VISIBLE_DEVICES` 时，配置索引仍按父进程可见
+设备解释，并保留用户给定顺序。
+
+`algo.num_envs` 是**每个 rank** 的环境数，不是全局预算。设 rank 数为 `W`、配置
+环境数为 `N`、rollout 长度为 `T`：
+
+```text
+每 rank 每轮样本数 = N * T
+全局每轮样本数     = W * N * T
+```
+
+每个 rank 独立持有 env、policy copy 和 rollout storage；rollout、GAE、advantage
+normalization 与 mini-batch shuffle 都留在本地。RSL-RL 在启动时广播 rank 0 的模型
+状态，并在每个 PPO mini-batch backward 后平均梯度。rank `i` 使用
+`algo.seed + i`。`training.num_timesteps` 按全局样本预算解释，因此推导 iteration
+数时使用 `W * N * T`。
+
+只有 rank 0 写 TensorBoard/W&B、checkpoint、`run_config.json` 与
+`run_summary.json`；所有 rank 销毁 process group 后，才由 rank 0 可选进入
+playback。`run_summary.json` 记录 world size、每 rank/全局环境数、每轮样本数和
+聚合训练吞吐率。RSL-RL 的 `Perf/total_fps` 同样是全局 samples/s；reward 与
+episode 统计仍是 rank 0 的本地视角。
+
+RSL-RL 启动后不会同步 observation normalizer buffer 或环境 curriculum 状态。因此，
+启用 empirical normalization 的 task（包括当前 Go2 flat owner）保留 rank-local
+统计，checkpoint 保存 rank 0 的副本。这是上游 RSL-RL 的分布式语义，不是先拼接
+全局 rollout 再训练的 PPO。
+
+集成 launcher 只覆盖单机。仓库已有 `go2_joystick_flat` 与
+`g1_motion_tracking` 的双卡 MuJoCo smoke；这不构成多机或 Motrix 多卡 support
+声明。当前验证的 RTX 6000D 主机沿用 production NCCL 兼容默认值
+`NCCL_P2P_DISABLE=1`、`NCCL_SHM_DISABLE=1`，用户显式环境变量优先。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -64,7 +64,8 @@ tfevents。rank 0 在每个 learner iteration 汇总跨 rank 标量：loss、rew
 取均值，计数与并行吞吐求和。`perf/steps_per_sec` / 终端 `Steps/s` 表示所有
 collector 的聚合 env-step 吞吐，`perf/effective_samples_per_sec` / 终端 `Samples/s`
 表示所有 learner 的聚合有效样本吞吐。checkpoint 同样由 rank 0 独占：每个保存间隔和
-训练结束只在 canonical run 目录写一份模型，rank 子目录不保存副本。
+训练结束只在 canonical run 目录写一份模型；其他 rank 复用该路径完成进程协调，不创建
+rank 子目录或任何日志文件。
 自动生成的多卡 run 目录以 `_gpuxN` 结尾（例如 `_gpux2`）；单卡目录和显式
 `training.log_dir` 保持原样。
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -76,9 +76,16 @@ collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段
 
 - 仅 SAC 与 FlashSAC：TD3 learner 未实现 optimizer-boundary gradient sync contract，
   多卡启动即报错。
-- NCCL gradient collective 不捕获进 optimizer CUDA Graph；若多卡配置请求 actor/critic
-  graph capture，learner 会自动切换到 eager optimizer update 并继续同步梯度，单卡行为不变。
-  runtime manifest 的 `dp_sync.cuda_graph_optimizer_capture=eager_fallback` 会记录该回退。
+- 多卡 actor/critic optimizer CUDA Graph 支持捕获 NCCL gradient all-reduce。首次 capture
+  前，DP owner 会先执行一次 eager all-reduce 并同步设备，完成 NCCL collective lazy
+  initialization；flat-gradient buffer 在 graph 生命周期内保持固定地址。runtime manifest
+  记录 `dp_sync.cuda_graph_optimizer_capture=enabled_after_collective_warmup` 和
+  `cuda_graph_collective_warmup=true`。销毁 process group 前会先释放 graph 中的 NCCL 节点。
+  Issue #978 的验证环境为 PyTorch 2.7.0+cu128、CUDA 12.8、NCCL 2.26.2、2 × RTX
+  6000D；TCP loopback 下同步 all-reduce 和 `async_op=True` + `Work.wait()` 均可 capture/replay，
+  默认 stream 与 side stream 均通过；跳过 warmup 时首个 all-reduce 会在 capture 中报
+  `operation not permitted when stream is capturing`。有限超时的最小复现见
+  `benchmark/rl/reproduce_nccl_cuda_graph_capture.py`。
 - 仅验证过 `mujoco` backend。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -46,32 +46,38 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
 
 `training.devices` 打开单节点多卡数据并行（data parallel）：rank i 在
 `cuda:devices[i]` 上各跑一套独立的 learner+collector，rank 0 负责 spawn 其余
-rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参数，之后每
-`training.dp_sync_interval`（默认 8）个 learner iteration 对 learner 可学习参数
-（actor / critic / 温度系数）做一次 all-reduce 平均；梯度不交换，各 rank 保留自己的
-optimizer 状态。
+rank 子进程。启动时 rank 0 一次性广播 actor、critic、target critic 和温度状态；稳态
+训练不再平均参数，而是在每个实际 optimizer step 前对对应的 actor、critic 或温度梯度
+执行阻塞式 flat-gradient `all_reduce(SUM) / world_size`。各 rank 不交换 replay 数据，
+在相同初值、平均梯度和更新顺序下各自维护一致的 optimizer 状态。
 
 off-policy 只公开 `training.devices` 这一个设备字段：`null` 或 `[]` 自动选择单个
 learner device，`[0]` 显式选择 `cuda:0`，两个以上索引才启动多卡拓扑。
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
-  training.devices=[0,1] \
-  training.dp_sync_interval=8
+  training.devices=[0,1]
 ```
 
 rank 0 独占终端与 TensorBoard/W&B logger；其他 learner 不刷新终端，也不创建独立
 tfevents。rank 0 在每个 learner iteration 汇总跨 rank 标量：loss、reward 和 timing
 取均值，计数与并行吞吐求和。`perf/steps_per_sec` / 终端 `Steps/s` 表示所有
 collector 的聚合 env-step 吞吐，`perf/effective_samples_per_sec` / 终端 `Samples/s`
-表示所有 learner 的聚合有效样本吞吐。
+表示所有 learner 的聚合有效样本吞吐。checkpoint 同样由 rank 0 独占：每个保存间隔和
+训练结束只在 canonical run 目录写一份模型，rank 子目录不保存副本。
+自动生成的多卡 run 目录以 `_gpuxN` 结尾（例如 `_gpux2`）；单卡目录和显式
+`training.log_dir` 保持原样。
 
 collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段），可用
 `training.dp_collector_cpu_ids` 显式指定。
 
 当前限制：
 
-- 仅 SAC 与 FlashSAC：TD3 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
+- 仅 SAC 与 FlashSAC：TD3 learner 未实现 optimizer-boundary gradient sync contract，
+  多卡启动即报错。
+- NCCL gradient collective 不捕获进 optimizer CUDA Graph；若多卡配置请求 actor/critic
+  graph capture，learner 会自动切换到 eager optimizer update 并继续同步梯度，单卡行为不变。
+  runtime manifest 的 `dp_sync.cuda_graph_optimizer_capture=eager_fallback` 会记录该回退。
 - 仅验证过 `mujoco` backend。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -51,25 +51,32 @@ rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参�
 （actor / critic / 温度系数）做一次 all-reduce 平均；梯度不交换，各 rank 保留自己的
 optimizer 状态。
 
+off-policy 只公开 `training.devices` 这一个设备字段：`null` 或 `[]` 自动选择单个
+learner device，`[0]` 显式选择 `cuda:0`，两个以上索引才启动多卡拓扑。
+
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
   training.devices=[0,1] \
   training.dp_sync_interval=8
 ```
 
-每个 rank 的日志落在同一 run 目录下：rank 0 直接在 run 目录（含
-`run_summary.json` 与 tfevents），rank i>0 在 `rank{i}/` 子目录（仅 tfevents）。
+rank 0 独占终端与 TensorBoard/W&B logger；其他 learner 不刷新终端，也不创建独立
+tfevents。rank 0 在每个 learner iteration 汇总跨 rank 标量：loss、reward 和 timing
+取均值，计数与并行吞吐求和。`perf/steps_per_sec` / 终端 `Steps/s` 表示所有
+collector 的聚合 env-step 吞吐，`perf/effective_samples_per_sec` / 终端 `Samples/s`
+表示所有 learner 的聚合有效样本吞吐。
+
 collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段），可用
 `training.dp_collector_cpu_ids` 显式指定。
 
 当前限制：
 
 - 仅 SAC 与 FlashSAC：TD3 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
-- 仅验证过 `mujoco` backend；`training.devices` 与 `training.device` 互斥。
+- 仅验证过 `mujoco` backend。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置
   时优先）——部分机型（如 RTX 6000D）的 NCCL P2P/SHM peer transport 不可靠，
   TCP loopback 是唯一稳定传输。
 
-2 卡聚合吞吐相对单卡的 scaling 验收基准见
+collector `Steps/s` 与 learner `Samples/s` 各自相对单卡的 scaling 基准见
 `benchmark/rl/benchmark_offpolicy_dp_scaling.py`（issue #968，真实运行不进 CI）。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -41,3 +41,34 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
   algo.max_iterations=1000 \
   training.no_play=true
 ```
+
+## 多卡数据并行
+
+`training.devices` 打开单节点多卡数据并行（data parallel）：rank i 在
+`cuda:devices[i]` 上各跑一套独立的 learner+collector，rank 0 负责 spawn 其余
+rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参数，之后每
+`training.dp_sync_interval`（默认 8）个 learner iteration 对 actor+critic 参数做
+一次 all-reduce 平均；梯度不交换，各 rank 保留自己的 optimizer 状态。
+
+```bash
+uv run train --algo sac --task g1_walk_flat --sim mujoco \
+  training.devices=[0,1] \
+  training.dp_sync_interval=8
+```
+
+每个 rank 的日志落在同一 run 目录下：rank 0 直接在 run 目录（含
+`run_summary.json` 与 tfevents），rank i>0 在 `rank{i}/` 子目录（仅 tfevents）。
+collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段），可用
+`training.dp_collector_cpu_ids` 显式指定。
+
+当前限制：
+
+- 仅 SAC：TD3 / FlashSAC 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
+- 仅验证过 `mujoco` backend；`training.devices` 与 `training.device` 互斥。
+- 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
+  loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置
+  时优先）——部分机型（如 RTX 6000D）的 NCCL P2P/SHM peer transport 不可靠，
+  TCP loopback 是唯一稳定传输。
+
+2 卡聚合吞吐相对单卡的 scaling 验收基准见
+`benchmark/rl/benchmark_offpolicy_dp_scaling.py`（issue #968，真实运行不进 CI）。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -47,8 +47,9 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco \
 `training.devices` 打开单节点多卡数据并行（data parallel）：rank i 在
 `cuda:devices[i]` 上各跑一套独立的 learner+collector，rank 0 负责 spawn 其余
 rank 子进程。同步是参数级的：启动时先广播 rank 0 的初始参数，之后每
-`training.dp_sync_interval`（默认 8）个 learner iteration 对 actor+critic 参数做
-一次 all-reduce 平均；梯度不交换，各 rank 保留自己的 optimizer 状态。
+`training.dp_sync_interval`（默认 8）个 learner iteration 对 learner 可学习参数
+（actor / critic / 温度系数）做一次 all-reduce 平均；梯度不交换，各 rank 保留自己的
+optimizer 状态。
 
 ```bash
 uv run train --algo sac --task g1_walk_flat --sim mujoco \
@@ -63,7 +64,7 @@ collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段
 
 当前限制：
 
-- 仅 SAC：TD3 / FlashSAC 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
+- 仅 SAC 与 FlashSAC：TD3 的 learner 未实现 `dp_sync_tensors()`，多卡启动即报错。
 - 仅验证过 `mujoco` backend；`training.devices` 与 `training.device` 互斥。
 - 仅单节点：rank 之间通过 run 目录里的 FileStore rendezvous，NCCL 走 TCP
   loopback（默认 `NCCL_P2P_DISABLE=1` / `NCCL_SHM_DISABLE=1`，环境变量显式设置

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
@@ -33,3 +33,16 @@ FlashSAC 要求同步采集，并与 SAC、TD3 共用唯一 replay 路径：有�
 training 不受支持。
 
 日志根目录为 `logs/flash_sac/<task>/`。
+
+## 多卡数据并行
+
+FlashSAC 与 SAC 共用同一套多卡数据并行机制：`training.devices` 下每个 rank 各跑一
+套独立的 learner+collector，`FlashSACLearner.dp_sync_tensors()` 同步 actor / critic /
+target critic / temperature 参数。用法与限制见
+{doc}`/zh_CN/2-user_guide/2-algorithms/3-sac` 的"多卡数据并行"小节。
+
+```bash
+uv run train --algo flashsac --task g1_walk_flat --sim mujoco \
+  training.devices=[0,1] \
+  training.dp_sync_interval=8
+```

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
@@ -37,12 +37,11 @@ training 不受支持。
 ## 多卡数据并行
 
 FlashSAC 与 SAC 共用同一套多卡数据并行机制：`training.devices` 下每个 rank 各跑一
-套独立的 learner+collector，`FlashSACLearner.dp_sync_tensors()` 同步 actor / critic /
-target critic / temperature 参数。用法与限制见
+套独立的 learner+collector；启动时广播完整模型状态，稳态在每个实际 optimizer step
+前分别平均 actor / critic / temperature 梯度。仅 rank 0 保存 checkpoint。用法与限制见
 {doc}`/zh_CN/2-user_guide/2-algorithms/3-sac` 的"多卡数据并行"小节。
 
 ```bash
 uv run train --algo flashsac --task g1_walk_flat --sim mujoco \
-  training.devices=[0,1] \
-  training.dp_sync_interval=8
+  training.devices=[0,1]
 ```

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
@@ -12,8 +12,10 @@ CPU physics backend -> collector / IPC -> learner
 MuJoCo or Motrix      shared memory       torch
 ```
 
-PPO 是同步的单进程路径。APPO 与 off-policy 算法则使用异步 runner、
-共享缓冲区，以及位于 `src/unilab/ipc/` 与 `src/unilab/algos/` 下的权重同步原语。
+PPO 是同步路径：默认单进程，也可在单机上按一卡一进程运行 RSL-RL 数据并行；
+每个 rank 独立持有 env/rollout，RSL-RL 在每个 mini-batch 后平均梯度。APPO 与
+off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `src/unilab/ipc/` 与
+`src/unilab/algos/` 下的权重同步原语。
 
 ## 分层边界
 

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
@@ -11,7 +11,15 @@
 
 `scripts/train_rsl_rl.py` 会 compose Hydra config、
 调用 registry bootstrap、通过 `registry.make(...)` 构造 env，并在同一进程内运行
-learner。RSL-RL 路径通过 `src/unilab/training/rsl_rl.py` 适配 `NpEnv`。
+learner。默认配置保持单进程；`training.devices` 指定多张卡时，父进程通过 PyTorch
+elastic launcher 启动本机 worker，worker 再进入同一脚本完成上述构造。RSL-RL 路径
+通过 `src/unilab/training/rsl_rl.py` 适配 `NpEnv`。
+
+多卡时每个 rank 按配置创建完整的 `algo.num_envs`、policy copy 与 rollout storage，
+数据和 GAE 不跨 rank 交换。RSL-RL 负责 startup model broadcast、adaptive-KL 标量
+同步，以及每个 PPO mini-batch 的梯度平均。UniLab 的 launcher 只负责 device/rank、
+共享 log dir、seed offset 与进程失败联动，不另建 PPO 同步协议。只有 rank 0 写日志与
+checkpoint；normalizer buffer、curriculum 和 episode 统计保持 rank-local。
 
 ### 异步 APPO 与 off-policy 路径
 
@@ -36,6 +44,8 @@ CPU physics env loop -> shared IPC buffer -> learner
 - GPU tensor 与 optimizer 状态属于 learner 代码，而非 env 代码。
 - Collector/learner 协议必须复用现有的 IPC 原语，而不是在 scripts 中另起临时的
   并行协议。
+- PPO 多卡必须复用 RSL-RL 的 distributed contract；`algo.num_envs` 是 per-rank
+  语义，不能在脚本中静默除以 world size。
 
 ## 仓库中的证据
 

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import os
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,6 +15,14 @@ from omegaconf import DictConfig, OmegaConf
 ROOT_DIR = Path(__file__).parent.parent
 sys.path.append(str(ROOT_DIR))
 
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_LOG_DIR,
+    DpRankSupervisor,
+    apply_dp_rank_config,
+    current_dp_rank,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
 from unilab.training import (
     BackendAdapter,
     apply_configured_training_seed,
@@ -670,6 +679,10 @@ def main(cfg: DictConfig) -> None:
     enable_faulthandler()
     ensure_registries()
 
+    devices = resolve_dp_topology(cfg.training.devices)
+    rank = current_dp_rank()
+    apply_dp_rank_config(cfg, devices, rank)
+
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     algo_name = cfg.algo.algo
     task_name = cfg.training.task_name
@@ -681,11 +694,20 @@ def main(cfg: DictConfig) -> None:
         log_dir = str(get_log_root(ROOT_DIR, cfg) / task_name / run_dir_name)
     else:
         log_dir = cfg.training.log_dir
+    if rank > 0:
+        # Spawned ranks reuse rank 0's run directory via a rank sub-directory;
+        # rank 0 owns the canonical checkpoints and the ExperimentTracker.
+        log_dir = os.path.join(os.environ[UNILAB_DP_LOG_DIR], f"rank{rank}")
+
+    supervisor: DpRankSupervisor | None = None
+    if devices is not None and rank == 0 and len(devices) > 1:
+        validate_dp_launchable(devices)
+        supervisor = DpRankSupervisor(devices, log_dir)
 
     import torch
 
     tracker = None
-    if not cfg.training.play_only:
+    if not cfg.training.play_only and rank == 0:
         tracker = ExperimentTracker(
             root_dir=ROOT_DIR,
             log_dir=log_dir,
@@ -700,45 +722,46 @@ def main(cfg: DictConfig) -> None:
         tracker.start()
 
     try:
-        if not cfg.training.play_only:
-            runner = None
-            try:
-                runner = build_runner(algo_name, cfg)
-                runner.learn(
-                    max_iterations=cfg.algo.max_iterations,
-                    save_interval=cfg.algo.save_interval,
-                    log_dir=log_dir,
-                    logger_type=cfg.training.logger,
-                )
-                run_summary = getattr(runner, "last_run_summary", None)
-                if isinstance(run_summary, dict) and run_summary.get("status") not in (
-                    None,
-                    "completed",
-                ):
-                    raise RuntimeError(
-                        f"Off-policy training ended with status={run_summary.get('status')!r}"
+        with supervisor if supervisor is not None else nullcontext():
+            if not cfg.training.play_only:
+                runner = None
+                try:
+                    runner = build_runner(algo_name, cfg)
+                    runner.learn(
+                        max_iterations=cfg.algo.max_iterations,
+                        save_interval=cfg.algo.save_interval,
+                        log_dir=log_dir,
+                        logger_type=cfg.training.logger,
                     )
-                if tracker is not None:
-                    tracker.update_summary(run_summary)
-            except BaseException as exc:
-                if tracker is not None:
-                    tracker.update_summary(
-                        build_failure_summary(exc, getattr(runner, "last_run_summary", None))
-                    )
-                raise
-            finally:
-                if runner is not None:
-                    runner.close()
+                    run_summary = getattr(runner, "last_run_summary", None)
+                    if isinstance(run_summary, dict) and run_summary.get("status") not in (
+                        None,
+                        "completed",
+                    ):
+                        raise RuntimeError(
+                            f"Off-policy training ended with status={run_summary.get('status')!r}"
+                        )
+                    if tracker is not None:
+                        tracker.update_summary(run_summary)
+                except BaseException as exc:
+                    if tracker is not None:
+                        tracker.update_summary(
+                            build_failure_summary(exc, getattr(runner, "last_run_summary", None))
+                        )
+                    raise
+                finally:
+                    if runner is not None:
+                        runner.close()
 
-        if should_run_playback(
-            play_only=cfg.training.play_only,
-            no_play=cfg.training.no_play,
-            play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
-        ):
-            print("@" * 50)
-            play_video_path = play_offpolicy(algo_name, cfg)
-            if tracker is not None:
-                tracker.log_video(play_video_path)
+            if rank == 0 and should_run_playback(
+                play_only=cfg.training.play_only,
+                no_play=cfg.training.no_play,
+                play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
+            ):
+                print("@" * 50)
+                play_video_path = play_offpolicy(algo_name, cfg)
+                if tracker is not None:
+                    tracker.log_video(play_video_path)
     finally:
         if tracker is not None:
             tracker.finish()

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -752,9 +752,9 @@ def main(cfg: DictConfig) -> None:
     else:
         log_dir = cfg.training.log_dir
     if rank > 0:
-        # Spawned ranks reuse rank 0's run directory via a rank sub-directory;
-        # rank 0 owns the canonical checkpoints and the ExperimentTracker.
-        log_dir = os.path.join(os.environ[UNILAB_DP_LOG_DIR], f"rank{rank}")
+        # Spawned ranks reuse the canonical run directory but never create
+        # logging backends, checkpoints, summaries, or traces there.
+        log_dir = os.environ[UNILAB_DP_LOG_DIR]
 
     supervisor: DpRankSupervisor | None = None
     if devices is not None and rank == 0 and len(devices) > 1:

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -21,6 +21,7 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     resolve_collector_cpu_ids,
+    resolve_dp_rendezvous_path,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -161,7 +162,7 @@ def build_offpolicy_env_cfg_override(algo_name: str, cfg: DictConfig) -> dict[st
     )
 
 
-def build_runner(algo_name: str, cfg: DictConfig):
+def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
     """Build algorithm runner from unified Hydra config."""
     env_cfg_override = build_offpolicy_env_cfg_override(algo_name, cfg)
     from unilab.algos.torch.offpolicy.thread_budget import (
@@ -177,16 +178,39 @@ def build_runner(algo_name: str, cfg: DictConfig):
     # only spawned ranks carry it), rank from the env (0 for rank 0).
     dp_devices = resolve_dp_topology(cfg.training.devices)
     dp_world_size = len(dp_devices) if dp_devices is not None else 1
+    dp_rank = current_dp_rank()
     host_cpu_count = os.cpu_count() or 1
     explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
     if explicit_cpu_ids is not None:
         explicit_cpu_ids = cast(list, OmegaConf.to_container(explicit_cpu_ids, resolve=True))
     collector_cpu_ids = resolve_collector_cpu_ids(
         dp_world_size,
-        current_dp_rank(),
+        dp_rank,
         host_cpu_count,
         explicit=explicit_cpu_ids,
     )
+
+    # Cold-path DP parameter sync: ranks average actor+critic parameters at
+    # the update boundary. world_size == 1 keeps dp_sync=None (bit-identical
+    # single-rank path, no process group is created).
+    dp_sync_interval = int(getattr(cfg.training, "dp_sync_interval", 8))
+    if dp_sync_interval < 1:
+        raise ValueError(f"training.dp_sync_interval must be >= 1, got {dp_sync_interval}")
+    dp_sync = None
+    if dp_world_size > 1:
+        if dp_rank == 0 and log_dir is None:
+            raise ValueError(
+                "build_runner requires log_dir for multi-GPU data-parallel rank 0 "
+                "(it anchors the DP rendezvous FileStore)"
+            )
+        from unilab.ipc.dp_sync import DpParameterSync
+
+        dp_sync = DpParameterSync(
+            world_size=dp_world_size,
+            rank=dp_rank,
+            rendezvous_path=resolve_dp_rendezvous_path(cast(str, log_dir), rank=dp_rank),
+            device=cfg.training.device,
+        )
 
     torch_thread_runtime = resolve_torch_thread_runtime(
         getattr(cfg.training, "torch_threads", None),
@@ -345,6 +369,8 @@ def build_runner(algo_name: str, cfg: DictConfig):
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "td3":
@@ -410,6 +436,8 @@ def build_runner(algo_name: str, cfg: DictConfig):
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "flashsac":
@@ -749,7 +777,7 @@ def main(cfg: DictConfig) -> None:
             if not cfg.training.play_only:
                 runner = None
                 try:
-                    runner = build_runner(algo_name, cfg)
+                    runner = build_runner(algo_name, cfg, log_dir=log_dir)
                     runner.learn(
                         max_iterations=cfg.algo.max_iterations,
                         save_interval=cfg.algo.save_interval,

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -20,6 +20,7 @@ from unilab.ipc.dp_launcher import (
     DpRankSupervisor,
     apply_dp_rank_config,
     current_dp_rank,
+    resolve_collector_cpu_ids,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -168,8 +169,28 @@ def build_runner(algo_name: str, cfg: DictConfig):
         resolve_torch_thread_runtime,
     )
 
+    # Cold-path DP CPU partition: each rank's collector owns one contiguous
+    # CPU block (single rank keeps the legacy unset behavior). The ids only
+    # reach the collector env override — never the num_envs=1 probe envs,
+    # whose MuJoCo pool would size itself from len(cpu_ids).
+    # world_size comes from training.devices (rank 0 has no UNILAB_DP_* env;
+    # only spawned ranks carry it), rank from the env (0 for rank 0).
+    dp_devices = resolve_dp_topology(cfg.training.devices)
+    dp_world_size = len(dp_devices) if dp_devices is not None else 1
+    host_cpu_count = os.cpu_count() or 1
+    explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
+    if explicit_cpu_ids is not None:
+        explicit_cpu_ids = cast(list, OmegaConf.to_container(explicit_cpu_ids, resolve=True))
+    collector_cpu_ids = resolve_collector_cpu_ids(
+        dp_world_size,
+        current_dp_rank(),
+        host_cpu_count,
+        explicit=explicit_cpu_ids,
+    )
+
     torch_thread_runtime = resolve_torch_thread_runtime(
-        getattr(cfg.training, "torch_threads", None)
+        getattr(cfg.training, "torch_threads", None),
+        cpu_count=host_cpu_count // dp_world_size if dp_world_size > 1 else None,
     )
     apply_torch_thread_runtime(torch_thread_runtime, role="learner")
 
@@ -323,6 +344,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             seed=cfg.algo.seed,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
         )
 
     if algo_name == "td3":
@@ -387,6 +409,7 @@ def build_runner(algo_name: str, cfg: DictConfig):
             replay_prefetch_mode=replay_prefetch_mode,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
         )
 
     if algo_name == "flashsac":

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -68,8 +68,9 @@ def build_failure_summary(exc: BaseException, run_summary: Any | None = None) ->
     return summary
 
 
-def build_run_dir_name(timestamp: str, sim_backend: str) -> str:
-    return f"{timestamp}_{sim_backend}"
+def build_run_dir_name(timestamp: str, sim_backend: str, *, world_size: int = 1) -> str:
+    gpu_suffix = f"_gpux{world_size}" if world_size > 1 else ""
+    return f"{timestamp}_{sim_backend}{gpu_suffix}"
 
 
 def default_device(torch_module, preferred: str | None = None) -> str:
@@ -194,12 +195,9 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
         explicit=explicit_cpu_ids,
     )
 
-    # Cold-path DP parameter sync: ranks average actor+critic parameters at
-    # the update boundary. world_size == 1 keeps dp_sync=None (bit-identical
-    # single-rank path, no process group is created).
-    dp_sync_interval = int(getattr(cfg.training, "dp_sync_interval", 8))
-    if dp_sync_interval < 1:
-        raise ValueError(f"training.dp_sync_interval must be >= 1, got {dp_sync_interval}")
+    # Cold-path DP process-group assembly. world_size == 1 keeps dp_sync=None
+    # (bit-identical single-rank path); multi-rank learners attach the group's
+    # flat-gradient collective at their optimizer boundaries.
     dp_sync = None
     if dp_world_size > 1:
         if dp_rank == 0 and log_dir is None:
@@ -373,7 +371,6 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
             dp_sync=dp_sync,
-            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "td3":
@@ -440,7 +437,6 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
             dp_sync=dp_sync,
-            dp_sync_interval=dp_sync_interval,
         )
 
     if algo_name == "flashsac":
@@ -457,7 +453,6 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
             dp_sync=dp_sync,
-            dp_sync_interval=dp_sync_interval,
         )
 
     raise ValueError(f"Unsupported algo: {algo_name}")
@@ -748,7 +743,11 @@ def main(cfg: DictConfig) -> None:
 
     if cfg.training.log_dir is None:
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        run_dir_name = build_run_dir_name(timestamp, str(cfg.training.sim_backend))
+        run_dir_name = build_run_dir_name(
+            timestamp,
+            str(cfg.training.sim_backend),
+            world_size=len(devices) if devices is not None else 1,
+        )
         log_dir = str(get_log_root(ROOT_DIR, cfg) / task_name / run_dir_name)
     else:
         log_dir = cfg.training.log_dir

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -21,6 +21,7 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     resolve_collector_cpu_ids,
+    resolve_dp_rank_device,
     resolve_dp_rendezvous_path,
     resolve_dp_topology,
     validate_dp_launchable,
@@ -179,6 +180,9 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
     dp_devices = resolve_dp_topology(cfg.training.devices)
     dp_world_size = len(dp_devices) if dp_devices is not None else 1
     dp_rank = current_dp_rank()
+    from unilab.utils.device import get_default_device
+
+    rank_device = resolve_dp_rank_device(dp_devices, dp_rank) or get_default_device()
     host_cpu_count = os.cpu_count() or 1
     explicit_cpu_ids = getattr(cfg.training, "dp_collector_cpu_ids", None)
     if explicit_cpu_ids is not None:
@@ -209,7 +213,7 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             world_size=dp_world_size,
             rank=dp_rank,
             rendezvous_path=resolve_dp_rendezvous_path(cast(str, log_dir), rank=dp_rank),
-            device=cfg.training.device,
+            device=rank_device,
         )
 
     torch_thread_runtime = resolve_torch_thread_runtime(
@@ -235,9 +239,8 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             "expected 'one_tick'"
         )
     from unilab.ipc.replay_pipelines.gpu_resident import require_offpolicy_replay_device
-    from unilab.utils.device import get_default_device
 
-    replay_device = require_offpolicy_replay_device(cfg.training.device or get_default_device())
+    replay_device = require_offpolicy_replay_device(rank_device)
     if algo_name == "sac":
         from unilab.algos.torch.fast_sac.learner import FastSACLearner
         from unilab.algos.torch.offpolicy.double_buffer_runner import (
@@ -490,7 +493,8 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
 
     env_cfg_override = build_offpolicy_env_cfg_override(algo_name, cfg)
 
-    device = default_device(torch, cfg.training.device)
+    devices = resolve_dp_topology(cfg.training.devices)
+    device = default_device(torch, resolve_dp_rank_device(devices, current_dp_rank()))
     print(f"Using device for play: {device}")
 
     env = cast(
@@ -735,7 +739,7 @@ def main(cfg: DictConfig) -> None:
 
     devices = resolve_dp_topology(cfg.training.devices)
     rank = current_dp_rank()
-    apply_dp_rank_config(cfg, devices, rank)
+    rank_device = apply_dp_rank_config(cfg, devices, rank)
 
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     algo_name = cfg.algo.algo
@@ -770,7 +774,7 @@ def main(cfg: DictConfig) -> None:
             sim_backend=cfg.training.sim_backend,
             training_cfg=cfg.training,
             full_cfg=cfg,
-            device=default_device(torch, cfg.training.device),
+            device=default_device(torch, rank_device),
             seed_info=seed_info,
         )
         tracker.start()

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -452,6 +452,9 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
             device=replay_device,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
+            collector_cpu_ids=collector_cpu_ids,
+            dp_sync=dp_sync,
+            dp_sync_interval=dp_sync_interval,
         )
 
     raise ValueError(f"Unsupported algo: {algo_name}")

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import statistics
 import sys
 import time
@@ -18,6 +19,15 @@ if str(ROOT_DIR) not in sys.path:
 
 from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_LOG_DIR,
+    current_torch_distributed_local_rank,
+    current_torch_distributed_rank,
+    current_torch_distributed_world_size,
+    launch_torchrun_workers,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
 from unilab.training import (
     BackendAdapter,
     apply_configured_training_seed,
@@ -35,7 +45,15 @@ from unilab.training.experiment import (
     patch_rsl_rl_resume_state,
     patch_rsl_rl_wandb_writer,
 )
-from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
+from unilab.training.rsl_rl import (
+    RslRlVecEnvWrapper,
+    apply_rsl_rl_rank_seed,
+    finish_rsl_rl_distributed,
+    normalize_ppo_train_cfg,
+    ppo_samples_per_iteration,
+    resolve_rsl_rl_device,
+    rsl_rl_single_process_topology,
+)
 from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
 from unilab.utils.device import get_default_device
 
@@ -101,6 +119,36 @@ def run_motrix_rsl_play_loop(
 
 def _get_log_root(cfg: DictConfig) -> str:
     return str(get_log_root(ROOT_DIR, cfg))
+
+
+def build_ppo_run_dir_name(timestamp: str, sim_backend: str, *, world_size: int = 1) -> str:
+    gpu_suffix = f"_gpux{world_size}" if world_size > 1 else ""
+    return f"{timestamp}_{sim_backend}{gpu_suffix}"
+
+
+def resolve_ppo_log_dir(
+    cfg: DictConfig,
+    *,
+    world_size: int,
+    timestamp: str | None = None,
+) -> str:
+    """Resolve one canonical run directory shared by all distributed ranks."""
+    distributed_log_dir = os.environ.get(UNILAB_DP_LOG_DIR)
+    if distributed_log_dir:
+        return distributed_log_dir
+    configured_log_dir = OmegaConf.select(cfg, "training.log_dir", default=None)
+    if configured_log_dir:
+        return str(configured_log_dir)
+    timestamp = timestamp or datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    return str(
+        Path(_get_log_root(cfg))
+        / str(cfg.training.task_name)
+        / build_ppo_run_dir_name(
+            timestamp,
+            str(cfg.training.sim_backend),
+            world_size=world_size,
+        )
+    )
 
 
 def _algo_config_dict(cfg: DictConfig) -> dict[str, Any]:
@@ -296,18 +344,70 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
 
 @hydra.main(version_base="1.3", config_path="../conf/ppo", config_name="config")
 def main(cfg: DictConfig) -> None:
-    ensure_registries()
+    devices = resolve_dp_topology(cfg.training.devices)
+    rank = current_torch_distributed_rank()
+    local_rank = current_torch_distributed_local_rank()
+    world_size = current_torch_distributed_world_size()
+    configured_device = OmegaConf.select(cfg, "training.device", default=None)
 
+    if configured_device is not None and devices is not None:
+        raise ValueError("Set either training.device or training.devices, not both")
+    if rank < 0 or rank >= world_size:
+        raise ValueError(f"RANK={rank} is out of range for WORLD_SIZE={world_size}")
+    if cfg.training.play_only and world_size > 1:
+        raise ValueError(
+            "Distributed play-only execution is not supported; launch eval normally and "
+            "select one device"
+        )
+
+    # The parent only composes config and invokes torchrun. CUDA, registry,
+    # env, tracker, and runner construction all happen inside workers.
+    if devices is not None and len(devices) > 1 and world_size == 1:
+        if not cfg.training.play_only:
+            log_dir = resolve_ppo_log_dir(cfg, world_size=len(devices))
+            launch_torchrun_workers(
+                devices,
+                script_path=Path(__file__),
+                argv=sys.argv[1:],
+                log_dir=log_dir,
+            )
+            return
+        validate_dp_launchable(devices)
+    elif devices is not None and world_size == 1:
+        validate_dp_launchable(devices)
+
+    if (
+        world_size > 1
+        and os.environ.get(UNILAB_DP_LOG_DIR) is None
+        and OmegaConf.select(cfg, "training.log_dir", default=None) is None
+    ):
+        raise ValueError(
+            "Distributed RSL-RL workers require one shared run directory; use "
+            "training.devices or set training.log_dir explicitly"
+        )
+
+    ensure_registries()
+    apply_rsl_rl_rank_seed(cfg, rank)
     seed_info = apply_configured_training_seed(cfg, torch_runtime=True, cuda=True)
     env_cfg_override = build_ppo_env_cfg_override(cfg)
 
-    device = get_default_device()
-    print(f"Using device: {device}")
+    device = resolve_rsl_rl_device(
+        configured_device=str(configured_device) if configured_device is not None else None,
+        devices=devices,
+        world_size=world_size,
+        local_rank=local_rank,
+        default_device=get_default_device(),
+    )
+    print(f"[rank {rank}/{world_size}] Using device: {device}")
 
     # Compute effective max_iterations (supports num_timesteps override)
     max_iterations = cfg.algo.max_iterations
     if cfg.training.num_timesteps:
-        n_steps_per_iter = cfg.algo.num_steps_per_env * cfg.algo.num_envs
+        n_steps_per_iter = ppo_samples_per_iteration(
+            num_envs=cfg.algo.num_envs,
+            num_steps_per_env=cfg.algo.num_steps_per_env,
+            world_size=world_size,
+        )
         max_iterations = max(1, int(cfg.training.num_timesteps / n_steps_per_iter))
         print(
             f"Overriding max_iterations to {max_iterations} based on "
@@ -315,16 +415,12 @@ def main(cfg: DictConfig) -> None:
         )
 
     if not cfg.training.play_only:
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_root = _get_log_root(cfg)
-        log_dir = str(
-            Path(log_root) / cfg.training.task_name / f"{timestamp}_{cfg.training.sim_backend}"
-        )
+        log_dir = resolve_ppo_log_dir(cfg, world_size=world_size)
     else:
         log_dir = None
 
     tracker = None
-    if not cfg.training.play_only and log_dir is not None:
+    if not cfg.training.play_only and log_dir is not None and rank == 0:
         tracker = ExperimentTracker(
             root_dir=ROOT_DIR,
             log_dir=log_dir,
@@ -338,6 +434,7 @@ def main(cfg: DictConfig) -> None:
         )
         tracker.start()
 
+    training_succeeded = False
     try:
         if not cfg.training.play_only:
             env = create_env(
@@ -400,48 +497,79 @@ def main(cfg: DictConfig) -> None:
                 resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
                 if resume_path:
                     print(f"Resuming from {resume_path}")
-                    runner.load(str(resume_path))
+                    runner.load(str(resume_path), map_location=device)
 
+            initial_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+            initial_training_time = float(getattr(runner.logger, "tot_time", 0.0))
             train_start_wall = time.time()
             runner.learn(num_learning_iterations=max_iterations, init_at_random_ep_len=True)
-            assert log_dir is not None
-            train_summary = {
-                "status": "completed",
-                "completed_iterations": int(runner.current_learning_iteration),
-                "total_env_steps": int(getattr(runner.logger, "tot_timesteps", 0)),
-                "final_mean_reward": (
-                    float(statistics.mean(runner.logger.rewbuffer))
-                    if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                    else None
-                ),
-                "best_mean_reward": (
-                    float(max(runner.logger.rewbuffer))
-                    if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                    else None
-                ),
-                "mean_episode_length": (
-                    float(statistics.mean(runner.logger.lenbuffer))
-                    if len(getattr(runner.logger, "lenbuffer", [])) > 0
-                    else None
-                ),
-                "last_checkpoint": str(
-                    Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
-                ),
-                "training_wall_time_sec": time.time() - train_start_wall,
-            }
-            if tracker is not None:
-                tracker.update_summary(train_summary)
+            training_succeeded = True
+            if rank == 0:
+                assert log_dir is not None
+                total_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+                total_training_time = float(getattr(runner.logger, "tot_time", 0.0))
+                run_timesteps = total_timesteps - initial_timesteps
+                run_training_time = total_training_time - initial_training_time
+                train_summary = {
+                    "status": "completed",
+                    "completed_iterations": int(runner.current_learning_iteration),
+                    "total_env_steps": total_timesteps,
+                    "run_env_steps": run_timesteps,
+                    "world_size": world_size,
+                    "num_envs_per_rank": int(cfg.algo.num_envs),
+                    "global_num_envs": int(cfg.algo.num_envs) * world_size,
+                    "samples_per_iteration": ppo_samples_per_iteration(
+                        num_envs=cfg.algo.num_envs,
+                        num_steps_per_env=cfg.algo.num_steps_per_env,
+                        world_size=world_size,
+                    ),
+                    "training_throughput_env_steps_per_sec": (
+                        run_timesteps / run_training_time if run_training_time > 0.0 else None
+                    ),
+                    "final_mean_reward": (
+                        float(statistics.mean(runner.logger.rewbuffer))
+                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                        else None
+                    ),
+                    "best_mean_reward": (
+                        float(max(runner.logger.rewbuffer))
+                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                        else None
+                    ),
+                    "mean_episode_length": (
+                        float(statistics.mean(runner.logger.lenbuffer))
+                        if len(getattr(runner.logger, "lenbuffer", [])) > 0
+                        else None
+                    ),
+                    "last_checkpoint": str(
+                        Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
+                    ),
+                    "training_wall_time_sec": time.time() - train_start_wall,
+                }
+                if tracker is not None:
+                    tracker.update_summary(train_summary)
             env.close()
 
-        if should_run_playback(
+            # Keep non-main ranks alive until rank 0 has persisted its final
+            # checkpoint and summary, then release NCCL before playback.
+            finish_rsl_rl_distributed(training_succeeded=training_succeeded)
+
+        if rank == 0 and should_run_playback(
             play_only=cfg.training.play_only,
             no_play=cfg.training.no_play,
             play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
         ):
-            play_video_path = play_rsl_rl(cfg, device)
+            # torchrun rank variables outlive the training process group. Mask
+            # them while playback constructs a new runner so rank 0 does not
+            # initialize a second NCCL group after sibling workers have exited.
+            with rsl_rl_single_process_topology():
+                play_video_path = play_rsl_rl(cfg, device)
             if tracker is not None:
                 tracker.log_video(play_video_path)
     finally:
+        # On failure, release an initialized group without a peer barrier;
+        # torchrun owns sibling termination and error propagation.
+        finish_rsl_rl_distributed(training_succeeded=training_succeeded)
         if tracker is not None:
             tracker.finish()
 

--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -308,7 +308,6 @@ class APPORunner(AsyncRunner):
             log_backend=logger_type,
             timing_profile="appo",
         )
-        logger.set_collection_sync(True, env_steps_per_sync)
         logger.log_status(
             f"Waiting for first rollout... "
             f"(staging_pool={self.staging_pool_size}, "
@@ -480,11 +479,8 @@ class APPORunner(AsyncRunner):
                         float(collector_active_steps_per_sec)
                     )
 
-                if "timeout_rate" in m or "terminated_rate" in m:
-                    logger.update_done_rates(
-                        timeout_rate=float(m.get("timeout_rate", 0.0)),
-                        terminated_rate=float(m.get("terminated_rate", 0.0)),
-                    )
+                if "timeout_rate" in m:
+                    logger.update_timeout_rate(float(m["timeout_rate"]))
 
                 if "total_steps" in m:
                     logger.log_collector(

--- a/src/unilab/algos/torch/appo/worker.py
+++ b/src/unilab/algos/torch/appo/worker.py
@@ -241,9 +241,9 @@ def appo_collector_fn(
     current_ep_lengths = np.zeros(num_envs, dtype=np.int32)
     ep_reward_components = defaultdict(list)
 
-    # Episode completion mode counters (reset after each metrics report)
+    # Episode completion counters (reset after each metrics report)
     ep_timeouts = 0
-    ep_terminates = 0
+    ep_completions = 0
 
     # Collector timing EMA (milliseconds, α=0.1 → slow-moving average)
     _EMA = 0.1
@@ -345,9 +345,8 @@ def appo_collector_fn(
                     ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
                     current_ep_rewards[reset_indices] = 0.0
                     current_ep_lengths[reset_indices] = 0
-                    # Count episode completion modes for timeout/terminated rates
+                    ep_completions += len(reset_indices)
                     ep_timeouts += int(np.sum(truncated_raw[reset_indices] > 0.5))
-                    ep_terminates += int(np.sum(truncated_raw[reset_indices] <= 0.5))
 
                 log_info = state.info.get("log", {})
                 for k, v in log_info.items():
@@ -364,13 +363,10 @@ def appo_collector_fn(
                             msg["mean_ep_length"] = (
                                 statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
                             )
-                        # Episode completion mode rates
-                        total_ep = ep_timeouts + ep_terminates
-                        if total_ep > 0:
-                            msg["timeout_rate"] = ep_timeouts / total_ep
-                            msg["terminated_rate"] = ep_terminates / total_ep
+                        if ep_completions > 0:
+                            msg["timeout_rate"] = ep_timeouts / ep_completions
                             ep_timeouts = 0
-                            ep_terminates = 0
+                            ep_completions = 0
                         # Collector-side timing breakdown
                         msg["collector_timing_ms"] = {
                             "rollout_ms": ema_rollout_ms,

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -1497,6 +1497,28 @@ class FastSACLearner:
                     for tgt, src in zip(target_params, source_params):
                         tgt.mul_(1.0 - self.tau).add_(src, alpha=self.tau)
 
+    def dp_sync_tensors(self) -> Dict[str, torch.Tensor]:
+        """Tensors synchronized across data-parallel ranks, as live references.
+
+        The values alias the parameter/buffer storage of ``actor``, ``qnet``
+        and ``qnet_target`` (plus the ``log_alpha`` leaf) rather than copies,
+        so the DP collectives (``unilab.ipc.dp_sync.DpParameterSync``) update
+        the model in place — required because CUDA-graph capture pins
+        parameter addresses. Optimizer state (AdamW moments) is deliberately
+        excluded: sync is parameter-level, each rank keeps its own optimizer
+        state, and the moments diverge across ranks by design.
+        """
+        tensors: Dict[str, torch.Tensor] = {}
+        for prefix, module in (
+            ("actor", self.actor),
+            ("qnet", self.qnet),
+            ("qnet_target", self.qnet_target),
+        ):
+            for key, value in module.state_dict().items():
+                tensors[f"{prefix}.{key}"] = value
+        tensors["log_alpha"] = self.log_alpha
+        return tensors
+
     def get_state_dict(self) -> Dict[str, Any]:
         """Save all components."""
         return {

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -445,7 +445,9 @@ class FastSACLearner:
         requested_cuda_graph_actor_packed_staging = bool(use_cuda_graph_actor_packed_staging)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor) and self._device_type == "cuda"
         self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
-        self.dp_cuda_graph_fallback = False
+        self._gradient_sync_graph_replay_recorder: Callable[[int], None] | None = None
+        self.dp_cuda_graph_gradient_sync = False
+        self._active_cuda_graph_gradient_sync_calls: list[int] | None = None
         self.nvtx_profile_ranges = bool(nvtx_profile_ranges) and self._device_type == "cuda"
         self.amp_dtype = amp_dtype
         self._amp_dtype = self._resolve_amp_dtype(amp_dtype, self._device_type)
@@ -575,6 +577,7 @@ class FastSACLearner:
             | None
         ) = None
         self._cuda_graph_critic_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
         self._cuda_graph_actor: torch.cuda.CUDAGraph | None = None
         self._cuda_graph_actor_static_inputs: dict[str, torch.Tensor] | None = None
         self._cuda_graph_actor_static_packed_input: torch.Tensor | None = None
@@ -589,6 +592,7 @@ class FastSACLearner:
             | None
         ) = None
         self._cuda_graph_actor_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
         if self.use_compile:
             self._compile_training_methods()
 
@@ -768,6 +772,7 @@ class FastSACLearner:
             self.scaler.update()
         else:
             actor_loss.backward()
+            self._sync_gradients(self.actor.parameters())
             if self.max_grad_norm > 0:
                 actor_grad_norm = torch.nn.utils.clip_grad_norm_(
                     self.actor.parameters(), max_norm=self.max_grad_norm
@@ -813,6 +818,7 @@ class FastSACLearner:
             self.scaler.update()
         else:
             qf_loss.backward()
+            self._sync_gradients(self.qnet.parameters())
             if self.max_grad_norm > 0:
                 critic_grad_norm = torch.nn.utils.clip_grad_norm_(
                     self.qnet.parameters(), max_norm=self.max_grad_norm
@@ -826,6 +832,7 @@ class FastSACLearner:
             self.alpha_optimizer.zero_grad(set_to_none=True)
             alpha_loss = self._alpha_loss_tensor(next_log_probs)
             alpha_loss.backward()
+            self._sync_gradients((self.log_alpha,))
             self.alpha_optimizer.step()
 
         return (
@@ -1065,7 +1072,10 @@ class FastSACLearner:
                         tensor.zero_()
 
     def _reset_critic_cuda_graph(self) -> None:
+        graph = self._cuda_graph_critic
         self._cuda_graph_critic = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_critic_static_inputs = None
         self._cuda_graph_critic_static_packed_input = None
         self._cuda_graph_sac_static_packed_input = None
@@ -1073,6 +1083,7 @@ class FastSACLearner:
         self._cuda_graph_critic_action_noise = None
         self._cuda_graph_critic_outputs = None
         self._cuda_graph_critic_shapes = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
 
     def _materialize_capturable_actor_optimizer_state(
         self,
@@ -1118,12 +1129,16 @@ class FastSACLearner:
                     tensor.zero_()
 
     def _reset_actor_cuda_graph(self) -> None:
+        graph = self._cuda_graph_actor
         self._cuda_graph_actor = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_actor_static_inputs = None
         self._cuda_graph_actor_static_packed_input = None
         self._cuda_graph_actor_action_noise = None
         self._cuda_graph_actor_outputs = None
         self._cuda_graph_actor_shapes = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
     def _capture_actor_cuda_graph(self, batch: Dict[str, torch.Tensor]) -> None:
         if not self.use_cuda_graph_actor:
@@ -1164,14 +1179,20 @@ class FastSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
-                self._cuda_graph_actor_static_inputs["obs"],
-                self._cuda_graph_actor_static_inputs["critic"],
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
+                    self._cuda_graph_actor_static_inputs["obs"],
+                    self._cuda_graph_actor_static_inputs["critic"],
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_actor = graph
+        self._cuda_graph_actor_gradient_sync_calls = sync_calls[0]
 
     def _actor_graph_output_metrics(self, *, read_items: bool = True) -> Dict[str, float]:
         if not read_items:
@@ -1229,19 +1250,25 @@ class FastSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
-                self._cuda_graph_critic_static_inputs["critic"],
-                self._cuda_graph_critic_static_inputs["actions"],
-                self._cuda_graph_critic_static_inputs["rewards"],
-                self._cuda_graph_critic_static_inputs["next_obs"],
-                self._cuda_graph_critic_static_inputs["next_critic"],
-                self._cuda_graph_critic_static_inputs["dones"],
-                self._cuda_graph_critic_static_inputs["truncated"],
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
+                    self._cuda_graph_critic_static_inputs["critic"],
+                    self._cuda_graph_critic_static_inputs["actions"],
+                    self._cuda_graph_critic_static_inputs["rewards"],
+                    self._cuda_graph_critic_static_inputs["next_obs"],
+                    self._cuda_graph_critic_static_inputs["next_critic"],
+                    self._cuda_graph_critic_static_inputs["dones"],
+                    self._cuda_graph_critic_static_inputs["truncated"],
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_critic = graph
+        self._cuda_graph_critic_gradient_sync_calls = sync_calls[0]
 
     def _critic_graph_output_metrics(self, *, read_items: bool = True) -> Dict[str, float]:
         if not read_items:
@@ -1285,6 +1312,7 @@ class FastSACLearner:
             self._copy_critic_graph_inputs(batch)
         with _cuda_nvtx_range("critic_graph/replay", self.nvtx_profile_ranges):
             self._cuda_graph_critic.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_critic_gradient_sync_calls)
         with _cuda_nvtx_range("critic_graph/output_metrics_item", self.nvtx_profile_ranges):
             return self._critic_graph_output_metrics(read_items=read_metrics)
 
@@ -1314,6 +1342,7 @@ class FastSACLearner:
             self._copy_actor_graph_inputs(batch)
         with _cuda_nvtx_range("actor_graph/replay", self.nvtx_profile_ranges):
             self._cuda_graph_actor.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_actor_gradient_sync_calls)
         with _cuda_nvtx_range("actor_graph/output_metrics_item", self.nvtx_profile_ranges):
             return self._actor_graph_output_metrics(read_items=read_metrics)
 
@@ -1507,23 +1536,39 @@ class FastSACLearner:
     def set_gradient_sync(
         self,
         sync: Callable[[Iterable[torch.Tensor]], None] | None,
+        *,
+        graph_replay_recorder: Callable[[int], None] | None = None,
     ) -> None:
         """Attach the per-optimizer gradient collective used by multi-GPU DP."""
-        self.dp_cuda_graph_fallback = bool(
-            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
-        )
-        if self.dp_cuda_graph_fallback:
-            self.use_cuda_graph_critic = False
-            self.use_cuda_graph_actor = False
-            self.use_cuda_graph_critic_packed_staging = False
-            self.use_cuda_graph_actor_packed_staging = False
+        if sync is None and graph_replay_recorder is not None:
+            raise ValueError("graph_replay_recorder requires a gradient sync callback")
+        if sync != self._gradient_sync:
             self._reset_critic_cuda_graph()
             self._reset_actor_cuda_graph()
         self._gradient_sync = sync
+        self._gradient_sync_graph_replay_recorder = graph_replay_recorder
+        self.dp_cuda_graph_gradient_sync = bool(
+            sync is not None
+            and (
+                (self.use_cuda_graph_critic and self.scaler is None)
+                or (self.use_cuda_graph_actor and self.scaler is None and not self.use_symmetry)
+            )
+        )
 
     def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         if self._gradient_sync is not None:
             self._gradient_sync(parameters)
+            if self._active_cuda_graph_gradient_sync_calls is not None:
+                self._active_cuda_graph_gradient_sync_calls[0] += 1
+
+    def _record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        if self._gradient_sync_graph_replay_recorder is not None and collective_calls > 0:
+            self._gradient_sync_graph_replay_recorder(collective_calls)
+
+    def release_cuda_graphs(self) -> None:
+        """Release captured NCCL nodes before the process group is destroyed."""
+        self._reset_critic_cuda_graph()
+        self._reset_actor_cuda_graph()
 
     def dp_initial_sync_tensors(self) -> Dict[str, torch.Tensor]:
         """Model state broadcast once from rank 0 before collection starts.

--- a/src/unilab/algos/torch/fast_sac/learner.py
+++ b/src/unilab/algos/torch/fast_sac/learner.py
@@ -11,7 +11,7 @@ Hyperparameters aligned with holosoma FastSACConfig defaults.
 from __future__ import annotations
 
 import math
-from collections.abc import Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from typing import Any, Dict, Tuple, cast
 
@@ -444,6 +444,8 @@ class FastSACLearner:
         requested_cuda_graph_critic_packed_staging = bool(use_cuda_graph_critic_packed_staging)
         requested_cuda_graph_actor_packed_staging = bool(use_cuda_graph_actor_packed_staging)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor) and self._device_type == "cuda"
+        self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
+        self.dp_cuda_graph_fallback = False
         self.nvtx_profile_ranges = bool(nvtx_profile_ranges) and self._device_type == "cuda"
         self.amp_dtype = amp_dtype
         self._amp_dtype = self._resolve_amp_dtype(amp_dtype, self._device_type)
@@ -1379,6 +1381,7 @@ class FastSACLearner:
             if self.scaler:
                 with _cuda_nvtx_range("critic/backward", self.nvtx_profile_ranges):
                     self.scaler.scale(qf_loss).backward()
+                self._sync_gradients(self.qnet.parameters())
                 self.scaler.unscale_(self.q_optimizer)
                 if self.max_grad_norm > 0:
                     with _cuda_nvtx_range("critic/grad_clip", self.nvtx_profile_ranges):
@@ -1393,6 +1396,7 @@ class FastSACLearner:
             else:
                 with _cuda_nvtx_range("critic/backward", self.nvtx_profile_ranges):
                     qf_loss.backward()
+                self._sync_gradients(self.qnet.parameters())
                 if self.max_grad_norm > 0:
                     with _cuda_nvtx_range("critic/grad_clip", self.nvtx_profile_ranges):
                         critic_grad_norm = torch.nn.utils.clip_grad_norm_(
@@ -1415,6 +1419,7 @@ class FastSACLearner:
                 if torch.isfinite(alpha_loss):
                     with _cuda_nvtx_range("critic/alpha_backward", self.nvtx_profile_ranges):
                         alpha_loss.backward()
+                    self._sync_gradients((self.log_alpha,))
                     with _cuda_nvtx_range("critic/alpha_optimizer_step", self.nvtx_profile_ranges):
                         self.alpha_optimizer.step()
 
@@ -1451,6 +1456,7 @@ class FastSACLearner:
             if self.scaler:
                 with _cuda_nvtx_range("actor/backward", self.nvtx_profile_ranges):
                     self.scaler.scale(actor_loss).backward()
+                self._sync_gradients(self.actor.parameters())
                 self.scaler.unscale_(self.actor_optimizer)
                 if self.max_grad_norm > 0:
                     with _cuda_nvtx_range("actor/grad_clip", self.nvtx_profile_ranges):
@@ -1465,6 +1471,7 @@ class FastSACLearner:
             else:
                 with _cuda_nvtx_range("actor/backward", self.nvtx_profile_ranges):
                     actor_loss.backward()
+                self._sync_gradients(self.actor.parameters())
                 if self.max_grad_norm > 0:
                     with _cuda_nvtx_range("actor/grad_clip", self.nvtx_profile_ranges):
                         actor_grad_norm = torch.nn.utils.clip_grad_norm_(
@@ -1497,16 +1504,35 @@ class FastSACLearner:
                     for tgt, src in zip(target_params, source_params):
                         tgt.mul_(1.0 - self.tau).add_(src, alpha=self.tau)
 
-    def dp_sync_tensors(self) -> Dict[str, torch.Tensor]:
-        """Tensors synchronized across data-parallel ranks, as live references.
+    def set_gradient_sync(
+        self,
+        sync: Callable[[Iterable[torch.Tensor]], None] | None,
+    ) -> None:
+        """Attach the per-optimizer gradient collective used by multi-GPU DP."""
+        self.dp_cuda_graph_fallback = bool(
+            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
+        )
+        if self.dp_cuda_graph_fallback:
+            self.use_cuda_graph_critic = False
+            self.use_cuda_graph_actor = False
+            self.use_cuda_graph_critic_packed_staging = False
+            self.use_cuda_graph_actor_packed_staging = False
+            self._reset_critic_cuda_graph()
+            self._reset_actor_cuda_graph()
+        self._gradient_sync = sync
+
+    def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
+        if self._gradient_sync is not None:
+            self._gradient_sync(parameters)
+
+    def dp_initial_sync_tensors(self) -> Dict[str, torch.Tensor]:
+        """Model state broadcast once from rank 0 before collection starts.
 
         The values alias the parameter/buffer storage of ``actor``, ``qnet``
         and ``qnet_target`` (plus the ``log_alpha`` leaf) rather than copies,
-        so the DP collectives (``unilab.ipc.dp_sync.DpParameterSync``) update
-        the model in place — required because CUDA-graph capture pins
-        parameter addresses. Optimizer state (AdamW moments) is deliberately
-        excluded: sync is parameter-level, each rank keeps its own optimizer
-        state, and the moments diverge across ranks by design.
+        so startup broadcast updates the model in place. Optimizer state starts
+        empty and remains aligned because every actual optimizer update uses
+        the same cross-rank mean gradient.
         """
         tensors: Dict[str, torch.Tensor] = {}
         for prefix, module in (

--- a/src/unilab/algos/torch/flash_sac/double_buffer.py
+++ b/src/unilab/algos/torch/flash_sac/double_buffer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from omegaconf import DictConfig
 
@@ -13,6 +13,9 @@ from unilab.training import create_env, ensure_registries
 from unilab.training.seed import apply_training_seed
 from unilab.utils.device import get_default_device
 from unilab.utils.nan_guard import NanGuardCfg
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
 
 
 def _validate_flashsac_double_buffer_runtime(
@@ -34,6 +37,9 @@ def build_flashsac_double_buffer_runner(
     device: str | None = None,
     nan_guard_cfg: NanGuardCfg | None = None,
     torch_thread_runtime: dict[str, Any] | None = None,
+    collector_cpu_ids: list[int] | None = None,
+    dp_sync: DpParameterSync | None = None,
+    dp_sync_interval: int = 8,
 ) -> Any:
     """Build FlashSAC with the bounded-ingress device replay pipeline."""
     from unilab.base.observations import get_obs_dims
@@ -122,4 +128,7 @@ def build_flashsac_double_buffer_runner(
         replay_prefetch_mode=replay_prefetch_mode,
         nan_guard_cfg=nan_guard_cfg,
         torch_thread_runtime=torch_thread_runtime,
+        collector_cpu_ids=collector_cpu_ids,
+        dp_sync=dp_sync,
+        dp_sync_interval=dp_sync_interval,
     )

--- a/src/unilab/algos/torch/flash_sac/double_buffer.py
+++ b/src/unilab/algos/torch/flash_sac/double_buffer.py
@@ -39,7 +39,6 @@ def build_flashsac_double_buffer_runner(
     torch_thread_runtime: dict[str, Any] | None = None,
     collector_cpu_ids: list[int] | None = None,
     dp_sync: DpParameterSync | None = None,
-    dp_sync_interval: int = 8,
 ) -> Any:
     """Build FlashSAC with the bounded-ingress device replay pipeline."""
     from unilab.base.observations import get_obs_dims
@@ -130,5 +129,4 @@ def build_flashsac_double_buffer_runner(
         torch_thread_runtime=torch_thread_runtime,
         collector_cpu_ids=collector_cpu_ids,
         dp_sync=dp_sync,
-        dp_sync_interval=dp_sync_interval,
     )

--- a/src/unilab/algos/torch/flash_sac/double_buffer.py
+++ b/src/unilab/algos/torch/flash_sac/double_buffer.py
@@ -44,7 +44,7 @@ def build_flashsac_double_buffer_runner(
     """Build FlashSAC with the bounded-ingress device replay pipeline."""
     from unilab.base.observations import get_obs_dims
 
-    device = require_offpolicy_replay_device(device or cfg.training.device or get_default_device())
+    device = require_offpolicy_replay_device(device or get_default_device())
     ensure_registries()
     apply_training_seed(cfg.algo.seed, torch_runtime=True, cuda=True)
     _validate_flashsac_double_buffer_runtime(

--- a/src/unilab/algos/torch/flash_sac/layers.py
+++ b/src/unilab/algos/torch/flash_sac/layers.py
@@ -141,7 +141,10 @@ class NormalTanhPolicy(nn.Module):
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         mean, std = self.get_mean_and_std(x)
-        dist = torch.distributions.Normal(mean, std)
+        # ``std`` is positive by construction (exp of bounded log_std). The
+        # distribution's generic validation performs a GPU-to-host truth check,
+        # which CUDA forbids while this actor is captured into an optimizer graph.
+        dist = torch.distributions.Normal(mean, std, validate_args=False)
         raw_action = dist.rsample()
         tanh_action = torch.tanh(raw_action)
         log_prob = dist.log_prob(raw_action)

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -195,7 +195,9 @@ class FlashSACLearner:
         self.use_cuda_graph_critic = bool(use_cuda_graph_critic)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor)
         self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
-        self.dp_cuda_graph_fallback = False
+        self._gradient_sync_graph_replay_recorder: Callable[[int], None] | None = None
+        self.dp_cuda_graph_gradient_sync = False
+        self._active_cuda_graph_gradient_sync_calls: list[int] | None = None
         self.use_cuda_graph_critic_packed_staging = bool(
             use_cuda_graph_critic_packed_staging and self.use_cuda_graph_critic
         )
@@ -263,6 +265,7 @@ class FlashSACLearner:
         self._cuda_graph_sac_static_source_ptr: int | None = None
         self._cuda_graph_critic_outputs: tuple[torch.Tensor, torch.Tensor] | None = None
         self._cuda_graph_critic_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
         self._cuda_graph_actor: torch.cuda.CUDAGraph | None = None
         self._cuda_graph_actor_static_inputs: dict[str, torch.Tensor] | None = None
         self._cuda_graph_actor_static_packed_input: torch.Tensor | None = None
@@ -270,6 +273,7 @@ class FlashSACLearner:
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
         ) = None
         self._cuda_graph_actor_shapes: dict[str, torch.Size] | None = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
         scheduler_fn = build_lr_lambda(
             init_lr=learning_rate_init,
@@ -591,6 +595,7 @@ class FlashSACLearner:
 
         self.critic_optimizer.zero_grad(set_to_none=True)
         critic_loss.backward()
+        self._sync_gradients(self.critic.parameters())
         self.critic_optimizer.step()
         reward_scale_std = (
             torch.sqrt(self.reward_normalizer.rms.var)
@@ -600,12 +605,16 @@ class FlashSACLearner:
         return critic_loss, reward_scale_std
 
     def _reset_critic_cuda_graph(self) -> None:
+        graph = self._cuda_graph_critic
         self._cuda_graph_critic = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_critic_static_inputs = None
         self._cuda_graph_sac_static_packed_input = None
         self._cuda_graph_sac_static_source_ptr = None
         self._cuda_graph_critic_outputs = None
         self._cuda_graph_critic_shapes = None
+        self._cuda_graph_critic_gradient_sync_calls = 0
 
     def _materialize_capturable_critic_optimizer_state(
         self,
@@ -668,13 +677,19 @@ class FlashSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
-                self._cuda_graph_critic_static_inputs
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_critic_outputs = self._update_critic_capture_candidate(
+                    self._cuda_graph_critic_static_inputs
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_critic = graph
+        self._cuda_graph_critic_gradient_sync_calls = sync_calls[0]
 
     def _critic_graph_output_metrics(self, *, read_items: bool = True) -> dict[str, float]:
         if not read_items:
@@ -713,6 +728,7 @@ class FlashSACLearner:
         assert self._cuda_graph_critic is not None
         self._copy_critic_graph_inputs(inputs)
         self._cuda_graph_critic.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_critic_gradient_sync_calls)
         self.critic_scheduler.step()
         self.critic.normalize_parameters()
         return self._critic_graph_output_metrics(read_items=read_metrics)
@@ -787,20 +803,26 @@ class FlashSACLearner:
 
         self.actor_optimizer.zero_grad(set_to_none=True)
         actor_loss.backward()
+        self._sync_gradients(self.actor.parameters())
         self.actor_optimizer.step()
 
         temp_loss = temp_value * (entropy - self.target_entropy)
         self.temperature_optimizer.zero_grad(set_to_none=True)
         temp_loss.backward()
+        self._sync_gradients(self.temperature.parameters())
         self.temperature_optimizer.step()
         return actor_loss, entropy, temp_value, temp_loss
 
     def _reset_actor_cuda_graph(self) -> None:
+        graph = self._cuda_graph_actor
         self._cuda_graph_actor = None
+        if isinstance(graph, torch.cuda.CUDAGraph):
+            graph.reset()
         self._cuda_graph_actor_static_inputs = None
         self._cuda_graph_actor_static_packed_input = None
         self._cuda_graph_actor_outputs = None
         self._cuda_graph_actor_shapes = None
+        self._cuda_graph_actor_gradient_sync_calls = 0
 
     def _materialize_capturable_actor_optimizer_state(
         self,
@@ -880,13 +902,19 @@ class FlashSACLearner:
         graph = torch.cuda.CUDAGraph()
         capture_stream = cast(torch.cuda.Stream, torch.cuda.Stream())
         capture_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
-            self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
-                self._cuda_graph_actor_static_inputs
-            )
+        sync_calls = [0]
+        self._active_cuda_graph_gradient_sync_calls = sync_calls
+        try:
+            with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+                self._cuda_graph_actor_outputs = self._update_actor_capture_candidate(
+                    self._cuda_graph_actor_static_inputs
+                )
+        finally:
+            self._active_cuda_graph_gradient_sync_calls = None
         torch.cuda.current_stream().wait_stream(capture_stream)
         torch.cuda.synchronize()
         self._cuda_graph_actor = graph
+        self._cuda_graph_actor_gradient_sync_calls = sync_calls[0]
 
     def _actor_graph_output_metrics(self, *, read_items: bool = True) -> dict[str, float]:
         if not read_items:
@@ -928,6 +956,7 @@ class FlashSACLearner:
         assert self._cuda_graph_actor is not None
         self._copy_actor_graph_inputs(inputs)
         self._cuda_graph_actor.replay()
+        self._record_cuda_graph_gradient_replay(self._cuda_graph_actor_gradient_sync_calls)
         self.actor_scheduler.step()
         self.temperature_scheduler.step()
         self.actor.normalize_parameters()
@@ -1063,23 +1092,38 @@ class FlashSACLearner:
     def set_gradient_sync(
         self,
         sync: Callable[[Iterable[torch.Tensor]], None] | None,
+        *,
+        graph_replay_recorder: Callable[[int], None] | None = None,
     ) -> None:
         """Attach the per-optimizer gradient collective used by multi-GPU DP."""
-        self.dp_cuda_graph_fallback = bool(
-            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
-        )
-        if self.dp_cuda_graph_fallback:
-            self.use_cuda_graph_critic = False
-            self.use_cuda_graph_actor = False
-            self.use_cuda_graph_critic_packed_staging = False
-            self.use_cuda_graph_actor_packed_staging = False
+        if sync is None and graph_replay_recorder is not None:
+            raise ValueError("graph_replay_recorder requires a gradient sync callback")
+        if sync != self._gradient_sync:
             self._reset_critic_cuda_graph()
             self._reset_actor_cuda_graph()
         self._gradient_sync = sync
+        self._gradient_sync_graph_replay_recorder = graph_replay_recorder
+        self.dp_cuda_graph_gradient_sync = bool(
+            sync is not None
+            and self.scaler is None
+            and isinstance(self.obs_normalizer, nn.Identity)
+            and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
+        )
 
     def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         if self._gradient_sync is not None:
             self._gradient_sync(parameters)
+            if self._active_cuda_graph_gradient_sync_calls is not None:
+                self._active_cuda_graph_gradient_sync_calls[0] += 1
+
+    def _record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        if self._gradient_sync_graph_replay_recorder is not None and collective_calls > 0:
+            self._gradient_sync_graph_replay_recorder(collective_calls)
+
+    def release_cuda_graphs(self) -> None:
+        """Release captured NCCL nodes before the process group is destroyed."""
+        self._reset_critic_cuda_graph()
+        self._reset_actor_cuda_graph()
 
     def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         """Model state broadcast once from rank 0 before collection starts.

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -193,6 +194,8 @@ class FlashSACLearner:
         )
         self.use_cuda_graph_critic = bool(use_cuda_graph_critic)
         self.use_cuda_graph_actor = bool(use_cuda_graph_actor)
+        self._gradient_sync: Callable[[Iterable[torch.Tensor]], None] | None = None
+        self.dp_cuda_graph_fallback = False
         self.use_cuda_graph_critic_packed_staging = bool(
             use_cuda_graph_critic_packed_staging and self.use_cuda_graph_critic
         )
@@ -978,11 +981,13 @@ class FlashSACLearner:
         self.critic_optimizer.zero_grad(set_to_none=True)
         if self.scaler is not None:
             self.scaler.scale(critic_loss).backward()
+            self._sync_gradients(self.critic.parameters())
             self.scaler.unscale_(self.critic_optimizer)
             self.scaler.step(self.critic_optimizer)
             self.scaler.update()
         else:
             critic_loss.backward()
+            self._sync_gradients(self.critic.parameters())
             self.critic_optimizer.step()
         self.critic_scheduler.step()
         self.critic.normalize_parameters()
@@ -1022,11 +1027,13 @@ class FlashSACLearner:
         self.actor_optimizer.zero_grad(set_to_none=True)
         if self.scaler is not None:
             self.scaler.scale(actor_loss).backward()
+            self._sync_gradients(self.actor.parameters())
             self.scaler.unscale_(self.actor_optimizer)
             self.scaler.step(self.actor_optimizer)
             self.scaler.update()
         else:
             actor_loss.backward()
+            self._sync_gradients(self.actor.parameters())
             self.actor_optimizer.step()
         self.actor_scheduler.step()
         self.actor.normalize_parameters()
@@ -1035,6 +1042,7 @@ class FlashSACLearner:
         temp_loss = temp_value * (entropy - self.target_entropy)
         self.temperature_optimizer.zero_grad(set_to_none=True)
         temp_loss.backward()
+        self._sync_gradients(self.temperature.parameters())
         self.temperature_optimizer.step()
         self.temperature_scheduler.step()
 
@@ -1052,17 +1060,35 @@ class FlashSACLearner:
             ):
                 target_param.data.mul_(1.0 - self.tau).add_(param.data, alpha=self.tau)
 
-    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
-        """Tensors synchronized across data-parallel ranks, as live references.
+    def set_gradient_sync(
+        self,
+        sync: Callable[[Iterable[torch.Tensor]], None] | None,
+    ) -> None:
+        """Attach the per-optimizer gradient collective used by multi-GPU DP."""
+        self.dp_cuda_graph_fallback = bool(
+            sync is not None and (self.use_cuda_graph_critic or self.use_cuda_graph_actor)
+        )
+        if self.dp_cuda_graph_fallback:
+            self.use_cuda_graph_critic = False
+            self.use_cuda_graph_actor = False
+            self.use_cuda_graph_critic_packed_staging = False
+            self.use_cuda_graph_actor_packed_staging = False
+            self._reset_critic_cuda_graph()
+            self._reset_actor_cuda_graph()
+        self._gradient_sync = sync
+
+    def _sync_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
+        if self._gradient_sync is not None:
+            self._gradient_sync(parameters)
+
+    def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Model state broadcast once from rank 0 before collection starts.
 
         The values alias the parameter/buffer storage of ``actor``, ``critic``,
-        ``target_critic`` and ``temperature`` rather than copies, so the DP
-        collectives (``unilab.ipc.dp_sync.DpParameterSync``) update the model
-        in place — required because CUDA-graph capture pins parameter
-        addresses. Optimizer state (Adam moments) and the observation/reward
-        normalizers' running statistics are deliberately excluded: sync is
-        parameter-level, each rank keeps its own optimizer state and running
-        statistics, and they diverge across ranks by design.
+        ``target_critic`` and ``temperature`` rather than copies. Optimizer
+        state starts empty and remains aligned because every actual optimizer
+        update uses the same cross-rank mean gradient. Observation/reward
+        normalizer statistics remain rank-local.
         """
         tensors: dict[str, torch.Tensor] = {}
         for prefix, module in (

--- a/src/unilab/algos/torch/flash_sac/learner.py
+++ b/src/unilab/algos/torch/flash_sac/learner.py
@@ -1052,6 +1052,29 @@ class FlashSACLearner:
             ):
                 target_param.data.mul_(1.0 - self.tau).add_(param.data, alpha=self.tau)
 
+    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Tensors synchronized across data-parallel ranks, as live references.
+
+        The values alias the parameter/buffer storage of ``actor``, ``critic``,
+        ``target_critic`` and ``temperature`` rather than copies, so the DP
+        collectives (``unilab.ipc.dp_sync.DpParameterSync``) update the model
+        in place — required because CUDA-graph capture pins parameter
+        addresses. Optimizer state (Adam moments) and the observation/reward
+        normalizers' running statistics are deliberately excluded: sync is
+        parameter-level, each rank keeps its own optimizer state and running
+        statistics, and they diverge across ranks by design.
+        """
+        tensors: dict[str, torch.Tensor] = {}
+        for prefix, module in (
+            ("actor", self.actor),
+            ("critic", self.critic),
+            ("target_critic", self.target_critic),
+            ("temperature", self.temperature),
+        ):
+            for key, value in module.state_dict().items():
+                tensors[f"{prefix}.{key}"] = value
+        return tensors
+
     def get_state_dict(self) -> dict[str, Any]:
         return {
             "actor": self.actor.state_dict(),

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -299,7 +299,6 @@ class HoraAPPORunner(APPORunner):
             log_backend=logger_type,
             timing_profile="appo",
         )
-        logger.set_collection_sync(True, env_steps_per_sync)
         logger.start()
         logger.log_status(
             f"Waiting for first rollout... "

--- a/src/unilab/algos/torch/hora/appo_worker.py
+++ b/src/unilab/algos/torch/hora/appo_worker.py
@@ -233,7 +233,7 @@ def hora_appo_collector_fn(
     current_ep_lengths = np.zeros(num_envs, dtype=np.int32)
     ep_reward_components = defaultdict(list)
     ep_timeouts = 0
-    ep_terminates = 0
+    ep_completions = 0
 
     _EMA = 0.1
     ema_mlp_infer_ms = 0.0
@@ -357,8 +357,8 @@ def hora_appo_collector_fn(
                     ep_lengths.extend(current_ep_lengths[reset_indices].tolist())
                     current_ep_rewards[reset_indices] = 0.0
                     current_ep_lengths[reset_indices] = 0
+                    ep_completions += len(reset_indices)
                     ep_timeouts += int(np.sum(truncated_raw[reset_indices] > 0.5))
-                    ep_terminates += int(np.sum(truncated_raw[reset_indices] <= 0.5))
 
                 log_info = state.info.get("log", {})
                 for k, v in log_info.items():
@@ -375,12 +375,10 @@ def hora_appo_collector_fn(
                             msg["mean_ep_length"] = (
                                 statistics.mean(ep_lengths[-100:]) if ep_lengths else 0.0
                             )
-                        total_ep = ep_timeouts + ep_terminates
-                        if total_ep > 0:
-                            msg["timeout_rate"] = ep_timeouts / total_ep
-                            msg["terminated_rate"] = ep_terminates / total_ep
+                        if ep_completions > 0:
+                            msg["timeout_rate"] = ep_timeouts / ep_completions
                             ep_timeouts = 0
-                            ep_terminates = 0
+                            ep_completions = 0
                         msg["collector_timing_ms"] = {
                             "rollout_ms": ema_rollout_ms,
                             "mlp_infer_ms": ema_mlp_infer_ms,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -115,6 +115,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         self,
         *,
         replay_prefetch_mode: str = "one_tick",
+        collector_cpu_ids: list[int] | None = None,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -124,6 +125,9 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "DoubleBufferOffPolicyRunner only supports replay_prefetch_mode='one_tick'"
             )
         self.replay_prefetch_mode = replay_prefetch_mode
+        # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
+        # merged into the collector-only env override at collector startup.
+        self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -135,6 +139,17 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_torch_inference": False,
             "learner_actor_reused": True,
         }
+
+    def _collector_env_cfg_override(self) -> dict | None:
+        """Env override copy for the collector process, with per-rank CPU ids.
+
+        MuJoCo sizes its BatchEnvPool worker count from ``len(cpu_ids)``, so
+        the affinity list must only reach the collector's copy — never the
+        learner-side probe envs, which keep the base override untouched.
+        """
+        if self.collector_cpu_ids is None:
+            return self.env_cfg_override
+        return {**(self.env_cfg_override or {}), "cpu_ids": list(self.collector_cpu_ids)}
 
     def _wait_for_inference_request(
         self,
@@ -572,7 +587,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "inference_request_queue": inference_request_queue,
                 "inference_response_queue": inference_response_queue,
                 "sim_backend": self.sim_backend,
-                "env_cfg_override": self.env_cfg_override,
+                "env_cfg_override": self._collector_env_cfg_override(),
                 "inference_slot": inference_slot,
                 "seed": derive_worker_seed(self.seed, worker_index=0),
                 "trace_enabled": self.trace_enabled,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -10,8 +10,12 @@ import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import torch
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
 
 from unilab.algos.torch.offpolicy.runner import (
     OffPolicyRunner,
@@ -116,6 +120,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         *,
         replay_prefetch_mode: str = "one_tick",
         collector_cpu_ids: list[int] | None = None,
+        dp_sync: DpParameterSync | None = None,
+        dp_sync_interval: int = 8,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -128,6 +134,14 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
         # merged into the collector-only env override at collector startup.
         self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
+        # Multi-GPU data-parallel parameter sync (None = single-rank default,
+        # bit-identical to the pre-DP behavior). Sync happens only at learner
+        # update boundaries — init broadcast before the collector starts, then
+        # an in-place all-reduce mean every dp_sync_interval iterations.
+        self.dp_sync = dp_sync
+        self.dp_sync_interval = int(dp_sync_interval)
+        if self.dp_sync is not None and self.dp_sync_interval < 1:
+            raise ValueError(f"dp_sync_interval must be >= 1, got {dp_sync_interval}")
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -139,6 +153,46 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_torch_inference": False,
             "learner_actor_reused": True,
         }
+        if self.dp_sync is not None:
+            self.runtime_manifest["dp_sync"] = {
+                "world_size": self.dp_sync.world_size,
+                "interval": self.dp_sync_interval,
+                "backend": self.dp_sync.backend,
+            }
+
+    def _dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Live parameter references handed to the DP collectives."""
+        dp_sync_tensors = getattr(self.learner, "dp_sync_tensors", None)
+        if not callable(dp_sync_tensors):
+            raise TypeError(
+                f"{type(self.learner).__name__} must implement dp_sync_tensors() "
+                "for multi-GPU data-parallel parameter sync"
+            )
+        return cast(dict[str, torch.Tensor], dp_sync_tensors())
+
+    def _dp_init_broadcast(self) -> None:
+        """Align initial parameters from rank 0 before the collector starts.
+
+        Ranks train with per-rank seeds, so without this broadcast each
+        rank's actor would serve different inference from the first tick.
+        """
+        if self.dp_sync is None:
+            return
+        self.dp_sync.start()
+        self.dp_sync.broadcast_from_rank0(self._dp_sync_tensors())
+
+    def _maybe_dp_sync(self, iteration: int, iter_metrics: defaultdict[str, list]) -> None:
+        """All-reduce parameter means at the configured update boundary."""
+        if self.dp_sync is None or iteration % self.dp_sync_interval != 0:
+            return
+        sync_start = time.perf_counter()
+        self.dp_sync.allreduce_mean(self._dp_sync_tensors())
+        iter_metrics["dp_sync_time"].append(time.perf_counter() - sync_start)
+
+    def close(self) -> None:
+        if self.dp_sync is not None:
+            self.dp_sync.close()
+        super().close()
 
     def _collector_env_cfg_override(self) -> dict | None:
         """Env override copy for the collector process, with per-rank CPU ids.
@@ -577,6 +631,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
             metrics_queue = _SPAWN_CTX.Queue(maxsize=100)
 
+            # --- DP init broadcast must land before the collector's first ---
+            # --- inference request reaches learner.actor ---
+            self._dp_init_broadcast()
+
             # --- start collector ---
             collector_kwargs = {
                 "env_name": self.env_name,
@@ -908,6 +966,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 train_time = time.perf_counter() - train_start
                 self.learner.update_count += 1
                 inference_scheduler.finish_update()
+                # DP parameter averaging sits at the update boundary: the
+                # update phase is done and the next iteration's inference
+                # tick has not started (strict learner/inference time-share).
+                self._maybe_dp_sync(iteration, iter_metrics)
                 if trace_recorder:
                     trace_recorder.add_counter(
                         "replay_size",

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -761,10 +761,11 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         log_dir: str = "logs",
         logger_type: str = "tensorboard",
     ) -> None:
-        os.makedirs(log_dir, exist_ok=True)
+        if self._is_primary_rank():
+            os.makedirs(log_dir, exist_ok=True)
         trace_output_path = None
         trace_recorder: TraceRecorder | None = None
-        if self.trace_enabled:
+        if self.trace_enabled and self._is_primary_rank():
             trace_root = Path(self.trace_output_dir or log_dir)
             trace_output_path = trace_root / "perfetto_offpolicy_timeline.json"
             trace_recorder = TraceRecorder("offpolicy_learner")

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -79,7 +79,6 @@ class _LocalLoggerStatistics(TypedDict):
     collector_active_steps_per_sec: float | None
     mean_ep_length: float
     timeout_rate: float
-    terminated_rate: float
     buffer_utilization: float
     collector_timing: dict[str, float]
     staging_pool_len: int
@@ -191,15 +190,17 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "logger_cross_rank_aggregation": self.dp_sync is not None,
         }
         if self.dp_sync is not None:
+            captures_gradient_sync = bool(
+                getattr(self.learner, "dp_cuda_graph_gradient_sync", False)
+            )
             self.runtime_manifest["dp_sync"] = {
                 "world_size": self.dp_sync.world_size,
                 "backend": self.dp_sync.backend,
                 "mode": "gradient_mean_per_optimizer_step",
                 "cuda_graph_optimizer_capture": (
-                    "eager_fallback"
-                    if bool(getattr(self.learner, "dp_cuda_graph_fallback", False))
-                    else "not_requested"
+                    "enabled_after_collective_warmup" if captures_gradient_sync else "not_requested"
                 ),
+                "cuda_graph_collective_warmup": captures_gradient_sync,
             }
 
     def _attach_dp_gradient_sync(self) -> None:
@@ -211,7 +212,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 f"{type(self.learner).__name__} must implement set_gradient_sync() "
                 "for multi-GPU data parallelism"
             )
-        setter(self.dp_sync.allreduce_gradients)
+        setter(
+            self.dp_sync.allreduce_gradients,
+            graph_replay_recorder=self.dp_sync.record_cuda_graph_gradient_replay,
+        )
 
     def _dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         """Live model-state references broadcast once before collection."""
@@ -233,6 +237,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             return
         self.dp_sync.start()
         self.dp_sync.broadcast_from_rank0(self._dp_initial_sync_tensors())
+        if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
+            self.dp_sync.prepare_cuda_graph_collectives()
 
     def _collect_dp_sync_metrics(self, iter_metrics: defaultdict[str, list]) -> None:
         """Move per-optimizer collective timing into this iteration's metrics."""
@@ -304,7 +310,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_active_steps_per_sec": logger._collector_active_steps_per_sec,
             "mean_ep_length": logger._mean_ep_length,
             "timeout_rate": logger._timeout_rate,
-            "terminated_rate": logger._terminated_rate,
             "buffer_utilization": logger._buffer_utilization,
             "collector_timing": dict(logger._collector_timing),
             "staging_pool_len": logger._staging_pool_len,
@@ -333,7 +338,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "timing::inference_time": inference_time,
             "timing::iteration_time": iteration_time,
             "logger::timeout_rate": float(logger._timeout_rate),
-            "logger::terminated_rate": float(logger._terminated_rate),
             "logger::buffer_utilization": float(logger._buffer_utilization),
             "extra::batch_size_per_rank": float(extra_info.get("batch_size_per_rank", 0) or 0),
         }
@@ -378,7 +382,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         logger._staging_pool_len = int(round(aggregated["logger::staging_pool_len"]))
         logger._staging_pool_max = int(round(aggregated["logger::staging_pool_max"]))
         logger._timeout_rate = aggregated["logger::timeout_rate"]
-        logger._terminated_rate = aggregated["logger::terminated_rate"]
         logger._buffer_utilization = aggregated["logger::buffer_utilization"]
         if "logger::mean_ep_length" in aggregated:
             logger._mean_ep_length = aggregated["logger::mean_ep_length"]
@@ -443,7 +446,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         logger._collector_active_steps_per_sec = None if active_rate is None else float(active_rate)
         logger._mean_ep_length = float(state["mean_ep_length"])
         logger._timeout_rate = float(state["timeout_rate"])
-        logger._terminated_rate = float(state["terminated_rate"])
         logger._buffer_utilization = float(state["buffer_utilization"])
         logger._collector_timing = dict(state["collector_timing"])
         logger._staging_pool_len = int(state["staging_pool_len"])
@@ -476,6 +478,14 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
     def close(self) -> None:
         if self.dp_sync is not None:
+            if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
+                release_cuda_graphs = getattr(self.learner, "release_cuda_graphs", None)
+                if not callable(release_cuda_graphs):
+                    raise TypeError(
+                        f"{type(self.learner).__name__} must implement release_cuda_graphs() "
+                        "before an NCCL process group with captured collectives is destroyed"
+                    )
+                release_cuda_graphs()
             self.dp_sync.close()
         super().close()
 
@@ -884,10 +894,10 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             env_name=self.env_name,
             obs_dim=self.obs_dim,
             action_dim=self.action_dim,
+            num_gpus=(self.dp_sync.world_size if self.dp_sync is not None else 1),
             log_dir=log_dir,
             log_backend=self._logger_backend(logger_type),
         )
-        logger.set_collection_sync(True, self.env_steps_per_sync)
         logger.update_runtime_manifest(self.runtime_manifest)
         if hasattr(self.learner, "use_symmetry") and self.learner.use_symmetry:
             logger.log_status("Symmetry augmentation: enabled")
@@ -912,10 +922,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             # --- inference coordination queues ---
             inference_request_queue = _SPAWN_CTX.Queue(maxsize=1)
             inference_response_queue = _SPAWN_CTX.Queue(maxsize=1)
-            print(
-                f"[DoubleBufferRunner] Collection sync enabled: "
-                f"env_steps_per_sync={self.env_steps_per_sync}"
-            )
 
             metrics_queue = _SPAWN_CTX.Queue(maxsize=100)
 
@@ -948,11 +954,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 )
 
             time.sleep(0.5)
-            if self._collector_process:
-                print(
-                    f"[DoubleBufferRunner] Collector process alive: "
-                    f"{self._collector_process.is_alive()}"
-                )
 
             reward_history: deque = deque(maxlen=100)
             latest_reward_components: dict[str, float] = {}

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -10,7 +10,7 @@ import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import torch
 
@@ -46,6 +46,44 @@ _ALGO_DISPLAY_NAMES = {
     "td3": "TD3",
     "flashsac": "FlashSAC",
 }
+
+_DP_METRIC_PREFIX = "metric::"
+_DP_REWARD_METRIC_PREFIX = "reward_metric::"
+_DP_REWARD_COMPONENT_PREFIX = "reward_component::"
+_DP_COLLECTOR_TIMING_PREFIX = "collector_timing::"
+
+
+class _LogStepPayload(TypedDict):
+    metrics: dict[str, float]
+    reward: float | None
+    reward_metrics: dict[str, float]
+    reward_components: dict[str, float]
+    train_time: float
+    collector_wait_time: float
+    replay_batch_wait_time: float
+    learner_replay_sample_time: float
+    sync_coordination_time: float
+    replay_ingress_h2d_submit_time: float
+    inference_h2d_time: float
+    inference_forward_time: float
+    inference_d2h_time: float
+    inference_time: float
+    iteration_time: float
+    extra_info: dict[str, int | float | None]
+
+
+class _LocalLoggerStatistics(TypedDict):
+    total_steps: int
+    buffer_size: int
+    buffer_target: int
+    collector_active_steps_per_sec: float | None
+    mean_ep_length: float
+    timeout_rate: float
+    terminated_rate: float
+    buffer_utilization: float
+    collector_timing: dict[str, float]
+    staging_pool_len: int
+    staging_pool_max: int
 
 
 def algo_display_name(algo_type: str) -> str:
@@ -140,6 +178,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         # an in-place all-reduce mean every dp_sync_interval iterations.
         self.dp_sync = dp_sync
         self.dp_sync_interval = int(dp_sync_interval)
+        self._local_logger_statistics: _LocalLoggerStatistics | None = None
         if self.dp_sync is not None and self.dp_sync_interval < 1:
             raise ValueError(f"dp_sync_interval must be >= 1, got {dp_sync_interval}")
         self.replay_pack_layout = "packed"
@@ -152,6 +191,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             "collector_accelerator_context": False,
             "collector_torch_inference": False,
             "learner_actor_reused": True,
+            "logger_owner_rank": 0,
+            "logger_cross_rank_aggregation": self.dp_sync is not None,
         }
         if self.dp_sync is not None:
             self.runtime_manifest["dp_sync"] = {
@@ -188,6 +229,219 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         sync_start = time.perf_counter()
         self.dp_sync.allreduce_mean(self._dp_sync_tensors())
         iter_metrics["dp_sync_time"].append(time.perf_counter() - sync_start)
+
+    def _aggregate_log_statistics(
+        self,
+        logger: OffPolicyLogger,
+        *,
+        metrics: dict[str, float],
+        reward: float | None,
+        reward_metrics: dict[str, float],
+        reward_components: dict[str, float],
+        train_time: float,
+        collector_wait_time: float,
+        replay_batch_wait_time: float,
+        learner_replay_sample_time: float,
+        sync_coordination_time: float,
+        replay_ingress_h2d_submit_time: float,
+        inference_h2d_time: float,
+        inference_forward_time: float,
+        inference_d2h_time: float,
+        inference_time: float,
+        iteration_time: float,
+        extra_info: dict[str, int | float | None],
+    ) -> _LogStepPayload:
+        """Return one log-step payload, reduced across ranks when DP is active.
+
+        Model/reward/timing scalars are means. Concurrent work rates and
+        capacity/sample counters are totals, so the rank-0 logger reports
+        aggregate collector Steps/s and aggregate learner Samples/s. Optional
+        collector fields use the sparse presence-mask contract implemented by
+        ``DpParameterSync.allreduce_statistics``.
+        """
+        payload: _LogStepPayload = {
+            "metrics": metrics,
+            "reward": reward,
+            "reward_metrics": reward_metrics,
+            "reward_components": reward_components,
+            "train_time": train_time,
+            "collector_wait_time": collector_wait_time,
+            "replay_batch_wait_time": replay_batch_wait_time,
+            "learner_replay_sample_time": learner_replay_sample_time,
+            "sync_coordination_time": sync_coordination_time,
+            "replay_ingress_h2d_submit_time": replay_ingress_h2d_submit_time,
+            "inference_h2d_time": inference_h2d_time,
+            "inference_forward_time": inference_forward_time,
+            "inference_d2h_time": inference_d2h_time,
+            "inference_time": inference_time,
+            "iteration_time": iteration_time,
+            "extra_info": extra_info,
+        }
+        if self.dp_sync is None:
+            return payload
+
+        # ``logger`` also receives collector telemetry asynchronously. Keep a
+        # rank-local snapshot before replacing its presentation state with the
+        # aggregate; the next iteration restores this snapshot so a field that
+        # is reported only every few collector cycles is never summed twice.
+        self._local_logger_statistics = {
+            "total_steps": logger._total_steps,
+            "buffer_size": logger._buffer_size,
+            "buffer_target": logger._buffer_target,
+            "collector_active_steps_per_sec": logger._collector_active_steps_per_sec,
+            "mean_ep_length": logger._mean_ep_length,
+            "timeout_rate": logger._timeout_rate,
+            "terminated_rate": logger._terminated_rate,
+            "buffer_utilization": logger._buffer_utilization,
+            "collector_timing": dict(logger._collector_timing),
+            "staging_pool_len": logger._staging_pool_len,
+            "staging_pool_max": logger._staging_pool_max,
+        }
+
+        mean: dict[str, float] = {
+            **{f"{_DP_METRIC_PREFIX}{key}": float(value) for key, value in metrics.items()},
+            **{
+                f"{_DP_REWARD_METRIC_PREFIX}{key}": float(value)
+                for key, value in reward_metrics.items()
+            },
+            **{
+                f"{_DP_REWARD_COMPONENT_PREFIX}{key}": float(value)
+                for key, value in reward_components.items()
+            },
+            "timing::train_time": train_time,
+            "timing::collector_wait_time": collector_wait_time,
+            "timing::replay_batch_wait_time": replay_batch_wait_time,
+            "timing::learner_replay_sample_time": learner_replay_sample_time,
+            "timing::sync_coordination_time": sync_coordination_time,
+            "timing::replay_ingress_h2d_submit_time": replay_ingress_h2d_submit_time,
+            "timing::inference_h2d_time": inference_h2d_time,
+            "timing::inference_forward_time": inference_forward_time,
+            "timing::inference_d2h_time": inference_d2h_time,
+            "timing::inference_time": inference_time,
+            "timing::iteration_time": iteration_time,
+            "logger::timeout_rate": float(logger._timeout_rate),
+            "logger::terminated_rate": float(logger._terminated_rate),
+            "logger::buffer_utilization": float(logger._buffer_utilization),
+            "extra::batch_size_per_rank": float(extra_info.get("batch_size_per_rank", 0) or 0),
+        }
+        if reward is not None:
+            mean["reward::mean"] = float(reward)
+        if logger._mean_ep_length > 0:
+            mean["logger::mean_ep_length"] = float(logger._mean_ep_length)
+        mean.update(
+            {
+                f"{_DP_COLLECTOR_TIMING_PREFIX}{key}": float(value)
+                for key, value in logger._collector_timing.items()
+            }
+        )
+
+        throughput_steps = int(extra_info.get("throughput_steps", 0) or 0)
+        learner_samples = int(extra_info.get("learner_samples_per_iter", 0) or 0)
+        total: dict[str, float] = {
+            "logger::total_steps": float(logger._total_steps),
+            "logger::buffer_size": float(logger._buffer_size),
+            "logger::buffer_target": float(logger._buffer_target),
+            "logger::staging_pool_len": float(logger._staging_pool_len),
+            "logger::staging_pool_max": float(logger._staging_pool_max),
+            "extra::throughput_steps": float(throughput_steps),
+            "extra::effective_batch_size": float(extra_info.get("effective_batch_size", 0) or 0),
+            "extra::replay_samples_per_iter": float(
+                extra_info.get("replay_samples_per_iter", 0) or 0
+            ),
+            "extra::learner_samples_per_iter": float(learner_samples),
+        }
+        if iteration_time > 0:
+            total["rate::steps_per_sec"] = throughput_steps / iteration_time
+            total["rate::learner_samples_per_sec"] = learner_samples / iteration_time
+        collector_active_steps_per_sec = extra_info.get("collector_active_steps_per_sec")
+        if collector_active_steps_per_sec is not None:
+            total["rate::collector_active_steps_per_sec"] = float(collector_active_steps_per_sec)
+
+        aggregated = self.dp_sync.allreduce_statistics(mean=mean, total=total)
+
+        logger._total_steps = int(round(aggregated["logger::total_steps"]))
+        logger._buffer_size = int(round(aggregated["logger::buffer_size"]))
+        logger._buffer_target = int(round(aggregated["logger::buffer_target"]))
+        logger._staging_pool_len = int(round(aggregated["logger::staging_pool_len"]))
+        logger._staging_pool_max = int(round(aggregated["logger::staging_pool_max"]))
+        logger._timeout_rate = aggregated["logger::timeout_rate"]
+        logger._terminated_rate = aggregated["logger::terminated_rate"]
+        logger._buffer_utilization = aggregated["logger::buffer_utilization"]
+        if "logger::mean_ep_length" in aggregated:
+            logger._mean_ep_length = aggregated["logger::mean_ep_length"]
+        logger._collector_timing = {
+            key.removeprefix(_DP_COLLECTOR_TIMING_PREFIX): value
+            for key, value in aggregated.items()
+            if key.startswith(_DP_COLLECTOR_TIMING_PREFIX)
+        }
+
+        aggregated_extra_info: dict[str, int | float | None] = {
+            "throughput_steps": int(round(aggregated["extra::throughput_steps"])),
+            "steps_per_sec": aggregated.get("rate::steps_per_sec"),
+            "learner_samples_per_sec": aggregated.get("rate::learner_samples_per_sec"),
+            "collector_active_steps_per_sec": aggregated.get(
+                "rate::collector_active_steps_per_sec"
+            ),
+            "batch_size_per_rank": int(round(aggregated["extra::batch_size_per_rank"])),
+            "effective_batch_size": int(round(aggregated["extra::effective_batch_size"])),
+            "replay_samples_per_iter": int(round(aggregated["extra::replay_samples_per_iter"])),
+            "learner_samples_per_iter": int(round(aggregated["extra::learner_samples_per_iter"])),
+        }
+        return {
+            "metrics": {
+                key.removeprefix(_DP_METRIC_PREFIX): value
+                for key, value in aggregated.items()
+                if key.startswith(_DP_METRIC_PREFIX)
+            },
+            "reward": aggregated.get("reward::mean"),
+            "reward_metrics": {
+                key.removeprefix(_DP_REWARD_METRIC_PREFIX): value
+                for key, value in aggregated.items()
+                if key.startswith(_DP_REWARD_METRIC_PREFIX)
+            },
+            "reward_components": {
+                key.removeprefix(_DP_REWARD_COMPONENT_PREFIX): value
+                for key, value in aggregated.items()
+                if key.startswith(_DP_REWARD_COMPONENT_PREFIX)
+            },
+            "train_time": aggregated["timing::train_time"],
+            "collector_wait_time": aggregated["timing::collector_wait_time"],
+            "replay_batch_wait_time": aggregated["timing::replay_batch_wait_time"],
+            "learner_replay_sample_time": aggregated["timing::learner_replay_sample_time"],
+            "sync_coordination_time": aggregated["timing::sync_coordination_time"],
+            "replay_ingress_h2d_submit_time": aggregated["timing::replay_ingress_h2d_submit_time"],
+            "inference_h2d_time": aggregated["timing::inference_h2d_time"],
+            "inference_forward_time": aggregated["timing::inference_forward_time"],
+            "inference_d2h_time": aggregated["timing::inference_d2h_time"],
+            "inference_time": aggregated["timing::inference_time"],
+            "iteration_time": aggregated["timing::iteration_time"],
+            "extra_info": aggregated_extra_info,
+        }
+
+    def _restore_local_logger_statistics(self, logger: OffPolicyLogger) -> None:
+        """Restore per-rank collector state after the previous aggregate log step."""
+        state = self._local_logger_statistics
+        if state is None:
+            return
+        logger._total_steps = int(state["total_steps"])
+        logger._buffer_size = int(state["buffer_size"])
+        logger._buffer_target = int(state["buffer_target"])
+        active_rate = state["collector_active_steps_per_sec"]
+        logger._collector_active_steps_per_sec = None if active_rate is None else float(active_rate)
+        logger._mean_ep_length = float(state["mean_ep_length"])
+        logger._timeout_rate = float(state["timeout_rate"])
+        logger._terminated_rate = float(state["terminated_rate"])
+        logger._buffer_utilization = float(state["buffer_utilization"])
+        logger._collector_timing = dict(state["collector_timing"])
+        logger._staging_pool_len = int(state["staging_pool_len"])
+        logger._staging_pool_max = int(state["staging_pool_max"])
+        self._local_logger_statistics = None
+
+    def _logger_backend(self, requested: str) -> str:
+        """Only rank 0 owns terminal and external logging backends."""
+        if self.dp_sync is not None and self.dp_sync.rank != 0:
+            return "no_print"
+        return requested
 
     def close(self) -> None:
         if self.dp_sync is not None:
@@ -232,6 +486,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     latest_reward_components,
                     logger,
                     trace_recorder,
+                    log_collector_reward=self.dp_sync is None,
                 )
                 if not self._check_collector_alive():
                     self._fail_collector_died(
@@ -454,6 +709,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 latest_reward_components,
                 logger,
                 trace_recorder,
+                log_collector_reward=self.dp_sync is None,
             )
             if not self._check_collector_alive():
                 self._fail_collector_died(
@@ -592,12 +848,12 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         logger = OffPolicyLogger(
             algo_name=algo_display_name(self.algo_type),
             max_iterations=max_iterations,
-            num_envs=self.num_envs,
+            num_envs=self.num_envs * (self.dp_sync.world_size if self.dp_sync is not None else 1),
             env_name=self.env_name,
             obs_dim=self.obs_dim,
             action_dim=self.action_dim,
             log_dir=log_dir,
-            log_backend=logger_type,
+            log_backend=self._logger_backend(logger_type),
         )
         logger.set_collection_sync(True, self.env_steps_per_sync)
         logger.update_runtime_manifest(self.runtime_manifest)
@@ -668,6 +924,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
             reward_history: deque = deque(maxlen=100)
             latest_reward_components: dict[str, float] = {}
+            has_logged_reward = False
             last_buf_log = 0
             write_read_ema = 0.0
             reward_stats_ptr = 0
@@ -692,6 +949,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
             # ---- training loop ----
             for iteration in range(1, max_iterations + 1):
+                self._restore_local_logger_statistics(logger)
                 iteration_start = time.perf_counter()
                 # -- wait for data --
                 wait_start = time.perf_counter()
@@ -750,6 +1008,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                         latest_reward_components,
                         logger,
                         trace_recorder,
+                        log_collector_reward=self.dp_sync is None,
                     )
                     replay_pipeline.progress(wait=True)
                     cur_size = int(replay_buffer.size[0])
@@ -789,6 +1048,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     latest_reward_components,
                     logger,
                     trace_recorder,
+                    log_collector_reward=self.dp_sync is None,
                 )
                 _reward_stats_ns = time.perf_counter_ns()
                 reward_stats_ptr = self._update_reward_stats_from_replay(
@@ -985,16 +1245,17 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 logger.update_buffer_utilization(write_read_ema)
 
                 avg_metrics = {k: statistics.mean(v) for k, v in iter_metrics.items() if v}
-                mean_reward = statistics.mean(reward_history) if reward_history else 0.0
-                last_mean_reward = float(mean_reward)
-                best_mean_reward = max(best_mean_reward, last_mean_reward)
+                mean_reward = statistics.mean(reward_history) if reward_history else None
 
                 self._sync_logger_replay_counters(logger, replay_buffer)
-                logger.log_step(
-                    iteration=iteration,
+                log_payload = self._aggregate_log_statistics(
+                    logger,
                     metrics=avg_metrics,
                     reward=mean_reward,
-                    reward_metrics=build_reward_comparison_metrics(reward_history, mean_reward),
+                    reward_metrics=build_reward_comparison_metrics(
+                        reward_history,
+                        mean_reward or 0.0,
+                    ),
                     reward_components=latest_reward_components,
                     train_time=train_time,
                     collector_wait_time=collector_wait_time,
@@ -1016,6 +1277,15 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                             learner=self.learner,
                         ),
                     },
+                )
+                logged_reward = log_payload["reward"]
+                if logged_reward is not None:
+                    last_mean_reward = float(logged_reward)
+                    best_mean_reward = max(best_mean_reward, last_mean_reward)
+                    has_logged_reward = True
+                logger.log_step(
+                    iteration=iteration,
+                    **log_payload,
                 )
 
                 if save_interval > 0 and iteration % save_interval == 0:
@@ -1043,7 +1313,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
             ckpt_path = os.path.join(log_dir, f"model_{max_iterations}.pt")
             torch.save(self.learner.get_state_dict(), ckpt_path)
             logger.log_save(ckpt_path)
-            self._sync_logger_replay_counters(logger, replay_buffer)
+            if self.dp_sync is None:
+                self._sync_logger_replay_counters(logger, replay_buffer)
             logger.finish()
             if trace_recorder and trace_output_path:
                 trace_recorder.write_json(trace_output_path)
@@ -1052,8 +1323,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "completed",
                 iteration,
                 logger,
-                last_mean_reward if reward_history else None,
-                best_mean_reward if reward_history else None,
+                last_mean_reward if has_logged_reward else None,
+                best_mean_reward if has_logged_reward else None,
                 ckpt_path,
                 train_start_wall,
                 str(trace_output_path) if trace_output_path else None,

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -477,17 +477,25 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         return ckpt_path
 
     def close(self) -> None:
-        if self.dp_sync is not None:
-            if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
-                release_cuda_graphs = getattr(self.learner, "release_cuda_graphs", None)
-                if not callable(release_cuda_graphs):
-                    raise TypeError(
-                        f"{type(self.learner).__name__} must implement release_cuda_graphs() "
-                        "before an NCCL process group with captured collectives is destroyed"
-                    )
-                release_cuda_graphs()
-            self.dp_sync.close()
-        super().close()
+        try:
+            # Rank 0 owns the live terminal, and every rank owns a collector and
+            # shared IPC resources. Release those before NCCL teardown, which
+            # may wait on a peer during Ctrl+C shutdown.
+            super().close()
+        finally:
+            if self.dp_sync is not None:
+                try:
+                    if bool(getattr(self.learner, "dp_cuda_graph_gradient_sync", False)):
+                        release_cuda_graphs = getattr(self.learner, "release_cuda_graphs", None)
+                        if not callable(release_cuda_graphs):
+                            raise TypeError(
+                                f"{type(self.learner).__name__} must implement "
+                                "release_cuda_graphs() before an NCCL process group with "
+                                "captured collectives is destroyed"
+                            )
+                        release_cuda_graphs()
+                finally:
+                    self.dp_sync.close()
 
     def _collector_env_cfg_override(self) -> dict | None:
         """Env override copy for the collector process, with per-rank CPU ids.

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -159,7 +159,6 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         replay_prefetch_mode: str = "one_tick",
         collector_cpu_ids: list[int] | None = None,
         dp_sync: DpParameterSync | None = None,
-        dp_sync_interval: int = 8,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -172,15 +171,12 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
         # merged into the collector-only env override at collector startup.
         self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
-        # Multi-GPU data-parallel parameter sync (None = single-rank default,
-        # bit-identical to the pre-DP behavior). Sync happens only at learner
-        # update boundaries — init broadcast before the collector starts, then
-        # an in-place all-reduce mean every dp_sync_interval iterations.
+        # Multi-GPU synchronous data parallelism (None = the bit-identical
+        # single-rank path): startup model broadcast, then gradient averaging
+        # before every actor/critic/temperature optimizer step.
         self.dp_sync = dp_sync
-        self.dp_sync_interval = int(dp_sync_interval)
         self._local_logger_statistics: _LocalLoggerStatistics | None = None
-        if self.dp_sync is not None and self.dp_sync_interval < 1:
-            raise ValueError(f"dp_sync_interval must be >= 1, got {dp_sync_interval}")
+        self._attach_dp_gradient_sync()
         self.replay_pack_layout = "packed"
         self.replay_pack_executor = "collector_thread"
         self.replay_h2d_submitter = "auto"
@@ -197,19 +193,35 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         if self.dp_sync is not None:
             self.runtime_manifest["dp_sync"] = {
                 "world_size": self.dp_sync.world_size,
-                "interval": self.dp_sync_interval,
                 "backend": self.dp_sync.backend,
+                "mode": "gradient_mean_per_optimizer_step",
+                "cuda_graph_optimizer_capture": (
+                    "eager_fallback"
+                    if bool(getattr(self.learner, "dp_cuda_graph_fallback", False))
+                    else "not_requested"
+                ),
             }
 
-    def _dp_sync_tensors(self) -> dict[str, torch.Tensor]:
-        """Live parameter references handed to the DP collectives."""
-        dp_sync_tensors = getattr(self.learner, "dp_sync_tensors", None)
-        if not callable(dp_sync_tensors):
+    def _attach_dp_gradient_sync(self) -> None:
+        if self.dp_sync is None:
+            return
+        setter = getattr(self.learner, "set_gradient_sync", None)
+        if not callable(setter):
             raise TypeError(
-                f"{type(self.learner).__name__} must implement dp_sync_tensors() "
-                "for multi-GPU data-parallel parameter sync"
+                f"{type(self.learner).__name__} must implement set_gradient_sync() "
+                "for multi-GPU data parallelism"
             )
-        return cast(dict[str, torch.Tensor], dp_sync_tensors())
+        setter(self.dp_sync.allreduce_gradients)
+
+    def _dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
+        """Live model-state references broadcast once before collection."""
+        initial_tensors = getattr(self.learner, "dp_initial_sync_tensors", None)
+        if not callable(initial_tensors):
+            raise TypeError(
+                f"{type(self.learner).__name__} must implement dp_initial_sync_tensors() "
+                "for multi-GPU data parallelism"
+            )
+        return cast(dict[str, torch.Tensor], initial_tensors())
 
     def _dp_init_broadcast(self) -> None:
         """Align initial parameters from rank 0 before the collector starts.
@@ -220,15 +232,16 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         if self.dp_sync is None:
             return
         self.dp_sync.start()
-        self.dp_sync.broadcast_from_rank0(self._dp_sync_tensors())
+        self.dp_sync.broadcast_from_rank0(self._dp_initial_sync_tensors())
 
-    def _maybe_dp_sync(self, iteration: int, iter_metrics: defaultdict[str, list]) -> None:
-        """All-reduce parameter means at the configured update boundary."""
-        if self.dp_sync is None or iteration % self.dp_sync_interval != 0:
+    def _collect_dp_sync_metrics(self, iter_metrics: defaultdict[str, list]) -> None:
+        """Move per-optimizer collective timing into this iteration's metrics."""
+        if self.dp_sync is None:
             return
-        sync_start = time.perf_counter()
-        self.dp_sync.allreduce_mean(self._dp_sync_tensors())
-        iter_metrics["dp_sync_time"].append(time.perf_counter() - sync_start)
+        sync_time, sync_calls = self.dp_sync.take_gradient_sync_metrics()
+        if sync_calls > 0:
+            iter_metrics["dp_sync_time"].append(sync_time)
+            iter_metrics["dp_gradient_sync_calls"].append(float(sync_calls))
 
     def _aggregate_log_statistics(
         self,
@@ -439,9 +452,27 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
     def _logger_backend(self, requested: str) -> str:
         """Only rank 0 owns terminal and external logging backends."""
-        if self.dp_sync is not None and self.dp_sync.rank != 0:
+        if not self._is_primary_rank():
             return "no_print"
         return requested
+
+    def _is_primary_rank(self) -> bool:
+        return self.dp_sync is None or self.dp_sync.rank == 0
+
+    def _save_checkpoint(
+        self,
+        *,
+        log_dir: str,
+        iteration: int,
+        logger: OffPolicyLogger,
+    ) -> str | None:
+        """Persist the single canonical checkpoint from rank 0 only."""
+        if not self._is_primary_rank():
+            return None
+        ckpt_path = os.path.join(log_dir, f"model_{iteration}.pt")
+        torch.save(self.learner.get_state_dict(), ckpt_path)
+        logger.log_save(ckpt_path)
+        return ckpt_path
 
     def close(self) -> None:
         if self.dp_sync is not None:
@@ -1226,10 +1257,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 train_time = time.perf_counter() - train_start
                 self.learner.update_count += 1
                 inference_scheduler.finish_update()
-                # DP parameter averaging sits at the update boundary: the
-                # update phase is done and the next iteration's inference
-                # tick has not started (strict learner/inference time-share).
-                self._maybe_dp_sync(iteration, iter_metrics)
+                self._collect_dp_sync_metrics(iter_metrics)
                 if trace_recorder:
                     trace_recorder.add_counter(
                         "replay_size",
@@ -1289,9 +1317,13 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 )
 
                 if save_interval > 0 and iteration % save_interval == 0:
-                    ckpt_path = os.path.join(log_dir, f"model_{iteration}.pt")
-                    torch.save(self.learner.get_state_dict(), ckpt_path)
-                    logger.log_save(ckpt_path)
+                    saved_path = self._save_checkpoint(
+                        log_dir=log_dir,
+                        iteration=iteration,
+                        logger=logger,
+                    )
+                    if saved_path is not None:
+                        ckpt_path = saved_path
 
             if trace_recorder:
                 trace_recorder.add_slice(
@@ -1310,9 +1342,15 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
 
             # -- finalize --
             replay_pipeline.close()
-            ckpt_path = os.path.join(log_dir, f"model_{max_iterations}.pt")
-            torch.save(self.learner.get_state_dict(), ckpt_path)
-            logger.log_save(ckpt_path)
+            final_ckpt_path = os.path.join(log_dir, f"model_{max_iterations}.pt")
+            if ckpt_path != final_ckpt_path:
+                saved_path = self._save_checkpoint(
+                    log_dir=log_dir,
+                    iteration=max_iterations,
+                    logger=logger,
+                )
+                if saved_path is not None:
+                    ckpt_path = saved_path
             if self.dp_sync is None:
                 self._sync_logger_replay_counters(logger, replay_buffer)
             logger.finish()

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -229,7 +229,15 @@ class OffPolicyRunner(AsyncRunner):
         super().close()
 
     @staticmethod
-    def _drain_metrics(queue, reward_history, reward_components, logger, trace_recorder=None):
+    def _drain_metrics(
+        queue,
+        reward_history,
+        reward_components,
+        logger,
+        trace_recorder=None,
+        *,
+        log_collector_reward: bool = True,
+    ):
         while True:
             try:
                 metrics = queue.get_nowait()
@@ -265,7 +273,11 @@ class OffPolicyRunner(AsyncRunner):
                     logger.log_collector(
                         metrics["total_steps"],
                         metrics["buffer_size"],
-                        metrics.get("mean_ep_reward", 0.0) if updated_reward else 0.0,
+                        (
+                            metrics.get("mean_ep_reward", 0.0)
+                            if updated_reward and log_collector_reward
+                            else 0.0
+                        ),
                     )
                 if trace_recorder and "trace_events" in metrics:
                     trace_recorder.extend(metrics["trace_events"])

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -264,11 +264,8 @@ class OffPolicyRunner(AsyncRunner):
                 active_steps_per_sec = metrics.get("collector_active_steps_per_sec")
                 if active_steps_per_sec is not None:
                     logger.update_collector_active_steps_per_sec(float(active_steps_per_sec))
-                if "timeout_rate" in metrics or "terminated_rate" in metrics:
-                    logger.update_done_rates(
-                        timeout_rate=float(metrics.get("timeout_rate", 0.0)),
-                        terminated_rate=float(metrics.get("terminated_rate", 0.0)),
-                    )
+                if "timeout_rate" in metrics:
+                    logger.update_timeout_rate(float(metrics["timeout_rate"]))
                 if "total_steps" in metrics and "buffer_size" in metrics:
                     logger.log_collector(
                         metrics["total_steps"],

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -223,10 +223,14 @@ class OffPolicyRunner(AsyncRunner):
 
     def close(self) -> None:
         active_logger = getattr(self, "_active_logger", None)
-        if active_logger is not None:
-            active_logger.close()
+        try:
+            if active_logger is not None:
+                active_logger.close()
+        finally:
             self._active_logger = None
-        super().close()
+            # Terminal restoration must not be able to prevent collector,
+            # shared-memory, queue, and pipe cleanup.
+            super().close()
 
     @staticmethod
     def _drain_metrics(

--- a/src/unilab/algos/torch/offpolicy/thread_budget.py
+++ b/src/unilab/algos/torch/offpolicy/thread_budget.py
@@ -1,8 +1,9 @@
 """Torch CPU thread budget helpers for off-policy training.
 
-Off-policy training runs Torch in multiple processes: the learner, the CPU
-collector, and optional multi-GPU learner workers. PyTorch defaults each process
-to a host-sized thread pool, so every role needs an explicit budget.
+Off-policy training runs Torch in multiple processes: the learner and the CPU
+collector of each rank (multi-GPU data parallel runs one learner+collector
+pair per rank). PyTorch defaults each process to a host-sized thread pool, so
+every role needs an explicit budget.
 """
 
 from __future__ import annotations

--- a/src/unilab/algos/torch/offpolicy/worker.py
+++ b/src/unilab/algos/torch/offpolicy/worker.py
@@ -19,16 +19,14 @@ from unilab.training.seed import apply_training_seed
 # Every key is recorded once per iteration so the reported averages share one
 # denominator and can be summed without double counting.
 # - replay_write_ms: pack transitions and write them into the bounded ingress
-# - bookkeeping_ms: per-cycle episode bookkeeping and metrics reporting
 COLLECTOR_TIMING_KEYS = (
     "inference_request_ms",
     "learner_action_wait_ms",
     "env_step_ms",
     "replay_write_ms",
-    "bookkeeping_ms",
 )
 COLLECTOR_ACTIVE_TIMING_KEYS = tuple(
-    key for key in COLLECTOR_TIMING_KEYS if key not in {"learner_action_wait_ms", "bookkeeping_ms"}
+    key for key in COLLECTOR_TIMING_KEYS if key != "learner_action_wait_ms"
 )
 
 
@@ -170,7 +168,6 @@ def off_policy_collector_fn(
     Error handling is provided by ``_collector_entry_wrapper`` in
     ``async_runner.py``.
     """
-    print("[Collector] Entry point called", file=sys.stderr, flush=True)
     _run_collector(
         stop_event=stop_event,
         env_name=env_name,
@@ -253,7 +250,6 @@ def _run_collector(
     timing_counts: defaultdict[str, int] = defaultdict(int)
     done_count_window = 0
     timeout_count_window = 0
-    terminated_count_window = 0
 
     state = env.state
     assert state is not None
@@ -263,8 +259,6 @@ def _run_collector(
     info_dict = state.info
     prev_dones_np = np.zeros(num_envs, dtype=np.float32)
     import time as _time
-
-    _last_log_time = _time.time()
 
     runtime_manifest = {
         "inference_owner": "learner",
@@ -376,7 +370,6 @@ def _run_collector(
             next_critic_np = np.asarray(next_critic_np, dtype=np.float32)
             rewards_np = np.asarray(state.reward, dtype=np.float32).ravel()
 
-            terminated_np = state.terminated.astype(np.float32, copy=False).ravel()
             truncated_np = state.truncated.astype(np.float32, copy=False).ravel()
             combined_dones = (
                 (state.terminated | state.truncated).astype(np.float32, copy=False).ravel()
@@ -384,11 +377,9 @@ def _run_collector(
             prev_dones_np = combined_dones
             done_mask_np = combined_dones > 0.5
             timeout_mask_np = truncated_np > 0.5
-            terminated_mask_np = np.logical_and(terminated_np > 0.5, ~timeout_mask_np)
 
             done_count_window += int(np.count_nonzero(done_mask_np))
             timeout_count_window += int(np.count_nonzero(timeout_mask_np))
-            terminated_count_window += int(np.count_nonzero(terminated_mask_np))
 
             terminal_contract = resolve_terminal_observation_contract(
                 next_obs_batch_size=next_obs_np.shape[0],
@@ -448,12 +439,6 @@ def _run_collector(
             critic_np = next_critic_np
             info_dict = state.info
             total_steps += num_envs
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "bookkeeping_ms", phase_start_ns)
-
-            # Progress log every 2 seconds
-            now = _time.time()
-            if now - _last_log_time > 2.0:
-                _last_log_time = now
 
             # Extract reward components from env info
             log_info = state.info.get("log", {})
@@ -500,10 +485,8 @@ def _run_collector(
 
                     if done_count_window > 0:
                         msg["timeout_rate"] = timeout_count_window / done_count_window
-                        msg["terminated_rate"] = terminated_count_window / done_count_window
                         done_count_window = 0
                         timeout_count_window = 0
-                        terminated_count_window = 0
 
                     if trace_recorder:
                         msg["trace_events"] = trace_recorder.drain_events()
@@ -514,8 +497,6 @@ def _run_collector(
                         timing_counts.clear()
                 except Exception as e:
                     print(f"[OffPolicyWorker] metrics enqueue error: {e}", file=sys.stderr)
-            phase_start_ns = _record_phase_ms(cycle_timing_ms, "bookkeeping_ms", phase_start_ns)
-
             for key, value in cycle_timing_ms.items():
                 _record_timing_ms(timing_accum_ms, timing_counts, key, value)
 

--- a/src/unilab/ipc/async_runner.py
+++ b/src/unilab/ipc/async_runner.py
@@ -71,6 +71,7 @@ class AsyncRunner(ABC):
         self._shared_resources: list = []
         self._error_recv: Any = None
         self._error_send: Any = None
+        self._close_complete = False
 
     @abstractmethod
     def _get_default_device(self) -> str:
@@ -127,6 +128,8 @@ class AsyncRunner(ABC):
         return format_collector_death(exitcode, traceback_text)
 
     def close(self) -> None:
+        if self._close_complete:
+            return
         self._stop_event.set()
         if self._collector_process is not None and self._collector_process.is_alive():
             self._collector_process.join(timeout=10)
@@ -163,6 +166,7 @@ class AsyncRunner(ABC):
             except Exception:
                 pass
             self._error_send = None
+        self._close_complete = True
 
     def __del__(self):
         try:

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -2,8 +2,8 @@
 
 Topology rules (config parsing, rank/device mapping, subprocess supervision)
 live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
-This module covers topology only; parameter sync between ranks is out of
-scope for this stage.
+This module covers topology only; the parameter-sync collectives between
+ranks live in ``dp_sync.py``.
 """
 
 from __future__ import annotations
@@ -64,6 +64,27 @@ def current_dp_rank() -> int:
 def current_dp_world_size() -> int:
     """Data-parallel world size of this process (1 when not spawned as a rank)."""
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def resolve_dp_rendezvous_path(log_dir: str, *, rank: int) -> str:
+    """Shared FileStore rendezvous path for the DP parameter-sync group.
+
+    Rank 0 anchors the store in its own run directory; spawned ranks point at
+    the same run root via ``UNILAB_DP_LOG_DIR`` (their own log_dir is a
+    per-rank subdirectory). The run directory is unique per run, which keeps
+    stale FileStore state from a previous run out of the rendezvous.
+
+    Cold path only: call at runner construction.
+    """
+    if int(rank) > 0:
+        root = os.environ.get(UNILAB_DP_LOG_DIR)
+        if root is None:
+            raise ValueError(
+                f"{UNILAB_DP_LOG_DIR} must be set for spawned data-parallel rank {rank}"
+            )
+    else:
+        root = str(log_dir)
+    return os.path.join(root, ".dp_rendezvous")
 
 
 def resolve_collector_cpu_ids(

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -1,9 +1,10 @@
-"""Multi-GPU data-parallel rank topology for off-policy training.
+"""Single-node multi-GPU data-parallel launch and rank topology helpers.
 
 Topology rules (config parsing, rank/device mapping, subprocess supervision)
-live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
-This module covers topology only; the parameter-sync collectives between
-ranks live in ``dp_sync.py``.
+live here so training scripts only assemble their flows. The off-policy path
+uses :class:`DpRankSupervisor`; RSL-RL PPO uses PyTorch's elastic launcher and
+standard ``WORLD_SIZE`` / ``RANK`` / ``LOCAL_RANK`` variables. Algorithm-level
+collectives remain owned by their respective learner implementations.
 """
 
 from __future__ import annotations
@@ -13,8 +14,9 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 UNILAB_DP_RANK = "UNILAB_DP_RANK"
 UNILAB_DP_WORLD_SIZE = "UNILAB_DP_WORLD_SIZE"
@@ -24,6 +26,7 @@ UNILAB_DP_LOG_DIR = "UNILAB_DP_LOG_DIR"
 _OFFPOLICY_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "train_offpolicy.py"
 
 _WATCHDOG_INTERVAL_S = 0.5
+_COOPERATIVE_EXIT_GRACE_S = 10.0
 _TERMINATE_TIMEOUT_S = 10.0
 # Grace window for sibling ranks to finish their own runs once rank 0
 # completed normally. Ranks run the same config, so they should land within
@@ -64,6 +67,21 @@ def current_dp_rank() -> int:
 def current_dp_world_size() -> int:
     """Data-parallel world size of this process (1 when not spawned as a rank)."""
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def current_torch_distributed_rank() -> int:
+    """Global torch-distributed rank of this process (0 outside torchrun)."""
+    return int(os.environ.get("RANK", "0"))
+
+
+def current_torch_distributed_local_rank() -> int:
+    """Node-local torch-distributed rank of this process (0 outside torchrun)."""
+    return int(os.environ.get("LOCAL_RANK", "0"))
+
+
+def current_torch_distributed_world_size() -> int:
+    """Torch-distributed world size of this process (1 outside torchrun)."""
+    return int(os.environ.get("WORLD_SIZE", "1"))
 
 
 def resolve_dp_rendezvous_path(log_dir: str, *, rank: int) -> str:
@@ -161,6 +179,83 @@ def validate_dp_launchable(devices: tuple[int, ...]) -> None:
         )
 
 
+def resolve_cuda_visible_devices(
+    devices: tuple[int, ...],
+    *,
+    current_visible_devices: str | None = None,
+) -> str:
+    """Map configured logical CUDA indices to a child ``CUDA_VISIBLE_DEVICES`` value.
+
+    ``training.devices`` indexes the CUDA devices visible to the parent process.
+    When the parent already has ``CUDA_VISIBLE_DEVICES`` set, preserve that
+    mapping (including UUID entries) instead of accidentally switching back to
+    host-global device indices.
+    """
+    if current_visible_devices is None:
+        return ",".join(str(index) for index in devices)
+
+    visible_entries = [
+        entry.strip() for entry in current_visible_devices.split(",") if entry.strip()
+    ]
+    missing = [index for index in devices if index >= len(visible_entries)]
+    if missing:
+        raise ValueError(
+            f"training.devices={list(devices)} requires visible CUDA index(es) {missing}, "
+            f"but CUDA_VISIBLE_DEVICES={current_visible_devices!r} exposes "
+            f"{len(visible_entries)} device(s)"
+        )
+    return ",".join(visible_entries[index] for index in devices)
+
+
+def launch_torchrun_workers(
+    devices: tuple[int, ...],
+    *,
+    script_path: str | os.PathLike[str],
+    argv: Sequence[str],
+    log_dir: str,
+) -> None:
+    """Launch one local torchrun worker per configured CUDA device.
+
+    PyTorch elastic owns worker supervision and failure propagation. Each
+    worker re-enters the regular training script with the original Hydra
+    arguments, while ``UNILAB_DP_LOG_DIR`` supplies one canonical rank-0-owned
+    run directory.
+    """
+    if len(devices) < 2:
+        raise ValueError("launch_torchrun_workers requires at least two CUDA devices")
+    validate_dp_launchable(devices)
+
+    launch_env = os.environ.copy()
+    launch_env["CUDA_VISIBLE_DEVICES"] = resolve_cuda_visible_devices(
+        devices,
+        current_visible_devices=os.environ.get("CUDA_VISIBLE_DEVICES"),
+    )
+    # Keep the production transport defaults already used by DpParameterSync:
+    # current RTX 6000D hosts hang with NCCL P2P and can fault with SHM. An
+    # explicit user environment still wins over these compatibility defaults.
+    launch_env.setdefault("NCCL_P2P_DISABLE", "1")
+    launch_env.setdefault("NCCL_SHM_DISABLE", "1")
+    launch_env[UNILAB_DP_LOG_DIR] = str(log_dir)
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        "--nnodes=1",
+        f"--nproc_per_node={len(devices)}",
+        str(Path(script_path).resolve()),
+        *argv,
+    ]
+    print(
+        f"Launching RSL-RL data parallel training on CUDA devices {list(devices)} "
+        f"with {len(devices)} workers.",
+        flush=True,
+    )
+    completed = subprocess.run(command, env=launch_env, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(f"torchrun workers failed with exit code {completed.returncode}")
+
+
 def resolve_dp_rank_device(devices: tuple[int, ...] | None, rank: int) -> str | None:
     """Return ``cuda:<index>`` for one configured rank, or None for auto selection."""
     if devices is None:
@@ -194,6 +289,34 @@ def _sigterm_system_exit(signum: int, _frame: Any) -> None:
     raise SystemExit(f"data-parallel rank 0 received signal {signum}")
 
 
+def _signal_process_group(child: subprocess.Popen, signum: int) -> None:
+    """Signal one rank and all of the worker processes it owns."""
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(child.pid, signum)
+        else:  # pragma: no cover - Windows fallback for non-CUDA test hosts.
+            child.send_signal(signum)
+    except ProcessLookupError:
+        pass
+
+
+def _process_group_exists(child: subprocess.Popen) -> bool:
+    """Return whether a rank process group still owns any live processes."""
+    # Reap an exited group leader before probing the group. Otherwise the
+    # leader may remain a zombie and make ``killpg(..., 0)`` look alive for the
+    # entire escalation timeout even though no rank resources remain.
+    child.poll()
+    if not hasattr(os, "killpg"):  # pragma: no cover - Windows fallback.
+        return child.returncode is None
+    try:
+        os.killpg(child.pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 class DpRankSupervisor:
     """Rank-0 supervisor that spawns and watches data-parallel rank subprocesses.
 
@@ -203,7 +326,9 @@ class DpRankSupervisor:
     subprocess dies with a non-zero exit code while active, the supervisor
     delivers SIGTERM to rank 0 so the runner lifecycle unwinds through the
     normal try/finally (``runner.close()``), and ``__exit__`` tears down the
-    remaining ranks.
+    remaining ranks. Each spawned rank owns a separate process group containing
+    its collector. Rank 0 forwards Ctrl+C to those groups for cooperative
+    cleanup before escalating to SIGTERM/SIGKILL.
     """
 
     def __init__(self, devices: tuple[int, ...], log_dir: str) -> None:
@@ -213,7 +338,8 @@ class DpRankSupervisor:
         self._children: list[subprocess.Popen] = []
         self._watchdog_stop = threading.Event()
         self._watchdog: threading.Thread | None = None
-        self._previous_sigterm_handler: Any = None
+        self._previous_signal_handlers: dict[int, Any] = {}
+        self._shutdown_requested = False
 
     def __enter__(self) -> DpRankSupervisor:
         if self._world_size <= 1:
@@ -224,6 +350,7 @@ class DpRankSupervisor:
             UNILAB_DP_DEVICES: ",".join(str(index) for index in self._devices),
             UNILAB_DP_LOG_DIR: self._log_dir,
         }
+        self._install_signal_handlers()
         try:
             for rank in range(1, self._world_size):
                 env = base_env | {UNILAB_DP_RANK: str(rank)}
@@ -231,12 +358,22 @@ class DpRankSupervisor:
                     subprocess.Popen(
                         [sys.executable, str(_OFFPOLICY_SCRIPT), *sys.argv[1:]],
                         env=env,
+                        # Rank-local collectors inherit this group. The terminal
+                        # only interrupts rank 0; the supervisor then forwards
+                        # one coordinated SIGINT to each complete rank tree.
+                        start_new_session=os.name == "posix",
                     )
                 )
         except BaseException:
-            self._terminate_children()
+            self._request_children_shutdown()
+            try:
+                self._wait_for_children(_COOPERATIVE_EXIT_GRACE_S)
+            finally:
+                try:
+                    self._terminate_children()
+                finally:
+                    self._restore_signal_handlers()
             raise
-        self._previous_sigterm_handler = signal.signal(signal.SIGTERM, _sigterm_system_exit)
         self._watchdog = threading.Thread(
             target=self._watchdog_loop,
             name="dp-rank-watchdog",
@@ -247,39 +384,48 @@ class DpRankSupervisor:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
         self._watchdog_stop.set()
-        if self._watchdog is not None:
-            self._watchdog.join(timeout=_TERMINATE_TIMEOUT_S)
-            self._watchdog = None
-        if self._previous_sigterm_handler is not None:
-            signal.signal(signal.SIGTERM, self._previous_sigterm_handler)
-            self._previous_sigterm_handler = None
+        failed: list[tuple[int, object]] = []
+        try:
+            if self._watchdog is not None:
+                self._watchdog.join(timeout=_TERMINATE_TIMEOUT_S)
+                self._watchdog = None
 
-        # Ranks that already exited on their own keep their exit code;
-        # non-zero means the data-parallel run failed even if rank 0 is fine.
-        failed: list[tuple[int, object]] = [
-            (rank, child.returncode)
-            for rank, child in enumerate(self._children, start=1)
-            if child.returncode is not None and child.returncode != 0
-        ]
-        if exc_type is None and not failed:
-            # Normal rank-0 completion: give sibling ranks a grace window to
-            # finish their own runs instead of cutting them short.
-            for rank, child in enumerate(self._children, start=1):
-                if child.returncode is not None:
-                    continue
-                try:
-                    child.wait(timeout=_NORMAL_EXIT_GRACE_S)
-                except subprocess.TimeoutExpired:
+            # Ranks that already exited on their own keep their exit code;
+            # non-zero means the data-parallel run failed even if rank 0 is fine.
+            failed = [
+                (rank, child.returncode)
+                for rank, child in enumerate(self._children, start=1)
+                if child.returncode is not None and child.returncode != 0
+            ]
+            if exc_type is None and not failed:
+                # Normal rank-0 completion: give sibling ranks a grace window to
+                # finish their own runs instead of cutting them short.
+                unfinished = self._wait_for_children(_NORMAL_EXIT_GRACE_S)
+                for rank, child in unfinished:
                     print(
                         f"[dp_launcher] rank {rank} subprocess pid={child.pid} did not "
                         f"exit within {_NORMAL_EXIT_GRACE_S}s of rank 0 completion",
                         file=sys.stderr,
                     )
-                if child.returncode != 0:
-                    failed.append(
-                        (rank, child.returncode if child.returncode is not None else "timeout")
-                    )
-        self._terminate_children()
+                    failed.append((rank, "timeout"))
+                for rank, child in enumerate(self._children, start=1):
+                    if child.returncode not in (None, 0) and not any(
+                        failed_rank == rank for failed_rank, _ in failed
+                    ):
+                        failed.append((rank, child.returncode))
+            else:
+                # For Ctrl+C this is normally a no-op because the signal handler
+                # already forwarded SIGINT. It also makes arbitrary rank-0
+                # failures unwind sibling runner lifecycles cooperatively.
+                self._request_children_shutdown()
+                self._wait_for_children(_COOPERATIVE_EXIT_GRACE_S)
+        finally:
+            # Always reap complete rank process groups, including collectors
+            # orphaned by a rank that exited before finishing its own cleanup.
+            try:
+                self._terminate_children()
+            finally:
+                self._restore_signal_handlers()
         if failed:
             message = "data-parallel rank subprocess(es) failed: " + ", ".join(
                 f"rank {rank} exit code {code}" for rank, code in failed
@@ -289,16 +435,96 @@ class DpRankSupervisor:
             print(f"[dp_launcher] {message}", file=sys.stderr)
         return False
 
+    def _install_signal_handlers(self) -> None:
+        try:
+            self._previous_signal_handlers[signal.SIGINT] = signal.signal(
+                signal.SIGINT, self._handle_sigint
+            )
+            self._previous_signal_handlers[signal.SIGTERM] = signal.signal(
+                signal.SIGTERM, self._handle_sigterm
+            )
+        except BaseException:
+            self._restore_signal_handlers()
+            raise
+
+    def _restore_signal_handlers(self) -> None:
+        for signum, previous in self._previous_signal_handlers.items():
+            signal.signal(signum, previous)
+        self._previous_signal_handlers.clear()
+
+    def _handle_sigint(self, signum: int, frame: Any) -> None:
+        self._request_children_shutdown()
+        previous = self._previous_signal_handlers.get(signal.SIGINT, signal.default_int_handler)
+        if previous == signal.SIG_IGN:
+            return
+        if previous == signal.SIG_DFL:
+            signal.default_int_handler(signum, frame)
+            return
+        previous(signum, frame)
+
+    def _handle_sigterm(self, signum: int, frame: Any) -> None:
+        # A child-rank watchdog failure uses SIGTERM to unwind rank 0. Sibling
+        # rank trees still receive SIGINT so their Python finally blocks run.
+        self._request_children_shutdown()
+        _sigterm_system_exit(signum, frame)
+
+    def _request_children_shutdown(self) -> None:
+        if self._shutdown_requested:
+            return
+        self._shutdown_requested = True
+        for child in self._children:
+            if _process_group_exists(child):
+                _signal_process_group(child, signal.SIGINT)
+
+    def _wait_for_children(self, timeout: float) -> list[tuple[int, subprocess.Popen]]:
+        deadline = time.monotonic() + max(float(timeout), 0.0)
+        pending = list(enumerate(self._children, start=1))
+        while pending:
+            pending = [(rank, child) for rank, child in pending if child.poll() is None]
+            if not pending:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                pending[0][1].wait(timeout=min(_WATCHDOG_INTERVAL_S, remaining))
+            except subprocess.TimeoutExpired:
+                pass
+        return pending
+
+    @staticmethod
+    def _wait_for_process_groups(
+        children: list[subprocess.Popen], timeout: float
+    ) -> list[subprocess.Popen]:
+        deadline = time.monotonic() + max(float(timeout), 0.0)
+        pending = [child for child in children if _process_group_exists(child)]
+        while pending:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(_WATCHDOG_INTERVAL_S, remaining))
+            pending = [child for child in pending if _process_group_exists(child)]
+        return pending
+
     def _terminate_children(self) -> None:
-        alive = [child for child in self._children if child.poll() is None]
-        for child in alive:
-            child.terminate()
-        for child in alive:
+        groups = [child for child in self._children if _process_group_exists(child)]
+        for child in groups:
+            _signal_process_group(child, signal.SIGTERM)
+        groups = self._wait_for_process_groups(groups, _TERMINATE_TIMEOUT_S)
+        for child in groups:
+            _signal_process_group(child, signal.SIGKILL)
+        self._wait_for_process_groups(groups, _TERMINATE_TIMEOUT_S)
+
+        # Reap every direct rank child after its complete process group has
+        # stopped so no zombie or Popen handle survives supervisor teardown.
+        for child in self._children:
+            if child.poll() is not None:
+                continue
             try:
                 child.wait(timeout=_TERMINATE_TIMEOUT_S)
             except subprocess.TimeoutExpired:
-                child.kill()
-                child.wait()
+                _signal_process_group(child, signal.SIGKILL)
+                child.wait(timeout=_TERMINATE_TIMEOUT_S)
 
     def _watchdog_loop(self) -> None:
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL_S):

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -66,6 +66,67 @@ def current_dp_world_size() -> int:
     return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
 
 
+def resolve_collector_cpu_ids(
+    world_size: int,
+    rank: int,
+    cpu_count: int,
+    explicit: Any = None,
+) -> list[int] | None:
+    """Resolve the CPU ids exclusively owned by this rank's collector.
+
+    Returns None for the single-rank default (``world_size <= 1``) so the
+    single-card path stays bit-identical to the pre-partition behavior.
+    Otherwise the host CPUs are split into ``world_size`` contiguous blocks of
+    ``cpu_count // world_size``: rank i owns ``[i*size, (i+1)*size)`` and any
+    remainder CPUs stay on default OS scheduling. ``explicit`` (config
+    ``training.dp_collector_cpu_ids``, one segment per rank) overrides the
+    automatic partition; the segments must number exactly ``world_size``, be
+    non-empty, contain non-negative ints, and not overlap. An empty
+    ``explicit`` falls back to the automatic partition.
+
+    Cold path only: call at runner construction, never from the collect loop.
+    """
+    world_size = int(world_size)
+    if world_size <= 1:
+        return None
+    rank = int(rank)
+    if rank < 0 or rank >= world_size:
+        raise ValueError(f"data-parallel rank {rank} is out of range for world_size={world_size}")
+    cpu_count = int(cpu_count)
+    if cpu_count < world_size:
+        raise ValueError(
+            f"cpu_count={cpu_count} cannot give each data-parallel rank its own CPU "
+            f"(world_size={world_size})"
+        )
+    if explicit is not None and len(explicit) > 0:
+        segments: list[list[int]] = [list(segment) for segment in explicit]
+        if len(segments) != world_size:
+            raise ValueError(
+                f"training.dp_collector_cpu_ids must provide exactly world_size={world_size} "
+                f"segments, got {len(segments)}"
+            )
+        seen: set[int] = set()
+        for segment in segments:
+            if not segment:
+                raise ValueError(
+                    f"training.dp_collector_cpu_ids segments must be non-empty, got {segments!r}"
+                )
+            for cpu_id in segment:
+                if isinstance(cpu_id, bool) or not isinstance(cpu_id, int) or cpu_id < 0:
+                    raise ValueError(
+                        "training.dp_collector_cpu_ids entries must be non-negative "
+                        f"integers, got {cpu_id!r}"
+                    )
+                if cpu_id in seen:
+                    raise ValueError(
+                        f"training.dp_collector_cpu_ids segments overlap on CPU {cpu_id}"
+                    )
+                seen.add(cpu_id)
+        return segments[rank]
+    size = cpu_count // world_size
+    return list(range(rank * size, rank * size + size))
+
+
 def validate_dp_launchable(devices: tuple[int, ...]) -> None:
     """Fail fast at launch time when the host lacks any requested CUDA device."""
     import torch

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -70,9 +70,9 @@ def resolve_dp_rendezvous_path(log_dir: str, *, rank: int) -> str:
     """Shared FileStore rendezvous path for the DP parameter-sync group.
 
     Rank 0 anchors the store in its own run directory; spawned ranks point at
-    the same run root via ``UNILAB_DP_LOG_DIR`` (their own log_dir is a
-    per-rank subdirectory). The run directory is unique per run, which keeps
-    stale FileStore state from a previous run out of the rendezvous.
+    the same canonical run root via ``UNILAB_DP_LOG_DIR``. The run directory
+    is unique per run, which keeps stale FileStore state from a previous run
+    out of the rendezvous.
 
     Cold path only: call at runner construction.
     """

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -1,0 +1,233 @@
+"""Multi-GPU data-parallel rank topology for off-policy training.
+
+Topology rules (config parsing, rank/device mapping, subprocess supervision)
+live here so that ``scripts/train_offpolicy.py`` only assembles the flow.
+This module covers topology only; parameter sync between ranks is out of
+scope for this stage.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Literal
+
+UNILAB_DP_RANK = "UNILAB_DP_RANK"
+UNILAB_DP_WORLD_SIZE = "UNILAB_DP_WORLD_SIZE"
+UNILAB_DP_DEVICES = "UNILAB_DP_DEVICES"
+UNILAB_DP_LOG_DIR = "UNILAB_DP_LOG_DIR"
+
+_OFFPOLICY_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "train_offpolicy.py"
+
+_WATCHDOG_INTERVAL_S = 0.5
+_TERMINATE_TIMEOUT_S = 10.0
+# Grace window for sibling ranks to finish their own runs once rank 0
+# completed normally. Ranks run the same config, so they should land within
+# startup skew of each other; exceeding the grace is treated as a failure.
+_NORMAL_EXIT_GRACE_S = 600.0
+
+
+def resolve_dp_topology(devices_cfg: Any) -> tuple[int, ...] | None:
+    """Normalize ``training.devices`` into an ordered CUDA-index tuple.
+
+    Returns None for the single-card default (null / empty list). The user
+    given order is preserved: rank i maps to ``cuda:{devices[i]}``.
+    """
+    if devices_cfg is None:
+        return None
+    devices = list(devices_cfg)
+    if len(devices) == 0:
+        return None
+    normalized: list[int] = []
+    for entry in devices:
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            raise ValueError(
+                f"training.devices entries must be integer CUDA indices, got {entry!r}"
+            )
+        if entry < 0:
+            raise ValueError(f"training.devices entries must be non-negative, got {entry}")
+        normalized.append(int(entry))
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"training.devices must not contain duplicates, got {normalized}")
+    return tuple(normalized)
+
+
+def current_dp_rank() -> int:
+    """Data-parallel rank of this process (0 when not spawned as a rank)."""
+    return int(os.environ.get(UNILAB_DP_RANK, "0"))
+
+
+def current_dp_world_size() -> int:
+    """Data-parallel world size of this process (1 when not spawned as a rank)."""
+    return int(os.environ.get(UNILAB_DP_WORLD_SIZE, "1"))
+
+
+def validate_dp_launchable(devices: tuple[int, ...]) -> None:
+    """Fail fast at launch time when the host lacks any requested CUDA device."""
+    import torch
+
+    device_count = torch.cuda.device_count()
+    missing = [index for index in devices if index >= device_count]
+    if missing:
+        raise ValueError(
+            f"training.devices={list(devices)} requires CUDA device index(es) {missing}, "
+            f"but torch.cuda.device_count()={device_count}"
+        )
+
+
+def apply_dp_rank_config(cfg: Any, devices: tuple[int, ...] | None, rank: int) -> None:
+    """Rewrite per-rank device and seed into the composed Hydra config.
+
+    Rank 0 keeps the configured seed; rank i>0 trains with ``seed + i`` until
+    init broadcast lands in a later stage.
+    """
+    if devices is None:
+        return
+    if cfg.training.device is not None:
+        raise ValueError(
+            "training.device and training.devices are mutually exclusive; "
+            "use training.devices for multi-GPU data-parallel training and leave "
+            "training.device null"
+        )
+    if rank < 0 or rank >= len(devices):
+        raise ValueError(
+            f"data-parallel rank {rank} is out of range for training.devices={list(devices)}"
+        )
+    from omegaconf import open_dict
+
+    with open_dict(cfg):
+        cfg.training.device = f"cuda:{devices[rank]}"
+        cfg.algo.seed = int(cfg.algo.seed) + rank
+
+
+def _sigterm_system_exit(signum: int, _frame: Any) -> None:
+    raise SystemExit(f"data-parallel rank 0 received signal {signum}")
+
+
+class DpRankSupervisor:
+    """Rank-0 supervisor that spawns and watches data-parallel rank subprocesses.
+
+    Ranks 1..N-1 re-run ``scripts/train_offpolicy.py`` with the same Hydra
+    argv plus the ``UNILAB_DP_*`` environment; each spawned rank builds its
+    own learner+collector pair through the regular runner path. If any rank
+    subprocess dies with a non-zero exit code while active, the supervisor
+    delivers SIGTERM to rank 0 so the runner lifecycle unwinds through the
+    normal try/finally (``runner.close()``), and ``__exit__`` tears down the
+    remaining ranks.
+    """
+
+    def __init__(self, devices: tuple[int, ...], log_dir: str) -> None:
+        self._devices = tuple(devices)
+        self._log_dir = log_dir
+        self._world_size = len(self._devices)
+        self._children: list[subprocess.Popen] = []
+        self._watchdog_stop = threading.Event()
+        self._watchdog: threading.Thread | None = None
+        self._previous_sigterm_handler: Any = None
+
+    def __enter__(self) -> DpRankSupervisor:
+        if self._world_size <= 1:
+            # Single-device degenerate case: nothing to spawn or watch.
+            return self
+        base_env = os.environ | {
+            UNILAB_DP_WORLD_SIZE: str(self._world_size),
+            UNILAB_DP_DEVICES: ",".join(str(index) for index in self._devices),
+            UNILAB_DP_LOG_DIR: self._log_dir,
+        }
+        try:
+            for rank in range(1, self._world_size):
+                env = base_env | {UNILAB_DP_RANK: str(rank)}
+                self._children.append(
+                    subprocess.Popen(
+                        [sys.executable, str(_OFFPOLICY_SCRIPT), *sys.argv[1:]],
+                        env=env,
+                    )
+                )
+        except BaseException:
+            self._terminate_children()
+            raise
+        self._previous_sigterm_handler = signal.signal(signal.SIGTERM, _sigterm_system_exit)
+        self._watchdog = threading.Thread(
+            target=self._watchdog_loop,
+            name="dp-rank-watchdog",
+            daemon=True,
+        )
+        self._watchdog.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
+        self._watchdog_stop.set()
+        if self._watchdog is not None:
+            self._watchdog.join(timeout=_TERMINATE_TIMEOUT_S)
+            self._watchdog = None
+        if self._previous_sigterm_handler is not None:
+            signal.signal(signal.SIGTERM, self._previous_sigterm_handler)
+            self._previous_sigterm_handler = None
+
+        # Ranks that already exited on their own keep their exit code;
+        # non-zero means the data-parallel run failed even if rank 0 is fine.
+        failed: list[tuple[int, object]] = [
+            (rank, child.returncode)
+            for rank, child in enumerate(self._children, start=1)
+            if child.returncode is not None and child.returncode != 0
+        ]
+        if exc_type is None and not failed:
+            # Normal rank-0 completion: give sibling ranks a grace window to
+            # finish their own runs instead of cutting them short.
+            for rank, child in enumerate(self._children, start=1):
+                if child.returncode is not None:
+                    continue
+                try:
+                    child.wait(timeout=_NORMAL_EXIT_GRACE_S)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[dp_launcher] rank {rank} subprocess pid={child.pid} did not "
+                        f"exit within {_NORMAL_EXIT_GRACE_S}s of rank 0 completion",
+                        file=sys.stderr,
+                    )
+                if child.returncode != 0:
+                    failed.append(
+                        (rank, child.returncode if child.returncode is not None else "timeout")
+                    )
+        self._terminate_children()
+        if failed:
+            message = "data-parallel rank subprocess(es) failed: " + ", ".join(
+                f"rank {rank} exit code {code}" for rank, code in failed
+            )
+            if exc_type is None:
+                raise RuntimeError(message)
+            print(f"[dp_launcher] {message}", file=sys.stderr)
+        return False
+
+    def _terminate_children(self) -> None:
+        alive = [child for child in self._children if child.poll() is None]
+        for child in alive:
+            child.terminate()
+        for child in alive:
+            try:
+                child.wait(timeout=_TERMINATE_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+
+    def _watchdog_loop(self) -> None:
+        while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL_S):
+            for rank, child in enumerate(self._children, start=1):
+                exit_code = child.poll()
+                if exit_code is None:
+                    continue
+                if exit_code == 0:
+                    # A rank that finishes cleanly (e.g. while rank 0 is still
+                    # in playback) is not a failure; keep watching the rest.
+                    continue
+                print(
+                    f"[dp_launcher] rank {rank} subprocess pid={child.pid} exited "
+                    f"unexpectedly with code {exit_code}; shutting down rank 0",
+                    file=sys.stderr,
+                )
+                os.kill(os.getpid(), signal.SIGTERM)
+                return

--- a/src/unilab/ipc/dp_launcher.py
+++ b/src/unilab/ipc/dp_launcher.py
@@ -161,29 +161,33 @@ def validate_dp_launchable(devices: tuple[int, ...]) -> None:
         )
 
 
-def apply_dp_rank_config(cfg: Any, devices: tuple[int, ...] | None, rank: int) -> None:
-    """Rewrite per-rank device and seed into the composed Hydra config.
-
-    Rank 0 keeps the configured seed; rank i>0 trains with ``seed + i`` until
-    init broadcast lands in a later stage.
-    """
+def resolve_dp_rank_device(devices: tuple[int, ...] | None, rank: int) -> str | None:
+    """Return ``cuda:<index>`` for one configured rank, or None for auto selection."""
     if devices is None:
-        return
-    if cfg.training.device is not None:
-        raise ValueError(
-            "training.device and training.devices are mutually exclusive; "
-            "use training.devices for multi-GPU data-parallel training and leave "
-            "training.device null"
-        )
+        return None
     if rank < 0 or rank >= len(devices):
         raise ValueError(
             f"data-parallel rank {rank} is out of range for training.devices={list(devices)}"
         )
+    return f"cuda:{devices[rank]}"
+
+
+def apply_dp_rank_config(cfg: Any, devices: tuple[int, ...] | None, rank: int) -> str | None:
+    """Apply the per-rank seed and return this rank's explicit CUDA device.
+
+    Rank 0 keeps the configured seed; rank i>0 trains with ``seed + i`` until
+    init broadcast lands in a later stage. ``training.devices`` is the sole
+    public off-policy device field, so the resolved runtime device is returned
+    instead of being written back into a synthetic ``training.device`` key.
+    """
+    if devices is None:
+        return None
+    device = resolve_dp_rank_device(devices, rank)
     from omegaconf import open_dict
 
     with open_dict(cfg):
-        cfg.training.device = f"cuda:{devices[rank]}"
         cfg.algo.seed = int(cfg.algo.seed) + rank
+    return device
 
 
 def _sigterm_system_exit(signum: int, _frame: Any) -> None:

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -1,0 +1,128 @@
+"""Periodic parameter averaging across data-parallel ranks (torch.distributed).
+
+Multi-GPU data-parallel off-policy training runs one independent
+learner+collector pair per rank (see ``dp_launcher.py``). Ranks start from
+different initial parameters (seed = cfg.algo.seed + rank), so the runner
+broadcasts rank 0's parameters before the collector starts, then averages
+actor/critic parameters every ``dp_sync_interval`` learner iterations at the
+update boundary (never overlapping an inference tick).
+
+This module owns only the process-group lifecycle and the two collectives;
+the runner decides when to call them. Synchronization is parameter-level by
+design: gradients are never exchanged and each rank keeps its own optimizer
+state (AdamW moments diverge across ranks — see
+``FastSACLearner.dp_sync_tensors``).
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import torch
+import torch.distributed as dist
+
+
+class DpParameterSync:
+    """torch.distributed process group for DP parameter broadcast/averaging.
+
+    Both collectives mutate the given tensors **in place**: CUDA-graph capture
+    pins parameter addresses and AMP master weights stay fp32, so after an
+    in-place all-reduce every rank already holds the mean with no write-back.
+
+    The synchronization key order is frozen on the first collective
+    (``sorted(keys)``) so every rank walks the identical sequence without
+    re-sorting per call; a later call with a different key set is a bug and
+    raises ValueError.
+    """
+
+    def __init__(
+        self,
+        *,
+        world_size: int,
+        rank: int,
+        rendezvous_path: str,
+        backend: str = "nccl",
+        device: str | None = None,
+        timeout_s: int = 120,
+    ) -> None:
+        if int(world_size) < 2:
+            raise ValueError(f"DpParameterSync requires world_size >= 2, got {world_size}")
+        if not (0 <= int(rank) < int(world_size)):
+            raise ValueError(f"rank {rank} is out of range for world_size={world_size}")
+        self.world_size = int(world_size)
+        self.rank = int(rank)
+        self.rendezvous_path = str(rendezvous_path)
+        self.backend = str(backend)
+        self.device = None if device is None else torch.device(device)
+        self.timeout_s = int(timeout_s)
+        self._key_order: tuple[str, ...] | None = None
+        self._started = False
+
+    def start(self) -> None:
+        """Init the process group over a shared-file rendezvous.
+
+        The rendezvous path must be unique per run (the caller derives it
+        from the per-run log directory), so no stale FileStore state from a
+        previous run can leak in and no pre-clean is needed.
+
+        For NCCL the current CUDA device is pinned to this rank's device
+        first: ProcessGroupNCCL binds communicators to the current device,
+        and without the pin every rank defaults to cuda:0, which hangs the
+        first collective on any rank whose learner lives on another GPU.
+
+        ``NCCL_P2P_DISABLE``/``NCCL_SHM_DISABLE`` default to 1 (env override
+        wins): on hosts with broken NCCL peer transport (e.g. RTX 6000D on
+        current drivers, where P2P hangs and SHM triggers CUDA illegal
+        memory access) the TCP loopback transport is the only reliable
+        path, and it is fast enough for periodic parameter averaging.
+        """
+        if self._started:
+            return
+        if self.backend == "nccl":
+            import os
+
+            os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+            os.environ.setdefault("NCCL_SHM_DISABLE", "1")
+        if self.backend == "nccl" and self.device is not None and self.device.type == "cuda":
+            torch.cuda.set_device(self.device)
+        dist.init_process_group(
+            backend=self.backend,
+            init_method=f"file://{self.rendezvous_path}",
+            rank=self.rank,
+            world_size=self.world_size,
+            timeout=datetime.timedelta(seconds=self.timeout_s),
+        )
+        self._started = True
+
+    def broadcast_from_rank0(self, tensors: dict[str, torch.Tensor]) -> None:
+        """Overwrite every rank's tensors with rank 0's values, in place."""
+        with torch.no_grad():
+            for key in self._ordered_keys(tensors):
+                dist.broadcast(tensors[key], src=0)
+
+    def allreduce_mean(self, tensors: dict[str, torch.Tensor]) -> None:
+        """Replace every tensor with the cross-rank mean, in place."""
+        with torch.no_grad():
+            for key in self._ordered_keys(tensors):
+                tensor = tensors[key]
+                dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+                tensor.div_(self.world_size)
+
+    def close(self) -> None:
+        """Destroy the process group; idempotent and safe before start()."""
+        if not self._started:
+            return
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+        self._started = False
+
+    def _ordered_keys(self, tensors: dict[str, torch.Tensor]) -> tuple[str, ...]:
+        if self._key_order is None:
+            self._key_order = tuple(sorted(tensors))
+            return self._key_order
+        if set(tensors) != set(self._key_order):
+            raise ValueError(
+                "DpParameterSync tensor keys changed between collectives: "
+                f"expected {sorted(self._key_order)}, got {sorted(tensors)}"
+            )
+        return self._key_order

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -1,22 +1,23 @@
-"""Periodic parameter averaging across data-parallel ranks (torch.distributed).
+"""Synchronous gradient averaging across data-parallel ranks.
 
 Multi-GPU data-parallel off-policy training runs one independent
-learner+collector pair per rank (see ``dp_launcher.py``). Ranks start from
-different initial parameters (seed = cfg.algo.seed + rank), so the runner
-broadcasts rank 0's parameters before the collector starts, then averages
-actor/critic parameters every ``dp_sync_interval`` learner iterations at the
-update boundary (never overlapping an inference tick).
+learner+collector pair per rank (see ``dp_launcher.py``). The runner broadcasts
+rank 0's model state before collection starts. During steady-state training,
+each learner averages the actor/critic/temperature gradients immediately after
+``backward()`` and before clipping or ``optimizer.step()``.
 
-This module owns the process-group lifecycle, parameter collectives, and the
-small scalar reduction used by the canonical rank-0 logger. The runner decides
-when to call them. Synchronization is parameter-level by design: gradients are
-never exchanged and each rank keeps its own optimizer state (AdamW moments
-diverge across ranks — see ``FastSACLearner.dp_sync_tensors``).
+This module owns the process-group lifecycle, the startup parameter broadcast,
+flat-gradient collectives, and the small scalar reduction used by the canonical
+rank-0 logger. Optimizer state is not communicated: identical initialization
+and identical averaged gradients keep each rank's optimizer state aligned.
 """
 
 from __future__ import annotations
 
 import datetime
+import json
+import time
+from collections.abc import Iterable
 from typing import cast
 
 import torch
@@ -24,13 +25,9 @@ import torch.distributed as dist
 
 
 class DpParameterSync:
-    """torch.distributed process group for DP parameter broadcast/averaging.
+    """Process group for startup state broadcast and steady-state gradients.
 
-    Both collectives mutate the given tensors **in place**: CUDA-graph capture
-    pins parameter addresses and AMP master weights stay fp32, so after an
-    in-place all-reduce every rank already holds the mean with no write-back.
-
-    The synchronization key order is frozen on the first collective
+    The startup synchronization key order is frozen on the first collective
     (``sorted(keys)``) so every rank walks the identical sequence without
     re-sorting per call; a later call with a different key set is a bug and
     raises ValueError.
@@ -58,6 +55,8 @@ class DpParameterSync:
         self.timeout_s = int(timeout_s)
         self._key_order: tuple[str, ...] | None = None
         self._statistics_schema: dict[str, str] = {}
+        self._gradient_sync_time_sec = 0.0
+        self._gradient_sync_calls = 0
         self._started = False
 
     def start(self) -> None:
@@ -76,7 +75,7 @@ class DpParameterSync:
         wins): on hosts with broken NCCL peer transport (e.g. RTX 6000D on
         current drivers, where P2P hangs and SHM triggers CUDA illegal
         memory access) the TCP loopback transport is the only reliable
-        path, and it is fast enough for periodic parameter averaging.
+        path.
         """
         if self._started:
             return
@@ -102,13 +101,60 @@ class DpParameterSync:
             for key in self._ordered_keys(tensors):
                 dist.broadcast(tensors[key], src=0)
 
-    def allreduce_mean(self, tensors: dict[str, torch.Tensor]) -> None:
-        """Replace every tensor with the cross-rank mean, in place."""
-        with torch.no_grad():
-            for key in self._ordered_keys(tensors):
-                tensor = tensors[key]
-                dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
-                tensor.div_(self.world_size)
+    def allreduce_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
+        """Average one optimizer's gradients with one flat all-reduce.
+
+        Existing gradients are packed in parameter order, matching the manual
+        collective used by Holosoma FastSAC. All ranks must execute the same
+        optimizer graph and therefore present the same gradient layout.
+        """
+        sync_start = time.perf_counter()
+        params = [
+            parameter
+            for parameter in parameters
+            if parameter.requires_grad and parameter.grad is not None
+        ]
+        if not params:
+            raise ValueError("gradient synchronization requires at least one existing gradient")
+
+        device = params[0].device
+        dtype = params[0].dtype
+        for parameter in params:
+            if parameter.device != device or parameter.dtype != dtype:
+                raise ValueError(
+                    "one flat gradient collective requires matching parameter devices and dtypes"
+                )
+
+        gradient_numel = sum(parameter.numel() for parameter in params)
+        packed = torch.empty(gradient_numel, device=device, dtype=dtype)
+        offset = 0
+        for parameter in params:
+            width = parameter.numel()
+            gradient = parameter.grad
+            assert gradient is not None
+            packed[offset : offset + width].copy_(gradient.detach().reshape(-1))
+            offset += width
+
+        dist.all_reduce(packed, op=dist.ReduceOp.SUM)
+        packed.div_(self.world_size)
+
+        offset = 0
+        for parameter in params:
+            width = parameter.numel()
+            gradient = parameter.grad
+            assert gradient is not None
+            gradient.copy_(packed[offset : offset + width].view_as(parameter))
+            offset += width
+
+        self._gradient_sync_time_sec += time.perf_counter() - sync_start
+        self._gradient_sync_calls += 1
+
+    def take_gradient_sync_metrics(self) -> tuple[float, int]:
+        """Return and reset this rank's gradient-sync time and call count."""
+        metrics = (self._gradient_sync_time_sec, self._gradient_sync_calls)
+        self._gradient_sync_time_sec = 0.0
+        self._gradient_sync_calls = 0
+        return metrics
 
     def allreduce_statistics(
         self,
@@ -125,9 +171,8 @@ class DpParameterSync:
         exchange happens only when a new field appears; the steady-state path
         is two small collectives (schema-change flag + packed scalar reduce).
 
-        This collective is intentionally separate from parameter averaging:
-        logging is aggregated every learner iteration while model parameters
-        retain the configured ``dp_sync_interval`` semantics.
+        This collective is intentionally separate from per-optimizer gradient
+        averaging: logging is aggregated once per outer learner iteration.
         """
         mean = dict(mean or {})
         total = dict(total or {})
@@ -150,12 +195,9 @@ class DpParameterSync:
         )
         dist.all_reduce(changed_tensor, op=dist.ReduceOp.MAX)
         if bool(changed_tensor.item()):
-            gathered: list[object | None] = [None] * self.world_size
-            dist.all_gather_object(gathered, tuple(sorted(local_schema.items())))
             merged = dict(self._statistics_schema)
-            for rank_schema in gathered:
-                assert rank_schema is not None
-                for key, reduction in cast(tuple[tuple[str, str], ...], rank_schema):
+            for rank_schema in self._gather_statistics_schemas(local_schema, device=device):
+                for key, reduction in rank_schema:
                     existing = merged.get(key)
                     if existing is not None and existing != reduction:
                         raise ValueError(
@@ -190,6 +232,47 @@ class DpParameterSync:
                 value /= count
             aggregated[key] = value
         return aggregated
+
+    def _gather_statistics_schemas(
+        self,
+        local_schema: dict[str, str],
+        *,
+        device: torch.device,
+    ) -> list[tuple[tuple[str, str], ...]]:
+        """Exchange sparse logger schemas without NCCL object collectives.
+
+        ``all_gather_object`` stages pickle payloads through an NCCL all-gather.
+        That path is both unnecessary for this string-only schema and has
+        caused CUDA out-of-range-address faults on supported multi-GPU hosts.
+        Rank-ordered byte broadcasts keep the exchange deterministic and use
+        the same well-tested NCCL primitive as the startup model sync.
+        """
+        payload = json.dumps(
+            sorted(local_schema.items()),
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        local_payload = torch.tensor(list(payload), dtype=torch.uint8, device=device)
+        gathered: list[tuple[tuple[str, str], ...]] = []
+
+        for source_rank in range(self.world_size):
+            payload_size = torch.tensor(
+                [len(payload) if self.rank == source_rank else 0],
+                dtype=torch.int64,
+                device=device,
+            )
+            dist.broadcast(payload_size, src=source_rank)
+            size = int(payload_size.item())
+            rank_payload = torch.empty(size, dtype=torch.uint8, device=device)
+            if self.rank == source_rank:
+                rank_payload.copy_(local_payload)
+            dist.broadcast(rank_payload, src=source_rank)
+
+            decoded = json.loads(bytes(rank_payload.cpu().tolist()).decode("utf-8"))
+            gathered.append(
+                tuple((cast(str, key), cast(str, reduction)) for key, reduction in decoded)
+            )
+        return gathered
 
     def close(self) -> None:
         """Destroy the process group; idempotent and safe before start()."""

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -57,6 +57,8 @@ class DpParameterSync:
         self._statistics_schema: dict[str, str] = {}
         self._gradient_sync_time_sec = 0.0
         self._gradient_sync_calls = 0
+        self._gradient_buffers: dict[tuple[int, ...], torch.Tensor] = {}
+        self._cuda_graph_collective_ready = False
         self._started = False
 
     def start(self) -> None:
@@ -101,6 +103,30 @@ class DpParameterSync:
             for key in self._ordered_keys(tensors):
                 dist.broadcast(tensors[key], src=0)
 
+    def prepare_cuda_graph_collectives(self) -> None:
+        """Warm up NCCL before the first graph-captured gradient collective.
+
+        NCCL communicator and collective-specific lazy initialization must run
+        eagerly. Capturing the first all-reduce either fails at capture time or
+        produces a graph that hangs on replay with the supported TCP-loopback
+        transport. This mirrors PyTorch's c10d CUDA Graph tests: one eager
+        all-reduce followed by a device synchronize before capture.
+        """
+        if self._cuda_graph_collective_ready:
+            return
+        if not self._started:
+            raise RuntimeError("start() must run before CUDA Graph collective warmup")
+        if self.backend != "nccl" or self.device is None or self.device.type != "cuda":
+            raise RuntimeError(
+                "optimizer CUDA Graph gradient synchronization requires "
+                "an NCCL process group with an explicit CUDA device"
+            )
+
+        warmup = torch.ones(1, device=self.device)
+        dist.all_reduce(warmup, op=dist.ReduceOp.SUM)
+        torch.cuda.synchronize(self.device)
+        self._cuda_graph_collective_ready = True
+
     def allreduce_gradients(self, parameters: Iterable[torch.Tensor]) -> None:
         """Average one optimizer's gradients with one flat all-reduce.
 
@@ -126,7 +152,16 @@ class DpParameterSync:
                 )
 
         gradient_numel = sum(parameter.numel() for parameter in params)
-        packed = torch.empty(gradient_numel, device=device, dtype=dtype)
+        buffer_key = tuple(id(parameter) for parameter in params)
+        packed = self._gradient_buffers.get(buffer_key)
+        if (
+            packed is None
+            or packed.numel() != gradient_numel
+            or packed.device != device
+            or packed.dtype != dtype
+        ):
+            packed = torch.empty(gradient_numel, device=device, dtype=dtype)
+            self._gradient_buffers[buffer_key] = packed
         offset = 0
         for parameter in params:
             width = parameter.numel()
@@ -135,6 +170,11 @@ class DpParameterSync:
             packed[offset : offset + width].copy_(gradient.detach().reshape(-1))
             offset += width
 
+        capturing = device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+        if capturing and not self._cuda_graph_collective_ready:
+            raise RuntimeError(
+                "NCCL gradient capture requires prepare_cuda_graph_collectives() first"
+            )
         dist.all_reduce(packed, op=dist.ReduceOp.SUM)
         packed.div_(self.world_size)
 
@@ -146,8 +186,18 @@ class DpParameterSync:
             gradient.copy_(packed[offset : offset + width].view_as(parameter))
             offset += width
 
-        self._gradient_sync_time_sec += time.perf_counter() - sync_start
-        self._gradient_sync_calls += 1
+        # Python executes once while a CUDA Graph is captured, not on replay.
+        # Learners report replayed collectives separately so this metric counts
+        # actual executions rather than graph construction.
+        if not capturing:
+            self._gradient_sync_time_sec += time.perf_counter() - sync_start
+            self._gradient_sync_calls += 1
+
+    def record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        """Account for collectives executed by one optimizer graph replay."""
+        if collective_calls < 0:
+            raise ValueError(f"collective_calls must be >= 0, got {collective_calls}")
+        self._gradient_sync_calls += int(collective_calls)
 
     def take_gradient_sync_metrics(self) -> tuple[float, int]:
         """Return and reset this rank's gradient-sync time and call count."""
@@ -280,6 +330,8 @@ class DpParameterSync:
             return
         if dist.is_available() and dist.is_initialized():
             dist.destroy_process_group()
+        self._gradient_buffers.clear()
+        self._cuda_graph_collective_ready = False
         self._started = False
 
     def _ordered_keys(self, tensors: dict[str, torch.Tensor]) -> tuple[str, ...]:

--- a/src/unilab/ipc/dp_sync.py
+++ b/src/unilab/ipc/dp_sync.py
@@ -7,16 +7,17 @@ broadcasts rank 0's parameters before the collector starts, then averages
 actor/critic parameters every ``dp_sync_interval`` learner iterations at the
 update boundary (never overlapping an inference tick).
 
-This module owns only the process-group lifecycle and the two collectives;
-the runner decides when to call them. Synchronization is parameter-level by
-design: gradients are never exchanged and each rank keeps its own optimizer
-state (AdamW moments diverge across ranks — see
-``FastSACLearner.dp_sync_tensors``).
+This module owns the process-group lifecycle, parameter collectives, and the
+small scalar reduction used by the canonical rank-0 logger. The runner decides
+when to call them. Synchronization is parameter-level by design: gradients are
+never exchanged and each rank keeps its own optimizer state (AdamW moments
+diverge across ranks — see ``FastSACLearner.dp_sync_tensors``).
 """
 
 from __future__ import annotations
 
 import datetime
+from typing import cast
 
 import torch
 import torch.distributed as dist
@@ -56,6 +57,7 @@ class DpParameterSync:
         self.device = None if device is None else torch.device(device)
         self.timeout_s = int(timeout_s)
         self._key_order: tuple[str, ...] | None = None
+        self._statistics_schema: dict[str, str] = {}
         self._started = False
 
     def start(self) -> None:
@@ -107,6 +109,87 @@ class DpParameterSync:
                 tensor = tensors[key]
                 dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
                 tensor.div_(self.world_size)
+
+    def allreduce_statistics(
+        self,
+        *,
+        mean: dict[str, float] | None = None,
+        total: dict[str, float] | None = None,
+    ) -> dict[str, float]:
+        """Aggregate sparse scalar statistics on every rank.
+
+        ``mean`` fields are averaged over ranks that supplied the field;
+        ``total`` fields are summed. A cached union schema plus a presence mask
+        allows optional collector/reward fields to appear at different times on
+        different ranks without treating a missing value as zero. Schema
+        exchange happens only when a new field appears; the steady-state path
+        is two small collectives (schema-change flag + packed scalar reduce).
+
+        This collective is intentionally separate from parameter averaging:
+        logging is aggregated every learner iteration while model parameters
+        retain the configured ``dp_sync_interval`` semantics.
+        """
+        mean = dict(mean or {})
+        total = dict(total or {})
+        overlap = set(mean) & set(total)
+        if overlap:
+            raise ValueError(
+                f"DP statistic fields cannot be both mean and total: {sorted(overlap)}"
+            )
+
+        local_schema = {key: "mean" for key in mean}
+        local_schema.update({key: "total" for key in total})
+        schema_changed = any(
+            self._statistics_schema.get(key) != reduction for key, reduction in local_schema.items()
+        )
+        device = self.device if self.device is not None else torch.device("cpu")
+        changed_tensor = torch.tensor(
+            [int(schema_changed)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(changed_tensor, op=dist.ReduceOp.MAX)
+        if bool(changed_tensor.item()):
+            gathered: list[object | None] = [None] * self.world_size
+            dist.all_gather_object(gathered, tuple(sorted(local_schema.items())))
+            merged = dict(self._statistics_schema)
+            for rank_schema in gathered:
+                assert rank_schema is not None
+                for key, reduction in cast(tuple[tuple[str, str], ...], rank_schema):
+                    existing = merged.get(key)
+                    if existing is not None and existing != reduction:
+                        raise ValueError(
+                            f"DP statistic {key!r} changed reduction from "
+                            f"{existing!r} to {reduction!r}"
+                        )
+                    merged[key] = reduction
+            self._statistics_schema = merged
+
+        if not self._statistics_schema:
+            return {}
+
+        keys = tuple(sorted(self._statistics_schema))
+        values = mean | total
+        packed = torch.zeros((2, len(keys)), dtype=torch.float64, device=device)
+        for index, key in enumerate(keys):
+            if key not in values:
+                continue
+            packed[0, index] = float(values[key])
+            packed[1, index] = 1.0
+        dist.all_reduce(packed, op=dist.ReduceOp.SUM)
+
+        value_sums = packed[0].tolist()
+        presence_counts = packed[1].tolist()
+        aggregated: dict[str, float] = {}
+        for index, key in enumerate(keys):
+            count = float(presence_counts[index])
+            if count <= 0:
+                continue
+            value = float(value_sums[index])
+            if self._statistics_schema[key] == "mean":
+                value /= count
+            aggregated[key] = value
+        return aggregated
 
     def close(self) -> None:
         """Destroy the process group; idempotent and safe before start()."""

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -76,6 +76,7 @@ class BaseTrainingLogger:
         wandb_tags: list[str] | None,
         wandb_notes: str | None,
         refresh_per_second: int = 4,
+        fixed_terminal_refresh: bool = False,
         tensorboard_subdir: str | None = "tb",
         wandb_config: dict[str, Any] | None = None,
     ):
@@ -91,6 +92,7 @@ class BaseTrainingLogger:
         self._console = Console(force_terminal=False if not self._unicode_console else None)
         self._live: Live | None = None
         self._refresh_rate = refresh_per_second
+        self._fixed_terminal_refresh = fixed_terminal_refresh
         self._last_live_refresh_time: float | None = None
 
         self._start_time: float = 0.0
@@ -211,9 +213,10 @@ class BaseTrainingLogger:
             self._live = Live(
                 self._build_display(),
                 console=self._console,
-                auto_refresh=False,
+                auto_refresh=self._fixed_terminal_refresh,
                 refresh_per_second=self._refresh_rate,
                 transient=False,
+                get_renderable=(self._build_display if self._fixed_terminal_refresh else None),
             )
             self._live.start(refresh=False)
 
@@ -277,6 +280,8 @@ class BaseTrainingLogger:
     def _refresh(self, *, force: bool = False):
         if self._live is None:
             return
+        if self._fixed_terminal_refresh and not force:
+            return
         now = time.time()
         if not force and self._refresh_rate > 0 and self._last_live_refresh_time is not None:
             min_interval_s = 1.0 / self._refresh_rate
@@ -285,12 +290,13 @@ class BaseTrainingLogger:
         self._last_live_refresh_time = now
         self._live.update(self._build_display(), refresh=True)
 
-    def _estimate_eta(self) -> str:
-        if self._iteration <= 0:
+    def _estimate_eta(self, *, iteration: int | None = None) -> str:
+        current_iteration = self._iteration if iteration is None else iteration
+        if current_iteration <= 0:
             return ""
         elapsed = time.time() - self._start_time
-        remaining = self.max_iterations - self._iteration
-        avg_iter = elapsed / self._iteration
+        remaining = self.max_iterations - current_iteration
+        avg_iter = elapsed / current_iteration
         eta_s = remaining * avg_iter
         return _fmt_time(eta_s)
 
@@ -324,8 +330,27 @@ class BaseTrainingLogger:
         include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
     ) -> Text:
+        return self._build_compact_header_state(
+            include_status=include_status,
+            include_identity=include_identity,
+            include_iteration=include_iteration,
+            extra_fields=extra_fields,
+            ep_length=self._mean_ep_length,
+            current_iteration=self._iteration,
+        )
+
+    def _build_compact_header_state(
+        self,
+        *,
+        include_status: bool,
+        include_identity: bool,
+        include_iteration: bool,
+        extra_fields: list[tuple[str, str]] | None,
+        ep_length: float,
+        current_iteration: int,
+    ) -> Text:
         elapsed = time.time() - self._start_time if self._start_time else 0
-        eta = self._estimate_eta()
+        eta = self._estimate_eta(iteration=current_iteration)
         fields: list[tuple[str, str]] = []
         if include_identity:
             fields.extend(
@@ -335,7 +360,7 @@ class BaseTrainingLogger:
                 ]
             )
         if include_iteration:
-            fields.append((f"iter {self._iteration}/{self.max_iterations}", "yellow"))
+            fields.append((f"iter {current_iteration}/{self.max_iterations}", "yellow"))
         fields.append(
             (
                 f"{'⏱' if self._unicode_console else 'time'} {_fmt_time(elapsed)}",
@@ -344,8 +369,8 @@ class BaseTrainingLogger:
         )
         if eta:
             fields.append((f"ETA {eta}", "bold magenta"))
-        if self._mean_ep_length > 0:
-            fields.append((f"Ep Len {self._mean_ep_length:.1f}", "yellow"))
+        if ep_length > 0:
+            fields.append((f"Ep Len {ep_length:.1f}", "yellow"))
         if extra_fields:
             fields.extend(extra_fields)
         if include_status and self._status:
@@ -363,6 +388,9 @@ class BaseTrainingLogger:
         *,
         wait_message: str,
         include_ep_length: bool = True,
+        reward_history: tuple[float, ...] | None = None,
+        reward_components: dict[str, float] | None = None,
+        mean_reward: float | None = None,
     ) -> Table:
         table = Table(
             box=box.SIMPLE_HEAVY,
@@ -375,9 +403,13 @@ class BaseTrainingLogger:
         table.add_column("Rewards", style="white", width=21, no_wrap=True)
         table.add_column("Value", justify="right", ratio=2, no_wrap=True)
 
-        if self._reward_history:
-            recent = list(self._reward_history)
-            mean_rew = sum(recent[-50:]) / max(len(recent[-50:]), 1)
+        recent = list(self._reward_history if reward_history is None else reward_history)
+        if recent:
+            mean_rew = (
+                mean_reward
+                if mean_reward is not None
+                else sum(recent[-50:]) / max(len(recent[-50:]), 1)
+            )
             peak_rew = max(recent) if recent else 0
 
             if len(recent) >= 10:
@@ -403,8 +435,11 @@ class BaseTrainingLogger:
         else:
             table.add_row(wait_message, "")
 
-        if self._latest_reward_components:
-            for name, val in sorted(self._latest_reward_components.items()):
+        components = (
+            self._latest_reward_components if reward_components is None else reward_components
+        )
+        if components:
+            for name, val in sorted(components.items()):
                 display = name.replace("reward/", "").replace("_", " ")
                 color = "green" if val > 0 else "red" if val < 0 else "dim"
                 table.add_row(f"  {display}", f"[{color}]{val:+.4f}[/]")

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -221,11 +221,23 @@ class BaseTrainingLogger:
             self._live.start(refresh=False)
 
     def _stop_live(self) -> None:
-        if self._live is not None:
-            self._live.update(self._build_display(), refresh=False)
-            self._live.stop()
-            self._live = None
-            self._last_live_refresh_time = None
+        live = self._live
+        if live is None:
+            return
+
+        # Drop the owned reference first so repeated cleanup stays idempotent
+        # even if Rich's final render fails. ``Live.stop()`` normally restores
+        # the cursor itself; the explicit final call covers failures before its
+        # internal cursor-restoration block and makes Ctrl+C teardown fail-safe.
+        self._live = None
+        self._last_live_refresh_time = None
+        try:
+            live.update(self._build_display(), refresh=False)
+        finally:
+            try:
+                live.stop()
+            finally:
+                self._console.show_cursor(True)
 
     def _close_backends(self) -> None:
         if self._tb_writer:
@@ -242,9 +254,13 @@ class BaseTrainingLogger:
         """Release live terminal state and backend handles without printing a summary."""
         if self._closed:
             return
-        self._stop_live()
-        self._close_backends()
-        self._closed = True
+        try:
+            self._stop_live()
+        finally:
+            try:
+                self._close_backends()
+            finally:
+                self._closed = True
 
     def finish(self, *, title: str = "Training Summary", extra_summary: str = ""):
         if self._finished:

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -201,6 +201,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._inference_time: float = 0.0
         self._iteration_time: float | None = None
         self._throughput_steps: int = 0
+        self._steps_per_sec_override: float | None = None
+        self._samples_per_sec_override: float | None = None
         self._collector_active_steps_per_sec: float | None = None
         self._batch_size_per_rank: int = 0
         self._effective_batch_size: int = 0
@@ -254,6 +256,8 @@ class OffPolicyLogger(BaseTrainingLogger):
             self._refresh()
 
     def _get_iter_steps_per_sec(self) -> float | None:
+        if self._steps_per_sec_override is not None:
+            return self._steps_per_sec_override
         if not self._has_iteration_extra_info or self._throughput_steps <= 0:
             return None
         iter_time = self._get_iter_wall_time()
@@ -262,6 +266,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         return self._throughput_steps / iter_time
 
     def _get_effective_samples_per_sec(self) -> float | None:
+        if self._samples_per_sec_override is not None:
+            return self._samples_per_sec_override
         if not self._has_iteration_extra_info or self._learner_samples_per_iter <= 0:
             return None
         iter_time = self._get_iter_wall_time()
@@ -324,10 +330,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         header_extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
             header_extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
-        if self._collector_active_steps_per_sec is not None:
-            header_extra_fields.append(
-                (f"Collector/s {self._collector_active_steps_per_sec:,.0f}", "bold magenta")
-            )
         if effective_samples_per_sec is not None:
             header_extra_fields.append((f"Samples/s {effective_samples_per_sec:,.0f}", "bold cyan"))
         if extra_fields:
@@ -419,6 +421,14 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._has_iteration_extra_info = extra_info is not None
         if extra_info:
             self._throughput_steps = int(extra_info.get("throughput_steps", 0))
+            steps_per_sec = extra_info.get("steps_per_sec")
+            self._steps_per_sec_override = (
+                float(steps_per_sec) if steps_per_sec is not None else None
+            )
+            samples_per_sec = extra_info.get("learner_samples_per_sec")
+            self._samples_per_sec_override = (
+                float(samples_per_sec) if samples_per_sec is not None else None
+            )
             collector_active_steps_per_sec = extra_info.get("collector_active_steps_per_sec")
             self._collector_active_steps_per_sec = (
                 float(collector_active_steps_per_sec)
@@ -437,6 +447,8 @@ class OffPolicyLogger(BaseTrainingLogger):
                 self._replay_samples_per_iter = self._learner_samples_per_iter
         else:
             self._throughput_steps = 0
+            self._steps_per_sec_override = None
+            self._samples_per_sec_override = None
             self._collector_active_steps_per_sec = None
             self._batch_size_per_rank = 0
             self._effective_batch_size = 0

--- a/src/unilab/logging/offpolicy.py
+++ b/src/unilab/logging/offpolicy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import time
+from collections import deque
+from dataclasses import dataclass
 from typing import Any
 
 from rich import box
@@ -96,7 +98,6 @@ _COLLECTOR_TIMING_SPECS = {
     "env_step_update_state_ms": (2.2, "  Update State", "env_step_detail"),
     "env_step_reset_done_ms": (2.3, "  Reset Done", "env_step_detail"),
     "replay_write_ms": (3.0, "Replay Write", "cycle_phase"),
-    "bookkeeping_ms": (4.0, "Bookkeeping", "cycle_phase"),
     "rollout_ms": (9.0, "Rollout Wall", "rollout_total"),
 }
 
@@ -109,6 +110,31 @@ OFFPOLICY_ENV_STEP_DETAIL_KEYS = (
 _OFFPOLICY_COLLECTOR_CYCLE_KEYS = tuple(
     key for key, (_, _, role) in _COLLECTOR_TIMING_SPECS.items() if role == "cycle_phase"
 )
+
+_TERMINAL_AVERAGE_WINDOW_SEC = 2.0
+_TERMINAL_AVERAGE_MAX_SAMPLES = 512
+
+
+@dataclass(frozen=True)
+class _TerminalSample:
+    timestamp: float
+    scalars: dict[str, float]
+    metrics: dict[str, float]
+    reward_components: dict[str, float]
+    collector_timing: dict[str, float]
+
+
+@dataclass(frozen=True)
+class _TerminalSnapshot:
+    iteration: int
+    sample_count: int
+    scalars: dict[str, float]
+    metrics: dict[str, float]
+    reward_components: dict[str, float]
+    collector_timing: dict[str, float]
+    reward_history: tuple[float, ...]
+    buffer_size: int
+    batch_size_per_rank: int
 
 
 def _metric_backend_key(key: str) -> str:
@@ -149,7 +175,8 @@ class OffPolicyLogger(BaseTrainingLogger):
         env_name: str = "",
         obs_dim: int = 0,
         action_dim: int = 0,
-        refresh_per_second: int = 4,
+        num_gpus: int = 1,
+        refresh_per_second: int = 2,
         log_dir: str = "",
         log_backend: str = "tensorboard",
         wandb_project: str = "unilab",
@@ -176,6 +203,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             wandb_tags=wandb_tags,
             wandb_notes=wandb_notes,
             refresh_per_second=refresh_per_second,
+            fixed_terminal_refresh=True,
             tensorboard_subdir=None,
             wandb_config={
                 "obs_dim": obs_dim,
@@ -185,6 +213,9 @@ class OffPolicyLogger(BaseTrainingLogger):
         )
         self.obs_dim = obs_dim
         self.action_dim = action_dim
+        if int(num_gpus) < 1:
+            raise ValueError("num_gpus must be >= 1")
+        self.num_gpus = int(num_gpus)
         self._total_steps: int = 0
         self._buffer_size: int = 0
         self._buffer_target: int = 0
@@ -214,16 +245,14 @@ class OffPolicyLogger(BaseTrainingLogger):
             raise ValueError("timing_profile must be 'sac_family' or 'appo'")
         self._timing_profile = timing_profile
         self._timeout_rate: float = 0.0
-        self._terminated_rate: float = 0.0
         self._buffer_utilization: float = 0.0
-        self._sync_collection: bool = False
-        self._env_steps_per_sync: int = 0
         self._runtime_manifest: dict[str, Any] = {}
         self._staging_pool_len: int = 0
         self._staging_pool_max: int = 0
         self._status: str = "Initializing..."
-        self._terminal_refresh_started: bool = False
         self._training_timer_started: bool = False
+        self._terminal_samples: deque[_TerminalSample] = deque(maxlen=_TERMINAL_AVERAGE_MAX_SAMPLES)
+        self._terminal_snapshot: _TerminalSnapshot | None = None
 
     def _format_tensorboard_message(self, tb_dir: str) -> str:
         return f"[dim]TensorBoard logging to: {tb_dir}[/]"
@@ -252,8 +281,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._buffer_target = target
         pct = current / max(target, 1) * 100
         self._status = f"Buffer fill: {current:,}/{target:,} ({pct:.0f}%)"
-        if self._terminal_refresh_started:
-            self._refresh()
 
     def _get_iter_steps_per_sec(self) -> float | None:
         if self._steps_per_sec_override is not None:
@@ -310,12 +337,16 @@ class OffPolicyLogger(BaseTrainingLogger):
             return self._iteration_time
         return self._get_learner_accounted_time()
 
-    def _get_collector_cycle_ms(self) -> float | None:
+    def _get_collector_cycle_ms(
+        self,
+        collector_timing: dict[str, float] | None = None,
+    ) -> float | None:
         if self._timing_profile != "sac_family":
             return None
-        if not all(key in self._collector_timing for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS):
+        timing = self._collector_timing if collector_timing is None else collector_timing
+        if not all(key in timing for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS):
             return None
-        return sum(self._collector_timing.get(key, 0.0) for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS)
+        return sum(timing.get(key, 0.0) for key in _OFFPOLICY_COLLECTOR_CYCLE_KEYS)
 
     def _build_compact_header(
         self,
@@ -324,21 +355,115 @@ class OffPolicyLogger(BaseTrainingLogger):
         include_identity: bool = True,
         include_iteration: bool = True,
         extra_fields: list[tuple[str, str]] | None = None,
+        terminal_snapshot: _TerminalSnapshot | None = None,
     ) -> Text:
-        iter_steps_per_sec = self._get_iter_steps_per_sec()
-        effective_samples_per_sec = self._get_effective_samples_per_sec()
+        snapshot = terminal_snapshot or self._terminal_snapshot
+        iter_steps_per_sec = (
+            snapshot.scalars.get("steps_per_sec")
+            if snapshot is not None
+            else self._get_iter_steps_per_sec()
+        )
+        effective_samples_per_sec = (
+            snapshot.scalars.get("samples_per_sec")
+            if snapshot is not None
+            else self._get_effective_samples_per_sec()
+        )
         header_extra_fields: list[tuple[str, str]] = []
         if iter_steps_per_sec is not None:
             header_extra_fields.append((f"Steps/s {iter_steps_per_sec:,.0f}", "bold green"))
         if effective_samples_per_sec is not None:
             header_extra_fields.append((f"Samples/s {effective_samples_per_sec:,.0f}", "bold cyan"))
+        if snapshot is not None:
+            header_extra_fields.append(
+                (
+                    f"Avg {_TERMINAL_AVERAGE_WINDOW_SEC:g}s (n={snapshot.sample_count})",
+                    "dim",
+                )
+            )
         if extra_fields:
             header_extra_fields.extend(extra_fields)
-        return super()._build_compact_header(
+        return self._build_compact_header_state(
             include_status=include_status,
             include_identity=include_identity,
             include_iteration=include_iteration,
             extra_fields=header_extra_fields,
+            ep_length=(
+                snapshot.scalars.get("mean_ep_length", 0.0)
+                if snapshot is not None
+                else self._mean_ep_length
+            ),
+            current_iteration=(snapshot.iteration if snapshot is not None else self._iteration),
+        )
+
+    @staticmethod
+    def _mean_sample_maps(
+        samples: tuple[_TerminalSample, ...],
+        attribute: str,
+    ) -> dict[str, float]:
+        totals: dict[str, float] = {}
+        counts: dict[str, int] = {}
+        for sample in samples:
+            values = getattr(sample, attribute)
+            for key, value in values.items():
+                totals[key] = totals.get(key, 0.0) + float(value)
+                counts[key] = counts.get(key, 0) + 1
+        return {key: total / counts[key] for key, total in totals.items()}
+
+    def _record_terminal_sample(
+        self,
+        *,
+        metrics: dict[str, float] | None,
+        reward: float | None,
+        reward_components: dict[str, float] | None,
+    ) -> None:
+        """Publish one immutable, time-smoothed terminal-only state snapshot."""
+        scalars = {
+            attribute: float(getattr(self, attribute))
+            for _, _, attribute in self._learner_timing_specs()
+        }
+        scalars.update(
+            {
+                "iter_wall_time": self._get_iter_wall_time(),
+                "learner_other_time": self._get_learner_other_time(),
+                "timeout_rate": self._timeout_rate,
+            }
+        )
+        if self._mean_ep_length > 0.0:
+            scalars["mean_ep_length"] = self._mean_ep_length
+        if reward is not None:
+            scalars["reward"] = float(reward)
+        steps_per_sec = self._get_iter_steps_per_sec()
+        if steps_per_sec is not None:
+            scalars["steps_per_sec"] = steps_per_sec
+        samples_per_sec = self._get_effective_samples_per_sec()
+        if samples_per_sec is not None:
+            scalars["samples_per_sec"] = samples_per_sec
+
+        now = time.monotonic()
+        self._terminal_samples.append(
+            _TerminalSample(
+                timestamp=now,
+                scalars=scalars,
+                metrics=dict(metrics or {}),
+                reward_components=dict(reward_components or {}),
+                collector_timing=dict(self._collector_timing),
+            )
+        )
+        cutoff = now - _TERMINAL_AVERAGE_WINDOW_SEC
+        while self._terminal_samples and self._terminal_samples[0].timestamp < cutoff:
+            self._terminal_samples.popleft()
+
+        samples = tuple(self._terminal_samples)
+        self._terminal_snapshot = _TerminalSnapshot(
+            iteration=self._iteration,
+            sample_count=len(samples),
+            scalars=self._mean_sample_maps(samples, "scalars"),
+            metrics=self._mean_sample_maps(samples, "metrics"),
+            reward_components=self._mean_sample_maps(samples, "reward_components"),
+            collector_timing=self._mean_sample_maps(samples, "collector_timing"),
+            reward_history=tuple(self._reward_history),
+            buffer_size=self._buffer_size,
+            batch_size_per_rank=self._batch_size_per_rank,
         )
 
     def update_collector_timing(self, timing_ms: dict[str, float]):
@@ -346,17 +471,15 @@ class OffPolicyLogger(BaseTrainingLogger):
         legacy_action_wait = normalized.pop("inference_wait_ms", None)
         if "learner_action_wait_ms" not in normalized and legacy_action_wait is not None:
             normalized["learner_action_wait_ms"] = legacy_action_wait
-        legacy_bookkeeping = normalized.pop("sync_idle_ms", None)
-        if "bookkeeping_ms" not in normalized and legacy_bookkeeping is not None:
-            normalized["bookkeeping_ms"] = legacy_bookkeeping
+        normalized.pop("sync_idle_ms", None)
+        normalized.pop("bookkeeping_ms", None)
         self._collector_timing.update(normalized)
 
     def update_collector_active_steps_per_sec(self, steps_per_sec: float):
         self._collector_active_steps_per_sec = float(steps_per_sec)
 
-    def update_done_rates(self, timeout_rate: float, terminated_rate: float):
+    def update_timeout_rate(self, timeout_rate: float):
         self._timeout_rate = float(timeout_rate)
-        self._terminated_rate = float(terminated_rate)
 
     def update_buffer_utilization(self, utilization: float):
         self._buffer_utilization = float(utilization)
@@ -367,10 +490,6 @@ class OffPolicyLogger(BaseTrainingLogger):
     def update_staging_pool(self, current_len: int, max_size: int):
         self._staging_pool_len = current_len
         self._staging_pool_max = max_size
-
-    def set_collection_sync(self, enabled: bool, env_steps_per_sync: int = 0):
-        self._sync_collection = enabled
-        self._env_steps_per_sync = env_steps_per_sync
 
     def update_runtime_manifest(self, manifest: dict[str, Any]) -> None:
         self._runtime_manifest.update(manifest)
@@ -461,8 +580,6 @@ class OffPolicyLogger(BaseTrainingLogger):
         if reward_components:
             self._latest_reward_components = reward_components
         self._status = "Training"
-        self._terminal_refresh_started = True
-        self._refresh()
         self._backend_log_step(
             iteration,
             metrics,
@@ -470,6 +587,11 @@ class OffPolicyLogger(BaseTrainingLogger):
             reward_metrics,
             reward_components,
             train_time,
+        )
+        self._record_terminal_sample(
+            metrics=metrics,
+            reward=reward,
+            reward_components=reward_components,
         )
 
     def _backend_log_step(
@@ -512,7 +634,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             if self._mean_ep_length > 0:
                 writer.add_scalar("episode/length", self._mean_ep_length, global_step)
             writer.add_scalar("episode/timeout_rate", self._timeout_rate, global_step)
-            writer.add_scalar("episode/terminated_rate", self._terminated_rate, global_step)
             for key, value_ms in learner_timing_ms.items():
                 writer.add_scalar(key, value_ms, global_step)
             for key, value in self._collector_timing.items():
@@ -565,7 +686,6 @@ class OffPolicyLogger(BaseTrainingLogger):
             if self._mean_ep_length > 0:
                 log_dict["episode/length"] = self._mean_ep_length
             log_dict["episode/timeout_rate"] = self._timeout_rate
-            log_dict["episode/terminated_rate"] = self._terminated_rate
             log_dict.update(learner_timing_ms)
             for key, value in self._collector_timing.items():
                 log_dict[f"timing/collector_{key}"] = value
@@ -589,18 +709,18 @@ class OffPolicyLogger(BaseTrainingLogger):
         self._status = status
         if "[red]" in status or "ERROR" in status:
             self._refresh(force=True)
-        elif self._terminal_refresh_started:
-            self._refresh()
 
     def _build_display(self) -> Panel:
+        snapshot = self._terminal_snapshot
         header = self._build_compact_header(
             include_status=self._status != "Training",
             include_identity=False,
             include_iteration=False,
+            terminal_snapshot=snapshot,
         )
-        left = self._build_metrics_table()
-        right = self._build_reward_table()
-        bottom = self._build_timing_table()
+        left = self._build_metrics_table(snapshot)
+        right = self._build_reward_table(snapshot)
+        bottom = self._build_timing_table(snapshot)
         grid = Table.grid(expand=True)
         grid.add_column(ratio=1)
         grid.add_column(width=2)
@@ -615,7 +735,10 @@ class OffPolicyLogger(BaseTrainingLogger):
         title.append("|", style="dim")
         title.append(f" {self.env_name} ", style="bold white")
         title.append("|", style="dim")
-        title.append(f" iter {self._iteration}/{self.max_iterations} ", style="yellow")
+        title.append(f" GPUs {self.num_gpus} ", style="bold magenta")
+        title.append("|", style="dim")
+        iteration = snapshot.iteration if snapshot is not None else self._iteration
+        title.append(f" iter {iteration}/{self.max_iterations} ", style="yellow")
         return Panel(
             Group(header, Text(""), grid, Text(""), bottom),
             title=title,
@@ -623,7 +746,8 @@ class OffPolicyLogger(BaseTrainingLogger):
             padding=(0, 1),
         )
 
-    def _build_metrics_table(self) -> Table:
+    def _build_metrics_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         table = Table(
             box=box.SIMPLE_HEAVY,
             show_header=True,
@@ -634,27 +758,33 @@ class OffPolicyLogger(BaseTrainingLogger):
         )
         table.add_column("Losses & Metrics", style="white", ratio=2)
         table.add_column("Value", style="yellow", justify="right", ratio=1)
-        if not self._latest_metrics:
+        metrics = snapshot.metrics if snapshot is not None else self._latest_metrics
+        if not metrics:
             table.add_row("[dim]Waiting for data...[/]", "")
         else:
-            loss_keys = sorted([key for key in self._latest_metrics if "loss" in key.lower()])
-            other_keys = sorted([key for key in self._latest_metrics if "loss" not in key.lower()])
+            loss_keys = sorted([key for key in metrics if "loss" in key.lower()])
+            other_keys = sorted([key for key in metrics if "loss" not in key.lower()])
             for key in loss_keys:
-                value = self._latest_metrics[key]
+                value = metrics[key]
                 style = "red" if value > 10 else "yellow"
                 table.add_row(key.replace("_", " ").title(), f"[{style}]{_fmt_number(value)}[/]")
             for key in other_keys:
-                value = self._latest_metrics[key]
+                value = metrics[key]
                 table.add_row(f"  {key.replace('_', ' ').title()}", _fmt_number(value))
         return table
 
-    def _build_reward_table(self) -> Table:
+    def _build_reward_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         return self._build_reward_table_common(
             wait_message="[dim]Waiting for data...[/]",
             include_ep_length=False,
+            reward_history=(snapshot.reward_history if snapshot is not None else None),
+            reward_components=(snapshot.reward_components if snapshot is not None else None),
+            mean_reward=(snapshot.scalars.get("reward") if snapshot is not None else None),
         )
 
-    def _build_timing_table(self) -> Table:
+    def _build_timing_table(self, snapshot: _TerminalSnapshot | None = None) -> Table:
+        snapshot = snapshot or self._terminal_snapshot
         table = Table(
             box=box.SIMPLE_HEAVY,
             show_header=True,
@@ -670,13 +800,24 @@ class OffPolicyLogger(BaseTrainingLogger):
         table.add_column("System", style="white", ratio=4, no_wrap=True)
         table.add_column("Value", style="yellow", justify="right", width=12, no_wrap=True)
 
+        iter_wall_time = (
+            snapshot.scalars.get("iter_wall_time", self._get_iter_wall_time())
+            if snapshot is not None
+            else self._get_iter_wall_time()
+        )
+
+        def _scalar(attribute: str, fallback: float) -> float:
+            if snapshot is None:
+                return fallback
+            return snapshot.scalars.get(attribute, fallback)
+
         def _fmt_phase(seconds: float, *, color: str | None = None) -> str:
             ms = seconds * 1000
-            pct = self._get_iter_pct(seconds)
+            pct = seconds / iter_wall_time * 100.0 if iter_wall_time > 0.0 else 0.0
             text = f"{ms:>7.1f}ms  {pct:>3.0f}%"
             return f"[{color}]{text}[/]" if color else text
 
-        collector_wait_ms = self._collector_wait_time * 1000
+        collector_wait_ms = _scalar("_collector_wait_time", self._collector_wait_time) * 1000
         wait_color = "red" if collector_wait_ms > 1.0 else "yellow"
         phase_colors = {
             "Collector Wait": wait_color,
@@ -686,7 +827,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             (
                 label,
                 _fmt_phase(
-                    float(getattr(self, attribute)),
+                    _scalar(attribute, float(getattr(self, attribute))),
                     color=phase_colors.get(label),
                 ),
             )
@@ -695,17 +836,20 @@ class OffPolicyLogger(BaseTrainingLogger):
         learner_items.append(
             (
                 _LEARNER_OTHER_TIMING_SPEC[1],
-                _fmt_phase(self._get_learner_other_time()),
+                _fmt_phase(_scalar("learner_other_time", self._get_learner_other_time())),
             )
         )
         learner_items.append(
             (
                 _ITER_WALL_TIMING_SPEC[1],
-                f"{self._get_iter_wall_time() * 1000:>7.1f}ms  100%",
+                f"{iter_wall_time * 1000:>7.1f}ms  100%",
             )
         )
+        collector_timing = (
+            snapshot.collector_timing if snapshot is not None else self._collector_timing
+        )
         sorted_collector_timing = sorted(
-            self._collector_timing.items(),
+            collector_timing.items(),
             key=lambda item: (
                 _COLLECTOR_TIMING_SPECS.get(item[0], (float("inf"), "", ""))[0],
                 item[0],
@@ -715,7 +859,7 @@ class OffPolicyLogger(BaseTrainingLogger):
             key for key, _ in sorted_collector_timing if key in OFFPOLICY_ENV_STEP_DETAIL_KEYS
         ]
         last_env_step_detail_key = env_step_detail_keys[-1] if env_step_detail_keys else None
-        cycle_total_ms = self._get_collector_cycle_ms() or 0.0
+        cycle_total_ms = self._get_collector_cycle_ms(collector_timing) or 0.0
         collector_items: list[tuple[str, str]] = []
         for key, value in sorted_collector_timing:
             _, label, role = _COLLECTOR_TIMING_SPECS.get(
@@ -742,44 +886,18 @@ class OffPolicyLogger(BaseTrainingLogger):
                 pct = value / cycle_total_ms * 100.0
                 value_text = f"{value:>7.1f}ms  {pct:>3.0f}%"
             collector_items.append((label, value_text))
+        buffer_size = snapshot.buffer_size if snapshot is not None else self._buffer_size
+        timeout_rate = _scalar("timeout_rate", self._timeout_rate)
+        batch_size_per_rank = (
+            snapshot.batch_size_per_rank if snapshot is not None else self._batch_size_per_rank
+        )
         system_items = [
-            ("Buffer", f"{self._buffer_size:,}"),
+            ("Buffer", f"{buffer_size:,}"),
+            ("Timeout Rate", f"{timeout_rate * 100:.1f}%"),
         ]
-        system_items.extend(
-            [
-                ("Timeout Rate", f"{self._timeout_rate * 100:.1f}%"),
-                ("Terminated Rate", f"{self._terminated_rate * 100:.1f}%"),
-            ]
-        )
         system_items.append(("Envs", f"{self.num_envs:,}"))
-        if self._batch_size_per_rank > 0:
-            system_items.append(("Batch/Rank", f"{self._batch_size_per_rank:,}"))
-        if (
-            self._effective_batch_size > 0
-            and self._effective_batch_size != self._batch_size_per_rank
-        ):
-            system_items.append(("Batch/Update", f"{self._effective_batch_size:,}"))
-        if (
-            self._replay_samples_per_iter > 0
-            and self._replay_samples_per_iter != self._learner_samples_per_iter
-        ):
-            system_items.append(("Replay/Iter", f"{self._replay_samples_per_iter:,}"))
-        if self._learner_samples_per_iter > 0:
-            system_items.append(("Samples/Iter", f"{self._learner_samples_per_iter:,}"))
-        yes_mark = "✓" if self._unicode_console else "yes"
-        no_mark = "✗" if self._unicode_console else "no"
-        sync_collect = (
-            f"{yes_mark} ({self._env_steps_per_sync})" if self._sync_collection else no_mark
-        )
-        system_items.append(("Sync Collect", sync_collect))
-        if self._staging_pool_max > 0:
-            staging_color = "green" if self._staging_pool_len < self._staging_pool_max else "yellow"
-            system_items.append(
-                (
-                    "Staging Pool",
-                    f"[{staging_color}]{self._staging_pool_len}/{self._staging_pool_max}[/]",
-                )
-            )
+        if batch_size_per_rank > 0:
+            system_items.append(("Batch/Rank", f"{batch_size_per_rank:,}"))
         row_count = max(len(learner_items), len(collector_items), len(system_items))
         for index in range(row_count):
             row: list[str] = []

--- a/src/unilab/training/rsl_rl.py
+++ b/src/unilab/training/rsl_rl.py
@@ -2,16 +2,109 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any
 
 import numpy as np
 import torch
+from omegaconf import open_dict
 from tensordict import TensorDict
 
 from unilab.base.final_observation import resolve_terminal_observation_contract
 from unilab.base.np_env import NpEnvState
 from unilab.utils.tensor import to_numpy, to_torch
+
+
+def apply_rsl_rl_rank_seed(cfg: Any, rank: int) -> int:
+    """Apply RSL-RL's ``base seed + global rank`` data-parallel contract."""
+    if rank < 0:
+        raise ValueError(f"rank must be non-negative, got {rank}")
+    base_seed = int(cfg.algo.seed)
+    with open_dict(cfg):
+        cfg.algo.seed = base_seed + int(rank)
+    return int(cfg.algo.seed)
+
+
+def resolve_rsl_rl_device(
+    *,
+    configured_device: str | None,
+    devices: tuple[int, ...] | None,
+    world_size: int,
+    local_rank: int,
+    default_device: str,
+) -> str:
+    """Resolve the exact device string expected by RSL-RL's runner.
+
+    Integrated multi-GPU workers see the selected physical devices through a
+    remapped ``CUDA_VISIBLE_DEVICES`` list, so RSL-RL must receive
+    ``cuda:LOCAL_RANK`` rather than the original host-global device index.
+    """
+    if configured_device is not None and devices is not None:
+        raise ValueError("Set either training.device or training.devices, not both")
+    if world_size < 1:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    if local_rank < 0 or local_rank >= world_size:
+        raise ValueError(f"local_rank={local_rank} is out of range for world_size={world_size}")
+    if world_size > 1:
+        if configured_device is not None:
+            raise ValueError(
+                "training.device cannot select one device in a distributed run; "
+                "use training.devices"
+            )
+        if devices is not None and len(devices) != world_size:
+            raise ValueError(
+                f"training.devices has {len(devices)} entries but WORLD_SIZE={world_size}"
+            )
+        return f"cuda:{local_rank}"
+    if devices is not None:
+        return f"cuda:{devices[0]}"
+    return configured_device or default_device
+
+
+def ppo_samples_per_iteration(*, num_envs: int, num_steps_per_env: int, world_size: int) -> int:
+    """Return the global fresh rollout sample count for one PPO iteration."""
+    return int(num_envs) * int(num_steps_per_env) * int(world_size)
+
+
+def finish_rsl_rl_distributed(*, training_succeeded: bool) -> None:
+    """Synchronize successful ranks and release RSL-RL's process group."""
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return
+    try:
+        if training_succeeded:
+            torch.distributed.barrier()
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@contextmanager
+def rsl_rl_single_process_topology() -> Iterator[None]:
+    """Temporarily hide torchrun's worker topology from rank-0-only work.
+
+    Destroying a process group does not clear ``WORLD_SIZE`` / ``RANK`` /
+    ``LOCAL_RANK``. RSL-RL would therefore initialize a second distributed
+    group when rank 0 constructs a fresh runner for post-training playback,
+    even though every other rank has already exited. Present the playback
+    scope as a single-process runtime, then restore launcher-owned variables.
+    """
+    single_process_topology = {
+        "WORLD_SIZE": "1",
+        "RANK": "0",
+        "LOCAL_RANK": "0",
+    }
+    previous = {name: os.environ.get(name) for name in single_process_topology}
+    os.environ.update(single_process_topology)
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def get_policy_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -33,19 +33,19 @@ def _offpolicy_cfg(overrides: list[str] | None = None):
     normalized: list[str] = []
     algo = "sac"
     task_selected = False
-    device_selected = False
+    devices_selected = False
     for override in overrides or []:
         if override.startswith("algo="):
             algo = override.split("=", 1)[1]
         elif override.startswith("task="):
             task_selected = True
-        elif override.startswith("training.device="):
-            device_selected = True
+        elif override.startswith("training.devices="):
+            devices_selected = True
         normalized.append(override)
     if not task_selected:
         normalized.append(f"task={algo}/g1_walk_flat/mujoco")
-    if not device_selected:
-        normalized.append("training.device=cuda")
+    if not devices_selected:
+        normalized.append("training.devices=[0]")
     with initialize_config_dir(config_dir=str(_CONF_DIR / "offpolicy"), version_base="1.3"):
         return compose("config", overrides=normalized, return_hydra_config=True)
 
@@ -110,6 +110,7 @@ def test_hora_uses_same_learner_inference_path():
         "training.num_gpus=2",
         "training.multi_gpu_sync_mode=sync_sgd",
         "training.multi_gpu_sync_interval=2",
+        "training.device=cuda",
         "training.inference_owner=collector",
         "training.collector_infer_device=cpu",
         "training.no_sync_collection=true",
@@ -130,13 +131,13 @@ def test_non_one_tick_prefetch_is_rejected_before_dispatch(mode: str):
 
 @pytest.mark.parametrize("algo", ["sac", "td3", "flashsac"])
 @pytest.mark.parametrize("device", ["cpu", "xpu"])
-def test_unsupported_training_device_fails_before_env_materialization(
+def test_non_cuda_training_devices_fail_before_env_materialization(
     monkeypatch: pytest.MonkeyPatch,
     algo: str,
     device: str,
 ):
     module = _offpolicy()
-    cfg = _offpolicy_cfg([f"algo={algo}", f"training.device={device}"])
+    cfg = _offpolicy_cfg([f"algo={algo}", f"training.devices=[{device}]"])
     env_calls = 0
 
     def reject_env(*args, **kwargs):
@@ -146,7 +147,7 @@ def test_unsupported_training_device_fails_before_env_materialization(
         raise AssertionError("unsupported replay device must fail before env creation")
 
     monkeypatch.setattr(module, "create_env", reject_env)
-    with pytest.raises(ValueError, match="CUDA or MPS learner device"):
+    with pytest.raises(ValueError, match="training.devices entries"):
         module.build_runner(algo, cfg)
     assert env_calls == 0
 
@@ -166,7 +167,7 @@ def test_sac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     runner = module.build_runner("sac", cfg)
     assert isinstance(runner, _FakeRunner)
     assert runner.kwargs["algo_type"] == "sac"
-    assert runner.kwargs["device"] == "cuda"
+    assert runner.kwargs["device"] == "cuda:0"
     assert runner.kwargs["replay_prefetch_mode"] == "one_tick"
     assert "inference_owner" not in runner.kwargs
     assert "collector_infer_device" not in runner.kwargs
@@ -190,7 +191,7 @@ def test_td3_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     runner = module.build_runner("td3", cfg)
     assert isinstance(runner, _FakeRunner)
     assert runner.kwargs["algo_type"] == "td3"
-    assert runner.kwargs["device"] == "cuda"
+    assert runner.kwargs["device"] == "cuda:0"
     assert "inference_owner" not in runner.kwargs
     assert "collector_infer_device" not in runner.kwargs
     assert "sync_collection" not in runner.kwargs
@@ -211,7 +212,7 @@ def test_flashsac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPa
     runner = module.build_runner("flashsac", cfg)
     assert isinstance(runner, _FakeRunner)
     assert runner.kwargs["algo_type"] == "flashsac"
-    assert runner.kwargs["device"] == "cuda"
+    assert runner.kwargs["device"] == "cuda:0"
     assert runner.kwargs["replay_prefetch_mode"] == "one_tick"
     assert "inference_owner" not in runner.kwargs
     assert "collector_infer_device" not in runner.kwargs

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -13,6 +13,8 @@ from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from hydra.errors import ConfigCompositionException
 
+from unilab.ipc.dp_launcher import UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
+
 _ROOT = Path(__file__).parent.parent.parent
 _CONF_DIR = _ROOT / "conf"
 
@@ -237,3 +239,121 @@ def test_inference_response_detects_dead_collector():
 
     with pytest.raises(RuntimeError, match="collector dead"):
         runner._publish_inference_response(full_queue, timeout=0.01)
+
+
+def _build_sac_runner_with_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: list[str],
+    *,
+    cpu_count: int = 128,
+):
+    """build_runner("sac", ...) with learner/env/runner fakes; returns captured state."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    probe_env_calls: list[dict] = []
+
+    def fake_create_env(*args, **kwargs):
+        del args
+        probe_env_calls.append(kwargs)
+        return _FakeEnv()
+
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", fake_create_env)
+    monkeypatch.setattr(module.os, "cpu_count", lambda: cpu_count)
+
+    import unilab.algos.torch.fast_sac.learner as learner_module
+    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+
+    monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+
+    runner = module.build_runner("sac", cfg)
+    return runner, probe_env_calls
+
+
+def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.MonkeyPatch):
+    # Spawned rank: rank comes from the env, world_size from training.devices.
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        cpu_count=128,
+    )
+    assert runner.kwargs["collector_cpu_ids"] == list(range(64, 128))
+    # The thread budget is resolved against the rank's CPU share, not the host.
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 64
+    # The num_envs=1 probe env must never see cpu_ids (it would size its
+    # MuJoCo BatchEnvPool worker count from len(cpu_ids)).
+    assert probe_env_calls
+    for call in probe_env_calls:
+        override = call.get("env_cfg_override") or {}
+        assert "cpu_ids" not in override
+
+
+def test_build_runner_rank_zero_partitions_without_dp_env(monkeypatch: pytest.MonkeyPatch):
+    # Rank 0 carries no UNILAB_DP_* env; world_size must come from the config.
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    runner, _ = _build_sac_runner_with_fakes(
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+        cpu_count=128,
+    )
+    assert runner.kwargs["collector_cpu_ids"] == list(range(0, 64))
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 64
+
+
+def test_build_runner_single_rank_keeps_collector_cpus_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch, ["algo=sac", "algo.use_symmetry=false"], cpu_count=128
+    )
+    assert runner.kwargs["collector_cpu_ids"] is None
+    # Single-rank thread budget still resolves against the full host.
+    assert runner.kwargs["torch_thread_runtime"]["cpu_count"] == 128
+    override = runner.kwargs["env_cfg_override"] or {}
+    assert "cpu_ids" not in override
+    for call in probe_env_calls:
+        assert "cpu_ids" not in (call.get("env_cfg_override") or {})
+
+
+def test_build_runner_explicit_dp_collector_cpu_ids(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "0")
+    runner, probe_env_calls = _build_sac_runner_with_fakes(
+        monkeypatch,
+        [
+            "algo=sac",
+            "algo.use_symmetry=false",
+            "training.devices=[0,1]",
+            "training.dp_collector_cpu_ids=[[0,1],[2,3]]",
+        ],
+        cpu_count=128,
+    )
+    assert runner.kwargs["collector_cpu_ids"] == [0, 1]
+    for call in probe_env_calls:
+        assert "cpu_ids" not in (call.get("env_cfg_override") or {})
+
+
+def test_collector_env_cfg_override_merges_cpu_ids_without_mutating_base():
+    runner = _bare_runner()
+    base = {"reward_config": {"x": 1}}
+    runner.env_cfg_override = base
+    runner.collector_cpu_ids = [0, 1]
+    merged = runner._collector_env_cfg_override()
+    assert merged == {"reward_config": {"x": 1}, "cpu_ids": [0, 1]}
+    assert "cpu_ids" not in base
+
+
+def test_collector_env_cfg_override_without_cpu_ids_passes_through():
+    runner = _bare_runner()
+    runner.env_cfg_override = {"a": 1}
+    runner.collector_cpu_ids = None
+    assert runner._collector_env_cfg_override() is runner.env_cfg_override
+
+
+def test_collector_env_cfg_override_from_none_base():
+    runner = _bare_runner()
+    runner.env_cfg_override = None
+    runner.collector_cpu_ids = [4, 5]
+    assert runner._collector_env_cfg_override() == {"cpu_ids": [4, 5]}

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -13,7 +13,7 @@ from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from hydra.errors import ConfigCompositionException
 
-from unilab.ipc.dp_launcher import UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
+from unilab.ipc.dp_launcher import UNILAB_DP_LOG_DIR, UNILAB_DP_RANK, UNILAB_DP_WORLD_SIZE
 
 _ROOT = Path(__file__).parent.parent.parent
 _CONF_DIR = _ROOT / "conf"
@@ -267,13 +267,14 @@ def _build_sac_runner_with_fakes(
     monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
     monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
 
-    runner = module.build_runner("sac", cfg)
+    runner = module.build_runner("sac", cfg, log_dir="/tmp/offpolicy_test_run")
     return runner, probe_env_calls
 
 
 def test_build_runner_partitions_collector_cpus_per_rank(monkeypatch: pytest.MonkeyPatch):
     # Spawned rank: rank comes from the env, world_size from training.devices.
     monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/offpolicy_test_run")
     runner, probe_env_calls = _build_sac_runner_with_fakes(
         monkeypatch,
         ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -161,6 +161,46 @@ def test_close_closes_dp_sync_idempotently():
     assert [name for name, _ in dp_sync.calls] == ["close", "close"]
 
 
+def test_close_restores_terminal_and_ipc_before_destroying_process_group(monkeypatch):
+    from unilab.algos.torch.offpolicy.runner import OffPolicyRunner
+
+    events: list[str] = []
+
+    class _GraphLearner(_SyncLearner):
+        def release_cuda_graphs(self) -> None:
+            events.append("release_cuda_graphs")
+
+    class _OrderedDpSync(_FakeDpSync):
+        def close(self) -> None:
+            events.append("dp_sync.close")
+
+    learner = _GraphLearner()
+    learner.dp_cuda_graph_gradient_sync = True
+    runner = _runner_with(learner, _OrderedDpSync())
+    monkeypatch.setattr(OffPolicyRunner, "close", lambda self: events.append("runner.close"))
+
+    runner.close()
+
+    assert events == ["runner.close", "release_cuda_graphs", "dp_sync.close"]
+
+
+def test_close_still_destroys_process_group_when_local_cleanup_fails(monkeypatch):
+    from unilab.algos.torch.offpolicy.runner import OffPolicyRunner
+
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(_SyncLearner(), dp_sync)
+
+    def fail_local_cleanup(self) -> None:
+        raise RuntimeError("local cleanup failed")
+
+    monkeypatch.setattr(OffPolicyRunner, "close", fail_local_cleanup)
+
+    with pytest.raises(RuntimeError, match="local cleanup failed"):
+        runner.close()
+
+    assert [name for name, _ in dp_sync.calls] == ["close"]
+
+
 def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
     from unilab.logging import OffPolicyLogger
 

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -1,0 +1,264 @@
+"""Runner/build_runner integration tests for DP parameter sync (CPU-only)."""
+
+from __future__ import annotations
+
+import inspect
+from collections import defaultdict
+
+import pytest
+import torch
+
+from tests.algos.test_offpolicy_double_buffer_runner import (
+    _FakeEnv,
+    _FakeRunner,
+    _offpolicy,
+    _offpolicy_cfg,
+)
+from unilab.ipc.dp_launcher import UNILAB_DP_LOG_DIR, UNILAB_DP_RANK
+from unilab.ipc.dp_sync import DpParameterSync
+
+
+def _bare_runner():
+    from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+
+    return object.__new__(DoubleBufferOffPolicyRunner)
+
+
+class _SyncLearner:
+    def __init__(self) -> None:
+        self.tensors = {
+            "actor.w": torch.ones(2),
+            "qnet.w": torch.full((2,), 2.0),
+        }
+
+    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+        return self.tensors
+
+
+class _NoSyncLearner:
+    pass
+
+
+class _FakeDpSync:
+    def __init__(self) -> None:
+        self.world_size = 2
+        self.backend = "gloo"
+        self.calls: list[tuple[str, object]] = []
+
+    def start(self) -> None:
+        self.calls.append(("start", None))
+
+    def broadcast_from_rank0(self, tensors) -> None:
+        self.calls.append(("broadcast_from_rank0", tensors))
+
+    def allreduce_mean(self, tensors) -> None:
+        self.calls.append(("allreduce_mean", tensors))
+
+    def close(self) -> None:
+        self.calls.append(("close", None))
+
+
+def _runner_with(learner, dp_sync, interval: int = 2):
+    runner = _bare_runner()
+    runner.learner = learner
+    runner.dp_sync = dp_sync
+    runner.dp_sync_interval = interval
+    return runner
+
+
+def test_maybe_dp_sync_allreduces_on_interval_boundary():
+    learner = _SyncLearner()
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync, interval=2)
+    metrics = defaultdict(list)
+
+    runner._maybe_dp_sync(1, metrics)
+    assert dp_sync.calls == []
+    assert "dp_sync_time" not in metrics
+
+    runner._maybe_dp_sync(2, metrics)
+    assert [name for name, _ in dp_sync.calls] == ["allreduce_mean"]
+    # The collectives receive the learner's live tensor references.
+    assert dp_sync.calls[0][1] is learner.tensors
+    assert len(metrics["dp_sync_time"]) == 1
+    assert metrics["dp_sync_time"][0] >= 0.0
+
+
+def test_maybe_dp_sync_skips_everything_without_dp_sync():
+    runner = _runner_with(_SyncLearner(), None, interval=1)
+    metrics = defaultdict(list)
+    runner._maybe_dp_sync(4, metrics)
+    assert metrics == {}
+
+
+def test_dp_init_broadcast_starts_group_then_broadcasts():
+    learner = _SyncLearner()
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync)
+    runner._dp_init_broadcast()
+    assert [name for name, _ in dp_sync.calls] == ["start", "broadcast_from_rank0"]
+    assert dp_sync.calls[1][1] is learner.tensors
+
+
+def test_dp_init_broadcast_is_a_noop_without_dp_sync():
+    runner = _runner_with(_SyncLearner(), None)
+    runner._dp_init_broadcast()  # must not touch the learner
+
+
+def test_learner_without_dp_sync_tensors_fails_with_type_error():
+    runner = _runner_with(_NoSyncLearner(), _FakeDpSync())
+    with pytest.raises(TypeError, match="dp_sync_tensors"):
+        runner._dp_init_broadcast()
+
+
+def test_close_closes_dp_sync_idempotently():
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(_SyncLearner(), dp_sync)
+    # Avoid the full AsyncRunner.close(); only the dp_sync branch is under test.
+    runner.dp_sync.close()
+    runner.dp_sync.close()
+    assert [name for name, _ in dp_sync.calls] == ["close", "close"]
+
+
+def test_learn_source_orders_sync_around_collector_and_logging():
+    """Structural contract: init broadcast precedes collector startup, and the
+    periodic all-reduce sits at the update boundary before log_step."""
+    from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+
+    source = inspect.getsource(DoubleBufferOffPolicyRunner.learn)
+    assert source.index("self._dp_init_broadcast()") < source.index("self._start_collector(")
+    assert (
+        source.index("inference_scheduler.finish_update()")
+        < source.index("self._maybe_dp_sync(iteration, iter_metrics)")
+        < source.index("logger.log_step(")
+    )
+
+
+# ---- FastSACLearner.dp_sync_tensors contract ----
+
+
+def test_fast_sac_dp_sync_tensors_returns_live_references():
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=False,
+        max_grad_norm=0.0,
+    )
+    tensors = learner.dp_sync_tensors()
+
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("qnet", learner.qnet),
+        ("qnet_target", learner.qnet_target),
+    ):
+        state = module.state_dict()
+        assert state, prefix
+        for key, value in state.items():
+            full_key = f"{prefix}.{key}"
+            assert full_key in tensors
+            # Live references, not copies: same storage as the module state.
+            assert tensors[full_key].data_ptr() == value.data_ptr()
+    assert tensors["log_alpha"] is learner.log_alpha
+
+    # In-place collective semantics propagate into the module parameters.
+    probe_key = next(key for key in tensors if key.startswith("actor."))
+    with torch.no_grad():
+        tensors[probe_key].mul_(0.0)
+    assert torch.all(tensors[probe_key] == 0.0)
+
+
+# ---- build_runner assembly ----
+
+
+def _build_sac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: list[str]):
+    """build_runner("sac", ...) with learner/env/runner fakes; returns runner kwargs."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
+
+    import unilab.algos.torch.fast_sac.learner as learner_module
+    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+
+    class _Learner:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    monkeypatch.setattr(learner_module, "FastSACLearner", _Learner)
+    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    runner = module.build_runner("sac", cfg, log_dir="/tmp/dp_sync_test_run")
+    return runner.kwargs
+
+
+def test_offpolicy_config_dp_sync_interval_defaults_to_eight():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.dp_sync_interval == 8
+
+
+def test_build_runner_rejects_invalid_dp_sync_interval():
+    cfg = _offpolicy_cfg(["algo=sac", "training.dp_sync_interval=0"])
+    with pytest.raises(ValueError, match="dp_sync_interval"):
+        _offpolicy().build_runner("sac", cfg)
+
+
+def test_build_runner_single_rank_keeps_dp_sync_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    kwargs = _build_sac_runner_with_dp_fakes(monkeypatch, ["algo=sac", "algo.use_symmetry=false"])
+    assert kwargs["dp_sync"] is None
+    assert kwargs["dp_sync_interval"] == 8
+
+
+def test_build_runner_multi_gpu_constructs_dp_sync_for_rank0(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    kwargs = _build_sac_runner_with_dp_fakes(
+        monkeypatch,
+        [
+            "algo=sac",
+            "algo.use_symmetry=false",
+            "training.devices=[0,1]",
+            "training.dp_sync_interval=4",
+        ],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.world_size == 2
+    assert dp_sync.rank == 0
+    assert dp_sync.backend == "nccl"
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
+    assert kwargs["dp_sync_interval"] == 4
+
+
+def test_build_runner_spawned_rank_uses_shared_run_root(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/dp_sync_shared_root")
+    kwargs = _build_sac_runner_with_dp_fakes(
+        monkeypatch,
+        ["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.rank == 1
+    # Spawned ranks rendezvous on rank 0's run root, not their rank sub-dir.
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_shared_root/.dp_rendezvous"
+
+
+def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.MonkeyPatch):
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=false", "training.devices=[0,1]"])
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    monkeypatch.setattr(module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    with pytest.raises(ValueError, match="log_dir"):
+        module.build_runner("sac", cfg)

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -42,6 +42,7 @@ class _NoSyncLearner:
 class _FakeDpSync:
     def __init__(self) -> None:
         self.world_size = 2
+        self.rank = 0
         self.backend = "gloo"
         self.calls: list[tuple[str, object]] = []
 
@@ -53,6 +54,13 @@ class _FakeDpSync:
 
     def allreduce_mean(self, tensors) -> None:
         self.calls.append(("allreduce_mean", tensors))
+
+    def allreduce_statistics(self, *, mean=None, total=None):
+        self.calls.append(("allreduce_statistics", {"mean": mean, "total": total}))
+        return {
+            **(mean or {}),
+            **{key: value * self.world_size for key, value in (total or {}).items()},
+        }
 
     def close(self) -> None:
         self.calls.append(("close", None))
@@ -118,6 +126,86 @@ def test_close_closes_dp_sync_idempotently():
     runner.dp_sync.close()
     runner.dp_sync.close()
     assert [name for name, _ in dp_sync.calls] == ["close", "close"]
+
+
+def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
+    from unilab.logging import OffPolicyLogger
+
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(_SyncLearner(), dp_sync)
+    logger = OffPolicyLogger(log_backend="none")
+    logger._total_steps = 100
+    logger._buffer_size = 50
+    logger._buffer_target = 200
+    logger._collector_active_steps_per_sec = 1_000.0
+    logger._mean_ep_length = 25.0
+    logger._collector_timing = {"env_step_ms": 2.0}
+
+    payload = runner._aggregate_log_statistics(
+        logger,
+        metrics={"critic_loss": 2.0},
+        reward=3.0,
+        reward_metrics={"mean_ep100": 4.0},
+        reward_components={"reward/tracking": 5.0},
+        train_time=0.4,
+        collector_wait_time=0.1,
+        replay_batch_wait_time=0.01,
+        learner_replay_sample_time=0.02,
+        sync_coordination_time=0.03,
+        replay_ingress_h2d_submit_time=0.04,
+        inference_h2d_time=0.05,
+        inference_forward_time=0.06,
+        inference_d2h_time=0.07,
+        inference_time=0.18,
+        iteration_time=0.5,
+        extra_info={
+            "throughput_steps": 100,
+            "collector_active_steps_per_sec": 1_000.0,
+            "batch_size_per_rank": 64,
+            "effective_batch_size": 64,
+            "replay_samples_per_iter": 128,
+            "learner_samples_per_iter": 256,
+        },
+    )
+
+    assert payload["metrics"] == {"critic_loss": pytest.approx(2.0)}
+    assert payload["reward"] == pytest.approx(3.0)
+    extra_info = payload["extra_info"]
+    assert isinstance(extra_info, dict)
+    assert extra_info["steps_per_sec"] == pytest.approx(400.0)
+    assert extra_info["learner_samples_per_sec"] == pytest.approx(1_024.0)
+    assert extra_info["collector_active_steps_per_sec"] == pytest.approx(2_000.0)
+    assert extra_info["effective_batch_size"] == 128
+    assert extra_info["learner_samples_per_iter"] == 512
+    assert logger._total_steps == 200
+    assert logger._buffer_size == 100
+    assert logger._collector_timing == {"env_step_ms": pytest.approx(2.0)}
+
+    logger.log_step(iteration=1, **payload)
+    assert logger._get_iter_steps_per_sec() == pytest.approx(400.0)
+    assert logger._get_effective_samples_per_sec() == pytest.approx(1_024.0)
+    header = logger._build_compact_header(include_status=False).plain
+    assert "Steps/s 400" in header
+    assert "Samples/s 1,024" in header
+    assert "Collector/s" not in header
+    runner._restore_local_logger_statistics(logger)
+    assert logger._total_steps == 100
+    assert logger._buffer_size == 50
+    assert logger._collector_active_steps_per_sec == pytest.approx(1_000.0)
+
+
+def test_only_rank_zero_owns_terminal_and_tensorboard_backend():
+    rank0_sync = _FakeDpSync()
+    rank0 = _runner_with(_SyncLearner(), rank0_sync)
+    assert rank0._logger_backend("tensorboard") == "tensorboard"
+
+    rank1_sync = _FakeDpSync()
+    rank1_sync.rank = 1
+    rank1 = _runner_with(_SyncLearner(), rank1_sync)
+    assert rank1._logger_backend("tensorboard") == "no_print"
+
+    single = _runner_with(_SyncLearner(), None)
+    assert single._logger_backend("tensorboard") == "tensorboard"
 
 
 def test_learn_source_orders_sync_around_collector_and_logging():

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -254,7 +254,6 @@ def test_only_rank_zero_persists_checkpoint(tmp_path):
     rank1 = _runner_with(rank1_learner, rank1_sync)
     rank1_logger = _Logger()
     rank1_dir = rank0_dir / "rank1"
-    rank1_dir.mkdir()
     assert (
         rank1._save_checkpoint(
             log_dir=str(rank1_dir),
@@ -263,7 +262,7 @@ def test_only_rank_zero_persists_checkpoint(tmp_path):
         )
         is None
     )
-    assert not (rank1_dir / "model_10.pt").exists()
+    assert not rank1_dir.exists()
     assert rank1_learner.state_reads == 0
     assert rank1_logger.paths == []
 

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -31,9 +31,12 @@ class _SyncLearner:
             "qnet.w": torch.full((2,), 2.0),
         }
         self.gradient_sync = None
+        self.graph_replay_recorder = None
+        self.dp_cuda_graph_gradient_sync = False
 
-    def set_gradient_sync(self, sync) -> None:
+    def set_gradient_sync(self, sync, *, graph_replay_recorder=None) -> None:
         self.gradient_sync = sync
+        self.graph_replay_recorder = graph_replay_recorder
 
     def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         return self.tensors
@@ -58,6 +61,12 @@ class _FakeDpSync:
 
     def allreduce_gradients(self, parameters) -> None:
         self.calls.append(("allreduce_gradients", tuple(parameters)))
+
+    def record_cuda_graph_gradient_replay(self, collective_calls: int) -> None:
+        self.calls.append(("record_cuda_graph_gradient_replay", collective_calls))
+
+    def prepare_cuda_graph_collectives(self) -> None:
+        self.calls.append(("prepare_cuda_graph_collectives", None))
 
     def take_gradient_sync_metrics(self):
         self.calls.append(("take_gradient_sync_metrics", None))
@@ -92,6 +101,9 @@ def test_runner_attaches_per_optimizer_gradient_collective():
     parameter.grad = torch.full_like(parameter, 2.0)
     learner.gradient_sync((parameter,))
     assert dp_sync.calls == [("allreduce_gradients", (parameter,))]
+    assert learner.graph_replay_recorder is not None
+    learner.graph_replay_recorder(2)
+    assert dp_sync.calls[-1] == ("record_cuda_graph_gradient_replay", 2)
 
 
 def test_runner_collects_per_iteration_gradient_sync_metrics():
@@ -114,6 +126,19 @@ def test_dp_init_broadcast_starts_group_then_broadcasts():
     runner._dp_init_broadcast()
     assert [name for name, _ in dp_sync.calls] == ["start", "broadcast_from_rank0"]
     assert dp_sync.calls[1][1] is learner.tensors
+
+
+def test_dp_init_warms_nccl_collective_when_optimizer_graph_is_enabled():
+    learner = _SyncLearner()
+    learner.dp_cuda_graph_gradient_sync = True
+    dp_sync = _FakeDpSync()
+    runner = _runner_with(learner, dp_sync)
+    runner._dp_init_broadcast()
+    assert [name for name, _ in dp_sync.calls] == [
+        "start",
+        "broadcast_from_rank0",
+        "prepare_cuda_graph_collectives",
+    ]
 
 
 def test_dp_init_broadcast_is_a_noop_without_dp_sync():
@@ -141,7 +166,7 @@ def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
 
     dp_sync = _FakeDpSync()
     runner = _runner_with(_SyncLearner(), dp_sync)
-    logger = OffPolicyLogger(log_backend="none")
+    logger = OffPolicyLogger(log_backend="none", num_gpus=dp_sync.world_size)
     logger._total_steps = 100
     logger._buffer_size = 50
     logger._buffer_target = 200
@@ -196,6 +221,7 @@ def test_log_statistics_mean_scalars_and_sum_concurrent_throughput():
     assert "Steps/s 400" in header
     assert "Samples/s 1,024" in header
     assert "Collector/s" not in header
+    assert "GPUs 2" in logger._build_display().title.plain
     runner._restore_local_logger_statistics(logger)
     assert logger._total_steps == 100
     assert logger._buffer_size == 50
@@ -362,8 +388,24 @@ def test_fast_sac_syncs_each_optimizer_gradient_before_step():
     assert len(calls) == 3  # critic, alpha, actor
     assert calls[1] == (1,)
 
+    calls.clear()
+    learner._cuda_graph_critic_action_noise = torch.zeros_like(batch["actions"])
+    learner._update_critic_capture_candidate(
+        batch["critic"],
+        batch["actions"],
+        batch["rewards"],
+        batch["next_obs"],
+        batch["next_critic"],
+        batch["dones"],
+        batch["truncated"],
+    )
+    learner._cuda_graph_actor_action_noise = torch.zeros_like(batch["actions"])
+    learner._update_actor_capture_candidate(batch["obs"], batch["critic"])
+    assert len(calls) == 3  # captured critic, alpha, actor collectives
+    assert calls[1] == (1,)
 
-def test_fast_sac_gradient_sync_disables_cuda_graph_capture():
+
+def test_fast_sac_gradient_sync_preserves_cuda_graph_capture():
     from unilab.algos.torch.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
@@ -384,11 +426,11 @@ def test_fast_sac_gradient_sync_disables_cuda_graph_capture():
 
     learner.set_gradient_sync(lambda parameters: None)
 
-    assert learner.dp_cuda_graph_fallback is True
-    assert learner.use_cuda_graph_critic is False
-    assert learner.use_cuda_graph_actor is False
-    assert learner.use_cuda_graph_critic_packed_staging is False
-    assert learner.use_cuda_graph_actor_packed_staging is False
+    assert learner.dp_cuda_graph_gradient_sync is True
+    assert learner.use_cuda_graph_critic is True
+    assert learner.use_cuda_graph_actor is True
+    assert learner.use_cuda_graph_critic_packed_staging is True
+    assert learner.use_cuda_graph_actor_packed_staging is True
 
 
 # ---- build_runner assembly ----
@@ -560,8 +602,14 @@ def test_flash_sac_syncs_each_optimizer_gradient_before_step():
     assert len(calls) == 3  # critic, actor, temperature
     assert calls[-1] == (1,)
 
+    calls.clear()
+    learner._update_critic_capture_candidate(learner._prepare_critic_graph_inputs(batch))
+    learner._update_actor_capture_candidate(learner._prepare_actor_graph_inputs(batch))
+    assert len(calls) == 3  # captured critic, actor, temperature collectives
+    assert calls[-1] == (1,)
 
-def test_gradient_sync_falls_back_from_cuda_graph_to_eager_updates():
+
+def test_flash_sac_gradient_sync_preserves_cuda_graph_and_cpu_fallback_updates():
     from unilab.algos.torch.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
@@ -587,11 +635,11 @@ def test_gradient_sync_falls_back_from_cuda_graph_to_eager_updates():
         calls.append(tuple(parameter.numel() for parameter in params))
 
     learner.set_gradient_sync(record_gradients)
-    assert learner.dp_cuda_graph_fallback is True
-    assert learner.use_cuda_graph_critic is False
-    assert learner.use_cuda_graph_actor is False
-    assert learner.use_cuda_graph_critic_packed_staging is False
-    assert learner.use_cuda_graph_actor_packed_staging is False
+    assert learner.dp_cuda_graph_gradient_sync is True
+    assert learner.use_cuda_graph_critic is True
+    assert learner.use_cuda_graph_actor is True
+    assert learner.use_cuda_graph_critic_packed_staging is True
+    assert learner.use_cuda_graph_actor_packed_staging is True
     batch_size = 4
     batch = {
         "obs": torch.randn(batch_size, 4),

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -262,3 +262,124 @@ def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.Monke
     monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
     with pytest.raises(ValueError, match="log_dir"):
         module.build_runner("sac", cfg)
+
+
+# ---- FlashSACLearner.dp_sync_tensors contract ----
+
+
+def test_flash_sac_dp_sync_tensors_returns_live_references():
+    from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+
+    learner = FlashSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=6,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        actor_num_blocks=1,
+        critic_num_blocks=1,
+        num_atoms=3,
+    )
+    tensors = learner.dp_sync_tensors()
+
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("critic", learner.critic),
+        ("target_critic", learner.target_critic),
+        ("temperature", learner.temperature),
+    ):
+        state = module.state_dict()
+        assert state, prefix
+        for key, value in state.items():
+            full_key = f"{prefix}.{key}"
+            assert full_key in tensors
+            # Live references, not copies: same storage as the module state.
+            assert tensors[full_key].data_ptr() == value.data_ptr()
+
+    # Every optimizer-updated tensor is covered by the sync set.
+    for prefix, module in (
+        ("actor", learner.actor),
+        ("critic", learner.critic),
+        ("target_critic", learner.target_critic),
+        ("temperature", learner.temperature),
+    ):
+        for key, param in module.named_parameters():
+            assert f"{prefix}.{key}" in tensors
+
+    # In-place collective semantics propagate into the module parameters.
+    probe_key = next(key for key in tensors if key.startswith("actor."))
+    with torch.no_grad():
+        tensors[probe_key].mul_(0.0)
+    assert torch.all(tensors[probe_key] == 0.0)
+
+
+# ---- flashsac build_runner assembly ----
+
+
+def _build_flashsac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: list[str]):
+    """build_runner("flashsac", ...) with learner/env/runner fakes; returns runner kwargs."""
+    module = _offpolicy()
+    cfg = _offpolicy_cfg(overrides)
+    monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
+
+    import unilab.algos.torch.flash_sac.double_buffer as flash_module
+
+    monkeypatch.setattr(flash_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(flash_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+
+    class _Learner:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+    monkeypatch.setattr(flash_module, "FlashSACLearner", _Learner)
+    monkeypatch.setattr(flash_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    runner = module.build_runner("flashsac", cfg, log_dir="/tmp/dp_sync_test_run")
+    return runner.kwargs
+
+
+def test_build_runner_single_rank_flashsac_keeps_dp_sync_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    kwargs = _build_flashsac_runner_with_dp_fakes(monkeypatch, ["algo=flashsac"])
+    assert kwargs["dp_sync"] is None
+    assert kwargs["dp_sync_interval"] == 8
+    assert kwargs["collector_cpu_ids"] is None
+
+
+def test_build_runner_multi_gpu_constructs_dp_sync_for_flashsac_rank0(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
+    kwargs = _build_flashsac_runner_with_dp_fakes(
+        monkeypatch,
+        [
+            "algo=flashsac",
+            "training.devices=[0,1]",
+            "training.dp_sync_interval=4",
+        ],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.world_size == 2
+    assert dp_sync.rank == 0
+    assert dp_sync.backend == "nccl"
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
+    assert kwargs["dp_sync_interval"] == 4
+    # Rank 0 collector owns the first contiguous CPU block.
+    assert kwargs["collector_cpu_ids"] == list(range(64))
+
+
+def test_build_runner_multi_gpu_flashsac_spawned_rank(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "1")
+    monkeypatch.setenv(UNILAB_DP_LOG_DIR, "/tmp/dp_sync_shared_root")
+    kwargs = _build_flashsac_runner_with_dp_fakes(
+        monkeypatch,
+        ["algo=flashsac", "training.devices=[0,1]"],
+    )
+    dp_sync = kwargs["dp_sync"]
+    assert isinstance(dp_sync, DpParameterSync)
+    assert dp_sync.rank == 1
+    # Spawned ranks rendezvous on rank 0's run root, not their rank sub-dir.
+    assert dp_sync.rendezvous_path == "/tmp/dp_sync_shared_root/.dp_rendezvous"
+    assert kwargs["collector_cpu_ids"] == list(range(64, 128))

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -1,4 +1,4 @@
-"""Runner/build_runner integration tests for DP parameter sync (CPU-only)."""
+"""Runner/build_runner integration tests for synchronous off-policy DP."""
 
 from __future__ import annotations
 
@@ -30,8 +30,12 @@ class _SyncLearner:
             "actor.w": torch.ones(2),
             "qnet.w": torch.full((2,), 2.0),
         }
+        self.gradient_sync = None
 
-    def dp_sync_tensors(self) -> dict[str, torch.Tensor]:
+    def set_gradient_sync(self, sync) -> None:
+        self.gradient_sync = sync
+
+    def dp_initial_sync_tensors(self) -> dict[str, torch.Tensor]:
         return self.tensors
 
 
@@ -52,8 +56,12 @@ class _FakeDpSync:
     def broadcast_from_rank0(self, tensors) -> None:
         self.calls.append(("broadcast_from_rank0", tensors))
 
-    def allreduce_mean(self, tensors) -> None:
-        self.calls.append(("allreduce_mean", tensors))
+    def allreduce_gradients(self, parameters) -> None:
+        self.calls.append(("allreduce_gradients", tuple(parameters)))
+
+    def take_gradient_sync_metrics(self):
+        self.calls.append(("take_gradient_sync_metrics", None))
+        return 0.25, 3
 
     def allreduce_statistics(self, *, mean=None, total=None):
         self.calls.append(("allreduce_statistics", {"mean": mean, "total": total}))
@@ -66,37 +74,37 @@ class _FakeDpSync:
         self.calls.append(("close", None))
 
 
-def _runner_with(learner, dp_sync, interval: int = 2):
+def _runner_with(learner, dp_sync):
     runner = _bare_runner()
     runner.learner = learner
     runner.dp_sync = dp_sync
-    runner.dp_sync_interval = interval
     return runner
 
 
-def test_maybe_dp_sync_allreduces_on_interval_boundary():
+def test_runner_attaches_per_optimizer_gradient_collective():
     learner = _SyncLearner()
     dp_sync = _FakeDpSync()
-    runner = _runner_with(learner, dp_sync, interval=2)
+    runner = _runner_with(learner, dp_sync)
+    runner._attach_dp_gradient_sync()
+    assert learner.gradient_sync is not None
+
+    parameter = torch.nn.Parameter(torch.ones(2))
+    parameter.grad = torch.full_like(parameter, 2.0)
+    learner.gradient_sync((parameter,))
+    assert dp_sync.calls == [("allreduce_gradients", (parameter,))]
+
+
+def test_runner_collects_per_iteration_gradient_sync_metrics():
+    runner = _runner_with(_SyncLearner(), _FakeDpSync())
     metrics = defaultdict(list)
-
-    runner._maybe_dp_sync(1, metrics)
-    assert dp_sync.calls == []
-    assert "dp_sync_time" not in metrics
-
-    runner._maybe_dp_sync(2, metrics)
-    assert [name for name, _ in dp_sync.calls] == ["allreduce_mean"]
-    # The collectives receive the learner's live tensor references.
-    assert dp_sync.calls[0][1] is learner.tensors
-    assert len(metrics["dp_sync_time"]) == 1
-    assert metrics["dp_sync_time"][0] >= 0.0
+    runner._collect_dp_sync_metrics(metrics)
+    assert metrics == {"dp_sync_time": [0.25], "dp_gradient_sync_calls": [3.0]}
 
 
-def test_maybe_dp_sync_skips_everything_without_dp_sync():
-    runner = _runner_with(_SyncLearner(), None, interval=1)
-    metrics = defaultdict(list)
-    runner._maybe_dp_sync(4, metrics)
-    assert metrics == {}
+def test_runner_requires_gradient_sync_contract():
+    runner = _runner_with(_NoSyncLearner(), _FakeDpSync())
+    with pytest.raises(TypeError, match="set_gradient_sync"):
+        runner._attach_dp_gradient_sync()
 
 
 def test_dp_init_broadcast_starts_group_then_broadcasts():
@@ -113,9 +121,9 @@ def test_dp_init_broadcast_is_a_noop_without_dp_sync():
     runner._dp_init_broadcast()  # must not touch the learner
 
 
-def test_learner_without_dp_sync_tensors_fails_with_type_error():
+def test_learner_without_initial_sync_tensors_fails_with_type_error():
     runner = _runner_with(_NoSyncLearner(), _FakeDpSync())
-    with pytest.raises(TypeError, match="dp_sync_tensors"):
+    with pytest.raises(TypeError, match="dp_initial_sync_tensors"):
         runner._dp_init_broadcast()
 
 
@@ -208,24 +216,75 @@ def test_only_rank_zero_owns_terminal_and_tensorboard_backend():
     assert single._logger_backend("tensorboard") == "tensorboard"
 
 
+def test_only_rank_zero_persists_checkpoint(tmp_path):
+    class _CheckpointLearner:
+        def __init__(self) -> None:
+            self.state_reads = 0
+
+        def get_state_dict(self):
+            self.state_reads += 1
+            return {"weight": torch.ones(1)}
+
+    class _Logger:
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        def log_save(self, path: str) -> None:
+            self.paths.append(path)
+
+    rank0_sync = _FakeDpSync()
+    rank0_learner = _CheckpointLearner()
+    rank0 = _runner_with(rank0_learner, rank0_sync)
+    rank0_logger = _Logger()
+    rank0_dir = tmp_path / "run"
+    rank0_dir.mkdir()
+    path = rank0._save_checkpoint(
+        log_dir=str(rank0_dir),
+        iteration=10,
+        logger=rank0_logger,
+    )
+    assert path == str(rank0_dir / "model_10.pt")
+    assert (rank0_dir / "model_10.pt").is_file()
+    assert rank0_learner.state_reads == 1
+    assert rank0_logger.paths == [path]
+
+    rank1_sync = _FakeDpSync()
+    rank1_sync.rank = 1
+    rank1_learner = _CheckpointLearner()
+    rank1 = _runner_with(rank1_learner, rank1_sync)
+    rank1_logger = _Logger()
+    rank1_dir = rank0_dir / "rank1"
+    rank1_dir.mkdir()
+    assert (
+        rank1._save_checkpoint(
+            log_dir=str(rank1_dir),
+            iteration=10,
+            logger=rank1_logger,
+        )
+        is None
+    )
+    assert not (rank1_dir / "model_10.pt").exists()
+    assert rank1_learner.state_reads == 0
+    assert rank1_logger.paths == []
+
+
 def test_learn_source_orders_sync_around_collector_and_logging():
-    """Structural contract: init broadcast precedes collector startup, and the
-    periodic all-reduce sits at the update boundary before log_step."""
+    """Startup broadcast precedes collection; timing is consumed after updates."""
     from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
 
     source = inspect.getsource(DoubleBufferOffPolicyRunner.learn)
     assert source.index("self._dp_init_broadcast()") < source.index("self._start_collector(")
     assert (
         source.index("inference_scheduler.finish_update()")
-        < source.index("self._maybe_dp_sync(iteration, iter_metrics)")
+        < source.index("self._collect_dp_sync_metrics(iter_metrics)")
         < source.index("logger.log_step(")
     )
 
 
-# ---- FastSACLearner.dp_sync_tensors contract ----
+# ---- FastSACLearner distributed contracts ----
 
 
-def test_fast_sac_dp_sync_tensors_returns_live_references():
+def test_fast_sac_initial_sync_tensors_return_live_references():
     from unilab.algos.torch.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
@@ -241,7 +300,7 @@ def test_fast_sac_dp_sync_tensors_returns_live_references():
         use_autotune=False,
         max_grad_norm=0.0,
     )
-    tensors = learner.dp_sync_tensors()
+    tensors = learner.dp_initial_sync_tensors()
 
     for prefix, module in (
         ("actor", learner.actor),
@@ -262,6 +321,75 @@ def test_fast_sac_dp_sync_tensors_returns_live_references():
     with torch.no_grad():
         tensors[probe_key].mul_(0.0)
     assert torch.all(tensors[probe_key] == 0.0)
+
+
+def test_fast_sac_syncs_each_optimizer_gradient_before_step():
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+        use_autotune=True,
+    )
+    calls: list[tuple[int, ...]] = []
+
+    def record_gradients(parameters) -> None:
+        params = tuple(parameters)
+        assert params
+        assert all(parameter.grad is not None for parameter in params)
+        calls.append(tuple(parameter.numel() for parameter in params))
+
+    learner.set_gradient_sync(record_gradients)
+    batch_size = 4
+    batch = {
+        "obs": torch.randn(batch_size, 4),
+        "critic": torch.randn(batch_size, 5),
+        "actions": torch.randn(batch_size, 2).tanh(),
+        "rewards": torch.randn(batch_size),
+        "next_obs": torch.randn(batch_size, 4),
+        "next_critic": torch.randn(batch_size, 5),
+        "dones": torch.zeros(batch_size),
+        "truncated": torch.zeros(batch_size),
+    }
+    learner.update_critic(batch)
+    learner.update_actor(batch)
+    assert len(calls) == 3  # critic, alpha, actor
+    assert calls[1] == (1,)
+
+
+def test_fast_sac_gradient_sync_disables_cuda_graph_capture():
+    from unilab.algos.torch.fast_sac.learner import FastSACLearner
+
+    learner = FastSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=5,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        num_atoms=3,
+        num_q_networks=2,
+        use_layer_norm=False,
+    )
+    learner.use_cuda_graph_critic = True
+    learner.use_cuda_graph_actor = True
+    learner.use_cuda_graph_critic_packed_staging = True
+    learner.use_cuda_graph_actor_packed_staging = True
+
+    learner.set_gradient_sync(lambda parameters: None)
+
+    assert learner.dp_cuda_graph_fallback is True
+    assert learner.use_cuda_graph_critic is False
+    assert learner.use_cuda_graph_actor is False
+    assert learner.use_cuda_graph_critic_packed_staging is False
+    assert learner.use_cuda_graph_actor_packed_staging is False
 
 
 # ---- build_runner assembly ----
@@ -288,22 +416,15 @@ def _build_sac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: 
     return runner.kwargs
 
 
-def test_offpolicy_config_dp_sync_interval_defaults_to_eight():
+def test_offpolicy_config_has_no_periodic_parameter_sync_interval():
     cfg = _offpolicy_cfg()
-    assert cfg.training.dp_sync_interval == 8
-
-
-def test_build_runner_rejects_invalid_dp_sync_interval():
-    cfg = _offpolicy_cfg(["algo=sac", "training.dp_sync_interval=0"])
-    with pytest.raises(ValueError, match="dp_sync_interval"):
-        _offpolicy().build_runner("sac", cfg)
+    assert "dp_sync_interval" not in cfg.training
 
 
 def test_build_runner_single_rank_keeps_dp_sync_none(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
     kwargs = _build_sac_runner_with_dp_fakes(monkeypatch, ["algo=sac", "algo.use_symmetry=false"])
     assert kwargs["dp_sync"] is None
-    assert kwargs["dp_sync_interval"] == 8
 
 
 def test_build_runner_multi_gpu_constructs_dp_sync_for_rank0(monkeypatch: pytest.MonkeyPatch):
@@ -315,7 +436,6 @@ def test_build_runner_multi_gpu_constructs_dp_sync_for_rank0(monkeypatch: pytest
             "algo=sac",
             "algo.use_symmetry=false",
             "training.devices=[0,1]",
-            "training.dp_sync_interval=4",
         ],
     )
     dp_sync = kwargs["dp_sync"]
@@ -324,7 +444,6 @@ def test_build_runner_multi_gpu_constructs_dp_sync_for_rank0(monkeypatch: pytest
     assert dp_sync.rank == 0
     assert dp_sync.backend == "nccl"
     assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
-    assert kwargs["dp_sync_interval"] == 4
 
 
 def test_build_runner_spawned_rank_uses_shared_run_root(monkeypatch: pytest.MonkeyPatch):
@@ -352,10 +471,10 @@ def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.Monke
         module.build_runner("sac", cfg)
 
 
-# ---- FlashSACLearner.dp_sync_tensors contract ----
+# ---- FlashSACLearner distributed contracts ----
 
 
-def test_flash_sac_dp_sync_tensors_returns_live_references():
+def test_flash_sac_initial_sync_tensors_return_live_references():
     from unilab.algos.torch.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
@@ -369,7 +488,7 @@ def test_flash_sac_dp_sync_tensors_returns_live_references():
         critic_num_blocks=1,
         num_atoms=3,
     )
-    tensors = learner.dp_sync_tensors()
+    tensors = learner.dp_initial_sync_tensors()
 
     for prefix, module in (
         ("actor", learner.actor),
@@ -402,6 +521,95 @@ def test_flash_sac_dp_sync_tensors_returns_live_references():
     assert torch.all(tensors[probe_key] == 0.0)
 
 
+def test_flash_sac_syncs_each_optimizer_gradient_before_step():
+    from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+
+    learner = FlashSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=6,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        actor_num_blocks=1,
+        critic_num_blocks=1,
+        num_atoms=3,
+        normalize_reward=False,
+    )
+    calls: list[tuple[int, ...]] = []
+
+    def record_gradients(parameters) -> None:
+        params = tuple(parameters)
+        assert params
+        assert all(parameter.grad is not None for parameter in params)
+        calls.append(tuple(parameter.numel() for parameter in params))
+
+    learner.set_gradient_sync(record_gradients)
+    batch_size = 4
+    batch = {
+        "obs": torch.randn(batch_size, 4),
+        "critic": torch.randn(batch_size, 6),
+        "actions": torch.randn(batch_size, 2).tanh(),
+        "rewards": torch.randn(batch_size),
+        "next_obs": torch.randn(batch_size, 4),
+        "next_critic": torch.randn(batch_size, 6),
+        "dones": torch.zeros(batch_size),
+        "truncated": torch.zeros(batch_size),
+    }
+    learner.update_critic(batch)
+    learner.update_actor(batch)
+    assert len(calls) == 3  # critic, actor, temperature
+    assert calls[-1] == (1,)
+
+
+def test_gradient_sync_falls_back_from_cuda_graph_to_eager_updates():
+    from unilab.algos.torch.flash_sac.learner import FlashSACLearner
+
+    learner = FlashSACLearner(
+        obs_dim=4,
+        action_dim=2,
+        critic_obs_dim=6,
+        device="cpu",
+        actor_hidden_dim=8,
+        critic_hidden_dim=8,
+        actor_num_blocks=1,
+        critic_num_blocks=1,
+        num_atoms=3,
+        use_cuda_graph_critic=True,
+        use_cuda_graph_actor=True,
+        use_cuda_graph_critic_packed_staging=True,
+        use_cuda_graph_actor_packed_staging=True,
+    )
+    calls: list[tuple[int, ...]] = []
+
+    def record_gradients(parameters) -> None:
+        params = tuple(parameters)
+        assert all(parameter.grad is not None for parameter in params)
+        calls.append(tuple(parameter.numel() for parameter in params))
+
+    learner.set_gradient_sync(record_gradients)
+    assert learner.dp_cuda_graph_fallback is True
+    assert learner.use_cuda_graph_critic is False
+    assert learner.use_cuda_graph_actor is False
+    assert learner.use_cuda_graph_critic_packed_staging is False
+    assert learner.use_cuda_graph_actor_packed_staging is False
+    batch_size = 4
+    batch = {
+        "obs": torch.randn(batch_size, 4),
+        "critic": torch.randn(batch_size, 6),
+        "actions": torch.randn(batch_size, 2).tanh(),
+        "rewards": torch.randn(batch_size),
+        "next_obs": torch.randn(batch_size, 4),
+        "next_critic": torch.randn(batch_size, 6),
+        "dones": torch.zeros(batch_size),
+        "truncated": torch.zeros(batch_size),
+    }
+    learner.update_critic_cuda_graph(batch)
+    learner.update_actor_cuda_graph(batch)
+
+    assert len(calls) == 3  # critic, actor, temperature
+
+
 # ---- flashsac build_runner assembly ----
 
 
@@ -430,7 +638,6 @@ def test_build_runner_single_rank_flashsac_keeps_dp_sync_none(monkeypatch: pytes
     monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
     kwargs = _build_flashsac_runner_with_dp_fakes(monkeypatch, ["algo=flashsac"])
     assert kwargs["dp_sync"] is None
-    assert kwargs["dp_sync_interval"] == 8
     assert kwargs["collector_cpu_ids"] is None
 
 
@@ -444,7 +651,6 @@ def test_build_runner_multi_gpu_constructs_dp_sync_for_flashsac_rank0(
         [
             "algo=flashsac",
             "training.devices=[0,1]",
-            "training.dp_sync_interval=4",
         ],
     )
     dp_sync = kwargs["dp_sync"]
@@ -453,7 +659,6 @@ def test_build_runner_multi_gpu_constructs_dp_sync_for_flashsac_rank0(
     assert dp_sync.rank == 0
     assert dp_sync.backend == "nccl"
     assert dp_sync.rendezvous_path == "/tmp/dp_sync_test_run/.dp_rendezvous"
-    assert kwargs["dp_sync_interval"] == 4
     # Rank 0 collector owns the first contiguous CPU block.
     assert kwargs["collector_cpu_ids"] == list(range(64))
 

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -548,6 +548,7 @@ def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.Monke
     monkeypatch.delenv(UNILAB_DP_LOG_DIR, raising=False)
     monkeypatch.setattr(module, "ensure_registries", lambda: None)
     monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
     with pytest.raises(ValueError, match="log_dir"):
         module.build_runner("sac", cfg)
 

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -6,10 +6,11 @@ import pytest
 from rich.console import Console
 
 import unilab.logging.common as common_logger_module
+import unilab.logging.offpolicy as offpolicy_logger_module
 from unilab.logging.offpolicy import OffPolicyLogger
 
 
-def test_offpolicy_logger_defers_warmup_refresh_until_training_step(monkeypatch) -> None:
+def test_offpolicy_logger_only_forces_refresh_for_errors(monkeypatch) -> None:
     logger = OffPolicyLogger(
         algo_name="SAC",
         max_iterations=2,
@@ -44,7 +45,7 @@ def test_offpolicy_logger_defers_warmup_refresh_until_training_step(monkeypatch)
     logger.log_status("Training")
     logger.log_buffer_fill(64, 64)
 
-    assert refresh_calls == [False, False, False]
+    assert refresh_calls == []
 
 
 def test_offpolicy_logger_stop_live_lets_rich_do_final_refresh() -> None:
@@ -97,7 +98,6 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
             "env_step_update_state_ms": 1.0,
             "env_step_reset_done_ms": 0.5,
             "replay_write_ms": 0.3,
-            "bookkeeping_ms": 0.0,
         }
     )
 
@@ -137,7 +137,7 @@ def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> 
     assert len(set(connector_columns)) == 1
 
 
-def test_offpolicy_logger_normalizes_pre_contract_collector_timing_names() -> None:
+def test_offpolicy_logger_discards_retired_collector_timing_names() -> None:
     logger = OffPolicyLogger(log_backend="none")
 
     logger.update_collector_timing(
@@ -148,10 +148,7 @@ def test_offpolicy_logger_normalizes_pre_contract_collector_timing_names() -> No
         }
     )
 
-    assert logger._collector_timing == {
-        "learner_action_wait_ms": 4.0,
-        "bookkeeping_ms": 3.0,
-    }
+    assert logger._collector_timing == {"learner_action_wait_ms": 4.0}
 
 
 def test_offpolicy_logger_waits_for_complete_collector_cycle_before_percentages() -> None:
@@ -369,9 +366,102 @@ def test_offpolicy_logger_moves_identity_and_iteration_to_panel_title() -> None:
 
     assert isinstance(display.title, type(header))
     assert display.title.plain == (
-        " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | iter 5000/5000 "
+        " 🚀 UniLab Off-Policy Training | FastSAC | G1WalkFlat | GPUs 1 | iter 5000/5000 "
     )
     assert "FastSAC" not in header.plain
     assert "G1WalkFlat" not in header.plain
     assert "iter 5000/5000" not in header.plain
     assert "Training" not in header.plain
+
+
+def test_offpolicy_terminal_averages_aggregated_samples_over_two_seconds(
+    monkeypatch,
+) -> None:
+    now = 100.0
+    monkeypatch.setattr(offpolicy_logger_module.time, "monotonic", lambda: now)
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.scalars: list[tuple[str, float, int]] = []
+
+        def add_scalar(self, tag: str, value: float, step: int) -> None:
+            self.scalars.append((tag, value, step))
+
+    logger = OffPolicyLogger(log_backend="none", num_gpus=2)
+    writer = _Writer()
+    logger._tb_writer = writer
+
+    logger.update_timeout_rate(0.2)
+    logger.update_collector_timing(
+        {
+            "inference_request_ms": 1.0,
+            "learner_action_wait_ms": 2.0,
+            "env_step_ms": 3.0,
+            "replay_write_ms": 4.0,
+        }
+    )
+    logger.log_step(
+        iteration=1,
+        metrics={"critic_loss": 2.0},
+        train_time=0.2,
+        iteration_time=0.5,
+        extra_info={
+            "steps_per_sec": 400.0,
+            "learner_samples_per_sec": 1_000.0,
+        },
+    )
+
+    now = 101.0
+    logger.update_timeout_rate(0.4)
+    logger.update_collector_timing(
+        {
+            "inference_request_ms": 3.0,
+            "learner_action_wait_ms": 4.0,
+            "env_step_ms": 5.0,
+            "replay_write_ms": 6.0,
+        }
+    )
+    logger.log_step(
+        iteration=2,
+        metrics={"critic_loss": 4.0},
+        train_time=0.4,
+        iteration_time=1.0,
+        extra_info={
+            "steps_per_sec": 800.0,
+            "learner_samples_per_sec": 3_000.0,
+        },
+    )
+
+    snapshot = logger._terminal_snapshot
+    assert snapshot is not None
+    assert snapshot.sample_count == 2
+    assert snapshot.metrics["critic_loss"] == pytest.approx(3.0)
+    assert snapshot.scalars["_train_time"] == pytest.approx(0.3)
+    assert snapshot.scalars["timeout_rate"] == pytest.approx(0.3)
+    assert snapshot.scalars["steps_per_sec"] == pytest.approx(600.0)
+    assert snapshot.scalars["samples_per_sec"] == pytest.approx(2_000.0)
+    assert snapshot.collector_timing["env_step_ms"] == pytest.approx(4.0)
+    collector_values = list(logger._build_timing_table().columns[3].cells)
+    assert "    4.0ms   29%" in collector_values
+    assert "Avg 2s (n=2)" in logger._build_compact_header(include_status=False).plain
+    assert "GPUs 2" in logger._build_display().title.plain
+
+    latest_backend_values = {tag: value for tag, value, _ in writer.scalars}
+    assert latest_backend_values["train/critic_loss"] == pytest.approx(4.0)
+    assert latest_backend_values["perf/steps_per_sec"] == pytest.approx(800.0)
+
+    now = 103.1
+    logger.log_step(
+        iteration=3,
+        metrics={"critic_loss": 10.0},
+        train_time=1.0,
+        iteration_time=2.0,
+        extra_info={
+            "steps_per_sec": 1_200.0,
+            "learner_samples_per_sec": 5_000.0,
+        },
+    )
+    snapshot = logger._terminal_snapshot
+    assert snapshot is not None
+    assert snapshot.sample_count == 1
+    assert snapshot.metrics["critic_loss"] == pytest.approx(10.0)

--- a/tests/algos/test_offpolicy_logger.py
+++ b/tests/algos/test_offpolicy_logger.py
@@ -81,6 +81,35 @@ def test_offpolicy_logger_stop_live_lets_rich_do_final_refresh() -> None:
     assert logger._last_live_refresh_time is None
 
 
+def test_offpolicy_logger_close_restores_cursor_and_backends_when_rich_stop_fails(
+    monkeypatch,
+) -> None:
+    logger = OffPolicyLogger(log_backend="none")
+
+    class _FailingLive:
+        def update(self, renderable: Any, *, refresh: bool) -> None:
+            del renderable, refresh
+
+        def stop(self) -> None:
+            raise RuntimeError("final render failed")
+
+    cursor_calls: list[bool] = []
+    backend_close_calls: list[bool] = []
+    monkeypatch.setattr(logger._console, "show_cursor", cursor_calls.append)
+    monkeypatch.setattr(logger, "_close_backends", lambda: backend_close_calls.append(True))
+    logger._live = _FailingLive()  # type: ignore[assignment]
+    logger._last_live_refresh_time = 123.0
+
+    with pytest.raises(RuntimeError, match="final render failed"):
+        logger.close()
+
+    assert cursor_calls == [True]
+    assert backend_close_calls == [True]
+    assert logger._live is None
+    assert logger._last_live_refresh_time is None
+    assert logger._closed is True
+
+
 def test_offpolicy_logger_displays_env_step_breakdown_as_indented_children() -> None:
     logger = OffPolicyLogger(
         algo_name="SAC",

--- a/tests/algos/test_offpolicy_runner_unit.py
+++ b/tests/algos/test_offpolicy_runner_unit.py
@@ -18,11 +18,13 @@ from unilab.algos.torch.offpolicy.double_buffer_runner import (
     algo_display_name,
 )
 from unilab.algos.torch.offpolicy.runner import (
+    OffPolicyRunner,
     build_offpolicy_sample_info,
     compute_train_start_threshold,
     replay_buffer_ready_for_learning,
     update_reward_stats_from_replay,
 )
+from unilab.ipc.async_runner import AsyncRunner
 from unilab.ipc.inference_slot import SharedInferenceSlot
 
 
@@ -101,6 +103,34 @@ def test_scheduler_rejects_out_of_order_collector_tick() -> None:
 
     with pytest.raises(RuntimeError, match="expected 0, got 1"):
         scheduler.record_inference(1)
+
+
+def test_runner_close_releases_ipc_when_terminal_cleanup_fails(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _ConcreteOffPolicyRunner(OffPolicyRunner):
+        def learn(
+            self,
+            max_iterations: int,
+            save_interval: int = 50,
+            log_dir: str = "logs",
+        ) -> None:
+            del max_iterations, save_interval, log_dir
+
+    class _FailingLogger:
+        def close(self) -> None:
+            events.append("logger.close")
+            raise RuntimeError("terminal cleanup failed")
+
+    runner = object.__new__(_ConcreteOffPolicyRunner)
+    runner._active_logger = _FailingLogger()
+    monkeypatch.setattr(AsyncRunner, "close", lambda self: events.append("async.close"))
+
+    with pytest.raises(RuntimeError, match="terminal cleanup failed"):
+        runner.close()
+
+    assert events == ["logger.close", "async.close"]
+    assert runner._active_logger is None
 
 
 class _Symmetry:

--- a/tests/algos/test_rsl_rl_ppo.py
+++ b/tests/algos/test_rsl_rl_ppo.py
@@ -1,13 +1,111 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from typing import Any
 
+import pytest
 import torch
+from omegaconf import OmegaConf
 from tensordict import TensorDict
 
 from unilab.algos.torch.rsl_rl_ppo import FinalObservationAwarePPO
-from unilab.training.rsl_rl import RslRlVecEnvWrapper, normalize_ppo_train_cfg
+from unilab.training.rsl_rl import (
+    RslRlVecEnvWrapper,
+    apply_rsl_rl_rank_seed,
+    finish_rsl_rl_distributed,
+    normalize_ppo_train_cfg,
+    ppo_samples_per_iteration,
+    resolve_rsl_rl_device,
+    rsl_rl_single_process_topology,
+)
+
+
+def test_rsl_rl_rank_seed_uses_base_seed_plus_global_rank() -> None:
+    cfg = OmegaConf.create({"algo": {"seed": 41}})
+
+    assert apply_rsl_rl_rank_seed(cfg, rank=3) == 44
+    assert cfg.algo.seed == 44
+
+
+def test_rsl_rl_device_uses_local_rank_after_cuda_visibility_remap() -> None:
+    assert (
+        resolve_rsl_rl_device(
+            configured_device=None,
+            devices=(3, 1),
+            world_size=2,
+            local_rank=1,
+            default_device="cuda",
+        )
+        == "cuda:1"
+    )
+
+
+def test_rsl_rl_device_supports_explicit_single_device() -> None:
+    assert (
+        resolve_rsl_rl_device(
+            configured_device=None,
+            devices=(2,),
+            world_size=1,
+            local_rank=0,
+            default_device="cuda",
+        )
+        == "cuda:2"
+    )
+
+
+def test_rsl_rl_device_rejects_singular_and_plural_config() -> None:
+    with pytest.raises(ValueError, match="either training.device or training.devices"):
+        resolve_rsl_rl_device(
+            configured_device="cuda:0",
+            devices=(0, 1),
+            world_size=2,
+            local_rank=0,
+            default_device="cuda",
+        )
+
+
+def test_ppo_samples_per_iteration_uses_per_rank_num_envs() -> None:
+    assert ppo_samples_per_iteration(num_envs=1024, num_steps_per_env=24, world_size=2) == 49152
+
+
+def test_finish_rsl_rl_distributed_barriers_only_after_success(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: calls.append("barrier"))
+    monkeypatch.setattr(torch.distributed, "destroy_process_group", lambda: calls.append("destroy"))
+
+    finish_rsl_rl_distributed(training_succeeded=True)
+
+    assert calls == ["barrier", "destroy"]
+
+
+def test_finish_rsl_rl_distributed_failure_skips_barrier(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: calls.append("barrier"))
+    monkeypatch.setattr(torch.distributed, "destroy_process_group", lambda: calls.append("destroy"))
+
+    finish_rsl_rl_distributed(training_succeeded=False)
+
+    assert calls == ["destroy"]
+
+
+def test_rsl_rl_single_process_topology_masks_and_restores_torchrun_env(monkeypatch) -> None:
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    with rsl_rl_single_process_topology():
+        assert os.environ["WORLD_SIZE"] == "1"
+        assert os.environ["RANK"] == "0"
+        assert os.environ["LOCAL_RANK"] == "0"
+
+    assert os.environ["WORLD_SIZE"] == "2"
+    assert os.environ["RANK"] == "0"
+    assert os.environ["LOCAL_RANK"] == "0"
 
 
 class _FakeActor:

--- a/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
+++ b/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from benchmark.rl import benchmark_offpolicy_dp_scaling as bench
+
+torch = pytest.importorskip("torch")
+from torch.utils.tensorboard import SummaryWriter  # noqa: E402
+
+
+def _write_tfevents(log_dir: Path, series: dict[str, list[float]]) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    writer = SummaryWriter(log_dir=str(log_dir))
+    try:
+        for tag, values in series.items():
+            for step, value in enumerate(values):
+                writer.add_scalar(tag, value, step)
+    finally:
+        writer.close()
+
+
+def _write_run_summary(run_dir: Path, **overrides: object) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "status": "completed",
+        "completed_iterations": 300,
+        "total_env_steps": 1_200_000,
+        "training_wall_time_sec": 600.0,
+        **overrides,
+    }
+    (run_dir / "run_summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+
+def _make_run_dir(
+    run_dir: Path,
+    *,
+    world_size: int,
+    steps_per_sec: list[float] | None = None,
+    rank_steps_per_sec: list[list[float]] | None = None,
+    reward: list[float] | None = None,
+    dp_sync_time: list[float] | None = None,
+) -> None:
+    _write_run_summary(run_dir)
+    rank0_series = {bench.STEPS_PER_SEC_TAG: steps_per_sec or []}
+    if reward is not None:
+        rank0_series[bench.REWARD_TAG] = reward
+    if dp_sync_time is not None:
+        rank0_series[bench.DP_SYNC_TIME_TAG] = dp_sync_time
+    _write_tfevents(run_dir, rank0_series)
+    for rank, series in enumerate(rank_steps_per_sec or [], start=1):
+        _write_tfevents(bench.rank_dir_for(run_dir, rank), {bench.STEPS_PER_SEC_TAG: series})
+    assert world_size == 1 + len(rank_steps_per_sec or [])
+
+
+def test_steady_state_mean_uses_tail_half() -> None:
+    # ceil(3/2)=2 tail points: (30+40)/2; warm-up prefix 10 is excluded.
+    assert bench.steady_state_mean([10.0, 30.0, 40.0]) == pytest.approx(35.0)
+    assert bench.steady_state_mean([1.0, 2.0, 3.0, 4.0]) == pytest.approx(3.5)
+    assert bench.steady_state_mean([7.0]) == pytest.approx(7.0)
+    assert bench.steady_state_mean([0.0, 100.0], tail_fraction=1.0) == pytest.approx(50.0)
+    with pytest.raises(ValueError, match="at least one sample"):
+        bench.steady_state_mean([])
+
+
+def test_verdict_for_ratio() -> None:
+    assert bench.verdict_for_ratio(1.7) == "pass"
+    assert bench.verdict_for_ratio(2.0) == "pass"
+    assert bench.verdict_for_ratio(1.69) == "below threshold"
+    assert bench.verdict_for_ratio(None) is None
+
+
+def test_build_train_command_matches_production_overrides(tmp_path: Path) -> None:
+    command = bench.build_train_command(tmp_path / "runs" / "n1", iterations=300, devices=None)
+    assert command[0] == sys.executable
+    assert command[1].endswith("scripts/train_offpolicy.py")
+    assert "algo=sac" in command
+    assert "task=sac/g1_walk_flat/mujoco" in command
+    assert "training.no_play=true" in command
+    assert "algo.max_iterations=300" in command
+    assert any(arg.startswith("training.log_dir=") for arg in command)
+    # N=1 baseline must not carry training.devices at all.
+    assert not any(arg.startswith("training.devices") for arg in command)
+    assert not any(arg.startswith("training.dp_sync_interval") for arg in command)
+
+    command_dp = bench.build_train_command(
+        tmp_path / "runs" / "n2",
+        iterations=300,
+        devices=[0, 1],
+        sync_interval=4,
+        extra_overrides=("algo.num_envs=2048",),
+    )
+    assert "training.devices=[0,1]" in command_dp
+    assert "training.dp_sync_interval=4" in command_dp
+    assert "algo.num_envs=2048" in command_dp
+
+
+def test_parse_run_single_rank(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n1"
+    _make_run_dir(
+        run_dir,
+        world_size=1,
+        steps_per_sec=[100.0, 200.0, 300.0, 400.0],
+        reward=[0.5, 1.5],
+    )
+    metrics = bench.parse_run(run_dir, world_size=1)
+    assert metrics["completed_iterations"] == 300
+    assert metrics["total_env_steps"] == 1_200_000
+    assert metrics["training_wall_time_sec"] == pytest.approx(600.0)
+    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(350.0)
+    assert metrics["final_mean_reward"] == pytest.approx(1.5)
+    assert metrics["mean_dp_sync_time_sec"] is None
+    assert len(metrics["ranks"]) == 1
+    assert metrics["ranks"][0]["steady_state_env_steps_per_s"] == pytest.approx(350.0)
+
+
+def test_parse_run_two_ranks_aggregates_and_reads_rank1_subdir(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n2"
+    _make_run_dir(
+        run_dir,
+        world_size=2,
+        steps_per_sec=[100.0, 200.0],
+        rank_steps_per_sec=[[150.0, 250.0]],
+        dp_sync_time=[0.02, 0.04],
+    )
+    metrics = bench.parse_run(run_dir, world_size=2)
+    assert metrics["world_size"] == 2
+    # Aggregate = rank0 steady state + rank1 steady state.
+    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(200.0 + 250.0)
+    assert metrics["ranks"][1]["log_dir"].endswith("rank1")
+    assert metrics["mean_dp_sync_time_sec"] == pytest.approx(0.03)
+
+
+def test_parse_run_missing_rank1_data_is_a_hard_error(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n2"
+    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0, 200.0])
+    with pytest.raises(bench.RunParseError, match="rank1"):
+        bench.parse_run(run_dir, world_size=2)
+
+    # rank1 directory exists but has no tfevents file.
+    bench.rank_dir_for(run_dir, 1).mkdir(parents=True)
+    with pytest.raises(bench.RunParseError, match="no tfevents"):
+        bench.parse_run(run_dir, world_size=2)
+
+
+def test_parse_run_rejects_non_completed_status(tmp_path: Path) -> None:
+    run_dir = tmp_path / "n1"
+    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0])
+    _write_run_summary(run_dir, status="failed", error="boom")
+    with pytest.raises(bench.RunParseError, match="did not complete"):
+        bench.parse_run(run_dir, world_size=1)
+
+    (run_dir / "run_summary.json").unlink()
+    with pytest.raises(bench.RunParseError, match="missing run summary"):
+        bench.parse_run(run_dir, world_size=1)
+
+
+def _record(config: str, aggregate: float | None, status: str = "ok") -> dict[str, object]:
+    return {
+        "config": config,
+        "status": status,
+        "error": None if status == "ok" else "boom",
+        "metrics": (
+            {"aggregate_env_steps_per_s": aggregate}
+            if status == "ok" and aggregate is not None
+            else None
+        ),
+    }
+
+
+def test_attach_scaling_computes_ratio_and_verdict() -> None:
+    records = [
+        _record("n1", 100_000.0),
+        _record("n2", 180_000.0),
+        _record("n2", None, status="failed"),
+    ]
+    bench.attach_scaling(records)
+    assert records[0]["scaling_vs_n1"] is None
+    assert records[0]["verdict"] is None
+    assert records[1]["scaling_vs_n1"] == pytest.approx(1.8)
+    assert records[1]["verdict"] == "pass"
+    assert records[2]["scaling_vs_n1"] is None
+    assert records[2]["verdict"] is None
+
+
+def test_attach_scaling_below_threshold_verdict() -> None:
+    records = [_record("n1", 100_000.0), _record("n2", 120_000.0)]
+    bench.attach_scaling(records)
+    assert records[1]["scaling_vs_n1"] == pytest.approx(1.2)
+    assert records[1]["verdict"] == "below threshold"
+
+
+def test_parse_args_skips_dp_config_with_single_device() -> None:
+    args = bench.parse_args(["--devices", "0"])
+    assert args.devices == "0"
+    assert args.keep_runs is True
+    args = bench.parse_args(["--no-keep-runs"])
+    assert args.keep_runs is False

--- a/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
+++ b/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
@@ -37,22 +37,21 @@ def _write_run_summary(run_dir: Path, **overrides: object) -> None:
 def _make_run_dir(
     run_dir: Path,
     *,
-    world_size: int,
     steps_per_sec: list[float] | None = None,
-    rank_steps_per_sec: list[list[float]] | None = None,
+    samples_per_sec: list[float] | None = None,
     reward: list[float] | None = None,
     dp_sync_time: list[float] | None = None,
 ) -> None:
     _write_run_summary(run_dir)
-    rank0_series = {bench.STEPS_PER_SEC_TAG: steps_per_sec or []}
+    rank0_series = {
+        bench.STEPS_PER_SEC_TAG: steps_per_sec or [],
+        bench.SAMPLES_PER_SEC_TAG: samples_per_sec or [],
+    }
     if reward is not None:
         rank0_series[bench.REWARD_TAG] = reward
     if dp_sync_time is not None:
         rank0_series[bench.DP_SYNC_TIME_TAG] = dp_sync_time
     _write_tfevents(run_dir, rank0_series)
-    for rank, series in enumerate(rank_steps_per_sec or [], start=1):
-        _write_tfevents(bench.rank_dir_for(run_dir, rank), {bench.STEPS_PER_SEC_TAG: series})
-    assert world_size == 1 + len(rank_steps_per_sec or [])
 
 
 def test_steady_state_mean_uses_tail_half() -> None:
@@ -101,53 +100,47 @@ def test_parse_run_single_rank(tmp_path: Path) -> None:
     run_dir = tmp_path / "n1"
     _make_run_dir(
         run_dir,
-        world_size=1,
         steps_per_sec=[100.0, 200.0, 300.0, 400.0],
+        samples_per_sec=[1_000.0, 2_000.0, 3_000.0, 4_000.0],
         reward=[0.5, 1.5],
     )
     metrics = bench.parse_run(run_dir, world_size=1)
     assert metrics["completed_iterations"] == 300
     assert metrics["total_env_steps"] == 1_200_000
     assert metrics["training_wall_time_sec"] == pytest.approx(600.0)
-    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(350.0)
+    assert metrics["steady_state_collector_steps_per_s"] == pytest.approx(350.0)
+    assert metrics["steady_state_learner_samples_per_s"] == pytest.approx(3_500.0)
     assert metrics["final_mean_reward"] == pytest.approx(1.5)
     assert metrics["mean_dp_sync_time_sec"] is None
-    assert len(metrics["ranks"]) == 1
-    assert metrics["ranks"][0]["steady_state_env_steps_per_s"] == pytest.approx(350.0)
+    assert metrics["num_collector_throughput_samples"] == 4
+    assert metrics["num_learner_throughput_samples"] == 4
 
 
-def test_parse_run_two_ranks_aggregates_and_reads_rank1_subdir(tmp_path: Path) -> None:
+def test_parse_run_two_ranks_reads_canonical_aggregate_tags(tmp_path: Path) -> None:
     run_dir = tmp_path / "n2"
     _make_run_dir(
         run_dir,
-        world_size=2,
-        steps_per_sec=[100.0, 200.0],
-        rank_steps_per_sec=[[150.0, 250.0]],
+        steps_per_sec=[300.0, 450.0],
+        samples_per_sec=[1_200.0, 1_800.0],
         dp_sync_time=[0.02, 0.04],
     )
     metrics = bench.parse_run(run_dir, world_size=2)
     assert metrics["world_size"] == 2
-    # Aggregate = rank0 steady state + rank1 steady state.
-    assert metrics["aggregate_env_steps_per_s"] == pytest.approx(200.0 + 250.0)
-    assert metrics["ranks"][1]["log_dir"].endswith("rank1")
+    assert metrics["steady_state_collector_steps_per_s"] == pytest.approx(450.0)
+    assert metrics["steady_state_learner_samples_per_s"] == pytest.approx(1_800.0)
     assert metrics["mean_dp_sync_time_sec"] == pytest.approx(0.03)
 
 
-def test_parse_run_missing_rank1_data_is_a_hard_error(tmp_path: Path) -> None:
+def test_parse_run_missing_learner_throughput_is_a_hard_error(tmp_path: Path) -> None:
     run_dir = tmp_path / "n2"
-    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0, 200.0])
-    with pytest.raises(bench.RunParseError, match="rank1"):
-        bench.parse_run(run_dir, world_size=2)
-
-    # rank1 directory exists but has no tfevents file.
-    bench.rank_dir_for(run_dir, 1).mkdir(parents=True)
-    with pytest.raises(bench.RunParseError, match="no tfevents"):
+    _make_run_dir(run_dir, steps_per_sec=[100.0, 200.0])
+    with pytest.raises(bench.RunParseError, match="effective_samples_per_sec"):
         bench.parse_run(run_dir, world_size=2)
 
 
 def test_parse_run_rejects_non_completed_status(tmp_path: Path) -> None:
     run_dir = tmp_path / "n1"
-    _make_run_dir(run_dir, world_size=1, steps_per_sec=[100.0])
+    _make_run_dir(run_dir, steps_per_sec=[100.0], samples_per_sec=[200.0])
     _write_run_summary(run_dir, status="failed", error="boom")
     with pytest.raises(bench.RunParseError, match="did not complete"):
         bench.parse_run(run_dir, world_size=1)
@@ -157,14 +150,22 @@ def test_parse_run_rejects_non_completed_status(tmp_path: Path) -> None:
         bench.parse_run(run_dir, world_size=1)
 
 
-def _record(config: str, aggregate: float | None, status: str = "ok") -> dict[str, object]:
+def _record(
+    config: str,
+    collector: float | None,
+    learner: float | None,
+    status: str = "ok",
+) -> dict[str, object]:
     return {
         "config": config,
         "status": status,
         "error": None if status == "ok" else "boom",
         "metrics": (
-            {"aggregate_env_steps_per_s": aggregate}
-            if status == "ok" and aggregate is not None
+            {
+                "steady_state_collector_steps_per_s": collector,
+                "steady_state_learner_samples_per_s": learner,
+            }
+            if status == "ok" and collector is not None and learner is not None
             else None
         ),
     }
@@ -172,23 +173,30 @@ def _record(config: str, aggregate: float | None, status: str = "ok") -> dict[st
 
 def test_attach_scaling_computes_ratio_and_verdict() -> None:
     records = [
-        _record("n1", 100_000.0),
-        _record("n2", 180_000.0),
-        _record("n2", None, status="failed"),
+        _record("n1", 100_000.0, 200_000.0),
+        _record("n2", 180_000.0, 300_000.0),
+        _record("n2", None, None, status="failed"),
     ]
     bench.attach_scaling(records)
-    assert records[0]["scaling_vs_n1"] is None
+    assert records[0]["collector_scaling_vs_n1"] is None
+    assert records[0]["learner_scaling_vs_n1"] is None
     assert records[0]["verdict"] is None
-    assert records[1]["scaling_vs_n1"] == pytest.approx(1.8)
+    assert records[1]["collector_scaling_vs_n1"] == pytest.approx(1.8)
+    assert records[1]["learner_scaling_vs_n1"] == pytest.approx(1.5)
     assert records[1]["verdict"] == "pass"
-    assert records[2]["scaling_vs_n1"] is None
+    assert records[2]["collector_scaling_vs_n1"] is None
+    assert records[2]["learner_scaling_vs_n1"] is None
     assert records[2]["verdict"] is None
 
 
 def test_attach_scaling_below_threshold_verdict() -> None:
-    records = [_record("n1", 100_000.0), _record("n2", 120_000.0)]
+    records = [
+        _record("n1", 100_000.0, 200_000.0),
+        _record("n2", 120_000.0, 240_000.0),
+    ]
     bench.attach_scaling(records)
-    assert records[1]["scaling_vs_n1"] == pytest.approx(1.2)
+    assert records[1]["collector_scaling_vs_n1"] == pytest.approx(1.2)
+    assert records[1]["learner_scaling_vs_n1"] == pytest.approx(1.2)
     assert records[1]["verdict"] == "below threshold"
 
 

--- a/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
+++ b/tests/benchmark/test_offpolicy_dp_scaling_benchmark.py
@@ -88,11 +88,10 @@ def test_build_train_command_matches_production_overrides(tmp_path: Path) -> Non
         tmp_path / "runs" / "n2",
         iterations=300,
         devices=[0, 1],
-        sync_interval=4,
         extra_overrides=("algo.num_envs=2048",),
     )
     assert "training.devices=[0,1]" in command_dp
-    assert "training.dp_sync_interval=4" in command_dp
+    assert not any(arg.startswith("training.dp_sync_interval") for arg in command_dp)
     assert "algo.num_envs=2048" in command_dp
 
 

--- a/tests/ipc/test_async_runner.py
+++ b/tests/ipc/test_async_runner.py
@@ -146,8 +146,11 @@ def test_close_with_no_collector_does_not_raise():
 
 def test_close_is_idempotent():
     r = _make_runner()
+    resource = MagicMock(spec=["cleanup"])
+    r._shared_resources.append(resource)
     r.close()
     r.close()
+    resource.cleanup.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -25,7 +25,12 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     current_dp_world_size,
+    current_torch_distributed_local_rank,
+    current_torch_distributed_rank,
+    current_torch_distributed_world_size,
+    launch_torchrun_workers,
     resolve_collector_cpu_ids,
+    resolve_cuda_visible_devices,
     resolve_dp_rank_device,
     resolve_dp_topology,
     validate_dp_launchable,
@@ -51,28 +56,39 @@ class _FakePopen:
     # When True, wait() on a still-running child makes it exit cleanly
     # (simulates a rank that finishes during the normal-exit grace window).
     wait_completes: bool = False
+    interrupt_exits: bool = True
 
     def __init__(self, argv, env=None, **kwargs):
-        del kwargs
         self.argv = list(argv)
         self.env = dict(env or {})
+        self.start_new_session = bool(kwargs.pop("start_new_session", False))
+        assert not kwargs
         self.pid = 10_000 + len(_FakePopen.instances)
         self.returncode: int | None = None
         self.terminated = False
         self.killed = False
+        self.signals: list[int] = []
         _FakePopen.instances.append(self)
 
     def poll(self):
         return self.returncode
 
     def terminate(self):
-        self.terminated = True
-        if self.returncode is None:
-            self.returncode = -signal.SIGTERM
+        self.send_signal(signal.SIGTERM)
 
     def kill(self):
-        self.killed = True
-        self.returncode = -signal.SIGKILL
+        self.send_signal(signal.SIGKILL)
+
+    def send_signal(self, signum):
+        self.signals.append(signum)
+        if signum == signal.SIGINT and self.interrupt_exits:
+            self.returncode = -signal.SIGINT
+        elif signum == signal.SIGTERM:
+            self.terminated = True
+            self.returncode = -signal.SIGTERM
+        elif signum == signal.SIGKILL:
+            self.killed = True
+            self.returncode = -signal.SIGKILL
 
     def wait(self, timeout=None):
         if self.returncode is None:
@@ -87,7 +103,17 @@ class _FakePopen:
 def fake_popen(monkeypatch: pytest.MonkeyPatch):
     _FakePopen.instances = []
     _FakePopen.wait_completes = False
+    _FakePopen.interrupt_exits = True
     monkeypatch.setattr(dp_launcher.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(
+        dp_launcher, "_signal_process_group", lambda child, signum: child.send_signal(signum)
+    )
+    monkeypatch.setattr(
+        dp_launcher, "_process_group_exists", lambda child: child.returncode is None
+    )
+    monkeypatch.setattr(dp_launcher, "_COOPERATIVE_EXIT_GRACE_S", 0.0)
+    monkeypatch.setattr(dp_launcher, "_TERMINATE_TIMEOUT_S", 0.0)
+    monkeypatch.setattr(dp_launcher, "_NORMAL_EXIT_GRACE_S", 0.01)
     return _FakePopen
 
 
@@ -132,6 +158,122 @@ def test_current_dp_rank_reads_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "4")
     assert current_dp_rank() == 2
     assert current_dp_world_size() == 4
+
+
+def test_current_torch_distributed_rank_defaults(monkeypatch: pytest.MonkeyPatch):
+    for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE"):
+        monkeypatch.delenv(name, raising=False)
+    assert current_torch_distributed_rank() == 0
+    assert current_torch_distributed_local_rank() == 0
+    assert current_torch_distributed_world_size() == 1
+
+
+def test_current_torch_distributed_rank_reads_torchrun_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    assert current_torch_distributed_rank() == 3
+    assert current_torch_distributed_local_rank() == 1
+    assert current_torch_distributed_world_size() == 4
+
+
+def test_resolve_cuda_visible_devices_preserves_parent_mapping():
+    assert resolve_cuda_visible_devices((2, 0)) == "2,0"
+    assert (
+        resolve_cuda_visible_devices(
+            (1, 0),
+            current_visible_devices="GPU-parent-0,GPU-parent-1",
+        )
+        == "GPU-parent-1,GPU-parent-0"
+    )
+
+
+def test_resolve_cuda_visible_devices_rejects_hidden_index():
+    with pytest.raises(ValueError, match="CUDA_VISIBLE_DEVICES"):
+        resolve_cuda_visible_devices((0, 2), current_visible_devices="4,7")
+
+
+def test_launch_torchrun_workers_builds_standard_single_node_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    captured: dict[str, object] = {}
+
+    def fake_run(command, *, env, check):
+        captured.update(command=list(command), env=dict(env), check=check)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(dp_launcher.subprocess, "run", fake_run)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-a,GPU-b,GPU-c")
+    monkeypatch.delenv("NCCL_P2P_DISABLE", raising=False)
+    monkeypatch.delenv("NCCL_SHM_DISABLE", raising=False)
+    script = tmp_path / "train_rsl_rl.py"
+
+    launch_torchrun_workers(
+        (2, 0),
+        script_path=script,
+        argv=["task=go2_joystick_flat/mujoco", "training.devices=[2,0]"],
+        log_dir="/tmp/ppo_gpux2",
+    )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[:3] == [sys.executable, "-m", "torch.distributed.run"]
+    assert "--standalone" in command
+    assert "--nnodes=1" in command
+    assert "--nproc_per_node=2" in command
+    assert command[-2:] == ["task=go2_joystick_flat/mujoco", "training.devices=[2,0]"]
+    launch_env = captured["env"]
+    assert isinstance(launch_env, dict)
+    assert launch_env["CUDA_VISIBLE_DEVICES"] == "GPU-c,GPU-a"
+    assert launch_env["NCCL_P2P_DISABLE"] == "1"
+    assert launch_env["NCCL_SHM_DISABLE"] == "1"
+    assert launch_env[UNILAB_DP_LOG_DIR] == "/tmp/ppo_gpux2"
+    assert captured["check"] is False
+
+
+def test_launch_torchrun_workers_propagates_failure(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(
+        dp_launcher.subprocess,
+        "run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 7})(),
+    )
+
+    with pytest.raises(RuntimeError, match="exit code 7"):
+        launch_torchrun_workers(
+            (0, 1),
+            script_path="scripts/train_rsl_rl.py",
+            argv=[],
+            log_dir="/tmp/ppo_gpux2",
+        )
+
+
+def test_launch_torchrun_workers_preserves_explicit_nccl_transport(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, str] = {}
+
+    def fake_run(*args, env, **kwargs):
+        del args, kwargs
+        captured.update(env)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(dp_launcher, "validate_dp_launchable", lambda devices: None)
+    monkeypatch.setattr(dp_launcher.subprocess, "run", fake_run)
+    monkeypatch.setenv("NCCL_P2P_DISABLE", "0")
+    monkeypatch.setenv("NCCL_SHM_DISABLE", "0")
+
+    launch_torchrun_workers(
+        (0, 1),
+        script_path="scripts/train_rsl_rl.py",
+        argv=[],
+        log_dir="/tmp/ppo_gpux2",
+    )
+
+    assert captured["NCCL_P2P_DISABLE"] == "0"
+    assert captured["NCCL_SHM_DISABLE"] == "0"
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +349,7 @@ def test_supervisor_spawn_argv_and_env(fake_popen, monkeypatch: pytest.MonkeyPat
             assert child.argv[0] == sys.executable
             assert child.argv[1].endswith("scripts/train_offpolicy.py")
             assert child.argv[2:] == ["algo=sac", "training.devices=[0,1,2]"]
+            assert child.start_new_session is (os.name == "posix")
             assert child.env[UNILAB_DP_RANK] == str(rank)
             assert child.env[UNILAB_DP_WORLD_SIZE] == "3"
             assert child.env[UNILAB_DP_DEVICES] == "0,1,2"
@@ -253,11 +396,27 @@ def test_supervisor_failed_child_makes_rank_zero_fail(fake_popen, monkeypatch: p
 
 
 def test_supervisor_error_exit_terminates_live_children(fake_popen):
+    fake_popen.interrupt_exits = False
     with pytest.raises(ValueError, match="boom"):
         with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
             raise ValueError("boom")
     assert all(child.terminated for child in fake_popen.instances)
     assert all(child.returncode == -signal.SIGTERM for child in fake_popen.instances)
+    assert all(child.signals == [signal.SIGINT, signal.SIGTERM] for child in fake_popen.instances)
+
+
+def test_supervisor_ctrl_c_forwards_sigint_for_cooperative_rank_cleanup(fake_popen):
+    previous_sigint = signal.getsignal(signal.SIGINT)
+
+    with pytest.raises(KeyboardInterrupt):
+        with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log") as supervisor:
+            installed = signal.getsignal(signal.SIGINT)
+            assert getattr(installed, "__self__", None) is supervisor
+            installed(signal.SIGINT, None)
+
+    assert all(child.signals == [signal.SIGINT] for child in fake_popen.instances)
+    assert all(child.returncode == -signal.SIGINT for child in fake_popen.instances)
+    assert signal.getsignal(signal.SIGINT) == previous_sigint
 
 
 def test_supervisor_watchdog_sigterms_rank_zero_on_child_death(
@@ -275,12 +434,36 @@ def test_supervisor_watchdog_sigterms_rank_zero_on_child_death(
     assert killed == [signal.SIGTERM]
 
 
-def test_supervisor_restores_sigterm_handler(fake_popen):
-    previous = signal.getsignal(signal.SIGTERM)
-    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
-        assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
+def test_supervisor_restores_signal_handlers(fake_popen):
+    previous_sigint = signal.getsignal(signal.SIGINT)
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log") as supervisor:
+        assert getattr(signal.getsignal(signal.SIGINT), "__self__", None) is supervisor
+        assert getattr(signal.getsignal(signal.SIGTERM), "__self__", None) is supervisor
         fake_popen.instances[0].returncode = 0
-    assert signal.getsignal(signal.SIGTERM) == previous
+    assert signal.getsignal(signal.SIGINT) == previous_sigint
+    assert signal.getsignal(signal.SIGTERM) == previous_sigterm
+
+
+def test_supervisor_restores_signal_handlers_when_group_reaping_fails(
+    fake_popen, monkeypatch: pytest.MonkeyPatch
+):
+    previous_sigint = signal.getsignal(signal.SIGINT)
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+    supervisor = DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log")
+    supervisor.__enter__()
+    fake_popen.instances[0].returncode = 0
+
+    def fail_reaping() -> None:
+        raise RuntimeError("group reaping failed")
+
+    monkeypatch.setattr(supervisor, "_terminate_children", fail_reaping)
+
+    with pytest.raises(RuntimeError, match="group reaping failed"):
+        supervisor.__exit__(None, None, None)
+
+    assert signal.getsignal(signal.SIGINT) == previous_sigint
+    assert signal.getsignal(signal.SIGTERM) == previous_sigterm
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -1,0 +1,288 @@
+"""Tests for the off-policy multi-GPU data-parallel rank topology."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+import unilab.ipc.dp_launcher as dp_launcher
+from unilab.ipc.dp_launcher import (
+    UNILAB_DP_DEVICES,
+    UNILAB_DP_LOG_DIR,
+    UNILAB_DP_RANK,
+    UNILAB_DP_WORLD_SIZE,
+    DpRankSupervisor,
+    apply_dp_rank_config,
+    current_dp_rank,
+    current_dp_world_size,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
+
+_ROOT = Path(__file__).parent.parent.parent
+_CONF_DIR = _ROOT / "conf"
+
+
+def _offpolicy_cfg(overrides: list[str] | None = None):
+    GlobalHydra.instance().clear()
+    normalized = list(overrides or [])
+    if not any(override.startswith("task=") for override in normalized):
+        normalized.append("task=sac/g1_walk_flat/mujoco")
+    with initialize_config_dir(config_dir=str(_CONF_DIR / "offpolicy"), version_base="1.3"):
+        return compose("config", overrides=normalized)
+
+
+class _FakePopen:
+    """Minimal subprocess.Popen stand-in with a scriptable exit code."""
+
+    instances: list["_FakePopen"] = []
+    # When True, wait() on a still-running child makes it exit cleanly
+    # (simulates a rank that finishes during the normal-exit grace window).
+    wait_completes: bool = False
+
+    def __init__(self, argv, env=None, **kwargs):
+        del kwargs
+        self.argv = list(argv)
+        self.env = dict(env or {})
+        self.pid = 10_000 + len(_FakePopen.instances)
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+        _FakePopen.instances.append(self)
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        if self.returncode is None:
+            self.returncode = -signal.SIGTERM
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -signal.SIGKILL
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            if _FakePopen.wait_completes:
+                self.returncode = 0
+                return 0
+            raise subprocess.TimeoutExpired(cmd=self.argv, timeout=timeout)
+        return self.returncode
+
+
+@pytest.fixture()
+def fake_popen(monkeypatch: pytest.MonkeyPatch):
+    _FakePopen.instances = []
+    _FakePopen.wait_completes = False
+    monkeypatch.setattr(dp_launcher.subprocess, "Popen", _FakePopen)
+    return _FakePopen
+
+
+# ---------------------------------------------------------------------------
+# resolve_dp_topology
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("devices_cfg", [None, []])
+def test_resolve_dp_topology_single_device_default(devices_cfg):
+    assert resolve_dp_topology(devices_cfg) is None
+
+
+def test_resolve_dp_topology_preserves_user_order():
+    assert resolve_dp_topology([0, 1]) == (0, 1)
+    assert resolve_dp_topology([2, 0]) == (2, 0)
+
+
+@pytest.mark.parametrize(
+    "devices_cfg",
+    [[0, 0], [-1], [0, "1"], [True], [0.5]],
+)
+def test_resolve_dp_topology_rejects_invalid_entries(devices_cfg):
+    with pytest.raises(ValueError, match="training.devices"):
+        resolve_dp_topology(devices_cfg)
+
+
+# ---------------------------------------------------------------------------
+# rank / world-size environment
+# ---------------------------------------------------------------------------
+
+
+def test_current_dp_rank_defaults(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.delenv(UNILAB_DP_WORLD_SIZE, raising=False)
+    assert current_dp_rank() == 0
+    assert current_dp_world_size() == 1
+
+
+def test_current_dp_rank_reads_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(UNILAB_DP_RANK, "2")
+    monkeypatch.setenv(UNILAB_DP_WORLD_SIZE, "4")
+    assert current_dp_rank() == 2
+    assert current_dp_world_size() == 4
+
+
+# ---------------------------------------------------------------------------
+# Hydra compose surface
+# ---------------------------------------------------------------------------
+
+
+def test_offpolicy_config_devices_defaults_to_null():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.devices is None
+    assert resolve_dp_topology(cfg.training.devices) is None
+
+
+def test_offpolicy_config_devices_compose():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null"])
+    assert resolve_dp_topology(cfg.training.devices) == (0, 1)
+
+
+def test_training_device_and_devices_are_mutually_exclusive():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=cuda"])
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        apply_dp_rank_config(cfg, resolve_dp_topology(cfg.training.devices), rank=0)
+
+
+# ---------------------------------------------------------------------------
+# apply_dp_rank_config / N=1 equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_apply_dp_rank_config_maps_rank_to_device_and_seed():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
+    base_seed = int(cfg.algo.seed)
+    apply_dp_rank_config(cfg, (0, 1), rank=1)
+    assert cfg.training.device == "cuda:1"
+    assert int(cfg.algo.seed) == base_seed + 1
+
+
+def test_apply_dp_rank_config_rank_zero_keeps_seed():
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
+    apply_dp_rank_config(cfg, (0, 1), rank=0)
+    assert cfg.training.device == "cuda:0"
+    assert int(cfg.algo.seed) == 42
+
+
+def test_single_device_topology_spawns_no_children(fake_popen, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    cfg = _offpolicy_cfg(["training.devices=[0]", "training.device=null"])
+    devices = resolve_dp_topology(cfg.training.devices)
+    assert devices == (0,)
+    apply_dp_rank_config(cfg, devices, rank=0)
+    assert cfg.training.device == "cuda:0"
+    with DpRankSupervisor(devices, log_dir="/tmp/dp_test_log"):
+        assert fake_popen.instances == []
+    assert os.environ.get(UNILAB_DP_RANK) is None
+
+
+# ---------------------------------------------------------------------------
+# DpRankSupervisor
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_spawn_argv_and_env(fake_popen, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
+    monkeypatch.setattr(sys, "argv", ["train_offpolicy.py", "algo=sac", "training.devices=[0,1,2]"])
+    with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
+        assert len(fake_popen.instances) == 2
+        for rank, child in enumerate(fake_popen.instances, start=1):
+            assert child.argv[0] == sys.executable
+            assert child.argv[1].endswith("scripts/train_offpolicy.py")
+            assert child.argv[2:] == ["algo=sac", "training.devices=[0,1,2]"]
+            assert child.env[UNILAB_DP_RANK] == str(rank)
+            assert child.env[UNILAB_DP_WORLD_SIZE] == "3"
+            assert child.env[UNILAB_DP_DEVICES] == "0,1,2"
+            assert child.env[UNILAB_DP_LOG_DIR] == "/tmp/dp_test_log"
+        # Rank 0's own environment stays untouched.
+        assert os.environ.get(UNILAB_DP_RANK) is None
+        for child in fake_popen.instances:
+            child.returncode = 0
+    for child in fake_popen.instances:
+        assert not child.terminated
+
+
+def test_supervisor_normal_exit_waits_for_children(fake_popen):
+    _FakePopen.wait_completes = True
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        pass
+    child = fake_popen.instances[0]
+    assert child.returncode == 0
+    assert not child.terminated
+
+
+def test_supervisor_grace_timeout_is_a_failure(fake_popen):
+    with pytest.raises(RuntimeError, match="rank 1 exit code timeout"):
+        with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+            pass
+    child = fake_popen.instances[0]
+    assert child.terminated
+    assert child.returncode == -signal.SIGTERM
+
+
+def test_supervisor_clean_child_exit_is_not_a_failure(fake_popen):
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        fake_popen.instances[0].returncode = 0
+
+
+def test_supervisor_failed_child_makes_rank_zero_fail(fake_popen, monkeypatch: pytest.MonkeyPatch):
+    # Keep the watchdog from polling so __exit__ observes the exit code first.
+    monkeypatch.setattr(dp_launcher, "_WATCHDOG_INTERVAL_S", 60.0)
+    supervisor = DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log")
+    supervisor.__enter__()
+    fake_popen.instances[0].returncode = 3
+    with pytest.raises(RuntimeError, match="rank 1 exit code 3"):
+        supervisor.__exit__(None, None, None)
+
+
+def test_supervisor_error_exit_terminates_live_children(fake_popen):
+    with pytest.raises(ValueError, match="boom"):
+        with DpRankSupervisor((0, 1, 2), log_dir="/tmp/dp_test_log"):
+            raise ValueError("boom")
+    assert all(child.terminated for child in fake_popen.instances)
+    assert all(child.returncode == -signal.SIGTERM for child in fake_popen.instances)
+
+
+def test_supervisor_watchdog_sigterms_rank_zero_on_child_death(
+    fake_popen, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(dp_launcher, "_WATCHDOG_INTERVAL_S", 0.01)
+    killed: list[int] = []
+    monkeypatch.setattr(dp_launcher.os, "kill", lambda pid, sig: killed.append(sig))
+    with pytest.raises(RuntimeError, match="exit code 1"):
+        with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+            fake_popen.instances[0].returncode = 1
+            deadline = time.monotonic() + 5.0
+            while not killed and time.monotonic() < deadline:
+                time.sleep(0.01)
+    assert killed == [signal.SIGTERM]
+
+
+def test_supervisor_restores_sigterm_handler(fake_popen):
+    previous = signal.getsignal(signal.SIGTERM)
+    with DpRankSupervisor((0, 1), log_dir="/tmp/dp_test_log"):
+        assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
+        fake_popen.instances[0].returncode = 0
+    assert signal.getsignal(signal.SIGTERM) == previous
+
+
+# ---------------------------------------------------------------------------
+# Hardware-gated smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires >=2 CUDA devices")
+@pytest.mark.slow
+def test_dp_topology_validates_on_two_gpu_host():
+    devices = resolve_dp_topology([0, 1])
+    assert devices == (0, 1)
+    validate_dp_launchable(devices)

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -26,6 +26,7 @@ from unilab.ipc.dp_launcher import (
     current_dp_rank,
     current_dp_world_size,
     resolve_collector_cpu_ids,
+    resolve_dp_rank_device,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -145,14 +146,13 @@ def test_offpolicy_config_devices_defaults_to_null():
 
 
 def test_offpolicy_config_devices_compose():
-    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null"])
+    cfg = _offpolicy_cfg(["training.devices=[0,1]"])
     assert resolve_dp_topology(cfg.training.devices) == (0, 1)
 
 
-def test_training_device_and_devices_are_mutually_exclusive():
-    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=cuda"])
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        apply_dp_rank_config(cfg, resolve_dp_topology(cfg.training.devices), rank=0)
+def test_offpolicy_config_has_no_redundant_singular_device():
+    cfg = _offpolicy_cfg()
+    assert "device" not in cfg.training
 
 
 # ---------------------------------------------------------------------------
@@ -161,27 +161,33 @@ def test_training_device_and_devices_are_mutually_exclusive():
 
 
 def test_apply_dp_rank_config_maps_rank_to_device_and_seed():
-    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "algo.seed=42"])
     base_seed = int(cfg.algo.seed)
-    apply_dp_rank_config(cfg, (0, 1), rank=1)
-    assert cfg.training.device == "cuda:1"
+    device = apply_dp_rank_config(cfg, (0, 1), rank=1)
+    assert device == "cuda:1"
+    assert "device" not in cfg.training
     assert int(cfg.algo.seed) == base_seed + 1
 
 
 def test_apply_dp_rank_config_rank_zero_keeps_seed():
-    cfg = _offpolicy_cfg(["training.devices=[0,1]", "training.device=null", "algo.seed=42"])
-    apply_dp_rank_config(cfg, (0, 1), rank=0)
-    assert cfg.training.device == "cuda:0"
+    cfg = _offpolicy_cfg(["training.devices=[0,1]", "algo.seed=42"])
+    assert apply_dp_rank_config(cfg, (0, 1), rank=0) == "cuda:0"
     assert int(cfg.algo.seed) == 42
+
+
+def test_resolve_dp_rank_device_uses_auto_selection_without_devices():
+    assert resolve_dp_rank_device(None, rank=0) is None
+    assert resolve_dp_rank_device((2, 0), rank=1) == "cuda:0"
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_dp_rank_device((0, 1), rank=2)
 
 
 def test_single_device_topology_spawns_no_children(fake_popen, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(UNILAB_DP_RANK, raising=False)
-    cfg = _offpolicy_cfg(["training.devices=[0]", "training.device=null"])
+    cfg = _offpolicy_cfg(["training.devices=[0]"])
     devices = resolve_dp_topology(cfg.training.devices)
     assert devices == (0,)
-    apply_dp_rank_config(cfg, devices, rank=0)
-    assert cfg.training.device == "cuda:0"
+    assert apply_dp_rank_config(cfg, devices, rank=0) == "cuda:0"
     with DpRankSupervisor(devices, log_dir="/tmp/dp_test_log"):
         assert fake_popen.instances == []
     assert os.environ.get(UNILAB_DP_RANK) is None

--- a/tests/ipc/test_dp_launcher.py
+++ b/tests/ipc/test_dp_launcher.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
 
 import unilab.ipc.dp_launcher as dp_launcher
 from unilab.ipc.dp_launcher import (
@@ -24,6 +25,7 @@ from unilab.ipc.dp_launcher import (
     apply_dp_rank_config,
     current_dp_rank,
     current_dp_world_size,
+    resolve_collector_cpu_ids,
     resolve_dp_topology,
     validate_dp_launchable,
 )
@@ -273,6 +275,78 @@ def test_supervisor_restores_sigterm_handler(fake_popen):
         assert signal.getsignal(signal.SIGTERM) is dp_launcher._sigterm_system_exit
         fake_popen.instances[0].returncode = 0
     assert signal.getsignal(signal.SIGTERM) == previous
+
+
+# ---------------------------------------------------------------------------
+# resolve_collector_cpu_ids
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_collector_cpu_ids_single_rank_returns_none():
+    assert resolve_collector_cpu_ids(1, 0, 128) is None
+    assert resolve_collector_cpu_ids(0, 0, 128) is None
+
+
+def test_resolve_collector_cpu_ids_even_partition():
+    assert resolve_collector_cpu_ids(2, 0, 128) == list(range(0, 64))
+    assert resolve_collector_cpu_ids(2, 1, 128) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_remainder_stays_unassigned():
+    # 129 CPUs / 2 ranks -> 64+64; CPU 128 keeps default OS scheduling.
+    assert resolve_collector_cpu_ids(2, 0, 129) == list(range(0, 64))
+    assert resolve_collector_cpu_ids(2, 1, 129) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_requires_one_cpu_per_rank():
+    with pytest.raises(ValueError, match="cpu_count"):
+        resolve_collector_cpu_ids(4, 0, 3)
+
+
+def test_resolve_collector_cpu_ids_rank_out_of_range():
+    with pytest.raises(ValueError, match="out of range"):
+        resolve_collector_cpu_ids(2, 2, 128)
+
+
+def test_resolve_collector_cpu_ids_explicit_valid():
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=[[0, 1], [2, 3]]) == [2, 3]
+
+
+def test_resolve_collector_cpu_ids_empty_explicit_falls_back_to_auto():
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=[]) == list(range(64, 128))
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_segment_count_mismatch():
+    with pytest.raises(ValueError, match="world_size"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0], [1], [2]])
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_overlapping_segments():
+    with pytest.raises(ValueError, match="overlap"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, 1], [1, 2]])
+
+
+def test_resolve_collector_cpu_ids_explicit_rejects_empty_segment():
+    with pytest.raises(ValueError, match="non-empty"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, 1], []])
+
+
+@pytest.mark.parametrize("bad_id", [-1, True, "2"])
+def test_resolve_collector_cpu_ids_explicit_rejects_invalid_ids(bad_id):
+    with pytest.raises(ValueError, match="non-negative integers"):
+        resolve_collector_cpu_ids(2, 0, 128, explicit=[[0, bad_id], [2, 3]])
+
+
+def test_offpolicy_config_dp_collector_cpu_ids_defaults_to_null():
+    cfg = _offpolicy_cfg()
+    assert cfg.training.dp_collector_cpu_ids is None
+
+
+def test_offpolicy_config_dp_collector_cpu_ids_compose():
+    cfg = _offpolicy_cfg(["training.dp_collector_cpu_ids=[[0,1],[2,3]]"])
+    explicit = OmegaConf.to_container(cfg.training.dp_collector_cpu_ids, resolve=True)
+    assert explicit == [[0, 1], [2, 3]]
+    assert resolve_collector_cpu_ids(2, 1, 128, explicit=explicit) == [2, 3]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -17,8 +17,8 @@ _SPAWN_CTX = mp.get_context("spawn")
 def _make_tensors(rank: int, *, reversed_order: bool = False) -> dict[str, torch.Tensor]:
     """Deterministic per-rank tensors; distinct values and shapes per key."""
     entries = [
-        ("actor.net.weight", torch.full((4, 3), 1.0 + rank)),
-        ("qnet.head.bias", torch.full((2,), 10.0 + rank)),
+        ("actor.net.weight", torch.full((4, 3), 1.0 + rank, requires_grad=True)),
+        ("qnet.head.bias", torch.full((2,), 10.0 + rank, requires_grad=True)),
         ("log_alpha", torch.full((1,), -0.5 + rank, requires_grad=True)),
     ]
     if reversed_order:
@@ -26,7 +26,7 @@ def _make_tensors(rank: int, *, reversed_order: bool = False) -> dict[str, torch
     return dict(entries)
 
 
-def _broadcast_and_allreduce_worker(
+def _broadcast_and_gradient_worker(
     rank: int, rendezvous_path: str, reversed_order: bool, result_queue
 ) -> None:
     tensors = _make_tensors(rank, reversed_order=reversed_order)
@@ -47,33 +47,34 @@ def _broadcast_and_allreduce_worker(
             f"rank {rank} broadcast mismatch on {key}"
         )
 
-    # In-place semantics: allreduce_mean must not rebind the storage.
-    ptrs_before = {key: tensor.data_ptr() for key, tensor in tensors.items()}
+    grad_ptrs: dict[str, int] = {}
+    gradient_base = {"actor.net.weight": 1.0, "qnet.head.bias": 2.0, "log_alpha": 3.0}
+    for key, tensor in tensors.items():
+        tensor.grad = torch.full_like(tensor, gradient_base[key] + 2.0 * rank)
+        grad_ptrs[key] = tensor.grad.data_ptr()
+    sync.allreduce_gradients(tensors[key] for key in sorted(tensors))
+    for key, tensor in tensors.items():
+        assert tensor.grad is not None
+        assert torch.allclose(tensor.grad, torch.full_like(tensor, gradient_base[key] + 1.0))
+        assert tensor.grad.data_ptr() == grad_ptrs[key]
 
-    # Per-rank perturbation -> allreduce_mean lands on the cross-rank mean.
-    for key, tensor in tensors.items():
-        with torch.no_grad():
-            tensor.add_(float(rank + 1))
-    sync.allreduce_mean(tensors)
-    for key, tensor in tensors.items():
-        base = expected[key].detach()
-        assert torch.allclose(tensor.detach(), base + 1.5), (
-            f"rank {rank} allreduce mismatch on {key}"
-        )
-        assert tensor.data_ptr() == ptrs_before[key], f"{key} was not updated in place"
+    sync_time, sync_calls = sync.take_gradient_sync_metrics()
+    assert sync_time >= 0.0
+    assert sync_calls == 1
+    assert sync.take_gradient_sync_metrics() == (0.0, 0)
 
     sync.close()
     sync.close()  # idempotent
     result_queue.put((rank, sorted(tensors)))
 
 
-def test_broadcast_then_allreduce_mean_two_ranks(tmp_path: Path):
+def test_broadcast_then_flat_gradient_mean_two_ranks(tmp_path: Path):
     rendezvous = str(tmp_path / "rendezvous")
     result_queue = _SPAWN_CTX.Queue()
     procs = [
         _SPAWN_CTX.Process(
-            target=_broadcast_and_allreduce_worker,
-            args=(rank, rendezvous, False, result_queue),
+            target=_broadcast_and_gradient_worker,
+            args=(rank, rendezvous, bool(rank), result_queue),
         )
         for rank in range(2)
     ]
@@ -84,42 +85,8 @@ def test_broadcast_then_allreduce_mean_two_ranks(tmp_path: Path):
     results = sorted(result_queue.get(timeout=10) for _ in procs)
     for proc in procs:
         assert proc.exitcode == 0
-    # Both ranks walked the same (sorted) key order.
+    # Different insertion order still resolves to the same startup key order.
     assert results[0][1] == results[1][1]
-
-
-def _key_order_worker(rank: int, rendezvous_path: str, result_queue) -> None:
-    # Insertion order differs per rank; the collective order must not.
-    tensors = _make_tensors(rank, reversed_order=bool(rank))
-    sync = DpParameterSync(
-        world_size=2,
-        rank=rank,
-        rendezvous_path=rendezvous_path,
-        backend="gloo",
-        timeout_s=60,
-    )
-    sync.start()
-    sync.allreduce_mean(tensors)
-    for key, tensor in tensors.items():
-        mean = (_make_tensors(0)[key].detach() + _make_tensors(1)[key].detach()) / 2
-        assert torch.allclose(tensor.detach(), mean), f"rank {rank} key-order mismatch on {key}"
-    sync.close()
-    result_queue.put(rank)
-
-
-def test_collective_key_order_is_insertion_order_independent(tmp_path: Path):
-    rendezvous = str(tmp_path / "rendezvous_key_order")
-    result_queue = _SPAWN_CTX.Queue()
-    procs = [
-        _SPAWN_CTX.Process(target=_key_order_worker, args=(rank, rendezvous, result_queue))
-        for rank in range(2)
-    ]
-    for proc in procs:
-        proc.start()
-    for proc in procs:
-        proc.join(timeout=120)
-    for proc in procs:
-        assert proc.exitcode == 0
 
 
 def _statistics_worker(rank: int, rendezvous_path: str, result_queue) -> None:
@@ -229,7 +196,7 @@ def test_resolve_dp_rendezvous_path_anchors_on_run_root(tmp_path: Path, monkeypa
 @pytest.mark.slow
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 CUDA devices")
 def test_nccl_two_gpu_smoke(tmp_path: Path):
-    """Real NCCL smoke: parameters and logger statistics across two GPUs."""
+    """Real NCCL smoke: startup state, gradients, and logger statistics."""
     rendezvous = str(tmp_path / "rendezvous_nccl")
     result_queue = _SPAWN_CTX.Queue()
     procs = [
@@ -249,7 +216,7 @@ def test_nccl_two_gpu_smoke(tmp_path: Path):
 
 def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
     device = torch.device(f"cuda:{rank}")
-    tensor = torch.full((8,), float(rank + 1), device=device)
+    tensor = torch.nn.Parameter(torch.full((8,), float(rank + 1), device=device))
     sync = DpParameterSync(
         world_size=2,
         rank=rank,
@@ -262,8 +229,9 @@ def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
     tensors = {"w": tensor}
     sync.broadcast_from_rank0(tensors)
     assert torch.equal(tensor, torch.ones(8, device=device))
-    sync.allreduce_mean(tensors)
-    assert torch.allclose(tensor, torch.full((8,), 0.5 + 0.5, device=device))
+    tensor.grad = torch.full_like(tensor, float(rank + 1))
+    sync.allreduce_gradients((tensor,))
+    assert torch.allclose(tensor.grad, torch.full((8,), 1.5, device=device))
     statistics = sync.allreduce_statistics(
         mean={"loss": float(rank + 1)},
         total={"steps_per_sec": float(100 * (rank + 1))},

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -122,6 +122,68 @@ def test_collective_key_order_is_insertion_order_independent(tmp_path: Path):
         assert proc.exitcode == 0
 
 
+def _statistics_worker(rank: int, rendezvous_path: str, result_queue) -> None:
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="gloo",
+        timeout_s=60,
+    )
+    sync.start()
+    first = sync.allreduce_statistics(
+        mean={
+            "loss": 1.0 + 2.0 * rank,
+            **({"rank0_optional": 10.0} if rank == 0 else {}),
+        },
+        total={"steps_per_sec": 100.0 * (rank + 1)},
+    )
+    second = sync.allreduce_statistics(
+        mean={
+            "loss": 5.0 + 2.0 * rank,
+            **({"late_rank1_field": 9.0} if rank == 1 else {}),
+        },
+        total={"steps_per_sec": 10.0 * (rank + 1)},
+    )
+    sync.close()
+    result_queue.put((rank, first, second))
+
+
+def test_allreduce_statistics_sums_rates_and_means_sparse_fields(tmp_path: Path):
+    rendezvous = str(tmp_path / "rendezvous_statistics")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(
+            target=_statistics_worker,
+            args=(rank, rendezvous, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+    results = sorted(result_queue.get(timeout=10) for _ in procs)
+    for proc in procs:
+        assert proc.exitcode == 0
+    for _, first, second in results:
+        assert first == pytest.approx({"loss": 2.0, "rank0_optional": 10.0, "steps_per_sec": 300.0})
+        assert second == pytest.approx(
+            {"loss": 6.0, "late_rank1_field": 9.0, "steps_per_sec": 30.0}
+        )
+
+
+def test_allreduce_statistics_rejects_overlapping_reduction_modes(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused_statistics"),
+        backend="gloo",
+    )
+    with pytest.raises(ValueError, match="both mean and total"):
+        sync.allreduce_statistics(mean={"x": 1.0}, total={"x": 2.0})
+
+
 def test_key_set_change_between_collectives_is_rejected(tmp_path: Path):
     sync = DpParameterSync(
         world_size=2,
@@ -167,7 +229,7 @@ def test_resolve_dp_rendezvous_path_anchors_on_run_root(tmp_path: Path, monkeypa
 @pytest.mark.slow
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 CUDA devices")
 def test_nccl_two_gpu_smoke(tmp_path: Path):
-    """Real NCCL smoke: init + broadcast + allreduce across cuda:0/cuda:1."""
+    """Real NCCL smoke: parameters and logger statistics across two GPUs."""
     rendezvous = str(tmp_path / "rendezvous_nccl")
     result_queue = _SPAWN_CTX.Queue()
     procs = [
@@ -202,5 +264,10 @@ def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
     assert torch.equal(tensor, torch.ones(8, device=device))
     sync.allreduce_mean(tensors)
     assert torch.allclose(tensor, torch.full((8,), 0.5 + 0.5, device=device))
+    statistics = sync.allreduce_statistics(
+        mean={"loss": float(rank + 1)},
+        total={"steps_per_sec": float(100 * (rank + 1))},
+    )
+    assert statistics == pytest.approx({"loss": 1.5, "steps_per_sec": 300.0})
     sync.close()
     result_queue.put(rank)

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import queue
+import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,68 @@ from unilab.ipc.dp_launcher import resolve_dp_rendezvous_path
 from unilab.ipc.dp_sync import DpParameterSync
 
 _SPAWN_CTX = mp.get_context("spawn")
+
+
+def _run_workers(
+    procs: list[mp.Process],
+    result_queue,
+    *,
+    result_count: int,
+    timeout_s: float,
+) -> list:
+    """Collect results before joining producers and always reap every child."""
+    started: list[mp.Process] = []
+    deadline = time.monotonic() + timeout_s
+    results = []
+    try:
+        for proc in procs:
+            proc.start()
+            started.append(proc)
+
+        while len(results) < result_count:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail(
+                    "timed out waiting for worker results: "
+                    f"{[(proc.pid, proc.exitcode) for proc in started]}"
+                )
+            try:
+                results.append(result_queue.get(timeout=min(1.0, remaining)))
+            except queue.Empty:
+                failed = [proc for proc in started if proc.exitcode not in (None, 0)]
+                if failed:
+                    pytest.fail(
+                        "worker exited before publishing a result: "
+                        f"{[(proc.pid, proc.exitcode) for proc in failed]}"
+                    )
+
+        for proc in started:
+            proc.join(timeout=max(0.0, deadline - time.monotonic()))
+        hanging = [proc for proc in started if proc.is_alive()]
+        if hanging:
+            pytest.fail(f"workers did not exit: {[proc.pid for proc in hanging]}")
+        failed = [proc for proc in started if proc.exitcode != 0]
+        if failed:
+            pytest.fail(
+                f"workers exited unsuccessfully: {[(proc.pid, proc.exitcode) for proc in failed]}"
+            )
+        return results
+    finally:
+        for proc in started:
+            if proc.is_alive():
+                proc.terminate()
+        cleanup_deadline = time.monotonic() + 5.0
+        for proc in started:
+            if proc.is_alive():
+                proc.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+        for proc in started:
+            if proc.is_alive():
+                proc.kill()
+        for proc in started:
+            if proc.is_alive():
+                proc.join(timeout=1.0)
+        result_queue.close()
+        result_queue.join_thread()
 
 
 def _make_tensors(rank: int, *, reversed_order: bool = False) -> dict[str, torch.Tensor]:
@@ -78,13 +142,7 @@ def test_broadcast_then_flat_gradient_mean_two_ranks(tmp_path: Path):
         )
         for rank in range(2)
     ]
-    for proc in procs:
-        proc.start()
-    for proc in procs:
-        proc.join(timeout=120)
-    results = sorted(result_queue.get(timeout=10) for _ in procs)
-    for proc in procs:
-        assert proc.exitcode == 0
+    results = sorted(_run_workers(procs, result_queue, result_count=2, timeout_s=120))
     # Different insertion order still resolves to the same startup key order.
     assert results[0][1] == results[1][1]
 
@@ -126,13 +184,7 @@ def test_allreduce_statistics_sums_rates_and_means_sparse_fields(tmp_path: Path)
         )
         for rank in range(2)
     ]
-    for proc in procs:
-        proc.start()
-    for proc in procs:
-        proc.join(timeout=120)
-    results = sorted(result_queue.get(timeout=10) for _ in procs)
-    for proc in procs:
-        assert proc.exitcode == 0
+    results = sorted(_run_workers(procs, result_queue, result_count=2, timeout_s=120))
     for _, first, second in results:
         assert first == pytest.approx({"loss": 2.0, "rank0_optional": 10.0, "steps_per_sec": 300.0})
         assert second == pytest.approx(
@@ -230,12 +282,8 @@ def test_nccl_two_gpu_smoke(tmp_path: Path):
         )
         for rank in range(2)
     ]
-    for proc in procs:
-        proc.start()
-    for proc in procs:
-        proc.join(timeout=180)
-    for proc in procs:
-        assert proc.exitcode == 0
+    results = sorted(_run_workers(procs, result_queue, result_count=2, timeout_s=180))
+    assert results == [0, 1]
 
 
 def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -170,7 +170,10 @@ def _statistics_worker(rank: int, rendezvous_path: str, result_queue) -> None:
         },
         total={"steps_per_sec": 10.0 * (rank + 1)},
     )
-    sync.close()
+    # This worker process owns the Gloo group lifetime. Explicit Gloo destroy
+    # can strand rank 0 after schema broadcasts on a single-vCPU runner, so
+    # process exit is the teardown boundary here. The broadcast/gradient test
+    # above separately covers close() and its idempotence.
     result_queue.put((rank, first, second))
 
 

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -1,0 +1,206 @@
+"""Two-process gloo tests for DpParameterSync (CPU-only)."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+import torch
+
+from unilab.ipc.dp_launcher import resolve_dp_rendezvous_path
+from unilab.ipc.dp_sync import DpParameterSync
+
+_SPAWN_CTX = mp.get_context("spawn")
+
+
+def _make_tensors(rank: int, *, reversed_order: bool = False) -> dict[str, torch.Tensor]:
+    """Deterministic per-rank tensors; distinct values and shapes per key."""
+    entries = [
+        ("actor.net.weight", torch.full((4, 3), 1.0 + rank)),
+        ("qnet.head.bias", torch.full((2,), 10.0 + rank)),
+        ("log_alpha", torch.full((1,), -0.5 + rank, requires_grad=True)),
+    ]
+    if reversed_order:
+        entries.reverse()
+    return dict(entries)
+
+
+def _broadcast_and_allreduce_worker(
+    rank: int, rendezvous_path: str, reversed_order: bool, result_queue
+) -> None:
+    tensors = _make_tensors(rank, reversed_order=reversed_order)
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="gloo",
+        timeout_s=60,
+    )
+    sync.start()
+
+    # Init broadcast: every rank ends up with rank 0's values, bit-exact.
+    sync.broadcast_from_rank0(tensors)
+    expected = _make_tensors(0)
+    for key, tensor in tensors.items():
+        assert torch.equal(tensor.detach(), expected[key].detach()), (
+            f"rank {rank} broadcast mismatch on {key}"
+        )
+
+    # In-place semantics: allreduce_mean must not rebind the storage.
+    ptrs_before = {key: tensor.data_ptr() for key, tensor in tensors.items()}
+
+    # Per-rank perturbation -> allreduce_mean lands on the cross-rank mean.
+    for key, tensor in tensors.items():
+        with torch.no_grad():
+            tensor.add_(float(rank + 1))
+    sync.allreduce_mean(tensors)
+    for key, tensor in tensors.items():
+        base = expected[key].detach()
+        assert torch.allclose(tensor.detach(), base + 1.5), (
+            f"rank {rank} allreduce mismatch on {key}"
+        )
+        assert tensor.data_ptr() == ptrs_before[key], f"{key} was not updated in place"
+
+    sync.close()
+    sync.close()  # idempotent
+    result_queue.put((rank, sorted(tensors)))
+
+
+def test_broadcast_then_allreduce_mean_two_ranks(tmp_path: Path):
+    rendezvous = str(tmp_path / "rendezvous")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(
+            target=_broadcast_and_allreduce_worker,
+            args=(rank, rendezvous, False, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+    results = sorted(result_queue.get(timeout=10) for _ in procs)
+    for proc in procs:
+        assert proc.exitcode == 0
+    # Both ranks walked the same (sorted) key order.
+    assert results[0][1] == results[1][1]
+
+
+def _key_order_worker(rank: int, rendezvous_path: str, result_queue) -> None:
+    # Insertion order differs per rank; the collective order must not.
+    tensors = _make_tensors(rank, reversed_order=bool(rank))
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="gloo",
+        timeout_s=60,
+    )
+    sync.start()
+    sync.allreduce_mean(tensors)
+    for key, tensor in tensors.items():
+        mean = (_make_tensors(0)[key].detach() + _make_tensors(1)[key].detach()) / 2
+        assert torch.allclose(tensor.detach(), mean), f"rank {rank} key-order mismatch on {key}"
+    sync.close()
+    result_queue.put(rank)
+
+
+def test_collective_key_order_is_insertion_order_independent(tmp_path: Path):
+    rendezvous = str(tmp_path / "rendezvous_key_order")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(target=_key_order_worker, args=(rank, rendezvous, result_queue))
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+    for proc in procs:
+        assert proc.exitcode == 0
+
+
+def test_key_set_change_between_collectives_is_rejected(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused"),
+        backend="gloo",
+    )
+    first = {"a": torch.zeros(1), "b": torch.zeros(1)}
+    sync._ordered_keys(first)
+    with pytest.raises(ValueError, match="tensor keys changed"):
+        sync._ordered_keys({"a": torch.zeros(1), "c": torch.zeros(1)})
+
+
+def test_close_without_start_is_idempotent(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused"),
+        backend="gloo",
+    )
+    sync.close()
+    sync.close()
+
+
+def test_invalid_world_size_and_rank_are_rejected(tmp_path: Path):
+    path = str(tmp_path / "unused")
+    with pytest.raises(ValueError, match="world_size >= 2"):
+        DpParameterSync(world_size=1, rank=0, rendezvous_path=path)
+    with pytest.raises(ValueError, match="out of range"):
+        DpParameterSync(world_size=2, rank=2, rendezvous_path=path)
+
+
+def test_resolve_dp_rendezvous_path_anchors_on_run_root(tmp_path: Path, monkeypatch):
+    # Rank 0 anchors in its own log_dir; spawned ranks use the shared run root.
+    monkeypatch.delenv("UNILAB_DP_LOG_DIR", raising=False)
+    rank0 = resolve_dp_rendezvous_path(str(tmp_path / "run"), rank=0)
+    assert rank0 == str(tmp_path / "run" / ".dp_rendezvous")
+    monkeypatch.setenv("UNILAB_DP_LOG_DIR", str(tmp_path / "run"))
+    rank1 = resolve_dp_rendezvous_path(str(tmp_path / "run" / "rank1"), rank=1)
+    assert rank1 == rank0
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 CUDA devices")
+def test_nccl_two_gpu_smoke(tmp_path: Path):
+    """Real NCCL smoke: init + broadcast + allreduce across cuda:0/cuda:1."""
+    rendezvous = str(tmp_path / "rendezvous_nccl")
+    result_queue = _SPAWN_CTX.Queue()
+    procs = [
+        _SPAWN_CTX.Process(
+            target=_nccl_smoke_worker,
+            args=(rank, rendezvous, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=180)
+    for proc in procs:
+        assert proc.exitcode == 0
+
+
+def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
+    device = torch.device(f"cuda:{rank}")
+    tensor = torch.full((8,), float(rank + 1), device=device)
+    sync = DpParameterSync(
+        world_size=2,
+        rank=rank,
+        rendezvous_path=rendezvous_path,
+        backend="nccl",
+        device=str(device),
+        timeout_s=120,
+    )
+    sync.start()
+    tensors = {"w": tensor}
+    sync.broadcast_from_rank0(tensors)
+    assert torch.equal(tensor, torch.ones(8, device=device))
+    sync.allreduce_mean(tensors)
+    assert torch.allclose(tensor, torch.full((8,), 0.5 + 0.5, device=device))
+    sync.close()
+    result_queue.put(rank)

--- a/tests/ipc/test_dp_sync.py
+++ b/tests/ipc/test_dp_sync.py
@@ -175,6 +175,30 @@ def test_close_without_start_is_idempotent(tmp_path: Path):
     sync.close()
 
 
+def test_cuda_graph_collective_warmup_requires_started_nccl_cuda_group(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused_graph_warmup"),
+        backend="gloo",
+    )
+    with pytest.raises(RuntimeError, match=r"start\(\) must run"):
+        sync.prepare_cuda_graph_collectives()
+
+
+def test_cuda_graph_replay_metrics_count_actual_collectives(tmp_path: Path):
+    sync = DpParameterSync(
+        world_size=2,
+        rank=0,
+        rendezvous_path=str(tmp_path / "unused_graph_metrics"),
+        backend="gloo",
+    )
+    sync.record_cuda_graph_gradient_replay(3)
+    assert sync.take_gradient_sync_metrics() == (0.0, 3)
+    with pytest.raises(ValueError, match=">= 0"):
+        sync.record_cuda_graph_gradient_replay(-1)
+
+
 def test_invalid_world_size_and_rank_are_rejected(tmp_path: Path):
     path = str(tmp_path / "unused")
     with pytest.raises(ValueError, match="world_size >= 2"):
@@ -237,5 +261,17 @@ def _nccl_smoke_worker(rank: int, rendezvous_path: str, result_queue) -> None:
         total={"steps_per_sec": float(100 * (rank + 1))},
     )
     assert statistics == pytest.approx({"loss": 1.5, "steps_per_sec": 300.0})
+    sync.prepare_cuda_graph_collectives()
+    tensor.grad = torch.full_like(tensor, float(rank + 1))
+    graph = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+        sync.allreduce_gradients((tensor,))
+    torch.cuda.current_stream(device).wait_stream(capture_stream)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.allclose(tensor.grad, torch.full((8,), 1.5, device=device))
+    graph.reset()
     sync.close()
     result_queue.put(rank)

--- a/tests/nan_injection/stage3_nan_inject.py
+++ b/tests/nan_injection/stage3_nan_inject.py
@@ -106,9 +106,6 @@ class _FakeLogger:
         self._buffer_size = 0
         self._mean_ep_length = 0.0
 
-    def set_collection_sync(self, enabled, env_steps_per_sync):
-        del enabled, env_steps_per_sync
-
     def start(self, **kwargs):
         del kwargs
 
@@ -133,8 +130,8 @@ class _FakeLogger:
     def update_collector_timing(self, timing_ms):
         del timing_ms
 
-    def update_done_rates(self, timeout_rate, terminated_rate):
-        del timeout_rate, terminated_rate
+    def update_timeout_rate(self, timeout_rate):
+        del timeout_rate
 
     def update_replay_queue(self, current_len, max_size):
         del current_len, max_size

--- a/tests/scripts/test_train_script_configs.py
+++ b/tests/scripts/test_train_script_configs.py
@@ -5,12 +5,14 @@ These tests verify that Hydra configs are complete and scripts don't crash on st
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 
 pytest.importorskip("mujoco")
 
@@ -170,3 +172,59 @@ def test_ppo_sharpa_motrix_one_iteration_training_smoke(tmp_path):
     )
     assert "Learning iteration 0/1" in result.stdout
     assert "reward/total" in result.stdout
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires >=2 CUDA devices")
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("task", "task_name"),
+    [
+        ("go2_joystick_flat/mujoco", "Go2JoystickFlat"),
+        ("g1_motion_tracking/mujoco", "G1MotionTracking"),
+    ],
+)
+def test_ppo_two_gpu_rsl_rl_training_smoke(task: str, task_name: str, tmp_path: Path) -> None:
+    """RSL-RL PPO uses one env/storage replica per rank and rank-0 artifacts."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/train_rsl_rl.py",
+            f"task={task}",
+            "training.devices=[0,1]",
+            "training.play_render_mode=record",
+            "training.play_steps=2",
+            "training.play_env_num=2",
+            "training.nan_guard.enabled=false",
+            f"training.log_root={tmp_path}",
+            "algo.num_envs=64",
+            "algo.num_steps_per_env=4",
+            "algo.max_iterations=1",
+            "algo.save_interval=100",
+            "algo.algorithm.num_learning_epochs=1",
+            "algo.algorithm.num_mini_batches=2",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, (
+        f"PPO two-GPU smoke failed for {task}:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "Synchronizing parameters for rank 0" in result.stdout
+    assert "Synchronizing parameters for rank 1" in result.stdout
+    assert "Done." in result.stdout
+    assert "device used by this process is currently unknown" not in result.stderr
+
+    run_dirs = list((tmp_path / task_name).glob("*_mujoco_gpux2"))
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    assert len(list(run_dir.glob("events.out.tfevents.*"))) == 1
+    assert len(list(run_dir.glob("model_*.pt"))) == 1
+    assert (run_dir / "play_video.mp4").is_file()
+    summary = json.loads((run_dir / "run_summary.json").read_text(encoding="utf-8"))
+    assert summary["world_size"] == 2
+    assert summary["num_envs_per_rank"] == 64
+    assert summary["global_num_envs"] == 128
+    assert summary["samples_per_iteration"] == 512
+    assert summary["run_env_steps"] == 512

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1416,6 +1416,10 @@ def test_offpolicy_build_run_dir_name_uses_timestamp_and_backend():
     mod = _offpolicy()
 
     assert mod.build_run_dir_name("2026-06-22_22-31-24", "mujoco") == ("2026-06-22_22-31-24_mujoco")
+    assert (
+        mod.build_run_dir_name("2026-06-22_22-31-24", "mujoco", world_size=2)
+        == "2026-06-22_22-31-24_mujoco_gpux2"
+    )
 
 
 def test_offpolicy_main_failure_summary_and_skips_playback(

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1464,7 +1464,7 @@ def test_offpolicy_main_failure_summary_and_skips_playback(
         mod, "assert_offpolicy_task_choice_matches_algo", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(mod, "ExperimentTracker", FakeTracker)
-    monkeypatch.setattr(mod, "build_runner", lambda algo_name, cfg: FakeRunner())
+    monkeypatch.setattr(mod, "build_runner", lambda algo_name, cfg, log_dir=None: FakeRunner())
     monkeypatch.setattr(
         mod,
         "play_offpolicy",

--- a/tests/utils/test_experiment_tracking.py
+++ b/tests/utils/test_experiment_tracking.py
@@ -70,10 +70,12 @@ class _FakeTensorBoardWriter:
 
 def test_training_logger_defers_initial_live_render(monkeypatch):
     start_refresh_values: list[bool] = []
+    live_kwargs: list[dict[str, Any]] = []
 
     class _FakeLive:
         def __init__(self, *args, **kwargs):
-            del args, kwargs
+            del args
+            live_kwargs.append(kwargs)
 
         def start(self, *, refresh: bool = False) -> None:
             start_refresh_values.append(refresh)
@@ -91,9 +93,12 @@ def test_training_logger_defers_initial_live_render(monkeypatch):
     logger.close()
 
     assert start_refresh_values == [False]
+    assert live_kwargs[0]["auto_refresh"] is True
+    assert live_kwargs[0]["refresh_per_second"] == 2
+    assert callable(live_kwargs[0]["get_renderable"])
 
 
-def test_offpolicy_training_terminal_refresh_uses_single_low_frequency_trigger(monkeypatch):
+def test_offpolicy_training_terminal_uses_fixed_clock_and_only_forces_errors(monkeypatch):
     update_refresh_values: list[bool | None] = []
     now = 100.0
 
@@ -120,19 +125,19 @@ def test_offpolicy_training_terminal_refresh_uses_single_low_frequency_trigger(m
     logger = OffPolicyLogger(log_backend="none", refresh_per_second=4)
     logger.start()
     logger.log_step(iteration=1, train_time=0.01, collector_wait_time=0.0)
-    assert update_refresh_values == [True]
+    assert update_refresh_values == []
 
     logger.log_collector(total_steps=128, buffer_size=128, mean_reward=2.0)
     logger.log_status("Collector metrics updated")
     logger.log_save("/tmp/model_2.pt")
-    assert update_refresh_values == [True]
+    assert update_refresh_values == []
 
     now += 0.3
     logger.log_step(iteration=2, train_time=0.01, collector_wait_time=0.0)
-    assert update_refresh_values == [True, True]
+    assert update_refresh_values == []
 
     logger.log_status("[red]ERROR: Collector died[/]")
-    assert update_refresh_values == [True, True, True]
+    assert update_refresh_values == [True]
 
     logger.close()
 
@@ -227,12 +232,15 @@ def test_offpolicy_logger_terminal_keeps_core_bottleneck_timing_rows():
     assert "Param Sync" not in output
     assert "Unaccounted" not in output
     assert "Other Loop" not in output
-    assert "GPUs" not in output
+    assert "GPUs 1" in output
     assert "Sync Mode" not in output
     assert "Sync Interval" not in output
+    assert "Sync Collect" not in output
+    assert "Terminated Rate" not in output
+    assert "Staging Pool" not in output
     assert "Batch/Rank" in output
     assert "Batch/Update" not in output
-    assert "Samples/Iter" in output
+    assert "Samples/Iter" not in output
     assert "Samples/s" in output
 
     logger.close()
@@ -296,8 +304,8 @@ def test_offpolicy_logger_terminal_shows_replay_rows_when_symmetry_expands_batch
     output = console.export_text()
 
     assert "Batch/Rank" in output
-    assert "Replay/Iter" in output
-    assert "Samples/Iter" in output
+    assert "Replay/Iter" not in output
+    assert "Samples/Iter" not in output
     assert "Samples/s" in output
     assert "Rank Barrier" not in output
     assert "Param Sync" not in output
@@ -631,7 +639,6 @@ def test_offpolicy_logger_uses_same_canonical_timing_names_in_terminal_and_backe
             "learner_action_wait_ms": 2.0,
             "env_step_ms": 3.0,
             "replay_write_ms": 4.0,
-            "bookkeeping_ms": 5.0,
         }
     )
     logger.log_step(
@@ -674,23 +681,22 @@ def test_offpolicy_logger_uses_same_canonical_timing_names_in_terminal_and_backe
         assert key in payload
     assert "timing/learner_replay_stage_ms" not in payload
     assert "timing/learner_weight_publish_ms" not in payload
-    assert collector_labels[:5] == [
+    assert collector_labels[:4] == [
         "Inference Request",
         "Learner Action Wait",
         "Env Step",
         "Replay Write",
-        "Bookkeeping",
     ]
     for key in (
         "timing/collector_inference_request_ms",
         "timing/collector_learner_action_wait_ms",
         "timing/collector_env_step_ms",
         "timing/collector_replay_write_ms",
-        "timing/collector_bookkeeping_ms",
         "perf/collector_cycle_ms",
     ):
         assert key in payload
-    assert payload["perf/collector_cycle_ms"] == pytest.approx(15.0)
+    assert "timing/collector_bookkeeping_ms" not in payload
+    assert payload["perf/collector_cycle_ms"] == pytest.approx(10.0)
     logger.finish()
 
 
@@ -748,6 +754,8 @@ def test_offpolicy_logger_tensorboard_logs_wall_clock_without_axis_scalars():
     assert scalars["perf/learner_other_pct"] == pytest.approx(0.16 / 2.15 * 100)
     assert scalars["perf/collector_active_steps_per_sec"] == pytest.approx(4321.0)
     assert scalars["perf/effective_samples_per_sec"] == pytest.approx(64.0 / 2.15)
+    assert scalars["episode/timeout_rate"] == pytest.approx(0.0)
+    assert "episode/terminated_rate" not in scalars
     for key in ("axis/iteration", "axis/env_steps_total"):
         assert key not in scalars
     assert not any(key.startswith("distributed/") for key in scalars)


### PR DESCRIPTION
## Summary

This is the final umbrella integration PR for #964. The implementation work was split across reviewed child PRs and accumulated on `feat/issue-964-offpolicy-multi-gpu-dp`; this PR does not introduce a new implementation scope.

- add single-node multi-GPU off-policy data parallelism with one learner, collector, rank-local replay, and GPU per rank
- support FastSAC and FlashSAC on MuJoCo, with rank 0 owning tracking, checkpoints, terminal output, and playback
- integrate the independently reviewed RSL-RL PPO multi-GPU path from #980 for Go2 joystick flat and G1 motion tracking
- report aggregate job throughput and topology for off-policy and PPO runs
- add bilingual README launch examples for PPO, FlashSAC, and FastSAC multi-GPU configurations
- include the NCCL CUDA Graph stabilization from #978/#979 and the post-playback process-group cleanup from #981
- make CPU-only distributed tests safe on single-core CI by draining result queues before joining producers and always reaping child processes

## Final off-policy contract

The original roadmap proposed periodic parameter averaging through `training.dp_sync_interval`. The final implementation and #964 have been explicitly revised:

- startup model and optimizer state are broadcast across ranks
- before every actual optimizer step, stable flat-gradient buffers are all-reduced and averaged
- each rank then performs its local optimizer step; there is no `training.dp_sync_interval`
- replay, environments, exploration seeds, and collectors remain rank-local
- collectors still own no actor and initialize no CUDA
- omitting `training.devices` preserves the existing single-GPU path

This uses runner-owned collectives rather than a PyTorch DDP wrapper and does not introduce a second collector/learner lifecycle.

## Included work

- #970: rank launcher, topology, config, and rank-0 ownership
- #971: disjoint per-collector CPU partitions
- #972: NCCL synchronization and lifecycle
- #973: scaling benchmark and support documentation
- #974: FlashSAC integration
- #979: NCCL CUDA Graph capture and aggregate logging
- #980: independently validated RSL-RL PPO multi-GPU integration
- #981: final stacked integration and shutdown cleanup

## Validation

The final PR head tree is identical to the tree validated by:

- `make test-all` — 1657 passed, 24 skipped, 1 xfailed; coverage 72%; benchmark import smoke passed
- all three README commands compose through Hydra `--cfg job`, resolving the documented 2/4/8-device lists; the hardware validation boundary remains the 2-GPU platform stated below
- single-core (`taskset -c 0`) IPC regression — 10 passed, 1 slow test deselected; sparse-statistics worker stress — 10/10 passed
- the GitHub Actions test job now has a 15-minute hard timeout
- FastSAC and FlashSAC two-GPU lifecycle, synchronization, checkpoint, and failure-propagation smokes
- FastSAC and FlashSAC graph-enabled two-GPU smokes, including a collective for every actual optimizer update
- RSL-RL PPO two-GPU slow smokes for Go2 joystick flat and G1 motion tracking
- direct Go2 train-to-playback regression: video creation followed by natural exit after `Done.`, without a second NCCL process group

The branch is 13 commits ahead of `main`; a merge-tree check reports no conflicts.

## Throughput

Off-policy validation used 2 × RTX 6000D and Threadripper 9980X with the production FastSAC configuration:

| GPUs | Aggregate env steps/s | Scaling | Final reward |
|---:|---:|---:|---:|
| 1 | 64,242 | 1.00× | 7.96 |
| 2 | 110,804 | 1.72× | 7.93 |

PPO results are weak-scaling measurements with 1024 environments per rank, rollout length 24, and 10 steady-state iterations after discarding 2 warmup iterations:

| Task | GPUs | Mean samples/s | Scaling |
|---|---:|---:|---:|
| Go2 joystick flat | 1 | 134,258.5 | 1.000× |
| Go2 joystick flat | 2 | 218,351.9 | 1.626× |
| G1 motion tracking | 1 | 67,999.5 | 1.000× |
| G1 motion tracking | 2 | 117,617.4 | 1.730× |

No PPO model-quality claim is made; acceptance is semantic correctness, lifecycle completion, and throughput reporting.

## Support boundary

- validated on Linux, one node, MuJoCo, and 2 × RTX 6000D
- off-policy support: FastSAC and FlashSAC
- PPO support: RSL-RL Go2 joystick flat and G1 motion tracking examples
- TD3, Motrix multi-GPU, cross-rank replay, and multi-node execution remain out of scope
- PPO observation normalization, curriculum, and episode statistics remain rank-local; rank 0 checkpoint/log state is authoritative
- `NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1` are defaults for the validated platform; explicit user environment values take precedence

Closes #964
Related: #978