### PR TITLE
refactor(tasks): move Go2W joystick owner

### DIFF
--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -312,7 +312,7 @@ def _go2_rough_env_cls() -> type:
 
 
 def _go2w_cfg(backend: str, config_overrides: list[str]) -> Any:
-    from unilab.envs.locomotion.go2w.joystick import Go2WJoystickCfg
+    from unilab.tasks.locomotion.go2w.joystick import Go2WJoystickCfg
 
     return _ppo_owner_yaml_cfg("go2w_joystick_flat", backend, Go2WJoystickCfg, config_overrides)
 
@@ -326,7 +326,7 @@ def _go2w_rough_cfg(backend: str, config_overrides: list[str]) -> Any:
 
 
 def _go2w_env_cls() -> type:
-    from unilab.envs.locomotion.go2w.joystick import Go2WJoystickEnv
+    from unilab.tasks.locomotion.go2w.joystick import Go2WJoystickEnv
 
     return Go2WJoystickEnv
 

--- a/src/unilab/envs/locomotion/go2w/__init__.py
+++ b/src/unilab/envs/locomotion/go2w/__init__.py
@@ -1,1 +1,1 @@
-from .joystick import Go2WJoystickCfg, Go2WJoystickEnv
+"""Legacy Go2W shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -10,8 +10,7 @@ and deterministic throughout the migration.
 __unilab_registry_modules__ = (
     "unilab.tasks.locomotion.go1",
     "unilab.tasks.locomotion.go2",
-    "unilab.envs.locomotion.go2w",
-    "unilab.tasks.locomotion.go2w.rough",
+    "unilab.tasks.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",
     "unilab.tasks.locomotion.a2",

--- a/src/unilab/tasks/locomotion/go2w/__init__.py
+++ b/src/unilab/tasks/locomotion/go2w/__init__.py
@@ -1,3 +1,9 @@
+from .joystick import Go2WJoystickCfg, Go2WJoystickEnv
 from .rough import Go2WJoystickRoughCfg, Go2WJoystickRoughEnv
 
-__all__ = ["Go2WJoystickRoughCfg", "Go2WJoystickRoughEnv"]
+__all__ = [
+    "Go2WJoystickCfg",
+    "Go2WJoystickEnv",
+    "Go2WJoystickRoughCfg",
+    "Go2WJoystickRoughEnv",
+]

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -88,12 +88,12 @@ class JoystickSensor:
 @registry.envcfg("Go2WJoystickFlat")
 @dataclass
 class Go2WJoystickCfg(Go2WBaseCfg):
-    scene: SceneCfg = field(
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "go2w" / "scene_flat.xml")
         )
     )
-    max_episode_seconds: float = 20.0
+    max_episode_seconds: float = 20.0  # pyright: ignore[reportIncompatibleVariableOverride]
     init_state: InitState = field(default_factory=InitState)
     commands: Commands = field(default_factory=Commands)
     reward_config: RewardConfig | None = None
@@ -229,7 +229,7 @@ class Go2WJoystickDomainRandomizationProvider(LocomotionDRProvider):
 @registry.env("Go2WJoystickFlat", sim_backend="mujoco")
 @registry.env("Go2WJoystickFlat", sim_backend="drake")
 class Go2WJoystickEnv(Go2WBaseEnv):
-    _cfg: Go2WJoystickCfg
+    _cfg: Go2WJoystickCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2WJoystickCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:

--- a/src/unilab/tasks/locomotion/go2w/rough.py
+++ b/src/unilab/tasks/locomotion/go2w/rough.py
@@ -32,7 +32,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainSpawnManager,
 )
 from unilab.envs.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
-from unilab.envs.locomotion.go2w.joystick import (
+from unilab.tasks.locomotion.go2w.joystick import (
     Go2WJoystickCfg,
     Go2WJoystickDomainRandomizationProvider,
     Go2WJoystickEnv,

--- a/tests/envs/locomotion/go2w/test_go2w_motor_control.py
+++ b/tests/envs/locomotion/go2w/test_go2w_motor_control.py
@@ -16,7 +16,7 @@ from unilab.envs.locomotion.go2w.base import (
     Go2WBaseEnv,
     compute_go2w_motor_ctrl,
 )
-from unilab.envs.locomotion.go2w.joystick import (
+from unilab.tasks.locomotion.go2w.joystick import (
     Go2WJoystickCfg,
     Go2WJoystickDomainRandomizationProvider,
     Go2WJoystickEnv,
@@ -135,7 +135,7 @@ def test_go2w_reset_plan_can_disable_initial_yaw_randomization() -> None:
 
 
 def test_go2w_init_does_not_pass_position_actuator_gains(monkeypatch: pytest.MonkeyPatch) -> None:
-    from unilab.envs.locomotion.go2w import joystick as go2w_module
+    from unilab.tasks.locomotion.go2w import joystick as go2w_module
 
     captured: dict[str, Any] = {}
 

--- a/tests/envs/locomotion/test_go2_terrain_spawn.py
+++ b/tests/envs/locomotion/test_go2_terrain_spawn.py
@@ -115,7 +115,7 @@ def test_go1_rough_initialization_and_reset_use_backend_terrain_contract():
 
 
 def test_go2w_rough_initialization_and_reset_use_backend_terrain_contract():
-    from unilab.envs.locomotion.go2w.joystick import RewardConfig
+    from unilab.tasks.locomotion.go2w.joystick import RewardConfig
     from unilab.tasks.locomotion.go2w.rough import Go2WJoystickRoughCfg, Go2WJoystickRoughEnv
 
     cfg = Go2WJoystickRoughCfg(

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -14,8 +14,7 @@ _ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
 _TASK_REGISTRY_MODULES = (
     "unilab.tasks.locomotion.go1",
     "unilab.tasks.locomotion.go2",
-    "unilab.envs.locomotion.go2w",
-    "unilab.tasks.locomotion.go2w.rough",
+    "unilab.tasks.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",
     "unilab.tasks.locomotion.a2",


### PR DESCRIPTION
## Summary

- move the Go2W flat joystick owner into `unilab.tasks.locomotion.go2w`
- make the Go2W tasks package the single registry leaf for joystick and rough
- atomically update rough, benchmark, terrain, and motor-control consumers
- keep the legacy Go2W package limited to the shared base pending its next migration

Closes #1135
Roadmap: #1042

## Validation

- focused tests: 282 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`