### PR TITLE
feat(base): add NumPy entity facade

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -1,0 +1,635 @@
+"""Base-owned NumPy scene/entity facade for manager terms.
+
+The facade deliberately describes partitions of an already materialized UniLab scene.
+It is not a second scene composer: all name resolution and state reads go through the
+public :class:`~unilab.base.backend.base.SimBackend` contract.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, NoReturn
+
+import numpy as np
+
+from unilab.base.backend.base import SimBackend
+
+if TYPE_CHECKING:
+    from unilab.base.scene import SceneCfg
+
+
+NamesCfg = tuple[str, ...] | list[str] | None
+
+
+@dataclass(frozen=True)
+class EntityCfg:
+    """Declare one logical entity inside an existing backend scene.
+
+    Names are explicit because UniLab keeps scene composition in task-owned XML and
+    backend adapters.  ``None`` means that the namespace is not exposed by this
+    entity; an empty sequence means that it is exposed but contains no elements.
+    """
+
+    root_body_name: str | None = None
+    joint_names: NamesCfg = None
+    body_names: NamesCfg = None
+    geom_names: NamesCfg = None
+    site_names: NamesCfg = None
+    actuator_names: NamesCfg = None
+
+
+def _normalize_names(entity_name: str, kind: str, names: NamesCfg) -> tuple[str, ...] | None:
+    if names is None:
+        return None
+    if isinstance(names, str):
+        raise TypeError(
+            f"Entity '{entity_name}' {kind} names must be a sequence of strings, not a scalar"
+        )
+    invalid = [value for value in names if not isinstance(value, str)]
+    if invalid:
+        raise TypeError(f"Entity '{entity_name}' {kind} names must be strings; got {invalid}")
+    normalized = tuple(names)
+    if any(not name for name in normalized):
+        raise ValueError(f"Entity '{entity_name}' {kind} names must be non-empty strings")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"Entity '{entity_name}' {kind} names must be unique: {normalized}")
+    return normalized
+
+
+def _readonly_ids(values: np.ndarray | Sequence[int], *, expected: int, label: str) -> np.ndarray:
+    raw_ids = np.asarray(values)
+    if not np.issubdtype(raw_ids.dtype, np.integer) or np.issubdtype(raw_ids.dtype, np.bool_):
+        raise TypeError(f"{label} resolver must return integer IDs, got dtype {raw_ids.dtype}")
+    ids = np.asarray(raw_ids, dtype=np.int32)
+    if ids.shape != (expected,):
+        raise ValueError(f"{label} resolver returned shape {ids.shape}, expected ({expected},)")
+    if np.any(ids < 0):
+        raise ValueError(f"{label} resolver returned negative IDs: {ids.tolist()}")
+    if np.unique(ids).size != ids.size:
+        raise ValueError(f"{label} resolver returned duplicate IDs: {ids.tolist()}")
+    ids = np.array(ids, copy=True, dtype=np.int32)
+    ids.setflags(write=False)
+    return ids
+
+
+def _as_column_index(ids: np.ndarray) -> slice | np.ndarray:
+    """Use a slice for contiguous columns and advanced indexing otherwise."""
+    if ids.size:
+        start = int(ids[0])
+        if np.array_equal(ids, np.arange(start, start + ids.size, dtype=ids.dtype)):
+            return slice(start, start + ids.size)
+    index = np.asarray(ids, dtype=np.intp).copy()
+    index.setflags(write=False)
+    return index
+
+
+# Matching semantics derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/utils/lab_api/string.py. Copyright 2025, The mjlab Developers;
+# adapted for the UniLab NumPy facade under Apache-2.0.
+def _resolve_matching_names(
+    keys: str | Sequence[str], names: Sequence[str], preserve_order: bool
+) -> tuple[list[int], list[str]]:
+    """Pinned mjlab-compatible full-regex matching over cached entity names."""
+    patterns = (keys,) if isinstance(keys, str) else tuple(keys)
+    matches: list[tuple[int, int, str]] = []
+    matched_by: list[str | None] = [None] * len(names)
+    per_pattern: list[list[str]] = [[] for _ in patterns]
+
+    for name_index, candidate in enumerate(names):
+        for pattern_index, pattern in enumerate(patterns):
+            try:
+                matched = re.fullmatch(pattern, candidate) is not None
+            except re.error as exc:
+                raise ValueError(f"Invalid entity selector regex {pattern!r}: {exc}") from exc
+            if not matched:
+                continue
+            if matched_by[name_index] is not None:
+                raise ValueError(
+                    f"Multiple matches for '{candidate}': "
+                    f"'{matched_by[name_index]}' and '{pattern}'!"
+                )
+            matched_by[name_index] = pattern
+            matches.append((pattern_index, name_index, candidate))
+            per_pattern[pattern_index].append(candidate)
+
+    if any(not values for values in per_pattern):
+        rendered = ", ".join(
+            f"{pattern!r}: {values}" for pattern, values in zip(patterns, per_pattern)
+        )
+        raise ValueError(
+            "Not all entity selector regular expressions matched; "
+            f"matches=({rendered}), available={list(names)}"
+        )
+
+    if preserve_order:
+        matches.sort(key=lambda item: item[0])
+    return [item[1] for item in matches], [item[2] for item in matches]
+
+
+class EntityData:
+    """Hot-path NumPy state surface backed by cached backend IDs."""
+
+    def __init__(
+        self,
+        backend: SimBackend,
+        *,
+        root_body_ids: np.ndarray | None,
+        joint_pos_ids: np.ndarray | None,
+        joint_vel_ids: np.ndarray | None,
+        body_ids: np.ndarray | None,
+        actuator_ctrl_range: np.ndarray | None,
+        entity_name: str,
+        backend_type: str,
+    ) -> None:
+        self._backend = backend
+        self._entity_name = entity_name
+        self._backend_type = backend_type
+        self._root_body_ids = root_body_ids
+        self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
+        self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
+        self._body_ids = body_ids
+        self._actuator_ctrl_range = actuator_ctrl_range
+
+    def _require(self, value, capability: str):
+        if value is None:
+            raise NotImplementedError(
+                f"Entity '{self._entity_name}' data capability '{capability}' is unavailable "
+                f"on backend '{self._backend_type}': it was not materialized"
+            )
+        return value
+
+    @property
+    def root_link_pos_w(self) -> np.ndarray:
+        ids = self._require(self._root_body_ids, "root body state")
+        return self._backend.get_body_pos_w(ids)[:, 0]
+
+    @property
+    def root_link_quat_w(self) -> np.ndarray:
+        ids = self._require(self._root_body_ids, "root body state")
+        return self._backend.get_body_quat_w(ids)[:, 0]
+
+    @property
+    def root_link_lin_vel_w(self) -> np.ndarray:
+        ids = self._require(self._root_body_ids, "root body state")
+        return self._backend.get_body_lin_vel_w(ids)[:, 0]
+
+    @property
+    def root_link_ang_vel_w(self) -> np.ndarray:
+        ids = self._require(self._root_body_ids, "root body state")
+        return self._backend.get_body_ang_vel_w(ids)[:, 0]
+
+    @property
+    def root_link_pose_w(self) -> np.ndarray:
+        return np.concatenate((self.root_link_pos_w, self.root_link_quat_w), axis=-1)
+
+    @property
+    def root_link_vel_w(self) -> np.ndarray:
+        return np.concatenate((self.root_link_lin_vel_w, self.root_link_ang_vel_w), axis=-1)
+
+    @property
+    def joint_pos(self) -> np.ndarray:
+        index = self._require(self._joint_pos_index, "joint position")
+        return self._backend.get_dof_pos()[:, index]
+
+    @property
+    def joint_vel(self) -> np.ndarray:
+        index = self._require(self._joint_vel_index, "joint velocity")
+        return self._backend.get_dof_vel()[:, index]
+
+    @property
+    def body_link_pos_w(self) -> np.ndarray:
+        ids = self._require(self._body_ids, "body state")
+        return self._backend.get_body_pos_w(ids)
+
+    @property
+    def body_link_quat_w(self) -> np.ndarray:
+        ids = self._require(self._body_ids, "body state")
+        return self._backend.get_body_quat_w(ids)
+
+    @property
+    def body_link_lin_vel_w(self) -> np.ndarray:
+        ids = self._require(self._body_ids, "body state")
+        return self._backend.get_body_lin_vel_w(ids)
+
+    @property
+    def body_link_ang_vel_w(self) -> np.ndarray:
+        ids = self._require(self._body_ids, "body state")
+        return self._backend.get_body_ang_vel_w(ids)
+
+    @property
+    def body_link_pose_w(self) -> np.ndarray:
+        return np.concatenate((self.body_link_pos_w, self.body_link_quat_w), axis=-1)
+
+    @property
+    def body_link_vel_w(self) -> np.ndarray:
+        return np.concatenate((self.body_link_lin_vel_w, self.body_link_ang_vel_w), axis=-1)
+
+    @property
+    def actuator_ctrl_range(self) -> np.ndarray:
+        return self._require(self._actuator_ctrl_range, "actuator control range")
+
+
+class Entity:
+    """Logical entity with cached local-to-backend mappings."""
+
+    def __init__(self, name: str, cfg: EntityCfg, backend: SimBackend) -> None:
+        if not name:
+            raise ValueError("Entity name must be a non-empty string")
+        self.name = name
+        self._backend_type = backend.backend_type
+
+        self._joint_names = _normalize_names(name, "joint", cfg.joint_names)
+        self._body_names = _normalize_names(name, "body", cfg.body_names)
+        self._geom_names = _normalize_names(name, "geom", cfg.geom_names)
+        self._site_names = _normalize_names(name, "site", cfg.site_names)
+        self._actuator_names = _normalize_names(name, "actuator", cfg.actuator_names)
+
+        root_body_ids = None
+        if cfg.root_body_name is not None:
+            if not isinstance(cfg.root_body_name, str) or not cfg.root_body_name:
+                raise TypeError(f"Entity '{self.name}' root_body_name must be a non-empty string")
+            root_body_ids = self._resolve_ids(
+                "root body",
+                (cfg.root_body_name,),
+                backend.get_body_ids,
+            )
+
+        joint_pos_ids = joint_vel_ids = None
+        if self._joint_names is not None:
+            joint_pos_ids = self._resolve_ids(
+                "joint position index",
+                self._joint_names,
+                backend.get_joint_dof_pos_indices,
+            )
+            joint_vel_ids = self._resolve_ids(
+                "joint velocity index",
+                self._joint_names,
+                backend.get_joint_dof_vel_indices,
+            )
+
+        body_ids = None
+        if self._body_names is not None:
+            body_ids = self._resolve_ids("body", self._body_names, backend.get_body_ids)
+
+        self._geom_ids = None
+        if self._geom_names is not None:
+            self._geom_ids = self._resolve_enumerated_ids(
+                "geom", self._geom_names, backend.get_geom_names
+            )
+
+        self._site_ids = None
+        if self._site_names is not None:
+            self._site_ids = self._resolve_ids("site", self._site_names, backend.get_site_ids)
+
+        actuator_ids = None
+        if self._actuator_names is not None:
+            actuator_ids = self._resolve_enumerated_ids(
+                "actuator", self._actuator_names, backend.get_actuator_names
+            )
+
+        self._validate_joint_state(backend, joint_pos_ids, joint_vel_ids)
+        self._validate_body_state(backend, root_body_ids, body_ids)
+        actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
+
+        self.data = EntityData(
+            backend,
+            root_body_ids=root_body_ids,
+            joint_pos_ids=joint_pos_ids,
+            joint_vel_ids=joint_vel_ids,
+            body_ids=body_ids,
+            actuator_ctrl_range=actuator_ctrl_range,
+            entity_name=self.name,
+            backend_type=self._backend_type,
+        )
+
+    def _capability_error(self, capability: str, detail: str) -> NotImplementedError:
+        return NotImplementedError(
+            f"Entity '{self.name}' capability '{capability}' is unavailable on "
+            f"backend '{self._backend_type}': {detail}"
+        )
+
+    def _resolve_ids(self, capability: str, names: tuple[str, ...], resolver) -> np.ndarray:
+        try:
+            values = resolver(names)
+        except NotImplementedError as exc:
+            raise self._capability_error(capability, str(exc)) from exc
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                f"Entity '{self.name}' could not resolve {capability} names {list(names)} "
+                f"on backend '{self._backend_type}': {exc}"
+            ) from exc
+        return _readonly_ids(
+            values,
+            expected=len(names),
+            label=f"Entity '{self.name}' {capability}",
+        )
+
+    def _resolve_enumerated_ids(
+        self, capability: str, names: tuple[str, ...], resolver
+    ) -> np.ndarray:
+        try:
+            all_names = tuple(resolver())
+        except NotImplementedError as exc:
+            raise self._capability_error(capability, str(exc)) from exc
+        invalid = [value for value in all_names if not isinstance(value, str)]
+        if invalid:
+            raise TypeError(
+                f"Entity '{self.name}' {capability} name resolver on backend "
+                f"'{self._backend_type}' returned non-string names: {invalid}"
+            )
+        nonempty_names = [value for value in all_names if value]
+        if len(set(nonempty_names)) != len(nonempty_names):
+            raise ValueError(
+                f"Entity '{self.name}' {capability} name resolver on backend "
+                f"'{self._backend_type}' returned duplicate names"
+            )
+        ids_by_name = {value: index for index, value in enumerate(all_names) if value}
+        missing = [value for value in names if value not in ids_by_name]
+        if missing:
+            raise ValueError(
+                f"Entity '{self.name}' could not resolve {capability} names {missing} on "
+                f"backend '{self._backend_type}'; available={list(all_names)}"
+            )
+        return _readonly_ids(
+            [ids_by_name[value] for value in names],
+            expected=len(names),
+            label=f"Entity '{self.name}' {capability}",
+        )
+
+    def _read_state(self, capability: str, getter, *args) -> np.ndarray:
+        try:
+            return np.asarray(getter(*args))
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error(capability, str(exc)) from exc
+
+    def _validate_joint_state(
+        self,
+        backend: SimBackend,
+        pos_ids: np.ndarray | None,
+        vel_ids: np.ndarray | None,
+    ) -> None:
+        for capability, getter, ids in (
+            ("joint position state", backend.get_dof_pos, pos_ids),
+            ("joint velocity state", backend.get_dof_vel, vel_ids),
+        ):
+            if ids is None:
+                continue
+            value = self._read_state(capability, getter)
+            if value.ndim != 2 or value.shape[0] != backend.num_envs:
+                raise ValueError(
+                    f"Entity '{self.name}' capability '{capability}' on backend "
+                    f"'{self._backend_type}' returned shape {value.shape}; expected "
+                    f"({backend.num_envs}, num_dof)"
+                )
+            if ids.size and int(np.max(ids)) >= value.shape[1]:
+                raise ValueError(
+                    f"Entity '{self.name}' capability '{capability}' resolved index "
+                    f"{int(np.max(ids))}, but backend '{self._backend_type}' returned "
+                    f"only {value.shape[1]} columns"
+                )
+
+    def _validate_body_state(
+        self,
+        backend: SimBackend,
+        root_body_ids: np.ndarray | None,
+        body_ids: np.ndarray | None,
+    ) -> None:
+        arrays = [values for values in (root_body_ids, body_ids) if values is not None]
+        if not arrays:
+            return
+        validation_ids = np.unique(np.concatenate(arrays)).astype(np.int32, copy=False)
+        for capability, getter, width in (
+            ("body position state", backend.get_body_pos_w, 3),
+            ("body quaternion state", backend.get_body_quat_w, 4),
+            ("body linear velocity state", backend.get_body_lin_vel_w, 3),
+            ("body angular velocity state", backend.get_body_ang_vel_w, 3),
+        ):
+            value = self._read_state(capability, getter, validation_ids)
+            expected = (backend.num_envs, len(validation_ids), width)
+            if value.shape != expected:
+                raise ValueError(
+                    f"Entity '{self.name}' capability '{capability}' on backend "
+                    f"'{self._backend_type}' returned shape {value.shape}; expected {expected}"
+                )
+
+    def _materialize_actuator_ctrl_range(
+        self, backend: SimBackend, actuator_ids: np.ndarray | None
+    ) -> np.ndarray | None:
+        if actuator_ids is None:
+            return None
+        ranges = self._read_state("actuator control range", backend.get_actuator_ctrl_range)
+        expected = (backend.num_actuators, 2)
+        if ranges.shape != expected:
+            raise ValueError(
+                f"Entity '{self.name}' capability 'actuator control range' on backend "
+                f"'{self._backend_type}' returned shape {ranges.shape}; expected {expected}"
+            )
+        selected = np.array(ranges[_as_column_index(actuator_ids)], copy=True)
+        selected.setflags(write=False)
+        return selected
+
+    def _require_names(self, kind: str, names: tuple[str, ...] | None) -> tuple[str, ...]:
+        if names is None:
+            raise self._capability_error(kind, "the namespace was not declared in EntityCfg")
+        return names
+
+    def _unsupported_names(self, kind: str) -> NoReturn:
+        raise self._capability_error(kind, "SimBackend does not declare this namespace")
+
+    @property
+    def joint_names(self) -> tuple[str, ...]:
+        return self._require_names("joint", self._joint_names)
+
+    @property
+    def body_names(self) -> tuple[str, ...]:
+        return self._require_names("body", self._body_names)
+
+    @property
+    def geom_names(self) -> tuple[str, ...]:
+        return self._require_names("geom", self._geom_names)
+
+    @property
+    def site_names(self) -> tuple[str, ...]:
+        return self._require_names("site", self._site_names)
+
+    @property
+    def actuator_names(self) -> tuple[str, ...]:
+        return self._require_names("actuator", self._actuator_names)
+
+    @property
+    def tendon_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("tendon")
+
+    @property
+    def camera_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("camera")
+
+    @property
+    def light_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("light")
+
+    @property
+    def material_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("material")
+
+    @property
+    def texture_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("texture")
+
+    @property
+    def pair_names(self) -> tuple[str, ...]:
+        return self._unsupported_names("pair")
+
+    @property
+    def num_joints(self) -> int:
+        return len(self.joint_names)
+
+    @property
+    def num_bodies(self) -> int:
+        return len(self.body_names)
+
+    @property
+    def num_geoms(self) -> int:
+        return len(self.geom_names)
+
+    @property
+    def num_sites(self) -> int:
+        return len(self.site_names)
+
+    @property
+    def num_actuators(self) -> int:
+        return len(self.actuator_names)
+
+    @property
+    def num_tendons(self) -> int:
+        return len(self.tendon_names)
+
+    @property
+    def num_cameras(self) -> int:
+        return len(self.camera_names)
+
+    @property
+    def num_lights(self) -> int:
+        return len(self.light_names)
+
+    @property
+    def num_materials(self) -> int:
+        return len(self.material_names)
+
+    @property
+    def num_textures(self) -> int:
+        return len(self.texture_names)
+
+    @property
+    def num_pairs(self) -> int:
+        return len(self.pair_names)
+
+    def _find(
+        self,
+        kind: str,
+        names: tuple[str, ...] | None,
+        keys: str | Sequence[str],
+        preserve_order: bool,
+    ) -> tuple[list[int], list[str]]:
+        return _resolve_matching_names(keys, self._require_names(kind, names), preserve_order)
+
+    def find_joints(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find("joint", self._joint_names, keys, preserve_order)
+
+    def find_bodies(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find("body", self._body_names, keys, preserve_order)
+
+    def find_geoms(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find("geom", self._geom_names, keys, preserve_order)
+
+    def find_sites(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find("site", self._site_names, keys, preserve_order)
+
+    def find_actuators(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        return self._find("actuator", self._actuator_names, keys, preserve_order)
+
+    def find_tendons(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("tendon")
+
+    def find_cameras(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("camera")
+
+    def find_lights(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("light")
+
+    def find_materials(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("material")
+
+    def find_textures(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("texture")
+
+    def find_pairs(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]:
+        del keys, preserve_order
+        return self._unsupported_names("pair")
+
+
+class EntityScene(Mapping[str, Entity]):
+    """Read-only name-addressable collection of backend-bound entities."""
+
+    def __init__(self, entities: Mapping[str, EntityCfg], backend: SimBackend) -> None:
+        materialized: dict[str, Entity] = {}
+        for name, cfg in entities.items():
+            if not isinstance(name, str) or not name:
+                raise TypeError(f"Scene entity names must be non-empty strings; got {name!r}")
+            if not isinstance(cfg, EntityCfg):
+                raise TypeError(
+                    f"Scene entity '{name}' must be EntityCfg, got {type(cfg).__name__}"
+                )
+            materialized[name] = Entity(name, cfg, backend)
+        self._entities = MappingProxyType(materialized)
+
+    @classmethod
+    def from_scene_cfg(cls, cfg: SceneCfg, backend: SimBackend) -> EntityScene:
+        return cls(cfg.entities, backend)
+
+    def __getitem__(self, name: str) -> Entity:
+        try:
+            return self._entities[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"Scene entity '{name}' not found; available={list(self._entities)}"
+            ) from exc
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._entities)
+
+    def __len__(self) -> int:
+        return len(self._entities)
+
+
+__all__ = ["Entity", "EntityCfg", "EntityData", "EntityScene"]

--- a/src/unilab/base/scene.py
+++ b/src/unilab/base/scene.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from unilab.base.entity import EntityCfg
 from unilab.terrains.terrain_generator import TerrainGeneratorCfg
 
 
@@ -38,6 +39,8 @@ class SceneCfg:
     model_file: str
     fragment_files: list[str] = field(default_factory=list)
     terrain: TerrainSceneCfg | None = None
+    entities: dict[str, EntityCfg] = field(default_factory=dict)
+    """Logical entity partitions materialized by the base-owned manager facade."""
     # Optional render-only model override. When set, offline playback/video
     # export renders this XML instead of ``model_file`` while physics keeps
     # using ``model_file``. Used to give the renderer a visual twin of the

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -7,6 +7,7 @@ an environment, backend, runner, or IPC implementation.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Protocol
 
 import numpy as np
@@ -15,17 +16,115 @@ import numpy as np
 class ManagerEntity(Protocol):
     """Cold-path entity metadata required by :class:`SceneEntityCfg`."""
 
-    joint_names: list[str]
-    body_names: list[str]
-    geom_names: list[str]
-    site_names: list[str]
-    actuator_names: list[str]
-    tendon_names: list[str]
-    camera_names: list[str]
-    light_names: list[str]
-    material_names: list[str]
-    texture_names: list[str]
-    pair_names: list[str]
+    @property
+    def joint_names(self) -> Sequence[str]: ...
+
+    @property
+    def body_names(self) -> Sequence[str]: ...
+
+    @property
+    def geom_names(self) -> Sequence[str]: ...
+
+    @property
+    def site_names(self) -> Sequence[str]: ...
+
+    @property
+    def actuator_names(self) -> Sequence[str]: ...
+
+    @property
+    def tendon_names(self) -> Sequence[str]: ...
+
+    @property
+    def camera_names(self) -> Sequence[str]: ...
+
+    @property
+    def light_names(self) -> Sequence[str]: ...
+
+    @property
+    def material_names(self) -> Sequence[str]: ...
+
+    @property
+    def texture_names(self) -> Sequence[str]: ...
+
+    @property
+    def pair_names(self) -> Sequence[str]: ...
+
+    @property
+    def num_joints(self) -> int: ...
+
+    @property
+    def num_bodies(self) -> int: ...
+
+    @property
+    def num_geoms(self) -> int: ...
+
+    @property
+    def num_sites(self) -> int: ...
+
+    @property
+    def num_actuators(self) -> int: ...
+
+    @property
+    def num_tendons(self) -> int: ...
+
+    @property
+    def num_cameras(self) -> int: ...
+
+    @property
+    def num_lights(self) -> int: ...
+
+    @property
+    def num_materials(self) -> int: ...
+
+    @property
+    def num_textures(self) -> int: ...
+
+    @property
+    def num_pairs(self) -> int: ...
+
+    def find_joints(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_bodies(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_geoms(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_sites(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_actuators(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_tendons(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_cameras(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_lights(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_materials(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_textures(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
+
+    def find_pairs(
+        self, keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[list[int], list[str]]: ...
 
 
 class ManagerScene(Protocol):

--- a/src/unilab/managers/manager_base.py
+++ b/src/unilab/managers/manager_base.py
@@ -151,9 +151,14 @@ class ManagerBase(abc.ABC):
         raise NotImplementedError
 
     def _resolve_common_term_cfg(self, term_name: str, term_cfg: ManagerTermBaseCfg) -> None:
-        del term_name  # Unused.
-        for value in term_cfg.params.values():
+        for param_name, value in term_cfg.params.items():
             if isinstance(value, SceneEntityCfg):
-                value.resolve(self._env.scene)
+                try:
+                    value.resolve(self._env.scene)
+                except (KeyError, TypeError, ValueError, NotImplementedError) as exc:
+                    message = (
+                        f"{type(self).__name__} term '{term_name}' parameter '{param_name}': {exc}"
+                    )
+                    raise type(exc)(message) from exc
         if inspect.isclass(term_cfg.func):
             term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)

--- a/src/unilab/managers/scene_entity_config.py
+++ b/src/unilab/managers/scene_entity_config.py
@@ -158,7 +158,12 @@ class SceneEntityCfg:
         entity = scene[self.name]
 
         for config in _FIELD_CONFIGS:
-            self._resolve_field(entity, config)
+            try:
+                self._resolve_field(entity, config)
+            except (TypeError, ValueError, NotImplementedError) as exc:
+                raise type(exc)(
+                    f"SceneEntityCfg entity '{self.name}' {config.kind_label} selector: {exc}"
+                ) from exc
 
     def _resolve_field(self, entity: ManagerEntity, config: _FieldConfig) -> None:
         """Resolve a single field's names and IDs.
@@ -199,7 +204,7 @@ class SceneEntityCfg:
                 config.ids_attr,
             )
         elif isinstance(ids, list):
-            self._resolve_ids_to_names(ids, entity_all_names, config.names_attr)
+            self._resolve_ids_to_names(ids, entity_all_names, config.names_attr, config.kind_label)
 
     def _normalize_to_list(self, value: str | int | tuple | list | None) -> list | None:
         """Convert single values to lists for uniform processing."""
@@ -225,6 +230,7 @@ class SceneEntityCfg:
           ValueError: If names and IDs don't match.
         """
         found_ids, _ = find_method(names, preserve_order=self.preserve_order)
+        self._validate_ids(ids, len(entity_all_names), kind_label)
         computed_names = [entity_all_names[i] for i in ids]
 
         if found_ids != ids or computed_names != names:
@@ -256,8 +262,26 @@ class SceneEntityCfg:
             setattr(self, ids_attr, found_ids)
 
     def _resolve_ids_to_names(
-        self, ids: list[int], entity_all_names: list[str], names_attr: str
+        self,
+        ids: list[int],
+        entity_all_names: list[str],
+        names_attr: str,
+        kind_label: str,
     ) -> None:
         """Resolve IDs to their corresponding names."""
+        self._validate_ids(ids, len(entity_all_names), kind_label)
         resolved_names = [entity_all_names[i] for i in ids]
         setattr(self, names_attr, resolved_names)
+
+    @staticmethod
+    def _validate_ids(ids: list[int], count: int, kind_label: str) -> None:
+        invalid_types = [
+            value for value in ids if isinstance(value, bool) or not isinstance(value, int)
+        ]
+        if invalid_types:
+            raise TypeError(f"{kind_label} IDs must be integers; got {invalid_types}")
+        out_of_range = [value for value in ids if value < 0 or value >= count]
+        if out_of_range:
+            raise ValueError(
+                f"{kind_label} IDs {out_of_range} are out of range for {count} available entries"
+            )

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from collections import Counter
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import unilab.base.entity as entity_module
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend.base import SimBackend
+from unilab.base.entity import EntityCfg, EntityScene
+from unilab.base.scene import SceneCfg
+from unilab.managers import RewardManager, RewardTermCfg, SceneEntityCfg
+
+
+class _StrictBackendProfile:
+    """Strict public-contract fake shared by backend capability profiles."""
+
+    num_envs = 3
+    num_actuators = 5
+
+    def __init__(self, backend_type: str, *, unsupported: frozenset[str] = frozenset()) -> None:
+        self.backend_type = backend_type
+        self.unsupported = unsupported
+        self.calls: Counter[str] = Counter()
+        self.joint_ids = {"hip": 2, "knee": 0, "ankle": 4}
+        self.body_ids = {"base": 4, "foot": 7}
+        self.site_ids = {"imu": 3}
+        self.geom_names = ("floor", "base_collision", "foot_collision")
+        self.actuator_names = ("knee", "unused", "hip", "unused_2", "ankle")
+        self.dof_pos = np.arange(self.num_envs * 5, dtype=np.float32).reshape(self.num_envs, 5)
+        self.dof_vel = self.dof_pos + 100.0
+        base = np.arange(self.num_envs * 10 * 3, dtype=np.float32)
+        self.body_pos = base.reshape(self.num_envs, 10, 3)
+        self.body_quat = np.zeros((self.num_envs, 10, 4), dtype=np.float32)
+        self.body_quat[..., 0] = 1.0
+        self.body_lin_vel = self.body_pos + 200.0
+        self.body_ang_vel = self.body_pos + 300.0
+
+    def _check(self, capability: str) -> None:
+        self.calls[capability] += 1
+        if capability in self.unsupported:
+            raise NotImplementedError(f"{self.backend_type} lacks {capability}")
+
+    def get_body_ids(self, names) -> np.ndarray:
+        self._check("body names")
+        return np.asarray([self.body_ids[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_pos_indices(self, names) -> np.ndarray:
+        self._check("joint position names")
+        return np.asarray([self.joint_ids[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names) -> np.ndarray:
+        self._check("joint velocity names")
+        return np.asarray([self.joint_ids[name] for name in names], dtype=np.int32)
+
+    def get_site_ids(self, names) -> np.ndarray:
+        self._check("site names")
+        return np.asarray([self.site_ids[name] for name in names], dtype=np.int32)
+
+    def get_geom_names(self) -> tuple[str, ...]:
+        self._check("geom names")
+        return self.geom_names
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        self._check("actuator names")
+        return self.actuator_names
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        self.calls["actuator range"] += 1
+        return np.arange(10, dtype=np.float32).reshape(5, 2)
+
+    def get_dof_pos(self) -> np.ndarray:
+        self._check("joint position state")
+        return self.dof_pos
+
+    def get_dof_vel(self) -> np.ndarray:
+        self._check("joint velocity state")
+        return self.dof_vel
+
+    def get_body_pos_w(self, ids: np.ndarray) -> np.ndarray:
+        self._check("body position state")
+        return self.body_pos[:, ids]
+
+    def get_body_quat_w(self, ids: np.ndarray) -> np.ndarray:
+        self._check("body quaternion state")
+        return self.body_quat[:, ids]
+
+    def get_body_lin_vel_w(self, ids: np.ndarray) -> np.ndarray:
+        self._check("body linear velocity state")
+        return self.body_lin_vel[:, ids]
+
+    def get_body_ang_vel_w(self, ids: np.ndarray) -> np.ndarray:
+        self._check("body angular velocity state")
+        return self.body_ang_vel[:, ids]
+
+
+def _scene(backend_type: str = "mujoco") -> tuple[_StrictBackendProfile, EntityScene]:
+    backend = _StrictBackendProfile(backend_type)
+    cfg = SceneCfg(
+        model_file="unused.xml",
+        entities={
+            "robot": EntityCfg(
+                root_body_name="base",
+                joint_names=("ankle", "hip"),
+                body_names=("foot", "base"),
+                geom_names=("foot_collision", "base_collision"),
+                site_names=("imu",),
+                actuator_names=("ankle", "hip"),
+            )
+        },
+    )
+    return backend, EntityScene.from_scene_cfg(cfg, cast(SimBackend, backend))
+
+
+@pytest.mark.parametrize("backend_type", ["mujoco", "motrix", "drake"])
+def test_backend_profiles_materialize_identical_local_entity_contract(backend_type: str) -> None:
+    backend, scene = _scene(backend_type)
+    robot = scene["robot"]
+
+    assert robot.joint_names == ("ankle", "hip")
+    assert robot.body_names == ("foot", "base")
+    np.testing.assert_array_equal(robot.data.joint_pos, backend.dof_pos[:, [4, 2]])
+    np.testing.assert_array_equal(robot.data.joint_vel, backend.dof_vel[:, [4, 2]])
+    np.testing.assert_array_equal(robot.data.body_link_pos_w, backend.body_pos[:, [7, 4]])
+    np.testing.assert_array_equal(robot.data.root_link_pos_w, backend.body_pos[:, 4])
+    np.testing.assert_array_equal(
+        robot.data.actuator_ctrl_range,
+        np.arange(10, dtype=np.float32).reshape(5, 2)[[4, 2]],
+    )
+
+
+def test_scene_entity_cfg_resolves_only_against_cached_names() -> None:
+    backend, scene = _scene()
+    cold_path_calls = backend.calls.copy()
+
+    cfg = SceneEntityCfg(
+        "robot",
+        joint_names=("hip", "ankle"),
+        body_names=".*",
+        geom_names="foot_.*",
+        site_names="imu",
+        actuator_names=["hip", "ankle"],
+        preserve_order=True,
+    )
+    cfg.resolve(scene)
+
+    assert cfg.joint_ids == [1, 0]
+    assert cfg.body_ids == slice(None)
+    assert cfg.geom_ids == [0]
+    assert cfg.site_ids == slice(None)
+    assert cfg.actuator_ids == [1, 0]
+    assert backend.calls == cold_path_calls
+
+    for _ in range(3):
+        scene["robot"].data.joint_pos
+        scene["robot"].data.root_link_quat_w
+    for key in (
+        "body names",
+        "joint position names",
+        "joint velocity names",
+        "site names",
+        "geom names",
+        "actuator names",
+    ):
+        assert backend.calls[key] == cold_path_calls[key]
+
+
+@pytest.mark.parametrize(
+    ("ids", "error_type", "message"),
+    [
+        ([-1], ValueError, "EntityCfg entity 'robot' joint selector.*out of range"),
+        ([2], ValueError, "EntityCfg entity 'robot' joint selector.*out of range"),
+        ([True], TypeError, "EntityCfg entity 'robot' joint selector.*must be integers"),
+        (["0"], TypeError, "EntityCfg entity 'robot' joint selector.*must be integers"),
+    ],
+)
+def test_scene_entity_cfg_rejects_invalid_ids(ids, error_type, message: str) -> None:
+    _, scene = _scene()
+    cfg = SceneEntityCfg("robot", joint_ids=ids)
+    with pytest.raises(error_type, match=message):
+        cfg.resolve(scene)
+
+
+def test_scene_entity_cfg_reports_entity_for_invalid_regex() -> None:
+    _, scene = _scene()
+    with pytest.raises(
+        ValueError,
+        match="SceneEntityCfg entity 'robot' joint selector.*Invalid entity selector regex",
+    ):
+        SceneEntityCfg("robot", joint_names="[").resolve(scene)
+
+
+def test_missing_entity_namespace_and_backend_capability_fail_closed() -> None:
+    backend = _StrictBackendProfile("drake", unsupported=frozenset({"actuator names"}))
+    with pytest.raises(
+        NotImplementedError,
+        match="Entity 'robot'.*actuator.*backend 'drake'",
+    ):
+        EntityScene(
+            {"robot": EntityCfg(actuator_names=("hip",))},
+            cast(SimBackend, backend),
+        )
+
+    _, scene = _scene("motrix")
+    with pytest.raises(
+        NotImplementedError,
+        match="Entity 'robot'.*tendon.*backend 'motrix'",
+    ):
+        SceneEntityCfg("robot", tendon_names=".*").resolve(scene)
+
+    sparse = EntityScene(
+        {"robot": EntityCfg(joint_names=("hip",))},
+        cast(SimBackend, _StrictBackendProfile("mujoco")),
+    )
+    with pytest.raises(NotImplementedError, match="body.*not declared"):
+        SceneEntityCfg("robot", body_names=".*").resolve(sparse)
+
+    state_missing = _StrictBackendProfile("mujoco", unsupported=frozenset({"body position state"}))
+    with pytest.raises(
+        NotImplementedError,
+        match="Entity 'robot'.*body position state.*backend 'mujoco'",
+    ):
+        EntityScene(
+            {"robot": EntityCfg(root_body_name="base")},
+            cast(SimBackend, state_missing),
+        )
+
+
+def test_entity_declaration_rejects_coercion_and_duplicate_names() -> None:
+    backend = cast(SimBackend, _StrictBackendProfile("mujoco"))
+    with pytest.raises(TypeError, match="sequence of strings, not a scalar"):
+        EntityScene(
+            {"robot": EntityCfg(joint_names=cast(Any, "hip"))},
+            backend,
+        )
+    with pytest.raises(TypeError, match="joint names must be strings"):
+        EntityScene(
+            {"robot": EntityCfg(joint_names=cast(Any, ("hip", 1)))},
+            backend,
+        )
+    with pytest.raises(ValueError, match="joint names must be unique"):
+        EntityScene(
+            {"robot": EntityCfg(joint_names=("hip", "hip"))},
+            backend,
+        )
+
+
+def test_manager_resolution_error_has_manager_term_entity_capability_and_backend() -> None:
+    _, scene = _scene("drake")
+    env = SimpleNamespace(
+        num_envs=3,
+        scene=scene,
+        rng=np.random.default_rng(7),
+        max_episode_length_s=2.0,
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            "RewardManager term 'unsupported' parameter 'asset_cfg'.*"
+            "Entity 'robot'.*tendon.*backend 'drake'"
+        ),
+    ):
+        RewardManager(
+            {
+                "unsupported": RewardTermCfg(
+                    func=lambda env, asset_cfg: np.zeros(env.num_envs),
+                    weight=1.0,
+                    params={"asset_cfg": SceneEntityCfg("robot", tendon_names=".*")},
+                )
+            },
+            cast(Any, env),
+        )
+
+
+def test_entity_facade_has_no_backend_model_or_asset_access() -> None:
+    tree = ast.parse(inspect.getsource(entity_module))
+    accessed_attributes = {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+    assert "model" not in accessed_attributes
+    assert "scene_model_file" not in accessed_attributes
+
+
+def test_real_mujoco_entity_selector_and_numpy_state_smoke() -> None:
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    joint_names = (
+        "FL_hip_joint",
+        "FL_thigh_joint",
+        "FL_calf_joint",
+        "FR_hip_joint",
+        "FR_thigh_joint",
+        "FR_calf_joint",
+        "RL_hip_joint",
+        "RL_thigh_joint",
+        "RL_calf_joint",
+        "RR_hip_joint",
+        "RR_thigh_joint",
+        "RR_calf_joint",
+    )
+    actuator_names = (
+        "FR_hip",
+        "FR_thigh",
+        "FR_calf",
+        "FL_hip",
+        "FL_thigh",
+        "FL_calf",
+        "RR_hip",
+        "RR_thigh",
+        "RR_calf",
+        "RL_hip",
+        "RL_thigh",
+        "RL_calf",
+    )
+    scene_cfg = SceneCfg(
+        model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
+        entities={
+            "robot": EntityCfg(
+                root_body_name="base",
+                joint_names=joint_names,
+                body_names=("base",),
+                actuator_names=actuator_names,
+            )
+        },
+    )
+    backend = MuJoCoBackend(
+        scene_cfg,
+        num_envs=2,
+        sim_dt=0.01,
+        base_name="base",
+        add_body_sensors=True,
+    )
+    backend.materialize()
+    scene = EntityScene.from_scene_cfg(scene_cfg, backend)
+
+    selector = SceneEntityCfg("robot", joint_names=".*_calf_joint")
+    selector.resolve(scene)
+    assert selector.joint_ids == [2, 5, 8, 11]
+    assert scene["robot"].data.joint_pos.shape == (2, 12)
+    assert scene["robot"].data.root_link_pose_w.shape == (2, 7)
+
+
+def test_scene_cfg_entity_defaults_are_not_shared() -> None:
+    first = SceneCfg(model_file="first.xml")
+    second = SceneCfg(model_file="second.xml")
+    first.entities["robot"] = EntityCfg()
+    assert second.entities == {}


### PR DESCRIPTION
## Summary

- add a base-owned `EntityCfg` / `EntityScene` / `EntityData` facade over the existing public `SimBackend` contract
- materialize explicit joint/body/geom/site/actuator partitions once, cache local-to-backend mappings, and expose NumPy root/joint/body state
- preserve pinned mjlab `SceneEntityCfg` regex/order/consistency semantics while rejecting invalid IDs and unsupported namespaces with entity/backend context
- attach manager/term/parameter context to selector failures without coupling managers to backends or `NpEnv`

## Boundaries

- no new `SimBackend` method or backend-private/model access
- no `NpEnv` lifecycle, production task, Hydra script, runner, learner, or IPC integration
- no XML/asset access in the facade and no name resolution on repeated state reads
- tendon/camera/light/material/texture/pair remain explicit unsupported capabilities

## Change accounting

- source-derived: 55 lines for pinned mjlab-compatible regex matching, with path/commit/Apache-2.0 provenance
- mechanical adaptation: 110 added / 11 removed lines expanding the standalone manager entity protocol
- UniLab-specific facade, validation, error context, and tests: 969 added / 6 removed lines
- modified existing: 4 files, +148 / -17 lines
- created: 2 files, 986 lines
- deleted existing files: none
- total: 6 files, +1,134 / -17; within the ≤25 file / ≤1,500-line child budget

## Validation

- focused manager/entity suite: 45 passed
- config + representative backend regression: 211 passed
- `make test-all`: 1,814 passed, 24 skipped, 1 xfailed; benchmark import smoke passed 65/67 with two platform-optional `mlx` skips
- ruff, mypy, and pyright: passed

Implements #1047
Umbrella: #1042