### PR TITLE
refactor(tasks): move locomotion DR provider

### DIFF
--- a/docs/sphinx/source/en/3-deployment/1-sim_to_real/6-domain_randomization.md
+++ b/docs/sphinx/source/en/3-deployment/1-sim_to_real/6-domain_randomization.md
@@ -45,7 +45,7 @@ range in the task owner only after recording why that range is plausible.
 Tasks that use DR attach a provider through the env initialization path:
 
 ```python
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 
 class MyTaskEnv(NpEnv):
     def __init__(self, cfg):

--- a/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/6-domain_randomization.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/6-domain_randomization.md
@@ -43,7 +43,7 @@
 使用 DR 的任务通过环境初始化路径挂接一个 provider：
 
 ```python
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 
 class MyTaskEnv(NpEnv):
     def __init__(self, cfg):

--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -6,7 +6,6 @@ from .base import (
     PdControlConfig,
     Sensor,
 )
-from .dr_provider import LocomotionDRProvider
 from .height_scan import (
     DEFAULT_SCAN_POINTS_X,
     DEFAULT_SCAN_POINTS_Y,
@@ -22,7 +21,6 @@ __all__ = [
     "HeightScanConfig",
     "LocomotionBaseCfg",
     "LocomotionBaseEnv",
-    "LocomotionDRProvider",
     "PdControlConfig",
     "RewardContext",
     "Sensor",

--- a/src/unilab/tasks/locomotion/a2/joystick.py
+++ b/src/unilab/tasks/locomotion/a2/joystick.py
@@ -24,9 +24,9 @@ from unilab.base import registry
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import sample_commands_with_standing
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go2.base import Asset, ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (
     Go2DomainRandConfig,

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -8,10 +8,12 @@ from .commands import (
     zero_small_xy_commands,
 )
 from .domain_rand import DomainRandConfig
+from .dr_provider import LocomotionDRProvider
 
 __all__ = [
     "Commands",
     "DomainRandConfig",
+    "LocomotionDRProvider",
     "apply_heading_yaw_feedback",
     "sample_heading_commands",
     "sample_velocity_commands",

--- a/src/unilab/tasks/locomotion/common/dr_provider.py
+++ b/src/unilab/tasks/locomotion/common/dr_provider.py
@@ -1,4 +1,4 @@
-"""Shared DomainRandomizationProvider for locomotion environments.
+"""Shared DomainRandomizationProvider for locomotion tasks.
 
 Implements the common reset/interval randomization logic shared by
 G1, Go1, and Go2 joystick environments.  Subclasses override hooks

--- a/src/unilab/tasks/locomotion/g1/joystick.py
+++ b/src/unilab/tasks/locomotion/g1/joystick.py
@@ -17,7 +17,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import (
     Commands,
@@ -25,6 +24,7 @@ from unilab.tasks.locomotion.common.commands import (
     zero_small_xy_commands,
 )
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 
 from .base import G1BaseCfg, G1BaseEnv
 

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -12,7 +12,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
@@ -20,6 +19,7 @@ from unilab.envs.locomotion.common.terrain_spawn import (
 )
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go2/footstand.py
+++ b/src/unilab/tasks/locomotion/go2/footstand.py
@@ -13,10 +13,10 @@ from unilab.base.scene import SceneCfg
 from unilab.dr import ResetPlan, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go2.base import ControlConfig, Go2BaseCfg, Go2BaseEnv, NoiseConfig
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse
 

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -13,7 +13,6 @@ from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.base import Sensor
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
@@ -25,6 +24,7 @@ from unilab.envs.manager_based_rl_env import (
 )
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -13,10 +13,10 @@ from unilab.base.scene import SceneCfg
 from unilab.dr.types import ResetPlan
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go2_arm.base import (
     Go2ArmBaseCfg,
     Go2ArmBaseEnv,

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -18,7 +18,6 @@ from unilab.dr.dr_utils import (
 )
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.commands import (
     Commands,
@@ -29,6 +28,7 @@ from unilab.tasks.locomotion.common.commands import (
     sample_heading_commands as sample_go2w_heading_commands,
 )
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
 from unilab.tasks.locomotion.go2w.base import (
     DEFAULT_GO2W_ANGLES,
     NUM_GO2W_ACTIONS,


### PR DESCRIPTION
## Summary

- move the locomotion-specific DR provider into `unilab.tasks.locomotion.common`
- switch every active task consumer and both documentation languages
- remove the env-owned module/export without a shim while retaining the public DR/SimBackend boundary

Tracks #1179
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 172 passed, 4 skipped, 15 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.