### PR TITLE
refactor(tasks): move locomotion manager terms

### DIFF
--- a/conf/appo/task/go2_joystick_flat/base.yaml
+++ b/conf/appo/task/go2_joystick_flat/base.yaml
@@ -67,7 +67,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
@@ -99,7 +99,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
@@ -178,29 +178,29 @@ env:
 reward:
   tracking_lin_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_lin_vel_xy_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_ang_vel_z_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.lin_vel_z_l2
+    func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.ang_vel_xy_l2
+    func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.base_height_l2
+    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
@@ -210,7 +210,7 @@ reward:
     weight: -0.005
   similar_to_default:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.joint_deviation_l1
+    func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   alive:
     _target_: unilab.managers.RewardTermCfg
@@ -218,7 +218,7 @@ reward:
     weight: 0.0
   contact:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_contact
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
       frequency: 2.0
@@ -231,7 +231,7 @@ reward:
       stance_threshold: 0.6
   swing_feet_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_swing_height
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:
       frequency: 2.0

--- a/conf/offpolicy/task/go2_joystick_flat/base.yaml
+++ b/conf/offpolicy/task/go2_joystick_flat/base.yaml
@@ -67,7 +67,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
@@ -99,7 +99,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
@@ -178,29 +178,29 @@ env:
 reward:
   tracking_lin_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_lin_vel_xy_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_ang_vel_z_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.lin_vel_z_l2
+    func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.ang_vel_xy_l2
+    func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.base_height_l2
+    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
@@ -210,11 +210,11 @@ reward:
     weight: -0.005
   similar_to_default:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.joint_deviation_l1
+    func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_contact
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
       frequency: 2.0
@@ -227,7 +227,7 @@ reward:
       stance_threshold: 0.6
   swing_feet_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_swing_height
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:
       frequency: 2.0

--- a/conf/ppo/task/go2_joystick_flat/base.yaml
+++ b/conf/ppo/task/go2_joystick_flat/base.yaml
@@ -67,7 +67,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
@@ -99,7 +99,7 @@ env:
             command_name: twist
         gait_phase:
           _target_: unilab.managers.ObservationTermCfg
-          func: unilab.envs.locomotion.common.manager_terms.quadruped_gait_phase
+          func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
@@ -178,29 +178,29 @@ env:
 reward:
   tracking_lin_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_lin_vel_xy_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.track_ang_vel_z_exp
+    func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.lin_vel_z_l2
+    func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.ang_vel_xy_l2
+    func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.base_height_l2
+    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
@@ -210,11 +210,11 @@ reward:
     weight: -0.005
   similar_to_default:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.joint_deviation_l1
+    func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_contact
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
       frequency: 2.0
@@ -227,7 +227,7 @@ reward:
       stance_threshold: 0.6
   swing_feet_z:
     _target_: unilab.managers.RewardTermCfg
-    func: unilab.envs.locomotion.common.manager_terms.feet_phase_swing_height
+    func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:
       frequency: 2.0

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared task-specific locomotion components."""

--- a/src/unilab/tasks/locomotion/common/manager_terms.py
+++ b/src/unilab/tasks/locomotion/common/manager_terms.py
@@ -1,4 +1,4 @@
-"""Task-owned Manager-Based terms for the quadruped locomotion pilots.
+"""Task-owned Manager-Based terms for quadruped locomotion.
 
 The equations come from UniLab's existing Go1/Go2 joystick tasks.  The adaptation
 uses community ``func + params`` terms, NumPy, and the base-owned sensor facade.

--- a/tests/envs/locomotion/test_manager_gait_terms.py
+++ b/tests/envs/locomotion/test_manager_gait_terms.py
@@ -11,7 +11,6 @@ import pytest
 
 from unilab.base.backend.base import BackendSensorView
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import manager_terms
 from unilab.managers import (
     ObservationGroupCfg,
     ObservationManager,
@@ -21,6 +20,7 @@ from unilab.managers import (
 )
 from unilab.managers._types import ManagerBasedRlEnv
 from unilab.managers.scene_entity_config import SceneEntityCfg
+from unilab.tasks.locomotion.common import manager_terms
 
 CONTACTS = ("fl_contact", "fr_contact", "rl_contact", "rr_contact")
 POSITIONS = ("fl_pos", "fr_pos", "rl_pos", "rr_pos")


### PR DESCRIPTION
## Summary

- move locomotion-specific Manager-Based gait/reward terms into `unilab.tasks.locomotion.common`
- switch all Go2 production Hydra owners to the task-owned callable path
- remove the old env-owned module without a shim

Tracks #1173
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 239 passed, 4 skipped, 4 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.