### PR TITLE
fix: narrow sim2sim load dimension guard (#985)

### DIFF
--- a/src/unilab/training/sim2sim.py
+++ b/src/unilab/training/sim2sim.py
@@ -192,18 +192,9 @@ def resolve_sim2sim_config(
     return target_cfg
 
 
-_DIM_MISMATCH_MARKERS: tuple[str, ...] = (
-    "size mismatch",
-    "copying a param",
-    "shape",
-    "dimension",
-    "expected",
-)
-
-
 def _looks_like_dim_mismatch(message: str) -> bool:
-    low = message.lower()
-    return any(marker in low for marker in _DIM_MISMATCH_MARKERS)
+    """Return whether ``load_state_dict`` reported a parameter size mismatch."""
+    return "size mismatch for " in message.lower()
 
 
 @contextmanager

--- a/tests/training/test_sim2sim_resolver.py
+++ b/tests/training/test_sim2sim_resolver.py
@@ -263,12 +263,23 @@ def test_dim_guard_translates_torch_size_mismatch():
     assert isinstance(excinfo.value.__cause__, RuntimeError)  # original chained
 
 
-def test_dim_guard_reraises_unrelated_errors_unchanged():
-    # A non-dimension load failure must propagate as-is (not masked as a sim2sim error).
-    with pytest.raises(RuntimeError) as excinfo:
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("CUDA out of memory"),
+        RuntimeError("Expected all tensors to be on the same device, but found cuda:0 and cpu"),
+        RuntimeError("expected scalar type Float but found Half"),
+        RuntimeError("shape '[12, 4]' is invalid for input of size 36"),
+        RuntimeError("no kernel image is available for execution on the device"),
+        RuntimeError("copying a param failed: expected all tensors to use the same dtype"),
+        ValueError("Expected input batch_size (32) to match target batch_size (16)"),
+    ],
+)
+def test_dim_guard_reraises_unrelated_errors_unchanged(error):
+    with pytest.raises(type(error)) as excinfo:
         with policy_load_dim_guard(env_obs_dim=10, env_action_dim=3):
-            raise RuntimeError("CUDA out of memory")
-    assert not isinstance(excinfo.value, CrossBackendIncompatibleError)
+            raise error
+    assert excinfo.value is error
 
 
 def test_dim_guard_does_not_swallow_keyerror():


### PR DESCRIPTION
## Summary

- translate only explicit PyTorch `size mismatch for ...` state-dict failures
- preserve device, dtype, kernel, shape-operation, OOM, and unrelated value errors unchanged
- retain the original exception as the cause of translated diagnostics

## Validation

- `make test-all` passed at `a37ea086fa321c3a7ac208883c7cf9d08ca0b3bc`
- 1660 passed, 27 skipped, 273 deselected, 1 xfailed
- benchmark smoke: 33/34 module-mode and 34/35 script-mode; MLX-only entries skipped

Closes #985