### PR TITLE
refactor: unify playback sim2sim preflight owner

### DIFF
--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -54,6 +54,7 @@ from unilab.training import (
     get_entrypoint_log_root,
     resolve_task_checkpoint_path,
 )
+from unilab.training.offpolicy import build_offpolicy_env_cfg_override
 from unilab.training.rsl_rl import (
     RslRlVecEnvWrapper,
     get_policy_obs_dims,
@@ -68,6 +69,7 @@ from unilab.visualization.interactive_playback import (
     create_hora_distill_playback_session,
     create_rsl_rl_playback_session,
     create_sac_playback_session,
+    make_sim2sim_preflight,
     prepare_motion_overlay_selection,
     select_torch_device,
 )
@@ -802,8 +804,7 @@ def _load_resolved_visual_viewer_model(env: Any):
 def _load_viewer_model(env: Any, *, use_env_visual_model: bool):
     import mujoco
 
-    backend = getattr(env, "_backend", None)
-    backend_visual_model_file = getattr(backend, "scene_visual_model_file", None)
+    backend_visual_model_file = env.get_scene_visual_model_file()
     if backend_visual_model_file:
         resolved = _load_resolved_visual_viewer_model(env)
         if resolved is not None:
@@ -1021,9 +1022,7 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
         from unilab.training import create_env
 
         if algo in _OFFPOLICY_INTERACTIVE_ALGOS:
-            from train_offpolicy import build_offpolicy_env_cfg_override
-
-            env_cfg_override = build_offpolicy_env_cfg_override(algo, cfg)
+            env_cfg_override = build_offpolicy_env_cfg_override(algo, cfg, root_dir=ROOT_DIR)
         else:
             env_cfg_override = _backend_adapter(cfg, algo_name=algo).build_task_env_cfg_override()
         try:
@@ -1068,6 +1067,7 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
                 runner_cls=OnPolicyRunner,
                 policy_obs_dims_getter=get_policy_obs_dims,
                 train_cfg_normalizer=normalize_ppo_train_cfg,
+                sim2sim_preflight=make_sim2sim_preflight(cfg, algo_name="ppo"),
                 log=lambda message: print(f"[play_interactive] {message}"),
             )
         elif algo == "appo":

--- a/scripts/play_viser.py
+++ b/scripts/play_viser.py
@@ -58,6 +58,7 @@ from unilab.training.rsl_rl import (
 from unilab.visualization.interactive_playback import (
     PlaybackControls,
     create_rsl_rl_playback_session,
+    make_sim2sim_preflight,
     select_torch_device,
 )
 from unilab.visualization.render_many import get_grid_offsets
@@ -256,6 +257,7 @@ def play_viser(args: PlayInteractiveArgs, cfg: DictConfig) -> None:
         runner_cls=OnPolicyRunner,
         policy_obs_dims_getter=get_policy_obs_dims,
         train_cfg_normalizer=normalize_ppo_train_cfg,
+        sim2sim_preflight=make_sim2sim_preflight(cfg, algo_name="ppo"),
         log=lambda message: print(f"[play_viser] {message}"),
     )
     env = playback_session.env

--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -24,6 +24,7 @@ from unilab.training import (
     ensure_registries,
     get_log_root,
     log_playback_plan,
+    resolve_appo_checkpoint_path,
     should_run_playback,
 )
 from unilab.training.experiment import ExperimentTracker
@@ -131,23 +132,6 @@ def run_motrix_play_loop(
                 dtype=np.float32,
             ),
         )
-
-
-def resolve_appo_checkpoint_path(
-    base_log_dir: str | Path,
-    load_run: str | int,
-) -> tuple[str | None, str | None]:
-    from unilab.training import resolve_checkpoint_path
-
-    checkpoint_path, checkpoint_dir = resolve_checkpoint_path(
-        base_log_dir,
-        str(load_run),
-        suffix=".pt",
-    )
-    return (
-        str(checkpoint_path) if checkpoint_path is not None else None,
-        str(checkpoint_dir) if checkpoint_dir is not None else None,
-    )
 
 
 def _get_log_root(cfg: DictConfig) -> str:

--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -42,9 +42,10 @@ from unilab.training import (
     BackendAdapter,
     create_env,
     ensure_registries,
-    get_latest_run,
+    format_hora_stage2_checkpoint_error,
     get_log_root,
     log_playback_plan,
+    resolve_hora_stage2_checkpoint_path,
     setup_logger,
     should_run_playback,
 )
@@ -101,78 +102,6 @@ def _build_play_env_cfg_override(cfg: DictConfig) -> dict[str, Any]:
         scene_materializer=materialize_scene_visual_override,
     )
     return cast(dict[str, Any], adapter.build_play_env_cfg_override())
-
-
-def _resolve_stage2_checkpoint_path(cfg: DictConfig) -> tuple[Path | None, Path | None]:
-    task_log_root = get_log_root(ROOT_DIR, cfg) / str(cfg.training.task_name)
-    load_run = str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
-    selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
-
-    run_dir: Path | None
-    if load_run == "-1":
-        run_dir = get_latest_run(task_log_root)
-    else:
-        candidate = Path(load_run)
-        if not candidate.exists():
-            candidate = task_log_root / load_run
-        if candidate.is_file():
-            return candidate, candidate.parent
-        run_dir = candidate if candidate.is_dir() else None
-
-    if run_dir is None:
-        return None, None
-
-    if selected_checkpoint not in (None, "", -1, "-1"):
-        checkpoint_name = (
-            f"hora_stage2_{selected_checkpoint}.pt"
-            if str(selected_checkpoint).isdigit()
-            else str(selected_checkpoint)
-        )
-        checkpoint_path = run_dir / checkpoint_name
-        return (checkpoint_path, run_dir) if checkpoint_path.exists() else (None, run_dir)
-
-    last_path = run_dir / "hora_stage2_last.pt"
-    if last_path.exists():
-        return last_path, run_dir
-
-    numbered = [
-        path for path in run_dir.glob("hora_stage2_*.pt") if path.stem.split("_")[-1].isdigit()
-    ]
-    if not numbered:
-        return None, run_dir
-    return max(numbered, key=lambda path: int(path.stem.split("_")[-1])), run_dir
-
-
-def _format_stage2_play_checkpoint_error(
-    cfg: DictConfig,
-    *,
-    task_log_root: Path,
-    load_path: Path | None,
-    load_path_dir: Path | None,
-) -> str:
-    selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
-    checkpoint_hint = (
-        f" algo.checkpoint={selected_checkpoint!r}"
-        if selected_checkpoint not in (None, "", -1, "-1")
-        else ""
-    )
-    if load_path_dir is not None and load_path is None and checkpoint_hint:
-        reason = f"Requested stage-2 checkpoint was not found under resolved_run={load_path_dir}."
-    elif not task_log_root.exists():
-        reason = "Task log root does not exist."
-    else:
-        latest_run = get_latest_run(task_log_root)
-        if latest_run is None:
-            reason = "No run directories were found under the task log root."
-        else:
-            reason = "Requested run or stage-2 checkpoint could not be resolved."
-    return (
-        "Could not resolve a stage-2 HORA checkpoint for play mode. "
-        f"{reason} task={cfg.training.task_name} task_log_root={task_log_root} "
-        f"algo.load_run={cfg.algo.load_run!r}{checkpoint_hint}. "
-        "Use algo.load_run=<run-dir-or-checkpoint-path> and optionally "
-        "algo.checkpoint=<iteration-or-filename>."
-    )
 
 
 def _student_policy(
@@ -234,10 +163,10 @@ def _cfg_with_checkpoint_runtime(cfg: DictConfig, checkpoint: dict[str, Any]) ->
 
 def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
     task_log_root = get_log_root(ROOT_DIR, cfg) / str(cfg.training.task_name)
-    load_path, load_path_dir = _resolve_stage2_checkpoint_path(cfg)
+    load_path, load_path_dir = resolve_hora_stage2_checkpoint_path(cfg, root_dir=ROOT_DIR)
     if load_path is None or load_path_dir is None or not load_path.exists():
         print(
-            _format_stage2_play_checkpoint_error(
+            format_hora_stage2_checkpoint_error(
                 cfg,
                 task_log_root=task_log_root,
                 load_path=load_path,

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -27,7 +27,6 @@ from unilab.ipc.dp_launcher import (
     validate_dp_launchable,
 )
 from unilab.training import (
-    BackendAdapter,
     apply_configured_training_seed,
     assert_offpolicy_task_choice_matches_algo,
     create_env,
@@ -36,10 +35,21 @@ from unilab.training import (
     log_playback_plan,
     should_run_playback,
 )
-from unilab.training import (
-    resolve_checkpoint_path as resolve_checkpoint_path_common,
-)
 from unilab.training.experiment import ExperimentTracker
+from unilab.training.offpolicy import (
+    build_offpolicy_env_cfg_override as _build_offpolicy_env_cfg_override,
+)
+from unilab.training.offpolicy import (
+    default_device,
+    extract_play_obs,
+    extract_reset_obs,
+    resolve_play_actor_spec,
+    resolve_play_obs_dim,
+    resolve_play_obs_dims,
+)
+from unilab.training.run import (
+    resolve_offpolicy_checkpoint_path as resolve_checkpoint_path,
+)
 from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
 from unilab.utils.nan_guard import NanGuardCfg
 
@@ -73,95 +83,8 @@ def build_run_dir_name(timestamp: str, sim_backend: str, *, world_size: int = 1)
     return f"{timestamp}_{sim_backend}{gpu_suffix}"
 
 
-def default_device(torch_module, preferred: str | None = None) -> str:
-    """Resolve runtime device with optional user override."""
-    if preferred:
-        return preferred
-    if torch_module.cuda.is_available():
-        return "cuda"
-    xpu = getattr(torch_module, "xpu", None)
-    xpu_is_available = getattr(xpu, "is_available", None)
-    if callable(xpu_is_available) and xpu_is_available():
-        return "xpu"
-    if torch_module.backends.mps.is_available():
-        return "mps"
-    return "cpu"
-
-
-def resolve_checkpoint_path(
-    root_dir: Path, algo_log_name: str, task: str, load_run: str | int
-) -> tuple[str | None, str | None]:
-    checkpoint_path, checkpoint_dir = resolve_checkpoint_path_common(
-        Path(root_dir) / "logs" / algo_log_name / task,
-        load_run,
-        suffix=".pt",
-    )
-    return (
-        str(checkpoint_path) if checkpoint_path is not None else None,
-        str(checkpoint_dir) if checkpoint_dir is not None else None,
-    )
-
-
-def extract_reset_obs(reset_result):
-    """Extract obs_dict from env.reset(...) using the current (obs_dict, info_dict) contract."""
-    if isinstance(reset_result, tuple):
-        if len(reset_result) == 2:
-            obs_out, _ = reset_result
-            return obs_out
-    raise ValueError(f"Unexpected env.reset return format: {type(reset_result)!r}")
-
-
-def resolve_play_obs_dim(obs_groups_spec: dict[str, int]) -> int:
-    obs_dim, _ = resolve_play_obs_dims(obs_groups_spec)
-    return obs_dim
-
-
-def resolve_play_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:
-    from unilab.base.observations import get_obs_dims
-
-    obs_dim, critic_obs_dim = get_obs_dims(obs_groups_spec)
-    return int(obs_dim), int(critic_obs_dim)
-
-
-def extract_play_obs(obs_dict):
-    from unilab.base.observations import split_obs_dict
-
-    obs_out, _ = split_obs_dict(obs_dict)
-    return obs_out
-
-
-def resolve_play_actor_spec(
-    algo_name: str,
-    cfg: DictConfig,
-    *,
-    obs_dim: int,
-    critic_obs_dim: int,
-) -> tuple[str, dict[str, Any]]:
-    """Resolve the actor implementation and model kwargs used by off-policy play."""
-    if algo_name != "sac":
-        return algo_name, {}
-
-    from unilab.algos.torch.offpolicy.runtime import resolve_custom_offpolicy_runtime
-
-    rl_cfg = cast(dict[str, Any], OmegaConf.to_container(cfg.algo, resolve=True))
-    custom_runtime = resolve_custom_offpolicy_runtime(rl_cfg)
-    if custom_runtime is None:
-        return "sac", {}
-
-    actor_algo_type = str(custom_runtime.algo_type or algo_name)
-    actor_kwargs = custom_runtime.build_model_kwargs(
-        obs_dim=int(obs_dim),
-        critic_obs_dim=int(critic_obs_dim),
-    )
-    return actor_algo_type, actor_kwargs
-
-
 def build_offpolicy_env_cfg_override(algo_name: str, cfg: DictConfig) -> dict[str, Any] | None:
-    assert_offpolicy_task_choice_matches_algo(cfg, algo_name=algo_name)
-    return cast(
-        dict[str, Any] | None,
-        BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name=algo_name).build_task_env_cfg_override(),
-    )
+    return _build_offpolicy_env_cfg_override(algo_name, cfg, root_dir=ROOT_DIR)
 
 
 def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):

--- a/src/unilab/algos/torch/hora/distill.py
+++ b/src/unilab/algos/torch/hora/distill.py
@@ -295,6 +295,57 @@ def load_distilled_checkpoint(
     return cast(dict[str, Any], checkpoint)
 
 
+def cfg_with_checkpoint_runtime(cfg: DictConfig, checkpoint: dict[str, Any]) -> DictConfig:
+    """Merge model-side runtime config stored in a stage-2 checkpoint.
+
+    Args:
+        cfg: Hydra-composed distillation config supplied to play mode.
+        checkpoint: Loaded stage-2 checkpoint dictionary.
+
+    Returns:
+        Config using the current owner env/reward settings and checkpoint model
+        construction fields.
+    """
+    from unilab.algos.torch.hora.distill_config import apply_teacher_defaults
+
+    cfg_with_owner_defaults = apply_teacher_defaults(cfg)
+    cfg_clone = OmegaConf.create(OmegaConf.to_container(cfg_with_owner_defaults, resolve=False))
+    runtime_cfg = checkpoint.get("distill_runtime_cfg")
+    if runtime_cfg is None:
+        return cast(DictConfig, cfg_clone)
+
+    runtime_model_cfg = OmegaConf.select(OmegaConf.create(runtime_cfg), "algo.model")
+    if runtime_model_cfg is None:
+        return cast(DictConfig, cfg_clone)
+    OmegaConf.update(
+        cfg_clone,
+        "algo.model",
+        OmegaConf.to_container(runtime_model_cfg, resolve=True),
+        merge=False,
+    )
+    return cast(DictConfig, cfg_clone)
+
+
+def student_policy(
+    actor: nn.Module,
+    hist_normalizer: EmpiricalNormalization,
+    obs: TensorDict,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    """Run the distilled student actor on wrapped-env observations."""
+    proprio_hist = hist_normalizer(obs["proprio_hist"].to(device), update=False)
+    policy_obs = TensorDict(
+        {
+            "actor": obs["actor"].to(device),
+            "proprio_hist": proprio_hist,
+        },
+        batch_size=obs.batch_size,
+        device=device,
+    )
+    return actor(policy_obs, stochastic_output=False).clamp_(-1.0, 1.0)
+
+
 class HoraDistillationTrainer:
     """Stage-2 HORA latent distillation trainer."""
 

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -131,6 +131,13 @@ class SimBackend(abc.ABC):
         """Return the materialized scene path for diagnostics, when available."""
         return None
 
+    def get_scene_visual_model_file(self) -> str | None:
+        """Return the scene visual model file on the cold path, when available.
+
+        Backends without a separate visual scene model return ``None``.
+        """
+        return None
+
     def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
         """Return backend-materialized terrain metadata on the cold path.
 

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -695,6 +695,9 @@ class MuJoCoBackend(SimBackend):
     def get_scene_model_file(self) -> str | None:
         return str(self.scene_model_file) if self.scene_model_file else None
 
+    def get_scene_visual_model_file(self) -> str | None:
+        return str(self.scene_visual_model_file) if self.scene_visual_model_file else None
+
     def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
         return self._terrain_spawn_data
 

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -551,6 +551,10 @@ class NpEnv(ABEnv):
         """
         return self._backend.get_playback_model(env_index)
 
+    def get_scene_visual_model_file(self) -> str | None:
+        """Return the backend scene visual model file on the cold path, when available."""
+        return self._backend.get_scene_visual_model_file()
+
     def set_nan_guard(self, guard: "NanGuard") -> None:
         self._nan_guard = guard
 

--- a/src/unilab/training/__init__.py
+++ b/src/unilab/training/__init__.py
@@ -11,13 +11,17 @@ from unilab.training.common import (
 from unilab.training.experiment import ExperimentTracker
 from unilab.training.monitoring import HardwareMonitor
 from unilab.training.run import (
+    format_hora_stage2_checkpoint_error,
     get_entrypoint_log_root,
     get_latest_checkpoint,
     get_latest_run,
     get_log_root,
     log_playback_plan,
     parse_checkpoint_path,
+    resolve_appo_checkpoint_path,
     resolve_checkpoint_path,
+    resolve_hora_stage2_checkpoint_path,
+    resolve_offpolicy_checkpoint_path,
     resolve_task_checkpoint_path,
     should_run_playback,
 )
@@ -50,6 +54,10 @@ __all__ = [
     "apply_configured_training_seed",
     "apply_training_seed",
     "derive_worker_seed",
+    "format_hora_stage2_checkpoint_error",
+    "resolve_appo_checkpoint_path",
+    "resolve_hora_stage2_checkpoint_path",
+    "resolve_offpolicy_checkpoint_path",
     "resolve_training_seed",
     "setup_logger",
 ]

--- a/src/unilab/training/offpolicy.py
+++ b/src/unilab/training/offpolicy.py
@@ -1,0 +1,95 @@
+"""Off-policy play helpers shared by training scripts and playback entrypoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from omegaconf import DictConfig, OmegaConf
+
+from unilab.training.common import assert_offpolicy_task_choice_matches_algo
+
+
+def default_device(torch_module, preferred: str | None = None) -> str:
+    """Resolve runtime device with optional user override."""
+    if preferred:
+        return preferred
+    if torch_module.cuda.is_available():
+        return "cuda"
+    xpu = getattr(torch_module, "xpu", None)
+    xpu_is_available = getattr(xpu, "is_available", None)
+    if callable(xpu_is_available) and xpu_is_available():
+        return "xpu"
+    if torch_module.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def extract_reset_obs(reset_result):
+    """Extract obs_dict from env.reset(...) using the current (obs_dict, info_dict) contract."""
+    if isinstance(reset_result, tuple):
+        if len(reset_result) == 2:
+            obs_out, _ = reset_result
+            return obs_out
+    raise ValueError(f"Unexpected env.reset return format: {type(reset_result)!r}")
+
+
+def resolve_play_obs_dim(obs_groups_spec: dict[str, int]) -> int:
+    obs_dim, _ = resolve_play_obs_dims(obs_groups_spec)
+    return obs_dim
+
+
+def resolve_play_obs_dims(obs_groups_spec: dict[str, int]) -> tuple[int, int]:
+    from unilab.base.observations import get_obs_dims
+
+    obs_dim, critic_obs_dim = get_obs_dims(obs_groups_spec)
+    return int(obs_dim), int(critic_obs_dim)
+
+
+def extract_play_obs(obs_dict):
+    from unilab.base.observations import split_obs_dict
+
+    obs_out, _ = split_obs_dict(obs_dict)
+    return obs_out
+
+
+def resolve_play_actor_spec(
+    algo_name: str,
+    cfg: DictConfig,
+    *,
+    obs_dim: int,
+    critic_obs_dim: int,
+) -> tuple[str, dict[str, Any]]:
+    """Resolve the actor implementation and model kwargs used by off-policy play."""
+    if algo_name != "sac":
+        return algo_name, {}
+
+    from unilab.algos.torch.offpolicy.runtime import resolve_custom_offpolicy_runtime
+
+    rl_cfg = cast(dict[str, Any], OmegaConf.to_container(cfg.algo, resolve=True))
+    custom_runtime = resolve_custom_offpolicy_runtime(rl_cfg)
+    if custom_runtime is None:
+        return "sac", {}
+
+    actor_algo_type = str(custom_runtime.algo_type or algo_name)
+    actor_kwargs = custom_runtime.build_model_kwargs(
+        obs_dim=int(obs_dim),
+        critic_obs_dim=int(critic_obs_dim),
+    )
+    return actor_algo_type, actor_kwargs
+
+
+def build_offpolicy_env_cfg_override(
+    algo_name: str,
+    cfg: DictConfig,
+    *,
+    root_dir: str | Path,
+) -> dict[str, Any] | None:
+    """Build the task env override for off-policy play through the backend adapter."""
+    from unilab.training.backend_adapter import BackendAdapter
+
+    assert_offpolicy_task_choice_matches_algo(cfg, algo_name=algo_name)
+    return cast(
+        dict[str, Any] | None,
+        BackendAdapter(cfg, root_dir=root_dir, algo_name=algo_name).build_task_env_cfg_override(),
+    )

--- a/src/unilab/training/run.py
+++ b/src/unilab/training/run.py
@@ -163,6 +163,118 @@ def parse_checkpoint_path(
     )
 
 
+def resolve_appo_checkpoint_path(
+    base_log_dir: str | Path,
+    load_run: str | int | PathLike[str],
+) -> tuple[str | None, str | None]:
+    """Resolve an APPO checkpoint under a task log root, returning string paths."""
+    checkpoint_path, checkpoint_dir = resolve_checkpoint_path(
+        base_log_dir,
+        str(load_run),
+        suffix=".pt",
+    )
+    return (
+        str(checkpoint_path) if checkpoint_path is not None else None,
+        str(checkpoint_dir) if checkpoint_dir is not None else None,
+    )
+
+
+def resolve_offpolicy_checkpoint_path(
+    root_dir: str | Path,
+    algo_log_name: str,
+    task: str,
+    load_run: str | int | PathLike[str],
+) -> tuple[str | None, str | None]:
+    """Resolve an off-policy checkpoint from the repo-rooted log tree."""
+    checkpoint_path, checkpoint_dir = resolve_checkpoint_path(
+        Path(root_dir) / "logs" / algo_log_name / task,
+        load_run,
+        suffix=".pt",
+    )
+    return (
+        str(checkpoint_path) if checkpoint_path is not None else None,
+        str(checkpoint_dir) if checkpoint_dir is not None else None,
+    )
+
+
+def resolve_hora_stage2_checkpoint_path(
+    cfg: DictConfig,
+    *,
+    root_dir: str | Path,
+) -> tuple[Path | None, Path | None]:
+    """Resolve the HORA stage-2 distillation checkpoint selected by ``cfg.algo``."""
+    task_log_root = get_log_root(root_dir, cfg) / str(OmegaConf.select(cfg, "training.task_name"))
+    load_run = str(OmegaConf.select(cfg, "algo.load_run", default="-1"))
+    selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
+
+    run_dir: Path | None
+    if load_run == "-1":
+        run_dir = get_latest_run(task_log_root)
+    else:
+        candidate = Path(load_run)
+        if not candidate.exists():
+            candidate = task_log_root / load_run
+        if candidate.is_file():
+            return candidate, candidate.parent
+        run_dir = candidate if candidate.is_dir() else None
+
+    if run_dir is None:
+        return None, None
+
+    if selected_checkpoint not in (None, "", -1, "-1"):
+        checkpoint_name = (
+            f"hora_stage2_{selected_checkpoint}.pt"
+            if str(selected_checkpoint).isdigit()
+            else str(selected_checkpoint)
+        )
+        checkpoint_path = run_dir / checkpoint_name
+        return (checkpoint_path, run_dir) if checkpoint_path.exists() else (None, run_dir)
+
+    last_path = run_dir / "hora_stage2_last.pt"
+    if last_path.exists():
+        return last_path, run_dir
+
+    numbered = [
+        path for path in run_dir.glob("hora_stage2_*.pt") if path.stem.split("_")[-1].isdigit()
+    ]
+    if not numbered:
+        return None, run_dir
+    return max(numbered, key=lambda path: int(path.stem.split("_")[-1])), run_dir
+
+
+def format_hora_stage2_checkpoint_error(
+    cfg: DictConfig,
+    *,
+    task_log_root: Path,
+    load_path: Path | None,
+    load_path_dir: Path | None,
+) -> str:
+    """Build the user-facing diagnostic for an unresolvable stage-2 checkpoint."""
+    selected_checkpoint = OmegaConf.select(cfg, "algo.checkpoint", default=-1)
+    checkpoint_hint = (
+        f" algo.checkpoint={selected_checkpoint!r}"
+        if selected_checkpoint not in (None, "", -1, "-1")
+        else ""
+    )
+    if load_path_dir is not None and load_path is None and checkpoint_hint:
+        reason = f"Requested stage-2 checkpoint was not found under resolved_run={load_path_dir}."
+    elif not task_log_root.exists():
+        reason = "Task log root does not exist."
+    else:
+        latest_run = get_latest_run(task_log_root)
+        if latest_run is None:
+            reason = "No run directories were found under the task log root."
+        else:
+            reason = "Requested run or stage-2 checkpoint could not be resolved."
+    return (
+        "Could not resolve a stage-2 HORA checkpoint for play mode. "
+        f"{reason} task={cfg.training.task_name} task_log_root={task_log_root} "
+        f"algo.load_run={cfg.algo.load_run!r}{checkpoint_hint}. "
+        "Use algo.load_run=<run-dir-or-checkpoint-path> and optionally "
+        "algo.checkpoint=<iteration-or-filename>."
+    )
+
+
 def resolve_task_checkpoint_path(
     root_dir: str | Path,
     *,

--- a/src/unilab/visualization/interactive_playback.py
+++ b/src/unilab/visualization/interactive_playback.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,13 +11,9 @@ from typing import Any, ClassVar, Protocol
 import numpy as np
 import torch
 
+from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
+
 LogFn = Callable[[str], None]
-
-
-def _ensure_scripts_dir(root_dir: str | Path) -> None:
-    scripts_dir = Path(root_dir) / "scripts"
-    if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
-        sys.path.insert(0, str(scripts_dir))
 
 
 @dataclass(frozen=True)
@@ -330,6 +325,31 @@ class OffPolicyPlaybackSession:
 _HORA_DISTILL_CHECKPOINT_UNAVAILABLE = "hora_distill_checkpoint_unavailable"
 
 
+def make_sim2sim_preflight(
+    cfg: Any,
+    *,
+    algo_name: str,
+) -> Callable[[str | None], Any] | None:
+    """Build a sim2sim contract preflight closure for interactive playback entrypoints.
+
+    Returns ``None`` when no Hydra config is available (legacy non-Hydra path).
+    Old runs without a contract snapshot keep the fallback + warning semantics of
+    :func:`resolve_sim2sim_config`.
+    """
+    if cfg is None:
+        return None
+
+    def _preflight(source_run_dir: str | None) -> Any:
+        return resolve_sim2sim_config(
+            source_run_dir,
+            cfg,
+            algo_name=algo_name,
+            strict=bool(getattr(cfg.training, "sim2sim_strict", True)),
+        )
+
+    return _preflight
+
+
 def select_torch_device() -> str:
     if torch.cuda.is_available():
         return "cuda"
@@ -352,6 +372,7 @@ def create_rsl_rl_playback_session(
     runner_cls: Any,
     policy_obs_dims_getter: Callable[[Any], tuple[int, int]],
     train_cfg_normalizer: Callable[[dict[str, Any]], dict[str, Any]],
+    sim2sim_preflight: Callable[[str | None], Any] | None = None,
     log: LogFn = print,
 ) -> tuple[RslRlPlaybackSession, str, str | None]:
     """Create a playback session and load the selected policy checkpoint."""
@@ -400,6 +421,8 @@ def create_rsl_rl_playback_session(
         if checkpoint_path is None:
             log("WARNING: no checkpoint found - falling back to zero actions.")
         else:
+            if sim2sim_preflight is not None:
+                sim2sim_preflight(str(Path(checkpoint_path).parent))
             log_dir = str(
                 entrypoint_log_root(
                     Path(root_dir),
@@ -410,16 +433,24 @@ def create_rsl_rl_playback_session(
                 / "play_temp"
             )
             runner = runner_cls(wrapped_env, train_cfg, log_dir=log_dir, device=device_name)
-            runner.load(
-                checkpoint_path,
-                load_cfg={
-                    "actor": True,
-                    "critic": False,
-                    "optimizer": False,
-                    "iteration": False,
-                    "rnd": False,
-                },
-            )
+            policy_obs_dim = actor_obs_dim if policy_obs_mode == "actor" else flat_obs_dim
+            action_shape = env.action_space.shape
+            policy_action_dim = int(action_shape[0]) if action_shape is not None else None
+            with policy_load_dim_guard(
+                env_obs_dim=policy_obs_dim,
+                env_action_dim=policy_action_dim,
+                algo_name=playback_cfg.algo_log_name,
+            ):
+                runner.load(
+                    checkpoint_path,
+                    load_cfg={
+                        "actor": True,
+                        "critic": False,
+                        "optimizer": False,
+                        "iteration": False,
+                        "rnd": False,
+                    },
+                )
             policy = runner.get_inference_policy(device=device_name)
 
     log(f"Action mode: {playback_cfg.action_mode}")
@@ -452,12 +483,15 @@ def _resolve_appo_checkpoint_from_cfg(
     *,
     root_dir: str | Path,
 ) -> tuple[str | None, str | None]:
-    _ensure_scripts_dir(root_dir)
-    from unilab.training import get_log_root, resolve_task_checkpoint_path
+    from unilab.training import (
+        get_log_root,
+        resolve_appo_checkpoint_path,
+        resolve_task_checkpoint_path,
+    )
 
     selected_checkpoint = _cfg_checkpoint_value(cfg)
     if selected_checkpoint is not None:
-        checkpoint_path, checkpoint_dir = resolve_task_checkpoint_path(
+        selected_path, selected_dir = resolve_task_checkpoint_path(
             root_dir,
             task_name=str(cfg.training.task_name),
             load_run=str(cfg.algo.load_run),
@@ -466,11 +500,9 @@ def _resolve_appo_checkpoint_from_cfg(
             log_root=getattr(cfg.training, "log_root", None),
         )
         return (
-            str(checkpoint_path) if checkpoint_path is not None else None,
-            str(checkpoint_dir) if checkpoint_dir is not None else None,
+            str(selected_path) if selected_path is not None else None,
+            str(selected_dir) if selected_dir is not None else None,
         )
-
-    from train_appo import resolve_appo_checkpoint_path
 
     base_log_dir = get_log_root(root_dir, cfg) / str(cfg.training.task_name)
     checkpoint_path, checkpoint_dir = resolve_appo_checkpoint_path(base_log_dir, cfg.algo.load_run)
@@ -488,7 +520,8 @@ def _build_appo_actor(
     rl_cfg: dict[str, Any],
     device: str,
     is_hora: bool,
-) -> Any:
+) -> tuple[Any, int, int]:
+    """Build the APPO actor and return it with ``(obs_dim, action_dim)``."""
     from copy import deepcopy
 
     from rsl_rl.utils import resolve_callable
@@ -555,7 +588,7 @@ def _build_appo_actor(
             shared_model=shared_model,
             **actor_cfg,
         )
-        return actor.to(device).eval()
+        return actor.to(device).eval(), obs_dim, action_dim
 
     obs_dim, critic_dim = get_obs_dims(env.obs_groups_spec)
     num_envs = int(getattr(wrapped_env, "num_envs", getattr(env, "num_envs", 1)))
@@ -581,7 +614,7 @@ def _build_appo_actor(
     actor_cls = resolve_callable(actor_cfg.pop("class_name"))
     actor_cfg.pop("num_actions", None)
     actor = actor_cls(td_example, rl_cfg_dict["obs_groups"], "actor", action_dim, **actor_cfg)
-    return actor.to(device).eval()
+    return actor.to(device).eval(), obs_dim, action_dim
 
 
 def create_appo_playback_session(
@@ -617,14 +650,20 @@ def create_appo_playback_session(
     policy = None
     checkpoint_path: str | None = None
     if playback_cfg.action_mode == "policy":
-        checkpoint_path, _checkpoint_dir = _resolve_appo_checkpoint_from_cfg(cfg, root_dir=root_dir)
+        checkpoint_path, checkpoint_dir = _resolve_appo_checkpoint_from_cfg(cfg, root_dir=root_dir)
         if checkpoint_path is None or not Path(checkpoint_path).exists():
             log(
                 "WARNING: no APPO checkpoint found for "
                 f"load_run={cfg.algo.load_run} - falling back to zero actions."
             )
         else:
-            actor = _build_appo_actor(
+            resolve_sim2sim_config(
+                checkpoint_dir,
+                cfg,
+                algo_name="appo",
+                strict=bool(getattr(cfg.training, "sim2sim_strict", True)),
+            )
+            actor, actor_obs_dim, action_dim = _build_appo_actor(
                 env=env,
                 wrapped_env=wrapped_env,
                 cfg=cfg,
@@ -633,7 +672,12 @@ def create_appo_playback_session(
                 is_hora=is_hora,
             )
             checkpoint = torch.load(checkpoint_path, map_location=device_name, weights_only=True)
-            actor.load_state_dict(checkpoint["actor"])
+            with policy_load_dim_guard(
+                env_obs_dim=actor_obs_dim,
+                env_action_dim=action_dim,
+                algo_name="appo",
+            ):
+                actor.load_state_dict(checkpoint["actor"])
             policy = actor
             log(f"Loading APPO checkpoint: {checkpoint_path}")
 
@@ -666,18 +710,15 @@ def create_sac_playback_session(
 
     import os
 
-    _ensure_scripts_dir(root_dir)
-
-    from train_offpolicy import (
+    from unilab.algos.torch.common.actor_factory import build_actor
+    from unilab.algos.torch.offpolicy.worker import resolve_offpolicy_actor_priv_info
+    from unilab.training.offpolicy import (
         default_device,
         extract_play_obs,
-        resolve_checkpoint_path,
         resolve_play_actor_spec,
         resolve_play_obs_dims,
     )
-
-    from unilab.algos.torch.common.actor_factory import build_actor
-    from unilab.algos.torch.offpolicy.worker import resolve_offpolicy_actor_priv_info
+    from unilab.training.run import resolve_offpolicy_checkpoint_path
 
     device_name = default_device(torch, str(device) if device is not None else None)
     env = env_factory(int(playback_cfg.num_envs))
@@ -722,7 +763,7 @@ def create_sac_playback_session(
             **actor_kwargs,
         )
         actor.eval()
-        checkpoint_path, _checkpoint_dir = resolve_checkpoint_path(
+        checkpoint_path, checkpoint_dir = resolve_offpolicy_checkpoint_path(
             Path(root_dir),
             cfg.algo.algo_log_name,
             cfg.training.task_name,
@@ -735,11 +776,22 @@ def create_sac_playback_session(
             )
             actor = None
         else:
+            resolve_sim2sim_config(
+                checkpoint_dir,
+                cfg,
+                algo_name=algo_name,
+                strict=bool(getattr(cfg.training, "sim2sim_strict", True)),
+            )
             checkpoint = torch.load(checkpoint_path, map_location=device_name, weights_only=True)
-            actor.load_state_dict(checkpoint["actor"])
-            if normalizer is not None and checkpoint.get("obs_normalizer"):
-                normalizer.load_state_dict(checkpoint["obs_normalizer"])
-                normalizer.eval()
+            with policy_load_dim_guard(
+                env_obs_dim=obs_dim,
+                env_action_dim=action_dim,
+                algo_name=algo_name,
+            ):
+                actor.load_state_dict(checkpoint["actor"])
+                if normalizer is not None and checkpoint.get("obs_normalizer"):
+                    normalizer.load_state_dict(checkpoint["obs_normalizer"])
+                    normalizer.eval()
             log(f"Loading {algo_name} checkpoint: {checkpoint_path}")
 
     log(f"Action mode: {playback_cfg.action_mode}")
@@ -761,34 +813,42 @@ def create_sac_playback_session(
 
 
 def _default_hora_distill_playback_deps(root_dir: str | Path) -> dict[str, Any]:
-    _ensure_scripts_dir(root_dir)
-    from train_hora_distill import (
-        _apply_teacher_defaults,
-        _build_play_env_cfg_override,
-        _cfg_with_checkpoint_runtime,
-        _format_stage2_play_checkpoint_error,
-        _resolve_stage2_checkpoint_path,
-        _student_policy,
-    )
-
     from unilab.algos.torch.hora.distill import (
         build_student_actor_and_normalizer,
+        cfg_with_checkpoint_runtime,
         load_distilled_checkpoint,
+        student_policy,
     )
+    from unilab.algos.torch.hora.distill_config import apply_teacher_defaults
     from unilab.algos.torch.hora.rsl_rl import HoraRslRlVecEnvWrapper
-    from unilab.training import create_env, get_log_root
+    from unilab.base.backend import materialize_scene_visual_override
+    from unilab.training import (
+        BackendAdapter,
+        create_env,
+        format_hora_stage2_checkpoint_error,
+        get_log_root,
+        resolve_hora_stage2_checkpoint_path,
+    )
 
     return {
-        "apply_teacher_defaults": _apply_teacher_defaults,
-        "build_play_env_cfg_override": _build_play_env_cfg_override,
+        "apply_teacher_defaults": apply_teacher_defaults,
+        "build_play_env_cfg_override": lambda cfg: BackendAdapter(
+            cfg,
+            root_dir=root_dir,
+            algo_name="hora_distill",
+            scene_materializer=materialize_scene_visual_override,
+        ).build_play_env_cfg_override(),
         "build_student_actor_and_normalizer": build_student_actor_and_normalizer,
-        "cfg_with_checkpoint_runtime": _cfg_with_checkpoint_runtime,
+        "cfg_with_checkpoint_runtime": cfg_with_checkpoint_runtime,
         "create_env": create_env,
-        "format_stage2_play_checkpoint_error": _format_stage2_play_checkpoint_error,
+        "format_stage2_play_checkpoint_error": format_hora_stage2_checkpoint_error,
         "get_log_root": get_log_root,
         "load_distilled_checkpoint": load_distilled_checkpoint,
-        "resolve_stage2_checkpoint_path": _resolve_stage2_checkpoint_path,
-        "student_policy": _student_policy,
+        "resolve_stage2_checkpoint_path": lambda cfg: resolve_hora_stage2_checkpoint_path(
+            cfg,
+            root_dir=root_dir,
+        ),
+        "student_policy": student_policy,
         "wrapper_cls": HoraRslRlVecEnvWrapper,
         "checkpoint_reader": torch.load,
     }
@@ -827,6 +887,12 @@ def create_hora_distill_playback_session(
             log("WARNING: falling back to zero actions.")
             runtime_cfg = resolved_deps["apply_teacher_defaults"](cfg)
         else:
+            resolve_sim2sim_config(
+                load_path_dir,
+                cfg,
+                algo_name="hora_distill",
+                strict=bool(getattr(cfg.training, "sim2sim_strict", True)),
+            )
             log(f"Loading distilled checkpoint: {load_path}")
             checkpoint = resolved_deps["checkpoint_reader"](
                 load_path, map_location="cpu", weights_only=False
@@ -872,12 +938,13 @@ def create_hora_distill_playback_session(
             runtime_cfg,
             device=torch_device,
         )
-        resolved_deps["load_distilled_checkpoint"](
-            actor,
-            hist_normalizer,
-            load_path,
-            device=torch_device,
-        )
+        with policy_load_dim_guard(algo_name="hora_distill"):
+            resolved_deps["load_distilled_checkpoint"](
+                actor,
+                hist_normalizer,
+                load_path,
+                device=torch_device,
+            )
         actor.eval()
         hist_normalizer.eval()
         student_policy = resolved_deps["student_policy"]
@@ -963,6 +1030,7 @@ __all__ = [
     "create_hora_distill_playback_session",
     "create_rsl_rl_playback_session",
     "create_sac_playback_session",
+    "make_sim2sim_preflight",
     "prepare_motion_overlay_selection",
     "select_torch_device",
 ]

--- a/tests/base/test_np_env.py
+++ b/tests/base/test_np_env.py
@@ -13,6 +13,7 @@ import gymnasium as gym
 import numpy as np
 import pytest
 
+from unilab.base.backend.base import SimBackend
 from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.scene import SceneCfg
@@ -142,6 +143,25 @@ class TestNanGuardModelPath:
         cfg.scene = SceneCfg(model_file="/changed.xml")
         assert _nan_dump_model_files(env) == [expected, expected]
         assert backend.get_scene_model_file.call_count == 1
+
+
+class TestSceneVisualModelFileContract:
+    def test_backend_default_is_none(self):
+        assert SimBackend.get_scene_visual_model_file(MagicMock()) is None
+
+    def test_env_passthrough_reads_backend_getter(self):
+        backend = MagicMock()
+        backend.backend_type = "mujoco"
+        backend.step.return_value = None
+        backend.get_scene_model_file.return_value = None
+        backend.get_scene_visual_model_file.return_value = "/visual.xml"
+        capabilities = MagicMock()
+        capabilities.supports_physics_state_playback = False
+        backend.get_play_capabilities.return_value = capabilities
+
+        env = _StubNpEnv(backend=backend)
+
+        assert env.get_scene_visual_model_file() == "/visual.xml"
 
 
 class _TerminatingStubEnv(_StubNpEnv):

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -87,6 +87,8 @@ def test_mujoco_backend_smoke_contract(robot):
 
     bkd.step(np.zeros((NUM_ENVS, bkd.model.nu)), nsteps=2)
 
+    assert bkd.get_scene_visual_model_file() == str(bkd.scene_visual_model_file)
+
     qpos = _identity_qpos_mujoco(bkd.model.nq, xyz=(1.0, 2.0, 0.8))
     bkd.set_state(np.array([0]), qpos, np.zeros((1, bkd.model.nv)))
     np.testing.assert_allclose(bkd.get_base_pos()[0], (1.0, 2.0, 0.8), atol=1e-5)

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1319,12 +1319,14 @@ def test_go2_arm_manip_loco_motrix_eval_uses_visual_floor(
     assert env_cfg_override["scene"].model_file == "/tmp/go2_arm_manip_loco_play_scene.xml"
 
 
-def test_run_motrix_rsl_play_loop_uses_render_spacing_and_offset_mode():
+def test_run_motrix_rsl_play_loop_uses_render_spacing_and_offset_mode(
+    monkeypatch: pytest.MonkeyPatch,
+):
     import numpy as np
     import torch
     from tensordict import TensorDict
 
-    mod = _train_rsl_rl(pytest.MonkeyPatch())
+    mod = _train_rsl_rl(monkeypatch)
 
     class FakePolicy:
         def __call__(self, obs):
@@ -3074,6 +3076,7 @@ def test_play_interactive_runner_log_dir_uses_algo_log_name(monkeypatch: pytest.
         action_space=types.SimpleNamespace(shape=(3,), low=np.full((3,), -1.0), high=np.ones((3,))),
         cfg=types.SimpleNamespace(ctrl_dt=0.02),
         get_playback_model=lambda: object(),
+        get_scene_visual_model_file=lambda: None,
         get_physics_state_snapshot=lambda: np.zeros((1, 8), dtype=np.float32),
     )
 

--- a/tests/scripts/test_visualization_entrypoints.py
+++ b/tests/scripts/test_visualization_entrypoints.py
@@ -273,11 +273,9 @@ def test_play_interactive_viewer_model_uses_shared_render_playback_resolver(
         fake_resolve_render_play_model_files,
     )
 
-    class FakeBackend:
-        scene_visual_model_file = str(visual_xml)
-
     class FakeEnv:
-        _backend = FakeBackend()
+        def get_scene_visual_model_file(self) -> str:
+            return str(visual_xml)
 
     env = FakeEnv()
     model = mod._load_viewer_model(env, use_env_visual_model=False)

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
 
 from unilab.base.backend.motrix.backend import MotrixBackend
 from unilab.base.backend.motrix.playback import run_motrix_playback
@@ -14,12 +15,16 @@ from unilab.base.backend.mujoco.playback import run_mujoco_playback
 from unilab.base.scene import SceneCfg
 from unilab.training import (
     BackendAdapter,
+    format_hora_stage2_checkpoint_error,
     get_entrypoint_log_root,
     get_latest_checkpoint,
     get_latest_run,
     get_log_root,
     parse_checkpoint_path,
+    resolve_appo_checkpoint_path,
     resolve_checkpoint_path,
+    resolve_hora_stage2_checkpoint_path,
+    resolve_offpolicy_checkpoint_path,
     resolve_task_checkpoint_path,
 )
 from unilab.visualization.playback import render_play_mode
@@ -105,6 +110,108 @@ def test_resolve_checkpoint_path_accepts_integer_latest_run(tmp_path: Path):
 
     assert checkpoint_path == selected_model
     assert checkpoint_dir == run_dir
+
+
+def test_resolve_appo_checkpoint_path_returns_string_paths(tmp_path: Path):
+    task_dir = tmp_path / "logs" / "appo" / "MyTask"
+    run_dir = task_dir / "2024-02-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    selected_model = run_dir / "model_9.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_appo_checkpoint_path(task_dir, "-1")
+
+    assert checkpoint_path == str(selected_model)
+    assert checkpoint_dir == str(run_dir)
+
+
+def test_resolve_offpolicy_checkpoint_path_reads_repo_log_tree(tmp_path: Path):
+    run_dir = tmp_path / "logs" / "sac" / "MyTask" / "2024-02-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    selected_model = run_dir / "model_9.pt"
+    selected_model.write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_offpolicy_checkpoint_path(
+        tmp_path, "sac", "MyTask", "-1"
+    )
+
+    assert checkpoint_path == str(selected_model)
+    assert checkpoint_dir == str(run_dir)
+
+
+def test_resolve_hora_stage2_checkpoint_path_prefers_last_then_numbered(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
+    cfg = OmegaConf.create(
+        {
+            "training": {"task_name": "Task", "log_root": None},
+            "algo": {"algo_log_name": "hora_distill", "load_run": "-1", "checkpoint": -1},
+        }
+    )
+    run_dir = tmp_path / "logs" / "hora_distill" / "Task" / "2024-02-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    (run_dir / "hora_stage2_10.pt").write_bytes(b"")
+    (run_dir / "hora_stage2_20.pt").write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_hora_stage2_checkpoint_path(cfg, root_dir=tmp_path)
+
+    assert checkpoint_path == run_dir / "hora_stage2_20.pt"
+    assert checkpoint_dir == run_dir
+
+    (run_dir / "hora_stage2_last.pt").write_bytes(b"")
+    checkpoint_path, checkpoint_dir = resolve_hora_stage2_checkpoint_path(cfg, root_dir=tmp_path)
+
+    assert checkpoint_path == run_dir / "hora_stage2_last.pt"
+    assert checkpoint_dir == run_dir
+
+
+def test_resolve_hora_stage2_checkpoint_path_reports_missing_explicit_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.delenv("UNILAB_TEST_LOG_ROOT", raising=False)
+    cfg = OmegaConf.create(
+        {
+            "training": {"task_name": "Task", "log_root": None},
+            "algo": {"algo_log_name": "hora_distill", "load_run": "-1", "checkpoint": 7},
+        }
+    )
+    run_dir = tmp_path / "logs" / "hora_distill" / "Task" / "2024-02-01_00-00-00_mujoco"
+    run_dir.mkdir(parents=True)
+    (run_dir / "hora_stage2_last.pt").write_bytes(b"")
+
+    checkpoint_path, checkpoint_dir = resolve_hora_stage2_checkpoint_path(cfg, root_dir=tmp_path)
+
+    assert checkpoint_path is None
+    assert checkpoint_dir == run_dir
+
+    message = format_hora_stage2_checkpoint_error(
+        cfg,
+        task_log_root=run_dir.parent,
+        load_path=checkpoint_path,
+        load_path_dir=checkpoint_dir,
+    )
+
+    assert "Requested stage-2 checkpoint was not found" in message
+    assert "algo.checkpoint=7" in message
+
+
+def test_format_hora_stage2_checkpoint_error_reports_missing_task_root(tmp_path: Path):
+    cfg = OmegaConf.create(
+        {
+            "training": {"task_name": "Task"},
+            "algo": {"load_run": "-1", "checkpoint": -1},
+        }
+    )
+
+    message = format_hora_stage2_checkpoint_error(
+        cfg,
+        task_log_root=tmp_path / "missing",
+        load_path=None,
+        load_path_dir=None,
+    )
+
+    assert "Task log root does not exist." in message
 
 
 def test_parse_checkpoint_path_uses_algo_log_name_from_cfg(

--- a/tests/visualization/test_interactive_playback.py
+++ b/tests/visualization/test_interactive_playback.py
@@ -401,6 +401,217 @@ def test_create_hora_distill_playback_session_missing_checkpoint_uses_zero_actio
     assert torch.equal(captured["actions"], torch.zeros((1, 2)))
 
 
+def _rsl_rl_session_test_env() -> SimpleNamespace:
+    return SimpleNamespace(
+        obs_groups_spec={"obs": 5},
+        action_space=SimpleNamespace(
+            shape=(2,),
+            low=np.full((2,), -1.0),
+            high=np.full((2,), 1.0),
+        ),
+        get_physics_state_snapshot=lambda: np.zeros((1, 4), dtype=np.float32),
+    )
+
+
+class _RslRlTestWrapper:
+    def __init__(self, wrapped_env, *, device, policy_obs_mode):
+        self.env = wrapped_env
+
+    def reset(self):
+        return "obs", {}
+
+    def step(self, actions):
+        return "obs", 0.0, False, {}
+
+
+def _rsl_rl_session_kwargs(tmp_path: Path) -> dict[str, Any]:
+    return dict(
+        playback_cfg=RslRlPlaybackConfig(
+            task="MyTask",
+            load_run="-1",
+            checkpoint=None,
+            action_mode="policy",
+            policy_obs_mode="actor",
+            algo_log_name="rsl_rl_ppo",
+            log_root=None,
+            num_envs=1,
+        ),
+        env_factory=lambda num_envs: _rsl_rl_session_test_env(),
+        algo_config={},
+        root_dir=tmp_path,
+        device="cpu",
+        checkpoint_resolver=lambda *args: None,
+        checkpoint_input_dim_reader=lambda path: 5,
+        entrypoint_log_root=lambda root_dir, *, algo_log_name, log_root=None: (
+            tmp_path / algo_log_name
+        ),
+        wrapper_cls=_RslRlTestWrapper,
+        policy_obs_dims_getter=lambda spec: (5, 7),
+        train_cfg_normalizer=lambda cfg: cfg,
+        log=lambda message: None,
+    )
+
+
+def test_create_rsl_rl_playback_session_runs_sim2sim_preflight(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run_1"
+    run_dir.mkdir()
+    checkpoint = run_dir / "model_10.pt"
+    torch.save({"actor": {}}, checkpoint)
+    preflight_calls: list[str | None] = []
+
+    class Runner:
+        def __init__(self, wrapped_env, train_cfg, log_dir, device):
+            pass
+
+        def load(self, checkpoint, load_cfg):
+            pass
+
+        def get_inference_policy(self, *, device):
+            return lambda obs: torch.ones((1, 2))
+
+    kwargs = _rsl_rl_session_kwargs(tmp_path)
+    kwargs["checkpoint_resolver"] = lambda *args: str(checkpoint)
+    kwargs["runner_cls"] = Runner
+    kwargs["sim2sim_preflight"] = lambda run_dir: preflight_calls.append(run_dir)
+
+    _session, _mode, resolved = create_rsl_rl_playback_session(**kwargs)
+
+    assert resolved == str(checkpoint)
+    assert preflight_calls == [str(run_dir)]
+
+
+def test_create_rsl_rl_playback_session_wraps_load_with_dim_guard(tmp_path: Path) -> None:
+    from unilab.training.sim2sim import CrossBackendIncompatibleError
+
+    run_dir = tmp_path / "run_1"
+    run_dir.mkdir()
+    checkpoint = run_dir / "model_10.pt"
+    torch.save({"actor": {}}, checkpoint)
+
+    class MismatchRunner:
+        def __init__(self, wrapped_env, train_cfg, log_dir, device):
+            pass
+
+        def load(self, checkpoint, load_cfg):
+            raise RuntimeError("size mismatch for actor.mlp.0.weight: ...")
+
+        def get_inference_policy(self, *, device):
+            raise AssertionError("unreachable")
+
+    kwargs = _rsl_rl_session_kwargs(tmp_path)
+    kwargs["checkpoint_resolver"] = lambda *args: str(checkpoint)
+    kwargs["runner_cls"] = MismatchRunner
+
+    with pytest.raises(CrossBackendIncompatibleError):
+        create_rsl_rl_playback_session(**kwargs)
+
+
+def test_interactive_playback_has_no_scripts_sys_path_hack() -> None:
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "unilab"
+        / "visualization"
+        / "interactive_playback.py"
+    ).read_text(encoding="utf-8")
+
+    assert "sys.path" not in source
+    assert "from train_appo import" not in source
+    assert "from train_offpolicy import" not in source
+    assert "from train_hora_distill import" not in source
+
+
+def test_sac_playback_session_runs_sim2sim_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from omegaconf import OmegaConf
+
+    import unilab.algos.torch.common.actor_factory as actor_factory
+    import unilab.training.offpolicy as offpolicy_play
+    import unilab.training.run as training_run
+    import unilab.visualization.interactive_playback as interactive_playback
+
+    checkpoint = tmp_path / "model_10.pt"
+    torch.save({"actor": {}}, checkpoint)
+    preflight_calls: list[tuple[Any, str]] = []
+
+    class FakeActor:
+        def eval(self):
+            return self
+
+        def load_state_dict(self, state_dict):
+            pass
+
+    class FakeEnv:
+        num_envs = 1
+        obs_groups_spec = {"obs": 3, "critic": 5}
+        action_space = SimpleNamespace(
+            shape=(2,),
+            low=np.full((2,), -1.0),
+            high=np.full((2,), 1.0),
+        )
+        state = SimpleNamespace(info={})
+
+        def get_physics_state_snapshot(self):
+            return np.zeros((1, 4), dtype=np.float32)
+
+    cfg = OmegaConf.create(
+        {
+            "training": {"task_name": "Task", "device": None},
+            "algo": {
+                "algo_log_name": "sac",
+                "load_run": "run",
+                "actor_hidden_dim": 16,
+                "use_layer_norm": False,
+            },
+        }
+    )
+
+    def fake_preflight(source_run_dir, target_cfg, *, algo_name, strict):
+        preflight_calls.append((source_run_dir, algo_name))
+        return target_cfg
+
+    monkeypatch.setattr(interactive_playback, "resolve_sim2sim_config", fake_preflight)
+    monkeypatch.setattr(
+        offpolicy_play,
+        "default_device",
+        lambda torch_module, preferred=None: "cpu",
+    )
+    monkeypatch.setattr(offpolicy_play, "resolve_play_obs_dims", lambda spec: (3, 5))
+    monkeypatch.setattr(
+        offpolicy_play,
+        "resolve_play_actor_spec",
+        lambda algo_name, cfg, *, obs_dim, critic_obs_dim: ("sac", {}),
+    )
+    monkeypatch.setattr(
+        training_run,
+        "resolve_offpolicy_checkpoint_path",
+        lambda *args, **kwargs: (str(checkpoint), str(tmp_path)),
+    )
+    monkeypatch.setattr(actor_factory, "build_actor", lambda *args, **kwargs: FakeActor())
+
+    _session, _mode, resolved = create_sac_playback_session(
+        playback_cfg=RslRlPlaybackConfig(
+            task="Task",
+            load_run="run",
+            checkpoint=None,
+            action_mode="policy",
+            policy_obs_mode="actor",
+            algo_log_name="sac",
+            log_root=None,
+        ),
+        cfg=cfg,
+        env_factory=lambda num_envs: FakeEnv(),
+        root_dir=tmp_path,
+        device="cpu",
+        log=lambda message: None,
+    )
+
+    assert resolved == str(checkpoint)
+    assert preflight_calls == [(str(tmp_path), "sac")]
+
+
 def test_keyboard_commander_nudges_stack_and_clamp_to_vel_limit() -> None:
     commander = KeyboardCommander.from_vel_limit(_VEL_LIMIT, step_lin=0.1, step_ang=0.2)
     assert commander.command.tolist() == [0.0, 0.0, 0.0]
@@ -569,10 +780,11 @@ def test_sac_hora_playback_session_updates_priv_info_after_reset_and_step(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import train_offpolicy
     from omegaconf import OmegaConf
 
     import unilab.algos.torch.common.actor_factory as actor_factory
+    import unilab.training.offpolicy as offpolicy_play
+    import unilab.training.run as training_run
 
     checkpoint = tmp_path / "model_10.pt"
     torch.save({"actor": {}}, checkpoint)
@@ -649,13 +861,13 @@ def test_sac_hora_playback_session_updates_priv_info_after_reset_and_step(
     )
 
     monkeypatch.setattr(
-        train_offpolicy,
+        offpolicy_play,
         "default_device",
         lambda torch_module, preferred=None: "cpu",
     )
-    monkeypatch.setattr(train_offpolicy, "resolve_play_obs_dims", lambda spec: (3, 5))
+    monkeypatch.setattr(offpolicy_play, "resolve_play_obs_dims", lambda spec: (3, 5))
     monkeypatch.setattr(
-        train_offpolicy,
+        offpolicy_play,
         "resolve_play_actor_spec",
         lambda algo_name, cfg, *, obs_dim, critic_obs_dim: (
             "hora_sac",
@@ -663,8 +875,8 @@ def test_sac_hora_playback_session_updates_priv_info_after_reset_and_step(
         ),
     )
     monkeypatch.setattr(
-        train_offpolicy,
-        "resolve_checkpoint_path",
+        training_run,
+        "resolve_offpolicy_checkpoint_path",
         lambda *args, **kwargs: (str(checkpoint), str(tmp_path)),
     )
     monkeypatch.setattr(actor_factory, "build_actor", lambda *args, **kwargs: FakeActor())
@@ -700,7 +912,6 @@ def test_hora_distill_playback_session_loads_stage2_checkpoint_and_student_polic
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import train_hora_distill
     from omegaconf import OmegaConf
     from tensordict import TensorDict
 
@@ -755,9 +966,9 @@ def test_hora_distill_playback_session_loads_stage2_checkpoint_and_student_polic
     )
 
     monkeypatch.setattr(
-        train_hora_distill,
-        "_resolve_stage2_checkpoint_path",
-        lambda cfg: (checkpoint, tmp_path),
+        training,
+        "resolve_hora_stage2_checkpoint_path",
+        lambda cfg, *, root_dir: (checkpoint, tmp_path),
     )
 
     def fake_cfg_with_checkpoint_runtime(cfg, checkpoint_payload):
@@ -765,14 +976,22 @@ def test_hora_distill_playback_session_loads_stage2_checkpoint_and_student_polic
         return cfg
 
     monkeypatch.setattr(
-        train_hora_distill,
-        "_cfg_with_checkpoint_runtime",
+        distill,
+        "cfg_with_checkpoint_runtime",
         fake_cfg_with_checkpoint_runtime,
     )
-    monkeypatch.setattr(train_hora_distill, "_build_play_env_cfg_override", lambda cfg: {})
+
+    class FakeBackendAdapter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_play_env_cfg_override(self):
+            return {}
+
+    monkeypatch.setattr(training, "BackendAdapter", FakeBackendAdapter)
     monkeypatch.setattr(
-        train_hora_distill,
-        "_student_policy",
+        distill,
+        "student_policy",
         lambda actor, hist_normalizer, obs, *, device: torch.ones((1, 2)),
     )
     monkeypatch.setattr(training, "create_env", lambda *args, **kwargs: fake_env)


### PR DESCRIPTION
Fixes #1010

## What

统一替代 playback 入口的 sim2sim preflight 与 checkpoint 解析 owner:

1. **Checkpoint 解析下沉到 `unilab.training` 公共 owner**
   - `src/unilab/training/run.py` 新增 `resolve_appo_checkpoint_path` / `resolve_offpolicy_checkpoint_path` / `resolve_hora_stage2_checkpoint_path` / `format_hora_stage2_checkpoint_error`(实现逐行搬自三个 train 脚本,语义不变)。
   - 新增 `src/unilab/training/offpolicy.py` 承接 off-policy play 共享逻辑(`default_device`、`extract_reset_obs`/`extract_play_obs`、`resolve_play_obs_dim(s)`、`resolve_play_actor_spec`、`build_offpolicy_env_cfg_override`)。
   - `interactive_playback.py` 删除 `_ensure_scripts_dir()` 的 sys.path hack 与对 `train_appo`/`train_offpolicy`/`train_hora_distill` 私有函数的反向 import;三个 train 脚本改为从 owner 模块 import(不保留两份实现)。
2. **替代 playback 入口统一 preflight + dim guard**
   - `create_appo_/sac_/hora_distill_playback_session` 在 checkpoint 加载前调用 `resolve_sim2sim_config`(旧 run 无 snapshot 时保持原有 fallback + warning 语义,判定逻辑未动),`load_state_dict`/`load_distilled_checkpoint` 包裹 `policy_load_dim_guard`。
   - `create_rsl_rl_playback_session` 新增 `sim2sim_preflight` 注入点与 `make_sim2sim_preflight` 工厂;`scripts/play_interactive.py`(ppo 路径)与 `scripts/play_viser.py` 接入,`runner.load` 包裹 dim guard。
3. **Backend 契约**:`SimBackend.get_scene_visual_model_file()` 只读冷路径 getter(默认 `None`),mujoco backend 接线;`NpEnv.get_scene_visual_model_file()` env 只读 passthrough;`play_interactive.py` 不再 `getattr(env, "_backend", None)` 探测私有成员。

## Boundary notes(与并行 PR 的边界)

- `scripts/train_hora_distill.py` 只删除两个 checkpoint 解析私有函数并更新其在 `play_hora_distill` 的调用点;config compose/defaults 段与 `distill_config.py` 未触碰。
- `_student_policy` / `_cfg_with_checkpoint_runtime` 的 canonical 实现落在 `unilab/algos/torch/hora/distill.py`(`student_policy` / `cfg_with_checkpoint_runtime`),`interactive_playback` 使用 owner 版本;`train_hora_distill.py` 中的私有副本按边界要求暂时保留,待 #1011 合并后由后续 child 收敛脚本侧。
- 未改 runner/lifecycle、sim2sim DENYLIST/WARNING_LIST 语义。

## Follow-up(登记)

- `src/unilab/algos/torch/hora/appo.py:181-188` 的直接 checkpoint 加载未纳入(纳入会超过本子 issue 文件/行数预算),登记为后续 child:接入 `resolve_sim2sim_config` + `policy_load_dim_guard`。
- `train_hora_distill.py` 收敛到 `distill.student_policy` / `distill.cfg_with_checkpoint_runtime`(待 #1011 落地后)。

## Tests

- 新增 contract 测试:preflight 被调用(rsl_rl 注入点 + sac 会话 mock 验证 `resolve_sim2sim_config` 调用参数)、dim guard 将 size mismatch 重抛为 `CrossBackendIncompatibleError`、`SimBackend` getter 默认 `None` + `NpEnv` passthrough + mujoco smoke 接线断言、无 `sys.path.insert`/`from train_* import` 残留静态检查、run.py 新 owner 函数行为(appo/offpolicy/hora stage2 解析与错误诊断)。
- 修复一处既有测试卫生问题:`test_run_motrix_rsl_play_loop_uses_render_spacing_and_offset_mode` 使用裸 `pytest.MonkeyPatch()`(无 undo),会清空 `sys.modules` 中全部 `unilab.*` 导致后续测试模块身份分裂;改为使用 `monkeypatch` fixture。
- 全仓 grep 确认无残留 `sys.path.insert(.*scripts` 与 `from train_(appo|offpolicy|hora_distill) import`。

## Validation

- `make test-all` 全绿(ruff format/check + mypy + pyright + `pytest -m "not slow" --cov` + benchmark smoke),exit 0。
- 注:本地初始环境缺 `motrixsim` 时全量套件中 `tests/base/test_motrix_backend_options.py::test_create_backend_warns_when_mjwarp_ignores_non_default_mujoco_options` 存在与本改动无关的既有失败(在 base 分支 `0713b0b7` 上以相同命令复现同样失败;CI 安装 motrix extra);`uv sync --extra mujoco --extra motrix` 补齐依赖后 `make test-all` 通过。
