### PR TITLE
feat(env): add NumPy manager-based lifecycle

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -140,7 +140,9 @@ class EntityData:
         joint_pos_ids: np.ndarray | None,
         joint_vel_ids: np.ndarray | None,
         body_ids: np.ndarray | None,
+        actuator_ids: np.ndarray | None,
         actuator_ctrl_range: np.ndarray | None,
+        control_buffer: np.ndarray | None,
         entity_name: str,
         backend_type: str,
     ) -> None:
@@ -151,7 +153,9 @@ class EntityData:
         self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
         self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
         self._body_ids = body_ids
+        self._actuator_index = None if actuator_ids is None else _as_column_index(actuator_ids)
         self._actuator_ctrl_range = actuator_ctrl_range
+        self._control_buffer = control_buffer
 
     def _require(self, value, capability: str):
         if value is None:
@@ -231,11 +235,81 @@ class EntityData:
     def actuator_ctrl_range(self) -> np.ndarray:
         return self._require(self._actuator_ctrl_range, "actuator control range")
 
+    def write_ctrl(
+        self,
+        values: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Write entity-local actuator controls into the env-owned control buffer.
+
+        This is an in-memory scene write, analogous to the pinned manager runtime's
+        entity target buffers.  Physics remains owned by ``NpEnv``/``SimBackend``;
+        this method never steps or calls a backend-private API.
+        """
+        actuator_index = self._require(self._actuator_index, "actuator control write")
+        control = self._require(self._control_buffer, "actuator control write")
+        if not isinstance(values, np.ndarray):
+            raise TypeError(
+                f"Entity '{self._entity_name}' write_ctrl expected np.ndarray, "
+                f"received {type(values).__name__}"
+            )
+        row_index: np.ndarray | slice
+        if env_ids is None:
+            row_index = slice(None)
+            row_count = control.shape[0]
+        elif isinstance(env_ids, slice):
+            row_index = env_ids
+            row_count = len(range(*env_ids.indices(control.shape[0])))
+        else:
+            raw_ids = np.asarray(env_ids)
+            if (
+                raw_ids.ndim != 1
+                or not np.issubdtype(raw_ids.dtype, np.integer)
+                or np.issubdtype(raw_ids.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self._entity_name}' write_ctrl env_ids must be a 1-D "
+                    f"integer array or slice, got shape={raw_ids.shape}, dtype={raw_ids.dtype}"
+                )
+            row_index = np.asarray(raw_ids, dtype=np.intp)
+            if np.any(row_index < 0) or np.any(row_index >= control.shape[0]):
+                raise IndexError(
+                    f"Entity '{self._entity_name}' write_ctrl env_ids out of range for "
+                    f"{control.shape[0]} environments: {row_index.tolist()}"
+                )
+            if np.unique(row_index).size != row_index.size:
+                raise ValueError(
+                    f"Entity '{self._entity_name}' write_ctrl env_ids contain duplicates: "
+                    f"{row_index.tolist()}"
+                )
+            row_count = len(row_index)
+
+        actuator_count = len(self._require(self._actuator_ctrl_range, "actuator control write"))
+        expected = (row_count, actuator_count)
+        if values.shape != expected:
+            raise ValueError(
+                f"Entity '{self._entity_name}' write_ctrl expected shape {expected}, "
+                f"received {values.shape}"
+            )
+        if not np.isfinite(values).all():
+            raise ValueError(f"Entity '{self._entity_name}' write_ctrl received NaN or Inf")
+
+        if isinstance(row_index, slice) or isinstance(actuator_index, slice):
+            control[row_index, actuator_index] = values
+        else:
+            control[row_index[:, None], actuator_index[None, :]] = values
+
 
 class Entity:
     """Logical entity with cached local-to-backend mappings."""
 
-    def __init__(self, name: str, cfg: EntityCfg, backend: SimBackend) -> None:
+    def __init__(
+        self,
+        name: str,
+        cfg: EntityCfg,
+        backend: SimBackend,
+        control_buffer: np.ndarray | None = None,
+    ) -> None:
         if not name:
             raise ValueError("Entity name must be a non-empty string")
         self.name = name
@@ -293,6 +367,18 @@ class Entity:
         self._validate_joint_state(backend, joint_pos_ids, joint_vel_ids)
         self._validate_body_state(backend, root_body_ids, body_ids)
         actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
+        if control_buffer is not None:
+            expected_control_shape = (backend.num_envs, backend.num_actuators)
+            if control_buffer.shape != expected_control_shape:
+                raise ValueError(
+                    f"Entity '{self.name}' control buffer has shape {control_buffer.shape}; "
+                    f"expected {expected_control_shape} on backend '{self._backend_type}'"
+                )
+            if not np.issubdtype(control_buffer.dtype, np.floating):
+                raise TypeError(
+                    f"Entity '{self.name}' control buffer must have floating dtype, "
+                    f"got {control_buffer.dtype}"
+                )
 
         self.data = EntityData(
             backend,
@@ -300,7 +386,9 @@ class Entity:
             joint_pos_ids=joint_pos_ids,
             joint_vel_ids=joint_vel_ids,
             body_ids=body_ids,
+            actuator_ids=actuator_ids,
             actuator_ctrl_range=actuator_ctrl_range,
+            control_buffer=control_buffer,
             entity_name=self.name,
             backend_type=self._backend_type,
         )
@@ -601,7 +689,12 @@ class Entity:
 class EntityScene(Mapping[str, Entity]):
     """Read-only name-addressable collection of backend-bound entities."""
 
-    def __init__(self, entities: Mapping[str, EntityCfg], backend: SimBackend) -> None:
+    def __init__(
+        self,
+        entities: Mapping[str, EntityCfg],
+        backend: SimBackend,
+        control_buffer: np.ndarray | None = None,
+    ) -> None:
         materialized: dict[str, Entity] = {}
         for name, cfg in entities.items():
             if not isinstance(name, str) or not name:
@@ -610,12 +703,17 @@ class EntityScene(Mapping[str, Entity]):
                 raise TypeError(
                     f"Scene entity '{name}' must be EntityCfg, got {type(cfg).__name__}"
                 )
-            materialized[name] = Entity(name, cfg, backend)
+            materialized[name] = Entity(name, cfg, backend, control_buffer)
         self._entities = MappingProxyType(materialized)
 
     @classmethod
-    def from_scene_cfg(cls, cfg: SceneCfg, backend: SimBackend) -> EntityScene:
-        return cls(cfg.entities, backend)
+    def from_scene_cfg(
+        cls,
+        cfg: SceneCfg,
+        backend: SimBackend,
+        control_buffer: np.ndarray | None = None,
+    ) -> EntityScene:
+        return cls(cfg.entities, backend, control_buffer)
 
     def __getitem__(self, name: str) -> Entity:
         try:

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -117,6 +117,7 @@ class NpEnv(ABEnv):
         self._init_randomization_applied = False
         self._nan_guard: NanGuard | None = None
         self._autoreset = True
+        self._autoreset_reset_active = False
         self._nan_guard_model_file = self._resolve_nan_guard_model_file()
 
     @property
@@ -156,18 +157,29 @@ class NpEnv(ABEnv):
         reward = np.zeros((self._num_envs,), dtype=dtype)
         terminated = np.ones((self._num_envs,), dtype=bool)
         truncated = np.zeros((self._num_envs,), dtype=bool)
-        if self._cfg.max_episode_steps:
-            steps = np.random.randint(
-                0, self._cfg.max_episode_steps, size=(self._num_envs,), dtype=np.uint32
-            )
-        else:
-            steps = np.zeros((self._num_envs,), dtype=np.uint32)
+        steps = self._initial_episode_steps()
         info: dict = {"steps": steps}
 
         self._state = NpEnvState(obs, reward, terminated, truncated, info)
         self._reset_done_envs()
         self._clear_step_final_observation()
         return self._state
+
+    def _initial_episode_steps(self) -> np.ndarray:
+        """Return initial per-env episode counters.
+
+        Existing monolithic tasks keep their randomized initialization.  A lifecycle
+        with different public semantics can override this cold-path hook without
+        duplicating :meth:`init_state` or the autoreset machinery.
+        """
+        if self._cfg.max_episode_steps:
+            return np.random.randint(
+                0,
+                self._cfg.max_episode_steps,
+                size=(self._num_envs,),
+                dtype=np.uint32,
+            )
+        return np.zeros((self._num_envs,), dtype=np.uint32)
 
     def step(self, actions: np.ndarray) -> NpEnvState:
         step_t0 = time.perf_counter()
@@ -274,7 +286,11 @@ class NpEnv(ABEnv):
         detail_timing["reset_done_terminal_obs_ms"] = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        new_obs, info1 = self.reset(env_indices)
+        self._autoreset_reset_active = True
+        try:
+            new_obs, info1 = self.reset(env_indices)
+        finally:
+            self._autoreset_reset_active = False
         detail_timing["reset_done_reset_call_ms"] = (time.perf_counter() - t0) * 1000.0
         if self._dr_manager is not None:
             detail_timing.update(self._dr_manager.last_reset_timing_ms)

--- a/src/unilab/envs/__init__.py
+++ b/src/unilab/envs/__init__.py
@@ -1,1 +1,13 @@
-"""Environment"""
+"""Environment public API."""
+
+from unilab.envs.manager_based_rl_env import ManagerBasedRLEnv as ManagerBasedRLEnv
+from unilab.envs.manager_based_rl_env import ManagerBasedRlEnv as ManagerBasedRlEnv
+from unilab.envs.manager_based_rl_env import ManagerBasedRLEnvCfg as ManagerBasedRLEnvCfg
+from unilab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg as ManagerBasedRlEnvCfg
+
+__all__ = [
+    "ManagerBasedRLEnv",
+    "ManagerBasedRLEnvCfg",
+    "ManagerBasedRlEnv",
+    "ManagerBasedRlEnvCfg",
+]

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -1,0 +1,556 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/envs/manager_based_rl_env.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for the NumPy NpEnv/SimBackend contracts; Apache-2.0.
+"""Community-compatible manager lifecycle on UniLab's NumPy runtime."""
+
+from __future__ import annotations
+
+import math
+import secrets
+from dataclasses import dataclass, field
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+
+from unilab.base.backend import SimBackend
+from unilab.base.base import EnvCfg
+from unilab.base.entity import EntityScene
+from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.base.scene import SceneCfg
+from unilab.dtype_config import get_global_dtype
+from unilab.managers import (
+    ActionManager,
+    ActionTermCfg,
+    CommandManager,
+    CommandTermCfg,
+    CurriculumManager,
+    CurriculumTermCfg,
+    EventManager,
+    EventTermCfg,
+    MetricsManager,
+    MetricsTermCfg,
+    NullCommandManager,
+    NullCurriculumManager,
+    NullMetricsManager,
+    NullRecorderManager,
+    ObservationGroupCfg,
+    ObservationManager,
+    RecorderManager,
+    RecorderTermCfg,
+    RewardManager,
+    RewardTermCfg,
+    TerminationManager,
+    TerminationTermCfg,
+)
+
+
+@dataclass
+class ManagerBasedRlEnvCfg(EnvCfg):
+    """Configuration for the manager-based NumPy environment.
+
+    Serializable values remain ordinary dataclass fields so task-owned Hydra owner
+    configs can overlay them without introducing a second configuration runtime.
+    """
+
+    observations: dict[str, ObservationGroupCfg | None] = field(default_factory=dict)
+    actions: dict[str, ActionTermCfg | None] = field(default_factory=dict)
+    events: dict[str, EventTermCfg | None] = field(default_factory=dict)
+    rewards: dict[str, RewardTermCfg | None] = field(default_factory=dict)
+    terminations: dict[str, TerminationTermCfg | None] = field(default_factory=dict)
+    commands: dict[str, CommandTermCfg | None] = field(default_factory=dict)
+    curriculum: dict[str, CurriculumTermCfg | None] = field(default_factory=dict)
+    metrics: dict[str, MetricsTermCfg | None] = field(default_factory=dict)
+    recorders: dict[str, RecorderTermCfg | None] = field(default_factory=dict)
+
+    seed: int | None = None
+    is_finite_horizon: bool = False
+    auto_reset: bool = True
+    scale_rewards_by_dt: bool = True
+    policy_observation_group: str = "policy"
+    critic_observation_group: str | None = None
+
+    def validate(self) -> None:
+        for name, value in (("sim_dt", self.sim_dt), ("ctrl_dt", self.ctrl_dt)):
+            if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+                raise TypeError(f"ManagerBasedRlEnvCfg {name} must be a real number")
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"ManagerBasedRlEnvCfg {name} must be finite and positive")
+        super().validate()
+        ratio = self.ctrl_dt / self.sim_dt
+        if not np.isclose(ratio, round(ratio), rtol=0.0, atol=1e-9):
+            raise ValueError(
+                "ManagerBasedRlEnvCfg ctrl_dt must be an integer multiple of sim_dt; "
+                f"received ctrl_dt={self.ctrl_dt}, sim_dt={self.sim_dt}"
+            )
+        if self.max_episode_seconds is None:
+            raise ValueError("ManagerBasedRlEnvCfg max_episode_seconds must be finite and positive")
+        if isinstance(self.max_episode_seconds, bool) or not isinstance(
+            self.max_episode_seconds, (int, float, np.number)
+        ):
+            raise TypeError("ManagerBasedRlEnvCfg max_episode_seconds must be a real number")
+        if not np.isfinite(self.max_episode_seconds) or self.max_episode_seconds <= 0.0:
+            raise ValueError("ManagerBasedRlEnvCfg max_episode_seconds must be finite and positive")
+        if self.seed is not None and (
+            isinstance(self.seed, bool)
+            or not isinstance(self.seed, (int, np.integer))
+            or self.seed < 0
+        ):
+            raise ValueError("ManagerBasedRlEnvCfg seed must be a non-negative integer or None")
+        if self.seed is not None:
+            self.seed = int(self.seed)
+        for name in (
+            "observations",
+            "actions",
+            "events",
+            "rewards",
+            "terminations",
+            "commands",
+            "curriculum",
+            "metrics",
+            "recorders",
+        ):
+            if not isinstance(getattr(self, name), dict):
+                raise TypeError(f"ManagerBasedRlEnvCfg {name} must be a dict")
+        for name in ("is_finite_horizon", "auto_reset", "scale_rewards_by_dt"):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"ManagerBasedRlEnvCfg {name} must be bool")
+        if not isinstance(self.policy_observation_group, str) or not self.policy_observation_group:
+            raise ValueError("policy_observation_group must be a non-empty string")
+        if self.critic_observation_group is not None:
+            if (
+                not isinstance(self.critic_observation_group, str)
+                or not self.critic_observation_group
+            ):
+                raise ValueError("critic_observation_group must be a non-empty string or None")
+            if self.critic_observation_group == self.policy_observation_group:
+                raise ValueError("policy and critic observation groups must be different")
+        if not isinstance(self.scene, SceneCfg):
+            raise TypeError(
+                "ManagerBasedRlEnvCfg scene must be a SceneCfg instance, "
+                f"got {type(self.scene).__name__}"
+            )
+
+
+class ManagerBasedRlEnv(NpEnv):
+    """Manager-Based API adapter that reuses the single :class:`NpEnv` lifecycle."""
+
+    is_vector_env = True
+    _cfg: ManagerBasedRlEnvCfg
+
+    def __init__(self, cfg: ManagerBasedRlEnvCfg, backend: SimBackend, num_envs: int):
+        if not isinstance(cfg, ManagerBasedRlEnvCfg):
+            raise TypeError(
+                f"ManagerBasedRlEnv expected ManagerBasedRlEnvCfg, received {type(cfg).__name__}"
+            )
+        cfg.validate()
+        if isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs <= 0:
+            raise ValueError(
+                f"ManagerBasedRlEnv num_envs must be a positive integer, got {num_envs!r}"
+            )
+        if backend.num_envs != num_envs:
+            raise ValueError(
+                f"ManagerBasedRlEnv num_envs={num_envs} does not match backend "
+                f"'{backend.backend_type}' num_envs={backend.num_envs}"
+            )
+
+        super().__init__(cfg, backend, num_envs)
+        actual_seed = cfg.seed if cfg.seed is not None else secrets.randbits(63)
+        cfg.seed = actual_seed
+        self.rng = np.random.default_rng(actual_seed)
+
+        self._control = np.zeros((num_envs, backend.num_actuators), dtype=get_global_dtype())
+        assert cfg.scene is not None
+        self.scene = EntityScene.from_scene_cfg(cfg.scene, backend, self._control)
+
+        self.common_step_counter = 0
+        self._sim_step_counter = 0
+        self.episode_length_buf = np.zeros(num_envs, dtype=np.int64)
+        self.reset_buf = np.zeros(num_envs, dtype=np.bool_)
+        self.reset_terminated = np.zeros(num_envs, dtype=np.bool_)
+        self.reset_time_outs = np.zeros(num_envs, dtype=np.bool_)
+        self.reward_buf = np.zeros(num_envs, dtype=get_global_dtype())
+        self.obs_buf: dict[str, np.ndarray] = {}
+        self.extras: dict[str, Any] = {"log": {}}
+        self._command_dt = np.zeros(num_envs, dtype=get_global_dtype())
+        self._no_truncation = np.zeros(num_envs, dtype=np.bool_)
+        self._manual_reset_pending = np.zeros(num_envs, dtype=np.bool_)
+        self._has_transition = False
+        self._uses_pre_step_control = False
+
+        self._load_managers()
+        self._mapped_obs_dims = self._validate_observation_mapping()
+        self._validate_substep_capabilities()
+        self._configure_action_control()
+        self.set_autoreset(cfg.auto_reset)
+
+        if "startup" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="startup")
+
+    @property
+    def physics_dt(self) -> float:
+        return self._cfg.sim_dt
+
+    @property
+    def step_dt(self) -> float:
+        return self._cfg.ctrl_dt
+
+    @property
+    def max_episode_length_s(self) -> float:
+        assert self._cfg.max_episode_seconds is not None
+        return self._cfg.max_episode_seconds
+
+    @property
+    def max_episode_length(self) -> int:
+        return math.ceil(self.max_episode_length_s / self.step_dt)
+
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        return dict(self._mapped_obs_dims)
+
+    @property
+    def action_space(self) -> gym.Space:
+        return gym.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self.action_manager.total_action_dim,),
+            dtype=get_global_dtype(),
+        )
+
+    @property
+    def unwrapped(self) -> ManagerBasedRlEnv:
+        return self
+
+    def _load_managers(self) -> None:
+        """Construct managers in the pinned community dependency order."""
+        self.event_manager = EventManager(self._cfg.events, self)
+        self.command_manager = (
+            CommandManager(self._cfg.commands, self) if self._cfg.commands else NullCommandManager()
+        )
+        self.action_manager = ActionManager(self._cfg.actions, self)
+        self.observation_manager = ObservationManager(self._cfg.observations, self)
+        self.termination_manager = TerminationManager(self._cfg.terminations, self)
+        self.reward_manager = RewardManager(
+            self._cfg.rewards,
+            self,
+            scale_by_dt=self._cfg.scale_rewards_by_dt,
+        )
+        self.curriculum_manager = (
+            CurriculumManager(self._cfg.curriculum, self)
+            if self._cfg.curriculum
+            else NullCurriculumManager()
+        )
+        self.metrics_manager = (
+            MetricsManager(self._cfg.metrics, self) if self._cfg.metrics else NullMetricsManager()
+        )
+        self.recorder_manager = (
+            RecorderManager(self._cfg.recorders, self)
+            if self._cfg.recorders
+            else NullRecorderManager()
+        )
+
+    def _validate_observation_mapping(self) -> dict[str, int]:
+        mapping = {"obs": self._cfg.policy_observation_group}
+        if self._cfg.critic_observation_group is not None:
+            mapping["critic"] = self._cfg.critic_observation_group
+        dims: dict[str, int] = {}
+        for output_name, group_name in mapping.items():
+            if group_name not in self.observation_manager.active_terms:
+                raise KeyError(
+                    f"ManagerBasedRlEnv observation mapping '{output_name}' requests group "
+                    f"'{group_name}', available={list(self.observation_manager.active_terms)}"
+                )
+            if not self.observation_manager.group_obs_concatenate[group_name]:
+                raise ValueError(
+                    f"ManagerBasedRlEnv observation group '{group_name}' mapped to "
+                    f"NpEnvState.obs['{output_name}'] must concatenate terms"
+                )
+            group_dim = self.observation_manager.group_obs_dim[group_name]
+            if not isinstance(group_dim, tuple) or len(group_dim) != 1:
+                raise ValueError(
+                    f"ManagerBasedRlEnv observation group '{group_name}' mapped to "
+                    f"NpEnvState.obs['{output_name}'] must be one-dimensional; got {group_dim}"
+                )
+            dims[output_name] = int(group_dim[0])
+        return dims
+
+    def _validate_substep_capabilities(self) -> None:
+        per_substep_terms = [
+            name
+            for name, term_cfg in self._cfg.metrics.items()
+            if term_cfg is not None and term_cfg.per_substep
+        ]
+        if self._cfg.sim_substeps > 1 and per_substep_terms:
+            raise NotImplementedError(
+                "MetricsManager capability 'post-physics per-substep metrics' is unavailable "
+                f"on backend '{self._backend.backend_type}' with sim_substeps="
+                f"{self._cfg.sim_substeps}; terms={per_substep_terms}. SimBackend does not "
+                "declare a post-substep hook."
+            )
+
+    def _configure_action_control(self) -> None:
+        if self._cfg.sim_substeps <= 1 or not self.action_manager.active_terms:
+            return
+        try:
+            self._backend.set_pre_step_control(self._apply_manager_control)
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                "ActionManager capability 'apply actions on every physics substep' is "
+                f"unavailable on backend '{self._backend.backend_type}': {exc}"
+            ) from exc
+        self._uses_pre_step_control = True
+
+    def _apply_manager_control(
+        self,
+        backend: SimBackend,
+        control: np.ndarray,
+    ) -> np.ndarray:
+        del backend, control
+        self._sim_step_counter += 1
+        self.action_manager.apply_action()
+        return self._control
+
+    def _initial_episode_steps(self) -> np.ndarray:
+        return np.zeros((self.num_envs,), dtype=np.uint32)
+
+    def init_state(self) -> NpEnvState:
+        state = super().init_state()
+        self.obs_buf = state.obs
+        self.reward_buf = state.reward
+        self.extras = state.info
+        return state
+
+    def step(self, actions: np.ndarray) -> NpEnvState:
+        if not self._autoreset and np.any(self._manual_reset_pending):
+            pending = np.flatnonzero(self._manual_reset_pending).tolist()
+            raise RuntimeError(
+                f"ManagerBasedRlEnv environments {pending} must be reset before step() "
+                "when auto_reset=False"
+            )
+        state = super().step(actions)
+        if not self._autoreset:
+            self._manual_reset_pending |= state.terminated | state.truncated
+        self.recorder_manager.record_post_step()
+        return state
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        del state
+        self.action_manager.process_action(actions)
+        if not self._uses_pre_step_control:
+            self._sim_step_counter += self._cfg.sim_substeps
+            self.action_manager.apply_action()
+        return self._control
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        log: dict[str, Any] = {}
+        state.info["log"] = log
+        self.extras = state.info
+
+        np.add(state.info["steps"], 1, out=self.episode_length_buf)
+        self.common_step_counter = self.step_counter + 1
+        self._sim_step_counter = self.common_step_counter * self._cfg.sim_substeps
+
+        self.termination_manager.compute()
+        if self._cfg.is_finite_horizon:
+            np.logical_or(
+                self.termination_manager.terminated,
+                self.termination_manager.time_outs,
+                out=self.reset_terminated,
+            )
+            self.reset_time_outs.fill(False)
+        else:
+            np.copyto(self.reset_terminated, self.termination_manager.terminated)
+            np.copyto(self.reset_time_outs, self.termination_manager.time_outs)
+        np.logical_or(self.reset_terminated, self.reset_time_outs, out=self.reset_buf)
+
+        self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
+        if self._cfg.sim_substeps == 1:
+            self.metrics_manager.compute_substep()
+        self.metrics_manager.compute()
+
+        if "step" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="step", dt=self.step_dt)
+        if "interval" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="interval", dt=self.step_dt)
+
+        self._command_dt.fill(self.step_dt)
+        self._command_dt[self.reset_buf] = 0.0
+        self.command_manager.compute(dt=self._command_dt)
+        manager_obs = self.observation_manager.compute(update_history=True)
+        self.obs_buf = self._map_observations(manager_obs)
+        self._has_transition = True
+
+        return state.replace(
+            obs=self.obs_buf,
+            reward=self.reward_buf,
+            terminated=self.reset_terminated,
+            truncated=self.reset_time_outs,
+            info=state.info,
+        )
+
+    def _compute_truncated(self, state: NpEnvState) -> np.ndarray:
+        del state
+        self._no_truncation.fill(False)
+        return self._no_truncation
+
+    def reset(
+        self,
+        env_indices: np.ndarray | None = None,
+        *,
+        seed: int | None = None,
+        env_ids: np.ndarray | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        del options
+        ids = self._normalize_reset_ids(env_indices, env_ids)
+        if seed is not None:
+            self.seed(seed)
+        if self._state is None:
+            all_ids = np.arange(self.num_envs, dtype=np.int32)
+            if not np.array_equal(ids, all_ids):
+                raise RuntimeError(
+                    "ManagerBasedRlEnv requires a full reset before the first partial reset"
+                )
+            state = self.init_state()
+            return state.obs, {"log": state.info.get("log", {})}
+
+        done_ids = ids[self.reset_buf[ids]]
+        if self._has_transition and len(done_ids) > 0:
+            self.recorder_manager.record_pre_reset(done_ids)
+
+        log: dict[str, Any] = {}
+        self.curriculum_manager.compute(env_ids=ids)
+        if "reset" in self.event_manager.available_modes:
+            self.event_manager.apply(
+                mode="reset",
+                env_ids=ids,
+                global_env_step_count=self.step_counter,
+            )
+
+        for manager in (
+            self.observation_manager,
+            self.action_manager,
+            self.reward_manager,
+            self.metrics_manager,
+            self.curriculum_manager,
+            self.command_manager,
+            self.event_manager,
+            self.termination_manager,
+        ):
+            log.update(manager.reset(ids))
+
+        self.episode_length_buf[ids] = 0
+        self._control[ids] = 0.0
+        self._manual_reset_pending[ids] = False
+        if self._state is not None:
+            self._state.info["steps"][ids] = 0
+
+        self.command_manager.compute(dt=0.0, env_ids=ids)
+        manager_obs = self.observation_manager.compute(update_history=True, env_ids=ids)
+        mapped_obs = self._map_observations(manager_obs)
+        reset_obs = {name: values[ids].copy() for name, values in mapped_obs.items()}
+
+        if self._state is not None:
+            for name, values in reset_obs.items():
+                self._state.obs[name][ids] = values
+            self._state.info["log"] = log
+            if not self._autoreset_reset_active:
+                self._state.terminated[ids] = False
+                self._state.truncated[ids] = False
+                self.reset_buf[ids] = False
+                self.reset_terminated[ids] = False
+                self.reset_time_outs[ids] = False
+        self.obs_buf = self._state.obs if self._state is not None else mapped_obs
+        self.extras = self._state.info if self._state is not None else {"log": log}
+        self.recorder_manager.record_post_reset(ids)
+        return reset_obs, {"log": log}
+
+    def _normalize_reset_ids(
+        self,
+        env_indices: np.ndarray | None,
+        env_ids: np.ndarray | None,
+    ) -> np.ndarray:
+        if env_indices is not None and env_ids is not None:
+            raise ValueError("Pass either env_indices or env_ids, not both")
+        values = env_ids if env_ids is not None else env_indices
+        if values is None:
+            return np.arange(self.num_envs, dtype=np.int32)
+        raw = np.asarray(values)
+        if (
+            raw.ndim != 1
+            or not np.issubdtype(raw.dtype, np.integer)
+            or np.issubdtype(raw.dtype, np.bool_)
+        ):
+            raise TypeError(
+                "ManagerBasedRlEnv reset env IDs must be a 1-D integer np.ndarray; "
+                f"got shape={raw.shape}, dtype={raw.dtype}"
+            )
+        ids = np.asarray(raw, dtype=np.int32)
+        if np.any(ids < 0) or np.any(ids >= self.num_envs):
+            raise IndexError(
+                f"ManagerBasedRlEnv reset env IDs out of range for {self.num_envs} envs: "
+                f"{ids.tolist()}"
+            )
+        if np.unique(ids).size != ids.size:
+            raise ValueError(f"ManagerBasedRlEnv reset env IDs contain duplicates: {ids.tolist()}")
+        return ids
+
+    def _map_observations(
+        self,
+        manager_obs: dict[str, np.ndarray | dict[str, np.ndarray]],
+    ) -> dict[str, np.ndarray]:
+        mapping = {"obs": self._cfg.policy_observation_group}
+        if self._cfg.critic_observation_group is not None:
+            mapping["critic"] = self._cfg.critic_observation_group
+        mapped: dict[str, np.ndarray] = {}
+        for output_name, group_name in mapping.items():
+            value = manager_obs[group_name]
+            if not isinstance(value, np.ndarray):
+                raise TypeError(
+                    f"ManagerBasedRlEnv observation group '{group_name}' returned "
+                    f"{type(value).__name__}, expected np.ndarray"
+                )
+            expected = (self.num_envs, self._mapped_obs_dims[output_name])
+            if value.shape != expected:
+                raise ValueError(
+                    f"ManagerBasedRlEnv observation group '{group_name}' returned shape "
+                    f"{value.shape}, expected {expected} for NpEnvState.obs['{output_name}']"
+                )
+            mapped[output_name] = value
+        return mapped
+
+    def get_observations(self) -> dict[str, np.ndarray]:
+        if self._state is None:
+            return self.init_state().obs
+        self.obs_buf = self._state.obs
+        return self.obs_buf
+
+    def seed(self, seed: int = -1) -> int:
+        if seed == -1:
+            seed = secrets.randbits(63)
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError(f"ManagerBasedRlEnv seed must be a non-negative integer, got {seed!r}")
+        replacement = np.random.default_rng(seed)
+        self.rng.bit_generator.state = replacement.bit_generator.state
+        self._cfg.seed = seed
+        return seed
+
+    def close(self) -> None:
+        self.recorder_manager.close()
+        if self._uses_pre_step_control:
+            self._backend.set_pre_step_control(None)
+            self._uses_pre_step_control = False
+        super().close()
+
+
+# Isaac Lab capitalization is a spelling-only alias.  There is one implementation.
+ManagerBasedRLEnv = ManagerBasedRlEnv
+ManagerBasedRLEnvCfg = ManagerBasedRlEnvCfg
+
+__all__ = [
+    "ManagerBasedRLEnv",
+    "ManagerBasedRLEnvCfg",
+    "ManagerBasedRlEnv",
+    "ManagerBasedRlEnvCfg",
+]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -140,12 +140,20 @@ class ManagerBasedRlEnv(Protocol):
     their concrete environment type, while the manager core depends only on this seam.
     """
 
-    num_envs: int
-    rng: np.random.Generator
-    scene: ManagerScene
-    max_episode_length_s: float
+    @property
+    def num_envs(self) -> int: ...
 
-    def __getattr__(self, name: str) -> Any: ...
+    @property
+    def rng(self) -> np.random.Generator: ...
+
+    @property
+    def scene(self) -> ManagerScene: ...
+
+    @property
+    def max_episode_length_s(self) -> float: ...
+
+    # Concrete task terms may still type their own richer env subclass.  The
+    # standalone manager core deliberately depends only on the properties above.
 
 
 DebugVisualizer = Any

--- a/src/unilab/managers/action_manager.py
+++ b/src/unilab/managers/action_manager.py
@@ -174,9 +174,12 @@ class ActionManager(ManagerBase):
         self._action[:] = action
         # Split the flat action vector and route each slice to its term.
         idx = 0
-        for term in self._terms.values():
+        for name, term in self._terms.items():
             term_actions = self._action[:, idx : idx + term.action_dim]
-            term.process_actions(term_actions)
+            try:
+                term.process_actions(term_actions)
+            except (TypeError, ValueError, NotImplementedError) as exc:
+                raise type(exc)(f"ActionManager term '{name}': {exc}") from exc
             idx += term.action_dim
 
     def apply_action(self) -> None:
@@ -185,8 +188,11 @@ class ActionManager(ManagerBase):
         Called on every decimation substep (physics step), not just once per policy
         step. Each term writes its most recently processed targets to the simulation.
         """
-        for term in self._terms.values():
-            term.apply_actions()
+        for name, term in self._terms.items():
+            try:
+                term.apply_actions()
+            except (TypeError, ValueError, NotImplementedError) as exc:
+                raise type(exc)(f"ActionManager term '{name}': {exc}") from exc
 
     def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
         terms = []

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -170,6 +170,42 @@ def test_scene_entity_cfg_resolves_only_against_cached_names() -> None:
         assert backend.calls[key] == cold_path_calls[key]
 
 
+def test_entity_control_write_uses_cached_actuator_columns_and_fails_closed() -> None:
+    backend = _StrictBackendProfile("mujoco")
+    control = np.zeros((backend.num_envs, backend.num_actuators), dtype=np.float32)
+    scene = EntityScene(
+        {"robot": EntityCfg(actuator_names=("ankle", "hip"))},
+        cast(SimBackend, backend),
+        control,
+    )
+    data = scene["robot"].data
+
+    data.write_ctrl(np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32))
+    np.testing.assert_array_equal(control[:, 4], [1.0, 3.0, 5.0])
+    np.testing.assert_array_equal(control[:, 2], [2.0, 4.0, 6.0])
+    data.write_ctrl(
+        np.array([[9.0, 8.0], [7.0, 6.0]], dtype=np.float32),
+        env_ids=np.array([2, 0], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(control[:, 4], [7.0, 3.0, 9.0])
+    np.testing.assert_array_equal(control[:, 2], [6.0, 4.0, 8.0])
+    assert backend.calls["actuator names"] == 1
+
+    with pytest.raises(ValueError, match="expected shape"):
+        data.write_ctrl(np.zeros((backend.num_envs, 1), dtype=np.float32))
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        data.write_ctrl(np.full((backend.num_envs, 2), np.nan, dtype=np.float32))
+    with pytest.raises(IndexError, match="out of range"):
+        data.write_ctrl(
+            np.zeros((1, 2), dtype=np.float32),
+            env_ids=np.array([backend.num_envs], dtype=np.int32),
+        )
+
+    _, read_only_scene = _scene()
+    with pytest.raises(NotImplementedError, match="actuator control write.*not materialized"):
+        read_only_scene["robot"].data.write_ctrl(np.zeros((backend.num_envs, 2), dtype=np.float32))
+
+
 @pytest.mark.parametrize(
     ("ids", "error_type", "message"),
     [

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -1,0 +1,449 @@
+"""Focused contract tests for the NumPy Manager-Based environment lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import unilab.envs.manager_based_rl_env as manager_env_module
+from unilab.base.backend.base import SimBackend
+from unilab.base.entity import EntityCfg
+from unilab.base.scene import SceneCfg
+from unilab.envs import (
+    ManagerBasedRLEnv,
+    ManagerBasedRlEnv,
+    ManagerBasedRLEnvCfg,
+    ManagerBasedRlEnvCfg,
+)
+from unilab.managers import (
+    ActionTerm,
+    ActionTermCfg,
+    CommandTerm,
+    CommandTermCfg,
+    CurriculumTermCfg,
+    EventTermCfg,
+    MetricsTermCfg,
+    ObservationGroupCfg,
+    ObservationTermCfg,
+    RecorderTerm,
+    RecorderTermCfg,
+    RewardTermCfg,
+    TerminationTermCfg,
+)
+
+
+class _FakeBackend:
+    backend_type = "fake"
+
+    def __init__(self, num_envs: int, *, reject_pre_step: bool = False) -> None:
+        self.num_envs = num_envs
+        self.num_actuators = 1
+        self.reject_pre_step = reject_pre_step
+        self.pre_step_control = None
+        self.applied_controls: list[np.ndarray] = []
+        self.cleanup_calls = 0
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return ("motor",)
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return np.array([[-2.0, 2.0]], dtype=np.float32)
+
+    def get_dof_pos(self) -> np.ndarray:
+        return np.empty((self.num_envs, 0), dtype=np.float32)
+
+    def get_dof_vel(self) -> np.ndarray:
+        return np.empty((self.num_envs, 0), dtype=np.float32)
+
+    def set_pre_step_control(self, fn) -> None:
+        if fn is not None and self.reject_pre_step:
+            raise NotImplementedError("host callback disabled")
+        self.pre_step_control = fn
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        native = ctrl
+        for _ in range(nsteps):
+            if self.pre_step_control is not None:
+                native = self.pre_step_control(self, ctrl)
+            self.applied_controls.append(native.copy())
+
+    def cleanup_scene_assets(self) -> None:
+        self.cleanup_calls += 1
+
+
+@dataclass(kw_only=True)
+class _DriveCfg(ActionTermCfg):
+    gain: float = 1.0
+
+    def build(self, env) -> ActionTerm:
+        return _DriveAction(self, env)
+
+
+class _DriveAction(ActionTerm):
+    def __init__(self, cfg: _DriveCfg, env) -> None:
+        super().__init__(cfg, env)
+        self._processed = np.zeros((self.num_envs, 1), dtype=np.float32)
+
+    @property
+    def action_dim(self) -> int:
+        return 1
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._processed
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        self._processed[:] = actions * cast(_DriveCfg, self.cfg).gain
+
+    def apply_actions(self) -> None:
+        self._env.trace.append("action_apply")
+        self._env.action_sim_steps.append(self._env._sim_step_counter)
+        self._entity.data.write_ctrl(self._processed)
+
+
+@dataclass(kw_only=True)
+class _CommandCfg(CommandTermCfg):
+    def build(self, env) -> CommandTerm:
+        return _Command(self, env)
+
+
+class _Command(CommandTerm):
+    def __init__(self, cfg: _CommandCfg, env) -> None:
+        super().__init__(cfg, env)
+        self._command = np.zeros((self.num_envs, 1), dtype=np.float32)
+
+    @property
+    def command(self) -> np.ndarray:
+        return self._command
+
+    def _update_metrics(self) -> None:
+        return None
+
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        self._command[env_ids, 0] = self._env.rng.uniform(size=len(env_ids))
+
+    def _update_command(self, env_ids: np.ndarray | None) -> None:
+        ids = None if env_ids is None else env_ids.copy()
+        self._env.command_update_ids.append(ids)
+
+
+class _Recorder(RecorderTerm):
+    def record_pre_reset(self, env_ids: np.ndarray) -> None:
+        self._env.trace.append(("pre_reset", env_ids.tolist()))
+
+    def record_post_reset(self, env_ids: np.ndarray) -> None:
+        self._env.trace.append(("post_reset", env_ids.tolist()))
+
+    def record_post_step(self) -> None:
+        self._env.trace.append("post_step")
+
+    def close(self) -> None:
+        self._env.trace.append("recorder_close")
+
+
+class _TestEnv(ManagerBasedRlEnv):
+    def __init__(self, cfg: ManagerBasedRlEnvCfg, backend: SimBackend, num_envs: int) -> None:
+        self.trace: list[Any] = []
+        self.command_update_ids: list[np.ndarray | None] = []
+        self.action_sim_steps: list[int] = []
+        super().__init__(cfg, backend, num_envs)
+
+
+def _policy_obs(env: _TestEnv) -> np.ndarray:
+    return np.column_stack(
+        (env.episode_length_buf.astype(np.float32), env.action_manager.action[:, 0])
+    )
+
+
+def _critic_obs(env: _TestEnv) -> np.ndarray:
+    return env.episode_length_buf[:, None].astype(np.float32)
+
+
+def _reward(env: _TestEnv) -> np.ndarray:
+    return env.action_manager.action[:, 0].copy()
+
+
+def _failure(env: _TestEnv) -> np.ndarray:
+    return env.action_manager.action[:, 0] > 0.8
+
+
+def _time_out(env: _TestEnv) -> np.ndarray:
+    return env.episode_length_buf >= 2
+
+
+def _metric(env: _TestEnv) -> np.ndarray:
+    return env.episode_length_buf.astype(np.float32)
+
+
+def _curriculum(env: _TestEnv, env_ids: np.ndarray | slice) -> float:
+    del env
+    return float(len(env_ids)) if isinstance(env_ids, np.ndarray) else 0.0
+
+
+def _event(env: _TestEnv, env_ids: np.ndarray | None) -> None:
+    rendered_ids = None if env_ids is None else env_ids.tolist()
+    env.trace.append(("event", rendered_ids))
+
+
+def _make_cfg(
+    *,
+    sim_substeps: int = 2,
+    finite_horizon: bool = False,
+    auto_reset: bool = True,
+    metrics: dict[str, MetricsTermCfg | None] | None = None,
+    observations: dict[str, ObservationGroupCfg | None] | None = None,
+    include_optional_managers: bool = True,
+) -> ManagerBasedRlEnvCfg:
+    if observations is None:
+        observations = {
+            "actor": ObservationGroupCfg(terms={"policy": ObservationTermCfg(func=_policy_obs)}),
+            "value": ObservationGroupCfg(terms={"critic": ObservationTermCfg(func=_critic_obs)}),
+        }
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            model_file="fake.xml",
+            entities={"robot": EntityCfg(actuator_names=("motor",))},
+        ),
+        sim_dt=0.01,
+        ctrl_dt=0.01 * sim_substeps,
+        max_episode_seconds=1.0,
+        seed=7,
+        observations=observations,
+        actions={"drive": _DriveCfg(entity_name="robot")},
+        rewards={"track": RewardTermCfg(func=_reward, weight=1.0)},
+        terminations={
+            "failure": TerminationTermCfg(func=_failure),
+            "time_out": TerminationTermCfg(func=_time_out, time_out=True),
+        },
+        events={"reset": EventTermCfg(func=_event, mode="reset")},
+        metrics={} if metrics is None else metrics,
+        policy_observation_group="actor",
+        critic_observation_group="value",
+        is_finite_horizon=finite_horizon,
+        auto_reset=auto_reset,
+    )
+    if include_optional_managers:
+        cfg.commands = {"target": _CommandCfg(resampling_time_range=(1.0, 1.0))}
+        cfg.curriculum = {"difficulty": CurriculumTermCfg(func=_curriculum)}
+        cfg.recorders = {"trace": RecorderTermCfg(func=_Recorder)}
+    return cfg
+
+
+def _make_env(
+    cfg: ManagerBasedRlEnvCfg | None = None,
+    *,
+    num_envs: int = 2,
+    reject_pre_step: bool = False,
+) -> tuple[_TestEnv, _FakeBackend]:
+    backend = _FakeBackend(num_envs, reject_pre_step=reject_pre_step)
+    env = _TestEnv(
+        cfg or _make_cfg(),
+        cast(SimBackend, backend),
+        num_envs,
+    )
+    return env, backend
+
+
+def test_public_names_are_spelling_only_aliases() -> None:
+    assert ManagerBasedRLEnv is ManagerBasedRlEnv
+    assert ManagerBasedRLEnvCfg is ManagerBasedRlEnvCfg
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error", "match"),
+    [
+        (lambda cfg: setattr(cfg, "sim_dt", True), TypeError, "sim_dt must be a real"),
+        (
+            lambda cfg: setattr(cfg, "ctrl_dt", 0.015),
+            ValueError,
+            "integer multiple",
+        ),
+        (
+            lambda cfg: setattr(cfg, "max_episode_seconds", None),
+            ValueError,
+            "max_episode_seconds",
+        ),
+        (lambda cfg: setattr(cfg, "scene", None), TypeError, "scene must be a SceneCfg"),
+    ],
+)
+def test_manager_based_config_rejects_invalid_contracts(mutate, error, match: str) -> None:
+    cfg = _make_cfg()
+    mutate(cfg)
+    with pytest.raises(error, match=match):
+        cfg.validate()
+
+
+def test_manager_construction_uses_pinned_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    order: list[str] = []
+    names = (
+        "EventManager",
+        "CommandManager",
+        "ActionManager",
+        "ObservationManager",
+        "TerminationManager",
+        "RewardManager",
+        "CurriculumManager",
+        "MetricsManager",
+        "RecorderManager",
+    )
+    cfg = _make_cfg(metrics={"progress": MetricsTermCfg(func=_metric)})
+    for name in names:
+        original = getattr(manager_env_module, name)
+
+        def wrapped(*args, _name=name, _original=original, **kwargs):
+            order.append(_name)
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(manager_env_module, name, wrapped)
+
+    _make_env(cfg)
+    assert order == list(names)
+
+
+def test_np_env_owns_substeps_autoreset_and_final_observation() -> None:
+    env, backend = _make_env()
+    initial_obs, initial_info = env.reset()
+    assert env.state is not None
+    initial = env.state
+
+    assert initial_obs["obs"].shape == (2, 2)
+    assert initial_obs["critic"].shape == (2, 1)
+    assert "log" in initial_info
+    np.testing.assert_array_equal(initial.info["steps"], [0, 0])
+    assert env._dr_manager is None
+
+    state = env.step(np.array([[0.25], [0.5]], dtype=np.float32))
+    assert len(backend.applied_controls) == 2
+    assert env.action_sim_steps == [1, 2]
+    np.testing.assert_allclose(backend.applied_controls[0][:, 0], [0.25, 0.5])
+    np.testing.assert_allclose(backend.applied_controls[1][:, 0], [0.25, 0.5])
+    np.testing.assert_allclose(state.reward, [0.005, 0.01])
+    np.testing.assert_array_equal(state.terminated, [False, False])
+    np.testing.assert_array_equal(state.truncated, [False, False])
+    np.testing.assert_array_equal(state.info["steps"], [1, 1])
+
+    state = env.step(np.array([[0.25], [0.5]], dtype=np.float32))
+    np.testing.assert_array_equal(state.truncated, [True, True])
+    np.testing.assert_array_equal(state.terminated, [False, False])
+    np.testing.assert_array_equal(state.info["steps"], [0, 0])
+    np.testing.assert_array_equal(state.obs["obs"][:, 0], [0.0, 0.0])
+    assert state.final_observation is not None
+    np.testing.assert_array_equal(state.final_observation["obs"][:, 0], [2.0, 2.0])
+    assert state.info["_final_observation"].tolist() == [True, True]
+    assert state.info["log"]["Episode_Termination/time_out"] == 2
+
+    pre_index = env.trace.index(("pre_reset", [0, 1]))
+    post_reset_index = env.trace.index(("post_reset", [0, 1]), pre_index)
+    post_step_index = len(env.trace) - 1
+    assert env.trace[post_step_index] == "post_step"
+    assert pre_index < post_reset_index < post_step_index
+
+
+def test_partial_reset_preserves_other_env_counter_and_terminal_obs() -> None:
+    env, _ = _make_env()
+    env.init_state()
+
+    state = env.step(np.array([[1.0], [0.0]], dtype=np.float32))
+
+    np.testing.assert_array_equal(state.terminated, [True, False])
+    np.testing.assert_array_equal(state.truncated, [False, False])
+    np.testing.assert_array_equal(state.info["steps"], [0, 1])
+    np.testing.assert_array_equal(state.obs["obs"][:, 0], [0.0, 1.0])
+    assert state.final_observation is not None
+    np.testing.assert_array_equal(state.final_observation["obs"][0], [1.0, 1.0])
+    assert state.info["_final_observation"].tolist() == [True, False]
+    assert ("event", [0]) in env.trace
+
+
+def test_finite_horizon_maps_time_out_to_terminated() -> None:
+    env, _ = _make_env(_make_cfg(finite_horizon=True))
+    env.init_state()
+    env.step(np.zeros((2, 1), dtype=np.float32))
+    state = env.step(np.zeros((2, 1), dtype=np.float32))
+    np.testing.assert_array_equal(state.terminated, [True, True])
+    np.testing.assert_array_equal(state.truncated, [False, False])
+
+
+def test_manual_reset_is_required_when_autoreset_is_disabled() -> None:
+    env, _ = _make_env(_make_cfg(auto_reset=False))
+    env.init_state()
+    state = env.step(np.array([[1.0], [0.0]], dtype=np.float32))
+    np.testing.assert_array_equal(state.info["steps"], [1, 1])
+    with pytest.raises(RuntimeError, match="must be reset"):
+        env.step(np.zeros((2, 1), dtype=np.float32))
+
+    reset_obs, info = env.reset(env_ids=np.array([0], dtype=np.int32))
+    assert reset_obs["obs"].shape == (1, 2)
+    assert "log" in info
+    assert not state.terminated[0]
+    env.step(np.zeros((2, 1), dtype=np.float32))
+
+
+def test_reset_seed_updates_the_shared_generator_in_place() -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.events = {}
+    env, _ = _make_env(cfg)
+    env.init_state()
+    generator = env.rng
+
+    env.reset(seed=123, env_ids=np.array([0], dtype=np.int32))
+
+    assert env.rng is generator
+    expected = np.random.default_rng(123).random()
+    assert env.rng.random() == pytest.approx(expected)
+
+
+def test_per_substep_metrics_fail_without_post_substep_backend_hook() -> None:
+    cfg = _make_cfg(
+        sim_substeps=2,
+        metrics={"energy": MetricsTermCfg(func=_metric, per_substep=True)},
+    )
+    with pytest.raises(NotImplementedError, match="post-physics per-substep metrics.*fake"):
+        _make_env(cfg)
+
+
+def test_multisubstep_action_fails_when_backend_rejects_callback() -> None:
+    with pytest.raises(NotImplementedError, match="ActionManager.*every physics substep.*fake"):
+        _make_env(reject_pre_step=True)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error", "match"),
+    [
+        (
+            lambda cfg: setattr(cfg, "policy_observation_group", "missing"),
+            KeyError,
+            "requests group 'missing'",
+        ),
+        (
+            lambda cfg: setattr(
+                cfg.observations["actor"],
+                "concatenate_terms",
+                False,  # type: ignore[union-attr]
+            ),
+            ValueError,
+            "must concatenate terms",
+        ),
+        (
+            lambda cfg: setattr(cfg, "critic_observation_group", "actor"),
+            ValueError,
+            "must be different",
+        ),
+    ],
+)
+def test_observation_mapping_fails_closed(mutate, error, match: str) -> None:
+    cfg = _make_cfg()
+    mutate(cfg)
+    with pytest.raises(error, match=match):
+        _make_env(cfg)
+
+
+def test_close_unhooks_callback_and_closes_owned_resources() -> None:
+    env, backend = _make_env()
+    env.close()
+    assert backend.pre_step_control is None
+    assert backend.cleanup_calls == 1
+    assert env.trace[-1] == "recorder_close"

--- a/tests/managers/test_core_managers.py
+++ b/tests/managers/test_core_managers.py
@@ -96,6 +96,32 @@ def test_action_rejects_invalid_input(fake_env: FakeEnv, action: np.ndarray, mat
         manager.process_action(action)
 
 
+class FailingAction(DummyAction):
+    def process_actions(self, actions: np.ndarray) -> None:
+        del actions
+        raise ValueError("invalid processed target")
+
+    def apply_actions(self) -> None:
+        raise NotImplementedError("backend control write unavailable")
+
+
+@dataclass(kw_only=True)
+class FailingActionCfg(DummyActionCfg):
+    def build(self, env: FakeEnv) -> FailingAction:
+        return FailingAction(self, env)
+
+
+def test_action_term_errors_include_manager_and_term_context(fake_env: FakeEnv) -> None:
+    manager = ActionManager(
+        {"broken": FailingActionCfg(entity_name="robot", dim=1)},
+        fake_env,
+    )
+    with pytest.raises(ValueError, match="ActionManager term 'broken'.*invalid processed"):
+        manager.process_action(np.zeros((fake_env.num_envs, 1), dtype=np.float32))
+    with pytest.raises(NotImplementedError, match="ActionManager term 'broken'.*control write"):
+        manager.apply_action()
+
+
 class StatefulReward:
     def __init__(self, cfg: RewardTermCfg, env: FakeEnv):
         self.reset_ids = None


### PR DESCRIPTION
## Summary

- add the canonical NumPy `ManagerBasedRlEnv` / `ManagerBasedRlEnvCfg` lifecycle on top of the single existing `NpEnv.step/reset/autoreset` path
- preserve `NpEnvState`, explicit policy/critic observation mapping, timeout semantics, final observations, manager ordering, recorder hooks, and env-owned RNG/control buffers
- fail closed at construction for unsupported mjwarp multi-substep callbacks and per-substep metrics; do not add legacy DR, backend-private, IPC, runner, or fallback paths

## Scope accounting

- 9 files changed: +1,229 / -22
- source-derived copied code: 0 lines (the pinned mjlab lifecycle semantics are implemented through the existing UniLab `NpEnv`; no second upstream loop is vendored)
- mechanical Torch → NumPy adaptation: 0 standalone lines in this child (completed in the manager-package child)
- UniLab-specific implementation: 718 production additions; adapted/focused tests: 511 additions
- modified existing: 7 files; new: 2 files; deleted: 22 lines / 0 files

## Validation

- focused manager/lifecycle tests: 123 passed
- representative regression: 387 passed, 14 skipped, 1 xfailed
- `make test-all`: 1,833 passed, 24 skipped, 1 xfailed; ruff, mypy, and pyright passed; benchmark smoke 65/67 with only the two optional `mlx` cases skipped

Implements #1049
Umbrella: #1042