### PR TITLE
refactor: cache NaN diagnostic model path (#987)

### DIFF
--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -117,6 +117,7 @@ class NpEnv(ABEnv):
         self._init_randomization_applied = False
         self._nan_guard: NanGuard | None = None
         self._autoreset = True
+        self._nan_guard_model_file = self._resolve_nan_guard_model_file()
 
     @property
     def cfg(self) -> EnvCfg:
@@ -190,7 +191,7 @@ class NpEnv(ABEnv):
             if bad_ctrl_ids is not None:
                 self._nan_guard.dump(
                     bad_ctrl_ids,
-                    self._nan_guard_model_file(),
+                    self._nan_guard_model_file,
                     self.step_counter,
                 )
 
@@ -238,7 +239,7 @@ class NpEnv(ABEnv):
                 self._state.obs, self._state.reward, step=self.step_counter
             )
             if nan_ids is not None:
-                self._nan_guard.dump(nan_ids, self._nan_guard_model_file(), self.step_counter)
+                self._nan_guard.dump(nan_ids, self._nan_guard_model_file, self.step_counter)
 
         np.nan_to_num(self._state.reward, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
 
@@ -313,7 +314,7 @@ class NpEnv(ABEnv):
         for key in RESET_DONE_DETAIL_TIMING_KEYS:
             timing[key] = 0.0
 
-    def _nan_guard_model_file(self) -> str:
+    def _resolve_nan_guard_model_file(self) -> str:
         scene = getattr(self._cfg, "scene", None)
         if isinstance(scene, SceneCfg) and scene.model_file:
             return str(scene.model_file)

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -15,6 +15,7 @@ import pytest
 
 from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.base.scene import SceneCfg
 
 # ---------------------------------------------------------------------------
 # Fixtures: minimal concrete NpEnv
@@ -38,11 +39,22 @@ class _StubNpEnv(NpEnv):
 
     OBS_SPEC = {"obs": 5, "critic": 7}
 
-    def __init__(self, num_envs: int = 4):
-        cfg = _StubCfg()
-        backend = MagicMock()
+    def __init__(
+        self,
+        num_envs: int = 4,
+        *,
+        cfg: _StubCfg | None = None,
+        backend: MagicMock | None = None,
+    ):
+        cfg = cfg or _StubCfg()
+        if backend is None:
+            backend = MagicMock()
+            backend.get_scene_model_file.return_value = None
+            capabilities = MagicMock()
+            capabilities.supports_physics_state_playback = False
+            backend.get_play_capabilities.return_value = capabilities
         backend.backend_type = "mujoco"
-        backend.step = MagicMock()
+        backend.step.return_value = None
         super().__init__(cfg, backend, num_envs)
         self._reset_count = 0
 
@@ -77,6 +89,59 @@ class _StubNpEnv(NpEnv):
             "critic": np.zeros((n, 7), dtype=np.float32),
         }
         return obs, {}
+
+
+def _nan_dump_model_files(env: _StubNpEnv) -> list[str]:
+    guard = MagicMock()
+    bad_ids = np.array([0], dtype=np.int32)
+    guard.check_ctrl.return_value = bad_ids
+    guard.check.return_value = bad_ids
+    env.set_nan_guard(guard)
+    env.step(np.zeros((env.num_envs, 3), dtype=np.float32))
+    return [call.args[1] for call in guard.dump.call_args_list]
+
+
+class TestNanGuardModelPath:
+    def test_scene_model_file_is_cached_and_prioritized(self):
+        backend = MagicMock()
+        backend.backend_type = "mujoco"
+        backend.step.return_value = None
+        backend.get_scene_model_file.return_value = "/backend.xml"
+        capabilities = MagicMock()
+        capabilities.supports_physics_state_playback = False
+        backend.get_play_capabilities.return_value = capabilities
+
+        cfg = _StubCfg(scene=SceneCfg(model_file="/scene.xml"))
+        env = _StubNpEnv(cfg=cfg, backend=backend)
+        backend.get_scene_model_file.assert_not_called()
+
+        cfg.scene = SceneCfg(model_file="/changed.xml")
+        assert _nan_dump_model_files(env) == ["/scene.xml", "/scene.xml"]
+        backend.get_scene_model_file.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("backend_model_file", "expected"),
+        [("/backend.xml", "/backend.xml"), ("", ""), (None, "")],
+    )
+    def test_backend_model_file_is_cached_once(self, backend_model_file, expected):
+        backend = MagicMock()
+        backend.backend_type = "mujoco"
+        backend.step.return_value = None
+        backend.get_scene_model_file.return_value = backend_model_file
+        capabilities = MagicMock()
+        capabilities.supports_physics_state_playback = False
+        backend.get_play_capabilities.return_value = capabilities
+
+        cfg = _StubCfg(scene=SceneCfg(model_file=""))
+        env = _StubNpEnv(cfg=cfg, backend=backend)
+        assert backend.get_scene_model_file.call_count == 1
+
+        backend.get_scene_model_file.side_effect = AssertionError(
+            "diagnostic model getter must not run from step"
+        )
+        cfg.scene = SceneCfg(model_file="/changed.xml")
+        assert _nan_dump_model_files(env) == [expected, expected]
+        assert backend.get_scene_model_file.call_count == 1
 
 
 class _TerminatingStubEnv(_StubNpEnv):


### PR DESCRIPTION
## Summary

- resolve and cache the NaN diagnostic model path during NpEnv construction
- keep SceneCfg precedence and backend fallback behavior unchanged
- make both step-time dump paths read only the cached string

## Validation

- make test-all passed at 5aa1eadd0949305d535656c6d952c0e7c7e53235
- 1658 passed, 27 skipped, 273 deselected, 1 xfailed
- 45 targeted NpEnv tests passed
- benchmark smoke: 33/34 module-mode and 34/35 script-mode; MLX-only entries skipped

Closes #987