### PR TITLE
refactor(backend): isolate body-state materialization

### DIFF
--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -98,6 +98,8 @@ def create_backend(
     scene: SceneCfg,
     num_envs: int,
     sim_dt: float,
+    *,
+    body_state_required: bool = False,
     **kwargs,
 ) -> SimBackend:
     """Create a simulation backend.
@@ -108,6 +110,9 @@ def create_backend(
         scene: SceneCfg for either static or composed scenes.
         num_envs: Number of environments.
         sim_dt: Simulation timestep.
+        body_state_required: Whether the caller requires public body-state views.
+            Backend adapters decide whether satisfying this request requires extra
+            cold-path scene materialization.
         **kwargs: Additional backend options such as ``position_actuator_gains``,
             ``iterations``, or ``motrix_max_iterations``.
 
@@ -116,6 +121,11 @@ def create_backend(
     """
     if scene is None:
         raise ValueError("SceneCfg must be provided")
+    if not isinstance(body_state_required, bool):
+        raise TypeError(
+            "create_backend body_state_required must be bool, "
+            f"got {type(body_state_required).__name__}"
+        )
 
     position_actuator_gains = kwargs.pop("position_actuator_gains", None)
     motrix_max_iterations = kwargs.pop("motrix_max_iterations", None)
@@ -131,6 +141,8 @@ def create_backend(
     drake_nthread = kwargs.pop("drake_nthread", None)
     if backend_type == "mujoco":
         MuJoCoBackend = _load_mujoco_backend()
+        if body_state_required:
+            kwargs["add_body_sensors"] = True
         if position_actuator_gains is not None:
             kwargs["position_actuator_gains"] = position_actuator_gains
         if post_step_forward_sensor is not None:
@@ -177,6 +189,8 @@ def create_backend(
         MotrixBackend, motrix_available = _load_motrix_backend()
         if not motrix_available:
             raise ImportError("MotrixSim not available, install motrixsim package")
+        if body_state_required:
+            kwargs["add_body_sensors"] = True
         if motrix_max_iterations is not None:
             kwargs["max_iterations"] = motrix_max_iterations
         return cast(SimBackend, MotrixBackend(scene, num_envs, sim_dt, **kwargs))

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -654,14 +654,13 @@ def make_manager_based_rl_env(
     base_name, body_state_requested = _resolve_backend_entity_contract(cfg)
     backend_kwargs = env_backend_kwargs(cfg)
     backend_kwargs["base_name"] = base_name
-    if backend_type in {"mujoco", "motrix"}:
-        backend_kwargs["add_body_sensors"] = body_state_requested
 
     backend = create_backend(
         backend_type,
         cfg.scene,
         num_envs,
         cfg.sim_dt,
+        body_state_required=body_state_requested,
         **backend_kwargs,
     )
     try:

--- a/tests/base/test_motrix_backend_options.py
+++ b/tests/base/test_motrix_backend_options.py
@@ -772,6 +772,106 @@ def test_create_backend_routes_post_step_forward_sensor_to_mujoco(monkeypatch) -
     assert captured["kwargs"]["post_step_forward_sensor"] is False
 
 
+@pytest.mark.parametrize("body_state_required", [False, True])
+def test_create_backend_maps_body_state_request_inside_mujoco_adapter(
+    monkeypatch, body_state_required: bool
+) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeMuJoCoBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(backend_factory, "_load_mujoco_backend", lambda: FakeMuJoCoBackend)
+
+    backend_factory.create_backend(
+        "mujoco",
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        body_state_required=body_state_required,
+    )
+
+    if body_state_required:
+        assert captured["kwargs"]["add_body_sensors"] is True
+    else:
+        assert "add_body_sensors" not in captured["kwargs"]
+
+
+def test_create_backend_maps_body_state_request_inside_motrix_adapter(monkeypatch) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeMotrixBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        backend_factory,
+        "_load_motrix_backend",
+        lambda: (FakeMotrixBackend, True),
+    )
+
+    backend_factory.create_backend(
+        "motrix",
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        body_state_required=True,
+    )
+
+    assert captured["kwargs"]["add_body_sensors"] is True
+
+
+@pytest.mark.parametrize("backend_type", ["drake", "mjwarp"])
+def test_create_backend_keeps_body_state_request_out_of_native_state_adapters(
+    monkeypatch, backend_type: str
+) -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    captured: dict[str, Any] = {}
+
+    class FakeBackend:
+        def __init__(self, scene: SceneCfg, num_envs: int, sim_dt: float, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+    if backend_type == "drake":
+        monkeypatch.setattr(backend_factory, "_load_drake_backend", lambda: FakeBackend)
+    else:
+        monkeypatch.setattr(backend_factory, "_load_mjwarp_backend", lambda: FakeBackend)
+
+    backend_factory.create_backend(
+        backend_type,
+        SceneCfg(model_file="model.xml"),
+        num_envs=1,
+        sim_dt=0.01,
+        body_state_required=True,
+    )
+
+    assert "body_state_required" not in captured["kwargs"]
+    assert "add_body_sensors" not in captured["kwargs"]
+
+
+def test_create_backend_rejects_non_bool_body_state_request() -> None:
+    import unilab.base.backend as backend_factory
+    from unilab.base.scene import SceneCfg
+
+    with pytest.raises(TypeError, match="body_state_required must be bool"):
+        backend_factory.create_backend(
+            "mujoco",
+            SceneCfg(model_file="model.xml"),
+            num_envs=1,
+            sim_dt=0.01,
+            body_state_required=1,  # type: ignore[arg-type]
+        )
+
+
 def test_create_backend_does_not_route_post_step_forward_sensor_to_motrix(monkeypatch) -> None:
     import unilab.base.backend as backend_factory
     from unilab.base.scene import SceneCfg

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -388,19 +388,10 @@ def test_public_names_are_spelling_only_aliases() -> None:
     assert make_manager_based_rl_env is manager_env_module.make_manager_based_rl_env
 
 
-@pytest.mark.parametrize(
-    ("backend_type", "expects_body_materialization"),
-    [
-        ("mujoco", True),
-        ("motrix", True),
-        ("mjwarp", False),
-        ("drake", False),
-    ],
-)
+@pytest.mark.parametrize("backend_type", ["mujoco", "motrix", "mjwarp", "drake"])
 def test_generic_factory_routes_only_public_backend_contract(
     monkeypatch: pytest.MonkeyPatch,
     backend_type: str,
-    expects_body_materialization: bool,
 ) -> None:
     cfg = _make_cfg(include_optional_managers=False)
     assert cfg.scene is not None
@@ -451,10 +442,8 @@ def test_generic_factory_routes_only_public_backend_contract(
     assert constructed["sim_dt"] == cfg.sim_dt
     kwargs = constructed["kwargs"]
     assert kwargs["base_name"] == "base"
-    if expects_body_materialization:
-        assert kwargs["add_body_sensors"] is True
-    else:
-        assert "add_body_sensors" not in kwargs
+    assert kwargs["body_state_required"] is True
+    assert "add_body_sensors" not in kwargs
     for key, value in env_backend_kwargs(cfg).items():
         assert kwargs[key] == value
 


### PR DESCRIPTION
Closes #1106
Parent: #1042

## Summary

- `make_manager_based_rl_env` now declares one backend-agnostic `body_state_required` request and contains no backend-name branch or `add_body_sensors` option.
- `create_backend` validates that request and maps it to MuJoCo/Motrix sensor augmentation inside the backend owner; Drake/MJWarp keep their native public state paths.
- Entity materialization remains the fail-closed capability boundary, and no `SimBackend` method was added or changed.

## Isolation

MBA/env/term/config no longer knows how a physical backend materializes body state. Backend-private constructor options remain confined to `src/unilab/base/backend`.

## Validation

On final commit `fd5b90d31c7e35ca6278a89cf05708edae997338`:

- `make test-all`
- 2064 passed / 27 skipped / 276 deselected / 1 xfailed
- ruff, mypy, pyright, coverage (76%), and benchmark smoke passed
- focused/adjacent: 109 passed / 4 skipped
- benchmark entry modes each had only one platform-optional MLX skip
- remote child CI intentionally not run under #1042 authorization

## Size

- 4 modified existing files
- 118 insertions / 16 deletions
- no source-derived or mechanical NumPy conversion lines
