### PR TITLE
refactor(tasks): move Go2 Arm shared base

### DIFF
--- a/docs/sphinx/source/api_reference/envs/locomotion.md
+++ b/docs/sphinx/source/api_reference/envs/locomotion.md
@@ -10,6 +10,6 @@
    unilab.envs.locomotion.g1
    unilab.tasks.locomotion.go1
    unilab.tasks.locomotion.go2
-   unilab.envs.locomotion.go2_arm
+   unilab.tasks.locomotion.go2_arm
    unilab.tasks.locomotion.go2w
 ```

--- a/scripts/manip_loco/play_go2_arm_ik_only.py
+++ b/scripts/manip_loco/play_go2_arm_ik_only.py
@@ -18,7 +18,7 @@ if str(SRC_DIR) not in sys.path:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from unilab.envs.locomotion.go2_arm.base import build_go2_arm_position_gains
+from unilab.tasks.locomotion.go2_arm.base import build_go2_arm_position_gains
 from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoCfg
 
 TARGET_BODY = "ik_mocap_target"

--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -1,6 +1,3 @@
 """Locomotion env registry bootstrap contract."""
 
-__unilab_registry_modules__ = (
-    "unilab.envs.locomotion.g1",
-    "unilab.envs.locomotion.go2_arm",
-)
+__unilab_registry_modules__ = ("unilab.envs.locomotion.g1",)

--- a/src/unilab/envs/locomotion/go2_arm/__init__.py
+++ b/src/unilab/envs/locomotion/go2_arm/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy Go2 Arm shared base pending migration to :mod:`unilab.tasks`."""

--- a/src/unilab/tasks/locomotion/go2_arm/base.py
+++ b/src/unilab/tasks/locomotion/go2_arm/base.py
@@ -128,7 +128,7 @@ def build_go2_arm_position_gains(cfg: ControlConfig) -> dict[str, np.ndarray]:
 
 
 class Go2ArmBaseEnv(LocomotionBaseEnv):
-    _cfg: Go2ArmBaseCfg
+    _cfg: Go2ArmBaseCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: Go2ArmBaseCfg, backend: SimBackend, num_envs: int = 1):
         super().__init__(cfg, backend, num_envs)

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -17,7 +17,7 @@ from unilab.envs.locomotion.common.commands import Commands
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.go2_arm.base import (
+from unilab.tasks.locomotion.go2_arm.base import (
     Go2ArmBaseCfg,
     Go2ArmBaseEnv,
     Go2ArmSensor,

--- a/tests/envs/locomotion/go2_arm/test_base_ik.py
+++ b/tests/envs/locomotion/go2_arm/test_base_ik.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from unilab.envs.locomotion.go2_arm.base import Go2ArmBaseCfg, Go2ArmBaseEnv
+from unilab.tasks.locomotion.go2_arm.base import Go2ArmBaseCfg, Go2ArmBaseEnv
 
 
 class _IkHarness(Go2ArmBaseEnv):


### PR DESCRIPTION
## Summary

- move the Go2 Arm shared base into `unilab.tasks.locomotion.go2_arm`
- remove the legacy Go2 Arm package and its registry metadata entry
- atomically update manip-loco, IK tooling, contract tests, and API documentation
- retain public `SimBackend` usage only, without a compatibility shim

Closes #1141
Roadmap: #1042

## Validation

- focused tests: 272 passed (7 deselected)
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`