### PR TITLE
refactor: HORA distill 配置改为标准 Hydra compose

### DIFF
--- a/conf/hora_distill/student_model/hora_actor.yaml
+++ b/conf/hora_distill/student_model/hora_actor.yaml
@@ -1,0 +1,17 @@
+# Teacher -> student `algo.model` mapping for HoraActorModel teachers (PPO/APPO).
+#
+# Loaded by unilab.algos.torch.hora.distill_config and merged next to the
+# Hydra-composed teacher owner config mounted at `teacher_owner`, so every
+# student field interpolates directly from the teacher owner YAML. The teacher
+# owner config stays the single source of truth for these hyperparameters;
+# missing teacher fields fail at resolution time instead of falling back to
+# Python-side defaults.
+model:
+  hidden_dims: ${teacher_owner.algo.actor.hidden_dims}
+  activation: ${teacher_owner.algo.actor.activation}
+  obs_normalization: ${teacher_owner.algo.actor.obs_normalization}
+  priv_info_embed_dim: ${teacher_owner.algo.actor.priv_info_embed_dim}
+  priv_mlp_hidden_dims: ${teacher_owner.algo.actor.priv_mlp_hidden_dims}
+  # The student re-binds its own distribution class; distill_config strips
+  # `class_name` from the resolved dict before exposing `algo.model`.
+  distribution_cfg: ${teacher_owner.algo.actor.distribution_cfg}

--- a/conf/hora_distill/student_model/hora_sac.yaml
+++ b/conf/hora_distill/student_model/hora_sac.yaml
@@ -1,0 +1,12 @@
+# Teacher -> student `algo.model` mapping for hora_sac teachers (offpolicy SAC).
+#
+# Loaded by unilab.algos.torch.hora.distill_config and merged next to the
+# Hydra-composed teacher owner config mounted at `teacher_owner`. Values come
+# from the teacher owner YAML; the `oc.select` fallback after the comma only
+# applies when the teacher owner config does not define the field at all.
+model:
+  teacher_arch: hora_sac
+  actor_hidden_dim: ${oc.select:teacher_owner.algo.actor_hidden_dim,512}
+  use_layer_norm: ${oc.select:teacher_owner.algo.use_layer_norm,true}
+  priv_info_embed_dim: ${oc.select:teacher_owner.algo.actor.priv_info_embed_dim,9}
+  priv_mlp_hidden_dims: ${oc.select:teacher_owner.algo.actor.priv_mlp_hidden_dims,[256, 128, 9]}

--- a/src/unilab/algos/torch/hora/distill_config.py
+++ b/src/unilab/algos/torch/hora/distill_config.py
@@ -6,11 +6,22 @@ import re
 from pathlib import Path
 from typing import Any, cast
 
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, OmegaConf
 
 from unilab.training.run import resolve_task_checkpoint_path
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
+
+# Teacher owner configs are Hydra-composed from their family config tree.
+# SAC teachers live in the shared offpolicy tree behind the `algo` group.
+_TEACHER_TREE_BY_FAMILY = {"sac": "offpolicy"}
+
+# Teacher -> student `algo.model` mappings expressed in YAML; see
+# conf/hora_distill/student_model/*.yaml. The mapping files interpolate against
+# the composed teacher owner config mounted at `teacher_owner`.
+_STUDENT_MODEL_MAPPING_DIR = Path("conf") / "hora_distill" / "student_model"
 
 
 def _root(root_dir: str | Path | None) -> Path:
@@ -29,53 +40,27 @@ def _sanitize_path_token(value: str, *, fallback: str) -> str:
     return sanitized or fallback
 
 
-def _teacher_config_paths(
-    algo_family: str,
-    task: str,
-    *,
-    root: Path,
-) -> tuple[Path, Path, Path | None]:
-    """Resolve teacher owner/default paths for supported HORA teacher families."""
-    algo_family = str(algo_family)
-    if algo_family == "sac":
-        return (
-            root / "conf" / "offpolicy" / "task" / f"{task}.yaml",
-            root / "conf" / "offpolicy",
-            root / "conf" / "offpolicy" / "algo" / "sac.yaml",
-        )
-    return (
-        root / "conf" / algo_family / "task" / f"{task}.yaml",
-        root / "conf" / algo_family,
-        None,
-    )
-
-
 def load_teacher_owner_config(
     algo_family: str,
     task: str,
     *,
     root_dir: str | Path | None = None,
 ) -> DictConfig:
-    """Load a HORA teacher owner config and its direct owner defaults."""
+    """Compose a HORA teacher owner config with standard Hydra semantics.
+
+    Uses ``initialize_config_dir`` + ``compose`` (same pattern as
+    ``scripts/audit_sim2sim_contracts.py``), so package directives, nested
+    ``defaults`` lists, and interpolations in the teacher tree all resolve.
+    """
     root = _root(root_dir)
-    owner_path, defaults_base, algo_defaults_path = _teacher_config_paths(
-        algo_family,
-        task,
-        root=root,
-    )
-    merged_cfg = OmegaConf.create()
-    if algo_defaults_path is not None:
-        merged_cfg = OmegaConf.merge(
-            merged_cfg,
-            OmegaConf.create({"algo": _load_yaml_config(algo_defaults_path)}),
-        )
-    owner_cfg = _load_yaml_config(owner_path)
-    for default_entry in owner_cfg.get("defaults", []):
-        if not isinstance(default_entry, str) or default_entry == "_self_":
-            continue
-        include_path = defaults_base / f"{default_entry.lstrip('/')}.yaml"
-        merged_cfg = OmegaConf.merge(merged_cfg, _load_yaml_config(include_path))
-    return cast(DictConfig, OmegaConf.merge(merged_cfg, owner_cfg))
+    algo_family = str(algo_family)
+    conf_dir = root / "conf" / _TEACHER_TREE_BY_FAMILY.get(algo_family, algo_family)
+    overrides = [f"task={task}"]
+    if algo_family == "sac":
+        overrides.insert(0, "algo=sac")
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(conf_dir.absolute()), version_base="1.3"):
+        return compose("config", overrides=overrides)
 
 
 def get_teacher_owner_spec(cfg: DictConfig) -> tuple[str | None, str | None]:
@@ -85,6 +70,63 @@ def get_teacher_owner_spec(cfg: DictConfig) -> tuple[str | None, str | None]:
     if algo_family in (None, "") or task in (None, ""):
         return None, None
     return str(algo_family), str(task)
+
+
+def _teacher_contract_mapping_name(
+    teacher_algo_family: str,
+    teacher_task: str,
+    teacher_cfg: DictConfig,
+) -> str:
+    """Validate the teacher owner contract and select the YAML mapping name."""
+    if teacher_algo_family == "sac":
+        runtime_impl = OmegaConf.select(teacher_cfg, "algo.runtime_impl")
+        if runtime_impl != "hora_sac":
+            raise ValueError(
+                "HORA distillation SAC teacher owner must select runtime_impl='hora_sac'. "
+                f"Got task={teacher_task} runtime_impl={runtime_impl!r}."
+            )
+        return "hora_sac"
+
+    actor_class_name = str(OmegaConf.select(teacher_cfg, "algo.actor.class_name") or "")
+    if "HoraActorModel" not in actor_class_name:
+        raise ValueError(
+            "HORA distillation teacher owner must resolve to HoraActorModel. "
+            f"Got algo_family={teacher_algo_family} task={teacher_task} "
+            f"actor.class_name={actor_class_name!r}."
+        )
+    return "hora_actor"
+
+
+def _student_model_defaults(
+    mapping_name: str,
+    teacher_cfg: DictConfig,
+    *,
+    root: Path,
+) -> dict[str, Any]:
+    """Resolve the YAML-expressed teacher -> student model mapping.
+
+    The mapping YAML is merged next to the composed teacher owner config
+    (mounted at ``teacher_owner``) so its interpolations resolve against the
+    Hydra-composed teacher hyperparameters. The mapping file owns all fallback
+    defaults; this function only mounts and resolves it.
+    """
+    mapping_path = root / _STUDENT_MODEL_MAPPING_DIR / f"{mapping_name}.yaml"
+    merged = OmegaConf.merge(
+        {"teacher_owner": teacher_cfg},
+        _load_yaml_config(mapping_path),
+    )
+    model_cfg = OmegaConf.to_container(OmegaConf.select(merged, "model"), resolve=True)
+    if not isinstance(model_cfg, dict):
+        raise TypeError(
+            f"Expected mapping 'model' dict from {mapping_path}, got {type(model_cfg)!r}"
+        )
+    model_cfg = cast(dict[str, Any], model_cfg)
+    distribution_cfg = model_cfg.get("distribution_cfg")
+    if isinstance(distribution_cfg, dict):
+        # The student re-binds its own distribution class; only the teacher's
+        # distribution hyperparameters carry over, not its class binding.
+        distribution_cfg.pop("class_name", None)
+    return model_cfg
 
 
 def teacher_default_cfg(
@@ -97,84 +139,24 @@ def teacher_default_cfg(
     if teacher_algo_family is None or teacher_task is None:
         return OmegaConf.create()
 
+    root = _root(root_dir)
     teacher_cfg = load_teacher_owner_config(
         teacher_algo_family,
         teacher_task,
-        root_dir=root_dir,
+        root_dir=root,
     )
-    if teacher_algo_family == "sac":
-        runtime_impl = OmegaConf.select(teacher_cfg, "algo.runtime_impl")
-        if runtime_impl != "hora_sac":
-            raise ValueError(
-                "HORA distillation SAC teacher owner must select runtime_impl='hora_sac'. "
-                f"Got task={teacher_task} runtime_impl={runtime_impl!r}."
-            )
-        actor_cfg = OmegaConf.to_container(
-            OmegaConf.select(teacher_cfg, "algo.actor"), resolve=True
-        )
-        if not isinstance(actor_cfg, dict):
-            actor_cfg = {}
-        return OmegaConf.create(
-            {
-                "training": OmegaConf.select(teacher_cfg, "training"),
-                "reward": OmegaConf.select(teacher_cfg, "reward"),
-                "env": OmegaConf.select(teacher_cfg, "env"),
-                "algo": {
-                    "model": {
-                        "teacher_arch": "hora_sac",
-                        "actor_hidden_dim": OmegaConf.select(
-                            teacher_cfg,
-                            "algo.actor_hidden_dim",
-                            default=512,
-                        ),
-                        "use_layer_norm": OmegaConf.select(
-                            teacher_cfg,
-                            "algo.use_layer_norm",
-                            default=True,
-                        ),
-                        "priv_info_embed_dim": actor_cfg.get("priv_info_embed_dim", 9),
-                        "priv_mlp_hidden_dims": actor_cfg.get(
-                            "priv_mlp_hidden_dims",
-                            [256, 128, 9],
-                        ),
-                    }
-                },
-            }
-        )
-
-    actor_cfg = OmegaConf.to_container(OmegaConf.select(teacher_cfg, "algo.actor"), resolve=True)
-    if not isinstance(actor_cfg, dict):
-        actor_cfg = {}
-    actor_cfg = dict(actor_cfg)
-    actor_class_name = str(actor_cfg.get("class_name", ""))
-    if "HoraActorModel" not in actor_class_name:
-        raise ValueError(
-            "HORA distillation teacher owner must resolve to HoraActorModel. "
-            f"Got algo_family={teacher_algo_family} task={teacher_task} "
-            f"actor.class_name={actor_class_name!r}."
-        )
-    actor_cfg.pop("class_name", None)
-    distribution_cfg = actor_cfg.get("distribution_cfg")
-    if isinstance(distribution_cfg, dict):
-        distribution_cfg = {
-            key: value for key, value in distribution_cfg.items() if key != "class_name"
-        }
-
+    mapping_name = _teacher_contract_mapping_name(
+        teacher_algo_family,
+        teacher_task,
+        teacher_cfg,
+    )
+    model_cfg = _student_model_defaults(mapping_name, teacher_cfg, root=root)
     return OmegaConf.create(
         {
             "training": OmegaConf.select(teacher_cfg, "training"),
             "reward": OmegaConf.select(teacher_cfg, "reward"),
             "env": OmegaConf.select(teacher_cfg, "env"),
-            "algo": {
-                "model": {
-                    "hidden_dims": actor_cfg.get("hidden_dims"),
-                    "activation": actor_cfg.get("activation"),
-                    "obs_normalization": actor_cfg.get("obs_normalization"),
-                    "priv_info_embed_dim": actor_cfg.get("priv_info_embed_dim"),
-                    "priv_mlp_hidden_dims": actor_cfg.get("priv_mlp_hidden_dims"),
-                    "distribution_cfg": distribution_cfg,
-                }
-            },
+            "algo": {"model": model_cfg},
         }
     )
 

--- a/tests/algos/test_hora_distill_config.py
+++ b/tests/algos/test_hora_distill_config.py
@@ -1,0 +1,230 @@
+"""Contract tests for HORA distill teacher-owner Hydra composition.
+
+The legacy reference implementation below freezes the pre-refactor manual
+loader (``OmegaConf.load`` + a loop over direct ``defaults`` entries) and the
+Python-held teacher -> student hyperparameter mapping. The parity tests pin
+the refactor to identical numerics while the loader moves to standard Hydra
+``initialize_config_dir + compose`` and the mapping moves into
+``conf/hora_distill/student_model/*.yaml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+from omegaconf.errors import InterpolationResolutionError
+
+from unilab.algos.torch.hora import distill_config
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+TEACHER_CASES = [
+    ("ppo", "sharpa_inhand/mujoco_hora"),
+    # The APPO HORA owner composes through /task/sharpa_inhand/mujoco, which
+    # exercises an owner whose own defaults chain into another owner file.
+    ("appo", "sharpa_inhand/mujoco_hora"),
+    ("sac", "sac/sharpa_inhand/mujoco_hora"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Legacy reference implementation (frozen copy of the pre-refactor behavior)
+# ---------------------------------------------------------------------------
+
+
+def _legacy_teacher_cfg(algo_family: str, task: str) -> Any:
+    if algo_family == "sac":
+        owner_path = _REPO_ROOT / "conf" / "offpolicy" / "task" / f"{task}.yaml"
+        defaults_base = _REPO_ROOT / "conf" / "offpolicy"
+        algo_defaults_path = _REPO_ROOT / "conf" / "offpolicy" / "algo" / "sac.yaml"
+    else:
+        owner_path = _REPO_ROOT / "conf" / algo_family / "task" / f"{task}.yaml"
+        defaults_base = _REPO_ROOT / "conf" / algo_family
+        algo_defaults_path = None
+    merged_cfg = OmegaConf.create()
+    if algo_defaults_path is not None:
+        merged_cfg = OmegaConf.merge(
+            merged_cfg,
+            OmegaConf.create({"algo": OmegaConf.load(algo_defaults_path)}),
+        )
+    owner_cfg = OmegaConf.load(owner_path)
+    for default_entry in owner_cfg.get("defaults", []):
+        if not isinstance(default_entry, str) or default_entry == "_self_":
+            continue
+        include_path = defaults_base / f"{default_entry.lstrip('/')}.yaml"
+        merged_cfg = OmegaConf.merge(merged_cfg, OmegaConf.load(include_path))
+    return OmegaConf.merge(merged_cfg, owner_cfg)
+
+
+def _legacy_model_cfg(algo_family: str, task: str) -> dict[str, Any]:
+    teacher_cfg = _legacy_teacher_cfg(algo_family, task)
+    if algo_family == "sac":
+        actor_cfg = OmegaConf.to_container(
+            OmegaConf.select(teacher_cfg, "algo.actor"), resolve=True
+        )
+        if not isinstance(actor_cfg, dict):
+            actor_cfg = {}
+        return {
+            "teacher_arch": "hora_sac",
+            "actor_hidden_dim": OmegaConf.select(teacher_cfg, "algo.actor_hidden_dim", default=512),
+            "use_layer_norm": OmegaConf.select(teacher_cfg, "algo.use_layer_norm", default=True),
+            "priv_info_embed_dim": actor_cfg.get("priv_info_embed_dim", 9),
+            "priv_mlp_hidden_dims": actor_cfg.get("priv_mlp_hidden_dims", [256, 128, 9]),
+        }
+    actor_cfg = OmegaConf.to_container(OmegaConf.select(teacher_cfg, "algo.actor"), resolve=True)
+    actor_cfg = dict(actor_cfg) if isinstance(actor_cfg, dict) else {}
+    actor_cfg.pop("class_name", None)
+    distribution_cfg = actor_cfg.get("distribution_cfg")
+    if isinstance(distribution_cfg, dict):
+        distribution_cfg = {
+            key: value for key, value in distribution_cfg.items() if key != "class_name"
+        }
+    return {
+        "hidden_dims": actor_cfg.get("hidden_dims"),
+        "activation": actor_cfg.get("activation"),
+        "obs_normalization": actor_cfg.get("obs_normalization"),
+        "priv_info_embed_dim": actor_cfg.get("priv_info_embed_dim"),
+        "priv_mlp_hidden_dims": actor_cfg.get("priv_mlp_hidden_dims"),
+        "distribution_cfg": distribution_cfg,
+    }
+
+
+def _assert_subset(legacy: Any, new: Any, path: str) -> None:
+    """Every leaf the legacy loader produced must be identical in the new one."""
+    if isinstance(legacy, dict) and isinstance(new, dict):
+        for key, value in legacy.items():
+            assert key in new, f"missing key {path}.{key}"
+            _assert_subset(value, new[key], f"{path}.{key}")
+        return
+    assert legacy == new, f"value mismatch at {path}: legacy={legacy!r} new={new!r}"
+
+
+# ---------------------------------------------------------------------------
+# Parity: new Hydra compose path vs frozen legacy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("algo_family", "task"), TEACHER_CASES)
+def test_teacher_default_cfg_matches_legacy_manual_loader(algo_family: str, task: str) -> None:
+    cfg = OmegaConf.create({"teacher": {"algo_family": algo_family, "task": task}})
+
+    new_cfg = OmegaConf.to_container(
+        distill_config.teacher_default_cfg(cfg, root_dir=_REPO_ROOT), resolve=True
+    )
+    legacy_cfg = OmegaConf.to_container(_legacy_teacher_cfg(algo_family, task), resolve=True)
+
+    assert new_cfg["algo"]["model"] == _legacy_model_cfg(algo_family, task)
+    for section in ("training", "reward", "env"):
+        _assert_subset(legacy_cfg.get(section), new_cfg.get(section), section)
+
+
+# ---------------------------------------------------------------------------
+# Compose capabilities the manual loader could not express
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_load_teacher_owner_config_supports_nested_defaults_packages_and_interpolation(
+    tmp_path: Path,
+) -> None:
+    conf_dir = tmp_path / "conf" / "ppo"
+    _write(
+        conf_dir / "config.yaml",
+        "defaults:\n  - _self_\n  - task: group/owner\n  - extra: packed\n\nroot_scalar: 3\n",
+    )
+    # Package directive: file content lands under `extra`, not at the root.
+    _write(conf_dir / "extra" / "packed.yaml", "# @package extra\ninner: ${root_scalar}\n")
+    _write(
+        conf_dir / "task" / "group" / "owner.yaml",
+        "# @package _global_\ndefaults:\n  - group/mid\n  - _self_\n\nleaf: owner\n",
+    )
+    # Nested defaults: an included group file with its own defaults list.
+    _write(
+        conf_dir / "task" / "group" / "mid.yaml",
+        "# @package _global_\ndefaults:\n  - nested_leaf\n  - _self_\n\nmid_value: 5\n",
+    )
+    _write(
+        conf_dir / "task" / "group" / "nested_leaf.yaml",
+        "# @package _global_\nnested_value: 42\n",
+    )
+
+    cfg = distill_config.load_teacher_owner_config("ppo", "group/owner", root_dir=tmp_path)
+
+    assert cfg.nested_value == 42
+    assert cfg.mid_value == 5
+    assert cfg.leaf == "owner"
+    assert cfg.extra.inner == 3
+
+
+def test_hora_sac_mapping_keeps_yaml_fallbacks_for_missing_teacher_fields(tmp_path: Path) -> None:
+    teacher_cfg = OmegaConf.create({"algo": {"runtime_impl": "hora_sac", "actor": {}}})
+
+    model_cfg = distill_config._student_model_defaults("hora_sac", teacher_cfg, root=_REPO_ROOT)
+
+    assert model_cfg == {
+        "teacher_arch": "hora_sac",
+        "actor_hidden_dim": 512,
+        "use_layer_norm": True,
+        "priv_info_embed_dim": 9,
+        "priv_mlp_hidden_dims": [256, 128, 9],
+    }
+
+
+def test_hora_actor_mapping_strips_distribution_class_name() -> None:
+    teacher_cfg = OmegaConf.create(
+        {
+            "algo": {
+                "actor": {
+                    "class_name": "unilab.algos.torch.hora:HoraActorModel",
+                    "hidden_dims": [64, 32],
+                    "activation": "relu",
+                    "obs_normalization": False,
+                    "priv_info_embed_dim": 4,
+                    "priv_mlp_hidden_dims": [16, 4],
+                    "distribution_cfg": {
+                        "class_name": "GaussianDistribution",
+                        "init_std": 0.5,
+                        "std_type": "scalar",
+                    },
+                }
+            }
+        }
+    )
+
+    model_cfg = distill_config._student_model_defaults("hora_actor", teacher_cfg, root=_REPO_ROOT)
+
+    assert model_cfg == {
+        "hidden_dims": [64, 32],
+        "activation": "relu",
+        "obs_normalization": False,
+        "priv_info_embed_dim": 4,
+        "priv_mlp_hidden_dims": [16, 4],
+        "distribution_cfg": {"init_std": 0.5, "std_type": "scalar"},
+    }
+
+
+def test_hora_actor_mapping_fails_closed_when_teacher_field_is_missing() -> None:
+    teacher_cfg = OmegaConf.create(
+        {
+            "algo": {
+                "actor": {
+                    "class_name": "unilab.algos.torch.hora:HoraActorModel",
+                    "activation": "elu",
+                    "obs_normalization": True,
+                    "priv_info_embed_dim": 9,
+                    "priv_mlp_hidden_dims": [256, 128, 9],
+                    "distribution_cfg": {"init_std": 1.0, "std_type": "scalar"},
+                }
+            }
+        }
+    )
+
+    with pytest.raises(InterpolationResolutionError):
+        distill_config._student_model_defaults("hora_actor", teacher_cfg, root=_REPO_ROOT)


### PR DESCRIPTION
Fixes #1011

## 改动

- `src/unilab/algos/torch/hora/distill_config.py`
  - `load_teacher_owner_config` 从手工 `OmegaConf.load` + for 循环解释 `defaults` 改为标准 Hydra `initialize_config_dir + compose`（与 `scripts/audit_sim2sim_contracts.py` 同款范式），package 指令 / 嵌套 defaults / 插值全部生效。
  - 删除 Python 层 teacher→student 超参映射与硬编码默认值（512 / True / 9 / [256, 128, 9] 等）。Python 只负责：compose teacher owner、校验 teacher contract（`HoraActorModel` / `runtime_impl='hora_sac'`）、挂载并 resolve 映射 YAML、剥离 `distribution_cfg.class_name`（student 自行绑定分布类，非超参）。
- `conf/hora_distill/student_model/hora_actor.yaml` / `hora_sac.yaml`（新增）：teacher→student `algo.model` 映射以 YAML 插值表达（`${teacher_owner...}` / `${oc.select:...,default}`），teacher owner YAML 成为唯一事实源。
- `tests/algos/test_hora_distill_config.py`（新增）：对拍测试 + compose 能力测试。
- `scripts/train_hora_distill.py`：入口函数签名与语义不变，无需改动。

## 对拍结果（新旧路径数值等价）

测试内冻结旧手工加载器作为 legacy 参考，对 ppo / appo / sac 三个 teacher（`sharpa_inhand/mujoco_hora`，其中 appo owner 经 `/task/sharpa_inhand/mujoco` 嵌套 defaults）逐一断言：

- `algo.model` 完全一致（精确相等）；
- legacy 路径产生的 `training` / `reward` / `env` 每个叶子在新路径中存在且数值相等（新路径额外包含 family 根 `config.yaml` 的默认键，属 compose 语义的正确补全）。

## Python 硬编码与 YAML 不一致项

无数值差异。两处实现层事实记录如下：

1. 旧手工加载器把 `conf/offpolicy/algo/sac.yaml` 错包到 `algo.algo.*` 下，`algo.actor_hidden_dim` / `algo.use_layer_norm` 实际永远走 Python fallback（512 / True）；新路径从 `algo/sac.yaml` 正确取到相同数值（512 / true），无数值漂移。
2. `hora_actor` 分支旧代码对缺失字段静默写入 `None`（下游随后即崩）；新映射改为 fail-closed，缺失 teacher 字段在 resolve 时抛 `InterpolationResolutionError`（有测试锁定）。仓库内现有 teacher owner 均字段齐全，行为不变。

## Validation

- `make test-all` 通过（ruff format/check、mypy、pyright、pytest 全量、benchmark smoke 33/34 + 34/35，仅平台可选 mlx 跳过）。
- 新增测试 7 项：3 个 teacher 对拍、嵌套 defaults + package 指令 + 插值的合成树 compose、sac 映射 fallback、hora_actor 映射 `class_name` 剥离、缺字段 fail-closed。
- 冒烟：`uv run scripts/train_hora_distill.py --help` 正常。