### PR TITLE
feat(env): add NumPy reward terms

### DIFF
--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -11,6 +11,17 @@ from unilab.envs.mdp.observations import joint_pos_rel as joint_pos_rel
 from unilab.envs.mdp.observations import joint_vel_rel as joint_vel_rel
 from unilab.envs.mdp.observations import last_action as last_action
 from unilab.envs.mdp.observations import projected_gravity as projected_gravity
+from unilab.envs.mdp.rewards import action_acc_l2 as action_acc_l2
+from unilab.envs.mdp.rewards import action_rate_l2 as action_rate_l2
+from unilab.envs.mdp.rewards import (
+    body_angular_velocity_penalty as body_angular_velocity_penalty,
+)
+from unilab.envs.mdp.rewards import flat_orientation_l2 as flat_orientation_l2
+from unilab.envs.mdp.rewards import is_alive as is_alive
+from unilab.envs.mdp.rewards import is_terminated as is_terminated
+from unilab.envs.mdp.rewards import joint_vel_l2 as joint_vel_l2
+from unilab.envs.mdp.rewards import track_angular_velocity as track_angular_velocity
+from unilab.envs.mdp.rewards import track_linear_velocity as track_linear_velocity
 from unilab.envs.mdp.terminations import bad_orientation as bad_orientation
 from unilab.envs.mdp.terminations import (
     root_height_below_minimum as root_height_below_minimum,
@@ -22,14 +33,23 @@ __all__ = [
     "JointPositionActionCfg",
     "UniformVelocityCommand",
     "UniformVelocityCommandCfg",
+    "action_acc_l2",
+    "action_rate_l2",
     "base_ang_vel",
     "base_lin_vel",
     "bad_orientation",
+    "body_angular_velocity_penalty",
+    "flat_orientation_l2",
     "generated_commands",
     "joint_pos_rel",
     "joint_vel_rel",
+    "joint_vel_l2",
     "last_action",
+    "is_alive",
+    "is_terminated",
     "projected_gravity",
     "root_height_below_minimum",
     "time_out",
+    "track_angular_velocity",
+    "track_linear_velocity",
 ]

--- a/src/unilab/envs/mdp/rewards.py
+++ b/src/unilab/envs/mdp/rewards.py
@@ -1,0 +1,143 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/envs/mdp/rewards.py and src/mjlab/tasks/velocity/mdp/rewards.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and the base-owned entity facade; Apache-2.0.
+"""Community-style reward terms for the NumPy manager runtime."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+
+
+def _positive_std(term_name: str, std: float) -> float:
+    if isinstance(std, bool) or not isinstance(std, (int, float, np.number)):
+        raise TypeError(f"{term_name} std must be a real number")
+    value = float(std)
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{term_name} std must be finite and positive")
+    return value
+
+
+def _command(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    try:
+        command = env.command_manager.get_command(command_name)
+    except KeyError as exc:
+        raise KeyError(f"Command term '{command_name}' not found") from exc
+    if command is None:
+        raise KeyError(f"Command term '{command_name}' not found")
+    return command
+
+
+def is_alive(env: ManagerBasedRlEnv) -> np.ndarray:
+    """Reward environments that have not reached a non-timeout termination."""
+    return np.logical_not(env.termination_manager.terminated).astype(np.float32, copy=False)
+
+
+def is_terminated(env: ManagerBasedRlEnv) -> np.ndarray:
+    """Return one for non-timeout terminations."""
+    return env.termination_manager.terminated.astype(np.float32, copy=False)
+
+
+def joint_vel_l2(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize selected joint velocities with an L2-squared kernel."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return np.sum(np.square(asset.data.joint_vel[:, asset_cfg.joint_ids]), axis=1)
+
+
+def action_rate_l2(env: ManagerBasedRlEnv) -> np.ndarray:
+    """Penalize the first difference of raw policy actions."""
+    delta = env.action_manager.action - env.action_manager.prev_action
+    return np.sum(np.square(delta), axis=1)
+
+
+def action_acc_l2(env: ManagerBasedRlEnv) -> np.ndarray:
+    """Penalize the second difference of raw policy actions."""
+    action_acc = (
+        env.action_manager.action
+        - 2.0 * env.action_manager.prev_action
+        + env.action_manager.prev_prev_action
+    )
+    return np.sum(np.square(action_acc), axis=1)
+
+
+def flat_orientation_l2(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize non-flat base orientation."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return np.sum(np.square(asset.data.projected_gravity_b[:, :2]), axis=1)
+
+
+def track_linear_velocity(
+    env: ManagerBasedRlEnv,
+    std: float,
+    command_name: str,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Reward commanded base linear velocity, assuming commanded z is zero."""
+    scale = _positive_std("track_linear_velocity", std)
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    command = _command(env, command_name)
+    actual = asset.data.root_link_lin_vel_b
+    xy_error = np.sum(np.square(command[:, :2] - actual[:, :2]), axis=1)
+    z_error = np.square(actual[:, 2])
+    return np.exp(-(xy_error + z_error) / scale**2)
+
+
+def track_angular_velocity(
+    env: ManagerBasedRlEnv,
+    std: float,
+    command_name: str,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Reward commanded yaw rate while keeping roll/pitch rates near zero."""
+    scale = _positive_std("track_angular_velocity", std)
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    command = _command(env, command_name)
+    actual = asset.data.root_link_ang_vel_b
+    z_error = np.square(command[:, 2] - actual[:, 2])
+    xy_error = np.sum(np.square(actual[:, :2]), axis=1)
+    return np.exp(-(z_error + xy_error) / scale**2)
+
+
+def body_angular_velocity_penalty(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize roll/pitch angular velocity of one selected body."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    ang_vel = asset.data.body_link_ang_vel_w[:, asset_cfg.body_ids, :]
+    if ang_vel.shape != (env.num_envs, 1, 3):
+        raise ValueError(
+            "body_angular_velocity_penalty requires exactly one body; "
+            f"received state shape {ang_vel.shape}"
+        )
+    return np.sum(np.square(ang_vel[:, 0, :2]), axis=1)
+
+
+__all__ = [
+    "action_acc_l2",
+    "action_rate_l2",
+    "body_angular_velocity_penalty",
+    "flat_orientation_l2",
+    "is_alive",
+    "is_terminated",
+    "joint_vel_l2",
+    "track_angular_velocity",
+    "track_linear_velocity",
+]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -142,11 +142,22 @@ class ManagerActionManager(Protocol):
     @property
     def action(self) -> np.ndarray: ...
 
+    @property
+    def prev_action(self) -> np.ndarray: ...
+
+    @property
+    def prev_prev_action(self) -> np.ndarray: ...
+
     def get_term(self, name: str) -> ManagerActionTerm: ...
 
 
 class ManagerCommandManager(Protocol):
     def get_command(self, name: str) -> np.ndarray | None: ...
+
+
+class ManagerTerminationManager(Protocol):
+    @property
+    def terminated(self) -> np.ndarray: ...
 
 
 class ManagerBasedRlEnv(Protocol):
@@ -176,6 +187,9 @@ class ManagerBasedRlEnv(Protocol):
 
     @property
     def command_manager(self) -> ManagerCommandManager: ...
+
+    @property
+    def termination_manager(self) -> ManagerTerminationManager: ...
 
     @property
     def episode_length_buf(self) -> np.ndarray: ...

--- a/tests/envs/mdp/test_rewards.py
+++ b/tests/envs/mdp/test_rewards.py
@@ -1,0 +1,216 @@
+"""Upstream-derived NumPy tests for sensor-free manager reward terms."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from unilab.envs import mdp
+from unilab.managers import RewardManager, RewardTermCfg
+from unilab.managers._types import ManagerBasedRlEnv
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+
+class _Entity:
+    joint_names = ("hip", "knee", "ankle")
+    body_names = ("base", "torso")
+    num_joints = 3
+    num_bodies = 2
+
+    def __init__(self) -> None:
+        self.data = SimpleNamespace(
+            joint_vel=np.asarray(
+                [[1.0, 2.0, 3.0], [-1.0, 0.5, 2.0], [0.0, -2.0, 1.0]],
+                dtype=np.float32,
+            ),
+            projected_gravity_b=np.asarray(
+                [[0.0, 0.0, -1.0], [0.3, 0.4, -0.866], [0.6, 0.0, -0.8]],
+                dtype=np.float32,
+            ),
+            root_link_lin_vel_b=np.asarray(
+                [[1.0, 0.0, 0.0], [0.0, 0.5, 0.25], [-0.5, 0.0, -0.2]],
+                dtype=np.float32,
+            ),
+            root_link_ang_vel_b=np.asarray(
+                [[0.0, 0.0, 0.5], [0.1, 0.2, -0.25], [-0.3, 0.0, 0.1]],
+                dtype=np.float32,
+            ),
+            body_link_ang_vel_w=np.asarray(
+                [
+                    [[0.1, 0.2, 0.3], [1.0, 2.0, 3.0]],
+                    [[-0.1, 0.4, 0.2], [-1.0, 0.5, 0.0]],
+                    [[0.0, -0.2, 0.7], [0.25, -0.75, 0.1]],
+                ],
+                dtype=np.float32,
+            ),
+        )
+
+    def find_joints(self, keys, preserve_order: bool = False):
+        patterns = (keys,) if isinstance(keys, str) else tuple(keys)
+        ids = [self.joint_names.index(name) for name in patterns]
+        return ids, [self.joint_names[index] for index in ids]
+
+
+class _CommandManager:
+    def __init__(self) -> None:
+        self.command = np.asarray(
+            [[1.0, 0.0, 0.5], [0.25, 0.0, -0.5], [0.0, 0.0, 0.0]], dtype=np.float32
+        )
+
+    def get_command(self, name: str) -> np.ndarray:
+        if name != "twist":
+            raise KeyError(name)
+        return self.command
+
+
+def _env() -> ManagerBasedRlEnv:
+    action = np.asarray(
+        [[1.0, 2.0], [0.5, -0.5], [-1.0, 0.25]],
+        dtype=np.float32,
+    )
+    return cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=3,
+            scene={"robot": _Entity()},
+            action_manager=SimpleNamespace(
+                action=action,
+                prev_action=action - 0.25,
+                prev_prev_action=action - 0.75,
+            ),
+            command_manager=_CommandManager(),
+            termination_manager=SimpleNamespace(
+                terminated=np.asarray([False, True, False], dtype=np.bool_)
+            ),
+            max_episode_length_s=2.0,
+        ),
+    )
+
+
+def test_generic_reward_terms_match_pinned_numpy_semantics() -> None:
+    env = _env()
+    entity = cast(Any, env.scene["robot"])
+
+    np.testing.assert_array_equal(mdp.is_alive(env), [1.0, 0.0, 1.0])
+    np.testing.assert_array_equal(mdp.is_terminated(env), [0.0, 1.0, 0.0])
+    np.testing.assert_allclose(
+        mdp.joint_vel_l2(env, SceneEntityCfg("robot", joint_ids=[2, 0])),
+        np.sum(np.square(entity.data.joint_vel[:, [2, 0]]), axis=1),
+    )
+    np.testing.assert_allclose(mdp.action_rate_l2(env), 2 * 0.25**2)
+    np.testing.assert_allclose(mdp.action_acc_l2(env), 2 * 0.25**2)
+    np.testing.assert_allclose(
+        mdp.flat_orientation_l2(env),
+        np.sum(np.square(entity.data.projected_gravity_b[:, :2]), axis=1),
+    )
+
+
+def test_velocity_tracking_terms_match_pinned_equations() -> None:
+    env = _env()
+    entity = cast(Any, env.scene["robot"])
+    command = cast(np.ndarray, env.command_manager.get_command("twist"))
+
+    linear_error = np.sum(
+        np.square(command[:, :2] - entity.data.root_link_lin_vel_b[:, :2]), axis=1
+    ) + np.square(entity.data.root_link_lin_vel_b[:, 2])
+    angular_error = np.square(command[:, 2] - entity.data.root_link_ang_vel_b[:, 2]) + np.sum(
+        np.square(entity.data.root_link_ang_vel_b[:, :2]), axis=1
+    )
+    np.testing.assert_allclose(
+        mdp.track_linear_velocity(env, std=0.5, command_name="twist"),
+        np.exp(-linear_error / 0.5**2),
+    )
+    np.testing.assert_allclose(
+        mdp.track_angular_velocity(env, std=0.4, command_name="twist"),
+        np.exp(-angular_error / 0.4**2),
+    )
+
+
+def test_body_angular_velocity_requires_one_selected_body() -> None:
+    env = _env()
+    np.testing.assert_allclose(
+        mdp.body_angular_velocity_penalty(env, SceneEntityCfg("robot", body_ids=[1])),
+        [5.0, 1.25, 0.625],
+    )
+    with pytest.raises(ValueError, match="requires exactly one body"):
+        mdp.body_angular_velocity_penalty(env)
+
+
+def test_terms_integrate_with_reward_manager_and_cold_selector_resolution() -> None:
+    env = _env()
+    selector = SceneEntityCfg("robot", joint_names=("ankle", "hip"), preserve_order=True)
+    manager = RewardManager(
+        {
+            "joint_velocity": RewardTermCfg(
+                func=mdp.joint_vel_l2,
+                weight=-0.5,
+                params={"asset_cfg": selector},
+            ),
+            "track_linear": RewardTermCfg(
+                func=mdp.track_linear_velocity,
+                weight=2.0,
+                params={"std": 0.5, "command_name": "twist"},
+            ),
+        },
+        env,
+        scale_by_dt=False,
+    )
+
+    result = manager.compute(dt=0.02)
+    entity = cast(Any, env.scene["robot"])
+    expected = -0.5 * np.sum(np.square(entity.data.joint_vel[:, [2, 0]]), axis=1)
+    expected += 2.0 * mdp.track_linear_velocity(env, std=0.5, command_name="twist")
+    np.testing.assert_allclose(result, expected)
+    resolved = manager.get_term_cfg("joint_velocity").params["asset_cfg"]
+    assert resolved.joint_ids == [2, 0]
+
+
+@pytest.mark.parametrize(
+    ("call", "message"),
+    [
+        (
+            lambda env: mdp.track_linear_velocity(env, std=0.0, command_name="twist"),
+            "std must be finite and positive",
+        ),
+        (
+            lambda env: mdp.track_angular_velocity(env, std=np.nan, command_name="twist"),
+            "std must be finite and positive",
+        ),
+        (
+            lambda env: mdp.track_linear_velocity(env, std=0.5, command_name="missing"),
+            "Command term 'missing' not found",
+        ),
+    ],
+)
+def test_invalid_reward_requests_fail_explicitly(call, message: str) -> None:
+    with pytest.raises((KeyError, ValueError), match=message):
+        call(_env())
+
+
+def test_reward_manager_reports_nonfinite_term_and_name() -> None:
+    env = _env()
+    cast(Any, env.scene["robot"]).data.joint_vel[1, 0] = np.nan
+    manager = RewardManager(
+        {"joint_velocity": RewardTermCfg(func=mdp.joint_vel_l2, weight=-1.0)},
+        env,
+    )
+    with pytest.raises(ValueError, match="RewardManager term 'joint_velocity'.*NaN"):
+        manager.compute(dt=0.02)
+
+
+def test_reward_module_has_no_forbidden_runtime_dependencies() -> None:
+    path = Path(__file__).resolve().parents[3] / "src" / "unilab" / "envs" / "mdp" / "rewards.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("torch", "unilab.ipc", "unilab.algos", "unilab.training", "unilab.base.backend")
+    imports = [node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)] + [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    ]
+    assert not [name for name in imports if name.startswith(forbidden)]


### PR DESCRIPTION
## Result

Ports nine pinned mjlab sensor-free reward terms to UniLab NumPy managers, covering termination status, action history, joint velocity, orientation, velocity tracking, and selected-body angular velocity.

## Scope

- Source-aligned functions and exports.
- Typed action-history and termination-manager context.
- Explicit missing-command/std/body-selection errors.
- Direct equations, selector resolution, manager aggregation, and finite diagnostics tests.
- No torque/acceleration/power/limit/contact capability claims; no production task, event/reset, Hydra, runner, or IPC changes.

## Change accounting

- Source-derived term structure: ~90 lines.
- Mechanical Torch→NumPy/import conversion: ~35 lines.
- UniLab-specific validation/glue: ~18 lines.
- Tests: 216 lines.
- Modified existing: 34 lines; deleted: 0 files / 0 lines.

## Validation

- Focused: 28 passed.
- `make test-all`: 1,890 passed, 25 skipped, 1 xfailed; benchmark import smoke passed.
- ruff, mypy, and pyright passed.

Refs #1063
Umbrella: #1042