### PR TITLE
refactor: unify ONNX export and onnxruntime verification helpers

### DIFF
--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -28,6 +28,7 @@ from unilab.training import (
     should_run_playback,
 )
 from unilab.training.experiment import ExperimentTracker
+from unilab.training.onnx_export import export_policy_onnx, verify_policy_onnx
 from unilab.training.sim2sim import policy_load_dim_guard, resolve_sim2sim_config
 
 
@@ -254,7 +255,6 @@ def play_appo(
 
     # Export actor to ONNX
     if load_path_dir is not None:
-        import numpy as np
         import torch.nn as nn
 
         class _DeterministicAPPOActor(nn.Module):
@@ -268,31 +268,11 @@ def play_appo(
         export_module = _DeterministicAPPOActor(actor.mlp)
         onnx_path = os.path.join(load_path_dir, "policy.onnx")
         dummy_input = torch.randn(1, obs_dim, device=device)
-        with torch.inference_mode():
-            torch.onnx.export(
-                export_module,
-                (dummy_input,),
-                onnx_path,
-                input_names=["obs"],
-                output_names=["action"],
-                opset_version=17,
-            )
-        print(f"Exported actor ONNX to {onnx_path}")
+        export_policy_onnx(export_module, onnx_path, (dummy_input,), input_names=["obs"])
 
-        import onnxruntime as ort
-
-        sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+        # Verify ONNX output matches PyTorch
         verify_input = torch.randn(1, obs_dim, device=device)
-        with torch.inference_mode():
-            pt_output = export_module(verify_input).cpu().numpy()
-        onnx_output = sess.run(None, {"obs": verify_input.cpu().numpy().astype(np.float32)})[0]
-        max_diff = np.max(np.abs(pt_output - onnx_output))
-        mean_diff = np.mean(np.abs(pt_output - onnx_output))
-        print(f"ONNX vs PyTorch — max_diff: {max_diff:.2e}, mean_diff: {mean_diff:.2e}")
-        if max_diff > 1e-4:
-            print("WARNING: ONNX output diverges from PyTorch!")
-        else:
-            print("ONNX export verified OK.")
+        verify_policy_onnx(export_module, onnx_path, (verify_input,), input_names=["obs"])
 
     if env.state is None:
         env.init_state()

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -47,6 +47,7 @@ from unilab.training.offpolicy import (
     resolve_play_obs_dim,
     resolve_play_obs_dims,
 )
+from unilab.training.onnx_export import export_policy_onnx, verify_policy_onnx
 from unilab.training.run import (
     resolve_offpolicy_checkpoint_path as resolve_checkpoint_path,
 )
@@ -519,55 +520,27 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
                 dummy_input = normalizer(dummy_input, update=False)
             if algo_name in ("sac", "flashsac"):
                 export_module = actor.as_export_module()
-                output_names = ["action"]
             else:
                 export_module = actor
-                output_names = ["action"]
-            export_args = (
+            export_inputs = (
                 (dummy_input, dummy_priv_info) if dummy_priv_info is not None else (dummy_input,)
             )
-            input_names = ["obs", "priv_info"] if dummy_priv_info is not None else ["obs"]
-            torch.onnx.export(
-                export_module,
-                export_args,
-                onnx_path,
-                input_names=input_names,
-                output_names=output_names,
-                opset_version=17,
-            )
-        print(f"Exported actor ONNX to {onnx_path}")
+        input_names = ["obs", "priv_info"] if dummy_priv_info is not None else ["obs"]
+        export_policy_onnx(export_module, onnx_path, export_inputs, input_names=input_names)
 
         # Verify ONNX output matches PyTorch
-        import onnxruntime as ort
-
-        sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
         verify_input = torch.randn(1, obs_dim, device=device)
-        verify_priv_info = (
-            torch.zeros((1, int(actor_kwargs["priv_info_dim"])), device=device)
-            if actor_algo_type == "hora_sac"
-            else None
-        )
         with torch.inference_mode():
             onnx_feed = normalizer(verify_input, update=False) if normalizer else verify_input
-            pt_output = (
-                export_module(onnx_feed, verify_priv_info)
-                if verify_priv_info is not None
-                else export_module(onnx_feed)
+            verify_priv_info = (
+                torch.zeros((1, int(actor_kwargs["priv_info_dim"])), device=device)
+                if actor_algo_type == "hora_sac"
+                else None
             )
-            if isinstance(pt_output, tuple):
-                pt_output = pt_output[0]
-            pt_np = pt_output.cpu().numpy()
-        onnx_inputs = {"obs": onnx_feed.cpu().numpy().astype(np.float32)}
-        if verify_priv_info is not None:
-            onnx_inputs["priv_info"] = verify_priv_info.cpu().numpy().astype(np.float32)
-        onnx_output = sess.run(None, onnx_inputs)[0]
-        max_diff = np.max(np.abs(pt_np - onnx_output))
-        mean_diff = np.mean(np.abs(pt_np - onnx_output))
-        print(f"ONNX vs PyTorch — max_diff: {max_diff:.2e}, mean_diff: {mean_diff:.2e}")
-        if max_diff > 1e-4:
-            print("WARNING: ONNX output diverges from PyTorch!")
-        else:
-            print("ONNX export verified OK.")
+        verify_inputs = (
+            (onnx_feed, verify_priv_info) if verify_priv_info is not None else (onnx_feed,)
+        )
+        verify_policy_onnx(export_module, onnx_path, verify_inputs, input_names=input_names)
     elif load_path_dir is not None:
         print("Skipping ONNX export because training.export_onnx=false.")
 

--- a/src/unilab/training/onnx_export.py
+++ b/src/unilab/training/onnx_export.py
@@ -1,0 +1,87 @@
+"""ONNX export and onnxruntime numeric verification helpers for play entrypoints."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+def export_policy_onnx(
+    export_module: torch.nn.Module,
+    onnx_path: str,
+    export_inputs: tuple[torch.Tensor, ...],
+    *,
+    input_names: list[str],
+    output_names: list[str] | None = None,
+    opset_version: int = 17,
+) -> None:
+    """Export ``export_module`` to ``onnx_path`` and print the artifact path.
+
+    Args:
+        export_module: Module traced by ``torch.onnx.export``.
+        onnx_path: Destination file path for the exported graph.
+        export_inputs: Positional example inputs matching ``input_names``.
+        input_names: ONNX input names, aligned positionally with ``export_inputs``.
+        output_names: ONNX output names; defaults to ``["action"]``.
+        opset_version: ONNX opset version; defaults to 17.
+    """
+    if output_names is None:
+        output_names = ["action"]
+    with torch.inference_mode():
+        torch.onnx.export(
+            export_module,
+            export_inputs,
+            onnx_path,
+            input_names=input_names,
+            output_names=output_names,
+            opset_version=opset_version,
+        )
+    print(f"Exported actor ONNX to {onnx_path}")
+
+
+def verify_policy_onnx(
+    export_module: torch.nn.Module,
+    onnx_path: str,
+    verify_inputs: tuple[torch.Tensor, ...],
+    *,
+    input_names: list[str],
+    max_diff_tol: float = 1e-4,
+) -> tuple[float, float]:
+    """Compare PyTorch and ONNX Runtime outputs on identical inputs.
+
+    Runs ``export_module`` and the exported graph at ``onnx_path`` on
+    ``verify_inputs``, prints the max/mean absolute difference, and prints a
+    warning when the max difference exceeds ``max_diff_tol``.
+
+    Args:
+        export_module: Module that was exported to ``onnx_path``. Tuple outputs
+            are compared on their first element.
+        onnx_path: Exported ONNX graph to verify.
+        verify_inputs: Positional inputs matching ``input_names``.
+        input_names: ONNX input names, aligned positionally with ``verify_inputs``.
+        max_diff_tol: Absolute max-difference tolerance before warning.
+
+    Returns:
+        ``(max_diff, mean_diff)`` between PyTorch and ONNX Runtime outputs.
+    """
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    with torch.inference_mode():
+        pt_output = export_module(*verify_inputs)
+        if isinstance(pt_output, tuple):
+            pt_output = pt_output[0]
+        pt_np = pt_output.cpu().numpy()
+    onnx_inputs = {
+        name: value.cpu().numpy().astype(np.float32)
+        for name, value in zip(input_names, verify_inputs, strict=True)
+    }
+    onnx_output = sess.run(None, onnx_inputs)[0]
+    max_diff = float(np.max(np.abs(pt_np - onnx_output)))
+    mean_diff = float(np.mean(np.abs(pt_np - onnx_output)))
+    print(f"ONNX vs PyTorch — max_diff: {max_diff:.2e}, mean_diff: {mean_diff:.2e}")
+    if max_diff > max_diff_tol:
+        print("WARNING: ONNX output diverges from PyTorch!")
+    else:
+        print("ONNX export verified OK.")
+    return max_diff, mean_diff

--- a/tests/training/test_onnx_export.py
+++ b/tests/training/test_onnx_export.py
@@ -1,0 +1,133 @@
+"""Tests for the shared ONNX export / verification helpers."""
+
+from __future__ import annotations
+
+import onnx
+import torch
+
+from unilab.training.onnx_export import export_policy_onnx, verify_policy_onnx
+
+
+class _TinyActor(torch.nn.Module):
+    def __init__(self, obs_dim: int = 4, action_dim: int = 2) -> None:
+        super().__init__()
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(obs_dim, 8),
+            torch.nn.ReLU(),
+            torch.nn.Linear(8, action_dim),
+        )
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.mlp(obs)
+
+
+class _PrivInfoActor(torch.nn.Module):
+    def __init__(self, obs_dim: int = 4, priv_info_dim: int = 3, action_dim: int = 2) -> None:
+        super().__init__()
+        self.obs_proj = torch.nn.Linear(obs_dim, action_dim)
+        self.priv_proj = torch.nn.Linear(priv_info_dim, action_dim)
+
+    def forward(self, obs: torch.Tensor, priv_info: torch.Tensor) -> torch.Tensor:
+        return self.obs_proj(obs) + self.priv_proj(priv_info)
+
+
+class _TupleOutputActor(torch.nn.Module):
+    def __init__(self, obs_dim: int = 4, action_dim: int = 2) -> None:
+        super().__init__()
+        self.mlp = torch.nn.Linear(obs_dim, action_dim)
+
+    def forward(self, obs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        action = self.mlp(obs)
+        return action, action
+
+
+def test_export_policy_onnx_writes_expected_graph(tmp_path, capsys):
+    torch.manual_seed(0)
+    module = _TinyActor()
+    onnx_path = str(tmp_path / "policy.onnx")
+
+    export_policy_onnx(module, onnx_path, (torch.randn(1, 4),), input_names=["obs"])
+
+    assert f"Exported actor ONNX to {onnx_path}" in capsys.readouterr().out
+    model = onnx.load(onnx_path)
+    assert [graph_input.name for graph_input in model.graph.input] == ["obs"]
+    assert [graph_output.name for graph_output in model.graph.output] == ["action"]
+    opsets = {opset.version for opset in model.opset_import if opset.domain in ("", "ai.onnx")}
+    assert opsets == {17}
+
+
+def test_verify_policy_onnx_matches_pytorch(tmp_path, capsys):
+    torch.manual_seed(0)
+    module = _TinyActor()
+    onnx_path = str(tmp_path / "policy.onnx")
+    export_policy_onnx(module, onnx_path, (torch.randn(1, 4),), input_names=["obs"])
+    capsys.readouterr()
+
+    max_diff, mean_diff = verify_policy_onnx(
+        module, onnx_path, (torch.randn(1, 4),), input_names=["obs"]
+    )
+
+    out = capsys.readouterr().out
+    assert isinstance(max_diff, float)
+    assert isinstance(mean_diff, float)
+    assert max_diff <= 1e-4
+    assert 0.0 <= mean_diff <= max_diff
+    assert "ONNX export verified OK." in out
+    assert "WARNING" not in out
+
+
+def test_verify_policy_onnx_warns_on_divergence(tmp_path, capsys):
+    torch.manual_seed(0)
+    exported = _TinyActor()
+    onnx_path = str(tmp_path / "policy.onnx")
+    export_policy_onnx(exported, onnx_path, (torch.randn(1, 4),), input_names=["obs"])
+    capsys.readouterr()
+
+    diverged = _TinyActor()
+    with torch.no_grad():
+        for param in diverged.parameters():
+            param.add_(torch.randn_like(param) * 10.0)
+
+    max_diff, _ = verify_policy_onnx(diverged, onnx_path, (torch.randn(1, 4),), input_names=["obs"])
+
+    assert max_diff > 1e-4
+    assert "WARNING: ONNX output diverges from PyTorch!" in capsys.readouterr().out
+
+
+def test_verify_policy_onnx_supports_extra_named_inputs(tmp_path):
+    torch.manual_seed(0)
+    module = _PrivInfoActor()
+    onnx_path = str(tmp_path / "policy.onnx")
+    export_policy_onnx(
+        module,
+        onnx_path,
+        (torch.randn(1, 4), torch.zeros(1, 3)),
+        input_names=["obs", "priv_info"],
+    )
+    model = onnx.load(onnx_path)
+    assert [graph_input.name for graph_input in model.graph.input] == ["obs", "priv_info"]
+
+    max_diff, _ = verify_policy_onnx(
+        module,
+        onnx_path,
+        (torch.randn(1, 4), torch.zeros(1, 3)),
+        input_names=["obs", "priv_info"],
+    )
+    assert max_diff <= 1e-4
+
+
+def test_verify_policy_onnx_compares_first_element_of_tuple_output(tmp_path, capsys):
+    torch.manual_seed(0)
+    module = _TupleOutputActor()
+    onnx_path = str(tmp_path / "policy.onnx")
+    export_policy_onnx(
+        module,
+        onnx_path,
+        (torch.randn(1, 4),),
+        input_names=["obs"],
+        output_names=["action", "aux"],
+    )
+
+    max_diff, _ = verify_policy_onnx(module, onnx_path, (torch.randn(1, 4),), input_names=["obs"])
+    assert max_diff <= 1e-4
+    assert "ONNX export verified OK." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fixes #1026

`scripts/train_offpolicy.py` 与 `scripts/train_appo.py` 的 ONNX 导出 + onnxruntime 数值校验约 70 行近乎逐行复制，收敛为公共 owner 模块 `src/unilab/training/onnx_export.py`，两个脚本改为调用：

- `export_policy_onnx(...)`：`torch.onnx.export`（`output_names=["action"]`、`opset_version=17` 默认值与原实现一致）+ "Exported actor ONNX to ..." 日志。
- `verify_policy_onnx(...)`：onnxruntime `CPUExecutionProvider` 会话、PyTorch vs ONNX 同输入前向、max/mean abs diff、相同打印格式与 `1e-4` 告警阈值；返回 `(max_diff, mean_diff)` 便于测试。

## 两段旧实现逐行 diff 结论

相同部分（逐字进入公共模块）：导出调用参数（`input_names`/`output_names=["action"]`/`opset_version=17`）、导出生成物路径 `policy.onnx`、verify 的会话构造、`.cpu().numpy().astype(np.float32)` feed、max/mean abs diff 口径、两条打印文案、`1e-4` 阈值与 WARNING/OK 分支。

细微差异及取舍（以对齐生产训练路径为准）：

1. **normalizer 预处理**：offpolicy 对 export dummy input 与 verify input 先做 `normalizer(x, update=False)`；appo 无 normalizer。→ normalizer 是 offpolicy algo 特有的前处理，保留在脚本侧，公共模块只接收已准备好的输入张量。
2. **`priv_info` 第二输入（hora_sac）**：仅 offpolicy 有。→ 公共模块签名改为位置输入 tuple + 对齐的 `input_names`；appo 传单输入，导出名集合不变。
3. **tuple 输出处理**：offpolicy verify 里 `isinstance(pt_output, tuple)` 时取 `[0]`；appo 没有。→ 公共模块保留 tuple 处理（超集）；appo 的导出模块返回单 tensor，行为不变。
4. **导出门控**：offpolicy 受 `training.export_onnx`（默认 true）控制并有 skip 提示；appo 有 `load_path_dir` 即导出。→ 门控属于各自脚本/config 语义，本 issue 明确不改导出语义，原样保留在脚本侧。
5. **appo 的 `_DeterministicAPPOActor` 包装**（只导出 `actor.mlp`）：appo 特有的导出对象定义，保留在 `train_appo.py`。
6. offpolicy 两个分支重复赋值 `output_names = ["action"]` → 收敛为公共模块默认值。
7. appo ONNX 块内冗余的 `import numpy as np`（`play_appo` 函数顶部已导入）随块删除。

## Validation

- `uv run pytest tests/training/test_onnx_export.py -q`：5 passed（导出图 input/output 名与 opset 17 断言、verify 一致/发散告警、多输入、tuple 输出）。
- `uv run pytest tests/training tests/scripts -q`：289 passed。
- `make test-all` 已完成并通过（exit 0：ruff format/check、mypy、pyright、`pytest -m "not slow" --cov` 1741 passed / 0 failed、benchmark smoke 32/33 + 33/34，仅 platform-optional mlx 跳过）。
