### PR TITLE
feat(env): add model-field reset terms

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -426,6 +426,7 @@ class Entity:
         self._reset_root_layout_error: str | None = None
         self._reset_joint_qpos_ids: np.ndarray | None = None
         self._reset_joint_qvel_ids: np.ndarray | None = None
+        self._joint_model_dof_ids: np.ndarray | None = None
 
         self._joint_names = _normalize_names(name, "joint", cfg.joint_names)
         self._body_names = _normalize_names(name, "body", cfg.body_names)
@@ -1091,6 +1092,106 @@ class Entity:
             term_name=f"{term_name}:{self.name}",
         )
 
+    def bind_joint_armature_write(
+        self,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local joints and immutable default DOF armatures."""
+        if self._reset_state is None:
+            raise self._capability_error(
+                "reset joint-armature write",
+                "EntityScene was materialized without an env-owned reset transaction",
+            )
+        model_dof_ids = self._materialize_joint_model_dof_ids()
+        local_ids = self._normalize_local_joint_ids(
+            joint_ids,
+            capability="reset joint-armature write",
+        )
+        if local_ids.size == 0:
+            raise ValueError(f"Entity '{self.name}' reset joint-armature write selected no joints")
+        _, defaults = self._reset_state.bind_dof_armature_write(
+            model_dof_ids[local_ids],
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_joint_armature_to_sim(
+        self,
+        values: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "joint_armature",
+    ) -> None:
+        """Stage selected entity joint armatures in the active reset transaction."""
+        if self._reset_state is None:
+            raise self._capability_error(
+                "reset joint-armature write",
+                "EntityScene was materialized without an env-owned reset transaction",
+            )
+        model_dof_ids = self._materialize_joint_model_dof_ids()
+        local_ids = self._normalize_local_joint_ids(
+            joint_ids,
+            capability="reset joint-armature write",
+        )
+        self._reset_state.write_dof_armature(
+            self._normalize_reset_env_ids(env_ids),
+            model_dof_ids[local_ids],
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_geom_friction_write(
+        self,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local geoms and immutable default friction vectors."""
+        if self._reset_state is None or self._geom_ids is None:
+            raise self._capability_error(
+                "reset geom-friction write",
+                "geom metadata or the env-owned reset transaction was not materialized",
+            )
+        local_ids = self._normalize_local_geom_ids(
+            geom_ids,
+            capability="reset geom-friction write",
+        )
+        if local_ids.size == 0:
+            raise ValueError(f"Entity '{self.name}' reset geom-friction write selected no geoms")
+        _, defaults = self._reset_state.bind_geom_friction_write(
+            self._geom_ids[local_ids],
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_geom_friction_to_sim(
+        self,
+        values: np.ndarray,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "geom_friction",
+    ) -> None:
+        """Stage selected entity geom friction in the active reset transaction."""
+        if self._reset_state is None or self._geom_ids is None:
+            raise self._capability_error(
+                "reset geom-friction write",
+                "geom metadata or the env-owned reset transaction was not materialized",
+            )
+        local_ids = self._normalize_local_geom_ids(
+            geom_ids,
+            capability="reset geom-friction write",
+        )
+        self._reset_state.write_geom_friction(
+            self._normalize_reset_env_ids(env_ids),
+            self._geom_ids[local_ids],
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
     def bind_body_mass_write(
         self,
         body_ids: np.ndarray | Sequence[int] | slice | None = None,
@@ -1363,6 +1464,33 @@ class Entity:
         bound_defaults.setflags(write=False)
         return bound_ids, bound_defaults
 
+    def _materialize_joint_model_dof_ids(self) -> np.ndarray:
+        """Resolve full model DOF addresses once for reset-time model fields."""
+        cached = self._joint_model_dof_ids
+        if cached is not None:
+            return cached
+        if self._joint_names is None:
+            raise self._capability_error(
+                "reset joint-armature write",
+                "joint_names were not declared in EntityCfg",
+            )
+        try:
+            values = self._backend.get_joint_dof_indices(self._joint_names)
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error("reset joint-armature write", str(exc)) from exc
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                f"Entity '{self.name}' could not resolve joint model DOF names "
+                f"{list(self._joint_names)} on backend '{self._backend_type}': {exc}"
+            ) from exc
+        resolved = _readonly_ids(
+            values,
+            expected=len(self._joint_names),
+            label=f"Entity '{self.name}' joint model DOF",
+        )
+        self._joint_model_dof_ids = resolved
+        return resolved
+
     def _normalize_local_body_ids(
         self,
         body_ids: np.ndarray | Sequence[int] | slice | None,
@@ -1426,6 +1554,39 @@ class Entity:
         if np.unique(ids).size != ids.size:
             raise ValueError(
                 f"Entity '{self.name}' {capability} joint_ids contain duplicates: {ids.tolist()}"
+            )
+        return ids
+
+    def _normalize_local_geom_ids(
+        self,
+        geom_ids: np.ndarray | Sequence[int] | slice | None,
+        *,
+        capability: str,
+    ) -> np.ndarray:
+        if geom_ids is None:
+            ids = np.arange(self.num_geoms, dtype=np.intp)
+        elif isinstance(geom_ids, slice):
+            ids = np.arange(self.num_geoms, dtype=np.intp)[geom_ids]
+        else:
+            raw = np.asarray(geom_ids)
+            if (
+                raw.ndim != 1
+                or not np.issubdtype(raw.dtype, np.integer)
+                or np.issubdtype(raw.dtype, np.bool_)
+            ):
+                raise TypeError(
+                    f"Entity '{self.name}' {capability} geom_ids must be a 1-D integer "
+                    "array or slice"
+                )
+            ids = np.asarray(raw, dtype=np.intp)
+        if np.any(ids < 0) or np.any(ids >= self.num_geoms):
+            raise IndexError(
+                f"Entity '{self.name}' {capability} geom_ids out of range for "
+                f"{self.num_geoms} geoms: {ids.tolist()}"
+            )
+        if np.unique(ids).size != ids.size:
+            raise ValueError(
+                f"Entity '{self.name}' {capability} geom_ids contain duplicates: {ids.tolist()}"
             )
         return ids
 

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -16,6 +16,8 @@ from unilab.base.backend.base import BackendRootStateLayout, SimBackend
 from unilab.dr.types import (
     RESET_TERM_BODY_IPOS,
     RESET_TERM_BODY_MASS,
+    RESET_TERM_DOF_ARMATURE,
+    RESET_TERM_GEOM_FRICTION,
     RESET_TERM_GRAVITY,
     RESET_TERM_KD,
     RESET_TERM_KP,
@@ -135,6 +137,48 @@ class ResetStateTransaction:
             term_name=term_name,
         )
 
+    def bind_dof_armature_write(
+        self,
+        dof_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind DOF-armature columns and immutable backend defaults."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_DOF_ARMATURE,
+            getter=self._backend.get_dof_armature,
+            expected_tail=None,
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            dof_ids,
+            width=default.shape[0],
+            capability="DOF armature IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def bind_geom_friction_write(
+        self,
+        geom_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind geom-friction rows and immutable backend defaults."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_GEOM_FRICTION,
+            getter=self._backend.get_geom_friction,
+            expected_tail=(3,),
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            geom_ids,
+            width=default.shape[0],
+            capability="geom friction IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
     def write_body_mass(
         self,
         env_ids: np.ndarray,
@@ -144,7 +188,7 @@ class ResetStateTransaction:
         term_name: str,
     ) -> None:
         """Stage selected body masses in the exactly-once reset payload."""
-        self._write_body_randomization(
+        self._write_selected_randomization(
             RESET_TERM_BODY_MASS,
             env_ids,
             body_ids,
@@ -162,7 +206,7 @@ class ResetStateTransaction:
         term_name: str,
     ) -> None:
         """Stage selected body inertial positions in the reset payload."""
-        self._write_body_randomization(
+        self._write_selected_randomization(
             RESET_TERM_BODY_IPOS,
             env_ids,
             body_ids,
@@ -199,6 +243,42 @@ class ResetStateTransaction:
         buffer[ids] = gravity
         mask[ids] = True
         self._dirty_mask[ids] = True
+
+    def write_dof_armature(
+        self,
+        env_ids: np.ndarray,
+        dof_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected DOF armatures in the reset payload."""
+        self._write_selected_randomization(
+            RESET_TERM_DOF_ARMATURE,
+            env_ids,
+            dof_ids,
+            values,
+            value_tail=(),
+            term_name=term_name,
+        )
+
+    def write_geom_friction(
+        self,
+        env_ids: np.ndarray,
+        geom_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected three-axis geom friction in the reset payload."""
+        self._write_selected_randomization(
+            RESET_TERM_GEOM_FRICTION,
+            env_ids,
+            geom_ids,
+            values,
+            value_tail=(3,),
+            term_name=term_name,
+        )
 
     def bind_actuator_gain_write(
         self,
@@ -612,11 +692,11 @@ class ResetStateTransaction:
         selected.setflags(write=False)
         return bound_columns, selected
 
-    def _write_body_randomization(
+    def _write_selected_randomization(
         self,
         field: str,
         env_ids: np.ndarray,
-        body_ids: np.ndarray,
+        column_ids: np.ndarray,
         values: np.ndarray,
         *,
         value_tail: tuple[int, ...],
@@ -629,9 +709,9 @@ class ResetStateTransaction:
         )
         default = self._require_randomization_default(field, term_name)
         columns = self._validate_columns(
-            body_ids,
+            column_ids,
             width=default.shape[0],
-            capability=f"{field} body IDs",
+            capability=f"{field} column IDs",
             term_name=term_name,
         )
         selected = self._validate_values(
@@ -655,7 +735,13 @@ class ResetStateTransaction:
         dirty_ids: np.ndarray,
     ) -> ResetRandomizationPayload | None:
         payload = ResetRandomizationPayload()
-        for field in (RESET_TERM_BODY_MASS, RESET_TERM_BODY_IPOS, RESET_TERM_GRAVITY):
+        for field in (
+            RESET_TERM_BODY_MASS,
+            RESET_TERM_BODY_IPOS,
+            RESET_TERM_DOF_ARMATURE,
+            RESET_TERM_GEOM_FRICTION,
+            RESET_TERM_GRAVITY,
+        ):
             mask = self._randomization_dirty_masks.get(field)
             if mask is None or not np.any(mask):
                 continue

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -4,6 +4,9 @@ from unilab.envs.mdp.actions import JointPositionAction as JointPositionAction
 from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActionCfg
 from unilab.envs.mdp.commands import UniformVelocityCommand as UniformVelocityCommand
 from unilab.envs.mdp.commands import UniformVelocityCommandCfg as UniformVelocityCommandCfg
+from unilab.envs.mdp.events import dof_armature as dof_armature
+from unilab.envs.mdp.events import geom_friction as geom_friction
+from unilab.envs.mdp.events import joint_armature as joint_armature
 from unilab.envs.mdp.events import pd_gains as pd_gains
 from unilab.envs.mdp.events import push_by_setting_velocity as push_by_setting_velocity
 from unilab.envs.mdp.events import (
@@ -54,9 +57,12 @@ __all__ = [
     "builtin_sensor",
     "bad_orientation",
     "body_angular_velocity_penalty",
+    "dof_armature",
     "flat_orientation_l2",
+    "geom_friction",
     "generated_commands",
     "joint_pos_rel",
+    "joint_armature",
     "joint_vel_rel",
     "joint_vel_l2",
     "last_action",

--- a/src/unilab/envs/mdp/events.py
+++ b/src/unilab/envs/mdp/events.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
@@ -247,6 +248,340 @@ def resolve_env_ids(env: ManagerBasedRlEnv, env_ids: np.ndarray | None) -> np.nd
     if env_ids is None:
         return np.arange(env.num_envs, dtype=np.int32)
     return env_ids
+
+
+class _ModelFieldRandomizer(ManagerTermBase):
+    """Cold-path-bound NumPy adapter for pinned mjlab model-field DR terms."""
+
+    _term_name = "model_field"
+    _field_width = 1
+    _default_axes: tuple[int, ...] = (0,)
+    _valid_axes: tuple[int, ...] = (0,)
+    _PARAMS = frozenset(
+        ("ranges", "asset_cfg", "distribution", "operation", "axes", "shared_random")
+    )
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        _validate_event_term(
+            cfg,
+            term_name=self._term_name,
+            mode="reset",
+            allowed_params=self._PARAMS,
+            required_params=("ranges",),
+        )
+        self._distribution = _event_choice(
+            cfg.params.get("distribution", "uniform"),
+            term_name=self._term_name,
+            name="distribution",
+            choices=_DISTRIBUTIONS,
+        )
+        self._operation = _event_choice(
+            cfg.params.get("operation", "abs"),
+            term_name=self._term_name,
+            name="operation",
+            choices=_OPERATIONS,
+        )
+        shared_random = cfg.params.get("shared_random", False)
+        if not isinstance(shared_random, bool):
+            raise TypeError(
+                f"EventManager term '{self._term_name}' parameter 'shared_random' must be bool"
+            )
+        self._shared_random = shared_random
+        asset_cfg = cfg.params.get("asset_cfg", _DEFAULT_ASSET_CFG)
+        if not isinstance(asset_cfg, SceneEntityCfg):
+            raise TypeError(
+                f"EventManager term '{self._term_name}' asset_cfg must be SceneEntityCfg, "
+                f"got {type(asset_cfg).__name__}"
+            )
+        entity = cast("Entity", env.scene[asset_cfg.name])
+        local_ids, defaults, names = self._bind(entity, asset_cfg)
+        ranges = cfg.params["ranges"]
+        local_ids, defaults, names, ranges = self._select_string_ranges(
+            local_ids,
+            defaults,
+            names,
+            ranges,
+        )
+        self._entity = entity
+        self._local_ids = local_ids
+        self._defaults = defaults
+        self._axes = self._resolve_axes(cfg.params.get("axes"), ranges)
+        self._ranges = self._resolve_ranges(ranges, names)
+
+    def _bind(
+        self,
+        entity: Entity,
+        asset_cfg: SceneEntityCfg,
+    ) -> tuple[np.ndarray, np.ndarray, tuple[str, ...]]:
+        raise NotImplementedError
+
+    def _write(
+        self,
+        values: np.ndarray,
+        env_ids: np.ndarray,
+    ) -> None:
+        raise NotImplementedError
+
+    def _select_string_ranges(
+        self,
+        local_ids: np.ndarray,
+        defaults: np.ndarray,
+        names: tuple[str, ...],
+        ranges: Any,
+    ) -> tuple[np.ndarray, np.ndarray, tuple[str, ...], Any]:
+        if not isinstance(ranges, dict) or not ranges:
+            return local_ids, defaults, names, ranges
+        keys = tuple(ranges)
+        if not all(isinstance(key, str) for key in keys):
+            if any(isinstance(key, str) for key in keys):
+                raise TypeError(
+                    f"EventManager term '{self._term_name}' ranges cannot mix string and integer keys"
+                )
+            return local_ids, defaults, names, ranges
+
+        assigned: list[Any | None] = [None] * len(names)
+        for pattern, bounds in ranges.items():
+            try:
+                matched = [index for index, name in enumerate(names) if re.fullmatch(pattern, name)]
+            except re.error as exc:
+                raise ValueError(
+                    f"EventManager term '{self._term_name}' ranges contains invalid regex "
+                    f"{pattern!r}: {exc}"
+                ) from exc
+            if not matched:
+                raise ValueError(
+                    f"EventManager term '{self._term_name}' ranges pattern {pattern!r} "
+                    f"matched no selected names; available={list(names)}"
+                )
+            for index in matched:
+                if assigned[index] is not None:
+                    raise ValueError(
+                        f"EventManager term '{self._term_name}' ranges patterns overlap for "
+                        f"selected name '{names[index]}'"
+                    )
+                assigned[index] = bounds
+        selected = np.asarray(
+            [index for index, value in enumerate(assigned) if value is not None],
+            dtype=np.intp,
+        )
+        return (
+            local_ids[selected],
+            defaults[selected],
+            tuple(names[index] for index in selected),
+            [assigned[index] for index in selected],
+        )
+
+    def _resolve_axes(self, value: Any, ranges: Any) -> tuple[int, ...]:
+        if value is None and isinstance(ranges, dict) and ranges:
+            value = list(ranges)
+        if value is None:
+            axes = self._default_axes
+        else:
+            if not isinstance(value, (list, tuple)):
+                raise TypeError(
+                    f"EventManager term '{self._term_name}' parameter 'axes' must be a sequence"
+                )
+            if any(
+                isinstance(axis, bool) or not isinstance(axis, (int, np.integer)) for axis in value
+            ):
+                raise TypeError(
+                    f"EventManager term '{self._term_name}' parameter 'axes' must contain integers"
+                )
+            axes = tuple(int(axis) for axis in value)
+        if not axes:
+            raise ValueError(
+                f"EventManager term '{self._term_name}' parameter 'axes' cannot be empty"
+            )
+        if len(set(axes)) != len(axes):
+            raise ValueError(
+                f"EventManager term '{self._term_name}' parameter 'axes' contains duplicates"
+            )
+        invalid = sorted(set(axes) - set(self._valid_axes))
+        if invalid:
+            raise ValueError(
+                f"EventManager term '{self._term_name}' has invalid axes {invalid}; "
+                f"valid axes are {list(self._valid_axes)}"
+            )
+        return axes
+
+    def _resolve_ranges(self, value: Any, names: tuple[str, ...]) -> np.ndarray:
+        per_entity: list[Any]
+        if (
+            isinstance(value, list)
+            and len(value) == len(names)
+            and any(isinstance(item, (tuple, list, np.ndarray)) for item in value)
+        ):
+            per_entity = list(value)
+            value = None
+        else:
+            per_entity = []
+
+        result = np.empty((len(names), self._field_width, 2), dtype=np.float64)
+        result[:] = np.nan
+        if per_entity:
+            if len(self._axes) != 1:
+                raise ValueError(
+                    f"EventManager term '{self._term_name}' string-keyed ranges require one axis"
+                )
+            for index, bounds in enumerate(per_entity):
+                result[index, self._axes[0]] = _distribution_parameters(
+                    bounds,
+                    term_name=self._term_name,
+                    name=f"ranges[{names[index]}]",
+                    distribution=self._distribution,
+                )
+        elif isinstance(value, dict):
+            unknown = sorted(set(value) - set(self._axes))
+            missing = sorted(set(self._axes) - set(value))
+            if unknown or missing:
+                raise ValueError(
+                    f"EventManager term '{self._term_name}' ranges axes mismatch; "
+                    f"missing={missing}, unknown={unknown}"
+                )
+            for axis in self._axes:
+                result[:, axis] = _distribution_parameters(
+                    value[axis],
+                    term_name=self._term_name,
+                    name=f"ranges[{axis}]",
+                    distribution=self._distribution,
+                )
+        else:
+            parameters = _distribution_parameters(
+                value,
+                term_name=self._term_name,
+                name="ranges",
+                distribution=self._distribution,
+            )
+            for axis in self._axes:
+                result[:, axis] = parameters
+        result.setflags(write=False)
+        return result
+
+    def _sample_axis(self, env: ManagerBasedRlEnv, axis: int, count: int) -> np.ndarray:
+        parameters = self._ranges[:, axis]
+        if self._shared_random:
+            samples = np.empty((count, len(parameters)), dtype=np.float64)
+            groups: dict[tuple[float, float], list[int]] = {}
+            for index, pair in enumerate(parameters):
+                groups.setdefault((float(pair[0]), float(pair[1])), []).append(index)
+            for (first, second), indices in groups.items():
+                if self._distribution == "gaussian":
+                    shared = env.rng.normal(first, second, size=(count, 1))
+                elif self._distribution == "log_uniform":
+                    shared = np.exp(env.rng.uniform(np.log(first), np.log(second), size=(count, 1)))
+                else:
+                    shared = env.rng.uniform(first, second, size=(count, 1))
+                samples[:, indices] = shared
+            return samples
+        if self._distribution == "gaussian":
+            return env.rng.normal(parameters[:, 0], parameters[:, 1], size=(count, len(parameters)))
+        if self._distribution == "log_uniform":
+            return np.exp(
+                env.rng.uniform(
+                    np.log(parameters[:, 0]),
+                    np.log(parameters[:, 1]),
+                    size=(count, len(parameters)),
+                )
+            )
+        return env.rng.uniform(
+            parameters[:, 0],
+            parameters[:, 1],
+            size=(count, len(parameters)),
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        ranges: Any,
+        asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+        distribution: str = "uniform",
+        operation: str = "abs",
+        axes: list[int] | None = None,
+        shared_random: bool = False,
+    ) -> None:
+        del ranges, asset_cfg, distribution, operation, axes, shared_random
+        ids = resolve_env_ids(env, env_ids)
+        defaults = self._defaults
+        scalar = defaults.ndim == 1
+        default_values = defaults[:, None] if scalar else defaults
+        values = np.broadcast_to(
+            default_values,
+            (len(ids), *default_values.shape),
+        ).copy()
+        for axis in self._axes:
+            samples = self._sample_axis(env, axis, len(ids))
+            values[:, :, axis] = _apply_randomization_operation(
+                default_values[None, :, axis],
+                samples,
+                self._operation,
+            )
+        if np.any(values < 0.0) or not np.isfinite(values).all():
+            raise ValueError(
+                f"EventManager term '{self._term_name}' produced negative, NaN, or Inf values"
+            )
+        self._write(values[:, :, 0] if scalar else values, ids)
+
+
+class GeomFriction(_ModelFieldRandomizer):
+    """Pinned mjlab-style geom friction randomization through the reset payload."""
+
+    _term_name = "geom_friction"
+    _field_width = 3
+    _default_axes = (0,)
+    _valid_axes = (0, 1, 2)
+
+    def _bind(
+        self,
+        entity: Entity,
+        asset_cfg: SceneEntityCfg,
+    ) -> tuple[np.ndarray, np.ndarray, tuple[str, ...]]:
+        local_ids, defaults = entity.bind_geom_friction_write(
+            asset_cfg.geom_ids,
+            term_name=self._term_name,
+        )
+        names = tuple(entity.geom_names[int(index)] for index in local_ids)
+        return local_ids, defaults, names
+
+    def _write(self, values: np.ndarray, env_ids: np.ndarray) -> None:
+        self._entity.write_geom_friction_to_sim(
+            values,
+            self._local_ids,
+            env_ids,
+            term_name=self._term_name,
+        )
+
+
+class JointArmature(_ModelFieldRandomizer):
+    """Pinned mjlab-style joint armature randomization through the reset payload."""
+
+    _term_name = "joint_armature"
+
+    def _bind(
+        self,
+        entity: Entity,
+        asset_cfg: SceneEntityCfg,
+    ) -> tuple[np.ndarray, np.ndarray, tuple[str, ...]]:
+        local_ids, defaults = entity.bind_joint_armature_write(
+            asset_cfg.joint_ids,
+            term_name=self._term_name,
+        )
+        names = tuple(entity.joint_names[int(index)] for index in local_ids)
+        return local_ids, defaults, names
+
+    def _write(self, values: np.ndarray, env_ids: np.ndarray) -> None:
+        self._entity.write_joint_armature_to_sim(
+            values,
+            self._local_ids,
+            env_ids,
+            term_name=self._term_name,
+        )
+
+
+geom_friction = GeomFriction
+joint_armature = JointArmature
+dof_armature = joint_armature
 
 
 class PdGains(ManagerTermBase):
@@ -682,6 +1017,9 @@ def reset_root_state_uniform(
 
 
 __all__ = [
+    "dof_armature",
+    "geom_friction",
+    "joint_armature",
     "pd_gains",
     "push_by_setting_velocity",
     "randomize_physics_scene_gravity",

--- a/tests/envs/mdp/test_events.py
+++ b/tests/envs/mdp/test_events.py
@@ -16,6 +16,8 @@ from unilab.base.reset_state import ResetStateTransaction
 from unilab.dr.types import (
     RESET_TERM_BODY_IPOS,
     RESET_TERM_BODY_MASS,
+    RESET_TERM_DOF_ARMATURE,
+    RESET_TERM_GEOM_FRICTION,
     RESET_TERM_GRAVITY,
     RESET_TERM_KD,
     RESET_TERM_KP,
@@ -182,6 +184,8 @@ class _Backend:
         self.body_mass = np.array([10.0])
         self.body_ipos = np.array([[0.0, 0.0, 0.0]])
         self.gravity = np.array([0.0, 0.0, -9.81])
+        self.dof_armature = np.array([0.0] * 6 + [1.0, 2.0, 3.0])
+        self.geom_friction = np.array([[0.5, 0.01, 0.001], [0.7, 0.02, 0.002], [0.9, 0.03, 0.003]])
         self.interval_plans: list[IntervalRandomizationPlan] = []
 
     def get_body_ids(self, names) -> np.ndarray:
@@ -203,13 +207,33 @@ class _Backend:
         return self.init_qvel.copy()
 
     def get_dof_pos(self) -> np.ndarray:
-        return np.empty((self.num_envs, 0))
+        return np.zeros((self.num_envs, 3))
 
     def get_dof_vel(self) -> np.ndarray:
-        return np.empty((self.num_envs, 0))
+        return np.zeros((self.num_envs, 3))
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return np.zeros(3)
+
+    def get_joint_dof_indices(self, names) -> np.ndarray:
+        table = {"j0": 6, "j1": 7, "j2": 8}
+        return np.asarray([table[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_pos_indices(self, names) -> np.ndarray:
+        table = {"j0": 0, "j1": 1, "j2": 2}
+        return np.asarray([table[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names)
+
+    def get_geom_names(self) -> tuple[str, ...]:
+        return ("floor", "foot", "base_geom")
 
     def get_actuator_names(self) -> tuple[str, ...]:
         return ("a0", "a1", "a2")
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return ("j0", "j1", "j2")
 
     def get_actuator_ctrl_range(self) -> np.ndarray:
         return np.tile([-1.0, 1.0], (self.num_actuators, 1))
@@ -217,7 +241,15 @@ class _Backend:
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         terms: set[str] = set((RESET_TERM_KP, RESET_TERM_KD)) if self.gain_supported else set()
         if self.randomization_supported:
-            terms.update((RESET_TERM_BODY_MASS, RESET_TERM_BODY_IPOS, RESET_TERM_GRAVITY))
+            terms.update(
+                (
+                    RESET_TERM_BODY_MASS,
+                    RESET_TERM_BODY_IPOS,
+                    RESET_TERM_DOF_ARMATURE,
+                    RESET_TERM_GEOM_FRICTION,
+                    RESET_TERM_GRAVITY,
+                )
+            )
         return DomainRandomizationCapabilities(
             supported_reset_terms=frozenset(terms),
             supports_interval_body_velocity_delta=self.interval_velocity_supported,
@@ -234,6 +266,12 @@ class _Backend:
 
     def get_gravity(self) -> np.ndarray:
         return self.gravity.copy()
+
+    def get_dof_armature(self) -> np.ndarray:
+        return self.dof_armature.copy()
+
+    def get_geom_friction(self) -> np.ndarray:
+        return self.geom_friction.copy()
 
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         self.interval_plans.append(plan)
@@ -287,7 +325,9 @@ def _transaction_env(
         {
             "robot": EntityCfg(
                 root_body_name="base",
+                joint_names=("j0", "j1", "j2"),
                 body_names=body_names,
+                geom_names=("floor", "foot", "base_geom"),
                 actuator_names=("a0", "a1", "a2"),
             )
         },
@@ -492,6 +532,104 @@ def test_reset_randomization_terms_compose_with_state_and_gains_exactly_once() -
     np.testing.assert_allclose(payload.gravity, [[0.0, 0.0, -10.0]] * 2)
     np.testing.assert_allclose(payload.kp, [[20.0, 40.0, 60.0]] * 2)
     np.testing.assert_allclose(payload.kd, [[3.0, 6.0, 9.0]] * 2)
+
+
+def test_model_field_terms_use_cached_selectors_and_one_dense_reset_payload() -> None:
+    env, backend, transaction = _transaction_env(rng_seed=23)
+    manager = EventManager(
+        {
+            "armature": EventTermCfg(
+                func=mdp.joint_armature,
+                mode="reset",
+                params={
+                    "asset_cfg": SceneEntityCfg(
+                        "robot",
+                        joint_names=("j2", "j0"),
+                        preserve_order=True,
+                    ),
+                    "ranges": (2.0, 2.0),
+                    "operation": "scale",
+                },
+            ),
+            "friction": EventTermCfg(
+                func=mdp.geom_friction,
+                mode="reset",
+                params={
+                    "asset_cfg": SceneEntityCfg("robot", geom_names=".*"),
+                    "ranges": {"floor": (2.0, 2.0), "base_.*": (3.0, 3.0)},
+                    "operation": "scale",
+                    "shared_random": True,
+                },
+            ),
+        },
+        env,
+    )
+    ids = np.array([0, 2], dtype=np.int32)
+
+    with transaction.scoped(ids):
+        mdp.reset_scene_to_default(env, ids)
+        manager.apply(mode="reset", env_ids=ids, global_env_step_count=0)
+        assert backend.set_state_calls == []
+
+    assert len(backend.set_state_calls) == 1
+    payload = backend.randomization_calls[0]
+    assert payload is not None
+    assert payload.dof_armature is not None
+    assert payload.geom_friction is not None
+    np.testing.assert_allclose(
+        payload.dof_armature,
+        [[0.0] * 6 + [2.0, 2.0, 6.0]] * 2,
+    )
+    expected_friction = backend.geom_friction.copy()
+    expected_friction[0, 0] *= 2.0
+    expected_friction[2, 0] *= 3.0
+    np.testing.assert_allclose(payload.geom_friction, [expected_friction] * 2)
+
+
+def test_model_field_aliases_are_identical_and_capability_gaps_fail_cold() -> None:
+    assert mdp.dof_armature is mdp.joint_armature
+    env, backend, _ = _transaction_env(randomization_supported=False)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="joint_armature:robot.*dof_armature randomization.*backend 'fake'",
+    ):
+        EventManager(
+            {
+                "armature": EventTermCfg(
+                    func=mdp.dof_armature,
+                    mode="reset",
+                    params={"ranges": (0.9, 1.1)},
+                )
+            },
+            env,
+        )
+    assert backend.set_state_calls == []
+
+
+@pytest.mark.parametrize(
+    ("func", "params", "match"),
+    [
+        (mdp.geom_friction, {"ranges": (0.5, 1.0), "axes": [3]}, "invalid axes"),
+        (mdp.joint_armature, {"ranges": (-1.0, -0.5)}, "produced negative"),
+    ],
+)
+def test_model_field_invalid_requests_fail_explicitly(func, params, match: str) -> None:
+    env, backend, transaction = _transaction_env()
+    if func is mdp.geom_friction:
+        with pytest.raises(ValueError, match=match):
+            EventManager({"field": EventTermCfg(func=func, mode="reset", params=params)}, env)
+    else:
+        manager = EventManager(
+            {"field": EventTermCfg(func=func, mode="reset", params=params)},
+            env,
+        )
+        ids = np.array([0, 1], dtype=np.int32)
+        with pytest.raises(ValueError, match=match):
+            with transaction.scoped(ids):
+                mdp.reset_scene_to_default(env, ids)
+                manager.apply(mode="reset", env_ids=ids, global_env_step_count=0)
+    assert backend.set_state_calls == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1200
Parent: #1042

## Result

Adds pinned mjlab-style NumPy `geom_friction`, `joint_armature`, and identical `dof_armature` reset-event APIs. Selectors and backend defaults bind on the cold path, while reset writes compose through `Entity -> ResetStateTransaction -> ResetRandomizationPayload -> SimBackend.set_state` exactly once.

Capability gaps, unsupported modes, invalid selectors/axes/ranges, sparse payload rows, and non-finite or negative results fail closed. No backend method, private backend object, runner, or IPC contract was added.

## Scope

Ordinary behavior child: 5 files, +739/-10, within the approved 750-line budget.

## Validation

- `make test-all`
  - ruff format/check: passed
  - mypy: passed
  - pyright: passed
  - pytest: 2082 passed, 27 skipped, 276 deselected, 1 xfailed
  - benchmark import smoke: passed

Per #1042's approved child workflow, validation is local-only and the final commit carries `[skip ci]`; no remote CI result is required for this child PR.
