### PR TITLE
docs(tasks): update locomotion owner paths

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/4-tasks/1-locomotion.md
+++ b/docs/sphinx/source/en/2-user_guide/4-tasks/1-locomotion.md
@@ -1,7 +1,7 @@
 # Locomotion
 
-Locomotion tasks are registered in `src/unilab/envs/locomotion/` and
-`src/unilab/envs/motion_tracking/`. The available owner YAMLs under `conf/`
+Locomotion tasks are registered in `src/unilab/tasks/locomotion/` and
+`src/unilab/tasks/motion_tracking/`. The available owner YAMLs under `conf/`
 define which algorithm and backend combinations are runnable.
 
 ## Families
@@ -33,7 +33,7 @@ backend: {doc}`../../5-reference/5-support_matrix`.
 
 - PPO config: `conf/ppo/task/go2_footstand/mujoco.yaml`
 - Registered env: `Go2FootStand` (registered for `sim_backend="mujoco"`)
-- Implementation: `src/unilab/envs/locomotion/go2/footstand.py`
+- Implementation: `src/unilab/tasks/locomotion/go2/footstand.py`
   (extends the Go2 base task)
 - Go2 model XML: `src/unilab/assets/robots/go2/go2.xml`
 

--- a/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/en/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -27,9 +27,9 @@ The shared types live in `src/unilab/dr/types.py`, and the manager lives in
 
 Representative provider implementations are in:
 
-- `src/unilab/envs/locomotion/go1/joystick.py`
+- `src/unilab/tasks/locomotion/go1/joystick.py`
 - `src/unilab/tasks/locomotion/g1/joystick.py`
-- `src/unilab/envs/motion_tracking/g1/tracking.py`
+- `src/unilab/tasks/motion_tracking/g1/tracking.py`
 - `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`
 - `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`
 

--- a/docs/sphinx/source/en/2-user_guide/6-terrain/2-heightfield_import.md
+++ b/docs/sphinx/source/en/2-user_guide/6-terrain/2-heightfield_import.md
@@ -10,7 +10,7 @@ example is `Go2JoystickRough`, with owners in
 
 - `src/unilab/terrains/heightfield_terrains.py`
 - `src/unilab/terrains/terrain_generator.py`
-- `src/unilab/envs/locomotion/go2/rough.py`
+- `src/unilab/tasks/locomotion/go2/rough.py`
 - `src/unilab/base/backend/mujoco/xml.py`
 - `src/unilab/base/backend/motrix/scene.py`
 

--- a/docs/sphinx/source/en/2-user_guide/7-tooling/5-robot_import.md
+++ b/docs/sphinx/source/en/2-user_guide/7-tooling/5-robot_import.md
@@ -44,7 +44,7 @@ where possible.
   only for position-control owners.
   - If the robot must preserve torque/motor actuator semantics, later task
     extension should follow the control pattern in
-    `src/unilab/envs/locomotion/go2w/`: keep action interpretation, PD/torque
+    `src/unilab/tasks/locomotion/go2w/`: keep action interpretation, PD/torque
     control, and the actuator contract inside the robot owner boundary.
 - After conversion, `mujoco.viewer` opens automatically to show the converted
   result and proceed to keyframe adjustment.

--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -32,7 +32,7 @@ mostly mechanical.
 ## Migration checklist
 
 1. Copy your URDF / MJCF assets under `src/unilab/assets/robots/<robot>/`.
-2. Create a task module under `src/unilab/envs/locomotion/<robot>/`.
+2. Create a task module under `src/unilab/tasks/locomotion/<robot>/`.
 3. Mirror your reward terms; keep the same names so reward parity is
    diff-able.
 4. Translate command sampling — Legged Gym's `_resample_commands` becomes

--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/4-scene_composition.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/4-scene_composition.md
@@ -105,7 +105,7 @@ Disallowed on hot paths:
 
 The current procedural terrain user-facing path is Go2 rough terrain:
 
-- Env owner: `src/unilab/envs/locomotion/go2/rough.py`
+- Task owner: `src/unilab/tasks/locomotion/go2/rough.py`
 - Terrain generator: `src/unilab/terrains/terrain_generator.py`
 - MuJoCo materializer: `src/unilab/base/backend/mujoco/xml.py`
 - Motrix materializer: `src/unilab/base/backend/motrix/scene.py`

--- a/docs/sphinx/source/en/4-developer_guide/3-extending/1-new_task.md
+++ b/docs/sphinx/source/en/4-developer_guide/3-extending/1-new_task.md
@@ -38,5 +38,5 @@ Start from the contracts: {doc}`../2-contracts/1-env_contract`,
 - Registry API: `src/unilab/base/registry.py`
 - Env state contract: `src/unilab/base/np_env.py`
 - Scene config: `src/unilab/base/scene.py`
-- Existing task examples: `src/unilab/envs/locomotion/go2/joystick.py`,
+- Existing task examples: `src/unilab/tasks/locomotion/go2/joystick.py`,
   `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`

--- a/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/1-locomotion.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/1-locomotion.md
@@ -1,7 +1,7 @@
 # 运动控制
 
-运动控制任务注册在 `src/unilab/envs/locomotion/` 和
-`src/unilab/envs/motion_tracking/` 中。`conf/` 下可用的 owner YAML
+运动控制任务注册在 `src/unilab/tasks/locomotion/` 和
+`src/unilab/tasks/motion_tracking/` 中。`conf/` 下可用的 owner YAML
 定义了哪些算法与后端组合是可运行的。
 
 ## 系列
@@ -33,7 +33,7 @@ uv run train --algo sac --task g1_walk_flat --sim mujoco
 
 - PPO 配置：`conf/ppo/task/go2_footstand/mujoco.yaml`
 - 环境注册名：`Go2FootStand`（注册于 `sim_backend="mujoco"`）
-- 环境实现：`src/unilab/envs/locomotion/go2/footstand.py`（继承 Go2 基础任务）
+- 环境实现：`src/unilab/tasks/locomotion/go2/footstand.py`（继承 Go2 基础任务）
 - Go2 模型 XML：`src/unilab/assets/robots/go2/go2.xml`
 
 ```bash

--- a/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/5-domain_randomization/2-writing_providers.md
@@ -26,9 +26,9 @@
 
 具有代表性的 provider 实现位于：
 
-- `src/unilab/envs/locomotion/go1/joystick.py`
+- `src/unilab/tasks/locomotion/go1/joystick.py`
 - `src/unilab/tasks/locomotion/g1/joystick.py`
-- `src/unilab/envs/motion_tracking/g1/tracking.py`
+- `src/unilab/tasks/motion_tracking/g1/tracking.py`
 - `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`
 - `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/6-terrain/2-heightfield_import.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/6-terrain/2-heightfield_import.md
@@ -6,7 +6,7 @@
 
 - `src/unilab/terrains/heightfield_terrains.py`
 - `src/unilab/terrains/terrain_generator.py`
-- `src/unilab/envs/locomotion/go2/rough.py`
+- `src/unilab/tasks/locomotion/go2/rough.py`
 - `src/unilab/base/backend/mujoco/xml.py`
 - `src/unilab/base/backend/motrix/scene.py`
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/7-tooling/5-robot_import.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/7-tooling/5-robot_import.md
@@ -36,7 +36,7 @@ visual mesh 作为 collision mesh，尽量把碰撞体简化为 box / capsule / 
 
 - 默认自动导入会把 actuator 写成 `position`，这只适合位置控制 owner。
   - 如果机器人必须保留 torque/motor actuator 语义，后续扩展任务时，需要参考
-    `src/unilab/envs/locomotion/go2w/` 的控制方式，把 action 解释、PD/力矩控制和
+    `src/unilab/tasks/locomotion/go2w/` 的控制方式，把 action 解释、PD/力矩控制和
     actuator contract 放在机器人 owner 的控制边界内。
 - 转换完成后，会自动弹出 `mujoco.viewer` 可视化界面展示转换结果，并进行下一步调整
   Keyframe。

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -29,7 +29,7 @@ Legged Gym 曾是那套 GPU 常驻的 PPO 模板，教会了整个领域如何�
 ## 迁移清单
 
 1. 把你的 URDF / MJCF asset 复制到 `src/unilab/assets/robots/<robot>/` 下。
-2. 在 `src/unilab/envs/locomotion/<robot>/` 下创建一个任务模块。
+2. 在 `src/unilab/tasks/locomotion/<robot>/` 下创建一个任务模块。
 3. 镜像你的 reward 项；保持名称相同，以便 reward 一致性可被 diff。
 4. 翻译命令采样 —— Legged Gym 的 `_resample_commands` 在 UniLab 中变成一个
    curriculum provider。

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/4-scene_composition.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/4-scene_composition.md
@@ -98,7 +98,7 @@ materializer。
 
 当前面向用户的程序化地形路径是 Go2 崎岖地形：
 
-- Env owner：`src/unilab/envs/locomotion/go2/rough.py`
+- Task owner：`src/unilab/tasks/locomotion/go2/rough.py`
 - 地形生成器：`src/unilab/terrains/terrain_generator.py`
 - MuJoCo materializer：`src/unilab/base/backend/mujoco/xml.py`
 - Motrix materializer：`src/unilab/base/backend/motrix/scene.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/1-new_task.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/1-new_task.md
@@ -38,5 +38,5 @@
 - Registry API：`src/unilab/base/registry.py`
 - Env 状态契约：`src/unilab/base/np_env.py`
 - 场景配置：`src/unilab/base/scene.py`
-- 现有任务示例：`src/unilab/envs/locomotion/go2/joystick.py`、
+- 现有任务示例：`src/unilab/tasks/locomotion/go2/joystick.py`、
   `src/unilab/tasks/manipulation/allegro_inhand/rotation.py`


### PR DESCRIPTION
## Summary

- point bilingual locomotion/task-authoring docs at `src/unilab/tasks`
- align DR, terrain, robot-import, migration, and scene examples with the new owner
- preserve the real `tests/envs/...` test paths

Refs #1193
Umbrella: #1112
Roadmap: #1042

## Contract impact

Documentation only. Hydra configuration, registry names, task behavior, backend behavior, and test layout are unchanged.

## Validation

- all concrete replacement paths verified in the source tree
- `uv run pytest tests/scripts/test_check_docs.py -q` (20 passed)
- prescribed nitpicky Sphinx build (succeeded with no warnings)
- `make test-all` (2078 passed, 27 skipped, 276 deselected, 1 xfailed; static checks, coverage, and benchmark import smoke passed)

Remote child CI is intentionally skipped under the #1042 development policy; the final dev-to-main PR retains the normal remote CI gate.
