### PR TITLE
feat(backend): support MuJoCo root velocity kicks

### DIFF
--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -353,6 +353,7 @@ class MuJoCoBackend(SimBackend):
         self._root_qpos_dim, self._root_qvel_dim = _root_state_dims(self._model)
         self._num_dof_pos = self.nq - self._root_qpos_dim
         self._num_dof_vel = self.nv - self._root_qvel_dim
+        self._interval_root_velocity_qvel_ids = self._resolve_interval_root_velocity_qvel_ids()
 
         # State storage.
         nstate = mujoco.mj_stateSize(self._model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
@@ -652,6 +653,7 @@ class MuJoCoBackend(SimBackend):
         )
         self._push_body_id = self._resolve_push_body_id(self._model)
         self._push_body_force_slice = self._resolve_push_body_force_slice(self._push_body_id)
+        self._interval_root_velocity_qvel_ids = self._resolve_interval_root_velocity_qvel_ids()
         self._base_body_mass = np.asarray(self._model.body_mass).copy()
         self._base_body_ipos = np.asarray(self._model.body_ipos).copy()
         self._pending_xfrc_applied = np.zeros(
@@ -770,6 +772,19 @@ class MuJoCoBackend(SimBackend):
             qpos_indices=tuple(range(qpos_start, qpos_start + 7)),
             qvel_indices=tuple(range(qvel_start, qvel_start + 6)),
         )
+
+    def _resolve_interval_root_velocity_qvel_ids(self) -> tuple[int, int, int] | None:
+        """Bind the configured free root's world-linear qvel columns on the cold path."""
+        if self._base_name is None or self._base_body_id < 0:
+            return None
+        try:
+            layout = self.get_root_state_layout(self._base_name)
+        except (NotImplementedError, ValueError):
+            return None
+        linear_ids = layout.qvel_indices[:3]
+        if linear_ids != tuple(range(linear_ids[0], linear_ids[0] + 3)):
+            return None
+        return int(linear_ids[0]), int(linear_ids[1]), int(linear_ids[2])
 
     def get_body_ids(self, names: "Sequence[str]") -> np.ndarray:
         ids: list[int] = []
@@ -1074,6 +1089,9 @@ class MuJoCoBackend(SimBackend):
                 }
             ),
             supports_interval_push=self._push_body_id >= 0,
+            supports_interval_body_velocity_delta=(
+                self._interval_root_velocity_qvel_ids is not None
+            ),
             supports_interval_body_force=True,
         )
 
@@ -1128,14 +1146,76 @@ class MuJoCoBackend(SimBackend):
         body_ids: np.ndarray,
         velocity_delta: np.ndarray,
     ) -> None:
-        """Apply a world-frame linear-velocity delta to specific bodies.
+        """Apply a row-selective world-frame velocity kick to the configured free root."""
+        qvel_ids = self._interval_root_velocity_qvel_ids
+        if qvel_ids is None:
+            raise NotImplementedError(
+                "MuJoCo interval body velocity perturbation requires base_name to identify "
+                "a body with exactly one free joint"
+            )
 
-        Backend-internal hook for ``apply_interval_randomization``; it is not
-        part of the public ``SimBackend`` surface.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support interval body velocity perturbation"
+        raw_body_ids = np.asarray(body_ids)
+        if (
+            raw_body_ids.ndim != 1
+            or not np.issubdtype(raw_body_ids.dtype, np.integer)
+            or np.issubdtype(raw_body_ids.dtype, np.bool_)
+        ):
+            raise TypeError(
+                "MuJoCo interval body velocity perturbation body_ids must be a 1-D "
+                f"integer array, got shape={raw_body_ids.shape}, dtype={raw_body_ids.dtype}"
+            )
+        resolved_body_ids = np.asarray(raw_body_ids, dtype=np.int32)
+        expected_body_ids = np.asarray([self._base_body_id], dtype=np.int32)
+        if not np.array_equal(resolved_body_ids, expected_body_ids):
+            raise NotImplementedError(
+                "MuJoCo interval body velocity perturbation only supports the configured "
+                f"free root body '{self._base_name}' (id={self._base_body_id}); "
+                f"received body_ids={resolved_body_ids.tolist()}"
+            )
+
+        if not isinstance(velocity_delta, np.ndarray):
+            raise TypeError(
+                "MuJoCo interval body velocity perturbation must be an np.ndarray, "
+                f"got {type(velocity_delta).__name__}"
+            )
+        expected_shape = (self._num_envs, 1, 3)
+        if velocity_delta.shape != expected_shape:
+            raise ValueError(
+                "MuJoCo interval body velocity perturbation has shape "
+                f"{velocity_delta.shape}; expected {expected_shape}"
+            )
+        if not np.issubdtype(velocity_delta.dtype, np.floating):
+            raise TypeError(
+                "MuJoCo interval body velocity perturbation must have floating dtype, "
+                f"got {velocity_delta.dtype}"
+            )
+        if not np.isfinite(velocity_delta).all():
+            raise ValueError("MuJoCo interval body velocity perturbation contains NaN or Inf")
+        if self._pool is None:
+            raise RuntimeError(
+                "MuJoCo interval body velocity perturbation requires a materialized backend"
+            )
+
+        active_rows = np.flatnonzero(np.any(velocity_delta[:, 0, :] != 0.0, axis=1)).astype(
+            np.int32,
+            copy=False,
         )
+        if active_rows.size == 0:
+            return
+
+        state_rows = np.asarray(self._physics_state[active_rows], dtype=np.float64).copy()
+        state_qvel_ids = np.asarray(
+            [self._idx_qvel + qvel_id for qvel_id in qvel_ids],
+            dtype=np.intp,
+        )
+        state_rows[:, state_qvel_ids] += velocity_delta[active_rows, 0, :]
+        state_out, sensor_out = self._pool.reset(
+            env_ids=active_rows,
+            initial_state=state_rows,
+            chunk_size=self._chunk_size,
+        )
+        self._physics_state[active_rows] = state_out.astype(self._np_dtype)
+        self._sensor_data[active_rows] = sensor_out.astype(self._np_dtype)
 
     def push_robots(self, force_range: Sequence[float] | np.ndarray) -> None:
         self._pending_xfrc_applied.fill(0.0)

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -14,7 +14,7 @@ import pytest
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.backend.mujoco.xml import get_named_body_ids
 from unilab.base.scene import SceneCfg
-from unilab.dr.types import ResetRandomizationPayload
+from unilab.dr.types import IntervalRandomizationPlan, ResetRandomizationPayload
 
 pytest.importorskip("mujoco", reason="mujoco not installed")
 
@@ -108,6 +108,7 @@ def test_mujoco_backend_smoke_contract(robot):
         "kd",
     }.issubset(caps.supported_reset_terms)
     assert caps.supports_interval_push
+    assert caps.supports_interval_body_velocity_delta
 
 
 def test_mujoco_backend_fixed_base_dof_views_do_not_skip_first_joint():
@@ -129,6 +130,117 @@ def test_mujoco_backend_fixed_base_dof_views_do_not_skip_first_joint():
     np.testing.assert_allclose(bkd.get_base_lin_vel(), 0.0, atol=1e-8)
     np.testing.assert_allclose(bkd.get_base_ang_vel(), 0.0, atol=1e-8)
     _unit_quat(bkd.get_base_quat(), "MuJoCo fixed-base smoke")
+    assert not bkd.get_dr_capabilities().supports_interval_body_velocity_delta
+
+
+def test_mujoco_interval_root_velocity_kick_is_row_selective_and_refreshes_sensors():
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(
+        SceneCfg(model_file=_xml("go2")),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="base",
+        add_body_sensors=True,
+    )
+    bkd.materialize()
+    qpos = np.broadcast_to(bkd.get_default_qpos(), (NUM_ENVS, bkd.model.nq)).copy()
+    qvel = np.zeros((NUM_ENVS, bkd.model.nv), dtype=np.float64)
+    bkd.set_state(np.arange(NUM_ENVS, dtype=np.int32), qpos, qvel)
+    bkd.step(np.zeros((NUM_ENVS, bkd.model.nu)), nsteps=1)
+    assert bkd._pool is not None
+    bkd._sensor_data[:] = bkd._pool.forward(bkd.get_physics_state())
+
+    body_ids = bkd.get_body_ids(("base",))
+    state_before = bkd.get_physics_state().copy()
+    body_velocity_before = bkd.get_body_lin_vel_w(body_ids).copy()
+    delta = np.zeros((NUM_ENVS, 1, 3), dtype=np.float64)
+    delta[1, 0] = (0.25, -0.4, 0.15)
+
+    bkd.apply_interval_randomization(
+        IntervalRandomizationPlan(
+            body_ids=body_ids,
+            body_linear_velocity_delta=delta,
+        )
+    )
+
+    state_after = bkd.get_physics_state()
+    body_velocity_after = bkd.get_body_lin_vel_w(body_ids)
+    np.testing.assert_array_equal(state_after[0], state_before[0])
+    np.testing.assert_allclose(state_after[1, 0], state_before[1, 0], atol=1e-12)
+    np.testing.assert_allclose(
+        state_after[1, bkd._idx_qpos : bkd._idx_qvel],
+        state_before[1, bkd._idx_qpos : bkd._idx_qvel],
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        state_after[1, bkd._idx_qvel + 3 :],
+        state_before[1, bkd._idx_qvel + 3 :],
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        state_after[1, bkd._idx_qvel : bkd._idx_qvel + 3],
+        state_before[1, bkd._idx_qvel : bkd._idx_qvel + 3] + delta[1, 0],
+        atol=1e-7,
+    )
+    np.testing.assert_allclose(
+        body_velocity_after[1, 0],
+        body_velocity_before[1, 0] + delta[1, 0],
+        atol=1e-6,
+    )
+
+
+def test_mujoco_interval_root_velocity_kick_rejects_invalid_contracts():
+    from unilab.base.backend.mujoco.backend import MuJoCoBackend
+
+    bkd = MuJoCoBackend(
+        SceneCfg(model_file=_xml("go2")),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="base",
+    )
+    body_ids = bkd.get_body_ids(("base",))
+    delta = np.zeros((NUM_ENVS, 1, 3), dtype=np.float64)
+
+    with pytest.raises(RuntimeError, match="requires a materialized backend"):
+        bkd.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=body_ids,
+                body_linear_velocity_delta=delta,
+            )
+        )
+
+    bkd.materialize()
+    with pytest.raises(TypeError, match="body_ids must be a 1-D integer array"):
+        bkd.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=body_ids.astype(np.float64),
+                body_linear_velocity_delta=delta,
+            )
+        )
+    with pytest.raises(NotImplementedError, match="only supports the configured free root"):
+        bkd.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=np.asarray([body_ids[0] + 1], dtype=np.int32),
+                body_linear_velocity_delta=delta,
+            )
+        )
+    with pytest.raises(ValueError, match=r"shape .* expected \(2, 1, 3\)"):
+        bkd.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=body_ids,
+                body_linear_velocity_delta=np.zeros((NUM_ENVS, 3), dtype=np.float64),
+            )
+        )
+    invalid = delta.copy()
+    invalid[0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="contains NaN or Inf"):
+        bkd.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=body_ids,
+                body_linear_velocity_delta=invalid,
+            )
+        )
 
 
 @pytest.mark.parametrize("robot", BASIC_ROBOTS)


### PR DESCRIPTION
Closes #1104
Parent: #1042

## Summary

- MuJoCo 仅对显式配置且确认为 free-joint root 的 body 声明 interval body velocity delta capability。
- 以 `BatchEnvPool.reset` 对非零 kick rows 直接增加 floating-root world linear velocity；保留 physics time、qpos、root angular/joint qvel 与其他 env rows，并刷新 sensor cache。
- 非 root、多 body、非法 shape/dtype、NaN/Inf 和未 materialize 均 fail-closed。
- MBA/env/term/config 仍只调用正式 `SimBackend.apply_interval_randomization(IntervalRandomizationPlan)`；MuJoCo 细节封装在 adapter 私有实现中，不泄露物理后端方法。

## Scope

不修改 Motrix/Drake/MJWarp，不接 production Hydra YAML，不回退到 legacy force push，也不新增 `SimBackend` 方法。

## Validation

在最终提交 `61c0c4f201bad8f27e486c88a6fb07878621a3cb` 上完成：

- `make test-all`
- 2058 passed / 27 skipped / 276 deselected / 1 xfailed
- ruff、mypy、pyright、coverage（76%）和 benchmark smoke 全部通过
- focused/邻接测试：43 passed
- benchmark 两种入口各仅 1 个 platform-optional MLX skip
- 按 #1042 授权未运行或等待远程 child CI

## Size

- 2 个 modified existing files
- 199 insertions / 7 deletions
