### PR TITLE
refactor(tasks): move Go2W shared base

### DIFF
--- a/docs/sphinx/source/api_reference/envs/locomotion.md
+++ b/docs/sphinx/source/api_reference/envs/locomotion.md
@@ -11,5 +11,5 @@
    unilab.tasks.locomotion.go1
    unilab.tasks.locomotion.go2
    unilab.envs.locomotion.go2_arm
-   unilab.envs.locomotion.go2w
+   unilab.tasks.locomotion.go2w
 ```

--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -1,7 +1,6 @@
 """Locomotion env registry bootstrap contract."""
 
 __unilab_registry_modules__ = (
-    "unilab.envs.locomotion.go2w",
     "unilab.envs.locomotion.g1",
     "unilab.envs.locomotion.go2_arm",
 )

--- a/src/unilab/envs/locomotion/go2w/__init__.py
+++ b/src/unilab/envs/locomotion/go2w/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy Go2W shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/locomotion/go2w/base.py
+++ b/src/unilab/tasks/locomotion/go2w/base.py
@@ -117,7 +117,7 @@ def compute_go2w_motor_ctrl(
 
 
 class Go2WBaseEnv(LocomotionBaseEnv):
-    _cfg: Go2WBaseCfg
+    _cfg: Go2WBaseCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def _init_action_space(self) -> None:
         self._action_space = gym.spaces.Box(

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -29,7 +29,7 @@ from unilab.envs.locomotion.common.commands import (
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2w.base import (
+from unilab.tasks.locomotion.go2w.base import (
     DEFAULT_GO2W_ANGLES,
     NUM_GO2W_ACTIONS,
     NUM_LEG_ACTIONS,

--- a/src/unilab/tasks/locomotion/go2w/rough.py
+++ b/src/unilab/tasks/locomotion/go2w/rough.py
@@ -31,7 +31,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )
-from unilab.envs.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
+from unilab.tasks.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
 from unilab.tasks.locomotion.go2w.joystick import (
     Go2WJoystickCfg,
     Go2WJoystickDomainRandomizationProvider,

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -367,7 +367,7 @@ def test_backend_batch_sensor_data_matches_individual_sensors(backend_type):
         pytest.importorskip("motrixsim")
 
     from unilab.base.backend import create_backend
-    from unilab.envs.locomotion.go2w.base import JOINT_SENSOR_PREFIXES
+    from unilab.tasks.locomotion.go2w.base import JOINT_SENSOR_PREFIXES
 
     bkd = create_backend(
         backend_type,

--- a/tests/envs/locomotion/go2w/test_go2w_motor_control.py
+++ b/tests/envs/locomotion/go2w/test_go2w_motor_control.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from unilab.base.np_env import NpEnvState
-from unilab.envs.locomotion.go2w.base import (
+from unilab.tasks.locomotion.go2w.base import (
     DEFAULT_GO2W_ANGLES,
     JOINT_SENSOR_PREFIXES,
     NUM_GO2W_ACTIONS,


### PR DESCRIPTION
## Summary

- move the Go2W shared base into the Go2W task owner package
- atomically switch joystick, rough, motor-control, and backend-smoke consumers
- remove the empty legacy Go2W package and its legacy registry metadata
- update the direct API reference without a compatibility shim

Closes #1137
Roadmap: #1042

## Validation

- focused tests: 297 passed
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`