### PR TITLE
refactor: add terrain spawn backend contract

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -14,6 +14,31 @@ from unilab.dr.types import (
 )
 
 PreStepControlFn = Callable[[Any, np.ndarray], np.ndarray]
+TerrainHeightSampleFn = Callable[[np.ndarray], np.ndarray]
+
+
+@dataclass(frozen=True)
+class BackendTerrainSpawnData:
+    """Read-only terrain spawn metadata materialized by a backend.
+
+    ``terrain_origins`` is a detached snapshot with shape
+    ``(num_rows, num_cols, 3)``. ``sample_height`` samples world-space XY
+    coordinates and returns an array with the same leading shape.
+    """
+
+    terrain_origins: np.ndarray
+    sample_height: TerrainHeightSampleFn | None = None
+
+    def __post_init__(self) -> None:
+        origins = np.array(self.terrain_origins, copy=True)
+        if origins.ndim != 3 or origins.shape[2] != 3:
+            raise ValueError(
+                f"terrain_origins must have shape (num_rows, num_cols, 3); got {origins.shape}"
+            )
+        origins.setflags(write=False)
+        object.__setattr__(self, "terrain_origins", origins)
+        if self.sample_height is not None and not callable(self.sample_height):
+            raise TypeError("sample_height must be callable")
 
 
 @dataclass(frozen=True)
@@ -104,6 +129,15 @@ class SimBackend(abc.ABC):
 
     def get_scene_model_file(self) -> str | None:
         """Return the materialized scene path for diagnostics, when available."""
+        return None
+
+    def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
+        """Return backend-materialized terrain metadata on the cold path.
+
+        Backends without generated terrain support return ``None``. Callers
+        should resolve this once during env initialization and cache the
+        returned height-sampling callable for reset/reward hot paths.
+        """
         return None
 
     @abc.abstractmethod

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -34,6 +34,7 @@ from ..base import (
     BackendHeightScanner,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    BackendTerrainSpawnData,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -165,6 +166,18 @@ class MotrixBackend(SimBackend):
         self.scene_artifacts_dir = None
         self.terrain_origins = scene_context.terrain_origins
         self.terrain_surface_sampler = scene_context.terrain_surface_sampler
+        self._terrain_spawn_data = (
+            None
+            if self.terrain_origins is None
+            else BackendTerrainSpawnData(
+                terrain_origins=self.terrain_origins,
+                sample_height=(
+                    None
+                    if self.terrain_surface_sampler is None
+                    else cast(Any, self.terrain_surface_sampler).sample_height
+                ),
+            )
+        )
         self._scene_cleanup_handle = scene_context.cleanup_handle
         self._base_name = base_name
 
@@ -360,6 +373,9 @@ class MotrixBackend(SimBackend):
         arr: np.ndarray = np.array(self._model.actuator_ctrl_limits, dtype=self._np_dtype)
         result: np.ndarray = arr.T.copy()
         return result
+
+    def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
+        return self._terrain_spawn_data
 
     def get_keyframe_qpos(self, name: str) -> np.ndarray:
         if hasattr(self._model, "keyframes") and self._model.num_keyframes > 0:

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -37,6 +37,7 @@ from ..base import (
     BackendHeightScanner,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    BackendTerrainSpawnData,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -290,6 +291,18 @@ class MuJoCoBackend(SimBackend):
         self.scene_artifacts_dir = scene_context.artifacts_dir
         self.terrain_origins = scene_context.terrain_origins
         self.terrain_surface_sampler = scene_context.terrain_surface_sampler
+        self._terrain_spawn_data = (
+            None
+            if self.terrain_origins is None
+            else BackendTerrainSpawnData(
+                terrain_origins=self.terrain_origins,
+                sample_height=(
+                    None
+                    if self.terrain_surface_sampler is None
+                    else self.terrain_surface_sampler.sample_height
+                ),
+            )
+        )
         self._scene_cleanup_handle = scene_context.cleanup_handle
         self.add_body_sensors = add_body_sensors
         self._base_name = base_name
@@ -681,6 +694,9 @@ class MuJoCoBackend(SimBackend):
 
     def get_scene_model_file(self) -> str | None:
         return str(self.scene_model_file) if self.scene_model_file else None
+
+    def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
+        return self._terrain_spawn_data
 
     def get_keyframe_qpos(self, name: str) -> np.ndarray:
         key_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_KEY, name)

--- a/src/unilab/envs/locomotion/common/terrain_spawn.py
+++ b/src/unilab/envs/locomotion/common/terrain_spawn.py
@@ -14,6 +14,7 @@ land on the correct surface height.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -66,7 +67,7 @@ class TerrainSpawnManager(BaseSpawnManager):
         terrain_origins: np.ndarray,
         cell_size: float,
         cfg: TerrainCurriculumCfg,
-        terrain_surface_sampler: object | None = None,
+        sample_height: Callable[[np.ndarray], np.ndarray] | None = None,
         spawn_height_points: np.ndarray | None = None,
     ) -> None:
         if terrain_origins.ndim != 3 or terrain_origins.shape[2] != 3:
@@ -85,7 +86,9 @@ class TerrainSpawnManager(BaseSpawnManager):
         self._num_cols = num_cols
         self._cell_size = float(cell_size)
         self._cfg = cfg
-        self._terrain_surface_sampler = terrain_surface_sampler
+        if sample_height is not None and not callable(sample_height):
+            raise TypeError("sample_height must be callable")
+        self._sample_height = sample_height
         if spawn_height_points is None:
             self._spawn_height_points = np.zeros((1, 3), dtype=np.float64)
         else:
@@ -130,7 +133,8 @@ class TerrainSpawnManager(BaseSpawnManager):
         out = np.asarray(qpos_xyz, dtype=np.float64).copy()
         base_height = out[:, 2].copy()
         out[:, 0:2] += origins[:, 0:2]
-        if self._terrain_surface_sampler is None:
+        sample_height = self._sample_height
+        if sample_height is None:
             out[:, 2] += origins[:, 2] + self._cfg.spawn_height_margin
             return out
 
@@ -138,6 +142,7 @@ class TerrainSpawnManager(BaseSpawnManager):
             out[:, 0:2],
             base_height=base_height,
             yaw=yaw,
+            sample_height=sample_height,
         )
         out[:, 2] = required_base_z + self._cfg.spawn_height_margin
         return out
@@ -148,12 +153,8 @@ class TerrainSpawnManager(BaseSpawnManager):
         *,
         base_height: np.ndarray,
         yaw: np.ndarray | None,
+        sample_height: Callable[[np.ndarray], np.ndarray],
     ) -> np.ndarray:
-        sampler = self._terrain_surface_sampler
-        sample_height = getattr(sampler, "sample_height", None)
-        if not callable(sample_height):
-            raise TypeError("terrain_surface_sampler must expose sample_height(xy)")
-
         points = self._spawn_height_points
         local_xy = points[:, :2]
         local_z = points[:, 2]

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -108,21 +108,20 @@ class Go1WalkTask(Go1BaseEnv):
             drake_backend_mode=cfg.drake_backend_mode,
             drake_nthread=cfg.drake_nthread,
         )
-        self._terrain_surface_sampler = getattr(backend, "terrain_surface_sampler", None)
-        terrain_origins = getattr(backend, "terrain_origins", None)
-        if terrain_origins is not None:
-            self._scene_terrain_origins = terrain_origins
+        terrain_spawn_data = backend.get_terrain_spawn_data()
+        if terrain_spawn_data is not None:
+            self._scene_terrain_origins = terrain_spawn_data.terrain_origins
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True
         self._reward_cfg = cfg.reward_config
         self._init_reward_functions()
-        if self._scene_terrain_origins is not None and terrain_generator is not None:
+        if terrain_spawn_data is not None and terrain_generator is not None:
             self._spawn = TerrainSpawnManager(
                 num_envs,
-                self._scene_terrain_origins,
+                terrain_spawn_data.terrain_origins,
                 cell_size=float(terrain_generator.size[0]),
                 cfg=getattr(cfg, "terrain_curriculum", TerrainCurriculumCfg()),
-                terrain_surface_sampler=self._terrain_surface_sampler,
+                sample_height=terrain_spawn_data.sample_height,
             )
         self.phase = np.zeros((num_envs,), dtype=np.float32)
         self.feet_phase = np.zeros((num_envs, len(cfg.sensor.feet_force)), dtype=np.float32)

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -118,23 +117,24 @@ class Go2WalkTask(Go2BaseEnv):
             drake_backend_mode=cfg.drake_backend_mode,
             drake_nthread=cfg.drake_nthread,
         )
-        self._terrain_surface_sampler = getattr(backend, "terrain_surface_sampler", None)
-        self._terrain_surface_sample_height = self._resolve_terrain_surface_sample_height()
-        terrain_origins = getattr(backend, "terrain_origins", None)
-        if terrain_origins is not None:
-            self._scene_terrain_origins = terrain_origins
+        terrain_spawn_data = backend.get_terrain_spawn_data()
+        self._terrain_surface_sample_height = (
+            None if terrain_spawn_data is None else terrain_spawn_data.sample_height
+        )
+        if terrain_spawn_data is not None:
+            self._scene_terrain_origins = terrain_spawn_data.terrain_origins
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True
         self._reward_cfg = cfg.reward_config
         self._init_reward_functions()
         self._init_domain_randomization(self._make_dr_provider())
-        if self._scene_terrain_origins is not None and terrain_generator is not None:
+        if terrain_spawn_data is not None and terrain_generator is not None:
             self._spawn = TerrainSpawnManager(
                 num_envs,
-                self._scene_terrain_origins,
+                terrain_spawn_data.terrain_origins,
                 cell_size=float(terrain_generator.size[0]),
                 cfg=cfg.terrain_curriculum,
-                terrain_surface_sampler=self._terrain_surface_sampler,
+                sample_height=self._terrain_surface_sample_height,
             )
         self.phase = np.zeros((num_envs,), dtype=np.float32)
         self.feet_phase = np.zeros((num_envs, len(cfg.sensor.feet_force)), dtype=np.float32)
@@ -153,18 +153,6 @@ class Go2WalkTask(Go2BaseEnv):
 
     def get_playback_model(self, env_index: int | None = None) -> Any:
         return super().get_playback_model(env_index)
-
-    def _resolve_terrain_surface_sample_height(
-        self,
-    ) -> Callable[[np.ndarray], np.ndarray] | None:
-        sampler = self._terrain_surface_sampler
-        if sampler is None:
-            return None
-
-        sample_height = getattr(sampler, "sample_height", None)
-        if not callable(sample_height):
-            raise TypeError("terrain_surface_sampler must expose sample_height(xy)")
-        return cast(Callable[[np.ndarray], np.ndarray], sample_height)
 
     @property
     def obs_groups_spec(self) -> dict[str, int]:

--- a/src/unilab/envs/locomotion/go2w/rough.py
+++ b/src/unilab/envs/locomotion/go2w/rough.py
@@ -208,15 +208,15 @@ class Go2WJoystickRoughEnv(Go2WJoystickEnv):
 
     def __init__(self, cfg: Go2WJoystickRoughCfg, num_envs=1, backend_type="mujoco"):
         super().__init__(cfg, num_envs=num_envs, backend_type=backend_type)
-        terrain_origins = getattr(self._backend, "terrain_origins", None)
+        terrain_spawn_data = self._backend.get_terrain_spawn_data()
         terrain_generator = cfg.scene.terrain.generator if cfg.scene.terrain is not None else None
-        if terrain_origins is not None and terrain_generator is not None:
+        if terrain_spawn_data is not None and terrain_generator is not None:
             self._spawn = TerrainSpawnManager(
                 num_envs,
-                terrain_origins,
+                terrain_spawn_data.terrain_origins,
                 cell_size=float(terrain_generator.size[0]),
                 cfg=cfg.terrain_curriculum,
-                terrain_surface_sampler=getattr(self._backend, "terrain_surface_sampler", None),
+                sample_height=terrain_spawn_data.sample_height,
             )
         self._dr_manager = DomainRandomizationManager(
             self, Go2WJoystickRoughDomainRandomizationProvider()

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -15,6 +15,7 @@ import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.backend import create_backend
+from unilab.base.backend.base import BackendTerrainSpawnData, SimBackend
 from unilab.base.scene import SceneCfg
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -22,6 +23,12 @@ SRC_ROOT = REPO_ROOT / "src"
 _FACTORY_FILE = SRC_ROOT / "unilab" / "base" / "backend" / "__init__.py"
 _BACKEND_CLASS_NAMES = frozenset(
     {"MuJoCoBackend", "MotrixBackend", "DrakeBackend", "MjwarpBackend"}
+)
+_TERRAIN_CONSUMER_FILES = (
+    SRC_ROOT / "unilab" / "envs" / "locomotion" / "common" / "terrain_spawn.py",
+    SRC_ROOT / "unilab" / "envs" / "locomotion" / "go1" / "joystick.py",
+    SRC_ROOT / "unilab" / "envs" / "locomotion" / "go2" / "joystick.py",
+    SRC_ROOT / "unilab" / "envs" / "locomotion" / "go2w" / "rough.py",
 )
 
 NUM_ENVS = 2
@@ -99,6 +106,46 @@ def test_backend_classes_are_only_instantiated_through_create_backend() -> None:
     )
 
 
+def test_terrain_spawn_contract_is_read_only_and_defaults_to_unsupported() -> None:
+    origins = np.arange(12, dtype=np.float64).reshape(2, 2, 3)
+
+    def sample_height(xy: np.ndarray) -> np.ndarray:
+        return np.zeros(np.asarray(xy).shape[:-1], dtype=np.float64)
+
+    data = BackendTerrainSpawnData(origins, sample_height=sample_height)
+
+    assert SimBackend.get_terrain_spawn_data(object()) is None  # type: ignore[arg-type]
+    assert data.sample_height is sample_height
+    assert not data.terrain_origins.flags.writeable
+    assert not np.shares_memory(data.terrain_origins, origins)
+    origins.fill(-1.0)
+    assert np.all(data.terrain_origins >= 0.0)
+
+    with pytest.raises(ValueError, match="terrain_origins must have shape"):
+        BackendTerrainSpawnData(np.zeros((2, 3), dtype=np.float64))
+    with pytest.raises(TypeError, match="sample_height must be callable"):
+        BackendTerrainSpawnData(
+            np.zeros((1, 1, 3), dtype=np.float64),
+            sample_height=object(),  # type: ignore[arg-type]
+        )
+
+
+def test_terrain_spawn_consumers_do_not_probe_private_backend_capabilities() -> None:
+    forbidden_names = {"terrain_origins", "terrain_surface_sampler", "sample_height"}
+    offenders: list[str] = []
+    for path in _TERRAIN_CONSUMER_FILES:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.func.id not in {"getattr", "hasattr"}:
+                continue
+            for arg in node.args[1:]:
+                if isinstance(arg, ast.Constant) and arg.value in forbidden_names:
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}: {arg.value}")
+    assert not offenders, "private terrain capability probes:\n" + "\n".join(offenders)
+
+
 @pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
 def test_legacy_contract_step_set_state_and_state_reads(backend_type: str) -> None:
     _require_backend(backend_type)
@@ -114,6 +161,7 @@ def test_legacy_contract_step_set_state_and_state_reads(backend_type: str) -> No
 
     assert backend.num_envs == NUM_ENVS
     assert backend.num_actuators > 0
+    assert backend.get_terrain_spawn_data() is None
 
     backend.step(np.zeros((NUM_ENVS, backend.num_actuators)), nsteps=2)
 

--- a/tests/envs/locomotion/test_go2_terrain_spawn.py
+++ b/tests/envs/locomotion/test_go2_terrain_spawn.py
@@ -18,17 +18,24 @@ def _class_path(obj) -> str:
     return f"{cls.__module__}.{cls.__name__}"
 
 
+def _configure_small_terrain(cfg, *, seed: int = 0) -> None:
+    assert cfg.scene.terrain is not None
+    generator = cfg.scene.terrain.generator
+    assert generator is not None
+    generator.num_rows = 3
+    generator.num_cols = 3
+    generator.border_width = 0.0
+    generator.add_lights = False
+    generator.seed = seed
+
+
 def _rough_cfg(*, curriculum_enabled: bool = False, seed: int = 0):
     from unilab.envs.locomotion.go2.rough import Go2JoystickRoughCfg, RoughRewardConfig
 
     cfg = Go2JoystickRoughCfg(
         reward_config=RoughRewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
     )
-    cfg.scene.terrain.generator.num_rows = 3
-    cfg.scene.terrain.generator.num_cols = 3
-    cfg.scene.terrain.generator.border_width = 0.0
-    cfg.scene.terrain.generator.add_lights = False
-    cfg.scene.terrain.generator.seed = seed
+    _configure_small_terrain(cfg, seed=seed)
     cfg.terrain_curriculum = TerrainCurriculumCfg(enabled=curriculum_enabled, seed=seed)
     return cfg
 
@@ -39,6 +46,11 @@ def test_terrain_spawn_attached_when_rough():
     cfg = _rough_cfg()
     env = Go2JoystickRoughEnv(cfg, num_envs=4, backend_type="mujoco")
     try:
+        terrain_data = env._backend.get_terrain_spawn_data()
+        assert terrain_data is not None
+        assert terrain_data.sample_height is not None
+        assert terrain_data.terrain_origins.shape == (3, 3, 3)
+        assert not terrain_data.terrain_origins.flags.writeable
         assert _class_path(env._spawn) == (
             "unilab.envs.locomotion.common.terrain_spawn.TerrainSpawnManager"
         )
@@ -58,6 +70,11 @@ def test_terrain_spawn_attached_when_rough_motrix():
     cfg.domain_rand.randomize_kd = False
     env = Go2WalkTask(cfg, num_envs=2, backend_type="motrix")
     try:
+        terrain_data = env._backend.get_terrain_spawn_data()
+        assert terrain_data is not None
+        assert terrain_data.sample_height is not None
+        assert terrain_data.terrain_origins.shape == (3, 3, 3)
+        assert not terrain_data.terrain_origins.flags.writeable
         assert _class_path(env._spawn) == (
             "unilab.envs.locomotion.common.terrain_spawn.TerrainSpawnManager"
         )
@@ -65,6 +82,59 @@ def test_terrain_spawn_attached_when_rough_motrix():
         assert env._scene_terrain_origins.shape == (3, 3, 3)
         state = env.init_state()
         assert state.obs["obs"].shape == (2, 49)
+    finally:
+        env.close()
+
+
+def test_go1_rough_initialization_and_reset_use_backend_terrain_contract():
+    from unilab.envs.locomotion.go1.rough import (
+        Go1JoystickRoughCfg,
+        Go1JoystickRoughEnv,
+        RoughRewardConfig,
+    )
+
+    cfg = Go1JoystickRoughCfg(
+        reward_config=RoughRewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
+    )
+    _configure_small_terrain(cfg)
+    cfg.terrain_scan.enabled = False
+    cfg.domain_rand.randomize_kp = False
+    cfg.domain_rand.randomize_kd = False
+
+    env = Go1JoystickRoughEnv(cfg, num_envs=2, backend_type="mujoco")
+    try:
+        terrain_data = env._backend.get_terrain_spawn_data()
+        assert terrain_data is not None
+        assert terrain_data.sample_height is not None
+        assert env._scene_terrain_origins is terrain_data.terrain_origins
+        assert env._spawn._sample_height is terrain_data.sample_height
+        state = env.init_state()
+        assert state.obs["obs"].shape == (2, 45)
+    finally:
+        env.close()
+
+
+def test_go2w_rough_initialization_and_reset_use_backend_terrain_contract():
+    from unilab.envs.locomotion.go2w.joystick import RewardConfig
+    from unilab.envs.locomotion.go2w.rough import Go2WJoystickRoughCfg, Go2WJoystickRoughEnv
+
+    cfg = Go2WJoystickRoughCfg(
+        reward_config=RewardConfig(scales={}, tracking_sigma=0.25, base_height_target=0.3)
+    )
+    _configure_small_terrain(cfg)
+    cfg.terrain_scan.enabled = False
+    cfg.domain_rand.randomize_kp = False
+    cfg.domain_rand.randomize_kd = False
+
+    env = Go2WJoystickRoughEnv(cfg, num_envs=2, backend_type="mujoco")
+    try:
+        terrain_data = env._backend.get_terrain_spawn_data()
+        assert terrain_data is not None
+        assert terrain_data.sample_height is not None
+        np.testing.assert_array_equal(env._spawn._terrain_origins, terrain_data.terrain_origins)
+        assert env._spawn._sample_height is terrain_data.sample_height
+        state = env.init_state()
+        assert state.obs["obs"].shape == (2, 53)
     finally:
         env.close()
 
@@ -77,13 +147,16 @@ def test_terrain_spawn_samples_height_after_xy_jitter():
 
     origins = np.zeros((1, 1, 3), dtype=np.float64)
     cfg = TerrainCurriculumCfg(spawn_height_margin=0.05)
+    surface = FakeSurface()
+    sample_height = surface.sample_height
     spawn = TerrainSpawnManager(
         1,
         origins,
         cell_size=1.0,
         cfg=cfg,
-        terrain_surface_sampler=FakeSurface(),
+        sample_height=sample_height,
     )
+    assert spawn._sample_height is sample_height
 
     qpos_xyz = np.asarray([[0.2, 0.4, 0.42]], dtype=np.float64)
     spawned = spawn.apply_spawn(np.asarray([0], dtype=np.int32), qpos_xyz)
@@ -91,6 +164,17 @@ def test_terrain_spawn_samples_height_after_xy_jitter():
     assert spawned[0, 0] == pytest.approx(0.2)
     assert spawned[0, 1] == pytest.approx(0.4)
     assert spawned[0, 2] == pytest.approx(0.2 * 0.5 + 0.4 * 0.25 + 0.42 + 0.05)
+
+
+def test_terrain_spawn_rejects_non_callable_height_sampler_on_init():
+    with pytest.raises(TypeError, match="sample_height must be callable"):
+        TerrainSpawnManager(
+            1,
+            np.zeros((1, 1, 3), dtype=np.float64),
+            cell_size=1.0,
+            cfg=TerrainCurriculumCfg(),
+            sample_height=object(),  # type: ignore[arg-type]
+        )
 
 
 def test_go2_rough_base_height_reward_uses_terrain_relative_height():
@@ -154,6 +238,7 @@ def test_default_spawn_used_when_flat():
     )
     env = Go2WalkTask(cfg, num_envs=4, backend_type="mujoco")
     try:
+        assert env._backend.get_terrain_spawn_data() is None
         assert _class_path(env._spawn) == (
             "unilab.envs.locomotion.common.terrain_spawn.BaseSpawnManager"
         )


### PR DESCRIPTION
## Summary

- add a narrow, read-only `BackendTerrainSpawnData` contract with a default no-capability result
- cache MuJoCo/Motrix terrain origins and height sampling capability on backend cold paths
- make Go1, Go2, and Go2W consume the public contract once during initialization
- cache the validated height callable in `TerrainSpawnManager`, removing reflective probing from reset/reward hot paths

Part of #983. Implements #998 on the integration branch.

## Validation

- focused contract/env/terrain regression tests: 93 passed (plus dependency-gated skips/deselections)
- `uv run ruff check` and targeted `uv run pyright`: passed
- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all`: 1703 passed, 27 skipped, 273 deselected, 1 xfailed; Ruff format/check, Mypy, Pyright, and benchmark smoke passed

## Impact

- Backend impact: MuJoCo and Motrix cold-path wiring; unsupported backends retain explicit `None` behavior
- Training effect expected: none; terrain generation, spawn/curriculum/reward numerics, reset protocol, and support matrix are unchanged

## Scope

9 files, +233/-46 (net +187). Base: `dev/issue-983-code-cleanup`. This PR must not target `main`.