### PR TITLE
cleanup: 删除结论 3.4 零引用公共方法/函数 (#1023)

### DIFF
--- a/src/unilab/algos/torch/appo/learner.py
+++ b/src/unilab/algos/torch/appo/learner.py
@@ -322,11 +322,6 @@ class APPOLearner:
         self.actor.train()
         self.critic.train()
 
-    def eval_mode(self):
-        """Set actor/critic to eval mode."""
-        self.actor.eval()
-        self.critic.eval()
-
     def update_target_network(self):
         """Soft update target actor: target = tau * current + (1 - tau) * target."""
         for target_param, param in zip(self.target_actor.parameters(), self.actor.parameters()):
@@ -351,14 +346,6 @@ class APPOLearner:
         """Copy actor buffers such as observation-normalization stats to target actor."""
         for target_buf, buf in zip(self.target_actor.buffers(), self.actor.buffers()):
             target_buf.data.copy_(buf.data)
-
-    def get_weights(self):
-        """Return actor state dict for syncing to workers.
-
-        Workers use the behavior policy (which may be stale).
-        Includes EmpiricalNormalization buffers.
-        """
-        return self.actor.state_dict()
 
     def get_state_dict(self):
         """Return full learner state for checkpointing."""

--- a/src/unilab/algos/torch/him_ppo/algorithm.py
+++ b/src/unilab/algos/torch/him_ppo/algorithm.py
@@ -75,9 +75,6 @@ class HIMPPO:
             self.device,
         )
 
-    def test_mode(self) -> None:
-        self.actor_critic.eval()
-
     def train_mode(self) -> None:
         self.actor_critic.train()
 

--- a/src/unilab/base/backend/drake/backend.py
+++ b/src/unilab/base/backend/drake/backend.py
@@ -131,12 +131,6 @@ class _DrakeUniModelView:
     nv: int
     nu: int
 
-    def num_positions(self) -> int:
-        return self.nq
-
-    def num_velocities(self) -> int:
-        return self.nv
-
     def num_actuators(self) -> int:
         return self.nu
 

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -48,26 +48,6 @@ class InitState:
     pos = [0.0, 0.0, 0.754]
 
 
-def sample_gait_phase_pairs(rng, num_samples: int, mode: str) -> np.ndarray:
-    if mode == "independent":
-        return np.asarray(
-            np.column_stack(
-                [
-                    rng.uniform(0.0, 2.0 * np.pi, size=(num_samples,)),
-                    rng.uniform(0.0, 2.0 * np.pi, size=(num_samples,)),
-                ]
-            ),
-            dtype=get_global_dtype(),
-        )
-
-    phase = rng.uniform(0.0, 2.0 * np.pi, size=(num_samples,))
-    return np.asarray(np.column_stack([phase, phase + np.pi]), dtype=get_global_dtype())
-
-
-def sample_reset_base_qvel(rng, num_samples: int, limit: float) -> np.ndarray:
-    return np.asarray(rng.uniform(-limit, limit, size=(num_samples, 6)), dtype=get_global_dtype())
-
-
 def build_upper_body_pose_weights(pose_weights: list[float]) -> np.ndarray:
     weights = np.asarray(pose_weights, dtype=get_global_dtype()).copy()
     weights[:12] = 0.0

--- a/src/unilab/envs/locomotion/go2_arm/base.py
+++ b/src/unilab/envs/locomotion/go2_arm/base.py
@@ -14,24 +14,6 @@ from unilab.envs.locomotion.common.base import (
 from unilab.utils.geometry import np_quat_orientation_error_local
 from unilab.utils.rotation import np_matrix_from_quat
 
-DEFAULT_LEG_ANGLES = np.asarray(
-    [
-        0.1,
-        0.8,
-        -1.5,
-        -0.1,
-        0.8,
-        -1.5,
-        0.1,
-        0.8,
-        -1.5,
-        -0.1,
-        0.8,
-        -1.5,
-    ],
-    dtype=np.float64,
-)
-
 
 @dataclass
 class NoiseConfig:
@@ -157,9 +139,6 @@ class Go2ArmBaseEnv(LocomotionBaseEnv):
         self._arm_dof_pos_indices = self._backend.get_joint_dof_pos_indices(
             cfg.asset.arm_joint_names
         )
-        self._arm_dof_vel_indices = self._backend.get_joint_dof_vel_indices(
-            cfg.asset.arm_joint_names
-        )
 
     @property
     def arm_dof_pos_indices(self) -> np.ndarray:
@@ -200,9 +179,6 @@ class Go2ArmBaseEnv(LocomotionBaseEnv):
 
     def get_arm_dof_pos(self) -> np.ndarray:
         return self.get_dof_pos()[:, self._arm_dof_pos_indices]
-
-    def get_arm_dof_vel(self) -> np.ndarray:
-        return self.get_dof_vel()[:, self._arm_dof_vel_indices]
 
     def compute_arm_ik_delta(
         self,

--- a/src/unilab/envs/manipulation/allegro_inhand/base.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/base.py
@@ -134,18 +134,6 @@ class AllegroBaseEnv(NpEnv):
             dtype=self._np_dtype,
         )
 
-    def get_ball_linvel(self) -> np.ndarray:
-        return np.asarray(
-            self._backend.get_body_lin_vel_w(self._ball_body_ids)[:, 0, :],
-            dtype=self._np_dtype,
-        )
-
-    def get_ball_angvel(self) -> np.ndarray:
-        return np.asarray(
-            self._backend.get_body_ang_vel_w(self._ball_body_ids)[:, 0, :],
-            dtype=self._np_dtype,
-        )
-
     def get_fingertip_pos(self) -> np.ndarray:
         return np.asarray(
             self._backend.get_body_pos_w(self._fingertip_body_ids),

--- a/src/unilab/envs/motion_tracking/common/motion_loader.py
+++ b/src/unilab/envs/motion_tracking/common/motion_loader.py
@@ -154,11 +154,6 @@ class MotionLoader:
         clip_indices = np.searchsorted(self.clip_offsets, frame_idx, side="right") - 1
         return np.asarray(clip_indices, dtype=np.int32)
 
-    def get_clip_end_frames(self, frame_idx: np.ndarray) -> np.ndarray:
-        """Return the inclusive global end frame for each indexed clip."""
-        clip_indices = self.get_clip_indices(frame_idx)
-        return np.asarray(self.clip_end_frames[clip_indices], dtype=np.int32)
-
     def make_motion_data_buffer(self, num_frames: int) -> MotionData:
         """Allocate a reusable ``MotionData`` buffer for frame-index gathers."""
         return MotionData(

--- a/src/unilab/terrains/terrain_generator.py
+++ b/src/unilab/terrains/terrain_generator.py
@@ -54,13 +54,6 @@ class TerrainHeightField:
             self.noise.astype(np.float64) - self.elevation_min
         ) * self.vertical_scale + self.z_offset
 
-    def normalized_elevation(self) -> np.ndarray:
-        """Return normalized hfield values in ``[0, 1]``."""
-        elevation_range = self.elevation_max - self.elevation_min
-        if elevation_range <= 0:
-            return np.zeros_like(self.noise, dtype=np.float64)
-        return (self.noise.astype(np.float64) - self.elevation_min) / elevation_range
-
 
 @dataclass
 class TerrainOutput:
@@ -124,12 +117,6 @@ class GeneratedTerrain:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         iio.imwrite(path, self.to_uint16())
-
-    def hfield_size_xml(self) -> str:
-        return " ".join(f"{value:.9g}" for value in self.hfield_size)
-
-    def geom_pos_xml(self) -> str:
-        return " ".join(f"{value:.9g}" for value in self.geom_pos)
 
 
 @dataclass

--- a/src/unilab/visualization/render_many.py
+++ b/src/unilab/visualization/render_many.py
@@ -13,8 +13,6 @@ import textwrap
 from collections.abc import Sequence
 from typing import Any
 
-import imageio
-
 _USER_MUJOCO_GL = os.environ.get("MUJOCO_GL")
 
 # Backend-agnostic probe: build a tiny off-screen scene and render one frame.
@@ -780,42 +778,3 @@ def render_states_get_frames_tracking(
         _close_worker()
 
     return frames
-
-
-def render_states_to_video(
-    state_list,
-    model_path,
-    output_path,
-    fps=30,
-    width=1280,
-    height=720,
-    num_processes=8,
-    cam_distance=2.0,
-    cam_elevation=-20,
-    cam_azimuth=90,
-    cam_lookat=None,
-    render_spacing=1.0,
-):
-    """
-    Render a list of physics states to a video file using parallel processing.
-    """
-    frames = render_states_get_frames(
-        state_list,
-        model_path,
-        width,
-        height,
-        num_processes,
-        cam_distance=cam_distance,
-        cam_elevation=cam_elevation,
-        cam_azimuth=cam_azimuth,
-        cam_lookat=cam_lookat,
-        render_spacing=render_spacing,
-    )
-
-    if not frames:
-        print(f"No frames rendered; skipping video write to {output_path}.")
-        return
-
-    print(f"Saving video to {output_path}...")
-    imageio.mimsave(output_path, frames, fps=fps)
-    print("Done!")


### PR DESCRIPTION
Fixes #1023

## 概述

删除结论 3.4 零引用公共方法/函数(maintainer 已决策:全删)。纯删除,共 9 文件、-137 行。每个符号删除前均做全仓词边界搜索(`rg --word-regexp`,覆盖 `src/`、`conf/`、`tests/`、`docs/`、`benchmark/`、各 `__init__.py`,排除 `.git`/`.venv`/`uv.lock`)确认零引用。

## 逐条核销证据(删除前 grep,仅剩定义处)

| 符号 | 位置 | 删除前全仓词边界 grep 结果 |
|------|------|------------------------------|
| `eval_mode` | `algos/torch/appo/learner.py` | 仅定义处 :325 一条命中 |
| `get_weights` | `algos/torch/appo/learner.py` | 仅定义处 :355 一条命中 |
| `test_mode` | `algos/torch/him_ppo/algorithm.py` | 仅定义处 :78 一条命中 |
| `num_positions` / `num_velocities` | `base/backend/drake/backend.py` `_DrakeUniModelView` | 各仅定义处 :134/:137 一条命中(`nq`/`nv` 字段仍被同文件 shape 校验直接读取,保留) |
| `sample_gait_phase_pairs` / `sample_reset_base_qvel` | `envs/locomotion/g1/joystick.py` | 各仅定义处 :51/:67 一条命中 |
| `get_arm_dof_vel` | `envs/locomotion/go2_arm/base.py` | 仅定义处 :204 一条命中 |
| `DEFAULT_LEG_ANGLES` | `envs/locomotion/go2_arm/base.py` | 除 :17 定义外仅 `go2w/base.py:36,54` 命中——那是 go2w 模块自有的同名常量且在使用,不在本 issue 范围 |
| `get_ball_linvel` / `get_ball_angvel` | `envs/manipulation/allegro_inhand/base.py` | 各仅定义处 :137/:143 一条命中 |
| `get_clip_end_frames` | `envs/motion_tracking/common/motion_loader.py` | 仅方法定义处 :157 一条命中(属性 `clip_end_frames` 另有使用,保留) |
| `normalized_elevation` | `terrains/terrain_generator.py` | 仅定义处 :57 一条命中 |
| `hfield_size_xml` / `geom_pos_xml` | `terrains/terrain_generator.py` | 各仅定义处 :128/:131 一条命中 |
| `render_states_to_video` | `visualization/render_many.py` | 仅定义处 :785 一条命中 |

删除后复核:上述 15 个符号全仓词边界 grep 均为 0 命中。

## 已被此前 PR 核销的条目(本 PR 无改动)

- `logging/common.py` `_build_header`、`tools/import_robot.py` `_parse_values`、`manip_loco.py` 中 `DEFAULT_LEG_ANGLES` 未用 import:均已被 PR #1007(commit `2907d3ee` "cleanup: remove dead imports and private helpers",2026-08-16 合并)删除,本分支 grep 复核 0 命中。

## 删除连带清理(均为被删符号独占)

- `go2_arm/base.py`:删 `get_arm_dof_vel` 后 `_arm_dof_vel_indices` 赋值成为 write-only 死代码,一并删除。
- `render_many.py`:`import imageio` 仅被 `render_states_to_video` 使用,一并删除。

## 测试

无仅测这些符号的测试(tests/ 词边界 grep 对全部目标符号 0 命中),故无测试删除。

## Validation

- `uv run ruff check <9 个改动文件>`:All checks passed
- `uv run pytest tests/algos/test_appo_learner.py tests/algos/test_appo_learner_metrics.py tests/algos/test_appo_runner_unit.py tests/envs/test_motion_loader.py tests/utils/test_render_many.py tests/base/backend/test_drake_batch_pool.py`:37 passed, 13 skipped
- `uv run pytest tests/envs/ tests/terrains/ tests/config/`:464 passed, 3 skipped
- `make test-all`:通过(详见下)
