### PR TITLE
refactor(tasks): move motion loader and reset owners

### DIFF
--- a/src/unilab/tasks/motion_tracking/common/domain_randomization.py
+++ b/src/unilab/tasks/motion_tracking/common/domain_randomization.py
@@ -22,7 +22,8 @@ from unilab.dr.dr_utils import (
 )
 from unilab.dr.types import RESET_TERM_GEOM_FRICTION, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
+
+from .reset import build_motion_reference_state
 
 
 class MotionTrackingDomainRandomizationProvider(DomainRandomizationProvider):

--- a/src/unilab/tasks/motion_tracking/common/motion_loader.py
+++ b/src/unilab/tasks/motion_tracking/common/motion_loader.py
@@ -1,4 +1,4 @@
-"""Motion loading and sampling for motion tracking tasks."""
+"""Shared motion loading and sampling for motion-tracking tasks."""
 
 from __future__ import annotations
 

--- a/src/unilab/tasks/motion_tracking/common/reset.py
+++ b/src/unilab/tasks/motion_tracking/common/reset.py
@@ -1,4 +1,4 @@
-"""Reset-state construction for motion tracking."""
+"""Shared reset-state construction for motion tracking."""
 
 from __future__ import annotations
 

--- a/src/unilab/tasks/motion_tracking/common/tracking.py
+++ b/src/unilab/tasks/motion_tracking/common/tracking.py
@@ -19,8 +19,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.g1.base import G1BaseEnv
 from unilab.envs.motion_tracking.common import observations
-from unilab.envs.motion_tracking.common.motion_loader import MotionData, MotionLoader, MotionSampler
-from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
 from unilab.envs.motion_tracking.common.rewards import (
     RewardContext,
     build_reward_functions,
@@ -31,6 +29,8 @@ from unilab.envs.motion_tracking.common.transforms import update_relative_transf
 
 from .config import MotionTrackingCfg, MotionTrackingDeployEnvCfg
 from .domain_randomization import MotionTrackingDomainRandomizationProvider
+from .motion_loader import MotionData, MotionLoader, MotionSampler
+from .reset import build_motion_reference_state
 
 
 class MotionTrackingEnv(G1BaseEnv):

--- a/src/unilab/tasks/motion_tracking/g1/motion_box_loader.py
+++ b/src/unilab/tasks/motion_tracking/g1/motion_box_loader.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from unilab.envs.motion_tracking.common.motion_loader import MotionData, MotionLoader
+from ..common.motion_loader import MotionData, MotionLoader
 
 
 @dataclass

--- a/src/unilab/tasks/motion_tracking/g1/tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
-from unilab.envs.motion_tracking.common.reset import build_motion_reference_state
 from unilab.envs.motion_tracking.common.rewards import RewardConfig
 
 from ..common.config import (
@@ -30,6 +29,7 @@ from ..common.config import (
 from ..common.domain_randomization import (
     MotionTrackingDomainRandomizationProvider,
 )
+from ..common.reset import build_motion_reference_state
 from ..common.tracking import (
     MotionTrackingDeployEnv,
     MotionTrackingEnv,

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -619,7 +619,7 @@ def test_g1_motion_tracking_uses_combined_body_pose_query():
 
 
 def test_g1_motion_tracking_reset_observation_uses_sparse_body_pose_rows():
-    from unilab.envs.motion_tracking.common.motion_loader import MotionData
+    from unilab.tasks.motion_tracking.common.motion_loader import MotionData
     from unilab.tasks.motion_tracking.g1.tracking import (
         G1MotionTrackingDomainRandomizationProvider,
     )
@@ -700,7 +700,7 @@ def test_g1_motion_tracking_reset_observation_uses_sparse_body_pose_rows():
 
 
 def _compute_g1_motion_tracking_obs_stub(env_cls: type):
-    from unilab.envs.motion_tracking.common.motion_loader import MotionData
+    from unilab.tasks.motion_tracking.common.motion_loader import MotionData
 
     env = cast(Any, object.__new__(env_cls))
     env._num_envs = 1
@@ -904,7 +904,7 @@ def test_g1_motion_tracking_relative_transform_fast_path_matches_reference():
 
 
 def test_g1_motion_tracking_reward_fast_path_matches_reference():
-    from unilab.envs.motion_tracking.common.motion_loader import MotionData
+    from unilab.tasks.motion_tracking.common.motion_loader import MotionData
     from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnv, RewardConfig
     from unilab.utils.rotation import np_quat_error_magnitude
 
@@ -1804,7 +1804,7 @@ def _make_g1_motion_tracking_clip_end_stub(
     step_env_ids: np.ndarray | None = None,
 ):
     from unilab.base.np_env import NpEnvState
-    from unilab.envs.motion_tracking.common.motion_loader import MotionData
+    from unilab.tasks.motion_tracking.common.motion_loader import MotionData
     from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnv
 
     class FakeBackend:

--- a/tests/envs/test_motion_loader.py
+++ b/tests/envs/test_motion_loader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from unilab.envs.motion_tracking.common.motion_loader import MotionLoader, MotionSampler
+from unilab.tasks.motion_tracking.common.motion_loader import MotionLoader, MotionSampler
 
 
 def _write_motion_npz(


### PR DESCRIPTION
Closes #1167

## Summary
- move motion loader/sampler and reference-reset helpers to `unilab.tasks.motion_tracking.common`
- switch task engine, DR, G1 core/box, and test consumers to the task-owned modules
- preserve motion schemas, sampler behavior, buffer reuse, and reset semantics

## Validation
- focused loader/config/contract suite: 292 passed, 4 skipped, 4 deselected
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark smoke passed

Remote CI is intentionally skipped per #1042 development policy; the final head SHA was validated locally.
