### PR TITLE
feat(config): route manager reward overrides

### DIFF
--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -25,6 +26,7 @@ from .config_overrides import (
 )
 
 TEnvCfg = TypeVar("TEnvCfg", bound=EnvCfg)
+RewardOverrideField = Literal["reward_config", "rewards"]
 _SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 _REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"
@@ -139,6 +141,44 @@ def find_available_sim_backend(env_name: str) -> str:
     if backend is None:
         raise ValueError(f"Environment '{env_name}' does not support any simulation backend.")
     return backend
+
+
+def resolve_reward_override_field(env_name: str) -> RewardOverrideField:
+    """Resolve the Hydra root reward target declared by an env config owner.
+
+    Legacy configs own a ``reward_config`` field. Manager-Based configs opt in
+    through the explicit manager-term mapping metadata on ``rewards``. The
+    registry resolves this on the config class without constructing an env or
+    backend so training adapters do not branch on task names.
+    """
+    if env_name not in _envs:
+        raise ValueError(f"Environment '{env_name}' is not registered.")
+
+    config_cls = _envs[env_name].env_cfg_cls
+    config_fields = {
+        config_field.name: config_field for config_field in dataclasses.fields(config_cls)
+    }
+    rewards_field = config_fields.get("rewards")
+    has_manager_rewards = (
+        rewards_field is not None
+        and rewards_field.metadata.get(CONFIG_MAPPING_POLICY_KEY) == MANAGER_TERM_MAPPING_POLICY
+    )
+    has_legacy_rewards = "reward_config" in config_fields
+
+    if has_manager_rewards and has_legacy_rewards:
+        raise ValueError(
+            f"Environment '{env_name}' config owner '{config_cls.__name__}' declares both "
+            "Manager-Based 'rewards' and legacy 'reward_config' targets"
+        )
+    if has_manager_rewards:
+        return "rewards"
+    if has_legacy_rewards:
+        return "reward_config"
+    raise ValueError(
+        f"Environment '{env_name}' config owner '{config_cls.__name__}' declares no "
+        "supported Hydra root reward target; expected legacy 'reward_config' or an "
+        "explicitly marked Manager-Based 'rewards' field"
+    )
 
 
 def _resolve_dataclass_type(type_hint: Any) -> Optional[Type[Any]]:

--- a/src/unilab/training/backend_adapter.py
+++ b/src/unilab/training/backend_adapter.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from omegaconf import DictConfig, OmegaConf
 
+from unilab.base import registry
 from unilab.base.backend import materialize_scene_visual_override
 from unilab.base.scene import SceneCfg
 from unilab.training.reward import extract_reward_config
@@ -30,8 +31,18 @@ class BackendAdapter:
 
     def build_task_env_cfg_override(self) -> dict[str, Any]:
         """Build env_cfg_override from the resolved reward + env sections."""
-        env_cfg_override = extract_reward_config(self.cfg)
-        env_cfg_override.update(self._to_plain_dict(getattr(self.cfg, "env", None)))
+        registry.ensure_registries()
+        task_name = str(self.cfg.training.task_name)
+        reward_target = registry.resolve_reward_override_field(task_name)
+        env_overrides = self._to_plain_dict(getattr(self.cfg, "env", None))
+        if reward_target in env_overrides:
+            raise ValueError(
+                f"Task '{task_name}' declares both Hydra root 'reward' and "
+                f"'env.{reward_target}'; use the root reward owner only"
+            )
+
+        env_cfg_override = extract_reward_config(self.cfg, target_field=reward_target)
+        env_cfg_override.update(env_overrides)
 
         return env_cfg_override
 

--- a/src/unilab/training/reward.py
+++ b/src/unilab/training/reward.py
@@ -39,16 +39,24 @@ def resolve_reward_dict(cfg: DictConfig) -> RewardDict:
     return reward_dict
 
 
-def extract_reward_config(cfg: DictConfig) -> dict[str, RewardDict]:
+def extract_reward_config(
+    cfg: DictConfig,
+    *,
+    target_field: str = "reward_config",
+) -> dict[str, RewardDict]:
     """Extract and validate reward config from Hydra config.
 
     Args:
         cfg: Hydra DictConfig containing reward section
 
     Returns:
-        Dictionary with reward_config key for env_cfg_override
+        Dictionary with ``target_field`` as the env config override key.
 
     Raises:
         ValueError: If reward config is missing
     """
-    return {"reward_config": resolve_reward_dict(cfg)}
+    if target_field not in {"reward_config", "rewards"}:
+        raise ValueError(
+            f"Reward config target_field must be 'reward_config' or 'rewards', got {target_field!r}"
+        )
+    return {target_field: resolve_reward_dict(cfg)}

--- a/tests/config/test_manager_reward_routing.py
+++ b/tests/config/test_manager_reward_routing.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pytest
+from omegaconf import OmegaConf
+
+from unilab.base import registry
+from unilab.base.base import EnvCfg
+from unilab.base.config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_TERM_MAPPING_POLICY,
+)
+from unilab.base.registry import apply_cfg_overrides
+from unilab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg
+from unilab.managers import RewardTermCfg
+from unilab.training.backend_adapter import BackendAdapter
+
+_MANAGER_ENV = "_TestManagerRewardRoute"
+_LEGACY_ENV = "_TestLegacyRewardRoute"
+_MISSING_ENV = "_TestMissingRewardRoute"
+_AMBIGUOUS_ENV = "_TestAmbiguousRewardRoute"
+
+
+@dataclass
+class _LegacyCfg(EnvCfg):
+    reward_config: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class _MissingCfg(EnvCfg):
+    pass
+
+
+@dataclass
+class _AmbiguousCfg(EnvCfg):
+    reward_config: dict[str, object] = field(default_factory=dict)
+    rewards: dict[str, object] = field(
+        default_factory=dict,
+        metadata={CONFIG_MAPPING_POLICY_KEY: MANAGER_TERM_MAPPING_POLICY},
+    )
+
+
+for _name, _cfg_cls in (
+    (_MANAGER_ENV, ManagerBasedRlEnvCfg),
+    (_LEGACY_ENV, _LegacyCfg),
+    (_MISSING_ENV, _MissingCfg),
+    (_AMBIGUOUS_ENV, _AmbiguousCfg),
+):
+    if not registry.contains(_name):
+        registry.register_env_config(_name, _cfg_cls)
+
+
+def _reward(_env, *, std: float) -> np.ndarray:
+    del std
+    return np.zeros(1, dtype=np.float32)
+
+
+def _alive(_env) -> np.ndarray:
+    return np.ones(1, dtype=np.float32)
+
+
+def _cfg(task_name: str, *, env: dict[str, object] | None = None):
+    return OmegaConf.create(
+        {
+            "training": {"task_name": task_name},
+            "reward": {
+                "tracking": {
+                    "weight": 2.0,
+                    "params": {"std": 0.25},
+                }
+            },
+            "env": env or {"ctrl_dt": 0.02},
+        }
+    )
+
+
+def test_backend_adapter_routes_manager_reward_and_preserves_factory_terms() -> None:
+    override = BackendAdapter(
+        _cfg(_MANAGER_ENV),
+        root_dir=Path("."),
+    ).build_task_env_cfg_override()
+
+    assert "reward_config" not in override
+    assert override["rewards"]["tracking"]["weight"] == pytest.approx(2.0)
+    assert override["ctrl_dt"] == pytest.approx(0.02)
+
+    manager_cfg = ManagerBasedRlEnvCfg(
+        rewards={
+            "tracking": RewardTermCfg(func=_reward, weight=1.0, params={"std": 0.5}),
+            "alive": RewardTermCfg(func=_alive, weight=0.1),
+        }
+    )
+    factory_tracking = manager_cfg.rewards["tracking"]
+    assert factory_tracking is not None
+    tracking_func = factory_tracking.func
+
+    apply_cfg_overrides(manager_cfg, override)
+
+    tracking = manager_cfg.rewards["tracking"]
+    assert tracking is not None
+    assert tracking.func is tracking_func
+    assert tracking.weight == pytest.approx(2.0)
+    assert tracking.params == {"std": 0.25}
+    assert manager_cfg.rewards["alive"] is not None
+    assert list(manager_cfg.rewards) == ["tracking", "alive"]
+
+
+def test_backend_adapter_preserves_legacy_reward_target() -> None:
+    override = BackendAdapter(
+        _cfg(_LEGACY_ENV),
+        root_dir=Path("."),
+    ).build_task_env_cfg_override()
+
+    assert "rewards" not in override
+    assert override["reward_config"]["tracking"]["weight"] == pytest.approx(2.0)
+    assert override["ctrl_dt"] == pytest.approx(0.02)
+
+
+def test_backend_adapter_rejects_duplicate_manager_reward_sources() -> None:
+    cfg = _cfg(_MANAGER_ENV, env={"rewards": {"tracking": {"weight": 3.0}}})
+
+    with pytest.raises(ValueError, match="root 'reward'.*env.rewards"):
+        BackendAdapter(cfg, root_dir=Path(".")).build_task_env_cfg_override()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "match"),
+    [
+        ("_UnregisteredRewardRoute", "not registered"),
+        (_MISSING_ENV, "declares no supported.*reward target"),
+        (_AMBIGUOUS_ENV, "declares both.*rewards.*reward_config"),
+    ],
+)
+def test_reward_target_resolution_fails_closed(env_name: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        registry.resolve_reward_override_field(env_name)


### PR DESCRIPTION
## Summary

- resolve the Hydra root reward target from the registered env config owner
- route legacy configs to `reward_config` and explicitly marked Manager-Based configs to `rewards`
- reject unregistered/missing/ambiguous targets and duplicate root/`env.rewards` sources
- preserve Python-owned reward callables, sibling terms, insertion order, and legacy dict replacement semantics

Implements #1070.
Part of #1042.

## Scope accounting

- source-derived code: 0 lines
- mechanical conversion: 0 lines
- UniLab-specific implementation/glue: 64 added, 5 deleted lines
- tests: 139 added lines
- files changed: 4

## Validation

- focused routing tests: 6 passed
- registry/config/training/script regression: 204 passed
- `make test-all`:
  - ruff, mypy, pyright passed
  - pytest: 1927 passed, 25 skipped, 274 deselected, 1 xfailed
  - benchmark module mode: 32/33 passed, 1 platform-optional skip
  - benchmark script mode: 33/34 passed, 1 platform-optional skip
