### PR TITLE
feat: add Manager-Based root-state reset contract

### DIFF
--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from unilab.base.scene import SceneCfg
 
-from .base import RenderClosedError, SimBackend
+from .base import BackendRootStateLayout, RenderClosedError, SimBackend
 
 if TYPE_CHECKING:
     from unilab.base.base import EnvCfg

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -52,6 +52,45 @@ class BackendTerrainSpawnData:
 
 
 @dataclass(frozen=True)
+class BackendRootStateLayout:
+    """Generalized-state columns for one floating root body.
+
+    ``qpos_indices`` address ``[x, y, z, qw, qx, qy, qz]`` in the public
+    :meth:`SimBackend.set_state` qpos representation. ``qvel_indices`` address
+    ``[linear_velocity_world, angular_velocity_body]``.  Manager-facing root
+    states use world-frame angular velocity, so the base-owned reset
+    transaction performs the frame conversion before calling ``set_state``.
+    """
+
+    qpos_indices: tuple[int, ...]
+    qvel_indices: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        for name, values, expected in (
+            ("qpos_indices", self.qpos_indices, 7),
+            ("qvel_indices", self.qvel_indices, 6),
+        ):
+            if not isinstance(values, tuple):
+                raise TypeError(f"BackendRootStateLayout {name} must be a tuple")
+            if len(values) != expected:
+                raise ValueError(
+                    f"BackendRootStateLayout {name} must contain {expected} columns; "
+                    f"got {len(values)}"
+                )
+            if any(
+                isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer))
+                for value in values
+            ):
+                raise TypeError(f"BackendRootStateLayout {name} must contain integer columns")
+            normalized = tuple(int(value) for value in values)
+            if any(value < 0 for value in normalized):
+                raise ValueError(f"BackendRootStateLayout {name} cannot contain negative columns")
+            if len(set(normalized)) != expected:
+                raise ValueError(f"BackendRootStateLayout {name} must contain unique columns")
+            object.__setattr__(self, name, normalized)
+
+
+@dataclass(frozen=True)
 class BackendPlayCapabilities:
     """Backend-native play/render capabilities surfaced through env contracts."""
 
@@ -202,6 +241,20 @@ class SimBackend(abc.ABC):
         Returns:
             Zero-filled qvel array.
         """
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        """Resolve one body's floating-root columns on the cold path.
+
+        Backends must verify that ``root_body_name`` owns a free/floating joint;
+        fixed bodies and runtimes without body-to-root metadata fail closed.
+        Name/model lookup is forbidden on reset and step hot paths, so callers
+        cache either the returned layout or the unsupported result during scene
+        materialization.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not expose root-state layout for "
+            f"body {root_body_name!r}"
+        )
 
     @abc.abstractmethod
     def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
@@ -358,8 +411,11 @@ class SimBackend(abc.ABC):
 
         Args:
             env_indices: Environment indices.
-            qpos: Position state.
-            qvel: Velocity state.
+            qpos: Position state. Free-root columns exposed by
+                :meth:`get_root_state_layout` use world xyz and wxyz quaternion.
+            qvel: Velocity state. Free-root columns exposed by
+                :meth:`get_root_state_layout` use world linear velocity and
+                body-frame angular velocity.
             randomization: Optional backend randomization payload.
 
         Returns:

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -19,6 +19,7 @@ import numpy as np
 from unilab.base.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    BackendRootStateLayout,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -345,6 +346,30 @@ class MjwarpBackend(SimBackend):
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self._nv,), dtype=np.float32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        try:
+            body_id = self._body_ids[root_body_name]
+        except KeyError as exc:
+            raise ValueError(f"Body {root_body_name!r} not found in mjwarp model") from exc
+        joint_count = int(self._cpu_model.body_jntnum[body_id])
+        joint_id = int(self._cpu_model.body_jntadr[body_id])
+        free_joint = int(self._mujoco.mjtJoint.mjJNT_FREE)
+        if (
+            joint_count != 1
+            or joint_id < 0
+            or int(self._cpu_model.jnt_type[joint_id]) != free_joint
+        ):
+            raise NotImplementedError(
+                "backend 'mjwarp' capability 'root-state layout' requires body "
+                f"{root_body_name!r} to own exactly one free joint"
+            )
+        qpos_start = int(self._cpu_model.jnt_qposadr[joint_id])
+        qvel_start = int(self._cpu_model.jnt_dofadr[joint_id])
+        return BackendRootStateLayout(
+            qpos_indices=tuple(range(qpos_start, qpos_start + 7)),
+            qvel_indices=tuple(range(qvel_start, qvel_start + 6)),
+        )
 
     def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
         resolved: list[int] = []

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -40,6 +40,7 @@ from ..base import (
     BackendHeightScanner,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    BackendRootStateLayout,
     BackendTerrainSpawnData,
     RenderClosedError,
     SimBackend,
@@ -447,6 +448,21 @@ class MotrixBackend(SimBackend):
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self._model.num_dof_vel,), dtype=self._np_dtype)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        body = self._model.get_body(root_body_name)
+        if body is None:
+            raise ValueError(f"Body '{root_body_name}' not found in Motrix model")
+        floating_base = body.floatingbase
+        if floating_base is None:
+            raise NotImplementedError(
+                "backend 'motrix' capability 'root-state layout' requires body "
+                f"'{root_body_name}' to own a floating base"
+            )
+        return BackendRootStateLayout(
+            qpos_indices=tuple(int(index) for index in floating_base.dof_pos_indices),
+            qvel_indices=tuple(int(index) for index in floating_base.dof_vel_indices),
+        )
 
     def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
         ids: list[int] = []

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -37,6 +37,7 @@ from ..base import (
     BackendHeightScanner,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    BackendRootStateLayout,
     BackendTerrainSpawnData,
     SimBackend,
     normalize_play_render_mode,
@@ -750,6 +751,25 @@ class MuJoCoBackend(SimBackend):
 
     def get_init_qvel(self) -> np.ndarray:
         return np.zeros((self.nv,), dtype=self._np_dtype)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        body_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, root_body_name)
+        if body_id < 0:
+            raise ValueError(f"Body '{root_body_name}' not found in MuJoCo model")
+        joint_count = int(self._model.body_jntnum[body_id])
+        joint_id = int(self._model.body_jntadr[body_id])
+        free_joint = int(mujoco.mjtJoint.mjJNT_FREE)
+        if joint_count != 1 or joint_id < 0 or int(self._model.jnt_type[joint_id]) != free_joint:
+            raise NotImplementedError(
+                "backend 'mujoco' capability 'root-state layout' requires body "
+                f"'{root_body_name}' to own exactly one free joint"
+            )
+        qpos_start = int(self._model.jnt_qposadr[joint_id])
+        qvel_start = int(self._model.jnt_dofadr[joint_id])
+        return BackendRootStateLayout(
+            qpos_indices=tuple(range(qpos_start, qpos_start + 7)),
+            qvel_indices=tuple(range(qvel_start, qvel_start + 6)),
+        )
 
     def get_body_ids(self, names: "Sequence[str]") -> np.ndarray:
         ids: list[int] = []

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -15,8 +15,8 @@ from typing import TYPE_CHECKING, NoReturn
 
 import numpy as np
 
-from unilab.base.backend.base import SimBackend
-from unilab.utils.rotation import np_quat_apply_inverse, np_yaw_from_quat
+from unilab.base.backend.base import BackendRootStateLayout, SimBackend
+from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse, np_yaw_from_quat
 
 if TYPE_CHECKING:
     from unilab.base.reset_state import ResetStateTransaction
@@ -141,6 +141,8 @@ class EntityData:
         root_body_ids: np.ndarray | None,
         joint_pos_ids: np.ndarray | None,
         joint_vel_ids: np.ndarray | None,
+        default_root_state: np.ndarray | None,
+        default_root_state_error: str | None,
         default_joint_pos: np.ndarray | None,
         default_joint_vel: np.ndarray | None,
         gravity_vec_w: np.ndarray | None,
@@ -157,6 +159,8 @@ class EntityData:
         self._root_body_ids = root_body_ids
         self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
         self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
+        self._default_root_state = default_root_state
+        self._default_root_state_error = default_root_state_error
         self._default_joint_pos = default_joint_pos
         self._default_joint_vel = default_joint_vel
         self._gravity_vec_w = gravity_vec_w
@@ -226,6 +230,17 @@ class EntityData:
     @property
     def root_link_vel_w(self) -> np.ndarray:
         return np.concatenate((self.root_link_lin_vel_w, self.root_link_ang_vel_w), axis=-1)
+
+    @property
+    def default_root_state(self) -> np.ndarray:
+        """Read-only 13-D community root state for every environment."""
+        if self._default_root_state is None:
+            detail = self._default_root_state_error or "root_body_name was not declared"
+            raise NotImplementedError(
+                f"Entity '{self._entity_name}' data capability 'default root state' is "
+                f"unavailable on backend '{self._backend_type}': {detail}"
+            )
+        return self._default_root_state
 
     @property
     def joint_pos(self) -> np.ndarray:
@@ -404,6 +419,8 @@ class Entity:
         self._backend_type = backend.backend_type
         self._backend = backend
         self._reset_state = reset_state
+        self._reset_root_layout: BackendRootStateLayout | None = None
+        self._reset_root_layout_error: str | None = None
         self._reset_joint_qpos_ids: np.ndarray | None = None
         self._reset_joint_qvel_ids: np.ndarray | None = None
 
@@ -458,6 +475,11 @@ class Entity:
 
         self._validate_joint_state(backend, joint_pos_ids, joint_vel_ids)
         self._validate_body_state(backend, root_body_ids, body_ids)
+        (
+            self._reset_root_layout,
+            default_root_state,
+            self._reset_root_layout_error,
+        ) = self._materialize_root_state(backend, cfg.root_body_name)
         default_joint_pos = self._materialize_default_joint_pos(backend, joint_pos_ids)
         default_joint_vel = self._materialize_default_joint_vel(backend, joint_vel_ids)
         gravity_vec_w = self._materialize_gravity_vector(backend, root_body_ids)
@@ -484,6 +506,8 @@ class Entity:
             root_body_ids=root_body_ids,
             joint_pos_ids=joint_pos_ids,
             joint_vel_ids=joint_vel_ids,
+            default_root_state=default_root_state,
+            default_root_state_error=self._reset_root_layout_error,
             default_joint_pos=default_joint_pos,
             default_joint_vel=default_joint_vel,
             gravity_vec_w=gravity_vec_w,
@@ -661,6 +685,78 @@ class Entity:
         materialized = np.broadcast_to(selected, (backend.num_envs, len(joint_pos_ids))).copy()
         materialized.setflags(write=False)
         return materialized
+
+    def _materialize_root_state(
+        self,
+        backend: SimBackend,
+        root_body_name: str | None,
+    ) -> tuple[BackendRootStateLayout | None, np.ndarray | None, str | None]:
+        if root_body_name is None:
+            return None, None, "root_body_name was not declared in EntityCfg"
+        try:
+            layout = backend.get_root_state_layout(root_body_name)
+        except (AttributeError, NotImplementedError) as exc:
+            return None, None, str(exc)
+        if not isinstance(layout, BackendRootStateLayout):
+            raise TypeError(
+                f"Entity '{self.name}' capability 'root-state layout' on backend "
+                f"'{self._backend_type}' must return BackendRootStateLayout, got "
+                f"{type(layout).__name__}"
+            )
+        try:
+            qpos = backend.get_default_qpos()
+            qvel = backend.get_init_qvel()
+        except (AttributeError, NotImplementedError) as exc:
+            return None, None, str(exc)
+        qpos_default = self._validate_root_default_vector(qpos, "default qpos")
+        qvel_default = self._validate_root_default_vector(qvel, "initial qvel")
+        qpos_indices = np.asarray(layout.qpos_indices, dtype=np.intp)
+        qvel_indices = np.asarray(layout.qvel_indices, dtype=np.intp)
+        if np.any(qpos_indices >= qpos_default.size):
+            raise ValueError(
+                f"Entity '{self.name}' root qpos layout exceeds backend "
+                f"'{self._backend_type}' width {qpos_default.size}: {qpos_indices.tolist()}"
+            )
+        if np.any(qvel_indices >= qvel_default.size):
+            raise ValueError(
+                f"Entity '{self.name}' root qvel layout exceeds backend "
+                f"'{self._backend_type}' width {qvel_default.size}: {qvel_indices.tolist()}"
+            )
+
+        pose = np.asarray(qpos_default[qpos_indices])
+        quaternion = pose[3:7]
+        norm = float(np.linalg.norm(quaternion))
+        if not np.isclose(norm, 1.0, rtol=1e-5, atol=1e-6):
+            raise ValueError(
+                f"Entity '{self.name}' default root quaternion on backend "
+                f"'{self._backend_type}' must be unit length; norm={norm}"
+            )
+        generalized_velocity = np.asarray(qvel_default[qvel_indices])
+        velocity_w = np.array(generalized_velocity, copy=True)
+        velocity_w[3:6] = np_quat_apply(quaternion, generalized_velocity[3:6])
+        root_state = np.concatenate((pose, velocity_w))
+        materialized = np.broadcast_to(root_state, (backend.num_envs, 13)).copy()
+        materialized.setflags(write=False)
+        return layout, materialized, None
+
+    def _validate_root_default_vector(self, value: np.ndarray, capability: str) -> np.ndarray:
+        if not isinstance(value, np.ndarray):
+            raise TypeError(
+                f"Entity '{self.name}' capability '{capability}' on backend "
+                f"'{self._backend_type}' must return np.ndarray, got {type(value).__name__}"
+            )
+        if value.ndim != 1 or not np.issubdtype(value.dtype, np.floating):
+            raise TypeError(
+                f"Entity '{self.name}' capability '{capability}' on backend "
+                f"'{self._backend_type}' must be a 1-D floating array; got "
+                f"shape={value.shape}, dtype={value.dtype}"
+            )
+        if not np.isfinite(value).all():
+            raise ValueError(
+                f"Entity '{self.name}' capability '{capability}' on backend "
+                f"'{self._backend_type}' returned NaN or Inf"
+            )
+        return value
 
     def _materialize_default_joint_vel(
         self, backend: SimBackend, joint_vel_ids: np.ndarray | None
@@ -880,6 +976,64 @@ class Entity:
                 f"for passive joints on backend '{self._backend_type}': {passive_names}"
             )
         self.data.write_ctrl(target, env_ids, actuator_ids=actuator_ids)
+
+    def write_root_state_to_sim(
+        self,
+        root_state: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Stage a 13-D world-frame root state in the active reset transaction."""
+        reset_state, layout = self._require_root_state_write()
+        resolved_env_ids = self._normalize_reset_env_ids(env_ids)
+        reset_state.write_root_state(
+            resolved_env_ids,
+            layout,
+            root_state,
+            term_name=f"{self.name}.write_root_state_to_sim",
+        )
+
+    def write_root_link_pose_to_sim(
+        self,
+        root_pose: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Stage world position and wxyz root orientation during reset."""
+        reset_state, layout = self._require_root_state_write()
+        resolved_env_ids = self._normalize_reset_env_ids(env_ids)
+        reset_state.write_root_pose(
+            resolved_env_ids,
+            layout,
+            root_pose,
+            term_name=f"{self.name}.write_root_link_pose_to_sim",
+        )
+
+    def write_root_link_velocity_to_sim(
+        self,
+        root_velocity: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+    ) -> None:
+        """Stage world linear/angular root velocity during reset."""
+        reset_state, layout = self._require_root_state_write()
+        resolved_env_ids = self._normalize_reset_env_ids(env_ids)
+        reset_state.write_root_velocity(
+            resolved_env_ids,
+            layout,
+            root_velocity,
+            term_name=f"{self.name}.write_root_link_velocity_to_sim",
+        )
+
+    def _require_root_state_write(
+        self,
+    ) -> tuple[ResetStateTransaction, BackendRootStateLayout]:
+        if self._reset_state is None:
+            raise self._capability_error(
+                "reset root-state write",
+                "EntityScene was materialized without an env-owned reset transaction",
+            )
+        if self._reset_root_layout is None:
+            detail = self._reset_root_layout_error or "root-state layout was not materialized"
+            raise self._capability_error("reset root-state layout", detail)
+        return self._reset_state, self._reset_root_layout
 
     def write_joint_state_to_sim(
         self,

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -12,7 +12,8 @@ from contextlib import contextmanager
 
 import numpy as np
 
-from unilab.base.backend.base import SimBackend
+from unilab.base.backend.base import BackendRootStateLayout, SimBackend
+from unilab.utils.rotation import np_quat_apply_inverse
 
 
 class ResetStateTransaction:
@@ -146,6 +147,87 @@ class ResetStateTransaction:
             self._qvel[ids[:, None], vel_columns[None, :]] = velocities
         self._dirty_mask[ids] = True
 
+    def write_root_state(
+        self,
+        env_ids: np.ndarray,
+        layout: BackendRootStateLayout,
+        root_state: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage a community 13-D world-frame root state."""
+        self._require_active()
+        ids = self._validate_ids(env_ids, capability="write_root_state")
+        values = self._validate_values(
+            root_state,
+            shape=(ids.size, 13),
+            capability="root state",
+            term_name=term_name,
+        )
+        self.write_root_pose(ids, layout, values[:, :7], term_name=term_name)
+        self.write_root_velocity(ids, layout, values[:, 7:], term_name=term_name)
+
+    def write_root_pose(
+        self,
+        env_ids: np.ndarray,
+        layout: BackendRootStateLayout,
+        pose: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage world position and wxyz orientation for one floating root."""
+        ids = self._prepare_state_write(env_ids, capability="root-pose", term_name=term_name)
+        positions = self._validate_values(
+            pose,
+            shape=(ids.size, 7),
+            capability="root pose",
+            term_name=term_name,
+        )
+        self._validate_quaternions(positions[:, 3:7], term_name=term_name)
+        qpos_columns, _ = self._validate_root_layout(layout, term_name=term_name)
+        assert self._qpos is not None
+        if ids.size:
+            self._qpos[ids[:, None], qpos_columns[None, :]] = positions
+        self._dirty_mask[ids] = True
+
+    def write_root_velocity(
+        self,
+        env_ids: np.ndarray,
+        layout: BackendRootStateLayout,
+        velocity_w: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage world-frame root velocity in generalized qvel columns.
+
+        The public generalized-state contract stores free-root linear velocity
+        in world coordinates and angular velocity in root-body coordinates.
+        The conversion uses the pose already staged in this transaction.
+        """
+        ids = self._prepare_state_write(env_ids, capability="root-velocity", term_name=term_name)
+        velocities = self._validate_values(
+            velocity_w,
+            shape=(ids.size, 6),
+            capability="root velocity",
+            term_name=term_name,
+        )
+        qpos_columns, qvel_columns = self._validate_root_layout(layout, term_name=term_name)
+        assert self._qpos is not None
+        assert self._qvel is not None
+        if ids.size:
+            quaternions = self._qpos[
+                ids[:, None],
+                qpos_columns[None, 3:7],
+            ]
+            self._validate_quaternions(quaternions, term_name=term_name)
+            encoded_velocity = np.array(velocities, copy=True)
+            encoded_velocity[:, 3:6] = np_quat_apply_inverse(
+                quaternions,
+                velocities[:, 3:6],
+            )
+            self._qvel[ids[:, None], qvel_columns[None, :]] = encoded_velocity
+        self._dirty_mask[ids] = True
+
     def commit(self) -> dict | None:
         """Commit all staged rows through one public backend call."""
         self._require_active()
@@ -193,6 +275,69 @@ class ResetStateTransaction:
         self._default_qvel = default_qvel
         self._qpos = np.empty((self._num_envs, default_qpos.size), dtype=default_qpos.dtype)
         self._qvel = np.empty((self._num_envs, default_qvel.size), dtype=default_qvel.dtype)
+
+    def _prepare_state_write(
+        self,
+        env_ids: np.ndarray,
+        *,
+        capability: str,
+        term_name: str,
+    ) -> np.ndarray:
+        self._require_active()
+        ids = self._validate_ids(env_ids, capability=f"write_{capability}")
+        outside = ids[~self._active_mask[ids]]
+        if outside.size:
+            raise ValueError(
+                f"EventManager term '{term_name}' attempted {capability} mutation outside "
+                f"the active reset: {outside.tolist()}"
+            )
+        self._requesting_terms.add(term_name)
+        self._materialize_default_state(term_name)
+        assert self._default_qpos is not None
+        assert self._default_qvel is not None
+        assert self._qpos is not None
+        assert self._qvel is not None
+        uninitialized = ids[~self._dirty_mask[ids]]
+        if uninitialized.size:
+            self._qpos[uninitialized] = self._default_qpos
+            self._qvel[uninitialized] = self._default_qvel
+        return ids
+
+    def _validate_root_layout(
+        self,
+        layout: BackendRootStateLayout,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if not isinstance(layout, BackendRootStateLayout):
+            raise TypeError(
+                f"EventManager term '{term_name}' root-state layout must be "
+                f"BackendRootStateLayout, got {type(layout).__name__}"
+            )
+        assert self._default_qpos is not None
+        assert self._default_qvel is not None
+        qpos_columns = self._validate_columns(
+            np.asarray(layout.qpos_indices, dtype=np.intp),
+            width=self._default_qpos.size,
+            capability="root qpos indices",
+            term_name=term_name,
+        )
+        qvel_columns = self._validate_columns(
+            np.asarray(layout.qvel_indices, dtype=np.intp),
+            width=self._default_qvel.size,
+            capability="root qvel indices",
+            term_name=term_name,
+        )
+        return qpos_columns, qvel_columns
+
+    def _validate_quaternions(self, values: np.ndarray, *, term_name: str) -> None:
+        norms = np.linalg.norm(values, axis=1)
+        invalid = ~np.isclose(norms, 1.0, rtol=1e-5, atol=1e-6)
+        if np.any(invalid):
+            raise ValueError(
+                f"EventManager term '{term_name}' root quaternion must be unit length; "
+                f"norms={norms[invalid].tolist()}"
+            )
 
     def _validate_state_vector(
         self,

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -15,7 +15,11 @@ import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.backend import create_backend
-from unilab.base.backend.base import BackendTerrainSpawnData, SimBackend
+from unilab.base.backend.base import (
+    BackendRootStateLayout,
+    BackendTerrainSpawnData,
+    SimBackend,
+)
 from unilab.base.scene import SceneCfg
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -139,6 +143,29 @@ def test_actuation_metadata_defaults_fail_closed() -> None:
         SimBackend.get_joint_state_qpos_indices(object(), ("joint",))  # type: ignore[arg-type]
     with pytest.raises(NotImplementedError, match="get_joint_state_qvel_indices"):
         SimBackend.get_joint_state_qvel_indices(object(), ("joint",))  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="root-state layout"):
+        SimBackend.get_root_state_layout(object(), "root")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("qpos_indices", "qvel_indices", "error", "match"),
+    [
+        (list(range(7)), tuple(range(6)), TypeError, "qpos_indices must be a tuple"),
+        (tuple(range(6)), tuple(range(6)), ValueError, "qpos_indices must contain 7"),
+        (tuple(range(7)), tuple(range(5)), ValueError, "qvel_indices must contain 6"),
+        ((0, 1, 2, 3, 4, 5, True), tuple(range(6)), TypeError, "integer columns"),
+        ((0, 1, 2, 3, 4, 5, -1), tuple(range(6)), ValueError, "negative columns"),
+        ((0, 1, 2, 3, 4, 5, 5), tuple(range(6)), ValueError, "unique columns"),
+    ],
+)
+def test_root_state_layout_metadata_fails_closed(
+    qpos_indices,
+    qvel_indices,
+    error,
+    match: str,
+) -> None:
+    with pytest.raises(error, match=match):
+        BackendRootStateLayout(qpos_indices, qvel_indices)
 
 
 @pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
@@ -190,6 +217,112 @@ def test_actuation_metadata_contract(backend_type: str) -> None:
     detached = default_dof_pos.copy()
     default_dof_pos[:] = np.nan
     np.testing.assert_array_equal(backend.get_default_dof_pos(), detached)
+
+
+@pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
+def test_root_state_layout_contract(backend_type: str) -> None:
+    _require_backend(backend_type)
+
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=_G1_SCENE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+
+    if backend_type == "drake":
+        with pytest.raises(
+            NotImplementedError,
+            match="DrakeBackend does not expose root-state layout.*pelvis",
+        ):
+            backend.get_root_state_layout("pelvis")
+        return
+
+    layout = backend.get_root_state_layout("pelvis")
+    assert isinstance(layout, BackendRootStateLayout)
+    qpos_indices = np.asarray(layout.qpos_indices)
+    qvel_indices = np.asarray(layout.qvel_indices)
+    assert qpos_indices.shape == (7,)
+    assert qvel_indices.shape == (6,)
+    assert np.all(qpos_indices < backend.get_default_qpos().size)
+    assert np.all(qvel_indices < backend.get_init_qvel().size)
+    root_pose = backend.get_default_qpos()[qpos_indices]
+    np.testing.assert_allclose(np.linalg.norm(root_pose[3:7]), 1.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend_type", ["mujoco", "motrix"])
+def test_root_qvel_body_angular_contract_reads_back_world_velocity(backend_type: str) -> None:
+    _require_backend(backend_type)
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=_G1_SCENE),
+        1,
+        SIM_DT,
+        base_name="pelvis",
+        add_body_sensors=True,
+    )
+    backend.materialize()
+    layout = backend.get_root_state_layout("pelvis")
+    qpos_indices = np.asarray(layout.qpos_indices)
+    qvel_indices = np.asarray(layout.qvel_indices)
+    qpos = backend.get_default_qpos()[None].copy()
+    qvel = backend.get_init_qvel()[None].copy()
+    half_sqrt = np.sqrt(0.5)
+    qpos[0, qpos_indices[3:7]] = [half_sqrt, 0.0, 0.0, half_sqrt]
+    qvel[0, qvel_indices[3:6]] = [0.0, -1.0, 0.0]
+
+    backend.set_state(np.array([0], dtype=np.int32), qpos, qvel)
+
+    root_body_id = backend.get_body_ids(["pelvis"])
+    np.testing.assert_allclose(
+        backend.get_body_ang_vel_w(root_body_id)[0, 0],
+        [1.0, 0.0, 0.0],
+        atol=2e-6,
+    )
+
+
+def test_mujoco_root_layout_resolves_a_nonfirst_free_joint() -> None:
+    import mujoco
+
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    model = mujoco.MjModel.from_xml_string(
+        """
+        <mujoco>
+          <worldbody>
+            <body name="hinged">
+              <joint name="hinge" type="hinge"/>
+              <geom type="sphere" size="0.1" mass="1"/>
+            </body>
+            <body name="floating">
+              <freejoint name="floating_free"/>
+              <geom type="sphere" size="0.1" mass="1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+    )
+    backend = object.__new__(MuJoCoBackend)
+    backend._model = model
+
+    layout = backend.get_root_state_layout("floating")
+    assert layout.qpos_indices == tuple(range(1, 8))
+    assert layout.qvel_indices == tuple(range(1, 7))
+    with pytest.raises(NotImplementedError, match="hinged.*exactly one free joint"):
+        backend.get_root_state_layout("hinged")
+
+
+def test_drake_root_layout_is_explicitly_unsupported_without_runtime_metadata() -> None:
+    from unilab.base.backend.drake.backend import DrakeBackend
+
+    backend = object.__new__(DrakeBackend)
+    with pytest.raises(
+        NotImplementedError,
+        match="DrakeBackend does not expose root-state layout.*trunk",
+    ):
+        backend.get_root_state_layout("trunk")
 
 
 def test_terrain_spawn_consumers_do_not_probe_private_backend_capabilities() -> None:

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -11,8 +11,9 @@ import pytest
 
 import unilab.base.entity as entity_module
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.base import SimBackend
+from unilab.base.backend.base import BackendRootStateLayout, SimBackend
 from unilab.base.entity import EntityCfg, EntityScene
+from unilab.base.reset_state import ResetStateTransaction
 from unilab.base.scene import SceneCfg
 from unilab.managers import RewardManager, RewardTermCfg, SceneEntityCfg
 
@@ -49,6 +50,15 @@ class _StrictBackendProfile:
         self.body_ang_vel = self.body_pos + 300.0
         self.body_lin_vel_b = self.body_pos + 400.0
         self.body_ang_vel_b = self.body_pos + 500.0
+        self.default_qpos = np.array(
+            [99.0, 1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 88.0],
+            dtype=np.float32,
+        )
+        self.init_qvel = np.array(
+            [77.0, 66.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 55.0],
+            dtype=np.float32,
+        )
+        self.set_state_calls: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
 
     def _check(self, capability: str) -> None:
         self.calls[capability] += 1
@@ -58,6 +68,30 @@ class _StrictBackendProfile:
     def get_body_ids(self, names) -> np.ndarray:
         self._check("body names")
         return np.asarray([self.body_ids[name] for name in names], dtype=np.int32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        self._check("root-state layout")
+        if root_body_name != "base":
+            raise ValueError(f"unknown root body {root_body_name}")
+        return BackendRootStateLayout(tuple(range(1, 8)), tuple(range(2, 8)))
+
+    def get_default_qpos(self) -> np.ndarray:
+        self._check("default qpos")
+        return self.default_qpos.copy()
+
+    def get_init_qvel(self) -> np.ndarray:
+        self._check("initial qvel")
+        return self.init_qvel.copy()
+
+    def set_state(
+        self,
+        env_ids: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization=None,
+    ) -> None:
+        assert randomization is None
+        self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
     def get_joint_dof_pos_indices(self, names) -> np.ndarray:
         self._check("joint position names")
@@ -160,6 +194,11 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
     np.testing.assert_array_equal(robot.data.heading_w, 0.0)
     np.testing.assert_array_equal(robot.data.projected_gravity_b, [[0.0, 0.0, -1.0]] * 3)
     np.testing.assert_array_equal(
+        robot.data.default_root_state,
+        np.tile([1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], (3, 1)),
+    )
+    assert not robot.data.default_root_state.flags.writeable
+    np.testing.assert_array_equal(
         robot.data.actuator_ctrl_range,
         np.arange(10, dtype=np.float32).reshape(5, 2)[[4, 2]],
     )
@@ -235,6 +274,78 @@ def test_entity_control_write_uses_cached_actuator_columns_and_fails_closed() ->
     _, read_only_scene = _scene()
     with pytest.raises(NotImplementedError, match="actuator control write.*not materialized"):
         read_only_scene["robot"].data.write_ctrl(np.zeros((backend.num_envs, 2), dtype=np.float32))
+
+
+def test_entity_root_writes_use_cached_layout_and_one_reset_commit() -> None:
+    backend = _StrictBackendProfile("mujoco")
+    transaction = ResetStateTransaction(cast(SimBackend, backend))
+    scene = EntityScene(
+        {"robot": EntityCfg(root_body_name="base")},
+        cast(SimBackend, backend),
+        reset_state=transaction,
+    )
+    robot = scene["robot"]
+    cold_layout_calls = backend.calls["root-state layout"]
+    half_sqrt = np.sqrt(0.5)
+
+    with transaction.scoped(np.array([0, 2], dtype=np.int32)):
+        robot.write_root_link_pose_to_sim(
+            np.array(
+                [
+                    [10.0, 11.0, 12.0, half_sqrt, 0.0, 0.0, half_sqrt],
+                    [20.0, 21.0, 22.0, 1.0, 0.0, 0.0, 0.0],
+                ],
+                dtype=np.float32,
+            ),
+            env_ids=np.array([2, 0], dtype=np.int32),
+        )
+        robot.write_root_link_velocity_to_sim(
+            np.array(
+                [[1.0, 2.0, 3.0, 1.0, 0.0, 0.0], [4.0, 5.0, 6.0, 0.0, 1.0, 2.0]],
+                dtype=np.float32,
+            ),
+            env_ids=np.array([2, 0], dtype=np.int32),
+        )
+
+    assert backend.calls["root-state layout"] == cold_layout_calls == 1
+    assert len(backend.set_state_calls) == 1
+    env_ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(env_ids, [0, 2])
+    np.testing.assert_allclose(qpos[0, 1:8], [20.0, 21.0, 22.0, 1.0, 0.0, 0.0, 0.0])
+    np.testing.assert_allclose(qpos[1, 1:8], [10.0, 11.0, 12.0, half_sqrt, 0.0, 0.0, half_sqrt])
+    np.testing.assert_allclose(qvel[0, 2:8], [4.0, 5.0, 6.0, 0.0, 1.0, 2.0])
+    np.testing.assert_allclose(qvel[1, 2:8], [1.0, 2.0, 3.0, 0.0, -1.0, 0.0], atol=1e-6)
+
+
+def test_entity_caches_unsupported_root_layout_without_hot_path_probe() -> None:
+    backend = _StrictBackendProfile(
+        "drake",
+        unsupported=frozenset({"root-state layout"}),
+    )
+    transaction = ResetStateTransaction(cast(SimBackend, backend))
+    scene = EntityScene(
+        {"robot": EntityCfg(root_body_name="base")},
+        cast(SimBackend, backend),
+        reset_state=transaction,
+    )
+    robot = scene["robot"]
+
+    with pytest.raises(
+        NotImplementedError,
+        match="default root state.*backend 'drake'.*drake lacks root-state layout",
+    ):
+        _ = robot.data.default_root_state
+    with pytest.raises(
+        NotImplementedError,
+        match="reset root-state layout.*backend 'drake'.*drake lacks root-state layout",
+    ):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            robot.write_root_state_to_sim(
+                np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]),
+                env_ids=np.array([0], dtype=np.int32),
+            )
+    assert backend.calls["root-state layout"] == 1
+    assert backend.set_state_calls == []
 
 
 def test_entity_joint_position_target_maps_natural_joint_order_to_control_order() -> None:

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -53,6 +53,9 @@ def test_real_cuda_init_reset_step() -> None:
     assert backend.backend_type == "mjwarp"
     assert backend.num_actuators == 29
     assert backend.num_dof_vel == 29
+    root_layout = backend.get_root_state_layout("pelvis")
+    assert root_layout.qpos_indices == tuple(range(7))
+    assert root_layout.qvel_indices == tuple(range(6))
 
     qpos, qvel = _stand_state(backend, 2)
     backend.set_state(np.asarray([0, 1], dtype=np.int32), qpos, qvel)

--- a/tests/base/test_motrix_backend_options.py
+++ b/tests/base/test_motrix_backend_options.py
@@ -328,6 +328,29 @@ def test_motrix_backend_get_body_pose_w_slices_cached_poses_once() -> None:
     np.testing.assert_allclose(quat, [[[0.8, 0.5, 0.6, 0.7]]])
 
 
+def test_motrix_root_layout_uses_selected_body_floating_base_indices() -> None:
+    import unilab.base.backend.motrix.backend as mod
+
+    floating_base = SimpleNamespace(
+        dof_pos_indices=[4, 5, 6, 7, 8, 9, 10],
+        dof_vel_indices=[3, 4, 5, 6, 7, 8],
+    )
+    bodies = {
+        "fixed": SimpleNamespace(floatingbase=None),
+        "floating": SimpleNamespace(floatingbase=floating_base),
+    }
+    backend = object.__new__(mod.MotrixBackend)
+    backend._model = SimpleNamespace(get_body=lambda name: bodies.get(name))
+
+    layout = backend.get_root_state_layout("floating")
+    assert layout.qpos_indices == tuple(range(4, 11))
+    assert layout.qvel_indices == tuple(range(3, 9))
+    with pytest.raises(NotImplementedError, match="fixed.*floating base"):
+        backend.get_root_state_layout("fixed")
+    with pytest.raises(ValueError, match="missing.*not found"):
+        backend.get_root_state_layout("missing")
+
+
 def test_motrix_backend_applies_init_geom_size_overrides(monkeypatch, tmp_path) -> None:
     mod, fake_model = _install_fake_motrix(monkeypatch, tmp_path)
     backend = mod.MotrixBackend(

--- a/tests/base/test_reset_state.py
+++ b/tests/base/test_reset_state.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from unilab.base.backend.base import SimBackend
+from unilab.base.backend.base import BackendRootStateLayout, SimBackend
 from unilab.base.reset_state import ResetStateTransaction
 
 
@@ -128,6 +128,137 @@ def test_joint_writes_initialize_defaults_and_compose_by_column() -> None:
     np.testing.assert_array_equal(ids, [0, 2])
     np.testing.assert_array_equal(qpos, [[1.0, 8.0, 3.0], [1.0, 9.0, 3.0]])
     np.testing.assert_array_equal(qvel, [[-2.0, 0.0], [-1.0, 0.0]])
+
+
+def test_root_pose_and_world_velocity_compose_at_nonzero_columns() -> None:
+    default_qpos = np.array([99.0, 1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 88.0])
+    default_qvel = np.array([77.0, 66.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 55.0])
+    backend = _Backend(qpos=default_qpos, qvel=default_qvel)
+    transaction = _transaction(backend)
+    layout = BackendRootStateLayout(tuple(range(1, 8)), tuple(range(2, 8)))
+    half_sqrt = np.sqrt(0.5)
+    poses = np.array(
+        [
+            [10.0, 11.0, 12.0, half_sqrt, 0.0, 0.0, half_sqrt],
+            [20.0, 21.0, 22.0, 1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    velocities_w = np.array(
+        [
+            [1.0, 2.0, 3.0, 1.0, 0.0, 0.0],
+            [4.0, 5.0, 6.0, 0.0, 1.0, 2.0],
+        ]
+    )
+
+    with transaction.scoped(np.array([0, 2], dtype=np.int32)):
+        transaction.write_root_pose(
+            np.array([2, 0], dtype=np.int32),
+            layout,
+            poses,
+            term_name="root_pose",
+        )
+        transaction.write_root_velocity(
+            np.array([2, 0], dtype=np.int32),
+            layout,
+            velocities_w,
+            term_name="root_velocity",
+        )
+
+    assert len(backend.set_state_calls) == 1
+    ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(ids, [0, 2])
+    np.testing.assert_array_equal(qpos[:, [0, 8]], [[99.0, 88.0], [99.0, 88.0]])
+    np.testing.assert_allclose(qpos[0, 1:8], poses[1])
+    np.testing.assert_allclose(qpos[1, 1:8], poses[0])
+    np.testing.assert_array_equal(qvel[:, [0, 1, 8]], [[77.0, 66.0, 55.0]] * 2)
+    np.testing.assert_allclose(qvel[0, 2:8], velocities_w[1])
+    np.testing.assert_allclose(qvel[1, 2:5], velocities_w[0, :3])
+    np.testing.assert_allclose(qvel[1, 5:8], [0.0, -1.0, 0.0], atol=1e-7)
+
+
+def test_combined_root_state_uses_staged_pose_for_angular_velocity() -> None:
+    backend = _Backend(
+        qpos=np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        qvel=np.zeros(6),
+    )
+    transaction = _transaction(backend)
+    layout = BackendRootStateLayout(tuple(range(7)), tuple(range(6)))
+    half_sqrt = np.sqrt(0.5)
+    root_state = np.array(
+        [[1.0, 2.0, 3.0, half_sqrt, 0.0, 0.0, half_sqrt, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0]]
+    )
+
+    with transaction.scoped(np.array([1], dtype=np.int32)):
+        transaction.write_root_state(
+            np.array([1], dtype=np.int32),
+            layout,
+            root_state,
+            term_name="root_state",
+        )
+
+    _, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_allclose(qpos[0], root_state[0, :7])
+    np.testing.assert_allclose(qvel[0, :3], root_state[0, 7:10])
+    np.testing.assert_allclose(qvel[0, 3:6], [0.0, -1.0, 0.0], atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    ("root_state", "error", "match"),
+    [
+        (np.zeros((1, 12)), ValueError, "root state.*expected"),
+        (np.zeros((1, 13), dtype=np.int32), TypeError, "root state.*floating"),
+        (np.full((1, 13), np.nan), ValueError, "root state.*NaN or Inf"),
+        (
+            np.array([[0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]),
+            ValueError,
+            "root quaternion must be unit length",
+        ),
+    ],
+)
+def test_root_state_values_fail_closed(root_state, error, match: str) -> None:
+    backend = _Backend(
+        qpos=np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        qvel=np.zeros(6),
+    )
+    transaction = _transaction(backend)
+    layout = BackendRootStateLayout(tuple(range(7)), tuple(range(6)))
+    with pytest.raises(error, match=match):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.write_root_state(
+                np.array([0], dtype=np.int32),
+                layout,
+                root_state,
+                term_name="bad_root",
+            )
+    assert backend.set_state_calls == []
+
+
+def test_root_layout_bounds_and_reset_scope_fail_closed() -> None:
+    backend = _Backend(
+        qpos=np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        qvel=np.zeros(6),
+    )
+    transaction = _transaction(backend)
+    out_of_bounds = BackendRootStateLayout(tuple(range(1, 8)), tuple(range(6)))
+
+    with pytest.raises(IndexError, match="root qpos indices out of range"):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.write_root_pose(
+                np.array([0], dtype=np.int32),
+                out_of_bounds,
+                np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),
+                term_name="bad_layout",
+            )
+
+    valid = BackendRootStateLayout(tuple(range(7)), tuple(range(6)))
+    with pytest.raises(ValueError, match="root-pose mutation outside the active reset"):
+        with transaction.scoped(np.array([0], dtype=np.int32)):
+            transaction.write_root_pose(
+                np.array([1], dtype=np.int32),
+                valid,
+                np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),
+                term_name="outside",
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a typed `BackendRootStateLayout` contract for canonical xyz+wxyz qpos and world-linear/body-angular qvel columns
- resolve and cache floating-root layouts in MuJoCo, Motrix, and MJWarp; keep Drake fail-closed because its current runtime metadata does not prove body-to-free-root ownership
- expose read-only 13-D `EntityData.default_root_state` plus transaction-owned root state/pose/velocity writes
- preserve one `SimBackend.set_state` commit per reset while converting community world angular velocity with the staged quaternion

Relates #1072
Umbrella: #1042

## Scope and size

- source-derived lines: 0
- mechanical NumPy conversion lines: 0
- UniLab-specific additions: 826 lines (implementation, diagnostics, and focused tests)
- modified existing files: 12
- deleted lines/files: 9 lines / 0 files
- no event sampling term, production task migration, Hydra, runner, IPC, or script change

## Validation

- `make test-all`
  - ruff format/check: passed
  - mypy: passed
  - pyright: passed
  - pytest: 1949 passed, 26 skipped, 275 deselected, 1 xfailed
  - benchmark smoke: module 32/33 and script 33/34; only platform-optional MLX skipped
- focused root/backend/entity/reset tests: 97 passed, 3 skipped, 3 deselected
- real MuJoCo/Motrix conformance verifies body-frame generalized angular velocity reads back as the expected world-frame body velocity
