### PR TITLE
cleanup: 核销结论五残余腐化项 (#1020)

### DIFF
--- a/src/unilab/algos/torch/fast_sac/runner.py
+++ b/src/unilab/algos/torch/fast_sac/runner.py
@@ -1,11 +1,14 @@
 """FastSAC runner using unified OffPolicyRunner."""
 
+import logging
 from typing import Any
 
 from unilab.algos.torch.fast_sac.learner import FastSACLearner
 from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
 from unilab.ipc.replay_pipelines.gpu_resident import require_offpolicy_replay_device
 from unilab.utils.device import get_default_device
+
+logger = logging.getLogger(__name__)
 
 
 class FastSACRunner(DoubleBufferOffPolicyRunner):
@@ -107,10 +110,10 @@ class FastSACRunner(DoubleBufferOffPolicyRunner):
                     f"{symmetry_augmentation.batch_multiplier}, got {batch_size}"
                 )
             batch_size = batch_size // symmetry_augmentation.batch_multiplier
-            print(
-                "[FastSAC] Symmetry enabled: "
-                f"batch_size adjusted to {batch_size} "
-                f"(effective: {batch_size * symmetry_augmentation.batch_multiplier})"
+            logger.info(
+                "[FastSAC] Symmetry enabled: batch_size adjusted to %d (effective: %d)",
+                batch_size,
+                batch_size * symmetry_augmentation.batch_multiplier,
             )
 
         super().__init__(

--- a/src/unilab/algos/torch/him_ppo/runner.py
+++ b/src/unilab/algos/torch/him_ppo/runner.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from collections import deque
@@ -14,9 +15,11 @@ import torch
 from unilab.algos.torch.him_ppo.actor_critic import HIMActorCritic
 from unilab.algos.torch.him_ppo.algorithm import HIMPPO
 
+logger = logging.getLogger(__name__)
 
-class _HIMLogger:
-    """Minimal logger compatible with train_rsl_rl.py summary extraction."""
+
+class _EpisodeStatsBuffer:
+    """Rolling episode-return/length buffers for training summary extraction."""
 
     def __init__(self) -> None:
         self.rewbuffer: deque[float] = deque(maxlen=100)
@@ -42,7 +45,9 @@ class HIMOnPolicyRunner:
         self.device = device
         self.log_dir = log_dir
         self.current_learning_iteration: int = 0
-        self.logger = _HIMLogger()
+        # Keep the established ``runner.logger`` access surface used by the
+        # training entrypoint; this object only owns rolling episode stats.
+        self.logger = _EpisodeStatsBuffer()
 
         # ── Parse config ────────────────────────────────────────────────────
         cfg: dict[str, Any] = dict(train_cfg)
@@ -157,7 +162,7 @@ class HIMOnPolicyRunner:
 
             # ── Logging ──────────────────────────────────────────────────────
             elapsed = time.time() - start_time
-            self._print_iter(
+            self._log_iter(
                 it + 1,
                 tot_iter,
                 value_loss,
@@ -279,7 +284,7 @@ class HIMOnPolicyRunner:
 
     # ── Helpers ──────────────────────────────────────────────────────────────
 
-    def _print_iter(
+    def _log_iter(
         self,
         it: int,
         tot: int,
@@ -304,18 +309,21 @@ class HIMOnPolicyRunner:
         time_str = time.strftime("%H:%M:%S", time.gmtime(elapsed))
         eta = elapsed / it * (tot - it) if it > 0 else 0.0
         eta_str = time.strftime("%H:%M:%S", time.gmtime(eta))
-        print(sep)
-        print(f"{'Iteration':>40}: {it}/{tot}")
-        print(f"{'Mean value loss':>40}: {value_loss:.4f}")
-        print(f"{'Mean surrogate loss':>40}: {surrogate_loss:.4f}")
-        print(f"{'Mean estimation loss':>40}: {estimation_loss:.4f}")
-        print(f"{'Mean swap loss':>40}: {swap_loss:.4f}")
+        lines = [
+            sep,
+            f"{'Iteration':>40}: {it}/{tot}",
+            f"{'Mean value loss':>40}: {value_loss:.4f}",
+            f"{'Mean surrogate loss':>40}: {surrogate_loss:.4f}",
+            f"{'Mean estimation loss':>40}: {estimation_loss:.4f}",
+            f"{'Mean swap loss':>40}: {swap_loss:.4f}",
+        ]
         if mean_rew:
-            print(f"{'Mean episode reward':>40}: {mean_rew:.4f}")
+            lines.append(f"{'Mean episode reward':>40}: {mean_rew:.4f}")
         if mean_len:
-            print(f"{'Mean episode length':>40}: {mean_len:.1f}")
+            lines.append(f"{'Mean episode length':>40}: {mean_len:.1f}")
         for k, v in (infos.get("log") or {}).items():
-            print(f"{k:>40}: {v:.4f}")
-        print(f"{'Time elapsed':>40}: {time_str}")
-        print(f"{'ETA':>40}: {eta_str}")
-        print(sep)
+            lines.append(f"{k:>40}: {v:.4f}")
+        lines.append(f"{'Time elapsed':>40}: {time_str}")
+        lines.append(f"{'ETA':>40}: {eta_str}")
+        lines.append(sep)
+        logger.info("\n".join(lines))

--- a/src/unilab/algos/torch/hora/ppo.py
+++ b/src/unilab/algos/torch/hora/ppo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from itertools import chain
 from typing import Any, cast
@@ -15,6 +16,8 @@ from tensordict import TensorDict
 
 from unilab.algos.torch.hora.models import HoraActorModel, HoraCriticModel, HoraSharedActorCritic
 from unilab.algos.torch.rsl_rl_ppo import FinalObservationAwarePPO
+
+logger = logging.getLogger(__name__)
 
 
 class HoraPPO(FinalObservationAwarePPO):
@@ -68,7 +71,9 @@ class HoraPPO(FinalObservationAwarePPO):
         if symmetry_cfg is not None:
             use_symmetry = symmetry_cfg["use_data_augmentation"] or symmetry_cfg["use_mirror_loss"]
             if not use_symmetry:
-                print("Symmetry not used for learning. We will use it for logging instead.")
+                logger.warning(
+                    "Symmetry not used for learning. We will use it for logging instead."
+                )
             from rsl_rl.utils import resolve_callable
 
             symmetry_cfg["data_augmentation_func"] = resolve_callable(

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from collections.abc import Sequence
@@ -51,6 +52,8 @@ from ..motrix_camera import (
     tracking_camera_lookat,
 )
 from .playback import run_motrix_playback
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 DEFAULT_MOTRIX_MAX_ITERATIONS = 3
@@ -936,7 +939,7 @@ class MotrixBackend(SimBackend):
             )
         except RenderClosedError:
             if not should_run_headless and not should_record_video:
-                print("Render window closed.")
+                logger.info("Render window closed.")
                 return None
             raise
 

--- a/src/unilab/envs/locomotion/g1/__init__.py
+++ b/src/unilab/envs/locomotion/g1/__init__.py
@@ -3,7 +3,6 @@ from .joystick import (
     G1WalkEnv,
     G1WalkEnvCfg,
     G1WalkFlatCfg,
-    G1WalkLegacyRewardConfig,
     G1WalkRewardConfig,
     G1WalkRoughCfg,
 )
@@ -13,7 +12,6 @@ __all__ = [
     "G1WalkEnv",
     "G1WalkEnvCfg",
     "G1WalkFlatCfg",
-    "G1WalkLegacyRewardConfig",
     "G1WalkRewardConfig",
     "G1WalkRoughCfg",
 ]

--- a/src/unilab/envs/locomotion/g1/joystick.py
+++ b/src/unilab/envs/locomotion/g1/joystick.py
@@ -162,11 +162,6 @@ class G1RewardConfig:
 
 
 @dataclass
-class G1WalkLegacyRewardConfig(G1RewardConfig):
-    pass
-
-
-@dataclass
 class CurriculumConfig:
     enabled: bool = False
     initial_scale: float = 0.5

--- a/src/unilab/envs/manipulation/allegro_inhand/rotation.py
+++ b/src/unilab/envs/manipulation/allegro_inhand/rotation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -33,6 +34,8 @@ from unilab.utils.geometry import (
 )
 
 from .base import AllegroBaseCfg, AllegroBaseEnv
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_grasp_cache_path(cache_path: str) -> epath.Path:
@@ -92,19 +95,22 @@ def _materialize_grasp_cache(cfg: AllegroRotationPPOCfg) -> np.ndarray | None:
 
     cache_path = resolve_grasp_cache_path(cfg.grasp_cache_path)
     if not cache_path.exists():
-        print(
+        logger.warning(
             "[allegro_inhand] Grasp cache is missing; no Hugging Face download will be "
-            f"attempted. Expected local cache: {cache_path}. Generate one with "
+            "attempted. Expected local cache: %s. Generate one with "
             "`uv run train --algo ppo --task allegro_inhand_grasp --sim mujoco "
             "training.no_play=true`, or point `env.grasp_cache_path` at an existing "
-            "local cache."
+            "local cache.",
+            cache_path,
         )
         return None
 
     grasp_cache = np.load(cache_path).astype(np.float64)
-    print(
-        "[allegro_inhand] Loaded grasp cache: "
-        f"{cache_path}, shape={grasp_cache.shape}, dtype={grasp_cache.dtype}"
+    logger.info(
+        "[allegro_inhand] Loaded grasp cache: %s, shape=%s, dtype=%s",
+        cache_path,
+        grasp_cache.shape,
+        grasp_cache.dtype,
     )
     return grasp_cache
 

--- a/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/envs/manipulation/sharpa_inhand/grasp_gen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -23,6 +24,8 @@ from unilab.envs.manipulation.sharpa_inhand.rotation import (
     SharpaInhandRotationEnv,
 )
 from unilab.utils.rotation import np_quat_error_magnitude
+
+logger = logging.getLogger(__name__)
 
 
 def _default_sharpa_grasp_domain_rand() -> SharpaDomainRandConfig:
@@ -210,11 +213,11 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
         """
         return tuple(len(bucket) for bucket in self._saved_grasping_states)
 
-    def _maybe_print_grasp_progress(self, force: bool = False) -> None:
-        """Print runtime grasp-collection progress grouped by scale.
+    def _maybe_log_grasp_progress(self, force: bool = False) -> None:
+        """Log runtime grasp-collection progress grouped by scale.
 
         Args:
-            force: When True, print even if throttling would normally skip.
+            force: When True, log even if throttling would normally skip.
         """
         if self.state is None:
             return
@@ -232,10 +235,11 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
         per_scale = ", ".join(
             f"scale={float(self.scale_values[i]):g}:{count}" for i, count in enumerate(counts)
         )
-        print(
-            "[SharpaInhandRotationGrasp] "
-            f"grasp progress total={total}/{int(self._cfg.grasp_collection_target)}, "
-            f"per_scale=[{per_scale}]"
+        logger.info(
+            "[SharpaInhandRotationGrasp] grasp progress total=%d/%d, per_scale=[%s]",
+            total,
+            int(self._cfg.grasp_collection_target),
+            per_scale,
         )
         self._last_grasp_progress_step = step
         self._last_grasp_progress_counts = counts
@@ -246,13 +250,15 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
         if not self._collection_target_reached():
             return
 
-        self._maybe_print_grasp_progress(force=True)
+        self._maybe_log_grasp_progress(force=True)
         self._grasp_target_reached_notified = True
         collected = self._total_saved_grasps()
         target = int(self._cfg.grasp_collection_target)
-        print(
+        logger.info(
             "[SharpaInhandRotationGrasp] Grasp collection target reached "
-            f"(saved={collected}, configured_target={target}). Collection completed."
+            "(saved=%d, configured_target=%d). Collection completed.",
+            collected,
+            target,
         )
 
         if self.state is not None:
@@ -289,7 +295,7 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
             if len(bucket) < self._grasp_target_per_scale:
                 bucket.append(all_states[i : i + 1])
 
-        self._maybe_print_grasp_progress()
+        self._maybe_log_grasp_progress()
         if self._grasp_cache_saved:
             return
 

--- a/src/unilab/utils/tensor.py
+++ b/src/unilab/utils/tensor.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def to_torch(x, device: str | torch.device) -> torch.Tensor:
@@ -15,11 +19,23 @@ def to_torch(x, device: str | torch.device) -> torch.Tensor:
         return x.to(device)
     if isinstance(x, np.ndarray):
         return torch.from_numpy(x).to(device)
-    try:
-        if hasattr(x, "__dlpack__"):
+    if hasattr(x, "__dlpack__"):
+        try:
             return torch.from_dlpack(x).to(device)  # pyright: ignore[reportPrivateImportUsage]
-    except Exception:
-        pass
+        except (
+            AttributeError,
+            BufferError,
+            NotImplementedError,
+            TypeError,
+            ValueError,
+            RuntimeError,
+        ) as exc:
+            logger.warning(
+                "to_torch: dlpack conversion failed for %s (%s); "
+                "falling back to a float32 numpy copy",
+                type(x).__name__,
+                exc,
+            )
     arr = np.asarray(x, dtype=np.float32)
     return torch.from_numpy(arr).to(device)
 

--- a/tests/algos/test_fast_sac_symmetry_contract.py
+++ b/tests/algos/test_fast_sac_symmetry_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from typing import Any
 
@@ -57,7 +58,10 @@ class _FakeEnv:
         self.closed = True
 
 
-def test_fast_sac_runner_uses_env_owned_symmetry_contract(monkeypatch: pytest.MonkeyPatch):
+def test_fast_sac_runner_uses_env_owned_symmetry_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
     import unilab.algos.torch.fast_sac.runner as runner_module
     import unilab.algos.torch.offpolicy.double_buffer_runner as device_runner_module
     from unilab.algos.torch.fast_sac.runner import FastSACRunner
@@ -75,23 +79,25 @@ def test_fast_sac_runner_uses_env_owned_symmetry_contract(monkeypatch: pytest.Mo
         lambda value: value,
     )
 
-    runner = FastSACRunner(
-        env_name="FakeEnv",
-        device="cpu",
-        num_envs=1,
-        replay_buffer_n=8,
-        batch_size=8,
-        learning_starts=0,
-        updates_per_step=1,
-        policy_frequency=1,
-        use_symmetry=True,
-        obs_normalization=False,
-    )
+    with caplog.at_level(logging.INFO, logger="unilab.algos.torch.fast_sac.runner"):
+        runner = FastSACRunner(
+            env_name="FakeEnv",
+            device="cpu",
+            num_envs=1,
+            replay_buffer_n=8,
+            batch_size=8,
+            learning_starts=0,
+            updates_per_step=1,
+            policy_frequency=1,
+            use_symmetry=True,
+            obs_normalization=False,
+        )
 
     assert fake_env.closed is True
     assert fake_env.last_device == "cpu"
     assert runner.batch_size == 4
     assert runner.learner.symmetry is augmentation
+    assert "[FastSAC] Symmetry enabled: batch_size adjusted to 4 (effective: 8)" in caplog.text
 
 
 def test_fast_sac_runner_skips_symmetry_builder_when_disabled(monkeypatch: pytest.MonkeyPatch):

--- a/tests/algos/test_him_ppo_runner.py
+++ b/tests/algos/test_him_ppo_runner.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+
+def test_him_iteration_progress_is_one_equivalent_multiline_log_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from unilab.algos.torch.him_ppo.runner import HIMOnPolicyRunner
+
+    runner = cast(Any, HIMOnPolicyRunner.__new__(HIMOnPolicyRunner))
+    runner.logger = SimpleNamespace(
+        rewbuffer=deque([1.0, 3.0]),
+        lenbuffer=deque([10.0, 14.0]),
+    )
+
+    with caplog.at_level(logging.INFO, logger="unilab.algos.torch.him_ppo.runner"):
+        runner._log_iter(
+            it=1,
+            tot=3,
+            value_loss=0.25,
+            surrogate_loss=0.5,
+            estimation_loss=0.75,
+            swap_loss=1.0,
+            elapsed=2.0,
+            infos={"log": {"reward/feet": 1.25}},
+        )
+
+    records = [
+        record for record in caplog.records if record.name == "unilab.algos.torch.him_ppo.runner"
+    ]
+    assert len(records) == 1
+    lines = records[0].getMessage().splitlines()
+    assert lines[0] == "-" * 80
+    assert lines[-1] == "-" * 80
+    assert f"{'Iteration':>40}: 1/3" in lines
+    assert f"{'Mean episode reward':>40}: 2.0000" in lines
+    assert f"{'Mean episode length':>40}: 12.0" in lines
+    assert f"{'reward/feet':>40}: 1.2500" in lines
+    assert f"{'Time elapsed':>40}: 00:00:02" in lines
+    assert f"{'ETA':>40}: 00:00:04" in lines

--- a/tests/algos/test_hora_contract.py
+++ b/tests/algos/test_hora_contract.py
@@ -3,11 +3,39 @@ from __future__ import annotations
 import ast
 import copy
 import inspect
+import logging
 import textwrap
+from typing import Any, cast
 
 import pytest
 import torch
 from tensordict import TensorDict
+
+
+def test_hora_ppo_logs_when_symmetry_is_logging_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from unilab.algos.torch.hora.ppo import HoraPPO
+
+    actor = torch.nn.Linear(2, 2)
+    critic = torch.nn.Linear(2, 1)
+    actor.is_recurrent = False  # type: ignore[attr-defined]
+    critic.is_recurrent = False  # type: ignore[attr-defined]
+    symmetry_cfg = {
+        "use_data_augmentation": False,
+        "use_mirror_loss": False,
+        "data_augmentation_func": lambda *_args: None,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="unilab.algos.torch.hora.ppo"):
+        HoraPPO(
+            cast(Any, actor),
+            cast(Any, critic),
+            cast(Any, object()),
+            symmetry_cfg=symmetry_cfg,
+        )
+
+    assert "Symmetry not used for learning. We will use it for logging instead." in caplog.text
 
 
 def test_hora_sac_actor_shapes_and_stable_module_names() -> None:

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -968,22 +968,6 @@ class TestCrossBackend:
         mj, mx, _ = synced
         np.testing.assert_allclose(mj.get_dof_vel(), mx.get_dof_vel(), atol=self.ATOL)
 
-    # --- after step ---
-
-    # def test_base_pos_after_step(self, synced):
-    #     mj, mx, _ = synced
-    #     ctrl = np.zeros((NUM_ENVS, mj.model.nu))
-    #     mj.step(ctrl, nsteps=5)
-    #     mx.step(ctrl, nsteps=5)
-    #     np.testing.assert_allclose(mj.get_base_pos(), mx.get_base_pos(), atol=self.ATOL)
-
-    # def test_dof_pos_after_step(self, synced):
-    #     mj, mx, _ = synced
-    #     ctrl = np.zeros((NUM_ENVS, mj.model.nu))
-    #     mj.step(ctrl, nsteps=5)
-    #     mx.step(ctrl, nsteps=5)
-    #     np.testing.assert_allclose(mj.get_dof_pos(), mx.get_dof_pos(), atol=self.ATOL)
-
 
 @pytest.mark.slow
 class TestCrossBackendBodySensors:

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -8,6 +8,7 @@ Slow tests actually call registry.make() and run reset + step.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 import textwrap
@@ -85,23 +86,10 @@ def test_registry_bootstrap_and_config_imports_do_not_require_mujoco():
 
 def test_g1_walk_env_cfg_obs_groups_spec():
     """G1WalkEnv must declare obs_groups_spec with actor and critic groups."""
-    from unilab.envs.locomotion.g1.joystick import G1WalkEnvCfg, G1WalkLegacyRewardConfig
+    from unilab.envs.locomotion.g1.joystick import G1WalkEnvCfg
 
     cfg = G1WalkEnvCfg()
     assert not hasattr(cfg, "obs_config"), "obs_config should have been removed"
-
-    reward_cfg = G1WalkLegacyRewardConfig(
-        scales={"feet_phase": 1.0},
-        tracking_sigma=0.25,
-        gait_frequency=1.5,
-        feet_phase_swing_height=0.09,
-        feet_phase_tracking_sigma=0.008,
-        base_height_target=0.765,
-        min_forward_speed_for_gait_reward=0.05,
-        min_base_height=0.5,
-        max_tilt_deg=35.0,
-    )
-    assert reward_cfg.min_forward_speed_for_gait_reward == pytest.approx(0.05)
 
 
 def test_g1_walk_flat_cfg_no_obs_config():
@@ -426,8 +414,8 @@ def test_allegro_grasp_obs_groups_spec_dims():
     assert spec == {"obs": 105}
 
 
-def test_allegro_missing_grasp_cache_prints_local_generation_notice(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def test_allegro_missing_grasp_cache_logs_local_generation_notice(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     from unilab.envs.manipulation.allegro_inhand.rotation import (
         AllegroRotationPPOCfg,
@@ -440,8 +428,11 @@ def test_allegro_missing_grasp_cache_prints_local_generation_notice(
         gen_grasp=False,
     )
 
-    assert _materialize_grasp_cache(cfg) is None
-    notice = capsys.readouterr().out
+    with caplog.at_level(
+        logging.WARNING, logger="unilab.envs.manipulation.allegro_inhand.rotation"
+    ):
+        assert _materialize_grasp_cache(cfg) is None
+    notice = caplog.text
 
     assert str(missing_cache) in notice
     assert "no Hugging Face download will be attempted" in notice
@@ -1617,7 +1608,9 @@ def test_sharpa_grasp_env_initializes_dr_once_with_grasp_provider(monkeypatch):
 
 
 def test_sharpa_grasp_target_saves_cache_then_raises_run_complete(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     from unilab.base.run_control import RunComplete
     from unilab.envs.manipulation.sharpa_inhand.grasp_gen import (
@@ -1662,8 +1655,12 @@ def test_sharpa_grasp_target_saves_cache_then_raises_run_complete(
         save_once,
     )
 
-    with pytest.raises(RunComplete) as caught:
-        env._collect_successful_grasps(np.asarray([0], dtype=np.int32))
+    with caplog.at_level(
+        logging.INFO,
+        logger="unilab.envs.manipulation.sharpa_inhand.grasp_gen",
+    ):
+        with pytest.raises(RunComplete) as caught:
+            env._collect_successful_grasps(np.asarray([0], dtype=np.int32))
 
     saved_path = tmp_path / "sharpa_0.8.npy"
     saved = np.load(saved_path)
@@ -1677,6 +1674,8 @@ def test_sharpa_grasp_target_saves_cache_then_raises_run_complete(
     np.testing.assert_array_equal(saved, expected)
     assert saved.dtype == np.float32
     assert save_calls == [saved_path]
+    assert "grasp progress total=1/1, per_scale=[scale=0.8:1]" in caplog.text
+    assert "target reached (saved=1, configured_target=1)" in caplog.text
     assert env.state.info["log"]["grasp_cache/saved"] == 1.0
     assert env.state.info["log"]["grasp_cache/num_states"] == 1.0
     assert env.state.info["log"]["grasp/target_reached"] == 1.0

--- a/tests/nan_injection/proto_him_ppo_inject.py
+++ b/tests/nan_injection/proto_him_ppo_inject.py
@@ -3,11 +3,20 @@ Stage 2 prototype B: validate NaN injection on REAL HIM-PPO runner with real
 Go2ArmManipLoco env (mujoco backend). Mirrors the patches from
 proto_nan_inject.py but applied to the actual training loop.
 
-This proves the helper functions work on a real algo runner before lifting
-them into the formal pytest file.
+Promotion status (registered 2026-08, issue #1020): the originally planned
+promotion into a formal pytest module (tests/algos/test_nan_inject_rsl_rl.py)
+was NOT carried out. Final disposition instead:
+- unit-level regression coverage lives in tests/test_nan_guard.py and
+  tests/ipc/test_nan_guard_spawn_pickle.py (both in CI);
+- real-runner HIM-PPO validation was lifted into
+  tests/nan_injection/stage2_nan_inject.py (HIM-PPO x {obs, reward, ctrl}
+  cases), kept as a manual tool per tests/nan_injection/README.md
+  (deliberately out of CI).
+This prototype is retained only as a minimal single-case reference; delete it
+together with stage2/stage3 if the manual validation tooling is ever dropped.
 
 Run:
-    .venv/bin/python tests/nan_injection/proto_him_ppo_inject.py
+    uv run python tests/nan_injection/proto_him_ppo_inject.py
 """
 
 from __future__ import annotations

--- a/tests/nan_injection/proto_nan_inject.py
+++ b/tests/nan_injection/proto_nan_inject.py
@@ -5,11 +5,22 @@ instance.
 
 This script uses the existing _StubNpEnv pattern from tests/base/test_np_env.py
 to keep things minimal — no full algo runner needed for the injection mechanic
-itself. Once validated here, the same patch helpers will be lifted into
-tests/algos/test_nan_inject_rsl_rl.py with a real PPO/HIM-PPO runner.
+itself.
+
+Promotion status (registered 2026-08, issue #1020): the originally planned
+promotion into a formal pytest module (tests/algos/test_nan_inject_rsl_rl.py)
+was NOT carried out. Final disposition instead:
+- unit-level regression coverage lives in tests/test_nan_guard.py and
+  tests/ipc/test_nan_guard_spawn_pickle.py (both in CI);
+- real-runner end-to-end validation was lifted into
+  tests/nan_injection/stage2_nan_inject.py, kept as a manual tool per
+  tests/nan_injection/README.md (deliberately out of CI).
+This prototype is retained only as the minimal stub-env smoke reference for
+the inject + dump pattern; delete it together with stage2/stage3 if the
+manual validation tooling is ever dropped.
 
 Run:
-    .venv/bin/python tests/nan_injection/proto_nan_inject.py
+    uv run python tests/nan_injection/proto_nan_inject.py
 """
 
 from __future__ import annotations

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -491,7 +492,9 @@ def test_motrix_record_play_render_plan_is_headless(tmp_path: Path):
     assert plan.num_steps == 12
 
 
-def test_motrix_interactive_run_playback_treats_window_close_as_done(capsys):
+def test_motrix_interactive_run_playback_treats_window_close_as_done(
+    caplog: pytest.LogCaptureFixture,
+):
     class FakeEnv:
         cfg = type("Cfg", (), {"render_spacing": 1.0, "ctrl_dt": 0.02})()
 
@@ -504,18 +507,19 @@ def test_motrix_interactive_run_playback_treats_window_close_as_done(capsys):
     backend.render = _render
     backend.capture_video_frame = lambda: np.zeros((2, 2, 3), dtype=np.uint8)
 
-    result = backend.run_playback(
-        env=FakeEnv(),
-        initialize=lambda: 0,
-        step=lambda obs: obs + 1,
-        num_steps=None,
-        output_video=None,
-        headless=False,
-        record_video=False,
-    )
+    with caplog.at_level(logging.INFO, logger="unilab.base.backend.motrix.backend"):
+        result = backend.run_playback(
+            env=FakeEnv(),
+            initialize=lambda: 0,
+            step=lambda obs: obs + 1,
+            num_steps=None,
+            output_video=None,
+            headless=False,
+            record_video=False,
+        )
 
     assert result is None
-    assert "Render window closed." in capsys.readouterr().out
+    assert "Render window closed." in caplog.text
 
 
 def test_motrix_record_run_playback_does_not_swallow_render_closed(tmp_path: Path):

--- a/tests/utils/test_mjspec_sensor_compile.py
+++ b/tests/utils/test_mjspec_sensor_compile.py
@@ -1,7 +1,4 @@
-"""Minimal regression test for MjSpec sensor compile failure.
-
-See: https://github.com/google-deepmind/mujoco/issues/XXX
-"""
+"""Minimal regression test for MjSpec sensor compile failure."""
 
 from __future__ import annotations
 

--- a/tests/utils/test_torch_utils.py
+++ b/tests/utils/test_torch_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -61,6 +63,88 @@ class TestToTorch:
         assert isinstance(result, torch.Tensor)
         assert result.device.type == "cpu"
         np.testing.assert_array_almost_equal(result.numpy(), x.numpy())
+
+    @pytest.mark.parametrize(
+        "error_type",
+        [
+            AttributeError,
+            BufferError,
+            NotImplementedError,
+            TypeError,
+            ValueError,
+            RuntimeError,
+        ],
+    )
+    def test_dlpack_expected_failure_logs_and_falls_back(
+        self,
+        error_type: type[Exception],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class ArrayWithDLPackFallback:
+            def __dlpack__(self):
+                raise AssertionError("torch.from_dlpack should own protocol invocation")
+
+            def __array__(self, dtype=None, copy=None):
+                del copy
+                return np.asarray([1.0, 2.0], dtype=dtype)
+
+        failure = error_type("broken dlpack")
+
+        def fail_dlpack(_value):
+            raise failure
+
+        monkeypatch.setattr(torch, "from_dlpack", fail_dlpack)
+        with caplog.at_level(logging.WARNING, logger="unilab.utils.tensor"):
+            result = to_torch(ArrayWithDLPackFallback(), "cpu")
+
+        torch.testing.assert_close(result, torch.tensor([1.0, 2.0]))
+        assert result.dtype == torch.float32
+        assert "dlpack conversion failed" in caplog.text
+        assert "broken dlpack" in caplog.text
+
+    def test_partial_dlpack_protocol_uses_numpy_fallback(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class PartialDLPack:
+            def __dlpack__(self):
+                raise AssertionError("missing __dlpack_device__ must fail first")
+
+            def __array__(self, dtype=None, copy=None):
+                del copy
+                return np.asarray([1.0, 2.0], dtype=dtype)
+
+        with caplog.at_level(logging.WARNING, logger="unilab.utils.tensor"):
+            result = to_torch(PartialDLPack(), "cpu")
+
+        torch.testing.assert_close(result, torch.tensor([1.0, 2.0]))
+        assert "has no attribute '__dlpack_device__'" in caplog.text
+
+    def test_dlpack_unexpected_failure_propagates_without_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class DLPackOnly:
+            def __dlpack__(self):
+                raise AssertionError("torch.from_dlpack should own protocol invocation")
+
+            def __array__(self, dtype=None, copy=None):
+                del dtype, copy
+                raise AssertionError("unexpected errors must not enter the numpy fallback")
+
+        failure = OSError("unexpected dlpack failure")
+
+        def fail_dlpack(_value):
+            raise failure
+
+        monkeypatch.setattr(torch, "from_dlpack", fail_dlpack)
+        with pytest.raises(OSError) as caught:
+            to_torch(DLPackOnly(), "cpu")
+
+        assert caught.value is failure
+        assert not caplog.records
 
     def test_list_input(self) -> None:
         x = [1.0, 2.0, 3.0]


### PR DESCRIPTION
Fixes #1020

Parent: #983（结论 5.3–5.6，roadmap child F 收尾）。

## Summary

逐条核销 #1020 的六项残余，不新增 runner/backend/env contract：

1. `to_torch` 不再 catch-all 静默吞掉 DLPack 失败；仅对协议不可用/转换失败的窄异常记录 warning 并保持 NumPy float32 fallback，未知异常原样传播。真实 partial-DLPack（缺 `__dlpack_device__`）路径有回归测试。
2. HIM-PPO、FastSAC、HORA、Allegro、Sharpa 与 Motrix 点名的库内裸 `print` 改为模块 logger，消息内容保持等价。Motrix 保留 #1028 已建立的公共 `RenderClosedError` 精确捕获；HIM 保留既有 `runner.logger` 访问面，仅把内部误导性的 `_HIMLogger` 改名为 episode stats buffer。
3. 删除零调用的 `G1WalkLegacyRewardConfig`、re-export 及仅测试该 alias 的断言。
4. 两个 nan-injection prototype 在文件头登记真实去向：unit coverage 已在 CI，real-runner 六例保留为手动 stage2 工具；运行命令改为 `uv run python`。
5. 删除 `test_sim_backend.py` 中两段注释 step 对照代码。
6. 删除 MjSpec test 的无效 `issues/XXX` 占位链接。

`unilab.logging` 当前是 Rich/TensorBoard/W&B training telemetry lifecycle；将它实例化到 env/backend 会新增 lifecycle 与输出语义。本 PR 沿用仓库已有的 `logging.getLogger(__name__)` 模式。Hydra 支持的训练入口 root level 为 INFO，目标进度/诊断仍可见；库直接调用遵循宿主 logging 配置。

## Scope

19 files, +330/-122。Maintainer 已明确批准本 child 超过默认 15 文件限制；仍保持单一 cleanup 结果并低于 800 行预算。

## Validation

最终提交：`14227872`

- `uv run --no-sync pytest tests/algos/test_him_ppo_runner.py tests/algos/test_hora_contract.py tests/algos/test_fast_sac_symmetry_contract.py tests/utils/test_torch_utils.py tests/envs/test_env_configs.py tests/training/test_training_helpers.py tests/utils/test_mjspec_sensor_compile.py -q` → 152 passed, 1 skipped。
- `make test-all` → PASS：
  - ruff format/check PASS；
  - mypy 227 source files PASS；
  - pyright 0 errors / 0 warnings；
  - pytest coverage: 1758 passed, 24 skipped, 273 deselected, 1 xfailed；
  - benchmark smoke: module-mode 32/33、script-mode 33/34（仅 platform-optional MLX skip）。
- `git diff --cached --check` → PASS。

## Impact

- Backend impact: Motrix 仅输出通道变化；MuJoCo 数值/行为不变。
- Platform impact: Linux 本地验证；无平台专属实现。
- Training effect expected: no（日志输出、错误可见性与死代码/测试清理；无算法超参、env 数值或 lifecycle 变化）。
- Docs/artifacts: 无用户工作流变化，无 W&B/benchmark/video/checkpoint 产物。
