### PR TITLE
refactor: use backend materializer facade

### DIFF
--- a/scripts/manip_loco/benchmark_site_jacobian.py
+++ b/scripts/manip_loco/benchmark_site_jacobian.py
@@ -19,8 +19,7 @@ if str(SRC_DIR) not in sys.path:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from unilab.base.backend.xml import materialize_scene_visual_override
-
+from unilab.base.backend import materialize_scene_visual_override
 from unilab.training import BackendAdapter, create_env, ensure_registries
 
 

--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -162,7 +162,7 @@ def _infer_checkpoint_actor_input_dim(ckpt_path: str) -> int | None:
 
 
 def _backend_adapter(cfg: DictConfig, *, algo_name: str = "ppo"):
-    from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+    from unilab.base.backend import materialize_scene_visual_override
     from unilab.training import BackendAdapter
 
     return BackendAdapter(

--- a/scripts/train_him_ppo.py
+++ b/scripts/train_him_ppo.py
@@ -19,7 +19,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from unilab.algos.torch.him_ppo.runner import HIMOnPolicyRunner
-from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.base.backend import materialize_scene_visual_override
 from unilab.training import (
     BackendAdapter,
     create_env,

--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -37,7 +37,7 @@ from unilab.algos.torch.hora.distill_config import (
     teacher_run_metadata as _teacher_run_metadata,
 )
 from unilab.algos.torch.hora.rsl_rl import HoraRslRlVecEnvWrapper as RslRlVecEnvWrapper
-from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.base.backend import materialize_scene_visual_override
 from unilab.training import (
     BackendAdapter,
     create_env,

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -18,7 +18,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
-from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.base.backend import materialize_scene_visual_override
 from unilab.ipc.dp_launcher import (
     UNILAB_DP_LOG_DIR,
     current_torch_distributed_local_rank,

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -10,6 +10,8 @@ from .base import SimBackend
 if TYPE_CHECKING:
     from unilab.base.base import EnvCfg
 
+    from .mujoco.xml import materialize_scene_visual_override
+
 
 def env_backend_kwargs(cfg: "EnvCfg") -> dict:
     """Bundle EnvCfg-level backend tuning fields for create_backend(**...)."""

--- a/src/unilab/training/backend_adapter.py
+++ b/src/unilab/training/backend_adapter.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 from omegaconf import DictConfig, OmegaConf
 
-from unilab.base.backend.mujoco.xml import materialize_scene_visual_override
+from unilab.base.backend import materialize_scene_visual_override
 from unilab.base.scene import SceneCfg
 from unilab.training.reward import extract_reward_config
 

--- a/tests/base/test_backend_imports.py
+++ b/tests/base/test_backend_imports.py
@@ -1,8 +1,72 @@
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MATERIALIZER_CONSUMERS = (
+    "src/unilab/training/backend_adapter.py",
+    "scripts/train_rsl_rl.py",
+    "scripts/train_him_ppo.py",
+    "scripts/train_hora_distill.py",
+    "scripts/play_interactive.py",
+    "scripts/manip_loco/benchmark_site_jacobian.py",
+)
+
+
+def test_materializer_consumers_use_backend_facade() -> None:
+    offenders: list[str] = []
+    for relative_path in _MATERIALIZER_CONSUMERS:
+        path = _REPO_ROOT / relative_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imports = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and any(alias.name == "materialize_scene_visual_override" for alias in node.names)
+        ]
+        if len(imports) != 1 or imports[0].module != "unilab.base.backend":
+            modules = [node.module for node in imports]
+            offenders.append(f"{relative_path}: {modules}")
+
+    assert offenders == []
+
+
+def test_site_jacobian_benchmark_imports_with_mujoco_stub() -> None:
+    code = textwrap.dedent(
+        """
+        import importlib.util
+        import sys
+        import types
+        from pathlib import Path
+
+        sys.modules["mujoco"] = types.ModuleType("mujoco")
+        path = Path(sys.argv[1])
+        spec = importlib.util.spec_from_file_location("benchmark_site_jacobian", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+
+        print(module.materialize_scene_visual_override.__module__)
+        print("mujoco_backend", "unilab.base.backend.mujoco.backend" in sys.modules)
+        """
+    )
+    script = _REPO_ROOT / "scripts" / "manip_loco" / "benchmark_site_jacobian.py"
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(script)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "unilab.base.backend.mujoco.xml",
+        "mujoco_backend False",
+    ]
 
 
 def test_mujoco_backend_import_path_does_not_eagerly_import_motrix() -> None:
@@ -17,6 +81,9 @@ def test_mujoco_backend_import_path_does_not_eagerly_import_motrix() -> None:
         assert create_backend is not None
         assert materialize_scene_visual_override is not None
         assert create_discardvisual_xml is not None
+
+        print("mujoco_runtime", "mujoco" in sys.modules)
+        print("mujoco_backend", "unilab.base.backend.mujoco.backend" in sys.modules)
 
         if importlib.util.find_spec("mujoco") is not None:
             import unilab.base.backend.mujoco.backend
@@ -37,8 +104,9 @@ def test_mujoco_backend_import_path_does_not_eagerly_import_motrix() -> None:
 
     assert "Motphys profiler initialized" not in result.stdout + result.stderr
     lines = result.stdout.splitlines()
-    assert lines[0] in {"mujoco_backend imported", "mujoco_backend skipped"}
-    assert lines[1:] == ["motrix_backend False", "motrixsim False"]
+    assert lines[:2] == ["mujoco_runtime False", "mujoco_backend False"]
+    assert lines[2] in {"mujoco_backend imported", "mujoco_backend skipped"}
+    assert lines[3:] == ["motrix_backend False", "motrixsim False"]
 
 
 def test_motrix_backend_import_path_does_not_eagerly_import_mujoco() -> None:


### PR DESCRIPTION
## Summary

- route training and interactive entrypoints through the existing `unilab.base.backend` facade
- repair the manip-loco benchmark import that referenced a nonexistent backend module
- preserve lazy optional-backend loading and add import-boundary regression coverage

## Scope

- Parent umbrella: #983
- Resolves child issue #992 after this PR is merged into `dev/issue-983-code-cleanup`
- Integration target: `dev/issue-983-code-cleanup` only; no change targets `main`

## Validation

- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all`
- pytest: 1675 passed, 27 skipped, 273 deselected, 1 xfailed
- benchmark smoke: 33/34 module imports and 34/35 script imports; only platform-optional MLX skipped
- pyright: 0 errors
- exact validated head: `de8364668e6a6cafc00f581dcbb652c841578d37`
