### PR TITLE
feat(backend): establish named sensor view contract

### DIFF
--- a/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
+++ b/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
@@ -111,6 +111,19 @@ scene composer 或通用 asset hierarchy。
 - 新 backend 能力必须作为独立 child 扩展 `SimBackend` 并补 conformance tests，不能在
   manager 或 env 中用 `getattr` / `hasattr` 探测私有实现。
 
+Named sensor 使用 `SimBackend.bind_sensor_data(names)` 在 materialization 冷路径校验名称、
+每个 sensor 的展平宽度、batch shape 与 finite 值，并返回 immutable
+`BackendSensorView`。term 热路径只调用 `view.read()`；MuJoCo、Drake 和 MJWarp adapter
+分别保留已解析的 host-cache slice 或数值 slot。MotrixSim 当前公开接口只提供 named
+sensor accessor、没有数值 sensor ID，因此 Motrix adapter 在 scene materialization 时缓存
+可用名称，并把原生批量 accessor 与 immutable 名称 tuple 封装为 backend-owned opaque
+reader；term 不接触名称解析、XML 或 model metadata，未知名称在进入原生调用前 fail-closed。
+
+这是 pinned mjlab sensor-facing 语义的 intentional NumPy/backend adaptation：社区侧的
+tensor/device view 在 UniLab 表达为按请求名称顺序拼接的二维 NumPy batch
+`(num_envs, sum(sensor_widths))`。名称顺序、单 sensor 宽度和当前值可见，Torch device、
+backend model/data 与原生 handle 不属于 manager contract。
+
 ### 5. Fail-closed capability rule
 
 用户显式禁用与实现缺失是两种不同状态。前者允许 Null manager；后者必须失败：
@@ -154,6 +167,7 @@ fallback 到旧单体 env 的永久兼容路径。
 | `ManagerBasedRlEnv` return | Adapted | 保留 `NpEnvState` 与 UniLab reset/final-observation contract |
 | config container | Adapted | plain instances + Hydra owner YAML overlay，不引入第二套 runtime |
 | `SceneEntityCfg` selectors | Adapted | 语义保留；只解析 `SimBackend` 已声明能力 |
+| named sensor view | Adapted | 冷路径 bind；有序展平 NumPy batch；reader 由 backend 拥有 |
 | event/domain randomization | Adapted | 调度语义保留；mutation 走 backend DR/capability contract |
 | Metrics/Recorder | Adapted | lifecycle hook 存在时启用；缺失时显式失败或显式空配置 |
 | Torch device、Warp mutation、viewer glue | Unsupported | 不进入 manager core，不提供静默替代 |

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/2-backend_contract.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/2-backend_contract.md
@@ -17,6 +17,9 @@ Optional capabilities are explicit:
   physics-state playback, and native video capture support.
 - `BackendHeightScanner` and `create_hfield_scanner(...)` expose terrain scan
   support through a reusable backend-owned object.
+- `BackendSensorView` and `bind_sensor_data(...)` validate ordered named sensors
+  on the cold path and retain a backend-owned reader for finite, shape-stable
+  NumPy batches. Manager hot paths do not inspect XML or model metadata.
 - Domain randomization support is surfaced through `get_dr_capabilities()` and
   the init, reset, and interval randomization methods.
 - Unsupported optional methods raise `NotImplementedError` from the base class.
@@ -37,5 +40,6 @@ Optional capabilities are explicit:
 - Backend factory: `src/unilab/base/backend/__init__.py`
 - MuJoCo backend: `src/unilab/base/backend/mujoco/backend.py`
 - Motrix backend: `src/unilab/base/backend/motrix/backend.py`
-- Backend contract tests: `tests/base/test_sim_backend.py`,
+- Backend contract tests: `tests/base/test_backend_sensor_view.py`,
+  `tests/base/test_backend_conformance.py`, `tests/base/test_sim_backend.py`,
   `tests/base/test_backend_imports.py`, `tests/base/test_motrix_backend_options.py`

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from unilab.base.scene import SceneCfg
 
-from .base import BackendRootStateLayout, RenderClosedError, SimBackend
+from .base import BackendRootStateLayout, BackendSensorView, RenderClosedError, SimBackend
 
 if TYPE_CHECKING:
     from unilab.base.base import EnvCfg
@@ -221,6 +221,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "SimBackend",
+    "BackendSensorView",
     "RenderClosedError",
     "MuJoCoBackend",
     "MjwarpBackend",

--- a/src/unilab/base/backend/base.py
+++ b/src/unilab/base/backend/base.py
@@ -1,6 +1,6 @@
 import abc
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from os import PathLike
 from typing import Any
 
@@ -15,6 +15,7 @@ from unilab.dr.types import (
 
 PreStepControlFn = Callable[[Any, np.ndarray], np.ndarray]
 TerrainHeightSampleFn = Callable[[np.ndarray], np.ndarray]
+SensorReadFn = Callable[[], np.ndarray]
 
 
 class RenderClosedError(RuntimeError):
@@ -88,6 +89,88 @@ class BackendRootStateLayout:
             if len(set(normalized)) != expected:
                 raise ValueError(f"BackendRootStateLayout {name} must contain unique columns")
             object.__setattr__(self, name, normalized)
+
+
+@dataclass(frozen=True)
+class BackendSensorView:
+    """Validated batch view over one or more named backend sensors.
+
+    Sensor names and flattened per-sensor widths are resolved while the backend
+    is materialized.  Manager terms retain this view and only call ``read`` on
+    the hot path; they never inspect backend model objects or resolve XML names.
+    The reader is intentionally backend-owned so adapters can use cached
+    numeric slots, stable host slices, or an opaque native batch reader without
+    changing the manager-facing contract.
+    """
+
+    backend_type: str
+    names: tuple[str, ...]
+    dimensions: tuple[int, ...]
+    num_envs: int
+    _reader: SensorReadFn = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend_type, str) or not self.backend_type:
+            raise ValueError("BackendSensorView backend_type must be a non-empty string")
+        if not isinstance(self.names, tuple) or not self.names:
+            raise ValueError("BackendSensorView names must be a non-empty tuple")
+        if any(not isinstance(name, str) or not name for name in self.names):
+            raise ValueError("BackendSensorView names must contain non-empty strings")
+        if len(set(self.names)) != len(self.names):
+            raise ValueError(f"BackendSensorView names must be unique: {self.names}")
+        if not isinstance(self.dimensions, tuple) or len(self.dimensions) != len(self.names):
+            raise ValueError("BackendSensorView dimensions must contain one entry per sensor name")
+        if any(
+            isinstance(value, (bool, np.bool_))
+            or not isinstance(value, (int, np.integer))
+            or int(value) <= 0
+            for value in self.dimensions
+        ):
+            raise ValueError("BackendSensorView dimensions must be positive integers")
+        if (
+            isinstance(self.num_envs, (bool, np.bool_))
+            or not isinstance(self.num_envs, (int, np.integer))
+            or int(self.num_envs) <= 0
+        ):
+            raise ValueError("BackendSensorView num_envs must be a positive integer")
+        if not callable(self._reader):
+            raise TypeError("BackendSensorView reader must be callable")
+        object.__setattr__(self, "dimensions", tuple(int(value) for value in self.dimensions))
+        object.__setattr__(self, "num_envs", int(self.num_envs))
+
+    @property
+    def width(self) -> int:
+        """Total flattened sensor width in the configured name order."""
+        return int(sum(self.dimensions))
+
+    def read(self) -> np.ndarray:
+        """Read the current sensor batch and enforce the stable view contract."""
+        try:
+            value = np.asarray(self._reader())
+        except (KeyError, NotImplementedError, ValueError) as exc:
+            raise type(exc)(
+                f"Backend '{self.backend_type}' sensor view {self.names} could not be read: {exc}"
+            ) from exc
+        if value.ndim != 2 or value.shape != (self.num_envs, self.width):
+            raise ValueError(
+                f"Backend '{self.backend_type}' sensor view {self.names} returned shape "
+                f"{value.shape}; expected ({self.num_envs}, {self.width})"
+            )
+        if not np.issubdtype(value.dtype, np.number) and not np.issubdtype(value.dtype, np.bool_):
+            raise TypeError(
+                f"Backend '{self.backend_type}' sensor view {self.names} returned non-numeric "
+                f"dtype {value.dtype}"
+            )
+        if not np.isfinite(value).all():
+            raise ValueError(
+                f"Backend '{self.backend_type}' sensor view {self.names} returned NaN or Inf"
+            )
+        return value
+
+    @property
+    def data(self) -> np.ndarray:
+        """Community-style spelling for a current sensor read."""
+        return self.read()
 
 
 @dataclass(frozen=True)
@@ -898,3 +981,75 @@ class SimBackend(abc.ABC):
         values = [np.asarray(self.get_sensor_data(name)) for name in sensor_names]
         flat_values = [value.reshape(value.shape[0], -1) for value in values]
         return np.concatenate(flat_values, axis=1)
+
+    def bind_sensor_data(self, names: Sequence[str]) -> BackendSensorView:
+        """Materialize a validated view over named sensors on the cold path.
+
+        The existing sensor getters remain the sole backend adapter surface.  This
+        method validates each requested sensor once, records its flattened width,
+        and returns a stable view for manager terms.  Backends override the
+        protected reader hook when numeric slots or stable cache slices are
+        available; callers do not depend on that implementation detail.
+        """
+        if isinstance(names, (str, bytes)):
+            raise TypeError(
+                f"Backend '{self.backend_type}' sensor view names must be a sequence of strings, "
+                "not one string"
+            )
+        sensor_names = tuple(names)
+        if not sensor_names:
+            raise ValueError(
+                f"Backend '{self.backend_type}' sensor view requires at least one name"
+            )
+        if any(not isinstance(name, str) or not name for name in sensor_names):
+            raise ValueError(
+                f"Backend '{self.backend_type}' sensor view names must be non-empty strings"
+            )
+        if len(set(sensor_names)) != len(sensor_names):
+            raise ValueError(
+                f"Backend '{self.backend_type}' sensor view names must be unique: {sensor_names}"
+            )
+
+        dimensions: list[int] = []
+        for name in sensor_names:
+            try:
+                value = np.asarray(self.get_sensor_data(name))
+            except (KeyError, NotImplementedError, ValueError) as exc:
+                raise type(exc)(
+                    f"Backend '{self.backend_type}' cannot bind sensor '{name}': {exc}"
+                ) from exc
+            if value.ndim < 1 or value.shape[0] != self.num_envs:
+                raise ValueError(
+                    f"Backend '{self.backend_type}' sensor '{name}' returned shape "
+                    f"{value.shape}; expected leading dimension {self.num_envs}"
+                )
+            width = int(np.prod(value.shape[1:], dtype=np.int64)) if value.ndim > 1 else 1
+            if width <= 0:
+                raise ValueError(
+                    f"Backend '{self.backend_type}' sensor '{name}' has empty data shape "
+                    f"{value.shape}"
+                )
+            dimensions.append(width)
+
+        view = BackendSensorView(
+            backend_type=self.backend_type,
+            names=sensor_names,
+            dimensions=tuple(dimensions),
+            num_envs=self.num_envs,
+            _reader=self._bind_sensor_data_reader(sensor_names),
+        )
+        # Validate the batch implementation at materialization as well.  This
+        # catches adapters whose individual and batch sensor contracts disagree.
+        view.read()
+        return view
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> SensorReadFn:
+        """Create the backend-owned reader retained by a materialized sensor view.
+
+        The default keeps the existing batch getter as the compatibility path
+        for lightweight adapters and test doubles.  Concrete backends that
+        expose stable numeric slots or host-cache slices override this hook so
+        manager hot paths never resolve model metadata.
+        """
+        batch_reader = self.get_sensor_data_batch
+        return lambda: batch_reader(names)

--- a/src/unilab/base/backend/drake/backend.py
+++ b/src/unilab/base/backend/drake/backend.py
@@ -733,6 +733,25 @@ class DrakeBackend(SimBackend):
             return self._sensor_views[name].copy()
         raise KeyError(f"Unknown DrakeUni sensor: {name}")
 
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> Callable[[], np.ndarray]:
+        """Capture DrakeUni sensor addresses; read only the refreshed host cache."""
+        name_to_index = {name: index for index, name in enumerate(self._sensor_names)}
+        slots = tuple(
+            (
+                int(self._sensor_adr[name_to_index[name]]),
+                int(self._sensor_dim[name_to_index[name]]),
+            )
+            for name in names
+        )
+
+        def read() -> np.ndarray:
+            values = [
+                self._sensor_data[:, address : address + dimension] for address, dimension in slots
+            ]
+            return np.concatenate(values, axis=1)
+
+        return read
+
     # Internal helpers.
     def _sync_runtime_state(self, output: dict[str, Any] | None = None) -> None:
         # Keep UniLab's cached state/sensor views aligned after every DrakeUni update.

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -10,7 +10,7 @@ transfer.
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from os import PathLike
 from typing import Any
 
@@ -816,3 +816,15 @@ class MjwarpBackend(SimBackend):
             available = ", ".join(sorted(self._sensor_slots))
             raise ValueError(f"Sensor {name!r} not found; available: {available}") from exc
         return self._sensor_cache[:, address : address + dimension]
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> Callable[[], np.ndarray]:
+        """Capture numeric host-cache slots for a zero-metadata hot-path view."""
+        slots = tuple(self._sensor_slots[name] for name in names)
+
+        def read() -> np.ndarray:
+            values = [
+                self._sensor_cache[:, address : address + dimension] for address, dimension in slots
+            ]
+            return np.concatenate(values, axis=1)
+
+        return read

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
@@ -84,6 +84,7 @@ def _contiguous_slice(indices: np.ndarray) -> slice | None:
 @dataclass
 class _MotrixSceneContext:
     model: "mtx.SceneModel"
+    sensor_names: tuple[str, ...]
     terrain_origins: np.ndarray | None = None
     terrain_surface_sampler: object | None = None
     cleanup_handle: object | None = None
@@ -112,8 +113,8 @@ def _build_motrix_scene_context(
     base_name: str,
 ) -> _MotrixSceneContext:
     from unilab.base.backend.motrix.scene import (
-        materialize_motrix_hfield_attached_scene,
-        materialize_motrix_scene,
+        _materialize_motrix_hfield_attached_scene_with_sensor_names,
+        _materialize_motrix_scene_with_sensor_names,
     )
 
     if scene is None:
@@ -122,29 +123,32 @@ def _build_motrix_scene_context(
         raise ValueError("SceneCfg.model_file must be provided")
 
     if scene.terrain is None:
-        model = materialize_motrix_scene(
+        model, sensor_names = _materialize_motrix_scene_with_sensor_names(
             model_file=scene.model_file,
             fragment_files=scene.fragment_files,
             add_body_sensors=add_body_sensors,
             base_name=base_name,
         )
-        return _MotrixSceneContext(model=model)
+        return _MotrixSceneContext(model=model, sensor_names=sensor_names)
 
     if scene.terrain.generator is None:
         raise ValueError("SceneCfg.terrain.generator must be configured for terrain scenes")
 
-    model, terrain_origins, terrain_surface_sampler = materialize_motrix_hfield_attached_scene(
-        model_file=scene.model_file,
-        terrain_cfg=scene.terrain.generator,
-        fragment_files=scene.fragment_files,
-        hfield_name=scene.terrain.hfield_name,
-        geom_name=scene.terrain.geom_name or "floor",
-        add_body_sensors=add_body_sensors,
-        base_name=base_name,
-        return_surface_sampler=True,
+    model, terrain_origins, terrain_surface_sampler, sensor_names = (
+        _materialize_motrix_hfield_attached_scene_with_sensor_names(
+            model_file=scene.model_file,
+            terrain_cfg=scene.terrain.generator,
+            fragment_files=scene.fragment_files,
+            hfield_name=scene.terrain.hfield_name,
+            geom_name=scene.terrain.geom_name or "floor",
+            add_body_sensors=add_body_sensors,
+            base_name=base_name,
+            return_surface_sampler=True,
+        )
     )
     return _MotrixSceneContext(
         model=model,
+        sensor_names=sensor_names,
         terrain_origins=terrain_origins,
         terrain_surface_sampler=terrain_surface_sampler,
     )
@@ -192,6 +196,7 @@ class MotrixBackend(SimBackend):
         self._base_name = base_name
 
         self._model = scene_context.model
+        self._sensor_names = frozenset(scene_context.sensor_names)
         self._body_id_to_name = {  # type: ignore[assignment]
             link.index: link.name for link in self._model.links if link.name
         }
@@ -1166,10 +1171,20 @@ class MotrixBackend(SimBackend):
     # Sensors                                                            #
     # ------------------------------------------------------------------ #
 
+    def _validate_sensor_names(self, names: Sequence[str]) -> tuple[str, ...]:
+        sensor_names = tuple(names)
+        missing = tuple(name for name in sensor_names if name not in self._sensor_names)
+        if missing:
+            available = ", ".join(sorted(self._sensor_names))
+            raise KeyError(f"Unknown Motrix sensor(s) {missing}; available sensors: {available}")
+        return sensor_names
+
     def get_sensor_data(self, name: str) -> np.ndarray:
+        self._validate_sensor_names((name,))
         return self._model.get_sensor_value(name, self._data)  # type: ignore[no-any-return]
 
     def get_sensor_data_rows(self, name: str, env_ids: np.ndarray) -> np.ndarray:
+        self._validate_sensor_names((name,))
         rows = np.asarray(env_ids, dtype=np.intp)
         mask = np.zeros(self._num_envs, dtype=bool)
         mask[rows] = True
@@ -1178,11 +1193,25 @@ class MotrixBackend(SimBackend):
         return selected_values[np.searchsorted(selected_rows, rows)]  # type: ignore[no-any-return]
 
     def get_sensor_data_batch(self, names: Sequence[str]) -> np.ndarray:
-        sensor_names = tuple(names)
+        sensor_names = self._validate_sensor_names(names)
         if not sensor_names:
             return np.empty((self._num_envs, 0), dtype=self._np_dtype)
         values = self._model.get_sensor_values(sensor_names, self._data)
         return np.asarray(values, dtype=self._np_dtype)
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> Callable[[], np.ndarray]:
+        """Retain Motrix's opaque native reader after cold-path name validation.
+
+        MotrixSim exposes named sensor access but no public numeric sensor ID;
+        the bound callable is therefore the narrowest backend-owned reader.
+        It does not inspect XML or model metadata on the manager hot path.
+        """
+        native_reader = self._model.get_sensor_values
+
+        def read() -> np.ndarray:
+            return np.asarray(native_reader(names, self._data), dtype=self._np_dtype)
+
+        return read
 
     # ------------------------------------------------------------------ #
     # MotrixSim-specific                                                 #

--- a/src/unilab/base/backend/motrix/scene.py
+++ b/src/unilab/base/backend/motrix/scene.py
@@ -16,6 +16,21 @@ if TYPE_CHECKING:
     from motrixsim.msd import Link, World
 
 
+def _motrix_sensor_names(world: "World") -> tuple[str, ...]:
+    """Collect the names accepted by Motrix's native sensor accessor once."""
+    groups = (
+        world.sensors.contact,
+        world.sensors.frame,
+        world.sensors.joint,
+        world.sensors.subtree,
+        world.sensors.touch,
+    )
+    names = tuple(str(sensor.name) for group in groups for sensor in group if sensor.name)
+    if len(set(names)) != len(names):
+        raise ValueError(f"Motrix scene contains duplicate sensor names: {names}")
+    return names
+
+
 def _extract_keyframes(fragment_file: Path) -> list[ET.Element]:
     """Return ``<keyframe>`` child elements declared inside ``fragment_file``."""
     root = ET.parse(fragment_file).getroot()
@@ -146,14 +161,14 @@ def add_motrix_tracking_frame_sensors(world: World, *, base_name: str) -> None:
             world.sensors.frame.append(sensor)
 
 
-def materialize_motrix_scene(
+def _materialize_motrix_scene_with_sensor_names(
     *,
     model_file: str,
     fragment_files: Sequence[str] = (),
     add_body_sensors: bool = False,
     base_name: str = "base",
-) -> SceneModel:
-    """Build a MotrixSim model through MSD scene composition."""
+) -> tuple["SceneModel", tuple[str, ...]]:
+    """Build a Motrix model and return its validated cold-path sensor names."""
     import motrixsim.msd as msd
 
     model_path = Path(model_file).resolve()
@@ -167,40 +182,29 @@ def materialize_motrix_scene(
             _attach_motrix_scene_fragment(world, fragment_path)
         if add_body_sensors:
             add_motrix_tracking_frame_sensors(world, base_name=base_name)
-        return msd.build(world)
+        model = msd.build(world)
+        return model, _motrix_sensor_names(world)
     finally:
         _cleanup_temp_xml(robot_path, model_path)
 
 
-@overload
-def materialize_motrix_hfield_attached_scene(
+def materialize_motrix_scene(
     *,
     model_file: str,
-    terrain_cfg: TerrainGeneratorCfg,
     fragment_files: Sequence[str] = (),
-    hfield_name: str = "terrain_hfield",
-    geom_name: str = "floor",
     add_body_sensors: bool = False,
     base_name: str = "base",
-    return_surface_sampler: Literal[False] = False,
-) -> tuple[SceneModel, np.ndarray]: ...
+) -> "SceneModel":
+    """Build a MotrixSim model through MSD scene composition."""
+    return _materialize_motrix_scene_with_sensor_names(
+        model_file=model_file,
+        fragment_files=fragment_files,
+        add_body_sensors=add_body_sensors,
+        base_name=base_name,
+    )[0]
 
 
-@overload
-def materialize_motrix_hfield_attached_scene(
-    *,
-    model_file: str,
-    terrain_cfg: TerrainGeneratorCfg,
-    fragment_files: Sequence[str] = (),
-    hfield_name: str = "terrain_hfield",
-    geom_name: str = "floor",
-    add_body_sensors: bool = False,
-    base_name: str = "base",
-    return_surface_sampler: Literal[True],
-) -> tuple[SceneModel, np.ndarray, object]: ...
-
-
-def materialize_motrix_hfield_attached_scene(
+def _materialize_motrix_hfield_attached_scene_with_sensor_names(
     *,
     model_file: str,
     terrain_cfg: TerrainGeneratorCfg,
@@ -210,8 +214,8 @@ def materialize_motrix_hfield_attached_scene(
     add_body_sensors: bool = False,
     base_name: str = "base",
     return_surface_sampler: bool = False,
-) -> tuple[SceneModel, np.ndarray] | tuple[SceneModel, np.ndarray, object]:
-    """Build a MotrixSim model with generated hfield terrain and attached robot."""
+) -> tuple[SceneModel, np.ndarray, object | None, tuple[str, ...]]:
+    """Build a Motrix terrain model and return its cold-path sensor names."""
     import motrixsim.msd as msd
 
     from unilab.terrains import TerrainGenerator
@@ -262,6 +266,63 @@ def materialize_motrix_hfield_attached_scene(
     if add_body_sensors:
         add_motrix_tracking_frame_sensors(world, base_name=base_name)
 
+    model = msd.build(world)
+    sampler = generated.surface_sampler() if return_surface_sampler else None
+    return model, generated.terrain_origins, sampler, _motrix_sensor_names(world)
+
+
+@overload
+def materialize_motrix_hfield_attached_scene(
+    *,
+    model_file: str,
+    terrain_cfg: TerrainGeneratorCfg,
+    fragment_files: Sequence[str] = (),
+    hfield_name: str = "terrain_hfield",
+    geom_name: str = "floor",
+    add_body_sensors: bool = False,
+    base_name: str = "base",
+    return_surface_sampler: Literal[False] = False,
+) -> tuple[SceneModel, np.ndarray]: ...
+
+
+@overload
+def materialize_motrix_hfield_attached_scene(
+    *,
+    model_file: str,
+    terrain_cfg: TerrainGeneratorCfg,
+    fragment_files: Sequence[str] = (),
+    hfield_name: str = "terrain_hfield",
+    geom_name: str = "floor",
+    add_body_sensors: bool = False,
+    base_name: str = "base",
+    return_surface_sampler: Literal[True],
+) -> tuple[SceneModel, np.ndarray, object]: ...
+
+
+def materialize_motrix_hfield_attached_scene(
+    *,
+    model_file: str,
+    terrain_cfg: TerrainGeneratorCfg,
+    fragment_files: Sequence[str] = (),
+    hfield_name: str = "terrain_hfield",
+    geom_name: str = "floor",
+    add_body_sensors: bool = False,
+    base_name: str = "base",
+    return_surface_sampler: bool = False,
+) -> tuple[SceneModel, np.ndarray] | tuple[SceneModel, np.ndarray, object]:
+    """Build a MotrixSim model with generated hfield terrain and attached robot."""
+    model, origins, sampler, _ = _materialize_motrix_hfield_attached_scene_with_sensor_names(
+        model_file=model_file,
+        terrain_cfg=terrain_cfg,
+        fragment_files=fragment_files,
+        hfield_name=hfield_name,
+        geom_name=geom_name,
+        add_body_sensors=add_body_sensors,
+        base_name=base_name,
+        return_surface_sampler=return_surface_sampler,
+    )
     if return_surface_sampler:
-        return msd.build(world), generated.terrain_origins, generated.surface_sampler()
-    return msd.build(world), generated.terrain_origins
+        if sampler is None:
+            raise RuntimeError("Motrix terrain materialization did not produce a surface sampler")
+        return model, origins, sampler
+    return model, origins

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import time
 import weakref
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from multiprocessing import cpu_count, current_process, get_context
@@ -1349,6 +1349,15 @@ class MuJoCoBackend(SimBackend):
             return np.empty((self._num_envs, 0), dtype=self._np_dtype)
         values = [self._sensor_views[name].reshape(self._num_envs, -1) for name in sensor_names]
         return np.concatenate(values, axis=1)
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> Callable[[], np.ndarray]:
+        """Capture MuJoCo's materialized sensor slices for hot-path reads."""
+        sensor_views = tuple(self._sensor_views[name].reshape(self._num_envs, -1) for name in names)
+
+        def read() -> np.ndarray:
+            return np.concatenate(sensor_views, axis=1)
+
+        return read
 
     def get_site_jacobian_w(
         self,

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -220,6 +220,41 @@ def test_actuation_metadata_contract(backend_type: str) -> None:
 
 
 @pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
+def test_named_sensor_view_contract(backend_type: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All available adapters expose the same ordered, finite sensor view."""
+    _require_backend(backend_type)
+
+    backend = create_backend(
+        backend_type,
+        SceneCfg(model_file=_G1_SCENE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+    names = ("pelvis_gyro", "pelvis_local_linvel")
+
+    view = backend.bind_sensor_data(names)
+    assert view.backend_type == backend.backend_type
+    assert view.names == names
+    assert view.dimensions == (3, 3)
+    assert view.width == 6
+    values = view.read()
+    assert values.shape == (NUM_ENVS, 6)
+    assert np.isfinite(values).all()
+    np.testing.assert_allclose(values, backend.get_sensor_data_batch(names))
+
+    def fail_if_public_batch_getter_is_used(*_args, **_kwargs):
+        raise AssertionError("materialized sensor view called the public batch getter")
+
+    monkeypatch.setattr(backend, "get_sensor_data_batch", fail_if_public_batch_getter_is_used)
+    np.testing.assert_allclose(view.read(), values)
+
+    with pytest.raises((KeyError, ValueError), match="missing_sensor|Missing|missing"):
+        backend.bind_sensor_data(("missing_sensor",))
+
+
+@pytest.mark.parametrize("backend_type", _BACKEND_PARAMS)
 def test_root_state_layout_contract(backend_type: str) -> None:
     _require_backend(backend_type)
 

--- a/tests/base/test_backend_sensor_view.py
+++ b/tests/base/test_backend_sensor_view.py
@@ -1,0 +1,126 @@
+"""Focused tests for the cold-path named sensor view contract."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+import pytest
+
+from unilab.base.backend import BackendSensorView
+from unilab.base.backend.base import SimBackend
+
+
+class _SensorBackend:
+    backend_type = "fake"
+    num_envs = 2
+
+    def __init__(self) -> None:
+        self.calls: Counter[str] = Counter()
+        self.values = {
+            "contact_a": np.asarray([[1.0], [0.0]], dtype=np.float32),
+            "contact_b": np.asarray([[0.0], [1.0]], dtype=np.float32),
+        }
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self.calls["single"] += 1
+        return self.values[name]
+
+    def get_sensor_data_batch(self, names: tuple[str, ...]) -> np.ndarray:
+        self.calls["batch"] += 1
+        return np.concatenate([self.values[name] for name in names], axis=1)
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]):
+        batch_reader = self.get_sensor_data_batch
+        return lambda: batch_reader(names)
+
+
+def test_bind_sensor_data_validates_once_and_reads_through_formal_view() -> None:
+    backend = _SensorBackend()
+
+    view = SimBackend.bind_sensor_data(backend, ("contact_a", "contact_b"))  # type: ignore[arg-type]
+
+    assert isinstance(view, BackendSensorView)
+    assert view.names == ("contact_a", "contact_b")
+    assert view.dimensions == (1, 1)
+    assert view.width == 2
+    assert backend.calls == {"single": 2, "batch": 1}
+
+    np.testing.assert_array_equal(view.read(), [[1.0, 0.0], [0.0, 1.0]])
+    assert backend.calls == {"single": 2, "batch": 2}
+
+
+@pytest.mark.parametrize(
+    "names, error, match",
+    [
+        ("contact_a", TypeError, "sequence of strings"),
+        ((), ValueError, "at least one name"),
+        (("",), ValueError, "non-empty strings"),
+        (("contact_a", "contact_a"), ValueError, "unique"),
+    ],
+)
+def test_bind_sensor_data_rejects_invalid_name_requests(
+    names: str | tuple[str, ...], error: type[Exception], match: str
+) -> None:
+    with pytest.raises(error, match=match):
+        SimBackend.bind_sensor_data(_SensorBackend(), names)  # type: ignore[arg-type]
+
+
+def test_bind_sensor_data_fails_closed_on_unknown_sensor() -> None:
+    with pytest.raises(KeyError, match="cannot bind sensor 'missing'"):
+        SimBackend.bind_sensor_data(_SensorBackend(), ("missing",))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value, error, match",
+    [
+        (np.zeros((1, 2), dtype=np.float32), ValueError, "expected leading dimension 2"),
+        (np.full((2, 1), np.nan, dtype=np.float32), ValueError, "NaN or Inf"),
+    ],
+)
+def test_backend_sensor_view_rejects_invalid_runtime_data(
+    value: np.ndarray, error: type[Exception], match: str
+) -> None:
+    backend = _SensorBackend()
+    backend.values["contact_a"] = value
+
+    if value.shape[0] != backend.num_envs:
+        with pytest.raises(error, match=match):
+            SimBackend.bind_sensor_data(backend, ("contact_a",))  # type: ignore[arg-type]
+        return
+
+    with pytest.raises(error, match=match):
+        SimBackend.bind_sensor_data(backend, ("contact_a",))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value, error, match",
+    [
+        (np.zeros((2, 2), dtype=np.float32), ValueError, r"expected \(2, 1\)"),
+        (np.full((2, 1), np.inf, dtype=np.float32), ValueError, "NaN or Inf"),
+        (np.full((2, 1), "invalid", dtype=object), TypeError, "non-numeric dtype"),
+    ],
+)
+def test_backend_sensor_view_detects_runtime_contract_drift(
+    value: np.ndarray, error: type[Exception], match: str
+) -> None:
+    backend = _SensorBackend()
+    view = SimBackend.bind_sensor_data(backend, ("contact_a",))  # type: ignore[arg-type]
+
+    backend.values["contact_a"] = value
+
+    with pytest.raises(error, match=match):
+        view.read()
+
+
+def test_backend_sensor_view_metadata_is_immutable() -> None:
+    view = BackendSensorView(
+        backend_type="fake",
+        names=("sensor",),
+        dimensions=(1,),
+        num_envs=1,
+        _reader=lambda: np.zeros((1, 1), dtype=np.float32),
+    )
+
+    with pytest.raises(AttributeError):
+        view.names = ("other",)  # type: ignore[misc]

--- a/tests/base/test_motrix_backend_options.py
+++ b/tests/base/test_motrix_backend_options.py
@@ -245,7 +245,11 @@ def _install_fake_motrix(monkeypatch, tmp_path):
         ),
         raising=False,
     )
-    monkeypatch.setattr(scene_mod, "materialize_motrix_scene", lambda **kwargs: fake_model)
+    monkeypatch.setattr(
+        scene_mod,
+        "_materialize_motrix_scene_with_sensor_names",
+        lambda **kwargs: (fake_model, ()),
+    )
     return mod, fake_model
 
 

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -275,6 +275,13 @@ def test_backend_batch_sensor_data_matches_individual_sensors(backend_type):
     np.testing.assert_allclose(bkd.get_sensor_data_batch(names), expected)
     _shape(bkd.get_sensor_data_batch(()), NUM_ENVS, 0)
 
+    view = bkd.bind_sensor_data(names)
+    assert view.names == names
+    assert view.dimensions == tuple(
+        int(np.asarray(bkd.get_sensor_data(name)).reshape(NUM_ENVS, -1).shape[1]) for name in names
+    )
+    np.testing.assert_allclose(view.read(), expected)
+
 
 def test_mujoco_model_properties_smoke():
     from unilab.base.backend.mujoco.backend import MuJoCoBackend


### PR DESCRIPTION
## 主要结果

为 Manager-Based term 建立跨 MuJoCo、Motrix、Drake、MJWarp 的冷路径 named-sensor view contract：

- 新增 `SimBackend.bind_sensor_data(names) -> BackendSensorView`，在 bind/materialization 边界 fail-closed 校验名称、顺序、宽度、batch shape、dtype 与 finite 值。
- MuJoCo、Drake、MJWarp reader 使用已缓存 host slice / numeric slot；Motrix 在 scene materialization 缓存可用名称，并封装其唯一的 named native accessor，未知名称不会进入原生 panic 路径。
- 增加 fake、MuJoCo/Motrix smoke、四 backend conformance（Drake/MJWarp 按可用性 skip）测试。
- ADR 与 backend contract 记录 pinned mjlab sensor-facing 语义到 UniLab NumPy/backend adaptation 的 intentional difference。

不包含 SceneCfg/entity facade、manager lifecycle、Go2 task、reward/observation/action/event/DR、runner/IPC。

## Validation

- `make test-all`
- ruff format/check、mypy、pyright
- `1972 passed, 27 skipped, 276 deselected, 1 xfailed`
- benchmark smoke：module mode 32/33（1 platform-optional MLX skip），script mode 33/34（1 platform-optional MLX skip）
- docs check：20 passed

## Change accounting

- source-derived: 0
- mechanical NumPy conversion: 0
- UniLab-specific contract/adapter glue: 约 331 行新增
- tests/docs and test-double updates: 约 196 行新增
- deleted/reworked: 51 行
- 13 files changed; 1 new test file

Closes #1076
Related to #1042
