### PR TITLE
refactor(tasks): move locomotion DR config

### DIFF
--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -6,7 +6,6 @@ from .base import (
     PdControlConfig,
     Sensor,
 )
-from .domain_rand import DomainRandConfig
 from .dr_provider import LocomotionDRProvider
 from .height_scan import (
     DEFAULT_SCAN_POINTS_X,
@@ -20,7 +19,6 @@ __all__ = [
     "ControlConfigBase",
     "DEFAULT_SCAN_POINTS_X",
     "DEFAULT_SCAN_POINTS_Y",
-    "DomainRandConfig",
     "HeightScanConfig",
     "LocomotionBaseCfg",
     "LocomotionBaseEnv",

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -7,9 +7,11 @@ from .commands import (
     sample_velocity_commands,
     zero_small_xy_commands,
 )
+from .domain_rand import DomainRandConfig
 
 __all__ = [
     "Commands",
+    "DomainRandConfig",
     "apply_heading_yaw_feedback",
     "sample_heading_commands",
     "sample_velocity_commands",

--- a/src/unilab/tasks/locomotion/common/domain_rand.py
+++ b/src/unilab/tasks/locomotion/common/domain_rand.py
@@ -1,3 +1,5 @@
+"""Shared domain-randomization config for locomotion tasks."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/unilab/tasks/locomotion/g1/joystick.py
+++ b/src/unilab/tasks/locomotion/g1/joystick.py
@@ -17,7 +17,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import (
@@ -25,6 +24,7 @@ from unilab.tasks.locomotion.common.commands import (
     sample_heading_commands,
     zero_small_xy_commands,
 )
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 
 from .base import G1BaseCfg, G1BaseEnv
 

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -12,7 +12,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
@@ -20,6 +19,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainSpawnManager,
 )
 from unilab.tasks.locomotion.common.commands import Commands
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -15,7 +15,6 @@ from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.height_scan import (
     HeightScanConfig,
     base_height_from_scan,
@@ -34,6 +33,7 @@ from unilab.tasks.locomotion.common.commands import (
     sample_heading_commands,
     zero_small_xy_commands,
 )
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go1.base import ControlConfig
 from unilab.tasks.locomotion.go1.joystick import (
     Go1JoystickCfg,

--- a/src/unilab/tasks/locomotion/go2/footstand.py
+++ b/src/unilab/tasks/locomotion/go2/footstand.py
@@ -13,10 +13,10 @@ from unilab.base.scene import SceneCfg
 from unilab.dr import ResetPlan, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import Commands
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go2.base import ControlConfig, Go2BaseCfg, Go2BaseEnv, NoiseConfig
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse
 

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -13,7 +13,6 @@ from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.base import Sensor
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
@@ -25,6 +24,7 @@ from unilab.envs.manager_based_rl_env import (
     make_manager_based_rl_env,
 )
 from unilab.tasks.locomotion.common.commands import Commands
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -13,10 +13,10 @@ from unilab.base.scene import SceneCfg
 from unilab.dr.types import ResetPlan
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import Commands
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go2_arm.base import (
     Go2ArmBaseCfg,
     Go2ArmBaseEnv,

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -18,7 +18,6 @@ from unilab.dr.dr_utils import (
 )
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.domain_rand import DomainRandConfig
 from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import (
@@ -29,6 +28,7 @@ from unilab.tasks.locomotion.common.commands import (
 from unilab.tasks.locomotion.common.commands import (
     sample_heading_commands as sample_go2w_heading_commands,
 )
+from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.go2w.base import (
     DEFAULT_GO2W_ANGLES,
     NUM_GO2W_ACTIONS,


### PR DESCRIPTION
## Summary

- move the shared locomotion domain-randomization config into `unilab.tasks.locomotion.common`
- switch every active locomotion consumer to the task-owned path
- remove the env-owned module and export without a shim

Tracks #1177
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 301 passed, 4 skipped, 15 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.