### PR TITLE
docs(tasks): align manipulation owner paths

### DIFF
--- a/docs/sphinx/source/adr/ADR-0004-registry-bootstrap-contract.md
+++ b/docs/sphinx/source/adr/ADR-0004-registry-bootstrap-contract.md
@@ -35,7 +35,7 @@ UniLab 的 env 注册依赖 `@registry.envcfg(...)` 与 `@registry.env(...)` dec
 
 ## Consequences
 
-- 新增 env package 时，需要同步声明 bootstrap modules。
+- 新增 task leaf 时，需要在 `unilab.tasks` 中同步声明 bootstrap module。
 - registry 相关回归可以在 `ensure_registries()` 边界直接测试，不必依赖顶层训练脚本间接发现。
 - 文档可以把 registry bootstrap 作为正式架构引用，而不是“当前实现细节”。
 
@@ -48,7 +48,7 @@ UniLab 的 env 注册依赖 `@registry.envcfg(...)` 与 `@registry.env(...)` dec
 
 - Registry 入口: `src/unilab/base/registry.py`
 - Bootstrap helper: `src/unilab/base/registry.py`
-- Env package 入口: `src/unilab/envs/locomotion/__init__.py`, `src/unilab/envs/motion_tracking/__init__.py`, `src/unilab/envs/manipulation/__init__.py`
+- Task package 入口: `src/unilab/tasks/__init__.py`
 - Bootstrap tests: `tests/utils/test_algo_utils.py`, `tests/base/test_registry.py`
 
 ## Related Documents

--- a/docs/sphinx/source/api_reference/envs/manipulation.md
+++ b/docs/sphinx/source/api_reference/envs/manipulation.md
@@ -1,4 +1,4 @@
-# `unilab.envs.manipulation`
+# `unilab.tasks.manipulation`
 
 ```{eval-rst}
 .. autosummary::
@@ -7,6 +7,6 @@
    :recursive:
 
    unilab.tasks.manipulation.allegro_inhand
-   unilab.envs.manipulation.sharpa_inhand
+   unilab.tasks.manipulation.sharpa_inhand
    unilab.tasks.manipulation.stewart
 ```

--- a/docs/sphinx/source/en/2-user_guide/4-tasks/3-manipulation.md
+++ b/docs/sphinx/source/en/2-user_guide/4-tasks/3-manipulation.md
@@ -1,7 +1,7 @@
 # Manipulation
 
-Manipulation tasks live in `src/unilab/envs/manipulation/` and the Go2 arm
-manip-loco env lives in `src/unilab/envs/locomotion/go2_arm/`.
+Manipulation tasks live in `src/unilab/tasks/manipulation/` and the Go2 arm
+manip-loco env lives in `src/unilab/tasks/locomotion/go2_arm/`.
 
 ## In-Hand
 

--- a/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -31,7 +31,7 @@ Representative provider implementations are in:
 - `src/unilab/tasks/locomotion/g1/joystick.py`
 - `src/unilab/envs/motion_tracking/g1/tracking.py`
 - `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`
-- `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`
+- `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`
 
 Developer contract details are in
 {doc}`../../4-developer_guide/2-contracts/4-dr_contract`.

--- a/docs/sphinx/source/en/3-deployment/1-sim_to_real/4-allegro_inhand.md
+++ b/docs/sphinx/source/en/3-deployment/1-sim_to_real/4-allegro_inhand.md
@@ -69,7 +69,7 @@ to the grasp generator**, retrain, and try again.
 
 The manipulation envs map policy actions to joint position targets through the
 task control config (`src/unilab/tasks/manipulation/allegro_inhand/base.py` and
-`src/unilab/envs/manipulation/sharpa_inhand/base.py`). The deploy controller
+`src/unilab/tasks/manipulation/sharpa_inhand/base.py`). The deploy controller
 must use the same joint order, action scale, and limit policy.
 
 ## Failure recovery

--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/5-registry.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/5-registry.md
@@ -8,11 +8,9 @@ defined by {doc}`/adr/ADR-0004-registry-bootstrap-contract` and implemented in
 
 1. Training entrypoints call `unilab.training.common.ensure_registries()`.
 2. That helper delegates to `unilab.base.registry.ensure_registries()`.
-3. The registry imports declared bootstrap packages:
-   `unilab.envs.locomotion`, `unilab.envs.manipulation`, and
-   `unilab.envs.motion_tracking`.
-4. Each package exposes `__unilab_registry_modules__`, a tuple of modules that
-   contain registration side effects.
+3. The registry imports its sole declared bootstrap package, `unilab.tasks`.
+4. `unilab.tasks` exposes `__unilab_registry_modules__`, an explicit tuple of
+   task leaf modules that contain registration side effects.
 5. Imported modules register configs with `@registry.envcfg(...)` and env
    implementations with `@registry.env(..., sim_backend=...)` or
    `registry.register_env(...)`.
@@ -22,9 +20,8 @@ defined by {doc}`/adr/ADR-0004-registry-bootstrap-contract` and implemented in
 
 ## Extension Rules
 
-- Add new env modules to the package-level `__unilab_registry_modules__` tuple
-  if they live in a new module that is not imported by an existing bootstrap
-  entry.
+- Add new task leaves to `unilab.tasks.__unilab_registry_modules__` when they
+  are not imported by an existing bootstrap entry.
 - Keep registration cheap. Scene materialization, XML processing, asset access,
   and backend construction belong after `registry.make(...)`, not in decorator
   registration.
@@ -35,7 +32,5 @@ defined by {doc}`/adr/ADR-0004-registry-bootstrap-contract` and implemented in
 
 - Bootstrap helper: `src/unilab/base/registry.py`
 - Training helper: `src/unilab/training/common.py`
-- Package declarations: `src/unilab/envs/locomotion/__init__.py`,
-  `src/unilab/envs/manipulation/__init__.py`,
-  `src/unilab/envs/motion_tracking/__init__.py`
+- Task bootstrap declaration: `src/unilab/tasks/__init__.py`
 - Tests: `tests/base/test_registry.py`, `tests/utils/test_algo_utils.py`

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
@@ -102,4 +102,4 @@ payloads.
 - Backend interface: `src/unilab/base/backend/base.py`
 - Example providers: `src/unilab/tasks/locomotion/g1/joystick.py`,
   `src/unilab/envs/motion_tracking/g1/tracking.py`,
-  `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`
+  `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/en/4-developer_guide/8-motrix_contact_sensor.md
+++ b/docs/sphinx/source/en/4-developer_guide/8-motrix_contact_sensor.md
@@ -91,7 +91,7 @@ contact-frame data (one normal scalar plus two tangent scalars).
 
 The env reads tactile force through `_read_tactile_force()` →
 `_extract_sensor_scalar()` in
-`src/unilab/envs/manipulation/sharpa_inhand/base.py`. That helper currently
+`src/unilab/tasks/manipulation/sharpa_inhand/base.py`. That helper currently
 collapses any `(N, >=3)` array with `np.linalg.norm(data[:, :3], axis=1)`.
 
 If the env still routes both backend shapes through that one branch, the
@@ -131,8 +131,8 @@ backend subclass.
 
 | File | Role |
 | --- | --- |
-| `src/unilab/envs/manipulation/sharpa_inhand/base.py` | `_extract_sensor_scalar()`, `_read_tactile_force()` |
-| `src/unilab/envs/manipulation/sharpa_inhand/rotation.py` | reward computation, virtual torque |
+| `src/unilab/tasks/manipulation/sharpa_inhand/base.py` | `_extract_sensor_scalar()`, `_read_tactile_force()` |
+| `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py` | reward computation, virtual torque |
 | `src/unilab/assets/robots/sharpa_wave/right_sharpa_wave.xml` | contact-sensor XML definitions |
 | `src/unilab/base/backend/motrix/backend.py` | Motrix `get_sensor_data()` |
 | `src/unilab/base/backend/mujoco/backend.py` | MuJoCo `get_sensor_data()` |

--- a/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/3-manipulation.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/3-manipulation.md
@@ -1,7 +1,7 @@
 # 操作
 
-操作任务位于 `src/unilab/envs/manipulation/` 中，Go2 机械臂 manip-loco
-env 位于 `src/unilab/envs/locomotion/go2_arm/` 中。
+操作任务位于 `src/unilab/tasks/manipulation/` 中，Go2 机械臂 manip-loco
+env 位于 `src/unilab/tasks/locomotion/go2_arm/` 中。
 
 ## 手内操作
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -30,7 +30,7 @@
 - `src/unilab/tasks/locomotion/g1/joystick.py`
 - `src/unilab/envs/motion_tracking/g1/tracking.py`
 - `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`
-- `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`
+- `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`
 
 开发者 contract 详情见
 {doc}`../../4-developer_guide/2-contracts/4-dr_contract`。

--- a/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/4-allegro_inhand.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/4-allegro_inhand.md
@@ -64,7 +64,7 @@ owner 与部署运行时在观测时序上达成一致。见
 
 操作类环境通过任务控制配置把策略动作映射为关节位置目标
 （`src/unilab/tasks/manipulation/allegro_inhand/base.py` 和
-`src/unilab/envs/manipulation/sharpa_inhand/base.py`）。部署控制器必须使用相同的
+`src/unilab/tasks/manipulation/sharpa_inhand/base.py`）。部署控制器必须使用相同的
 关节顺序、动作缩放与限位策略。
 
 ## 失败恢复

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/5-registry.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/5-registry.md
@@ -8,10 +8,9 @@ Registry bootstrap 是一个针对环境的显式导入契约。它由
 
 1. 训练入口调用 `unilab.training.common.ensure_registries()`。
 2. 该 helper 委托给 `unilab.base.registry.ensure_registries()`。
-3. registry 导入已声明的 bootstrap 包：
-   `unilab.envs.locomotion`、`unilab.envs.manipulation` 与
-   `unilab.envs.motion_tracking`。
-4. 每个包都暴露 `__unilab_registry_modules__`，即一个包含注册副作用的模块元组。
+3. registry 导入唯一声明的 bootstrap 包 `unilab.tasks`。
+4. `unilab.tasks` 暴露 `__unilab_registry_modules__`，即一个包含注册副作用的
+   task leaf module 显式元组。
 5. 被导入的模块通过 `@registry.envcfg(...)` 注册 config，并通过
    `@registry.env(..., sim_backend=...)` 或 `registry.register_env(...)` 注册
    env 实现。
@@ -20,8 +19,8 @@ Registry bootstrap 是一个针对环境的显式导入契约。它由
 
 ## 扩展规则
 
-- 如果新的 env 模块位于某个尚未被现有 bootstrap 条目导入的新模块中，需将其加入
-  包级别的 `__unilab_registry_modules__` 元组。
+- 如果新的 task leaf 尚未被现有 bootstrap 条目导入，需将其加入
+  `unilab.tasks.__unilab_registry_modules__`。
 - 保持注册过程轻量。场景 materialization、XML 处理、资源访问以及 backend 构造
   应放在 `registry.make(...)` 之后，而不是放在装饰器注册中。
 - 重复的 env config 以及重复的 `(env, sim_backend)` 注册会在
@@ -31,7 +30,5 @@ Registry bootstrap 是一个针对环境的显式导入契约。它由
 
 - Bootstrap helper：`src/unilab/base/registry.py`
 - 训练 helper：`src/unilab/training/common.py`
-- 包声明：`src/unilab/envs/locomotion/__init__.py`、
-  `src/unilab/envs/manipulation/__init__.py`、
-  `src/unilab/envs/motion_tracking/__init__.py`
+- Task bootstrap 声明：`src/unilab/tasks/__init__.py`
 - 测试：`tests/base/test_registry.py`、`tests/utils/test_algo_utils.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
@@ -92,4 +92,4 @@ actuator 的机制泄漏到共享 payload 里。
 - Backend 接口：`src/unilab/base/backend/base.py`
 - 示例 provider：`src/unilab/tasks/locomotion/g1/joystick.py`、
   `src/unilab/envs/motion_tracking/g1/tracking.py`、
-  `src/unilab/envs/manipulation/sharpa_inhand/rotation.py`
+  `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/8-motrix_contact_sensor.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/8-motrix_contact_sensor.md
@@ -80,7 +80,7 @@ shape = (num_envs, 1 + 4 * 12) = (num_envs, 49)
 
 ## 单一 norm 分支为何不够
 
-env 通过 `src/unilab/envs/manipulation/sharpa_inhand/base.py` 中的
+env 通过 `src/unilab/tasks/manipulation/sharpa_inhand/base.py` 中的
 `_read_tactile_force()` → `_extract_sensor_scalar()` 读取触觉力。该 helper 目前对任意 `(N, >=3)` 数组都用 `np.linalg.norm(data[:, :3], axis=1)` 折叠。
 
 如果 env 仍把两种后端形状都走这一个分支，MuJoCo 的 `(N, 3)` 是正确的（对真实力向量取 norm），但 Motrix 的 `(N, 4)` 会出错：`data[:, :3]` 取到的是 `[count, fx, fy]`——把接触点数当成了力分量，并且漏掉了 `fz`。正确做法不是在 env 里按形状特判，而是把每个后端的布局知识下沉到 backend 方法。
@@ -104,8 +104,8 @@ env 层的 `_read_tactile_force()` 对 contact sensor 走 `get_contact_force_mag
 
 | 文件 | 说明 |
 | --- | --- |
-| `src/unilab/envs/manipulation/sharpa_inhand/base.py` | `_extract_sensor_scalar()`, `_read_tactile_force()` |
-| `src/unilab/envs/manipulation/sharpa_inhand/rotation.py` | reward 计算，virtual torque |
+| `src/unilab/tasks/manipulation/sharpa_inhand/base.py` | `_extract_sensor_scalar()`, `_read_tactile_force()` |
+| `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py` | reward 计算，virtual torque |
 | `src/unilab/assets/robots/sharpa_wave/right_sharpa_wave.xml` | contact sensor XML 定义 |
 | `src/unilab/base/backend/motrix/backend.py` | Motrix `get_sensor_data()` |
 | `src/unilab/base/backend/mujoco/backend.py` | MuJoCo `get_sensor_data()` |


### PR DESCRIPTION
## Summary

- align all manipulation API, task, provider, deployment, and backend-contract paths with `unilab.tasks`
- update the bilingual registry guide to the actual `ensure_registries() → unilab.tasks → explicit leaf` flow
- update ADR evidence to the sole task bootstrap owner
- remove all documentation claims that `unilab.envs.manipulation` owns concrete tasks

Closes #1153
Umbrella: #1112
Roadmap: #1042

## Validation

- docs/registry focused tests: 56 passed
- docs stale-path audit: no legacy manipulation owner references
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed)
- child remote CI intentionally skipped per #1042 development policy; final commit contains `[skip ci]`