### PR TITLE
refactor(tasks): move locomotion height scan

### DIFF
--- a/docs/sphinx/source/en/4-developer_guide/3-extending/4-new_terrain.md
+++ b/docs/sphinx/source/en/4-developer_guide/3-extending/4-new_terrain.md
@@ -35,4 +35,4 @@ materialization out of `step()`, `reset()`, and hot domain-randomization loops.
 - Terrain configs and presets: `src/unilab/terrains/config.py`
 - Terrain generator: `src/unilab/terrains/terrain_generator.py`
 - Heightfield terrain types: `src/unilab/terrains/heightfield_terrains.py`
-- Height-scan helper: `src/unilab/envs/locomotion/common/height_scan.py`
+- Height-scan helper: `src/unilab/tasks/locomotion/common/height_scan.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/4-new_terrain.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/4-new_terrain.md
@@ -35,4 +35,4 @@
 - 地形配置与 preset：`src/unilab/terrains/config.py`
 - 地形生成器：`src/unilab/terrains/terrain_generator.py`
 - Heightfield 地形类型：`src/unilab/terrains/heightfield_terrains.py`
-- 高度扫描辅助工具：`src/unilab/envs/locomotion/common/height_scan.py`
+- 高度扫描辅助工具：`src/unilab/tasks/locomotion/common/height_scan.py`

--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -6,19 +6,11 @@ from .base import (
     PdControlConfig,
     Sensor,
 )
-from .height_scan import (
-    DEFAULT_SCAN_POINTS_X,
-    DEFAULT_SCAN_POINTS_Y,
-    HeightScanConfig,
-)
 from .rewards import RewardContext
 
 __all__ = [
     "BaseNoiseConfig",
     "ControlConfigBase",
-    "DEFAULT_SCAN_POINTS_X",
-    "DEFAULT_SCAN_POINTS_Y",
-    "HeightScanConfig",
     "LocomotionBaseCfg",
     "LocomotionBaseEnv",
     "PdControlConfig",

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -9,10 +9,18 @@ from .commands import (
 )
 from .domain_rand import DomainRandConfig
 from .dr_provider import LocomotionDRProvider
+from .height_scan import (
+    DEFAULT_SCAN_POINTS_X,
+    DEFAULT_SCAN_POINTS_Y,
+    HeightScanConfig,
+)
 
 __all__ = [
     "Commands",
+    "DEFAULT_SCAN_POINTS_X",
+    "DEFAULT_SCAN_POINTS_Y",
     "DomainRandConfig",
+    "HeightScanConfig",
     "LocomotionDRProvider",
     "apply_heading_yaw_feedback",
     "sample_heading_commands",

--- a/src/unilab/tasks/locomotion/common/height_scan.py
+++ b/src/unilab/tasks/locomotion/common/height_scan.py
@@ -1,4 +1,4 @@
-"""Shared height-scan and terrain-bound helpers for rough locomotion envs.
+"""Shared height-scan and terrain-bound helpers for rough locomotion tasks.
 
 These functions and the ``HeightScanConfig`` dataclass are consumed by Go2,
 Go2W, Go1, and G1 rough environments — anywhere the policy / critic ingests

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -15,14 +15,6 @@ from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.height_scan import (
-    HeightScanConfig,
-    base_height_from_scan,
-    height_scan_obs,
-    init_height_scan_sensor,
-    raw_height_scan_obs,
-    terrain_out_of_bounds,
-)
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
@@ -34,6 +26,14 @@ from unilab.tasks.locomotion.common.commands import (
     zero_small_xy_commands,
 )
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
+from unilab.tasks.locomotion.common.height_scan import (
+    HeightScanConfig,
+    base_height_from_scan,
+    height_scan_obs,
+    init_height_scan_sensor,
+    raw_height_scan_obs,
+    terrain_out_of_bounds,
+)
 from unilab.tasks.locomotion.go1.base import ControlConfig
 from unilab.tasks.locomotion.go1.joystick import (
     Go1JoystickCfg,

--- a/src/unilab/tasks/locomotion/go2/rough.py
+++ b/src/unilab/tasks/locomotion/go2/rough.py
@@ -13,7 +13,13 @@ from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.height_scan import (
+from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common.commands import (
+    apply_heading_yaw_feedback,
+    sample_heading_commands,
+    zero_small_xy_commands,
+)
+from unilab.tasks.locomotion.common.height_scan import (
     DEFAULT_SCAN_POINTS_X,
     DEFAULT_SCAN_POINTS_Y,
     HeightScanConfig,
@@ -22,12 +28,6 @@ from unilab.envs.locomotion.common.height_scan import (
     init_height_scan_sensor,
     raw_height_scan_obs,
     terrain_out_of_bounds,
-)
-from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.tasks.locomotion.common.commands import (
-    apply_heading_yaw_feedback,
-    sample_heading_commands,
-    zero_small_xy_commands,
 )
 from unilab.tasks.locomotion.go2.base import ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (

--- a/src/unilab/tasks/locomotion/go2w/rough.py
+++ b/src/unilab/tasks/locomotion/go2w/rough.py
@@ -13,14 +13,6 @@ from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.height_scan import (
-    HeightScanConfig,
-    base_height_from_scan,
-    height_scan_obs,
-    init_height_scan_sensor,
-    raw_height_scan_obs,
-    terrain_out_of_bounds,
-)
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
@@ -30,6 +22,14 @@ from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
     zero_small_xy_commands,
+)
+from unilab.tasks.locomotion.common.height_scan import (
+    HeightScanConfig,
+    base_height_from_scan,
+    height_scan_obs,
+    init_height_scan_sensor,
+    raw_height_scan_obs,
+    terrain_out_of_bounds,
 )
 from unilab.tasks.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
 from unilab.tasks.locomotion.go2w.joystick import (

--- a/tests/envs/locomotion/test_go2_rough_height_scan.py
+++ b/tests/envs/locomotion/test_go2_rough_height_scan.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 
-from unilab.envs.locomotion.common.height_scan import height_scan_offsets as _height_scan_offsets
+from unilab.tasks.locomotion.common.height_scan import height_scan_offsets as _height_scan_offsets
 from unilab.tasks.locomotion.go2.rough import Go2JoystickRoughEnv
 
 


### PR DESCRIPTION
## Summary

- move rough-locomotion height-scan helpers into `unilab.tasks.locomotion.common`
- switch Go1/Go2/Go2W rough tasks, the focused test, and both terrain docs
- remove the env-owned module/export without a shim while retaining cached public-backend access

Tracks #1181
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 162 passed, 4 skipped, 4 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.