### PR TITLE
feat(registry): support callable env factories

### DIFF
--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     Literal,
     Optional,
+    Protocol,
     Type,
     TypeVar,
     cast,
@@ -27,6 +28,21 @@ from .config_overrides import (
 
 EnvCfgFactory = Callable[[], EnvCfg]
 TEnvCfgFactory = TypeVar("TEnvCfgFactory", bound=EnvCfgFactory)
+
+
+class EnvFactory(Protocol):
+    """Construct an environment for one materialized config and backend."""
+
+    def __call__(
+        self,
+        cfg: Any,
+        *,
+        num_envs: int = 1,
+        backend_type: str = "mujoco",
+    ) -> ABEnv: ...
+
+
+TEnvFactory = TypeVar("TEnvFactory", bound=EnvFactory)
 RewardOverrideField = Literal["reward_config", "rewards"]
 _SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
@@ -47,18 +63,18 @@ logger = logging.getLogger(__name__)
 @dataclass
 class EnvMeta:
     env_cfg_factory: EnvCfgFactory
-    env_cls_dict: Dict[str, Type[ABEnv]] = field(default_factory=dict)
+    env_factory_dict: Dict[str, EnvFactory] = field(default_factory=dict)
 
     def available_sim_backend(self) -> Optional[str]:
         """Return the explicit default simulation backend for this environment."""
         for backend in _DEFAULT_SIM_BACKEND_ORDER:
-            if backend in self.env_cls_dict:
+            if backend in self.env_factory_dict:
                 return backend
-        return next(iter(self.env_cls_dict), None)
+        return next(iter(self.env_factory_dict), None)
 
     def support_sim_backend(self, sim_backend: str) -> bool:
         """Check if the environment supports a specific simulation backend."""
-        return sim_backend in self.env_cls_dict
+        return sim_backend in self.env_factory_dict
 
 
 _envs: Dict[str, EnvMeta] = {}
@@ -70,6 +86,10 @@ def contains(name: str) -> bool:
 
 
 def _config_factory_name(factory: EnvCfgFactory) -> str:
+    return str(getattr(factory, "__qualname__", type(factory).__qualname__))
+
+
+def _env_factory_name(factory: EnvFactory) -> str:
     return str(getattr(factory, "__qualname__", type(factory).__qualname__))
 
 
@@ -122,8 +142,8 @@ def materialize_env_config(name: str) -> EnvCfg:
     return env_cfg
 
 
-def register_env(name: str, env_cls: Type[ABEnv], sim_backend: str):
-    """Register an environment class with a name and simulation backend."""
+def register_env(name: str, env_factory: TEnvFactory, sim_backend: str) -> TEnvFactory:
+    """Register and return an environment class or function factory."""
     if sim_backend not in _SUPPORTED_SIM_BACKENDS:
         raise ValueError(
             f"Unsupported simulation backend: {sim_backend}. "
@@ -135,27 +155,37 @@ def register_env(name: str, env_cls: Type[ABEnv], sim_backend: str):
             f"Environment '{name}' is not registered. Please register the config first."
         )
 
-    if sim_backend in _envs[name].env_cls_dict:
+    if not callable(env_factory):
+        raise TypeError(
+            f"Environment '{name}' backend '{sim_backend}' factory must be callable, got "
+            f"{type(env_factory).__name__}"
+        )
+
+    if sim_backend in _envs[name].env_factory_dict:
         raise ValueError(
             f"Environment '{name}' with sim backend '{sim_backend}' is already registered."
         )
 
-    _envs[name].env_cls_dict[sim_backend] = env_cls
+    _envs[name].env_factory_dict[sim_backend] = env_factory
+    return env_factory
 
 
-def env(name: str, sim_backend: str) -> Callable[[Type[ABEnv]], Type[ABEnv]]:
+def env(name: str, sim_backend: str) -> Callable[[TEnvFactory], TEnvFactory]:
     """
-    Decorator to register an environment class with a name and simulation backend.
+    Decorator to register an environment class or function factory.
 
     Usage:
-        @register_env_decorator("my-env", "np")
+        @env("my-env", "mujoco")
         class MyEnv(ABEnv):
+            ...
+
+        @env("my-manager-env", "mujoco")
+        def make_my_env(cfg, num_envs=1, backend_type="mujoco"):
             ...
     """
 
-    def decorator(cls: Type[ABEnv]) -> Type[ABEnv]:
-        register_env(name, cls, sim_backend)
-        return cls
+    def decorator(factory: TEnvFactory) -> TEnvFactory:
+        return register_env(name, factory, sim_backend)
 
     return decorator
 
@@ -413,8 +443,14 @@ def make(
         )
 
     # Create environment instance
-    env_cls_any: Any = meta.env_cls_dict[sim_backend]
-    env: ABEnv = env_cls_any(env_cfg, num_envs=num_envs, backend_type=sim_backend)
+    factory = meta.env_factory_dict[sim_backend]
+    env = factory(env_cfg, num_envs=num_envs, backend_type=sim_backend)
+    if not isinstance(env, ABEnv):
+        raise TypeError(
+            f"Environment '{name}' backend '{sim_backend}' factory "
+            f"'{_env_factory_name(factory)}' returned {type(env).__name__}, "
+            "expected an ABEnv instance"
+        )
     return env
 
 
@@ -424,7 +460,7 @@ def list_registered_envs() -> Dict[str, Dict[str, Any]]:
     for name, meta in _envs.items():
         result[name] = {
             "config_factory": _config_factory_name(meta.env_cfg_factory),
-            "available_backends": list(meta.env_cls_dict.keys()),
+            "available_backends": list(meta.env_factory_dict.keys()),
         }
     return result
 

--- a/tests/base/test_registry.py
+++ b/tests/base/test_registry.py
@@ -150,6 +150,19 @@ def test_env_decorator_registers():
     assert "mujoco" in listed[_name]["available_backends"]
 
 
+def test_env_decorator_registers_plain_factory_and_returns_it_unchanged():
+    _name = "_TestDecoratorEnvFactory"
+    registry_mod.register_env_config(_name, _TestCfgA)
+
+    def make_env(cfg: EnvCfg, num_envs: int = 1, backend_type: str = "mujoco") -> ABEnv:
+        return _TestEnvA(cfg, num_envs=num_envs, backend_type=backend_type)
+
+    registered = registry_mod.env(_name, "mujoco")(make_env)
+
+    assert registered is make_env
+    assert registry_mod._envs[_name].env_factory_dict["mujoco"] is make_env
+
+
 def test_contains_before_and_after_registration():
     _name = "_TestContainsDynamic"
     assert not registry_mod.contains(_name)
@@ -222,9 +235,17 @@ def test_register_env_duplicate_backend_raises():
         registry_mod.register_env(_TEST_ENV_A, _TestEnvA, "mujoco")
 
 
-def test_find_available_sim_backend_no_env_cls_raises():
-    """find_available_sim_backend() raises when config exists but no env_cls registered."""
-    # _TEST_ENV_B has config but no env class (registered above without env)
+def test_register_env_rejects_non_callable_factory():
+    _name = "_TestNonCallableEnvFactory"
+    registry_mod.register_env_config(_name, _TestCfgA)
+
+    with pytest.raises(TypeError, match=r"_TestNonCallableEnvFactory.*mujoco.*callable.*object"):
+        registry_mod.register_env(_name, object(), "mujoco")  # type: ignore[arg-type]
+
+
+def test_find_available_sim_backend_no_env_factory_raises():
+    """find_available_sim_backend() raises when config exists but no env factory is registered."""
+    # _TEST_ENV_B has config but no env factory (registered above without env)
     with pytest.raises(ValueError, match="does not support any simulation backend"):
         registry_mod.find_available_sim_backend(_TEST_ENV_B)
 
@@ -245,14 +266,60 @@ def test_make_auto_selects_default_backend_independent_of_registration_order():
     assert isinstance(env, _TestEnvA)
 
 
+def test_make_calls_plain_factory_with_cfg_num_envs_and_backend():
+    @dataclass
+    class _CallableFactoryCfg(EnvCfg):
+        ctrl_dt: float = 0.02
+
+    _name = "_TestCallableEnvFactory"
+    received: dict[str, object] = {}
+
+    def make_env(cfg: EnvCfg, num_envs: int = 1, backend_type: str = "mujoco") -> ABEnv:
+        received.update(cfg=cfg, num_envs=num_envs, backend_type=backend_type)
+        return _TestEnvA(cfg, num_envs=num_envs, backend_type=backend_type)
+
+    registry_mod.register_env_config(_name, _CallableFactoryCfg)
+    registered = registry_mod.register_env(_name, make_env, "motrix")
+
+    made = registry_mod.make(
+        _name,
+        sim_backend=None,
+        env_cfg_override={"ctrl_dt": 0.05},
+        num_envs=7,
+    )
+
+    assert registered is make_env
+    assert isinstance(made, _TestEnvA)
+    assert received["cfg"] is made.cfg
+    assert received["num_envs"] == 7
+    assert received["backend_type"] == "motrix"
+    assert made.cfg.ctrl_dt == pytest.approx(0.05)
+
+
+def test_make_rejects_invalid_factory_output_at_registry_boundary():
+    _name = "_TestInvalidEnvFactoryOutput"
+
+    def make_invalid_env(cfg: EnvCfg, num_envs: int = 1, backend_type: str = "mujoco") -> object:
+        return object()
+
+    registry_mod.register_env_config(_name, _TestCfgA)
+    registry_mod.register_env(_name, make_invalid_env, "mujoco")  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match=r"_TestInvalidEnvFactoryOutput.*mujoco.*make_invalid_env.*object.*ABEnv",
+    ):
+        registry_mod.make(_name, sim_backend="mujoco")
+
+
 def test_make_unsupported_backend_raises():
     """make() with an unsupported backend name raises ValueError."""
     with pytest.raises(ValueError, match="does not support simulation backend"):
         registry_mod.make(_TEST_ENV_A, sim_backend="motrix")
 
 
-def test_make_no_env_cls_raises():
-    """make() when no env class registered (only config) raises ValueError."""
+def test_make_no_env_factory_raises():
+    """make() when no env factory is registered (only config) raises ValueError."""
     with pytest.raises(ValueError, match="does not support any simulation backend"):
         registry_mod.make(_TEST_ENV_B, sim_backend=None)
 

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -350,7 +350,7 @@ def test_go2_joystick_rough_motrix_registers_rough_env():
     from unilab.base import registry
     from unilab.envs.locomotion.go2.rough import Go2JoystickRoughEnv
 
-    assert registry._envs["Go2JoystickRough"].env_cls_dict["motrix"] is Go2JoystickRoughEnv
+    assert registry._envs["Go2JoystickRough"].env_factory_dict["motrix"] is Go2JoystickRoughEnv
 
 
 def test_offpolicy_g1_rough_terrain_task_overrides():

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -183,7 +183,8 @@ def test_g1_owner_yaml_regression_contract(case: dict[str, Any]):
     assert full_env_cfg.curriculum.enabled is case["curriculum_enabled"]
     assert env._uses_walk_observation_profile() is (case["profile"] == "walk")
     assert (
-        registry._envs[cfg.training.task_name].env_cls_dict[cfg.training.sim_backend] is G1WalkEnv
+        registry._envs[cfg.training.task_name].env_factory_dict[cfg.training.sim_backend]
+        is G1WalkEnv
     )
 
     if "model_suffix" in case:


### PR DESCRIPTION
## Summary

- define one `EnvFactory` contract for existing class constructors and plain function factories
- make `register_env` / `env` preserve factory identity and make `registry.make()` pass the materialized `cfg`, `num_envs`, and selected `backend_type`
- fail closed at the Registry boundary when a callable returns a non-`ABEnv` value; preserve config materialization, override, validation, and backend-selection order

Refs #1096
Umbrella #1042
Architecture: [ADR-0006](https://github.com/unilabsim/UniLab/blob/80aae37b/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md), [ADR-0004](https://github.com/unilabsim/UniLab/blob/80aae37b/docs/sphinx/source/adr/ADR-0004-registry-bootstrap-contract.md)

## Scope

- 4 files
- 128 additions / 24 deletions / 104 net lines
- no Manager-Based backend adapter, production Go2 registration, Hydra, training script, runner, backend, or IPC changes
- existing class registrations and backend behavior remain compatible across MuJoCo, MJWarp, Motrix, and Drake

## Validation

- `make test-all`: 2023 passed, 27 skipped, 276 deselected, 1 xfailed
- ruff, mypy, pyright, coverage suite, and benchmark smoke passed
- remote CI intentionally skipped per #1042