### PR TITLE
refactor(tasks): finish motion tracking common owner

### DIFF
--- a/src/unilab/envs/motion_tracking/__init__.py
+++ b/src/unilab/envs/motion_tracking/__init__.py
@@ -1,1 +1,0 @@
-"""Shared motion-tracking runtime package."""

--- a/src/unilab/envs/motion_tracking/common/__init__.py
+++ b/src/unilab/envs/motion_tracking/common/__init__.py
@@ -1,8 +1,0 @@
-"""Robot-agnostic motion-tracking engine and owner modules.
-
-This package holds the motion-tracking task engine (:class:`MotionTrackingEnv`
-/ :class:`MotionTrackingDeployEnv`) and its per-concern owner modules (config,
-rewards, observations, terminations, transforms, reset, domain randomization,
-motion loading). Per-robot profiles live under ``g1/`` and
-``x2/`` and only carry robot-specific defaults and thin registry subclasses.
-"""

--- a/src/unilab/tasks/motion_tracking/common/__init__.py
+++ b/src/unilab/tasks/motion_tracking/common/__init__.py
@@ -1,1 +1,7 @@
-"""Shared motion-tracking task engine."""
+"""Shared motion-tracking task engine and owner modules.
+
+This package holds the motion-tracking task engine and its per-concern owner
+modules: config, rewards, observations, terminations, transforms, reset,
+domain randomization, and motion loading. Per-robot profiles live under
+``g1/`` and ``x2/`` and contain robot-specific defaults and registry leaves.
+"""

--- a/src/unilab/tasks/motion_tracking/common/config.py
+++ b/src/unilab/tasks/motion_tracking/common/config.py
@@ -14,7 +14,8 @@ from typing import Literal
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.scene import SceneCfg
 from unilab.envs.locomotion.g1.base import G1BaseCfg
-from unilab.envs.motion_tracking.common.rewards import RewardConfig
+
+from .rewards import RewardConfig
 
 
 @dataclass

--- a/src/unilab/tasks/motion_tracking/common/observations.py
+++ b/src/unilab/tasks/motion_tracking/common/observations.py
@@ -1,4 +1,4 @@
-"""Observation construction for motion tracking.
+"""Shared observation construction for motion tracking.
 
 Holds the robot-agnostic observation builders. The environment classes keep a
 thin polymorphic method surface (``_compute_obs`` / ``_build_actor_obs`` /

--- a/src/unilab/tasks/motion_tracking/common/rewards.py
+++ b/src/unilab/tasks/motion_tracking/common/rewards.py
@@ -1,4 +1,4 @@
-"""Reward configuration and reward functions for motion tracking.
+"""Shared reward configuration and functions for motion tracking.
 
 Reward terms are plain module-level callables ``fn(ctx: RewardContext) -> np.ndarray``
 mirroring :mod:`unilab.envs.locomotion.common.rewards`. Robot-specific terms that

--- a/src/unilab/tasks/motion_tracking/common/terminations.py
+++ b/src/unilab/tasks/motion_tracking/common/terminations.py
@@ -1,4 +1,4 @@
-"""Termination computation for motion tracking."""
+"""Shared termination computation for motion tracking."""
 
 from __future__ import annotations
 

--- a/src/unilab/tasks/motion_tracking/common/tracking.py
+++ b/src/unilab/tasks/motion_tracking/common/tracking.py
@@ -18,19 +18,19 @@ from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.g1.base import G1BaseEnv
-from unilab.envs.motion_tracking.common import observations
-from unilab.envs.motion_tracking.common.rewards import (
-    RewardContext,
-    build_reward_functions,
-    compute_reward,
-)
-from unilab.envs.motion_tracking.common.terminations import compute_terminations
-from unilab.envs.motion_tracking.common.transforms import update_relative_transforms
 
+from . import observations
 from .config import MotionTrackingCfg, MotionTrackingDeployEnvCfg
 from .domain_randomization import MotionTrackingDomainRandomizationProvider
 from .motion_loader import MotionData, MotionLoader, MotionSampler
 from .reset import build_motion_reference_state
+from .rewards import (
+    RewardContext,
+    build_reward_functions,
+    compute_reward,
+)
+from .terminations import compute_terminations
+from .transforms import update_relative_transforms
 
 
 class MotionTrackingEnv(G1BaseEnv):

--- a/src/unilab/tasks/motion_tracking/common/transforms.py
+++ b/src/unilab/tasks/motion_tracking/common/transforms.py
@@ -1,4 +1,4 @@
-"""Relative body-transform computation for motion tracking.
+"""Shared relative body-transform computation for motion tracking.
 
 Fills the environment's ``body_pos_relative_w`` / ``body_quat_relative_w``
 reference buffers each step. The op order and in-place ``out=`` usage are

--- a/src/unilab/tasks/motion_tracking/g1/box_tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/box_tracking.py
@@ -13,7 +13,6 @@ from unilab.base.scene import SceneCfg
 from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.motion_tracking.common.rewards import RewardContext
 from unilab.utils.geometry import np_sample_uniform
 from unilab.utils.rotation import (
     np_matrix_from_quat,
@@ -25,6 +24,7 @@ from unilab.utils.rotation import (
     np_subtract_frame_transforms,
 )
 
+from ..common.rewards import RewardContext
 from .motion_box_loader import BoxMotionData, BoxMotionLoader
 from .tracking import (
     G1MotionTrackingCfg,

--- a/src/unilab/tasks/motion_tracking/g1/tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
-from unilab.envs.motion_tracking.common.rewards import RewardConfig
 
 from ..common.config import (
     Domain_Rand,
@@ -30,6 +29,7 @@ from ..common.domain_randomization import (
     MotionTrackingDomainRandomizationProvider,
 )
 from ..common.reset import build_motion_reference_state
+from ..common.rewards import RewardConfig
 from ..common.tracking import (
     MotionTrackingDeployEnv,
     MotionTrackingEnv,

--- a/src/unilab/tasks/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking_obs.py
@@ -44,8 +44,8 @@ from unilab.dr.dr_utils import (
 from unilab.dr.types import RESET_TERM_GEOM_FRICTION
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.g1.base import NoiseConfig
-from unilab.envs.motion_tracking.common.rewards import RewardContext
 
+from ..common.rewards import RewardContext
 from .tracking import (
     Domain_Rand,
     G1MotionTrackingDomainRandomizationProvider,

--- a/tests/envs/test_motion_tracking_rewards.py
+++ b/tests/envs/test_motion_tracking_rewards.py
@@ -10,8 +10,8 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from unilab.envs.motion_tracking.common import rewards
-from unilab.envs.motion_tracking.common.rewards import RewardConfig, RewardContext
+from unilab.tasks.motion_tracking.common import rewards
+from unilab.tasks.motion_tracking.common.rewards import RewardConfig, RewardContext
 
 
 def _make_ctx(*, scales: dict[str, float] | None = None) -> RewardContext:


### PR DESCRIPTION
Closes #1169

## Summary
- move the remaining observation, reward, termination, and transform leaves to `unilab.tasks.motion_tracking.common`
- switch all shared/G1/test consumers to the task-owned modules
- remove the now-empty legacy `unilab.envs.motion_tracking` source package

## Validation
- focused motion/config/contract suite: 300 passed, 4 skipped, 4 deselected
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark smoke passed

Remote CI is intentionally skipped per #1042 development policy; the final head SHA was validated locally.
