### PR TITLE
refactor(env): materialize grasp caches on cold path

### DIFF
--- a/src/unilab/envs/manipulation/allegro_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/rotation.py
@@ -85,6 +85,30 @@ def sample_cached_grasps(
     return sampled[:, :16], sampled[:, 16:19], sampled[:, 19:23]
 
 
+def _materialize_grasp_cache(cfg: AllegroRotationPPOCfg) -> np.ndarray | None:
+    """Load the optional Allegro grasp cache on the env construction path."""
+    if cfg.gen_grasp:
+        return None
+
+    cache_path = resolve_grasp_cache_path(cfg.grasp_cache_path)
+    if not cache_path.exists():
+        print(
+            "[allegro_inhand] Grasp cache is missing; no Hugging Face download will be "
+            f"attempted. Expected local cache: {cache_path}. Generate one with "
+            "`uv run train --algo ppo --task allegro_inhand_grasp --sim mujoco "
+            "training.no_play=true`, or point `env.grasp_cache_path` at an existing "
+            "local cache."
+        )
+        return None
+
+    grasp_cache = np.load(cache_path).astype(np.float64)
+    print(
+        "[allegro_inhand] Loaded grasp cache: "
+        f"{cache_path}, shape={grasp_cache.shape}, dtype={grasp_cache.dtype}"
+    )
+    return grasp_cache
+
+
 @dataclass
 class RewardConfigPPO:
     scales: dict[str, float]
@@ -138,39 +162,11 @@ class AllegroRotationDomainRandomizationProvider(DomainRandomizationProvider):
     ) -> IntervalRandomizationPlan | None:
         return build_interval_push_plan(env, step_counter)
 
-    def _load_grasp_cache(self, env: Any) -> np.ndarray | None:
-        if env._grasp_cache_loaded:
-            return cast(np.ndarray | None, env._grasp_cache)
-        if env.cfg.gen_grasp:
-            env._grasp_cache = None
-            env._grasp_cache_loaded = True
-            return None
-
-        cache_path = resolve_grasp_cache_path(env.cfg.grasp_cache_path)
-        if not cache_path.exists():
-            print(
-                "[allegro_inhand] Grasp cache is missing; no Hugging Face download will be "
-                f"attempted. Expected local cache: {cache_path}. Generate one with "
-                "`uv run train --algo ppo --task allegro_inhand_grasp --sim mujoco "
-                "training.no_play=true`, or point `env.grasp_cache_path` at an existing "
-                "local cache."
-            )
-            env._grasp_cache = None
-            env._grasp_cache_loaded = True
-            return None
-        env._grasp_cache = np.load(cache_path).astype(np.float64)
-        env._grasp_cache_loaded = True
-        print(
-            "[allegro_inhand] Loaded grasp cache: "
-            f"{cache_path}, shape={env._grasp_cache.shape}, dtype={env._grasp_cache.dtype}"
-        )
-        return cast(np.ndarray | None, env._grasp_cache)
-
     def _sample_reset_state(
         self, env: Any, num_reset: int
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         dr = env.cfg.domain_rand
-        grasp_cache = self._load_grasp_cache(env)
+        grasp_cache = cast(np.ndarray | None, env._grasp_cache)
         if grasp_cache is not None:
             hand_qpos, ball_pos, ball_quat = sample_cached_grasps(grasp_cache, num_reset)
         else:
@@ -293,8 +289,7 @@ class AllegroRotationPPO(AllegroBaseEnv):
         self._dof_range = self._ctrl_upper - self._ctrl_lower
         self._dof_mid = (self._ctrl_upper + self._ctrl_lower) / 2.0
         self._rot_axis = normalize_rotation_axis(cfg.rotation_axis)
-        self._grasp_cache: np.ndarray | None = None
-        self._grasp_cache_loaded = False
+        self._grasp_cache = _materialize_grasp_cache(cfg)
 
         self._init_reward_functions()
         self._init_domain_randomization(AllegroRotationDomainRandomizationProvider())

--- a/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
@@ -138,6 +138,7 @@ class SharpaInhandGraspDRProvider(SharpaInhandRotationDRProvider):
 @registry.env("SharpaInhandRotationGrasp", sim_backend="motrix")
 class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
     _cfg: SharpaInhandRotationGraspCfg
+    _MATERIALIZE_ROTATION_GRASP_CACHE = False
 
     def __init__(
         self,

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -82,6 +82,34 @@ def sample_random_quaternion(num_envs: int) -> np.ndarray:
     return np_sample_uniform_quaternion(num_envs).astype(np.float64)
 
 
+def _materialize_grasp_caches(
+    grasp_cache_path: str,
+    scale_values: np.ndarray,
+) -> tuple[np.ndarray, ...]:
+    """Load one Sharpa grasp cache for each scale on the env construction path."""
+    grasp_caches: list[np.ndarray] = []
+    missing_files: list[str] = []
+    for scale_value in np.asarray(scale_values, dtype=np.float64):
+        cache_file = resolve_grasp_cache_file(grasp_cache_path, float(scale_value))
+        resolved = cast(str, resolve_grasp_cache_files(str(cache_file)))
+        cache_file = Path(resolved)
+        if not cache_file.exists():
+            missing_files.append(str(cache_file))
+            continue
+        grasp_caches.append(np.load(cache_file).astype(np.float64))
+
+    if missing_files:
+        missing = ", ".join(missing_files)
+        raise RuntimeError(
+            f"Missing Sharpa grasp cache file(s): {missing}\n"
+            "Generate them with:\n"
+            "  bash scripts/sharpa_collect_grasps.sh 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5 1.6\n"
+            "See docs/sphinx/source/zh_CN/user_guide/D-tasks/04-sharpa-inhand.md"
+        )
+
+    return tuple(grasp_caches)
+
+
 class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
     def validate(self, env: Any, capabilities: DomainRandomizationCapabilities) -> None:
         unsupported = validate_common_reset_randomization(env, capabilities)
@@ -152,42 +180,6 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
             model_assignments=np.asarray(env.scale_ids, dtype=np.int32).copy(),
             model_variants=model_variants,
         )
-
-    def _load_grasp_cache(self, env: Any) -> tuple[np.ndarray, ...]:
-        """Load one grasp cache file for each configured object scale.
-
-        Args:
-            env: Sharpa rotation env instance.
-
-        Returns:
-            Tuple of cache arrays ordered the same as ``env.scale_values``.
-        """
-        if getattr(env, "_grasp_cache", None) is not None:
-            return cast(tuple[np.ndarray, ...], env._grasp_cache)
-
-        grasp_caches: list[np.ndarray] = []
-        missing_files: list[str] = []
-        for scale_value in np.asarray(env.scale_values, dtype=np.float64):
-            cache_file = resolve_grasp_cache_file(env.cfg.grasp_cache_path, float(scale_value))
-            # Auto-download from HF if the cache file is missing locally.
-            resolved = cast(str, resolve_grasp_cache_files(str(cache_file)))
-            cache_file = Path(resolved)
-            if not cache_file.exists():
-                missing_files.append(str(cache_file))
-                continue
-            grasp_caches.append(np.load(cache_file).astype(np.float64))
-
-        if missing_files:
-            missing = ", ".join(missing_files)
-            raise RuntimeError(
-                f"Missing Sharpa grasp cache file(s): {missing}\n"
-                "Generate them with:\n"
-                "  bash scripts/sharpa_collect_grasps.sh 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5 1.6\n"
-                "See docs/sphinx/source/zh_CN/user_guide/D-tasks/04-sharpa-inhand.md"
-            )
-
-        env._grasp_cache = tuple(grasp_caches)
-        return cast(tuple[np.ndarray, ...], env._grasp_cache)
 
     def _sample_reset_pd_gains(
         self,
@@ -330,7 +322,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
         randomized_com_offset = env._sample_object_com_offset(num_reset)
         gravity = env._sample_reset_gravity(num_reset)
         p_gain, d_gain = self._sample_reset_pd_gains(env, num_reset, dtype=get_global_dtype())
-        grasp_cache = self._load_grasp_cache(env)
+        grasp_cache = cast(tuple[np.ndarray, ...], env._grasp_cache)
         sampled_pose = sample_scale_grasp_caches(grasp_cache, env.scale_ids[env_ids])
 
         hand_qpos = sampled_pose[:, : env._num_action]
@@ -454,6 +446,7 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
 class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
     _cfg: SharpaInhandRotationCfg
     _reward_cfg: RewardConfig
+    _MATERIALIZE_ROTATION_GRASP_CACHE = True
     _OBS_MODE_ALIASES: dict[str, str] = {
         "separated": "separated",
         "flattened": "flattened",
@@ -514,7 +507,7 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         self._reward_cfg = cfg.reward_config
         self._zero_action_test_mode = bool(cfg.zero_action_test_mode)
         self._enable_reward_log = True
-        self._grasp_cache: np.ndarray | None = None
+        self._grasp_cache: tuple[np.ndarray, ...] | None = None
 
         axis = np.asarray(cfg.rot_axis, dtype=self._np_dtype)
         axis_norm = np.linalg.norm(axis)
@@ -523,6 +516,8 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
         self._rot_axis = np.asarray(axis / axis_norm, dtype=self._np_dtype)
 
         provider = dr_provider if dr_provider is not None else SharpaInhandRotationDRProvider()
+        if self._MATERIALIZE_ROTATION_GRASP_CACHE:
+            self._grasp_cache = _materialize_grasp_caches(cfg.grasp_cache_path, self.scale_values)
         self._init_domain_randomization(provider)
 
     def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -430,27 +430,80 @@ def test_allegro_missing_grasp_cache_prints_local_generation_notice(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from unilab.envs.manipulation.allegro_inhand.rotation import (
-        AllegroRotationDomainRandomizationProvider,
+        AllegroRotationPPOCfg,
+        _materialize_grasp_cache,
     )
 
     missing_cache = tmp_path / "missing_allegro_cache.npy"
-    env = SimpleNamespace(
-        _grasp_cache=None,
-        _grasp_cache_loaded=False,
-        cfg=SimpleNamespace(gen_grasp=False, grasp_cache_path=str(missing_cache)),
+    cfg = AllegroRotationPPOCfg(
+        grasp_cache_path=str(missing_cache),
+        gen_grasp=False,
     )
 
-    provider = AllegroRotationDomainRandomizationProvider()
-
-    assert provider._load_grasp_cache(env) is None
+    assert _materialize_grasp_cache(cfg) is None
     notice = capsys.readouterr().out
 
-    assert env._grasp_cache is None
-    assert env._grasp_cache_loaded is True
     assert str(missing_cache) in notice
     assert "no Hugging Face download will be attempted" in notice
     assert "uv run train --algo ppo --task allegro_inhand_grasp --sim mujoco" in notice
     assert "env.grasp_cache_path" in notice
+
+
+def test_allegro_grasp_generation_skips_cache_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unilab.envs.manipulation.allegro_inhand import rotation
+
+    def fail_io(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("grasp generation must not resolve or load a rotation cache")
+
+    monkeypatch.setattr(rotation, "resolve_grasp_cache_path", fail_io)
+    monkeypatch.setattr(rotation.np, "load", fail_io)
+
+    cfg = rotation.AllegroRotationPPOCfg(gen_grasp=True)
+    assert rotation._materialize_grasp_cache(cfg) is None
+
+
+def test_allegro_reset_samples_materialized_cache_without_file_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unilab.envs.manipulation.allegro_inhand import rotation
+
+    cache_path = tmp_path / "allegro.npy"
+    cache = np.zeros((4, 23), dtype=np.float64)
+    cache[:, 16] = 0.1
+    cache[:, 19] = 1.0
+    np.save(cache_path, cache)
+    cfg = rotation.AllegroRotationPPOCfg(grasp_cache_path=str(cache_path))
+    materialized = rotation._materialize_grasp_cache(cfg)
+    assert materialized is not None
+
+    monkeypatch.setattr(
+        rotation, "resolve_grasp_cache_path", lambda _: (_ for _ in ()).throw(AssertionError)
+    )
+    monkeypatch.setattr(
+        rotation.np, "load", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
+    )
+    env = SimpleNamespace(
+        _grasp_cache=materialized,
+        cfg=SimpleNamespace(
+            domain_rand=SimpleNamespace(joint_noise=0.0, ball_vel_noise=0.0, ball_z_offset=0.0)
+        ),
+        default_angles=np.zeros(16),
+        _NUM_HAND_DOF=16,
+        _ctrl_lower=-np.ones(16),
+        _ctrl_upper=np.ones(16),
+        _init_qpos=np.zeros(23),
+        nv=23,
+    )
+
+    provider = rotation.AllegroRotationDomainRandomizationProvider()
+    for _ in range(2):
+        hand_qpos, ball_pos, ball_quat, qvel = provider._sample_reset_state(env, 2)
+        assert hand_qpos.shape == (2, 16)
+        assert ball_pos.shape == (2, 3)
+        assert ball_quat.shape == (2, 4)
+        assert qvel.shape == (2, 23)
 
 
 def test_g1_motion_tracking_uses_combined_body_pose_query():
@@ -1335,15 +1388,12 @@ def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatc
     assert calls["reward_init"] is True
 
 
-def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
+def _patch_sharpa_rotation_constructor(
+    monkeypatch: pytest.MonkeyPatch,
+    initialized_providers: list[Any],
+) -> Any:
     from unilab.envs.manipulation.sharpa_inhand import rotation as sharpa_rotation_module
     from unilab.envs.manipulation.sharpa_inhand.base import SharpaInhandBaseEnv
-    from unilab.envs.manipulation.sharpa_inhand.grasp_gen import (
-        SharpaInhandRotationGraspCfg,
-        SharpaInhandRotationGraspEnv,
-    )
-
-    calls: list[str] = []
 
     def fake_base_init(self, cfg, backend, num_envs):
         self._cfg = cfg
@@ -1353,6 +1403,7 @@ def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
         self._num_action = 22
         self._num_tactile = 5
         self._num_scales = len(cfg.domain_rand.scale_list)
+        self.scale_values = np.asarray(cfg.domain_rand.scale_list, dtype=np.float64)
         self.scale_ids = np.zeros((num_envs,), dtype=np.int32)
         self._object_body_ids = np.zeros((0,), dtype=np.int32)
 
@@ -1382,10 +1433,61 @@ def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
     )
     monkeypatch.setattr(SharpaInhandBaseEnv, "__init__", fake_base_init)
     monkeypatch.setattr(
-        SharpaInhandRotationGraspEnv,
+        sharpa_rotation_module.SharpaInhandRotationEnv,
         "_init_domain_randomization",
-        lambda self, provider: calls.append(provider.__class__.__name__),
+        lambda self, provider: initialized_providers.append(provider),
     )
+    return sharpa_rotation_module
+
+
+def test_sharpa_rotation_explicit_default_provider_materializes_cache(monkeypatch):
+    from unilab.envs.manipulation.sharpa_inhand.rotation import (
+        RewardConfig,
+        SharpaInhandRotationCfg,
+        SharpaInhandRotationDRProvider,
+        SharpaInhandRotationEnv,
+    )
+
+    initialized_providers: list[Any] = []
+    rotation = _patch_sharpa_rotation_constructor(monkeypatch, initialized_providers)
+    materialize_calls: list[tuple[str, np.ndarray]] = []
+    sentinel_cache = (np.zeros((1, 29), dtype=np.float64),)
+
+    def materialize(path: str, scale_values: np.ndarray) -> tuple[np.ndarray, ...]:
+        materialize_calls.append((path, scale_values.copy()))
+        return sentinel_cache
+
+    monkeypatch.setattr(rotation, "_materialize_grasp_caches", materialize)
+    cfg = SharpaInhandRotationCfg(reward_config=RewardConfig())
+    provider = SharpaInhandRotationDRProvider()
+
+    env = cast(Any, SharpaInhandRotationEnv)(
+        cfg,
+        num_envs=4,
+        backend_type="mujoco",
+        dr_provider=provider,
+    )
+
+    assert initialized_providers == [provider]
+    assert len(materialize_calls) == 1
+    assert materialize_calls[0][0] == cfg.grasp_cache_path
+    np.testing.assert_array_equal(materialize_calls[0][1], env.scale_values)
+    assert env._grasp_cache is sentinel_cache
+
+
+def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
+    from unilab.envs.manipulation.sharpa_inhand.grasp_gen import (
+        SharpaInhandRotationGraspCfg,
+        SharpaInhandRotationGraspEnv,
+    )
+
+    initialized_providers: list[Any] = []
+    rotation = _patch_sharpa_rotation_constructor(monkeypatch, initialized_providers)
+
+    def fail_materialization(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("grasp generation must not materialize rotation caches")
+
+    monkeypatch.setattr(rotation, "_materialize_grasp_caches", fail_materialization)
 
     cfg = SharpaInhandRotationGraspCfg()
     assert cfg.domain_rand.randomize_pd_gains is False
@@ -1411,7 +1513,9 @@ def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
     assert cfg.priv_info.include_gravity_direction is False
     env = cast(Any, SharpaInhandRotationGraspEnv)(cfg, num_envs=4, backend_type="mujoco")
 
-    assert calls == ["SharpaInhandGraspDRProvider"]
+    assert [provider.__class__.__name__ for provider in initialized_providers] == [
+        "SharpaInhandGraspDRProvider"
+    ]
     assert len(env._saved_grasping_states) == env._num_scales
 
 

--- a/tests/envs/test_sharpa.py
+++ b/tests/envs/test_sharpa.py
@@ -17,7 +17,10 @@ from unilab.envs.manipulation.sharpa_inhand.base import (
     SharpaInhandBaseEnv,
     resolve_grasp_cache_file,
 )
-from unilab.envs.manipulation.sharpa_inhand.rotation import SharpaInhandRotationDRProvider
+from unilab.envs.manipulation.sharpa_inhand.rotation import (
+    SharpaInhandRotationDRProvider,
+    _materialize_grasp_caches,
+)
 
 _CONF_DIR = Path(__file__).resolve().parents[2] / "conf"
 _SRC_DIR = Path(__file__).resolve().parents[2] / "src"
@@ -181,6 +184,88 @@ def _write_sharpa_grasp_cache(
     cache = np.broadcast_to(np.concatenate([hand_qpos, object_pose]), (rows, 29)).copy()
     for scale_value in scale_values:
         np.save(resolve_grasp_cache_file(str(cache_prefix), float(scale_value)), cache)
+
+
+def test_sharpa_grasp_cache_is_materialized_once_and_reset_samples_memory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_prefix = tmp_path / "sharpa_grasp"
+    scale_values = np.asarray([0.8, 1.0], dtype=np.float64)
+    _write_sharpa_grasp_cache(cache_prefix, [0.8, 1.0])
+
+    from unilab.envs.manipulation.sharpa_inhand import rotation
+
+    path_resolve_calls: list[tuple[str, float]] = []
+    hf_resolve_calls: list[str] = []
+    load_calls: list[Path] = []
+    original_resolve_grasp_cache_file = rotation.resolve_grasp_cache_file
+    original_load = rotation.np.load
+
+    def resolve_path_once(path: str, scale: float) -> Path:
+        path_resolve_calls.append((path, scale))
+        return original_resolve_grasp_cache_file(path, scale)
+
+    def resolve_hf_once(path: str) -> str:
+        hf_resolve_calls.append(path)
+        return path
+
+    def load_once(path: Path) -> np.ndarray:
+        load_calls.append(path)
+        return original_load(path)
+
+    monkeypatch.setattr(rotation, "resolve_grasp_cache_file", resolve_path_once)
+    monkeypatch.setattr(rotation, "resolve_grasp_cache_files", resolve_hf_once)
+    monkeypatch.setattr(rotation.np, "load", load_once)
+    caches = _materialize_grasp_caches(str(cache_prefix), scale_values)
+    assert len(path_resolve_calls) == 2
+    assert len(hf_resolve_calls) == 2
+    assert len(load_calls) == 2
+
+    def fail_io(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("reset must not resolve or load grasp cache files")
+
+    monkeypatch.setattr(rotation, "resolve_grasp_cache_file", fail_io)
+    monkeypatch.setattr(rotation, "resolve_grasp_cache_files", fail_io)
+    monkeypatch.setattr(rotation.np, "load", fail_io)
+
+    cleared_env_ids: list[np.ndarray] = []
+    env = SimpleNamespace(
+        _grasp_cache=caches,
+        scale_ids=np.asarray([0, 1], dtype=np.int32),
+        _num_action=22,
+        _obj_pos_slice=slice(22, 25),
+        _obj_quat_slice=slice(25, 29),
+        _rot_axis=np.asarray([0.0, 0.0, 1.0]),
+        _random_object_force=np.ones((2, 3), dtype=np.float64),
+        nq=29,
+        nv=28,
+        cfg=SimpleNamespace(reset_height_lower=0.61, reset_height_upper=0.63),
+        _sample_friction_scale=lambda _num_reset: None,
+        _sample_object_mass=lambda _num_reset: None,
+        _sample_object_com_offset=lambda _num_reset: None,
+        _sample_reset_gravity=lambda _num_reset: None,
+        _clear_tactile_history=lambda env_ids: cleared_env_ids.append(env_ids.copy()),
+        _build_reset_randomization=lambda *_args, **_kwargs: None,
+    )
+    provider = SharpaInhandRotationDRProvider()
+
+    def sample_reset_pd_gains(
+        _env: Any, num_reset: int, *, dtype: np.dtype[Any]
+    ) -> tuple[np.ndarray, np.ndarray]:
+        gains = np.zeros((num_reset, env._num_action), dtype=dtype)
+        return gains, gains.copy()
+
+    monkeypatch.setattr(provider, "_sample_reset_pd_gains", sample_reset_pd_gains)
+    monkeypatch.setattr(provider, "_build_info_updates", lambda _env, **_kwargs: {})
+
+    env_ids = np.asarray([0, 1], dtype=np.int32)
+    for _ in range(2):
+        plan = provider.build_reset_plan(env, env_ids)
+        assert plan.qpos.shape == (2, 29)
+        assert plan.qvel.shape == (2, 28)
+        assert np.all(np.isfinite(plan.qpos))
+
+    assert len(cleared_env_ids) == 2
 
 
 def _build_fake_tactile_env(


### PR DESCRIPTION
## Summary

- materialize Allegro rotation grasp caches during env initialization
- resolve and preload Sharpa rotation scale caches during env initialization
- keep reset providers memory-only while preserving grasp-generation owners through an explicit class hook
- preserve explicit default rotation-provider construction and add regression coverage through repeated reset-plan execution

## Scope

- Parent umbrella: #983
- Resolves child issue #994 after this PR is merged into `dev/issue-983-code-cleanup`
- Integration target: `dev/issue-983-code-cleanup` only; no change targets `main`

## Validation

- focused env tests: 73 passed, 3 skipped, 5 deselected
- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all`
- pytest: 1679 passed, 27 skipped, 273 deselected, 1 xfailed
- benchmark smoke: 33/34 module imports and 34/35 script imports; only platform-optional MLX skipped
- Ruff, mypy, and pyright passed
- exact validated head: `4c80e373f6b3bf6416ff0b9fefaee8170a36f4f9`
