### PR TITLE
feat(env): add reset event state transaction

### DIFF
--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -774,6 +774,23 @@ class SimBackend(abc.ABC):
             f"{type(self).__name__} does not implement get_joint_dof_vel_indices"
         )
 
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        """Resolve single-DoF joints to full ``set_state`` qpos columns.
+
+        Unlike :meth:`get_joint_dof_pos_indices`, these indices address the
+        complete qpos vector accepted by :meth:`set_state`, including any root
+        coordinates.  Manager reset transactions resolve them on the cold path.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement get_joint_state_qpos_indices"
+        )
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        """Resolve single-DoF joints to full ``set_state`` qvel columns."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement get_joint_state_qvel_indices"
+        )
+
     def get_site_jacobian_w(
         self,
         site_id: int,

--- a/src/unilab/base/backend/drake/backend.py
+++ b/src/unilab/base/backend/drake/backend.py
@@ -431,6 +431,28 @@ class DrakeBackend(SimBackend):
                 raise ValueError(f"Drake model does not contain joint {key!r}") from exc
         return np.asarray(indices, dtype=np.int32)
 
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices: list[int] = []
+        for name in names:
+            key = str(name)
+            self._require_single_dof_joint(key)
+            try:
+                indices.append(self._joint_qpos_adr_by_name[key])
+            except KeyError as exc:
+                raise ValueError(f"Drake model does not contain joint {key!r}") from exc
+        return np.asarray(indices, dtype=np.int32)
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices: list[int] = []
+        for name in names:
+            key = str(name)
+            self._require_single_dof_joint(key)
+            try:
+                indices.append(self._joint_qvel_adr_by_name[key])
+            except KeyError as exc:
+                raise ValueError(f"Drake model does not contain joint {key!r}") from exc
+        return np.asarray(indices, dtype=np.int32)
+
     # Stepping and reset.
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict | None:
         # UniLab passes one actuator command per env. An optional pre-step hook

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -461,6 +461,14 @@ class MjwarpBackend(SimBackend):
 
         return self.get_joint_dof_indices(names) - self._root_qvel_dim
 
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        """Resolve named joints to full reset qpos columns."""
+        return self.get_joint_dof_pos_indices(names) + self._root_qpos_dim
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        """Resolve named joints to full reset qvel columns."""
+        return self.get_joint_dof_vel_indices(names) + self._root_qvel_dim
+
     def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
         """Expose immutable model defaults; this does not advertise gain DR support."""
         kp = np.asarray(self._cpu_model.actuator_gainprm[:, 0], dtype=np.float32).copy()

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -487,6 +487,14 @@ class MotrixBackend(SimBackend):
             indices.append(self._joint_dof_local_index(name, int(joint.dof_vel_index), pos=False))
         return np.array(indices, dtype=np.int32)
 
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices = [int(self._resolve_single_dof_joint(name).dof_pos_index) for name in names]
+        return np.asarray(indices, dtype=np.int32)
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        indices = [int(self._resolve_single_dof_joint(name).dof_vel_index) for name in names]
+        return np.asarray(indices, dtype=np.int32)
+
     def get_site_jacobian_w(
         self,
         site_id: int,

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -872,6 +872,12 @@ class MuJoCoBackend(SimBackend):
     def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
         return self.get_joint_dof_indices(names) - self._root_qvel_dim
 
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names) + self._root_qpos_dim
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_vel_indices(names) + self._root_qvel_dim
+
     def get_joint_range(self) -> np.ndarray | None:
         jnt_range = self._model.jnt_range
         mask = self._model.jnt_type != int(mujoco.mjtJoint.mjJNT_FREE)

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -19,6 +19,7 @@ from unilab.base.backend.base import SimBackend
 from unilab.utils.rotation import np_quat_apply_inverse, np_yaw_from_quat
 
 if TYPE_CHECKING:
+    from unilab.base.reset_state import ResetStateTransaction
     from unilab.base.scene import SceneCfg
 
 
@@ -395,11 +396,16 @@ class Entity:
         cfg: EntityCfg,
         backend: SimBackend,
         control_buffer: np.ndarray | None = None,
+        reset_state: ResetStateTransaction | None = None,
     ) -> None:
         if not name:
             raise ValueError("Entity name must be a non-empty string")
         self.name = name
         self._backend_type = backend.backend_type
+        self._backend = backend
+        self._reset_state = reset_state
+        self._reset_joint_qpos_ids: np.ndarray | None = None
+        self._reset_joint_qvel_ids: np.ndarray | None = None
 
         self._joint_names = _normalize_names(name, "joint", cfg.joint_names)
         self._body_names = _normalize_names(name, "body", cfg.body_names)
@@ -860,32 +866,10 @@ class Entity:
                 "joint position target",
                 "joint-to-actuator metadata was not materialized",
             )
-        if joint_ids is None:
-            local_joint_ids = np.arange(self.num_joints, dtype=np.intp)
-        elif isinstance(joint_ids, slice):
-            local_joint_ids = np.arange(self.num_joints, dtype=np.intp)[joint_ids]
-        else:
-            raw_joint_ids = np.asarray(joint_ids)
-            if (
-                raw_joint_ids.ndim != 1
-                or not np.issubdtype(raw_joint_ids.dtype, np.integer)
-                or np.issubdtype(raw_joint_ids.dtype, np.bool_)
-            ):
-                raise TypeError(
-                    f"Entity '{self.name}' joint position target joint_ids must be a 1-D "
-                    "integer array or slice"
-                )
-            local_joint_ids = np.asarray(raw_joint_ids, dtype=np.intp)
-        if np.any(local_joint_ids < 0) or np.any(local_joint_ids >= self.num_joints):
-            raise IndexError(
-                f"Entity '{self.name}' joint position target joint_ids out of range for "
-                f"{self.num_joints} joints: {local_joint_ids.tolist()}"
-            )
-        if np.unique(local_joint_ids).size != local_joint_ids.size:
-            raise ValueError(
-                f"Entity '{self.name}' joint position target joint_ids contain duplicates: "
-                f"{local_joint_ids.tolist()}"
-            )
+        local_joint_ids = self._normalize_local_joint_ids(
+            joint_ids,
+            capability="joint position target",
+        )
         actuator_ids = joint_to_actuator[local_joint_ids]
         if np.any(actuator_ids < 0):
             passive_names = [
@@ -896,6 +880,101 @@ class Entity:
                 f"for passive joints on backend '{self._backend_type}': {passive_names}"
             )
         self.data.write_ctrl(target, env_ids, actuator_ids=actuator_ids)
+
+    def write_joint_state_to_sim(
+        self,
+        position: np.ndarray,
+        velocity: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Stage community-style joint state writes in the active reset transaction."""
+        if self._reset_state is None:
+            raise self._capability_error(
+                "reset joint-state write",
+                "EntityScene was materialized without an env-owned reset transaction",
+            )
+        if self._joint_names is None:
+            raise self._capability_error(
+                "reset joint-state write",
+                "joint_names were not declared in EntityCfg",
+            )
+        local_joint_ids = self._normalize_local_joint_ids(
+            joint_ids,
+            capability="reset joint-state write",
+        )
+        resolved_env_ids = self._normalize_reset_env_ids(env_ids)
+        self._materialize_reset_joint_indices()
+        assert self._reset_joint_qpos_ids is not None
+        assert self._reset_joint_qvel_ids is not None
+        self._reset_state.write_joint_state(
+            resolved_env_ids,
+            self._reset_joint_qpos_ids[local_joint_ids],
+            self._reset_joint_qvel_ids[local_joint_ids],
+            position,
+            velocity,
+            term_name=f"{self.name}.write_joint_state_to_sim",
+        )
+
+    def _materialize_reset_joint_indices(self) -> None:
+        if self._reset_joint_qpos_ids is not None:
+            return
+        assert self._joint_names is not None
+        try:
+            qpos_ids = self._backend.get_joint_state_qpos_indices(self._joint_names)
+            qvel_ids = self._backend.get_joint_state_qvel_indices(self._joint_names)
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error("reset joint-state layout", str(exc)) from exc
+        self._reset_joint_qpos_ids = _readonly_ids(
+            qpos_ids,
+            expected=len(self._joint_names),
+            label=f"Entity '{self.name}' reset qpos",
+        )
+        self._reset_joint_qvel_ids = _readonly_ids(
+            qvel_ids,
+            expected=len(self._joint_names),
+            label=f"Entity '{self.name}' reset qvel",
+        )
+
+    def _normalize_local_joint_ids(
+        self,
+        joint_ids: np.ndarray | Sequence[int] | slice | None,
+        *,
+        capability: str,
+    ) -> np.ndarray:
+        if joint_ids is None:
+            ids = np.arange(self.num_joints, dtype=np.intp)
+        elif isinstance(joint_ids, slice):
+            ids = np.arange(self.num_joints, dtype=np.intp)[joint_ids]
+        else:
+            raw = np.asarray(joint_ids)
+            if (
+                raw.ndim != 1
+                or not np.issubdtype(raw.dtype, np.integer)
+                or np.issubdtype(raw.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self.name}' {capability} joint_ids must be a 1-D integer "
+                    "array or slice"
+                )
+            ids = np.asarray(raw, dtype=np.intp)
+        if np.any(ids < 0) or np.any(ids >= self.num_joints):
+            raise IndexError(
+                f"Entity '{self.name}' {capability} joint_ids out of range for "
+                f"{self.num_joints} joints: {ids.tolist()}"
+            )
+        if np.unique(ids).size != ids.size:
+            raise ValueError(
+                f"Entity '{self.name}' {capability} joint_ids contain duplicates: {ids.tolist()}"
+            )
+        return ids
+
+    def _normalize_reset_env_ids(self, env_ids: np.ndarray | slice | None) -> np.ndarray:
+        if env_ids is None:
+            return np.arange(self._backend.num_envs, dtype=np.int32)
+        if isinstance(env_ids, slice):
+            return np.arange(self._backend.num_envs, dtype=np.int32)[env_ids]
+        return env_ids
 
     def find_bodies(
         self, keys: str | Sequence[str], preserve_order: bool = False
@@ -962,6 +1041,8 @@ class EntityScene(Mapping[str, Entity]):
         entities: Mapping[str, EntityCfg],
         backend: SimBackend,
         control_buffer: np.ndarray | None = None,
+        *,
+        reset_state: ResetStateTransaction | None = None,
     ) -> None:
         materialized: dict[str, Entity] = {}
         for name, cfg in entities.items():
@@ -971,8 +1052,12 @@ class EntityScene(Mapping[str, Entity]):
                 raise TypeError(
                     f"Scene entity '{name}' must be EntityCfg, got {type(cfg).__name__}"
                 )
-            materialized[name] = Entity(name, cfg, backend, control_buffer)
+            materialized[name] = Entity(name, cfg, backend, control_buffer, reset_state)
         self._entities = MappingProxyType(materialized)
+        self._reset_state = reset_state
+        env_origins = np.zeros((backend.num_envs, 3), dtype=np.float32)
+        env_origins.setflags(write=False)
+        self._env_origins = env_origins
 
     @classmethod
     def from_scene_cfg(
@@ -980,8 +1065,34 @@ class EntityScene(Mapping[str, Entity]):
         cfg: SceneCfg,
         backend: SimBackend,
         control_buffer: np.ndarray | None = None,
+        *,
+        reset_state: ResetStateTransaction | None = None,
     ) -> EntityScene:
-        return cls(cfg.entities, backend, control_buffer)
+        return cls(cfg.entities, backend, control_buffer, reset_state=reset_state)
+
+    @property
+    def entities(self) -> Mapping[str, Entity]:
+        """Pinned community-style read-only entity mapping."""
+        return self._entities
+
+    @property
+    def env_origins(self) -> np.ndarray:
+        """Read-only per-environment origins; flat UniLab scenes default to zero."""
+        return self._env_origins
+
+    def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None:
+        """Stage a full-scene default state in the active reset transaction."""
+        if self._reset_state is None:
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' reset-state capability is unavailable: "
+                "EntityScene was materialized without an env-owned reset transaction"
+            )
+        if np.any(self._env_origins):
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' cannot apply non-zero env_origins without "
+                "a formal backend root-state layout"
+            )
+        self._reset_state.reset_to_default(env_ids, term_name=term_name)
 
     def __getitem__(self, name: str) -> Entity:
         try:

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -1,0 +1,337 @@
+"""Base-owned reset-state transaction for Manager-Based event terms.
+
+The transaction composes NumPy state writes in memory and hands the finished
+batch to :meth:`SimBackend.set_state` exactly once.  It deliberately knows
+nothing about task configuration, IPC, runners, or backend-private state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import numpy as np
+
+from unilab.base.backend.base import SimBackend
+
+
+class ResetStateTransaction:
+    """Reusable, fail-closed transaction for reset-mode state mutation."""
+
+    def __init__(self, backend: SimBackend) -> None:
+        self._backend = backend
+        self._num_envs = backend.num_envs
+        self._active = False
+        self._active_mask = np.zeros(self._num_envs, dtype=np.bool_)
+        self._dirty_mask = np.zeros(self._num_envs, dtype=np.bool_)
+        self._default_qpos: np.ndarray | None = None
+        self._default_qvel: np.ndarray | None = None
+        self._qpos: np.ndarray | None = None
+        self._qvel: np.ndarray | None = None
+        self._requesting_terms: set[str] = set()
+
+    @property
+    def active(self) -> bool:
+        """Whether a reset lifecycle currently owns the transaction."""
+        return self._active
+
+    @contextmanager
+    def scoped(self, env_ids: np.ndarray) -> Iterator[ResetStateTransaction]:
+        """Begin a reset transaction and commit it only after all terms succeed."""
+        self.begin(env_ids)
+        try:
+            yield self
+        except BaseException:
+            self.abort()
+            raise
+        else:
+            self.commit()
+
+    def begin(self, env_ids: np.ndarray) -> None:
+        """Open a transaction for the concrete reset environment IDs."""
+        if self._active:
+            raise RuntimeError("ManagerBased reset-state transaction is already active")
+        ids = self._validate_ids(env_ids, capability="begin")
+        self._active_mask.fill(False)
+        self._active_mask[ids] = True
+        self._dirty_mask.fill(False)
+        self._requesting_terms.clear()
+        self._active = True
+
+    def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None:
+        """Stage backend default qpos/qvel for a subset of the active reset."""
+        self._require_active()
+        ids = self._validate_ids(env_ids, capability="reset_to_default")
+        outside = ids[~self._active_mask[ids]]
+        if outside.size:
+            raise ValueError(
+                "EventManager term "
+                f"'{term_name}' attempted reset-state mutation outside the active reset: "
+                f"{outside.tolist()}"
+            )
+        if ids.size == 0:
+            return
+        self._requesting_terms.add(term_name)
+        self._materialize_default_state(term_name)
+        assert self._default_qpos is not None
+        assert self._default_qvel is not None
+        assert self._qpos is not None
+        assert self._qvel is not None
+        self._qpos[ids] = self._default_qpos
+        self._qvel[ids] = self._default_qvel
+        self._dirty_mask[ids] = True
+
+    def write_joint_state(
+        self,
+        env_ids: np.ndarray,
+        qpos_indices: np.ndarray,
+        qvel_indices: np.ndarray,
+        position: np.ndarray,
+        velocity: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected joint position and velocity columns in the reset batch."""
+        self._require_active()
+        ids = self._validate_ids(env_ids, capability="write_joint_state")
+        outside = ids[~self._active_mask[ids]]
+        if outside.size:
+            raise ValueError(
+                f"EventManager term '{term_name}' attempted joint-state mutation outside "
+                f"the active reset: {outside.tolist()}"
+            )
+        self._requesting_terms.add(term_name)
+        self._materialize_default_state(term_name)
+        assert self._default_qpos is not None
+        assert self._default_qvel is not None
+        assert self._qpos is not None
+        assert self._qvel is not None
+
+        pos_columns = self._validate_columns(
+            qpos_indices,
+            width=self._default_qpos.size,
+            capability="qpos indices",
+            term_name=term_name,
+        )
+        vel_columns = self._validate_columns(
+            qvel_indices,
+            width=self._default_qvel.size,
+            capability="qvel indices",
+            term_name=term_name,
+        )
+        if pos_columns.size != vel_columns.size:
+            raise ValueError(
+                f"EventManager term '{term_name}' joint-state qpos/qvel index counts differ: "
+                f"{pos_columns.size} != {vel_columns.size}"
+            )
+        positions = self._validate_values(
+            position,
+            shape=(ids.size, pos_columns.size),
+            capability="joint position",
+            term_name=term_name,
+        )
+        velocities = self._validate_values(
+            velocity,
+            shape=(ids.size, vel_columns.size),
+            capability="joint velocity",
+            term_name=term_name,
+        )
+
+        uninitialized = ids[~self._dirty_mask[ids]]
+        if uninitialized.size:
+            self._qpos[uninitialized] = self._default_qpos
+            self._qvel[uninitialized] = self._default_qvel
+        if ids.size and pos_columns.size:
+            self._qpos[ids[:, None], pos_columns[None, :]] = positions
+            self._qvel[ids[:, None], vel_columns[None, :]] = velocities
+        self._dirty_mask[ids] = True
+
+    def commit(self) -> dict | None:
+        """Commit all staged rows through one public backend call."""
+        self._require_active()
+        dirty_ids = np.flatnonzero(self._dirty_mask).astype(np.int32, copy=False)
+        try:
+            if dirty_ids.size == 0:
+                return None
+            assert self._qpos is not None
+            assert self._qvel is not None
+            try:
+                return self._backend.set_state(
+                    dirty_ids,
+                    self._qpos[dirty_ids],
+                    self._qvel[dirty_ids],
+                )
+            except (AttributeError, NotImplementedError) as exc:
+                terms = ", ".join(sorted(self._requesting_terms))
+                raise NotImplementedError(
+                    "EventManager reset-state capability 'SimBackend.set_state' is unavailable "
+                    f"for term(s) [{terms}] on backend '{self._backend.backend_type}': {exc}"
+                ) from exc
+        finally:
+            self._finish()
+
+    def abort(self) -> None:
+        """Discard staged rows without touching the backend."""
+        if self._active:
+            self._finish()
+
+    def _materialize_default_state(self, term_name: str) -> None:
+        if self._default_qpos is not None:
+            return
+        try:
+            qpos = self._backend.get_default_qpos()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error(term_name, "default qpos", exc) from exc
+        try:
+            qvel = self._backend.get_init_qvel()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error(term_name, "initial qvel", exc) from exc
+
+        default_qpos = self._validate_state_vector(qpos, "default qpos", term_name)
+        default_qvel = self._validate_state_vector(qvel, "initial qvel", term_name)
+        self._default_qpos = default_qpos
+        self._default_qvel = default_qvel
+        self._qpos = np.empty((self._num_envs, default_qpos.size), dtype=default_qpos.dtype)
+        self._qvel = np.empty((self._num_envs, default_qvel.size), dtype=default_qvel.dtype)
+
+    def _validate_state_vector(
+        self,
+        value: np.ndarray,
+        capability: str,
+        term_name: str,
+    ) -> np.ndarray:
+        if not isinstance(value, np.ndarray):
+            raise TypeError(
+                f"EventManager term '{term_name}' capability '{capability}' on backend "
+                f"'{self._backend.backend_type}' must return np.ndarray, got "
+                f"{type(value).__name__}"
+            )
+        if value.ndim != 1:
+            raise ValueError(
+                f"EventManager term '{term_name}' capability '{capability}' on backend "
+                f"'{self._backend.backend_type}' returned shape {value.shape}; expected 1-D"
+            )
+        if not np.issubdtype(value.dtype, np.floating):
+            raise TypeError(
+                f"EventManager term '{term_name}' capability '{capability}' on backend "
+                f"'{self._backend.backend_type}' must be floating, got {value.dtype}"
+            )
+        if not np.isfinite(value).all():
+            raise ValueError(
+                f"EventManager term '{term_name}' capability '{capability}' on backend "
+                f"'{self._backend.backend_type}' returned NaN or Inf"
+            )
+        result = np.array(value, copy=True)
+        result.setflags(write=False)
+        return result
+
+    def _validate_ids(self, env_ids: np.ndarray, *, capability: str) -> np.ndarray:
+        if not isinstance(env_ids, np.ndarray):
+            raise TypeError(
+                f"ManagerBased reset-state {capability} env_ids must be np.ndarray, "
+                f"got {type(env_ids).__name__}"
+            )
+        if (
+            env_ids.ndim != 1
+            or not np.issubdtype(env_ids.dtype, np.integer)
+            or np.issubdtype(env_ids.dtype, np.bool_)
+        ):
+            raise TypeError(
+                f"ManagerBased reset-state {capability} env_ids must be a 1-D integer "
+                f"np.ndarray, got shape={env_ids.shape}, dtype={env_ids.dtype}"
+            )
+        ids = np.asarray(env_ids, dtype=np.int32)
+        if np.any(ids < 0) or np.any(ids >= self._num_envs):
+            raise IndexError(
+                f"ManagerBased reset-state {capability} env_ids out of range for "
+                f"{self._num_envs} environments: {ids.tolist()}"
+            )
+        if np.unique(ids).size != ids.size:
+            raise ValueError(
+                f"ManagerBased reset-state {capability} env_ids contain duplicates: {ids.tolist()}"
+            )
+        return ids
+
+    def _validate_columns(
+        self,
+        values: np.ndarray,
+        *,
+        width: int,
+        capability: str,
+        term_name: str,
+    ) -> np.ndarray:
+        if not isinstance(values, np.ndarray):
+            raise TypeError(
+                f"EventManager term '{term_name}' {capability} must be np.ndarray, "
+                f"got {type(values).__name__}"
+            )
+        if (
+            values.ndim != 1
+            or not np.issubdtype(values.dtype, np.integer)
+            or np.issubdtype(values.dtype, np.bool_)
+        ):
+            raise TypeError(
+                f"EventManager term '{term_name}' {capability} must be a 1-D integer array"
+            )
+        columns = np.asarray(values, dtype=np.intp)
+        if np.any(columns < 0) or np.any(columns >= width):
+            raise IndexError(
+                f"EventManager term '{term_name}' {capability} out of range for width "
+                f"{width}: {columns.tolist()}"
+            )
+        if np.unique(columns).size != columns.size:
+            raise ValueError(
+                f"EventManager term '{term_name}' {capability} contain duplicates: "
+                f"{columns.tolist()}"
+            )
+        return columns
+
+    def _validate_values(
+        self,
+        values: np.ndarray,
+        *,
+        shape: tuple[int, int],
+        capability: str,
+        term_name: str,
+    ) -> np.ndarray:
+        if not isinstance(values, np.ndarray):
+            raise TypeError(
+                f"EventManager term '{term_name}' {capability} must be np.ndarray, "
+                f"got {type(values).__name__}"
+            )
+        if values.shape != shape:
+            raise ValueError(
+                f"EventManager term '{term_name}' {capability} has shape {values.shape}; "
+                f"expected {shape}"
+            )
+        if not np.issubdtype(values.dtype, np.floating):
+            raise TypeError(
+                f"EventManager term '{term_name}' {capability} must be floating, got {values.dtype}"
+            )
+        if not np.isfinite(values).all():
+            raise ValueError(f"EventManager term '{term_name}' {capability} contains NaN or Inf")
+        return values
+
+    def _capability_error(
+        self,
+        term_name: str,
+        capability: str,
+        exc: BaseException,
+    ) -> NotImplementedError:
+        return NotImplementedError(
+            f"EventManager term '{term_name}' reset-state capability '{capability}' is "
+            f"unavailable on backend '{self._backend.backend_type}': {exc}"
+        )
+
+    def _require_active(self) -> None:
+        if not self._active:
+            raise RuntimeError("ManagerBased reset-state mutation requires an active reset event")
+
+    def _finish(self) -> None:
+        self._active = False
+        self._active_mask.fill(False)
+        self._dirty_mask.fill(False)
+        self._requesting_terms.clear()
+
+
+__all__ = ["ResetStateTransaction"]

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -18,6 +18,7 @@ from unilab.base.backend import SimBackend
 from unilab.base.base import EnvCfg
 from unilab.base.entity import EntityScene
 from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.base.reset_state import ResetStateTransaction
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.managers import (
@@ -170,8 +171,14 @@ class ManagerBasedRlEnv(NpEnv):
         self.rng = np.random.default_rng(actual_seed)
 
         self._control = np.zeros((num_envs, backend.num_actuators), dtype=get_global_dtype())
+        self._reset_state = ResetStateTransaction(backend)
         assert cfg.scene is not None
-        self.scene = EntityScene.from_scene_cfg(cfg.scene, backend, self._control)
+        self.scene = EntityScene.from_scene_cfg(
+            cfg.scene,
+            backend,
+            self._control,
+            reset_state=self._reset_state,
+        )
 
         self.common_step_counter = 0
         self._sim_step_counter = 0
@@ -431,11 +438,12 @@ class ManagerBasedRlEnv(NpEnv):
         log: dict[str, Any] = {}
         self.curriculum_manager.compute(env_ids=ids)
         if "reset" in self.event_manager.available_modes:
-            self.event_manager.apply(
-                mode="reset",
-                env_ids=ids,
-                global_env_step_count=self.step_counter,
-            )
+            with self._reset_state.scoped(ids):
+                self.event_manager.apply(
+                    mode="reset",
+                    env_ids=ids,
+                    global_env_step_count=self.step_counter,
+                )
 
         for manager in (
             self.observation_manager,

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -4,6 +4,8 @@ from unilab.envs.mdp.actions import JointPositionAction as JointPositionAction
 from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActionCfg
 from unilab.envs.mdp.commands import UniformVelocityCommand as UniformVelocityCommand
 from unilab.envs.mdp.commands import UniformVelocityCommandCfg as UniformVelocityCommandCfg
+from unilab.envs.mdp.events import reset_scene_to_default as reset_scene_to_default
+from unilab.envs.mdp.events import resolve_env_ids as resolve_env_ids
 from unilab.envs.mdp.observations import base_ang_vel as base_ang_vel
 from unilab.envs.mdp.observations import base_lin_vel as base_lin_vel
 from unilab.envs.mdp.observations import generated_commands as generated_commands
@@ -48,6 +50,8 @@ __all__ = [
     "is_alive",
     "is_terminated",
     "projected_gravity",
+    "reset_scene_to_default",
+    "resolve_env_ids",
     "root_height_below_minimum",
     "time_out",
     "track_angular_velocity",

--- a/src/unilab/envs/mdp/events.py
+++ b/src/unilab/envs/mdp/events.py
@@ -1,0 +1,32 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/envs/mdp/events.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy reset transactions; Apache-2.0.
+"""Community-style reset event terms for UniLab's NumPy manager runtime."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+def resolve_env_ids(env: ManagerBasedRlEnv, env_ids: np.ndarray | None) -> np.ndarray:
+    """Return concrete NumPy environment IDs, preserving community sentinel semantics."""
+    if env_ids is None:
+        return np.arange(env.num_envs, dtype=np.int32)
+    return env_ids
+
+
+def reset_scene_to_default(env: ManagerBasedRlEnv, env_ids: np.ndarray | None) -> None:
+    """Reset all materialized scene entities to backend default qpos/qvel."""
+    ids = resolve_env_ids(env, env_ids)
+    if not env.scene.entities:
+        return
+    env.scene.reset_to_default(ids, term_name="reset_scene_to_default")
+
+
+__all__ = ["reset_scene_to_default", "resolve_env_ids"]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -7,7 +7,7 @@ an environment, backend, runner, or IPC implementation.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Protocol
 
 import numpy as np
@@ -126,11 +126,27 @@ class ManagerEntity(Protocol):
         self, keys: str | Sequence[str], preserve_order: bool = False
     ) -> tuple[list[int], list[str]]: ...
 
+    def write_joint_state_to_sim(
+        self,
+        position: np.ndarray,
+        velocity: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None: ...
+
 
 class ManagerScene(Protocol):
     """Minimal name-addressable scene surface consumed by managers."""
 
+    @property
+    def entities(self) -> Mapping[str, ManagerEntity]: ...
+
+    @property
+    def env_origins(self) -> np.ndarray: ...
+
     def __getitem__(self, name: str) -> ManagerEntity: ...
+
+    def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None: ...
 
 
 class ManagerActionTerm(Protocol):

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -135,6 +135,10 @@ def test_actuation_metadata_defaults_fail_closed() -> None:
         SimBackend.get_actuator_joint_names(object())  # type: ignore[arg-type]
     with pytest.raises(NotImplementedError, match="default DoF positions"):
         SimBackend.get_default_dof_pos(object())  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="get_joint_state_qpos_indices"):
+        SimBackend.get_joint_state_qpos_indices(object(), ("joint",))  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="get_joint_state_qvel_indices"):
+        SimBackend.get_joint_state_qvel_indices(object(), ("joint",))  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
@@ -153,6 +157,8 @@ def test_actuation_metadata_contract(backend_type: str) -> None:
     actuator_names = backend.get_actuator_names()
     target_joint_names = backend.get_actuator_joint_names()
     default_dof_pos = backend.get_default_dof_pos()
+    reset_qpos_ids = backend.get_joint_state_qpos_indices(target_joint_names)
+    reset_qvel_ids = backend.get_joint_state_qvel_indices(target_joint_names)
 
     assert len(actuator_names) == backend.num_actuators
     assert len(set(actuator_names)) == len(actuator_names)
@@ -162,7 +168,24 @@ def test_actuation_metadata_contract(backend_type: str) -> None:
     assert default_dof_pos.shape == backend.get_dof_pos().shape[1:]
     assert np.issubdtype(default_dof_pos.dtype, np.floating)
     assert np.isfinite(default_dof_pos).all()
+    assert reset_qpos_ids.shape == (backend.num_actuators,)
+    assert reset_qvel_ids.shape == (backend.num_actuators,)
+    assert np.issubdtype(reset_qpos_ids.dtype, np.integer)
+    assert np.issubdtype(reset_qvel_ids.dtype, np.integer)
+    assert np.unique(reset_qpos_ids).size == reset_qpos_ids.size
+    assert np.unique(reset_qvel_ids).size == reset_qvel_ids.size
+    assert np.all((reset_qpos_ids >= 0) & (reset_qpos_ids < backend.get_default_qpos().size))
+    assert np.all((reset_qvel_ids >= 0) & (reset_qvel_ids < backend.get_init_qvel().size))
     np.testing.assert_allclose(default_dof_pos, backend.get_dof_pos()[0], atol=1e-6)
+
+    qpos = np.broadcast_to(
+        backend.get_default_qpos(), (NUM_ENVS, backend.get_default_qpos().size)
+    ).copy()
+    qvel = np.broadcast_to(backend.get_init_qvel(), (NUM_ENVS, backend.get_init_qvel().size)).copy()
+    expected_joint_pos = np.broadcast_to(default_dof_pos + 0.01, (NUM_ENVS, default_dof_pos.size))
+    qpos[:, reset_qpos_ids] = expected_joint_pos
+    backend.set_state(np.arange(NUM_ENVS, dtype=np.int32), qpos, qvel)
+    np.testing.assert_allclose(backend.get_dof_pos(), expected_joint_pos, atol=1e-5)
 
     detached = default_dof_pos.copy()
     default_dof_pos[:] = np.nan

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -494,3 +494,16 @@ def test_scene_cfg_entity_defaults_are_not_shared() -> None:
     second = SceneCfg(model_file="second.xml")
     first.entities["robot"] = EntityCfg()
     assert second.entities == {}
+
+
+def test_scene_exposes_read_only_community_entities_and_zero_origins() -> None:
+    _, scene = _scene()
+
+    assert scene.entities["robot"] is scene["robot"]
+    with pytest.raises(TypeError):
+        scene.entities["other"] = scene["robot"]  # type: ignore[index]
+
+    assert scene.env_origins.shape == (3, 3)
+    np.testing.assert_array_equal(scene.env_origins, 0.0)
+    with pytest.raises(ValueError, match="read-only"):
+        scene.env_origins[0, 0] = 1.0

--- a/tests/base/test_reset_state.py
+++ b/tests/base/test_reset_state.py
@@ -1,0 +1,233 @@
+"""Focused tests for the base-owned Manager-Based reset transaction."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from unilab.base.backend.base import SimBackend
+from unilab.base.reset_state import ResetStateTransaction
+
+
+class _Backend:
+    backend_type = "fake"
+
+    def __init__(
+        self,
+        *,
+        qpos: Any = None,
+        qvel: Any = None,
+        fail_set_state: bool = False,
+    ) -> None:
+        self.num_envs = 4
+        self.qpos = np.array([1.0, 2.0, 3.0]) if qpos is None else qpos
+        self.qvel = np.array([0.0, 0.0]) if qvel is None else qvel
+        self.fail_set_state = fail_set_state
+        self.default_qpos_calls = 0
+        self.init_qvel_calls = 0
+        self.set_state_calls: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
+
+    def get_default_qpos(self):
+        self.default_qpos_calls += 1
+        return self.qpos
+
+    def get_init_qvel(self):
+        self.init_qvel_calls += 1
+        return self.qvel
+
+    def set_state(
+        self,
+        env_ids: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization=None,
+    ) -> dict:
+        assert randomization is None
+        if self.fail_set_state:
+            raise NotImplementedError("reset upload disabled")
+        self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
+        return {"timing": {"set_state_ms": 1.0}}
+
+
+def _transaction(backend: _Backend) -> ResetStateTransaction:
+    return ResetStateTransaction(cast(SimBackend, backend))
+
+
+def test_transaction_is_lazy_and_combines_terms_into_one_commit() -> None:
+    backend = _Backend()
+    transaction = _transaction(backend)
+
+    with transaction.scoped(np.array([0, 2, 3], dtype=np.int32)):
+        assert transaction.active
+    assert backend.default_qpos_calls == 0
+    assert backend.init_qvel_calls == 0
+    assert backend.set_state_calls == []
+
+    with transaction.scoped(np.array([0, 2, 3], dtype=np.int32)):
+        transaction.reset_to_default(
+            np.array([2], dtype=np.int32),
+            term_name="first",
+        )
+        transaction.reset_to_default(
+            np.array([3, 0], dtype=np.int32),
+            term_name="second",
+        )
+        assert backend.set_state_calls == []
+
+    assert not transaction.active
+    assert backend.default_qpos_calls == 1
+    assert backend.init_qvel_calls == 1
+    assert len(backend.set_state_calls) == 1
+    ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(ids, [0, 2, 3])
+    np.testing.assert_array_equal(qpos, np.tile(backend.qpos, (3, 1)))
+    np.testing.assert_array_equal(qvel, np.tile(backend.qvel, (3, 1)))
+
+    with transaction.scoped(np.array([1], dtype=np.int32)):
+        transaction.reset_to_default(np.array([1], dtype=np.int32), term_name="third")
+    assert backend.default_qpos_calls == 1
+    assert backend.init_qvel_calls == 1
+    assert len(backend.set_state_calls) == 2
+
+
+def test_exception_aborts_without_backend_mutation_and_next_reset_is_clean() -> None:
+    backend = _Backend()
+    transaction = _transaction(backend)
+
+    with pytest.raises(RuntimeError, match="term failed"):
+        with transaction.scoped(np.array([0, 1], dtype=np.int32)):
+            transaction.reset_to_default(np.array([0], dtype=np.int32), term_name="broken")
+            raise RuntimeError("term failed")
+
+    assert not transaction.active
+    assert backend.set_state_calls == []
+
+    with transaction.scoped(np.array([1], dtype=np.int32)):
+        transaction.reset_to_default(np.array([1], dtype=np.int32), term_name="healthy")
+    assert len(backend.set_state_calls) == 1
+    np.testing.assert_array_equal(backend.set_state_calls[0][0], [1])
+
+
+def test_joint_writes_initialize_defaults_and_compose_by_column() -> None:
+    backend = _Backend()
+    transaction = _transaction(backend)
+
+    with transaction.scoped(np.array([0, 2], dtype=np.int32)):
+        transaction.write_joint_state(
+            np.array([2, 0], dtype=np.int32),
+            np.array([1], dtype=np.int32),
+            np.array([0], dtype=np.int32),
+            np.array([[9.0], [8.0]], dtype=np.float32),
+            np.array([[-1.0], [-2.0]], dtype=np.float32),
+            term_name="robot.write_joint_state_to_sim",
+        )
+
+    ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(ids, [0, 2])
+    np.testing.assert_array_equal(qpos, [[1.0, 8.0, 3.0], [1.0, 9.0, 3.0]])
+    np.testing.assert_array_equal(qvel, [[-2.0, 0.0], [-1.0, 0.0]])
+
+
+@pytest.mark.parametrize(
+    ("position", "velocity", "error", "match"),
+    [
+        (np.zeros((1, 2)), np.zeros((1, 1)), ValueError, "joint position.*expected"),
+        (np.zeros((1, 1)), np.zeros((2, 1)), ValueError, "joint velocity.*expected"),
+        (np.zeros((1, 1), dtype=np.int32), np.zeros((1, 1)), TypeError, "must be floating"),
+        (np.full((1, 1), np.nan), np.zeros((1, 1)), ValueError, "NaN or Inf"),
+    ],
+)
+def test_joint_write_values_fail_closed(position, velocity, error, match: str) -> None:
+    transaction = _transaction(_Backend())
+    with pytest.raises(error, match=match):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.write_joint_state(
+                np.array([0], dtype=np.int32),
+                np.array([1], dtype=np.int32),
+                np.array([0], dtype=np.int32),
+                position,
+                velocity,
+                term_name="joint_term",
+            )
+
+
+def test_mutation_must_stay_inside_active_reset() -> None:
+    transaction = _transaction(_Backend())
+    with transaction.scoped(np.array([1, 2], dtype=np.int32)):
+        with pytest.raises(ValueError, match="outside the active reset.*3"):
+            transaction.reset_to_default(np.array([3], dtype=np.int32), term_name="bad")
+
+    with pytest.raises(RuntimeError, match="requires an active reset event"):
+        transaction.reset_to_default(np.array([1], dtype=np.int32), term_name="late")
+
+
+@pytest.mark.parametrize(
+    ("ids", "error", "match"),
+    [
+        ([0], TypeError, "must be np.ndarray"),
+        (np.array([[0]], dtype=np.int32), TypeError, "1-D integer"),
+        (np.array([True]), TypeError, "1-D integer"),
+        (np.array([-1], dtype=np.int32), IndexError, "out of range"),
+        (np.array([4], dtype=np.int32), IndexError, "out of range"),
+        (np.array([1, 1], dtype=np.int32), ValueError, "duplicates"),
+    ],
+)
+def test_begin_rejects_invalid_environment_ids(ids, error, match: str) -> None:
+    with pytest.raises(error, match=match):
+        _transaction(_Backend()).begin(ids)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error", "match"),
+    [
+        ("qpos", [1.0], TypeError, "default qpos.*np.ndarray"),
+        ("qpos", np.zeros((1, 1)), ValueError, "default qpos.*expected 1-D"),
+        ("qpos", np.array([1], dtype=np.int32), TypeError, "default qpos.*floating"),
+        ("qpos", np.array([np.nan]), ValueError, "default qpos.*NaN or Inf"),
+        ("qvel", np.array([np.inf]), ValueError, "initial qvel.*NaN or Inf"),
+    ],
+)
+def test_backend_default_state_contract_fails_at_mutation_boundary(
+    field: str,
+    value,
+    error,
+    match: str,
+) -> None:
+    kwargs = {field: value}
+    transaction = _transaction(_Backend(**kwargs))
+    with pytest.raises(error, match=match):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.reset_to_default(
+                np.array([0], dtype=np.int32),
+                term_name="reset_scene_to_default",
+            )
+    assert not transaction.active
+
+
+def test_missing_default_and_set_state_capabilities_name_term_and_backend() -> None:
+    missing = type("MissingBackend", (), {"num_envs": 1, "backend_type": "missing"})()
+    transaction = ResetStateTransaction(cast(SimBackend, missing))
+    with pytest.raises(
+        NotImplementedError,
+        match="EventManager term 'reset_scene_to_default'.*default qpos.*backend 'missing'",
+    ):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.reset_to_default(
+                np.array([0], dtype=np.int32),
+                term_name="reset_scene_to_default",
+            )
+
+    backend = _Backend(fail_set_state=True)
+    transaction = _transaction(backend)
+    with pytest.raises(
+        NotImplementedError,
+        match="SimBackend.set_state.*reset_scene_to_default.*backend 'fake'",
+    ):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.reset_to_default(
+                np.array([0], dtype=np.int32),
+                term_name="reset_scene_to_default",
+            )
+    assert not transaction.active

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -17,6 +17,7 @@ from unilab.envs import (
     ManagerBasedRlEnv,
     ManagerBasedRLEnvCfg,
     ManagerBasedRlEnvCfg,
+    mdp,
 )
 from unilab.managers import (
     ActionTerm,
@@ -72,6 +73,63 @@ class _FakeBackend:
 
     def cleanup_scene_assets(self) -> None:
         self.cleanup_calls += 1
+
+
+class _ResetBackend(_FakeBackend):
+    def __init__(self, num_envs: int) -> None:
+        super().__init__(num_envs)
+        self.default_qpos_calls = 0
+        self.init_qvel_calls = 0
+        self.joint_layout_calls = 0
+        self.set_state_calls: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
+
+    def get_default_qpos(self) -> np.ndarray:
+        self.default_qpos_calls += 1
+        return np.array([0.0, 0.0, 0.5, 0.0], dtype=np.float64)
+
+    def get_init_qvel(self) -> np.ndarray:
+        self.init_qvel_calls += 1
+        return np.array([0.0, 0.0, 0.0], dtype=np.float32)
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return ("joint",)
+
+    def get_joint_dof_pos_indices(self, names) -> np.ndarray:
+        assert tuple(names) == ("joint",)
+        return np.array([0], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names) -> np.ndarray:
+        assert tuple(names) == ("joint",)
+        return np.array([0], dtype=np.int32)
+
+    def get_joint_state_qpos_indices(self, names) -> np.ndarray:
+        assert tuple(names) == ("joint",)
+        self.joint_layout_calls += 1
+        return np.array([3], dtype=np.int32)
+
+    def get_joint_state_qvel_indices(self, names) -> np.ndarray:
+        assert tuple(names) == ("joint",)
+        self.joint_layout_calls += 1
+        return np.array([2], dtype=np.int32)
+
+    def get_dof_pos(self) -> np.ndarray:
+        return np.zeros((self.num_envs, 1), dtype=np.float32)
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.zeros((1,), dtype=np.float32)
+
+    def get_dof_vel(self) -> np.ndarray:
+        return np.zeros((self.num_envs, 1), dtype=np.float32)
+
+    def set_state(
+        self,
+        env_ids: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization=None,
+    ) -> None:
+        assert randomization is None
+        self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
 
 @dataclass(kw_only=True)
@@ -186,6 +244,22 @@ def _curriculum(env: _TestEnv, env_ids: np.ndarray | slice) -> float:
 def _event(env: _TestEnv, env_ids: np.ndarray | None) -> None:
     rendered_ids = None if env_ids is None else env_ids.tolist()
     env.trace.append(("event", rendered_ids))
+
+
+def _observe_uncommitted_reset(env: _TestEnv, env_ids: np.ndarray | None) -> None:
+    del env_ids
+    backend = cast(_ResetBackend, env._backend)
+    env.trace.append(("commit_count_during_event", len(backend.set_state_calls)))
+
+
+def _write_reset_joint_state(env: _TestEnv, env_ids: np.ndarray | None) -> None:
+    assert env_ids is not None
+    count = len(env_ids)
+    env.scene["robot"].write_joint_state_to_sim(
+        np.full((count, 1), 0.25, dtype=np.float32),
+        np.full((count, 1), -0.5, dtype=np.float32),
+        env_ids=env_ids,
+    )
 
 
 def _make_cfg(
@@ -340,6 +414,57 @@ def test_np_env_owns_substeps_autoreset_and_final_observation() -> None:
     post_step_index = len(env.trace) - 1
     assert env.trace[post_step_index] == "post_step"
     assert pre_index < post_reset_index < post_step_index
+
+
+def test_reset_events_compose_then_commit_default_state_once() -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.events = {
+        "default_first": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset"),
+        "joint_state": EventTermCfg(func=_write_reset_joint_state, mode="reset"),
+        "observe_uncommitted": EventTermCfg(func=_observe_uncommitted_reset, mode="reset"),
+    }
+    cfg.scene.entities["robot"] = EntityCfg(
+        joint_names=("joint",),
+        actuator_names=("motor",),
+    )
+    backend = _ResetBackend(2)
+    env = _TestEnv(cfg, cast(SimBackend, backend), 2)
+
+    assert backend.default_qpos_calls == 0
+    assert backend.init_qvel_calls == 0
+    assert backend.joint_layout_calls == 0
+    env.reset()
+
+    assert env.trace[-1] == ("commit_count_during_event", 0)
+    assert backend.default_qpos_calls == 1
+    assert backend.init_qvel_calls == 1
+    assert len(backend.set_state_calls) == 1
+    ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(ids, [0, 1])
+    np.testing.assert_array_equal(
+        qpos,
+        [[0.0, 0.0, 0.5, 0.25], [0.0, 0.0, 0.5, 0.25]],
+    )
+    np.testing.assert_array_equal(qvel, [[0.0, 0.0, -0.5], [0.0, 0.0, -0.5]])
+    assert backend.joint_layout_calls == 2
+
+    env.reset(env_ids=np.array([1], dtype=np.int32))
+    assert ("commit_count_during_event", 1) in env.trace
+    assert len(backend.set_state_calls) == 2
+    np.testing.assert_array_equal(backend.set_state_calls[1][0], [1])
+    assert backend.default_qpos_calls == 1
+    assert backend.init_qvel_calls == 1
+    assert backend.joint_layout_calls == 2
+
+
+def test_pure_reset_event_does_not_request_backend_state_capability() -> None:
+    env, backend = _make_env()
+
+    env.reset()
+    env.reset(env_ids=np.array([0], dtype=np.int32))
+
+    assert isinstance(backend, _FakeBackend)
+    assert not hasattr(backend, "get_default_qpos")
 
 
 def test_partial_reset_preserves_other_env_counter_and_terminal_obs() -> None:


### PR DESCRIPTION
## Result

Adds the formal, base-owned NumPy reset-state transaction used by reset-mode `EventManager` terms. Requested state writes compose in memory and reach `SimBackend.set_state` exactly once after all terms succeed; failures abort without backend mutation.

## Contract

- `reset_scene_to_default` is the first pinned-mjlab-aligned event term.
- `Entity.write_joint_state_to_sim` stages community-style joint writes in the same transaction.
- MuJoCo, Motrix, Drake, and mjwarp expose explicit full-qpos/qvel joint-column metadata through `SimBackend`.
- `EntityScene.entities` and zero `env_origins` are read-only community surfaces.
- State capability remains lazy: empty/pure scheduling events do not request default-state or `set_state` support.
- IDs, shapes, dtypes, finite values, mapping, and missing capabilities fail at the reset boundary with manager/term/backend context.

## Scope exclusions

No root/uniform randomization, DR payload/model mutation, interval perturbation, production task, Hydra, sensor, runner, learner, or IPC changes. The legacy DR warning/filter path is not reused.

## Change accounting

- Source-derived public term/entity structure: ~35 lines.
- Mechanical Torch→NumPy/signature conversion: ~20 lines.
- UniLab-specific contract/glue: ~545 lines.
- Tests: 394 lines.
- 15 files total: 12 modified + 3 added; 34 deleted/replaced lines; 0 deleted files.

## Validation

- Focused owner/backend/lifecycle suites: 161 passed, 15 skipped (optional backends), 224 deselected.
- Exact final commit `make test-all`: 1,913 passed, 25 skipped, 1 xfailed; benchmark import smoke passed.
- ruff, mypy, and pyright passed.
- Final worktree clean before push.

Refs #1066
Umbrella: #1042
