### PR TITLE
refactor(tasks): move Go1 joystick owner

### DIFF
--- a/scripts/benchmark/benchmark_drake_performance.py
+++ b/scripts/benchmark/benchmark_drake_performance.py
@@ -101,12 +101,12 @@ class StepProfiler:
 
 def _task_specs() -> dict[str, TaskSpec]:
     def go1_cfg() -> Any:
-        from unilab.envs.locomotion.go1.joystick import Go1JoystickCfg
+        from unilab.tasks.locomotion.go1.joystick import Go1JoystickCfg
 
         return Go1JoystickCfg()
 
     def go1_env() -> type:
-        from unilab.envs.locomotion.go1.joystick import Go1WalkTask
+        from unilab.tasks.locomotion.go1.joystick import Go1WalkTask
 
         return Go1WalkTask
 

--- a/scripts/benchmark/core/task_names.py
+++ b/scripts/benchmark/core/task_names.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from unilab.envs.locomotion.g1.joystick import G1WalkFlatCfg
-from unilab.envs.locomotion.go1.joystick import Go1JoystickCfg
 from unilab.envs.manipulation.sharpa_inhand.rotation import SharpaInhandRotationCfg
+from unilab.tasks.locomotion.go1.joystick import Go1JoystickCfg
 from unilab.tasks.locomotion.go2.joystick import Go2JoystickCfg
 
 

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -276,13 +276,13 @@ def _materialize_sharpa_motrix_scene() -> str:
 
 
 def _go1_cfg(backend: str, config_overrides: list[str]) -> Any:
-    from unilab.envs.locomotion.go1.joystick import Go1JoystickCfg
+    from unilab.tasks.locomotion.go1.joystick import Go1JoystickCfg
 
     return _ppo_owner_yaml_cfg("go1_joystick_flat", backend, Go1JoystickCfg, config_overrides)
 
 
 def _go1_env_cls() -> type:
-    from unilab.envs.locomotion.go1.joystick import Go1WalkTask
+    from unilab.tasks.locomotion.go1.joystick import Go1WalkTask
 
     return Go1WalkTask
 

--- a/src/unilab/envs/locomotion/go1/__init__.py
+++ b/src/unilab/envs/locomotion/go1/__init__.py
@@ -1,1 +1,1 @@
-from .joystick import Go1JoystickCfg, Go1WalkTask
+"""Legacy Go1 shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -8,8 +8,7 @@ and deterministic throughout the migration.
 """
 
 __unilab_registry_modules__ = (
-    "unilab.envs.locomotion.go1",
-    "unilab.tasks.locomotion.go1.rough",
+    "unilab.tasks.locomotion.go1",
     "unilab.tasks.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",

--- a/src/unilab/tasks/locomotion/go1/__init__.py
+++ b/src/unilab/tasks/locomotion/go1/__init__.py
@@ -1,3 +1,9 @@
+from .joystick import Go1JoystickCfg, Go1WalkTask
 from .rough import Go1JoystickRoughCfg, Go1JoystickRoughEnv
 
-__all__ = ["Go1JoystickRoughCfg", "Go1JoystickRoughEnv"]
+__all__ = [
+    "Go1JoystickCfg",
+    "Go1JoystickRoughCfg",
+    "Go1JoystickRoughEnv",
+    "Go1WalkTask",
+]

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -46,12 +46,12 @@ class JoystickSensor:
 @registry.envcfg("Go1JoystickFlat")
 @dataclass
 class Go1JoystickCfg(Go1BaseCfg):
-    scene: SceneCfg = field(
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "go1" / "scene_flat.xml")
         )
     )
-    max_episode_seconds: float = 20.0
+    max_episode_seconds: float = 20.0  # pyright: ignore[reportIncompatibleVariableOverride]
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     reward_config: RewardConfig | None = None
@@ -86,7 +86,7 @@ class Go1JoystickDomainRandomizationProvider(LocomotionDRProvider):
 @registry.env("Go1JoystickFlat", sim_backend="motrix")
 @registry.env("Go1JoystickFlat", sim_backend="drake")
 class Go1WalkTask(Go1BaseEnv):
-    _cfg: Go1JoystickCfg
+    _cfg: Go1JoystickCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go1JoystickCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -35,7 +35,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
 )
 from unilab.envs.locomotion.go1.base import ControlConfig
-from unilab.envs.locomotion.go1.joystick import (
+from unilab.tasks.locomotion.go1.joystick import (
     Go1JoystickCfg,
     Go1JoystickDomainRandomizationProvider,
     Go1WalkTask,

--- a/tests/base/test_reward_override.py
+++ b/tests/base/test_reward_override.py
@@ -12,7 +12,7 @@ def test_reward_override_go1():
     """Test Go1 reward config override."""
     ensure_registries()
 
-    from unilab.envs.locomotion.go1.joystick import RewardConfig
+    from unilab.tasks.locomotion.go1.joystick import RewardConfig
 
     override_config = RewardConfig(
         scales={"tracking_lin_vel": 999.0},

--- a/tests/integration/test_reward_injection_integration.py
+++ b/tests/integration/test_reward_injection_integration.py
@@ -38,7 +38,7 @@ def test_reward_override_propagation():
     """Test reward override propagates through multiprocess collector."""
     from unilab.base import registry
     from unilab.base.registry import ensure_registries
-    from unilab.envs.locomotion.go1.joystick import RewardConfig
+    from unilab.tasks.locomotion.go1.joystick import RewardConfig
 
     ensure_registries()
 
@@ -102,7 +102,7 @@ def test_zero_scale_skips_computation():
     """Test that reward functions with scale=0 are skipped."""
     from unilab.base import registry
     from unilab.base.registry import ensure_registries
-    from unilab.envs.locomotion.go1.joystick import RewardConfig
+    from unilab.tasks.locomotion.go1.joystick import RewardConfig
 
     ensure_registries()
 

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -12,8 +12,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
 
 _TASK_REGISTRY_MODULES = (
-    "unilab.envs.locomotion.go1",
-    "unilab.tasks.locomotion.go1.rough",
+    "unilab.tasks.locomotion.go1",
     "unilab.tasks.locomotion.go2",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",


### PR DESCRIPTION
## Summary

- move the Go1 flat joystick owner into `unilab.tasks.locomotion.go1`
- make the Go1 tasks package the single registry leaf for joystick and rough
- atomically update rough, benchmark, reward-injection, and test consumers
- keep the legacy Go1 package limited to the shared base pending its next migration

Closes #1129
Roadmap: #1042

## Validation

- focused tests: 275 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`