### PR TITLE
refactor(tasks): finish locomotion common rewards

### DIFF
--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/6-reward_porting.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/6-reward_porting.md
@@ -38,7 +38,7 @@ Notes:
 
 - UniLab's `state` carries `prev_contact` so you don't need to manage
   edge detection yourself. See
-  `unilab.envs.locomotion.common.rewards`.
+  `unilab.tasks.locomotion.common.rewards`.
 
 ## Pattern: action smoothness penalty
 
@@ -47,7 +47,7 @@ def reward_action_rate(self, state):
     return -np.sum((state.action - state.prev_action) ** 2, axis=1)
 ```
 
-Already a stock helper in `unilab.envs.locomotion.common.rewards`.
+Already a stock helper in `unilab.tasks.locomotion.common.rewards`.
 
 ## Pattern: posture penalty
 
@@ -77,4 +77,4 @@ def reward_termination(self, state):
 
 - {doc}`5-task_config_translation`
 - `unilab.training.reward`
-- `unilab.envs.locomotion.common.rewards`
+- `unilab.tasks.locomotion.common.rewards`

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/6-reward_porting.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/6-reward_porting.md
@@ -37,7 +37,7 @@ def reward_feet_air_time(self, state):
 注意：
 
 - UniLab 的 `state` 携带了 `prev_contact`，因此你无需自己管理边沿检测。参见
-  `unilab.envs.locomotion.common.rewards`。
+  `unilab.tasks.locomotion.common.rewards`。
 
 ## 模式：动作平滑惩罚
 
@@ -46,7 +46,7 @@ def reward_action_rate(self, state):
     return -np.sum((state.action - state.prev_action) ** 2, axis=1)
 ```
 
-它已经是 `unilab.envs.locomotion.common.rewards` 中的现成辅助函数。
+它已经是 `unilab.tasks.locomotion.common.rewards` 中的现成辅助函数。
 
 ## 模式：姿态惩罚
 
@@ -75,4 +75,4 @@ def reward_termination(self, state):
 
 - {doc}`5-task_config_translation`
 - `unilab.training.reward`
-- `unilab.envs.locomotion.common.rewards`
+- `unilab.tasks.locomotion.common.rewards`

--- a/src/unilab/envs/locomotion/common/__init__.py
+++ b/src/unilab/envs/locomotion/common/__init__.py
@@ -1,5 +1,0 @@
-from .rewards import RewardContext
-
-__all__ = [
-    "RewardContext",
-]

--- a/src/unilab/tasks/locomotion/a2/joystick.py
+++ b/src/unilab/tasks/locomotion/a2/joystick.py
@@ -23,10 +23,10 @@ from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import sample_commands_with_standing
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2.base import Asset, ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (
     Go2DomainRandConfig,

--- a/src/unilab/tasks/locomotion/common/__init__.py
+++ b/src/unilab/tasks/locomotion/common/__init__.py
@@ -22,6 +22,7 @@ from .height_scan import (
     DEFAULT_SCAN_POINTS_Y,
     HeightScanConfig,
 )
+from .rewards import RewardContext
 
 __all__ = [
     "BaseNoiseConfig",
@@ -35,6 +36,7 @@ __all__ = [
     "LocomotionBaseCfg",
     "LocomotionBaseEnv",
     "PdControlConfig",
+    "RewardContext",
     "Sensor",
     "apply_heading_yaw_feedback",
     "sample_heading_commands",

--- a/src/unilab/tasks/locomotion/common/rewards.py
+++ b/src/unilab/tasks/locomotion/common/rewards.py
@@ -1,4 +1,4 @@
-"""Shared reward functions for locomotion environments.
+"""Shared reward functions for locomotion tasks.
 
 Introduces ``RewardContext`` — a dataclass that bundles all state any
 reward function might need.  Shared reward functions are plain

--- a/src/unilab/tasks/locomotion/g1/joystick.py
+++ b/src/unilab/tasks/locomotion/g1/joystick.py
@@ -16,8 +16,7 @@ from unilab.base.curriculum import EpisodeLengthTracker, PenaltyCurriculum
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     sample_heading_commands,
@@ -25,6 +24,7 @@ from unilab.tasks.locomotion.common.commands import (
 )
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 
 from .base import G1BaseCfg, G1BaseEnv
 

--- a/src/unilab/tasks/locomotion/go1/joystick.py
+++ b/src/unilab/tasks/locomotion/go1/joystick.py
@@ -11,11 +11,11 @@ from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,

--- a/src/unilab/tasks/locomotion/go1/rough.py
+++ b/src/unilab/tasks/locomotion/go1/rough.py
@@ -14,8 +14,7 @@ from unilab.base.scene import SceneCfg, TerrainSceneCfg
 from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -31,6 +30,7 @@ from unilab.tasks.locomotion.common.height_scan import (
     raw_height_scan_obs,
     terrain_out_of_bounds,
 )
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
 )

--- a/src/unilab/tasks/locomotion/go2/footstand.py
+++ b/src/unilab/tasks/locomotion/go2/footstand.py
@@ -12,11 +12,11 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr import ResetPlan, ResetRandomizationPayload
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2.base import ControlConfig, Go2BaseCfg, Go2BaseEnv, NoiseConfig
 from unilab.utils.rotation import np_quat_apply, np_quat_apply_inverse
 

--- a/src/unilab/tasks/locomotion/go2/joystick.py
+++ b/src/unilab/tasks/locomotion/go2/joystick.py
@@ -11,16 +11,16 @@ from unilab.base.backend import create_backend, env_backend_kwargs
 from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
 from unilab.envs.manager_based_rl_env import (
     ManagerBasedRlEnvCfg,
     make_manager_based_rl_env,
 )
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.base import Sensor
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,

--- a/src/unilab/tasks/locomotion/go2/rough.py
+++ b/src/unilab/tasks/locomotion/go2/rough.py
@@ -12,8 +12,7 @@ from unilab.base.scene import SceneCfg, TerrainSceneCfg
 from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization, zero_actions
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     apply_heading_yaw_feedback,
     sample_heading_commands,
@@ -29,6 +28,7 @@ from unilab.tasks.locomotion.common.height_scan import (
     raw_height_scan_obs,
     terrain_out_of_bounds,
 )
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2.base import ControlConfig
 from unilab.tasks.locomotion.go2.joystick import (
     Commands,

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -12,11 +12,11 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import ResetPlan
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2_arm.base import (
     Go2ArmBaseCfg,
     Go2ArmBaseEnv,

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -17,8 +17,7 @@ from unilab.dr.dr_utils import (
     zero_actions,
 )
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -29,6 +28,7 @@ from unilab.tasks.locomotion.common.commands import (
 )
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
 from unilab.tasks.locomotion.common.dr_provider import LocomotionDRProvider
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2w.base import (
     DEFAULT_GO2W_ANGLES,
     NUM_GO2W_ACTIONS,

--- a/src/unilab/tasks/locomotion/go2w/rough.py
+++ b/src/unilab/tasks/locomotion/go2w/rough.py
@@ -12,8 +12,7 @@ from unilab.base.scene import SceneCfg, TerrainSceneCfg
 from unilab.dr import DomainRandomizationManager, ResetPlan
 from unilab.dr.dr_utils import zero_actions
 from unilab.dtype_config import get_global_dtype
-from unilab.envs.locomotion.common import rewards
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     Commands,
     apply_heading_yaw_feedback,
@@ -27,6 +26,7 @@ from unilab.tasks.locomotion.common.height_scan import (
     raw_height_scan_obs,
     terrain_out_of_bounds,
 )
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.common.terrain_spawn import (
     TerrainCurriculumCfg,
     TerrainSpawnManager,

--- a/src/unilab/tasks/motion_tracking/common/rewards.py
+++ b/src/unilab/tasks/motion_tracking/common/rewards.py
@@ -1,7 +1,7 @@
 """Shared reward configuration and functions for motion tracking.
 
 Reward terms are plain module-level callables ``fn(ctx: RewardContext) -> np.ndarray``
-mirroring :mod:`unilab.envs.locomotion.common.rewards`. Robot-specific terms that
+mirroring :mod:`unilab.tasks.locomotion.common.rewards`. Robot-specific terms that
 live on env subclasses (box-object / joint-effort terms) are stored in the same
 ``_reward_fns`` dispatch table as bound methods and are called with the same
 ``ctx`` argument.

--- a/tests/envs/locomotion/a2/test_a2_joystick_contract.py
+++ b/tests/envs/locomotion/a2/test_a2_joystick_contract.py
@@ -440,7 +440,7 @@ def test_a2_cfg_reward_config_annotation_is_a2_type():
 
 
 def _a2_ctx(commands, dof_pos=None):
-    from unilab.envs.locomotion.common.rewards import RewardContext
+    from unilab.tasks.locomotion.common.rewards import RewardContext
 
     n = commands.shape[0]
     return RewardContext(

--- a/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
+++ b/tests/envs/locomotion/go2_arm/test_manip_loco_contract.py
@@ -183,7 +183,7 @@ def test_go2_arm_command_postprocess_can_force_zero_commands():
 
 def test_go2_arm_stand_still_reward_uses_same_command_mask():
     """stand_still should not penalize leg pose under lateral, yaw, or forward commands."""
-    from unilab.envs.locomotion.common.rewards import RewardContext
+    from unilab.tasks.locomotion.common.rewards import RewardContext
     from unilab.tasks.locomotion.go2_arm.manip_loco import Go2ArmManipLocoEnv
 
     env = object.__new__(Go2ArmManipLocoEnv)

--- a/tests/envs/locomotion/test_go2_footstand.py
+++ b/tests/envs/locomotion/test_go2_footstand.py
@@ -7,7 +7,7 @@ from unilab.base import registry
 from unilab.base.np_env import NpEnvState
 from unilab.base.registry import ensure_registries
 from unilab.dr import ResetRandomizationPayload
-from unilab.envs.locomotion.common.rewards import RewardContext
+from unilab.tasks.locomotion.common.rewards import RewardContext
 from unilab.tasks.locomotion.go2.footstand import (
     FootstandControlConfig,
     FootstandSensor,

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -243,7 +243,7 @@ def test_g1_walk_env_reward_dispatch_restores_motrix_terms():
 
 
 def test_g1_walk_env_feet_phase_reward_is_gated_by_forward_speed():
-    from unilab.envs.locomotion.common.rewards import RewardContext
+    from unilab.tasks.locomotion.common.rewards import RewardContext
     from unilab.tasks.locomotion.g1.joystick import G1WalkEnv
 
     class FakeBackend:


### PR DESCRIPTION
## Summary

- move the final shared locomotion reward context/functions/dispatch into `unilab.tasks.locomotion.common`
- switch every locomotion/motion-tracking source consumer, direct test, and bilingual reward-porting reference
- delete the now-empty env-owned common package without a shim

Tracks #1187
Umbrella: #1112
Roadmap: #1042

## Change classification

- task migration + cleanup exception: 20 files
- source-derived/mechanical move: 374 lines
- UniLab-specific new behavior: 0 lines
- deleted package-only lines: 5

## Validation

- focused gate: 185 passed, 4 skipped, 15 deselected
- ruff, mypy, and pyright: passed
- `make test-all`: 2077 passed, 27 skipped, 276 deselected, 1 xfailed; benchmark import smoke passed (32/33 module-mode and 33/34 script-mode, MLX-only entries skipped)

## CI policy

Remote CI is intentionally skipped with `[skip ci]` under the approved #1042 child-PR workflow; the complete gate ran on the final local commit.