### PR TITLE
feat(env): add Go2 Manager-Based reward parity terms

### DIFF
--- a/src/unilab/envs/locomotion/common/manager_terms.py
+++ b/src/unilab/envs/locomotion/common/manager_terms.py
@@ -6,14 +6,16 @@ uses community ``func + params`` terms, NumPy, and the base-owned sensor facade.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
 import numpy as np
 
 from unilab.dtype_config import get_global_dtype
 from unilab.managers.manager_base import ManagerTermBase, ManagerTermBaseCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg
 
 if TYPE_CHECKING:
+    from unilab.base.entity import Entity
     from unilab.managers._types import ManagerBasedRlEnv, ManagerSensorView
 
     class _GaitEnv(ManagerBasedRlEnv, Protocol):
@@ -22,6 +24,7 @@ if TYPE_CHECKING:
 
 
 _OFFSETS = (0.0, 0.5, 0.5, 0.0)
+_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 
 
 def _real(
@@ -73,6 +76,138 @@ def _names(term: str, value: Any) -> tuple[str, ...]:
     if len(set(names)) != 4:
         raise ValueError(f"{term} sensor_names must be unique: {names}")
     return names
+
+
+def _state(term: str, capability: str, value: Any, shape: tuple[int, ...]) -> np.ndarray:
+    if not isinstance(value, np.ndarray):
+        raise TypeError(f"{term} {capability} must be an np.ndarray")
+    if value.shape != shape:
+        raise ValueError(f"{term} {capability} must have shape {shape}, got {value.shape}")
+    if not np.isfinite(value).all():
+        env_ids = np.flatnonzero(~np.isfinite(value).reshape(shape[0], -1).all(axis=1)).tolist()
+        raise ValueError(f"{term} {capability} contains NaN or Inf for environments {env_ids[:10]}")
+    return value
+
+
+def _command(env: ManagerBasedRlEnv, term: str, command_name: str) -> np.ndarray:
+    if not isinstance(command_name, str) or not command_name:
+        raise ValueError(f"{term} command_name must be a non-empty string")
+    try:
+        command = env.command_manager.get_command(command_name)
+    except KeyError as exc:
+        raise KeyError(f"{term} command capability '{command_name}' is unavailable") from exc
+    if command is None:
+        raise KeyError(f"{term} command capability '{command_name}' is unavailable")
+    return _state(term, f"command '{command_name}'", command, (env.num_envs, 3))
+
+
+def _asset(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> Entity:
+    return cast("Entity", env.scene[asset_cfg.name])
+
+
+def track_lin_vel_xy_exp(
+    env: ManagerBasedRlEnv,
+    std: float,
+    command_name: str,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Track commanded planar velocity with the legacy independent exponential kernel."""
+    scale = _real("track_lin_vel_xy_exp", "std", std, minimum=0.0, strict_minimum=True)
+    actual = _state(
+        "track_lin_vel_xy_exp",
+        "root linear velocity",
+        _asset(env, asset_cfg).data.root_link_lin_vel_b,
+        (env.num_envs, 3),
+    )
+    error = np.sum(
+        np.square(_command(env, "track_lin_vel_xy_exp", command_name)[:, :2] - actual[:, :2]),
+        axis=1,
+    )
+    return np.asarray(np.exp(-error / scale**2), dtype=get_global_dtype())
+
+
+def track_ang_vel_z_exp(
+    env: ManagerBasedRlEnv,
+    std: float,
+    command_name: str,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Track commanded yaw velocity without folding roll/pitch into the kernel."""
+    scale = _real("track_ang_vel_z_exp", "std", std, minimum=0.0, strict_minimum=True)
+    actual = _state(
+        "track_ang_vel_z_exp",
+        "root angular velocity",
+        _asset(env, asset_cfg).data.root_link_ang_vel_b,
+        (env.num_envs, 3),
+    )
+    error = np.square(_command(env, "track_ang_vel_z_exp", command_name)[:, 2] - actual[:, 2])
+    return np.asarray(np.exp(-error / scale**2), dtype=get_global_dtype())
+
+
+def lin_vel_z_l2(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize vertical root velocity independently from planar tracking."""
+    velocity = _state(
+        "lin_vel_z_l2",
+        "root linear velocity",
+        _asset(env, asset_cfg).data.root_link_lin_vel_b,
+        (env.num_envs, 3),
+    )
+    return np.asarray(np.square(velocity[:, 2]), dtype=get_global_dtype())
+
+
+def ang_vel_xy_l2(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize root roll/pitch angular velocity independently from yaw tracking."""
+    velocity = _state(
+        "ang_vel_xy_l2",
+        "root angular velocity",
+        _asset(env, asset_cfg).data.root_link_ang_vel_b,
+        (env.num_envs, 3),
+    )
+    return np.asarray(np.sum(np.square(velocity[:, :2]), axis=1), dtype=get_global_dtype())
+
+
+def base_height_l2(
+    env: ManagerBasedRlEnv,
+    target_height: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize world-frame root height error for the flat-ground pilot."""
+    target = _real("base_height_l2", "target_height", target_height)
+    position = _state(
+        "base_height_l2",
+        "root position",
+        _asset(env, asset_cfg).data.root_link_pos_w,
+        (env.num_envs, 3),
+    )
+    return np.asarray(np.square(position[:, 2] - target), dtype=get_global_dtype())
+
+
+def joint_deviation_l1(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize selected joint displacement from the default pose with an L1 kernel."""
+    asset = _asset(env, asset_cfg)
+    position = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    default = asset.data.default_joint_pos[:, asset_cfg.joint_ids]
+    if (
+        not isinstance(position, np.ndarray)
+        or position.ndim != 2
+        or position.shape[0] != env.num_envs
+    ):
+        shape = getattr(position, "shape", None)
+        raise ValueError(
+            f"joint_deviation_l1 joint position must be 2-D with leading dimension {env.num_envs}, got {shape}"
+        )
+    default = _state("joint_deviation_l1", "default joint position", default, position.shape)
+    position = _state("joint_deviation_l1", "joint position", position, position.shape)
+    return np.asarray(np.sum(np.abs(position - default), axis=1), dtype=get_global_dtype())
 
 
 class _GaitTerm(ManagerTermBase):
@@ -231,4 +366,14 @@ class feet_phase_swing_height(_FootSensorTerm):
         return np.mean(reward, axis=1).astype(get_global_dtype(), copy=False)
 
 
-__all__ = ["feet_phase_contact", "feet_phase_swing_height", "quadruped_gait_phase"]
+__all__ = [
+    "ang_vel_xy_l2",
+    "base_height_l2",
+    "feet_phase_contact",
+    "feet_phase_swing_height",
+    "joint_deviation_l1",
+    "lin_vel_z_l2",
+    "quadruped_gait_phase",
+    "track_ang_vel_z_exp",
+    "track_lin_vel_xy_exp",
+]

--- a/tests/envs/locomotion/test_manager_gait_terms.py
+++ b/tests/envs/locomotion/test_manager_gait_terms.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from unilab.base.backend.base import BackendSensorView
+from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import manager_terms
 from unilab.managers import (
     ObservationGroupCfg,
@@ -19,6 +20,7 @@ from unilab.managers import (
     RewardTermCfg,
 )
 from unilab.managers._types import ManagerBasedRlEnv
+from unilab.managers.scene_entity_config import SceneEntityCfg
 
 CONTACTS = ("fl_contact", "fr_contact", "rl_contact", "rr_contact")
 POSITIONS = ("fl_pos", "fr_pos", "rl_pos", "rr_pos")
@@ -50,6 +52,38 @@ class _Scene:
         view = BackendSensorView("fake", names, dimensions, 2, read)
         view.read()  # Mirror SimBackend.bind_sensor_data materialization validation.
         return view
+
+
+class _ParityScene:
+    def __init__(self) -> None:
+        self.robot = SimpleNamespace(
+            data=SimpleNamespace(
+                root_link_lin_vel_b=np.array(
+                    [[0.2, 0.1, -0.3], [0.3, -0.2, 0.5]], dtype=np.float32
+                ),
+                root_link_ang_vel_b=np.array(
+                    [[0.1, -0.2, 0.4], [-0.3, 0.2, -0.1]], dtype=np.float32
+                ),
+                root_link_pos_w=np.array([[1.0, 2.0, 0.4], [-1.0, 0.5, 0.2]], dtype=np.float32),
+                joint_pos=np.array([[0.2, -0.1, 0.5], [-0.4, 0.3, 0.1]], dtype=np.float32),
+                default_joint_pos=np.array([[0.1, -0.2, 0.5], [-0.1, 0.1, 0.0]], dtype=np.float32),
+            )
+        )
+
+    def __getitem__(self, name: str):
+        if name != "robot":
+            raise KeyError(name)
+        return self.robot
+
+
+class _Commands:
+    def __init__(self) -> None:
+        self.command = np.array([[0.5, -0.2, 0.3], [-0.1, 0.4, -0.2]], dtype=np.float32)
+
+    def get_command(self, name: str) -> np.ndarray:
+        if name != "twist":
+            raise KeyError(name)
+        return self.command
 
 
 def _env(counter: int = 0, scene: _Scene | None = None) -> ManagerBasedRlEnv:
@@ -87,6 +121,23 @@ def _rewards(env: ManagerBasedRlEnv) -> RewardManager:
         ),
     }
     return RewardManager(terms, env, scale_by_dt=False)
+
+
+def _parity_env() -> ManagerBasedRlEnv:
+    return cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=2,
+            scene=_ParityScene(),
+            command_manager=_Commands(),
+            max_episode_length_s=20.0,
+        ),
+    )
+
+
+def _reward_value(env: ManagerBasedRlEnv, func, **params: Any) -> np.ndarray:
+    cfg = RewardTermCfg(func=func, weight=1.0, params=params)
+    return RewardManager({"parity": cfg}, env, scale_by_dt=False).compute(dt=0.02)
 
 
 def test_gait_phase_matches_global_legacy_clock_and_ignores_episode_reset() -> None:
@@ -164,3 +215,75 @@ def test_runtime_nonfinite_sensor_data_reports_term_and_backend() -> None:
     scene.values["fl_contact"][1, 0] = np.nan
     with pytest.raises(ValueError, match="feet_phase_contact.*backend 'fake'.*NaN or Inf"):
         manager.compute(dt=0.02)
+
+
+def test_base_reward_terms_match_go2_flat_equations() -> None:
+    env = _parity_env()
+    asset = SceneEntityCfg("robot")
+    data = cast(Any, env).scene.robot.data
+    command = cast(Any, env).command_manager.command
+    std = 0.5
+    actual = {
+        "track_xy": _reward_value(
+            env,
+            manager_terms.track_lin_vel_xy_exp,
+            std=std,
+            command_name="twist",
+            asset_cfg=asset,
+        ),
+        "track_yaw": _reward_value(
+            env,
+            manager_terms.track_ang_vel_z_exp,
+            std=std,
+            command_name="twist",
+            asset_cfg=SceneEntityCfg("robot"),
+        ),
+        "lin_z": _reward_value(env, manager_terms.lin_vel_z_l2, asset_cfg=SceneEntityCfg("robot")),
+        "ang_xy": _reward_value(
+            env, manager_terms.ang_vel_xy_l2, asset_cfg=SceneEntityCfg("robot")
+        ),
+        "height": _reward_value(
+            env,
+            manager_terms.base_height_l2,
+            target_height=0.3,
+            asset_cfg=SceneEntityCfg("robot"),
+        ),
+        "pose": _reward_value(
+            env, manager_terms.joint_deviation_l1, asset_cfg=SceneEntityCfg("robot")
+        ),
+    }
+    expected = {
+        "track_xy": np.exp(
+            -np.sum(np.square(command[:, :2] - data.root_link_lin_vel_b[:, :2]), axis=1) / std**2
+        ),
+        "track_yaw": np.exp(-np.square(command[:, 2] - data.root_link_ang_vel_b[:, 2]) / std**2),
+        "lin_z": np.square(data.root_link_lin_vel_b[:, 2]),
+        "ang_xy": np.sum(np.square(data.root_link_ang_vel_b[:, :2]), axis=1),
+        "height": np.square(data.root_link_pos_w[:, 2] - 0.3),
+        "pose": np.sum(np.abs(data.joint_pos - data.default_joint_pos), axis=1),
+    }
+    for name in expected:
+        assert actual[name].shape == (2,)
+        assert actual[name].dtype == np.dtype(get_global_dtype())
+        np.testing.assert_allclose(actual[name], expected[name], rtol=1e-6, atol=1e-7)
+
+
+def test_base_reward_terms_fail_closed_at_nearest_boundary() -> None:
+    env = _parity_env()
+    with pytest.raises(ValueError, match="track_lin_vel_xy_exp std must be greater than 0.0"):
+        _reward_value(env, manager_terms.track_lin_vel_xy_exp, std=0.0, command_name="twist")
+    with pytest.raises(KeyError, match="track_ang_vel_z_exp command capability 'missing'"):
+        _reward_value(env, manager_terms.track_ang_vel_z_exp, std=0.5, command_name="missing")
+    with pytest.raises(ValueError, match="base_height_l2 target_height must be finite"):
+        _reward_value(env, manager_terms.base_height_l2, target_height=np.nan)
+
+    cast(Any, env).scene.robot.data.root_link_lin_vel_b[1, 2] = np.inf
+    with pytest.raises(ValueError, match="lin_vel_z_l2 root linear velocity contains NaN or Inf"):
+        _reward_value(env, manager_terms.lin_vel_z_l2)
+
+    with pytest.raises(KeyError, match="RewardManager term 'parity'.*asset_cfg.*missing"):
+        _reward_value(
+            _parity_env(),
+            manager_terms.joint_deviation_l1,
+            asset_cfg=SceneEntityCfg("missing"),
+        )


### PR DESCRIPTION
## Summary

- add six task-owned NumPy reward terms for independent planar/yaw tracking, vertical/roll-pitch penalties, flat root height, and L1 default-pose deviation
- preserve current Go2 flat equations while using community `func + params`, `std`, command-manager, and `SceneEntityCfg` structure
- validate command/state shape and finite values at the nearest term boundary
- leave pinned generic MDP terms, production Go2 registration/config, backend, DR, runner, and IPC unchanged

## Scope accounting

- files: 2 modified
- additions: 270
- deletions: 2
- source-derived: 0
- mechanical: 0
- task-owned code: 147 additions / 2 replaced lines
- tests: 123 additions

## Local validation

- focused: 10 passed
- adjacent entity/manager/reward regression: 53 passed
- ruff: passed
- mypy: passed
- pyright: passed
- `make test-all`: passed (`1991 passed, 27 skipped, 276 deselected, 1 xfailed`; benchmark module mode 32/33 and script mode 33/34, with one platform-optional MLX skip in each mode)

Per the #1042 child workflow, these gates ran locally on final head `a0d7c2ec`; remote CI/Docs are intentionally not triggered.

Refs #1042
Closes #1084
