### PR TITLE
refactor(tasks): move locomotion terrain spawn

### DIFF
--- a/src/unilab/tasks/locomotion/common/base.py
+++ b/src/unilab/tasks/locomotion/common/base.py
@@ -12,7 +12,7 @@ from unilab.base.backend import SimBackend
 from unilab.base.base import EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common.terrain_spawn import BaseSpawnManager
+from unilab.tasks.locomotion.common.terrain_spawn import BaseSpawnManager
 
 
 @dataclass

--- a/src/unilab/tasks/locomotion/common/terrain_spawn.py
+++ b/src/unilab/tasks/locomotion/common/terrain_spawn.py
@@ -1,4 +1,4 @@
-"""Spawn-origin managers for locomotion envs.
+"""Spawn-origin managers for locomotion tasks.
 
 ``BaseSpawnManager`` is a no-op default: every env spawns at the world origin
 (plus the existing per-env xy jitter from the dr_provider). Used whenever the

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -13,13 +13,13 @@ from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.common.terrain_spawn import (
-    TerrainCurriculumCfg,
-    TerrainSpawnManager,
-)
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.terrain_spawn import (
+    TerrainCurriculumCfg,
+    TerrainSpawnManager,
+)
 from unilab.tasks.locomotion.go1.base import Go1BaseCfg, Go1BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -16,9 +16,6 @@ from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.common.terrain_spawn import (
-    TerrainCurriculumCfg,
-)
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -33,6 +30,9 @@ from unilab.tasks.locomotion.common.height_scan import (
     init_height_scan_sensor,
     raw_height_scan_obs,
     terrain_out_of_bounds,
+)
+from unilab.tasks.locomotion.common.terrain_spawn import (
+    TerrainCurriculumCfg,
 )
 from unilab.tasks.locomotion.go1.base import ControlConfig
 from unilab.tasks.locomotion.go1.joystick import (

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -13,10 +13,6 @@ from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.common.terrain_spawn import (
-    TerrainCurriculumCfg,
-    TerrainSpawnManager,
-)
 from unilab.envs.manager_based_rl_env import (
     ManagerBasedRlEnvCfg,
     make_manager_based_rl_env,
@@ -25,6 +21,10 @@ from unilab.tasks.locomotion.common.base import Sensor
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.terrain_spawn import (
+    TerrainCurriculumCfg,
+    TerrainSpawnManager,
+)
 from unilab.tasks.locomotion.go2.base import Go2BaseCfg, Go2BaseEnv
 
 

--- a/src/unilab/tasks/locomotion/go2w/rough.py
+++ b/src/unilab/tasks/locomotion/go2w/rough.py
@@ -14,10 +14,6 @@ from unilab.dr.dr_utils import zero_actions
 from unilab.dtype_config import get_global_dtype
 from unilab.envs.locomotion.common import rewards
 from unilab.envs.locomotion.common.rewards import RewardContext
-from unilab.envs.locomotion.common.terrain_spawn import (
-    TerrainCurriculumCfg,
-    TerrainSpawnManager,
-)
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -30,6 +26,10 @@ from unilab.tasks.locomotion.common.height_scan import (
     init_height_scan_sensor,
     raw_height_scan_obs,
     terrain_out_of_bounds,
+)
+from unilab.tasks.locomotion.common.terrain_spawn import (
+    TerrainCurriculumCfg,
+    TerrainSpawnManager,
 )
 from unilab.tasks.locomotion.go2w.base import NUM_GO2W_ACTIONS, NUM_LEG_ACTIONS
 from unilab.tasks.locomotion.go2w.joystick import (

--- a/tests/envs/locomotion/go2w/test_go2w_motor_control.py
+++ b/tests/envs/locomotion/go2w/test_go2w_motor_control.py
@@ -107,7 +107,7 @@ def test_go2w_backend_reset_randomization_excludes_kp_kd_payload() -> None:
 
 
 def test_go2w_reset_plan_can_disable_initial_yaw_randomization() -> None:
-    from unilab.envs.locomotion.common.terrain_spawn import BaseSpawnManager
+    from unilab.tasks.locomotion.common.terrain_spawn import BaseSpawnManager
 
     cfg = Go2WJoystickCfg(reward_config=_reward_config())
     cfg.domain_rand.randomize_init_yaw = False

--- a/tests/envs/locomotion/test_go2_terrain_spawn.py
+++ b/tests/envs/locomotion/test_go2_terrain_spawn.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from unilab.envs.locomotion.common.terrain_spawn import (
+from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )
@@ -52,7 +52,7 @@ def test_terrain_spawn_attached_when_rough():
         assert terrain_data.terrain_origins.shape == (3, 3, 3)
         assert not terrain_data.terrain_origins.flags.writeable
         assert _class_path(env._spawn) == (
-            "unilab.envs.locomotion.common.terrain_spawn.TerrainSpawnManager"
+            "unilab.tasks.locomotion.common.terrain_spawn.TerrainSpawnManager"
         )
         assert env._scene_terrain_origins is not None
         assert env._scene_terrain_origins.shape == (3, 3, 3)
@@ -76,7 +76,7 @@ def test_terrain_spawn_attached_when_rough_motrix():
         assert terrain_data.terrain_origins.shape == (3, 3, 3)
         assert not terrain_data.terrain_origins.flags.writeable
         assert _class_path(env._spawn) == (
-            "unilab.envs.locomotion.common.terrain_spawn.TerrainSpawnManager"
+            "unilab.tasks.locomotion.common.terrain_spawn.TerrainSpawnManager"
         )
         assert env._scene_terrain_origins is not None
         assert env._scene_terrain_origins.shape == (3, 3, 3)
@@ -240,7 +240,7 @@ def test_default_spawn_used_when_flat():
     try:
         assert env._backend.get_terrain_spawn_data() is None
         assert _class_path(env._spawn) == (
-            "unilab.envs.locomotion.common.terrain_spawn.BaseSpawnManager"
+            "unilab.tasks.locomotion.common.terrain_spawn.BaseSpawnManager"
         )
         assert env._scene_terrain_origins is None
         # Origins are zeros (flat scene needs no spread; per-env xy jitter still applies).
@@ -359,7 +359,7 @@ def test_episode_start_recorded_after_reset(preset):
     try:
         env.init_state()
         sm = env._spawn
-        if _class_path(sm) == "unilab.envs.locomotion.common.terrain_spawn.TerrainSpawnManager":
+        if _class_path(sm) == "unilab.tasks.locomotion.common.terrain_spawn.TerrainSpawnManager":
             assert np.all(sm._has_started)
     finally:
         env.close()

--- a/tests/envs/locomotion/test_terrain_spawn.py
+++ b/tests/envs/locomotion/test_terrain_spawn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from unilab.envs.locomotion.common.terrain_spawn import (
+from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,
 )


### PR DESCRIPTION
## Summary

- move terrain-spawn and curriculum managers into `unilab.tasks.locomotion.common`
- switch all task/test consumers and full class-path assertions
- remove the env-owned module without a shim while retaining the read-only public backend terrain contract

Tracks #1185
Umbrella: #1112
Roadmap: #1042

## Validation

- focused gate: 161 passed, 4 skipped, 4 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.