### PR TITLE
feat(env): add NumPy joint position action

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -139,6 +139,7 @@ class EntityData:
         root_body_ids: np.ndarray | None,
         joint_pos_ids: np.ndarray | None,
         joint_vel_ids: np.ndarray | None,
+        default_joint_pos: np.ndarray | None,
         body_ids: np.ndarray | None,
         actuator_ids: np.ndarray | None,
         actuator_ctrl_range: np.ndarray | None,
@@ -152,8 +153,14 @@ class EntityData:
         self._root_body_ids = root_body_ids
         self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
         self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
+        self._default_joint_pos = default_joint_pos
+        self._encoder_bias = (
+            None
+            if default_joint_pos is None
+            else np.zeros(default_joint_pos.shape, dtype=default_joint_pos.dtype)
+        )
         self._body_ids = body_ids
-        self._actuator_index = None if actuator_ids is None else _as_column_index(actuator_ids)
+        self._actuator_ids = actuator_ids
         self._actuator_ctrl_range = actuator_ctrl_range
         self._control_buffer = control_buffer
 
@@ -204,6 +211,16 @@ class EntityData:
         return self._backend.get_dof_vel()[:, index]
 
     @property
+    def default_joint_pos(self) -> np.ndarray:
+        """Read-only per-environment default joint positions."""
+        return self._require(self._default_joint_pos, "default joint position")
+
+    @property
+    def encoder_bias(self) -> np.ndarray:
+        """Mutable per-environment joint encoder bias used by position actions."""
+        return self._require(self._encoder_bias, "joint encoder bias")
+
+    @property
     def body_link_pos_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
         return self._backend.get_body_pos_w(ids)
@@ -239,6 +256,8 @@ class EntityData:
         self,
         values: np.ndarray,
         env_ids: np.ndarray | slice | None = None,
+        *,
+        actuator_ids: np.ndarray | Sequence[int] | slice | None = None,
     ) -> None:
         """Write entity-local actuator controls into the env-owned control buffer.
 
@@ -246,7 +265,7 @@ class EntityData:
         entity target buffers.  Physics remains owned by ``NpEnv``/``SimBackend``;
         this method never steps or calls a backend-private API.
         """
-        actuator_index = self._require(self._actuator_index, "actuator control write")
+        entity_actuator_ids = self._require(self._actuator_ids, "actuator control write")
         control = self._require(self._control_buffer, "actuator control write")
         if not isinstance(values, np.ndarray):
             raise TypeError(
@@ -284,7 +303,38 @@ class EntityData:
                 )
             row_count = len(row_index)
 
-        actuator_count = len(self._require(self._actuator_ctrl_range, "actuator control write"))
+        if actuator_ids is None:
+            selected_actuator_ids = entity_actuator_ids
+        elif isinstance(actuator_ids, slice):
+            selected_actuator_ids = entity_actuator_ids[actuator_ids]
+        else:
+            raw_actuator_ids = np.asarray(actuator_ids)
+            if (
+                raw_actuator_ids.ndim != 1
+                or not np.issubdtype(raw_actuator_ids.dtype, np.integer)
+                or np.issubdtype(raw_actuator_ids.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self._entity_name}' write_ctrl actuator_ids must be a 1-D "
+                    "integer array or slice"
+                )
+            local_actuator_ids = np.asarray(raw_actuator_ids, dtype=np.intp)
+            if np.any(local_actuator_ids < 0) or np.any(
+                local_actuator_ids >= len(entity_actuator_ids)
+            ):
+                raise IndexError(
+                    f"Entity '{self._entity_name}' write_ctrl actuator_ids out of range for "
+                    f"{len(entity_actuator_ids)} entity actuators: {local_actuator_ids.tolist()}"
+                )
+            if np.unique(local_actuator_ids).size != local_actuator_ids.size:
+                raise ValueError(
+                    f"Entity '{self._entity_name}' write_ctrl actuator_ids contain duplicates: "
+                    f"{local_actuator_ids.tolist()}"
+                )
+            selected_actuator_ids = entity_actuator_ids[local_actuator_ids]
+
+        actuator_index = _as_column_index(np.asarray(selected_actuator_ids, dtype=np.int32))
+        actuator_count = len(selected_actuator_ids)
         expected = (row_count, actuator_count)
         if values.shape != expected:
             raise ValueError(
@@ -366,7 +416,12 @@ class Entity:
 
         self._validate_joint_state(backend, joint_pos_ids, joint_vel_ids)
         self._validate_body_state(backend, root_body_ids, body_ids)
+        default_joint_pos = self._materialize_default_joint_pos(backend, joint_pos_ids)
         actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
+        (
+            self._actuator_target_joint_names,
+            self._joint_to_actuator_local,
+        ) = self._materialize_joint_actuator_mapping(backend, actuator_ids)
         if control_buffer is not None:
             expected_control_shape = (backend.num_envs, backend.num_actuators)
             if control_buffer.shape != expected_control_shape:
@@ -385,6 +440,7 @@ class Entity:
             root_body_ids=root_body_ids,
             joint_pos_ids=joint_pos_ids,
             joint_vel_ids=joint_vel_ids,
+            default_joint_pos=default_joint_pos,
             body_ids=body_ids,
             actuator_ids=actuator_ids,
             actuator_ctrl_range=actuator_ctrl_range,
@@ -519,6 +575,63 @@ class Entity:
         selected.setflags(write=False)
         return selected
 
+    def _materialize_default_joint_pos(
+        self, backend: SimBackend, joint_pos_ids: np.ndarray | None
+    ) -> np.ndarray | None:
+        if joint_pos_ids is None:
+            return None
+        defaults = self._read_state("default joint position", backend.get_default_dof_pos)
+        current = self._read_state("joint position state", backend.get_dof_pos)
+        if defaults.shape != current.shape[1:]:
+            raise ValueError(
+                f"Entity '{self.name}' capability 'default joint position' on backend "
+                f"'{self._backend_type}' returned shape {defaults.shape}; expected "
+                f"{current.shape[1:]} to match get_dof_pos()"
+            )
+        selected = np.asarray(defaults[_as_column_index(joint_pos_ids)])
+        materialized = np.broadcast_to(selected, (backend.num_envs, len(joint_pos_ids))).copy()
+        materialized.setflags(write=False)
+        return materialized
+
+    def _materialize_joint_actuator_mapping(
+        self, backend: SimBackend, actuator_ids: np.ndarray | None
+    ) -> tuple[tuple[str, ...] | None, np.ndarray | None]:
+        if actuator_ids is None or self._joint_names is None:
+            return None, None
+        try:
+            all_target_names = tuple(backend.get_actuator_joint_names())
+        except NotImplementedError as exc:
+            raise self._capability_error("actuator target joint", str(exc)) from exc
+        if len(all_target_names) != backend.num_actuators:
+            raise ValueError(
+                f"Entity '{self.name}' capability 'actuator target joint' on backend "
+                f"'{self._backend_type}' returned {len(all_target_names)} names for "
+                f"{backend.num_actuators} actuators"
+            )
+        target_names = tuple(all_target_names[int(index)] for index in actuator_ids)
+        if any(not isinstance(name, str) or not name for name in target_names):
+            raise ValueError(
+                f"Entity '{self.name}' actuator target joint names must be non-empty strings; "
+                f"got {target_names}"
+            )
+        if len(set(target_names)) != len(target_names):
+            raise ValueError(
+                f"Entity '{self.name}' actuator target joints must be unique for position "
+                f"control; got {target_names}"
+            )
+        joint_index_by_name = {name: index for index, name in enumerate(self._joint_names)}
+        missing = [name for name in target_names if name not in joint_index_by_name]
+        if missing:
+            raise ValueError(
+                f"Entity '{self.name}' actuators target joints outside its declared joint "
+                f"partition on backend '{self._backend_type}': {missing}"
+            )
+        joint_to_actuator = np.full(len(self._joint_names), -1, dtype=np.int32)
+        for actuator_local_id, joint_name in enumerate(target_names):
+            joint_to_actuator[joint_index_by_name[joint_name]] = actuator_local_id
+        joint_to_actuator.setflags(write=False)
+        return target_names, joint_to_actuator
+
     def _require_names(self, kind: str, names: tuple[str, ...] | None) -> tuple[str, ...]:
         if names is None:
             raise self._capability_error(kind, "the namespace was not declared in EntityCfg")
@@ -628,6 +741,72 @@ class Entity:
         self, keys: str | Sequence[str], preserve_order: bool = False
     ) -> tuple[list[int], list[str]]:
         return self._find("joint", self._joint_names, keys, preserve_order)
+
+    def find_joints_by_actuator_names(
+        self, keys: str | Sequence[str]
+    ) -> tuple[list[int], list[str]]:
+        """Resolve actuator-target joint patterns in natural entity joint order."""
+        target_names = self._actuator_target_joint_names
+        if target_names is None:
+            raise self._capability_error(
+                "actuator target joint",
+                "joint_names and actuator_names must both be declared in EntityCfg",
+            )
+        target_set = set(target_names)
+        natural_ids = [index for index, name in enumerate(self.joint_names) if name in target_set]
+        natural_names = [self.joint_names[index] for index in natural_ids]
+        matched_ids, matched_names = _resolve_matching_names(keys, natural_names, False)
+        return [natural_ids[index] for index in matched_ids], matched_names
+
+    def set_joint_position_target(
+        self,
+        target: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Map entity-local joint targets to the env-owned actuator control buffer."""
+        joint_to_actuator = self._joint_to_actuator_local
+        if joint_to_actuator is None:
+            raise self._capability_error(
+                "joint position target",
+                "joint-to-actuator metadata was not materialized",
+            )
+        if joint_ids is None:
+            local_joint_ids = np.arange(self.num_joints, dtype=np.intp)
+        elif isinstance(joint_ids, slice):
+            local_joint_ids = np.arange(self.num_joints, dtype=np.intp)[joint_ids]
+        else:
+            raw_joint_ids = np.asarray(joint_ids)
+            if (
+                raw_joint_ids.ndim != 1
+                or not np.issubdtype(raw_joint_ids.dtype, np.integer)
+                or np.issubdtype(raw_joint_ids.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self.name}' joint position target joint_ids must be a 1-D "
+                    "integer array or slice"
+                )
+            local_joint_ids = np.asarray(raw_joint_ids, dtype=np.intp)
+        if np.any(local_joint_ids < 0) or np.any(local_joint_ids >= self.num_joints):
+            raise IndexError(
+                f"Entity '{self.name}' joint position target joint_ids out of range for "
+                f"{self.num_joints} joints: {local_joint_ids.tolist()}"
+            )
+        if np.unique(local_joint_ids).size != local_joint_ids.size:
+            raise ValueError(
+                f"Entity '{self.name}' joint position target joint_ids contain duplicates: "
+                f"{local_joint_ids.tolist()}"
+            )
+        actuator_ids = joint_to_actuator[local_joint_ids]
+        if np.any(actuator_ids < 0):
+            passive_names = [
+                self.joint_names[int(index)] for index in local_joint_ids[actuator_ids < 0]
+            ]
+            raise NotImplementedError(
+                f"Entity '{self.name}' capability 'joint position target' is unavailable "
+                f"for passive joints on backend '{self._backend_type}': {passive_names}"
+            )
+        self.data.write_ctrl(target, env_ids, actuator_ids=actuator_ids)
 
     def find_bodies(
         self, keys: str | Sequence[str], preserve_order: bool = False

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -1,0 +1,6 @@
+"""Community-style built-in MDP terms for UniLab's NumPy manager runtime."""
+
+from unilab.envs.mdp.actions import JointPositionAction as JointPositionAction
+from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActionCfg
+
+__all__ = ["JointPositionAction", "JointPositionActionCfg"]

--- a/src/unilab/envs/mdp/actions/__init__.py
+++ b/src/unilab/envs/mdp/actions/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in action terms supported by the NumPy runtime."""
+
+from unilab.envs.mdp.actions.actions import JointPositionAction as JointPositionAction
+from unilab.envs.mdp.actions.actions import JointPositionActionCfg as JointPositionActionCfg
+
+__all__ = ["JointPositionAction", "JointPositionActionCfg"]

--- a/src/unilab/envs/mdp/actions/actions.py
+++ b/src/unilab/envs/mdp/actions/actions.py
@@ -1,0 +1,223 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/envs/mdp/actions/actions.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and the SimBackend/entity contracts; Apache-2.0.
+"""Actions that write joint-position targets to entity actuator controls."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from numbers import Real
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from unilab.dtype_config import get_global_dtype
+from unilab.managers.action_manager import ActionTerm, ActionTermCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+def _real(value: Any, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number, got {type(value).__name__}")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be finite, got {result}")
+    return result
+
+
+def _resolve_named_values(
+    values: dict[str, Any], names: list[str], *, label: str
+) -> tuple[list[int], list[Any]]:
+    """Resolve regex-keyed values once, preserving target-name order."""
+    if not isinstance(values, dict):
+        raise TypeError(f"{label} must be a dict")
+    patterns = list(values)
+    matched_by_pattern = [False] * len(patterns)
+    indices: list[int] = []
+    resolved: list[Any] = []
+    for index, name in enumerate(names):
+        matches: list[int] = []
+        for pattern_index, pattern in enumerate(patterns):
+            try:
+                matches_pattern = re.fullmatch(pattern, name) is not None
+            except re.error as exc:
+                raise ValueError(f"{label} contains invalid regex {pattern!r}: {exc}") from exc
+            if matches_pattern:
+                matches.append(pattern_index)
+        if len(matches) > 1:
+            rendered = [patterns[pattern_index] for pattern_index in matches]
+            raise ValueError(f"{label} patterns {rendered} both match target '{name}'")
+        if matches:
+            pattern_index = matches[0]
+            matched_by_pattern[pattern_index] = True
+            indices.append(index)
+            resolved.append(values[patterns[pattern_index]])
+    missing = [pattern for pattern, matched in zip(patterns, matched_by_pattern) if not matched]
+    if missing:
+        raise ValueError(f"{label} patterns {missing} match no targets; available={names}")
+    return indices, resolved
+
+
+@dataclass(kw_only=True)
+class BaseActionCfg(ActionTermCfg):
+    """Configuration shared by entity joint actions."""
+
+    actuator_names: tuple[str, ...] | list[str]
+    scale: float | dict[str, float] = 1.0
+    offset: float | dict[str, float] = 0.0
+    preserve_order: bool = False
+
+
+class BaseAction(ActionTerm):
+    """Apply a cold-path-resolved affine transform to raw policy actions."""
+
+    cfg: BaseActionCfg
+    _entity: Entity
+
+    def __init__(self, cfg: BaseActionCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg=cfg, env=env)
+        target_ids, target_names = self._entity.find_joints_by_actuator_names(cfg.actuator_names)
+        self._target_ids = np.asarray(target_ids, dtype=np.intp)
+        self._target_ids.setflags(write=False)
+        self._target_names = list(target_names)
+        self._action_dim = len(target_ids)
+        dtype = get_global_dtype()
+        self._raw_actions = np.zeros((self.num_envs, self.action_dim), dtype=dtype)
+        self._processed_actions = np.zeros_like(self._raw_actions)
+        self._scale = self._resolve_affine(cfg.scale, default=1.0, label="scale")
+        self._offset = self._resolve_affine(cfg.offset, default=0.0, label="offset")
+        self._clip = self._resolve_clip(cfg.clip)
+
+    def _resolve_affine(
+        self, value: float | dict[str, float], *, default: float, label: str
+    ) -> float | np.ndarray:
+        if isinstance(value, dict):
+            result = np.full_like(self._raw_actions, default)
+            indices, resolved = _resolve_named_values(
+                value, self._target_names, label=f"{type(self).__name__} {label}"
+            )
+            result[:, indices] = [
+                _real(item, label=f"{type(self).__name__} {label}") for item in resolved
+            ]
+            return result
+        return _real(value, label=f"{type(self).__name__} {label}")
+
+    def _resolve_clip(self, value: dict[str, tuple] | None) -> np.ndarray | None:
+        if value is None:
+            return None
+        result = np.empty((*self._raw_actions.shape, 2), dtype=self._raw_actions.dtype)
+        result[..., 0] = -np.inf
+        result[..., 1] = np.inf
+        indices, bounds = _resolve_named_values(
+            value, self._target_names, label=f"{type(self).__name__} clip"
+        )
+        for index, raw_bounds in zip(indices, bounds, strict=True):
+            if not isinstance(raw_bounds, (tuple, list)) or len(raw_bounds) != 2:
+                raise TypeError(
+                    f"{type(self).__name__} clip for '{self._target_names[index]}' "
+                    "must be a (min, max) pair"
+                )
+            lower = _real(raw_bounds[0], label=f"{type(self).__name__} clip lower")
+            upper = _real(raw_bounds[1], label=f"{type(self).__name__} clip upper")
+            if lower > upper:
+                raise ValueError(
+                    f"{type(self).__name__} clip lower {lower} exceeds upper {upper} "
+                    f"for '{self._target_names[index]}'"
+                )
+            result[:, index, 0] = lower
+            result[:, index, 1] = upper
+        return result
+
+    @property
+    def scale(self) -> float | np.ndarray:
+        return self._scale
+
+    @property
+    def offset(self) -> float | np.ndarray:
+        return self._offset
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._raw_actions
+
+    @property
+    def processed_action(self) -> np.ndarray:
+        return self._processed_actions
+
+    @property
+    def action_dim(self) -> int:
+        return self._action_dim
+
+    @property
+    def target_ids(self) -> np.ndarray:
+        return self._target_ids
+
+    @property
+    def target_names(self) -> list[str]:
+        return list(self._target_names)
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(
+                f"{type(self).__name__} expected np.ndarray, got {type(actions).__name__}"
+            )
+        if actions.shape != self._raw_actions.shape:
+            raise ValueError(
+                f"{type(self).__name__} expected action shape {self._raw_actions.shape}, "
+                f"got {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError(f"{type(self).__name__} received NaN or Inf actions")
+        self._raw_actions[:] = actions
+        np.multiply(self._raw_actions, self._scale, out=self._processed_actions)
+        np.add(self._processed_actions, self._offset, out=self._processed_actions)
+        if self._clip is not None:
+            np.clip(
+                self._processed_actions,
+                self._clip[..., 0],
+                self._clip[..., 1],
+                out=self._processed_actions,
+            )
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        if env_ids is None:
+            env_ids = slice(None)
+        self._raw_actions[env_ids] = 0.0
+
+
+@dataclass(kw_only=True)
+class JointPositionActionCfg(BaseActionCfg):
+    """Configuration for joint-position control."""
+
+    use_default_offset: bool = True
+
+    def build(self, env: ManagerBasedRlEnv) -> JointPositionAction:
+        return JointPositionAction(self, env)
+
+
+class JointPositionAction(BaseAction):
+    """Convert policy actions into entity joint-position targets."""
+
+    cfg: JointPositionActionCfg
+
+    def __init__(self, cfg: JointPositionActionCfg, env: ManagerBasedRlEnv):
+        if not isinstance(cfg.use_default_offset, bool):
+            raise TypeError("JointPositionActionCfg use_default_offset must be bool")
+        super().__init__(cfg=cfg, env=env)
+        if cfg.use_default_offset:
+            self._offset = self._entity.data.default_joint_pos[:, self._target_ids].copy()
+        self._target = np.empty_like(self._processed_actions)
+
+    def apply_actions(self) -> None:
+        encoder_bias = self._entity.data.encoder_bias[:, self._target_ids]
+        np.subtract(self._processed_actions, encoder_bias, out=self._target)
+        self._entity.set_joint_position_target(self._target, joint_ids=self._target_ids)
+
+
+__all__ = ["JointPositionAction", "JointPositionActionCfg"]

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -32,6 +32,13 @@ class _StrictBackendProfile:
         self.site_ids = {"imu": 3}
         self.geom_names = ("floor", "base_collision", "foot_collision")
         self.actuator_names = ("knee", "unused", "hip", "unused_2", "ankle")
+        self.actuator_joint_names = (
+            "knee",
+            "unused_joint",
+            "hip",
+            "unused_2_joint",
+            "ankle",
+        )
         self.dof_pos = np.arange(self.num_envs * 5, dtype=np.float32).reshape(self.num_envs, 5)
         self.dof_vel = self.dof_pos + 100.0
         base = np.arange(self.num_envs * 10 * 3, dtype=np.float32)
@@ -70,6 +77,10 @@ class _StrictBackendProfile:
         self._check("actuator names")
         return self.actuator_names
 
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        self._check("actuator target joints")
+        return self.actuator_joint_names
+
     def get_actuator_ctrl_range(self) -> np.ndarray:
         self.calls["actuator range"] += 1
         return np.arange(10, dtype=np.float32).reshape(5, 2)
@@ -77,6 +88,10 @@ class _StrictBackendProfile:
     def get_dof_pos(self) -> np.ndarray:
         self._check("joint position state")
         return self.dof_pos
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        self._check("default joint position")
+        return np.arange(5, dtype=np.float32) + 10.0
 
     def get_dof_vel(self) -> np.ndarray:
         self._check("joint velocity state")
@@ -204,6 +219,74 @@ def test_entity_control_write_uses_cached_actuator_columns_and_fails_closed() ->
     _, read_only_scene = _scene()
     with pytest.raises(NotImplementedError, match="actuator control write.*not materialized"):
         read_only_scene["robot"].data.write_ctrl(np.zeros((backend.num_envs, 2), dtype=np.float32))
+
+
+def test_entity_joint_position_target_maps_natural_joint_order_to_control_order() -> None:
+    backend = _StrictBackendProfile("mujoco")
+    control = np.zeros((backend.num_envs, backend.num_actuators), dtype=np.float32)
+    scene = EntityScene(
+        {
+            "robot": EntityCfg(
+                joint_names=("ankle", "hip", "knee"),
+                actuator_names=("ankle", "hip"),
+            )
+        },
+        cast(SimBackend, backend),
+        control,
+    )
+    robot = scene["robot"]
+
+    ids, names = robot.find_joints_by_actuator_names(".*")
+    assert ids == [0, 1]
+    assert names == ["ankle", "hip"]
+    np.testing.assert_array_equal(
+        robot.data.default_joint_pos,
+        np.asarray([[14.0, 12.0, 10.0]] * backend.num_envs, dtype=np.float32),
+    )
+    np.testing.assert_array_equal(robot.data.encoder_bias, 0.0)
+
+    targets = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+    robot.set_joint_position_target(targets, joint_ids=np.asarray(ids, dtype=np.int32))
+    np.testing.assert_array_equal(control[:, 4], targets[:, 0])
+    np.testing.assert_array_equal(control[:, 2], targets[:, 1])
+    np.testing.assert_array_equal(control[:, [0, 1, 3]], 0.0)
+
+    with pytest.raises(NotImplementedError, match="passive joints.*knee"):
+        robot.set_joint_position_target(
+            np.ones((backend.num_envs, 1), dtype=np.float32),
+            joint_ids=np.asarray([2], dtype=np.int32),
+        )
+
+
+@pytest.mark.parametrize(
+    ("actuator_joint_names", "joint_names", "message"),
+    [
+        (("hip", "unused", "hip", "unused_2", "knee"), ("hip",), "must be unique"),
+        (
+            ("knee", "unused_joint", "hip", "unused_2_joint", "ankle"),
+            ("hip",),
+            "outside its declared joint partition.*knee",
+        ),
+    ],
+)
+def test_entity_joint_actuator_mapping_rejects_ambiguous_or_missing_targets(
+    actuator_joint_names: tuple[str, ...],
+    joint_names: tuple[str, ...],
+    message: str,
+) -> None:
+    backend = _StrictBackendProfile("mujoco")
+    backend.actuator_joint_names = actuator_joint_names
+
+    with pytest.raises(ValueError, match=message):
+        EntityScene(
+            {
+                "robot": EntityCfg(
+                    joint_names=joint_names,
+                    actuator_names=("knee", "hip"),
+                )
+            },
+            cast(SimBackend, backend),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/envs/mdp/test_joint_position_action.py
+++ b/tests/envs/mdp/test_joint_position_action.py
@@ -1,0 +1,246 @@
+"""Upstream-derived NumPy tests for the manager joint-position action."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import create_backend
+from unilab.base.backend.base import SimBackend
+from unilab.base.entity import EntityCfg, EntityScene
+from unilab.base.scene import SceneCfg
+from unilab.envs.mdp import JointPositionAction, JointPositionActionCfg
+from unilab.envs.mdp.actions import (
+    JointPositionAction as ExportedJointPositionAction,
+)
+from unilab.envs.mdp.actions import (
+    JointPositionActionCfg as ExportedJointPositionActionCfg,
+)
+from unilab.managers._types import ManagerBasedRlEnv
+
+
+class _Backend:
+    backend_type = "fake"
+    num_envs = 2
+    num_actuators = 3
+
+    def __init__(self) -> None:
+        self.actuator_names = ("knee_motor", "hip_motor", "ankle_motor")
+        self.target_joint_names = ("knee", "hip", "ankle")
+        self.joint_index = {"hip": 0, "knee": 1, "ankle": 2}
+        self.dof_pos = np.zeros((self.num_envs, 3), dtype=np.float32)
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self.actuator_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return self.target_joint_names
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return np.tile(np.asarray([[-10.0, 10.0]], dtype=np.float32), (3, 1))
+
+    def get_joint_dof_pos_indices(self, names) -> np.ndarray:
+        return np.asarray([self.joint_index[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names)
+
+    def get_dof_pos(self) -> np.ndarray:
+        return self.dof_pos
+
+    def get_dof_vel(self) -> np.ndarray:
+        return np.zeros_like(self.dof_pos)
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+
+
+def _action(
+    **overrides,
+) -> tuple[JointPositionAction, np.ndarray, EntityScene]:
+    backend = _Backend()
+    control = np.zeros((backend.num_envs, backend.num_actuators), dtype=np.float32)
+    scene = EntityScene(
+        {
+            "robot": EntityCfg(
+                joint_names=("hip", "knee", "ankle"),
+                actuator_names=backend.actuator_names,
+            )
+        },
+        cast(SimBackend, backend),
+        control,
+    )
+    cfg_values = {
+        "entity_name": "robot",
+        "actuator_names": ("hip|knee",),
+        **overrides,
+    }
+    cfg = JointPositionActionCfg(**cfg_values)
+    env = cast(ManagerBasedRlEnv, SimpleNamespace(num_envs=backend.num_envs, scene=scene))
+    return cfg.build(env), control, scene
+
+
+def test_public_exports_are_canonical_objects() -> None:
+    assert JointPositionAction is ExportedJointPositionAction
+    assert JointPositionActionCfg is ExportedJointPositionActionCfg
+
+
+def test_default_offset_encoder_bias_and_control_order() -> None:
+    action, control, scene = _action(scale=2.0)
+    raw = np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    scene["robot"].data.encoder_bias[:, 0] = np.asarray([0.05, 0.1])
+
+    action.process_actions(raw)
+    action.apply_actions()
+
+    assert action.target_names == ["hip", "knee"]
+    np.testing.assert_array_equal(action.target_ids, [0, 1])
+    np.testing.assert_allclose(action.processed_action, raw * 2.0 + [0.1, 0.2])
+    np.testing.assert_allclose(control[:, 1], action.processed_action[:, 0] - [0.05, 0.1])
+    np.testing.assert_allclose(control[:, 0], action.processed_action[:, 1])
+    np.testing.assert_array_equal(control[:, 2], 0.0)
+
+
+def test_regex_scale_offset_clip_and_local_reset() -> None:
+    action, _, _ = _action(
+        scale={"hip": 2.0, "knee": 3.0},
+        offset={"hip": 0.5, "knee": -0.5},
+        clip={"hip": (-1.0, 1.0)},
+        use_default_offset=False,
+    )
+    raw = np.asarray([[2.0, 2.0], [-2.0, -2.0]], dtype=np.float32)
+
+    action.process_actions(raw)
+
+    np.testing.assert_allclose(action.processed_action, [[1.0, 5.5], [-1.0, -6.5]])
+    np.testing.assert_array_equal(action.raw_action, raw)
+    action.reset(np.asarray([1], dtype=np.int32))
+    np.testing.assert_array_equal(action.raw_action[0], raw[0])
+    np.testing.assert_array_equal(action.raw_action[1], 0.0)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"scale": {"missing": 1.0}}, ValueError, "match no targets"),
+        (
+            {"scale": {"hip|knee": 1.0, ".*": 2.0}},
+            ValueError,
+            "both match target",
+        ),
+        ({"clip": {"hip": (1.0, -1.0)}}, ValueError, "exceeds upper"),
+        ({"offset": float("nan")}, ValueError, "must be finite"),
+        ({"use_default_offset": 1}, TypeError, "must be bool"),
+    ],
+)
+def test_invalid_action_config_fails_at_construction(overrides, error, message) -> None:
+    with pytest.raises(error, match=message):
+        _action(**overrides)
+
+
+def test_non_finite_and_wrong_shape_actions_fail_before_control_write() -> None:
+    action, control, _ = _action()
+    with pytest.raises(ValueError, match="expected action shape"):
+        action.process_actions(np.zeros((2, 1), dtype=np.float32))
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        action.process_actions(np.full((2, 2), np.nan, dtype=np.float32))
+    np.testing.assert_array_equal(control, 0.0)
+
+
+@pytest.mark.parametrize("backend_type", ["mujoco", "motrix"])
+def test_go2_joint_targets_are_mapped_to_backend_control_order(backend_type: str) -> None:
+    if backend_type == "motrix":
+        pytest.importorskip("motrixsim")
+    joint_names = (
+        "FL_hip_joint",
+        "FL_thigh_joint",
+        "FL_calf_joint",
+        "FR_hip_joint",
+        "FR_thigh_joint",
+        "FR_calf_joint",
+        "RL_hip_joint",
+        "RL_thigh_joint",
+        "RL_calf_joint",
+        "RR_hip_joint",
+        "RR_thigh_joint",
+        "RR_calf_joint",
+    )
+    scene_cfg = SceneCfg(
+        model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
+        entities={
+            "robot": EntityCfg(
+                joint_names=joint_names,
+                actuator_names=(
+                    "FR_hip",
+                    "FR_thigh",
+                    "FR_calf",
+                    "FL_hip",
+                    "FL_thigh",
+                    "FL_calf",
+                    "RR_hip",
+                    "RR_thigh",
+                    "RR_calf",
+                    "RL_hip",
+                    "RL_thigh",
+                    "RL_calf",
+                ),
+            )
+        },
+    )
+    backend = create_backend(
+        backend_type,
+        scene_cfg,
+        2,
+        0.01,
+        base_name="base",
+    )
+    control = np.zeros((2, backend.num_actuators), dtype=np.float32)
+    scene = EntityScene.from_scene_cfg(scene_cfg, backend, control)
+    env = cast(ManagerBasedRlEnv, SimpleNamespace(num_envs=2, scene=scene))
+    action = JointPositionActionCfg(
+        entity_name="robot",
+        actuator_names=(".*",),
+        scale=0.25,
+        offset={".*_hip_joint": 0.1, ".*_thigh_joint": 0.2, ".*_calf_joint": -0.3},
+        use_default_offset=False,
+    ).build(env)
+    raw = np.arange(24, dtype=np.float32).reshape(2, 12) / 10.0
+
+    action.process_actions(raw)
+    action.apply_actions()
+
+    target_index = {name: index for index, name in enumerate(joint_names)}
+    expected = np.column_stack(
+        [
+            action.processed_action[:, target_index[name]]
+            for name in backend.get_actuator_joint_names()
+        ]
+    )
+    np.testing.assert_allclose(control, expected)
+
+
+def test_action_module_has_no_runtime_or_backend_private_dependencies() -> None:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "unilab"
+        / "envs"
+        / "mdp"
+        / "actions"
+        / "actions.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("torch", "unilab.ipc", "unilab.algos", "unilab.training", "unilab.base.backend")
+    imports = [node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)] + [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    ]
+    assert not [name for name in imports if name.startswith(forbidden)]


### PR DESCRIPTION
## Summary

- port pinned mjlab v1.6.0 `BaseAction` and `JointPositionAction` semantics to NumPy
- materialize joint-to-actuator mapping, default pose, and encoder bias in the base-owned entity facade
- fail closed on missing, passive, duplicate, invalid-shape, or non-finite targets; keep managers independent of IPC and backend-private objects

## Provenance

Source: `mujocolab/mjlab` v1.6.0, commit `0fb8a681136be94ffc636a3dd423cabb97d91f10`, `src/mjlab/envs/mdp/actions/actions.py`; adapted under Apache-2.0.

## Validation

- `uv run pytest -q tests/base/test_entity_facade.py tests/envs/mdp/test_joint_position_action.py tests/envs/test_manager_based_rl_env.py` — 48 passed
- `make test-all` — 1,853 passed, 25 skipped, 1 xfailed; benchmark smoke passed in module and script modes
- mypy and pyright — 0 errors

Validated head: `dbb138d99b8742179088f39e10845e86333a9b8f`

## Change accounting

- source-derived / mechanical NumPy port: 235 added lines
- UniLab-specific entity glue: 182 added lines
- tests: 329 added lines
- modified existing: 2 files, +265/-3
- new: 4 files
- deleted: 3 lines, 0 files

Refs #1054
Umbrella #1042