### PR TITLE
feat(env): support named-keyframe Manager defaults

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -412,6 +412,8 @@ class Entity:
         backend: SimBackend,
         control_buffer: np.ndarray | None = None,
         reset_state: ResetStateTransaction | None = None,
+        *,
+        default_qpos: np.ndarray | None = None,
     ) -> None:
         if not name:
             raise ValueError("Entity name must be a non-empty string")
@@ -479,8 +481,12 @@ class Entity:
             self._reset_root_layout,
             default_root_state,
             self._reset_root_layout_error,
-        ) = self._materialize_root_state(backend, cfg.root_body_name)
-        default_joint_pos = self._materialize_default_joint_pos(backend, joint_pos_ids)
+        ) = self._materialize_root_state(backend, cfg.root_body_name, default_qpos)
+        default_joint_pos = self._materialize_default_joint_pos(
+            backend,
+            joint_pos_ids,
+            default_qpos,
+        )
         default_joint_vel = self._materialize_default_joint_vel(backend, joint_vel_ids)
         gravity_vec_w = self._materialize_gravity_vector(backend, root_body_ids)
         actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
@@ -669,20 +675,46 @@ class Entity:
         return selected
 
     def _materialize_default_joint_pos(
-        self, backend: SimBackend, joint_pos_ids: np.ndarray | None
+        self,
+        backend: SimBackend,
+        joint_pos_ids: np.ndarray | None,
+        default_qpos: np.ndarray | None,
     ) -> np.ndarray | None:
         if joint_pos_ids is None:
             return None
-        defaults = self._read_state("default joint position", backend.get_default_dof_pos)
         current = self._read_state("joint position state", backend.get_dof_pos)
-        if defaults.shape != current.shape[1:]:
-            raise ValueError(
-                f"Entity '{self.name}' capability 'default joint position' on backend "
-                f"'{self._backend_type}' returned shape {defaults.shape}; expected "
-                f"{current.shape[1:]} to match get_dof_pos()"
+        if default_qpos is None:
+            defaults = self._read_state("default joint position", backend.get_default_dof_pos)
+            if defaults.shape != current.shape[1:]:
+                raise ValueError(
+                    f"Entity '{self.name}' capability 'default joint position' on backend "
+                    f"'{self._backend_type}' returned shape {defaults.shape}; expected "
+                    f"{current.shape[1:]} to match get_dof_pos()"
+                )
+            selected = np.asarray(defaults[_as_column_index(joint_pos_ids)])
+        else:
+            assert self._joint_names is not None
+            defaults = self._validate_root_default_vector(default_qpos, "selected default qpos")
+            try:
+                state_qpos_ids = backend.get_joint_state_qpos_indices(self._joint_names)
+            except (AttributeError, NotImplementedError) as exc:
+                raise self._capability_error("default joint-state layout", str(exc)) from exc
+            resolved_qpos_ids = _readonly_ids(
+                state_qpos_ids,
+                expected=len(self._joint_names),
+                label=f"Entity '{self.name}' default qpos",
             )
-        selected = np.asarray(defaults[_as_column_index(joint_pos_ids)])
-        materialized = np.broadcast_to(selected, (backend.num_envs, len(joint_pos_ids))).copy()
+            if resolved_qpos_ids.size and int(np.max(resolved_qpos_ids)) >= defaults.size:
+                raise ValueError(
+                    f"Entity '{self.name}' default qpos layout exceeds backend "
+                    f"'{self._backend_type}' width {defaults.size}: {resolved_qpos_ids.tolist()}"
+                )
+            selected = np.asarray(defaults[_as_column_index(resolved_qpos_ids)])
+            self._reset_joint_qpos_ids = resolved_qpos_ids
+        materialized = np.broadcast_to(
+            selected,
+            (backend.num_envs, len(joint_pos_ids)),
+        ).astype(current.dtype, copy=True)
         materialized.setflags(write=False)
         return materialized
 
@@ -690,6 +722,7 @@ class Entity:
         self,
         backend: SimBackend,
         root_body_name: str | None,
+        default_qpos: np.ndarray | None,
     ) -> tuple[BackendRootStateLayout | None, np.ndarray | None, str | None]:
         if root_body_name is None:
             return None, None, "root_body_name was not declared in EntityCfg"
@@ -704,7 +737,7 @@ class Entity:
                 f"{type(layout).__name__}"
             )
         try:
-            qpos = backend.get_default_qpos()
+            qpos = backend.get_default_qpos() if default_qpos is None else default_qpos
             qvel = backend.get_init_qvel()
         except (AttributeError, NotImplementedError) as exc:
             return None, None, str(exc)
@@ -1071,11 +1104,15 @@ class Entity:
         )
 
     def _materialize_reset_joint_indices(self) -> None:
-        if self._reset_joint_qpos_ids is not None:
+        if self._reset_joint_qpos_ids is not None and self._reset_joint_qvel_ids is not None:
             return
         assert self._joint_names is not None
         try:
-            qpos_ids = self._backend.get_joint_state_qpos_indices(self._joint_names)
+            qpos_ids = (
+                self._reset_joint_qpos_ids
+                if self._reset_joint_qpos_ids is not None
+                else self._backend.get_joint_state_qpos_indices(self._joint_names)
+            )
             qvel_ids = self._backend.get_joint_state_qvel_indices(self._joint_names)
         except (AttributeError, NotImplementedError) as exc:
             raise self._capability_error("reset joint-state layout", str(exc)) from exc
@@ -1197,6 +1234,7 @@ class EntityScene(Mapping[str, Entity]):
         control_buffer: np.ndarray | None = None,
         *,
         reset_state: ResetStateTransaction | None = None,
+        default_qpos: np.ndarray | None = None,
     ) -> None:
         self._backend = backend
         materialized: dict[str, Entity] = {}
@@ -1207,7 +1245,14 @@ class EntityScene(Mapping[str, Entity]):
                 raise TypeError(
                     f"Scene entity '{name}' must be EntityCfg, got {type(cfg).__name__}"
                 )
-            materialized[name] = Entity(name, cfg, backend, control_buffer, reset_state)
+            materialized[name] = Entity(
+                name,
+                cfg,
+                backend,
+                control_buffer,
+                reset_state,
+                default_qpos=default_qpos,
+            )
         self._entities = MappingProxyType(materialized)
         self._reset_state = reset_state
         env_origins = np.zeros((backend.num_envs, 3), dtype=np.float32)
@@ -1222,8 +1267,15 @@ class EntityScene(Mapping[str, Entity]):
         control_buffer: np.ndarray | None = None,
         *,
         reset_state: ResetStateTransaction | None = None,
+        default_qpos: np.ndarray | None = None,
     ) -> EntityScene:
-        return cls(cfg.entities, backend, control_buffer, reset_state=reset_state)
+        return cls(
+            cfg.entities,
+            backend,
+            control_buffer,
+            reset_state=reset_state,
+            default_qpos=default_qpos,
+        )
 
     @property
     def entities(self) -> Mapping[str, Entity]:

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -19,9 +19,15 @@ from unilab.utils.rotation import np_quat_apply_inverse
 class ResetStateTransaction:
     """Reusable, fail-closed transaction for reset-mode state mutation."""
 
-    def __init__(self, backend: SimBackend) -> None:
+    def __init__(
+        self,
+        backend: SimBackend,
+        *,
+        default_qpos: np.ndarray | None = None,
+    ) -> None:
         self._backend = backend
         self._num_envs = backend.num_envs
+        self._selected_default_qpos = default_qpos
         self._active = False
         self._active_mask = np.zeros(self._num_envs, dtype=np.bool_)
         self._dirty_mask = np.zeros(self._num_envs, dtype=np.bool_)
@@ -260,10 +266,12 @@ class ResetStateTransaction:
     def _materialize_default_state(self, term_name: str) -> None:
         if self._default_qpos is not None:
             return
-        try:
-            qpos = self._backend.get_default_qpos()
-        except (AttributeError, NotImplementedError) as exc:
-            raise self._capability_error(term_name, "default qpos", exc) from exc
+        qpos = self._selected_default_qpos
+        if qpos is None:
+            try:
+                qpos = self._backend.get_default_qpos()
+            except (AttributeError, NotImplementedError) as exc:
+                raise self._capability_error(term_name, "default qpos", exc) from exc
         try:
             qvel = self._backend.get_init_qvel()
         except (AttributeError, NotImplementedError) as exc:

--- a/src/unilab/base/scene.py
+++ b/src/unilab/base/scene.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
 
 from unilab.base.entity import EntityCfg
 from unilab.terrains.terrain_generator import TerrainGeneratorCfg
+
+if TYPE_CHECKING:
+    from unilab.base.backend.base import SimBackend
 
 
 def resolve_scene_fragment_path(fragment_file: str, model_file: Path) -> Path:
@@ -47,3 +53,56 @@ class SceneCfg:
     # scene (e.g. a per-env replicable obstacle) without touching the trained
     # collision model. ``None`` => render with ``model_file`` (unchanged).
     visual_model_file: str | None = None
+    default_keyframe_name: str | None = None
+    """Optional named keyframe used as the Manager-Based default state."""
+
+
+def resolve_scene_default_qpos(cfg: SceneCfg, backend: SimBackend) -> np.ndarray | None:
+    """Resolve one named default-qpos snapshot without changing the qpos0 path."""
+    keyframe_name = cfg.default_keyframe_name
+    if keyframe_name is not None and not isinstance(keyframe_name, str):
+        raise TypeError(
+            "SceneCfg default_keyframe_name must be a non-empty string or None, "
+            f"got {type(keyframe_name).__name__}"
+        )
+    if keyframe_name == "":
+        raise ValueError("SceneCfg default_keyframe_name must be a non-empty string or None")
+    if keyframe_name is None:
+        return None
+
+    capability = f"default keyframe {keyframe_name!r} qpos"
+    try:
+        value = backend.get_keyframe_qpos(keyframe_name)
+    except (AttributeError, NotImplementedError) as exc:
+        raise NotImplementedError(
+            f"Manager scene default keyframe {keyframe_name!r} is unavailable on "
+            f"backend '{backend.backend_type}': {exc}"
+        ) from exc
+    except (KeyError, ValueError) as exc:
+        raise ValueError(
+            f"Manager scene could not resolve default keyframe {keyframe_name!r} on "
+            f"backend '{backend.backend_type}': {exc}"
+        ) from exc
+
+    if not isinstance(value, np.ndarray):
+        raise TypeError(
+            f"Manager scene {capability} on backend '{backend.backend_type}' must return "
+            f"np.ndarray, got {type(value).__name__}"
+        )
+    if value.ndim != 1:
+        raise ValueError(
+            f"Manager scene {capability} on backend '{backend.backend_type}' returned shape "
+            f"{value.shape}; expected 1-D"
+        )
+    if not np.issubdtype(value.dtype, np.floating):
+        raise TypeError(
+            f"Manager scene {capability} on backend '{backend.backend_type}' must be "
+            f"floating, got {value.dtype}"
+        )
+    if not np.isfinite(value).all():
+        raise ValueError(
+            f"Manager scene {capability} on backend '{backend.backend_type}' returned NaN or Inf"
+        )
+    resolved = np.array(value, copy=True)
+    resolved.setflags(write=False)
+    return resolved

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -23,7 +23,7 @@ from unilab.base.config_overrides import (
 from unilab.base.entity import EntityScene
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.reset_state import ResetStateTransaction
-from unilab.base.scene import SceneCfg
+from unilab.base.scene import SceneCfg, resolve_scene_default_qpos
 from unilab.dtype_config import get_global_dtype
 from unilab.managers import (
     ActionManager,
@@ -181,14 +181,16 @@ class ManagerBasedRlEnv(NpEnv):
         cfg.seed = actual_seed
         self.rng = np.random.default_rng(actual_seed)
 
-        self._control = np.zeros((num_envs, backend.num_actuators), dtype=get_global_dtype())
-        self._reset_state = ResetStateTransaction(backend)
         assert cfg.scene is not None
+        default_qpos = resolve_scene_default_qpos(cfg.scene, backend)
+        self._control = np.zeros((num_envs, backend.num_actuators), dtype=get_global_dtype())
+        self._reset_state = ResetStateTransaction(backend, default_qpos=default_qpos)
         self.scene = EntityScene.from_scene_cfg(
             cfg.scene,
             backend,
             self._control,
             reset_state=self._reset_state,
+            default_qpos=default_qpos,
         )
 
         self.common_step_counter = 0

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -151,6 +151,32 @@ class _ResetBackend(_FakeBackend):
         self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
 
+class _KeyframeBackend(_ResetBackend):
+    def __init__(
+        self,
+        num_envs: int,
+        *,
+        keyframe_qpos: Any = None,
+        keyframe_error: Exception | None = None,
+    ) -> None:
+        super().__init__(num_envs)
+        self.keyframe_qpos = (
+            np.array([0.0, 0.0, 0.3, 0.75], dtype=np.float64)
+            if keyframe_qpos is None
+            else keyframe_qpos
+        )
+        self.keyframe_error = keyframe_error
+        self.keyframe_qpos_calls = 0
+
+    def get_keyframe_qpos(self, name: str) -> Any:
+        self.keyframe_qpos_calls += 1
+        if self.keyframe_error is not None:
+            raise self.keyframe_error
+        if name != "home":
+            raise ValueError(f"unknown keyframe {name!r}")
+        return self.keyframe_qpos
+
+
 @dataclass(kw_only=True)
 class _DriveCfg(ActionTermCfg):
     gain: float = 1.0
@@ -437,6 +463,121 @@ def test_backend_materialization_failure_has_lifecycle_context() -> None:
         _make_env(reject_materialize=True)
 
 
+@pytest.mark.parametrize(
+    ("selector", "error"),
+    [
+        (1, TypeError),
+        ("", ValueError),
+    ],
+)
+def test_default_keyframe_selector_fails_at_env_initialization(
+    selector: Any,
+    error: type[Exception],
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.scene.default_keyframe_name = selector
+    backend = _KeyframeBackend(2)
+
+    with pytest.raises(error, match="default_keyframe_name.*non-empty string or None"):
+        _TestEnv(cfg, cast(SimBackend, backend), 2)
+
+    assert backend.keyframe_qpos_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "error", "match"),
+    [
+        ([0.0], TypeError, "must return np.ndarray"),
+        (np.zeros((1, 1), dtype=np.float32), ValueError, "expected 1-D"),
+        (np.zeros(1, dtype=np.int32), TypeError, "must be floating"),
+        (np.array([np.nan], dtype=np.float32), ValueError, "NaN or Inf"),
+    ],
+)
+def test_default_keyframe_qpos_contract_fails_at_env_initialization(
+    value: Any,
+    error: type[Exception],
+    match: str,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.scene.default_keyframe_name = "home"
+    backend = _KeyframeBackend(2, keyframe_qpos=value)
+
+    with pytest.raises(error, match=f"default keyframe 'home'.*backend 'fake'.*{match}"):
+        _TestEnv(cfg, cast(SimBackend, backend), 2)
+
+    assert backend.keyframe_qpos_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("failure", "error", "match"),
+    [
+        (
+            NotImplementedError("named keyframes disabled"),
+            NotImplementedError,
+            "default keyframe 'home'.*backend 'fake'.*named keyframes disabled",
+        ),
+        (
+            ValueError("keyframe missing"),
+            ValueError,
+            "resolve default keyframe 'home'.*backend 'fake'.*keyframe missing",
+        ),
+    ],
+)
+def test_default_keyframe_resolution_names_backend_and_keyframe(
+    failure: Exception,
+    error: type[Exception],
+    match: str,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.scene.default_keyframe_name = "home"
+    backend = _KeyframeBackend(2, keyframe_error=failure)
+
+    with pytest.raises(error, match=match):
+        _TestEnv(cfg, cast(SimBackend, backend), 2)
+
+    assert backend.keyframe_qpos_calls == 1
+
+
+def test_named_keyframe_snapshot_is_shared_by_entity_and_reset_cold_path() -> None:
+    source_qpos = np.array([0.0, 0.0, 0.3, 0.75], dtype=np.float64)
+    backend = _KeyframeBackend(2, keyframe_qpos=source_qpos)
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.scene.default_keyframe_name = "home"
+    cfg.scene.entities["robot"] = EntityCfg(
+        joint_names=("joint",),
+        actuator_names=("motor",),
+    )
+    cfg.events = {
+        "reset_default": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset"),
+    }
+
+    env = _TestEnv(cfg, cast(SimBackend, backend), 2)
+    selected_qpos = env._reset_state._selected_default_qpos
+
+    assert backend.keyframe_qpos_calls == 1
+    assert backend.default_qpos_calls == 0
+    assert backend.joint_layout_calls == 1
+    assert selected_qpos is not source_qpos
+    assert selected_qpos is not None
+    assert not selected_qpos.flags.writeable
+    np.testing.assert_array_equal(env.scene["robot"].data.default_joint_pos, 0.75)
+    assert not env.scene["robot"].data.default_joint_pos.flags.writeable
+
+    source_qpos[:] = 9.0
+    env.reset()
+    env.reset(env_ids=np.array([1], dtype=np.int32))
+
+    assert backend.keyframe_qpos_calls == 1
+    assert backend.default_qpos_calls == 0
+    assert backend.joint_layout_calls == 1
+    assert len(backend.set_state_calls) == 2
+    np.testing.assert_array_equal(
+        backend.set_state_calls[0][1],
+        [[0.0, 0.0, 0.3, 0.75], [0.0, 0.0, 0.3, 0.75]],
+    )
+    np.testing.assert_array_equal(backend.set_state_calls[1][1], [[0.0, 0.0, 0.3, 0.75]])
+
+
 def test_real_mujoco_backend_is_materialized_before_first_reset() -> None:
     scene = SceneCfg(
         model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
@@ -475,6 +616,89 @@ def test_real_mujoco_backend_is_materialized_before_first_reset() -> None:
         state = env.step(np.empty((2, 0), dtype=np.float32))
         assert np.isfinite(state.obs["obs"]).all()
         assert np.isfinite(state.reward).all()
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize(
+    ("default_keyframe_name", "expected_root_z", "expected_joint_pos"),
+    [
+        (None, 0.445, np.zeros(12, dtype=np.float32)),
+        (
+            "home",
+            0.3,
+            np.array(
+                [0.0, 0.8, -1.5, 0.0, 0.8, -1.5, 0.0, 1.0, -1.5, 0.0, 1.0, -1.5],
+                dtype=np.float32,
+            ),
+        ),
+    ],
+)
+def test_real_mujoco_default_state_matches_qpos0_or_named_home(
+    default_keyframe_name: str | None,
+    expected_root_z: float,
+    expected_joint_pos: np.ndarray,
+) -> None:
+    joint_names = (
+        "FL_hip_joint",
+        "FL_thigh_joint",
+        "FL_calf_joint",
+        "FR_hip_joint",
+        "FR_thigh_joint",
+        "FR_calf_joint",
+        "RL_hip_joint",
+        "RL_thigh_joint",
+        "RL_calf_joint",
+        "RR_hip_joint",
+        "RR_thigh_joint",
+        "RR_calf_joint",
+    )
+    scene = SceneCfg(
+        model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
+        entities={
+            "robot": EntityCfg(
+                root_body_name="base",
+                joint_names=joint_names,
+            )
+        },
+        default_keyframe_name=default_keyframe_name,
+    )
+    cfg = ManagerBasedRlEnvCfg(
+        scene=scene,
+        sim_dt=0.01,
+        ctrl_dt=0.02,
+        max_episode_seconds=1.0,
+        observations={
+            "actor": ObservationGroupCfg(
+                terms={"state": ObservationTermCfg(func=_episode_step_observation)}
+            )
+        },
+        actions={},
+        events={"reset_default": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset")},
+        rewards={"alive": RewardTermCfg(func=mdp.is_alive, weight=1.0)},
+        terminations={"time_out": TerminationTermCfg(func=mdp.time_out, time_out=True)},
+        policy_observation_group="actor",
+    )
+    backend = create_backend(
+        "mujoco",
+        scene,
+        2,
+        cfg.sim_dt,
+        base_name="base",
+        add_body_sensors=True,
+        **env_backend_kwargs(cfg),
+    )
+    env = ManagerBasedRlEnv(cfg, backend, 2)
+    try:
+        robot = env.scene["robot"]
+        np.testing.assert_allclose(robot.data.default_root_state[:, 2], expected_root_z)
+        expected_batch = np.broadcast_to(expected_joint_pos, (2, expected_joint_pos.size))
+        np.testing.assert_allclose(robot.data.default_joint_pos, expected_batch)
+
+        env.init_state()
+
+        np.testing.assert_allclose(robot.data.root_link_pos_w[:, 2], expected_root_z)
+        np.testing.assert_allclose(robot.data.joint_pos, expected_batch)
     finally:
         env.close()
 


### PR DESCRIPTION
## Summary

- add SceneCfg.default_keyframe_name as the optional Manager-Based default-state selector
- resolve and validate one detached read-only keyframe qpos snapshot during env initialization
- inject the same snapshot into Entity root/joint defaults and ResetStateTransaction
- preserve the unconfigured qpos0 path and existing lazy reset behavior
- fail closed for invalid selectors, missing keyframes/capabilities, and invalid qpos arrays

## Scope accounting

- files: 5 modified
- additions: 369
- deletions: 24
- source: 145 additions / 24 deletions
- tests: 224 additions

## Local validation

- focused Manager-Based env: 33 passed
- adjacent entity/reset/event regression: 58 passed
- ruff: passed
- mypy: passed
- pyright: passed
- make test-all: passed (2002 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark module mode 32/33 and script mode 33/34, with one platform-optional MLX skip in each mode)

Per the #1042 child workflow, all gates ran locally on final head 55ce7423; remote CI/Docs are intentionally not triggered.

Refs #1042
Closes #1087