### PR TITLE
feat(env): add NumPy observation terms

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, NoReturn
 import numpy as np
 
 from unilab.base.backend.base import SimBackend
-from unilab.utils.rotation import np_yaw_from_quat
+from unilab.utils.rotation import np_quat_apply_inverse, np_yaw_from_quat
 
 if TYPE_CHECKING:
     from unilab.base.scene import SceneCfg
@@ -141,6 +141,8 @@ class EntityData:
         joint_pos_ids: np.ndarray | None,
         joint_vel_ids: np.ndarray | None,
         default_joint_pos: np.ndarray | None,
+        default_joint_vel: np.ndarray | None,
+        gravity_vec_w: np.ndarray | None,
         body_ids: np.ndarray | None,
         actuator_ids: np.ndarray | None,
         actuator_ctrl_range: np.ndarray | None,
@@ -155,6 +157,8 @@ class EntityData:
         self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
         self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
         self._default_joint_pos = default_joint_pos
+        self._default_joint_vel = default_joint_vel
+        self._gravity_vec_w = gravity_vec_w
         self._encoder_bias = (
             None
             if default_joint_pos is None
@@ -209,6 +213,12 @@ class EntityData:
         return np_yaw_from_quat(self.root_link_quat_w)
 
     @property
+    def projected_gravity_b(self) -> np.ndarray:
+        """Unit gravity vector projected into the root link frame."""
+        gravity = self._require(self._gravity_vec_w, "projected gravity")
+        return np_quat_apply_inverse(self.root_link_quat_w, gravity)
+
+    @property
     def root_link_pose_w(self) -> np.ndarray:
         return np.concatenate((self.root_link_pos_w, self.root_link_quat_w), axis=-1)
 
@@ -227,9 +237,19 @@ class EntityData:
         return self._backend.get_dof_vel()[:, index]
 
     @property
+    def joint_pos_biased(self) -> np.ndarray:
+        """Joint positions with the manager-owned encoder bias applied."""
+        return self.joint_pos + self.encoder_bias
+
+    @property
     def default_joint_pos(self) -> np.ndarray:
         """Read-only per-environment default joint positions."""
         return self._require(self._default_joint_pos, "default joint position")
+
+    @property
+    def default_joint_vel(self) -> np.ndarray:
+        """Read-only zero default velocities from the UniLab reset contract."""
+        return self._require(self._default_joint_vel, "default joint velocity")
 
     @property
     def encoder_bias(self) -> np.ndarray:
@@ -433,6 +453,8 @@ class Entity:
         self._validate_joint_state(backend, joint_pos_ids, joint_vel_ids)
         self._validate_body_state(backend, root_body_ids, body_ids)
         default_joint_pos = self._materialize_default_joint_pos(backend, joint_pos_ids)
+        default_joint_vel = self._materialize_default_joint_vel(backend, joint_vel_ids)
+        gravity_vec_w = self._materialize_gravity_vector(backend, root_body_ids)
         actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
         (
             self._actuator_target_joint_names,
@@ -457,6 +479,8 @@ class Entity:
             joint_pos_ids=joint_pos_ids,
             joint_vel_ids=joint_vel_ids,
             default_joint_pos=default_joint_pos,
+            default_joint_vel=default_joint_vel,
+            gravity_vec_w=gravity_vec_w,
             body_ids=body_ids,
             actuator_ids=actuator_ids,
             actuator_ctrl_range=actuator_ctrl_range,
@@ -631,6 +655,32 @@ class Entity:
         materialized = np.broadcast_to(selected, (backend.num_envs, len(joint_pos_ids))).copy()
         materialized.setflags(write=False)
         return materialized
+
+    def _materialize_default_joint_vel(
+        self, backend: SimBackend, joint_vel_ids: np.ndarray | None
+    ) -> np.ndarray | None:
+        if joint_vel_ids is None:
+            return None
+        current = self._read_state("joint velocity state", backend.get_dof_vel)
+        materialized = np.zeros(
+            (backend.num_envs, len(joint_vel_ids)),
+            dtype=current.dtype,
+        )
+        materialized.setflags(write=False)
+        return materialized
+
+    def _materialize_gravity_vector(
+        self, backend: SimBackend, root_body_ids: np.ndarray | None
+    ) -> np.ndarray | None:
+        if root_body_ids is None:
+            return None
+        quat = self._read_state(
+            "root body quaternion state", backend.get_body_quat_w, root_body_ids
+        )
+        gravity = np.zeros((backend.num_envs, 3), dtype=quat.dtype)
+        gravity[:, 2] = -1.0
+        gravity.setflags(write=False)
+        return gravity
 
     def _materialize_joint_actuator_mapping(
         self, backend: SimBackend, actuator_ids: np.ndarray | None

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -138,6 +138,15 @@ class ManagerBasedRlEnv(NpEnv):
 
     is_vector_env = True
     _cfg: ManagerBasedRlEnvCfg
+    event_manager: EventManager
+    command_manager: CommandManager | NullCommandManager
+    action_manager: ActionManager
+    observation_manager: ObservationManager
+    termination_manager: TerminationManager
+    reward_manager: RewardManager
+    curriculum_manager: CurriculumManager | NullCurriculumManager
+    metrics_manager: MetricsManager | NullMetricsManager
+    recorder_manager: RecorderManager | NullRecorderManager
 
     def __init__(self, cfg: ManagerBasedRlEnvCfg, backend: SimBackend, num_envs: int):
         if not isinstance(cfg, ManagerBasedRlEnvCfg):

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -4,10 +4,24 @@ from unilab.envs.mdp.actions import JointPositionAction as JointPositionAction
 from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActionCfg
 from unilab.envs.mdp.commands import UniformVelocityCommand as UniformVelocityCommand
 from unilab.envs.mdp.commands import UniformVelocityCommandCfg as UniformVelocityCommandCfg
+from unilab.envs.mdp.observations import base_ang_vel as base_ang_vel
+from unilab.envs.mdp.observations import base_lin_vel as base_lin_vel
+from unilab.envs.mdp.observations import generated_commands as generated_commands
+from unilab.envs.mdp.observations import joint_pos_rel as joint_pos_rel
+from unilab.envs.mdp.observations import joint_vel_rel as joint_vel_rel
+from unilab.envs.mdp.observations import last_action as last_action
+from unilab.envs.mdp.observations import projected_gravity as projected_gravity
 
 __all__ = [
     "JointPositionAction",
     "JointPositionActionCfg",
     "UniformVelocityCommand",
     "UniformVelocityCommandCfg",
+    "base_ang_vel",
+    "base_lin_vel",
+    "generated_commands",
+    "joint_pos_rel",
+    "joint_vel_rel",
+    "last_action",
+    "projected_gravity",
 ]

--- a/src/unilab/envs/mdp/observations.py
+++ b/src/unilab/envs/mdp/observations.py
@@ -1,0 +1,96 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/envs/mdp/observations.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and the base-owned entity facade; Apache-2.0.
+"""Community-style observation terms for the NumPy manager runtime."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+
+
+def base_lin_vel(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return asset.data.root_link_lin_vel_b
+
+
+def base_ang_vel(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return asset.data.root_link_ang_vel_b
+
+
+def projected_gravity(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return asset.data.projected_gravity_b
+
+
+def joint_pos_rel(
+    env: ManagerBasedRlEnv,
+    biased: bool = False,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    if not isinstance(biased, bool):
+        raise TypeError(f"joint_pos_rel biased must be bool, got {type(biased).__name__}")
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_ids = asset_cfg.joint_ids
+    joint_pos = asset.data.joint_pos_biased if biased else asset.data.joint_pos
+    return joint_pos[:, joint_ids] - asset.data.default_joint_pos[:, joint_ids]
+
+
+def joint_vel_rel(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_ids = asset_cfg.joint_ids
+    return asset.data.joint_vel[:, joint_ids] - asset.data.default_joint_vel[:, joint_ids]
+
+
+def last_action(env: ManagerBasedRlEnv, action_name: str | None = None) -> np.ndarray:
+    if action_name is None:
+        return env.action_manager.action
+    try:
+        return env.action_manager.get_term(action_name).raw_action
+    except KeyError as exc:
+        raise KeyError(f"Action term '{action_name}' not found") from exc
+
+
+def generated_commands(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    try:
+        command = env.command_manager.get_command(command_name)
+    except KeyError as exc:
+        raise KeyError(f"Command term '{command_name}' not found") from exc
+    if command is None:
+        raise KeyError(f"Command term '{command_name}' not found")
+    return command
+
+
+__all__ = [
+    "base_ang_vel",
+    "base_lin_vel",
+    "generated_commands",
+    "joint_pos_rel",
+    "joint_vel_rel",
+    "last_action",
+    "projected_gravity",
+]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -133,6 +133,22 @@ class ManagerScene(Protocol):
     def __getitem__(self, name: str) -> ManagerEntity: ...
 
 
+class ManagerActionTerm(Protocol):
+    @property
+    def raw_action(self) -> np.ndarray: ...
+
+
+class ManagerActionManager(Protocol):
+    @property
+    def action(self) -> np.ndarray: ...
+
+    def get_term(self, name: str) -> ManagerActionTerm: ...
+
+
+class ManagerCommandManager(Protocol):
+    def get_command(self, name: str) -> np.ndarray | None: ...
+
+
 class ManagerBasedRlEnv(Protocol):
     """Structural context visible to manager terms.
 
@@ -154,6 +170,12 @@ class ManagerBasedRlEnv(Protocol):
 
     @property
     def scene(self) -> ManagerScene: ...
+
+    @property
+    def action_manager(self) -> ManagerActionManager: ...
+
+    @property
+    def command_manager(self) -> ManagerCommandManager: ...
 
     @property
     def max_episode_length_s(self) -> float: ...

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -151,11 +151,14 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
     assert robot.body_names == ("foot", "base")
     np.testing.assert_array_equal(robot.data.joint_pos, backend.dof_pos[:, [4, 2]])
     np.testing.assert_array_equal(robot.data.joint_vel, backend.dof_vel[:, [4, 2]])
+    np.testing.assert_array_equal(robot.data.default_joint_vel, 0.0)
+    np.testing.assert_array_equal(robot.data.joint_pos_biased, backend.dof_pos[:, [4, 2]])
     np.testing.assert_array_equal(robot.data.body_link_pos_w, backend.body_pos[:, [7, 4]])
     np.testing.assert_array_equal(robot.data.root_link_pos_w, backend.body_pos[:, 4])
     np.testing.assert_array_equal(robot.data.root_link_lin_vel_b, backend.body_lin_vel_b[:, 4])
     np.testing.assert_array_equal(robot.data.root_link_ang_vel_b, backend.body_ang_vel_b[:, 4])
     np.testing.assert_array_equal(robot.data.heading_w, 0.0)
+    np.testing.assert_array_equal(robot.data.projected_gravity_b, [[0.0, 0.0, -1.0]] * 3)
     np.testing.assert_array_equal(
         robot.data.actuator_ctrl_range,
         np.arange(10, dtype=np.float32).reshape(5, 2)[[4, 2]],
@@ -477,9 +480,13 @@ def test_real_mujoco_entity_selector_and_numpy_state_smoke() -> None:
     assert scene["robot"].data.root_link_lin_vel_b.shape == (2, 3)
     assert scene["robot"].data.root_link_ang_vel_b.shape == (2, 3)
     assert scene["robot"].data.heading_w.shape == (2,)
+    assert scene["robot"].data.projected_gravity_b.shape == (2, 3)
+    assert scene["robot"].data.default_joint_vel.shape == (2, 12)
     assert np.isfinite(scene["robot"].data.root_link_lin_vel_b).all()
     assert np.isfinite(scene["robot"].data.root_link_ang_vel_b).all()
     assert np.isfinite(scene["robot"].data.heading_w).all()
+    assert np.isfinite(scene["robot"].data.projected_gravity_b).all()
+    np.testing.assert_array_equal(scene["robot"].data.default_joint_vel, 0.0)
 
 
 def test_scene_cfg_entity_defaults_are_not_shared() -> None:

--- a/tests/envs/mdp/test_observations.py
+++ b/tests/envs/mdp/test_observations.py
@@ -1,0 +1,247 @@
+"""Upstream-derived NumPy tests for basic manager observation terms."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from unilab.base.backend.base import SimBackend
+from unilab.base.entity import EntityCfg, EntityScene
+from unilab.envs import mdp
+from unilab.managers import ObservationGroupCfg, ObservationManager, ObservationTermCfg
+from unilab.managers._types import ManagerBasedRlEnv
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+
+class _Backend:
+    backend_type = "fake"
+    num_envs = 2
+    num_actuators = 0
+
+    def __init__(self) -> None:
+        self.joint_names = ("hip", "knee", "ankle")
+        self.dof_pos = np.asarray(
+            [[0.4, 0.1, -0.2], [0.0, 0.3, 0.7]],
+            dtype=np.float32,
+        )
+        self.dof_vel = np.asarray(
+            [[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]],
+            dtype=np.float32,
+        )
+        self.body_pos = np.zeros((2, 1, 3), dtype=np.float32)
+        self.body_quat = np.zeros((2, 1, 4), dtype=np.float32)
+        self.body_quat[0, 0, 0] = 1.0
+        half = np.sqrt(0.5)
+        self.body_quat[1, 0] = [half, half, 0.0, 0.0]
+        self.body_lin_vel_w = np.zeros((2, 1, 3), dtype=np.float32)
+        self.body_ang_vel_w = np.zeros((2, 1, 3), dtype=np.float32)
+        self.body_lin_vel_b = np.asarray(
+            [[[0.5, 0.25, 0.0]], [[-0.5, -0.25, 0.1]]], dtype=np.float32
+        )
+        self.body_ang_vel_b = np.asarray(
+            [[[0.1, 0.2, 0.3]], [[-0.1, -0.2, -0.3]]], dtype=np.float32
+        )
+
+    def get_joint_dof_pos_indices(self, names) -> np.ndarray:
+        return np.asarray([self.joint_names.index(name) for name in names], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names)
+
+    def get_body_ids(self, names) -> np.ndarray:
+        if tuple(names) != ("base",):
+            raise KeyError(names)
+        return np.asarray([0], dtype=np.int32)
+
+    def get_dof_pos(self) -> np.ndarray:
+        return self.dof_pos
+
+    def get_dof_vel(self) -> np.ndarray:
+        return self.dof_vel
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+
+    def get_body_pos_w(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_pos[:, ids]
+
+    def get_body_quat_w(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_quat[:, ids]
+
+    def get_body_lin_vel_w(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_lin_vel_w[:, ids]
+
+    def get_body_ang_vel_w(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_ang_vel_w[:, ids]
+
+    def get_body_lin_vel_b(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_lin_vel_b[:, ids]
+
+    def get_body_ang_vel_b(self, ids: np.ndarray) -> np.ndarray:
+        return self.body_ang_vel_b[:, ids]
+
+
+class _ActionManager:
+    def __init__(self) -> None:
+        self.action = np.arange(6, dtype=np.float32).reshape(2, 3)
+        self._terms = {
+            "legs": SimpleNamespace(raw_action=self.action[:, [0, 2]]),
+        }
+
+    def get_term(self, name: str):
+        return self._terms[name]
+
+
+class _CommandManager:
+    def __init__(self) -> None:
+        self.command = np.asarray([[1.0, 0.0, 0.2], [0.5, -0.1, -0.2]], dtype=np.float32)
+
+    def get_command(self, name: str) -> np.ndarray:
+        if name != "twist":
+            raise KeyError(name)
+        return self.command
+
+
+def _env() -> tuple[ManagerBasedRlEnv, _Backend]:
+    backend = _Backend()
+    scene = EntityScene(
+        {
+            "robot": EntityCfg(
+                root_body_name="base",
+                joint_names=backend.joint_names,
+            )
+        },
+        cast(SimBackend, backend),
+    )
+    env = cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=backend.num_envs,
+            scene=scene,
+            action_manager=_ActionManager(),
+            command_manager=_CommandManager(),
+            rng=np.random.default_rng(4),
+        ),
+    )
+    return env, backend
+
+
+def test_root_joint_action_and_command_terms_match_numpy_contract() -> None:
+    env, backend = _env()
+    robot = cast(Any, env.scene["robot"])
+    robot.data.encoder_bias[:] = [[0.01, 0.02, 0.03], [-0.01, -0.02, -0.03]]
+
+    np.testing.assert_array_equal(mdp.base_lin_vel(env), backend.body_lin_vel_b[:, 0])
+    np.testing.assert_array_equal(mdp.base_ang_vel(env), backend.body_ang_vel_b[:, 0])
+    np.testing.assert_allclose(
+        mdp.projected_gravity(env),
+        [[0.0, 0.0, -1.0], [0.0, -1.0, 0.0]],
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        mdp.joint_pos_rel(env),
+        backend.dof_pos - [0.1, 0.2, 0.3],
+    )
+    np.testing.assert_allclose(
+        mdp.joint_pos_rel(env, biased=True),
+        backend.dof_pos + robot.data.encoder_bias - [0.1, 0.2, 0.3],
+    )
+    np.testing.assert_array_equal(mdp.joint_vel_rel(env), backend.dof_vel)
+    np.testing.assert_array_equal(mdp.last_action(env), env.action_manager.action)
+    np.testing.assert_array_equal(
+        mdp.last_action(env, "legs"), env.action_manager.get_term("legs").raw_action
+    )
+    np.testing.assert_array_equal(
+        mdp.generated_commands(env, "twist"), env.command_manager.get_command("twist")
+    )
+
+
+def test_scene_entity_selector_is_resolved_once_by_observation_manager() -> None:
+    env, backend = _env()
+    selector = SceneEntityCfg("robot", joint_names=("ankle", "hip"), preserve_order=True)
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "joint_pos": ObservationTermCfg(
+                        func=mdp.joint_pos_rel,
+                        params={"asset_cfg": selector},
+                    ),
+                    "joint_vel": ObservationTermCfg(
+                        func=mdp.joint_vel_rel,
+                        params={"asset_cfg": selector},
+                    ),
+                    "command": ObservationTermCfg(
+                        func=mdp.generated_commands,
+                        params={"command_name": "twist"},
+                    ),
+                }
+            )
+        },
+        env,
+    )
+
+    result = manager.compute()["policy"]
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2, 7)
+    np.testing.assert_allclose(result[:, :2], backend.dof_pos[:, [2, 0]] - [0.3, 0.1])
+    np.testing.assert_array_equal(result[:, 2:4], backend.dof_vel[:, [2, 0]])
+    assert selector.joint_ids == slice(None)
+    resolved = manager.get_term_cfg("policy", "joint_pos").params["asset_cfg"]
+    assert resolved.joint_ids == [2, 0]
+
+
+@pytest.mark.parametrize(
+    ("call", "message"),
+    [
+        (lambda env: mdp.last_action(env, "missing"), "Action term 'missing' not found"),
+        (
+            lambda env: mdp.generated_commands(env, "missing"),
+            "Command term 'missing' not found",
+        ),
+        (lambda env: mdp.joint_pos_rel(env, biased=1), "biased must be bool"),
+    ],
+)
+def test_invalid_term_requests_fail_explicitly(call, message: str) -> None:
+    env, _ = _env()
+    with pytest.raises((KeyError, TypeError), match=message):
+        call(env)
+
+
+def test_missing_entity_capability_fails_instead_of_returning_zeros() -> None:
+    backend = _Backend()
+    scene = EntityScene(
+        {"robot": EntityCfg(joint_names=backend.joint_names)},
+        cast(SimBackend, backend),
+    )
+    env = cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=2,
+            scene=scene,
+            action_manager=_ActionManager(),
+            command_manager=_CommandManager(),
+        ),
+    )
+    with pytest.raises(NotImplementedError, match="projected gravity.*not materialized"):
+        mdp.projected_gravity(env)
+
+
+def test_observation_module_has_no_forbidden_runtime_dependencies() -> None:
+    path = (
+        Path(__file__).resolve().parents[3] / "src" / "unilab" / "envs" / "mdp" / "observations.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("torch", "unilab.ipc", "unilab.algos", "unilab.training", "unilab.base.backend")
+    imports = [node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)] + [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    ]
+    assert not [name for name in imports if name.startswith(forbidden)]


### PR DESCRIPTION
Closes #1059

## Result

Ports the pinned mjlab basic observation surface to NumPy: root linear/angular velocity, projected gravity, relative joint position/velocity, last action, and generated commands. Adds only the required read-only entity views and typed manager context; missing action/command/capability requests fail explicitly.

## Scope accounting

- Source-derived/mechanical NumPy port: 96 source lines
- UniLab-specific entity/context glue: 83 source lines
- Modified existing: 5 files
- Tests: 254 lines
- Deleted: 1 line

## Validation

- focused manager/entity suite: 67 passed
- `make test-all`: 1,872 passed, 25 skipped, 1 xfailed; benchmark import smoke passed
- ruff, mypy, and pyright passed

Umbrella: #1042