### PR TITLE
fix: audit off-policy sim2sim owners (#984)

### DIFF
--- a/scripts/audit_sim2sim_contracts.py
+++ b/scripts/audit_sim2sim_contracts.py
@@ -2,6 +2,8 @@
 
 For every task with >=2 backend YAMLs, hydra-composes each backend's effective config
 and compares the DENYLIST / WARNING_LIST fields from ``unilab.training.sim2sim``.
+Off-policy owners are grouped by algorithm so SAC, TD3, and FlashSAC are never
+compared with one another.
 
 Read-only.
 
@@ -50,9 +52,19 @@ def _select(cfg: Any, path: str) -> Any:
 
 def _compose(tree: str, task_variant: str) -> Any:
     conf_dir = str(CONF_ROOT / tree)
+    overrides: list[str] = []
+    if tree == "offpolicy":
+        variant_parts = task_variant.split("/")
+        if len(variant_parts) != 3:
+            raise ValueError(
+                f"offpolicy task variants must use '<algo>/<task>/<backend>', got {task_variant!r}"
+            )
+        algo = variant_parts[0]
+        overrides.append(f"algo={algo}")
+    overrides.append(f"task={task_variant}")
     GlobalHydra.instance().clear()
     with initialize_config_dir(config_dir=conf_dir, version_base="1.3"):
-        return compose("config", overrides=[f"task={task_variant}"])
+        return compose("config", overrides=overrides)
 
 
 def _discover(tree: str) -> dict[str, list[str]]:
@@ -60,11 +72,14 @@ def _discover(tree: str) -> dict[str, list[str]]:
     out: dict[str, list[str]] = {}
     if not base.is_dir():
         return out
-    for task_dir in sorted(p for p in base.iterdir() if p.is_dir()):
-        backends = sorted(p.stem for p in task_dir.glob("*.yaml") if p.stem != "base")
-        if backends:
-            out[task_dir.name] = backends
-    return out
+    for owner_file in sorted(base.rglob("*.yaml")):
+        if owner_file.stem == "base":
+            continue
+        task_variant = owner_file.parent.relative_to(base).as_posix()
+        if task_variant == ".":
+            continue
+        out.setdefault(task_variant, []).append(owner_file.stem)
+    return {task: sorted(backends) for task, backends in sorted(out.items())}
 
 
 def _diff_field(path: str, mj: Any, mx: Any) -> dict[str, Any] | None:
@@ -91,7 +106,10 @@ def _diff_field(path: str, mj: Any, mx: Any) -> dict[str, Any] | None:
 
 def audit_tree(tree: str) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for task, backends in _discover(tree).items():
+    discovered = _discover(tree)
+    if not discovered:
+        raise ValueError(f"No task owner configs discovered under conf/{tree}/task")
+    for task, backends in discovered.items():
         values: dict[str, dict[str, Any]] = {}
         errors: dict[str, str] = {}
         for backend in backends:

--- a/tests/scripts/test_audit_sim2sim_contracts.py
+++ b/tests/scripts/test_audit_sim2sim_contracts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "audit_sim2sim_contracts.py"
+
+
+def _load_audit_module():
+    spec = importlib.util.spec_from_file_location("audit_sim2sim_contracts", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_discover_preserves_standard_task_layout() -> None:
+    audit = _load_audit_module()
+
+    discovered = audit._discover("ppo")
+
+    assert {"mujoco", "motrix"}.issubset(discovered["g1_walk_flat"])
+
+
+def test_discover_groups_offpolicy_owners_by_algorithm() -> None:
+    audit = _load_audit_module()
+
+    discovered = audit._discover("offpolicy")
+
+    assert {"mujoco", "motrix", "mjwarp"}.issubset(discovered["sac/g1_walk_flat"])
+    assert {"mujoco", "motrix", "mjwarp"}.issubset(discovered["flashsac/g1_walk_flat"])
+    assert discovered["td3/g1_walk_flat"] == ["mujoco"]
+
+
+@pytest.mark.parametrize(
+    ("task_variant", "expected_algo"),
+    [
+        ("sac/g1_walk_flat/mujoco", "sac"),
+        ("td3/g1_walk_flat/mujoco", "td3"),
+        ("flashsac/g1_walk_flat/mujoco", "flashsac"),
+    ],
+)
+def test_compose_selects_matching_offpolicy_algo(task_variant: str, expected_algo: str) -> None:
+    audit = _load_audit_module()
+
+    cfg = audit._compose("offpolicy", task_variant)
+
+    assert cfg.algo.algo == expected_algo
+
+
+def test_audit_tree_compares_one_offpolicy_backend_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit = _load_audit_module()
+    monkeypatch.setattr(
+        audit,
+        "_discover",
+        lambda tree: {"flashsac/g1_walk_flat": ["motrix", "mujoco"]},
+    )
+
+    rows = audit.audit_tree("offpolicy")
+
+    assert len(rows) == 1
+    assert rows[0]["task"] == "flashsac/g1_walk_flat"
+    assert rows[0]["backends"] == ["motrix", "mujoco"]
+    assert rows[0]["errors"] == {}
+
+
+def test_audit_tree_rejects_empty_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    audit = _load_audit_module()
+    monkeypatch.setattr(audit, "_discover", lambda tree: {})
+
+    with pytest.raises(ValueError, match="No task owner configs discovered"):
+        audit.audit_tree("offpolicy")
+
+
+def test_compose_rejects_offpolicy_variant_without_algo() -> None:
+    audit = _load_audit_module()
+
+    with pytest.raises(ValueError, match="<algo>/<task>/<backend>"):
+        audit._compose("offpolicy", "g1_walk_flat")


### PR DESCRIPTION
## Summary

- discover both task/backend and algo/task/backend owner layouts
- compose off-policy owners with their matching algorithm group
- fail closed when a requested config tree contains no owner configs

## Validation

- `make test-all` passed at `dc628f57aedd2ce82b384fe23b890ae4312e7a4b`
- 1662 passed, 27 skipped, 273 deselected, 1 xfailed
- benchmark smoke: 33/34 module-mode and 34/35 script-mode; MLX-only entries skipped
- `uv run scripts/audit_sim2sim_contracts.py --trees offpolicy --json`: 24 rows, 8 MuJoCo/Motrix pairs, 0 compose errors

Closes #984