### PR TITLE
refactor(tasks): move Go2 joystick owner

### DIFF
--- a/scripts/benchmark/benchmark_drake_performance.py
+++ b/scripts/benchmark/benchmark_drake_performance.py
@@ -111,12 +111,12 @@ def _task_specs() -> dict[str, TaskSpec]:
         return Go1WalkTask
 
     def go2_cfg() -> Any:
-        from unilab.envs.locomotion.go2.joystick import Go2JoystickCfg
+        from unilab.tasks.locomotion.go2.joystick import Go2JoystickCfg
 
         return Go2JoystickCfg()
 
     def go2_env() -> type:
-        from unilab.envs.locomotion.go2.joystick import Go2WalkTask
+        from unilab.tasks.locomotion.go2.joystick import Go2WalkTask
 
         return Go2WalkTask
 

--- a/scripts/benchmark/core/task_names.py
+++ b/scripts/benchmark/core/task_names.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from unilab.envs.locomotion.g1.joystick import G1WalkFlatCfg
 from unilab.envs.locomotion.go1.joystick import Go1JoystickCfg
-from unilab.envs.locomotion.go2.joystick import Go2JoystickCfg
 from unilab.envs.manipulation.sharpa_inhand.rotation import SharpaInhandRotationCfg
+from unilab.tasks.locomotion.go2.joystick import Go2JoystickCfg
 
 
 @dataclass(frozen=True)

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -288,13 +288,13 @@ def _go1_env_cls() -> type:
 
 
 def _go2_cfg(backend: str, config_overrides: list[str]) -> Any:
-    from unilab.envs.locomotion.go2.joystick import Go2JoystickCfg
+    from unilab.tasks.locomotion.go2.joystick import Go2JoystickCfg
 
     return _ppo_owner_yaml_cfg("go2_joystick_flat", backend, Go2JoystickCfg, config_overrides)
 
 
 def _go2_env_cls() -> type:
-    from unilab.envs.locomotion.go2.joystick import Go2WalkTask
+    from unilab.tasks.locomotion.go2.joystick import Go2WalkTask
 
     return Go2WalkTask
 

--- a/scripts/play_interactive.py
+++ b/scripts/play_interactive.py
@@ -894,12 +894,14 @@ def _state_has_velocity_commands(env: Any) -> bool:
     )
 
 
-def _is_locomotion_env(env: Any) -> bool:
-    return type(env).__module__.startswith("unilab.envs.locomotion")
+def _has_velocity_command_config(env: Any) -> bool:
+    cfg = getattr(env, "cfg", None)
+    commands_cfg = getattr(cfg, "commands", None) if cfg is not None else None
+    return getattr(commands_cfg, "vel_limit", None) is not None
 
 
 def _is_velocity_command_locomotion_task(env: Any) -> bool:
-    if not _is_locomotion_env(env):
+    if not _has_velocity_command_config(env):
         return False
     cfg = getattr(env, "cfg", None)
     candidate_names = [

--- a/src/unilab/envs/locomotion/go2/__init__.py
+++ b/src/unilab/envs/locomotion/go2/__init__.py
@@ -1,1 +1,1 @@
-from .joystick import Go2JoystickCfg, Go2WalkTask
+"""Legacy Go2 shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -9,9 +9,7 @@ and deterministic throughout the migration.
 
 __unilab_registry_modules__ = (
     "unilab.envs.locomotion.go1",
-    "unilab.tasks.locomotion.go2.footstand",
-    "unilab.envs.locomotion.go2",
-    "unilab.tasks.locomotion.go2.rough",
+    "unilab.tasks.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",

--- a/src/unilab/tasks/locomotion/a2/joystick.py
+++ b/src/unilab/tasks/locomotion/a2/joystick.py
@@ -28,7 +28,7 @@ from unilab.envs.locomotion.common.commands import sample_commands_with_standing
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.go2.base import Asset, ControlConfig
-from unilab.envs.locomotion.go2.joystick import (
+from unilab.tasks.locomotion.go2.joystick import (
     Go2DomainRandConfig,
     Go2JoystickCfg,
     Go2JoystickDomainRandomizationProvider,

--- a/src/unilab/tasks/locomotion/go2/__init__.py
+++ b/src/unilab/tasks/locomotion/go2/__init__.py
@@ -1,9 +1,12 @@
 from .footstand import Go2FootStandCfg, Go2FootStandTask
+from .joystick import Go2JoystickCfg, Go2WalkTask
 from .rough import Go2JoystickRoughCfg, Go2JoystickRoughEnv
 
 __all__ = [
     "Go2FootStandCfg",
     "Go2FootStandTask",
+    "Go2JoystickCfg",
     "Go2JoystickRoughCfg",
     "Go2JoystickRoughEnv",
+    "Go2WalkTask",
 ]

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -60,16 +60,18 @@ class JoystickSensor(Sensor):
 
 @dataclass
 class Go2JoystickCfg(Go2BaseCfg):
-    scene: SceneCfg = field(
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "go2" / "scene_flat.xml")
         )
     )
-    max_episode_seconds: float = 20.0
+    max_episode_seconds: float = 20.0  # pyright: ignore[reportIncompatibleVariableOverride]
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     reward_config: RewardConfig | None = None
-    sensor: JoystickSensor = field(default_factory=JoystickSensor)
+    sensor: JoystickSensor = field(  # pyright: ignore[reportIncompatibleVariableOverride]
+        default_factory=JoystickSensor
+    )
     domain_rand: Go2DomainRandConfig = field(default_factory=Go2DomainRandConfig)
     terrain_curriculum: TerrainCurriculumCfg = field(default_factory=TerrainCurriculumCfg)
 
@@ -95,7 +97,7 @@ class Go2JoystickDomainRandomizationProvider(LocomotionDRProvider):
 
 
 class Go2WalkTask(Go2BaseEnv):
-    _cfg: Go2JoystickCfg
+    _cfg: Go2JoystickCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2JoystickCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:

--- a/src/unilab/tasks/locomotion/go2/rough.py
+++ b/src/unilab/tasks/locomotion/go2/rough.py
@@ -30,7 +30,7 @@ from unilab.envs.locomotion.common.height_scan import (
 )
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.go2.base import ControlConfig
-from unilab.envs.locomotion.go2.joystick import (
+from unilab.tasks.locomotion.go2.joystick import (
     Commands,
     Go2JoystickCfg,
     Go2JoystickDomainRandomizationProvider,

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -259,7 +259,7 @@ def test_go2_joystick_rough_playback_model_uses_backend_scene(tmp_path):
     """Offline playback / video rendering must reuse the backend-compiled scene model."""
     import mujoco
 
-    from unilab.envs.locomotion.go2.joystick import RewardConfig
+    from unilab.tasks.locomotion.go2.joystick import RewardConfig
     from unilab.tasks.locomotion.go2.rough import Go2JoystickRoughCfg, Go2JoystickRoughEnv
     from unilab.visualization.playback import _resolve_render_play_model_files
 
@@ -296,7 +296,7 @@ def test_go2_joystick_rough_playback_model_uses_backend_scene(tmp_path):
 
 def test_go2_joystick_flat_no_terrain_materialized():
     """Flat task keeps the static scene source and has no terrain origins."""
-    from unilab.envs.locomotion.go2.joystick import (
+    from unilab.tasks.locomotion.go2.joystick import (
         Go2JoystickCfg,
         Go2WalkTask,
         RewardConfig,

--- a/tests/envs/locomotion/test_go2_joystick_stand_still.py
+++ b/tests/envs/locomotion/test_go2_joystick_stand_still.py
@@ -67,7 +67,7 @@ def test_sample_commands_with_standing_matches_rough_block():
 def test_go2_advance_phase_is_unconditional():
     """Go2WalkTask advances the gait clock every step regardless of command —
     the A2 standing freeze must not have leaked into the Go2 owner."""
-    from unilab.envs.locomotion.go2.joystick import Go2WalkTask
+    from unilab.tasks.locomotion.go2.joystick import Go2WalkTask
 
     stub = SimpleNamespace(_cfg=SimpleNamespace(ctrl_dt=0.02), gait_frequency=2.0)
     phase = np.array([0.3, 0.3])
@@ -81,7 +81,7 @@ def test_go2_reward_config_has_no_command_threshold():
     must not declare it."""
     import dataclasses
 
-    from unilab.envs.locomotion.go2.joystick import RewardConfig
+    from unilab.tasks.locomotion.go2.joystick import RewardConfig
 
     names = {f.name for f in dataclasses.fields(RewardConfig)}
     assert "command_threshold" not in names

--- a/tests/envs/locomotion/test_go2_terrain_spawn.py
+++ b/tests/envs/locomotion/test_go2_terrain_spawn.py
@@ -63,7 +63,7 @@ def test_terrain_spawn_attached_when_rough():
 def test_terrain_spawn_attached_when_rough_motrix():
     pytest.importorskip("motrixsim")
 
-    from unilab.envs.locomotion.go2.joystick import Go2WalkTask
+    from unilab.tasks.locomotion.go2.joystick import Go2WalkTask
 
     cfg = _rough_cfg()
     cfg.domain_rand.randomize_kp = False
@@ -178,7 +178,7 @@ def test_terrain_spawn_rejects_non_callable_height_sampler_on_init():
 
 
 def test_go2_rough_base_height_reward_uses_terrain_relative_height():
-    from unilab.envs.locomotion.go2.joystick import Go2WalkTask
+    from unilab.tasks.locomotion.go2.joystick import Go2WalkTask
 
     class FakeBackend:
         def get_base_pos(self):
@@ -227,7 +227,7 @@ def test_go2_rough_pd_torque_estimate_returns_dof_order():
 
 
 def test_default_spawn_used_when_flat():
-    from unilab.envs.locomotion.go2.joystick import (
+    from unilab.tasks.locomotion.go2.joystick import (
         Go2JoystickCfg,
         Go2WalkTask,
         RewardConfig,
@@ -340,7 +340,7 @@ def test_curriculum_logs_appear_after_done():
 
 @pytest.mark.parametrize("preset", ["flat", "rough"])
 def test_episode_start_recorded_after_reset(preset):
-    from unilab.envs.locomotion.go2.joystick import (
+    from unilab.tasks.locomotion.go2.joystick import (
         Go2JoystickCfg,
         Go2WalkTask,
         RewardConfig,

--- a/tests/scripts/test_visualization_entrypoints.py
+++ b/tests/scripts/test_visualization_entrypoints.py
@@ -201,7 +201,7 @@ def test_velocity_arrows_require_velocity_command_task_and_policy_obs():
     joystick_env = _keyboard_env(
         env_cls_name="Go2WalkTask",
         cfg_cls_name="Go2JoystickCfg",
-        module="unilab.envs.locomotion.go2.joystick",
+        module="unilab.tasks.locomotion.go2.joystick",
         obs_contains_command=True,
     )
     manip_loco_env = _keyboard_env(
@@ -213,7 +213,7 @@ def test_velocity_arrows_require_velocity_command_task_and_policy_obs():
     missing_obs_command_env = _keyboard_env(
         env_cls_name="Go2WalkTask",
         cfg_cls_name="Go2JoystickCfg",
-        module="unilab.envs.locomotion.go2.joystick",
+        module="unilab.tasks.locomotion.go2.joystick",
         obs_contains_command=False,
     )
 

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -13,9 +13,7 @@ _ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
 
 _TASK_REGISTRY_MODULES = (
     "unilab.envs.locomotion.go1",
-    "unilab.tasks.locomotion.go2.footstand",
-    "unilab.envs.locomotion.go2",
-    "unilab.tasks.locomotion.go2.rough",
+    "unilab.tasks.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",


### PR DESCRIPTION
## Summary

- move the Go2 joystick owner into `unilab.tasks.locomotion.go2` without a compatibility shim
- make the Go2 tasks package the single registry leaf for FootStand, joystick, and rough
- update task, benchmark, interactive-play, and test consumers to the new owner

Closes #1121
Roadmap: #1042

## Validation

- focused tests: 84 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`