### PR TITLE
fix: finish grasp collection through run signal

### DIFF
--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -19,6 +19,7 @@ if str(ROOT_DIR) not in sys.path:
 
 from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 from unilab.base.backend import materialize_scene_visual_override
+from unilab.base.run_control import RunComplete
 from unilab.ipc.dp_launcher import (
     UNILAB_DP_LOG_DIR,
     current_torch_distributed_local_rank,
@@ -185,6 +186,25 @@ def apply_ppo_runtime_flags(
         return
     if not training_enabled:
         algorithm_cfg["enable_compile"] = False
+
+
+def validate_ppo_run_completion_topology(
+    cfg: DictConfig,
+    *,
+    devices: tuple[int, ...] | None,
+    world_size: int,
+) -> None:
+    """Reject grasp collection on a topology without run-completion coordination."""
+    if cfg.training.play_only:
+        return
+    if OmegaConf.select(cfg, "env.grasp_collection_target", default=None) is None:
+        return
+    effective_world_size = len(devices) if devices is not None and world_size == 1 else world_size
+    if effective_world_size > 1:
+        raise ValueError(
+            "Grasp collection run completion currently requires one process; "
+            "multi-rank completion needs an explicit cross-rank lifecycle protocol"
+        )
 
 
 def _format_play_checkpoint_error(
@@ -359,6 +379,7 @@ def main(cfg: DictConfig) -> None:
             "Distributed play-only execution is not supported; launch eval normally and "
             "select one device"
         )
+    validate_ppo_run_completion_topology(cfg, devices=devices, world_size=world_size)
 
     # The parent only composes config and invokes torchrun. CUDA, registry,
     # env, tracker, and runner construction all happen inside workers.
@@ -435,129 +456,162 @@ def main(cfg: DictConfig) -> None:
         tracker.start()
 
     training_succeeded = False
+    run_completion: RunComplete | None = None
+    pending_summary: dict[str, object] | None = None
     try:
-        if not cfg.training.play_only:
-            env = create_env(
-                cfg,
-                num_envs=cfg.algo.num_envs,
-                env_cfg_override=env_cfg_override,
-            )
-            rl_cfg = _algo_config_dict(cfg)
-            wrapper_cls = _resolve_ppo_wrapper_cls(rl_cfg)
-
-            nan_guard_cfg = getattr(cfg.training, "nan_guard", None)
-            if nan_guard_cfg is not None and getattr(nan_guard_cfg, "enabled", False):
-                from unilab.utils.nan_guard import NanGuard, NanGuardCfg
-
-                guard = NanGuard(
-                    NanGuardCfg(
-                        enabled=True,
-                        buffer_size=int(getattr(nan_guard_cfg, "buffer_size", 100)),
-                        max_envs_to_dump=int(getattr(nan_guard_cfg, "max_envs_to_dump", 5)),
-                        output_dir=getattr(nan_guard_cfg, "output_dir", None),
-                    ),
-                    num_envs=env.num_envs,
-                    supports_state_playback=env.play_capabilities.supports_physics_state_playback,
+        try:
+            if not cfg.training.play_only:
+                env = create_env(
+                    cfg,
+                    num_envs=cfg.algo.num_envs,
+                    env_cfg_override=env_cfg_override,
                 )
-                env.set_nan_guard(guard)
+                try:
+                    rl_cfg = _algo_config_dict(cfg)
+                    wrapper_cls = _resolve_ppo_wrapper_cls(rl_cfg)
 
-            wrapped_env = wrapper_cls(env, device=device)
+                    nan_guard_cfg = getattr(cfg.training, "nan_guard", None)
+                    if nan_guard_cfg is not None and getattr(nan_guard_cfg, "enabled", False):
+                        from unilab.utils.nan_guard import NanGuard, NanGuardCfg
 
-            train_cfg = normalize_ppo_train_cfg(rl_cfg)
-            apply_ppo_runtime_flags(train_cfg, cfg, training_enabled=True)
-            if "runner" not in train_cfg:
-                train_cfg["runner"] = {}
+                        guard = NanGuard(
+                            NanGuardCfg(
+                                enabled=True,
+                                buffer_size=int(getattr(nan_guard_cfg, "buffer_size", 100)),
+                                max_envs_to_dump=int(getattr(nan_guard_cfg, "max_envs_to_dump", 5)),
+                                output_dir=getattr(nan_guard_cfg, "output_dir", None),
+                            ),
+                            num_envs=env.num_envs,
+                            supports_state_playback=(
+                                env.play_capabilities.supports_physics_state_playback
+                            ),
+                        )
+                        env.set_nan_guard(guard)
 
-            logger_type = (
-                cfg.training.logger if cfg.training.logger in ["tensorboard", "wandb"] else "none"
-            )
-            train_cfg["runner"]["logger"] = logger_type
-            train_cfg["logger"] = logger_type
+                    wrapped_env = wrapper_cls(env, device=device)
 
-            patch_rsl_rl_resume_state()
+                    train_cfg = normalize_ppo_train_cfg(rl_cfg)
+                    apply_ppo_runtime_flags(train_cfg, cfg, training_enabled=True)
+                    if "runner" not in train_cfg:
+                        train_cfg["runner"] = {}
 
-            if tracker is not None and logger_type == "wandb":
-                patch_rsl_rl_wandb_writer()
-                wandb_settings = tracker.wandb_settings
-                train_cfg["wandb_project"] = wandb_settings["project"]
-                train_cfg["wandb_entity"] = wandb_settings["entity"]
-                train_cfg["wandb_group"] = wandb_settings["group"]
-                train_cfg["wandb_job_type"] = wandb_settings["job_type"]
-                train_cfg["wandb_tags"] = wandb_settings["tags"]
-                train_cfg["wandb_notes"] = wandb_settings["notes"]
-                train_cfg["wandb_mode"] = wandb_settings["mode"]
+                    logger_type = (
+                        cfg.training.logger
+                        if cfg.training.logger in ["tensorboard", "wandb"]
+                        else "none"
+                    )
+                    train_cfg["runner"]["logger"] = logger_type
+                    train_cfg["logger"] = logger_type
 
-            runner = cast(
-                Any,
-                OnPolicyRunner(cast(Any, wrapped_env), train_cfg, log_dir=log_dir, device=device),
-            )
-            _patch_runner_action_std_logging(runner)
+                    patch_rsl_rl_resume_state()
 
-            if cfg.algo.load_run != "-1":
-                resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
-                if resume_path:
-                    print(f"Resuming from {resume_path}")
-                    runner.load(str(resume_path), map_location=device)
+                    if tracker is not None and logger_type == "wandb":
+                        patch_rsl_rl_wandb_writer()
+                        wandb_settings = tracker.wandb_settings
+                        train_cfg["wandb_project"] = wandb_settings["project"]
+                        train_cfg["wandb_entity"] = wandb_settings["entity"]
+                        train_cfg["wandb_group"] = wandb_settings["group"]
+                        train_cfg["wandb_job_type"] = wandb_settings["job_type"]
+                        train_cfg["wandb_tags"] = wandb_settings["tags"]
+                        train_cfg["wandb_notes"] = wandb_settings["notes"]
+                        train_cfg["wandb_mode"] = wandb_settings["mode"]
 
-            initial_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
-            initial_training_time = float(getattr(runner.logger, "tot_time", 0.0))
-            train_start_wall = time.time()
-            runner.learn(num_learning_iterations=max_iterations, init_at_random_ep_len=True)
-            training_succeeded = True
-            if rank == 0:
-                assert log_dir is not None
-                total_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
-                total_training_time = float(getattr(runner.logger, "tot_time", 0.0))
-                run_timesteps = total_timesteps - initial_timesteps
-                run_training_time = total_training_time - initial_training_time
-                train_summary = {
-                    "status": "completed",
-                    "completed_iterations": int(runner.current_learning_iteration),
-                    "total_env_steps": total_timesteps,
-                    "run_env_steps": run_timesteps,
-                    "world_size": world_size,
-                    "num_envs_per_rank": int(cfg.algo.num_envs),
-                    "global_num_envs": int(cfg.algo.num_envs) * world_size,
-                    "samples_per_iteration": ppo_samples_per_iteration(
-                        num_envs=cfg.algo.num_envs,
-                        num_steps_per_env=cfg.algo.num_steps_per_env,
-                        world_size=world_size,
-                    ),
-                    "training_throughput_env_steps_per_sec": (
-                        run_timesteps / run_training_time if run_training_time > 0.0 else None
-                    ),
-                    "final_mean_reward": (
-                        float(statistics.mean(runner.logger.rewbuffer))
-                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                        else None
-                    ),
-                    "best_mean_reward": (
-                        float(max(runner.logger.rewbuffer))
-                        if len(getattr(runner.logger, "rewbuffer", [])) > 0
-                        else None
-                    ),
-                    "mean_episode_length": (
-                        float(statistics.mean(runner.logger.lenbuffer))
-                        if len(getattr(runner.logger, "lenbuffer", [])) > 0
-                        else None
-                    ),
-                    "last_checkpoint": str(
-                        Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
-                    ),
-                    "training_wall_time_sec": time.time() - train_start_wall,
-                }
-                if tracker is not None:
-                    tracker.update_summary(train_summary)
-            env.close()
+                    runner = cast(
+                        Any,
+                        OnPolicyRunner(
+                            cast(Any, wrapped_env), train_cfg, log_dir=log_dir, device=device
+                        ),
+                    )
+                    _patch_runner_action_std_logging(runner)
 
+                    if cfg.algo.load_run != "-1":
+                        resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)
+                        if resume_path:
+                            print(f"Resuming from {resume_path}")
+                            runner.load(str(resume_path), map_location=device)
+
+                    initial_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+                    initial_training_time = float(getattr(runner.logger, "tot_time", 0.0))
+                    train_start_wall = time.time()
+                    try:
+                        runner.learn(
+                            num_learning_iterations=max_iterations,
+                            init_at_random_ep_len=True,
+                        )
+                    except RunComplete as completion:
+                        if world_size != 1:
+                            raise RuntimeError(
+                                "RSL-RL RunComplete handling requires a single-process topology"
+                            ) from completion
+                        run_completion = completion
+                    if run_completion is None and rank == 0:
+                        assert log_dir is not None
+                        total_timesteps = int(getattr(runner.logger, "tot_timesteps", 0))
+                        total_training_time = float(getattr(runner.logger, "tot_time", 0.0))
+                        run_timesteps = total_timesteps - initial_timesteps
+                        run_training_time = total_training_time - initial_training_time
+                        pending_summary = {
+                            "status": "completed",
+                            "completed_iterations": int(runner.current_learning_iteration),
+                            "total_env_steps": total_timesteps,
+                            "run_env_steps": run_timesteps,
+                            "world_size": world_size,
+                            "num_envs_per_rank": int(cfg.algo.num_envs),
+                            "global_num_envs": int(cfg.algo.num_envs) * world_size,
+                            "samples_per_iteration": ppo_samples_per_iteration(
+                                num_envs=cfg.algo.num_envs,
+                                num_steps_per_env=cfg.algo.num_steps_per_env,
+                                world_size=world_size,
+                            ),
+                            "training_throughput_env_steps_per_sec": (
+                                run_timesteps / run_training_time
+                                if run_training_time > 0.0
+                                else None
+                            ),
+                            "final_mean_reward": (
+                                float(statistics.mean(runner.logger.rewbuffer))
+                                if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                                else None
+                            ),
+                            "best_mean_reward": (
+                                float(max(runner.logger.rewbuffer))
+                                if len(getattr(runner.logger, "rewbuffer", [])) > 0
+                                else None
+                            ),
+                            "mean_episode_length": (
+                                float(statistics.mean(runner.logger.lenbuffer))
+                                if len(getattr(runner.logger, "lenbuffer", [])) > 0
+                                else None
+                            ),
+                            "last_checkpoint": str(
+                                Path(log_dir) / f"model_{int(runner.current_learning_iteration)}.pt"
+                            ),
+                            "training_wall_time_sec": time.time() - train_start_wall,
+                        }
+                finally:
+                    env.close()
+                if run_completion is not None:
+                    pending_summary = {
+                        **dict(run_completion.summary),
+                        "completion_reason": run_completion.reason,
+                        "status": "collection_completed",
+                    }
+                if tracker is not None and pending_summary is not None:
+                    tracker.update_summary(pending_summary)
+                training_succeeded = True
+        finally:
             # Keep non-main ranks alive until rank 0 has persisted its final
-            # checkpoint and summary, then release NCCL before playback.
+            # summary, then release NCCL before playback.
             finish_rsl_rl_distributed(training_succeeded=training_succeeded)
 
-        if rank == 0 and should_run_playback(
-            play_only=cfg.training.play_only,
-            no_play=cfg.training.no_play,
-            play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
+        if (
+            run_completion is None
+            and rank == 0
+            and should_run_playback(
+                play_only=cfg.training.play_only,
+                no_play=cfg.training.no_play,
+                play_render_mode=getattr(cfg.training, "play_render_mode", "auto"),
+            )
         ):
             # torchrun rank variables outlive the training process group. Mask
             # them while playback constructs a new runner so rank 0 does not
@@ -567,9 +621,6 @@ def main(cfg: DictConfig) -> None:
             if tracker is not None:
                 tracker.log_video(play_video_path)
     finally:
-        # On failure, release an initialized group without a peer barrier;
-        # torchrun owns sibling termination and error propagation.
-        finish_rsl_rl_distributed(training_succeeded=training_succeeded)
         if tracker is not None:
             tracker.finish()
 

--- a/src/unilab/base/run_control.py
+++ b/src/unilab/base/run_control.py
@@ -1,0 +1,27 @@
+"""Typed control-flow signals shared by environments and entrypoints."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+
+class RunComplete(Exception):  # noqa: N818 - this is a normal control signal, not an error
+    """Signal that a run reached its intended non-error completion condition."""
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        summary: Mapping[str, object] | None = None,
+    ) -> None:
+        if not reason:
+            raise ValueError("RunComplete reason must be non-empty")
+        self.reason = reason
+        self._summary = MappingProxyType(dict(summary or {}))
+        super().__init__(reason)
+
+    @property
+    def summary(self) -> Mapping[str, object]:
+        """Return the completion facts without allowing caller mutation."""
+        return self._summary

--- a/src/unilab/envs/manipulation/allegro_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/grasp_gen.py
@@ -10,6 +10,7 @@ import numpy as np
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.np_env import NpEnvState
+from unilab.base.run_control import RunComplete
 
 from .rotation import AllegroRotationPPO, AllegroRotationPPOCfg, RewardConfigPPO
 
@@ -115,7 +116,7 @@ class AllegroRotationGrasp(AllegroRotationPPO):
         self._grasp_target_reached_notified = True
         print(
             "[AllegroInhandRotationGrasp] Grasp collection target reached "
-            f"({total}/{target}). Program stopped."
+            f"({total}/{target}). Collection completed."
         )
 
         if self.state is not None:
@@ -123,10 +124,17 @@ class AllegroRotationGrasp(AllegroRotationPPO):
             log["grasp/target_reached"] = 1.0
             self.state.info["log"] = log
 
-        exit(0)
+        raise RunComplete(
+            reason="grasp_collection_target_reached",
+            summary={
+                "collected_grasps": int(total),
+                "saved_grasps": int(min(total, target)),
+                "grasp_collection_target": target,
+            },
+        )
 
     def _save_grasp_cache(self, force: bool = False) -> None:
-        if self._grasp_cache_saved and not force:
+        if self._grasp_cache_saved:
             return
 
         total = self._total_saved_grasps()

--- a/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
@@ -8,6 +8,7 @@ import numpy as np
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.np_env import NpEnvState
+from unilab.base.run_control import RunComplete
 from unilab.dr import ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization
 from unilab.envs.manipulation.sharpa_inhand.base import (
@@ -251,7 +252,7 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
         target = int(self._cfg.grasp_collection_target)
         print(
             "[SharpaInhandRotationGrasp] Grasp collection target reached "
-            f"(saved={collected}, configured_target={target}). Program stopped."
+            f"(saved={collected}, configured_target={target}). Collection completed."
         )
 
         if self.state is not None:
@@ -259,7 +260,14 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
             log["grasp/target_reached"] = 1.0
             self.state.info["log"] = log
 
-        exit(0)
+        raise RunComplete(
+            reason="grasp_collection_target_reached",
+            summary={
+                "collected_grasps": int(collected),
+                "grasp_collection_target": int(self._grasp_target_per_scale),
+                "grasp_collection_counts_by_scale": self._get_per_scale_grasp_counts(),
+            },
+        )
 
     def _collect_successful_grasps(self, env_ids: np.ndarray) -> None:
         if self.state is None or len(env_ids) == 0:

--- a/tests/base/test_run_control.py
+++ b/tests/base/test_run_control.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from unilab.base.run_control import RunComplete
+
+
+def test_run_complete_summary_is_copied_and_read_only() -> None:
+    source = {"collected_grasps": 2}
+    completion = RunComplete(reason="grasp_collection_target_reached", summary=source)
+    source["collected_grasps"] = 3
+
+    assert str(completion) == "grasp_collection_target_reached"
+    assert completion.reason == "grasp_collection_target_reached"
+    assert completion.summary == {"collected_grasps": 2}
+    with pytest.raises(TypeError):
+        cast(Any, completion.summary)["collected_grasps"] = 4
+    with pytest.raises(AttributeError):
+        completion.summary = {}  # type: ignore[misc]

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -464,6 +464,103 @@ def test_allegro_grasp_generation_skips_cache_materialization(
     assert rotation._materialize_grasp_cache(cfg) is None
 
 
+def test_allegro_grasp_target_raises_run_complete_without_resaving_on_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unilab.base.run_control import RunComplete
+    from unilab.envs.manipulation.allegro_inhand import grasp_gen
+
+    cache_path = tmp_path / "allegro.npy"
+    env = cast(Any, object.__new__(grasp_gen.AllegroRotationGrasp))
+    env._cfg = grasp_gen.AllegroRotationGraspCfg(
+        grasp_collection_target=2,
+        grasp_cache_path=str(cache_path),
+        grasp_auto_save=True,
+        grasp_quality_check=False,
+    )
+    states = np.arange(3 * 23, dtype=np.float64).reshape(3, 23)
+    env._saved_grasping_states = []
+    env._grasp_cache_saved = False
+    env._grasp_target_reached_notified = False
+    env._state = SimpleNamespace(
+        truncated=np.ones((3,), dtype=bool),
+        terminated=np.zeros((3,), dtype=bool),
+        info={
+            "curr_dof_pos": states[:, :16],
+            "curr_ball_pos": states[:, 16:19],
+            "curr_ball_quat": states[:, 19:23],
+        },
+    )
+    env.get_hand_dof_pos = lambda: states[:, :16]
+    env.get_ball_pos = lambda: states[:, 16:19]
+    env.get_ball_quat = lambda: states[:, 19:23]
+
+    save_calls: list[Path] = []
+    real_save = grasp_gen.np.save
+
+    def save_once(path: str | Path, values: np.ndarray) -> None:
+        save_calls.append(Path(path))
+        real_save(path, values)
+
+    parent_closes: list[Any] = []
+    monkeypatch.setattr(grasp_gen.np, "save", save_once)
+    monkeypatch.setattr(
+        grasp_gen.AllegroRotationPPO,
+        "close",
+        lambda instance: parent_closes.append(instance),
+    )
+
+    with pytest.raises(RunComplete) as caught:
+        env._collect_successful_grasps(np.arange(3, dtype=np.int32))
+
+    saved = np.load(cache_path)
+    np.testing.assert_array_equal(saved, states[:2].astype(np.float32))
+    assert saved.dtype == np.float32
+    assert save_calls == [cache_path]
+    assert env.state.info["log"] == {
+        "grasp_cache/saved": 1.0,
+        "grasp_cache/num_states": 2.0,
+        "grasp/target_reached": 1.0,
+    }
+    assert dict(caught.value.summary) == {
+        "collected_grasps": 3,
+        "saved_grasps": 2,
+        "grasp_collection_target": 2,
+    }
+
+    env.close()
+    env._stop_collection()
+    assert save_calls == [cache_path]
+    assert parent_closes == [env]
+
+
+def test_allegro_grasp_save_failure_does_not_signal_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unilab.envs.manipulation.allegro_inhand import grasp_gen
+
+    env = cast(Any, object.__new__(grasp_gen.AllegroRotationGrasp))
+    env._cfg = grasp_gen.AllegroRotationGraspCfg(
+        grasp_collection_target=1,
+        grasp_cache_path=str(tmp_path / "allegro.npy"),
+    )
+    env._saved_grasping_states = [np.zeros((1, 23), dtype=np.float32)]
+    env._grasp_cache_saved = False
+    env._grasp_target_reached_notified = False
+    env._state = SimpleNamespace(info={})
+    sentinel = OSError("disk full")
+    monkeypatch.setattr(
+        grasp_gen.np, "save", lambda *_args, **_kwargs: (_ for _ in ()).throw(sentinel)
+    )
+
+    with pytest.raises(OSError) as caught:
+        env._save_grasp_cache()
+
+    assert caught.value is sentinel
+    assert env._grasp_cache_saved is False
+    assert env._grasp_target_reached_notified is False
+
+
 def test_allegro_reset_samples_materialized_cache_without_file_io(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1517,6 +1614,105 @@ def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
         "SharpaInhandGraspDRProvider"
     ]
     assert len(env._saved_grasping_states) == env._num_scales
+
+
+def test_sharpa_grasp_target_saves_cache_then_raises_run_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unilab.base.run_control import RunComplete
+    from unilab.envs.manipulation.sharpa_inhand.grasp_gen import (
+        SharpaInhandRotationGraspCfg,
+        SharpaInhandRotationGraspEnv,
+    )
+
+    cache_path = tmp_path / "sharpa.npy"
+    env = cast(Any, object.__new__(SharpaInhandRotationGraspEnv))
+    env._cfg = SharpaInhandRotationGraspCfg(
+        grasp_collection_target=1,
+        grasp_cache_path=str(cache_path),
+        grasp_auto_save=True,
+    )
+    env._grasp_target_per_scale = 1
+    env._num_scales = 1
+    env.scale_values = np.asarray([0.8], dtype=np.float64)
+    env.scale_ids = np.asarray([0], dtype=np.int32)
+    env._saved_grasping_states = [[]]
+    env._grasp_cache_saved = False
+    env._grasp_target_reached_notified = False
+    env._last_grasp_progress_counts = ()
+    env._last_grasp_progress_step = -1
+    env._state = SimpleNamespace(
+        truncated=np.asarray([True]),
+        terminated=np.asarray([False]),
+        info={"steps": np.asarray([1], dtype=np.uint32), "log": {}},
+    )
+    env.get_hand_dof_pos = lambda: np.arange(22, dtype=np.float64).reshape(1, 22)
+    env.get_object_pos = lambda: np.asarray([[1.0, 2.0, 3.0]], dtype=np.float64)
+    env.get_object_quat = lambda: np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=np.float64)
+
+    save_calls: list[Path] = []
+    real_save = np.save
+
+    def save_once(path: str | Path, values: np.ndarray) -> None:
+        save_calls.append(Path(path))
+        real_save(path, values)
+
+    monkeypatch.setattr(
+        "unilab.envs.manipulation.sharpa_inhand.grasp_gen.np.save",
+        save_once,
+    )
+
+    with pytest.raises(RunComplete) as caught:
+        env._collect_successful_grasps(np.asarray([0], dtype=np.int32))
+
+    saved_path = tmp_path / "sharpa_0.8.npy"
+    saved = np.load(saved_path)
+    expected = np.concatenate(
+        [
+            np.arange(22, dtype=np.float32),
+            np.asarray([1.0, 2.0, 3.0], dtype=np.float32),
+            np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        ]
+    )[None, :]
+    np.testing.assert_array_equal(saved, expected)
+    assert saved.dtype == np.float32
+    assert save_calls == [saved_path]
+    assert env.state.info["log"]["grasp_cache/saved"] == 1.0
+    assert env.state.info["log"]["grasp_cache/num_states"] == 1.0
+    assert env.state.info["log"]["grasp/target_reached"] == 1.0
+    assert dict(caught.value.summary) == {
+        "collected_grasps": 1,
+        "grasp_collection_target": 1,
+        "grasp_collection_counts_by_scale": (1,),
+    }
+
+    env._collect_successful_grasps(np.asarray([0], dtype=np.int32))
+    env._stop_collection()
+    assert save_calls == [saved_path]
+
+
+def test_sharpa_run_complete_reports_effective_collection_target() -> None:
+    from unilab.base.run_control import RunComplete
+    from unilab.envs.manipulation.sharpa_inhand.grasp_gen import (
+        SharpaInhandRotationGraspCfg,
+        SharpaInhandRotationGraspEnv,
+    )
+
+    env = cast(Any, object.__new__(SharpaInhandRotationGraspEnv))
+    env._cfg = SharpaInhandRotationGraspCfg(grasp_collection_target=0)
+    env._grasp_target_per_scale = 1
+    env._saved_grasping_states = [[np.zeros((1, 29), dtype=np.float32)]]
+    env._grasp_target_reached_notified = False
+    env._state = None
+
+    with pytest.raises(RunComplete) as caught:
+        env._stop_collection()
+
+    assert dict(caught.value.summary) == {
+        "collected_grasps": 1,
+        "grasp_collection_target": 1,
+        "grasp_collection_counts_by_scale": (1,),
+    }
 
 
 def test_g1_flip_tracking_cfg_uses_flip_profile():

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -942,6 +942,261 @@ def test_build_ppo_env_cfg_override_sharpa_grasp_motrix_owner(
     assert env_cfg_override["domain_rand"]["scale_list"] == [0.8]
 
 
+def _build_rsl_lifecycle_case(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    learn_exception: Exception | None,
+    *,
+    run_complete: bool = False,
+    close_exception: Exception | None = None,
+    play_only: bool = False,
+) -> tuple[Any, Any, dict[str, Any], Exception | None]:
+    mod = _train_rsl_rl(monkeypatch)
+    if run_complete:
+        assert learn_exception is None
+        learn_exception = mod.RunComplete(
+            reason="grasp_collection_target_reached",
+            summary={"collected_grasps": 12, "status": "payload_must_not_override"},
+        )
+    cfg = _ppo_cfg(
+        [
+            "task=sharpa_inhand_grasp/mujoco",
+            f"training.log_dir={tmp_path}",
+            "training.logger=none",
+            "training.nan_guard.enabled=false",
+            "training.no_play=false",
+            "training.play_render_mode=record",
+            f"training.play_only={str(play_only).lower()}",
+        ]
+    )
+    captured: dict[str, Any] = {
+        "env_create": 0,
+        "env_close": 0,
+        "distributed": [],
+        "summaries": [],
+        "tracker_finish": 0,
+        "playback": 0,
+    }
+
+    class FakeEnv:
+        num_envs = 1
+        play_capabilities = types.SimpleNamespace(supports_physics_state_playback=False)
+
+        def close(self) -> None:
+            captured["env_close"] += 1
+            if close_exception is not None:
+                raise close_exception
+
+    class FakeWrapper:
+        def __init__(self, env: Any, device: str) -> None:
+            del env, device
+
+    class FakeRunner:
+        logger = types.SimpleNamespace(
+            tot_timesteps=0,
+            tot_time=0.0,
+            rewbuffer=[],
+            lenbuffer=[],
+        )
+        current_learning_iteration = 3
+
+        def __init__(self, wrapped_env: Any, train_cfg: dict[str, Any], log_dir: str, device: str):
+            del wrapped_env, train_cfg, log_dir, device
+
+        def learn(self, **kwargs: Any) -> None:
+            del kwargs
+            if learn_exception is not None:
+                raise learn_exception
+            self.logger.tot_timesteps = 8
+            self.logger.tot_time = 2.0
+
+    class FakeTracker:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def start(self) -> None:
+            captured["tracker_start"] = True
+
+        def update_summary(self, summary: dict[str, Any]) -> None:
+            captured["summaries"].append(summary)
+
+        def finish(self) -> None:
+            captured["tracker_finish"] += 1
+
+        def log_video(self, path: str | None) -> None:
+            captured["video"] = path
+
+    monkeypatch.setattr(mod, "resolve_dp_topology", lambda _devices: None)
+    monkeypatch.setattr(mod, "current_torch_distributed_rank", lambda: 0)
+    monkeypatch.setattr(mod, "current_torch_distributed_local_rank", lambda: 0)
+    monkeypatch.setattr(mod, "current_torch_distributed_world_size", lambda: 1)
+    monkeypatch.setattr(mod, "ensure_registries", lambda: None)
+    monkeypatch.setattr(mod, "apply_rsl_rl_rank_seed", lambda _cfg, _rank: 0)
+    monkeypatch.setattr(mod, "apply_configured_training_seed", lambda *args, **kwargs: {})
+    monkeypatch.setattr(mod, "build_ppo_env_cfg_override", lambda _cfg: {})
+    monkeypatch.setattr(mod, "get_default_device", lambda: "cpu")
+    monkeypatch.setattr(mod, "resolve_rsl_rl_device", lambda **kwargs: "cpu")
+    monkeypatch.setattr(mod, "resolve_ppo_log_dir", lambda _cfg, world_size: str(tmp_path))
+    monkeypatch.setattr(mod, "ExperimentTracker", FakeTracker)
+
+    def create_env(*args: Any, **kwargs: Any) -> FakeEnv:
+        del args, kwargs
+        captured["env_create"] += 1
+        return FakeEnv()
+
+    monkeypatch.setattr(mod, "create_env", create_env)
+    monkeypatch.setattr(mod, "_algo_config_dict", lambda _cfg: {})
+    monkeypatch.setattr(mod, "_resolve_ppo_wrapper_cls", lambda _rl_cfg: FakeWrapper)
+    monkeypatch.setattr(mod, "normalize_ppo_train_cfg", lambda _rl_cfg: {})
+    monkeypatch.setattr(mod, "patch_rsl_rl_resume_state", lambda: None)
+    monkeypatch.setattr(mod, "OnPolicyRunner", FakeRunner)
+    monkeypatch.setattr(mod, "_patch_runner_action_std_logging", lambda _runner: None)
+    monkeypatch.setattr(
+        mod,
+        "finish_rsl_rl_distributed",
+        lambda *, training_succeeded: captured["distributed"].append(training_succeeded),
+    )
+
+    def playback(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        captured["playback"] += 1
+
+    monkeypatch.setattr(mod, "play_rsl_rl", playback)
+    return mod, cfg, captured, learn_exception
+
+
+def test_train_rsl_rl_run_complete_closes_resources_and_skips_playback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mod, cfg, captured, _ = _build_rsl_lifecycle_case(
+        monkeypatch,
+        tmp_path,
+        None,
+        run_complete=True,
+    )
+
+    assert mod.main.__wrapped__(cfg) is None
+    assert captured["env_close"] == 1
+    assert captured["distributed"] == [True]
+    assert captured["tracker_finish"] == 1
+    assert captured["playback"] == 0
+    assert captured["summaries"] == [
+        {
+            "collected_grasps": 12,
+            "status": "collection_completed",
+            "completion_reason": "grasp_collection_target_reached",
+        }
+    ]
+
+
+def test_train_rsl_rl_success_keeps_playback_and_single_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mod, cfg, captured, raised = _build_rsl_lifecycle_case(monkeypatch, tmp_path, None)
+
+    assert raised is None
+    assert mod.main.__wrapped__(cfg) is None
+    assert captured["env_close"] == 1
+    assert captured["distributed"] == [True]
+    assert captured["tracker_finish"] == 1
+    assert captured["playback"] == 1
+    assert captured["summaries"][0]["status"] == "completed"
+    assert captured["summaries"][0]["run_env_steps"] == 8
+
+
+def test_train_rsl_rl_runtime_error_propagates_after_single_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sentinel = RuntimeError("runner failed")
+    mod, cfg, captured, raised = _build_rsl_lifecycle_case(monkeypatch, tmp_path, sentinel)
+
+    with pytest.raises(RuntimeError) as caught:
+        mod.main.__wrapped__(cfg)
+
+    assert caught.value is raised is sentinel
+    assert captured["env_close"] == 1
+    assert captured["distributed"] == [False]
+    assert captured["tracker_finish"] == 1
+    assert captured["playback"] == 0
+    assert captured["summaries"] == []
+
+
+def test_train_rsl_rl_run_complete_close_error_is_not_misclassified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sentinel = RuntimeError("close failed")
+    mod, cfg, captured, _ = _build_rsl_lifecycle_case(
+        monkeypatch,
+        tmp_path,
+        None,
+        run_complete=True,
+        close_exception=sentinel,
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        mod.main.__wrapped__(cfg)
+
+    assert caught.value is sentinel
+    assert captured["env_close"] == 1
+    assert captured["distributed"] == [False]
+    assert captured["tracker_finish"] == 1
+    assert captured["playback"] == 0
+    assert captured["summaries"] == []
+
+
+def test_train_rsl_rl_play_only_keeps_single_cleanup_and_runs_playback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mod, cfg, captured, raised = _build_rsl_lifecycle_case(
+        monkeypatch,
+        tmp_path,
+        None,
+        play_only=True,
+    )
+
+    assert raised is None
+    assert mod.main.__wrapped__(cfg) is None
+    assert captured["env_create"] == 0
+    assert captured["env_close"] == 0
+    assert captured["distributed"] == [False]
+    assert captured["tracker_finish"] == 0
+    assert captured["playback"] == 1
+    assert captured["summaries"] == []
+
+
+@pytest.mark.parametrize(
+    ("devices", "world_size"),
+    [
+        ((0, 1), 1),
+        (None, 2),
+    ],
+)
+def test_train_rsl_rl_grasp_collection_rejects_multi_rank_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    devices: tuple[int, ...] | None,
+    world_size: int,
+) -> None:
+    mod = _train_rsl_rl(monkeypatch)
+    cfg = _ppo_cfg(["task=sharpa_inhand_grasp/mujoco"])
+    monkeypatch.setattr(mod, "resolve_dp_topology", lambda _devices: devices)
+    monkeypatch.setattr(mod, "current_torch_distributed_rank", lambda: 0)
+    monkeypatch.setattr(mod, "current_torch_distributed_local_rank", lambda: 0)
+    monkeypatch.setattr(mod, "current_torch_distributed_world_size", lambda: world_size)
+    monkeypatch.setattr(
+        mod,
+        "launch_torchrun_workers",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must fail before launch")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "ensure_registries",
+        lambda: (_ for _ in ()).throw(AssertionError("must fail before registry bootstrap")),
+    )
+
+    with pytest.raises(ValueError, match="requires one process"):
+        mod.main.__wrapped__(cfg)
+
+
 def test_ppo_cli_algo_override_wins_over_base(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
Parent: #983
Fixes #1008

## Summary
- Add a typed, read-only `RunComplete` control signal in the base layer.
- Replace the Allegro and Sharpa grasp-cache `exit(0)` paths after their existing save/log ordering.
- Make the PPO entrypoint own env close, distributed cleanup, summary/tracker finish, and playback suppression.
- Reject grasp collection on multi-process topologies (including external torchrun workers) until an explicit cross-rank completion protocol exists.
- Keep ordinary exceptions unchanged and prevent cache double-write during close.

## Scope
Seven files; 692 additions / 126 deletions (under the issue hard stop of 15 files / 800 net lines). The extra lines are lifecycle and positive/negative contract tests; the runner block is necessarily re-indented to express resource ownership.

## Validation
- `make test-all` passed: 1715 passed, 27 skipped, 1 xfailed, 273 deselected; coverage completed.
- Benchmark smoke passed in both module and script modes (one optional `mlx` case skipped).
- `uv run mypy src/unilab` passed.
- `uv run pyright` passed.
- `uv run ruff check .` and `uv run ruff format --check .` passed.

No changes were made to `main`; this PR targets the #983 integration branch.