### PR TITLE
docs(tasks): align G1 task owner paths

### DIFF
--- a/docs/sphinx/source/api_reference/envs/locomotion.md
+++ b/docs/sphinx/source/api_reference/envs/locomotion.md
@@ -7,7 +7,7 @@
    :recursive:
 
    unilab.envs.locomotion.common
-   unilab.envs.locomotion.g1
+   unilab.tasks.locomotion.g1
    unilab.tasks.locomotion.go1
    unilab.tasks.locomotion.go2
    unilab.tasks.locomotion.go2_arm

--- a/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -28,7 +28,7 @@ The shared types live in `src/unilab/dr/types.py`, and the manager lives in
 Representative provider implementations are in:
 
 - `src/unilab/envs/locomotion/go1/joystick.py`
-- `src/unilab/envs/locomotion/g1/joystick.py`
+- `src/unilab/tasks/locomotion/g1/joystick.py`
 - `src/unilab/envs/motion_tracking/g1/tracking.py`
 - `src/unilab/envs/manipulation/allegro_inhand/rotation.py`
 - `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
@@ -100,6 +100,6 @@ payloads.
 - DR types: `src/unilab/dr/types.py`
 - DR manager: `src/unilab/dr/manager.py`
 - Backend interface: `src/unilab/base/backend/base.py`
-- Example providers: `src/unilab/envs/locomotion/g1/joystick.py`,
+- Example providers: `src/unilab/tasks/locomotion/g1/joystick.py`,
   `src/unilab/envs/motion_tracking/g1/tracking.py`,
   `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -27,7 +27,7 @@
 具有代表性的 provider 实现位于：
 
 - `src/unilab/envs/locomotion/go1/joystick.py`
-- `src/unilab/envs/locomotion/g1/joystick.py`
+- `src/unilab/tasks/locomotion/g1/joystick.py`
 - `src/unilab/envs/motion_tracking/g1/tracking.py`
 - `src/unilab/envs/manipulation/allegro_inhand/rotation.py`
 - `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
@@ -90,6 +90,6 @@ actuator 的机制泄漏到共享 payload 里。
 - DR 类型：`src/unilab/dr/types.py`
 - DR manager：`src/unilab/dr/manager.py`
 - Backend 接口：`src/unilab/base/backend/base.py`
-- 示例 provider：`src/unilab/envs/locomotion/g1/joystick.py`、
+- 示例 provider：`src/unilab/tasks/locomotion/g1/joystick.py`、
   `src/unilab/envs/motion_tracking/g1/tracking.py`、
   `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -78,7 +78,7 @@ save_json = _OUTPUT.save_json
 def _install_mjwarp_patch() -> bool:
     """Route ``backend_type == "mjwarp"`` to ``scripts/benchmark/mjwarp`` via factory patch.
 
-    Must run before any task env module (e.g. ``unilab.envs.locomotion.g1.joystick``)
+    Must run before any task env module (e.g. ``unilab.tasks.locomotion.g1.joystick``)
     is imported, because those modules bind ``create_backend`` at module load
     time via ``from unilab.base.backend import create_backend``.
 

--- a/scripts/benchmark/torch_env/walk_flat.py
+++ b/scripts/benchmark/torch_env/walk_flat.py
@@ -3,7 +3,7 @@
 Faithful xp-port of the NumPy computation in the collector-timed sections of
 `uv run train --algo sac --task g1_walk_flat --sim mujoco` (num_envs=2048):
 
-- `G1WalkEnv.update_state` (src/unilab/envs/locomotion/g1/joystick.py):
+- `G1WalkEnv.update_state` (src/unilab/tasks/locomotion/g1/joystick.py):
   termination, `_compute_reward` (9 active terms under the SAC scales incl.
   per-term logging every 4 steps), `_compute_obs` (noise + concat, walk
   profile), and the done-triggered curriculum bookkeeping.


### PR DESCRIPTION
## Summary

- update G1 joystick source references to the `unilab.tasks` owner
- point the locomotion API reference at `unilab.tasks.locomotion.g1`
- align benchmark comments/docstrings without changing executable behavior
- remove all stale G1 joystick legacy-owner text

Closes #1145
Umbrella: #1112
Roadmap: #1042

## Validation

- docs/repository focused tests: 26 passed
- stale-path audit: no G1 joystick legacy owner references
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`