### PR TITLE
refactor(tasks): move G1 box-tracking owner

### DIFF
--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -3,13 +3,6 @@
 __unilab_registry_modules__ = ("unilab.envs.motion_tracking.g1",)
 
 from .g1 import (
-    BoxMotionData,
-    BoxMotionLoader,
-    G1BoxTracking23DofCfg,
-    G1BoxTracking23DofEnvCfg,
-    G1BoxTrackingCfg,
-    G1BoxTrackingEnv,
-    G1BoxTrackingEnvCfg,
     G1ClimbTrackingCfg,
     G1ClimbTrackingEnv,
     G1ClimbTrackingEnvCfg,
@@ -59,11 +52,6 @@ __all__ = [
     "G1ClimbTrackingCfg",
     "G1ClimbTrackingEnv",
     "G1ClimbTrackingEnvCfg",
-    "G1BoxTrackingCfg",
-    "G1BoxTrackingEnv",
-    "G1BoxTrackingEnvCfg",
-    "BoxMotionData",
-    "BoxMotionLoader",
     # 23-DoF variants (from parent UniLab/, under testing)
     "G1MotionTracking23DofCfg",
     "G1MotionTracking23DofDeployEnvCfg",
@@ -79,6 +67,4 @@ __all__ = [
     "G1WallFlipTracking23DofEnvCfg",
     "G1WallFlipTrackingSAC23DofCfg",
     "G1WallFlipTrackingSAC23DofEnv",
-    "G1BoxTracking23DofCfg",
-    "G1BoxTracking23DofEnvCfg",
 ]

--- a/src/unilab/envs/motion_tracking/g1/__init__.py
+++ b/src/unilab/envs/motion_tracking/g1/__init__.py
@@ -1,12 +1,5 @@
 """Motion tracking environments for Unitree G1."""
 
-from .box_tracking import (
-    G1BoxTracking23DofCfg,
-    G1BoxTracking23DofEnvCfg,
-    G1BoxTrackingCfg,
-    G1BoxTrackingEnv,
-    G1BoxTrackingEnvCfg,
-)
 from .flip_tracking import (
     G1ClimbTrackingCfg,
     G1ClimbTrackingEnv,
@@ -32,7 +25,6 @@ from .flip_tracking_sac import (
     G1WallFlipTrackingSACCfg,
     G1WallFlipTrackingSACEnv,
 )
-from .motion_box_loader import BoxMotionData, BoxMotionLoader
 from .tracking import (
     G1MotionTracking23DofCfg,
     G1MotionTracking23DofDeployEnvCfg,
@@ -88,11 +80,4 @@ __all__ = [
     "G1ClimbTrackingCfg",
     "G1ClimbTrackingEnv",
     "G1ClimbTrackingEnvCfg",
-    "G1BoxTracking23DofCfg",
-    "G1BoxTracking23DofEnvCfg",
-    "G1BoxTrackingCfg",
-    "G1BoxTrackingEnv",
-    "G1BoxTrackingEnvCfg",
-    "BoxMotionData",
-    "BoxMotionLoader",
 ]

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -18,6 +18,7 @@ __unilab_registry_modules__ = (
     "unilab.tasks.manipulation.sharpa_inhand",
     "unilab.tasks.manipulation.stewart",
     "unilab.envs.motion_tracking.g1",
+    "unilab.tasks.motion_tracking.g1.box_tracking",
     "unilab.tasks.motion_tracking.x2",
 )
 

--- a/src/unilab/tasks/motion_tracking/__init__.py
+++ b/src/unilab/tasks/motion_tracking/__init__.py
@@ -1,5 +1,14 @@
 """Motion-tracking task packages."""
 
+from .g1 import (
+    BoxMotionData,
+    BoxMotionLoader,
+    G1BoxTracking23DofCfg,
+    G1BoxTracking23DofEnvCfg,
+    G1BoxTrackingCfg,
+    G1BoxTrackingEnv,
+    G1BoxTrackingEnvCfg,
+)
 from .x2 import (
     X2MotionTrackingCfg,
     X2WallFlipTrackingCfg,
@@ -8,6 +17,13 @@ from .x2 import (
 )
 
 __all__ = [
+    "BoxMotionData",
+    "BoxMotionLoader",
+    "G1BoxTracking23DofCfg",
+    "G1BoxTracking23DofEnvCfg",
+    "G1BoxTrackingCfg",
+    "G1BoxTrackingEnv",
+    "G1BoxTrackingEnvCfg",
     "X2MotionTrackingCfg",
     "X2WallFlipTrackingCfg",
     "X2WallFlipTrackingEnv",

--- a/src/unilab/tasks/motion_tracking/g1/__init__.py
+++ b/src/unilab/tasks/motion_tracking/g1/__init__.py
@@ -1,0 +1,20 @@
+"""G1 box-tracking tasks."""
+
+from .box_tracking import (
+    G1BoxTracking23DofCfg,
+    G1BoxTracking23DofEnvCfg,
+    G1BoxTrackingCfg,
+    G1BoxTrackingEnv,
+    G1BoxTrackingEnvCfg,
+)
+from .motion_box_loader import BoxMotionData, BoxMotionLoader
+
+__all__ = [
+    "BoxMotionData",
+    "BoxMotionLoader",
+    "G1BoxTracking23DofCfg",
+    "G1BoxTracking23DofEnvCfg",
+    "G1BoxTrackingCfg",
+    "G1BoxTrackingEnv",
+    "G1BoxTrackingEnvCfg",
+]

--- a/src/unilab/tasks/motion_tracking/g1/box_tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/box_tracking.py
@@ -13,6 +13,13 @@ from unilab.base.scene import SceneCfg
 from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
+from unilab.envs.motion_tracking.common.rewards import RewardContext
+from unilab.envs.motion_tracking.g1.tracking import (
+    G1MotionTrackingCfg,
+    G1MotionTrackingDomainRandomizationProvider,
+    G1MotionTrackingEnv,
+    RewardConfig,
+)
 from unilab.utils.geometry import np_sample_uniform
 from unilab.utils.rotation import (
     np_matrix_from_quat,
@@ -24,14 +31,7 @@ from unilab.utils.rotation import (
     np_subtract_frame_transforms,
 )
 
-from ..common.rewards import RewardContext
 from .motion_box_loader import BoxMotionData, BoxMotionLoader
-from .tracking import (
-    G1MotionTrackingCfg,
-    G1MotionTrackingDomainRandomizationProvider,
-    G1MotionTrackingEnv,
-    RewardConfig,
-)
 
 
 @dataclass
@@ -65,7 +65,9 @@ class G1BoxTrackingCfg(G1MotionTrackingCfg):
     object_body_name: str = "largebox"
     object_pos_threshold: float = 0.25
     object_ori_threshold: float = 0.8
-    reward_config: BoxRewardConfig = field(default_factory=BoxRewardConfig)
+    reward_config: BoxRewardConfig = field(  # pyright: ignore[reportIncompatibleVariableOverride]
+        default_factory=BoxRewardConfig
+    )
 
 
 @registry.envcfg("G1BoxTracking")
@@ -227,7 +229,7 @@ class G1BoxTrackingDomainRandomizationProvider(G1MotionTrackingDomainRandomizati
 class G1BoxTrackingEnv(G1MotionTrackingEnv):
     """Motion tracking env extended with large-box state and rewards."""
 
-    _cfg: G1BoxTrackingCfg
+    _cfg: G1BoxTrackingCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: G1BoxTrackingCfg, num_envs=1, backend_type="mujoco"):
         super().__init__(cfg, num_envs, backend_type)

--- a/src/unilab/tasks/motion_tracking/g1/motion_box_loader.py
+++ b/src/unilab/tasks/motion_tracking/g1/motion_box_loader.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from ..common.motion_loader import MotionData, MotionLoader
+from unilab.envs.motion_tracking.common.motion_loader import MotionData, MotionLoader
 
 
 @dataclass

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -1086,7 +1086,7 @@ def test_g1_motion_tracking_deploy_actor_matches_unitree_mimic_terms():
 
 
 def test_g1_box_tracking_cfg_uses_largebox_scene_and_motion_defaults():
-    from unilab.envs.motion_tracking.g1.box_tracking import BoxRewardConfig, G1BoxTrackingCfg
+    from unilab.tasks.motion_tracking.g1.box_tracking import BoxRewardConfig, G1BoxTrackingCfg
 
     cfg = G1BoxTrackingCfg()
 
@@ -1101,22 +1101,22 @@ def test_g1_box_tracking_cfg_uses_largebox_scene_and_motion_defaults():
 
 
 def test_g1_box_tracking_is_exported_from_g1_and_motion_tracking_packages():
-    from unilab.envs.motion_tracking import (
+    from unilab.tasks.motion_tracking import (
         G1BoxTrackingCfg as TopLevelCfg,
     )
-    from unilab.envs.motion_tracking import (
+    from unilab.tasks.motion_tracking import (
         G1BoxTrackingEnv as TopLevelEnv,
     )
-    from unilab.envs.motion_tracking import (
+    from unilab.tasks.motion_tracking import (
         G1BoxTrackingEnvCfg as TopLevelEnvCfg,
     )
-    from unilab.envs.motion_tracking.g1 import (
+    from unilab.tasks.motion_tracking.g1 import (
         G1BoxTrackingCfg as G1PkgCfg,
     )
-    from unilab.envs.motion_tracking.g1 import (
+    from unilab.tasks.motion_tracking.g1 import (
         G1BoxTrackingEnv as G1PkgEnv,
     )
-    from unilab.envs.motion_tracking.g1 import (
+    from unilab.tasks.motion_tracking.g1 import (
         G1BoxTrackingEnvCfg as G1PkgEnvCfg,
     )
 
@@ -1126,8 +1126,8 @@ def test_g1_box_tracking_is_exported_from_g1_and_motion_tracking_packages():
 
 
 def _compute_g1_box_tracking_obs_stub():
-    from unilab.envs.motion_tracking.g1.box_tracking import G1BoxTrackingEnv
-    from unilab.envs.motion_tracking.g1.motion_box_loader import BoxMotionData
+    from unilab.tasks.motion_tracking.g1.box_tracking import G1BoxTrackingEnv
+    from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionData
 
     env = cast(Any, object.__new__(G1BoxTrackingEnv))
     env._num_envs = 1
@@ -1219,8 +1219,8 @@ def test_g1_box_tracking_actor_matches_deploy_and_critic_adds_object_state():
 
 
 def test_g1_box_tracking_critic_object_state_respects_subset_env_order():
-    from unilab.envs.motion_tracking.g1.box_tracking import G1BoxTrackingEnv
-    from unilab.envs.motion_tracking.g1.motion_box_loader import BoxMotionData
+    from unilab.tasks.motion_tracking.g1.box_tracking import G1BoxTrackingEnv
+    from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionData
 
     env = cast(Any, object.__new__(G1BoxTrackingEnv))
     env._num_envs = 4

--- a/tests/envs/test_motion_loader.py
+++ b/tests/envs/test_motion_loader.py
@@ -185,7 +185,7 @@ def test_motion_sampler_step_respects_current_clip_end(tmp_path):
 
 
 def test_box_motion_loader_reads_object_state_and_trims_robot_joints(tmp_path):
-    from unilab.envs.motion_tracking.g1.motion_box_loader import BoxMotionLoader
+    from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionLoader
 
     motion = tmp_path / "motion_box.npz"
     _write_box_motion_npz(motion, base_value=1.0, num_frames=2, num_joints=2)
@@ -207,7 +207,7 @@ def test_box_motion_loader_reads_object_state_and_trims_robot_joints(tmp_path):
 
 
 def test_box_motion_loader_rejects_partial_object_key_sets(tmp_path):
-    from unilab.envs.motion_tracking.g1.motion_box_loader import BoxMotionLoader
+    from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionLoader
 
     motion = tmp_path / "motion_box_missing_keys.npz"
     _write_box_motion_npz(motion, base_value=1.0, num_frames=2, num_joints=2)
@@ -221,7 +221,7 @@ def test_box_motion_loader_rejects_partial_object_key_sets(tmp_path):
 
 
 def test_box_motion_loader_rejects_multi_clip_object_presence_mismatch(tmp_path):
-    from unilab.envs.motion_tracking.g1.motion_box_loader import BoxMotionLoader
+    from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionLoader
 
     motion_without_object = tmp_path / "motion_without_object.npz"
     motion_with_object = tmp_path / "motion_with_object.npz"

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -22,6 +22,7 @@ _TASK_REGISTRY_MODULES = (
     "unilab.tasks.manipulation.sharpa_inhand",
     "unilab.tasks.manipulation.stewart",
     "unilab.envs.motion_tracking.g1",
+    "unilab.tasks.motion_tracking.g1.box_tracking",
     "unilab.tasks.motion_tracking.x2",
 )
 


### PR DESCRIPTION
Closes #1157

## Summary
- move G1 box-tracking task and object motion loader to `unilab.tasks.motion_tracking.g1`
- switch registry bootstrap and public task exports to the new owner
- remove legacy env exports without compatibility shims or duplicate registration

## Validation
- `uv run pytest -q tests/envs/test_env_configs.py tests/envs/test_motion_loader.py tests/tasks/test_package_boundary.py tests/base/test_backend_conformance.py tests/config/test_locomotion_params.py` (131 passed, 4 skipped, 4 deselected)
- `make test-all` (2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark smoke passed)

Remote CI is intentionally skipped per #1042 development policy; the final head SHA was validated locally.
