### PR TITLE
refactor(tasks): move Go2 FootStand owner

### DIFF
--- a/src/unilab/envs/locomotion/go2/__init__.py
+++ b/src/unilab/envs/locomotion/go2/__init__.py
@@ -1,3 +1,2 @@
-from .footstand import Go2FootStandCfg, Go2FootStandTask
 from .joystick import Go2JoystickCfg, Go2WalkTask
 from .rough import Go2JoystickRoughCfg, Go2JoystickRoughEnv

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -9,6 +9,7 @@ and deterministic throughout the migration.
 
 __unilab_registry_modules__ = (
     "unilab.envs.locomotion.go1",
+    "unilab.tasks.locomotion.go2.footstand",
     "unilab.envs.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",

--- a/src/unilab/tasks/locomotion/go2/__init__.py
+++ b/src/unilab/tasks/locomotion/go2/__init__.py
@@ -1,0 +1,3 @@
+from .footstand import Go2FootStandCfg, Go2FootStandTask
+
+__all__ = ["Go2FootStandCfg", "Go2FootStandTask"]

--- a/src/unilab/tasks/locomotion/go2/footstand.py
+++ b/src/unilab/tasks/locomotion/go2/footstand.py
@@ -83,12 +83,12 @@ class JoystickSensor:
 
 @dataclass
 class Go2HandStandCfg(Go2BaseCfg):
-    scene: SceneCfg = field(
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml")
         )
     )
-    max_episode_seconds: float = 20.0
+    max_episode_seconds: float = 20.0  # pyright: ignore[reportIncompatibleVariableOverride]
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     reward_config: RewardConfig | None = None
@@ -127,7 +127,7 @@ class Go2HandStandDomainRandomizationProvider(LocomotionDRProvider):
 
 
 class Go2HandStandTask(Go2BaseEnv):
-    _cfg: Go2HandStandCfg
+    _cfg: Go2HandStandCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2HandStandCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:
@@ -449,7 +449,7 @@ class Go2FootStandDomainRandomizationProvider(Go2HandStandDomainRandomizationPro
 @registry.env("Go2FootStand", sim_backend="motrix")
 @registry.env("Go2FootStand", sim_backend="drake")
 class Go2FootStandTask(Go2HandStandTask):
-    _cfg: Go2FootStandCfg
+    _cfg: Go2FootStandCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2FootStandCfg, num_envs=1, backend_type="mujoco"):
         super().__init__(cfg, num_envs=num_envs, backend_type=backend_type)

--- a/tests/envs/locomotion/test_go2_footstand.py
+++ b/tests/envs/locomotion/test_go2_footstand.py
@@ -8,7 +8,7 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.registry import ensure_registries
 from unilab.dr import ResetRandomizationPayload
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2.footstand import (
+from unilab.tasks.locomotion.go2.footstand import (
     FootstandControlConfig,
     FootstandSensor,
     Go2FootStandCfg,

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -13,6 +13,7 @@ _ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
 
 _TASK_REGISTRY_MODULES = (
     "unilab.envs.locomotion.go1",
+    "unilab.tasks.locomotion.go2.footstand",
     "unilab.envs.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",


### PR DESCRIPTION
## Summary

- move Go2 FootStand to `unilab.tasks.locomotion.go2.footstand`
- update the explicit registry order and focused consumers atomically
- leave shared Go2/common owners in `envs` so dependency direction remains `tasks → envs`
- add four precise pyright suppressions for pre-existing mutable dataclass/config narrowing

No shim, duplicate registration, task behavior, Hydra, backend contract, runner, IPC, or performance change.

## Change size

- 6 files
- 1 implementation file moved, 1 package export added
- 10 insertions, 6 deletions

## Validation

Final commit `2db519ab96d2d0ab8df0e9903d7960e2b577fab1`:

- focused: 34 passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed
- ruff, mypy, pyright, coverage, benchmark smoke: passed

Remote child CI is intentionally skipped under the #1042 override; final commit includes `[skip ci]`.

Closes #1117
Part of #1112
Roadmap #1042