### PR TITLE
refactor(tasks): establish registry bootstrap boundary

### DIFF
--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -42,11 +42,7 @@ RewardOverrideField = Literal["reward_config", "rewards"]
 _SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 _REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"
-_DEFAULT_REGISTRY_PACKAGES = (
-    "unilab.envs.locomotion",
-    "unilab.envs.manipulation",
-    "unilab.envs.motion_tracking",
-)
+_DEFAULT_REGISTRY_PACKAGES = ("unilab.tasks",)
 # Environment variable used to extend ensure_registries() with extra packages.
 # Mainly intended for test setups that need to ship a fixture-only registry into
 # spawn subprocesses (which do not inherit pytest conftest state).

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -1,0 +1,24 @@
+"""Production task registry bootstrap.
+
+Concrete task implementations are moving from :mod:`unilab.envs` into this
+package under issue #1112.  Until each task family moves, this explicit list
+records its legacy module as the last remaining consumer of that path.  The
+registry imports these leaf modules directly, so registration stays explicit
+and deterministic throughout the migration.
+"""
+
+__unilab_registry_modules__ = (
+    "unilab.envs.locomotion.go1",
+    "unilab.envs.locomotion.go2",
+    "unilab.envs.locomotion.go2w",
+    "unilab.envs.locomotion.g1",
+    "unilab.envs.locomotion.go2_arm",
+    "unilab.envs.locomotion.a2",
+    "unilab.envs.manipulation.allegro_inhand",
+    "unilab.envs.manipulation.sharpa_inhand",
+    "unilab.envs.manipulation.stewart",
+    "unilab.envs.motion_tracking.g1",
+    "unilab.envs.motion_tracking.x2",
+)
+
+__all__ = ["__unilab_registry_modules__"]

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -1,0 +1,53 @@
+"""Task bootstrap and package dependency boundary tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from unilab.base import registry
+from unilab.tasks import __unilab_registry_modules__
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
+
+_LEGACY_TASK_MODULES = (
+    "unilab.envs.locomotion.go1",
+    "unilab.envs.locomotion.go2",
+    "unilab.envs.locomotion.go2w",
+    "unilab.envs.locomotion.g1",
+    "unilab.envs.locomotion.go2_arm",
+    "unilab.envs.locomotion.a2",
+    "unilab.envs.manipulation.allegro_inhand",
+    "unilab.envs.manipulation.sharpa_inhand",
+    "unilab.envs.manipulation.stewart",
+    "unilab.envs.motion_tracking.g1",
+    "unilab.envs.motion_tracking.x2",
+)
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+        elif isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+    return modules
+
+
+def test_tasks_is_the_only_default_registry_bootstrap() -> None:
+    assert registry._DEFAULT_REGISTRY_PACKAGES == ("unilab.tasks",)
+    assert __unilab_registry_modules__ == _LEGACY_TASK_MODULES
+
+
+def test_env_runtime_does_not_depend_on_tasks() -> None:
+    violations = [
+        (path.relative_to(_REPO_ROOT).as_posix(), module)
+        for path in sorted(_ENV_PACKAGE.rglob("*.py"))
+        for module in sorted(_imports(path))
+        if module == "unilab.tasks" or module.startswith("unilab.tasks.")
+    ]
+
+    assert violations == [], "unilab.envs must not import concrete unilab.tasks modules"


### PR DESCRIPTION
## Summary

- add `unilab.tasks` as the single production task registry bootstrap owner
- keep the current leaf-module order explicit while task families migrate under #1112
- enforce the one-way `tasks → envs` dependency boundary with an AST source test

No task files, Hydra owners, runtime semantics, backend contracts, runner, or IPC paths change in this PR. It adds no import alias or duplicate registration.

## Change size

- 3 files
- 78 insertions, 5 deletions
- no generated or source-derived code

## Validation

Final commit `bfd33ea5a7b14c2bff7a52231fbbb41abe2c06a3`:

- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed
- ruff format/check: passed
- mypy: passed
- pyright: passed
- coverage: 75%
- benchmark import smoke: passed

Per the maintainer's #1042 workflow override, remote child CI is intentionally skipped; the commit includes `[skip ci]`.

Closes #1113
Part of #1112
Roadmap #1042