### PR TITLE
cleanup: inherit HORA RSL-RL wrapper methods

### DIFF
--- a/src/unilab/algos/torch/hora/rsl_rl.py
+++ b/src/unilab/algos/torch/hora/rsl_rl.py
@@ -125,33 +125,3 @@ class HoraRslRlVecEnvWrapper(RslRlVecEnvWrapper):
             dones,
             infos,
         )
-
-    def reset(self) -> tuple[TensorDict, dict[str, Any]]:
-        """Reset the wrapped env and preserve HORA privileged reset payloads.
-
-        Args:
-            None.
-
-        Returns:
-            Tuple ``(obs_td, info)`` where ``obs_td`` retains HORA privileged inputs.
-        """
-        if self.env.state is None:
-            self.env.init_state()
-
-        env_indices = np.arange(self.num_envs, dtype=np.int32)
-        obs_out, info = self.env.reset(env_indices)
-        self.episode_returns[:] = 0
-        self.episode_lengths[:] = 0
-        return self._obs_to_tensordict(obs_out, info), info
-
-    def get_observations(self) -> TensorDict:
-        """Return the current HORA-aware observation TensorDict.
-
-        Args:
-            None.
-
-        Returns:
-            TensorDict containing the current observation batch with HORA extras.
-        """
-        assert self.env.state is not None
-        return self._obs_to_tensordict(self.env.state.obs, self.env.state.info)

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -2111,6 +2111,7 @@ def test_play_wrapper_preserves_hora_priv_info_and_proprio_history():
                 {
                     "obs": {
                         "obs": np.array([[1.0, 2.0, 3.0]], dtype=np.float32),
+                        "proprio": np.array([[6.0, 7.0]], dtype=np.float32),
                         "critic": np.array([[1.0, 2.0, 3.0, 4.0, 5.0]], dtype=np.float32),
                     },
                     "info": {
@@ -2125,7 +2126,7 @@ def test_play_wrapper_preserves_hora_priv_info_and_proprio_history():
             self.cfg = type("Cfg", (), {"max_episode_seconds": 10.0, "ctrl_dt": 0.02})()
             self.observation_space = type("Space", (), {"shape": (5,)})()
             self.action_space = type("Space", (), {"shape": (2,)})()
-            self.obs_groups_spec = {"obs": 3, "critic": 5}
+            self.obs_groups_spec = {"obs": 3, "proprio": 2, "critic": 5}
 
         def init_state(self):
             pass
@@ -2137,17 +2138,27 @@ def test_play_wrapper_preserves_hora_priv_info_and_proprio_history():
                 cast(dict[str, np.ndarray], getattr(self.state, "info")),
             )
 
-    wrapper = HoraRslRlVecEnvWrapper(FakeEnv(), device="cpu", policy_obs_mode="flat")
-    obs_td, _ = wrapper.reset()
+    assert "reset" not in HoraRslRlVecEnvWrapper.__dict__
+    assert "get_observations" not in HoraRslRlVecEnvWrapper.__dict__
 
-    np.testing.assert_allclose(
-        obs_td["priv_info"].cpu().numpy(),
-        np.array([[4.0, 5.0]], dtype=np.float32),
-    )
-    np.testing.assert_allclose(
-        obs_td["proprio_hist"].cpu().numpy(),
-        np.array([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]], dtype=np.float32),
-    )
+    wrapper = HoraRslRlVecEnvWrapper(FakeEnv(), device="cpu", policy_obs_mode="flat")
+    reset_obs_td, reset_info = wrapper.reset()
+    current_obs_td = wrapper.get_observations()
+
+    assert reset_info is wrapper.env.state.info
+    for obs_td in (reset_obs_td, current_obs_td):
+        np.testing.assert_allclose(
+            obs_td["policy"].cpu().numpy(),
+            np.array([[1.0, 2.0, 3.0, 6.0, 7.0]], dtype=np.float32),
+        )
+        np.testing.assert_allclose(
+            obs_td["priv_info"].cpu().numpy(),
+            np.array([[4.0, 5.0]], dtype=np.float32),
+        )
+        np.testing.assert_allclose(
+            obs_td["proprio_hist"].cpu().numpy(),
+            np.array([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]], dtype=np.float32),
+        )
 
 
 def test_play_wrapper_step_exports_timeout_bootstrap_obs():


### PR DESCRIPTION
## Summary

- remove the HORA adapter overrides that were byte-for-byte copies of the base wrapper
- keep HORA-specific observation conversion and `step()` behavior unchanged
- assert inherited virtual dispatch and the existing HORA payload

Part of #983. Implements #1002 on the integration branch.

## Validation

- `uv run pytest tests/scripts/test_train_scripts.py -k hora`
- `uv run ruff check src/unilab/algos/torch/hora/rsl_rl.py tests/scripts/test_train_scripts.py`
- `uv run pyright src/unilab/algos/torch/hora/rsl_rl.py tests/scripts/test_train_scripts.py`
- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all` — 1685 passed, 27 skipped, 273 deselected, 1 xfailed; benchmark smoke passed (one platform-optional MLX module skipped in each import mode)

## Scope

Base: `dev/issue-983-code-cleanup`. This PR must not target `main`.