### PR TITLE
refactor: HORA APPO play 路径接入 sim2sim preflight

### DIFF
--- a/src/unilab/algos/torch/hora/appo.py
+++ b/src/unilab/algos/torch/hora/appo.py
@@ -19,6 +19,7 @@ from unilab.algos.torch.hora.rsl_rl_compat import (
 )
 from unilab.base.observations import get_obs_dims
 from unilab.training import BackendAdapter, create_env, log_playback_plan
+from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
 
 from .models import build_hora_shared_actor_critic
 from .observations import build_hora_actor_tensordict, split_hora_obs_with_priv_info
@@ -183,9 +184,17 @@ def play_hora_appo(
         print(f"Could not find run to load. load_path={load_path}")
         return None
 
+    resolve_sim2sim_config(
+        load_path_dir,
+        cfg,
+        algo_name="appo",
+        strict=bool(getattr(cfg.training, "sim2sim_strict", True)),
+    )
+
     print(f"Loading model: {load_path}")
     checkpoint = torch.load(load_path, map_location=device, weights_only=True)
-    actor.load_state_dict(checkpoint["actor"])
+    with policy_load_dim_guard(env_obs_dim=obs_dim, env_action_dim=action_dim, algo_name="appo"):
+        actor.load_state_dict(checkpoint["actor"])
 
     current_priv_info: np.ndarray | None = None
 

--- a/tests/algos/test_hora_contract.py
+++ b/tests/algos/test_hora_contract.py
@@ -370,6 +370,141 @@ def test_hora_appo_play_builds_explicit_shared_actor_core() -> None:
     assert len(shared_model_keywords) >= 1
 
 
+def _patch_hora_appo_play_fakes(monkeypatch: pytest.MonkeyPatch, *, actor_cls: type) -> None:
+    """Patch env/actor construction fakes for ``play_hora_appo`` contract tests."""
+    from types import SimpleNamespace
+
+    import numpy as np
+    import rsl_rl.utils as rsl_rl_utils
+
+    import unilab.algos.torch.hora.appo as hora_appo
+
+    fake_env = SimpleNamespace(
+        obs_groups_spec={"obs": 3, "critic": 5},
+        action_space=SimpleNamespace(shape=(2,)),
+        state=SimpleNamespace(
+            obs={"obs": np.zeros((1, 3), dtype=np.float32)},
+            info={},
+        ),
+        cfg=SimpleNamespace(render_spacing=1.0),
+        run_playback_mode=lambda **kwargs: None,
+    )
+
+    class FakeBackendAdapter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_task_env_cfg_override(self):
+            return {}
+
+    monkeypatch.setattr(hora_appo, "BackendAdapter", FakeBackendAdapter)
+    monkeypatch.setattr(hora_appo, "create_env", lambda *args, **kwargs: fake_env)
+    monkeypatch.setattr(
+        hora_appo,
+        "split_hora_obs_with_priv_info",
+        lambda obs, info: (
+            np.zeros((1, 3), dtype=np.float32),
+            None,
+            np.zeros((1, 2), dtype=np.float32),
+        ),
+    )
+    monkeypatch.setattr(hora_appo, "is_rsl_rl_v5", lambda: True)
+    monkeypatch.setattr(
+        hora_appo,
+        "build_hora_shared_actor_critic",
+        lambda **kwargs: torch.nn.Identity(),
+    )
+    monkeypatch.setattr(rsl_rl_utils, "resolve_callable", lambda path: actor_cls)
+
+
+def _hora_appo_play_cfg():
+    from omegaconf import OmegaConf
+
+    return OmegaConf.create(
+        {
+            "training": {
+                "task_name": "Task",
+                "device": "cpu",
+                "play_env_num": 1,
+                "cam_distance": 3.0,
+                "cam_elevation": -20.0,
+                "cam_azimuth": 45.0,
+            },
+        }
+    )
+
+
+def test_hora_appo_play_runs_sim2sim_preflight_before_checkpoint_load(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import unilab.algos.torch.hora.appo as hora_appo
+
+    checkpoint = tmp_path / "model_10.pt"
+    torch.save({"actor": {"weight": torch.tensor(1.0)}}, checkpoint)
+    events: list[str] = []
+    preflight_calls: list[tuple] = []
+
+    class FakeActor(torch.nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def load_state_dict(self, state_dict, strict=True):
+            events.append("load")
+            return None
+
+    _patch_hora_appo_play_fakes(monkeypatch, actor_cls=FakeActor)
+
+    def fake_preflight(source_run_dir, target_cfg, *, algo_name, strict):
+        events.append("preflight")
+        preflight_calls.append((source_run_dir, algo_name, strict))
+        return target_cfg
+
+    monkeypatch.setattr(hora_appo, "resolve_sim2sim_config", fake_preflight)
+
+    hora_appo.play_hora_appo(
+        _hora_appo_play_cfg(),
+        {"actor": {"class_name": "fake.Actor"}, "critic": {}},
+        root_dir=tmp_path,
+        resolve_checkpoint_path=lambda current_cfg: (str(checkpoint), str(tmp_path)),
+    )
+
+    assert preflight_calls == [(str(tmp_path), "appo", True)]
+    assert events == ["preflight", "load"]
+
+
+def test_hora_appo_play_dim_mismatch_reraises_explicit_sim2sim_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys,
+) -> None:
+    import unilab.algos.torch.hora.appo as hora_appo
+    from unilab.training.sim2sim import CrossBackendIncompatibleError
+
+    checkpoint = tmp_path / "model_10.pt"
+    torch.save({"actor": {"weight": torch.tensor(1.0)}}, checkpoint)
+
+    class MismatchActor(torch.nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def load_state_dict(self, state_dict, strict=True):
+            raise RuntimeError("size mismatch for actor.mlp.0.weight: copying a param ...")
+
+    _patch_hora_appo_play_fakes(monkeypatch, actor_cls=MismatchActor)
+
+    with pytest.raises(CrossBackendIncompatibleError, match="does not fit this play environment"):
+        hora_appo.play_hora_appo(
+            _hora_appo_play_cfg(),
+            {"actor": {"class_name": "fake.Actor"}, "critic": {}},
+            root_dir=tmp_path,
+            resolve_checkpoint_path=lambda current_cfg: (str(checkpoint), str(tmp_path)),
+        )
+
+    # Old runs without a contract snapshot keep the fallback + warning semantics.
+    assert "no contract_snapshot" in capsys.readouterr().out
+
+
 def test_hora_appo_resume_rejects_inconsistent_shared_checkpoint() -> None:
     from unilab.algos.torch.hora.appo_runner import _validate_hora_shared_checkpoint
 


### PR DESCRIPTION
Fixes #1018

## Summary
- `src/unilab/algos/torch/hora/appo.py` 的 `play_hora_appo` 此前直接 `torch.load` + `actor.load_state_dict` 加载 checkpoint,是 PR #1016 统一 playback 入口后的最后漏网点。
- 现在加载前先走 `resolve_sim2sim_config`(`algo_name="appo"`,`strict` 取 `training.sim2sim_strict`,默认 `True`;旧 run 无 contract snapshot 保持既有 fallback + warning 语义),加载用 `policy_load_dim_guard(env_obs_dim, env_action_dim, algo_name="appo")` 包裹,行为对齐 #1016 后的 `create_appo_playback_session` / `play_appo` 等其余入口。
- 补两个 contract 测试(风格参考 `tests/visualization/test_interactive_playback.py` 的 #1016 测试):preflight 在 checkpoint 加载前被调用且参数正确;维度不匹配被 `policy_load_dim_guard` 重抛为 `CrossBackendIncompatibleError` 显式诊断,同时钉住旧 run 无 snapshot 的 fallback warning。

## Out of scope(并行 PR 防冲突)
- 未动 `hora/appo_runner.py` lifecycle、`hora/rsl_rl.py` / `rsl_rl_compat.py`、`scripts/train_hora_distill.py`;未改 `sim2sim.py` 判定语义与 DENYLIST/WARNING_LIST 字段。

## Validation
- `uv run pytest tests/algos/test_hora_contract.py`:18 passed。
- `uv run pytest tests/algos tests/visualization tests/scripts`:479 passed。
- `make test-all` 已完成且全绿:ruff format/check 通过;mypy 229 files 无 issue;pyright 0 errors;pytest 1738 passed / 24 skipped / 1 xfailed;benchmark smoke module-mode 32/33、script-mode 33/34(各 1 个 platform-optional mlx 跳过)。