### PR TITLE
fix(env): materialize manager backend before reset

### DIFF
--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/6-manager_based_api.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/6-manager_based_api.md
@@ -20,6 +20,9 @@ The normative compatibility matrix and mechanical migration example are in
 - Named-sensor observation terms bind a backend-owned view through
   `EntityScene.bind_sensor_data(...)` during construction; their hot path only reads
   that view and never re-resolves sensor names or XML/model metadata.
+- `ManagerBasedRlEnv` owns backend materialization exactly once: manager construction
+  and startup events run first, then `SimBackend.materialize()` completes before any
+  reset or step can execute.
 - Explicitly empty configuration may use a Null manager. A requested capability that
   is unavailable fails at the nearest boundary; it is never skipped, zero-filled, or
   routed back to a legacy environment.

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
@@ -16,6 +16,8 @@ NumPy，并保留现有 `NpEnvState`、Hydra owner YAML、`SimBackend`、registr
   `SimBackend` contract，热路径复用缓存 ID/view。
 - named-sensor observation term 在构造时通过 `EntityScene.bind_sensor_data(...)` 绑定
   backend-owned view；热路径只读该 view，不重复解析 sensor 名称或 XML/model metadata。
+- `ManagerBasedRlEnv` 恰好拥有一次 backend 物化：先完成 manager 构造和 startup event，
+  再调用 `SimBackend.materialize()`，任何 reset/step 都不能在物化前执行。
 - 用户显式空配置可以使用 Null manager；配置请求但 runtime/backend 不支持的能力必须在
   最近边界报错，不能 warning、skip、返回零或回退旧 env。
 - 热路径避免明显的重复解析、逐环境 Python 循环、复制和临时分配；进一步优化需要

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -214,6 +214,22 @@ class ManagerBasedRlEnv(NpEnv):
 
         if "startup" in self.event_manager.available_modes:
             self.event_manager.apply(mode="startup")
+        self._materialize_backend()
+
+    def _materialize_backend(self) -> None:
+        """Finalize backend runtime resources before the first reset or step."""
+        try:
+            self._backend.materialize()
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                "ManagerBasedRlEnv lifecycle capability 'SimBackend.materialize' is "
+                f"unavailable on backend '{self._backend.backend_type}': {exc}"
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                "ManagerBasedRlEnv failed to materialize backend "
+                f"'{self._backend.backend_type}' after startup events: {exc}"
+            ) from exc
 
     @property
     def physics_dt(self) -> float:

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 
 import unilab.envs.manager_based_rl_env as manager_env_module
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.backend.base import SimBackend
 from unilab.base.entity import EntityCfg
 from unilab.base.scene import SceneCfg
@@ -39,13 +41,28 @@ from unilab.managers import (
 class _FakeBackend:
     backend_type = "fake"
 
-    def __init__(self, num_envs: int, *, reject_pre_step: bool = False) -> None:
+    def __init__(
+        self,
+        num_envs: int,
+        *,
+        reject_pre_step: bool = False,
+        reject_materialize: bool = False,
+    ) -> None:
         self.num_envs = num_envs
         self.num_actuators = 1
         self.reject_pre_step = reject_pre_step
+        self.reject_materialize = reject_materialize
         self.pre_step_control = None
         self.applied_controls: list[np.ndarray] = []
         self.cleanup_calls = 0
+        self.materialize_calls = 0
+        self.lifecycle: list[str] = []
+
+    def materialize(self) -> None:
+        if self.reject_materialize:
+            raise RuntimeError("pool construction failed")
+        self.materialize_calls += 1
+        self.lifecycle.append("materialize")
 
     def get_actuator_names(self) -> tuple[str, ...]:
         return ("motor",)
@@ -65,6 +82,7 @@ class _FakeBackend:
         self.pre_step_control = fn
 
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        assert self.materialize_calls == 1
         native = ctrl
         for _ in range(nsteps):
             if self.pre_step_control is not None:
@@ -129,6 +147,7 @@ class _ResetBackend(_FakeBackend):
         randomization=None,
     ) -> None:
         assert randomization is None
+        assert self.materialize_calls == 1
         self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
 
@@ -220,6 +239,10 @@ def _critic_obs(env: _TestEnv) -> np.ndarray:
     return env.episode_length_buf[:, None].astype(np.float32)
 
 
+def _episode_step_observation(env: ManagerBasedRlEnv) -> np.ndarray:
+    return env.episode_length_buf[:, None].astype(np.float32)
+
+
 def _reward(env: _TestEnv) -> np.ndarray:
     return env.action_manager.action[:, 0].copy()
 
@@ -244,6 +267,12 @@ def _curriculum(env: _TestEnv, env_ids: np.ndarray | slice) -> float:
 def _event(env: _TestEnv, env_ids: np.ndarray | None) -> None:
     rendered_ids = None if env_ids is None else env_ids.tolist()
     env.trace.append(("event", rendered_ids))
+
+
+def _startup_event(env: _TestEnv, env_ids: np.ndarray | None) -> None:
+    assert env_ids is None
+    backend = cast(_FakeBackend, env._backend)
+    backend.lifecycle.append("startup")
 
 
 def _observe_uncommitted_reset(env: _TestEnv, env_ids: np.ndarray | None) -> None:
@@ -311,8 +340,13 @@ def _make_env(
     *,
     num_envs: int = 2,
     reject_pre_step: bool = False,
+    reject_materialize: bool = False,
 ) -> tuple[_TestEnv, _FakeBackend]:
-    backend = _FakeBackend(num_envs, reject_pre_step=reject_pre_step)
+    backend = _FakeBackend(
+        num_envs,
+        reject_pre_step=reject_pre_step,
+        reject_materialize=reject_materialize,
+    )
     env = _TestEnv(
         cfg or _make_cfg(),
         cast(SimBackend, backend),
@@ -375,6 +409,74 @@ def test_manager_construction_uses_pinned_order(monkeypatch: pytest.MonkeyPatch)
 
     _make_env(cfg)
     assert order == list(names)
+
+
+def test_backend_materializes_once_after_startup_and_before_runtime() -> None:
+    cfg = _make_cfg()
+    cfg.events = {
+        "startup": EventTermCfg(func=_startup_event, mode="startup"),
+        "reset": EventTermCfg(func=_event, mode="reset"),
+    }
+    env, backend = _make_env(cfg)
+
+    assert backend.lifecycle == ["startup", "materialize"]
+    assert backend.materialize_calls == 1
+
+    env.reset()
+    env.step(np.zeros((2, 1), dtype=np.float32))
+    env.reset()
+
+    assert backend.materialize_calls == 1
+
+
+def test_backend_materialization_failure_has_lifecycle_context() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="ManagerBasedRlEnv failed to materialize backend 'fake'.*pool construction failed",
+    ):
+        _make_env(reject_materialize=True)
+
+
+def test_real_mujoco_backend_is_materialized_before_first_reset() -> None:
+    scene = SceneCfg(
+        model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
+        entities={"robot": EntityCfg()},
+    )
+    cfg = ManagerBasedRlEnvCfg(
+        scene=scene,
+        sim_dt=0.01,
+        ctrl_dt=0.02,
+        max_episode_seconds=1.0,
+        observations={
+            "actor": ObservationGroupCfg(
+                terms={"state": ObservationTermCfg(func=_episode_step_observation)}
+            )
+        },
+        actions={},
+        events={"reset_default": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset")},
+        rewards={"alive": RewardTermCfg(func=mdp.is_alive, weight=1.0)},
+        terminations={"time_out": TerminationTermCfg(func=mdp.time_out, time_out=True)},
+        policy_observation_group="actor",
+    )
+    backend = create_backend(
+        "mujoco",
+        scene,
+        2,
+        cfg.sim_dt,
+        base_name="base",
+        **env_backend_kwargs(cfg),
+    )
+    env = ManagerBasedRlEnv(cfg, backend, 2)
+    try:
+        state = env.init_state()
+        assert state.obs["obs"].shape == (2, 1)
+        assert np.isfinite(state.obs["obs"]).all()
+
+        state = env.step(np.empty((2, 0), dtype=np.float32))
+        assert np.isfinite(state.obs["obs"]).all()
+        assert np.isfinite(state.reward).all()
+    finally:
+        env.close()
 
 
 def test_np_env_owns_substeps_autoreset_and_final_observation() -> None:


### PR DESCRIPTION
## 主要结果

让 `ManagerBasedRlEnv` 在 manager 构造和 startup event 完成后，通过正式 `SimBackend.materialize()` 恰好物化 backend 一次，并保证任何首次 reset/step 都不能抢跑。

- startup event → backend materialization → reset/step 的生命周期顺序由 env owner 固定。
- 重复 reset/step 不重复物化 backend。
- 物化不受支持或失败时，错误携带 Manager-Based lifecycle 与 backend 诊断。
- 增加真实 MuJoCo Go2 scene 的首次 reset/step smoke；不迁移 production task/config，不新增 backend contract，不修改 runner/IPC/scripts。

## Validation

- `make test-all`
- ruff format/check、mypy、pyright
- `1981 passed, 27 skipped, 276 deselected, 1 xfailed`
- focused lifecycle/reset/entity/backend suite：`90 passed`
- focused manager lifecycle suite：`22 passed`
- benchmark smoke：module mode 32/33、script mode 33/34（各 1 个 platform-optional MLX skip）

## Change accounting

- lifecycle implementation and diagnostics：16 added lines
- fake/real backend ordering and reset smoke：tests concentrated in one existing file
- lifecycle invariant docs：English and Chinese architecture pages
- 4 files changed; 125 additions, 2 deletions

Closes #1080
Related to #1042