### PR TITLE
refactor: 下沉 off-policy 装配与 play actor owner (#1025)

### DIFF
--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -40,10 +40,11 @@ from unilab.training.offpolicy import (
     build_offpolicy_env_cfg_override as _build_offpolicy_env_cfg_override,
 )
 from unilab.training.offpolicy import (
+    build_play_actor,
     default_device,
     extract_play_obs,
     extract_reset_obs,
-    resolve_play_actor_spec,
+    load_play_actor,
     resolve_play_obs_dim,
     resolve_play_obs_dims,
 )
@@ -164,133 +165,15 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
 
     replay_device = require_offpolicy_replay_device(rank_device)
     if algo_name == "sac":
-        from unilab.algos.torch.fast_sac.learner import FastSACLearner
-        from unilab.algos.torch.offpolicy.double_buffer_runner import (
-            DoubleBufferOffPolicyRunner,
+        from unilab.algos.torch.fast_sac.double_buffer import (
+            build_sac_double_buffer_runner,
         )
-        from unilab.algos.torch.offpolicy.runtime import resolve_custom_offpolicy_runtime
-        from unilab.base.registry import ensure_registries as _ensure
 
-        _ensure()
-        _device = replay_device
-        _rl_cfg = cast(dict[str, Any], OmegaConf.to_container(cfg.algo, resolve=True))
-        _custom_runtime = resolve_custom_offpolicy_runtime(_rl_cfg)
-        _env = create_env(cfg, num_envs=1, env_cfg_override=env_cfg_override)
-        try:
-            assert _env.action_space.shape
-            from unilab.base.observations import get_obs_dims as _get_obs_dims
-
-            _obs_dim, _critic_dim = _get_obs_dims(_env.obs_groups_spec)
-            _action_dim = _env.action_space.shape[0]
-            _symmetry_aug = None
-            if (
-                _custom_runtime is not None
-                and cfg.algo.use_symmetry
-                and not _custom_runtime.supports_symmetry
-            ):
-                raise ValueError("Selected SAC off-policy runtime does not support symmetry.")
-            if cfg.algo.use_symmetry:
-                _symmetry_aug = _env.build_symmetry_augmentation(device=_device)
-                if _symmetry_aug is None:
-                    raise ValueError(
-                        f"{cfg.training.task_name} does not provide symmetry augmentation"
-                    )
-        finally:
-            _env.close()
-
-        _batch_size = cfg.algo.batch_size
-        if _symmetry_aug is not None:
-            if _batch_size % _symmetry_aug.batch_multiplier != 0:
-                raise ValueError(
-                    "Symmetry augmentation requires batch_size divisible by "
-                    f"{_symmetry_aug.batch_multiplier}, got {_batch_size}"
-                )
-            _batch_size = _batch_size // _symmetry_aug.batch_multiplier
-
-        _learner_cls = FastSACLearner
-        _algo_type = "sac"
-        _learner_extra_kwargs: dict[str, Any] = {}
-        if _custom_runtime is not None:
-            _learner_extra_kwargs = cast(
-                dict[str, Any],
-                _custom_runtime.build_model_kwargs(
-                    obs_dim=int(_obs_dim),
-                    critic_obs_dim=int(_critic_dim),
-                ),
-            )
-            if _custom_runtime.learner_cls is not None:
-                _learner_cls = _custom_runtime.learner_cls
-            if _custom_runtime.algo_type is not None:
-                _algo_type = str(_custom_runtime.algo_type)
-
-        _learner_kwargs = {
-            "obs_dim": _obs_dim,
-            "action_dim": _action_dim,
-            "gamma": cfg.algo.gamma,
-            "tau": cfg.algo.tau,
-            "actor_lr": cfg.algo.actor_lr,
-            "critic_lr": cfg.algo.critic_lr,
-            "alpha_lr": cfg.algo.algo_params.alpha_lr,
-            "alpha_init": cfg.algo.algo_params.alpha_init,
-            "target_entropy_ratio": cfg.algo.algo_params.target_entropy_ratio,
-            "actor_hidden_dim": cfg.algo.actor_hidden_dim,
-            "critic_hidden_dim": cfg.algo.critic_hidden_dim,
-            "num_atoms": cfg.algo.num_atoms,
-            "use_layer_norm": cfg.algo.use_layer_norm,
-            "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
-            "use_amp": cfg.training.use_amp,
-            "amp_dtype": cfg.algo.algo_params.amp_dtype,
-            "use_compile": cfg.algo.algo_params.use_compile,
-            "obs_normalization": cfg.algo.obs_normalization,
-            "use_cuda_graph_critic": bool(
-                getattr(cfg.algo.algo_params, "use_cuda_graph_critic", False)
-            ),
-            "use_cuda_graph_actor": bool(
-                getattr(cfg.algo.algo_params, "use_cuda_graph_actor", False)
-            ),
-            "use_cuda_graph_critic_packed_staging": bool(
-                getattr(
-                    cfg.algo.algo_params,
-                    "use_cuda_graph_critic_packed_staging",
-                    False,
-                )
-            ),
-            "use_cuda_graph_actor_packed_staging": bool(
-                getattr(
-                    cfg.algo.algo_params,
-                    "use_cuda_graph_actor_packed_staging",
-                    False,
-                )
-            ),
-            "nvtx_profile_ranges": bool(getattr(cfg.training, "nvtx_profile_ranges", False)),
-            "use_symmetry": cfg.algo.use_symmetry,
-            "symmetry_augmentation": _symmetry_aug,
-            "critic_obs_dim": _critic_dim,
-            **_learner_extra_kwargs,
-        }
-
-        _learner = _learner_cls(device=_device, **_learner_kwargs)
-        return DoubleBufferOffPolicyRunner(
-            learner=_learner,
-            env_name=cfg.training.task_name,
-            algo_type=_algo_type,
-            num_envs=cfg.algo.num_envs,
-            replay_buffer_n=cfg.algo.replay_buffer_n,
-            batch_size=_batch_size,
-            learning_starts=cfg.algo.learning_starts,
-            updates_per_step=cfg.algo.updates_per_step,
-            policy_frequency=cfg.algo.policy_frequency,
-            env_steps_per_sync=cfg.training.env_steps_per_sync,
-            device=_device,
-            obs_normalization=cfg.algo.obs_normalization,
-            sim_backend=cfg.training.sim_backend,
+        return build_sac_double_buffer_runner(
+            cfg,
             env_cfg_override=env_cfg_override,
-            trace_enabled=cfg.training.trace_enabled,
-            trace_output_dir=cfg.training.trace_output_dir,
-            trace_thread_time=cfg.training.trace_thread_time,
-            trace_cuda_events=cfg.training.trace_cuda_events,
             replay_prefetch_mode=replay_prefetch_mode,
-            seed=cfg.algo.seed,
+            device=replay_device,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
@@ -298,65 +181,15 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
         )
 
     if algo_name == "td3":
-        from unilab.algos.torch.common.device import get_env_dims
-        from unilab.algos.torch.fast_td3.learner import FastTD3Learner
-        from unilab.algos.torch.offpolicy.double_buffer_runner import (
-            DoubleBufferOffPolicyRunner,
+        from unilab.algos.torch.fast_td3.double_buffer import (
+            build_td3_double_buffer_runner,
         )
 
-        _device = replay_device
-        _obs_dim, _action_dim, _critic_dim = get_env_dims(
-            cfg.training.task_name,
-            cfg.training.sim_backend,
+        return build_td3_double_buffer_runner(
+            cfg,
             env_cfg_override=env_cfg_override,
-        )
-        _learner = FastTD3Learner(
-            obs_dim=_obs_dim,
-            action_dim=_action_dim,
-            critic_obs_dim=_critic_dim,
-            num_envs=cfg.algo.num_envs,
-            device=_device,
-            gamma=cfg.algo.gamma,
-            tau=cfg.algo.tau,
-            actor_lr=cfg.algo.actor_lr,
-            critic_lr=cfg.algo.critic_lr,
-            actor_hidden_dim=cfg.algo.actor_hidden_dim,
-            critic_hidden_dim=cfg.algo.critic_hidden_dim,
-            num_atoms=cfg.algo.num_atoms,
-            v_min=cfg.algo.algo_params.v_min,
-            v_max=cfg.algo.algo_params.v_max,
-            init_scale=cfg.algo.algo_params.init_scale,
-            log_std_min=cfg.algo.algo_params.log_std_min,
-            log_std_max=cfg.algo.algo_params.log_std_max,
-            weight_decay=cfg.algo.algo_params.weight_decay,
-            use_cdq=cfg.algo.algo_params.use_cdq,
-            policy_noise=cfg.algo.algo_params.policy_noise,
-            noise_clip=cfg.algo.algo_params.noise_clip,
-            policy_frequency=cfg.algo.policy_frequency,
-            obs_normalization=cfg.algo.obs_normalization,
-        )
-
-        return DoubleBufferOffPolicyRunner(
-            learner=_learner,
-            env_name=cfg.training.task_name,
-            algo_type="td3",
-            env_cfg_override=env_cfg_override,
-            device=_device,
-            num_envs=cfg.algo.num_envs,
-            replay_buffer_n=cfg.algo.replay_buffer_n,
-            batch_size=cfg.algo.batch_size,
-            learning_starts=cfg.algo.learning_starts,
-            updates_per_step=cfg.algo.updates_per_step,
-            policy_frequency=cfg.algo.policy_frequency,
-            env_steps_per_sync=cfg.training.env_steps_per_sync,
-            obs_normalization=cfg.algo.obs_normalization,
-            sim_backend=cfg.training.sim_backend,
-            seed=cfg.algo.seed,
-            trace_enabled=cfg.training.trace_enabled,
-            trace_output_dir=cfg.training.trace_output_dir,
-            trace_thread_time=cfg.training.trace_thread_time,
-            trace_cuda_events=cfg.training.trace_cuda_events,
             replay_prefetch_mode=replay_prefetch_mode,
+            device=replay_device,
             nan_guard_cfg=_nan_guard_cfg,
             torch_thread_runtime=torch_thread_runtime,
             collector_cpu_ids=collector_cpu_ids,
@@ -387,7 +220,6 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
     import numpy as np
     import torch
 
-    from unilab.algos.torch.common.actor_factory import build_actor
     from unilab.algos.torch.offpolicy.worker import resolve_offpolicy_actor_priv_info
 
     load_path, load_path_dir = resolve_checkpoint_path(
@@ -429,78 +261,23 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
     if action_shape is None:
         raise ValueError("env.action_space.shape must be defined")
     action_dim = int(action_shape[0])
-    actor_algo_type, actor_kwargs = resolve_play_actor_spec(
+    actor, normalizer, actor_algo_type, actor_kwargs = build_play_actor(
         algo_name,
         cfg,
         obs_dim=obs_dim,
         critic_obs_dim=critic_obs_dim,
+        action_dim=action_dim,
+        device=device,
     )
-
-    normalizer = None
-    if algo_name == "sac":
-        actor = build_actor(
-            actor_algo_type,
-            obs_dim,
-            action_dim,
-            cfg.algo.actor_hidden_dim,
-            cfg.algo.use_layer_norm,
-            device,
-            **actor_kwargs,
-        )
-    elif algo_name == "td3":
-        import torch
-
-        from unilab.algos.torch.fast_td3.learner import EmpiricalNormalization, TD3Actor
-
-        actor = TD3Actor(
-            obs_dim,
-            action_dim,
-            cfg.training.play_env_num,
-            cfg.algo.algo_params.init_scale,
-            cfg.algo.actor_hidden_dim,
-            cfg.algo.algo_params.log_std_min,
-            cfg.algo.algo_params.log_std_max,
-            torch.device(device),
-        )
-        if cfg.algo.obs_normalization:
-            normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
-    elif algo_name == "flashsac":
-        actor = build_actor(
-            "flashsac",
-            obs_dim,
-            action_dim,
-            cfg.algo.actor_hidden_dim,
-            cfg.algo.use_layer_norm,
-            device,
-            actor_num_blocks=cfg.algo.algo_params.actor_num_blocks,
-            actor_noise_zeta_mu=cfg.algo.algo_params.actor_noise_zeta_mu,
-            actor_noise_zeta_max=cfg.algo.algo_params.actor_noise_zeta_max,
-        )
-        if cfg.algo.obs_normalization:
-            from unilab.algos.torch.common.normalization import EmpiricalNormalization
-
-            normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
-    else:
-        raise ValueError(f"Unsupported algo: {algo_name}")
-
-    actor.eval()
-
     print(f"Loading model: {load_path}")
     checkpoint = torch.load(load_path, map_location=device, weights_only=True)
     with policy_load_dim_guard(env_obs_dim=obs_dim, env_action_dim=action_dim, algo_name=algo_name):
-        if algo_name in ("sac", "flashsac"):
-            actor.load_state_dict(checkpoint["actor"])
-            if normalizer and checkpoint.get("obs_normalizer"):
-                normalizer.load_state_dict(checkpoint["obs_normalizer"])
-                normalizer.eval()
-        else:
-            actor_state = {
-                k: v for k, v in checkpoint["actor"].items() if k not in ("noise_scales",)
-            }
-            actor.load_state_dict(actor_state, strict=False)
-            if normalizer and checkpoint.get("obs_normalizer"):
-                normalizer.load_state_dict(checkpoint["obs_normalizer"])
-                normalizer.eval()
+        load_play_actor(
+            algo_name,
+            actor,
+            normalizer,
+            checkpoint,
+        )
 
     # Export actor to ONNX
     if load_path_dir is not None and bool(getattr(cfg.training, "export_onnx", True)):

--- a/scripts/train_rsl_rl.py
+++ b/scripts/train_rsl_rl.py
@@ -43,6 +43,7 @@ from unilab.training import (
 )
 from unilab.training.experiment import (
     ExperimentTracker,
+    patch_rsl_rl_action_std_logging,
     patch_rsl_rl_resume_state,
     patch_rsl_rl_wandb_writer,
 )
@@ -63,22 +64,6 @@ try:
 except ImportError:
     print("Could not import rsl_rl. Please ensure it is installed.")
     sys.exit(1)
-
-
-def _patch_runner_action_std_logging(runner: Any) -> None:
-    original_log = runner.logger.log
-
-    def _safe_log(self, *args, **kwargs):
-        policy = runner.alg.get_policy()
-        dist = policy.distribution
-        if dist.std_type == "scalar":
-            std = dist.std_param
-        else:
-            std = torch.exp(dist.log_std_param)
-        kwargs["action_std"] = std.detach().clone()
-        return original_log(*args, **kwargs)
-
-    runner.logger.log = _safe_log.__get__(runner.logger, type(runner.logger))
 
 
 def _backend_adapter(cfg: DictConfig) -> BackendAdapter:
@@ -520,7 +505,7 @@ def main(cfg: DictConfig) -> None:
                             cast(Any, wrapped_env), train_cfg, log_dir=log_dir, device=device
                         ),
                     )
-                    _patch_runner_action_std_logging(runner)
+                    patch_rsl_rl_action_std_logging(runner)
 
                     if cfg.algo.load_run != "-1":
                         resume_path, _ = parse_checkpoint_path(cfg, root_dir=ROOT_DIR)

--- a/src/unilab/algos/torch/fast_sac/double_buffer.py
+++ b/src/unilab/algos/torch/fast_sac/double_buffer.py
@@ -1,0 +1,145 @@
+"""FastSAC builder for the device-authoritative replay path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from omegaconf import DictConfig, OmegaConf
+
+from unilab.algos.torch.fast_sac.learner import FastSACLearner
+from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+from unilab.algos.torch.offpolicy.runtime import resolve_custom_offpolicy_runtime
+from unilab.base.np_env import NpEnv
+from unilab.training import create_env, ensure_registries
+from unilab.utils.nan_guard import NanGuardCfg
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
+
+
+def build_sac_double_buffer_runner(
+    cfg: DictConfig,
+    *,
+    env_cfg_override: dict[str, Any] | None,
+    replay_prefetch_mode: str,
+    device: str,
+    nan_guard_cfg: NanGuardCfg | None = None,
+    torch_thread_runtime: dict[str, Any] | None = None,
+    collector_cpu_ids: list[int] | None = None,
+    dp_sync: DpParameterSync | None = None,
+) -> Any:
+    """Build SAC from its Hydra owner config without interpreting it in the entrypoint."""
+    from unilab.base.observations import get_obs_dims
+
+    ensure_registries()
+    rl_cfg = cast(dict[str, Any], OmegaConf.to_container(cfg.algo, resolve=True))
+    custom_runtime = resolve_custom_offpolicy_runtime(rl_cfg)
+
+    env = cast(NpEnv, create_env(cfg, num_envs=1, env_cfg_override=env_cfg_override))
+    try:
+        action_shape = env.action_space.shape
+        assert action_shape
+        obs_dim, critic_obs_dim = get_obs_dims(env.obs_groups_spec)
+        action_dim = int(action_shape[0])
+        symmetry_augmentation = None
+        if (
+            custom_runtime is not None
+            and cfg.algo.use_symmetry
+            and not custom_runtime.supports_symmetry
+        ):
+            raise ValueError("Selected SAC off-policy runtime does not support symmetry.")
+        if cfg.algo.use_symmetry:
+            symmetry_augmentation = env.build_symmetry_augmentation(device=device)
+            if symmetry_augmentation is None:
+                raise ValueError(f"{cfg.training.task_name} does not provide symmetry augmentation")
+    finally:
+        env.close()
+
+    batch_size = cfg.algo.batch_size
+    if symmetry_augmentation is not None:
+        if batch_size % symmetry_augmentation.batch_multiplier != 0:
+            raise ValueError(
+                "Symmetry augmentation requires batch_size divisible by "
+                f"{symmetry_augmentation.batch_multiplier}, got {batch_size}"
+            )
+        batch_size = batch_size // symmetry_augmentation.batch_multiplier
+
+    learner_cls: type[Any] = FastSACLearner
+    algo_type = "sac"
+    learner_extra_kwargs: dict[str, Any] = {}
+    if custom_runtime is not None:
+        learner_extra_kwargs = cast(
+            dict[str, Any],
+            custom_runtime.build_model_kwargs(
+                obs_dim=int(obs_dim),
+                critic_obs_dim=int(critic_obs_dim),
+            ),
+        )
+        if custom_runtime.learner_cls is not None:
+            learner_cls = custom_runtime.learner_cls
+        if custom_runtime.algo_type is not None:
+            algo_type = str(custom_runtime.algo_type)
+
+    learner_kwargs = {
+        "obs_dim": obs_dim,
+        "action_dim": action_dim,
+        "gamma": cfg.algo.gamma,
+        "tau": cfg.algo.tau,
+        "actor_lr": cfg.algo.actor_lr,
+        "critic_lr": cfg.algo.critic_lr,
+        "alpha_lr": cfg.algo.algo_params.alpha_lr,
+        "alpha_init": cfg.algo.algo_params.alpha_init,
+        "target_entropy_ratio": cfg.algo.algo_params.target_entropy_ratio,
+        "actor_hidden_dim": cfg.algo.actor_hidden_dim,
+        "critic_hidden_dim": cfg.algo.critic_hidden_dim,
+        "num_atoms": cfg.algo.num_atoms,
+        "use_layer_norm": cfg.algo.use_layer_norm,
+        "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
+        "use_amp": cfg.training.use_amp,
+        "amp_dtype": cfg.algo.algo_params.amp_dtype,
+        "use_compile": cfg.algo.algo_params.use_compile,
+        "obs_normalization": cfg.algo.obs_normalization,
+        "use_cuda_graph_critic": bool(
+            getattr(cfg.algo.algo_params, "use_cuda_graph_critic", False)
+        ),
+        "use_cuda_graph_actor": bool(getattr(cfg.algo.algo_params, "use_cuda_graph_actor", False)),
+        "use_cuda_graph_critic_packed_staging": bool(
+            getattr(cfg.algo.algo_params, "use_cuda_graph_critic_packed_staging", False)
+        ),
+        "use_cuda_graph_actor_packed_staging": bool(
+            getattr(cfg.algo.algo_params, "use_cuda_graph_actor_packed_staging", False)
+        ),
+        "nvtx_profile_ranges": bool(getattr(cfg.training, "nvtx_profile_ranges", False)),
+        "use_symmetry": cfg.algo.use_symmetry,
+        "symmetry_augmentation": symmetry_augmentation,
+        "critic_obs_dim": critic_obs_dim,
+    }
+    learner_kwargs.update(learner_extra_kwargs)
+    learner = learner_cls(device=device, **learner_kwargs)
+
+    return DoubleBufferOffPolicyRunner(
+        learner=learner,
+        env_name=cfg.training.task_name,
+        algo_type=algo_type,
+        num_envs=cfg.algo.num_envs,
+        replay_buffer_n=cfg.algo.replay_buffer_n,
+        batch_size=batch_size,
+        learning_starts=cfg.algo.learning_starts,
+        updates_per_step=cfg.algo.updates_per_step,
+        policy_frequency=cfg.algo.policy_frequency,
+        env_steps_per_sync=cfg.training.env_steps_per_sync,
+        device=device,
+        obs_normalization=cfg.algo.obs_normalization,
+        sim_backend=cfg.training.sim_backend,
+        env_cfg_override=env_cfg_override,
+        trace_enabled=cfg.training.trace_enabled,
+        trace_output_dir=cfg.training.trace_output_dir,
+        trace_thread_time=cfg.training.trace_thread_time,
+        trace_cuda_events=cfg.training.trace_cuda_events,
+        replay_prefetch_mode=replay_prefetch_mode,
+        seed=cfg.algo.seed,
+        nan_guard_cfg=nan_guard_cfg,
+        torch_thread_runtime=torch_thread_runtime,
+        collector_cpu_ids=collector_cpu_ids,
+        dp_sync=dp_sync,
+    )

--- a/src/unilab/algos/torch/fast_td3/double_buffer.py
+++ b/src/unilab/algos/torch/fast_td3/double_buffer.py
@@ -1,0 +1,86 @@
+"""FastTD3 builder for the device-authoritative replay path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from omegaconf import DictConfig
+
+from unilab.algos.torch.common.device import get_env_dims
+from unilab.algos.torch.fast_td3.learner import FastTD3Learner
+from unilab.algos.torch.offpolicy.double_buffer_runner import DoubleBufferOffPolicyRunner
+from unilab.utils.nan_guard import NanGuardCfg
+
+if TYPE_CHECKING:
+    from unilab.ipc.dp_sync import DpParameterSync
+
+
+def build_td3_double_buffer_runner(
+    cfg: DictConfig,
+    *,
+    env_cfg_override: dict[str, Any] | None,
+    replay_prefetch_mode: str,
+    device: str,
+    nan_guard_cfg: NanGuardCfg | None = None,
+    torch_thread_runtime: dict[str, Any] | None = None,
+    collector_cpu_ids: list[int] | None = None,
+    dp_sync: DpParameterSync | None = None,
+) -> Any:
+    """Build TD3 from its Hydra owner config without interpreting it in the entrypoint."""
+    obs_dim, action_dim, critic_obs_dim = get_env_dims(
+        cfg.training.task_name,
+        cfg.training.sim_backend,
+        env_cfg_override=env_cfg_override,
+    )
+    learner = FastTD3Learner(
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        critic_obs_dim=critic_obs_dim,
+        num_envs=cfg.algo.num_envs,
+        device=device,
+        gamma=cfg.algo.gamma,
+        tau=cfg.algo.tau,
+        actor_lr=cfg.algo.actor_lr,
+        critic_lr=cfg.algo.critic_lr,
+        actor_hidden_dim=cfg.algo.actor_hidden_dim,
+        critic_hidden_dim=cfg.algo.critic_hidden_dim,
+        num_atoms=cfg.algo.num_atoms,
+        v_min=cfg.algo.algo_params.v_min,
+        v_max=cfg.algo.algo_params.v_max,
+        init_scale=cfg.algo.algo_params.init_scale,
+        log_std_min=cfg.algo.algo_params.log_std_min,
+        log_std_max=cfg.algo.algo_params.log_std_max,
+        weight_decay=cfg.algo.algo_params.weight_decay,
+        use_cdq=cfg.algo.algo_params.use_cdq,
+        policy_noise=cfg.algo.algo_params.policy_noise,
+        noise_clip=cfg.algo.algo_params.noise_clip,
+        policy_frequency=cfg.algo.policy_frequency,
+        obs_normalization=cfg.algo.obs_normalization,
+    )
+
+    return DoubleBufferOffPolicyRunner(
+        learner=learner,
+        env_name=cfg.training.task_name,
+        algo_type="td3",
+        env_cfg_override=env_cfg_override,
+        device=device,
+        num_envs=cfg.algo.num_envs,
+        replay_buffer_n=cfg.algo.replay_buffer_n,
+        batch_size=cfg.algo.batch_size,
+        learning_starts=cfg.algo.learning_starts,
+        updates_per_step=cfg.algo.updates_per_step,
+        policy_frequency=cfg.algo.policy_frequency,
+        env_steps_per_sync=cfg.training.env_steps_per_sync,
+        obs_normalization=cfg.algo.obs_normalization,
+        sim_backend=cfg.training.sim_backend,
+        seed=cfg.algo.seed,
+        trace_enabled=cfg.training.trace_enabled,
+        trace_output_dir=cfg.training.trace_output_dir,
+        trace_thread_time=cfg.training.trace_thread_time,
+        trace_cuda_events=cfg.training.trace_cuda_events,
+        replay_prefetch_mode=replay_prefetch_mode,
+        nan_guard_cfg=nan_guard_cfg,
+        torch_thread_runtime=torch_thread_runtime,
+        collector_cpu_ids=collector_cpu_ids,
+        dp_sync=dp_sync,
+    )

--- a/src/unilab/training/experiment.py
+++ b/src/unilab/training/experiment.py
@@ -360,6 +360,24 @@ class ExperimentTracker:
         path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
+def patch_rsl_rl_action_std_logging(runner: Any) -> None:
+    """Attach rsl-rl action standard deviation to each logger payload."""
+    import torch
+
+    original_log = runner.logger.log
+
+    def _safe_log(self: Any, *args: Any, **kwargs: Any) -> Any:
+        distribution = runner.alg.get_policy().distribution
+        if distribution.std_type == "scalar":
+            action_std = distribution.std_param
+        else:
+            action_std = torch.exp(distribution.log_std_param)
+        kwargs["action_std"] = action_std.detach().clone()
+        return original_log(*args, **kwargs)
+
+    runner.logger.log = _safe_log.__get__(runner.logger, type(runner.logger))
+
+
 def patch_rsl_rl_wandb_writer() -> None:
     """Patch rsl-rl W&B writer so it can reuse an already-open run."""
     try:

--- a/src/unilab/training/offpolicy.py
+++ b/src/unilab/training/offpolicy.py
@@ -79,6 +79,96 @@ def resolve_play_actor_spec(
     return actor_algo_type, actor_kwargs
 
 
+def build_play_actor(
+    algo_name: str,
+    cfg: DictConfig,
+    *,
+    obs_dim: int,
+    critic_obs_dim: int,
+    action_dim: int,
+    device: str,
+) -> tuple[Any, Any | None, str, dict[str, Any]]:
+    """Build the policy actor selected by an off-policy owner config."""
+    import torch
+
+    from unilab.algos.torch.common.actor_factory import build_actor
+
+    actor_algo_type, actor_kwargs = resolve_play_actor_spec(
+        algo_name,
+        cfg,
+        obs_dim=obs_dim,
+        critic_obs_dim=critic_obs_dim,
+    )
+    normalizer = None
+    if algo_name == "sac":
+        actor = build_actor(
+            actor_algo_type,
+            obs_dim,
+            action_dim,
+            cfg.algo.actor_hidden_dim,
+            cfg.algo.use_layer_norm,
+            device,
+            **actor_kwargs,
+        )
+    elif algo_name == "td3":
+        from unilab.algos.torch.fast_td3.learner import EmpiricalNormalization, TD3Actor
+
+        actor = TD3Actor(
+            obs_dim,
+            action_dim,
+            cfg.training.play_env_num,
+            cfg.algo.algo_params.init_scale,
+            cfg.algo.actor_hidden_dim,
+            cfg.algo.algo_params.log_std_min,
+            cfg.algo.algo_params.log_std_max,
+            torch.device(device),
+        )
+        if cfg.algo.obs_normalization:
+            normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
+    elif algo_name == "flashsac":
+        actor = build_actor(
+            "flashsac",
+            obs_dim,
+            action_dim,
+            cfg.algo.actor_hidden_dim,
+            cfg.algo.use_layer_norm,
+            device,
+            actor_num_blocks=cfg.algo.algo_params.actor_num_blocks,
+            actor_noise_zeta_mu=cfg.algo.algo_params.actor_noise_zeta_mu,
+            actor_noise_zeta_max=cfg.algo.algo_params.actor_noise_zeta_max,
+        )
+        if cfg.algo.obs_normalization:
+            from unilab.algos.torch.common.normalization import EmpiricalNormalization
+
+            normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
+    else:
+        raise ValueError(f"Unsupported algo: {algo_name}")
+
+    actor.eval()
+    return actor, normalizer, actor_algo_type, actor_kwargs
+
+
+def load_play_actor(
+    algo_name: str,
+    actor: Any,
+    normalizer: Any | None,
+    checkpoint: dict[str, Any],
+) -> None:
+    """Restore an off-policy play actor and its optional observation normalizer."""
+    if algo_name in ("sac", "flashsac"):
+        actor.load_state_dict(checkpoint["actor"])
+    elif algo_name == "td3":
+        actor_state = {
+            key: value for key, value in checkpoint["actor"].items() if key not in ("noise_scales",)
+        }
+        actor.load_state_dict(actor_state, strict=False)
+    else:
+        raise ValueError(f"Unsupported algo: {algo_name}")
+    if normalizer is not None and checkpoint.get("obs_normalizer"):
+        normalizer.load_state_dict(checkpoint["obs_normalizer"])
+        normalizer.eval()
+
+
 def build_offpolicy_env_cfg_override(
     algo_name: str,
     cfg: DictConfig,

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -146,7 +146,18 @@ def test_non_cuda_training_devices_fail_before_env_materialization(
         env_calls += 1
         raise AssertionError("unsupported replay device must fail before env creation")
 
-    monkeypatch.setattr(module, "create_env", reject_env)
+    if algo == "sac":
+        import unilab.algos.torch.fast_sac.double_buffer as owner_module
+
+        monkeypatch.setattr(owner_module, "create_env", reject_env)
+    elif algo == "td3":
+        import unilab.algos.torch.fast_td3.double_buffer as owner_module
+
+        monkeypatch.setattr(owner_module, "get_env_dims", reject_env)
+    else:
+        import unilab.algos.torch.flash_sac.double_buffer as owner_module
+
+        monkeypatch.setattr(owner_module, "create_env", reject_env)
     with pytest.raises(ValueError, match="training.devices entries"):
         module.build_runner(algo, cfg)
     assert env_calls == 0
@@ -155,14 +166,13 @@ def test_non_cuda_training_devices_fail_before_env_materialization(
 def test_sac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     module = _offpolicy()
     cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=false"])
-    monkeypatch.setattr(module, "ensure_registries", lambda: None)
-    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
 
-    import unilab.algos.torch.fast_sac.learner as learner_module
-    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+    import unilab.algos.torch.fast_sac.double_buffer as owner_module
 
-    monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
-    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(owner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
 
     runner = module.build_runner("sac", cfg)
     assert isinstance(runner, _FakeRunner)
@@ -174,19 +184,173 @@ def test_sac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     assert "sync_collection" not in runner.kwargs
     assert "replay_pipeline" not in runner.kwargs
     assert "verbose_metrics" not in runner.kwargs
+    assert runner.kwargs["learner"].kwargs == {
+        "device": "cuda:0",
+        "obs_dim": 4,
+        "action_dim": 2,
+        "gamma": cfg.algo.gamma,
+        "tau": cfg.algo.tau,
+        "actor_lr": cfg.algo.actor_lr,
+        "critic_lr": cfg.algo.critic_lr,
+        "alpha_lr": cfg.algo.algo_params.alpha_lr,
+        "alpha_init": cfg.algo.algo_params.alpha_init,
+        "target_entropy_ratio": cfg.algo.algo_params.target_entropy_ratio,
+        "actor_hidden_dim": cfg.algo.actor_hidden_dim,
+        "critic_hidden_dim": cfg.algo.critic_hidden_dim,
+        "num_atoms": cfg.algo.num_atoms,
+        "use_layer_norm": cfg.algo.use_layer_norm,
+        "max_grad_norm": cfg.algo.algo_params.max_grad_norm,
+        "use_amp": cfg.training.use_amp,
+        "amp_dtype": cfg.algo.algo_params.amp_dtype,
+        "use_compile": cfg.algo.algo_params.use_compile,
+        "obs_normalization": cfg.algo.obs_normalization,
+        "use_cuda_graph_critic": cfg.algo.algo_params.use_cuda_graph_critic,
+        "use_cuda_graph_actor": cfg.algo.algo_params.use_cuda_graph_actor,
+        "use_cuda_graph_critic_packed_staging": (
+            cfg.algo.algo_params.use_cuda_graph_critic_packed_staging
+        ),
+        "use_cuda_graph_actor_packed_staging": (
+            cfg.algo.algo_params.use_cuda_graph_actor_packed_staging
+        ),
+        "nvtx_profile_ranges": cfg.training.nvtx_profile_ranges,
+        "use_symmetry": False,
+        "symmetry_augmentation": None,
+        "critic_obs_dim": 6,
+    }
+
+
+def test_sac_owner_custom_runtime_can_override_base_learner_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unilab.algos.torch.fast_sac import double_buffer as owner_module
+    from unilab.algos.torch.offpolicy.runtime import OffPolicyRuntime
+
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=false"])
+    custom_runtime = OffPolicyRuntime(
+        learner_cls=_FakeLearner,
+        algo_type="custom_sac",
+        actor_kwargs={"gamma": 0.123, "critic_obs_dim": 17},
+    )
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(
+        owner_module,
+        "resolve_custom_offpolicy_runtime",
+        lambda _cfg: custom_runtime,
+    )
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+
+    runner = owner_module.build_sac_double_buffer_runner(
+        cfg,
+        env_cfg_override={},
+        replay_prefetch_mode="one_tick",
+        device="cuda:0",
+    )
+
+    assert runner.kwargs["algo_type"] == "custom_sac"
+    assert runner.kwargs["learner"].kwargs["gamma"] == pytest.approx(0.123)
+    assert runner.kwargs["learner"].kwargs["critic_obs_dim"] == 17
+    assert runner.kwargs["learner"].kwargs["tau"] == cfg.algo.tau
+
+
+def test_sac_owner_rejects_custom_runtime_without_symmetry_support(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unilab.algos.torch.fast_sac import double_buffer as owner_module
+    from unilab.algos.torch.offpolicy.runtime import OffPolicyRuntime
+
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=true"])
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(
+        owner_module,
+        "resolve_custom_offpolicy_runtime",
+        lambda _cfg: OffPolicyRuntime(supports_symmetry=False),
+    )
+
+    with pytest.raises(ValueError, match="does not support symmetry"):
+        owner_module.build_sac_double_buffer_runner(
+            cfg,
+            env_cfg_override={},
+            replay_prefetch_mode="one_tick",
+            device="cuda:0",
+        )
+
+
+def test_sac_owner_preserves_symmetry_batch_and_learner_contract(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import unilab.algos.torch.fast_sac.double_buffer as owner_module
+
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=true"])
+    symmetry = MagicMock(batch_multiplier=4)
+
+    class SymmetricEnv(_FakeEnv):
+        def build_symmetry_augmentation(self, device=None):
+            assert device == "cuda:0"
+            return symmetry
+
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: SymmetricEnv())
+    monkeypatch.setattr(owner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+
+    runner = owner_module.build_sac_double_buffer_runner(
+        cfg,
+        env_cfg_override={},
+        replay_prefetch_mode="one_tick",
+        device="cuda:0",
+    )
+
+    assert runner.kwargs["batch_size"] == cfg.algo.batch_size // 4
+    learner_kwargs = runner.kwargs["learner"].kwargs
+    assert learner_kwargs["use_symmetry"] is True
+    assert learner_kwargs["symmetry_augmentation"] is symmetry
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "symmetry", "match"),
+    [
+        (512, None, "does not provide symmetry augmentation"),
+        (10, MagicMock(batch_multiplier=4), "batch_size divisible by 4"),
+    ],
+)
+def test_sac_owner_preserves_symmetry_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+    symmetry: MagicMock | None,
+    match: str,
+):
+    import unilab.algos.torch.fast_sac.double_buffer as owner_module
+
+    cfg = _offpolicy_cfg(["algo=sac", "algo.use_symmetry=true", f"algo.batch_size={batch_size}"])
+
+    class SymmetricEnv(_FakeEnv):
+        def build_symmetry_augmentation(self, device=None):
+            del device
+            return symmetry
+
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: SymmetricEnv())
+
+    with pytest.raises(ValueError, match=match):
+        owner_module.build_sac_double_buffer_runner(
+            cfg,
+            env_cfg_override={},
+            replay_prefetch_mode="one_tick",
+            device="cuda:0",
+        )
 
 
 def test_td3_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     module = _offpolicy()
     cfg = _offpolicy_cfg(["algo=td3"])
 
-    import unilab.algos.torch.common.device as device_module
-    import unilab.algos.torch.fast_td3.learner as learner_module
-    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+    import unilab.algos.torch.fast_td3.double_buffer as owner_module
 
-    monkeypatch.setattr(device_module, "get_env_dims", lambda *args, **kwargs: (4, 2, 6))
-    monkeypatch.setattr(learner_module, "FastTD3Learner", _FakeLearner)
-    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    monkeypatch.setattr(owner_module, "get_env_dims", lambda *args, **kwargs: (4, 2, 6))
+    monkeypatch.setattr(owner_module, "FastTD3Learner", _FakeLearner)
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
 
     runner = module.build_runner("td3", cfg)
     assert isinstance(runner, _FakeRunner)
@@ -196,6 +360,58 @@ def test_td3_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     assert "collector_infer_device" not in runner.kwargs
     assert "sync_collection" not in runner.kwargs
     assert "replay_pipeline" not in runner.kwargs
+    assert runner.kwargs["replay_prefetch_mode"] == "one_tick"
+    nan_guard_cfg = runner.kwargs["nan_guard_cfg"]
+    assert nan_guard_cfg.enabled is True
+    assert nan_guard_cfg.buffer_size == cfg.training.nan_guard.buffer_size
+    assert nan_guard_cfg.max_envs_to_dump == cfg.training.nan_guard.max_envs_to_dump
+    assert nan_guard_cfg.output_dir == cfg.training.nan_guard.output_dir
+    assert runner.kwargs["torch_thread_runtime"] is not None
+    assert runner.kwargs["collector_cpu_ids"] is None
+    assert runner.kwargs["dp_sync"] is None
+    assert runner.kwargs["learner"].kwargs == {
+        "obs_dim": 4,
+        "action_dim": 2,
+        "critic_obs_dim": 6,
+        "num_envs": cfg.algo.num_envs,
+        "device": "cuda:0",
+        "gamma": cfg.algo.gamma,
+        "tau": cfg.algo.tau,
+        "actor_lr": cfg.algo.actor_lr,
+        "critic_lr": cfg.algo.critic_lr,
+        "actor_hidden_dim": cfg.algo.actor_hidden_dim,
+        "critic_hidden_dim": cfg.algo.critic_hidden_dim,
+        "num_atoms": cfg.algo.num_atoms,
+        "v_min": cfg.algo.algo_params.v_min,
+        "v_max": cfg.algo.algo_params.v_max,
+        "init_scale": cfg.algo.algo_params.init_scale,
+        "log_std_min": cfg.algo.algo_params.log_std_min,
+        "log_std_max": cfg.algo.algo_params.log_std_max,
+        "weight_decay": cfg.algo.algo_params.weight_decay,
+        "use_cdq": cfg.algo.algo_params.use_cdq,
+        "policy_noise": cfg.algo.algo_params.policy_noise,
+        "noise_clip": cfg.algo.algo_params.noise_clip,
+        "policy_frequency": cfg.algo.policy_frequency,
+        "obs_normalization": cfg.algo.obs_normalization,
+    }
+
+    nan_guard = MagicMock()
+    thread_runtime = {"marker": "threads"}
+    dp_sync = MagicMock()
+    forwarded = owner_module.build_td3_double_buffer_runner(
+        cfg,
+        env_cfg_override={},
+        replay_prefetch_mode="one_tick",
+        device="cuda:0",
+        nan_guard_cfg=nan_guard,
+        torch_thread_runtime=thread_runtime,
+        collector_cpu_ids=[2, 3],
+        dp_sync=dp_sync,
+    )
+    assert forwarded.kwargs["nan_guard_cfg"] is nan_guard
+    assert forwarded.kwargs["torch_thread_runtime"] is thread_runtime
+    assert forwarded.kwargs["collector_cpu_ids"] == [2, 3]
+    assert forwarded.kwargs["dp_sync"] is dp_sync
 
 
 def test_flashsac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
@@ -258,15 +474,14 @@ def _build_sac_runner_with_fakes(
         probe_env_calls.append(kwargs)
         return _FakeEnv()
 
-    monkeypatch.setattr(module, "ensure_registries", lambda: None)
-    monkeypatch.setattr(module, "create_env", fake_create_env)
     monkeypatch.setattr(module.os, "cpu_count", lambda: cpu_count)
 
-    import unilab.algos.torch.fast_sac.learner as learner_module
-    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+    import unilab.algos.torch.fast_sac.double_buffer as owner_module
 
-    monkeypatch.setattr(learner_module, "FastSACLearner", _FakeLearner)
-    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", fake_create_env)
+    monkeypatch.setattr(owner_module, "FastSACLearner", _FakeLearner)
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
 
     runner = module.build_runner("sac", cfg, log_dir="/tmp/offpolicy_test_run")
     return runner, probe_env_calls

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -480,19 +480,18 @@ def _build_sac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: 
     """build_runner("sac", ...) with learner/env/runner fakes; returns runner kwargs."""
     module = _offpolicy()
     cfg = _offpolicy_cfg(overrides)
-    monkeypatch.setattr(module, "ensure_registries", lambda: None)
-    monkeypatch.setattr(module, "create_env", lambda *args, **kwargs: _FakeEnv())
     monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
 
-    import unilab.algos.torch.fast_sac.learner as learner_module
-    import unilab.algos.torch.offpolicy.double_buffer_runner as runner_module
+    import unilab.algos.torch.fast_sac.double_buffer as owner_module
 
     class _Learner:
         def __init__(self, *args, **kwargs):
             del args, kwargs
 
-    monkeypatch.setattr(learner_module, "FastSACLearner", _Learner)
-    monkeypatch.setattr(runner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
+    monkeypatch.setattr(owner_module, "ensure_registries", lambda: None)
+    monkeypatch.setattr(owner_module, "create_env", lambda *args, **kwargs: _FakeEnv())
+    monkeypatch.setattr(owner_module, "FastSACLearner", _Learner)
+    monkeypatch.setattr(owner_module, "DoubleBufferOffPolicyRunner", _FakeRunner)
     runner = module.build_runner("sac", cfg, log_dir="/tmp/dp_sync_test_run")
     return runner.kwargs
 

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -945,6 +945,47 @@ def test_build_ppo_env_cfg_override_sharpa_grasp_motrix_owner(
     assert env_cfg_override["domain_rand"]["scale_list"] == [0.8]
 
 
+@pytest.mark.parametrize("std_type", ["scalar", "vector"])
+def test_rsl_action_std_logging_patch_delegates_with_detached_clone(std_type: str):
+    import torch
+
+    from unilab.training.experiment import patch_rsl_rl_action_std_logging
+
+    captured: dict[str, Any] = {}
+    expected = torch.tensor([0.25, 0.5], requires_grad=True)
+    distribution = types.SimpleNamespace(
+        std_type=std_type,
+        std_param=expected,
+        log_std_param=torch.log(expected),
+    )
+
+    class Logger:
+        def log(self, *args, **kwargs):
+            captured["call"] = (args, kwargs)
+            return "logged"
+
+    runner = types.SimpleNamespace(
+        logger=Logger(),
+        alg=types.SimpleNamespace(
+            get_policy=lambda: types.SimpleNamespace(distribution=distribution)
+        ),
+    )
+
+    patch_rsl_rl_action_std_logging(runner)
+    result = runner.logger.log("payload", iteration=3)
+
+    assert result == "logged"
+    args, kwargs = captured["call"]
+    assert args == ("payload",)
+    assert kwargs["iteration"] == 3
+    action_std = kwargs["action_std"]
+    torch.testing.assert_close(action_std, expected)
+    assert action_std.requires_grad is False
+    assert action_std.data_ptr() != expected.data_ptr()
+    source = (_SCRIPTS_DIR / "train_rsl_rl.py").read_text(encoding="utf-8")
+    assert "def _patch_runner_action_std_logging" not in source
+
+
 def _build_rsl_lifecycle_case(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1053,7 +1094,7 @@ def _build_rsl_lifecycle_case(
     monkeypatch.setattr(mod, "normalize_ppo_train_cfg", lambda _rl_cfg: {})
     monkeypatch.setattr(mod, "patch_rsl_rl_resume_state", lambda: None)
     monkeypatch.setattr(mod, "OnPolicyRunner", FakeRunner)
-    monkeypatch.setattr(mod, "_patch_runner_action_std_logging", lambda _runner: None)
+    monkeypatch.setattr(mod, "patch_rsl_rl_action_std_logging", lambda _runner: None)
     monkeypatch.setattr(
         mod,
         "finish_rsl_rl_distributed",
@@ -1868,6 +1909,8 @@ def test_offpolicy_extract_play_obs_uses_obs_group_only():
 
 
 def test_offpolicy_play_actor_spec_uses_hora_sac_runtime():
+    from unilab.training.offpolicy import resolve_play_actor_spec
+
     cfg = _offpolicy_cfg(
         [
             "algo=sac",
@@ -1875,7 +1918,7 @@ def test_offpolicy_play_actor_spec_uses_hora_sac_runtime():
         ]
     )
 
-    actor_algo_type, actor_kwargs = _offpolicy().resolve_play_actor_spec(
+    actor_algo_type, actor_kwargs = resolve_play_actor_spec(
         "sac",
         cfg,
         obs_dim=4,
@@ -1887,17 +1930,18 @@ def test_offpolicy_play_actor_spec_uses_hora_sac_runtime():
 
 
 def test_offpolicy_play_actor_spec_keeps_standard_sac_and_flashsac():
-    mod = _offpolicy()
+    from unilab.training.offpolicy import resolve_play_actor_spec
+
     sac_cfg = _offpolicy_cfg(["algo=sac", "task=sac/g1_walk_flat/mujoco"])
     flashsac_cfg = _offpolicy_cfg(["algo=flashsac", "task=flashsac/g1_walk_flat/mujoco"])
 
-    sac_algo_type, sac_kwargs = mod.resolve_play_actor_spec(
+    sac_algo_type, sac_kwargs = resolve_play_actor_spec(
         "sac",
         sac_cfg,
         obs_dim=98,
         critic_obs_dim=101,
     )
-    flash_algo_type, flash_kwargs = mod.resolve_play_actor_spec(
+    flash_algo_type, flash_kwargs = resolve_play_actor_spec(
         "flashsac",
         flashsac_cfg,
         obs_dim=98,
@@ -1906,6 +1950,137 @@ def test_offpolicy_play_actor_spec_keeps_standard_sac_and_flashsac():
 
     assert (sac_algo_type, sac_kwargs) == ("sac", {})
     assert (flash_algo_type, flash_kwargs) == ("flashsac", {})
+
+
+def test_offpolicy_build_play_actor_preserves_flashsac_model_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import unilab.algos.torch.common.actor_factory as actor_factory
+    import unilab.algos.torch.common.normalization as normalization
+    from unilab.training.offpolicy import build_play_actor
+
+    captured: dict[str, Any] = {}
+
+    class FakeActor:
+        def eval(self):
+            captured["actor_eval"] = True
+
+    class FakeNormalizer:
+        def __init__(self, *args, **kwargs):
+            captured["normalizer_init"] = (args, kwargs)
+
+    def fake_build_actor(*args, **kwargs):
+        captured["actor_init"] = (args, kwargs)
+        return FakeActor()
+
+    monkeypatch.setattr(actor_factory, "build_actor", fake_build_actor)
+    monkeypatch.setattr(normalization, "EmpiricalNormalization", FakeNormalizer)
+    cfg = _offpolicy_cfg(["algo=flashsac", "algo.obs_normalization=true"])
+
+    actor, normalizer, actor_algo_type, actor_kwargs = build_play_actor(
+        "flashsac",
+        cfg,
+        obs_dim=98,
+        critic_obs_dim=101,
+        action_dim=12,
+        device="cpu",
+    )
+
+    assert isinstance(actor, FakeActor)
+    assert isinstance(normalizer, FakeNormalizer)
+    assert (actor_algo_type, actor_kwargs) == ("flashsac", {})
+    args, kwargs = captured["actor_init"]
+    assert args == (
+        "flashsac",
+        98,
+        12,
+        cfg.algo.actor_hidden_dim,
+        cfg.algo.use_layer_norm,
+        "cpu",
+    )
+    assert kwargs == {
+        "actor_num_blocks": cfg.algo.algo_params.actor_num_blocks,
+        "actor_noise_zeta_mu": cfg.algo.algo_params.actor_noise_zeta_mu,
+        "actor_noise_zeta_max": cfg.algo.algo_params.actor_noise_zeta_max,
+    }
+    assert captured["normalizer_init"] == ((), {"shape": 98, "device": "cpu"})
+    assert captured["actor_eval"] is True
+
+
+def test_offpolicy_build_play_actor_restores_td3_state_and_normalizer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import torch
+
+    import unilab.algos.torch.fast_td3.learner as learner_module
+    from unilab.training.offpolicy import build_play_actor, load_play_actor
+
+    captured: dict[str, Any] = {}
+
+    class FakeActor:
+        def __init__(self, *args, **kwargs):
+            captured["actor_init"] = (args, kwargs)
+
+        def eval(self):
+            captured["actor_eval"] = True
+
+        def load_state_dict(self, state_dict, strict=True):
+            captured["actor_load"] = (state_dict, strict)
+
+    class FakeNormalizer:
+        def __init__(self, *args, **kwargs):
+            captured["normalizer_init"] = (args, kwargs)
+
+        def load_state_dict(self, state_dict):
+            captured["normalizer_load"] = state_dict
+
+        def eval(self):
+            captured["normalizer_eval"] = True
+
+    monkeypatch.setattr(learner_module, "TD3Actor", FakeActor)
+    monkeypatch.setattr(learner_module, "EmpiricalNormalization", FakeNormalizer)
+    cfg = _offpolicy_cfg(["algo=td3"])
+    actor_state = {"weight": torch.ones(1), "noise_scales": torch.zeros(1)}
+    normalizer_state = {"mean": torch.ones(1)}
+
+    actor, normalizer, actor_algo_type, actor_kwargs = build_play_actor(
+        "td3",
+        cfg,
+        obs_dim=4,
+        critic_obs_dim=6,
+        action_dim=2,
+        device="cpu",
+    )
+    load_play_actor(
+        "td3",
+        actor,
+        normalizer,
+        {"actor": actor_state, "obs_normalizer": normalizer_state},
+    )
+
+    assert isinstance(actor, FakeActor)
+    assert isinstance(normalizer, FakeNormalizer)
+    assert (actor_algo_type, actor_kwargs) == ("td3", {})
+    assert captured["actor_load"] == ({"weight": actor_state["weight"]}, False)
+    assert captured["actor_eval"] is True
+    assert captured["normalizer_load"] == normalizer_state
+    assert captured["normalizer_eval"] is True
+
+
+@pytest.mark.parametrize("algo_name", ["sac", "flashsac"])
+def test_offpolicy_load_play_actor_keeps_sac_state_dict_strict(algo_name: str):
+    from unilab.training.offpolicy import load_play_actor
+
+    captured: dict[str, Any] = {}
+
+    class FakeActor:
+        def load_state_dict(self, state_dict):
+            captured["state_dict"] = state_dict
+
+    actor_state = {"weight": object()}
+    load_play_actor(algo_name, FakeActor(), None, {"actor": actor_state})
+
+    assert captured["state_dict"] is actor_state
 
 
 def test_play_offpolicy_can_skip_onnx_export_and_still_record_video(


### PR DESCRIPTION
Fixes #1025

Parent: #983（结论 2.3）。

## Summary

将 `scripts/train_offpolicy.py` 中的长期业务规则移回 owner 层，保持现有训练与 playback 行为等价：

1. 新增 `fast_sac/double_buffer.py` 与 `fast_td3/double_buffer.py` owner builder；SAC/TD3 learner 30+ kwargs、探针 env 维度解析、symmetry 校验/批量缩放及 runner 装配不再滞留脚本。
2. SAC custom runtime 仍可在基础 kwargs 之后覆盖同名项，并保留 custom learner class / algo type；DP sync、thread runtime、collector CPU、nan guard、trace 与 replay prefetch 参数完整透传。
3. `training/offpolicy.py` 统一拥有 play actor 的构造与 checkpoint 恢复：
   - SAC/FlashSAC 保持 strict load；
   - TD3 继续过滤 `noise_scales` 并 `strict=False`；
   - observation normalizer 与 HORA privileged-info actor kwargs 保持不变；
   - actor 构造仍在 `policy_load_dim_guard` 外，checkpoint load 仍在 guard 内。
4. RSL-RL action-std logging patch 从 `train_rsl_rl.py` 下沉到 `training/experiment.py`；scalar/vector 分支、detach+clone 与原 logger 委托语义不变。
5. 脚本仅保留 Hydra/DP/device/thread/nan/replay 公共装配与 owner dispatch。

## Non-goals

- 未改任何算法超参或配置默认值。
- 未改 ONNX 导出（#1026 已独立完成）。
- 未改 HORA、visualization、env/backend contract 或 runner/IPC lifecycle。

## Scope

9 files, +782/-292，净 +490 行；Maintainer 已批准该 Standard scope，仍在 issue 的 ≤500 净手写/迁移预算内。

## Validation

最终提交：`433e7a7e`

- `uv run pytest tests/algos/test_offpolicy_double_buffer_runner.py tests/algos/test_offpolicy_dp_sync.py tests/scripts/test_train_scripts.py tests/integration/test_reward_injection_integration.py -q` → 215 passed。
- 独立审查稳定版定向组合 → 221 passed。
- `make test-all` → PASS：
  - ruff format/check PASS；
  - mypy 229 source files PASS；
  - pyright 0 errors / 0 warnings；
  - pytest coverage: 1759 passed, 24 skipped, 273 deselected, 1 xfailed；
  - benchmark smoke 两种模式通过（各仅 platform-optional MLX skip）。
- `git diff --check` → PASS。

新增/增强的风险边界测试逐项锁定 SAC/TD3 learner kwargs、runner/DP/thread/collector/nan 透传、custom runtime override、symmetry 行为、SAC/FlashSAC/TD3/HORA actor 构造与加载，以及 RSL action-std patch。

## Impact

- Backend impact: none。
- Platform impact: Linux 本地验证；无平台专属实现。
- Training effect expected: no（owner 搬迁，装配数值与 lifecycle 不变）。
- Docs/artifacts: 无用户工作流变化，无 W&B/benchmark/video/checkpoint 产物。
