### PR TITLE
refactor(tasks): move motion tracking orchestration

### DIFF
--- a/src/unilab/tasks/motion_tracking/common/__init__.py
+++ b/src/unilab/tasks/motion_tracking/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared motion-tracking task engine."""

--- a/src/unilab/tasks/motion_tracking/common/config.py
+++ b/src/unilab/tasks/motion_tracking/common/config.py
@@ -14,8 +14,7 @@ from typing import Literal
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.scene import SceneCfg
 from unilab.envs.locomotion.g1.base import G1BaseCfg
-
-from .rewards import RewardConfig
+from unilab.envs.motion_tracking.common.rewards import RewardConfig
 
 
 @dataclass
@@ -108,7 +107,7 @@ def _zero_velocity_randomization() -> VelocityRandomization:
 class MotionTrackingCfg(G1BaseCfg):
     """Configuration for the motion tracking environment."""
 
-    scene: SceneCfg = field(
+    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default_factory=lambda: SceneCfg(
             model_file=str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
         )
@@ -141,7 +140,7 @@ class MotionTrackingCfg(G1BaseCfg):
     sampling_mode: Literal["start", "clip_start", "uniform", "adaptive", "mixed"] = "adaptive"
     sampling_start_ratio: float = 0.0
     truncate_on_clip_end: bool = False
-    max_episode_seconds: float = 10.0
+    max_episode_seconds: float = 10.0  # pyright: ignore[reportIncompatibleVariableOverride]
     reward_config: RewardConfig = field(default_factory=RewardConfig)
     pose_randomization: PoseRandomization = field(default_factory=PoseRandomization)
     velocity_randomization: VelocityRandomization = field(default_factory=VelocityRandomization)

--- a/src/unilab/tasks/motion_tracking/common/domain_randomization.py
+++ b/src/unilab/tasks/motion_tracking/common/domain_randomization.py
@@ -22,8 +22,7 @@ from unilab.dr.dr_utils import (
 )
 from unilab.dr.types import RESET_TERM_GEOM_FRICTION, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
-
-from .reset import build_motion_reference_state
+from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
 
 
 class MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):

--- a/src/unilab/tasks/motion_tracking/common/tracking.py
+++ b/src/unilab/tasks/motion_tracking/common/tracking.py
@@ -18,21 +18,25 @@ from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.g1.base import G1BaseEnv
+from unilab.envs.motion_tracking.common import observations
+from unilab.envs.motion_tracking.common.motion_loader import MotionData, MotionLoader, MotionSampler
+from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
+from unilab.envs.motion_tracking.common.rewards import (
+    RewardContext,
+    build_reward_functions,
+    compute_reward,
+)
+from unilab.envs.motion_tracking.common.terminations import compute_terminations
+from unilab.envs.motion_tracking.common.transforms import update_relative_transforms
 
-from . import observations
 from .config import MotionTrackingCfg, MotionTrackingDeployEnvCfg
 from .domain_randomization import MotionTrackingDomainRandomizationProvider
-from .motion_loader import MotionData, MotionLoader, MotionSampler
-from .reset import build_motion_reference_state
-from .rewards import RewardContext, build_reward_functions, compute_reward
-from .terminations import compute_terminations
-from .transforms import update_relative_transforms
 
 
 class MotionTrackingEnv(G1BaseEnv):
     """Motion Tracking Environment (robot-agnostic imitation engine)."""
 
-    _cfg: MotionTrackingCfg
+    _cfg: MotionTrackingCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def __init__(self, cfg: MotionTrackingCfg, num_envs=1, backend_type="mujoco"):
         if not cfg.motion_file:
@@ -508,7 +512,7 @@ class MotionTrackingEnv(G1BaseEnv):
 class MotionTrackingDeployEnv(MotionTrackingEnv):
     """Deploy-oriented motion tracking env with unitree_rl_lab mimic actor inputs."""
 
-    _cfg: MotionTrackingDeployEnvCfg
+    _cfg: MotionTrackingDeployEnvCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def _actor_obs_dim(self, n: int) -> int:
         return observations.mimic_actor_obs_dim(n)

--- a/src/unilab/tasks/motion_tracking/g1/flip_tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/flip_tracking.py
@@ -12,11 +12,11 @@ from typing import Literal
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
-from unilab.envs.motion_tracking.common.config import (
+
+from ..common.config import (
     _zero_pose_randomization,
     _zero_velocity_randomization,
 )
-
 from .tracking import (
     G1MotionTrackingCfg,
     G1MotionTrackingEnv,

--- a/src/unilab/tasks/motion_tracking/g1/tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking.py
@@ -1,7 +1,7 @@
 """G1 Motion Tracking profiles — thin registry subclasses over the shared engine.
 
-The robot-agnostic engine and owner modules now live in
-:mod:`unilab.envs.motion_tracking.common`. This module keeps the G1 registry
+The robot-agnostic engine and owner modules live in
+:mod:`unilab.tasks.motion_tracking.common`. This module keeps the G1 registry
 entries (``G1MotionTracking`` / ``G1MotionTrackingDeploy``) and re-exports the
 historical ``G1*`` / ``Domain_Rand`` / ``_build_motion_reference_state`` symbol
 names so existing subclasses and tests keep importing them from ``.tracking``.
@@ -14,7 +14,10 @@ from dataclasses import dataclass, field
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
-from unilab.envs.motion_tracking.common.config import (
+from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
+from unilab.envs.motion_tracking.common.rewards import RewardConfig
+
+from ..common.config import (
     Domain_Rand,
     DomainRand,
     MotionTrackingCfg,
@@ -24,12 +27,10 @@ from unilab.envs.motion_tracking.common.config import (
     _zero_pose_randomization,
     _zero_velocity_randomization,
 )
-from unilab.envs.motion_tracking.common.domain_randomization import (
+from ..common.domain_randomization import (
     MotionTrackingDomainRandomizationProvider,
 )
-from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
-from unilab.envs.motion_tracking.common.rewards import RewardConfig
-from unilab.envs.motion_tracking.common.tracking import (
+from ..common.tracking import (
     MotionTrackingDeployEnv,
     MotionTrackingEnv,
 )

--- a/src/unilab/tasks/motion_tracking/x2/flip_tracking.py
+++ b/src/unilab/tasks/motion_tracking/x2/flip_tracking.py
@@ -9,13 +9,14 @@ from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
 from unilab.envs.locomotion.g1.base import Sensor
-from unilab.envs.motion_tracking.common.config import (
+
+from ..common.config import (
     PoseRandomization,
     VelocityRandomization,
     _zero_pose_randomization,
     _zero_velocity_randomization,
 )
-from unilab.envs.motion_tracking.common.tracking import (
+from ..common.tracking import (
     MotionTrackingDeployEnv,
     MotionTrackingDeployEnvCfg,
 )

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -1393,7 +1393,7 @@ def test_g1_motion_tracking_cfg_preserves_legacy_defaults():
 
 def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatch):
     from unilab.envs.locomotion.g1.base import G1BaseEnv
-    from unilab.envs.motion_tracking.common import tracking as tracking_module
+    from unilab.tasks.motion_tracking.common import tracking as tracking_module
     from unilab.tasks.motion_tracking.g1.tracking import (
         G1MotionTrackingCfg,
         G1MotionTrackingEnv,


### PR DESCRIPTION
Closes #1165

## Summary
- move motion-tracking config, domain-randomization provider, and orchestration engine to `unilab.tasks.motion_tracking.common`
- switch G1/X2 concrete owners and focused tests to the task-owned modules
- keep not-yet-migrated numeric/runtime leaves behind an explicit one-way `tasks → envs` boundary

## Validation
- focused contract/config/motion suite: 300 passed, 4 skipped, 4 deselected
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark smoke passed

Remote CI is intentionally skipped per #1042 development policy; the final head SHA was validated locally.
