### PR TITLE
feat(managers): port manager core to NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
+    "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
     "torch==2.7.0 ; sys_platform != 'linux' or platform_machine != 'aarch64'",
     "gymnasium",

--- a/src/unilab/managers/__init__.py
+++ b/src/unilab/managers/__init__.py
@@ -1,0 +1,40 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/__init__.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Environment managers."""
+
+from unilab.managers.action_manager import ActionManager as ActionManager
+from unilab.managers.action_manager import ActionTerm as ActionTerm
+from unilab.managers.action_manager import ActionTermCfg as ActionTermCfg
+from unilab.managers.command_manager import CommandManager as CommandManager
+from unilab.managers.command_manager import CommandTerm as CommandTerm
+from unilab.managers.command_manager import CommandTermCfg as CommandTermCfg
+from unilab.managers.command_manager import NullCommandManager as NullCommandManager
+from unilab.managers.curriculum_manager import CurriculumManager as CurriculumManager
+from unilab.managers.curriculum_manager import CurriculumTermCfg as CurriculumTermCfg
+from unilab.managers.curriculum_manager import (
+    NullCurriculumManager as NullCurriculumManager,
+)
+from unilab.managers.event_manager import EventManager as EventManager
+from unilab.managers.event_manager import EventMode as EventMode
+from unilab.managers.event_manager import EventTermCfg as EventTermCfg
+from unilab.managers.manager_base import ManagerBase as ManagerBase
+from unilab.managers.manager_base import ManagerTermBase as ManagerTermBase
+from unilab.managers.manager_base import ManagerTermBaseCfg as ManagerTermBaseCfg
+from unilab.managers.metrics_manager import MetricsManager as MetricsManager
+from unilab.managers.metrics_manager import MetricsTermCfg as MetricsTermCfg
+from unilab.managers.metrics_manager import NullMetricsManager as NullMetricsManager
+from unilab.managers.observation_manager import (
+    ObservationGroupCfg as ObservationGroupCfg,
+)
+from unilab.managers.observation_manager import ObservationManager as ObservationManager
+from unilab.managers.observation_manager import ObservationTermCfg as ObservationTermCfg
+from unilab.managers.recorder_manager import NullRecorderManager as NullRecorderManager
+from unilab.managers.recorder_manager import RecorderManager as RecorderManager
+from unilab.managers.recorder_manager import RecorderTerm as RecorderTerm
+from unilab.managers.recorder_manager import RecorderTermCfg as RecorderTermCfg
+from unilab.managers.reward_manager import RewardManager as RewardManager
+from unilab.managers.reward_manager import RewardTermCfg as RewardTermCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg as SceneEntityCfg
+from unilab.managers.termination_manager import TerminationManager as TerminationManager
+from unilab.managers.termination_manager import TerminationTermCfg as TerminationTermCfg

--- a/src/unilab/managers/_buffers/__init__.py
+++ b/src/unilab/managers/_buffers/__init__.py
@@ -1,0 +1,7 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/buffers/__init__.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Buffer utilities."""
+
+from unilab.managers._buffers.circular_buffer import CircularBuffer as CircularBuffer
+from unilab.managers._buffers.delay_buffer import DelayBuffer as DelayBuffer

--- a/src/unilab/managers/_buffers/circular_buffer.py
+++ b/src/unilab/managers/_buffers/circular_buffer.py
@@ -1,0 +1,258 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/buffers/circular_buffer.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Circular buffer for storing a history of batched tensor data.
+
+Understanding Dimensions
+========================
+
+Internal storage shape: (max_len, batch_size, ...)
+                         ↑         ↑
+                         time      environments
+                         axis      axis
+
+External view (buffer property): (batch_size, max_len, ...)
+                                  ↑           ↑
+                                  environments time
+                                  axis        axis
+
+Why different?
+  - Internal: time-first for clean API (self._buffer[pointer] = data)
+  - External: batch-first for typical use (iterate over environments)
+
+Backfill Behavior
+=================
+
+When you first append to a new or reset batch row, that first value is copied
+to ALL history slots for that row:
+
+  buffer = CircularBuffer(max_len=3, batch_size=2)
+  buffer.append(np.array([[5.0], [10.0]]))
+
+  # buffer.buffer contains (shape: 2, 3, 1):
+  # Batch 0: [5.0, 5.0, 5.0]   <- all slots filled with first value
+  # Batch 1: [10.0, 10.0, 10.0] <- all slots filled with first value
+
+Why backfill?
+  You always have valid data. If training expects 3 frames of history, you
+  don't want garbage/zeros for the first 2 timesteps.
+
+Per-Batch Reset
+===============
+
+Reset affects specific batch rows. The circular pointer advances globally, but
+reset rows get "first-append" treatment on their next write:
+
+  buffer = CircularBuffer(max_len=3, batch_size=3)
+
+  buffer.append(np.array([[1.0], [10.0], [100.0]]))   # t0
+  buffer.append(np.array([[2.0], [20.0], [200.0]]))   # t1
+  buffer.append(np.array([[3.0], [30.0], [300.0]]))   # t2
+
+  # buffer.buffer:
+  # Batch 0: [1.0, 2.0, 3.0]
+  # Batch 1: [10.0, 20.0, 30.0]
+  # Batch 2: [100.0, 200.0, 300.0]
+
+  buffer.reset(batch_ids=[1])  # Reset only batch 1
+
+  # buffer.buffer after reset:
+  # Batch 0: [1.0, 2.0, 3.0]       <- unchanged
+  # Batch 1: [0.0, 0.0, 0.0]       <- zeroed
+  # Batch 2: [100.0, 200.0, 300.0] <- unchanged
+
+  # current_length: [3, 0, 3]  <- batch 1 has 0 valid frames
+
+  buffer.append(np.array([[4.0], [99.0], [400.0]]))  # t3
+
+  # buffer.buffer after append:
+  # Batch 0: [2.0, 3.0, 4.0]        <- oldest overwritten (normal)
+  # Batch 1: [99.0, 99.0, 99.0]     <- BACKFILLED with 99.0
+  # Batch 2: [200.0, 300.0, 400.0]  <- oldest overwritten (normal)
+
+Key insight:
+  Reset only affects specific batch rows. The pointer keeps advancing for
+  everyone, but reset rows get backfilled on their next append.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+
+class CircularBuffer:
+    """Fixed-length circular buffer for batched tensor history.
+
+    Stores history with shape (max_len, batch_size, ...) internally.
+    The `buffer` property returns chronologically ordered data (oldest to newest)
+    with shape (batch_size, max_len, ...).
+
+    Storage and Retrieval
+    ---------------------
+    Internal storage (circular):
+      ┌─────┬─────┬─────┐
+      │  2  │  3  │  1  │  <- pointer at index 1 (newest = 3)
+      └─────┴─────┴─────┘
+       idx:0  idx:1  idx:2
+
+    buffer property returns (chronological, oldest→newest):
+      ┌─────┬─────┬─────┐
+      │  1  │  2  │  3  │
+      └─────┴─────┴─────┘
+
+    LIFO Retrieval via __getitem__
+    -------------------------------
+    Given buffer with [1, 2, 3] (oldest to newest):
+      buffer[lag=0] -> 3  (most recent)
+      buffer[lag=1] -> 2  (one step back)
+      buffer[lag=2] -> 1  (oldest)
+
+    Per-Batch Reset
+    ---------------
+    After reset(batch_ids=[1]):
+      Batch 0: [1, 2, 3]  (unchanged)
+      Batch 1: [0, 0, 0]  (zeroed, current_length=0)
+      Batch 2: [1, 2, 3]  (unchanged)
+
+    Next append backfills reset rows with first value.
+
+    Args:
+      max_len: Maximum number of historical frames to retain.
+      batch_size: Size of the batch dimension.
+    """
+
+    def __init__(self, max_len: int, batch_size: int) -> None:
+        if max_len < 1:
+            raise ValueError(f"Buffer size must be >= 1, got {max_len}")
+
+        self._max_len = max_len
+        self._batch_size = batch_size
+        self._pointer: int = -1
+        self._buffer: np.ndarray | None = None
+        self._all_indices = np.arange(batch_size)
+        self._num_pushes = np.zeros(batch_size, dtype=np.int64)
+        self._max_len_array = np.full(batch_size, max_len, dtype=np.int64)
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    @property
+    def max_length(self) -> int:
+        return self._max_len
+
+    @property
+    def current_length(self) -> np.ndarray:
+        """Per-batch count of valid frames. Shape: (batch_size,)."""
+        return np.minimum(self._num_pushes, self._max_len_array)
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the buffer has been initialized with at least one append."""
+        return self._buffer is not None
+
+    @property
+    def buffer(self) -> np.ndarray:
+        """History in chronological order (oldest to newest).
+
+        Returns:
+          Tensor of shape (batch_size, max_len, ...) where index 0 is oldest
+          and index -1 is newest.
+        """
+        if self._buffer is None:
+            raise RuntimeError("Buffer not initialized. Call append() first.")
+
+        start = (self._pointer + 1) % self._max_len
+        idx = (np.arange(self._max_len) + start) % self._max_len
+        buf = self._buffer[idx]  # (max_len, batch, ...)
+        return np.swapaxes(buf, 0, 1)  # (batch, max_len, ...)
+
+    def reset(self, batch_ids: Sequence[int] | np.ndarray | slice | None = None) -> None:
+        """Zero out values and counters for specified batch rows.
+
+        Args:
+          batch_ids: Batch indices to reset, or None to reset all.
+        """
+        ids: Sequence[int] | np.ndarray | slice = slice(None) if batch_ids is None else batch_ids
+        self._num_pushes[ids] = 0
+        if self._buffer is not None:
+            self._buffer[:, ids] = 0.0
+
+    def backfill(self, data: np.ndarray, batch_ids: np.ndarray) -> None:
+        """Fill the given rows' entire history with one frame, without advancing time.
+
+        Unlike append, the global pointer does not move and other rows are
+        untouched. Used after a partial reset: the reset rows get their first
+        post-reset frame in every slot (the same backfill their next append would
+        apply) while the remaining rows keep their history intact.
+
+        Args:
+          data: Tensor of shape (batch_size, ...); only rows at batch_ids are read.
+          batch_ids: Batch indices to backfill.
+        """
+        if data.shape[0] != self._batch_size:
+            raise ValueError(f"Expected batch size {self._batch_size}, got {data.shape[0]}")
+        if self._buffer is None:
+            raise RuntimeError("Buffer not initialized. Call append() first.")
+
+        data = np.asarray(data)
+        self._buffer[:, batch_ids] = np.expand_dims(data[batch_ids], axis=0)
+        self._num_pushes[batch_ids] = 1
+
+    def append(self, data: np.ndarray) -> None:
+        """Append a new frame for all batch elements.
+
+        Args:
+          data: Tensor of shape (batch_size, ...).
+        """
+        if data.shape[0] != self._batch_size:
+            raise ValueError(f"Expected batch size {self._batch_size}, got {data.shape[0]}")
+
+        data = np.asarray(data)
+
+        if self._buffer is None:
+            self._pointer = -1
+            self._buffer = np.empty((self._max_len, *data.shape), dtype=data.dtype)
+
+        self._pointer = (self._pointer + 1) % self._max_len
+        self._buffer[self._pointer] = data
+
+        # Backfill only newly initialized rows. After warm-up this branch avoids
+        # scanning the full history buffer on every hot-path append.
+        is_first_push = self._num_pushes == 0
+        if np.any(is_first_push):
+            first_ids = np.flatnonzero(is_first_push)
+            self._buffer[:, first_ids] = np.expand_dims(data[first_ids], axis=0)
+
+        self._num_pushes += 1
+
+    def __getitem__(self, key: np.ndarray | int) -> np.ndarray:
+        """Retrieve lagged frames per batch (LIFO).
+
+        Args:
+          key: Per-batch lags (Tensor) or shared lag (int). Shape (batch_size,) or scalar.
+        """
+        if self._buffer is None:
+            raise RuntimeError("Buffer not initialized. Call append() first.")
+
+        if isinstance(key, int):
+            key = np.full(self._batch_size, key, dtype=np.int64)
+        else:
+            key = np.asarray(key, dtype=np.int64)
+            if key.ndim == 0:
+                key = np.full(self._batch_size, key.item(), dtype=np.int64)
+
+        if key.size != self._batch_size:
+            raise ValueError(f"Expected {self._batch_size} lags, got {key.size}")
+
+        # Clamp to the oldest retained frame: without the max_len bound, a lag
+        # beyond the buffer length would wrap around to a newer frame once
+        # num_pushes exceeds max_len.
+        pushes = np.maximum(self._num_pushes, 1)
+        max_lag = np.minimum(pushes, self._max_len_array) - 1
+        valid = np.maximum(np.minimum(key, max_lag), 0)
+
+        idx = np.remainder(self._pointer - valid, self._max_len)
+        return self._buffer[idx, self._all_indices]

--- a/src/unilab/managers/_buffers/delay_buffer.py
+++ b/src/unilab/managers/_buffers/delay_buffer.py
@@ -1,0 +1,304 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/buffers/delay_buffer.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Delay buffer for stochastically delayed observations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from unilab.managers._buffers import CircularBuffer
+
+
+class DelayBuffer:
+    """Serve stochastically delayed observations from a rolling history.
+
+    Wraps a CircularBuffer to simulate observation delays by returning frames from T-lag
+    timesteps ago, where lag is sampled from [min_lag, max_lag].
+
+    Core Behavior
+    =============
+
+    At each timestep:
+      1. Append new observation to history
+      2. Sample or hold lag value (0 = no delay, 3 = 3 timesteps old)
+      3. Return observation from T-lag
+
+    Example with lag=2:
+      t=0: append obs_0 → return obs_0 (not enough history)
+      t=1: append obs_1 → return obs_0 (clamped to available history)
+      t=2: append obs_2 → return obs_0 (lag=2, so T-2 = 0)
+      t=3: append obs_3 → return obs_1 (lag=2, so T-2 = 1)
+
+    Lag Update Policy
+    =================
+
+    Lags can be refreshed every step or periodically:
+
+      **Every-step updates (update_period=0)**
+        Each timestep may sample a new lag (subject to hold_prob).
+
+      **Periodic updates (update_period=N)**
+        Lags refresh only every N steps per environment:
+          if (step_count + phase_offset) % N == 0:
+              sample new lag
+          else:
+              keep previous lag
+
+      **Staggered updates (per_env_phase=True)**
+        Each environment gets a random phase_offset ∈ [0, N), causing
+        lag updates to occur on different timesteps:
+          Env 0: updates at t=0, N, 2N, ...
+          Env 1: updates at t=3, N+3, 2N+3, ...
+          Env 2: updates at t=7, N+7, 2N+7, ...
+
+      **Hold probability (hold_prob=0.2)**
+        Even when an update would occur, keep previous lag with 20% chance.
+        Creates temporal correlation in delay patterns.
+
+    Per-Environment vs Shared Lags
+    ==============================
+
+      **per_env=True** (default)
+        Each environment has independent lag:
+          Batch 0: lag=1 → returns obs from t-1
+          Batch 1: lag=3 → returns obs from t-3
+          Batch 2: lag=0 → returns current obs
+
+      **per_env=False**
+        All environments share one sampled lag:
+          All batches: lag=2 → all return obs from t-2
+
+    Reset Behavior
+    ==============
+
+      reset(batch_ids=[1]) clears history for specified environments:
+        - Sets lag and step counter to zero
+        - Clears circular buffer for those rows
+        - Next append backfills their history with first new value
+        - Until that append, compute() returns zeros for reset rows
+
+    Args:
+      min_lag (int, optional): Minimum lag (inclusive). Must be >= 0.
+      max_lag (int, optional): Maximum lag (inclusive). Must be >= `min_lag`.
+      batch_size (int, optional): Number of parallel environments (leading
+        dimension of inputs).
+      per_env (bool, optional): If True, sample a separate lag per environment;
+        otherwise sample one lag and share it across environments.
+      hold_prob (float, optional): Probability in `[0.0, 1.0]` to keep the previous
+        lag when an update would occur. Creates temporal correlation in delays.
+      update_period (int, optional): If > 0, refresh lags every N steps per
+        environment; if 0, consider updating every step.
+      per_env_phase (bool, optional): If True and `update_period > 0`, each
+        environment uses a different phase offset in `[0, update_period)`, causing
+        staggered refresh steps across the batch.
+      generator (np.random.Generator | None, optional): RNG for sampling lags.
+
+    Examples:
+      Constant delay (lag = 2):
+        >>> buf = DelayBuffer(min_lag=2, max_lag=2, batch_size=4)
+        >>> buf.append(obs)                # obs.shape == (4, ...)
+        >>> delayed = buf.compute()        # delayed[t] = obs[t-2]
+
+      Stochastic delay (uniform 0-3):
+        >>> buf = DelayBuffer(min_lag=0, max_lag=3, batch_size=4)
+        >>> buf.append(obs)
+        >>> delayed = buf.compute()        # per-env lag sampled in {0,1,2,3}
+
+      Periodic updates with staggering:
+        >>> buf = DelayBuffer(
+        ...     min_lag=1, max_lag=5, batch_size=8,
+        ...     update_period=10,           # refresh every 10 steps
+        ...     per_env_phase=True,         # stagger across envs
+        ...     hold_prob=0.2               # 20% chance to hold lag
+        ... )
+        >>> # Env 0 refreshes at t=0,10,20,...
+        >>> # Env 1 refreshes at t=3,13,23,... (random offset)
+        >>> # But each refresh has 20% chance to keep previous lag
+    """
+
+    def __init__(
+        self,
+        min_lag: int = 0,
+        max_lag: int = 3,
+        batch_size: int = 1,
+        per_env: bool = True,
+        hold_prob: float = 0.0,
+        update_period: int = 0,
+        per_env_phase: bool = True,
+        generator: np.random.Generator | None = None,
+    ) -> None:
+        if min_lag < 0:
+            raise ValueError(f"min_lag must be >= 0, got {min_lag}")
+        if max_lag < min_lag:
+            raise ValueError(f"max_lag ({max_lag}) must be >= min_lag ({min_lag})")
+        if not 0.0 <= hold_prob <= 1.0:
+            raise ValueError(f"hold_prob must be in [0, 1], got {hold_prob}")
+        if update_period < 0:
+            raise ValueError(f"update_period must be >= 0, got {update_period}")
+
+        self.min_lag = min_lag
+        self.max_lag = max_lag
+        self.batch_size = batch_size
+        self.per_env = per_env
+        self.hold_prob = hold_prob
+        self.update_period = update_period
+        self.per_env_phase = per_env_phase
+        self.generator = generator
+
+        buffer_size = max_lag + 1 if max_lag > 0 else 1
+        self._buffer = CircularBuffer(max_len=buffer_size, batch_size=batch_size)
+        self._current_lags = np.zeros(batch_size, dtype=np.int64)
+        self._step_count = np.zeros(batch_size, dtype=np.int64)
+
+        if update_period > 0 and per_env_phase:
+            self._phase_offsets = self._require_generator().integers(
+                0, update_period, size=batch_size, dtype=np.int64
+            )
+        else:
+            self._phase_offsets = np.zeros(batch_size, dtype=np.int64)
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if buffer has been initialized with at least one append."""
+        return self._buffer.is_initialized
+
+    @property
+    def current_lags(self) -> np.ndarray:
+        """Current lag per environment. Shape: (batch_size,)."""
+        return self._current_lags
+
+    def set_lags(
+        self,
+        lags: np.ndarray,
+        batch_ids: Sequence[int] | np.ndarray | slice | None = None,
+    ) -> None:
+        """Set lag values for specified environments.
+
+        Args:
+          lags: Lag values to set. Shape: (num_batch_ids,) or scalar.
+          batch_ids: Batch indices to set, or None to set all.
+        """
+        idx = slice(None) if batch_ids is None else batch_ids
+        self._current_lags[idx] = np.clip(lags, self.min_lag, self.max_lag)
+
+    def reset(self, batch_ids: Sequence[int] | np.ndarray | slice | None = None) -> None:
+        """Reset specified environments to initial state.
+
+        Args:
+          batch_ids: Batch indices to reset, or None to reset all.
+        """
+        if isinstance(batch_ids, slice):
+            indices = range(*batch_ids.indices(self.batch_size))
+            batch_ids = list(indices)
+
+        self._buffer.reset(batch_ids=batch_ids)
+        idx = slice(None) if batch_ids is None else batch_ids
+        self._current_lags[idx] = 0
+        self._step_count[idx] = 0
+        if self.update_period > 0 and self.per_env_phase:
+            new_phases = self._require_generator().integers(
+                0, self.update_period, size=self.batch_size, dtype=np.int64
+            )
+            self._phase_offsets[idx] = new_phases[idx]
+
+    def append(self, data: np.ndarray) -> None:
+        """Append new observation to buffer.
+
+        Args:
+          data: Observation tensor of shape (batch_size, ...).
+        """
+        self._buffer.append(data)
+
+    def backfill(self, data: np.ndarray, batch_ids: np.ndarray) -> None:
+        """Backfill the given rows with one frame, without advancing time.
+
+        Used after a partial reset: the reset rows (whose lags and step counters
+        were just zeroed by reset) get their first post-reset frame while the
+        remaining rows keep their history, lags, and update schedule intact.
+
+        Args:
+          data: Tensor of shape (batch_size, ...); only rows at batch_ids are read.
+          batch_ids: Batch indices to backfill.
+        """
+        self._buffer.backfill(data, batch_ids)
+
+    def compute(self) -> np.ndarray:
+        """Compute delayed observation for current step.
+
+        Advances the lag update schedule, then returns the delayed observation.
+
+        Returns:
+          Delayed observation with shape (batch_size, ...).
+        """
+        if not self.is_initialized:
+            raise RuntimeError("Buffer not initialized. Call append() first.")
+
+        self._update_lags()
+        return self.peek()
+
+    def peek(self) -> np.ndarray:
+        """Return the delayed observation using current lags, without advancing.
+
+        Unlike compute, this neither steps the update schedule nor resamples lags,
+        so it is safe to call outside the once-per-step cadence.
+
+        Returns:
+          Delayed observation with shape (batch_size, ...).
+        """
+        if not self.is_initialized:
+            raise RuntimeError("Buffer not initialized. Call append() first.")
+
+        # Clamp lags to valid range [0, buffer_length - 1].
+        # Buffer may not be full yet (e.g., only 2 frames but sampled lag=3).
+        valid_lags = np.minimum(self._current_lags, self._buffer.current_length - 1)
+        valid_lags = np.maximum(valid_lags, 0)
+
+        return self._buffer[valid_lags]
+
+    def _update_lags(self) -> None:
+        """Update current lags according to configured policy."""
+        if self.update_period > 0:
+            phase_adjusted_count = (self._step_count + self._phase_offsets) % (self.update_period)
+            should_update = phase_adjusted_count == 0
+        else:
+            should_update = np.ones(self.batch_size, dtype=np.bool_)
+        new_lags = self._sample_lags(should_update)
+        self._current_lags = np.where(should_update, new_lags, self._current_lags)
+        self._step_count += 1
+
+    def _sample_lags(self, mask: np.ndarray) -> np.ndarray:
+        """Sample new lags for specified environments.
+
+        Args:
+          mask: Boolean mask of shape (batch_size,) indicating which envs to sample.
+
+        Returns:
+          New lags with shape (batch_size,).
+        """
+        if self.min_lag == self.max_lag:
+            candidate_lags = np.full(self.batch_size, self.min_lag, dtype=np.int64)
+        elif self.per_env:
+            candidate_lags = self._require_generator().integers(
+                self.min_lag, self.max_lag + 1, size=self.batch_size, dtype=np.int64
+            )
+        else:
+            shared_lag = self._require_generator().integers(self.min_lag, self.max_lag + 1)
+            candidate_lags = np.full(self.batch_size, shared_lag, dtype=np.int64)
+
+        if self.hold_prob > 0.0:
+            should_sample = self._require_generator().random(self.batch_size) >= self.hold_prob
+            update_mask = mask & should_sample
+        else:
+            update_mask = mask
+
+        return np.where(update_mask, candidate_lags, self._current_lags)
+
+    def _require_generator(self) -> np.random.Generator:
+        if self.generator is None:
+            raise ValueError(
+                "DelayBuffer stochastic sampling requires an env-owned NumPy generator."
+            )
+        return self.generator

--- a/src/unilab/managers/_noise/__init__.py
+++ b/src/unilab/managers/_noise/__init__.py
@@ -1,0 +1,15 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/noise/__init__.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+from unilab.managers._noise.noise_cfg import ConstantNoiseCfg as ConstantNoiseCfg
+from unilab.managers._noise.noise_cfg import GaussianNoiseCfg as GaussianNoiseCfg
+from unilab.managers._noise.noise_cfg import NoiseCfg as NoiseCfg
+from unilab.managers._noise.noise_cfg import NoiseModelCfg as NoiseModelCfg
+from unilab.managers._noise.noise_cfg import (
+    NoiseModelWithAdditiveBiasCfg as NoiseModelWithAdditiveBiasCfg,
+)
+from unilab.managers._noise.noise_cfg import UniformNoiseCfg as UniformNoiseCfg
+from unilab.managers._noise.noise_model import NoiseModel as NoiseModel
+from unilab.managers._noise.noise_model import (
+    NoiseModelWithAdditiveBias as NoiseModelWithAdditiveBias,
+)

--- a/src/unilab/managers/_noise/noise_cfg.py
+++ b/src/unilab/managers/_noise/noise_cfg.py
@@ -1,0 +1,143 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/noise/noise_cfg.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import ClassVar, Literal
+
+import numpy as np
+from typing_extensions import override
+
+from unilab.managers._noise import noise_model
+
+# Type alias for noise parameters: scalar or per-dimension values.
+NoiseParam = float | tuple[float, ...]
+
+
+@dataclass(kw_only=True)
+class NoiseCfg(abc.ABC):
+    """Base configuration for a noise term."""
+
+    operation: Literal["add", "scale", "abs"] = "add"
+
+    @staticmethod
+    def _as_array(value: NoiseParam, dtype: np.dtype) -> np.ndarray:
+        """Convert a scalar or per-component parameter without a device abstraction."""
+        return np.asarray(value, dtype=dtype)
+
+    @abc.abstractmethod
+    def apply(self, data: np.ndarray, *, rng: np.random.Generator | None = None) -> np.ndarray:
+        """Apply noise to the input data."""
+
+
+@dataclass
+class ConstantNoiseCfg(NoiseCfg):
+    bias: NoiseParam = 0.0
+
+    @override
+    def apply(self, data: np.ndarray, *, rng: np.random.Generator | None = None) -> np.ndarray:
+        del rng
+        bias = self._as_array(self.bias, data.dtype)
+
+        if self.operation == "add":
+            return data + bias
+        elif self.operation == "scale":
+            return data * bias
+        elif self.operation == "abs":
+            return np.zeros_like(data) + bias
+        else:
+            raise ValueError(f"Unsupported noise operation: {self.operation}")
+
+
+@dataclass
+class UniformNoiseCfg(NoiseCfg):
+    n_min: NoiseParam = -1.0
+    n_max: NoiseParam = 1.0
+
+    def __post_init__(self):
+        if isinstance(self.n_min, float) and isinstance(self.n_max, float):
+            if self.n_min >= self.n_max:
+                raise ValueError(f"n_min ({self.n_min}) must be less than n_max ({self.n_max})")
+
+    @override
+    def apply(self, data: np.ndarray, *, rng: np.random.Generator | None = None) -> np.ndarray:
+        if rng is None:
+            raise ValueError("UniformNoiseCfg requires an env-owned NumPy generator.")
+        n_min = self._as_array(self.n_min, data.dtype)
+        n_max = self._as_array(self.n_max, data.dtype)
+
+        # Generate uniform noise in [0, 1) and scale to [n_min, n_max).
+        noise = rng.random(data.shape).astype(data.dtype, copy=False)
+        noise = noise * (n_max - n_min) + n_min
+
+        if self.operation == "add":
+            return data + noise
+        elif self.operation == "scale":
+            return data * noise
+        elif self.operation == "abs":
+            return noise
+        else:
+            raise ValueError(f"Unsupported noise operation: {self.operation}")
+
+
+@dataclass
+class GaussianNoiseCfg(NoiseCfg):
+    mean: NoiseParam = 0.0
+    std: NoiseParam = 1.0
+
+    def __post_init__(self):
+        if isinstance(self.std, float) and self.std <= 0:
+            raise ValueError(f"std ({self.std}) must be positive")
+
+    @override
+    def apply(self, data: np.ndarray, *, rng: np.random.Generator | None = None) -> np.ndarray:
+        if rng is None:
+            raise ValueError("GaussianNoiseCfg requires an env-owned NumPy generator.")
+        mean = self._as_array(self.mean, data.dtype)
+        std = self._as_array(self.std, data.dtype)
+
+        # Generate standard normal noise and scale.
+        noise = rng.standard_normal(data.shape).astype(data.dtype, copy=False)
+        noise = mean + std * noise
+
+        if self.operation == "add":
+            return data + noise
+        elif self.operation == "scale":
+            return data * noise
+        elif self.operation == "abs":
+            return noise
+        else:
+            raise ValueError(f"Unsupported noise operation: {self.operation}")
+
+
+##
+# Noise models.
+##
+
+
+@dataclass(kw_only=True)
+class NoiseModelCfg:
+    """Configuration for a noise model."""
+
+    noise_cfg: NoiseCfg
+
+    class_type: ClassVar[type[noise_model.NoiseModel]] = noise_model.NoiseModel
+
+    def __init_subclass__(cls, class_type: type[noise_model.NoiseModel]):
+        cls.class_type = class_type
+
+
+@dataclass(kw_only=True)
+class NoiseModelWithAdditiveBiasCfg(
+    NoiseModelCfg, class_type=noise_model.NoiseModelWithAdditiveBias
+):
+    """Configuration for an additive Gaussian noise with bias model."""
+
+    bias_noise_cfg: NoiseCfg | None = None
+    sample_bias_per_component: bool = True
+
+    def __post_init__(self):
+        if self.bias_noise_cfg is None:
+            raise ValueError("bias_noise_cfg must be specified for NoiseModelWithAdditiveBiasCfg")

--- a/src/unilab/managers/_noise/noise_model.py
+++ b/src/unilab/managers/_noise/noise_model.py
@@ -1,0 +1,97 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/utils/noise/noise_model.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from unilab.managers._noise import noise_cfg
+
+
+class NoiseModel:
+    """Base class for noise models."""
+
+    def __init__(
+        self,
+        noise_model_cfg: noise_cfg.NoiseModelCfg,
+        num_envs: int,
+        rng: np.random.Generator,
+    ):
+        self._noise_model_cfg = noise_model_cfg
+        self._num_envs = num_envs
+        self._rng = rng
+
+        # Validate configuration.
+        if not hasattr(noise_model_cfg, "noise_cfg") or noise_model_cfg.noise_cfg is None:
+            raise ValueError("NoiseModelCfg must have a valid noise_cfg")
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        """Reset noise model state. Override in subclasses if needed."""
+
+    def __call__(self, data: np.ndarray) -> np.ndarray:
+        """Apply noise to input data."""
+        assert self._noise_model_cfg.noise_cfg is not None
+        return self._noise_model_cfg.noise_cfg.apply(data, rng=self._rng)
+
+
+class NoiseModelWithAdditiveBias(NoiseModel):
+    """Noise model with additional additive bias that is constant for the duration
+    of the entire episode."""
+
+    def __init__(
+        self,
+        noise_model_cfg: noise_cfg.NoiseModelWithAdditiveBiasCfg,
+        num_envs: int,
+        rng: np.random.Generator,
+    ):
+        super().__init__(noise_model_cfg, num_envs, rng)
+
+        # Validate bias configuration.
+        if not hasattr(noise_model_cfg, "bias_noise_cfg") or noise_model_cfg.bias_noise_cfg is None:
+            raise ValueError("NoiseModelWithAdditiveBiasCfg must have a valid bias_noise_cfg")
+
+        self._bias_noise_cfg = noise_model_cfg.bias_noise_cfg
+        self._sample_bias_per_component = noise_model_cfg.sample_bias_per_component
+
+        # Shape is materialized from the first observation so scalar and
+        # higher-rank terms broadcast without a device-specific convention.
+        self._bias = np.zeros((num_envs, 1), dtype=np.float32)
+        self._bias_initialized = False
+
+    @override
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        """Reset bias values for specified environments."""
+        indices = slice(None) if env_ids is None else env_ids
+        # Sample new bias values.
+        self._bias[indices] = self._bias_noise_cfg.apply(self._bias[indices], rng=self._rng)
+
+    def _initialize_bias_shape(self, data: np.ndarray) -> None:
+        """Initialize bias tensor shape based on data and configuration."""
+        if not self._bias_initialized:
+            if data.ndim == 0 or data.shape[0] != self._num_envs:
+                raise ValueError(
+                    f"NoiseModel expected leading dimension {self._num_envs}, "
+                    f"received shape {data.shape}."
+                )
+            if self._sample_bias_per_component:
+                bias_shape = data.shape
+            else:
+                bias_shape = (self._num_envs, *([1] * (data.ndim - 1)))
+            self._bias = np.zeros(bias_shape, dtype=data.dtype)
+            self._bias_initialized = True
+            self.reset()
+        elif self._bias.shape != data.shape and self._sample_bias_per_component:
+            raise ValueError(
+                f"NoiseModel observation shape changed from {self._bias.shape} to {data.shape}."
+            )
+
+    @override
+    def __call__(self, data: np.ndarray) -> np.ndarray:
+        """Apply noise and additive bias to input data."""
+        self._initialize_bias_shape(data)
+        noisy_data = super().__call__(data)
+        return noisy_data + self._bias

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -1,0 +1,52 @@
+"""Typing-only contracts used by the standalone manager package.
+
+The production environment and scene adapters implement these structural protocols in
+later integration layers.  Keeping them here prevents the manager core from importing
+an environment, backend, runner, or IPC implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+
+
+class ManagerEntity(Protocol):
+    """Cold-path entity metadata required by :class:`SceneEntityCfg`."""
+
+    joint_names: list[str]
+    body_names: list[str]
+    geom_names: list[str]
+    site_names: list[str]
+    actuator_names: list[str]
+    tendon_names: list[str]
+    camera_names: list[str]
+    light_names: list[str]
+    material_names: list[str]
+    texture_names: list[str]
+    pair_names: list[str]
+
+
+class ManagerScene(Protocol):
+    """Minimal name-addressable scene surface consumed by managers."""
+
+    def __getitem__(self, name: str) -> ManagerEntity: ...
+
+
+class ManagerBasedRlEnv(Protocol):
+    """Structural context visible to manager terms.
+
+    Additional task-owned state is intentionally not enumerated: term callables may use
+    their concrete environment type, while the manager core depends only on this seam.
+    """
+
+    num_envs: int
+    rng: np.random.Generator
+    scene: ManagerScene
+    max_episode_length_s: float
+
+    def __getattr__(self, name: str) -> Any: ...
+
+
+DebugVisualizer = Any

--- a/src/unilab/managers/action_manager.py
+++ b/src/unilab/managers/action_manager.py
@@ -1,0 +1,219 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/action_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Action manager for processing actions sent to the environment."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBase
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass(kw_only=True)
+class ActionTermCfg(abc.ABC):
+    """Configuration for an action term.
+
+    Action terms process raw actions from the policy and apply them to entities
+    in the scene (e.g., setting joint positions, velocities, or efforts).
+    """
+
+    entity_name: str
+    """Name of the entity in the scene that this action term controls."""
+
+    clip: dict[str, tuple] | None = None
+    """Optional clipping bounds applied to processed actions (after scale
+  and offset). Dict maps actuator name regex patterns to (min, max)
+  tuples, resolved the same way as ``scale`` and ``offset``."""
+
+    @abc.abstractmethod
+    def build(self, env: ManagerBasedRlEnv) -> ActionTerm:
+        """Build the action term from this config."""
+        raise NotImplementedError
+
+
+class ActionTerm(ManagerTermBase):
+    """Base class for action terms.
+
+    The action term is responsible for processing the raw actions sent to the environment
+    and applying them to the entity managed by the term.
+    """
+
+    def __init__(self, cfg: ActionTermCfg, env: ManagerBasedRlEnv):
+        self.cfg = cfg
+        super().__init__(env)
+        self._entity = self._env.scene[self.cfg.entity_name]
+
+    @property
+    @abc.abstractmethod
+    def action_dim(self) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def process_actions(self, actions: np.ndarray) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def apply_actions(self) -> None:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def raw_action(self) -> np.ndarray:
+        raise NotImplementedError
+
+
+class ActionManager(ManagerBase):
+    """Manages action processing for the environment.
+
+    The action manager aggregates multiple action terms, each controlling a different
+    entity or aspect of the simulation. It splits the policy's action tensor and
+    routes each slice to the appropriate action term.
+    """
+
+    def __init__(self, cfg: dict[str, ActionTermCfg | None], env: ManagerBasedRlEnv):
+        self.cfg = cfg
+        super().__init__(env=env)
+
+        # Create buffers to store actions.
+        self._action = np.zeros((self.num_envs, self.total_action_dim), dtype=np.float32)
+        self._prev_action = np.zeros_like(self._action)
+        self._prev_prev_action = np.zeros_like(self._action)
+
+    def __str__(self) -> str:
+        msg = f"<ActionManager> contains {len(self._term_names)} active terms.\n"
+        table = PrettyTable()
+        table.title = f"Active Action Terms (shape: {self.total_action_dim})"
+        table.field_names = ["Index", "Name", "Dimension"]
+        table.align["Name"] = "l"
+        table.align["Dimension"] = "r"
+        for index, (name, term) in enumerate(self._terms.items()):
+            table.add_row([index, name, term.action_dim])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def total_action_dim(self) -> int:
+        return sum(self.action_term_dim)
+
+    @property
+    def action_term_dim(self) -> list[int]:
+        return [term.action_dim for term in self._terms.values()]
+
+    @property
+    def action(self) -> np.ndarray:
+        """Raw policy output from the current step, before per-term
+        scale/offset. Shape: ``(num_envs, total_action_dim)``."""
+        return self._action
+
+    @property
+    def prev_action(self) -> np.ndarray:
+        """Raw policy output from the previous step, before per-term
+        scale/offset. Shape: ``(num_envs, total_action_dim)``."""
+        return self._prev_action
+
+    @property
+    def prev_prev_action(self) -> np.ndarray:
+        """Raw policy output from two steps ago, before per-term
+        scale/offset. Shape: ``(num_envs, total_action_dim)``."""
+        return self._prev_prev_action
+
+    @property
+    def active_terms(self) -> list[str]:
+        return self._term_names
+
+    # Methods.
+
+    def get_term(self, name: str) -> ActionTerm:
+        return self._terms[name]
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
+        if env_ids is None:
+            env_ids = slice(None)
+        # Reset action history.
+        self._prev_action[env_ids] = 0.0
+        self._prev_prev_action[env_ids] = 0.0
+        self._action[env_ids] = 0.0
+        # Reset action terms.
+        for term in self._terms.values():
+            term.reset(env_ids=env_ids)
+        return {}
+
+    def process_action(self, action: np.ndarray) -> None:
+        """Store the raw policy output and route slices to each action term.
+
+        Called once per policy step. The raw action tensor is saved into the
+        history buffers (``action``, ``prev_action``, ``prev_prev_action``) *before*
+        any per-term scale/offset is applied. Each term then receives its slice and
+        independently applies its own affine transformation via
+        :meth:`ActionTerm.process_actions`.
+        """
+        if not isinstance(action, np.ndarray):
+            raise TypeError(f"ActionManager expected np.ndarray, received {type(action).__name__}.")
+        expected_shape = (self.num_envs, self.total_action_dim)
+        if action.shape != expected_shape:
+            raise ValueError(
+                f"Invalid action shape, expected {expected_shape}, received {action.shape}."
+            )
+        if not np.isfinite(action).all():
+            raise ValueError("ActionManager received an action containing NaN or Inf.")
+        # Shift history: prev_prev ← prev ← current ← new.
+        self._prev_prev_action[:] = self._prev_action
+        self._prev_action[:] = self._action
+        self._action[:] = action
+        # Split the flat action vector and route each slice to its term.
+        idx = 0
+        for term in self._terms.values():
+            term_actions = self._action[:, idx : idx + term.action_dim]
+            term.process_actions(term_actions)
+            idx += term.action_dim
+
+    def apply_action(self) -> None:
+        """Write processed actions to entity actuator targets.
+
+        Called on every decimation substep (physics step), not just once per policy
+        step. Each term writes its most recently processed targets to the simulation.
+        """
+        for term in self._terms.values():
+            term.apply_actions()
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+        idx = 0
+        for name, term in self._terms.items():
+            term_actions = self._action[env_idx, idx : idx + term.action_dim]
+            terms.append((name, term_actions.tolist()))
+            idx += term.action_dim
+        return terms
+
+    def _prepare_terms(self) -> None:
+        self._term_names: list[str] = list()
+        self._terms: dict[str, ActionTerm] = dict()
+
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            term = term_cfg.build(self._env)
+            if not isinstance(term, ActionTerm):
+                raise TypeError(
+                    f"ActionManager term '{term_name}' build() returned "
+                    f"{type(term).__name__}, expected ActionTerm."
+                )
+            if not isinstance(term.action_dim, int) or term.action_dim < 0:
+                raise ValueError(
+                    f"ActionManager term '{term_name}' has invalid action_dim {term.action_dim}."
+                )
+            self._term_names.append(term_name)
+            self._terms[term_name] = term

--- a/src/unilab/managers/command_manager.py
+++ b/src/unilab/managers/command_manager.py
@@ -1,0 +1,313 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/command_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Command manager for generating and updating commands."""
+
+from __future__ import annotations
+
+import abc
+import inspect
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBase
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass(kw_only=True)
+class CommandTermCfg(abc.ABC):
+    """Configuration for a command generator term.
+
+    Command terms generate goal commands for the agent (e.g., target velocity,
+    target position). Commands are automatically resampled at configurable
+    intervals and can track metrics for logging.
+    """
+
+    resampling_time_range: tuple[float, float]
+    """Time range in seconds for command resampling. When the timer expires, a new
+  command is sampled and the timer is reset to a value uniformly drawn from
+  ``[min, max]``. Set both values equal for fixed-interval resampling."""
+
+    debug_vis: bool = False
+    """Whether to enable debug visualization for this command term. When True,
+  the command term's ``_debug_vis_impl`` method is called each frame to render
+  visual aids (e.g., velocity arrows, target markers)."""
+
+    @abc.abstractmethod
+    def build(self, env: ManagerBasedRlEnv) -> CommandTerm:
+        """Build the command term from this config."""
+        raise NotImplementedError
+
+
+class CommandTerm(ManagerTermBase):
+    """Base class for command terms."""
+
+    def __init__(self, cfg: CommandTermCfg, env: ManagerBasedRlEnv):
+        self.cfg = cfg
+        super().__init__(env)
+        lower, upper = cfg.resampling_time_range
+        if not np.isfinite((lower, upper)).all() or lower > upper:
+            raise ValueError(
+                f"CommandTerm '{self.name}' has invalid resampling_time_range "
+                f"{cfg.resampling_time_range}."
+            )
+        self._resampling_time_range = (lower, upper)
+        self._check_update_command_signature()
+        self.metrics: dict[str, np.ndarray] = {}
+        self.time_left = np.zeros(self.num_envs, dtype=np.float32)
+        self.command_counter = np.zeros(self.num_envs, dtype=np.int64)
+
+    @property
+    @abc.abstractmethod
+    def command(self):
+        raise NotImplementedError
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> dict[str, float]:
+        assert isinstance(env_ids, np.ndarray)
+        extras = {}
+        for metric_name, metric_value in self.metrics.items():
+            metric_slice = metric_value[env_ids]
+            if not np.isfinite(metric_slice).all():
+                raise ValueError(
+                    f"CommandTerm '{self.name}' metric '{metric_name}' contains NaN or Inf."
+                )
+            extras[metric_name] = float(np.mean(metric_slice))
+            metric_value[env_ids] = 0.0
+        self.command_counter[env_ids] = 0
+        self._resample(env_ids)
+        return extras
+
+    def compute(self, dt: float | np.ndarray, env_ids: np.ndarray | None = None) -> None:
+        """Advance the command state by dt.
+
+        With env_ids=None (the per-step path) all envs are updated; with env_ids
+        (the reset path) timers and the command update are scoped to those envs.
+        Metrics are always refreshed.
+
+        dt may be a scalar (all envs) or a per-env tensor (auto-reset path,
+        where freshly reset envs get zero to keep their timers full). A tensor
+        dt requires env_ids=None.
+        """
+        if isinstance(dt, np.ndarray):
+            if env_ids is not None:
+                raise ValueError("Per-environment command dt requires env_ids=None.")
+            if dt.shape != (self.num_envs,):
+                raise ValueError(
+                    f"CommandTerm '{self.name}' expected dt shape ({self.num_envs},), "
+                    f"received {dt.shape}."
+                )
+        dt_is_finite = np.isfinite(dt).all() if isinstance(dt, np.ndarray) else np.isfinite(dt)
+        if not dt_is_finite:
+            raise ValueError(f"CommandTerm '{self.name}' received non-finite dt.")
+        self._update_metrics()
+        self._validate_metrics()
+        if env_ids is None:
+            self.time_left -= dt
+            resample_env_ids = np.flatnonzero(self.time_left <= 0.0)
+        else:
+            assert not isinstance(dt, np.ndarray)
+            self.time_left[env_ids] -= dt
+            resample_env_ids = env_ids[self.time_left[env_ids] <= 0.0]
+        if len(resample_env_ids) > 0:
+            self._resample(resample_env_ids)
+        self._update_command(env_ids)
+
+    def _validate_metrics(self) -> None:
+        for metric_name, metric_value in self.metrics.items():
+            if not isinstance(metric_value, np.ndarray):
+                raise TypeError(
+                    f"CommandTerm '{self.name}' metric '{metric_name}' returned "
+                    f"{type(metric_value).__name__}, expected np.ndarray."
+                )
+            if metric_value.ndim == 0 or metric_value.shape[0] != self.num_envs:
+                raise ValueError(
+                    f"CommandTerm '{self.name}' metric '{metric_name}' returned shape "
+                    f"{metric_value.shape}, expected leading dimension {self.num_envs}."
+                )
+            if not np.isfinite(metric_value).all():
+                raise ValueError(
+                    f"CommandTerm '{self.name}' metric '{metric_name}' contains NaN or Inf."
+                )
+
+    def _check_update_command_signature(self) -> None:
+        """Fail fast with a migration hint for terms with the old signature."""
+        try:
+            sig = inspect.signature(self._update_command)
+        except (TypeError, ValueError):
+            return
+        if len(sig.parameters) == 0:
+            raise TypeError(
+                f"{type(self).__name__}._update_command must accept env_ids: "
+                "_update_command(self, env_ids: np.ndarray | None). It receives "
+                "None on the per-step update and the reset env ids on reset(); "
+                "scope per-step state advances to env_ids."
+            )
+
+    def _resample(self, env_ids: np.ndarray) -> None:
+        if len(env_ids) != 0:
+            lower, upper = self._resampling_time_range
+            self.time_left[env_ids] = self._env.rng.uniform(lower, upper, len(env_ids))
+            self._resample_command(env_ids)
+            self.command_counter[env_ids] += 1
+
+    @abc.abstractmethod
+    def _update_metrics(self) -> None:
+        """Update the metrics based on the current state."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        """Resample the command for the specified environments."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _update_command(self, env_ids: np.ndarray | None) -> None:
+        """Update the command based on the current state.
+
+        env_ids is None on the per-step update (all envs) and the reset env ids on reset().
+        Scope per-step state advances (e.g. a motion frame index) to env_ids; pure
+        functions of the current state may ignore it.
+        """
+        raise NotImplementedError
+
+
+class CommandManager(ManagerBase):
+    """Manages command generation for the environment.
+
+    The command manager generates and updates goal commands for the agent (e.g.,
+    target velocity, target position). Commands are resampled at configurable
+    intervals and can track metrics for logging.
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(self, cfg: dict[str, CommandTermCfg | None], env: ManagerBasedRlEnv):
+        self._terms: dict[str, CommandTerm] = dict()
+
+        self.cfg = cfg
+        super().__init__(env)
+
+    def __str__(self) -> str:
+        msg = f"<CommandManager> contains {len(self._terms.values())} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Command Terms"
+        table.field_names = ["Index", "Name", "Type"]
+        table.align["Name"] = "l"
+        for index, (name, term) in enumerate(self._terms.items()):
+            table.add_row([index, name, term.__class__.__name__])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> list[str]:
+        return list(self._terms.keys())
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+        for name, term in self._terms.items():
+            command = self._validate_command(name, term.command)
+            terms.append((name, command[env_idx].tolist()))
+        return terms
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> dict[str, float]:
+        if env_ids is None:
+            env_ids = np.arange(self.num_envs)
+        elif isinstance(env_ids, slice):
+            env_ids = np.arange(self.num_envs)[env_ids]
+        extras = {}
+        for name, term in self._terms.items():
+            metrics = term.reset(env_ids=env_ids)
+            self._validate_command(name, term.command)
+            for metric_name, metric_value in metrics.items():
+                extras[f"Metrics/{name}/{metric_name}"] = metric_value
+        return extras
+
+    def compute(self, dt: float | np.ndarray, env_ids: np.ndarray | None = None) -> None:
+        for name, term in self._terms.items():
+            term.compute(dt, env_ids)
+            self._validate_command(name, term.command)
+
+    def get_command(self, name: str) -> np.ndarray:
+        return self._validate_command(name, self._terms[name].command)
+
+    def get_term(self, name: str) -> CommandTerm:
+        return self._terms[name]
+
+    def get_term_cfg(self, name: str) -> CommandTermCfg:
+        term_cfg = self.cfg[name]
+        if term_cfg is None:
+            raise KeyError(f"Command term '{name}' is disabled.")
+        return term_cfg
+
+    def _prepare_terms(self) -> None:
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            if term_cfg.debug_vis:
+                raise NotImplementedError(
+                    f"CommandManager term '{term_name}' requested viewer debug visualization; "
+                    "viewer glue is unsupported by the UniLab manager core."
+                )
+            term = term_cfg.build(self._env)
+            if not isinstance(term, CommandTerm):
+                raise TypeError(
+                    f"Returned object for the term {term_name} is not of type CommandType."
+                )
+            self._terms[term_name] = term
+
+    def _validate_command(self, name: str, command: np.ndarray) -> np.ndarray:
+        if not isinstance(command, np.ndarray):
+            raise TypeError(
+                f"CommandManager term '{name}' returned {type(command).__name__}, "
+                "expected np.ndarray."
+            )
+        if command.ndim < 1 or command.shape[0] != self.num_envs:
+            raise ValueError(
+                f"CommandManager term '{name}' returned shape {command.shape}, "
+                f"expected leading dimension {self.num_envs}."
+            )
+        if not np.isfinite(command).all():
+            raise ValueError(f"CommandManager term '{name}' returned NaN or Inf.")
+        return command
+
+
+class NullCommandManager:
+    """Placeholder for absent command manager that safely no-ops all operations."""
+
+    def __init__(self):
+        self.active_terms: list[str] = []
+        self._terms: dict[str, Any] = {}
+        self.cfg = None
+
+    def __str__(self) -> str:
+        return "<NullCommandManager> (inactive)"
+
+    def __repr__(self) -> str:
+        return "NullCommandManager()"
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        return []
+
+    def reset(self, env_ids: np.ndarray | None = None) -> dict[str, np.ndarray]:
+        return {}
+
+    def compute(self, dt: float | np.ndarray, env_ids: np.ndarray | None = None) -> None:
+        pass
+
+    def get_command(self, name: str) -> None:
+        return None
+
+    def get_term(self, name: str) -> None:
+        return None
+
+    def get_term_cfg(self, name: str) -> None:
+        return None

--- a/src/unilab/managers/curriculum_manager.py
+++ b/src/unilab/managers/curriculum_manager.py
@@ -1,0 +1,166 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/curriculum_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Curriculum manager for updating environment quantities subject to a training curriculum."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass(kw_only=True)
+class CurriculumTermCfg(ManagerTermBaseCfg):
+    """Configuration for a curriculum term.
+
+    Curriculum terms modify environment parameters during training to implement
+    curriculum learning strategies (e.g., gradually increasing task difficulty).
+    """
+
+    pass
+
+
+class CurriculumManager(ManagerBase):
+    """Manages curriculum learning for the environment.
+
+    The curriculum manager updates environment parameters during training based
+    on agent performance. Each term can modify different aspects of the task
+    difficulty (e.g., terrain complexity, command ranges).
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(self, cfg: dict[str, CurriculumTermCfg | None], env: ManagerBasedRlEnv):
+        self._term_names: list[str] = list()
+        self._term_cfgs: list[CurriculumTermCfg] = list()
+        self._class_term_cfgs: list[CurriculumTermCfg] = list()
+
+        self.cfg = deepcopy(cfg)
+        super().__init__(env)
+
+        self._curriculum_state: dict[str, Any] = {}
+        for term_name in self._term_names:
+            self._curriculum_state[term_name] = None
+
+    def __str__(self) -> str:
+        msg = f"<CurriculumManager> contains {len(self._term_names)} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Curriculum Terms"
+        table.field_names = ["Index", "Name"]
+        table.align["Name"] = "l"
+        for index, name in enumerate(self._term_names):
+            table.add_row([index, name])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> list[str]:
+        return self._term_names
+
+    # Methods.
+
+    def get_term_cfg(self, term_name: str) -> CurriculumTermCfg:
+        if term_name not in self._term_names:
+            raise ValueError(f"Term '{term_name}' not found in active terms.")
+        return self._term_cfgs[self._term_names.index(term_name)]
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+        for term_name, term_state in self._curriculum_state.items():
+            if term_state is not None:
+                data = []
+                if isinstance(term_state, dict):
+                    for _key, value in term_state.items():
+                        if isinstance(value, np.ndarray):
+                            value = value.item()
+                        data.append(value)
+                else:
+                    if isinstance(term_state, np.ndarray):
+                        term_state = term_state.item()
+                    data.append(term_state)
+                terms.append((term_name, data))
+        return terms
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
+        extras = {}
+        for term_name, term_state in self._curriculum_state.items():
+            if term_state is not None:
+                if isinstance(term_state, dict):
+                    for key, value in term_state.items():
+                        if isinstance(value, np.ndarray):
+                            value = value.item()
+                        extras[f"Curriculum/{term_name}/{key}"] = value
+                else:
+                    if isinstance(term_state, np.ndarray):
+                        term_state = term_state.item()
+                    extras[f"Curriculum/{term_name}"] = term_state
+        for term_cfg in self._class_term_cfgs:
+            term_cfg.func.reset(env_ids=env_ids)
+        return extras
+
+    def compute(self, env_ids: np.ndarray | slice | None = None) -> None:
+        if env_ids is None:
+            env_ids = slice(None)
+        for name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
+            state = term_cfg.func(self._env, env_ids, **term_cfg.params)
+            self._validate_state(name, state)
+            self._curriculum_state[name] = state
+
+    def _validate_state(self, term_name: str, state: Any) -> None:
+        values = state.values() if isinstance(state, dict) else (state,)
+        for value in values:
+            if isinstance(value, np.ndarray):
+                finite = np.isfinite(value).all()
+            elif isinstance(value, (int, float, np.number)):
+                finite = bool(np.isfinite(value))
+            else:
+                continue
+            if not finite:
+                raise ValueError(f"CurriculumManager term '{term_name}' returned NaN or Inf.")
+
+    def _prepare_terms(self) -> None:
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            self._resolve_common_term_cfg(term_name, term_cfg)
+            self._term_names.append(term_name)
+            self._term_cfgs.append(term_cfg)
+            if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                self._class_term_cfgs.append(term_cfg)
+
+
+class NullCurriculumManager:
+    """Placeholder for absent curriculum manager that safely no-ops all operations."""
+
+    def __init__(self):
+        self.active_terms: list[str] = []
+        self._curriculum_state: dict[str, Any] = {}
+        self.cfg = None
+
+    def __str__(self) -> str:
+        return "<NullCurriculumManager> (inactive)"
+
+    def __repr__(self) -> str:
+        return "NullCurriculumManager()"
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        return []
+
+    def reset(self, env_ids: np.ndarray | None = None) -> dict[str, float]:
+        return {}
+
+    def compute(self, env_ids: np.ndarray | None = None) -> None:
+        pass

--- a/src/unilab/managers/event_manager.py
+++ b/src/unilab/managers/event_manager.py
@@ -1,0 +1,276 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/event_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Event manager for orchestrating operations based on different simulation events."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+EventMode = Literal["startup", "reset", "interval", "step"]
+
+
+@dataclass(kw_only=True)
+class EventTermCfg(ManagerTermBaseCfg):
+    """Configuration for an event term.
+
+    Event terms trigger operations at specific simulation events. They're commonly
+    used for domain randomization, state resets, and periodic perturbations.
+
+    The four modes determine when the event fires:
+
+    - ``"startup"``: Once when the environment initializes. Use for parameters that
+      should be randomized per-environment but stay constant within an episode (e.g.,
+      domain randomization).
+
+    - ``"reset"``: On every episode reset. Use for parameters that should vary between
+      episodes (e.g., initial robot pose, domain randomization).
+
+    - ``"interval"``: Periodically during simulation, controlled by ``interval_range_s``.
+      Use for perturbations that should happen during episodes (e.g., pushing the robot,
+      external disturbances).
+
+    - ``"step"``: Every environment step, unconditionally on all envs. Use for terms that
+      manage per-step state such as force lifetimes (e.g., ``apply_body_impulse``).
+    """
+
+    mode: EventMode
+    """When the event triggers: ``"startup"`` (once at init), ``"reset"`` (every
+  episode), ``"interval"`` (periodically during simulation), or ``"step"`` (every
+  environment step)."""
+
+    interval_range_s: tuple[float, float] | None = None
+    """Time range in seconds for interval mode. The next trigger time is uniformly
+  sampled from ``[min, max]``. Required when ``mode="interval"``."""
+
+    is_global_time: bool = False
+    """Whether all environments share the same timer. If True, all envs trigger
+  simultaneously. If False (default), each env has an independent timer that
+  resets on episode reset. Only applies to ``mode="interval"``."""
+
+    min_step_count_between_reset: int = 0
+    """Minimum environment steps between triggers. Prevents the event from firing
+  too frequently when episodes reset rapidly. Only applies to ``mode="reset"``.
+  Set to 0 (default) to trigger on every reset."""
+
+
+class EventManager(ManagerBase):
+    """Manages event-based operations for the environment.
+
+    The event manager triggers operations at different simulation events: startup
+    (once at initialization), reset (on episode reset), or interval (periodically
+    during simulation). Common uses include domain randomization and state resets.
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(self, cfg: dict[str, EventTermCfg | None], env: ManagerBasedRlEnv):
+        self.cfg = deepcopy(cfg)
+        self._mode_term_names: dict[EventMode, list[str]] = dict()
+        self._mode_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
+        self._mode_class_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
+
+        super().__init__(env=env)
+
+    def __str__(self) -> str:
+        msg = f"<EventManager> contains {len(self._mode_term_names)} active terms.\n"
+        for mode in self._mode_term_names:
+            table = PrettyTable()
+            table.title = f"Active Event Terms in Mode: '{mode}'"
+            if mode == "interval":
+                table.field_names = ["Index", "Name", "Interval time range (s)"]
+                table.align["Name"] = "l"
+                for index, (name, cfg) in enumerate(
+                    zip(self._mode_term_names[mode], self._mode_term_cfgs[mode], strict=False)
+                ):
+                    table.add_row([index, name, cfg.interval_range_s])
+            else:
+                table.field_names = ["Index", "Name"]
+                table.align["Name"] = "l"
+                for index, name in enumerate(self._mode_term_names[mode]):
+                    table.add_row([index, name])
+            msg += str(table.get_string())
+            msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> dict[EventMode, list[str]]:
+        return self._mode_term_names
+
+    @property
+    def available_modes(self) -> list[EventMode]:
+        return list(self._mode_term_names.keys())
+
+    # Methods.
+
+    def get_term_cfg(self, term_name: str) -> EventTermCfg:
+        """Get the configuration of a specific event term by name."""
+        for mode in self._mode_term_names:
+            if term_name in self._mode_term_names[mode]:
+                index = self._mode_term_names[mode].index(term_name)
+                return self._mode_term_cfgs[mode][index]
+        raise ValueError(f"Event term '{term_name}' not found in active terms.")
+
+    def reset(self, env_ids: np.ndarray | None = None):
+        for mode_cfg in self._mode_class_term_cfgs.values():
+            for term_cfg in mode_cfg:
+                term_cfg.func.reset(env_ids=env_ids)
+        if env_ids is None:
+            num_envs = self._env.num_envs
+            ids: np.ndarray | slice = slice(None)
+        else:
+            num_envs = len(env_ids)
+            ids = env_ids
+        # Iterate the full interval term list: _interval_term_time_left is parallel
+        # to _mode_term_cfgs["interval"], not the class-only subset.
+        if "interval" in self._mode_term_cfgs:
+            for index, term_cfg in enumerate(self._mode_term_cfgs["interval"]):
+                if not term_cfg.is_global_time:
+                    assert term_cfg.interval_range_s is not None
+                    lower, upper = term_cfg.interval_range_s
+                    sampled_interval = self._env.rng.uniform(lower, upper, num_envs)
+                    self._interval_term_time_left[index][ids] = sampled_interval
+        return {}
+
+    def apply(
+        self,
+        mode: EventMode,
+        env_ids: np.ndarray | slice | None = None,
+        dt: float | None = None,
+        global_env_step_count: int | None = None,
+    ):
+        if mode not in ("startup", "reset", "interval", "step"):
+            raise ValueError(f"Unsupported event mode '{mode}'.")
+        if mode not in self._mode_term_cfgs:
+            return
+        if mode == "interval" and dt is None:
+            raise ValueError(f"Event mode '{mode}' requires the time-step of the environment.")
+        if mode == "interval" and env_ids is not None:
+            raise ValueError(
+                f"Event mode '{mode}' does not require environment indices. This is an undefined behavior"
+                " as the environment indices are computed based on the time left for each environment."
+            )
+        if mode == "reset" and global_env_step_count is None:
+            raise ValueError(
+                f"Event mode '{mode}' requires the total number of environment steps to be provided."
+            )
+        if mode == "step" and dt is None:
+            raise ValueError(f"Event mode '{mode}' requires the time-step of the environment.")
+
+        for index, term_cfg in enumerate(self._mode_term_cfgs[mode]):
+            if mode == "interval":
+                time_left = self._interval_term_time_left[index]
+                assert dt is not None
+                time_left -= dt
+                if term_cfg.is_global_time:
+                    if time_left < 1e-6:
+                        assert term_cfg.interval_range_s is not None
+                        lower, upper = term_cfg.interval_range_s
+                        sampled_interval = self._env.rng.uniform(lower, upper, 1)
+                        self._interval_term_time_left[index][:] = sampled_interval
+                        term_cfg.func(self._env, None, **term_cfg.params)
+                else:
+                    valid_env_ids = np.flatnonzero(time_left < 1e-6)
+                    if len(valid_env_ids) > 0:
+                        assert term_cfg.interval_range_s is not None
+                        lower, upper = term_cfg.interval_range_s
+                        sampled_time = self._env.rng.uniform(lower, upper, len(valid_env_ids))
+                        self._interval_term_time_left[index][valid_env_ids] = sampled_time
+                        term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+            elif mode == "step":
+                term_cfg.func(self._env, None, **term_cfg.params)
+            elif mode == "reset":
+                assert global_env_step_count is not None
+                # Reset events require concrete indices: callers (e.g. ManagerBasedRlEnv)
+                # resolve None to all environments upstream. Enforce that here so a future
+                # caller passing None fails loudly instead of leaking a slice into event
+                # functions, which only understand None or a tensor.
+                if env_ids is None:
+                    raise ValueError("Event mode 'reset' requires concrete environment indices.")
+                min_step_count = term_cfg.min_step_count_between_reset
+                if min_step_count == 0:
+                    self._reset_term_last_triggered_step_id[index][env_ids] = global_env_step_count
+                    self._reset_term_last_triggered_once[index][env_ids] = True
+                    term_cfg.func(self._env, env_ids, **term_cfg.params)
+                else:
+                    last_triggered_step = self._reset_term_last_triggered_step_id[index][env_ids]
+                    triggered_at_least_once = self._reset_term_last_triggered_once[index][env_ids]
+                    steps_since_triggered = global_env_step_count - last_triggered_step
+                    valid_trigger = steps_since_triggered >= min_step_count
+                    valid_trigger |= (last_triggered_step == 0) & ~triggered_at_least_once
+                    if isinstance(env_ids, np.ndarray):
+                        valid_env_ids = env_ids[valid_trigger]
+                    else:
+                        valid_env_ids = np.flatnonzero(valid_trigger)
+                    if len(valid_env_ids) > 0:
+                        self._reset_term_last_triggered_once[index][valid_env_ids] = True
+                        self._reset_term_last_triggered_step_id[index][valid_env_ids] = (
+                            global_env_step_count
+                        )
+                        term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+            else:
+                term_cfg.func(self._env, env_ids, **term_cfg.params)
+
+    def _prepare_terms(self) -> None:
+        self._interval_term_time_left: list[np.ndarray] = list()
+        self._reset_term_last_triggered_step_id: list[np.ndarray] = list()
+        self._reset_term_last_triggered_once: list[np.ndarray] = list()
+
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            self._resolve_common_term_cfg(term_name, term_cfg)
+            if term_cfg.mode not in ("startup", "reset", "interval", "step"):
+                raise ValueError(
+                    f"EventManager term '{term_name}' has unsupported mode '{term_cfg.mode}'."
+                )
+            if term_cfg.mode not in self._mode_term_names:
+                self._mode_term_names[term_cfg.mode] = list()
+                self._mode_term_cfgs[term_cfg.mode] = list()
+                self._mode_class_term_cfgs[term_cfg.mode] = list()
+            self._mode_term_names[term_cfg.mode].append(term_name)
+            self._mode_term_cfgs[term_cfg.mode].append(term_cfg)
+            if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                self._mode_class_term_cfgs[term_cfg.mode].append(term_cfg)
+            if term_cfg.mode == "interval":
+                if term_cfg.interval_range_s is None:
+                    raise ValueError(
+                        f"Event term '{term_name}' has mode 'interval' but 'interval_range_s' is not specified."
+                    )
+                lower, upper = term_cfg.interval_range_s
+                if not np.isfinite((lower, upper)).all() or lower > upper:
+                    raise ValueError(
+                        f"EventManager term '{term_name}' has invalid interval_range_s "
+                        f"{term_cfg.interval_range_s}."
+                    )
+                if term_cfg.is_global_time:
+                    time_left = self._env.rng.uniform(lower, upper, 1)
+                    self._interval_term_time_left.append(time_left)
+                else:
+                    time_left = self._env.rng.uniform(lower, upper, self.num_envs)
+                    self._interval_term_time_left.append(time_left)
+            elif term_cfg.mode == "reset":
+                step_count = np.zeros(self.num_envs, dtype=np.int64)
+                self._reset_term_last_triggered_step_id.append(step_count)
+                no_trigger = np.zeros(self.num_envs, dtype=np.bool_)
+                self._reset_term_last_triggered_once.append(no_trigger)
+
+            func = term_cfg.func
+            if hasattr(func, "model_fields"):
+                raise NotImplementedError(
+                    f"EventManager term '{term_name}' requests direct model-field mutation; "
+                    "this capability is unsupported by the standalone UniLab manager core."
+                )

--- a/src/unilab/managers/manager_base.py
+++ b/src/unilab/managers/manager_base.py
@@ -1,0 +1,159 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/manager_base.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+from __future__ import annotations
+
+import abc
+import inspect
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass
+class ManagerTermBaseCfg:
+    """Base configuration for manager terms.
+
+    This is the base config for terms in observation, reward, termination, curriculum,
+    and event managers. It provides a common interface for specifying a callable
+    and its parameters.
+
+    The ``func`` field accepts either a function or a class:
+
+    **Function-based terms** are simpler and suitable for stateless computations:
+
+    .. code-block:: python
+
+        RewardTermCfg(func=mdp.joint_torques_l2, weight=-0.01)
+
+    **Class-based terms** are instantiated with ``(cfg, env)`` and useful when you need
+    to:
+
+    - Cache computed values at initialization (e.g., resolve regex patterns to indices)
+    - Maintain state across calls
+    - Perform expensive setup once rather than every call
+
+    .. code-block:: python
+
+        class posture:
+          def __init__(self, cfg: RewardTermCfg, env: ManagerBasedRlEnv):
+            # Resolve std dict to tensor once at init
+            self.std = resolve_std_to_tensor(cfg.params["std"], env)
+
+          def __call__(self, env, **kwargs) -> np.ndarray:
+            # Use cached self.std
+            return compute_posture_reward(env, self.std)
+
+        RewardTermCfg(func=posture, params={"std": {".*knee.*": 0.3}}, weight=1.0)
+
+    Class-based terms can optionally implement ``reset(env_ids)`` for per-episode state.
+    """
+
+    func: Any
+    """The callable that computes this term's value. Can be a function or a class.
+  Classes are auto-instantiated with ``(cfg=term_cfg, env=env)``."""
+
+    params: dict[str, Any] = field(default_factory=lambda: {})
+    """Additional keyword arguments passed to func when called."""
+
+
+class ManagerTermBase:
+    def __init__(self, env: ManagerBasedRlEnv):
+        self._env = env
+
+    # Properties.
+
+    @property
+    def num_envs(self) -> int:
+        return self._env.num_envs
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    # Methods.
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> Any:
+        """Resets the manager term."""
+        del env_ids  # Unused.
+        pass
+
+    def __call__(self, *args, **kwargs) -> Any:
+        """Returns the value of the term required by the manager."""
+        raise NotImplementedError
+
+
+class ManagerBase(abc.ABC):
+    """Base class for all managers."""
+
+    def __init__(self, env: ManagerBasedRlEnv):
+        self._env = env
+
+        self._prepare_terms()
+
+    # Properties.
+
+    @property
+    def num_envs(self) -> int:
+        return self._env.num_envs
+
+    @property
+    @abc.abstractmethod
+    def active_terms(self) -> list[str] | dict[Any, list[str]]:
+        raise NotImplementedError
+
+    # Methods.
+
+    def reset(self, env_ids: np.ndarray) -> dict[str, Any]:
+        """Resets the manager and returns logging info for the current step."""
+        del env_ids  # Unused.
+        return {}
+
+    def _check_term_shape(self, term_name: str, value: np.ndarray) -> None:
+        if not isinstance(value, np.ndarray):
+            manager_name = type(self).__name__
+            raise TypeError(
+                f"{manager_name} term '{term_name}' returned {type(value).__name__}, "
+                "expected np.ndarray."
+            )
+        if value.shape != (self.num_envs,):
+            manager_name = type(self).__name__
+            raise ValueError(
+                f"{manager_name} term '{term_name}' returned shape {tuple(value.shape)}, "
+                f"expected ({self.num_envs},)."
+            )
+
+    def _check_term_finite(self, term_name: str, value: np.ndarray) -> None:
+        if np.isfinite(value).all():
+            return
+        manager_name = type(self).__name__
+        has_nan = np.isnan(value).any()
+        has_inf = np.isinf(value).any()
+        invalid_kind = "NaN/Inf" if has_nan and has_inf else "NaN" if has_nan else "Inf"
+        env_ids = np.flatnonzero(~np.isfinite(value)).tolist()
+        raise ValueError(
+            f"{manager_name} term '{term_name}' returned {invalid_kind} for "
+            f"environments {env_ids[:10]}."
+        )
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _prepare_terms(self) -> None:
+        raise NotImplementedError
+
+    def _resolve_common_term_cfg(self, term_name: str, term_cfg: ManagerTermBaseCfg) -> None:
+        del term_name  # Unused.
+        for value in term_cfg.params.values():
+            if isinstance(value, SceneEntityCfg):
+                value.resolve(self._env.scene)
+        if inspect.isclass(term_cfg.func):
+            term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)

--- a/src/unilab/managers/metrics_manager.py
+++ b/src/unilab/managers/metrics_manager.py
@@ -1,0 +1,242 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/metrics_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Metrics manager for logging custom per-step metrics during training."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+REDUCE_OPTIONS = ("last", "max", "mean", "sum")
+
+
+@dataclass(kw_only=True)
+class MetricsTermCfg(ManagerTermBaseCfg):
+    """Configuration for a metrics term.
+
+    Attributes:
+      per_substep: If True, evaluate this term once per physics substep inside
+        the decimation loop and report the per-step mean. Only the integrated
+        state (qpos, qvel, act) is current mid-loop; all derived quantities
+        (xpos, xquat, site_xpos, actuator_force, contacts, ...) are stale.
+
+      reduce: How to aggregate per-step values into an episode metric.
+        - ``"mean"`` (default) reports ``sum / step_count``.
+        - ``"last"`` reports the value from the final step of the episode,
+          useful for binary success metrics that should not be averaged over
+          timesteps.
+        - ``"max"`` reports the highest value seen during the episode, useful
+          for peak metrics like maximum power or contact force.
+        - ``"sum"`` reports the accumulated total over the episode, useful for
+          cumulative quantities like episodic reward or total distance
+          traveled.
+    """
+
+    per_substep: bool = False
+    reduce: Literal["last", "max", "mean", "sum"] = "mean"
+
+
+class MetricsManager(ManagerBase):
+    """Accumulates per-step metric values, reports episode averages.
+
+    Unlike rewards, metrics have no weight, no dt scaling, and no
+    normalization by episode length. Episode values are true per-step
+    averages (sum / step_count), so a metric in [0,1] stays in [0,1]
+    in the logger.
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(self, cfg: dict[str, MetricsTermCfg | None], env: ManagerBasedRlEnv):
+        self._term_names: list[str] = list()
+        self._term_cfgs: list[MetricsTermCfg] = list()
+        self._class_term_cfgs: list[MetricsTermCfg] = list()
+        self._step_term_indices: list[int] = list()
+        self._substep_term_indices: list[int] = list()
+
+        self.cfg = deepcopy(cfg)
+        super().__init__(env=env)
+
+        self._episode_sums: dict[str, np.ndarray] = {}
+        self._episode_max: dict[str, np.ndarray] = {}
+        for idx, term_name in enumerate(self._term_names):
+            if self._term_cfgs[idx].reduce not in REDUCE_OPTIONS:
+                msg = (
+                    f"The reduce method '{self._term_cfgs[idx].reduce}' for metric '{term_name}' "
+                    f"is unknown. Valid options are {REDUCE_OPTIONS}."
+                )
+                raise ValueError(msg)
+
+            self._episode_sums[term_name] = np.zeros(self.num_envs, dtype=np.float32)
+
+            if self._term_cfgs[idx].reduce == "max":
+                self._episode_max[term_name] = np.full(
+                    self.num_envs, float("-inf"), dtype=np.float32
+                )
+        # Pre-resolved tensor refs for substep terms to avoid dict lookups in
+        # the hot loop.
+        self._substep_accum: list[np.ndarray] = []
+        self._substep_episode_sums: list[np.ndarray] = []
+        self._substep_episode_max: list[np.ndarray | None] = []
+        for idx in self._substep_term_indices:
+            name = self._term_names[idx]
+            buf = np.zeros(self.num_envs, dtype=np.float32)
+            self._substep_accum.append(buf)
+            self._substep_episode_sums.append(self._episode_sums[name])
+            self._substep_episode_max.append(self._episode_max.get(name))
+        self._substep_count: int = 0
+        self._step_count = np.zeros(self.num_envs, dtype=np.int64)
+        self._step_values = np.zeros((self.num_envs, len(self._term_names)), dtype=np.float32)
+
+    def __str__(self) -> str:
+        msg = f"<MetricsManager> contains {len(self._term_names)} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Metrics Terms"
+        table.field_names = ["Index", "Name"]
+        table.align["Name"] = "l"
+        for index, name in enumerate(self._term_names):
+            table.add_row([index, name])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> list[str]:
+        return self._term_names
+
+    # Methods.
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
+        if env_ids is None:
+            env_ids = slice(None)
+        extras = {}
+        counts = self._step_count[env_ids].astype(np.float32)
+        # Avoid division by zero for envs that haven't stepped.
+        safe_counts = np.maximum(counts, 1.0)
+        for idx, key in enumerate(self._episode_sums):
+            reduce = self._term_cfgs[idx].reduce
+            if reduce == "max":
+                extras["Episode_Metrics/" + key] = float(np.mean(self._episode_max[key][env_ids]))
+                self._episode_max[key][env_ids] = float("-inf")
+
+            elif reduce == "last":
+                extras["Episode_Metrics/" + key] = float(np.mean(self._step_values[env_ids, idx]))
+
+            elif reduce == "sum":
+                extras["Episode_Metrics/" + key] = float(np.mean(self._episode_sums[key][env_ids]))
+
+            else:
+                extras["Episode_Metrics/" + key] = float(
+                    np.mean(self._episode_sums[key][env_ids] / safe_counts)
+                )
+
+            self._episode_sums[key][env_ids] = 0.0
+        self._step_count[env_ids] = 0
+
+        for buf in self._substep_accum:
+            buf[env_ids] = 0.0
+
+        for term_cfg in self._class_term_cfgs:
+            term_cfg.func.reset(env_ids=env_ids)
+
+        return extras
+
+    def compute_substep(self) -> None:
+        """Accumulate per-substep metric values inside the decimation loop.
+
+        No-op when no ``per_substep`` terms are configured.
+        """
+        if not self._substep_term_indices:
+            return
+        for i, idx in enumerate(self._substep_term_indices):
+            value = self._compute_term(idx)
+            self._substep_accum[i] += value
+        self._substep_count += 1
+
+    def compute(self) -> None:
+        self._step_count += 1
+        if self._substep_term_indices and self._substep_count > 0:
+            for i, idx in enumerate(self._substep_term_indices):
+                avg = self._substep_accum[i] / self._substep_count
+                self._substep_episode_sums[i] += avg
+                self._step_values[:, idx] = avg
+                max_buf = self._substep_episode_max[i]
+                if max_buf is not None:
+                    np.maximum(max_buf, avg, out=max_buf)
+                self._substep_accum[i].fill(0.0)
+            self._substep_count = 0
+        for idx in self._step_term_indices:
+            name = self._term_names[idx]
+            value = self._compute_term(idx)
+            self._episode_sums[name] += value
+            self._step_values[:, idx] = value
+            if name in self._episode_max:
+                np.maximum(self._episode_max[name], value, out=self._episode_max[name])
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+        for idx, name in enumerate(self._term_names):
+            terms.append((name, [self._step_values[env_idx, idx].item()]))
+        return terms
+
+    def _prepare_terms(self) -> None:
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            self._resolve_common_term_cfg(term_name, term_cfg)
+            idx = len(self._term_names)
+            self._term_names.append(term_name)
+            self._term_cfgs.append(term_cfg)
+            if term_cfg.per_substep:
+                self._substep_term_indices.append(idx)
+            else:
+                self._step_term_indices.append(idx)
+            if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                self._class_term_cfgs.append(term_cfg)
+
+    def _compute_term(self, idx: int) -> np.ndarray:
+        name = self._term_names[idx]
+        term_cfg = self._term_cfgs[idx]
+        value = term_cfg.func(self._env, **term_cfg.params)
+        self._check_term_shape(name, value)
+        self._check_term_finite(name, value)
+        return value
+
+
+class NullMetricsManager:
+    """Placeholder for absent metrics manager that safely no-ops all operations."""
+
+    def __init__(self):
+        self.active_terms: list[str] = []
+        self.cfg = None
+
+    def __str__(self) -> str:
+        return "<NullMetricsManager> (inactive)"
+
+    def __repr__(self) -> str:
+        return "NullMetricsManager()"
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        return []
+
+    def reset(self, env_ids: np.ndarray | None = None) -> dict[str, float]:
+        return {}
+
+    def compute_substep(self) -> None:
+        pass
+
+    def compute(self) -> None:
+        pass

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -1,0 +1,570 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/observation_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Observation manager for computing observations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers._buffers import CircularBuffer, DelayBuffer
+from unilab.managers._noise import noise_cfg, noise_model
+from unilab.managers._noise.noise_cfg import NoiseCfg, NoiseModelCfg
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass
+class ObservationTermCfg(ManagerTermBaseCfg):
+    """Configuration for an observation term.
+
+    Processing pipeline: compute → noise → clip → scale → delay → history.
+    Delay models sensor latency. History provides temporal context. Both are optional
+    and can be combined.
+    """
+
+    noise: NoiseCfg | NoiseModelCfg | None = None
+    """Noise model to apply to the observation."""
+
+    clip: tuple[float, float] | None = None
+    """Range (min, max) to clip the observation values."""
+
+    scale: tuple[float, ...] | float | np.ndarray | None = None
+    """Scaling factor(s) to multiply the observation by."""
+
+    delay_min_lag: int = 0
+    """Minimum lag (in steps) for delayed observations. Lag sampled uniformly from
+  [min_lag, max_lag]. Convert to ms: lag * (1000 / control_hz)."""
+
+    delay_max_lag: int = 0
+    """Maximum lag (in steps) for delayed observations. Use min=max for constant delay."""
+
+    delay_per_env: bool = True
+    """If True, each environment samples its own lag. If False, all environments share
+  the same lag at each step."""
+
+    delay_hold_prob: float = 0.0
+    """Probability of reusing the previous lag instead of resampling. Useful for
+  temporally correlated latency patterns."""
+
+    delay_update_period: int = 0
+    """Resample lag every N steps (models multi-rate sensors). If 0, update every step."""
+
+    delay_per_env_phase: bool = True
+    """If True and update_period > 0, stagger update timing across envs to avoid
+  synchronized resampling."""
+
+    history_length: int = 0
+    """Number of past observations to keep in history. 0 = no history."""
+
+    flatten_history_dim: bool = True
+    """Whether to flatten the history dimension into observation.
+
+  When True and concatenate_terms=True, uses term-major ordering:
+  [A_t0, A_t1, ..., A_tH-1, B_t0, B_t1, ..., B_tH-1, ...]
+  See docs/source/observation.rst for details on ordering."""
+
+
+@dataclass
+class ObservationGroupCfg:
+    """Configuration for an observation group.
+
+    An observation group bundles multiple observation terms together. Groups are
+    typically used to separate observations for different purposes (e.g., "actor"
+    for the actor, "critic" for the value function).
+    """
+
+    terms: dict[str, ObservationTermCfg | None]
+    """Dictionary mapping term names to their configurations."""
+
+    concatenate_terms: bool = True
+    """Whether to concatenate all terms into a single tensor. If False, returns
+  a dict mapping term names to their individual tensors."""
+
+    concatenate_dim: int = -1
+    """Dimension along which to concatenate terms. Default -1 (last dimension)."""
+
+    enable_corruption: bool = False
+    """Whether to apply noise corruption to observations. Set to True during
+  training for domain randomization, False during evaluation."""
+
+    history_length: int | None = None
+    """Group-level history length override. If set, applies to all terms in
+  this group. If None, each term uses its own ``history_length`` setting."""
+
+    flatten_history_dim: bool = True
+    """Whether to flatten history into the observation dimension. If True,
+  observations have shape ``(num_envs, obs_dim * history_length)``. If False,
+  shape is ``(num_envs, history_length, obs_dim)``."""
+
+    nan_policy: Literal["disabled", "warn", "sanitize", "error"] = "error"
+    """NaN/Inf handling policy for observations in this group.
+
+  - 'disabled': No checks (explicit opt-out)
+  - 'warn': Log warning with term name and env IDs, then sanitize (debugging)
+  - 'sanitize': Silent sanitization to 0.0 like reward manager (safe for production)
+  - 'error': Raise ValueError on NaN/Inf (strict development mode)
+  """
+
+    nan_check_per_term: bool = True
+    """If True, check each observation term individually to identify NaN source.
+  If False, check only the final concatenated output (faster but less informative).
+  Only applies when nan_policy != 'disabled'."""
+
+
+class ObservationManager(ManagerBase):
+    """Manages observation computation for the environment.
+
+    The observation manager computes observations from multiple terms organized
+    into groups. Each term can have noise, clipping, scaling, delay, and history
+    applied. Groups can optionally concatenate their terms into a single tensor.
+    """
+
+    def __init__(self, cfg: dict[str, ObservationGroupCfg | None], env: ManagerBasedRlEnv):
+        self.cfg = deepcopy(cfg)
+        super().__init__(env=env)
+
+        self._group_obs_dim: dict[str, tuple[int, ...] | list[tuple[int, ...]]] = dict()
+
+        for group_name, group_term_dims in self._group_obs_term_dim.items():
+            if self._group_obs_concatenate[group_name]:
+                term_dims = np.stack([np.asarray(dims) for dims in group_term_dims], axis=0)
+                if len(term_dims.shape) > 1:
+                    if self._group_obs_concatenate_dim[group_name] >= 0:
+                        dim = self._group_obs_concatenate_dim[group_name] - 1
+                    else:
+                        dim = self._group_obs_concatenate_dim[group_name]
+                    dim_sum = np.sum(term_dims[:, dim], axis=0)
+                    term_dims[0, dim] = dim_sum
+                    term_dims = term_dims[0]
+                else:
+                    term_dims = np.sum(term_dims, axis=0)
+                self._group_obs_dim[group_name] = tuple(term_dims.tolist())
+            else:
+                self._group_obs_dim[group_name] = group_term_dims
+
+        self._obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] | None = None
+
+    def __str__(self) -> str:
+        msg = f"<ObservationManager> contains {len(self._group_obs_term_names)} groups.\n"
+        for group_name, group_dim in self._group_obs_dim.items():
+            table = PrettyTable()
+            table.title = f"Active Observation Terms in Group: '{group_name}'"
+            if self._group_obs_concatenate[group_name]:
+                table.title += f" (shape: {group_dim})"  # type: ignore
+            table.field_names = ["Index", "Name", "Shape"]
+            table.align["Name"] = "l"
+            obs_terms = zip(
+                self._group_obs_term_names[group_name],
+                self._group_obs_term_dim[group_name],
+                self._group_obs_term_cfgs[group_name],
+                strict=False,
+            )
+            for index, (name, dims, term_cfg) in enumerate(obs_terms):
+                if term_cfg.history_length > 0 and term_cfg.flatten_history_dim:
+                    # Flattened history: show (9,) ← 3×(3,)
+                    original_size = int(np.prod(dims)) // term_cfg.history_length
+                    original_shape = (original_size,) if len(dims) == 1 else dims[1:]
+                    shape_str = f"{dims}  ← {term_cfg.history_length}×{original_shape}"
+                else:
+                    shape_str = str(tuple(dims))
+                table.add_row([index, name, shape_str])
+            msg += str(table.get_string())
+            msg += "\n"
+        return msg
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+
+        if self._obs_buffer is None:
+            self.compute()
+        assert self._obs_buffer is not None
+        obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] = self._obs_buffer
+
+        for group_name, _ in self.group_obs_dim.items():
+            if not self.group_obs_concatenate[group_name]:
+                buffers = obs_buffer[group_name]
+                assert isinstance(buffers, dict)
+                for name, term in buffers.items():
+                    terms.append((group_name + "-" + name, term[env_idx].tolist()))
+                continue
+
+            idx = 0
+            data = obs_buffer[group_name]
+            assert isinstance(data, np.ndarray)
+            for name, shape in zip(
+                self._group_obs_term_names[group_name],
+                self._group_obs_term_dim[group_name],
+                strict=False,
+            ):
+                data_length = np.prod(shape)
+                term = data[env_idx, idx : idx + data_length]
+                terms.append((group_name + "-" + name, term.tolist()))
+                idx += data_length
+
+        return terms
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> dict[str, list[str]]:
+        return self._group_obs_term_names
+
+    @property
+    def group_obs_dim(self) -> dict[str, tuple[int, ...] | list[tuple[int, ...]]]:
+        return self._group_obs_dim
+
+    @property
+    def group_obs_term_dim(self) -> dict[str, list[tuple[int, ...]]]:
+        return self._group_obs_term_dim
+
+    @property
+    def group_obs_concatenate(self) -> dict[str, bool]:
+        return self._group_obs_concatenate
+
+    # Methods.
+
+    def get_term_cfg(self, group_name: str, term_name: str) -> ObservationTermCfg:
+        if group_name not in self._group_obs_term_names:
+            raise ValueError(f"Group '{group_name}' not found in active groups.")
+        if term_name not in self._group_obs_term_names[group_name]:
+            raise ValueError(f"Term '{term_name}' not found in group '{group_name}'.")
+        index = self._group_obs_term_names[group_name].index(term_name)
+        return self._group_obs_term_cfgs[group_name][index]
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
+        # Invalidate cache since reset envs will have different observations.
+        self._obs_buffer = None
+
+        for group_name, group_cfg in self._group_obs_class_term_cfgs.items():
+            for term_cfg in group_cfg:
+                term_cfg.func.reset(env_ids=env_ids)
+            for term_name in self._group_obs_term_names[group_name]:
+                batch_ids = env_ids
+                if term_name in self._group_obs_term_delay_buffer[group_name]:
+                    self._group_obs_term_delay_buffer[group_name][term_name].reset(
+                        batch_ids=batch_ids
+                    )
+                if term_name in self._group_obs_term_history_buffer[group_name]:
+                    self._group_obs_term_history_buffer[group_name][term_name].reset(
+                        batch_ids=batch_ids
+                    )
+        for group_mods in self._group_obs_class_instances.values():
+            for mod in group_mods.values():
+                mod.reset(env_ids=env_ids)
+        return {}
+
+    def _check_and_handle_nans(self, tensor: np.ndarray, context: str, policy: str) -> np.ndarray:
+        """Check for NaN/Inf and handle according to policy.
+
+        Args:
+          tensor: Observation tensor to check.
+          context: Context string for error/warning messages (e.g., "actor/base_lin_vel").
+          policy: NaN handling policy ("disabled", "warn", "sanitize", "error").
+
+        Returns:
+          The tensor, potentially sanitized depending on policy.
+
+        Raises:
+          ValueError: If policy is "error" and NaN/Inf detected.
+        """
+        if policy == "disabled":
+            return tensor
+
+        has_nan = np.isnan(tensor).any()
+        has_inf = np.isinf(tensor).any()
+
+        if not (has_nan or has_inf):
+            return tensor
+
+        if policy == "error":
+            invalid = ~np.isfinite(tensor)
+            nan_mask = invalid.reshape(self.num_envs, -1).any(axis=1)
+            nan_env_ids = np.flatnonzero(nan_mask).tolist()
+            invalid_kind = (
+                "NaN"
+                if has_nan and not has_inf
+                else "Inf"
+                if has_inf and not has_nan
+                else "NaN/Inf"
+            )
+            raise ValueError(
+                f"{invalid_kind} detected in ObservationManager term '{context}' "
+                f"for environments: {nan_env_ids[:10]}"
+            )
+
+        if policy == "warn":
+            invalid = ~np.isfinite(tensor)
+            nan_mask = invalid.reshape(self.num_envs, -1).any(axis=1)
+            nan_env_ids = np.flatnonzero(nan_mask).tolist()
+            print(
+                f"[ObservationManager] NaN/Inf in '{context}' "
+                f"(envs: {nan_env_ids[:5]}). Sanitizing to 0."
+            )
+
+        # Sanitize (applies to both "warn" and "sanitize" policies).
+        return np.nan_to_num(tensor, nan=0.0, posinf=0.0, neginf=0.0)
+
+    def compute(
+        self,
+        update_history: bool = False,
+        env_ids: np.ndarray | None = None,
+    ) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
+        """Compute observations for all groups.
+
+        With env_ids=None (the per-step path), history and delay buffers advance
+        for all envs. With env_ids (the reset path), only the reset envs' buffers
+        receive their post-reset frame (a backfill); other envs' buffers, delay
+        schedules, and lag draws are untouched, so a partial reset does not
+        advance their observation timelines.
+        """
+        if env_ids is not None and not update_history:
+            raise ValueError("env_ids is only meaningful with update_history=True.")
+        # Return cached observations if not updating and cache exists.
+        # This prevents double-pushing to delay buffers when compute() is called
+        # multiple times per control step (e.g., in get_observations() after step()).
+        if not update_history and self._obs_buffer is not None:
+            return self._obs_buffer
+
+        obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] = dict()
+        for group_name in self._group_obs_term_names:
+            obs_buffer[group_name] = self.compute_group(group_name, update_history, env_ids)
+        self._obs_buffer = obs_buffer
+        return obs_buffer
+
+    def compute_group(
+        self,
+        group_name: str,
+        update_history: bool = False,
+        env_ids: np.ndarray | None = None,
+    ) -> np.ndarray | dict[str, np.ndarray]:
+        group_cfg = self.cfg[group_name]
+        if group_cfg is None:
+            raise KeyError(f"Observation group '{group_name}' is disabled.")
+        group_term_names = self._group_obs_term_names[group_name]
+        group_obs: dict[str, np.ndarray] = {}
+        obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name], strict=False)
+        for term_name, term_cfg in obs_terms:
+            obs = term_cfg.func(self._env, **term_cfg.params)
+            if not isinstance(obs, np.ndarray):
+                raise TypeError(
+                    f"ObservationManager term '{group_name}/{term_name}' returned "
+                    f"{type(obs).__name__}, expected np.ndarray."
+                )
+            if obs.ndim < 2 or obs.shape[0] != self.num_envs:
+                raise ValueError(
+                    f"ObservationManager term '{group_name}/{term_name}' returned shape "
+                    f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
+                )
+            obs = obs.copy()
+            if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
+                obs = term_cfg.noise.apply(obs, rng=self._env.rng)
+            elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
+                obs = self._group_obs_class_instances[group_name][term_name](obs)
+            if term_cfg.clip:
+                np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
+            if term_cfg.scale is not None:
+                scale = term_cfg.scale
+                assert isinstance(scale, np.ndarray)
+                np.multiply(obs, scale, out=obs)
+
+            # Check for NaN/Inf before delay/history buffers (per-term checking).
+            if group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+                obs = self._check_and_handle_nans(
+                    obs, context=f"{group_name}/{term_name}", policy=group_cfg.nan_policy
+                )
+
+            if term_cfg.delay_max_lag > 0:
+                delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
+                if env_ids is None or not delay_buffer.is_initialized:
+                    delay_buffer.append(obs)
+                    obs = delay_buffer.compute()
+                else:
+                    delay_buffer.backfill(obs, env_ids)
+                    obs = delay_buffer.peek()
+            if term_cfg.history_length > 0:
+                circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
+                if env_ids is None or not circular_buffer.is_initialized:
+                    if update_history or not circular_buffer.is_initialized:
+                        circular_buffer.append(obs)
+                else:
+                    circular_buffer.backfill(obs, env_ids)
+
+                if term_cfg.flatten_history_dim:
+                    group_obs[term_name] = circular_buffer.buffer.reshape(self._env.num_envs, -1)
+                else:
+                    group_obs[term_name] = circular_buffer.buffer
+            else:
+                group_obs[term_name] = obs
+
+        # Final NaN check for non-per-term checking.
+        if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+            if self._group_obs_concatenate[group_name]:
+                # Will check after concatenation below.
+                pass
+            else:
+                for term_name in group_obs:
+                    group_obs[term_name] = self._check_and_handle_nans(
+                        group_obs[term_name],
+                        context=f"{group_name}/{term_name}",
+                        policy=group_cfg.nan_policy,
+                    )
+
+        if self._group_obs_concatenate[group_name]:
+            result = np.concatenate(
+                list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
+            )
+            # Final check for concatenated result (non-per-term checking).
+            if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+                result = self._check_and_handle_nans(
+                    result, context=group_name, policy=group_cfg.nan_policy
+                )
+            return result
+        return group_obs
+
+    def _prepare_terms(self) -> None:
+        self._group_obs_term_names: dict[str, list[str]] = dict()
+        self._group_obs_term_dim: dict[str, list[tuple[int, ...]]] = dict()
+        self._group_obs_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
+        self._group_obs_class_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
+        self._group_obs_concatenate: dict[str, bool] = dict()
+        self._group_obs_concatenate_dim: dict[str, int] = dict()
+        self._group_obs_class_instances: dict[str, dict[str, noise_model.NoiseModel]] = {}
+        self._group_obs_term_delay_buffer: dict[str, dict[str, DelayBuffer]] = dict()
+        self._group_obs_term_history_buffer: dict[str, dict[str, CircularBuffer]] = dict()
+
+        for group_name, group_cfg in self.cfg.items():
+            if group_cfg is None:
+                print(f"group: {group_name} set to None, skipping...")
+                continue
+
+            if not any(t is not None for t in group_cfg.terms.values()):
+                print(f"group: {group_name} has no active terms, skipping...")
+                continue
+
+            if group_cfg.nan_policy not in ("disabled", "warn", "sanitize", "error"):
+                raise ValueError(
+                    f"Observation group '{group_name}' has unsupported NaN policy "
+                    f"'{group_cfg.nan_policy}'."
+                )
+            if group_cfg.history_length is not None and group_cfg.history_length < 0:
+                raise ValueError(
+                    f"Observation group '{group_name}' has negative history_length "
+                    f"{group_cfg.history_length}."
+                )
+
+            self._group_obs_term_names[group_name] = list()
+            self._group_obs_term_dim[group_name] = list()
+            self._group_obs_term_cfgs[group_name] = list()
+            self._group_obs_class_term_cfgs[group_name] = list()
+            self._group_obs_class_instances[group_name] = {}
+            group_entry_delay_buffer: dict[str, DelayBuffer] = dict()
+            group_entry_history_buffer: dict[str, CircularBuffer] = dict()
+
+            self._group_obs_concatenate[group_name] = group_cfg.concatenate_terms
+            self._group_obs_concatenate_dim[group_name] = (
+                group_cfg.concatenate_dim + 1
+                if group_cfg.concatenate_dim >= 0
+                else group_cfg.concatenate_dim
+            )
+
+            for term_name, term_cfg in group_cfg.terms.items():
+                if term_cfg is None:
+                    print(f"term: {term_name} set to None, skipping...")
+                    continue
+
+                if term_cfg.delay_min_lag < 0 or term_cfg.delay_max_lag < term_cfg.delay_min_lag:
+                    raise ValueError(
+                        f"ObservationManager term '{group_name}/{term_name}' has invalid "
+                        f"delay range [{term_cfg.delay_min_lag}, {term_cfg.delay_max_lag}]."
+                    )
+                if term_cfg.history_length < 0:
+                    raise ValueError(
+                        f"ObservationManager term '{group_name}/{term_name}' has negative "
+                        f"history_length {term_cfg.history_length}."
+                    )
+                if term_cfg.clip is not None and term_cfg.clip[0] > term_cfg.clip[1]:
+                    raise ValueError(
+                        f"ObservationManager term '{group_name}/{term_name}' has invalid "
+                        f"clip range {term_cfg.clip}."
+                    )
+
+                # NOTE: This deepcopy is important to avoid cross-group contamination of term
+                # configs.
+                term_cfg = deepcopy(term_cfg)
+                self._resolve_common_term_cfg(term_name, term_cfg)
+
+                if not group_cfg.enable_corruption:
+                    term_cfg.noise = None
+                if group_cfg.history_length is not None:
+                    term_cfg.history_length = group_cfg.history_length
+                    term_cfg.flatten_history_dim = group_cfg.flatten_history_dim
+                self._group_obs_term_names[group_name].append(term_name)
+                self._group_obs_term_cfgs[group_name].append(term_cfg)
+                if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                    self._group_obs_class_term_cfgs[group_name].append(term_cfg)
+
+                initial_obs = term_cfg.func(self._env, **term_cfg.params)
+                if not isinstance(initial_obs, np.ndarray):
+                    raise TypeError(
+                        f"ObservationManager term '{group_name}/{term_name}' returned "
+                        f"{type(initial_obs).__name__}, expected np.ndarray."
+                    )
+                if initial_obs.ndim < 2 or initial_obs.shape[0] != self.num_envs:
+                    raise ValueError(
+                        f"ObservationManager term '{group_name}/{term_name}' returned shape "
+                        f"{initial_obs.shape}, expected (num_envs, ...) with "
+                        f"num_envs={self.num_envs}."
+                    )
+                obs_dims = tuple(initial_obs.shape)
+
+                if term_cfg.scale is not None:
+                    term_cfg.scale = np.asarray(term_cfg.scale, dtype=np.float32).copy()
+
+                if term_cfg.noise is not None and isinstance(
+                    term_cfg.noise, noise_cfg.NoiseModelCfg
+                ):
+                    noise_model_cls = term_cfg.noise.class_type
+                    if not issubclass(noise_model_cls, noise_model.NoiseModel):
+                        raise TypeError(
+                            f"ObservationManager term '{group_name}/{term_name}' noise model "
+                            f"{noise_model_cls} is not a NoiseModel subclass."
+                        )
+                    self._group_obs_class_instances[group_name][term_name] = noise_model_cls(
+                        term_cfg.noise, num_envs=self._env.num_envs, rng=self._env.rng
+                    )
+
+                if term_cfg.delay_max_lag > 0:
+                    group_entry_delay_buffer[term_name] = DelayBuffer(
+                        min_lag=term_cfg.delay_min_lag,
+                        max_lag=term_cfg.delay_max_lag,
+                        batch_size=self._env.num_envs,
+                        per_env=term_cfg.delay_per_env,
+                        hold_prob=term_cfg.delay_hold_prob,
+                        update_period=term_cfg.delay_update_period,
+                        per_env_phase=term_cfg.delay_per_env_phase,
+                        generator=self._env.rng,
+                    )
+
+                if term_cfg.history_length > 0:
+                    group_entry_history_buffer[term_name] = CircularBuffer(
+                        max_len=term_cfg.history_length,
+                        batch_size=self._env.num_envs,
+                    )
+                    old_dims = list(obs_dims)
+                    old_dims.insert(1, term_cfg.history_length)
+                    obs_dims = tuple(old_dims)
+                    if term_cfg.flatten_history_dim:
+                        obs_dims = (obs_dims[0], int(np.prod(obs_dims[1:])))
+
+                self._group_obs_term_dim[group_name].append(obs_dims[1:])
+
+            self._group_obs_term_delay_buffer[group_name] = group_entry_delay_buffer
+            self._group_obs_term_history_buffer[group_name] = group_entry_history_buffer

--- a/src/unilab/managers/recorder_manager.py
+++ b/src/unilab/managers/recorder_manager.py
@@ -1,0 +1,267 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/recorder_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Recorder manager for logging environment data during rollouts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass
+class RecorderTermCfg(ManagerTermBaseCfg):
+    """Configuration for a recorder term.
+
+    ``func`` must be a :class:`RecorderTerm` subclass. Function-based terms are not
+    supported because recorder terms are stateful (file handles, buffers, etc.).
+    """
+
+
+class RecorderTerm(ManagerTermBase):
+    """Base class for recorder terms.
+
+    Override only the lifecycle methods you need. Each method is a no-op by default so
+    subclasses are not required to implement all of them.
+
+    The environment is available as ``self._env``, giving access to ``self._env.obs_buf``,
+    ``self._env.action_manager.action``, and all other environment state.
+
+    Example::
+
+      class CsvRecorder(RecorderTerm):
+        def __init__(self, cfg, env):
+          super().__init__(cfg, env)
+          self._file = open(cfg.params["path"], "w", newline="")
+          self._writer = csv.writer(self._file)
+
+        def record_pre_reset(self, env_ids):
+          # Terminal transition: action is still intact here.
+          # It will be zeroed by _reset_idx immediately after this returns.
+          obs = self._env.obs_buf["actor"][env_ids]
+          act = self._env.action_manager.action[env_ids]
+          for o, a in zip(obs, act):
+            self._writer.writerow(o.tolist() + a.tolist())
+
+        def record_post_step(self):
+          # Skip envs that just reset: their terminal pair was written in record_pre_reset
+          # and their action is now zeroed.
+          mask = ~self._env.reset_buf
+          obs = self._env.obs_buf["actor"][mask]
+          act = self._env.action_manager.action[mask]
+          for o, a in zip(obs, act):
+            self._writer.writerow(o.tolist() + a.tolist())
+
+        def close(self):
+          self._file.close()
+    """
+
+    def __init__(self, cfg: RecorderTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)  # ManagerTermBase only accepts env
+        self.cfg = cfg
+
+    def record_pre_reset(self, env_ids: np.ndarray) -> None:
+        """Called in ``env.step()`` before terminated environments are reset.
+
+        **What is available:**
+
+        - ``obs_buf`` contains the observation from the *end of the previous step* (the
+          input the agent used to choose the terminal action). It does **not** contain the
+          post-action terminal observation (the state reached after applying the action),
+          which is never computed for resetting environments.
+        - ``action_manager.action`` contains the action applied during this step. This is
+          the correct terminal action. It will be zeroed for these environments by
+          ``_reset_idx`` immediately after this hook returns, so capture it here if you
+          need it later.
+        - ``reward_buf`` contains the reward for this terminal step.
+        - ``reset_terminated`` and ``reset_time_outs`` reflect why each environment is
+          resetting.
+
+        This is the right hook to record the terminal transition
+        ``(obs_t, action_t, reward_t, done=True)`` for each resetting environment.
+
+        Args:
+          env_ids: Indices of environments that are about to be reset.
+        """
+        del env_ids  # Unused in base implementation.
+
+    def record_post_reset(self, env_ids: np.ndarray) -> None:
+        """Called after a reset completes with fresh observations computed.
+
+        Fires at the end of ``env.reset()`` (covering all environments on the initial call)
+        and within ``env.step()`` for each batch of environments that terminates, after
+        state has been overwritten and new observations computed.
+
+        At this point ``obs_buf[env_ids]`` holds the initial observation of the new episode
+        and ``action_manager.action[env_ids]`` is zero (no action has been taken in the new
+        episode yet).
+
+        Use this hook to initialize per-episode state or record the first observation of a
+        new episode.
+
+        Args:
+          env_ids: Indices of environments that were reset.
+        """
+        del env_ids  # Unused in base implementation.
+
+    def record_post_step(self) -> None:
+        """Called at the end of every ``env.step()`` with fresh observations.
+
+        At this point ``obs_buf`` holds the new observation for every environment and
+        ``action_manager.action`` holds the action that was applied during this step.
+        **Exception:** for environments that reset during this step,
+        ``action_manager.action`` has been zeroed by ``_reset_idx`` and ``obs_buf`` holds
+        the initial observation of the new episode rather than the post-action terminal
+        observation. Use ``record_pre_reset`` to capture the terminal ``(obs, action)``
+        pair for those environments. Resetting environments are identified by
+        ``self._env.reset_buf``.
+        """
+
+    def close(self) -> None:
+        """Called when the environment closes.
+
+        Release file handles, flush write buffers, or finalize output here.
+        """
+
+    def __call__(self):
+        raise NotImplementedError(
+            "RecorderTerm is not invoked via __call__. Override the lifecycle methods instead."
+        )
+
+
+class RecorderManager(ManagerBase):
+    """Orchestrates recorder terms during environment rollouts.
+
+    Holds a collection of :class:`RecorderTerm` instances and calls their lifecycle
+    methods at the appropriate points in the environment loop. The manager has no opinion
+    on how data is stored; each term handles its own I/O entirely.
+
+    Register terms by adding them to the ``recorders`` dict on
+    :class:`ManagerBasedRlEnvCfg`. If the dict is empty, the environment
+    substitutes a :class:`NullRecorderManager` with zero overhead.
+    """
+
+    def __init__(self, cfg: dict[str, RecorderTermCfg | None], env: ManagerBasedRlEnv):
+        self._terms: dict[str, RecorderTerm] = {}
+        self.cfg = deepcopy(cfg)
+        super().__init__(env)  # calls _prepare_terms()
+
+    def __str__(self) -> str:
+        msg = f"<RecorderManager> contains {len(self._terms)} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Recorder Terms"
+        table.field_names = ["Index", "Name"]
+        for idx, name in enumerate(self._terms):
+            table.add_row([idx, name])
+        return msg + str(table.get_string())
+
+    def __contains__(self, name: str) -> bool:
+        """Return True if a term named ``name`` is registered."""
+        return name in self._terms
+
+    @property
+    def active_terms(self) -> list[str]:
+        """List of active term names."""
+        return list(self._terms.keys())
+
+    def get_term(self, name: str) -> RecorderTerm:
+        """Return the recorder term registered under ``name``.
+
+        Use this to reach a recorder's public methods (e.g. to start/stop logging)
+        from outside the env loop without touching private state.
+
+        Args:
+          name: Term name as registered in ``ManagerBasedRlEnvCfg.recorders``.
+
+        Raises:
+          KeyError: If no term is registered under ``name``.
+        """
+        try:
+            return self._terms[name]
+        except KeyError:
+            msg = f"No recorder term named '{name}'. Active terms: {self.active_terms}"
+            raise KeyError(msg) from None
+
+    def record_pre_reset(self, env_ids: np.ndarray) -> None:
+        """Forward to each term's :meth:`RecorderTerm.record_pre_reset`."""
+        for term in self._terms.values():
+            term.record_pre_reset(env_ids)
+
+    def record_post_reset(self, env_ids: np.ndarray) -> None:
+        """Forward to each term's :meth:`RecorderTerm.record_post_reset`."""
+        for term in self._terms.values():
+            term.record_post_reset(env_ids)
+
+    def record_post_step(self) -> None:
+        """Forward to each term's :meth:`RecorderTerm.record_post_step`."""
+        for term in self._terms.values():
+            term.record_post_step()
+
+    def close(self) -> None:
+        """Forward to each term's :meth:`RecorderTerm.close`."""
+        for term in self._terms.values():
+            term.close()
+
+    def _prepare_terms(self) -> None:
+        for name, cfg in self.cfg.items():
+            if cfg is None:
+                continue
+            self._resolve_common_term_cfg(name, cfg)
+            # _resolve_common_term_cfg instantiates class-based terms in-place.
+            if not isinstance(cfg.func, RecorderTerm):
+                raise TypeError(
+                    f"Recorder term '{name}': func must be a RecorderTerm subclass,"
+                    f" got {type(cfg.func).__name__}. Function-based terms are not"
+                    " supported."
+                )
+            self._terms[name] = cfg.func
+
+
+class NullRecorderManager:
+    """No-op fallback used when no recorder terms are configured.
+
+    All methods are no-ops. This class is not a :class:`ManagerBase` subclass
+    so it carries zero overhead.
+    """
+
+    def __init__(self):
+        self.active_terms: list[str] = []
+        self.cfg = None
+
+    def __str__(self) -> str:
+        return "<NullRecorderManager> (inactive)"
+
+    def __repr__(self) -> str:
+        return "NullRecorderManager()"
+
+    def __contains__(self, name: str) -> bool:
+        """Always returns False since there are no terms."""
+        del name
+        return False
+
+    def get_term(self, name: str) -> RecorderTerm:
+        """Always raises KeyError since there are no terms."""
+        del name
+        msg = "NullRecorderManager has no terms."
+        raise KeyError(msg)
+
+    def record_pre_reset(self, env_ids: np.ndarray) -> None:
+        del env_ids
+
+    def record_post_reset(self, env_ids: np.ndarray) -> None:
+        del env_ids
+
+    def record_post_step(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass

--- a/src/unilab/managers/reward_manager.py
+++ b/src/unilab/managers/reward_manager.py
@@ -1,0 +1,154 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/reward_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Reward manager for computing reward signals."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import DebugVisualizer, ManagerBasedRlEnv
+
+
+@dataclass(kw_only=True)
+class RewardTermCfg(ManagerTermBaseCfg):
+    """Configuration for a reward term."""
+
+    func: Any
+    """The callable that computes this reward term's value."""
+
+    weight: float
+    """Weight multiplier for this reward term."""
+
+
+class RewardManager(ManagerBase):
+    """Manages reward computation by aggregating weighted reward terms.
+
+    Reward Scaling Behavior:
+      By default, rewards are scaled by the environment step duration (dt). This
+      normalizes cumulative episodic rewards across different simulation frequencies.
+      The scaling can be disabled via the ``scale_by_dt`` parameter.
+
+      When ``scale_by_dt=True`` (default):
+        - ``reward_buf`` (returned by ``compute()``) = raw_value * weight * dt
+        - ``_episode_sums`` (cumulative rewards) are scaled by dt
+        - ``Episode_Reward/*`` logged metrics are scaled by dt
+
+      When ``scale_by_dt=False``:
+        - ``reward_buf`` = raw_value * weight (no dt scaling)
+
+      Regardless of the scaling setting:
+        - ``_step_reward`` (via ``get_active_iterable_terms()``) always contains
+          the unscaled reward rate (raw_value * weight)
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(
+        self,
+        cfg: dict[str, RewardTermCfg | None],
+        env: ManagerBasedRlEnv,
+        *,
+        scale_by_dt: bool = True,
+    ):
+        self._term_names: list[str] = list()
+        self._term_cfgs: list[RewardTermCfg] = list()
+        self._class_term_cfgs: list[RewardTermCfg] = list()
+        self._scale_by_dt = scale_by_dt
+
+        self.cfg = deepcopy(cfg)
+        super().__init__(env=env)
+        self._episode_sums = dict()
+        for term_name in self._term_names:
+            self._episode_sums[term_name] = np.zeros(self.num_envs, dtype=np.float32)
+        self._reward_buf = np.zeros(self.num_envs, dtype=np.float32)
+        self._step_reward = np.zeros((self.num_envs, len(self._term_names)), dtype=np.float32)
+
+    def __str__(self) -> str:
+        msg = f"<RewardManager> contains {len(self._term_names)} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Reward Terms"
+        table.field_names = ["Index", "Name", "Weight"]
+        table.align["Name"] = "l"
+        table.align["Weight"] = "r"
+        for index, (name, term_cfg) in enumerate(
+            zip(self._term_names, self._term_cfgs, strict=False)
+        ):
+            table.add_row([index, name, term_cfg.weight])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> list[str]:
+        return self._term_names
+
+    # Methods.
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
+        if env_ids is None:
+            env_ids = slice(None)
+        extras = {}
+        for key in self._episode_sums.keys():
+            episodic_sum_avg = float(np.mean(self._episode_sums[key][env_ids]))
+            extras["Episode_Reward/" + key] = episodic_sum_avg / self._env.max_episode_length_s
+            self._episode_sums[key][env_ids] = 0.0
+        for term_cfg in self._class_term_cfgs:
+            term_cfg.func.reset(env_ids=env_ids)
+        return extras
+
+    def compute(self, dt: float) -> np.ndarray:
+        if not np.isfinite(dt) or (self._scale_by_dt and dt <= 0.0):
+            raise ValueError(f"RewardManager received invalid dt {dt}.")
+        self._reward_buf[:] = 0.0
+        scale = dt if self._scale_by_dt else 1.0
+        for term_idx, (name, term_cfg) in enumerate(
+            zip(self._term_names, self._term_cfgs, strict=False)
+        ):
+            if term_cfg.weight == 0.0:
+                self._step_reward[:, term_idx] = 0.0
+                continue
+            value = term_cfg.func(self._env, **term_cfg.params)
+            self._check_term_shape(name, value)
+            self._check_term_finite(name, value)
+            value = value * term_cfg.weight * scale
+            self._reward_buf += value
+            self._episode_sums[name] += value
+            self._step_reward[:, term_idx] = value / scale
+        return self._reward_buf
+
+    def get_active_iterable_terms(self, env_idx: int) -> list[tuple[str, list[float]]]:
+        terms = []
+        for idx, name in enumerate(self._term_names):
+            terms.append((name, [self._step_reward[env_idx, idx].item()]))
+        return terms
+
+    def get_term_cfg(self, term_name: str) -> RewardTermCfg:
+        if term_name not in self._term_names:
+            raise ValueError(f"Term '{term_name}' not found in active terms.")
+        return self._term_cfgs[self._term_names.index(term_name)]
+
+    def _prepare_terms(self) -> None:
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            if not np.isfinite(term_cfg.weight):
+                raise ValueError(
+                    f"RewardManager term '{term_name}' has non-finite weight {term_cfg.weight}."
+                )
+            self._resolve_common_term_cfg(term_name, term_cfg)
+            self._term_names.append(term_name)
+            self._term_cfgs.append(term_cfg)
+            if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                self._class_term_cfgs.append(term_cfg)

--- a/src/unilab/managers/scene_entity_config.py
+++ b/src/unilab/managers/scene_entity_config.py
@@ -1,0 +1,263 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/scene_entity_config.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Configuration for scene entities used by manager terms."""
+
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+from unilab.managers._types import ManagerEntity, ManagerScene
+
+
+class _FieldConfig(NamedTuple):
+    """Configuration for a resolvable entity field."""
+
+    names_attr: str
+    ids_attr: str
+    find_method: str
+    num_attr: str
+    kind_label: str
+
+
+_FIELD_CONFIGS = [
+    _FieldConfig("joint_names", "joint_ids", "find_joints", "num_joints", "joint"),
+    _FieldConfig("body_names", "body_ids", "find_bodies", "num_bodies", "body"),
+    _FieldConfig("geom_names", "geom_ids", "find_geoms", "num_geoms", "geom"),
+    _FieldConfig("site_names", "site_ids", "find_sites", "num_sites", "site"),
+    _FieldConfig("actuator_names", "actuator_ids", "find_actuators", "num_actuators", "actuator"),
+    _FieldConfig("tendon_names", "tendon_ids", "find_tendons", "num_tendons", "tendon"),
+    _FieldConfig(
+        "camera_names",
+        "camera_ids",
+        "find_cameras",
+        "num_cameras",
+        "camera",
+    ),
+    _FieldConfig(
+        "light_names",
+        "light_ids",
+        "find_lights",
+        "num_lights",
+        "light",
+    ),
+    _FieldConfig(
+        "material_names",
+        "material_ids",
+        "find_materials",
+        "num_materials",
+        "material",
+    ),
+    _FieldConfig(
+        "texture_names",
+        "texture_ids",
+        "find_textures",
+        "num_textures",
+        "texture",
+    ),
+    _FieldConfig("pair_names", "pair_ids", "find_pairs", "num_pairs", "pair"),
+]
+
+
+@dataclass
+class SceneEntityCfg:
+    """Configuration for a scene entity that is used by the manager's term.
+
+    This configuration allows flexible specification of entity components either by name
+    or by ID. During resolution, it ensures consistency between names and IDs, and can
+    optimize to slice(None) when all components are selected.
+    """
+
+    name: str
+    """The name of the entity in the scene."""
+
+    joint_names: str | tuple[str, ...] | None = None
+    """Names of joints to include. Can be a single string or tuple."""
+
+    joint_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of joints to include. Can be a list or slice."""
+
+    body_names: str | tuple[str, ...] | None = None
+    """Names of bodies to include. Can be a single string or tuple."""
+
+    body_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of bodies to include. Can be a list or slice."""
+
+    geom_names: str | tuple[str, ...] | None = None
+    """Names of geometries to include. Can be a single string or tuple."""
+
+    geom_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of geometries to include. Can be a list or slice."""
+
+    site_names: str | tuple[str, ...] | None = None
+    """Names of sites to include. Can be a single string or tuple."""
+
+    site_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of sites to include. Can be a list or slice."""
+
+    actuator_names: str | list[str] | None = None
+    """Names of actuators to include. Can be a single string or list."""
+
+    actuator_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of actuators to include. Can be a list or slice."""
+
+    tendon_names: str | tuple[str, ...] | None = None
+    """Names of tendons to include. Can be a single string or tuple."""
+
+    tendon_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of tendons to include. Can be a list or slice."""
+
+    camera_names: str | tuple[str, ...] | None = None
+    """Names of cameras to include. Can be a single string or tuple."""
+
+    camera_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of cameras to include. Can be a list or slice."""
+
+    light_names: str | tuple[str, ...] | None = None
+    """Names of lights to include. Can be a single string or tuple."""
+
+    light_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of lights to include. Can be a list or slice."""
+
+    material_names: str | tuple[str, ...] | None = None
+    """Names of materials to include. Can be a single string or tuple."""
+
+    material_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of materials to include. Can be a list or slice."""
+
+    texture_names: str | tuple[str, ...] | None = None
+    """Names of textures to include. Can be a single string or tuple."""
+
+    texture_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of textures to include. Can be a list or slice."""
+
+    pair_names: str | tuple[str, ...] | None = None
+    """Names of contact pairs to include. Can be a single string or tuple."""
+
+    pair_ids: list[int] | slice = field(default_factory=lambda: slice(None))
+    """IDs of contact pairs to include. Can be a list or slice."""
+
+    preserve_order: bool = False
+    """If True, maintains the order of components as specified."""
+
+    def resolve(self, scene: ManagerScene) -> None:
+        """Resolve names and IDs for all configured fields.
+
+        This method ensures consistency between names and IDs for each field type.
+        It handles three cases:
+        1. Both names and IDs provided: Validates they match
+        2. Only names provided: Computes IDs (optimizes to slice(None) if all selected)
+        3. Only IDs provided: Computes names
+
+        Args:
+          scene: The scene containing the entity to resolve against.
+
+        Raises:
+          ValueError: If provided names and IDs are inconsistent.
+          KeyError: If the entity name is not found in the scene.
+        """
+        entity = scene[self.name]
+
+        for config in _FIELD_CONFIGS:
+            self._resolve_field(entity, config)
+
+    def _resolve_field(self, entity: ManagerEntity, config: _FieldConfig) -> None:
+        """Resolve a single field's names and IDs.
+
+        Args:
+          entity: The entity to resolve against.
+          config: Field configuration specifying attribute names and methods.
+        """
+        names = getattr(self, config.names_attr)
+        ids = getattr(self, config.ids_attr)
+
+        # Early return if nothing to resolve.
+        if names is None and not isinstance(ids, list):
+            return
+
+        # Get entity metadata.
+        entity_all_names = getattr(entity, config.names_attr)
+        entity_count = getattr(entity, config.num_attr)
+        find_method = getattr(entity, config.find_method)
+
+        # Normalize single values to lists for uniform processing.
+        names = self._normalize_to_list(names)
+        if isinstance(ids, (int, list)):
+            ids = self._normalize_to_list(ids)
+            setattr(self, config.ids_attr, ids)
+
+        # Handle three resolution cases.
+        if names is not None and isinstance(ids, list):
+            setattr(self, config.names_attr, names)
+            self._validate_consistency(names, ids, entity_all_names, find_method, config.kind_label)
+        elif names is not None:
+            self._resolve_names_to_ids(
+                names,
+                entity_all_names,
+                entity_count,
+                find_method,
+                config.names_attr,
+                config.ids_attr,
+            )
+        elif isinstance(ids, list):
+            self._resolve_ids_to_names(ids, entity_all_names, config.names_attr)
+
+    def _normalize_to_list(self, value: str | int | tuple | list | None) -> list | None:
+        """Convert single values to lists for uniform processing."""
+        if value is None:
+            return None
+        if isinstance(value, (str, int)):
+            return [value]
+        if isinstance(value, list):
+            return value
+        return list(value)
+
+    def _validate_consistency(
+        self,
+        names: list[str],
+        ids: list[int],
+        entity_all_names: list[str],
+        find_method,
+        kind_label: str,
+    ) -> None:
+        """Validate that provided names and IDs are consistent.
+
+        Raises:
+          ValueError: If names and IDs don't match.
+        """
+        found_ids, _ = find_method(names, preserve_order=self.preserve_order)
+        computed_names = [entity_all_names[i] for i in ids]
+
+        if found_ids != ids or computed_names != names:
+            raise ValueError(
+                f"Inconsistent {kind_label} names and indices. "
+                f"Names {names} resolved to indices {found_ids}, "
+                f"but indices {ids} (mapping to names {computed_names}) were provided."
+            )
+
+    def _resolve_names_to_ids(
+        self,
+        names: list[str],
+        entity_all_names: list[str],
+        entity_count: int,
+        find_method,
+        names_attr: str,
+        ids_attr: str,
+    ) -> None:
+        """Resolve names to IDs, optimizing to slice(None) when all are selected."""
+        found_ids, found_names = find_method(names, preserve_order=self.preserve_order)
+
+        # Keep names and IDs in the same order.
+        setattr(self, names_attr, found_names)
+
+        # Optimize to slice(None) if all components are selected in order.
+        if len(found_ids) == entity_count and found_names == list(entity_all_names):
+            setattr(self, ids_attr, slice(None))
+        else:
+            setattr(self, ids_attr, found_ids)
+
+    def _resolve_ids_to_names(
+        self, ids: list[int], entity_all_names: list[str], names_attr: str
+    ) -> None:
+        """Resolve IDs to their corresponding names."""
+        resolved_names = [entity_all_names[i] for i in ids]
+        setattr(self, names_attr, resolved_names)

--- a/src/unilab/managers/termination_manager.py
+++ b/src/unilab/managers/termination_manager.py
@@ -1,0 +1,139 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), src/mjlab/managers/termination_manager.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
+"""Termination manager for computing done signals."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+from prettytable import PrettyTable
+
+from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+@dataclass
+class TerminationTermCfg(ManagerTermBaseCfg):
+    """Configuration for a termination term."""
+
+    time_out: bool = False
+    """Whether the term contributes towards episodic timeouts."""
+
+
+class TerminationManager(ManagerBase):
+    """Manages termination conditions for the environment.
+
+    The termination manager aggregates multiple termination terms to compute
+    episode done signals. Terms can be either truncations (time-based) or
+    terminations (failure conditions).
+    """
+
+    _env: ManagerBasedRlEnv
+
+    def __init__(self, cfg: dict[str, TerminationTermCfg | None], env: ManagerBasedRlEnv):
+        self._term_names: list[str] = list()
+        self._term_cfgs: list[TerminationTermCfg] = list()
+        self._class_term_cfgs: list[TerminationTermCfg] = list()
+
+        self.cfg = deepcopy(cfg)
+        super().__init__(env)
+
+        self._term_dones = dict()
+        for term_name in self._term_names:
+            self._term_dones[term_name] = np.zeros(self.num_envs, dtype=np.bool_)
+        self._truncated_buf = np.zeros(self.num_envs, dtype=np.bool_)
+        self._terminated_buf = np.zeros_like(self._truncated_buf)
+
+    def __str__(self) -> str:
+        msg = f"<TerminationManager> contains {len(self._term_names)} active terms.\n"
+        table = PrettyTable()
+        table.title = "Active Termination Terms"
+        table.field_names = ["Index", "Name", "Time Out"]
+        table.align["Name"] = "l"
+        for index, (name, term_cfg) in enumerate(
+            zip(self._term_names, self._term_cfgs, strict=False)
+        ):
+            table.add_row([index, name, term_cfg.time_out])
+        msg += str(table.get_string())
+        msg += "\n"
+        return msg
+
+    # Properties.
+
+    @property
+    def active_terms(self) -> list[str]:
+        return self._term_names
+
+    @property
+    def dones(self) -> np.ndarray:
+        return self._truncated_buf | self._terminated_buf
+
+    @property
+    def time_outs(self) -> np.ndarray:
+        return self._truncated_buf
+
+    @property
+    def terminated(self) -> np.ndarray:
+        return self._terminated_buf
+
+    # Methods.
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, int]:
+        if env_ids is None:
+            env_ids = slice(None)
+        extras = {}
+        for key in self._term_dones.keys():
+            extras["Episode_Termination/" + key] = int(
+                np.count_nonzero(self._term_dones[key][env_ids])
+            )
+        for term_cfg in self._class_term_cfgs:
+            term_cfg.func.reset(env_ids=env_ids)
+        return extras
+
+    def compute(self) -> np.ndarray:
+        self._truncated_buf[:] = False
+        self._terminated_buf[:] = False
+        for name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
+            value = term_cfg.func(self._env, **term_cfg.params)
+            self._check_term_shape(name, value)
+            if value.dtype != np.bool_:
+                raise TypeError(
+                    f"TerminationManager term '{name}' returned dtype {value.dtype}, expected bool."
+                )
+            if term_cfg.time_out:
+                self._truncated_buf |= value
+            else:
+                self._terminated_buf |= value
+            self._term_dones[name][:] = value
+        return self._truncated_buf | self._terminated_buf
+
+    def get_term(self, name: str) -> np.ndarray:
+        return self._term_dones[name]
+
+    def get_term_cfg(self, term_name: str) -> TerminationTermCfg:
+        if term_name not in self._term_names:
+            raise ValueError(f"Term '{term_name}' not found in active terms.")
+        return self._term_cfgs[self._term_names.index(term_name)]
+
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
+        terms = []
+        for key in self._term_dones.keys():
+            terms.append((key, [float(self._term_dones[key][env_idx])]))
+        return terms
+
+    def _prepare_terms(self) -> None:
+        for term_name, term_cfg in self.cfg.items():
+            if term_cfg is None:
+                print(f"term: {term_name} set to None, skipping...")
+                continue
+            self._resolve_common_term_cfg(term_name, term_cfg)
+            self._term_names.append(term_name)
+            self._term_cfgs.append(term_cfg)
+            if hasattr(term_cfg.func, "reset") and callable(term_cfg.func.reset):
+                self._class_term_cfgs.append(term_cfg)

--- a/tests/managers/__init__.py
+++ b/tests/managers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the standalone NumPy manager package."""

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -1,0 +1,58 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), manager test fixtures.
+# Modified by UniLab for NumPy and the standalone manager contract; Apache-2.0.
+
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+class FakeEntity:
+    def __init__(self) -> None:
+        self.joint_names = ["hip", "knee", "ankle"]
+        self.body_names = ["base", "foot"]
+        self.num_joints = len(self.joint_names)
+        self.num_bodies = len(self.body_names)
+
+    @staticmethod
+    def _find(
+        all_names: list[str], patterns: list[str], preserve_order: bool
+    ) -> tuple[list[int], list[str]]:
+        if preserve_order:
+            found = [
+                name for pattern in patterns for name in all_names if re.fullmatch(pattern, name)
+            ]
+        else:
+            found = [name for name in all_names if any(re.fullmatch(p, name) for p in patterns)]
+        return [all_names.index(name) for name in found], found
+
+    def find_joints(
+        self, patterns: list[str], *, preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find(self.joint_names, patterns, preserve_order)
+
+    def find_bodies(
+        self, patterns: list[str], *, preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find(self.body_names, patterns, preserve_order)
+
+
+class FakeEnv:
+    def __init__(self, seed: int = 7, num_envs: int = 4) -> None:
+        self.num_envs = num_envs
+        self.rng = np.random.default_rng(seed)
+        self.scene = {"robot": FakeEntity()}
+        self.max_episode_length_s = 2.0
+        self.value = np.arange(num_envs, dtype=np.float32)
+        self.obs = np.arange(num_envs * 2, dtype=np.float32).reshape(num_envs, 2)
+        self.calls: list[tuple[str, np.ndarray | None]] = []
+        self.obs_buf: dict[str, np.ndarray] = {}
+        self.reset_buf = np.zeros(num_envs, dtype=np.bool_)
+
+
+@pytest.fixture
+def fake_env() -> FakeEnv:
+    return FakeEnv()

--- a/tests/managers/test_core_managers.py
+++ b/tests/managers/test_core_managers.py
@@ -1,0 +1,195 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), manager tests.
+# Modified by UniLab for NumPy and fail-closed term validation; Apache-2.0.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from unilab.managers import (
+    ActionManager,
+    ActionTerm,
+    ActionTermCfg,
+    CurriculumManager,
+    CurriculumTermCfg,
+    NullCurriculumManager,
+    RewardManager,
+    RewardTermCfg,
+    SceneEntityCfg,
+    TerminationManager,
+    TerminationTermCfg,
+)
+
+from .conftest import FakeEnv
+
+
+class DummyAction(ActionTerm):
+    def __init__(self, cfg: DummyActionCfg, env: FakeEnv):
+        super().__init__(cfg, env)
+        self._raw = np.zeros((env.num_envs, cfg.dim), dtype=np.float32)
+        self.applied = 0
+        self.reset_ids: np.ndarray | slice | None = None
+
+    @property
+    def action_dim(self) -> int:
+        return self._raw.shape[1]
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._raw
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        self._raw[:] = actions
+
+    def apply_actions(self) -> None:
+        self.applied += 1
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> None:
+        self.reset_ids = env_ids
+        self._raw[env_ids] = 0.0
+
+
+@dataclass(kw_only=True)
+class DummyActionCfg(ActionTermCfg):
+    dim: int
+
+    def build(self, env: FakeEnv) -> DummyAction:
+        return DummyAction(self, env)
+
+
+def test_action_split_history_apply_and_partial_reset(fake_env: FakeEnv) -> None:
+    manager = ActionManager(
+        {
+            "legs": DummyActionCfg(entity_name="robot", dim=2),
+            "disabled": None,
+            "arm": DummyActionCfg(entity_name="robot", dim=1),
+        },
+        fake_env,
+    )
+    assert manager.active_terms == ["legs", "arm"]
+    first = np.arange(12, dtype=np.float32).reshape(4, 3)
+    second = first + 20
+    manager.process_action(first)
+    manager.process_action(second)
+    np.testing.assert_array_equal(manager.prev_action, first)
+    np.testing.assert_array_equal(manager.action, second)
+    np.testing.assert_array_equal(manager.get_term("legs").raw_action, second[:, :2])
+    manager.apply_action()
+    assert manager.get_term("legs").applied == 1
+    manager.reset(np.array([1, 3]))
+    np.testing.assert_array_equal(manager.action[[1, 3]], 0.0)
+    np.testing.assert_array_equal(manager.action[[0, 2]], second[[0, 2]])
+
+
+@pytest.mark.parametrize(
+    "action,match",
+    [
+        (np.zeros((4, 2), dtype=np.float32), "Invalid action shape"),
+        (np.full((4, 3), np.nan, dtype=np.float32), "NaN or Inf"),
+    ],
+)
+def test_action_rejects_invalid_input(fake_env: FakeEnv, action: np.ndarray, match: str) -> None:
+    manager = ActionManager({"a": DummyActionCfg(entity_name="robot", dim=3)}, fake_env)
+    with pytest.raises(ValueError, match=match):
+        manager.process_action(action)
+
+
+class StatefulReward:
+    def __init__(self, cfg: RewardTermCfg, env: FakeEnv):
+        self.reset_ids = None
+
+    def __call__(self, env: FakeEnv) -> np.ndarray:
+        return env.value.copy()
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> None:
+        self.reset_ids = env_ids
+
+
+def test_reward_dt_scaling_reset_and_config_immutability(fake_env: FakeEnv) -> None:
+    cfg = {"stateful": RewardTermCfg(func=StatefulReward, weight=2.0)}
+    manager = RewardManager(cfg, fake_env)
+    np.testing.assert_allclose(manager.compute(dt=0.25), fake_env.value * 0.5)
+    assert manager.get_active_iterable_terms(2) == [("stateful", [4.0])]
+    extras = manager.reset(np.array([1, 2]))
+    assert extras["Episode_Reward/stateful"] == pytest.approx(0.375)
+    assert cfg["stateful"].func is StatefulReward
+    assert isinstance(manager.get_term_cfg("stateful").func, StatefulReward)
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_reward_nonfinite_is_an_error(fake_env: FakeEnv, bad: float) -> None:
+    def reward(env: FakeEnv) -> np.ndarray:
+        value = np.ones(env.num_envs, dtype=np.float32)
+        value[2] = bad
+        return value
+
+    manager = RewardManager({"bad_reward": RewardTermCfg(func=reward, weight=1.0)}, fake_env)
+    with pytest.raises(ValueError, match="RewardManager term 'bad_reward'"):
+        manager.compute(0.01)
+
+
+def test_reward_and_termination_shape_validation(fake_env: FakeEnv) -> None:
+    reward = RewardManager(
+        {"bad": RewardTermCfg(func=lambda env: np.zeros((env.num_envs, 1)), weight=1.0)},
+        fake_env,
+    )
+    with pytest.raises(ValueError, match=r"expected \(4,\)"):
+        reward.compute(0.1)
+
+    termination = TerminationManager(
+        {"bad": TerminationTermCfg(func=lambda env: np.zeros(env.num_envs))}, fake_env
+    )
+    with pytest.raises(TypeError, match="expected bool"):
+        termination.compute()
+
+
+def test_termination_splits_timeouts_and_failures(fake_env: FakeEnv) -> None:
+    timeout = np.array([True, False, False, True])
+    failure = np.array([False, True, False, True])
+    manager = TerminationManager(
+        {
+            "timeout": TerminationTermCfg(func=lambda env: timeout.copy(), time_out=True),
+            "failure": TerminationTermCfg(func=lambda env: failure.copy()),
+        },
+        fake_env,
+    )
+    np.testing.assert_array_equal(manager.compute(), timeout | failure)
+    np.testing.assert_array_equal(manager.time_outs, timeout)
+    np.testing.assert_array_equal(manager.terminated, failure)
+    assert manager.reset(np.array([0, 1])) == {
+        "Episode_Termination/timeout": 1,
+        "Episode_Termination/failure": 1,
+    }
+
+
+def test_curriculum_and_null_semantics(fake_env: FakeEnv) -> None:
+    def update(env: FakeEnv, env_ids: np.ndarray | slice) -> dict[str, float]:
+        return {"difficulty": 3.0}
+
+    manager = CurriculumManager({"terrain": CurriculumTermCfg(func=update)}, fake_env)
+    manager.compute(np.array([1, 2]))
+    assert manager.reset()["Curriculum/terrain/difficulty"] == 3.0
+    null = NullCurriculumManager()
+    assert null.active_terms == []
+    assert null.reset() == {}
+
+    bad = CurriculumManager({"bad": CurriculumTermCfg(func=lambda env, env_ids: np.nan)}, fake_env)
+    with pytest.raises(ValueError, match="CurriculumManager term 'bad'"):
+        bad.compute()
+
+
+def test_scene_entity_selector_resolution(fake_env: FakeEnv) -> None:
+    cfg = SceneEntityCfg(name="robot", joint_names=("ankle", "hip"), preserve_order=True)
+    cfg.resolve(fake_env.scene)
+    assert cfg.joint_names == ["ankle", "hip"]
+    assert cfg.joint_ids == [2, 0]
+
+    all_joints = SceneEntityCfg(name="robot", joint_names=".*")
+    all_joints.resolve(fake_env.scene)
+    assert all_joints.joint_ids == slice(None)
+
+    inconsistent = SceneEntityCfg(name="robot", joint_names="hip", joint_ids=[1])
+    with pytest.raises(ValueError, match="Inconsistent joint"):
+        inconsistent.resolve(fake_env.scene)

--- a/tests/managers/test_event_command_metrics_recorder.py
+++ b/tests/managers/test_event_command_metrics_recorder.py
@@ -1,0 +1,263 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), manager tests.
+# Modified by UniLab for NumPy scheduling and unsupported capability errors; Apache-2.0.
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import unilab.managers as managers
+from unilab.managers import (
+    CommandManager,
+    CommandTerm,
+    CommandTermCfg,
+    EventManager,
+    EventTermCfg,
+    MetricsManager,
+    MetricsTermCfg,
+    NullCommandManager,
+    NullMetricsManager,
+    NullRecorderManager,
+    RecorderManager,
+    RecorderTerm,
+    RecorderTermCfg,
+)
+
+from .conftest import FakeEnv
+
+
+def _record(env: FakeEnv, env_ids: np.ndarray | None, *, label: str) -> None:
+    copied = None if env_ids is None else np.asarray(env_ids).copy()
+    env.calls.append((label, copied))
+
+
+def test_event_modes_interval_reset_throttle_and_order(fake_env: FakeEnv) -> None:
+    cfg = {
+        "startup": EventTermCfg(func=_record, params={"label": "startup"}, mode="startup"),
+        "reset": EventTermCfg(
+            func=_record,
+            params={"label": "reset"},
+            mode="reset",
+            min_step_count_between_reset=3,
+        ),
+        "interval": EventTermCfg(
+            func=_record,
+            params={"label": "interval"},
+            mode="interval",
+            interval_range_s=(0.1, 0.1),
+        ),
+        "step": EventTermCfg(func=_record, params={"label": "step"}, mode="step"),
+    }
+    manager = EventManager(cfg, fake_env)
+    assert list(manager.active_terms) == ["startup", "reset", "interval", "step"]
+    manager.apply("startup", env_ids=np.array([0, 2]))
+    manager.apply("step", dt=0.01)
+    manager.apply("interval", dt=0.1)
+    manager.apply("reset", env_ids=np.array([1, 3]), global_env_step_count=1)
+    manager.apply("reset", env_ids=np.array([1, 3]), global_env_step_count=2)
+    assert [label for label, _ in fake_env.calls] == ["startup", "step", "interval", "reset"]
+    np.testing.assert_array_equal(fake_env.calls[2][1], np.arange(fake_env.num_envs))
+
+
+def test_event_validation_and_model_mutation_failure(fake_env: FakeEnv) -> None:
+    with pytest.raises(ValueError, match="interval_range_s"):
+        EventManager({"bad": EventTermCfg(func=_record, mode="interval")}, fake_env)
+
+    def model_mutation(env: FakeEnv, env_ids: np.ndarray | None) -> None:
+        pass
+
+    model_mutation.model_fields = ("body_mass",)  # type: ignore[attr-defined]
+    with pytest.raises(NotImplementedError, match="model-field mutation"):
+        EventManager({"unsupported": EventTermCfg(func=model_mutation, mode="startup")}, fake_env)
+
+    empty = EventManager({}, fake_env)
+    empty.apply("interval")
+
+
+def test_event_interval_rng_is_reproducible() -> None:
+    cfg = {
+        "interval": EventTermCfg(
+            func=_record,
+            params={"label": "interval"},
+            mode="interval",
+            interval_range_s=(0.1, 2.0),
+        )
+    }
+    left = EventManager(cfg, FakeEnv(seed=17))
+    right = EventManager(cfg, FakeEnv(seed=17))
+    np.testing.assert_array_equal(left._interval_term_time_left, right._interval_term_time_left)
+
+
+class DummyCommand(CommandTerm):
+    def __init__(self, cfg: DummyCommandCfg, env: FakeEnv):
+        super().__init__(cfg, env)
+        self._command = np.zeros((env.num_envs, 1), dtype=np.float32)
+        self.metrics["error"] = np.arange(env.num_envs, dtype=np.float32)
+
+    @property
+    def command(self) -> np.ndarray:
+        return self._command
+
+    def _update_metrics(self) -> None:
+        self.metrics["error"] += 1.0
+
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        self._command[env_ids, 0] = self.command_counter[env_ids]
+
+    def _update_command(self, env_ids: np.ndarray | None) -> None:
+        pass
+
+
+@dataclass(kw_only=True)
+class DummyCommandCfg(CommandTermCfg):
+    def build(self, env: FakeEnv) -> DummyCommand:
+        return DummyCommand(self, env)
+
+
+def test_command_resample_metrics_validation_and_null(fake_env: FakeEnv) -> None:
+    manager = CommandManager({"goal": DummyCommandCfg(resampling_time_range=(0.5, 0.5))}, fake_env)
+    extras = manager.reset(np.array([1, 2]))
+    assert extras == {"Metrics/goal/error": 1.5}
+    np.testing.assert_array_equal(manager.get_command("goal")[[1, 2]], 0.0)
+    manager.compute(0.5)
+    np.testing.assert_array_equal(manager.get_term("goal").command[:, 0], [0, 1, 1, 0])
+    assert manager.get_term("goal").command_counter.tolist() == [1, 2, 2, 1]
+
+    manager.get_term("goal").command[0, 0] = np.nan
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        manager.get_command("goal")
+
+    null = NullCommandManager()
+    assert null.get_command("missing") is None
+    assert null.reset() == {}
+
+
+def test_command_viewer_request_and_old_signature_fail_closed(fake_env: FakeEnv) -> None:
+    with pytest.raises(NotImplementedError, match="viewer"):
+        CommandManager(
+            {"goal": DummyCommandCfg(resampling_time_range=(1.0, 1.0), debug_vis=True)},
+            fake_env,
+        )
+
+    class OldCommand(DummyCommand):
+        def _update_command(self) -> None:  # type: ignore[override]
+            pass
+
+    @dataclass(kw_only=True)
+    class OldCfg(CommandTermCfg):
+        def build(self, env: FakeEnv) -> OldCommand:
+            return OldCommand(self, env)
+
+    with pytest.raises(TypeError, match="must accept env_ids"):
+        CommandManager({"old": OldCfg(resampling_time_range=(1.0, 1.0))}, fake_env)
+
+
+def test_metrics_reductions_substeps_reset_and_finite_failure(fake_env: FakeEnv) -> None:
+    manager = MetricsManager(
+        {
+            "mean": MetricsTermCfg(func=lambda env: env.value.copy(), reduce="mean"),
+            "max": MetricsTermCfg(func=lambda env: env.value.copy(), reduce="max"),
+            "sum": MetricsTermCfg(func=lambda env: env.value.copy(), reduce="sum"),
+            "last": MetricsTermCfg(func=lambda env: env.value.copy(), reduce="last"),
+            "substep": MetricsTermCfg(
+                func=lambda env: env.value.copy(), per_substep=True, reduce="mean"
+            ),
+        },
+        fake_env,
+    )
+    manager.compute_substep()
+    fake_env.value += 2
+    manager.compute_substep()
+    manager.compute()
+    extras = manager.reset(np.array([1, 2]))
+    assert extras["Episode_Metrics/mean"] == pytest.approx(3.5)
+    assert extras["Episode_Metrics/max"] == pytest.approx(3.5)
+    assert extras["Episode_Metrics/sum"] == pytest.approx(3.5)
+    assert extras["Episode_Metrics/last"] == pytest.approx(3.5)
+    assert extras["Episode_Metrics/substep"] == pytest.approx(2.5)
+
+    bad = MetricsManager(
+        {"bad": MetricsTermCfg(func=lambda env: np.full(env.num_envs, np.inf))}, fake_env
+    )
+    with pytest.raises(ValueError, match="MetricsManager term 'bad'"):
+        bad.compute()
+    assert NullMetricsManager().reset() == {}
+
+
+class TraceRecorder(RecorderTerm):
+    def __init__(self, cfg: RecorderTermCfg, env: FakeEnv):
+        super().__init__(cfg, env)
+        self.events: list[tuple[str, list[int] | None]] = []
+
+    def record_pre_reset(self, env_ids: np.ndarray) -> None:
+        self.events.append(("pre", env_ids.tolist()))
+
+    def record_post_reset(self, env_ids: np.ndarray) -> None:
+        self.events.append(("post_reset", env_ids.tolist()))
+
+    def record_post_step(self) -> None:
+        self.events.append(("step", None))
+
+    def close(self) -> None:
+        self.events.append(("close", None))
+
+
+def test_recorder_lifecycle_and_null(fake_env: FakeEnv) -> None:
+    cfg = {"trace": RecorderTermCfg(func=TraceRecorder)}
+    manager = RecorderManager(cfg, fake_env)
+    ids = np.array([0, 3])
+    manager.record_pre_reset(ids)
+    manager.record_post_reset(ids)
+    manager.record_post_step()
+    manager.close()
+    assert manager.get_term("trace").events == [
+        ("pre", [0, 3]),
+        ("post_reset", [0, 3]),
+        ("step", None),
+        ("close", None),
+    ]
+    assert cfg["trace"].func is TraceRecorder
+    null = NullRecorderManager()
+    with pytest.raises(KeyError, match="has no terms"):
+        null.get_term("trace")
+
+
+def test_public_exports_and_repository_import_boundary() -> None:
+    expected = {
+        "ManagerBase",
+        "ManagerTermBase",
+        "ManagerTermBaseCfg",
+        "ActionManager",
+        "ObservationManager",
+        "RewardManager",
+        "TerminationManager",
+        "EventManager",
+        "CommandManager",
+        "CurriculumManager",
+        "MetricsManager",
+        "RecorderManager",
+        "SceneEntityCfg",
+    }
+    assert expected <= set(vars(managers))
+
+    package_root = Path(managers.__file__).parent
+    forbidden_roots = {"torch", "mjlab"}
+    forbidden_unilab = {"unilab.ipc", "unilab.runners", "unilab.scripts", "unilab.base.backend"}
+    for path in package_root.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module)
+        assert not ({name.split(".")[0] for name in imports} & forbidden_roots), path
+        assert not any(
+            name == prefix or name.startswith(prefix + ".")
+            for name in imports
+            for prefix in forbidden_unilab
+        ), path

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -1,0 +1,205 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681), observation/buffer/noise tests.
+# Modified by UniLab for NumPy and env-owned RNG; Apache-2.0.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from unilab.managers import ObservationGroupCfg, ObservationManager, ObservationTermCfg
+from unilab.managers._buffers import CircularBuffer, DelayBuffer
+from unilab.managers._noise import (
+    ConstantNoiseCfg,
+    GaussianNoiseCfg,
+    NoiseModelWithAdditiveBiasCfg,
+    UniformNoiseCfg,
+)
+
+from .conftest import FakeEnv
+
+
+def test_circular_buffer_history_backfill_lag_and_partial_reset() -> None:
+    buffer = CircularBuffer(max_len=3, batch_size=2)
+    first = np.array([[1.0], [10.0]], dtype=np.float32)
+    buffer.append(first)
+    np.testing.assert_array_equal(buffer.buffer[:, :, 0], [[1, 1, 1], [10, 10, 10]])
+    buffer.append(np.array([[2.0], [20.0]], dtype=np.float32))
+    buffer.append(np.array([[3.0], [30.0]], dtype=np.float32))
+    np.testing.assert_array_equal(buffer[np.array([0, 2])][:, 0], [3, 10])
+
+    buffer.reset([1])
+    buffer.append(np.array([[4.0], [99.0]], dtype=np.float32))
+    np.testing.assert_array_equal(buffer.buffer[0, :, 0], [2, 3, 4])
+    np.testing.assert_array_equal(buffer.buffer[1, :, 0], [99, 99, 99])
+
+
+def test_circular_buffer_rejects_invalid_usage() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        CircularBuffer(max_len=0, batch_size=2)
+    buffer = CircularBuffer(max_len=2, batch_size=2)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        _ = buffer.buffer
+    with pytest.raises(ValueError, match="batch size"):
+        buffer.append(np.zeros((3, 1)))
+
+
+def test_delay_buffer_constant_delay_and_partial_backfill() -> None:
+    buffer = DelayBuffer(min_lag=2, max_lag=2, batch_size=2)
+    outputs = []
+    for value in (1.0, 2.0, 3.0, 4.0):
+        buffer.append(np.full((2, 1), value, dtype=np.float32))
+        outputs.append(buffer.compute().copy())
+    np.testing.assert_array_equal(np.stack(outputs)[:, 0, 0], [1, 1, 1, 2])
+
+    buffer.reset(np.array([1]))
+    buffer.backfill(np.array([[8.0], [9.0]], dtype=np.float32), np.array([1]))
+    np.testing.assert_array_equal(buffer.peek()[1], [9.0])
+
+
+def test_delay_rng_is_reproducible_and_required() -> None:
+    def draw(seed: int) -> list[np.ndarray]:
+        buffer = DelayBuffer(
+            min_lag=0,
+            max_lag=3,
+            batch_size=8,
+            generator=np.random.default_rng(seed),
+        )
+        values = []
+        for step in range(5):
+            buffer.append(np.full((8, 1), step, dtype=np.float32))
+            buffer.compute()
+            values.append(buffer.current_lags.copy())
+        return values
+
+    for left, right in zip(draw(123), draw(123), strict=True):
+        np.testing.assert_array_equal(left, right)
+
+    missing_rng = DelayBuffer(min_lag=0, max_lag=2, batch_size=2)
+    missing_rng.append(np.zeros((2, 1)))
+    with pytest.raises(ValueError, match="env-owned"):
+        missing_rng.compute()
+
+
+def test_noise_configs_use_supplied_generator() -> None:
+    data = np.ones((4, 3), dtype=np.float32)
+    uniform = UniformNoiseCfg(n_min=-0.2, n_max=0.2)
+    first = uniform.apply(data, rng=np.random.default_rng(9))
+    second = uniform.apply(data, rng=np.random.default_rng(9))
+    np.testing.assert_array_equal(first, second)
+    assert first.dtype == np.float32
+    with pytest.raises(ValueError, match="env-owned"):
+        uniform.apply(data)
+
+    gaussian = GaussianNoiseCfg(mean=0.0, std=0.1)
+    assert gaussian.apply(data, rng=np.random.default_rng(2)).shape == data.shape
+    np.testing.assert_array_equal(ConstantNoiseCfg(bias=2.0, operation="abs").apply(data), 2.0)
+
+
+def test_additive_bias_noise_supports_scalar_terms() -> None:
+    from unilab.managers._noise import NoiseModelWithAdditiveBias
+
+    cfg = NoiseModelWithAdditiveBiasCfg(
+        noise_cfg=ConstantNoiseCfg(bias=0.0),
+        bias_noise_cfg=ConstantNoiseCfg(bias=0.5),
+    )
+    model = NoiseModelWithAdditiveBias(cfg, num_envs=4, rng=np.random.default_rng(2))
+    result = model(np.ones(4, dtype=np.float32))
+    np.testing.assert_array_equal(result, 1.5)
+    assert result.shape == (4,)
+
+
+def test_observation_groups_pipeline_order_and_history(fake_env: FakeEnv) -> None:
+    cfg = {
+        "policy": ObservationGroupCfg(
+            terms={
+                "state": ObservationTermCfg(
+                    func=lambda env: env.obs,
+                    clip=(-1.0, 4.0),
+                    scale=2.0,
+                    history_length=2,
+                ),
+                "bias": ObservationTermCfg(
+                    func=lambda env: np.ones((env.num_envs, 1), dtype=np.float32)
+                ),
+            }
+        ),
+        "dict_group": ObservationGroupCfg(
+            terms={"state": ObservationTermCfg(func=lambda env: env.obs)},
+            concatenate_terms=False,
+        ),
+    }
+    manager = ObservationManager(cfg, fake_env)
+    first = manager.compute(update_history=True)
+    expected_first = np.clip(fake_env.obs, -1, 4) * 2
+    np.testing.assert_array_equal(first["policy"][:, :4], np.tile(expected_first, (1, 2)))
+    assert list(first["dict_group"]) == ["state"]
+    assert manager.group_obs_dim["policy"] == (5,)
+
+    fake_env.obs = fake_env.obs + 10
+    second = manager.compute(update_history=True)["policy"]
+    expected_second = np.clip(fake_env.obs, -1, 4) * 2
+    np.testing.assert_array_equal(second[:, :2], expected_first)
+    np.testing.assert_array_equal(second[:, 2:4], expected_second)
+    assert manager.get_active_iterable_terms(0)[0][0] == "policy-state"
+
+
+def test_observation_noise_model_delay_and_seed_reproducibility() -> None:
+    cfg = {
+        "policy": ObservationGroupCfg(
+            terms={
+                "state": ObservationTermCfg(
+                    func=lambda env: env.obs,
+                    noise=NoiseModelWithAdditiveBiasCfg(
+                        noise_cfg=GaussianNoiseCfg(std=0.1),
+                        bias_noise_cfg=UniformNoiseCfg(n_min=-0.2, n_max=0.2),
+                    ),
+                    delay_min_lag=1,
+                    delay_max_lag=1,
+                )
+            },
+            enable_corruption=True,
+        )
+    }
+    left = ObservationManager(cfg, FakeEnv(seed=11)).compute(update_history=True)
+    right = ObservationManager(cfg, FakeEnv(seed=11)).compute(update_history=True)
+    np.testing.assert_array_equal(left["policy"], right["policy"])
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf])
+def test_observation_default_finite_policy_fails_closed(fake_env: FakeEnv, bad: float) -> None:
+    def invalid(env: FakeEnv) -> np.ndarray:
+        result = env.obs.copy()
+        result[1, 0] = bad
+        return result
+
+    manager = ObservationManager(
+        {"policy": ObservationGroupCfg(terms={"bad": ObservationTermCfg(func=invalid)})},
+        fake_env,
+    )
+    with pytest.raises(ValueError, match="ObservationManager term 'policy/bad'"):
+        manager.compute()
+
+
+def test_observation_explicit_sanitize_and_shape_error(fake_env: FakeEnv) -> None:
+    sanitize = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "bad": ObservationTermCfg(func=lambda env: np.full((env.num_envs, 1), np.nan))
+                },
+                nan_policy="sanitize",
+            )
+        },
+        fake_env,
+    )
+    np.testing.assert_array_equal(sanitize.compute()["policy"], 0.0)
+
+    with pytest.raises(ValueError, match="num_envs"):
+        ObservationManager(
+            {
+                "policy": ObservationGroupCfg(
+                    terms={"bad": ObservationTermCfg(func=lambda env: np.zeros((2, 1)))}
+                )
+            },
+            fake_env,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2734,6 +2734,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prettytable"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl", hash = "sha256:b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a", size = 37357, upload-time = "2026-06-22T16:07:48.595Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -3921,6 +3933,7 @@ dependencies = [
     { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
+    { name = "prettytable" },
     { name = "rich" },
     { name = "rsl-rl-lib" },
     { name = "setuptools" },
@@ -3981,6 +3994,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.20" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.20" },
     { name = "packaging" },
+    { name = "prettytable", specifier = ">=3.10" },
     { name = "pybind11", marker = "extra == 'mujoco'", specifier = ">=2.12" },
     { name = "rich" },
     { name = "rsl-rl-lib", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Summary

- port the pinned mjlab v1.6.0 manager package into unilab.managers with preserved manager roles, config objects, ordering, and lifecycle semantics
- replace manager-facing Torch tensors, devices, buffers, noise, and RNG with NumPy arrays and an env-owned NumPy generator
- fail closed on invalid shapes, non-finite outputs, unsupported viewer/model mutation, and missing stochastic RNG
- keep the package independent from production NpEnv, backends, Hydra, runners, and IPC

## Provenance

Source baseline: mujocolab/mjlab v1.6.0, commit 0fb8a681136be94ffc636a3dd423cabb97d91f10, Apache-2.0. Every source-derived file records the upstream path and modification notice.

## Change accounting

- source-derived surface: 18 manager/buffer/noise files, 3,632 lines
- mechanical NumPy adaptation and upstream-derived tests: included in those source files plus 722 test lines
- UniLab-specific glue: 52 lines in the private typed context module
- modified existing: pyproject.toml and uv.lock, +15 lines for PrettyTable
- deleted existing UniLab code: none; upstream Torch device, viewer GUI, and direct model-mutation paths were intentionally omitted
- total: 26 files, 4,421 added lines; within the source-aligned exception

## Validation

- focused manager suite: 30 passed
- ruff: passed
- mypy: passed
- pyright: passed
- make test-all: 1,799 passed, 24 skipped, 1 xfailed; benchmark import smoke passed 65/67 with two platform-optional mlx skips

Implements #1045
Umbrella: #1042