### PR TITLE
refactor(tasks): move Go2 shared base

### DIFF
--- a/docs/sphinx/source/api_reference/envs/locomotion.md
+++ b/docs/sphinx/source/api_reference/envs/locomotion.md
@@ -9,7 +9,7 @@
    unilab.envs.locomotion.common
    unilab.envs.locomotion.g1
    unilab.envs.locomotion.go1
-   unilab.envs.locomotion.go2
+   unilab.tasks.locomotion.go2
    unilab.envs.locomotion.go2_arm
    unilab.envs.locomotion.go2w
 ```

--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -2,7 +2,6 @@
 
 __unilab_registry_modules__ = (
     "unilab.envs.locomotion.go1",
-    "unilab.envs.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",

--- a/src/unilab/envs/locomotion/go2/__init__.py
+++ b/src/unilab/envs/locomotion/go2/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy Go2 shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/locomotion/a2/joystick.py
+++ b/src/unilab/tasks/locomotion/a2/joystick.py
@@ -27,7 +27,7 @@ from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.commands import sample_commands_with_standing
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2.base import Asset, ControlConfig
+from unilab.tasks.locomotion.go2.base import Asset, ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (
     Go2DomainRandConfig,
     Go2JoystickCfg,

--- a/src/unilab/tasks/locomotion/go2/base.py
+++ b/src/unilab/tasks/locomotion/go2/base.py
@@ -39,7 +39,7 @@ class Go2BaseCfg(LocomotionBaseCfg):
 
 
 class Go2BaseEnv(LocomotionBaseEnv):
-    _cfg: Go2BaseCfg
+    _cfg: Go2BaseCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def get_foot_pos(self) -> np.ndarray:
         """Get foot positions. Returns shape (num_envs, 4, 3)"""

--- a/src/unilab/tasks/locomotion/go2/footstand.py
+++ b/src/unilab/tasks/locomotion/go2/footstand.py
@@ -17,7 +17,7 @@ from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2.base import ControlConfig, Go2BaseCfg, Go2BaseEnv, NoiseConfig
+from unilab.tasks.locomotion.go2.base import ControlConfig, Go2BaseCfg, Go2BaseEnv, NoiseConfig
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse
 
 

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -21,11 +21,11 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )
-from unilab.envs.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 from unilab.envs.manager_based_rl_env import (
     ManagerBasedRlEnvCfg,
     make_manager_based_rl_env,
 )
+from unilab.tasks.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 
 
 @dataclass

--- a/src/unilab/tasks/locomotion/go2/rough.py
+++ b/src/unilab/tasks/locomotion/go2/rough.py
@@ -29,7 +29,7 @@ from unilab.envs.locomotion.common.height_scan import (
     terrain_out_of_bounds,
 )
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2.base import ControlConfig
+from unilab.tasks.locomotion.go2.base import ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (
     Commands,
     Go2JoystickCfg,

--- a/tests/envs/test_go2_obs_noise.py
+++ b/tests/envs/test_go2_obs_noise.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from unilab.envs.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv, NoiseConfig
+from unilab.tasks.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv, NoiseConfig
 
 
 class _ConcreteGo2Env(Go2BaseEnv):


### PR DESCRIPTION
## Summary

- move the Go2 shared base into the Go2 task owner package
- atomically switch Go2/A2 and test consumers to the new path
- remove the empty legacy Go2 package and its legacy registry metadata
- update the direct API reference without adding a compatibility shim

Closes #1125
Roadmap: #1042

## Validation

- focused tests: 121 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`