### PR TITLE
feat(config): materialize Hydra-owned Manager-Based configs

### DIFF
--- a/docs/sphinx/source/adr/ADR-0003-task-owner-and-config-compose-contract.md
+++ b/docs/sphinx/source/adr/ADR-0003-task-owner-and-config-compose-contract.md
@@ -25,12 +25,17 @@ orphan: true
 2. owner YAML 直接持有 `training.task_name`、`training.sim_backend`、`reward`、`env` 及 task-specific `algo`。
 3. `training.sim_backend` 是 owner 身份字段，不是独立 backend switch。
 4. CLI override 允许参数覆盖，但不能破坏 task owner 的 backend identity。
+5. Manager-Based production task 也不例外：owner YAML 完整持有 manager/term/callable 与
+   observation mapping，compose 后在 Registry 冷路径物化为 typed cfg；Python 不保存
+   task-specific config mirror。
 
 ## Stable Contracts
 
 - PPO/APPO owner 路径: `conf/{ppo,appo}/task/<task>/<backend>.yaml`
 - Offpolicy owner 路径: `conf/offpolicy/task/<algo>/<task>/<backend>.yaml`
 - reward 注入与 backend 差异表达必须在 owner YAML 层显式存在。
+- Manager-Based cfg 使用 Hydra `_target_` 与 dotted callable reference；解析失败或类型错误
+  必须在 env/backend 构造前报错。
 
 ## Consequences
 

--- a/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
+++ b/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
@@ -89,9 +89,18 @@ Manager 内可以使用社区常见的 `policy` / `actor` / `critic` observation
 映射为 `NpEnvState.obs["critic"]`。runner、learner 与 IPC 不推断、不拼接 group。
 `reset() -> (obs_dict, info_dict)`、final observation 与 `obs_groups_spec` 保持现有 contract。
 
-Callable 和 typed config instance 由 task-owned Python factory 声明；Hydra owner YAML 只按
-manager/term 名覆盖可序列化字段。现有 CLI、registry、algorithm YAML 和
-`task=<task>/<backend>` owner compose 保持唯一配置入口。Scripts 不解释 term 业务规则。
+Production task 的唯一配置 source of truth 是 Hydra owner YAML。它完整声明 scene/backend
+tuning、manager/group/term 的顺序与启停、具体 cfg 类型、callable、params、weight 和
+observation group mapping；compose 后按以下冷路径进入现有 registry：
+
+`owner YAML -> DictConfig -> typed config materialization -> Registry factory -> ManagerBasedRlEnv`
+
+具体 cfg 类型使用 Hydra `_target_`，term callable 使用完整 dotted reference。通用
+materializer 将其解析为 plain dataclass instance，并在未知字段、target/callable 解析失败、
+抽象或错误 term cfg 类型及缺少必填字段时 fail-closed。Python 只拥有 term 实现、公共 cfg
+类型和通用 factory，不保存第二份 task-specific term 清单或默认值；直接构造 typed cfg
+只用于底层单测。DictConfig 与解析逻辑不能进入 reset/step 热路径，scripts 不解释 term
+业务规则。
 
 ### 4. Scene/entity owner boundary
 
@@ -165,7 +174,7 @@ fallback 到旧单体 env 的永久兼容路径。
 | observation groups、clip/scale/noise/delay/history | Adapted | 数值为 NumPy；group 在 env boundary 显式映射 |
 | manager buffers、env IDs、RNG | Adapted | Torch→NumPy；无 device API |
 | `ManagerBasedRlEnv` return | Adapted | 保留 `NpEnvState` 与 UniLab reset/final-observation contract |
-| config container | Adapted | plain instances + Hydra owner YAML overlay，不引入第二套 runtime |
+| config container | Adapted | Hydra owner YAML 唯一持有 task 配置，冷路径物化为 plain typed instances |
 | `SceneEntityCfg` selectors | Adapted | 语义保留；只解析 `SimBackend` 已声明能力 |
 | named sensor view | Adapted | 冷路径 bind；有序展平 NumPy batch；reader 由 backend 拥有 |
 | event/domain randomization | Adapted | 调度语义保留；mutation 走 backend DR/capability contract |
@@ -225,6 +234,8 @@ Apache-2.0 和 UniLab 的修改类别。实现 PR 分别报告：
 - 先设计 compiler、fused term protocol 或专用 fast path。拒绝：在 benchmark 证明瓶颈前
   增加结构复杂度，并可能牺牲社区 term 语义。
 - 缺失能力 warning + skip 或回退旧 env。拒绝：配置表面与真实执行不一致，不能用于生产。
+- task-owned Python factory 声明 callable/term，Hydra 只做字段 overlay。拒绝：会让同一 task
+  在 Python 和 YAML 中拥有两份配置，增加迁移 friction 和语义漂移。
 
 ## Consequences
 
@@ -233,6 +244,8 @@ Apache-2.0 和 UniLab 的修改类别。实现 PR 分别报告：
   compatibility matrix 中先记录。
 - Scene/entity 采用最小 base facade，#586 不再阻塞 manager port；真实 backend 能力仍按
   独立 child 和 conformance evidence 接入。
+- Config/Registry 永久维护一个通用 Hydra `_target_` / dotted callable 到 typed manager cfg
+  的冷路径 materializer；production task 不维护 Python config mirror。
 - 迁移初期允许 production 旧 task 与未接入的 manager package 同时存在，但 task 一旦迁移
   就必须删除对应旧实现；umbrella 结束时不能保留双 lifecycle。
 - 性能 gate 关注明显低效与实测瓶颈，不以复杂度换取未经证明的小收益。
@@ -243,7 +256,7 @@ Apache-2.0 和 UniLab 的修改类别。实现 PR 分别报告：
 - Backend contract: `src/unilab/base/backend/base.py`
 - Scene config owner: `src/unilab/base/scene.py`
 - Config schema and registry: `src/unilab/structured_configs.py`,
-  `src/unilab/base/registry.py`, `conf/`
+  `src/unilab/base/config_materialization.py`, `src/unilab/base/registry.py`, `conf/`
 - Observation/IPC contract: `docs/sphinx/source/adr/ADR-0005-unified-obs-critic-env-and-ipc-contract.md`
 - Layer boundary: `docs/sphinx/source/adr/ADR-0001-runtime-model-and-layer-boundaries.md`
 - Upstream checkout used for the decision:

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.md
@@ -10,6 +10,11 @@ NumPy，并保留现有 `NpEnvState`、Hydra owner YAML、`SimBackend`、registr
 ## 不变量
 
 - 公共 manager 结构优先保持社区语义；不为局部性能制造 UniLab-only term API。
+- Production task 只从 Hydra owner YAML 配置：YAML 完整声明 manager/group/term、具体 cfg
+  `_target_`、dotted callable、params、weight 与 observation mapping；Registry 冷路径将其
+  物化为 plain typed cfg，Python 不保留 task config mirror。
+- 未知字段、无法解析的 target/callable、抽象或错误 cfg 类型直接报错；DictConfig 和解析
+  不进入 reset/step，scripts 不解释 task 业务规则。
 - manager buffer、term return、env ID 和 entity view 使用 `np.ndarray` / `slice`，core 不依赖
   Torch、Warp、runner、learner 或 IPC。
 - `SceneEntityCfg` 在冷路径通过 base scene/entity facade 解析；facade 只调用正式

--- a/src/unilab/base/config_materialization.py
+++ b/src/unilab/base/config_materialization.py
@@ -1,0 +1,377 @@
+"""Cold-path materialization of Hydra-owned typed configuration."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import types
+from collections.abc import Mapping
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+from hydra.utils import get_object, instantiate
+from omegaconf import OmegaConf
+
+from .config_overrides import (
+    CONFIG_MAPPING_POLICY_KEY,
+    MANAGER_PARAMS_MAPPING_POLICY,
+    MANAGER_TERM_MAPPING_POLICY,
+)
+
+HYDRA_TARGET_KEY = "_target_"
+_MISSING = object()
+
+
+def _plain(value: Any) -> Any:
+    if OmegaConf.is_config(value):
+        return OmegaConf.to_container(value, resolve=True)
+    return value
+
+
+def _hints(target_type: type[Any]) -> dict[str, Any]:
+    try:
+        return get_type_hints(target_type)
+    except (NameError, TypeError):
+        return {field.name: field.type for field in dataclasses.fields(target_type)}
+
+
+def _dataclass_types(annotation: Any) -> tuple[type[Any], ...]:
+    if annotation in (Any, None):
+        return ()
+    origin = get_origin(annotation)
+    if origin in (types.UnionType, Union):
+        return tuple(
+            target
+            for item in get_args(annotation)
+            if item is not type(None)
+            for target in _dataclass_types(item)
+        )
+    if isinstance(annotation, type) and dataclasses.is_dataclass(annotation):
+        return (annotation,)
+    return ()
+
+
+def _dict_value_type(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin is dict:
+        args = get_args(annotation)
+        return args[1] if len(args) == 2 else Any
+    if origin in (types.UnionType, Union):
+        for item in get_args(annotation):
+            value_type = _dict_value_type(item)
+            if value_type is not _MISSING:
+                return value_type
+    return _MISSING
+
+
+def _resolve(reference: Any, *, path: str) -> Any:
+    if not isinstance(reference, str) or not reference.strip():
+        raise TypeError(f"Config field '{path}' must be a non-empty dotted string")
+    try:
+        return get_object(reference)
+    except Exception as exc:
+        raise ValueError(
+            f"Config field '{path}' could not resolve dotted reference {reference!r}: {exc}"
+        ) from exc
+
+
+def _resolve_target(
+    reference: Any,
+    *,
+    expected: Any,
+    path: str,
+) -> type[Any]:
+    target = _resolve(reference, path=f"{path}.{HYDRA_TARGET_KEY}")
+    if not isinstance(target, type) or not dataclasses.is_dataclass(target):
+        raise TypeError(
+            f"Config field '{path}.{HYDRA_TARGET_KEY}' must resolve to a dataclass type"
+        )
+    expected_types = _dataclass_types(expected)
+    if expected_types and not any(issubclass(target, item) for item in expected_types):
+        names = ", ".join(item.__qualname__ for item in expected_types)
+        raise TypeError(
+            f"Config field '{path}.{HYDRA_TARGET_KEY}' resolved to {target.__qualname__}, "
+            f"expected a subclass of {names}"
+        )
+    if inspect.isabstract(target):
+        raise TypeError(
+            f"Config field '{path}.{HYDRA_TARGET_KEY}' resolved to abstract config "
+            f"{target.__qualname__}; select a concrete term config"
+        )
+    return target
+
+
+def _target_path(target: type[Any]) -> str:
+    return f"{target.__module__}.{target.__qualname__}"
+
+
+def _prepare_value(value: Any, *, annotation: Any, path: str) -> Any:
+    value = _plain(value)
+    if isinstance(value, Mapping):
+        values = dict(value)
+        if HYDRA_TARGET_KEY in values:
+            return _prepare_dataclass(values, expected=annotation, path=path, require_target=True)
+
+        candidates = _dataclass_types(annotation)
+        if len(candidates) == 1 and not inspect.isabstract(candidates[0]):
+            return _prepare_dataclass(values, expected=annotation, path=path, require_target=False)
+
+        value_type = _dict_value_type(annotation)
+        return {
+            key: _prepare_value(
+                item,
+                annotation=Any if value_type is _MISSING else value_type,
+                path=f"{path}.{key}",
+            )
+            for key, item in values.items()
+        }
+    if isinstance(value, list):
+        return [
+            _prepare_value(item, annotation=Any, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    return value
+
+
+def _prepare_manager_mapping(value: Any, *, annotation: Any, path: str) -> dict[str, Any]:
+    value = _plain(value)
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Config field '{path}' must be a mapping")
+    value_type = _dict_value_type(annotation)
+    if value_type is _MISSING:
+        raise TypeError(f"Config field '{path}' manager policy requires a typed dict")
+
+    result: dict[str, Any] = {}
+    for name, raw_entry in value.items():
+        if not isinstance(name, str) or not name:
+            raise TypeError(f"Config field '{path}' term names must be non-empty strings")
+        entry_path = f"{path}.{name}"
+        entry = _plain(raw_entry)
+        if entry is None:
+            result[name] = None
+        elif not isinstance(entry, Mapping):
+            raise TypeError(f"Config field '{entry_path}' must be a mapping or None")
+        else:
+            result[name] = _prepare_dataclass(
+                dict(entry),
+                expected=value_type,
+                path=entry_path,
+                require_target=True,
+            )
+    return result
+
+
+def _prepare_dataclass(
+    values: Mapping[str, Any],
+    *,
+    expected: Any,
+    path: str,
+    require_target: bool,
+) -> dict[str, Any]:
+    values = dict(values)
+    reference = values.pop(HYDRA_TARGET_KEY, _MISSING)
+    if reference is _MISSING:
+        candidates = _dataclass_types(expected)
+        if require_target:
+            raise ValueError(
+                f"Config field '{path}' is a new Manager-Based entry and must declare "
+                f"'{HYDRA_TARGET_KEY}'"
+            )
+        if len(candidates) != 1 or inspect.isabstract(candidates[0]):
+            raise ValueError(
+                f"Config field '{path}' cannot infer one concrete dataclass type; "
+                f"declare '{HYDRA_TARGET_KEY}'"
+            )
+        target = candidates[0]
+        reference = _target_path(target)
+    else:
+        target = _resolve_target(reference, expected=expected, path=path)
+
+    fields = {field.name: field for field in dataclasses.fields(target) if field.init}
+    unknown = [name for name in values if name not in fields]
+    if unknown:
+        raise ValueError(
+            f"Config field '{path}' target {target.__qualname__} has no fields {unknown}"
+        )
+
+    hints = _hints(target)
+    prepared: dict[str, Any] = {HYDRA_TARGET_KEY: reference}
+    for name, raw_value in values.items():
+        field = fields[name]
+        field_path = f"{path}.{name}"
+        annotation = hints.get(name, field.type)
+        policy = field.metadata.get(CONFIG_MAPPING_POLICY_KEY)
+        if policy == MANAGER_TERM_MAPPING_POLICY:
+            prepared[name] = _prepare_manager_mapping(
+                raw_value,
+                annotation=annotation,
+                path=field_path,
+            )
+        elif name == "func":
+            resolved = _resolve(raw_value, path=field_path)
+            if not callable(resolved):
+                raise TypeError(
+                    f"Config field '{field_path}' resolved to {type(resolved).__name__}, "
+                    "expected a callable"
+                )
+            prepared[name] = resolved
+        else:
+            prepared[name] = _prepare_value(raw_value, annotation=annotation, path=field_path)
+    return prepared
+
+
+def _materialize_entry(value: Mapping[str, Any], *, expected: Any, path: str) -> Any:
+    prepared = _prepare_dataclass(value, expected=expected, path=path, require_target=True)
+    try:
+        result = instantiate(prepared, _convert_="all")
+    except Exception as exc:
+        raise TypeError(
+            f"Config field '{path}' could not construct its typed config: {exc}"
+        ) from exc
+    expected_types = _dataclass_types(expected)
+    if expected_types and not isinstance(result, expected_types):
+        raise TypeError(
+            f"Config field '{path}' materialized {type(result).__name__}, expected "
+            f"{', '.join(item.__qualname__ for item in expected_types)}"
+        )
+    return result
+
+
+def _policy(target_obj: Any, name: str) -> str | None:
+    if not dataclasses.is_dataclass(target_obj) or isinstance(target_obj, type):
+        return None
+    field = next((item for item in dataclasses.fields(target_obj) if item.name == name), None)
+    value = None if field is None else field.metadata.get(CONFIG_MAPPING_POLICY_KEY)
+    return str(value) if value is not None else None
+
+
+def _is_term_cfg(target_obj: Any) -> bool:
+    return (
+        dataclasses.is_dataclass(target_obj)
+        and not isinstance(target_obj, type)
+        and any(
+            field.metadata.get(CONFIG_MAPPING_POLICY_KEY) == MANAGER_PARAMS_MAPPING_POLICY
+            for field in dataclasses.fields(target_obj)
+        )
+    )
+
+
+def _apply_manager_mapping(
+    target_obj: Any,
+    name: str,
+    overrides: Any,
+    *,
+    annotation: Any,
+    policy: str,
+) -> None:
+    owner = f"{type(target_obj).__name__}.{name}"
+    existing = getattr(target_obj, name)
+    overrides = _plain(overrides)
+    if not isinstance(existing, dict) or not isinstance(overrides, Mapping):
+        raise TypeError(f"Config field '{owner}' manager value and override must be mappings")
+
+    if policy == MANAGER_PARAMS_MAPPING_POLICY:
+        for param_name, raw_value in overrides.items():
+            path = f"{owner}.{param_name}"
+            value = _plain(raw_value)
+            current = existing.get(param_name, _MISSING)
+            if isinstance(value, Mapping) and HYDRA_TARGET_KEY in value:
+                existing[param_name] = _materialize_entry(value, expected=Any, path=path)
+            elif isinstance(value, Mapping) and dataclasses.is_dataclass(current):
+                apply_cfg_overrides(current, value, _path=path)
+            else:
+                existing[param_name] = _prepare_value(value, annotation=Any, path=path)
+        return
+    if policy != MANAGER_TERM_MAPPING_POLICY:
+        raise ValueError(f"Config field '{owner}' has unknown mapping policy {policy!r}")
+
+    value_type = _dict_value_type(annotation)
+    if value_type is _MISSING:
+        raise TypeError(f"Config field '{owner}' manager policy requires a typed dict")
+    for term_name, raw_value in overrides.items():
+        path = f"{owner}.{term_name}"
+        value = _plain(raw_value)
+        if value is None:
+            existing[term_name] = None
+        elif not isinstance(value, Mapping):
+            raise TypeError(f"Config field '{path}' must be a field mapping or None")
+        elif HYDRA_TARGET_KEY in value:
+            existing[term_name] = _materialize_entry(value, expected=value_type, path=path)
+        else:
+            current = existing.get(term_name, _MISSING)
+            if current is _MISSING or current is None:
+                raise ValueError(
+                    f"Config field '{path}' is a new Manager-Based entry and must declare "
+                    f"'{HYDRA_TARGET_KEY}'"
+                )
+            if not dataclasses.is_dataclass(current) or isinstance(current, type):
+                raise TypeError(f"Config field '{path}' does not contain a dataclass config")
+            apply_cfg_overrides(current, value, _path=path)
+
+
+def apply_cfg_overrides(
+    target_obj: Any,
+    overrides: Mapping[str, Any],
+    *,
+    _path: str | None = None,
+) -> None:
+    """Apply overrides and materialize explicitly typed Manager-Based entries."""
+    overrides = _plain(overrides)
+    if not isinstance(overrides, Mapping):
+        raise TypeError(f"Config overrides for {type(target_obj).__name__} must be a mapping")
+    hints = _hints(type(target_obj)) if dataclasses.is_dataclass(target_obj) else {}
+    fields = (
+        {field.name: field for field in dataclasses.fields(target_obj)}
+        if dataclasses.is_dataclass(target_obj) and not isinstance(target_obj, type)
+        else {}
+    )
+    owner_path = _path or type(target_obj).__name__
+
+    for key, raw_value in overrides.items():
+        if not isinstance(key, str) or not hasattr(target_obj, key):
+            raise ValueError(f"Config class '{type(target_obj).__name__}' has no attribute '{key}'")
+        value = _plain(raw_value)
+        existing = getattr(target_obj, key)
+        annotation = hints.get(key, fields[key].type if key in fields else Any)
+        policy = _policy(target_obj, key)
+        if policy is not None:
+            _apply_manager_mapping(
+                target_obj,
+                key,
+                value,
+                annotation=annotation,
+                policy=policy,
+            )
+            continue
+        if key == "func" and _is_term_cfg(target_obj):
+            raise ValueError(
+                f"Config field '{type(target_obj).__name__}.func' belongs to the typed term "
+                "declaration and cannot be changed by a partial override"
+            )
+
+        path = f"{owner_path}.{key}"
+        if isinstance(value, Mapping):
+            if HYDRA_TARGET_KEY in value:
+                setattr(target_obj, key, _materialize_entry(value, expected=annotation, path=path))
+                continue
+            if dataclasses.is_dataclass(existing) and not isinstance(existing, type):
+                apply_cfg_overrides(existing, value, _path=path)
+                continue
+            candidates = _dataclass_types(annotation)
+            if existing is None and len(candidates) == 1:
+                prepared = _prepare_dataclass(
+                    value,
+                    expected=annotation,
+                    path=path,
+                    require_target=False,
+                )
+                try:
+                    setattr(target_obj, key, instantiate(prepared, _convert_="all"))
+                except Exception as exc:
+                    raise TypeError(
+                        f"Config field '{path}' could not construct its typed config: {exc}"
+                    ) from exc
+                continue
+        setattr(target_obj, key, _prepare_value(value, annotation=Any, path=path))
+
+
+__all__ = ["HYDRA_TARGET_KEY", "apply_cfg_overrides"]

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -11,18 +11,13 @@ from typing import (
     Literal,
     Optional,
     Protocol,
-    Type,
     TypeVar,
-    cast,
-    get_args,
-    get_origin,
-    get_type_hints,
 )
 
 from .base import ABEnv, EnvCfg
+from .config_materialization import apply_cfg_overrides
 from .config_overrides import (
     CONFIG_MAPPING_POLICY_KEY,
-    MANAGER_PARAMS_MAPPING_POLICY,
     MANAGER_TERM_MAPPING_POLICY,
 )
 
@@ -237,167 +232,6 @@ def resolve_reward_override_field(env_name: str) -> RewardOverrideField:
         "supported Hydra root reward target; expected legacy 'reward_config' or an "
         "explicitly marked Manager-Based 'rewards' field"
     )
-
-
-def _resolve_dataclass_type(type_hint: Any) -> Optional[Type[Any]]:
-    """Strip Optional/Union and return the underlying dataclass type, or None."""
-    if type_hint is None:
-        return None
-    origin = get_origin(type_hint)
-    if origin is not None:
-        args = get_args(type_hint)
-        type_hint = next((arg for arg in args if arg is not type(None)), None)
-    if (
-        type_hint is not None
-        and dataclasses.is_dataclass(type_hint)
-        and isinstance(type_hint, type)
-    ):
-        return cast(Type[Any], type_hint)
-    return None
-
-
-def _construct_dataclass_from_dict(target_type: Type[Any], values: Dict[str, Any]) -> Any:
-    try:
-        target_obj = target_type()
-    except TypeError:
-        return target_type(**values)
-    apply_cfg_overrides(target_obj, values)
-    return target_obj
-
-
-def _config_mapping_policy(target_obj: Any, field_name: str) -> str | None:
-    if not dataclasses.is_dataclass(target_obj) or isinstance(target_obj, type):
-        return None
-    for config_field in dataclasses.fields(target_obj):
-        if config_field.name == field_name:
-            policy = config_field.metadata.get(CONFIG_MAPPING_POLICY_KEY)
-            return str(policy) if policy is not None else None
-    return None
-
-
-def _is_manager_callable_term_cfg(target_obj: Any) -> bool:
-    if not dataclasses.is_dataclass(target_obj) or isinstance(target_obj, type):
-        return False
-    return any(
-        config_field.metadata.get(CONFIG_MAPPING_POLICY_KEY) == MANAGER_PARAMS_MAPPING_POLICY
-        for config_field in dataclasses.fields(target_obj)
-    )
-
-
-def _apply_manager_mapping_overrides(
-    target_obj: Any,
-    field_name: str,
-    existing: Any,
-    overrides: Any,
-    *,
-    policy: str,
-) -> None:
-    owner = f"{type(target_obj).__name__}.{field_name}"
-    if not isinstance(existing, dict):
-        raise TypeError(
-            f"Config field '{owner}' declares manager mapping policy but contains "
-            f"{type(existing).__name__}, expected dict"
-        )
-    if not isinstance(overrides, dict):
-        raise TypeError(
-            f"Config field '{owner}' must be overridden by a mapping, not "
-            f"{type(overrides).__name__}"
-        )
-
-    if policy == MANAGER_PARAMS_MAPPING_POLICY:
-        for param_name, value in overrides.items():
-            current = existing.get(param_name)
-            if isinstance(value, dict) and dataclasses.is_dataclass(current):
-                apply_cfg_overrides(current, value)
-            else:
-                existing[param_name] = value
-        return
-
-    if policy != MANAGER_TERM_MAPPING_POLICY:
-        raise ValueError(f"Config field '{owner}' has unknown mapping policy {policy!r}")
-
-    for term_name, value in overrides.items():
-        if term_name not in existing:
-            raise ValueError(
-                f"Config field '{owner}' has no factory-owned term '{term_name}'; "
-                "declare its callable/config in the task Python factory first"
-            )
-        if value is None:
-            existing[term_name] = None
-            continue
-
-        current = existing[term_name]
-        if current is None:
-            raise ValueError(
-                f"Config field '{owner}' term '{term_name}' is disabled; set a concrete "
-                "config in the task Python factory before overriding its fields"
-            )
-        if not dataclasses.is_dataclass(current):
-            raise TypeError(
-                f"Config field '{owner}' term '{term_name}' contains "
-                f"{type(current).__name__}, expected a dataclass config"
-            )
-        if not isinstance(value, dict):
-            raise TypeError(
-                f"Config field '{owner}' term '{term_name}' must be overridden by a "
-                "field mapping or None; replacing the factory-owned term is not allowed"
-            )
-        apply_cfg_overrides(current, value)
-
-
-def apply_cfg_overrides(target_obj: Any, overrides: Dict[str, Any]) -> None:
-    """Apply a (possibly nested) dict of overrides to ``target_obj`` in place.
-
-    Behavior:
-      - For each ``key, value`` in ``overrides``, ``target_obj.key`` must exist
-        (otherwise ``ValueError``).
-      - If ``value`` is a dict and ``target_obj.key`` is already a dataclass
-        instance, recurse into it (deep merge — preserves fields not present
-        in ``value``). This is what lets Hydra-style partial overrides like
-        ``env.scene.terrain.generator.num_rows=4`` keep ``sub_terrains`` and other
-        defaults intact.
-      - If ``value`` is a dict and ``target_obj.key`` is currently ``None``,
-        instantiate the field's annotated dataclass type from the dict
-        (full-construction path).
-      - Fields explicitly marked as manager mappings merge only existing
-        factory-owned entries. ``None`` disables an entry; unknown entries and
-        callable/config replacement fail closed.
-      - Otherwise ``setattr`` the value directly (scalar / list / non-dataclass).
-    """
-    try:
-        type_hints = get_type_hints(type(target_obj))
-    except Exception:
-        type_hints = {}
-
-    for key, value in overrides.items():
-        if not hasattr(target_obj, key):
-            raise ValueError(f"Config class '{type(target_obj).__name__}' has no attribute '{key}'")
-        existing = getattr(target_obj, key)
-        mapping_policy = _config_mapping_policy(target_obj, key)
-        if mapping_policy is not None:
-            _apply_manager_mapping_overrides(
-                target_obj,
-                key,
-                existing,
-                value,
-                policy=mapping_policy,
-            )
-            continue
-        if key == "func" and _is_manager_callable_term_cfg(target_obj):
-            raise ValueError(
-                f"Config field '{type(target_obj).__name__}.func' is factory-owned and "
-                "cannot be overridden"
-            )
-        if isinstance(value, dict):
-            if dataclasses.is_dataclass(existing) and not isinstance(existing, type):
-                apply_cfg_overrides(existing, value)
-                continue
-            if existing is None:
-                target_type = _resolve_dataclass_type(type_hints.get(key))
-                if target_type is not None:
-                    setattr(target_obj, key, _construct_dataclass_from_dict(target_type, value))
-                    continue
-        setattr(target_obj, key, value)
 
 
 def make(

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -62,8 +62,9 @@ def _manager_terms_field() -> Any:
 class ManagerBasedRlEnvCfg(EnvCfg):
     """Configuration for the manager-based NumPy environment.
 
-    Serializable values remain ordinary dataclass fields so task-owned Hydra owner
-    configs can overlay them without introducing a second configuration runtime.
+    Production task owners declare these fields in Hydra. The Registry materializes
+    them into this plain typed config on the cold path; Python factories do not mirror
+    task-specific manager or term declarations.
     """
 
     observations: dict[str, ObservationGroupCfg | None] = _manager_terms_field()

--- a/tests/base/test_manager_config_overlay.py
+++ b/tests/base/test_manager_config_overlay.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 
 import numpy as np
 import pytest
+from omegaconf import OmegaConf
 
 from unilab.base.registry import apply_cfg_overrides
 from unilab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg
-from unilab.envs.mdp import JointPositionActionCfg
+from unilab.envs.mdp import JointPositionActionCfg, UniformVelocityCommandCfg
 from unilab.managers import (
+    CurriculumTermCfg,
     EventTermCfg,
+    MetricsTermCfg,
     ObservationGroupCfg,
     ObservationTermCfg,
+    RecorderTermCfg,
     RewardTermCfg,
     SceneEntityCfg,
+    TerminationTermCfg,
 )
 
 
@@ -68,7 +73,9 @@ def _manager_cfg() -> ManagerBasedRlEnvCfg:
 
 def test_manager_mapping_overlay_preserves_factory_terms_and_order() -> None:
     cfg = _manager_cfg()
-    reward_func = cfg.rewards["tracking"].func
+    initial_tracking = cfg.rewards["tracking"]
+    assert initial_tracking is not None
+    reward_func = initial_tracking.func
 
     apply_cfg_overrides(
         cfg,
@@ -100,7 +107,7 @@ def test_manager_mapping_overlay_preserves_factory_terms_and_order() -> None:
     assert reset.func is _first_term
     assert reset.min_step_count_between_reset == 3
     action = cfg.actions["joint_pos"]
-    assert action is not None
+    assert isinstance(action, JointPositionActionCfg)
     assert action.entity_name == "robot"
     assert action.actuator_names == (".*",)
     assert action.scale == pytest.approx(0.4)
@@ -132,19 +139,247 @@ def test_observation_group_and_term_overlay_preserve_siblings() -> None:
     assert list(policy.terms) == ["first", "second"]
 
 
+def _assert_no_omegaconf(value: object) -> None:
+    assert not OmegaConf.is_config(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        for config_field in fields(value):
+            _assert_no_omegaconf(getattr(value, config_field.name))
+    elif isinstance(value, dict):
+        for item in value.values():
+            _assert_no_omegaconf(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _assert_no_omegaconf(item)
+
+
+def test_hydra_mapping_fully_materializes_empty_manager_config() -> None:
+    cfg = ManagerBasedRlEnvCfg()
+    hydra_mapping = OmegaConf.create(
+        {
+            "scene": {
+                "model_file": "robot.xml",
+                "entities": {
+                    "robot": {
+                        "root_body_name": "base",
+                        "joint_names": ["joint"],
+                        "actuator_names": ["motor"],
+                    }
+                },
+            },
+            "sim_dt": 0.01,
+            "ctrl_dt": 0.02,
+            "max_episode_seconds": 20.0,
+            "observations": {
+                "policy": {
+                    "_target_": "unilab.managers.ObservationGroupCfg",
+                    "terms": {
+                        "joint_pos": {
+                            "_target_": "unilab.managers.ObservationTermCfg",
+                            "func": "unilab.envs.mdp.joint_pos_rel",
+                            "params": {
+                                "asset_cfg": {
+                                    "_target_": "unilab.managers.SceneEntityCfg",
+                                    "name": "robot",
+                                    "joint_names": ".*",
+                                }
+                            },
+                        },
+                        "disabled": None,
+                    },
+                }
+            },
+            "actions": {
+                "joint_pos": {
+                    "_target_": "unilab.envs.mdp.JointPositionActionCfg",
+                    "entity_name": "robot",
+                    "actuator_names": [".*"],
+                    "scale": 0.25,
+                }
+            },
+            "commands": {
+                "twist": {
+                    "_target_": "unilab.envs.mdp.UniformVelocityCommandCfg",
+                    "entity_name": "robot",
+                    "resampling_time_range": [1.0, 1.0],
+                    "ranges": {
+                        "lin_vel_x": [-1.0, 1.0],
+                        "lin_vel_y": [-0.5, 0.5],
+                        "ang_vel_z": [-1.0, 1.0],
+                    },
+                }
+            },
+            "events": {
+                "reset": {
+                    "_target_": "unilab.managers.EventTermCfg",
+                    "func": "unilab.envs.mdp.reset_scene_to_default",
+                    "mode": "reset",
+                }
+            },
+            "rewards": {
+                "alive": {
+                    "_target_": "unilab.managers.RewardTermCfg",
+                    "func": "unilab.envs.mdp.is_alive",
+                    "weight": 1.0,
+                }
+            },
+            "terminations": {
+                "time_out": {
+                    "_target_": "unilab.managers.TerminationTermCfg",
+                    "func": "unilab.envs.mdp.time_out",
+                    "time_out": True,
+                }
+            },
+            "curriculum": {
+                "difficulty": {
+                    "_target_": "unilab.managers.CurriculumTermCfg",
+                    "func": "unilab.envs.mdp.is_alive",
+                }
+            },
+            "metrics": {
+                "alive": {
+                    "_target_": "unilab.managers.MetricsTermCfg",
+                    "func": "unilab.envs.mdp.is_alive",
+                }
+            },
+            "recorders": {
+                "trace": {
+                    "_target_": "unilab.managers.RecorderTermCfg",
+                    "func": "unilab.managers.RecorderTerm",
+                }
+            },
+            "policy_observation_group": "policy",
+        }
+    )
+
+    apply_cfg_overrides(cfg, hydra_mapping)
+    cfg.validate()
+
+    assert cfg.scene is not None
+    assert cfg.scene.entities["robot"].joint_names == ["joint"]
+    assert list(cfg.observations) == ["policy"]
+    policy = cfg.observations["policy"]
+    assert isinstance(policy, ObservationGroupCfg)
+    assert list(policy.terms) == ["joint_pos", "disabled"]
+    joint_obs = policy.terms["joint_pos"]
+    assert isinstance(joint_obs, ObservationTermCfg)
+    assert joint_obs.func is not None and callable(joint_obs.func)
+    assert isinstance(joint_obs.params["asset_cfg"], SceneEntityCfg)
+    assert isinstance(cfg.actions["joint_pos"], JointPositionActionCfg)
+    twist = cfg.commands["twist"]
+    assert isinstance(twist, UniformVelocityCommandCfg)
+    assert isinstance(twist.ranges, UniformVelocityCommandCfg.Ranges)
+    assert isinstance(cfg.events["reset"], EventTermCfg)
+    assert isinstance(cfg.rewards["alive"], RewardTermCfg)
+    assert isinstance(cfg.terminations["time_out"], TerminationTermCfg)
+    assert isinstance(cfg.curriculum["difficulty"], CurriculumTermCfg)
+    assert isinstance(cfg.metrics["alive"], MetricsTermCfg)
+    assert isinstance(cfg.recorders["trace"], RecorderTermCfg)
+    _assert_no_omegaconf(cfg)
+
+
 @pytest.mark.parametrize(
     ("overrides", "match"),
     [
-        ({"rewards": {"missing": {"weight": 1.0}}}, "rewards.*missing"),
-        ({"rewards": {"disabled": {"weight": 1.0}}}, "disabled.*task Python factory"),
-        ({"rewards": {"tracking": _second_term}}, "tracking.*replacing"),
+        ({"rewards": {"missing": {"weight": 1.0}}}, "missing.*_target_"),
+        ({"rewards": {"disabled": {"weight": 1.0}}}, "disabled.*_target_"),
+        ({"rewards": {"tracking": _second_term}}, "tracking.*field mapping"),
         ({"rewards": []}, "rewards.*mapping"),
-        ({"rewards": {"tracking": {"func": _second_term}}}, "func.*factory-owned"),
+        ({"rewards": {"tracking": {"func": _second_term}}}, "func.*typed term"),
     ],
 )
 def test_manager_mapping_overlay_fails_closed(overrides: dict, match: str) -> None:
     with pytest.raises((TypeError, ValueError), match=match):
         apply_cfg_overrides(_manager_cfg(), overrides)
+
+
+@pytest.mark.parametrize(
+    ("entry", "match"),
+    [
+        (
+            {
+                "_target_": "unilab.managers.EventTermCfg",
+                "func": "unilab.envs.mdp.is_alive",
+                "mode": "reset",
+            },
+            "EventTermCfg.*RewardTermCfg",
+        ),
+        (
+            {"_target_": "unilab.envs.mdp.is_alive", "func": "unilab.envs.mdp.is_alive"},
+            "dataclass type",
+        ),
+        (
+            {"_target_": "unilab.managers.MissingCfg", "func": "unilab.envs.mdp.is_alive"},
+            "_target_.*could not resolve",
+        ),
+        (
+            {
+                "_target_": "unilab.managers.RewardTermCfg",
+                "func": "unilab.envs.mdp.missing",
+                "weight": 1.0,
+            },
+            "func.*could not resolve",
+        ),
+        (
+            {
+                "_target_": "unilab.managers.RewardTermCfg",
+                "func": "unilab.base.config_overrides.CONFIG_MAPPING_POLICY_KEY",
+                "weight": 1.0,
+            },
+            "expected a callable",
+        ),
+        (
+            {
+                "_target_": "unilab.managers.RewardTermCfg",
+                "func": "unilab.envs.mdp.is_alive",
+                "weight": 1.0,
+                "unknown": 1,
+            },
+            "has no fields.*unknown",
+        ),
+        (
+            {"_target_": "unilab.managers.RewardTermCfg", "func": "unilab.envs.mdp.is_alive"},
+            "could not construct",
+        ),
+    ],
+)
+def test_hydra_manager_materialization_fails_closed(entry: dict, match: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        apply_cfg_overrides(ManagerBasedRlEnvCfg(), {"rewards": {"term": entry}})
+
+
+def test_hydra_manager_materialization_rejects_abstract_action_config() -> None:
+    with pytest.raises(TypeError, match="abstract config.*ActionTermCfg"):
+        apply_cfg_overrides(
+            ManagerBasedRlEnvCfg(),
+            {
+                "actions": {
+                    "joint": {
+                        "_target_": "unilab.managers.ActionTermCfg",
+                        "entity_name": "robot",
+                    }
+                }
+            },
+        )
+
+
+def test_hydra_manager_materialization_rejects_wrong_nested_config_type() -> None:
+    with pytest.raises(TypeError, match="SceneCfg.*Ranges"):
+        apply_cfg_overrides(
+            ManagerBasedRlEnvCfg(),
+            {
+                "commands": {
+                    "twist": {
+                        "_target_": "unilab.envs.mdp.UniformVelocityCommandCfg",
+                        "entity_name": "robot",
+                        "resampling_time_range": [1.0, 1.0],
+                        "ranges": {
+                            "_target_": "unilab.base.scene.SceneCfg",
+                            "model_file": "robot.xml",
+                        },
+                    }
+                }
+            },
+        )
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- make Hydra owner mappings able to construct new ordered Manager-Based groups/terms through explicit `_target_` declarations and dotted callable references
- materialize nested typed dataclasses on the Registry cold path and reject unknown fields, unresolved/non-callable references, abstract or incompatible cfg types, and missing required fields
- remove the old Registry rule that required task Python factories to pre-own every term; retain partial structural overlay only for existing typed objects used by low-level tests
- update ADR-0003/ADR-0006 and the architecture guide to make Hydra the sole production task config source

Fixes #1098
Umbrella: #1042

## Scope / accounting

- source-derived lines: 0
- mechanical NumPy conversion: 0
- UniLab-specific materializer: 377 new lines
- tests/docs and modified existing contract: 275 added lines
- deleted: 167 lines of Registry-owned legacy manager overlay; no files deleted
- total: 7 files, 652 additions, 182 deletions

No production task/YAML, backend, lifecycle, runner, learner, script, or IPC path changes.

## Validation

Final commit: `d33b3531a05f5307a96484aab2ffd412854e7e56`

- `make test-all`
  - ruff format/check: passed
  - mypy: passed (264 source files)
  - pyright: 0 errors / 0 warnings
  - pytest: 2033 passed / 27 skipped / 276 deselected / 1 xfailed
  - benchmark smoke: module 32/33 and script 33/34; only platform-optional MLX skips
- focused materializer/Registry tests: 46 passed

Per the approved #1042 child workflow, the commit uses `[skip ci]`; remote CI is not requested or awaited. Backend behavior is unchanged.
