### PR TITLE
feat(config): support registry config factories

### DIFF
--- a/scripts/visualize_task_env.py
+++ b/scripts/visualize_task_env.py
@@ -284,13 +284,14 @@ def _run_mujoco(env, num_envs: int) -> None:
 
 def _build_env_cfg_override(task_name: str) -> dict[str, Any]:
     """Build the env_cfg_override dict from CLI args alone — no Hydra."""
-    if task_name not in registry._envs:
+    if not registry.contains(task_name):
         raise SystemExit(
-            f"Task '{task_name}' is not registered. Available: {sorted(registry._envs.keys())}"
+            f"Task '{task_name}' is not registered. "
+            f"Available: {sorted(registry.list_registered_envs())}"
         )
-    env_cfg_cls = registry._envs[task_name].env_cfg_cls
+    env_cfg = registry.materialize_env_config(task_name)
     override: dict[str, Any] = {}
-    reward_stub = _build_reward_stub(env_cfg_cls)
+    reward_stub = _build_reward_stub(type(env_cfg))
     if reward_stub is not None:
         override["reward_config"] = reward_stub
     return override

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -25,7 +25,8 @@ from .config_overrides import (
     MANAGER_TERM_MAPPING_POLICY,
 )
 
-TEnvCfg = TypeVar("TEnvCfg", bound=EnvCfg)
+EnvCfgFactory = Callable[[], EnvCfg]
+TEnvCfgFactory = TypeVar("TEnvCfgFactory", bound=EnvCfgFactory)
 RewardOverrideField = Literal["reward_config", "rewards"]
 _SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EnvMeta:
-    env_cfg_cls: Type[EnvCfg]
+    env_cfg_factory: EnvCfgFactory
     env_cls_dict: Dict[str, Type[ABEnv]] = field(default_factory=dict)
 
     def available_sim_backend(self) -> Optional[str]:
@@ -68,29 +69,57 @@ def contains(name: str) -> bool:
     return name in _envs
 
 
-def register_env_config(name: str, env_cfg_cls: Type[EnvCfg]):
-    """Register an environment configuration class with a name."""
+def _config_factory_name(factory: EnvCfgFactory) -> str:
+    return str(getattr(factory, "__qualname__", type(factory).__qualname__))
+
+
+def register_env_config(name: str, env_cfg_factory: EnvCfgFactory) -> None:
+    """Register a zero-argument environment configuration factory."""
     if name in _envs.keys():
         raise ValueError(f"Environment '{name}' is already registered.")
-    _envs[name] = EnvMeta(env_cfg_cls=env_cfg_cls)
+    if not callable(env_cfg_factory):
+        raise TypeError(
+            f"Environment '{name}' config factory must be callable, got "
+            f"{type(env_cfg_factory).__name__}"
+        )
+    _envs[name] = EnvMeta(env_cfg_factory=env_cfg_factory)
 
 
-def envcfg(name: str) -> Callable[[Type[TEnvCfg]], Type[TEnvCfg]]:
+def envcfg(name: str) -> Callable[[TEnvCfgFactory], TEnvCfgFactory]:
     """
-    Decorator to register an environment configuration class with a name.
+    Decorator to register an environment configuration class or factory.
 
     Usage:
-        @register_env_config_decorator("my-env")
+        @envcfg("my-env")
         @dataclass
         class MyEnvCfg(EnvCfg):
             ...
+
+        @envcfg("my-manager-env")
+        def make_my_env_cfg() -> EnvCfg:
+            ...
     """
 
-    def decorator(cls: Type[TEnvCfg]) -> Type[TEnvCfg]:
-        register_env_config(name, cls)
-        return cls
+    def decorator(factory: TEnvCfgFactory) -> TEnvCfgFactory:
+        register_env_config(name, factory)
+        return factory
 
     return decorator
+
+
+def materialize_env_config(name: str) -> EnvCfg:
+    """Construct one config instance from the registered cold-path factory."""
+    if name not in _envs:
+        raise ValueError(f"Environment '{name}' is not registered.")
+
+    factory = _envs[name].env_cfg_factory
+    env_cfg = factory()
+    if not isinstance(env_cfg, EnvCfg):
+        raise TypeError(
+            f"Environment '{name}' config factory '{_config_factory_name(factory)}' returned "
+            f"{type(env_cfg).__name__}, expected an EnvCfg instance"
+        )
+    return env_cfg
 
 
 def register_env(name: str, env_cls: Type[ABEnv], sim_backend: str):
@@ -154,20 +183,19 @@ def resolve_reward_override_field(env_name: str) -> RewardOverrideField:
     if env_name not in _envs:
         raise ValueError(f"Environment '{env_name}' is not registered.")
 
-    config_cls = _envs[env_name].env_cfg_cls
-    config_fields = {
-        config_field.name: config_field for config_field in dataclasses.fields(config_cls)
-    }
+    config = materialize_env_config(env_name)
+    config_fields = {config_field.name: config_field for config_field in dataclasses.fields(config)}
     rewards_field = config_fields.get("rewards")
     has_manager_rewards = (
         rewards_field is not None
         and rewards_field.metadata.get(CONFIG_MAPPING_POLICY_KEY) == MANAGER_TERM_MAPPING_POLICY
     )
     has_legacy_rewards = "reward_config" in config_fields
+    config_owner = type(config).__name__
 
     if has_manager_rewards and has_legacy_rewards:
         raise ValueError(
-            f"Environment '{env_name}' config owner '{config_cls.__name__}' declares both "
+            f"Environment '{env_name}' config owner '{config_owner}' declares both "
             "Manager-Based 'rewards' and legacy 'reward_config' targets"
         )
     if has_manager_rewards:
@@ -175,7 +203,7 @@ def resolve_reward_override_field(env_name: str) -> RewardOverrideField:
     if has_legacy_rewards:
         return "reward_config"
     raise ValueError(
-        f"Environment '{env_name}' config owner '{config_cls.__name__}' declares no "
+        f"Environment '{env_name}' config owner '{config_owner}' declares no "
         "supported Hydra root reward target; expected legacy 'reward_config' or an "
         "explicitly marked Manager-Based 'rewards' field"
     )
@@ -366,7 +394,7 @@ def make(
     meta: EnvMeta = _envs[name]
 
     # Create environment config
-    env_cfg = meta.env_cfg_cls()
+    env_cfg = materialize_env_config(name)
     if env_cfg_override is not None:
         apply_cfg_overrides(env_cfg, env_cfg_override)
 
@@ -395,7 +423,7 @@ def list_registered_envs() -> Dict[str, Dict[str, Any]]:
     result = {}
     for name, meta in _envs.items():
         result[name] = {
-            "config_class": meta.env_cfg_cls.__name__,
+            "config_factory": _config_factory_name(meta.env_cfg_factory),
             "available_backends": list(meta.env_cls_dict.keys()),
         }
     return result

--- a/tests/base/test_registry.py
+++ b/tests/base/test_registry.py
@@ -104,6 +104,38 @@ def test_envcfg_decorator_registers():
     assert registry_mod.contains(_name)
 
 
+def test_envcfg_decorator_registers_plain_factory_and_returns_it_unchanged():
+    _name = "_TestDecoratorFactoryEnv"
+
+    def make_cfg() -> EnvCfg:
+        return _TestCfgA()
+
+    registered = registry_mod.envcfg(_name)(make_cfg)
+
+    assert registered is make_cfg
+    assert registry_mod.materialize_env_config(_name) == _TestCfgA()
+
+
+def test_materialize_env_config_rejects_invalid_factory_output():
+    _name = "_TestInvalidFactoryOutput"
+
+    def make_invalid_cfg():
+        return {"sim_dt": 0.01}
+
+    registry_mod.register_env_config(_name, make_invalid_cfg)
+
+    with pytest.raises(
+        TypeError,
+        match=r"_TestInvalidFactoryOutput.*make_invalid_cfg.*dict.*EnvCfg",
+    ):
+        registry_mod.materialize_env_config(_name)
+
+
+def test_register_env_config_rejects_non_callable():
+    with pytest.raises(TypeError, match="config factory must be callable"):
+        registry_mod.register_env_config("_TestNonCallableFactory", None)  # type: ignore[arg-type]
+
+
 def test_env_decorator_registers():
     _name = "_TestDecoratorEnv2"
     if not registry_mod.contains(_name):
@@ -159,6 +191,7 @@ def test_make_unregistered_raises():
 def test_list_registered_envs_includes_registered():
     listed = registry_mod.list_registered_envs()
     assert _TEST_ENV_A in listed
+    assert listed[_TEST_ENV_A]["config_factory"] == "_TestCfgA"
     assert "mujoco" in listed[_TEST_ENV_A]["available_backends"]
 
 
@@ -238,6 +271,31 @@ def test_make_with_valid_cfg_override():
 
     env = registry_mod.make(_name, sim_backend="mujoco", env_cfg_override={"ctrl_dt": 0.05})
     assert env.cfg.ctrl_dt == 0.05
+
+
+def test_make_materializes_fresh_function_owned_config_for_each_call():
+    @dataclass
+    class _FactoryCfg(EnvCfg):
+        ctrl_dt: float = 0.02
+
+    _name = "_TestFunctionFactoryOverrideEnv"
+
+    def make_cfg() -> EnvCfg:
+        return _FactoryCfg()
+
+    registry_mod.register_env_config(_name, make_cfg)
+    registry_mod.register_env(_name, _TestEnvA, "mujoco")
+
+    overridden = registry_mod.make(
+        _name,
+        sim_backend="mujoco",
+        env_cfg_override={"ctrl_dt": 0.05},
+    )
+    default = registry_mod.make(_name, sim_backend="mujoco")
+
+    assert overridden.cfg.ctrl_dt == 0.05
+    assert default.cfg.ctrl_dt == 0.02
+    assert overridden.cfg is not default.cfg
 
 
 def test_make_with_invalid_cfg_override_raises():

--- a/tests/config/test_manager_reward_routing.py
+++ b/tests/config/test_manager_reward_routing.py
@@ -19,6 +19,7 @@ from unilab.managers import RewardTermCfg
 from unilab.training.backend_adapter import BackendAdapter
 
 _MANAGER_ENV = "_TestManagerRewardRoute"
+_MANAGER_FACTORY_ENV = "_TestManagerFactoryRewardRoute"
 _LEGACY_ENV = "_TestLegacyRewardRoute"
 _MISSING_ENV = "_TestMissingRewardRoute"
 _AMBIGUOUS_ENV = "_TestAmbiguousRewardRoute"
@@ -43,14 +44,19 @@ class _AmbiguousCfg(EnvCfg):
     )
 
 
-for _name, _cfg_cls in (
+def _make_manager_cfg() -> ManagerBasedRlEnvCfg:
+    return ManagerBasedRlEnvCfg()
+
+
+for _name, _cfg_factory in (
     (_MANAGER_ENV, ManagerBasedRlEnvCfg),
+    (_MANAGER_FACTORY_ENV, _make_manager_cfg),
     (_LEGACY_ENV, _LegacyCfg),
     (_MISSING_ENV, _MissingCfg),
     (_AMBIGUOUS_ENV, _AmbiguousCfg),
 ):
     if not registry.contains(_name):
-        registry.register_env_config(_name, _cfg_cls)
+        registry.register_env_config(_name, _cfg_factory)
 
 
 def _reward(_env, *, std: float) -> np.ndarray:
@@ -77,9 +83,12 @@ def _cfg(task_name: str, *, env: dict[str, object] | None = None):
     )
 
 
-def test_backend_adapter_routes_manager_reward_and_preserves_factory_terms() -> None:
+@pytest.mark.parametrize("env_name", [_MANAGER_ENV, _MANAGER_FACTORY_ENV])
+def test_backend_adapter_routes_manager_reward_and_preserves_factory_terms(
+    env_name: str,
+) -> None:
     override = BackendAdapter(
-        _cfg(_MANAGER_ENV),
+        _cfg(env_name),
         root_dir=Path("."),
     ).build_task_env_cfg_override()
 


### PR DESCRIPTION
## Summary
- make zero-argument `EnvCfg` factories the formal registry config-owner contract while retaining class decorators as the same callable shape
- materialize and type-check configs through one cold path used by env construction and Hydra reward-target resolution
- remove the visualization entrypoint's dependency on private config-class registry state

## Scope
- no Go2 production registration, Hydra path migration, backend, lifecycle, runner, or IPC changes
- 4 modified files; 123 UniLab-specific lines added and 27 existing lines removed
- 0 source-derived lines, 0 mechanical NumPy-conversion lines, 0 files added/deleted
- contract follows ADR-0006's task-owned plain config factory decision and remains compatible with ADR-0004 bootstrap

## Validation
- focused registry/config/visualization: 43 passed
- `make test-all`: 2009 passed, 27 skipped, 276 deselected, 1 xfailed
- ruff, mypy, and pyright passed
- benchmark smoke passed in module and script modes; each had one platform-optional MLX skip
- remote CI/Docs intentionally skipped under the #1042 child-PR strategy

Closes #1090
Umbrella: #1042
