### PR TITLE
feat(env): add generic Manager-Based factory

### DIFF
--- a/src/unilab/envs/__init__.py
+++ b/src/unilab/envs/__init__.py
@@ -4,10 +4,12 @@ from unilab.envs.manager_based_rl_env import ManagerBasedRLEnv as ManagerBasedRL
 from unilab.envs.manager_based_rl_env import ManagerBasedRlEnv as ManagerBasedRlEnv
 from unilab.envs.manager_based_rl_env import ManagerBasedRLEnvCfg as ManagerBasedRLEnvCfg
 from unilab.envs.manager_based_rl_env import ManagerBasedRlEnvCfg as ManagerBasedRlEnvCfg
+from unilab.envs.manager_based_rl_env import make_manager_based_rl_env as make_manager_based_rl_env
 
 __all__ = [
     "ManagerBasedRLEnv",
     "ManagerBasedRLEnvCfg",
     "ManagerBasedRlEnv",
     "ManagerBasedRlEnvCfg",
+    "make_manager_based_rl_env",
 ]

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -14,13 +14,13 @@ from typing import Any
 import gymnasium as gym
 import numpy as np
 
-from unilab.base.backend import SimBackend
+from unilab.base.backend import SimBackend, create_backend, env_backend_kwargs
 from unilab.base.base import EnvCfg
 from unilab.base.config_overrides import (
     CONFIG_MAPPING_POLICY_KEY,
     MANAGER_TERM_MAPPING_POLICY,
 )
-from unilab.base.entity import EntityScene
+from unilab.base.entity import EntityCfg, EntityScene
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.base.reset_state import ResetStateTransaction
 from unilab.base.scene import SceneCfg, resolve_scene_default_qpos
@@ -144,6 +144,43 @@ class ManagerBasedRlEnvCfg(EnvCfg):
                 "ManagerBasedRlEnvCfg scene must be a SceneCfg instance, "
                 f"got {type(self.scene).__name__}"
             )
+
+
+def _resolve_backend_entity_contract(cfg: ManagerBasedRlEnvCfg) -> tuple[str, bool]:
+    """Resolve task-independent backend inputs from declared scene entities."""
+    assert cfg.scene is not None
+    root_entities: list[tuple[str, str]] = []
+    body_state_requested = False
+    for entity_name, entity_cfg in cfg.scene.entities.items():
+        if not isinstance(entity_name, str) or not entity_name:
+            raise TypeError(
+                f"ManagerBasedRlEnv scene entity names must be non-empty strings; "
+                f"got {entity_name!r}"
+            )
+        if not isinstance(entity_cfg, EntityCfg):
+            raise TypeError(
+                f"ManagerBasedRlEnv scene entity '{entity_name}' must be EntityCfg, "
+                f"got {type(entity_cfg).__name__}"
+            )
+        root_body_name = entity_cfg.root_body_name
+        if root_body_name is not None:
+            if not isinstance(root_body_name, str) or not root_body_name:
+                raise TypeError(
+                    f"ManagerBasedRlEnv root entity '{entity_name}' root_body_name must be "
+                    "a non-empty string"
+                )
+            root_entities.append((entity_name, root_body_name))
+            body_state_requested = True
+        if entity_cfg.body_names is not None:
+            body_state_requested = True
+
+    if len(root_entities) != 1:
+        declared = [name for name, _ in root_entities]
+        raise ValueError(
+            "ManagerBasedRlEnv factory requires exactly one scene entity with an explicit "
+            f"root_body_name; found {len(root_entities)} root entities {declared}"
+        )
+    return root_entities[0][1], body_state_requested
 
 
 class ManagerBasedRlEnv(NpEnv):
@@ -591,6 +628,49 @@ class ManagerBasedRlEnv(NpEnv):
         super().close()
 
 
+def make_manager_based_rl_env(
+    cfg: ManagerBasedRlEnvCfg,
+    num_envs: int = 1,
+    backend_type: str = "mujoco",
+) -> ManagerBasedRlEnv:
+    """Construct the generic Registry-owned Manager-Based production runtime."""
+    if not isinstance(cfg, ManagerBasedRlEnvCfg):
+        raise TypeError(
+            "make_manager_based_rl_env expected ManagerBasedRlEnvCfg, "
+            f"received {type(cfg).__name__}"
+        )
+    if isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs <= 0:
+        raise ValueError(
+            f"make_manager_based_rl_env num_envs must be a positive integer, got {num_envs!r}"
+        )
+    if not isinstance(backend_type, str) or not backend_type:
+        raise ValueError(
+            "make_manager_based_rl_env backend_type must be a non-empty string, "
+            f"got {backend_type!r}"
+        )
+
+    cfg.validate()
+    assert cfg.scene is not None
+    base_name, body_state_requested = _resolve_backend_entity_contract(cfg)
+    backend_kwargs = env_backend_kwargs(cfg)
+    backend_kwargs["base_name"] = base_name
+    if backend_type in {"mujoco", "motrix"}:
+        backend_kwargs["add_body_sensors"] = body_state_requested
+
+    backend = create_backend(
+        backend_type,
+        cfg.scene,
+        num_envs,
+        cfg.sim_dt,
+        **backend_kwargs,
+    )
+    try:
+        return ManagerBasedRlEnv(cfg, backend, num_envs)
+    except Exception:
+        backend.cleanup_scene_assets()
+        raise
+
+
 # Isaac Lab capitalization is a spelling-only alias.  There is one implementation.
 ManagerBasedRLEnv = ManagerBasedRlEnv
 ManagerBasedRLEnvCfg = ManagerBasedRlEnvCfg
@@ -600,4 +680,5 @@ __all__ = [
     "ManagerBasedRLEnvCfg",
     "ManagerBasedRlEnv",
     "ManagerBasedRlEnvCfg",
+    "make_manager_based_rl_env",
 ]

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -19,6 +19,7 @@ from unilab.envs import (
     ManagerBasedRlEnv,
     ManagerBasedRLEnvCfg,
     ManagerBasedRlEnvCfg,
+    make_manager_based_rl_env,
     mdp,
 )
 from unilab.managers import (
@@ -384,6 +385,238 @@ def _make_env(
 def test_public_names_are_spelling_only_aliases() -> None:
     assert ManagerBasedRLEnv is ManagerBasedRlEnv
     assert ManagerBasedRLEnvCfg is ManagerBasedRlEnvCfg
+    assert make_manager_based_rl_env is manager_env_module.make_manager_based_rl_env
+
+
+@pytest.mark.parametrize(
+    ("backend_type", "expects_body_materialization"),
+    [
+        ("mujoco", True),
+        ("motrix", True),
+        ("mjwarp", False),
+        ("drake", False),
+    ],
+)
+def test_generic_factory_routes_only_public_backend_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    backend_type: str,
+    expects_body_materialization: bool,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    assert cfg.scene is not None
+    cfg.scene.entities["robot"] = EntityCfg(
+        root_body_name="base",
+        actuator_names=("motor",),
+    )
+    backend = _FakeBackend(3)
+    constructed: dict[str, Any] = {}
+
+    def fake_create_backend(
+        requested_backend: str,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        **kwargs: Any,
+    ) -> SimBackend:
+        constructed.update(
+            backend_type=requested_backend,
+            scene=scene,
+            num_envs=num_envs,
+            sim_dt=sim_dt,
+            kwargs=kwargs,
+        )
+        return cast(SimBackend, backend)
+
+    sentinel = object()
+
+    def fake_make_env(
+        received_cfg: ManagerBasedRlEnvCfg,
+        received_backend: SimBackend,
+        received_num_envs: int,
+    ) -> Any:
+        assert received_cfg is cfg
+        assert received_backend is backend
+        assert received_num_envs == 3
+        return sentinel
+
+    monkeypatch.setattr(manager_env_module, "create_backend", fake_create_backend)
+    monkeypatch.setattr(manager_env_module, "ManagerBasedRlEnv", fake_make_env)
+
+    result = make_manager_based_rl_env(cfg, num_envs=3, backend_type=backend_type)
+
+    assert result is sentinel
+    assert constructed["backend_type"] == backend_type
+    assert constructed["scene"] is cfg.scene
+    assert constructed["num_envs"] == 3
+    assert constructed["sim_dt"] == cfg.sim_dt
+    kwargs = constructed["kwargs"]
+    assert kwargs["base_name"] == "base"
+    if expects_body_materialization:
+        assert kwargs["add_body_sensors"] is True
+    else:
+        assert "add_body_sensors" not in kwargs
+    for key, value in env_backend_kwargs(cfg).items():
+        assert kwargs[key] == value
+
+
+@pytest.mark.parametrize(
+    ("entities", "match"),
+    [
+        ({"robot": EntityCfg(actuator_names=("motor",))}, "found 0 root entities"),
+        (
+            {
+                "robot": EntityCfg(root_body_name="base", actuator_names=("motor",)),
+                "payload": EntityCfg(root_body_name="box"),
+            },
+            "found 2 root entities.*robot.*payload",
+        ),
+    ],
+)
+def test_generic_factory_requires_exactly_one_explicit_root_entity(
+    monkeypatch: pytest.MonkeyPatch,
+    entities: dict[str, EntityCfg],
+    match: str,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    assert cfg.scene is not None
+    cfg.scene.entities = entities
+    backend_constructed = False
+
+    def reject_backend_construction(*args: Any, **kwargs: Any) -> SimBackend:
+        nonlocal backend_constructed
+        backend_constructed = True
+        raise AssertionError("backend construction must not run")
+
+    monkeypatch.setattr(manager_env_module, "create_backend", reject_backend_construction)
+
+    with pytest.raises(ValueError, match=match):
+        make_manager_based_rl_env(cfg, num_envs=2, backend_type="mujoco")
+    assert not backend_constructed
+
+
+@pytest.mark.parametrize(
+    ("cfg_value", "num_envs", "backend_type", "error", "match"),
+    [
+        (object(), 2, "mujoco", TypeError, "expected ManagerBasedRlEnvCfg"),
+        (None, 0, "mujoco", ValueError, "num_envs must be a positive integer"),
+        (None, True, "mujoco", ValueError, "num_envs must be a positive integer"),
+        (None, 2, "", ValueError, "backend_type must be a non-empty string"),
+    ],
+)
+def test_generic_factory_rejects_invalid_public_arguments_before_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg_value: object | None,
+    num_envs: int,
+    backend_type: str,
+    error: type[Exception],
+    match: str,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False) if cfg_value is None else cfg_value
+    backend_constructed = False
+
+    def reject_backend_construction(*args: Any, **kwargs: Any) -> SimBackend:
+        nonlocal backend_constructed
+        backend_constructed = True
+        raise AssertionError("backend construction must not run")
+
+    monkeypatch.setattr(manager_env_module, "create_backend", reject_backend_construction)
+
+    with pytest.raises(error, match=match):
+        make_manager_based_rl_env(
+            cast(ManagerBasedRlEnvCfg, cfg),
+            num_envs=num_envs,
+            backend_type=backend_type,
+        )
+    assert not backend_constructed
+
+
+@pytest.mark.parametrize(
+    ("entities", "error", "match"),
+    [
+        (
+            cast(dict[str, EntityCfg], {1: EntityCfg(root_body_name="base")}),
+            TypeError,
+            "entity names must be non-empty strings",
+        ),
+        (
+            cast(dict[str, EntityCfg], {"robot": object()}),
+            TypeError,
+            "scene entity 'robot' must be EntityCfg",
+        ),
+        (
+            {"robot": EntityCfg(root_body_name="")},
+            TypeError,
+            "root_body_name must be a non-empty string",
+        ),
+    ],
+)
+def test_generic_factory_rejects_invalid_entity_contract_before_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    entities: dict[str, EntityCfg],
+    error: type[Exception],
+    match: str,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    assert cfg.scene is not None
+    cfg.scene.entities = entities
+    backend_constructed = False
+
+    def reject_backend_construction(*args: Any, **kwargs: Any) -> SimBackend:
+        nonlocal backend_constructed
+        backend_constructed = True
+        raise AssertionError("backend construction must not run")
+
+    monkeypatch.setattr(manager_env_module, "create_backend", reject_backend_construction)
+
+    with pytest.raises(error, match=match):
+        make_manager_based_rl_env(cfg, num_envs=2, backend_type="mujoco")
+    assert not backend_constructed
+
+
+def test_generic_factory_preserves_backend_construction_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    assert cfg.scene is not None
+    cfg.scene.entities["robot"] = EntityCfg(
+        root_body_name="base",
+        actuator_names=("motor",),
+    )
+
+    def fail_backend_construction(*args: Any, **kwargs: Any) -> SimBackend:
+        raise NotImplementedError("body-state capability is unavailable")
+
+    monkeypatch.setattr(manager_env_module, "create_backend", fail_backend_construction)
+
+    with pytest.raises(NotImplementedError, match="body-state capability is unavailable"):
+        make_manager_based_rl_env(cfg, num_envs=2, backend_type="mjwarp")
+
+
+def test_generic_factory_cleans_backend_when_env_construction_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    assert cfg.scene is not None
+    cfg.scene.entities["robot"] = EntityCfg(
+        root_body_name="base",
+        actuator_names=("motor",),
+    )
+    backend = _FakeBackend(2)
+
+    monkeypatch.setattr(
+        manager_env_module,
+        "create_backend",
+        lambda *args, **kwargs: cast(SimBackend, backend),
+    )
+
+    def fail_env_construction(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("manager initialization failed")
+
+    monkeypatch.setattr(manager_env_module, "ManagerBasedRlEnv", fail_env_construction)
+
+    with pytest.raises(RuntimeError, match="manager initialization failed"):
+        make_manager_based_rl_env(cfg, num_envs=2, backend_type="mujoco")
+    assert backend.cleanup_calls == 1
 
 
 @pytest.mark.parametrize(
@@ -581,7 +814,7 @@ def test_named_keyframe_snapshot_is_shared_by_entity_and_reset_cold_path() -> No
 def test_real_mujoco_backend_is_materialized_before_first_reset() -> None:
     scene = SceneCfg(
         model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml"),
-        entities={"robot": EntityCfg()},
+        entities={"robot": EntityCfg(root_body_name="base")},
     )
     cfg = ManagerBasedRlEnvCfg(
         scene=scene,
@@ -599,15 +832,7 @@ def test_real_mujoco_backend_is_materialized_before_first_reset() -> None:
         terminations={"time_out": TerminationTermCfg(func=mdp.time_out, time_out=True)},
         policy_observation_group="actor",
     )
-    backend = create_backend(
-        "mujoco",
-        scene,
-        2,
-        cfg.sim_dt,
-        base_name="base",
-        **env_backend_kwargs(cfg),
-    )
-    env = ManagerBasedRlEnv(cfg, backend, 2)
+    env = make_manager_based_rl_env(cfg, num_envs=2, backend_type="mujoco")
     try:
         state = env.init_state()
         assert state.obs["obs"].shape == (2, 1)


### PR DESCRIPTION
Closes #1102
Parent: #1042

## Summary

- 导出唯一的通用 `make_manager_based_rl_env(cfg, num_envs, backend_type)`，按正式顺序执行 typed config validate → scene entity contract resolve → `create_backend` → `ManagerBasedRlEnv`。
- 要求恰好一个显式 root entity，不猜 task/entity/body 名；错误在 backend 构造前 fail-closed。
- MuJoCo/Motrix 仅根据正式 root/body state 请求启用 body sensors；MJWarp/Drake 按公开 constructor contract 路由。
- env 构造失败时释放 backend-owned 冷路径 scene assets；不接 production task/YAML/Registry entry，不引入 task-specific Python config。

## Hydra boundary

Hydra owner YAML 仍是 production task 唯一配置入口和唯一 task-specific source of truth。本 factory 只消费通用 materializer 产出的 typed `ManagerBasedRlEnvCfg`；不接受 DictConfig 进入 runtime，也不保存 task defaults 或 term 清单。

## Validation

在最终提交 `be79ccf1e28b8896e934eb96c460147365a42821` 上完成：

- `make test-all`
- 2056 passed / 27 skipped / 276 deselected / 1 xfailed
- ruff、mypy、pyright、coverage（76%）和 benchmark smoke 全部通过
- benchmark 两种入口各仅 1 个 platform-optional MLX skip
- 按 #1042 授权未运行或等待远程 child CI

## Size

- 3 个 modified existing files
- source-derived：0 行
- mechanical NumPy conversion：0 行
- UniLab-specific：85 行 production + 235 行 focused tests
- deleted：12 行
