### PR TITLE
refactor(tasks): remove legacy env task packages

### DIFF
--- a/src/unilab/envs/locomotion/__init__.py
+++ b/src/unilab/envs/locomotion/__init__.py
@@ -1,3 +1,0 @@
-"""Generic locomotion environment components."""
-
-__unilab_registry_modules__: tuple[str, ...] = ()

--- a/src/unilab/envs/manipulation/__init__.py
+++ b/src/unilab/envs/manipulation/__init__.py
@@ -1,3 +1,0 @@
-"""Generic manipulation environment components."""
-
-__unilab_registry_modules__: tuple[str, ...] = ()

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -10,6 +10,7 @@ from unilab.tasks import __unilab_registry_modules__
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ENV_PACKAGE = _REPO_ROOT / "src" / "unilab" / "envs"
+_CONCRETE_TASK_PACKAGES = ("locomotion", "manipulation", "motion_tracking")
 
 _TASK_REGISTRY_MODULES = (
     "unilab.tasks.locomotion.go1",
@@ -51,3 +52,13 @@ def test_env_runtime_does_not_depend_on_tasks() -> None:
     ]
 
     assert violations == [], "unilab.envs must not import concrete unilab.tasks modules"
+
+
+def test_env_runtime_does_not_own_concrete_task_packages() -> None:
+    violations = [
+        path.relative_to(_REPO_ROOT).as_posix()
+        for package in _CONCRETE_TASK_PACKAGES
+        for path in sorted((_ENV_PACKAGE / package).rglob("*.py"))
+    ]
+
+    assert violations == [], "concrete task source must be owned by unilab.tasks"

--- a/tests/utils/test_algo_utils.py
+++ b/tests/utils/test_algo_utils.py
@@ -53,7 +53,7 @@ class TestEnsureRegistries:
         # Use real package + fake optional package
         with caplog.at_level(logging.WARNING):
             ensure_registries(
-                ["unilab.envs.locomotion", "nonexistent_optional_12345"],
+                ["unilab.tasks.locomotion", "nonexistent_optional_12345"],
                 optional_packages=["nonexistent_optional_12345"],
             )
 


### PR DESCRIPTION
## Summary

- remove the final empty concrete-task packages from `unilab.envs`
- point the registry bootstrap test at the task-owned namespace
- enforce that concrete task families cannot regain Python source under `unilab.envs`

Refs #1189
Umbrella: #1112
Roadmap: #1042

## Contract impact

No registry names, Hydra owners, environment lifecycle, backend behavior, or task behavior change. The dependency remains `tasks → envs`; no compatibility shim or fallback is introduced.

## Validation

- `uv run pytest -q tests/tasks/test_package_boundary.py tests/utils/test_algo_utils.py` (21 passed)
- `make test-all` (2078 passed, 27 skipped, 276 deselected, 1 xfailed; ruff, mypy, pyright, coverage, and benchmark import smoke passed)

Remote child CI is intentionally skipped under the #1042 development policy; the final dev-to-main PR retains the normal remote CI gate.
