### PR TITLE
feat(env): add Manager-Based randomization events

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, NoReturn
 import numpy as np
 
 from unilab.base.backend.base import BackendRootStateLayout, BackendSensorView, SimBackend
+from unilab.dr.types import IntervalRandomizationPlan
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse, np_yaw_from_quat
 
 if TYPE_CHECKING:
@@ -441,6 +442,7 @@ class Entity:
                 (cfg.root_body_name,),
                 backend.get_body_ids,
             )
+        self._root_body_ids = root_body_ids
 
         joint_pos_ids = joint_vel_ids = None
         if self._joint_names is not None:
@@ -458,6 +460,7 @@ class Entity:
         body_ids = None
         if self._body_names is not None:
             body_ids = self._resolve_ids("body", self._body_names, backend.get_body_ids)
+        self._body_ids = body_ids
 
         self._geom_ids = None
         if self._geom_names is not None:
@@ -1088,6 +1091,144 @@ class Entity:
             term_name=f"{term_name}:{self.name}",
         )
 
+    def bind_body_mass_write(
+        self,
+        body_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local body columns and immutable default masses."""
+        reset_state, local_ids, backend_ids = self._bind_body_randomization(
+            body_ids,
+            capability="reset body-mass write",
+        )
+        _, defaults = reset_state.bind_body_mass_write(
+            backend_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_body_mass_to_sim(
+        self,
+        values: np.ndarray,
+        body_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "randomize_rigid_body_mass",
+    ) -> None:
+        """Stage selected entity body masses in the active reset transaction."""
+        reset_state, _, backend_ids = self._bind_body_randomization(
+            body_ids,
+            capability="reset body-mass write",
+        )
+        reset_state.write_body_mass(
+            self._normalize_reset_env_ids(env_ids),
+            backend_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_body_ipos_write(
+        self,
+        body_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local body columns and immutable inertial positions."""
+        reset_state, local_ids, backend_ids = self._bind_body_randomization(
+            body_ids,
+            capability="reset body-ipos write",
+        )
+        _, defaults = reset_state.bind_body_ipos_write(
+            backend_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_body_ipos_to_sim(
+        self,
+        values: np.ndarray,
+        body_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "randomize_rigid_body_com",
+    ) -> None:
+        """Stage selected entity body inertial positions in the reset transaction."""
+        reset_state, _, backend_ids = self._bind_body_randomization(
+            body_ids,
+            capability="reset body-ipos write",
+        )
+        reset_state.write_body_ipos(
+            self._normalize_reset_env_ids(env_ids),
+            backend_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_root_linear_velocity_delta(self, *, term_name: str) -> None:
+        """Validate the interval root-velocity capability on the cold path."""
+        if self._root_body_ids is None:
+            raise self._capability_error(
+                "interval root velocity delta",
+                "root_body_name was not declared in EntityCfg",
+            )
+        try:
+            capabilities = self._backend.get_dr_capabilities()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error("interval root velocity delta", str(exc)) from exc
+        if not capabilities.supports_interval_body_velocity_delta:
+            raise self._capability_error(
+                "interval root velocity delta",
+                f"EventManager term '{term_name}' requested an unsupported backend capability",
+            )
+
+    def apply_root_linear_velocity_delta_to_sim(
+        self,
+        values: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "push_by_setting_velocity",
+    ) -> None:
+        """Dispatch a cached root linear-velocity delta through the formal interval plan."""
+        if self._root_body_ids is None:
+            raise self._capability_error(
+                "interval root velocity delta",
+                "root_body_name was not declared in EntityCfg",
+            )
+        ids = self._normalize_reset_env_ids(env_ids)
+        if not isinstance(values, np.ndarray):
+            raise TypeError(
+                f"EventManager term '{term_name}' root velocity delta must be np.ndarray, "
+                f"got {type(values).__name__}"
+            )
+        expected = (ids.size, 3)
+        if values.shape != expected:
+            raise ValueError(
+                f"EventManager term '{term_name}' root velocity delta has shape "
+                f"{values.shape}; expected {expected}"
+            )
+        if not np.issubdtype(values.dtype, np.floating) or not np.isfinite(values).all():
+            raise ValueError(
+                f"EventManager term '{term_name}' root velocity delta must be finite floating data"
+            )
+        delta = np.zeros(
+            (self._backend.num_envs, len(self._root_body_ids), 3),
+            dtype=values.dtype,
+        )
+        delta[ids, 0, :] = values
+        try:
+            self._backend.apply_interval_randomization(
+                IntervalRandomizationPlan(
+                    body_ids=self._root_body_ids,
+                    body_linear_velocity_delta=delta,
+                )
+            )
+        except NotImplementedError as exc:
+            raise self._capability_error(
+                "interval root velocity delta",
+                f"EventManager term '{term_name}': {exc}",
+            ) from exc
+
     def write_root_link_pose_to_sim(
         self,
         root_pose: np.ndarray,
@@ -1189,6 +1330,71 @@ class Entity:
             expected=len(self._joint_names),
             label=f"Entity '{self.name}' reset qvel",
         )
+
+    def _bind_body_randomization(
+        self,
+        body_ids: np.ndarray | Sequence[int] | slice | None,
+        *,
+        capability: str,
+    ) -> tuple[ResetStateTransaction, np.ndarray, np.ndarray]:
+        if self._reset_state is None:
+            raise self._capability_error(
+                capability,
+                "EntityScene was materialized without an env-owned reset transaction",
+            )
+        if self._body_ids is None:
+            raise self._capability_error(
+                capability,
+                "body_names were not declared in EntityCfg",
+            )
+        local_ids = self._normalize_local_body_ids(body_ids, capability=capability)
+        if local_ids.size == 0:
+            raise ValueError(f"Entity '{self.name}' {capability} selected no bodies")
+        return self._reset_state, local_ids, self._body_ids[local_ids]
+
+    def _readonly_local_binding(
+        self,
+        local_ids: np.ndarray,
+        defaults: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        bound_ids = np.array(local_ids, copy=True)
+        bound_ids.setflags(write=False)
+        bound_defaults = np.array(defaults, copy=True)
+        bound_defaults.setflags(write=False)
+        return bound_ids, bound_defaults
+
+    def _normalize_local_body_ids(
+        self,
+        body_ids: np.ndarray | Sequence[int] | slice | None,
+        *,
+        capability: str,
+    ) -> np.ndarray:
+        if body_ids is None:
+            ids = np.arange(self.num_bodies, dtype=np.intp)
+        elif isinstance(body_ids, slice):
+            ids = np.arange(self.num_bodies, dtype=np.intp)[body_ids]
+        else:
+            raw = np.asarray(body_ids)
+            if (
+                raw.ndim != 1
+                or not np.issubdtype(raw.dtype, np.integer)
+                or np.issubdtype(raw.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self.name}' {capability} body_ids must be a 1-D integer "
+                    "array or slice"
+                )
+            ids = np.asarray(raw, dtype=np.intp)
+        if np.any(ids < 0) or np.any(ids >= self.num_bodies):
+            raise IndexError(
+                f"Entity '{self.name}' {capability} body_ids out of range for "
+                f"{self.num_bodies} bodies: {ids.tolist()}"
+            )
+        if np.unique(ids).size != ids.size:
+            raise ValueError(
+                f"Entity '{self.name}' {capability} body_ids contain duplicates: {ids.tolist()}"
+            )
+        return ids
 
     def _normalize_local_joint_ids(
         self,
@@ -1396,6 +1602,30 @@ class EntityScene(Mapping[str, Entity]):
                 "a formal backend root-state layout"
             )
         self._reset_state.reset_to_default(env_ids, term_name=term_name)
+
+    def bind_gravity_write(self, *, term_name: str) -> np.ndarray:
+        """Bind immutable backend gravity for a reset event on the cold path."""
+        if self._reset_state is None:
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' gravity capability is unavailable: "
+                "EntityScene was materialized without an env-owned reset transaction"
+            )
+        return self._reset_state.bind_gravity_write(term_name=term_name)
+
+    def write_gravity_to_sim(
+        self,
+        values: np.ndarray,
+        env_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage gravity values in the exactly-once reset transaction."""
+        if self._reset_state is None:
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' gravity capability is unavailable: "
+                "EntityScene was materialized without an env-owned reset transaction"
+            )
+        self._reset_state.write_gravity(env_ids, values, term_name=term_name)
 
     def bind_sensor_data(self, names: Sequence[str]) -> BackendSensorView:
         """Bind existing backend sensors for a manager term on the cold path.

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -13,7 +13,14 @@ from contextlib import contextmanager
 import numpy as np
 
 from unilab.base.backend.base import BackendRootStateLayout, SimBackend
-from unilab.dr.types import RESET_TERM_KD, RESET_TERM_KP, ResetRandomizationPayload
+from unilab.dr.types import (
+    RESET_TERM_BODY_IPOS,
+    RESET_TERM_BODY_MASS,
+    RESET_TERM_GRAVITY,
+    RESET_TERM_KD,
+    RESET_TERM_KP,
+    ResetRandomizationPayload,
+)
 from unilab.utils.rotation import np_quat_apply_inverse
 
 
@@ -41,6 +48,9 @@ class ResetStateTransaction:
         self._kp: np.ndarray | None = None
         self._kd: np.ndarray | None = None
         self._gain_dirty_mask = np.zeros(self._num_envs, dtype=np.bool_)
+        self._randomization_defaults: dict[str, np.ndarray] = {}
+        self._randomization_values: dict[str, np.ndarray] = {}
+        self._randomization_dirty_masks: dict[str, np.ndarray] = {}
         self._requesting_terms: set[str] = set()
 
     @property
@@ -69,8 +79,126 @@ class ResetStateTransaction:
         self._active_mask[ids] = True
         self._dirty_mask.fill(False)
         self._gain_dirty_mask.fill(False)
+        for mask in self._randomization_dirty_masks.values():
+            mask.fill(False)
         self._requesting_terms.clear()
         self._active = True
+
+    def bind_body_mass_write(
+        self,
+        body_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind body-mass columns and immutable backend defaults on the cold path."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_BODY_MASS,
+            getter=self._backend.get_body_mass,
+            expected_tail=None,
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            body_ids,
+            width=default.shape[0],
+            capability="body mass IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def bind_body_ipos_write(
+        self,
+        body_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind body inertial-position columns and immutable backend defaults."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_BODY_IPOS,
+            getter=self._backend.get_body_ipos,
+            expected_tail=(3,),
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            body_ids,
+            width=default.shape[0],
+            capability="body ipos IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def bind_gravity_write(self, *, term_name: str) -> np.ndarray:
+        """Bind the immutable backend gravity vector on the cold path."""
+        return self._materialize_randomization_default(
+            RESET_TERM_GRAVITY,
+            getter=self._backend.get_gravity,
+            expected_tail=(),
+            term_name=term_name,
+        )
+
+    def write_body_mass(
+        self,
+        env_ids: np.ndarray,
+        body_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected body masses in the exactly-once reset payload."""
+        self._write_body_randomization(
+            RESET_TERM_BODY_MASS,
+            env_ids,
+            body_ids,
+            values,
+            value_tail=(),
+            term_name=term_name,
+        )
+
+    def write_body_ipos(
+        self,
+        env_ids: np.ndarray,
+        body_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected body inertial positions in the reset payload."""
+        self._write_body_randomization(
+            RESET_TERM_BODY_IPOS,
+            env_ids,
+            body_ids,
+            values,
+            value_tail=(3,),
+            term_name=term_name,
+        )
+
+    def write_gravity(
+        self,
+        env_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage per-environment gravity vectors in the reset payload."""
+        ids = self._prepare_state_write(
+            env_ids,
+            capability="gravity",
+            term_name=term_name,
+        )
+        default = self._require_randomization_default(RESET_TERM_GRAVITY, term_name)
+        gravity = self._validate_values(
+            values,
+            shape=(ids.size, 3),
+            capability="gravity",
+            term_name=term_name,
+        )
+        buffer = self._randomization_values[RESET_TERM_GRAVITY]
+        mask = self._randomization_dirty_masks[RESET_TERM_GRAVITY]
+        uninitialized = ids[~mask[ids]]
+        if uninitialized.size:
+            buffer[uninitialized] = default
+        buffer[ids] = gravity
+        mask[ids] = True
+        self._dirty_mask[ids] = True
 
     def bind_actuator_gain_write(
         self,
@@ -399,27 +527,170 @@ class ResetStateTransaction:
             dtype=default_kd.dtype,
         )
 
+    def _materialize_randomization_default(
+        self,
+        field: str,
+        *,
+        getter,
+        expected_tail: tuple[int, ...] | None,
+        term_name: str,
+    ) -> np.ndarray:
+        cached = self._randomization_defaults.get(field)
+        if cached is not None:
+            return cached
+        try:
+            capabilities = self._backend.get_dr_capabilities()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error(term_name, f"{field} randomization", exc) from exc
+        unsupported = capabilities.get_unsupported_reset_terms(frozenset((field,)))
+        if unsupported:
+            raise self._capability_error(
+                term_name,
+                f"{field} randomization",
+                NotImplementedError(f"unsupported reset payload field: {field}"),
+            )
+        try:
+            value = getter()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error(term_name, f"default {field}", exc) from exc
+        if not isinstance(value, np.ndarray):
+            raise TypeError(
+                f"EventManager term '{term_name}' capability 'default {field}' on backend "
+                f"'{self._backend.backend_type}' must return np.ndarray, got "
+                f"{type(value).__name__}"
+            )
+        expected_ndim = 1 if expected_tail is None else 1 + len(expected_tail)
+        if value.ndim != expected_ndim:
+            raise ValueError(
+                f"EventManager term '{term_name}' capability 'default {field}' on backend "
+                f"'{self._backend.backend_type}' returned shape {value.shape}; expected "
+                f"{expected_ndim}-D"
+            )
+        if expected_tail is not None and value.shape[1:] != expected_tail:
+            raise ValueError(
+                f"EventManager term '{term_name}' capability 'default {field}' on backend "
+                f"'{self._backend.backend_type}' returned shape {value.shape}; expected tail "
+                f"{expected_tail}"
+            )
+        if not np.issubdtype(value.dtype, np.floating):
+            raise TypeError(
+                f"EventManager term '{term_name}' capability 'default {field}' on backend "
+                f"'{self._backend.backend_type}' must be floating, got {value.dtype}"
+            )
+        if not np.isfinite(value).all():
+            raise ValueError(
+                f"EventManager term '{term_name}' capability 'default {field}' on backend "
+                f"'{self._backend.backend_type}' returned NaN or Inf"
+            )
+        default = np.array(value, copy=True)
+        default.setflags(write=False)
+        self._randomization_defaults[field] = default
+        self._randomization_values[field] = np.empty(
+            (self._num_envs, *default.shape),
+            dtype=default.dtype,
+        )
+        self._randomization_dirty_masks[field] = np.zeros(self._num_envs, dtype=np.bool_)
+        return default
+
+    def _require_randomization_default(self, field: str, term_name: str) -> np.ndarray:
+        try:
+            return self._randomization_defaults[field]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"EventManager term '{term_name}' must bind reset field '{field}' "
+                "during manager construction before writing it"
+            ) from exc
+
+    def _readonly_binding(
+        self,
+        columns: np.ndarray,
+        selected_default: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        bound_columns = np.array(columns, copy=True)
+        bound_columns.setflags(write=False)
+        selected = np.array(selected_default, copy=True)
+        selected.setflags(write=False)
+        return bound_columns, selected
+
+    def _write_body_randomization(
+        self,
+        field: str,
+        env_ids: np.ndarray,
+        body_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        value_tail: tuple[int, ...],
+        term_name: str,
+    ) -> None:
+        ids = self._prepare_state_write(
+            env_ids,
+            capability=field,
+            term_name=term_name,
+        )
+        default = self._require_randomization_default(field, term_name)
+        columns = self._validate_columns(
+            body_ids,
+            width=default.shape[0],
+            capability=f"{field} body IDs",
+            term_name=term_name,
+        )
+        selected = self._validate_values(
+            values,
+            shape=(ids.size, columns.size, *value_tail),
+            capability=field,
+            term_name=term_name,
+        )
+        buffer = self._randomization_values[field]
+        mask = self._randomization_dirty_masks[field]
+        uninitialized = ids[~mask[ids]]
+        if uninitialized.size:
+            buffer[uninitialized] = default
+        if ids.size and columns.size:
+            buffer[ids[:, None], columns[None, :]] = selected
+        mask[ids] = True
+        self._dirty_mask[ids] = True
+
     def _build_randomization_payload(
         self,
         dirty_ids: np.ndarray,
     ) -> ResetRandomizationPayload | None:
+        payload = ResetRandomizationPayload()
+        for field in (RESET_TERM_BODY_MASS, RESET_TERM_BODY_IPOS, RESET_TERM_GRAVITY):
+            mask = self._randomization_dirty_masks.get(field)
+            if mask is None or not np.any(mask):
+                continue
+            self._require_dense_randomization_rows(field, mask, dirty_ids)
+            setattr(
+                payload,
+                field,
+                np.array(self._randomization_values[field][dirty_ids], copy=True),
+            )
+
         gain_ids = np.flatnonzero(self._gain_dirty_mask).astype(np.int32, copy=False)
-        if gain_ids.size == 0:
-            return None
-        missing = dirty_ids[~self._gain_dirty_mask[dirty_ids]]
+        if gain_ids.size:
+            self._require_dense_randomization_rows(
+                "actuator gains", self._gain_dirty_mask, dirty_ids
+            )
+            assert self._kp is not None
+            assert self._kd is not None
+            payload.kp = np.array(self._kp[dirty_ids], copy=True)
+            payload.kd = np.array(self._kd[dirty_ids], copy=True)
+        return None if payload.is_empty() else payload
+
+    def _require_dense_randomization_rows(
+        self,
+        field: str,
+        mask: np.ndarray,
+        dirty_ids: np.ndarray,
+    ) -> None:
+        missing = dirty_ids[~mask[dirty_ids]]
         if missing.size:
             terms = ", ".join(sorted(self._requesting_terms))
             raise RuntimeError(
-                "EventManager reset actuator-gain payload cannot represent sparse rows in "
-                f"one SimBackend.set_state call for term(s) [{terms}] on backend "
+                f"EventManager reset {field} payload cannot represent sparse rows in one "
+                f"SimBackend.set_state call for term(s) [{terms}] on backend "
                 f"'{self._backend.backend_type}'; missing env IDs {missing.tolist()}"
             )
-        assert self._kp is not None
-        assert self._kd is not None
-        return ResetRandomizationPayload(
-            kp=np.array(self._kp[dirty_ids], copy=True),
-            kd=np.array(self._kd[dirty_ids], copy=True),
-        )
 
     def _prepare_state_write(
         self,
@@ -595,7 +866,7 @@ class ResetStateTransaction:
         self,
         values: np.ndarray,
         *,
-        shape: tuple[int, int],
+        shape: tuple[int, ...],
         capability: str,
         term_name: str,
     ) -> np.ndarray:
@@ -637,6 +908,8 @@ class ResetStateTransaction:
         self._active_mask.fill(False)
         self._dirty_mask.fill(False)
         self._gain_dirty_mask.fill(False)
+        for mask in self._randomization_dirty_masks.values():
+            mask.fill(False)
         self._requesting_terms.clear()
 
 

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -5,6 +5,12 @@ from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActio
 from unilab.envs.mdp.commands import UniformVelocityCommand as UniformVelocityCommand
 from unilab.envs.mdp.commands import UniformVelocityCommandCfg as UniformVelocityCommandCfg
 from unilab.envs.mdp.events import pd_gains as pd_gains
+from unilab.envs.mdp.events import push_by_setting_velocity as push_by_setting_velocity
+from unilab.envs.mdp.events import (
+    randomize_physics_scene_gravity as randomize_physics_scene_gravity,
+)
+from unilab.envs.mdp.events import randomize_rigid_body_com as randomize_rigid_body_com
+from unilab.envs.mdp.events import randomize_rigid_body_mass as randomize_rigid_body_mass
 from unilab.envs.mdp.events import reset_root_state_uniform as reset_root_state_uniform
 from unilab.envs.mdp.events import reset_scene_to_default as reset_scene_to_default
 from unilab.envs.mdp.events import resolve_env_ids as resolve_env_ids
@@ -55,6 +61,10 @@ __all__ = [
     "joint_vel_l2",
     "last_action",
     "pd_gains",
+    "push_by_setting_velocity",
+    "randomize_physics_scene_gravity",
+    "randomize_rigid_body_com",
+    "randomize_rigid_body_mass",
     "is_alive",
     "is_terminated",
     "projected_gravity",

--- a/src/unilab/envs/mdp/events.py
+++ b/src/unilab/envs/mdp/events.py
@@ -2,6 +2,8 @@
 # src/mjlab/envs/mdp/events.py.
 # Copyright 2025, The mjlab Developers.
 # Modified by UniLab for NumPy reset transactions; Apache-2.0.
+# The mass/CoM/gravity public names and signatures follow Isaac Lab v2.2.0;
+# their implementation here is UniLab's original payload adapter, not vendored PhysX code.
 """Community-style reset event terms for UniLab's NumPy manager runtime."""
 
 from __future__ import annotations
@@ -22,7 +24,10 @@ if TYPE_CHECKING:
 
 _DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
 _SE3_KEYS = ("x", "y", "z", "roll", "pitch", "yaw")
+_XYZ_KEYS = ("x", "y", "z")
 _PD_GAIN_PARAM_NAMES = frozenset(("kp_range", "kd_range", "asset_cfg", "distribution", "operation"))
+_DISTRIBUTIONS = ("uniform", "log_uniform", "gaussian")
+_OPERATIONS = ("add", "scale", "abs")
 
 
 def _gain_range(
@@ -102,6 +107,139 @@ def _sample_se3_range(
         keys = [_SE3_KEYS[index] for index in np.flatnonzero(invalid)]
         raise ValueError(f"reset_root_state_uniform range minimum exceeds maximum for keys {keys}")
     return rng.uniform(ranges[:, 0], ranges[:, 1], size=shape)
+
+
+def _event_choice(value: Any, *, term_name: str, name: str, choices: tuple[str, ...]) -> str:
+    if not isinstance(value, str):
+        raise TypeError(
+            f"EventManager term '{term_name}' parameter '{name}' must be a string, "
+            f"got {type(value).__name__}"
+        )
+    if value not in choices:
+        raise ValueError(
+            f"EventManager term '{term_name}' parameter '{name}' must be one of "
+            f"{choices}, got {value!r}"
+        )
+    return value
+
+
+def _distribution_parameters(
+    value: Any,
+    *,
+    term_name: str,
+    name: str,
+    width: int | None = None,
+    distribution: str,
+) -> np.ndarray:
+    try:
+        params = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"EventManager term '{term_name}' parameter '{name}' must contain numeric values"
+        ) from exc
+    expected = (2,) if width is None else (2, width)
+    if params.shape != expected:
+        raise ValueError(
+            f"EventManager term '{term_name}' parameter '{name}' has shape {params.shape}; "
+            f"expected {expected}"
+        )
+    if not np.isfinite(params).all():
+        raise ValueError(
+            f"EventManager term '{term_name}' parameter '{name}' must contain only finite values"
+        )
+    if distribution == "gaussian":
+        if np.any(params[1] < 0.0):
+            raise ValueError(
+                f"EventManager term '{term_name}' parameter '{name}' standard deviation "
+                "must be non-negative"
+            )
+    else:
+        if np.any(params[0] > params[1]):
+            raise ValueError(
+                f"EventManager term '{term_name}' parameter '{name}' lower bound exceeds upper bound"
+            )
+        if distribution == "log_uniform" and np.any(params <= 0.0):
+            raise ValueError(
+                f"EventManager term '{term_name}' parameter '{name}' must be positive "
+                "for log_uniform sampling"
+            )
+    result = np.array(params, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+def _sample_distribution(
+    rng: np.random.Generator,
+    params: np.ndarray,
+    shape: tuple[int, ...],
+    distribution: str,
+) -> np.ndarray:
+    if distribution == "gaussian":
+        return rng.normal(params[0], params[1], size=shape)
+    if distribution == "log_uniform":
+        return np.exp(rng.uniform(np.log(params[0]), np.log(params[1]), size=shape))
+    return rng.uniform(params[0], params[1], size=shape)
+
+
+def _apply_randomization_operation(
+    default: np.ndarray,
+    samples: np.ndarray,
+    operation: str,
+) -> np.ndarray:
+    if operation == "add":
+        return default + samples
+    if operation == "scale":
+        return default * samples
+    return samples
+
+
+def _axis_ranges(
+    value: Any,
+    *,
+    term_name: str,
+    name: str,
+    keys: tuple[str, ...],
+) -> np.ndarray:
+    if not isinstance(value, dict):
+        raise TypeError(f"EventManager term '{term_name}' parameter '{name}' must be a dict")
+    unknown = sorted(set(value) - set(keys))
+    if unknown:
+        raise ValueError(
+            f"EventManager term '{term_name}' parameter '{name}' has unknown axes {unknown}"
+        )
+    parameters = np.asarray([value.get(key, (0.0, 0.0)) for key in keys], dtype=object).T
+    return _distribution_parameters(
+        parameters,
+        term_name=term_name,
+        name=name,
+        width=len(keys),
+        distribution="uniform",
+    ).T
+
+
+def _validate_event_term(
+    cfg: EventTermCfg,
+    *,
+    term_name: str,
+    mode: str,
+    allowed_params: frozenset[str],
+    required_params: tuple[str, ...],
+) -> None:
+    if cfg.mode != mode:
+        raise NotImplementedError(
+            f"EventManager term '{term_name}' only supports mode='{mode}' on the UniLab runtime"
+        )
+    if mode == "reset" and cfg.min_step_count_between_reset != 0:
+        raise NotImplementedError(
+            f"EventManager term '{term_name}' requires min_step_count_between_reset=0 "
+            "because sparse reset payload rows cannot be represented"
+        )
+    unknown = sorted(set(cfg.params) - allowed_params)
+    if unknown:
+        raise ValueError(f"EventManager term '{term_name}' has unknown parameters {unknown}")
+    missing = [name for name in required_params if name not in cfg.params]
+    if missing:
+        raise ValueError(f"EventManager term '{term_name}' is missing parameters {missing}")
 
 
 def resolve_env_ids(env: ManagerBasedRlEnv, env_ids: np.ndarray | None) -> np.ndarray:
@@ -205,6 +343,300 @@ class PdGains(ManagerTermBase):
 pd_gains = PdGains
 
 
+class RandomizeRigidBodyMass(ManagerTermBase):
+    """Community-compatible body-mass randomization via the reset payload."""
+
+    _PARAMS = frozenset(
+        (
+            "asset_cfg",
+            "mass_distribution_params",
+            "operation",
+            "distribution",
+            "recompute_inertia",
+            "min_mass",
+        )
+    )
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        term_name = "randomize_rigid_body_mass"
+        _validate_event_term(
+            cfg,
+            term_name=term_name,
+            mode="reset",
+            allowed_params=self._PARAMS,
+            required_params=("asset_cfg", "mass_distribution_params", "operation"),
+        )
+        asset_cfg = cfg.params["asset_cfg"]
+        if not isinstance(asset_cfg, SceneEntityCfg):
+            raise TypeError(
+                f"EventManager term '{term_name}' asset_cfg must be SceneEntityCfg, "
+                f"got {type(asset_cfg).__name__}"
+            )
+        recompute_inertia = cfg.params.get("recompute_inertia", True)
+        if not isinstance(recompute_inertia, bool):
+            raise TypeError(f"EventManager term '{term_name}' recompute_inertia must be bool")
+        if recompute_inertia:
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' recompute_inertia=True is unavailable: "
+                "ResetRandomizationPayload has no inertia-recomputation contract; set it "
+                "explicitly to false or do not configure this term"
+            )
+        self._operation = _event_choice(
+            cfg.params["operation"],
+            term_name=term_name,
+            name="operation",
+            choices=_OPERATIONS,
+        )
+        self._distribution = _event_choice(
+            cfg.params.get("distribution", "uniform"),
+            term_name=term_name,
+            name="distribution",
+            choices=_DISTRIBUTIONS,
+        )
+        self._distribution_params = _distribution_parameters(
+            cfg.params["mass_distribution_params"],
+            term_name=term_name,
+            name="mass_distribution_params",
+            distribution=self._distribution,
+        )
+        min_mass = cfg.params.get("min_mass", 1e-6)
+        if isinstance(min_mass, bool) or not isinstance(min_mass, (int, float)):
+            raise TypeError(f"EventManager term '{term_name}' min_mass must be numeric")
+        self._min_mass = float(min_mass)
+        if not np.isfinite(self._min_mass) or self._min_mass < 1e-6:
+            raise ValueError(
+                f"EventManager term '{term_name}' min_mass must be finite and at least 1e-6"
+            )
+        self._entity = cast("Entity", env.scene[asset_cfg.name])
+        self._body_ids, self._default_mass = self._entity.bind_body_mass_write(
+            asset_cfg.body_ids,
+            term_name=term_name,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        asset_cfg: SceneEntityCfg,
+        mass_distribution_params: tuple[float, float],
+        operation: Literal["add", "scale", "abs"],
+        distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+        recompute_inertia: bool = True,
+        min_mass: float = 1e-6,
+    ) -> None:
+        del (
+            asset_cfg,
+            mass_distribution_params,
+            operation,
+            distribution,
+            recompute_inertia,
+            min_mass,
+        )
+        ids = resolve_env_ids(env, env_ids)
+        samples = _sample_distribution(
+            env.rng,
+            self._distribution_params,
+            (ids.size, self._body_ids.size),
+            self._distribution,
+        )
+        values = _apply_randomization_operation(
+            self._default_mass[None, :],
+            samples,
+            self._operation,
+        )
+        np.maximum(values, self._min_mass, out=values)
+        self._entity.write_body_mass_to_sim(
+            values,
+            body_ids=self._body_ids,
+            env_ids=ids,
+            term_name="randomize_rigid_body_mass",
+        )
+
+
+randomize_rigid_body_mass = RandomizeRigidBodyMass
+
+
+class RandomizeRigidBodyCom(ManagerTermBase):
+    """Community-compatible additive rigid-body CoM randomization."""
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        term_name = "randomize_rigid_body_com"
+        _validate_event_term(
+            cfg,
+            term_name=term_name,
+            mode="reset",
+            allowed_params=frozenset(("com_range", "asset_cfg")),
+            required_params=("com_range", "asset_cfg"),
+        )
+        asset_cfg = cfg.params["asset_cfg"]
+        if not isinstance(asset_cfg, SceneEntityCfg):
+            raise TypeError(
+                f"EventManager term '{term_name}' asset_cfg must be SceneEntityCfg, "
+                f"got {type(asset_cfg).__name__}"
+            )
+        self._ranges = _axis_ranges(
+            cfg.params["com_range"],
+            term_name=term_name,
+            name="com_range",
+            keys=_XYZ_KEYS,
+        )
+        self._entity = cast("Entity", env.scene[asset_cfg.name])
+        self._body_ids, self._default_ipos = self._entity.bind_body_ipos_write(
+            asset_cfg.body_ids,
+            term_name=term_name,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        com_range: dict[str, tuple[float, float]],
+        asset_cfg: SceneEntityCfg,
+    ) -> None:
+        del com_range, asset_cfg
+        ids = resolve_env_ids(env, env_ids)
+        offsets = env.rng.uniform(
+            self._ranges[:, 0],
+            self._ranges[:, 1],
+            size=(ids.size, 3),
+        )
+        values = self._default_ipos[None, :, :] + offsets[:, None, :]
+        self._entity.write_body_ipos_to_sim(
+            values,
+            body_ids=self._body_ids,
+            env_ids=ids,
+            term_name="randomize_rigid_body_com",
+        )
+
+
+randomize_rigid_body_com = RandomizeRigidBodyCom
+
+
+class RandomizePhysicsSceneGravity(ManagerTermBase):
+    """Community-compatible gravity randomization through reset transactions."""
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        term_name = "randomize_physics_scene_gravity"
+        _validate_event_term(
+            cfg,
+            term_name=term_name,
+            mode="reset",
+            allowed_params=frozenset(("gravity_distribution_params", "operation", "distribution")),
+            required_params=("gravity_distribution_params", "operation"),
+        )
+        self._operation = _event_choice(
+            cfg.params["operation"],
+            term_name=term_name,
+            name="operation",
+            choices=_OPERATIONS,
+        )
+        self._distribution = _event_choice(
+            cfg.params.get("distribution", "uniform"),
+            term_name=term_name,
+            name="distribution",
+            choices=_DISTRIBUTIONS,
+        )
+        self._distribution_params = _distribution_parameters(
+            cfg.params["gravity_distribution_params"],
+            term_name=term_name,
+            name="gravity_distribution_params",
+            width=3,
+            distribution=self._distribution,
+        )
+        self._default_gravity = env.scene.bind_gravity_write(term_name=term_name)
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        gravity_distribution_params: tuple[list[float], list[float]],
+        operation: Literal["add", "scale", "abs"],
+        distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+    ) -> None:
+        del gravity_distribution_params, operation, distribution
+        ids = resolve_env_ids(env, env_ids)
+        samples = _sample_distribution(
+            env.rng,
+            self._distribution_params,
+            (ids.size, 3),
+            self._distribution,
+        )
+        values = _apply_randomization_operation(
+            self._default_gravity[None, :],
+            samples,
+            self._operation,
+        )
+        env.scene.write_gravity_to_sim(
+            values,
+            ids,
+            term_name="randomize_physics_scene_gravity",
+        )
+
+
+randomize_physics_scene_gravity = RandomizePhysicsSceneGravity
+
+
+class PushBySettingVelocity(ManagerTermBase):
+    """Pinned community velocity kick dispatched through the interval plan."""
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        term_name = "push_by_setting_velocity"
+        _validate_event_term(
+            cfg,
+            term_name=term_name,
+            mode="interval",
+            allowed_params=frozenset(("velocity_range", "asset_cfg")),
+            required_params=("velocity_range",),
+        )
+        asset_cfg = cfg.params.get("asset_cfg", _DEFAULT_ASSET_CFG)
+        if not isinstance(asset_cfg, SceneEntityCfg):
+            raise TypeError(
+                f"EventManager term '{term_name}' asset_cfg must be SceneEntityCfg, "
+                f"got {type(asset_cfg).__name__}"
+            )
+        ranges = _axis_ranges(
+            cfg.params["velocity_range"],
+            term_name=term_name,
+            name="velocity_range",
+            keys=_SE3_KEYS,
+        )
+        if np.any(ranges[3:] != 0.0):
+            raise NotImplementedError(
+                f"EventManager term '{term_name}' angular velocity ranges are unsupported: "
+                "IntervalRandomizationPlan only declares body_linear_velocity_delta"
+            )
+        self._ranges = ranges[:3]
+        self._entity = cast("Entity", env.scene[asset_cfg.name])
+        self._entity.bind_root_linear_velocity_delta(term_name=term_name)
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        velocity_range: dict[str, tuple[float, float]],
+        asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    ) -> None:
+        del velocity_range, asset_cfg
+        ids = resolve_env_ids(env, env_ids)
+        delta = env.rng.uniform(
+            self._ranges[:, 0],
+            self._ranges[:, 1],
+            size=(ids.size, 3),
+        )
+        self._entity.apply_root_linear_velocity_delta_to_sim(
+            delta,
+            env_ids=ids,
+            term_name="push_by_setting_velocity",
+        )
+
+
+push_by_setting_velocity = PushBySettingVelocity
+
+
 def reset_scene_to_default(env: ManagerBasedRlEnv, env_ids: np.ndarray | None) -> None:
     """Reset all materialized scene entities to backend default qpos/qvel."""
     ids = resolve_env_ids(env, env_ids)
@@ -249,4 +681,13 @@ def reset_root_state_uniform(
     asset.write_root_state_to_sim(root_states, env_ids=ids)
 
 
-__all__ = ["pd_gains", "reset_root_state_uniform", "reset_scene_to_default", "resolve_env_ids"]
+__all__ = [
+    "pd_gains",
+    "push_by_setting_velocity",
+    "randomize_physics_scene_gravity",
+    "randomize_rigid_body_com",
+    "randomize_rigid_body_mass",
+    "reset_root_state_uniform",
+    "reset_scene_to_default",
+    "resolve_env_ids",
+]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -168,6 +168,12 @@ class ManagerScene(Protocol):
 
     def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None: ...
 
+    def bind_gravity_write(self, *, term_name: str) -> np.ndarray: ...
+
+    def write_gravity_to_sim(
+        self, values: np.ndarray, env_ids: np.ndarray, *, term_name: str
+    ) -> None: ...
+
 
 class ManagerActionTerm(Protocol):
     @property

--- a/tests/envs/locomotion/go2/test_manager_based_cfg.py
+++ b/tests/envs/locomotion/go2/test_manager_based_cfg.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import math
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import numpy as np
 import pytest
 
 from unilab.base.backend import create_backend, env_backend_kwargs
+from unilab.base.entity import EntityCfg
 from unilab.base.np_env import NpEnvState
 from unilab.envs import ManagerBasedRlEnv, mdp
 from unilab.envs.locomotion.common import manager_terms
@@ -16,6 +17,7 @@ from unilab.envs.locomotion.go2.manager_based_cfg import (
     make_go2_joystick_flat_manager_cfg,
 )
 from unilab.envs.mdp import JointPositionAction, JointPositionActionCfg
+from unilab.managers import EventTermCfg, SceneEntityCfg
 
 _JOINT_NAMES = (
     "FL_hip_joint",
@@ -300,6 +302,72 @@ def test_go2_manager_factory_executes_on_real_mujoco() -> None:
             assert np.isfinite(value).all()
         assert state.terminated.dtype == np.bool_
         assert state.truncated.dtype == np.bool_
+    finally:
+        env.close()
+
+
+def test_go2_manager_reset_randomization_mutates_real_mujoco_payload() -> None:
+    cfg = make_go2_joystick_flat_manager_cfg()
+    assert cfg.scene is not None
+    robot = cfg.scene.entities["robot"]
+    cfg.scene.entities["robot"] = EntityCfg(
+        root_body_name=robot.root_body_name,
+        joint_names=robot.joint_names,
+        body_names=("base",),
+        actuator_names=robot.actuator_names,
+    )
+    asset_cfg = SceneEntityCfg("robot", body_names=("base",))
+    cfg.events.update(
+        {
+            "mass": EventTermCfg(
+                func=mdp.randomize_rigid_body_mass,
+                mode="reset",
+                params={
+                    "asset_cfg": asset_cfg,
+                    "mass_distribution_params": (1.25, 1.25),
+                    "operation": "scale",
+                    "recompute_inertia": False,
+                },
+            ),
+            "com": EventTermCfg(
+                func=mdp.randomize_rigid_body_com,
+                mode="reset",
+                params={"asset_cfg": asset_cfg, "com_range": {"x": (0.02, 0.02)}},
+            ),
+            "gravity": EventTermCfg(
+                func=mdp.randomize_physics_scene_gravity,
+                mode="reset",
+                params={
+                    "gravity_distribution_params": ([0.0, 0.0, -9.7],) * 2,
+                    "operation": "abs",
+                },
+            ),
+        }
+    )
+    backend = create_backend(
+        "mujoco",
+        cfg.scene,
+        2,
+        cfg.sim_dt,
+        base_name="base",
+        add_body_sensors=True,
+        **env_backend_kwargs(cfg),
+    )
+    base_id = int(backend.get_body_ids(("base",))[0])
+    default_mass = backend.get_body_mass()
+    default_ipos = backend.get_body_ipos()
+    env = ManagerBasedRlEnv(cfg, backend, 2)
+    try:
+        env.reset(seed=31)
+        pool = cast(Any, backend)._pool
+        assert pool is not None
+        for env_id in range(2):
+            mass = pool.get_field(env_id, "body_mass")
+            ipos = pool.get_field(env_id, "body_ipos").reshape(-1, 3)
+            gravity = pool.get_field(env_id, "gravity")
+            assert mass[base_id] == pytest.approx(default_mass[base_id] * 1.25)
+            np.testing.assert_allclose(ipos[base_id], default_ipos[base_id] + [0.02, 0.0, 0.0])
+            np.testing.assert_allclose(gravity, [0.0, 0.0, -9.7])
     finally:
         env.close()
 

--- a/tests/envs/mdp/test_events.py
+++ b/tests/envs/mdp/test_events.py
@@ -14,9 +14,13 @@ from unilab.base.backend.base import BackendRootStateLayout, SimBackend
 from unilab.base.entity import EntityCfg, EntityScene
 from unilab.base.reset_state import ResetStateTransaction
 from unilab.dr.types import (
+    RESET_TERM_BODY_IPOS,
+    RESET_TERM_BODY_MASS,
+    RESET_TERM_GRAVITY,
     RESET_TERM_KD,
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
+    IntervalRandomizationPlan,
     ResetRandomizationPayload,
 )
 from unilab.envs import mdp
@@ -160,9 +164,13 @@ class _Backend:
         *,
         root_layout_supported: bool = True,
         gain_supported: bool = True,
+        randomization_supported: bool = True,
+        interval_velocity_supported: bool = True,
     ) -> None:
         self.root_layout_supported = root_layout_supported
         self.gain_supported = gain_supported
+        self.randomization_supported = randomization_supported
+        self.interval_velocity_supported = interval_velocity_supported
         self.default_qpos = np.asarray([0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0])
         self.init_qvel = np.zeros(6)
         self.set_state_calls: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
@@ -171,6 +179,10 @@ class _Backend:
         self.body_quat = np.zeros((self.num_envs, 1, 4))
         self.body_quat[:, :, 0] = 1.0
         self.body_velocity = np.zeros((self.num_envs, 1, 3))
+        self.body_mass = np.array([10.0])
+        self.body_ipos = np.array([[0.0, 0.0, 0.0]])
+        self.gravity = np.array([0.0, 0.0, -9.81])
+        self.interval_plans: list[IntervalRandomizationPlan] = []
 
     def get_body_ids(self, names) -> np.ndarray:
         if tuple(names) != ("base",):
@@ -203,11 +215,28 @@ class _Backend:
         return np.tile([-1.0, 1.0], (self.num_actuators, 1))
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
-        terms = frozenset((RESET_TERM_KP, RESET_TERM_KD)) if self.gain_supported else frozenset()
-        return DomainRandomizationCapabilities(supported_reset_terms=terms)
+        terms: set[str] = set((RESET_TERM_KP, RESET_TERM_KD)) if self.gain_supported else set()
+        if self.randomization_supported:
+            terms.update((RESET_TERM_BODY_MASS, RESET_TERM_BODY_IPOS, RESET_TERM_GRAVITY))
+        return DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset(terms),
+            supports_interval_body_velocity_delta=self.interval_velocity_supported,
+        )
 
     def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
         return np.array([10.0, 20.0, 30.0]), np.array([1.0, 2.0, 3.0])
+
+    def get_body_mass(self) -> np.ndarray:
+        return self.body_mass.copy()
+
+    def get_body_ipos(self) -> np.ndarray:
+        return self.body_ipos.copy()
+
+    def get_gravity(self) -> np.ndarray:
+        return self.gravity.copy()
+
+    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
+        self.interval_plans.append(plan)
 
     def get_body_pos_w(self, ids: np.ndarray) -> np.ndarray:
         return self.body_pos[:, ids]
@@ -239,15 +268,29 @@ class _Backend:
 
 
 def _transaction_env(
-    *, root_layout_supported: bool = True, gain_supported: bool = True, rng_seed: int = 5
+    *,
+    root_layout_supported: bool = True,
+    gain_supported: bool = True,
+    randomization_supported: bool = True,
+    interval_velocity_supported: bool = True,
+    body_names: tuple[str, ...] | None = ("base",),
+    rng_seed: int = 5,
 ) -> tuple[ManagerBasedRlEnv, _Backend, ResetStateTransaction]:
     backend = _Backend(
         root_layout_supported=root_layout_supported,
         gain_supported=gain_supported,
+        randomization_supported=randomization_supported,
+        interval_velocity_supported=interval_velocity_supported,
     )
     transaction = ResetStateTransaction(cast(SimBackend, backend))
     scene = EntityScene(
-        {"robot": EntityCfg(root_body_name="base", actuator_names=("a0", "a1", "a2"))},
+        {
+            "robot": EntityCfg(
+                root_body_name="base",
+                body_names=body_names,
+                actuator_names=("a0", "a1", "a2"),
+            )
+        },
         cast(SimBackend, backend),
         reset_state=transaction,
     )
@@ -385,6 +428,192 @@ def test_pd_gains_missing_backend_capability_fails_during_manager_construction()
     ):
         EventManager({"gain": cfg}, env)
     assert backend.set_state_calls == []
+
+
+def test_reset_randomization_terms_compose_with_state_and_gains_exactly_once() -> None:
+    env, backend, transaction = _transaction_env(rng_seed=13)
+    asset_cfg = SceneEntityCfg("robot", body_names=("base",))
+    manager = EventManager(
+        {
+            "mass": EventTermCfg(
+                func=mdp.randomize_rigid_body_mass,
+                mode="reset",
+                params={
+                    "asset_cfg": asset_cfg,
+                    "mass_distribution_params": (1.5, 1.5),
+                    "operation": "scale",
+                    "recompute_inertia": False,
+                },
+            ),
+            "com": EventTermCfg(
+                func=mdp.randomize_rigid_body_com,
+                mode="reset",
+                params={
+                    "asset_cfg": asset_cfg,
+                    "com_range": {"x": (0.1, 0.1), "z": (-0.2, -0.2)},
+                },
+            ),
+            "gravity": EventTermCfg(
+                func=mdp.randomize_physics_scene_gravity,
+                mode="reset",
+                params={
+                    "gravity_distribution_params": (
+                        [0.0, 0.0, -10.0],
+                        [0.0, 0.0, -10.0],
+                    ),
+                    "operation": "abs",
+                },
+            ),
+            "gains": EventTermCfg(
+                func=mdp.pd_gains,
+                mode="reset",
+                params={"kp_range": (2.0, 2.0), "kd_range": (3.0, 3.0)},
+            ),
+        },
+        env,
+    )
+    ids = np.array([0, 2], dtype=np.int32)
+
+    with transaction.scoped(ids):
+        mdp.reset_scene_to_default(env, ids)
+        manager.apply(mode="reset", env_ids=ids, global_env_step_count=0)
+        assert backend.set_state_calls == []
+
+    assert len(backend.set_state_calls) == 1
+    payload = backend.randomization_calls[0]
+    assert payload is not None
+    assert payload.body_mass is not None
+    assert payload.body_ipos is not None
+    assert payload.gravity is not None
+    assert payload.kp is not None
+    assert payload.kd is not None
+    np.testing.assert_allclose(payload.body_mass, [[15.0], [15.0]])
+    np.testing.assert_allclose(payload.body_ipos, [[[0.1, 0.0, -0.2]]] * 2)
+    np.testing.assert_allclose(payload.gravity, [[0.0, 0.0, -10.0]] * 2)
+    np.testing.assert_allclose(payload.kp, [[20.0, 40.0, 60.0]] * 2)
+    np.testing.assert_allclose(payload.kd, [[3.0, 6.0, 9.0]] * 2)
+
+
+@pytest.mark.parametrize(
+    ("func", "params", "match"),
+    [
+        (
+            mdp.randomize_rigid_body_mass,
+            {
+                "asset_cfg": SceneEntityCfg("robot", body_names=("base",)),
+                "mass_distribution_params": (0.9, 1.1),
+                "operation": "scale",
+            },
+            "recompute_inertia=True",
+        ),
+        (
+            mdp.randomize_rigid_body_mass,
+            {
+                "asset_cfg": SceneEntityCfg("robot", body_names=("base",)),
+                "mass_distribution_params": (0.9, 1.1),
+                "operation": "scale",
+                "recompute_inertia": False,
+            },
+            "body_mass randomization.*unsupported",
+        ),
+    ],
+)
+def test_mass_randomization_capability_gaps_fail_during_construction(
+    func, params: dict[str, Any], match: str
+) -> None:
+    env, backend, _ = _transaction_env(randomization_supported=False)
+    with pytest.raises(NotImplementedError, match=match):
+        EventManager(
+            {"mass": EventTermCfg(func=func, mode="reset", params=params)},
+            env,
+        )
+    assert backend.set_state_calls == []
+
+
+def test_reset_randomization_sparse_rows_abort_without_backend_mutation() -> None:
+    env, backend, transaction = _transaction_env()
+    manager = EventManager(
+        {
+            "gravity": EventTermCfg(
+                func=mdp.randomize_physics_scene_gravity,
+                mode="reset",
+                params={
+                    "gravity_distribution_params": ([0.0, 0.0, -10.0],) * 2,
+                    "operation": "abs",
+                },
+            )
+        },
+        env,
+    )
+    cfg = manager.get_term_cfg("gravity")
+    ids = np.array([0, 1], dtype=np.int32)
+
+    with pytest.raises(RuntimeError, match=r"gravity payload.*sparse rows.*missing env IDs \[1\]"):
+        with transaction.scoped(ids):
+            mdp.reset_scene_to_default(env, ids)
+            cfg.func(env, np.array([0], dtype=np.int32), **cfg.params)
+    assert backend.set_state_calls == []
+
+
+def test_velocity_push_uses_env_rng_and_interval_subset_plan() -> None:
+    env, backend, _ = _transaction_env(rng_seed=19)
+    manager = EventManager(
+        {
+            "push": EventTermCfg(
+                func=mdp.push_by_setting_velocity,
+                mode="interval",
+                interval_range_s=(1.0, 1.0),
+                params={
+                    "velocity_range": {
+                        "x": (0.2, 0.2),
+                        "y": (-0.3, -0.3),
+                        "z": (0.4, 0.4),
+                    }
+                },
+            )
+        },
+        env,
+    )
+    manager._interval_term_time_left[0][:] = [0.0, 1.0, 0.0]
+
+    manager.apply(mode="interval", dt=0.1)
+
+    assert len(backend.interval_plans) == 1
+    plan = backend.interval_plans[0]
+    np.testing.assert_array_equal(plan.body_ids, [0])
+    assert plan.body_linear_velocity_delta is not None
+    np.testing.assert_allclose(
+        plan.body_linear_velocity_delta[:, 0],
+        [[0.2, -0.3, 0.4], [0.0, 0.0, 0.0], [0.2, -0.3, 0.4]],
+    )
+
+
+@pytest.mark.parametrize(
+    ("supported", "velocity_range", "match"),
+    [
+        (False, {"x": (-0.1, 0.1)}, "unsupported backend capability"),
+        (True, {"yaw": (-0.1, 0.1)}, "angular velocity ranges are unsupported"),
+    ],
+)
+def test_velocity_push_capability_gaps_fail_during_construction(
+    supported: bool,
+    velocity_range: dict[str, tuple[float, float]],
+    match: str,
+) -> None:
+    env, backend, _ = _transaction_env(interval_velocity_supported=supported)
+    with pytest.raises(NotImplementedError, match=match):
+        EventManager(
+            {
+                "push": EventTermCfg(
+                    func=mdp.push_by_setting_velocity,
+                    mode="interval",
+                    interval_range_s=(1.0, 1.0),
+                    params={"velocity_range": velocity_range},
+                )
+            },
+            env,
+        )
+    assert backend.interval_plans == []
 
 
 def test_uniform_root_state_fixed_or_mocap_capability_fails_closed() -> None:


### PR DESCRIPTION
## Summary

- add community-named NumPy mass, CoM, gravity, and velocity-push event terms
- compose body tables, gravity, qpos/qvel, and actuator gains into one fail-closed reset transaction
- dispatch interval velocity kicks only through `IntervalRandomizationPlan`, with cold-path capability validation
- prove payload behavior with focused/fake tests and a real Go2 MuJoCo reset smoke

## Contract

- `recompute_inertia=True`, angular velocity kicks, unsupported lifecycle/backend capabilities, and sparse reset rows raise explicitly
- terms use env-owned RNG and cached entity/backend bindings; no asset/XML/private capability probing enters reset/step
- no production task, Hydra owner, registry, runner, learner, IPC, or `main` changes

## Provenance / size

- pinned mjlab v1.6.0 event lifecycle and `push_by_setting_velocity` semantics remain the base
- mass/CoM/gravity public names and signatures follow Isaac Lab v2.2.0; no PhysX implementation was vendored
- source-derived copied lines: 0
- mechanical Torch→NumPy lines: 0
- UniLab-specific implementation/tests: +1,276 lines
- modified existing: 7 files
- deleted: 19 lines, 0 files

## Validation

- final head: `52057157f5bdd0bf8952af2cec5fd18c6fa42ef5`
- `make test-all`
- 2041 passed, 27 skipped, 276 deselected, 1 xfailed
- ruff, mypy, pyright, coverage, and benchmark smoke passed
- remote child CI intentionally skipped per #1042 workflow

Closes #1100
