### PR TITLE
refactor(tasks): move G1 shared base owner

### DIFF
--- a/src/unilab/envs/locomotion/g1/__init__.py
+++ b/src/unilab/envs/locomotion/g1/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy G1 shared base pending motion-tracking migration."""

--- a/src/unilab/tasks/locomotion/g1/base.py
+++ b/src/unilab/tasks/locomotion/g1/base.py
@@ -1,3 +1,5 @@
+"""Shared runtime and configuration for G1 task owners."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -45,14 +47,16 @@ class Asset:
 class G1BaseCfg(LocomotionBaseCfg):
     noise_config: NoiseConfig = field(default_factory=NoiseConfig)  # type: ignore[assignment]
     control_config: ControlConfig = field(default_factory=ControlConfig)  # type: ignore[assignment]
-    sensor: Sensor = field(default_factory=Sensor)
+    sensor: Sensor = field(  # pyright: ignore[reportIncompatibleVariableOverride]
+        default_factory=Sensor
+    )
     asset: Asset = field(default_factory=Asset)
     sim_dt: float = 0.02 / 3.0
     ctrl_dt: float = 0.02
 
 
 class G1BaseEnv(LocomotionBaseEnv):
-    _cfg: G1BaseCfg
+    _cfg: G1BaseCfg  # pyright: ignore[reportIncompatibleVariableOverride]
     _keyframe_name = "stand"
     _use_global_dtype = False
 

--- a/src/unilab/tasks/locomotion/g1/joystick.py
+++ b/src/unilab/tasks/locomotion/g1/joystick.py
@@ -25,7 +25,8 @@ from unilab.envs.locomotion.common.commands import (
 from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv
+
+from .base import G1BaseCfg, G1BaseEnv
 
 
 @dataclass

--- a/src/unilab/tasks/motion_tracking/common/config.py
+++ b/src/unilab/tasks/motion_tracking/common/config.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base.scene import SceneCfg
-from unilab.envs.locomotion.g1.base import G1BaseCfg
+from unilab.tasks.locomotion.g1.base import G1BaseCfg
 
 from .rewards import RewardConfig
 

--- a/src/unilab/tasks/motion_tracking/common/tracking.py
+++ b/src/unilab/tasks/motion_tracking/common/tracking.py
@@ -17,7 +17,7 @@ import numpy as np
 from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.g1.base import G1BaseEnv
+from unilab.tasks.locomotion.g1.base import G1BaseEnv
 
 from . import observations
 from .config import MotionTrackingCfg, MotionTrackingDeployEnvCfg

--- a/src/unilab/tasks/motion_tracking/g1/tracking_obs.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking_obs.py
@@ -43,7 +43,7 @@ from unilab.dr.dr_utils import (
 )
 from unilab.dr.types import RESET_TERM_GEOM_FRICTION
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.g1.base import NoiseConfig
+from unilab.tasks.locomotion.g1.base import NoiseConfig
 
 from ..common.rewards import RewardContext
 from .tracking import (

--- a/src/unilab/tasks/motion_tracking/x2/flip_tracking.py
+++ b/src/unilab/tasks/motion_tracking/x2/flip_tracking.py
@@ -8,7 +8,7 @@ from typing import Literal
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
-from unilab.envs.locomotion.g1.base import Sensor
+from unilab.tasks.locomotion.g1.base import Sensor
 
 from ..common.config import (
     PoseRandomization,

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -1392,7 +1392,7 @@ def test_g1_motion_tracking_cfg_preserves_legacy_defaults():
 
 
 def test_g1_motion_tracking_init_delegates_motion_body_ids_to_backend(monkeypatch):
-    from unilab.envs.locomotion.g1.base import G1BaseEnv
+    from unilab.tasks.locomotion.g1.base import G1BaseEnv
     from unilab.tasks.motion_tracking.common import tracking as tracking_module
     from unilab.tasks.motion_tracking.g1.tracking import (
         G1MotionTrackingCfg,

--- a/tests/envs/test_g1_obs_noise.py
+++ b/tests/envs/test_g1_obs_noise.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from unilab.envs.locomotion.g1.base import G1BaseCfg, G1BaseEnv, NoiseConfig
+from unilab.tasks.locomotion.g1.base import G1BaseCfg, G1BaseEnv, NoiseConfig
 
 
 class _ConcreteG1Env(G1BaseEnv):


### PR DESCRIPTION
## Summary

- move the G1 locomotion shared base into `unilab.tasks.locomotion.g1`
- switch joystick, motion-tracking, and direct-test consumers to the task-owned path
- remove the empty legacy `unilab.envs.locomotion.g1` package

Tracks #1171
Roadmap: #1042

## Validation

- focused gate: 317 passed, 4 skipped, 4 deselected
- `uv run ruff check`: passed
- `uv run mypy`: passed
- `uv run pyright`: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran locally.