### PR TITLE
refactor(tasks): move locomotion shared base

### DIFF
--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -9,7 +9,7 @@ mostly mechanical.
 
 | Legged Gym | UniLab |
 |---|---|
-| `LeggedRobot` env class | `unilab.envs.locomotion.common.base` |
+| `LeggedRobot` env class | `unilab.tasks.locomotion.common.base` |
 | `compute_observations()` | env-side obs builder + `unilab.base.observations` |
 | `_reward_*` methods | env's `compute_reward()` + reward term registry |
 | `command_ranges` | task owner YAML's `commands` block |

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -8,7 +8,7 @@ Legged Gym 曾是那套 GPU 常驻的 PPO 模板，教会了整个领域如何�
 
 | Legged Gym | UniLab |
 |---|---|
-| `LeggedRobot` env 类 | `unilab.envs.locomotion.common.base` |
+| `LeggedRobot` env 类 | `unilab.tasks.locomotion.common.base` |
 | `compute_observations()` | env 侧 obs 构建器 + `unilab.base.observations` |
 | `_reward_*` 方法 | env 的 `compute_reward()` + reward 项 registry |
 | `command_ranges` | 任务 owner YAML 的 `commands` 块 |

--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -1,19 +1,5 @@
-from .base import (
-    BaseNoiseConfig,
-    ControlConfigBase,
-    LocomotionBaseCfg,
-    LocomotionBaseEnv,
-    PdControlConfig,
-    Sensor,
-)
 from .rewards import RewardContext
 
 __all__ = [
-    "BaseNoiseConfig",
-    "ControlConfigBase",
-    "LocomotionBaseCfg",
-    "LocomotionBaseEnv",
-    "PdControlConfig",
     "RewardContext",
-    "Sensor",
 ]

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -1,5 +1,13 @@
 """Shared task-specific locomotion components."""
 
+from .base import (
+    BaseNoiseConfig,
+    ControlConfigBase,
+    LocomotionBaseCfg,
+    LocomotionBaseEnv,
+    PdControlConfig,
+    Sensor,
+)
 from .commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -16,12 +24,18 @@ from .height_scan import (
 )
 
 __all__ = [
+    "BaseNoiseConfig",
     "Commands",
+    "ControlConfigBase",
     "DEFAULT_SCAN_POINTS_X",
     "DEFAULT_SCAN_POINTS_Y",
     "DomainRandConfig",
     "HeightScanConfig",
     "LocomotionDRProvider",
+    "LocomotionBaseCfg",
+    "LocomotionBaseEnv",
+    "PdControlConfig",
+    "Sensor",
     "apply_heading_yaw_feedback",
     "sample_heading_commands",
     "sample_velocity_commands",

--- a/src/unilab/tasks/locomotion/common/base.py
+++ b/src/unilab/tasks/locomotion/common/base.py
@@ -1,3 +1,5 @@
+"""Shared base environment and configuration for legacy locomotion tasks."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/unilab/tasks/locomotion/g1/base.py
+++ b/src/unilab/tasks/locomotion/g1/base.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     BaseNoiseConfig,
     ControlConfigBase,
     LocomotionBaseCfg,
     LocomotionBaseEnv,
 )
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     Sensor as LocomotionSensor,
 )
 

--- a/src/unilab/tasks/locomotion/go1/base.py
+++ b/src/unilab/tasks/locomotion/go1/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     BaseNoiseConfig,
     LocomotionBaseCfg,
     LocomotionBaseEnv,

--- a/src/unilab/tasks/locomotion/go2/base.py
+++ b/src/unilab/tasks/locomotion/go2/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     BaseNoiseConfig,
     LocomotionBaseCfg,
     LocomotionBaseEnv,

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -12,7 +12,6 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.base import Sensor
 from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
@@ -22,6 +21,7 @@ from unilab.envs.manager_based_rl_env import (
     ManagerBasedRlEnvCfg,
     make_manager_based_rl_env,
 )
+from unilab.tasks.locomotion.common.base import Sensor
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider

--- a/src/unilab/tasks/locomotion/go2_arm/base.py
+++ b/src/unilab/tasks/locomotion/go2_arm/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from unilab.base.backend import SimBackend
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     ControlConfigBase,
     LocomotionBaseCfg,
     LocomotionBaseEnv,

--- a/src/unilab/tasks/locomotion/go2w/base.py
+++ b/src/unilab/tasks/locomotion/go2w/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 import gymnasium as gym
 import numpy as np
 
-from unilab.envs.locomotion.common.base import (
+from unilab.tasks.locomotion.common.base import (
     BaseNoiseConfig,
     LocomotionBaseCfg,
     LocomotionBaseEnv,

--- a/tests/envs/locomotion/a2/test_a2_joystick_contract.py
+++ b/tests/envs/locomotion/a2/test_a2_joystick_contract.py
@@ -135,7 +135,7 @@ def test_a2_control_config_per_joint_gains():
 
 def test_pd_control_config_position_gains_default_is_scalar():
     """Base PdControlConfig keeps the scalar gain contract (Go2 path unchanged)."""
-    from unilab.envs.locomotion.common.base import PdControlConfig
+    from unilab.tasks.locomotion.common.base import PdControlConfig
 
     gains = PdControlConfig(Kp=35.0, Kd=0.5).position_gains()
     assert gains == {"kp": 35.0, "kd": 0.5}


### PR DESCRIPTION
## Summary

- move the legacy locomotion env/config/control/noise base into `unilab.tasks.locomotion.common`
- switch all active robot-family consumers, the direct test, and both migration docs
- remove the env-owned module/export without a shim; its temporary terrain-spawn dependency remains in the allowed tasks-to-envs direction until the next child

Tracks #1183
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 187 passed, 4 skipped, 15 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.