### PR TITLE
feat(sim2sim): guard Manager-Based policy contracts

### DIFF
--- a/docs/sphinx/source/en/3-deployment/2-sim_to_sim/7-config_guard.md
+++ b/docs/sphinx/source/en/3-deployment/2-sim_to_sim/7-config_guard.md
@@ -27,7 +27,7 @@ Fields are classified by dotted path into three tiers (see `src/unilab/training/
 
 | Tier | Behavior | Fields |
 |---|---|---|
-| **DENYLIST** | Mismatch → `CrossBackendIncompatibleError`, aborts | `algo.obs_groups`, `env.control_config.action_scale`, `algo.policy.actor_hidden_dims` / `critic_hidden_dims`, `algo.empirical_normalization` / `algo.obs_normalization`, `env.sampling_mode` |
+| **DENYLIST** | Mismatch → `CrossBackendIncompatibleError`, aborts | `algo.obs_groups`, legacy `env.control_config.action_scale`, Manager-Based `env.observations` / `env.actions` / policy and critic group mapping, `algo.policy.actor_hidden_dims` / `critic_hidden_dims`, `algo.empirical_normalization` / `algo.obs_normalization`, `env.sampling_mode` |
 | **WARNING_LIST** | Prints a warning, continues | `reward.*`, `env.control_config.simulate_action_latency`, `env.ctrl_dt` |
 | **ALLOWLIST** | Free to override, not checked | `training.sim_backend`, `env.scene`, `training.play_steps`, `env.domain_rand`, `env.noise_config`, `env.commands.vel_limit` |
 
@@ -39,6 +39,12 @@ If the target backend's DENYLIST fields differ from training (e.g. a task whose 
 - **Force through** (at your own risk): `uv run eval ... training.sim2sim_strict=false` downgrades DENYLIST mismatches to warnings.
 
 > Legacy runs: if `run_config.json` has no `contract_snapshot` (older training), the guard skips with a warning instead of breaking your workflow.
+
+Manager-Based snapshots store the complete typed observation and action declarations from
+Hydra. A snapshot from before those fields existed cannot prove that its policy I/O is
+equivalent to a Manager-Based target, so asymmetric presence fails closed. Set
+`training.sim2sim_strict=false` only as an explicit user override; the load-time dimension
+guard still remains active.
 
 ## See also
 

--- a/docs/sphinx/source/zh_CN/3-deployment/2-sim_to_sim/7-config_guard.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/2-sim_to_sim/7-config_guard.md
@@ -27,7 +27,7 @@ uv run eval  --algo ppo --task go2_joystick_flat --sim motrix --load-run -1
 
 | 档位 | 行为 | 字段 |
 |---|---|---|
-| **DENYLIST** | 差异即 `CrossBackendIncompatibleError`，中断 | `algo.obs_groups`、`env.control_config.action_scale`、`algo.policy.actor_hidden_dims` / `critic_hidden_dims`、`algo.empirical_normalization` / `algo.obs_normalization`、`env.sampling_mode` |
+| **DENYLIST** | 差异即 `CrossBackendIncompatibleError`，中断 | `algo.obs_groups`、legacy `env.control_config.action_scale`、Manager-Based `env.observations` / `env.actions` / policy 与 critic group mapping、`algo.policy.actor_hidden_dims` / `critic_hidden_dims`、`algo.empirical_normalization` / `algo.obs_normalization`、`env.sampling_mode` |
 | **WARNING_LIST** | 仅打印 warning，继续 | `reward.*`、`env.control_config.simulate_action_latency`、`env.ctrl_dt` |
 | **ALLOWLIST** | 自由覆盖，不检查 | `training.sim_backend`、`env.scene`、`training.play_steps`、`env.domain_rand`、`env.noise_config`、`env.commands.vel_limit` |
 
@@ -39,6 +39,10 @@ uv run eval  --algo ppo --task go2_joystick_flat --sim motrix --load-run -1
 - **强制放行**（自担风险）：`uv run eval ... training.sim2sim_strict=false`，把 DENYLIST 差异降级为 warning。
 
 > 兼容旧 run：若 `run_config.json` 没有 `contract_snapshot`（早期训练），守卫自动跳过并打印 warning，不会中断现有工作流。
+
+Manager-Based snapshot 会保存 Hydra 中完整的 typed observation/action 声明。缺少这些字段的旧
+snapshot 无法证明其 policy I/O 与 Manager-Based 目标等价，因此不对称出现时会 fail-closed。
+只有用户显式设置 `training.sim2sim_strict=false` 才会继续；加载权重时的维度守卫仍然生效。
 
 ## 另请参阅
 

--- a/src/unilab/training/sim2sim.py
+++ b/src/unilab/training/sim2sim.py
@@ -36,6 +36,10 @@ WARNING_LIST: list[str] = [
 DENYLIST: list[str] = [
     "algo.obs_groups",
     "env.control_config.action_scale",
+    "env.observations",
+    "env.actions",
+    "env.policy_observation_group",
+    "env.critic_observation_group",
     "algo.policy.actor_hidden_dims",
     "algo.policy.critic_hidden_dims",
     "algo.empirical_normalization",

--- a/tests/training/test_sim2sim_resolver.py
+++ b/tests/training/test_sim2sim_resolver.py
@@ -56,6 +56,47 @@ def _mujoco_cfg() -> Any:
     )
 
 
+def _manager_cfg() -> Any:
+    return OmegaConf.create(
+        {
+            "training": {"sim_backend": "mujoco"},
+            "algo": {"obs_groups": {"actor": ["actor"]}},
+            "env": {
+                "observations": {
+                    "policy": {
+                        "_target_": "unilab.managers.ObservationGroupCfg",
+                        "terms": {
+                            "joint_pos": {
+                                "_target_": "unilab.managers.ObservationTermCfg",
+                                "func": "unilab.envs.mdp.joint_pos_rel",
+                            }
+                        },
+                    },
+                    "critic": {
+                        "_target_": "unilab.managers.ObservationGroupCfg",
+                        "terms": {
+                            "joint_pos": {
+                                "_target_": "unilab.managers.ObservationTermCfg",
+                                "func": "unilab.envs.mdp.joint_pos_rel",
+                            }
+                        },
+                    },
+                },
+                "actions": {
+                    "joint_pos": {
+                        "_target_": "unilab.envs.mdp.JointPositionActionCfg",
+                        "entity_name": "robot",
+                        "actuator_names": [".*"],
+                        "scale": 0.25,
+                    }
+                },
+                "policy_observation_group": "policy",
+                "critic_observation_group": "critic",
+            },
+        }
+    )
+
+
 def test_field_lists_are_disjoint():
     deny, warn, allow = set(DENYLIST), set(WARNING_LIST), set(ALLOWLIST)
     assert deny.isdisjoint(warn)
@@ -81,6 +122,46 @@ def test_extract_snapshot_includes_only_present_contract_fields():
 def test_snapshot_json_round_trips():
     snapshot = extract_contract_snapshot(_mujoco_cfg())
     assert json.loads(json.dumps(snapshot)) == snapshot
+
+
+def test_extract_snapshot_captures_manager_policy_io_contract() -> None:
+    cfg = _manager_cfg()
+
+    snapshot = extract_contract_snapshot(cfg)
+
+    assert snapshot["env.actions"]["joint_pos"]["scale"] == pytest.approx(0.25)
+    assert snapshot["env.observations"]["policy"]["terms"]["joint_pos"]["func"] == (
+        "unilab.envs.mdp.joint_pos_rel"
+    )
+    assert snapshot["env.policy_observation_group"] == "policy"
+    assert snapshot["env.critic_observation_group"] == "critic"
+    assert "env.control_config.action_scale" not in snapshot
+
+
+def test_matching_manager_policy_io_contract_passes(tmp_path: Path) -> None:
+    _write_sidecar(tmp_path, extract_contract_snapshot(_manager_cfg()))
+    target = _manager_cfg()
+
+    assert resolve_sim2sim_config(tmp_path, target) is target
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("env.actions.joint_pos.scale", 0.5),
+        ("env.observations.policy.terms.joint_pos.func", "unilab.envs.mdp.joint_vel_rel"),
+        ("env.policy_observation_group", "critic"),
+        ("env.critic_observation_group", "policy"),
+    ],
+)
+def test_manager_policy_io_mismatch_fails_closed(tmp_path: Path, path: str, value: object) -> None:
+    source = _manager_cfg()
+    _write_sidecar(tmp_path, extract_contract_snapshot(source))
+    target = _manager_cfg()
+    OmegaConf.update(target, path, value, merge=False)
+
+    with pytest.raises(CrossBackendIncompatibleError, match="env\\."):
+        resolve_sim2sim_config(tmp_path, target)
 
 
 def test_matching_contract_returns_same_cfg(tmp_path):
@@ -185,7 +266,14 @@ def test_action_scale_list_form(tmp_path):
 
 
 def test_env_structural_denylist_is_the_env_subset():
-    assert ENV_STRUCTURAL_DENYLIST == ["env.control_config.action_scale", "env.sampling_mode"]
+    assert ENV_STRUCTURAL_DENYLIST == [
+        "env.control_config.action_scale",
+        "env.observations",
+        "env.actions",
+        "env.policy_observation_group",
+        "env.critic_observation_group",
+        "env.sampling_mode",
+    ]
     assert set(ENV_STRUCTURAL_DENYLIST) <= set(DENYLIST)
 
 


### PR DESCRIPTION
Closes #1108
Parent: #1042

## Summary

- Extends the existing fail-closed Sim2Sim DENYLIST with complete Manager-Based `env.observations`, `env.actions`, and policy/critic observation-group mappings.
- Keeps all legacy dotted paths unchanged; asymmetric presence in either direction remains a structural denial.
- Documents that pre-MBA snapshots cannot be guessed equivalent to a Manager-Based target; users must explicitly opt out with `training.sim2sim_strict=false`.
- Adds focused snapshot, equality, mismatch, and structural-set coverage without changing env/backend/runner/IPC behavior.

## Validation

On final commit `4267677e80004e88e8527b28436de97efbe46eae`:

- `make test-all`
- 2070 passed / 27 skipped / 276 deselected / 1 xfailed
- ruff, mypy, pyright, coverage (76%), and benchmark smoke passed
- focused resolver/audit tests: 52 passed
- benchmark entry modes each had only one platform-optional MLX skip
- remote child CI intentionally not run under #1042 authorization

## Size

- 4 modified existing files
- 105 insertions / 3 deletions
- no source-derived or mechanical NumPy conversion lines
