### PR TITLE
chore(tasks): finish ownership metadata cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 /scripts/train_*.py @TATP-233 @caozx1110
 
 # Task and environment ownership
-/src/unilab/envs/motion_tracking/ @caozx1110
-/src/unilab/envs/manipulation/ @Mingrui-Yu
+/src/unilab/tasks/motion_tracking/ @caozx1110
+/src/unilab/tasks/manipulation/ @Mingrui-Yu
 /scripts/motion/ @caozx1110
 
 # Project process and docs

--- a/scripts/benchmark/torch_env/motion_tracking.py
+++ b/scripts/benchmark/torch_env/motion_tracking.py
@@ -5,7 +5,7 @@ Faithful xp-port of the NumPy computation in the collector-timed sections of
 (num_envs=2048, 29-dof, 14 tracked bodies):
 
 - `MotionTrackingEnv.update_state`
-  (src/unilab/envs/motion_tracking/common/tracking.py):
+  (src/unilab/tasks/motion_tracking/common/tracking.py):
   motion gather, relative transforms (transforms.py), terminations
   (terminations.py), 9 active reward terms (rewards.py, incl. per-term logging
   every 4 steps), observation build (observations.py, actor 160 / critic 289

--- a/scripts/deploy/export_motion_bin.py
+++ b/scripts/deploy/export_motion_bin.py
@@ -15,7 +15,7 @@ Layout (little-endian, contiguous):
     body_lin_vel_w  [num_frames][num_bodies][3]
     body_ang_vel_w  [num_frames][num_bodies][3]
 
-NPZ source layout (per src/unilab/envs/motion_tracking/g1/motion_loader.py):
+NPZ source layout (per src/unilab/tasks/motion_tracking/common/motion_loader.py):
   - 'fps' (int)
   - 'joint_pos' (N, 29)
   - 'joint_vel' (N, 29)

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -1,10 +1,8 @@
 """Production task registry bootstrap.
 
-Concrete task implementations are moving from :mod:`unilab.envs` into this
-package under issue #1112.  Until each task family moves, this explicit list
-records its legacy module as the last remaining consumer of that path.  The
-registry imports these leaf modules directly, so registration stays explicit
-and deterministic throughout the migration.
+Concrete task implementations live in this package.  The registry imports the
+explicit leaf-module list directly, so registration stays deterministic and
+does not depend on package discovery or import order.
 """
 
 __unilab_registry_modules__ = (

--- a/tests/nan_injection/stage3_nan_inject.py
+++ b/tests/nan_injection/stage3_nan_inject.py
@@ -306,7 +306,7 @@ def _print_manual_recipe():
         To exercise NaN detection end-to-end inside a collector subprocess:
 
         1. Pick a task env file, e.g.
-           src/unilab/envs/locomotion/go1/go1_joystick.py
+           src/unilab/tasks/locomotion/go1/joystick.py
         2. Inside the env's update_state or apply_action, add a temporary
            one-shot NaN raise guarded by an env-counter, for example:
 


### PR DESCRIPTION
## Summary

- move motion-tracking and manipulation CODEOWNERS paths to `unilab.tasks`
- replace the migration-period task bootstrap docstring with the stable contract
- update deploy, benchmark, and NaN-debug source-path comments

Refs #1197
Umbrella: #1112
Roadmap: #1042

## Contract impact

No runtime behavior changes. Registry modules, reviewer identities, benchmark workload, deployment format, and task behavior are unchanged.

## Validation

- repository audit found no removed concrete-task source namespace outside the intentionally retained `tests/envs/...` test layout
- `uv run pytest -q tests/tasks/test_package_boundary.py tests/scripts/test_repo_hygiene.py` (9 passed)
- `make test-all` (2078 passed, 27 skipped, 276 deselected, 1 xfailed; static checks, coverage, and benchmark import smoke passed)

Remote child CI is intentionally skipped under the #1042 development policy; the final dev-to-main PR retains the normal remote CI gate.
