### PR TITLE
refactor: remove unused async collector hook (#986)

### DIFF
--- a/src/unilab/algos/torch/appo/runner.py
+++ b/src/unilab/algos/torch/appo/runner.py
@@ -194,9 +194,6 @@ class APPORunner(AsyncRunner):
         )
         return learner
 
-    def _collector_fn(self, stop_event, **kwargs):
-        appo_collector_fn(stop_event=stop_event, **kwargs)
-
     def learn(
         self,
         max_iterations: int = 1500,

--- a/src/unilab/algos/torch/hora/appo_runner.py
+++ b/src/unilab/algos/torch/hora/appo_runner.py
@@ -202,9 +202,6 @@ class HoraAPPORunner(APPORunner):
             enable_compile=algo_cfg.get("enable_compile", True),
         )
 
-    def _collector_fn(self, stop_event, **kwargs):
-        hora_appo_collector_fn(stop_event=stop_event, **kwargs)
-
     def learn(
         self,
         max_iterations: int = 1500,

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -9,7 +9,6 @@ from typing import Any
 import torch
 
 from unilab.algos.torch.common.device import get_env_dims
-from unilab.algos.torch.offpolicy.worker import off_policy_collector_fn
 from unilab.ipc.async_runner import AsyncRunner
 from unilab.logging import OffPolicyLogger
 from unilab.training.seed import apply_training_seed
@@ -194,9 +193,6 @@ class OffPolicyRunner(AsyncRunner):
 
     def _build_learner(self):
         return self.learner
-
-    def _collector_fn(self, stop_event, **kwargs):
-        off_policy_collector_fn(stop_event=stop_event, **kwargs)
 
     @staticmethod
     def _sync_logger_replay_counters(logger, replay_buffer) -> None:

--- a/src/unilab/ipc/async_runner.py
+++ b/src/unilab/ipc/async_runner.py
@@ -82,9 +82,6 @@ class AsyncRunner(ABC):
     def _build_learner(self) -> Any: ...
 
     @abstractmethod
-    def _collector_fn(self, stop_event: Any, **kwargs) -> None: ...
-
-    @abstractmethod
     def learn(
         self, max_iterations: int, save_interval: int = 50, log_dir: str = "logs"
     ) -> None: ...

--- a/tests/ipc/test_async_runner.py
+++ b/tests/ipc/test_async_runner.py
@@ -31,9 +31,6 @@ class _StubRunner(AsyncRunner):
     def _build_learner(self) -> Any:
         return None
 
-    def _collector_fn(self, stop_event: Any, **kwargs) -> None:
-        pass
-
     def learn(self, max_iterations: int, save_interval: int = 50, log_dir: str = "logs") -> None:
         pass
 


### PR DESCRIPTION
## Summary

- remove the unused `AsyncRunner._collector_fn` abstract hook
- remove APP, off-policy, and HORA forwarding overrides plus the test stub
- retain each runner explicit `_start_collector(target_fn=...)` dispatch unchanged

## Validation

- `make test-all` passed at `0fcbc2655e80299850e52d20389c132e9fd71959`
- 1654 passed, 27 skipped, 273 deselected, 1 xfailed
- benchmark smoke: 33/34 module-mode and 34/35 script-mode; MLX-only entries skipped
- production tree contains no `_collector_fn` definition or call

Closes #986
