### PR TITLE
feat(backend): expose manager actuation metadata

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -137,6 +137,18 @@ class SimBackend(abc.ABC):
         """Return actuator names in control-vector order on the cold path."""
         raise NotImplementedError(f"{self.__class__.__name__} does not expose actuator names")
 
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        """Return each actuator's target single-DoF joint in control-vector order.
+
+        Backends must fail closed when an actuator does not target exactly one
+        hinge/slide joint.  Manager action terms use this cold-path metadata to
+        map community joint selectors onto the backend control vector without
+        inspecting backend-private model objects.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not expose actuator target joints"
+        )
+
     def get_scene_model_file(self) -> str | None:
         """Return the materialized scene path for diagnostics, when available."""
         return None
@@ -171,6 +183,17 @@ class SimBackend(abc.ABC):
     def get_default_qpos(self) -> np.ndarray:
         """Return the backend/model default qpos through a stable contract."""
         raise NotImplementedError(f"{self.__class__.__name__} does not expose default qpos")
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        """Return default joint positions in the same column order as ``get_dof_pos``.
+
+        The returned array is detached, one-dimensional, and excludes floating
+        root coordinates.  Backends whose DoF view is actuator-indexed must use
+        that same actuator-target order here.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not expose default DoF positions"
+        )
 
     @abc.abstractmethod
     def get_init_qvel(self) -> np.ndarray:

--- a/src/unilab/base/backend/drake/backend.py
+++ b/src/unilab/base/backend/drake/backend.py
@@ -222,6 +222,10 @@ class DrakeBackend(SimBackend):
         self._actuator_damping = model_info.actuator_damping.copy()
         self._actuator_qpos_adr = model_info.actuator_qpos_adr.astype(np.intp, copy=True)
         self._actuator_qvel_adr = model_info.actuator_qvel_adr.astype(np.intp, copy=True)
+        raw_actuator_names = getattr(model_info, "actuator_names", None)
+        self._actuator_names = (
+            None if raw_actuator_names is None else tuple(str(name) for name in raw_actuator_names)
+        )
         self._sensor_names = tuple(model_info.sensor_names)
         self._sensor_adr = model_info.sensor_adr.copy()
         self._sensor_dim = model_info.sensor_dim.copy()
@@ -253,6 +257,19 @@ class DrakeBackend(SimBackend):
                 strict=True,
             )
         }
+        joint_name_by_qpos_adr = {
+            int(adr): str(name)
+            for name, adr, dim in zip(
+                getattr(model_info, "joint_names", ()),
+                getattr(model_info, "joint_qpos_adr", ()),
+                getattr(model_info, "joint_qpos_dim", ()),
+                strict=True,
+            )
+            if int(dim) == 1
+        }
+        self._actuator_joint_names = tuple(
+            joint_name_by_qpos_adr.get(int(adr), "") for adr in self._actuator_qpos_adr
+        )
         self._root_qpos_dim = (
             int(np.min(self._actuator_qpos_adr)) if self._actuator_qpos_adr.size else 0
         )
@@ -311,6 +328,35 @@ class DrakeBackend(SimBackend):
     def get_actuator_ctrl_range(self) -> np.ndarray:
         return self._ctrl_limits.copy()
 
+    def get_actuator_names(self) -> tuple[str, ...]:
+        names = self._actuator_names
+        if names is None:
+            raise NotImplementedError(
+                "backend 'drake' capability 'actuator names' is unavailable: "
+                "DrakeUni model_info does not expose actuator_names"
+            )
+        if len(names) != self.num_actuators or any(not name for name in names):
+            raise NotImplementedError(
+                "backend 'drake' capability 'actuator names' requires one non-empty name "
+                f"per control column; received {names}"
+            )
+        if len(set(names)) != len(names):
+            raise NotImplementedError(
+                "backend 'drake' capability 'actuator names' requires unique names; "
+                f"received {names}"
+            )
+        return names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        names = self._actuator_joint_names
+        if len(names) != self.num_actuators or any(not name for name in names):
+            raise NotImplementedError(
+                "backend 'drake' capability 'actuator target joint' requires every "
+                "actuator_qpos_adr to resolve to one named single-DoF joint; "
+                f"received {names}"
+            )
+        return names
+
     def get_scene_model_file(self) -> str | None:
         return self._scene_model_file
 
@@ -324,6 +370,9 @@ class DrakeBackend(SimBackend):
 
     def get_default_qpos(self) -> np.ndarray:
         return self._home_qpos_mujoco.copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.asarray(self._home_qpos_mujoco[self._actuator_qpos_adr], dtype=np.float64).copy()
 
     def get_init_qvel(self) -> np.ndarray:
         return self._home_qvel_mujoco.copy()

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -292,6 +292,41 @@ class MjwarpBackend(SimBackend):
     def get_actuator_names(self) -> tuple[str, ...]:
         return self._actuator_names
 
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        supported_transmissions = {
+            int(self._mujoco.mjtTrn.mjTRN_JOINT),
+            int(self._mujoco.mjtTrn.mjTRN_JOINTINPARENT),
+        }
+        supported_joint_types = {
+            int(self._mujoco.mjtJoint.mjJNT_HINGE),
+            int(self._mujoco.mjtJoint.mjJNT_SLIDE),
+        }
+        names: list[str] = []
+        for actuator_id, actuator_name in enumerate(self._actuator_names):
+            transmission = int(self._cpu_model.actuator_trntype[actuator_id])
+            joint_id = int(self._cpu_model.actuator_trnid[actuator_id, 0])
+            if transmission not in supported_transmissions or joint_id < 0:
+                raise NotImplementedError(
+                    "backend 'mjwarp' capability 'actuator target joint' requires a "
+                    f"joint transmission; actuator '{actuator_name}' uses "
+                    f"transmission type {transmission}"
+                )
+            if int(self._cpu_model.jnt_type[joint_id]) not in supported_joint_types:
+                raise NotImplementedError(
+                    "backend 'mjwarp' capability 'actuator target joint' requires a "
+                    f"single-DoF joint; actuator '{actuator_name}' targets joint id {joint_id}"
+                )
+            joint_name = self._mujoco.mj_id2name(
+                self._cpu_model, self._mujoco.mjtObj.mjOBJ_JOINT, joint_id
+            )
+            if not joint_name:
+                raise NotImplementedError(
+                    "backend 'mjwarp' capability 'actuator target joint' requires named "
+                    f"joints; actuator '{actuator_name}' targets unnamed joint id {joint_id}"
+                )
+            names.append(str(joint_name))
+        return tuple(names)
+
     def get_scene_model_file(self) -> str | None:
         return self.scene_model_file
 
@@ -304,6 +339,9 @@ class MjwarpBackend(SimBackend):
 
     def get_default_qpos(self) -> np.ndarray:
         return np.asarray(self._cpu_model.qpos0, dtype=np.float32).copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.qpos0[self._root_qpos_dim :], dtype=np.float32).copy()
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self._nv,), dtype=np.float32)

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -383,6 +383,45 @@ class MotrixBackend(SimBackend):
         result: np.ndarray = arr.T.copy()
         return result
 
+    def get_actuator_names(self) -> tuple[str, ...]:
+        actuators = sorted(self._model.actuators, key=lambda actuator: int(actuator.index))
+        names = tuple(str(actuator.name) for actuator in actuators)
+        if len(names) != self.num_actuators or any(not name for name in names):
+            raise NotImplementedError(
+                "backend 'motrix' capability 'actuator names' requires one non-empty name "
+                f"per control column; received {names}"
+            )
+        if len(set(names)) != len(names):
+            raise NotImplementedError(
+                "backend 'motrix' capability 'actuator names' requires unique names; "
+                f"received {names}"
+            )
+        return names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        actuators = sorted(self._model.actuators, key=lambda actuator: int(actuator.index))
+        names: list[str] = []
+        for actuator in actuators:
+            if actuator.target_type != "joint":
+                raise NotImplementedError(
+                    "backend 'motrix' capability 'actuator target joint' requires a joint "
+                    f"transmission; actuator '{actuator.name}' targets '{actuator.target_type}'"
+                )
+            joint = self._model.get_joint(actuator.target_name)
+            if joint is None or int(joint.num_dof_pos) != 1 or int(joint.num_dof_vel) != 1:
+                raise NotImplementedError(
+                    "backend 'motrix' capability 'actuator target joint' requires a "
+                    f"single-DoF joint; actuator '{actuator.name}' targets "
+                    f"'{actuator.target_name}'"
+                )
+            names.append(str(actuator.target_name))
+        if len(names) != self.num_actuators:
+            raise NotImplementedError(
+                "backend 'motrix' capability 'actuator target joint' returned "
+                f"{len(names)} targets for {self.num_actuators} actuators"
+            )
+        return tuple(names)
+
     def get_terrain_spawn_data(self) -> BackendTerrainSpawnData | None:
         return self._terrain_spawn_data
 
@@ -396,6 +435,15 @@ class MotrixBackend(SimBackend):
     def get_default_qpos(self) -> np.ndarray:
         qpos = np.array(self._model.compute_init_dof_pos(), dtype=self._np_dtype)
         return self._motrix_qpos_to_mujoco(qpos)
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        qpos = np.asarray(self._model.compute_init_dof_pos(), dtype=self._np_dtype)
+        indices = (
+            self._actuator_joint_pos_indices
+            if self._actuator_joint_pos_indices is not None
+            else self._joint_dof_pos_indices
+        )
+        return np.asarray(qpos[indices], dtype=self._np_dtype).copy()
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self._model.num_dof_vel,), dtype=self._np_dtype)

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -692,6 +692,41 @@ class MuJoCoBackend(SimBackend):
             for actuator_id in range(int(self._model.nu))
         )
 
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        supported_transmissions = {
+            int(mujoco.mjtTrn.mjTRN_JOINT),
+            int(mujoco.mjtTrn.mjTRN_JOINTINPARENT),
+        }
+        supported_joint_types = {
+            int(mujoco.mjtJoint.mjJNT_HINGE),
+            int(mujoco.mjtJoint.mjJNT_SLIDE),
+        }
+        names: list[str] = []
+        for actuator_id in range(int(self._model.nu)):
+            transmission = int(self._model.actuator_trntype[actuator_id])
+            joint_id = int(self._model.actuator_trnid[actuator_id, 0])
+            if transmission not in supported_transmissions or joint_id < 0:
+                actuator_name = self.get_actuator_names()[actuator_id]
+                raise NotImplementedError(
+                    "backend 'mujoco' capability 'actuator target joint' requires "
+                    f"a joint transmission; actuator '{actuator_name}' uses "
+                    f"transmission type {transmission}"
+                )
+            if int(self._model.jnt_type[joint_id]) not in supported_joint_types:
+                actuator_name = self.get_actuator_names()[actuator_id]
+                raise NotImplementedError(
+                    "backend 'mujoco' capability 'actuator target joint' requires "
+                    f"a single-DoF joint; actuator '{actuator_name}' targets joint id {joint_id}"
+                )
+            joint_name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+            if not joint_name:
+                raise NotImplementedError(
+                    "backend 'mujoco' capability 'actuator target joint' requires named joints; "
+                    f"actuator id {actuator_id} targets unnamed joint id {joint_id}"
+                )
+            names.append(joint_name)
+        return tuple(names)
+
     def get_scene_model_file(self) -> str | None:
         return str(self.scene_model_file) if self.scene_model_file else None
 
@@ -709,6 +744,9 @@ class MuJoCoBackend(SimBackend):
 
     def get_default_qpos(self) -> np.ndarray:
         return np.asarray(self._model.qpos0, dtype=np.float64).copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.asarray(self._model.qpos0[self._root_qpos_dim :], dtype=self._np_dtype).copy()
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self.nv,), dtype=self._np_dtype)

--- a/tests/base/backend/test_drake_batch_pool.py
+++ b/tests/base/backend/test_drake_batch_pool.py
@@ -5,7 +5,9 @@ import json
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 
@@ -148,6 +150,34 @@ def test_drake_batch_thread_policy_matches_mujoco_auto(monkeypatch: pytest.Monke
     assert backend._resolve_batch_nthread(8, 0) == 8
     assert backend._resolve_batch_nthread(1024, 4) == 4
     assert backend._resolve_batch_nthread(2, 8) == 2
+
+
+def test_drake_actuation_metadata_is_detached_and_fails_closed() -> None:
+    from unilab.base.backend.drake.backend import DrakeBackend
+
+    backend = object.__new__(DrakeBackend)
+    backend._model = SimpleNamespace(nu=2)
+    backend._actuator_names = ("hip_motor", "knee_motor")
+    backend._actuator_joint_names = ("hip", "knee")
+    backend._actuator_qpos_adr = np.asarray([7, 8], dtype=np.intp)
+    backend._home_qpos_mujoco = np.arange(9, dtype=np.float64)
+
+    assert backend.get_actuator_names() == ("hip_motor", "knee_motor")
+    assert backend.get_actuator_joint_names() == ("hip", "knee")
+    default = backend.get_default_dof_pos()
+    np.testing.assert_array_equal(default, np.asarray([7.0, 8.0]))
+    default[:] = -1.0
+    np.testing.assert_array_equal(backend.get_default_dof_pos(), np.asarray([7.0, 8.0]))
+
+    backend._actuator_names = None
+    with pytest.raises(NotImplementedError, match="DrakeUni model_info.*actuator_names"):
+        backend.get_actuator_names()
+    backend._actuator_names = ("duplicate", "duplicate")
+    with pytest.raises(NotImplementedError, match="unique names"):
+        backend.get_actuator_names()
+    backend._actuator_joint_names = ("hip", "")
+    with pytest.raises(NotImplementedError, match="single-DoF joint"):
+        backend.get_actuator_joint_names()
 
 
 def test_batch_backend_mode_rejects_existing_pydrake_module() -> None:

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -130,6 +130,45 @@ def test_terrain_spawn_contract_is_read_only_and_defaults_to_unsupported() -> No
         )
 
 
+def test_actuation_metadata_defaults_fail_closed() -> None:
+    with pytest.raises(NotImplementedError, match="actuator target joints"):
+        SimBackend.get_actuator_joint_names(object())  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="default DoF positions"):
+        SimBackend.get_default_dof_pos(object())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
+def test_actuation_metadata_contract(backend_type: str) -> None:
+    _require_backend(backend_type)
+
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=_G1_SCENE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+
+    actuator_names = backend.get_actuator_names()
+    target_joint_names = backend.get_actuator_joint_names()
+    default_dof_pos = backend.get_default_dof_pos()
+
+    assert len(actuator_names) == backend.num_actuators
+    assert len(set(actuator_names)) == len(actuator_names)
+    assert all(actuator_names)
+    assert len(target_joint_names) == backend.num_actuators
+    assert all(target_joint_names)
+    assert default_dof_pos.shape == backend.get_dof_pos().shape[1:]
+    assert np.issubdtype(default_dof_pos.dtype, np.floating)
+    assert np.isfinite(default_dof_pos).all()
+    np.testing.assert_allclose(default_dof_pos, backend.get_dof_pos()[0], atol=1e-6)
+
+    detached = default_dof_pos.copy()
+    default_dof_pos[:] = np.nan
+    np.testing.assert_array_equal(backend.get_default_dof_pos(), detached)
+
+
 def test_terrain_spawn_consumers_do_not_probe_private_backend_capabilities() -> None:
     forbidden_names = {"terrain_origins", "terrain_surface_sampler", "sample_height"}
     offenders: list[str] = []

--- a/tests/base/test_mjwarp_identity.py
+++ b/tests/base/test_mjwarp_identity.py
@@ -9,6 +9,7 @@ import textwrap
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from unilab.base.backend.mjwarp import dependencies
@@ -140,3 +141,29 @@ def test_mjwarp_getters_do_not_materialize_warp_arrays() -> None:
             ):
                 offenders.append(getter.name)
     assert offenders == []
+
+
+def test_mjwarp_actuation_metadata_uses_cpu_model_only() -> None:
+    import mujoco
+
+    from unilab.assets import ASSETS_ROOT_PATH
+    from unilab.base.backend.mjwarp.backend import MjwarpBackend
+
+    model = mujoco.MjModel.from_xml_path(
+        str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml")
+    )
+    backend = object.__new__(MjwarpBackend)
+    backend._mujoco = mujoco
+    backend._cpu_model = model
+    backend._root_qpos_dim = 7
+    backend._actuator_names = tuple(
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, index) or f"#{index}"
+        for index in range(model.nu)
+    )
+
+    assert len(backend.get_actuator_joint_names()) == model.nu
+    assert backend.get_actuator_joint_names()[0] == "FR_hip_joint"
+    default = backend.get_default_dof_pos()
+    np.testing.assert_array_equal(default, model.qpos0[7:])
+    default[:] = np.nan
+    assert np.isfinite(backend.get_default_dof_pos()).all()


### PR DESCRIPTION
## Summary

- add formal cold-path `SimBackend` contracts for actuator names, actuator-target joint names, and default DoF positions
- implement the metadata in MuJoCo, Motrix, Drake, and mjwarp adapters without exposing backend-private model objects to env/manager code
- fail closed for non-joint/multi-DoF transmissions and for DrakeUni runtimes that do not expose real actuator names; no inferred-name fallback

## Scope accounting

- 8 files changed: +292 / -0
- source-derived code: 0 lines
- mechanical Torch → NumPy adaptation: 0 lines
- UniLab-specific backend contract/adapter implementation: 196 additions
- focused/conformance tests: 96 additions
- modified existing: 8 files; new/deleted files: 0; deleted lines: 0

## Validation

- focused and representative backend/entity/lifecycle regression: 74 passed, 15 skipped
- direct Go2 MuJoCo/Motrix metadata probe confirmed identical actuator/control ordering and target-joint mapping
- `make test-all`: 1,838 passed, 25 skipped, 1 xfailed; ruff, mypy, and pyright passed; benchmark smoke 65/67 with only two platform-optional `mlx` cases skipped
- Drake production dependency is not installed in this workspace; fake runtime contract tests cover valid metadata and explicit missing/invalid failures, without claiming an unexecuted production backend

Implements #1052
Umbrella: #1042