### PR TITLE
cleanup: converge train_hora_distill script helpers to algo owner

### DIFF
--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -7,7 +7,6 @@ from typing import Any, cast
 import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
-from tensordict import TensorDict
 
 ROOT_DIR = Path(__file__).parent.parent
 SRC_DIR = ROOT_DIR / "src"
@@ -19,7 +18,9 @@ if str(ROOT_DIR) not in sys.path:
 from unilab.algos.torch.hora import HoraDistillationTrainer
 from unilab.algos.torch.hora.distill import (
     build_student_actor_and_normalizer,
+    cfg_with_checkpoint_runtime,
     load_distilled_checkpoint,
+    student_policy,
 )
 from unilab.algos.torch.hora.distill_config import (
     apply_teacher_defaults as _apply_teacher_defaults,
@@ -104,21 +105,6 @@ def _build_play_env_cfg_override(cfg: DictConfig) -> dict[str, Any]:
     return cast(dict[str, Any], adapter.build_play_env_cfg_override())
 
 
-def _student_policy(
-    actor, hist_normalizer, obs: TensorDict, *, device: torch.device
-) -> torch.Tensor:
-    proprio_hist = hist_normalizer(obs["proprio_hist"].to(device), update=False)
-    policy_obs = TensorDict(
-        {
-            "actor": obs["actor"].to(device),
-            "proprio_hist": proprio_hist,
-        },
-        batch_size=obs.batch_size,
-        device=device,
-    )
-    return actor(policy_obs, stochastic_output=False).clamp_(-1.0, 1.0)
-
-
 def _play_camera_kwargs(cfg: DictConfig) -> dict[str, Any]:
     camera_kwargs = {
         "cam_tracking": getattr(cfg.training, "cam_tracking", False),
@@ -130,35 +116,6 @@ def _play_camera_kwargs(cfg: DictConfig) -> dict[str, Any]:
         if value is not None:
             camera_kwargs[key] = value
     return camera_kwargs
-
-
-def _cfg_with_checkpoint_runtime(cfg: DictConfig, checkpoint: dict[str, Any]) -> DictConfig:
-    """Merge model-side runtime config stored in a stage-2 checkpoint.
-
-    Args:
-        cfg: Hydra-composed distillation config supplied to play mode.
-        checkpoint: Loaded stage-2 checkpoint dictionary.
-
-    Returns:
-        Config using the current owner env/reward settings and checkpoint model
-        construction fields.
-    """
-    cfg_with_owner_defaults = _apply_teacher_defaults(cfg)
-    cfg_clone = OmegaConf.create(OmegaConf.to_container(cfg_with_owner_defaults, resolve=False))
-    runtime_cfg = checkpoint.get("distill_runtime_cfg")
-    if runtime_cfg is None:
-        return cast(DictConfig, cfg_clone)
-
-    runtime_model_cfg = OmegaConf.select(OmegaConf.create(runtime_cfg), "algo.model")
-    if runtime_model_cfg is None:
-        return cast(DictConfig, cfg_clone)
-    OmegaConf.update(
-        cfg_clone,
-        "algo.model",
-        OmegaConf.to_container(runtime_model_cfg, resolve=True),
-        merge=False,
-    )
-    return cast(DictConfig, cfg_clone)
 
 
 def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
@@ -184,7 +141,7 @@ def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
         )
         return None
 
-    cfg = _cfg_with_checkpoint_runtime(cfg, checkpoint)
+    cfg = cfg_with_checkpoint_runtime(cfg, checkpoint)
     env = create_env(
         cfg,
         num_envs=int(cfg.training.play_env_num),
@@ -211,7 +168,7 @@ def play_hora_distill(cfg: DictConfig, device: str) -> str | None:
             ),
             initialize=lambda: wrapped_env.reset()[0],
             step=lambda obs: wrapped_env.step(
-                _student_policy(actor, hist_normalizer, obs, device=torch_device)
+                student_policy(actor, hist_normalizer, obs, device=torch_device)
             )[0],
             camera_kwargs=_play_camera_kwargs(cfg),
             on_plan=log_playback_plan,

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -407,7 +407,8 @@ def test_hora_distill_runtime_checkpoint_records_model_only():
 
 
 def test_hora_distill_checkpoint_runtime_only_restores_model_structure():
-    mod = _train_hora_distill()
+    from unilab.algos.torch.hora.distill import cfg_with_checkpoint_runtime
+
     cfg = _hora_distill_cfg(["task=sharpa_inhand/mujoco_nodr"])
     checkpoint = {
         "distill_runtime_cfg": {
@@ -435,7 +436,7 @@ def test_hora_distill_checkpoint_runtime_only_restores_model_structure():
         }
     }
 
-    restored = mod._cfg_with_checkpoint_runtime(cfg, checkpoint)
+    restored = cfg_with_checkpoint_runtime(cfg, checkpoint)
 
     assert restored.training.task_name == "SharpaInhandRotation"
     assert restored.training.sim_backend == "mujoco"
@@ -470,7 +471,9 @@ def test_hora_distill_checkpoint_runtime_only_overrides_model_side(
     teacher_algo_family: str,
     checkpoint_model: dict[str, Any],
 ):
-    mod = _train_hora_distill()
+    from unilab.algos.torch.hora import distill_config
+    from unilab.algos.torch.hora.distill import cfg_with_checkpoint_runtime
+
     owner_cfg = OmegaConf.create(
         {
             "teacher": {"algo_family": teacher_algo_family},
@@ -504,9 +507,9 @@ def test_hora_distill_checkpoint_runtime_only_overrides_model_side(
         },
     }
 
-    monkeypatch.setattr(mod, "_apply_teacher_defaults", lambda cfg: owner_cfg)
+    monkeypatch.setattr(distill_config, "apply_teacher_defaults", lambda cfg: owner_cfg)
 
-    effective_cfg = mod._cfg_with_checkpoint_runtime(OmegaConf.create({}), checkpoint)
+    effective_cfg = cfg_with_checkpoint_runtime(OmegaConf.create({}), checkpoint)
 
     assert effective_cfg.training.task_name == "OwnerTask"
     assert effective_cfg.training.cam_distance == pytest.approx(1.5)


### PR DESCRIPTION
Fixes #1019

## Summary
- `scripts/train_hora_distill.py` 删除脚本侧私有副本 `_student_policy` / `_cfg_with_checkpoint_runtime`,改为 import `unilab.algos.torch.hora.distill` 的 canonical 实现 `student_policy` / `cfg_with_checkpoint_runtime`,并更新 `play_hora_distill` 内两处调用点;移除因此闲置的 `tensordict` 导入。
- `tests/scripts/test_train_scripts.py` 两处原覆盖私有副本的测试改调 canonical 实现。

## 副本 vs canonical 逐行 diff 结论
逐行比对脚本副本与 `src/unilab/algos/torch/hora/distill.py` canonical 实现,**语义完全一致**,以 canonical 为准无副作用:
1. `_student_policy` vs `student_policy`(distill.py:329):函数体逐行相同(hist_normalizer(update=False) → 构造 actor/proprio_hist TensorDict → `actor(...).clamp_(-1, 1)`);差异仅限 canonical 增加类型标注与 docstring,无运行时差异。
2. `_cfg_with_checkpoint_runtime` vs `cfg_with_checkpoint_runtime`(distill.py:298):函数体逐行相同;唯一差异是 canonical 在函数体内局部 import `apply_teacher_defaults`(避免循环依赖),与脚本模块级别名 `_apply_teacher_defaults` 是同一函数对象。
3. canonical 无功能缺失,未改动 canonical / `distill_config.py` 任何语义。

## 测试调用点适配说明
- `test_hora_distill_checkpoint_runtime_only_restores_model_structure`:直接改调 canonical(真实 Hydra compose cfg,canonical 内部 `apply_teacher_defaults` 与原脚本别名同函数,行为不变)。
- `test_hora_distill_checkpoint_runtime_only_overrides_model_side`(ppo/appo/sac 三组):monkeypatch 目标由脚本模块属性改为 `distill_config.apply_teacher_defaults`(canonical 在函数体内局部 import,patch 模块属性在调用时生效),断言不变。
- `tests/visualization/test_interactive_playback.py` 无需改动:其 monkeypatch 目标本来就是 canonical 模块属性。

## Validation
- `make test-all` 已在最终提交上完成并通过(exit 0;check=format+type、test-cov、test-benchmark-smoke 32/33 module-mode + 33/34 script-mode,1 个 mlx 平台可选 skip)。
- `uv run pytest tests/scripts/test_train_scripts.py -k hora_distill tests/algos/test_hora_distill_config.py tests/algos/test_hora_contract.py tests/algos/test_hora_imports.py -q`:23 passed。
- `uv run pytest tests/visualization/test_interactive_playback.py -k hora_distill -q`:3 passed。
- `uv run ruff check` / `ruff format --check` 两个改动文件通过。
- grep 确认脚本内 `_student_policy` / `_cfg_with_checkpoint_runtime` 定义与引用清零。

## 边界
未触碰 `src/unilab/algos/torch/hora/distill.py` / `distill_config.py` 语义,未动 `hora/appo.py`、`hora/rsl_rl.py` / `rsl_rl_compat.py`。