### PR TITLE
refactor(tasks): move Go1 shared base

### DIFF
--- a/docs/sphinx/source/api_reference/envs/locomotion.md
+++ b/docs/sphinx/source/api_reference/envs/locomotion.md
@@ -8,7 +8,7 @@
 
    unilab.envs.locomotion.common
    unilab.envs.locomotion.g1
-   unilab.envs.locomotion.go1
+   unilab.tasks.locomotion.go1
    unilab.tasks.locomotion.go2
    unilab.envs.locomotion.go2_arm
    unilab.envs.locomotion.go2w

--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -1,7 +1,6 @@
 """Locomotion env registry bootstrap contract."""
 
 __unilab_registry_modules__ = (
-    "unilab.envs.locomotion.go1",
     "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",

--- a/src/unilab/envs/locomotion/go1/__init__.py
+++ b/src/unilab/envs/locomotion/go1/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy Go1 shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/locomotion/go1/base.py
+++ b/src/unilab/tasks/locomotion/go1/base.py
@@ -37,4 +37,4 @@ class Go1BaseCfg(LocomotionBaseCfg):
 
 
 class Go1BaseEnv(LocomotionBaseEnv):
-    _cfg: Go1BaseCfg
+    _cfg: Go1BaseCfg  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -20,7 +20,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )
-from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
+from unilab.tasks.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 
 
 @dataclass

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -34,7 +34,7 @@ from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
 )
-from unilab.envs.locomotion.go1.base import ControlConfig
+from unilab.tasks.locomotion.go1.base import ControlConfig
 from unilab.tasks.locomotion.go1.joystick import (
     Go1JoystickCfg,
     Go1JoystickDomainRandomizationProvider,

--- a/tests/envs/test_go1_obs_noise.py
+++ b/tests/envs/test_go1_obs_noise.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from unilab.envs.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv, NoiseConfig
+from unilab.tasks.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv, NoiseConfig
 
 
 class _ConcreteGo1Env(Go1BaseEnv):


### PR DESCRIPTION
## Summary

- move the Go1 shared base into the Go1 task owner package
- atomically switch joystick, rough, and noise-test consumers
- remove the empty legacy Go1 package and its legacy registry metadata
- update the direct API reference without a compatibility shim

Closes #1131
Roadmap: #1042

## Validation

- focused tests: 273 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`