### PR TITLE
docs(tasks): update motion tracking owner paths

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/4-tasks/2-motion_tracking.md
+++ b/docs/sphinx/source/en/2-user_guide/4-tasks/2-motion_tracking.md
@@ -1,12 +1,12 @@
 # Motion Tracking
 
-G1 motion tracking tasks live under `src/unilab/envs/motion_tracking/` and are
+G1 motion tracking tasks live under `src/unilab/tasks/motion_tracking/` and are
 selected through task owner YAMLs in `conf/ppo/`, `conf/appo/`, and selected
 off-policy paths.
 
 > **Motion assets moved to Hugging Face.** The `.npz` clips are no longer shipped
 > in the repository. On first use `MotionLoader`
-> (`src/unilab/envs/motion_tracking/g1/motion_loader.py`) downloads them on demand
+> (`src/unilab/tasks/motion_tracking/common/motion_loader.py`) downloads them on demand
 > from [unilabsim/unilab-motions](https://huggingface.co/datasets/unilabsim/unilab-motions)
 > via `src/unilab/assets/hub.py` (`_HF_MOTIONS_REPO_ID`). `uv sync` already installs
 > the required `huggingface_hub` dependency.
@@ -75,7 +75,7 @@ uv run eval --algo sac --task g1_motion_tracking --sim motrix \
 Motion NPZ files are read through `env.motion_file`, which also accepts a list of
 paths. A standard clip must contain the seven keys `fps`, `joint_pos`,
 `joint_vel`, `body_pos_w`, `body_quat_w`, `body_lin_vel_w`, and `body_ang_vel_w`
-(validated in `g1/motion_loader.py`):
+(validated in `common/motion_loader.py`):
 
 ```yaml
 env:

--- a/docs/sphinx/source/en/3-deployment/1-sim_to_real/2-g1_whole_body.md
+++ b/docs/sphinx/source/en/3-deployment/1-sim_to_real/2-g1_whole_body.md
@@ -115,7 +115,7 @@ clip. On hardware you need a wall-clock → phase mapping that is:
 - **Bounded rate** — clip dφ/dt to the value the policy was trained with
   (the motion loader records this; load `reference_motion.npz`).
 
-See `unilab.envs.motion_tracking.g1.motion_loader` for the sim-side
+See `unilab.tasks.motion_tracking.common.motion_loader` for the sim-side
 loader you should mirror on hardware.
 
 ## 5. Safety layer

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/4-dr_contract.md
@@ -101,5 +101,5 @@ payloads.
 - DR manager: `src/unilab/dr/manager.py`
 - Backend interface: `src/unilab/base/backend/base.py`
 - Example providers: `src/unilab/tasks/locomotion/g1/joystick.py`,
-  `src/unilab/envs/motion_tracking/g1/tracking.py`,
+  `src/unilab/tasks/motion_tracking/g1/tracking.py`,
   `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/en/4-developer_guide/7-motion_assets.md
+++ b/docs/sphinx/source/en/4-developer_guide/7-motion_assets.md
@@ -115,12 +115,12 @@ To add a new robot's meshes:
 - Asset resolver module: `src/unilab/assets/hub.py`
   (`resolve_motion_files`).
 - Single integration point: `MotionLoader.__init__` in
-  `src/unilab/envs/motion_tracking/g1/motion_loader.py`, which calls the
+  `src/unilab/tasks/motion_tracking/common/motion_loader.py`, which calls the
   resolver once on a cold path.
 - Hot paths (`step` / `reset`) never trigger any file download or parsing.
 - `ASSETS_ROOT_PATH` is unchanged, so the download target matches the
   original local path exactly.
 - Robot meshes use the same directory resolver (`resolve_robot_asset_dir`),
   integrated at `X2WallFlipTrackingEnv.__init__` in
-  `src/unilab/envs/motion_tracking/x2/flip_tracking.py`, and exposed as the
+  `src/unilab/tasks/motion_tracking/x2/flip_tracking.py`, and exposed as the
   `unilab-pull-assets` CLI.

--- a/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/2-motion_tracking.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/4-tasks/2-motion_tracking.md
@@ -1,10 +1,10 @@
 # 动作追踪
 
-G1 动作追踪任务位于 `src/unilab/envs/motion_tracking/` 下，并通过
+G1 动作追踪任务位于 `src/unilab/tasks/motion_tracking/` 下，并通过
 `conf/ppo/`、`conf/appo/` 以及选定的 off-policy 路径中的 task owner YAML 选择。
 
 > **Motion 资产已迁移到 Hugging Face。** `.npz` 片段不再随仓库分发，首次使用时由
-> `MotionLoader`（`src/unilab/envs/motion_tracking/g1/motion_loader.py`）按需从
+> `MotionLoader`（`src/unilab/tasks/motion_tracking/common/motion_loader.py`）按需从
 > [unilabsim/unilab-motions](https://huggingface.co/datasets/unilabsim/unilab-motions)
 > 下载，下载逻辑在 `src/unilab/assets/hub.py`（`_HF_MOTIONS_REPO_ID`）。`uv sync`
 > 已自动安装所需的 `huggingface_hub` 依赖。
@@ -71,7 +71,7 @@ uv run eval --algo sac --task g1_motion_tracking --sim motrix \
 
 动作 NPZ 文件通过 `env.motion_file` 读取，也支持路径列表。标准片段必须包含七个 key：
 `fps`、`joint_pos`、`joint_vel`、`body_pos_w`、`body_quat_w`、`body_lin_vel_w`、
-`body_ang_vel_w`（在 `g1/motion_loader.py` 中校验）：
+`body_ang_vel_w`（在 `common/motion_loader.py` 中校验）：
 
 ```yaml
 env:

--- a/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/2-g1_whole_body.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/1-sim_to_real/2-g1_whole_body.md
@@ -110,7 +110,7 @@ G1 部署原型将 actor 输出严格映射为：
 - **速率有界** —— 将 dφ/dt 钳制到策略训练时所用的值（运动加载器会记录这个值；加载
   `reference_motion.npz`）。
 
-参见 `unilab.envs.motion_tracking.g1.motion_loader`，这是你应当在硬件上镜像的仿真侧
+参见 `unilab.tasks.motion_tracking.common.motion_loader`，这是你应当在硬件上镜像的仿真侧
 加载器。
 
 ## 5. 安全层

--- a/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/4-dr_contract.md
@@ -91,5 +91,5 @@ actuator 的机制泄漏到共享 payload 里。
 - DR manager：`src/unilab/dr/manager.py`
 - Backend 接口：`src/unilab/base/backend/base.py`
 - 示例 provider：`src/unilab/tasks/locomotion/g1/joystick.py`、
-  `src/unilab/envs/motion_tracking/g1/tracking.py`、
+  `src/unilab/tasks/motion_tracking/g1/tracking.py`、
   `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/7-motion_assets.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/7-motion_assets.md
@@ -103,10 +103,10 @@ uv run unilab-pull-assets --robot x2
 ## 架构说明
 
 - 资产解析模块：`src/unilab/assets/hub.py`（`resolve_motion_files`）。
-- 唯一集成点：`src/unilab/envs/motion_tracking/g1/motion_loader.py` 中的
+- 唯一集成点：`src/unilab/tasks/motion_tracking/common/motion_loader.py` 中的
   `MotionLoader.__init__`，在冷路径上调用一次 resolver。
 - 热路径（`step` / `reset`）**不会**触发任何文件下载或解析。
 - `ASSETS_ROOT_PATH` 定义不变，下载落盘位置与原始本地路径完全一致。
 - 机器人网格使用同一目录 resolver（`resolve_robot_asset_dir`），集成点为
-  `src/unilab/envs/motion_tracking/x2/flip_tracking.py` 中的
+  `src/unilab/tasks/motion_tracking/x2/flip_tracking.py` 中的
   `X2WallFlipTrackingEnv.__init__`，并通过 `unilab-pull-assets` CLI 暴露。


### PR DESCRIPTION
## Summary

- point bilingual motion-tracking docs at `unilab.tasks`
- document the shared loader's actual `common.motion_loader` owner
- align G1/X2 asset and DR evidence paths with the migrated source tree

Refs #1195
Umbrella: #1112
Roadmap: #1042

## Contract impact

Documentation only. Motion loading, assets, DR, deployment, Hydra owners, registry names, and backend behavior are unchanged.

## Validation

- replacement files verified and `unilab.tasks.motion_tracking.common.motion_loader` imported successfully
- `uv run pytest tests/scripts/test_check_docs.py -q` (20 passed)
- prescribed nitpicky Sphinx build (succeeded with no warnings)
- `make test-all` (2078 passed, 27 skipped, 276 deselected, 1 xfailed; static checks, coverage, and benchmark import smoke passed)

Remote child CI is intentionally skipped under the #1042 development policy; the final dev-to-main PR retains the normal remote CI gate.
