### PR TITLE
cleanup: remove dead imports and private helpers

### DIFF
--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from unilab.algos.torch.common.device import get_env_dims
 from unilab.algos.torch.fast_sac.learner import FastSACLearner
 from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
 from unilab.ipc.replay_pipelines.gpu_resident import require_offpolicy_replay_device

--- a/src/unilab/algos/torch/him_ppo/runner.py
+++ b/src/unilab/algos/torch/him_ppo/runner.py
@@ -10,7 +10,6 @@ from collections import deque
 from typing import Any, Callable, cast
 
 import torch
-from tensordict import TensorDict
 
 from unilab.algos.torch.him_ppo.actor_critic import HIMActorCritic
 from unilab.algos.torch.him_ppo.algorithm import HIMPPO

--- a/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/torch/offpolicy/double_buffer_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import queue as queue_module
 import statistics
-import sys
 import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
@@ -21,7 +20,6 @@ from unilab.algos.torch.offpolicy.runner import (
     OffPolicyRunner,
     build_offpolicy_sample_info,
     build_reward_comparison_metrics,
-    compute_train_start_threshold,
     replay_buffer_ready_for_learning,
 )
 from unilab.algos.torch.offpolicy.thread_budget import (

--- a/src/unilab/algos/torch/offpolicy/runner.py
+++ b/src/unilab/algos/torch/offpolicy/runner.py
@@ -6,8 +6,6 @@ import sys
 from collections import deque
 from typing import Any
 
-import torch
-
 from unilab.algos.torch.common.device import get_env_dims
 from unilab.ipc.async_runner import AsyncRunner
 from unilab.logging import OffPolicyLogger

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
-from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
-from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
@@ -22,7 +21,6 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainSpawnManager,
 )
 from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
-from unilab.utils.rotation import np_quat_mul, np_yaw_to_quat
 
 
 @dataclass

--- a/src/unilab/envs/locomotion/go2/footstand.py
+++ b/src/unilab/envs/locomotion/go2/footstand.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 import numpy as np
-from etils import epath
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry

--- a/src/unilab/envs/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/envs/locomotion/go2_arm/manip_loco.py
@@ -18,7 +18,6 @@ from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.go2_arm.base import (
-    DEFAULT_LEG_ANGLES,
     Go2ArmBaseCfg,
     Go2ArmBaseEnv,
     Go2ArmSensor,

--- a/src/unilab/envs/manipulation/sharpa_inhand/base.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/base.py
@@ -13,7 +13,6 @@ from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
-from unilab.utils.rotation import np_quat_apply, np_quat_mul
 
 DEFAULT_ACTUATED_JOINT_NAMES: list[str] = [
     "right_thumb_CMC_FE",

--- a/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 

--- a/src/unilab/envs/manipulation/stewart/balance.py
+++ b/src/unilab/envs/manipulation/stewart/balance.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import SimBackend, create_backend, env_backend_kwargs
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.scene import SceneCfg

--- a/src/unilab/ipc/replay_pipelines/native_h2d.py
+++ b/src/unilab/ipc/replay_pipelines/native_h2d.py
@@ -12,7 +12,7 @@ import logging
 import shutil
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import torch
 

--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -316,28 +316,6 @@ class BaseTrainingLogger:
         eta_s = remaining * avg_iter
         return _fmt_time(eta_s)
 
-    def _build_header(self, *, include_status: bool) -> Panel:
-        elapsed = time.time() - self._start_time if self._start_time else 0
-        eta = self._estimate_eta()
-
-        header_text = Text()
-        header_text.append(f" {self.algo_name}", style="bold cyan")
-        header_text.append("  │  ", style="dim")
-        header_text.append(f"{self.env_name}", style="bold white")
-        header_text.append("  │  ", style="dim")
-        header_text.append(f"iter {self._iteration}/{self.max_iterations}", style="yellow")
-        header_text.append("  │  ", style="dim")
-        time_label = "⏱" if self._unicode_console else "time"
-        header_text.append(f"{time_label} {_fmt_time(elapsed)}", style="green")
-        if eta:
-            header_text.append("  │  ETA ", style="dim")
-            header_text.append(eta, style="bold magenta")
-        if include_status and self._status:
-            header_text.append("  │  ", style="dim")
-            header_text.append(self._status, style="dim italic")
-
-        return Panel(header_text, style="dim", box=box.SIMPLE)
-
     def _build_compact_header(
         self,
         *,

--- a/src/unilab/tools/import_robot.py
+++ b/src/unilab/tools/import_robot.py
@@ -222,12 +222,6 @@ def _ensure_robot_default_joint(root: ET.Element) -> None:
     joint.set("frictionloss", "0.2")
 
 
-def _parse_values(text: str | None) -> list[float]:
-    if text is None:
-        return []
-    return [float(part) for part in text.split()]
-
-
 def _format_float(value: float) -> str:
     return f"{value:.8g}"
 

--- a/src/unilab/tools/viz_nan.py
+++ b/src/unilab/tools/viz_nan.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
## Summary

- remove 17 unused import bindings from 13 runtime modules
- remove `BaseTrainingLogger._build_header` and `import_robot._parse_values`, both private leaf helpers with no direct, string, or reflective callers
- preserve registry/Hydra entries, package re-exports, public APIs, logger output, robot parsing behavior, and all execution paths

Part of #983. Implements #1001 on the integration branch. The maintainer approved this as one PR.

## Validation

- exact-file Ruff and 15-module import smoke: passed
- focused training/logging/import_robot tests: 92 passed
- focused env/config owner tests: 108 passed, 8 deselected
- focused env reset/step tests: 10 passed
- `PYTHONPATH="$PWD/src" UV_NO_SYNC=1 make test-all`: 1703 passed, 27 skipped, 273 deselected, 1 xfailed; Ruff format/check, Mypy, Pyright, and benchmark smoke passed

## Impact

- Backend impact: none
- Training effect expected: none; this is deletion of unread bindings and unreachable private helpers only

## Scope

15 production files, +3/-44 (net -41). Base: `dev/issue-983-code-cleanup` at `38545f90` (includes #998). This PR must not target `main`.