### PR TITLE
refactor(tools): share BONES-SEED CSV parsing

### DIFF
--- a/scripts/motion/bones_seed_csv_to_npz.py
+++ b/scripts/motion/bones_seed_csv_to_npz.py
@@ -32,7 +32,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,18 +41,15 @@ from tqdm import tqdm
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
+from unilab.tools.bones_seed_csv import (
+    ROOT_COLUMNS,
+    euler_deg_to_quat_wxyz,
+    load_header,
+    parse_joint_names,
+    resolve_input_files,
+)
 from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
 
-ROOT_COLUMNS = [
-    "Frame",
-    "root_translateX",
-    "root_translateY",
-    "root_translateZ",
-    "root_rotateX",
-    "root_rotateY",
-    "root_rotateZ",
-]
-EXPECTED_JOINT_COUNT = 29
 DEFAULT_INPUT = "src/unilab/assets/motions/g1/flip"
 DEFAULT_OUTPUT_DIR = "src/unilab/assets/motions/g1/flip_npz"
 
@@ -76,11 +72,6 @@ def quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
     return w1 * q1 + w2 * q2
 
 
-def natural_sort_key(value: str | Path) -> list[int | str]:
-    text = value.as_posix() if isinstance(value, Path) else value
-    return [int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", text)]
-
-
 def default_model_path() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
 
@@ -90,25 +81,6 @@ def resolve_model_path(model_file: str | None) -> str:
     if not path.exists():
         raise FileNotFoundError(f"MuJoCo model file not found: {path}")
     return str(path)
-
-
-def resolve_input_files(input_path: str) -> list[Path]:
-    path = Path(input_path).expanduser().resolve()
-    if not path.exists():
-        raise FileNotFoundError(f"Input path not found: {path}")
-
-    if path.is_file():
-        if path.suffix.lower() != ".csv":
-            raise ValueError(f"Expected a CSV file, got: {path}")
-        return [path]
-
-    csv_files = sorted(
-        [candidate for candidate in path.rglob("*.csv") if candidate.is_file()],
-        key=lambda candidate: natural_sort_key(candidate.relative_to(path)),
-    )
-    if not csv_files:
-        raise FileNotFoundError(f"No CSV files found in directory: {path}")
-    return csv_files
 
 
 def resolve_output_targets(
@@ -128,46 +100,6 @@ def resolve_output_targets(
 
     output_root = Path(output_path or DEFAULT_OUTPUT_DIR).expanduser().resolve()
     return [output_root / f"{csv_file.stem}.npz" for csv_file in csv_files]
-
-
-def load_header(csv_file: Path) -> list[str]:
-    first_line = csv_file.read_text(encoding="utf-8").splitlines()[0]
-    return [part.strip() for part in first_line.split(",")]
-
-
-def parse_joint_names(header: list[str], csv_file: Path) -> list[str]:
-    root_columns = header[: len(ROOT_COLUMNS)]
-    if root_columns != ROOT_COLUMNS:
-        raise ValueError(
-            f"Unexpected root columns in {csv_file}.\n"
-            f"Expected: {ROOT_COLUMNS}\n"
-            f"Actual:   {root_columns}"
-        )
-
-    joint_columns = header[len(ROOT_COLUMNS) :]
-    if len(joint_columns) != EXPECTED_JOINT_COUNT:
-        raise ValueError(
-            f"{csv_file} has {len(joint_columns)} joint columns, expected {EXPECTED_JOINT_COUNT}"
-        )
-    if len(set(joint_columns)) != len(joint_columns):
-        raise ValueError(f"{csv_file} has duplicate joint columns")
-    if any(not name.endswith("_dof") for name in joint_columns):
-        raise ValueError(f"{csv_file} has non-joint columns after the root columns")
-    return [name.removesuffix("_dof") for name in joint_columns]
-
-
-def _swap_case_for_mujoco_euler(order: str) -> str:
-    """Translate ProtoMotions/Scipy Euler case semantics to MuJoCo semantics."""
-    return "".join(ch.lower() if ch.isupper() else ch.upper() for ch in order)
-
-
-def euler_deg_to_quat_wxyz(euler_deg: np.ndarray, order: str) -> np.ndarray:
-    mujoco_order = _swap_case_for_mujoco_euler(order)
-    euler_rad = np.deg2rad(euler_deg)
-    quat_wxyz = np.zeros((euler_deg.shape[0], 4), dtype=np.float64)
-    for idx in range(euler_deg.shape[0]):
-        mujoco.mju_euler2Quat(quat_wxyz[idx], euler_rad[idx], mujoco_order)
-    return quat_wxyz
 
 
 @dataclass

--- a/scripts/motion/replay_bones_seed_csv.py
+++ b/scripts/motion/replay_bones_seed_csv.py
@@ -29,7 +29,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,17 +38,14 @@ import mujoco.viewer
 import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
+from unilab.tools.bones_seed_csv import (
+    ROOT_COLUMNS,
+    euler_deg_to_quat_wxyz,
+    load_header,
+    parse_joint_names,
+    resolve_input_files,
+)
 
-ROOT_COLUMNS = [
-    "Frame",
-    "root_translateX",
-    "root_translateY",
-    "root_translateZ",
-    "root_rotateX",
-    "root_rotateY",
-    "root_rotateZ",
-]
-EXPECTED_JOINT_COUNT = 29
 DEFAULT_INPUT = "src/unilab/assets/motions/g1/flip"
 
 
@@ -71,76 +67,11 @@ def default_model_path() -> str:
     return str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
 
 
-def natural_sort_key(value: str | Path) -> list[int | str]:
-    text = value.as_posix() if isinstance(value, Path) else value
-    return [int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", text)]
-
-
 def resolve_model_path(model_file: str | None) -> str:
     path = Path(model_file or default_model_path()).expanduser().resolve()
     if not path.exists():
         raise FileNotFoundError(f"MuJoCo model file not found: {path}")
     return str(path)
-
-
-def resolve_input_files(input_path: str) -> list[Path]:
-    path = Path(input_path).expanduser().resolve()
-    if not path.exists():
-        raise FileNotFoundError(f"Input path not found: {path}")
-
-    if path.is_file():
-        if path.suffix.lower() != ".csv":
-            raise ValueError(f"Expected a CSV file, got: {path}")
-        return [path]
-
-    csv_files = sorted(
-        [candidate for candidate in path.rglob("*.csv") if candidate.is_file()],
-        key=lambda candidate: natural_sort_key(candidate.relative_to(path)),
-    )
-    if not csv_files:
-        raise FileNotFoundError(f"No CSV files found in directory: {path}")
-    return csv_files
-
-
-def load_header(csv_file: Path) -> list[str]:
-    first_line = csv_file.read_text(encoding="utf-8").splitlines()[0]
-    return [part.strip() for part in first_line.split(",")]
-
-
-def parse_joint_names(header: list[str], csv_file: Path) -> list[str]:
-    root_columns = header[: len(ROOT_COLUMNS)]
-    if root_columns != ROOT_COLUMNS:
-        raise ValueError(
-            f"Unexpected root columns in {csv_file}.\n"
-            f"Expected: {ROOT_COLUMNS}\n"
-            f"Actual:   {root_columns}"
-        )
-
-    joint_columns = header[len(ROOT_COLUMNS) :]
-    if len(joint_columns) != EXPECTED_JOINT_COUNT:
-        raise ValueError(
-            f"{csv_file} has {len(joint_columns)} joint columns, expected {EXPECTED_JOINT_COUNT}"
-        )
-    if len(set(joint_columns)) != len(joint_columns):
-        raise ValueError(f"{csv_file} has duplicate joint columns")
-    if any(not name.endswith("_dof") for name in joint_columns):
-        raise ValueError(f"{csv_file} has non-joint columns after the root columns")
-
-    return [name.removesuffix("_dof") for name in joint_columns]
-
-
-def _swap_case_for_mujoco_euler(order: str) -> str:
-    """Translate ProtoMotions/Scipy Euler case semantics to MuJoCo semantics."""
-    return "".join(ch.lower() if ch.isupper() else ch.upper() for ch in order)
-
-
-def euler_deg_to_quat_wxyz(euler_deg: np.ndarray, order: str) -> np.ndarray:
-    mujoco_order = _swap_case_for_mujoco_euler(order)
-    euler_rad = np.deg2rad(euler_deg)
-    quat_wxyz = np.zeros((euler_deg.shape[0], 4), dtype=np.float64)
-    for idx in range(euler_deg.shape[0]):
-        mujoco.mju_euler2Quat(quat_wxyz[idx], euler_rad[idx], mujoco_order)
-    return quat_wxyz
 
 
 def load_motion(csv_file: Path, position_scale: float, euler_order: str) -> CsvMotion:

--- a/src/unilab/tools/bones_seed_csv.py
+++ b/src/unilab/tools/bones_seed_csv.py
@@ -1,0 +1,88 @@
+"""MuJoCo-only BONES-SEED CSV input contract helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+ROOT_COLUMNS = [
+    "Frame",
+    "root_translateX",
+    "root_translateY",
+    "root_translateZ",
+    "root_rotateX",
+    "root_rotateY",
+    "root_rotateZ",
+]
+EXPECTED_JOINT_COUNT = 29
+
+
+def natural_sort_key(value: str | Path) -> list[int | str]:
+    text = value.as_posix() if isinstance(value, Path) else value
+    return [int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", text)]
+
+
+def resolve_input_files(input_path: str) -> list[Path]:
+    path = Path(input_path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Input path not found: {path}")
+
+    if path.is_file():
+        if path.suffix.lower() != ".csv":
+            raise ValueError(f"Expected a CSV file, got: {path}")
+        return [path]
+
+    csv_files = sorted(
+        [candidate for candidate in path.rglob("*.csv") if candidate.is_file()],
+        key=lambda candidate: natural_sort_key(candidate.relative_to(path)),
+    )
+    if not csv_files:
+        raise FileNotFoundError(f"No CSV files found in directory: {path}")
+    return csv_files
+
+
+def load_header(csv_file: Path) -> list[str]:
+    first_line = csv_file.read_text(encoding="utf-8").splitlines()[0]
+    return [part.strip() for part in first_line.split(",")]
+
+
+def parse_joint_names(header: list[str], csv_file: Path) -> list[str]:
+    root_columns = header[: len(ROOT_COLUMNS)]
+    if root_columns != ROOT_COLUMNS:
+        raise ValueError(
+            f"Unexpected root columns in {csv_file}.\n"
+            f"Expected: {ROOT_COLUMNS}\n"
+            f"Actual:   {root_columns}"
+        )
+
+    joint_columns = header[len(ROOT_COLUMNS) :]
+    if len(joint_columns) != EXPECTED_JOINT_COUNT:
+        raise ValueError(
+            f"{csv_file} has {len(joint_columns)} joint columns, expected {EXPECTED_JOINT_COUNT}"
+        )
+    if len(set(joint_columns)) != len(joint_columns):
+        raise ValueError(f"{csv_file} has duplicate joint columns")
+    if any(not name.endswith("_dof") for name in joint_columns):
+        raise ValueError(f"{csv_file} has non-joint columns after the root columns")
+    return [name.removesuffix("_dof") for name in joint_columns]
+
+
+def _swap_case_for_mujoco_euler(order: str) -> str:
+    """Translate ProtoMotions/Scipy Euler case semantics to MuJoCo semantics."""
+    return "".join(ch.lower() if ch.isupper() else ch.upper() for ch in order)
+
+
+def euler_deg_to_quat_wxyz(euler_deg: np.ndarray, order: str) -> np.ndarray:
+    import mujoco as _mujoco
+
+    mujoco: Any = _mujoco
+
+    mujoco_order = _swap_case_for_mujoco_euler(order)
+    euler_rad = np.deg2rad(euler_deg)
+    quat_wxyz = np.zeros((euler_deg.shape[0], 4), dtype=np.float64)
+    for idx in range(euler_deg.shape[0]):
+        mujoco.mju_euler2Quat(quat_wxyz[idx], euler_rad[idx], mujoco_order)
+    return quat_wxyz

--- a/tests/scripts/test_mujoco_only_tooling_markers.py
+++ b/tests/scripts/test_mujoco_only_tooling_markers.py
@@ -11,6 +11,7 @@ def test_mujoco_only_tooling_is_marked_explicitly():
         root / "scripts" / "motion" / "replay_npz.py",
         root / "scripts" / "motion" / "bones_seed_csv_to_npz.py",
         root / "scripts" / "motion" / "replay_bones_seed_csv.py",
+        root / "src" / "unilab" / "tools" / "bones_seed_csv.py",
         root / "src" / "unilab" / "visualization" / "render_many.py",
     ]
 

--- a/tests/test_bones_seed_csv.py
+++ b/tests/test_bones_seed_csv.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unilab.tools import bones_seed_csv
+from unilab.tools.bones_seed_csv import (
+    ROOT_COLUMNS,
+    euler_deg_to_quat_wxyz,
+    load_header,
+    parse_joint_names,
+    resolve_input_files,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATHS = (
+    REPO_ROOT / "scripts" / "motion" / "bones_seed_csv_to_npz.py",
+    REPO_ROOT / "scripts" / "motion" / "replay_bones_seed_csv.py",
+)
+SHARED_NAMES = {
+    "ROOT_COLUMNS",
+    "EXPECTED_JOINT_COUNT",
+    "natural_sort_key",
+    "resolve_input_files",
+    "load_header",
+    "parse_joint_names",
+    "_swap_case_for_mujoco_euler",
+    "euler_deg_to_quat_wxyz",
+}
+
+
+def _joint_columns() -> list[str]:
+    return [f"joint_{index:02d}_dof" for index in range(29)]
+
+
+def test_resolve_input_files_uses_natural_order_and_accepts_single_csv(tmp_path: Path) -> None:
+    csv_paths = [tmp_path / name for name in ("flip_10.csv", "flip_2.csv", "flip_1.csv")]
+    for path in csv_paths:
+        path.write_text("", encoding="utf-8")
+    (tmp_path / "ignored.txt").write_text("", encoding="utf-8")
+
+    assert resolve_input_files(str(tmp_path)) == [csv_paths[2], csv_paths[1], csv_paths[0]]
+    assert resolve_input_files(str(csv_paths[1])) == [csv_paths[1]]
+
+
+def test_resolve_input_files_preserves_path_errors(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError, match="Input path not found"):
+        resolve_input_files(str(missing))
+
+    non_csv = tmp_path / "motion.txt"
+    non_csv.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected a CSV file"):
+        resolve_input_files(str(non_csv))
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="No CSV files found in directory"):
+        resolve_input_files(str(empty_dir))
+
+
+def test_load_header_and_parse_joint_names_accept_bones_seed_schema(tmp_path: Path) -> None:
+    csv_file = tmp_path / "motion.csv"
+    header = [*ROOT_COLUMNS, *_joint_columns()]
+    csv_file.write_text(", ".join(header) + "\n", encoding="utf-8")
+
+    loaded_header = load_header(csv_file)
+
+    assert loaded_header == header
+    assert parse_joint_names(loaded_header, csv_file) == [
+        name.removesuffix("_dof") for name in _joint_columns()
+    ]
+
+
+@pytest.mark.parametrize(
+    ("header", "message"),
+    [
+        (["frame", *ROOT_COLUMNS[1:], *_joint_columns()], "Unexpected root columns"),
+        ([*ROOT_COLUMNS, *_joint_columns()[:-1]], "has 28 joint columns"),
+        (
+            [*ROOT_COLUMNS, *_joint_columns()[:-1], _joint_columns()[0]],
+            "duplicate joint columns",
+        ),
+        ([*ROOT_COLUMNS, *_joint_columns()[:-1], "bad_joint"], "non-joint columns"),
+    ],
+)
+def test_parse_joint_names_preserves_schema_errors(header: list[str], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_joint_names(header, Path("motion.csv"))
+
+
+@pytest.mark.parametrize(
+    ("order", "expected"),
+    [
+        (
+            "xyz",
+            np.asarray([[1.0, 0.0, 0.0, 0.0], [0.95154852, 0.23929834, 0.18930786, 0.03813458]]),
+        ),
+        (
+            "XYZ",
+            np.asarray([[1.0, 0.0, 0.0, 0.0], [0.94371436, 0.26853582, 0.14487813, 0.12767944]]),
+        ),
+    ],
+)
+def test_euler_deg_to_quat_wxyz_matches_existing_golden(order: str, expected: np.ndarray) -> None:
+    pytest.importorskip("mujoco")
+    euler_deg = np.asarray([[0.0, 0.0, 0.0], [30.0, 20.0, 10.0]], dtype=np.float64)
+
+    actual = euler_deg_to_quat_wxyz(euler_deg, order)
+
+    assert actual.dtype == np.float64
+    np.testing.assert_allclose(actual, expected, atol=1.0e-8, rtol=0.0)
+
+
+def test_bones_seed_scripts_use_shared_owner_exports() -> None:
+    pytest.importorskip("mujoco")
+    from scripts.motion import bones_seed_csv_to_npz, replay_bones_seed_csv
+
+    for script in (bones_seed_csv_to_npz, replay_bones_seed_csv):
+        assert script.ROOT_COLUMNS == bones_seed_csv.ROOT_COLUMNS
+        for name in (
+            "resolve_input_files",
+            "load_header",
+            "parse_joint_names",
+            "euler_deg_to_quat_wxyz",
+        ):
+            assert getattr(script, name).__module__ == bones_seed_csv.__name__
+
+
+def test_bones_seed_scripts_do_not_redefine_shared_contract() -> None:
+    for script_path in SCRIPT_PATHS:
+        module = ast.parse(script_path.read_text(encoding="utf-8"))
+        defined_names = {
+            node.name
+            for node in module.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        assigned_names = {
+            target.id
+            for node in module.body
+            if isinstance(node, (ast.Assign, ast.AnnAssign))
+            for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+            if isinstance(target, ast.Name)
+        }
+        assert SHARED_NAMES.isdisjoint(defined_names | assigned_names)
+
+
+@pytest.mark.parametrize("script_path", SCRIPT_PATHS)
+def test_bones_seed_cli_help_smoke(script_path: Path) -> None:
+    pytest.importorskip("mujoco")
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["MUJOCO_GL"] = "disable"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- add one tooling owner for the BONES-SEED CSV schema, recursive discovery, natural ordering, validation, and Euler decoding
- remove the duplicated implementations from both conversion and replay scripts
- preserve each script’s model path, CLI, dtype, loader, interpolation, NPZ export, and viewer flow
- add golden, error, ownership, and headless-safe CLI smoke coverage

Part of #983. Implements #1003 on the integration branch.

## Validation

- focused tests: 27 passed, including render-backend environment interaction
- `uv run ruff check` and `uv run ruff format --check`
- `uv run pyright`: 0 errors
- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all` — 1698 passed, 27 skipped, 273 deselected, 1 xfailed; benchmark smoke passed (one platform-optional MLX module skipped in each import mode)

## Scope

5 files, +273/-151. Base: `dev/issue-983-code-cleanup`. This PR must not target `main`.