### PR TITLE
refactor: 收敛 env/脚本按 backend 类型的业务分支 (#1028)

### DIFF
--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -18,7 +18,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from unilab.algos.torch.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
-from unilab.base.backend import materialize_scene_visual_override
+from unilab.base.backend import RenderClosedError, materialize_scene_visual_override
 from unilab.base.run_control import RunComplete
 from unilab.ipc.dp_launcher import (
     UNILAB_DP_LOG_DIR,
@@ -352,11 +352,9 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
                     else None
                 ),
             )
-    except Exception as e:
-        if cfg.training.sim_backend == "motrix" and "RenderClosedError" in str(type(e).__name__):
-            print("Render window closed.")
-        else:
-            raise
+    except RenderClosedError:
+        # Interface-level signal: the user closed the backend render window.
+        print("Render window closed.")
     if playback_mode != "none" and num_steps is not None:
         print("Done.")
     return play_video_path

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from unilab.base.scene import SceneCfg
 
-from .base import SimBackend
+from .base import RenderClosedError, SimBackend
 
 if TYPE_CHECKING:
     from unilab.base.base import EnvCfg
@@ -24,6 +24,8 @@ def env_backend_kwargs(cfg: "EnvCfg") -> dict:
         "bench_nsteps": cfg.sim_substeps,
         "mjwarp_nconmax": cfg.mjwarp_nconmax,
         "mjwarp_njmax": cfg.mjwarp_njmax,
+        "drake_backend_mode": cfg.drake_backend_mode,
+        "drake_nthread": cfg.drake_nthread,
     }
 
 
@@ -106,8 +108,8 @@ def create_backend(
         scene: SceneCfg for either static or composed scenes.
         num_envs: Number of environments.
         sim_dt: Simulation timestep.
-        **kwargs: Additional backend options such as ``position_actuator_gains``
-            or ``motrix_max_iterations``.
+        **kwargs: Additional backend options such as ``position_actuator_gains``,
+            ``iterations``, or ``motrix_max_iterations``.
 
     Returns:
         SimBackend instance.
@@ -118,6 +120,7 @@ def create_backend(
     position_actuator_gains = kwargs.pop("position_actuator_gains", None)
     motrix_max_iterations = kwargs.pop("motrix_max_iterations", None)
     post_step_forward_sensor = kwargs.pop("post_step_forward_sensor", None)
+    iterations = kwargs.pop("iterations", None)
     chunk_size = kwargs.pop("chunk_size", None)
     adaptive_chunk_size = kwargs.pop("adaptive_chunk_size", False)
     cpu_ids = kwargs.pop("cpu_ids", None)
@@ -132,6 +135,7 @@ def create_backend(
             kwargs["position_actuator_gains"] = position_actuator_gains
         if post_step_forward_sensor is not None:
             kwargs["post_step_forward_sensor"] = post_step_forward_sensor
+        kwargs["iterations"] = iterations
         kwargs["chunk_size"] = chunk_size
         kwargs["adaptive_chunk_size"] = adaptive_chunk_size
         kwargs["cpu_ids"] = cpu_ids
@@ -148,6 +152,7 @@ def create_backend(
             key: value
             for key, value, default in (
                 ("post_step_forward_sensor", post_step_forward_sensor, None),
+                ("iterations", iterations, None),
                 ("chunk_size", chunk_size, None),
                 ("adaptive_chunk_size", adaptive_chunk_size, False),
                 ("cpu_ids", cpu_ids, None),
@@ -163,7 +168,8 @@ def create_backend(
                 stacklevel=2,
             )
         # These generic EnvCfg fields are routed only to the MuJoCo pool.
-        del post_step_forward_sensor, chunk_size, adaptive_chunk_size, cpu_ids, bench_nsteps
+        del post_step_forward_sensor, iterations, chunk_size, adaptive_chunk_size, cpu_ids
+        del bench_nsteps
         kwargs["nconmax"] = mjwarp_nconmax
         kwargs["njmax"] = mjwarp_njmax
         return cast(SimBackend, MjwarpBackend(scene, num_envs, sim_dt, **kwargs))
@@ -215,6 +221,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "SimBackend",
+    "RenderClosedError",
     "MuJoCoBackend",
     "MjwarpBackend",
     "MotrixBackend",

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -17,6 +17,16 @@ PreStepControlFn = Callable[[Any, np.ndarray], np.ndarray]
 TerrainHeightSampleFn = Callable[[np.ndarray], np.ndarray]
 
 
+class RenderClosedError(RuntimeError):
+    """Interface-level signal that the user closed the backend render window.
+
+    Backends with a native renderer translate their private window-closed
+    errors into this type at the interface boundary (``render`` /
+    ``capture_video_frame``), so play loops can catch it by type instead of
+    matching backend-private exception names.
+    """
+
+
 @dataclass(frozen=True)
 class BackendTerrainSpawnData:
     """Read-only terrain spawn metadata materialized by a backend.
@@ -439,13 +449,21 @@ class SimBackend(abc.ABC):
         raise NotImplementedError(f"{self.__class__.__name__} does not support native rendering")
 
     def render(self) -> None:
-        """Render one frame through a backend-native interactive renderer."""
+        """Render one frame through a backend-native interactive renderer.
+
+        Raises:
+            RenderClosedError: If the user closed the render window.
+        """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support native interactive rendering"
         )
 
     def capture_video_frame(self) -> np.ndarray:
-        """Capture one RGB frame through a backend-native renderer."""
+        """Capture one RGB frame through a backend-native renderer.
+
+        Raises:
+            RenderClosedError: If the user closed the render window.
+        """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support native video capture"
         )

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -25,16 +25,22 @@ from unilab.dr.types import (
 try:
     import motrixsim as mtx
     from motrixsim.render import RenderApp, RenderSettings
+    from motrixsim.render import RenderClosedError as _MotrixRenderClosedError
 
     MOTRIX_AVAILABLE = True
 except ImportError:
     MOTRIX_AVAILABLE = False
+    # No motrixsim in this process: the ``except _MotrixRenderClosedError``
+    # clauses below never match, which is correct because the renderer cannot
+    # exist without the package.
+    _MotrixRenderClosedError = ()
 
 from ..base import (
     BackendHeightScanner,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendTerrainSpawnData,
+    RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -928,12 +934,8 @@ class MotrixBackend(SimBackend):
                 record_video=should_record_video,
                 camera_kwargs=camera_kwargs,
             )
-        except Exception as e:
-            if (
-                not should_run_headless
-                and not should_record_video
-                and "RenderClosedError" in type(e).__name__
-            ):
+        except RenderClosedError:
+            if not should_run_headless and not should_record_video:
                 print("Render window closed.")
                 return None
             raise
@@ -1457,12 +1459,17 @@ class MotrixBackend(SimBackend):
         if capture:
             self._model.cameras.set_system_render_target("image", int(width), int(height))
         render_app = RenderApp(headless=headless)
-        render_app.launch(
-            self._model,
-            batch=self._num_envs,
-            render_offset=offsets,
-            render_settings=settings,
-        )
+        try:
+            render_app.launch(
+                self._model,
+                batch=self._num_envs,
+                render_offset=offsets,
+                render_settings=settings,
+            )
+        except _MotrixRenderClosedError as e:
+            # Normalize the motrixsim-private window-closed error to the
+            # interface-level signal declared on SimBackend.
+            raise RenderClosedError(str(e)) from e
         if use_configured_camera:
             render_app.system_camera.set_view(
                 camera_view.lookat,
@@ -1484,7 +1491,12 @@ class MotrixBackend(SimBackend):
         self._assert_render_context_available(headless=False, capture=False)
         assert self._render_app is not None
         self._update_tracking_camera_view()
-        self._render_app.sync(data=self._data)
+        try:
+            self._render_app.sync(data=self._data)
+        except _MotrixRenderClosedError as e:
+            # Normalize the motrixsim-private window-closed error to the
+            # interface-level signal declared on SimBackend.
+            raise RenderClosedError(str(e)) from e
 
     def capture_video_frame(self) -> np.ndarray:
         """Capture one RGB frame from Motrix's system camera."""
@@ -1495,9 +1507,14 @@ class MotrixBackend(SimBackend):
         assert self._render_app is not None
 
         self._update_tracking_camera_view()
-        task = self._render_app.system_camera.capture()
-        self._render_app.sync(data=self._data, wait=True)
-        image = task.take_image()
+        try:
+            task = self._render_app.system_camera.capture()
+            self._render_app.sync(data=self._data, wait=True)
+            image = task.take_image()
+        except _MotrixRenderClosedError as e:
+            # Normalize the motrixsim-private window-closed error to the
+            # interface-level signal declared on SimBackend.
+            raise RenderClosedError(str(e)) from e
         if image is None:
             raise RuntimeError("Motrix system camera capture did not return an image")
 

--- a/src/unilab/envs/locomotion/go1/joystick.py
+++ b/src/unilab/envs/locomotion/go1/joystick.py
@@ -103,8 +103,6 @@ class Go1WalkTask(Go1BaseEnv):
             push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         terrain_spawn_data = backend.get_terrain_spawn_data()
         if terrain_spawn_data is not None:

--- a/src/unilab/envs/locomotion/go2/footstand.py
+++ b/src/unilab/envs/locomotion/go2/footstand.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import ResetPlan, ResetRandomizationPayload
@@ -132,19 +132,24 @@ class Go2HandStandTask(Go2BaseEnv):
     def __init__(self, cfg: Go2HandStandCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:
             raise ValueError("reward_config must be provided via Hydra configuration")
+        # Footstand historically left the MuJoCo pool tuning knobs at the
+        # create_backend defaults; keep them pinned so this convergence does
+        # not silently enable adaptive chunk tuning for the task.
+        backend_kwargs: dict[str, Any] = {
+            "base_name": cfg.asset.base_name,
+            "push_body_name": cfg.domain_rand.push_body_name,
+            "add_body_sensors": bool(getattr(cfg, "add_body_sensors", False)),
+            "position_actuator_gains": {"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
+            **env_backend_kwargs(cfg),
+            "adaptive_chunk_size": False,
+            "bench_nsteps": 1,
+        }
         backend = create_backend(
             backend_type,
             cfg.scene,
             num_envs,
             cfg.sim_dt,
-            base_name=cfg.asset.base_name,
-            push_body_name=cfg.domain_rand.push_body_name,
-            add_body_sensors=bool(getattr(cfg, "add_body_sensors", False)),
-            position_actuator_gains={"kp": cfg.control_config.Kp, "kd": cfg.control_config.Kd},
-            motrix_max_iterations=cfg.motrix_max_iterations,
-            post_step_forward_sensor=cfg.post_step_forward_sensor,
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
+            **backend_kwargs,
         )
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True

--- a/src/unilab/envs/locomotion/go2/joystick.py
+++ b/src/unilab/envs/locomotion/go2/joystick.py
@@ -114,8 +114,6 @@ class Go2WalkTask(Go2BaseEnv):
             push_body_name=cfg.domain_rand.push_body_name,
             position_actuator_gains=cfg.control_config.position_gains(),
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         terrain_spawn_data = backend.get_terrain_spawn_data()
         self._terrain_surface_sample_height = (

--- a/src/unilab/envs/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/envs/locomotion/go2_arm/manip_loco.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import ResetPlan
@@ -278,23 +278,18 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
             )
 
         scene = _resolve_go2_arm_scene(cfg)
+        # Single assembly point: every entry is routed (or dropped) by
+        # create_backend/env_backend_kwargs per backend, so the env never
+        # branches on backend_type. Go2Arm's single ``iterations`` knob feeds
+        # both MuJoCo (``iterations``) and Motrix (``max_iterations``).
         backend_kwargs: dict[str, Any] = {
             "base_name": cfg.asset.base_name,
             "push_body_name": cfg.domain_rand.push_body_name,
-            "drake_backend_mode": cfg.drake_backend_mode,
-            "drake_nthread": cfg.drake_nthread,
+            "position_actuator_gains": build_go2_arm_position_gains(cfg.control_config),
+            "iterations": cfg.iterations,
+            **env_backend_kwargs(cfg),
+            "motrix_max_iterations": cfg.iterations,
         }
-        if backend_type == "motrix":
-            backend_kwargs["motrix_max_iterations"] = cfg.iterations
-        elif backend_type == "mujoco":
-            backend_kwargs["position_actuator_gains"] = build_go2_arm_position_gains(
-                cfg.control_config
-            )
-            backend_kwargs["iterations"] = cfg.iterations
-            backend_kwargs["post_step_forward_sensor"] = cfg.post_step_forward_sensor
-            backend_kwargs["chunk_size"] = cfg.chunk_size
-            backend_kwargs["adaptive_chunk_size"] = cfg.adaptive_chunk_size
-            backend_kwargs["bench_nsteps"] = cfg.sim_substeps
         backend = create_backend(
             backend_type,
             scene,

--- a/src/unilab/envs/locomotion/go2w/joystick.py
+++ b/src/unilab/envs/locomotion/go2w/joystick.py
@@ -242,8 +242,6 @@ class Go2WJoystickEnv(Go2WBaseEnv):
             base_name=cfg.asset.base_name,
             push_body_name=cfg.domain_rand.push_body_name,
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         super().__init__(cfg, backend, num_envs)
         self._np_dtype = get_global_dtype()

--- a/src/unilab/envs/manipulation/allegro_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/rotation.py
@@ -279,8 +279,6 @@ class AllegroRotationPPO(AllegroBaseEnv):
                 "actuator_ids": slice(0, 16),
             },
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         super().__init__(cfg, backend, num_envs)
         self._enable_reward_log = True

--- a/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/rotation.py
@@ -472,8 +472,6 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
             push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         super().__init__(cfg, backend, num_envs)
 

--- a/src/unilab/envs/motion_tracking/common/tracking.py
+++ b/src/unilab/envs/motion_tracking/common/tracking.py
@@ -47,8 +47,6 @@ class MotionTrackingEnv(G1BaseEnv):
             push_body_name=cfg.domain_rand.push_body_name,
             add_body_sensors=True,
             **env_backend_kwargs(cfg),
-            drake_backend_mode=cfg.drake_backend_mode,
-            drake_nthread=cfg.drake_nthread,
         )
         super().__init__(cfg, backend, num_envs)
 

--- a/tests/base/backend/test_mujoco_chunk_size_wiring.py
+++ b/tests/base/backend/test_mujoco_chunk_size_wiring.py
@@ -45,6 +45,15 @@ def test_env_backend_kwargs_maps_fields():
     assert "motrix_max_iterations" in kw
 
 
+def test_env_backend_kwargs_maps_drake_fields():
+    kw = env_backend_kwargs(EnvCfg(drake_backend_mode="batch", drake_nthread=8))
+    assert kw["drake_backend_mode"] == "batch"
+    assert kw["drake_nthread"] == 8
+    default_kw = env_backend_kwargs(EnvCfg())
+    assert default_kw["drake_backend_mode"] == "batch"
+    assert default_kw["drake_nthread"] == 0
+
+
 def _build_small_backend(**backend_kwargs):
     """Build a minimal real MuJoCoBackend.
 

--- a/tests/base/test_motrix_backend_options.py
+++ b/tests/base/test_motrix_backend_options.py
@@ -803,3 +803,100 @@ def test_create_backend_warns_when_mjwarp_ignores_non_default_mujoco_options(
     assert "post_step_forward_sensor" not in captured["kwargs"]
     assert "adaptive_chunk_size" not in captured["kwargs"]
     assert "bench_nsteps" not in captured["kwargs"]
+
+
+def test_create_backend_routes_iterations_to_mujoco(monkeypatch) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeMuJoCoBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(backend_factory, "_load_mujoco_backend", lambda: FakeMuJoCoBackend)
+
+    backend_factory.create_backend(
+        "mujoco",
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        iterations=7,
+    )
+
+    assert captured["kwargs"]["iterations"] == 7
+
+
+def test_create_backend_does_not_route_iterations_to_motrix(monkeypatch) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeMotrixBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        backend_factory,
+        "_load_motrix_backend",
+        lambda: (FakeMotrixBackend, True),
+    )
+
+    backend_factory.create_backend(
+        "motrix",
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        iterations=7,
+    )
+
+    assert "iterations" not in captured["kwargs"]
+
+
+def test_create_backend_does_not_route_iterations_to_drake(monkeypatch) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeDrakeBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(backend_factory, "_load_drake_backend", lambda: FakeDrakeBackend)
+
+    backend_factory.create_backend(
+        "drake",
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        iterations=7,
+    )
+
+    assert "iterations" not in captured["kwargs"]
+
+
+def test_create_backend_warns_when_mjwarp_ignores_iterations(monkeypatch) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeMjwarpBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(backend_factory, "_load_mjwarp_backend", lambda: FakeMjwarpBackend)
+
+    with pytest.warns(UserWarning, match="iterations=7"):
+        backend_factory.create_backend(
+            "mjwarp",
+            SceneCfg(model_file="model.xml"),
+            num_envs=1,
+            sim_dt=0.01,
+            iterations=7,
+        )
+
+    assert "iterations" not in captured["kwargs"]

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -8,6 +8,7 @@ from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import OmegaConf
 
+from unilab.base.backend import RenderClosedError
 from unilab.base.backend.motrix.backend import MotrixBackend
 from unilab.base.backend.motrix.playback import run_motrix_playback
 from unilab.base.backend.mujoco.backend import MuJoCoBackend
@@ -491,9 +492,6 @@ def test_motrix_record_play_render_plan_is_headless(tmp_path: Path):
 
 
 def test_motrix_interactive_run_playback_treats_window_close_as_done(capsys):
-    class RenderClosedError(RuntimeError):
-        pass
-
     class FakeEnv:
         cfg = type("Cfg", (), {"render_spacing": 1.0, "ctrl_dt": 0.02})()
 
@@ -521,9 +519,6 @@ def test_motrix_interactive_run_playback_treats_window_close_as_done(capsys):
 
 
 def test_motrix_record_run_playback_does_not_swallow_render_closed(tmp_path: Path):
-    class RenderClosedError(RuntimeError):
-        pass
-
     class FakeEnv:
         cfg = type("Cfg", (), {"render_spacing": 1.0, "ctrl_dt": 0.02})()
 


### PR DESCRIPTION
Fixes #1028

父 issue: #983（结论 1.4 残余）。三项逐条核销如下；接口只增不改，各 backend 实际收到的 kwargs 内容不变。

## 改动内容

### 1. `go2_arm/manip_loco.py` 按 `backend_type` 分支组装 kwargs → 统一组装路径
- env `__init__` 不再按 `backend_type` 分支：统一为单 dict 组装（`env_backend_kwargs(cfg)` + go2_arm 自有项），由 `create_backend` 负责逐 backend 路由/丢弃。
- `create_backend` 新增对 `iterations` 的收敛：顶部 pop，仅转发给 MuJoCo（mjwarp 分支将其列入 non-default warning 清单；motrix/drake 不可见）。go2_arm 的单一 `cfg.iterations` 旋钮继续同时喂 MuJoCo(`iterations`) 与 Motrix(`max_iterations`，经 `motrix_max_iterations=cfg.iterations` 显式覆盖）。
- 逐 backend 等价性（已核对 `conf/ppo/task/go2_arm_manip_loco/{mujoco,motrix}.yaml` 均未设置 `cpu_ids`/`motrix_max_iterations` 等字段）：
  - mujoco: base_name, push_body_name, position_actuator_gains, iterations, post_step_forward_sensor, chunk_size, adaptive_chunk_size, cpu_ids(None), bench_nsteps(sim_substeps) —— 与之前完全一致。
  - motrix: base_name, push_body_name, max_iterations(=cfg.iterations, None 时缺省) —— 一致。
  - drake: drake_backend_mode, nthread(=cfg.drake_nthread) —— 一致。

### 2. `scripts/train_rsl_rl.py` 异常名字符串匹配 → 接口级信号
- `SimBackend` 所在接口层新增 `RenderClosedError(RuntimeError)`（`src/unilab/base/backend/base.py`，`render`/`capture_video_frame` docstring 同步声明）。
- motrix backend 在接口边界（`init_renderer` 的 `launch`、`render`/`capture_video_frame` 的 `sync`/`capture`/`take_image`）把 motrixsim 私有 `motrixsim.render.RenderClosedError`（按真实类型 isinstance 捕获，不再按名字符串）转换为接口级 `RenderClosedError`；`run_playback` 的 interactive 吞掉语义不变（打印 "Render window closed." 并返回 None），record/headless 模式继续上抛（类型变为接口级）。
- `train_rsl_rl.py` play 入口改为 `except RenderClosedError`，不再检查 `sim_backend == "motrix"` 或异常类名字符串。

### 3. drake 专属参数并入 `env_backend_kwargs()` 收敛点
- `env_backend_kwargs()` 新增 `drake_backend_mode`/`drake_nthread` 两项。
- 删除 6 处手写透传：go1/joystick、go2/joystick、go2w/joystick、allegro_inhand/rotation、sharpa_inhand/rotation、motion_tracking/common/tracking。
- go2/footstand 改用 `env_backend_kwargs(cfg)`，并显式钉住其历史生效值 `adaptive_chunk_size=False, bench_nsteps=1`（该任务此前未传这两项，走 create_backend 默认值；钉住避免收敛顺手改变 MuJoCo pool 调参行为）。
- 行为备注：stewart/balance 此前已用 `env_backend_kwargs` 但未透传 drake 参数，其 drake owner YAML（如 `conf/offpolicy/task/sac/stewart_balance/drake.yaml` 的 `drake_nthread: 20`）此前被 env 丢弃、现在随收敛生效（`nthread` 仅为 DrakeBatch 线程数，不改物理语义；`conf/ppo/task/stewart_balance/drake.yaml` 为 0，与默认值相同）。

## 明确不做（遵循 issue 边界）
- 未动 `scripts/train_offpolicy.py`/`train_appo.py`（#1026 并行）、`scripts/deploy/`/`play_interactive.py`（#1027 并行）、`g1/joystick.py`/`go2_arm/base.py`（#1023）、`hora/`、`ipc/`。
- 未新增 backend 支持矩阵声明；未动 terrain spawn contract。

## Validation
- `make test-all` 通过（check = ruff format + ruff check + mypy + pyright；test-cov 全绿；benchmark smoke 32/33 module-mode、33/34 script-mode，跳过项均为平台可选 mlx），最终提交 22384ea7。
- 相关子集：`uv run pytest tests/envs tests/base tests/scripts tests/training -m "not slow" -q` → 764 passed, 18 skipped, 1 xfailed。
- 新增/更新测试：`test_motrix_backend_options.py` 增加 `iterations` 逐 backend 路由 4 例；`test_mujoco_chunk_size_wiring.py` 增加 drake 字段映射断言；`test_training_helpers.py` 两个 RenderClosed 用例改用接口级异常类型。