### PR TITLE
cleanup: 删除结论 3.2 兼容别名与旧调用点残留 (issue #1022)

### DIFF
--- a/src/unilab/algos/torch/fast_td3/learner.py
+++ b/src/unilab/algos/torch/fast_td3/learner.py
@@ -355,11 +355,6 @@ class FastTD3Learner:
         torch._foreach_mul_(tgt_ps, 1.0 - self.tau)
         torch._foreach_add_(tgt_ps, src_ps, alpha=self.tau)
 
-    @torch.no_grad()
-    def soft_update(self) -> None:
-        """Backward-compatible alias for older call sites."""
-        self.soft_update_target()
-
     def get_state_dict(self) -> Dict:
         return {
             "actor": self.actor.state_dict(),

--- a/src/unilab/algos/torch/him_ppo/storage.py
+++ b/src/unilab/algos/torch/him_ppo/storage.py
@@ -129,9 +129,6 @@ class HIMRolloutStorage:
         self.sigma[self.step].copy_(transition.action_sigma)
         self.step += 1
 
-    def add_transitions(self, transition: Transition) -> None:
-        self.add_transition(transition)
-
     def clear(self) -> None:
         self.step = 0
 

--- a/src/unilab/algos/torch/hora/rsl_rl.py
+++ b/src/unilab/algos/torch/hora/rsl_rl.py
@@ -33,24 +33,6 @@ def resolve_hora_ppo_runtime(
     return HoraRslRlPPORuntime(wrapper_cls=HoraRslRlVecEnvWrapper)
 
 
-def resolve_hora_ppo_wrapper_cls(
-    rl_cfg: dict[str, Any],
-) -> type[RslRlVecEnvWrapper] | None:
-    """Return the HORA-specific PPO wrapper class when the config selects it.
-
-    Args:
-        rl_cfg: Resolved algorithm config dictionary from Hydra composition.
-
-    Returns:
-        ``HoraRslRlVecEnvWrapper`` when the owner config selects HORA PPO, otherwise
-        ``None``.
-    """
-    runtime = resolve_hora_ppo_runtime(rl_cfg)
-    if runtime is None:
-        return None
-    return runtime.wrapper_cls
-
-
 class HoraRslRlVecEnvWrapper(RslRlVecEnvWrapper):
     """RSL-RL adapter that preserves HORA teacher-policy observation payloads."""
 

--- a/src/unilab/algos/torch/hora/rsl_rl_compat.py
+++ b/src/unilab/algos/torch/hora/rsl_rl_compat.py
@@ -185,23 +185,3 @@ def convert_config_v3_to_v4(cfg: dict[str, Any]) -> dict[str, Any]:
     if "multi_gpu" not in converted:
         converted["multi_gpu"] = None
     return converted
-
-
-def convert_config_v5(cfg: dict[str, Any]) -> dict[str, Any]:
-    """Convert a legacy UniLab PPO/APPO config into the RSL-RL v5 schema.
-
-    Args:
-        cfg: Resolved owner config dictionary before RSL-RL construction.
-
-    Returns:
-        Deep-copied config dictionary aligned with the RSL-RL v5 actor/critic
-        schema and obs-group naming.
-    """
-    converted = deepcopy(cfg)
-    _convert_policy_to_actor_critic(
-        converted,
-        distribution_class_name="GaussianDistribution",
-    )
-    _normalize_algorithm_cfg(converted)
-    _normalize_obs_groups_for_rsl(converted)
-    return converted

--- a/src/unilab/ipc/collector_error.py
+++ b/src/unilab/ipc/collector_error.py
@@ -31,16 +31,6 @@ class ExceptionWrapper:
         self.exc_msg = "".join(traceback.format_exception(*exc_info))
         self.where = where
 
-    def reraise(self) -> None:
-        exc_type = self.exc_type
-        if exc_type is None:
-            raise RuntimeError(f"Unknown exception {self.where}.\n{self.exc_msg}")
-        msg = f"Caught {exc_type.__name__} {self.where}.\nOriginal traceback:\n{self.exc_msg}"
-        try:
-            raise exc_type(msg)
-        except TypeError:
-            raise RuntimeError(msg) from None
-
 
 def create_error_pipe() -> tuple[Any, Any]:
     """Create a unidirectional pipe for error reporting.

--- a/src/unilab/ipc/replay_pipelines/gpu_resident.py
+++ b/src/unilab/ipc/replay_pipelines/gpu_resident.py
@@ -743,9 +743,6 @@ class GPUResidentReplayPipeline:
             return False
         return self._prepare_state == "ready"
 
-    def wait_ready(self) -> None:
-        return None
-
     def wait_until_ready(self, tick_id: int, sample_count: int) -> bool:
         self._validate_sample_count(sample_count)
         metadata = self._prepared_or_wait(tick_id)

--- a/src/unilab/ipc/replay_pipelines/native_h2d.py
+++ b/src/unilab/ipc/replay_pipelines/native_h2d.py
@@ -119,11 +119,6 @@ def get_diagnostic() -> str:
     return _DIAGNOSTIC
 
 
-def ensure_available() -> bool:
-    """Attempt to load native extension. Returns True if available."""
-    return is_available()
-
-
 def submit_h2d(
     dst: torch.Tensor,
     src: torch.Tensor,


### PR DESCRIPTION
Fixes #1022

Parent: #983(结论 3.2;maintainer 已决策:全删)。

## What

删除结论 3.2 的 7 条兼容别名/旧调用点残留。七条在动手时全部仍在仓内(无"此前 PR 已核销"项),本 PR 全部删除,净改动 7 文件 / -64 行。

| # | 符号 | 位置 | 处置 |
|---|------|------|------|
| 1 | `FastTD3Learner.soft_update()` | `src/unilab/algos/torch/fast_td3/learner.py` | 删除(`soft_update_target` 的别名) |
| 2 | `RolloutStorage.add_transitions()` | `src/unilab/algos/torch/him_ppo/storage.py` | 删除(`add_transition` 的别名) |
| 3 | `resolve_hora_ppo_wrapper_cls()` | `src/unilab/algos/torch/hora/rsl_rl.py` | 删除(调用方均用 `resolve_hora_ppo_runtime`) |
| 4 | `convert_config_v5()` | `src/unilab/algos/torch/hora/rsl_rl_compat.py` | 删除(调用方均用 `convert_config_v3_to_v4`) |
| 5 | `ExceptionWrapper.reraise()` | `src/unilab/ipc/collector_error.py` | 删除(parent 只读 `exc_type`/`exc_msg`) |
| 6 | `ensure_available()` | `src/unilab/ipc/replay_pipelines/native_h2d.py` | 删除(`is_available` 的别名) |
| 7 | `GPUResidentReplayPipeline.wait_ready()` | `src/unilab/ipc/replay_pipelines/gpu_resident.py` | 删除(空实现,无调用点) |

## Grep 证据(词边界,范围 src/ tests/ conf/ docs/ scripts/ benchmark/ .github/)

删除前每条符号全仓仅命中定义处、零调用点:

- `soft_update\b`:仅 `fast_td3/learner.py:359` 定义(其余命中均为活跃符号 `soft_update_target`,已排除)
- `add_transitions`:仅 `him_ppo/storage.py:132` 定义
- `resolve_hora_ppo_wrapper_cls`:仅 `hora/rsl_rl.py:36` 定义
- `convert_config_v5`:仅 `hora/rsl_rl_compat.py:190` 定义(`hora/appo.py`、`appo_runner.py`、`appo_worker.py`、`visualization/interactive_playback.py` 只 import `convert_config_v3_to_v4`/`is_rsl_rl_v4`/`is_rsl_rl_v5`)
- `\breraise\b`:仅 `ipc/collector_error.py:34` 定义(`tests/training/test_sim2sim_resolver.py` 的 `test_dim_guard_reraises_...` 测的是 sim2sim dim guard,与本符号无关)
- `ensure_available`:仅 `native_h2d.py:122` 定义
- `wait_ready`:仅 `gpu_resident.py:746` 定义

删除后同一命令复核:七条均 `(no matches)`。无仅服务于这些符号的测试需要清理;无 `__init__.py` re-export 涉及这些符号。

## 明确不做(边界遵守)

- 未动 `hora/appo.py`、`hora/distill.py`、`distill_config.py`、`scripts/train_hora_distill.py`(并行 PR)。
- 未动结论 3.4 零引用公共方法(#1023)与 `fast_sac/runner.py`(#1024)。

## Validation

- 定向子集:`uv run pytest tests/algos/test_fast_td3_learner.py tests/algos/test_hora_contract.py tests/algos/test_hora_imports.py tests/ipc/test_async_runner.py tests/ipc/test_replay_pipeline_gpu_resident.py tests/ipc/test_nan_guard_spawn_pickle.py -x -q` → 84 passed, 7 skipped。
- `make test-all` 在最终提交 `83606ca3` 上通过(exit 0;含 benchmark module-mode 32/33、script-mode 33/34,仅 platform-optional `mlx` 跳过)。
- `uv run ruff check` 7 个改动文件全部通过。
