### PR TITLE
feat(config): add manager term overlays

### DIFF
--- a/src/unilab/base/config_overrides.py
+++ b/src/unilab/base/config_overrides.py
@@ -1,0 +1,11 @@
+"""Metadata shared by config owners and the registry override engine."""
+
+CONFIG_MAPPING_POLICY_KEY = "unilab_config_mapping_policy"
+MANAGER_TERM_MAPPING_POLICY = "manager_terms"
+MANAGER_PARAMS_MAPPING_POLICY = "manager_params"
+
+__all__ = [
+    "CONFIG_MAPPING_POLICY_KEY",
+    "MANAGER_PARAMS_MAPPING_POLICY",
+    "MANAGER_TERM_MAPPING_POLICY",
+]

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -18,6 +18,11 @@ from typing import (
 )
 
 from .base import ABEnv, EnvCfg
+from .config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_PARAMS_MAPPING_POLICY,
+    MANAGER_TERM_MAPPING_POLICY,
+)
 
 TEnvCfg = TypeVar("TEnvCfg", bound=EnvCfg)
 _SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
@@ -162,6 +167,86 @@ def _construct_dataclass_from_dict(target_type: Type[Any], values: Dict[str, Any
     return target_obj
 
 
+def _config_mapping_policy(target_obj: Any, field_name: str) -> str | None:
+    if not dataclasses.is_dataclass(target_obj) or isinstance(target_obj, type):
+        return None
+    for config_field in dataclasses.fields(target_obj):
+        if config_field.name == field_name:
+            policy = config_field.metadata.get(CONFIG_MAPPING_POLICY_KEY)
+            return str(policy) if policy is not None else None
+    return None
+
+
+def _is_manager_callable_term_cfg(target_obj: Any) -> bool:
+    if not dataclasses.is_dataclass(target_obj) or isinstance(target_obj, type):
+        return False
+    return any(
+        config_field.metadata.get(CONFIG_MAPPING_POLICY_KEY) == MANAGER_PARAMS_MAPPING_POLICY
+        for config_field in dataclasses.fields(target_obj)
+    )
+
+
+def _apply_manager_mapping_overrides(
+    target_obj: Any,
+    field_name: str,
+    existing: Any,
+    overrides: Any,
+    *,
+    policy: str,
+) -> None:
+    owner = f"{type(target_obj).__name__}.{field_name}"
+    if not isinstance(existing, dict):
+        raise TypeError(
+            f"Config field '{owner}' declares manager mapping policy but contains "
+            f"{type(existing).__name__}, expected dict"
+        )
+    if not isinstance(overrides, dict):
+        raise TypeError(
+            f"Config field '{owner}' must be overridden by a mapping, not "
+            f"{type(overrides).__name__}"
+        )
+
+    if policy == MANAGER_PARAMS_MAPPING_POLICY:
+        for param_name, value in overrides.items():
+            current = existing.get(param_name)
+            if isinstance(value, dict) and dataclasses.is_dataclass(current):
+                apply_cfg_overrides(current, value)
+            else:
+                existing[param_name] = value
+        return
+
+    if policy != MANAGER_TERM_MAPPING_POLICY:
+        raise ValueError(f"Config field '{owner}' has unknown mapping policy {policy!r}")
+
+    for term_name, value in overrides.items():
+        if term_name not in existing:
+            raise ValueError(
+                f"Config field '{owner}' has no factory-owned term '{term_name}'; "
+                "declare its callable/config in the task Python factory first"
+            )
+        if value is None:
+            existing[term_name] = None
+            continue
+
+        current = existing[term_name]
+        if current is None:
+            raise ValueError(
+                f"Config field '{owner}' term '{term_name}' is disabled; set a concrete "
+                "config in the task Python factory before overriding its fields"
+            )
+        if not dataclasses.is_dataclass(current):
+            raise TypeError(
+                f"Config field '{owner}' term '{term_name}' contains "
+                f"{type(current).__name__}, expected a dataclass config"
+            )
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"Config field '{owner}' term '{term_name}' must be overridden by a "
+                "field mapping or None; replacing the factory-owned term is not allowed"
+            )
+        apply_cfg_overrides(current, value)
+
+
 def apply_cfg_overrides(target_obj: Any, overrides: Dict[str, Any]) -> None:
     """Apply a (possibly nested) dict of overrides to ``target_obj`` in place.
 
@@ -176,6 +261,9 @@ def apply_cfg_overrides(target_obj: Any, overrides: Dict[str, Any]) -> None:
       - If ``value`` is a dict and ``target_obj.key`` is currently ``None``,
         instantiate the field's annotated dataclass type from the dict
         (full-construction path).
+      - Fields explicitly marked as manager mappings merge only existing
+        factory-owned entries. ``None`` disables an entry; unknown entries and
+        callable/config replacement fail closed.
       - Otherwise ``setattr`` the value directly (scalar / list / non-dataclass).
     """
     try:
@@ -187,6 +275,21 @@ def apply_cfg_overrides(target_obj: Any, overrides: Dict[str, Any]) -> None:
         if not hasattr(target_obj, key):
             raise ValueError(f"Config class '{type(target_obj).__name__}' has no attribute '{key}'")
         existing = getattr(target_obj, key)
+        mapping_policy = _config_mapping_policy(target_obj, key)
+        if mapping_policy is not None:
+            _apply_manager_mapping_overrides(
+                target_obj,
+                key,
+                existing,
+                value,
+                policy=mapping_policy,
+            )
+            continue
+        if key == "func" and _is_manager_callable_term_cfg(target_obj):
+            raise ValueError(
+                f"Config field '{type(target_obj).__name__}.func' is factory-owned and "
+                "cannot be overridden"
+            )
         if isinstance(value, dict):
             if dataclasses.is_dataclass(existing) and not isinstance(existing, type):
                 apply_cfg_overrides(existing, value)

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -16,6 +16,10 @@ import numpy as np
 
 from unilab.base.backend import SimBackend
 from unilab.base.base import EnvCfg
+from unilab.base.config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_TERM_MAPPING_POLICY,
+)
 from unilab.base.entity import EntityScene
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.reset_state import ResetStateTransaction
@@ -47,6 +51,13 @@ from unilab.managers import (
 )
 
 
+def _manager_terms_field() -> Any:
+    return field(
+        default_factory=dict,
+        metadata={CONFIG_MAPPING_POLICY_KEY: MANAGER_TERM_MAPPING_POLICY},
+    )
+
+
 @dataclass
 class ManagerBasedRlEnvCfg(EnvCfg):
     """Configuration for the manager-based NumPy environment.
@@ -55,15 +66,15 @@ class ManagerBasedRlEnvCfg(EnvCfg):
     configs can overlay them without introducing a second configuration runtime.
     """
 
-    observations: dict[str, ObservationGroupCfg | None] = field(default_factory=dict)
-    actions: dict[str, ActionTermCfg | None] = field(default_factory=dict)
-    events: dict[str, EventTermCfg | None] = field(default_factory=dict)
-    rewards: dict[str, RewardTermCfg | None] = field(default_factory=dict)
-    terminations: dict[str, TerminationTermCfg | None] = field(default_factory=dict)
-    commands: dict[str, CommandTermCfg | None] = field(default_factory=dict)
-    curriculum: dict[str, CurriculumTermCfg | None] = field(default_factory=dict)
-    metrics: dict[str, MetricsTermCfg | None] = field(default_factory=dict)
-    recorders: dict[str, RecorderTermCfg | None] = field(default_factory=dict)
+    observations: dict[str, ObservationGroupCfg | None] = _manager_terms_field()
+    actions: dict[str, ActionTermCfg | None] = _manager_terms_field()
+    events: dict[str, EventTermCfg | None] = _manager_terms_field()
+    rewards: dict[str, RewardTermCfg | None] = _manager_terms_field()
+    terminations: dict[str, TerminationTermCfg | None] = _manager_terms_field()
+    commands: dict[str, CommandTermCfg | None] = _manager_terms_field()
+    curriculum: dict[str, CurriculumTermCfg | None] = _manager_terms_field()
+    metrics: dict[str, MetricsTermCfg | None] = _manager_terms_field()
+    recorders: dict[str, RecorderTermCfg | None] = _manager_terms_field()
 
     seed: int | None = None
     is_finite_horizon: bool = False

--- a/src/unilab/managers/manager_base.py
+++ b/src/unilab/managers/manager_base.py
@@ -11,6 +11,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from unilab.base.config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_PARAMS_MAPPING_POLICY,
+)
 from unilab.managers.scene_entity_config import SceneEntityCfg
 
 if TYPE_CHECKING:
@@ -60,7 +64,10 @@ class ManagerTermBaseCfg:
     """The callable that computes this term's value. Can be a function or a class.
   Classes are auto-instantiated with ``(cfg=term_cfg, env=env)``."""
 
-    params: dict[str, Any] = field(default_factory=lambda: {})
+    params: dict[str, Any] = field(
+        default_factory=dict,
+        metadata={CONFIG_MAPPING_POLICY_KEY: MANAGER_PARAMS_MAPPING_POLICY},
+    )
     """Additional keyword arguments passed to func when called."""
 
 

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -6,12 +6,16 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, Sequence
 
 import numpy as np
 from prettytable import PrettyTable
 
+from unilab.base.config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_TERM_MAPPING_POLICY,
+)
 from unilab.managers._buffers import CircularBuffer, DelayBuffer
 from unilab.managers._noise import noise_cfg, noise_model
 from unilab.managers._noise.noise_cfg import NoiseCfg, NoiseModelCfg
@@ -81,7 +85,9 @@ class ObservationGroupCfg:
     for the actor, "critic" for the value function).
     """
 
-    terms: dict[str, ObservationTermCfg | None]
+    terms: dict[str, ObservationTermCfg | None] = field(
+        metadata={CONFIG_MAPPING_POLICY_KEY: MANAGER_TERM_MAPPING_POLICY}
+    )
     """Dictionary mapping term names to their configurations."""
 
     concatenate_terms: bool = True

--- a/tests/base/test_manager_config_overlay.py
+++ b/tests/base/test_manager_config_overlay.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pytest
+
+from unilab.base.registry import apply_cfg_overrides
+from unilab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg
+from unilab.envs.mdp import JointPositionActionCfg
+from unilab.managers import (
+    EventTermCfg,
+    ObservationGroupCfg,
+    ObservationTermCfg,
+    RewardTermCfg,
+    SceneEntityCfg,
+)
+
+
+def _first_term(_env, *, command_name: str, std: float) -> np.ndarray:
+    del command_name, std
+    return np.zeros(1, dtype=np.float32)
+
+
+def _second_term(_env) -> np.ndarray:
+    return np.zeros(1, dtype=np.float32)
+
+
+def _manager_cfg() -> ManagerBasedRlEnvCfg:
+    return ManagerBasedRlEnvCfg(
+        observations={
+            "policy": ObservationGroupCfg(
+                terms={
+                    "first": ObservationTermCfg(func=_first_term),
+                    "second": ObservationTermCfg(func=_second_term),
+                }
+            )
+        },
+        actions={
+            "joint_pos": JointPositionActionCfg(
+                entity_name="robot",
+                actuator_names=(".*",),
+                scale=0.25,
+            )
+        },
+        events={
+            "reset": EventTermCfg(
+                func=_first_term,
+                mode="reset",
+                params={"command_name": "twist", "std": 0.5},
+            )
+        },
+        rewards={
+            "tracking": RewardTermCfg(
+                func=_first_term,
+                weight=1.0,
+                params={
+                    "command_name": "twist",
+                    "std": 0.5,
+                    "asset_cfg": SceneEntityCfg("robot", joint_names=".*"),
+                },
+            ),
+            "alive": RewardTermCfg(func=_second_term, weight=0.1),
+            "disabled": None,
+        },
+    )
+
+
+def test_manager_mapping_overlay_preserves_factory_terms_and_order() -> None:
+    cfg = _manager_cfg()
+    reward_func = cfg.rewards["tracking"].func
+
+    apply_cfg_overrides(
+        cfg,
+        {
+            "rewards": {
+                "tracking": {
+                    "weight": 2.0,
+                    "params": {"std": 0.25, "asset_cfg": {"preserve_order": True}},
+                },
+                "alive": None,
+            },
+            "events": {"reset": {"min_step_count_between_reset": 3}},
+            "actions": {"joint_pos": {"scale": 0.4}},
+        },
+    )
+
+    tracking = cfg.rewards["tracking"]
+    assert tracking is not None
+    assert tracking.func is reward_func
+    assert tracking.weight == pytest.approx(2.0)
+    assert tracking.params["command_name"] == "twist"
+    assert tracking.params["std"] == pytest.approx(0.25)
+    assert tracking.params["asset_cfg"].joint_names == ".*"
+    assert tracking.params["asset_cfg"].preserve_order is True
+    assert cfg.rewards["alive"] is None
+    assert list(cfg.rewards) == ["tracking", "alive", "disabled"]
+    reset = cfg.events["reset"]
+    assert reset is not None
+    assert reset.func is _first_term
+    assert reset.min_step_count_between_reset == 3
+    action = cfg.actions["joint_pos"]
+    assert action is not None
+    assert action.entity_name == "robot"
+    assert action.actuator_names == (".*",)
+    assert action.scale == pytest.approx(0.4)
+
+
+def test_observation_group_and_term_overlay_preserve_siblings() -> None:
+    cfg = _manager_cfg()
+
+    apply_cfg_overrides(
+        cfg,
+        {
+            "observations": {
+                "policy": {
+                    "enable_corruption": True,
+                    "terms": {"first": {"scale": 2.0}, "second": None},
+                }
+            }
+        },
+    )
+
+    policy = cfg.observations["policy"]
+    assert policy is not None
+    assert policy.enable_corruption is True
+    first = policy.terms["first"]
+    assert first is not None
+    assert first.func is _first_term
+    assert first.scale == pytest.approx(2.0)
+    assert policy.terms["second"] is None
+    assert list(policy.terms) == ["first", "second"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"rewards": {"missing": {"weight": 1.0}}}, "rewards.*missing"),
+        ({"rewards": {"disabled": {"weight": 1.0}}}, "disabled.*task Python factory"),
+        ({"rewards": {"tracking": _second_term}}, "tracking.*replacing"),
+        ({"rewards": []}, "rewards.*mapping"),
+        ({"rewards": {"tracking": {"func": _second_term}}}, "func.*factory-owned"),
+    ],
+)
+def test_manager_mapping_overlay_fails_closed(overrides: dict, match: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        apply_cfg_overrides(_manager_cfg(), overrides)
+
+
+@dataclass
+class _LegacyCfg:
+    reward_config: dict[str, object] = field(
+        default_factory=lambda: {
+            "scales": {"tracking": 1.0, "alive": 0.1},
+            "tracking_sigma": 0.25,
+        }
+    )
+
+
+def test_legacy_plain_dict_keeps_replacement_semantics() -> None:
+    cfg = _LegacyCfg()
+
+    apply_cfg_overrides(cfg, {"reward_config": {"scales": {"alive": 1.0}}})
+
+    assert cfg.reward_config == {"scales": {"alive": 1.0}}


### PR DESCRIPTION
## Summary

- add explicit dataclass metadata for Manager-Based term and parameter mappings
- overlay only factory-owned manager/group/term fields while preserving callables, sibling terms, nested dataclass parameters, and insertion order
- treat `null` / `None` as term disablement and fail closed for unknown terms, disabled-term enablement, raw replacement, or `func` overrides
- preserve the registry's existing replacement semantics for ordinary unmarked dictionaries

Implements #1068.
Part of #1042.

## Scope accounting

- source-derived code: 0 lines
- mechanical changes: dataclass metadata plumbing only (about 30 lines)
- UniLab-specific implementation/glue: about 150 added lines
- tests: 165 added lines
- files changed: 6

## Validation

- `uv run pytest tests/base/test_manager_config_overlay.py -q`: 8 passed
- broader manager suite: 107 passed
- `make test-all`:
  - ruff, mypy, pyright passed
  - pytest: 1921 passed, 25 skipped, 274 deselected, 1 xfailed
  - benchmark module mode: 32/33 passed, 1 platform-optional skip
  - benchmark script mode: 33/34 passed, 1 platform-optional skip
