### PR TITLE
refactor(tasks): move Go2 Arm manip-loco owner

### DIFF
--- a/scripts/manip_loco/diagnose_go2_arm_ik.py
+++ b/scripts/manip_loco/diagnose_go2_arm_ik.py
@@ -16,7 +16,7 @@ if str(ROOT_DIR) not in sys.path:
 
 from unilab.base import registry
 from unilab.base.registry import ensure_registries
-from unilab.envs.locomotion.go2_arm.manip_loco import RewardConfig
+from unilab.tasks.locomotion.go2_arm.manip_loco import RewardConfig
 from unilab.utils.rotation import np_matrix_from_quat
 
 

--- a/scripts/manip_loco/play_go2_arm_ik_only.py
+++ b/scripts/manip_loco/play_go2_arm_ik_only.py
@@ -19,7 +19,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from unilab.envs.locomotion.go2_arm.base import build_go2_arm_position_gains
-from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoCfg
+from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoCfg
 
 TARGET_BODY = "ik_mocap_target"
 

--- a/src/unilab/envs/locomotion/go2_arm/__init__.py
+++ b/src/unilab/envs/locomotion/go2_arm/__init__.py
@@ -1,1 +1,1 @@
-from .manip_loco import Go2ArmManipLocoCfg, Go2ArmManipLocoEnv
+"""Legacy Go2 Arm shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -12,7 +12,7 @@ __unilab_registry_modules__ = (
     "unilab.tasks.locomotion.go2",
     "unilab.tasks.locomotion.go2w",
     "unilab.envs.locomotion.g1",
-    "unilab.envs.locomotion.go2_arm",
+    "unilab.tasks.locomotion.go2_arm",
     "unilab.tasks.locomotion.a2",
     "unilab.envs.manipulation.allegro_inhand",
     "unilab.envs.manipulation.sharpa_inhand",

--- a/src/unilab/tasks/locomotion/go2_arm/__init__.py
+++ b/src/unilab/tasks/locomotion/go2_arm/__init__.py
@@ -1,0 +1,3 @@
+from .manip_loco import Go2ArmManipLocoCfg, Go2ArmManipLocoEnv
+
+__all__ = ["Go2ArmManipLocoCfg", "Go2ArmManipLocoEnv"]

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -150,9 +150,11 @@ class ArmStageConfig:
 @registry.envcfg("Go2ArmManipLoco")
 @dataclass
 class Go2ArmManipLocoCfg(Go2ArmBaseCfg):
-    scene: SceneCfg = field(default_factory=_default_go2_arm_scene)
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
+        default_factory=_default_go2_arm_scene
+    )
     model_file: str = field(default_factory=_default_go2_arm_model_file)
-    max_episode_seconds: float = 20.0
+    max_episode_seconds: float = 20.0  # pyright: ignore[reportIncompatibleVariableOverride]
     init_state: InitState = field(default_factory=InitState)
     commands: CommandsConfig = field(default_factory=CommandsConfig)  # type: ignore[assignment]
     reward_config: RewardConfig | None = None
@@ -266,7 +268,7 @@ class Go2ArmManipLocoDRProvider(LocomotionDRProvider):
 @registry.env("Go2ArmManipLoco", sim_backend="drake")
 @registry.env("Go2ArmManipLoco", sim_backend="mujoco")
 class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
-    _cfg: Go2ArmManipLocoCfg
+    _cfg: Go2ArmManipLocoCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2ArmManipLocoCfg, num_envs=1, backend_type="mujoco"):
         if cfg.reward_config is None:

--- a/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
+++ b/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
@@ -11,7 +11,7 @@ from gymnasium import spaces
 
 from unilab.base.np_env import NpEnvState
 
-_GO2_ARM_MANIP_LOCO_MODULE = "unilab.envs.locomotion.go2_arm.manip_loco"
+_GO2_ARM_MANIP_LOCO_MODULE = "unilab.tasks.locomotion.go2_arm.manip_loco"
 _REGISTRY_MODULE = "unilab.base.registry"
 
 
@@ -24,7 +24,7 @@ def _skip_if_no_mujoco():
 
 
 def _default_reward_cfg():
-    from unilab.envs.locomotion.go2_arm.manip_loco import RewardConfig
+    from unilab.tasks.locomotion.go2_arm.manip_loco import RewardConfig
 
     return RewardConfig(
         scales={
@@ -88,7 +88,7 @@ def test_go2_arm_manip_loco_registers_motrix_backend():
 def test_go2_arm_manip_loco_cfg_declares_scene_for_playback():
     """MuJoCo video playback needs the original visual scene, not only legacy model_file."""
     from unilab.base.scene import SceneCfg
-    from unilab.envs.locomotion.go2_arm.manip_loco import (
+    from unilab.tasks.locomotion.go2_arm.manip_loco import (
         Go2ArmManipLocoCfg,
         _resolve_go2_arm_scene,
     )
@@ -107,7 +107,7 @@ def test_go2_arm_manip_loco_cfg_declares_scene_for_playback():
 
 def test_go2_arm_ee_goal_collision_check_matches_reference_semantics():
     """Any EE goal path sample inside the collision box or below ground is unsafe."""
-    from unilab.envs.locomotion.go2_arm.manip_loco import (
+    from unilab.tasks.locomotion.go2_arm.manip_loco import (
         EEGoalConfig,
         Go2ArmManipLocoCfg,
         Go2ArmManipLocoEnv,
@@ -131,7 +131,7 @@ def test_go2_arm_ee_goal_collision_check_matches_reference_semantics():
 
 def test_go2_arm_command_moving_mask_includes_all_velocity_axes():
     """A command is moving when vx, vy, or vyaw exceeds the motion threshold."""
-    from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
+    from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)
     clip = env._CMD_CLIP
@@ -156,7 +156,7 @@ def test_go2_arm_command_moving_mask_includes_all_velocity_axes():
 
 def test_go2_arm_command_postprocess_can_force_zero_commands():
     """zero_command_prob should inject exact zero commands after small-command zeroing."""
-    from unilab.envs.locomotion.go2_arm.manip_loco import (
+    from unilab.tasks.locomotion.go2_arm.manip_loco import (
         Go2ArmManipLocoCfg,
         Go2ArmManipLocoEnv,
     )
@@ -184,7 +184,7 @@ def test_go2_arm_command_postprocess_can_force_zero_commands():
 def test_go2_arm_stand_still_reward_uses_same_command_mask():
     """stand_still should not penalize leg pose under lateral, yaw, or forward commands."""
     from unilab.envs.locomotion.common.rewards import RewardContext
-    from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
+    from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)
     clip = env._CMD_CLIP
@@ -212,7 +212,7 @@ def test_go2_arm_stand_still_reward_uses_same_command_mask():
 
 def test_go2_arm_write_feet_phase_updates_indexed_envs():
     """Resetting env subsets must write back feet_phase instead of losing fancy-index copies."""
-    from unilab.envs.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
+    from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)
     env.phase = np.asarray([0.2, 0.4, 0.6], dtype=np.float32)
@@ -229,7 +229,7 @@ def test_go2_arm_write_feet_phase_updates_indexed_envs():
 
 def test_go2_arm_apply_action_uses_arm_action_scale_for_arm_residual():
     """Leg residuals use action_scale while arm residuals use arm_action_scale."""
-    from unilab.envs.locomotion.go2_arm.manip_loco import (
+    from unilab.tasks.locomotion.go2_arm.manip_loco import (
         Go2ArmManipLocoCfg,
         Go2ArmManipLocoEnv,
     )

--- a/tests/scripts/test_visualization_entrypoints.py
+++ b/tests/scripts/test_visualization_entrypoints.py
@@ -207,7 +207,7 @@ def test_velocity_arrows_require_velocity_command_task_and_policy_obs():
     manip_loco_env = _keyboard_env(
         env_cls_name="Go2ArmManipLocoEnv",
         cfg_cls_name="Go2ArmManipLocoCfg",
-        module="unilab.envs.locomotion.go2_arm.manip_loco",
+        module="unilab.tasks.locomotion.go2_arm.manip_loco",
         obs_contains_command=True,
     )
     missing_obs_command_env = _keyboard_env(

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -16,7 +16,7 @@ _TASK_REGISTRY_MODULES = (
     "unilab.tasks.locomotion.go2",
     "unilab.tasks.locomotion.go2w",
     "unilab.envs.locomotion.g1",
-    "unilab.envs.locomotion.go2_arm",
+    "unilab.tasks.locomotion.go2_arm",
     "unilab.tasks.locomotion.a2",
     "unilab.envs.manipulation.allegro_inhand",
     "unilab.envs.manipulation.sharpa_inhand",


### PR DESCRIPTION
## Summary

- move the Go2 Arm manipulation-locomotion owner into `unilab.tasks.locomotion.go2_arm`
- make the tasks package the direct registry owner while leaving only the shared base in the legacy package
- atomically update IK tooling, contract tests, and visualization consumers
- retain public `SimBackend` usage only, without a compatibility shim

Closes #1139
Roadmap: #1042

## Validation

- focused tests: 272 passed (7 deselected)
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`