### PR TITLE
feat(env): add named sensor observation terms

### DIFF
--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/6-manager_based_api.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/6-manager_based_api.md
@@ -17,6 +17,9 @@ The normative compatibility matrix and mechanical migration example are in
 - `SceneEntityCfg` resolves through a base-owned scene/entity facade on the cold path.
   The facade uses only the public `SimBackend` contract, and hot paths reuse cached IDs
   and views.
+- Named-sensor observation terms bind a backend-owned view through
+  `EntityScene.bind_sensor_data(...)` during construction; their hot path only reads
+  that view and never re-resolves sensor names or XML/model metadata.
 - Explicitly empty configuration may use a Null manager. A requested capability that
   is unavailable fails at the nearest boundary; it is never skipped, zero-filled, or
   routed back to a legacy environment.

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
@@ -14,6 +14,8 @@ NumPy，并保留现有 `NpEnvState`、Hydra owner YAML、`SimBackend`、registr
   Torch、Warp、runner、learner 或 IPC。
 - `SceneEntityCfg` 在冷路径通过 base scene/entity facade 解析；facade 只调用正式
   `SimBackend` contract，热路径复用缓存 ID/view。
+- named-sensor observation term 在构造时通过 `EntityScene.bind_sensor_data(...)` 绑定
+  backend-owned view；热路径只读该 view，不重复解析 sensor 名称或 XML/model metadata。
 - 用户显式空配置可以使用 Null manager；配置请求但 runtime/backend 不支持的能力必须在
   最近边界报错，不能 warning、skip、返回零或回退旧 env。
 - 热路径避免明显的重复解析、逐环境 Python 循环、复制和临时分配；进一步优化需要

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 import numpy as np
 
-from unilab.base.backend.base import BackendRootStateLayout, SimBackend
+from unilab.base.backend.base import BackendRootStateLayout, BackendSensorView, SimBackend
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse, np_yaw_from_quat
 
 if TYPE_CHECKING:
@@ -1198,6 +1198,7 @@ class EntityScene(Mapping[str, Entity]):
         *,
         reset_state: ResetStateTransaction | None = None,
     ) -> None:
+        self._backend = backend
         materialized: dict[str, Entity] = {}
         for name, cfg in entities.items():
             if not isinstance(name, str) or not name:
@@ -1247,6 +1248,21 @@ class EntityScene(Mapping[str, Entity]):
                 "a formal backend root-state layout"
             )
         self._reset_state.reset_to_default(env_ids, term_name=term_name)
+
+    def bind_sensor_data(self, names: Sequence[str]) -> BackendSensorView:
+        """Bind existing backend sensors for a manager term on the cold path.
+
+        The returned view owns the backend-specific reader.  Terms retain that
+        view and only call :meth:`BackendSensorView.read` while stepping, so the
+        scene facade never exposes a backend model, data object, or native handle.
+        """
+        try:
+            return self._backend.bind_sensor_data(names)
+        except (KeyError, TypeError, ValueError, NotImplementedError) as exc:
+            raise type(exc)(
+                "Manager scene named-sensor capability on backend "
+                f"'{self._backend.backend_type}': {exc}"
+            ) from exc
 
     def __getitem__(self, name: str) -> Entity:
         try:

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -9,11 +9,15 @@ from unilab.envs.mdp.events import reset_scene_to_default as reset_scene_to_defa
 from unilab.envs.mdp.events import resolve_env_ids as resolve_env_ids
 from unilab.envs.mdp.observations import base_ang_vel as base_ang_vel
 from unilab.envs.mdp.observations import base_lin_vel as base_lin_vel
+from unilab.envs.mdp.observations import builtin_sensor as builtin_sensor
 from unilab.envs.mdp.observations import generated_commands as generated_commands
 from unilab.envs.mdp.observations import joint_pos_rel as joint_pos_rel
 from unilab.envs.mdp.observations import joint_vel_rel as joint_vel_rel
 from unilab.envs.mdp.observations import last_action as last_action
 from unilab.envs.mdp.observations import projected_gravity as projected_gravity
+from unilab.envs.mdp.observations import (
+    projected_gravity_from_sensor as projected_gravity_from_sensor,
+)
 from unilab.envs.mdp.rewards import action_acc_l2 as action_acc_l2
 from unilab.envs.mdp.rewards import action_rate_l2 as action_rate_l2
 from unilab.envs.mdp.rewards import (
@@ -40,6 +44,7 @@ __all__ = [
     "action_rate_l2",
     "base_ang_vel",
     "base_lin_vel",
+    "builtin_sensor",
     "bad_orientation",
     "body_angular_velocity_penalty",
     "flat_orientation_l2",
@@ -51,6 +56,7 @@ __all__ = [
     "is_alive",
     "is_terminated",
     "projected_gravity",
+    "projected_gravity_from_sensor",
     "reset_root_state_uniform",
     "reset_scene_to_default",
     "resolve_env_ids",

--- a/src/unilab/envs/mdp/observations.py
+++ b/src/unilab/envs/mdp/observations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
+from unilab.managers.manager_base import ManagerTermBase, ManagerTermBaseCfg
 from unilab.managers.scene_entity_config import SceneEntityCfg
 
 if TYPE_CHECKING:
@@ -18,6 +19,76 @@ if TYPE_CHECKING:
 
 
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+
+
+class _NamedSensorObservation(ManagerTermBase):
+    """Cold-path binding shared by pinned named-sensor observation terms."""
+
+    _term_name = "named_sensor"
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        sensor_name = cfg.params.get("sensor_name")
+        if not isinstance(sensor_name, str) or not sensor_name:
+            raise ValueError(
+                f"Observation term '{self._term_name}' capability 'named sensor' "
+                "requires a non-empty sensor_name"
+            )
+        self._sensor_name = sensor_name
+        try:
+            self._view = env.scene.bind_sensor_data((sensor_name,))
+        except (KeyError, TypeError, ValueError, NotImplementedError) as exc:
+            raise type(exc)(
+                f"Observation term '{self._term_name}' capability 'named sensor "
+                f"{sensor_name}' could not be materialized: {exc}"
+            ) from exc
+
+    def _validate_call_name(self, sensor_name: str) -> None:
+        if sensor_name != self._sensor_name:
+            raise ValueError(
+                f"Observation term '{self._term_name}' was bound to sensor "
+                f"'{self._sensor_name}', received '{sensor_name}'"
+            )
+
+    def _read(self) -> np.ndarray:
+        try:
+            return self._view.read()
+        except (KeyError, TypeError, ValueError, NotImplementedError) as exc:
+            raise type(exc)(
+                f"Observation term '{self._term_name}' capability 'named sensor "
+                f"{self._sensor_name}' failed on backend '{self._view.backend_type}': {exc}"
+            ) from exc
+
+
+class builtin_sensor(_NamedSensorObservation):
+    """Read one existing backend sensor through a cached NumPy view."""
+
+    _term_name = "builtin_sensor"
+
+    def __call__(self, env: ManagerBasedRlEnv, sensor_name: str) -> np.ndarray:
+        del env
+        self._validate_call_name(sensor_name)
+        return self._read()
+
+
+class projected_gravity_from_sensor(_NamedSensorObservation):
+    """Negate a cached 3-D up-vector sensor to obtain projected gravity."""
+
+    _term_name = "projected_gravity_from_sensor"
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        if self._view.dimensions != (3,):
+            raise ValueError(
+                "Observation term 'projected_gravity_from_sensor' capability "
+                f"'3-D named sensor {self._sensor_name}' received dimensions "
+                f"{self._view.dimensions} on backend '{self._view.backend_type}'"
+            )
+
+    def __call__(self, env: ManagerBasedRlEnv, sensor_name: str) -> np.ndarray:
+        del env
+        self._validate_call_name(sensor_name)
+        return -self._read()
 
 
 def base_lin_vel(
@@ -88,9 +159,11 @@ def generated_commands(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
 __all__ = [
     "base_ang_vel",
     "base_lin_vel",
+    "builtin_sensor",
     "generated_commands",
     "joint_pos_rel",
     "joint_vel_rel",
     "last_action",
     "projected_gravity",
+    "projected_gravity_from_sensor",
 ]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -135,6 +135,24 @@ class ManagerEntity(Protocol):
     ) -> None: ...
 
 
+class ManagerSensorView(Protocol):
+    """Backend-owned named-sensor view retained by a manager term."""
+
+    @property
+    def backend_type(self) -> str: ...
+
+    @property
+    def names(self) -> tuple[str, ...]: ...
+
+    @property
+    def dimensions(self) -> tuple[int, ...]: ...
+
+    @property
+    def data(self) -> np.ndarray: ...
+
+    def read(self) -> np.ndarray: ...
+
+
 class ManagerScene(Protocol):
     """Minimal name-addressable scene surface consumed by managers."""
 
@@ -145,6 +163,8 @@ class ManagerScene(Protocol):
     def env_origins(self) -> np.ndarray: ...
 
     def __getitem__(self, name: str) -> ManagerEntity: ...
+
+    def bind_sensor_data(self, names: Sequence[str]) -> ManagerSensorView: ...
 
     def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None: ...
 

--- a/tests/envs/mdp/test_observations.py
+++ b/tests/envs/mdp/test_observations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -24,6 +25,11 @@ class _Backend:
     num_actuators = 0
 
     def __init__(self) -> None:
+        self.sensor_calls: Counter[str] = Counter()
+        self.sensor_values = {
+            "gyro": np.asarray([[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]], dtype=np.float32),
+            "upvector": np.asarray([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+        }
         self.joint_names = ("hip", "knee", "ankle")
         self.dof_pos = np.asarray(
             [[0.4, 0.1, -0.2], [0.0, 0.3, 0.7]],
@@ -84,6 +90,25 @@ class _Backend:
 
     def get_body_ang_vel_b(self, ids: np.ndarray) -> np.ndarray:
         return self.body_ang_vel_b[:, ids]
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self.sensor_calls["single"] += 1
+        try:
+            return self.sensor_values[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown sensor {name!r}") from exc
+
+    def get_sensor_data_batch(self, names: tuple[str, ...]) -> np.ndarray:
+        self.sensor_calls["batch"] += 1
+        values = [self.sensor_values[name].reshape(self.num_envs, -1) for name in names]
+        return np.concatenate(values, axis=1)
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]):
+        return lambda: self.get_sensor_data_batch(names)
+
+    def bind_sensor_data(self, names):
+        self.sensor_calls["bind"] += 1
+        return SimBackend.bind_sensor_data(self, names)  # type: ignore[arg-type]
 
 
 class _ActionManager:
@@ -196,6 +221,128 @@ def test_scene_entity_selector_is_resolved_once_by_observation_manager() -> None
     assert resolved.joint_ids == [2, 0]
 
 
+def _sensor_manager(env: ManagerBasedRlEnv) -> ObservationManager:
+    return ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "gyro": ObservationTermCfg(
+                        func=mdp.builtin_sensor,
+                        params={"sensor_name": "gyro"},
+                    ),
+                    "gravity": ObservationTermCfg(
+                        func=mdp.projected_gravity_from_sensor,
+                        params={"sensor_name": "upvector"},
+                    ),
+                }
+            )
+        },
+        env,
+    )
+
+
+def test_named_sensor_terms_bind_once_and_only_read_cached_views() -> None:
+    env, backend = _env()
+
+    manager = _sensor_manager(env)
+
+    assert manager.group_obs_dim == {"policy": (6,)}
+    assert backend.sensor_calls == {"bind": 2, "single": 2, "batch": 4}
+
+    first = manager.compute_group("policy")
+    second = manager.compute_group("policy")
+    assert isinstance(first, np.ndarray)
+    assert isinstance(second, np.ndarray)
+    expected = np.concatenate(
+        [backend.sensor_values["gyro"], -backend.sensor_values["upvector"]], axis=1
+    )
+    np.testing.assert_array_equal(first, expected)
+    np.testing.assert_array_equal(second, expected)
+    assert backend.sensor_calls == {"bind": 2, "single": 2, "batch": 8}
+
+    gyro_term = manager.get_term_cfg("policy", "gyro").func
+    gravity_term = manager.get_term_cfg("policy", "gravity").func
+    assert isinstance(gyro_term, mdp.builtin_sensor)
+    assert isinstance(gravity_term, mdp.projected_gravity_from_sensor)
+
+
+@pytest.mark.parametrize(
+    ("sensor_name", "error", "message"),
+    [
+        ("", ValueError, "builtin_sensor.*non-empty sensor_name"),
+        ("missing", KeyError, "builtin_sensor.*missing.*backend.*fake"),
+    ],
+)
+def test_named_sensor_term_materialization_fails_closed(
+    sensor_name: str, error: type[Exception], message: str
+) -> None:
+    env, _ = _env()
+    with pytest.raises(error, match=message):
+        ObservationManager(
+            {
+                "policy": ObservationGroupCfg(
+                    terms={
+                        "sensor": ObservationTermCfg(
+                            func=mdp.builtin_sensor,
+                            params={"sensor_name": sensor_name},
+                        )
+                    }
+                )
+            },
+            env,
+        )
+
+
+def test_named_sensor_scene_seam_rejects_duplicate_names() -> None:
+    env, _ = _env()
+    with pytest.raises(ValueError, match="named-sensor.*unique"):
+        env.scene.bind_sensor_data(("gyro", "gyro"))
+
+
+def test_projected_gravity_sensor_requires_one_three_dimensional_view() -> None:
+    env, backend = _env()
+    backend.sensor_values["upvector"] = np.zeros((2, 2), dtype=np.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=r"projected_gravity_from_sensor.*3-D.*dimensions \(2,\).*backend 'fake'",
+    ):
+        ObservationManager(
+            {
+                "policy": ObservationGroupCfg(
+                    terms={
+                        "gravity": ObservationTermCfg(
+                            func=mdp.projected_gravity_from_sensor,
+                            params={"sensor_name": "upvector"},
+                        )
+                    }
+                )
+            },
+            env,
+        )
+
+
+def test_named_sensor_runtime_drift_reports_term_and_backend() -> None:
+    env, backend = _env()
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "gyro": ObservationTermCfg(
+                        func=mdp.builtin_sensor,
+                        params={"sensor_name": "gyro"},
+                    )
+                }
+            )
+        },
+        env,
+    )
+    backend.sensor_values["gyro"] = np.full((2, 3), np.nan, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="builtin_sensor.*gyro.*backend 'fake'.*NaN or Inf"):
+        manager.compute_group("policy")
+
+
 @pytest.mark.parametrize(
     ("call", "message"),
     [
@@ -204,7 +351,10 @@ def test_scene_entity_selector_is_resolved_once_by_observation_manager() -> None
             lambda env: mdp.generated_commands(env, "missing"),
             "Command term 'missing' not found",
         ),
-        (lambda env: mdp.joint_pos_rel(env, biased=1), "biased must be bool"),
+        (
+            lambda env: mdp.joint_pos_rel(env, biased=1),  # type: ignore[arg-type]
+            "biased must be bool",
+        ),
     ],
 )
 def test_invalid_term_requests_fail_explicitly(call, message: str) -> None:


### PR DESCRIPTION
## 主要结果

把已完成的 backend named-sensor contract 接到 Manager-Based scene/context：`builtin_sensor` 与 `projected_gravity_from_sensor` 在 term construction 冷路径绑定 `BackendSensorView`，热路径只读取 backend-owned view。

- `EntityScene.bind_sensor_data(...)` 只委托正式 `SimBackend` contract，不暴露 backend/model/data。
- 保留 pinned mjlab term 名称、`sensor_name` 参数与 projected-gravity 取负语义。
- unknown/duplicate/空名称、非 3-D gravity 以及 runtime shape/dtype/finite drift 均 fail-closed，并携带 term/backend 诊断。
- 不新增 `SceneCfg.sensors`、backend 方法或 sensor composer；不迁移 production task、runner、IPC 或 scripts。

## Validation

- `make test-all`
- ruff format/check、mypy、pyright
- `1978 passed, 27 skipped, 276 deselected, 1 xfailed`
- focused owner-boundary suite：`189 passed, 4 skipped, 4 deselected`
- focused sensor observation suite：`25 passed`
- benchmark smoke：module mode 32/33、script mode 33/34（各 1 个 platform-optional MLX skip）

## Change accounting

- source-derived public names/equations: 约 8 行
- mechanical Torch→NumPy conversion: 0 行
- UniLab-specific scene/protocol/class-term glue: 约 108 行
- tests/docs: 约 156 行
- reworked/deleted: 2 行；0 files
- 7 files changed; 272 additions, 2 deletions

Closes #1078
Related to #1042