### PR TITLE
feat(tasks): migrate Stewart balance to Manager-Based runtime

### DIFF
--- a/conf/offpolicy/task/sac/stewart_balance/drake.yaml
+++ b/conf/offpolicy/task/sac/stewart_balance/drake.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/stewart_balance/base
+  - _self_
+
 training:
   task_name: StewartBalance
   sim_backend: drake
@@ -29,10 +33,3 @@ algo:
 env:
   drake_backend_mode: batch
   drake_nthread: 20
-
-reward:
-  scales:
-    center: 0.7
-    progress: 0.6
-    still: 3.0
-  fall_penalty: -6.0

--- a/conf/offpolicy/task/stewart_balance/base.yaml
+++ b/conf/offpolicy/task/stewart_balance/base.yaml
@@ -1,0 +1,126 @@
+# @package _global_
+# Off-policy copy of the canonical Stewart Manager-Based declaration. Hydra
+# config groups have separate search roots, so this intentionally mirrors PPO.
+env:
+  scene:
+    model_file: src/unilab/assets/robots/stewart/scene.xml
+    entities:
+      stewart:
+        root_body_name: ball
+        actuator_names: [a0, a1, a2, a3, a4, a5]
+        body_names:
+          - ball
+          - top
+          - leg00
+          - leg10
+          - leg01
+          - leg11
+          - leg02
+          - leg12
+          - top_connect00
+          - top_connect10
+          - top_connect01
+          - top_connect11
+          - top_connect02
+          - top_connect12
+  sim_dt: 0.004
+  ctrl_dt: 0.02
+  max_episode_seconds: 24.0
+  render_spacing: 4.5
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        balance:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.tasks.manipulation.stewart.balance.StewartObservation
+          params:
+            entity_name: stewart
+            action_name: tilt
+            ball_body_name: ball
+            top_body_name: top
+            target_rotation_limit_deg: 6.0
+            vel_smooth: 0.25
+  actions:
+    tilt:
+      _target_: unilab.tasks.manipulation.stewart.balance.StewartTiltActionCfg
+      entity_name: stewart
+      actuator_names: [a0, a1, a2, a3, a4, a5]
+      top_body_name: top
+      ball_body_name: ball
+      leg_body_names: [leg00, leg10, leg01, leg11, leg02, leg12]
+      top_connect_body_names:
+        - top_connect00
+        - top_connect10
+        - top_connect01
+        - top_connect11
+        - top_connect02
+        - top_connect12
+      raw_action_clip: [-1.0, 1.0]
+      target_rotation_limit_deg: 6.0
+      action_smooth: 0.60
+      center_control_radius: 0.25
+      center_control_min_gain: 0.15
+  events:
+    reset_scene_to_default:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    reset_ball:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.tasks.manipulation.stewart.balance.StewartBallReset
+      mode: reset
+      params:
+        entity_name: stewart
+        platform_radius: 0.8
+        init_ball_radius_ratio: 0.18
+        ball_home_z: 1.2
+  terminations:
+    balance_state:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.tasks.manipulation.stewart.balance.StewartBalanceState
+      params:
+        observation_group: policy
+        observation_term: balance
+        platform_radius: 0.8
+        fall_radius: 0.5
+        top_center_z: 1.0
+        still_xy: 0.12
+        still_vel: 0.07
+        still_xy_hysteresis: 1.15
+        still_vel_hysteresis: 1.20
+        zero_vel_thresh: 0.07
+        still_steps_needed: 5
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  scale_rewards_by_dt: false
+  policy_observation_group: policy
+  critic_observation_group: null
+
+reward:
+  center:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.center_reward
+    weight: 0.7
+    params:
+      state_term_name: balance_state
+  progress:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.progress_reward
+    weight: 0.6
+    params:
+      state_term_name: balance_state
+  still:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.still_reward
+    weight: 3.0
+    params:
+      state_term_name: balance_state
+  fall:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.fall_reward
+    weight: -6.0
+    params:
+      state_term_name: balance_state

--- a/conf/ppo/task/stewart_balance/base.yaml
+++ b/conf/ppo/task/stewart_balance/base.yaml
@@ -1,0 +1,128 @@
+# @package _global_
+# Canonical Stewart Manager-Based task declaration. Backend leaves own only
+# backend identity and algorithm/runtime tuning.
+env:
+  scene:
+    model_file: src/unilab/assets/robots/stewart/scene.xml
+    entities:
+      stewart:
+        root_body_name: ball
+        actuator_names: [a0, a1, a2, a3, a4, a5]
+        body_names:
+          - ball
+          - top
+          - leg00
+          - leg10
+          - leg01
+          - leg11
+          - leg02
+          - leg12
+          - top_connect00
+          - top_connect10
+          - top_connect01
+          - top_connect11
+          - top_connect02
+          - top_connect12
+  # The stiff closed-loop model requires a physics step no larger than ~0.005 s.
+  sim_dt: 0.004
+  ctrl_dt: 0.02
+  max_episode_seconds: 24.0
+  render_spacing: 4.5
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        balance:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.tasks.manipulation.stewart.balance.StewartObservation
+          params:
+            entity_name: stewart
+            action_name: tilt
+            ball_body_name: ball
+            top_body_name: top
+            target_rotation_limit_deg: 6.0
+            vel_smooth: 0.25
+  actions:
+    tilt:
+      _target_: unilab.tasks.manipulation.stewart.balance.StewartTiltActionCfg
+      entity_name: stewart
+      actuator_names: [a0, a1, a2, a3, a4, a5]
+      top_body_name: top
+      ball_body_name: ball
+      leg_body_names: [leg00, leg10, leg01, leg11, leg02, leg12]
+      top_connect_body_names:
+        - top_connect00
+        - top_connect10
+        - top_connect01
+        - top_connect11
+        - top_connect02
+        - top_connect12
+      raw_action_clip: [-1.0, 1.0]
+      target_rotation_limit_deg: 6.0
+      action_smooth: 0.60
+      center_control_radius: 0.25
+      center_control_min_gain: 0.15
+  events:
+    reset_scene_to_default:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    reset_ball:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.tasks.manipulation.stewart.balance.StewartBallReset
+      mode: reset
+      params:
+        entity_name: stewart
+        platform_radius: 0.8
+        init_ball_radius_ratio: 0.18
+        ball_home_z: 1.2
+  terminations:
+    balance_state:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.tasks.manipulation.stewart.balance.StewartBalanceState
+      params:
+        observation_group: policy
+        observation_term: balance
+        platform_radius: 0.8
+        fall_radius: 0.5
+        top_center_z: 1.0
+        still_xy: 0.12
+        still_vel: 0.07
+        still_xy_hysteresis: 1.15
+        still_vel_hysteresis: 1.20
+        zero_vel_thresh: 0.07
+        still_steps_needed: 5
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  # Legacy Stewart rewards were discrete per-control-step values, not rates.
+  scale_rewards_by_dt: false
+  policy_observation_group: policy
+  critic_observation_group: null
+
+reward:
+  center:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.center_reward
+    weight: 0.7
+    params:
+      state_term_name: balance_state
+  progress:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.progress_reward
+    weight: 0.6
+    params:
+      state_term_name: balance_state
+  still:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.still_reward
+    weight: 3.0
+    params:
+      state_term_name: balance_state
+  fall:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.manipulation.stewart.balance.fall_reward
+    weight: -6.0
+    params:
+      state_term_name: balance_state

--- a/conf/ppo/task/stewart_balance/drake.yaml
+++ b/conf/ppo/task/stewart_balance/drake.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/stewart_balance/base
+  - _self_
+
 training:
   task_name: StewartBalance
   sim_backend: drake
@@ -42,10 +46,3 @@ algo:
     gamma: 0.99
     lam: 0.95
   save_interval: 50
-
-reward:
-  scales:
-    center: 0.7
-    progress: 0.6
-    still: 3.0
-  fall_penalty: -6.0

--- a/conf/ppo/task/stewart_balance/motrix.yaml
+++ b/conf/ppo/task/stewart_balance/motrix.yaml
@@ -2,6 +2,10 @@
 # Stewart-platform ball-balancing (motrix). A short, runnable PPO baseline, not
 # tuned for best final performance (raise max_iterations / num_envs for higher
 # success rates).
+defaults:
+  - /task/stewart_balance/base
+  - _self_
+
 training:
   task_name: StewartBalance
   sim_backend: motrix
@@ -40,12 +44,6 @@ algo:
     gamma: 0.99
     lam: 0.95
   save_interval: 50
-reward:
-  scales:
-    center: 0.7
-    progress: 0.6
-    still: 3.0
-  fall_penalty: -6.0
 play_profile:
   enabled: true
   env:

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -445,11 +445,29 @@ class MuJoCoBackend(SimBackend):
             for tmp_path in reversed(tmp_paths):
                 os.remove(tmp_path)
 
-        self._tracked_body_ids = tracked_body_ids
         if self.add_body_sensors:
+            # MjSpec compilation can reorder bodies expanded from <replicate>.
+            # Sensor columns follow ``valid_bnames`` insertion order, so rebuild
+            # the name-to-column map from the final compiled model instead of
+            # retaining IDs from the pre-injection source model.
+            self._tracked_body_ids = [
+                mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name) for name in valid_bnames
+            ]
+            missing = [
+                name
+                for name, body_id in zip(valid_bnames, self._tracked_body_ids, strict=True)
+                if body_id < 0
+            ]
+            if missing:
+                raise ValueError(
+                    "Injected MuJoCo body tracking sensors reference bodies missing from "
+                    f"the compiled model: {missing}"
+                )
             self._body_id_to_tracked_idx = np.full(model.nbody, -1, dtype=int)
             for idx, bid in enumerate(self._tracked_body_ids):
                 self._body_id_to_tracked_idx[bid] = idx
+        else:
+            self._tracked_body_ids = tracked_body_ids
         self._valid_bnames = valid_bnames
         self._configure_model(model)
         return model

--- a/src/unilab/tasks/manipulation/stewart/__init__.py
+++ b/src/unilab/tasks/manipulation/stewart/__init__.py
@@ -1,4 +1,15 @@
-from . import balance  # registers StewartBalance via @registry decorators
-from .balance import StewartBalanceCfg, StewartBalanceEnv
+from . import balance as balance
+from .balance import StewartBalanceState as StewartBalanceState
+from .balance import StewartBallReset as StewartBallReset
+from .balance import StewartObservation as StewartObservation
+from .balance import StewartTiltAction as StewartTiltAction
+from .balance import StewartTiltActionCfg as StewartTiltActionCfg
 
-__all__ = ["StewartBalanceCfg", "StewartBalanceEnv"]
+__all__ = [
+    "StewartBalanceState",
+    "StewartBallReset",
+    "StewartObservation",
+    "StewartTiltAction",
+    "StewartTiltActionCfg",
+    "balance",
+]

--- a/src/unilab/tasks/manipulation/stewart/balance.py
+++ b/src/unilab/tasks/manipulation/stewart/balance.py
@@ -1,28 +1,21 @@
-"""Stewart-platform ball-balancing task.
+"""Manager-Based terms for Stewart-platform ball balancing.
 
-A 6-DOF parallel (Stewart) platform balances a free ball on its top plate. The
-policy commands a 2-D platform tilt (roll, pitch); an inverse-kinematics step
-converts the commanded plate pose into the six prismatic leg lengths that the
-position actuators track. The objective is to bring the ball to the plate center
-and hold it still. The platform base is welded to the world.
+Hydra owns the production task declaration.  This module contains only the
+task-specific NumPy terms and the generic Manager-Based registry binding.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from numbers import Real
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
-import gymnasium as gym
 import numpy as np
 
-from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
-from unilab.base.backend import create_backend, env_backend_kwargs
-from unilab.base.base import EnvCfg
-from unilab.base.np_env import NpEnv, NpEnvState
-from unilab.base.scene import SceneCfg
-from unilab.dr.provider import DomainRandomizationProvider
-from unilab.dr.types import DomainRandomizationCapabilities, ResetPlan
 from unilab.dtype_config import get_global_dtype
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
+from unilab.managers import ActionTerm, ActionTermCfg, ManagerTermBase, ManagerTermBaseCfg
 from unilab.utils.geometry import np_roll_pitch_from_quat
 from unilab.utils.rotation import (
     np_quat_apply_batched,
@@ -33,414 +26,771 @@ from unilab.utils.rotation import (
     np_quat_to_axis_angle,
 )
 
-# Leg base / top-connect bodies in actuator order (a0..a5 -> slide00,slide10,
-# slide01,slide11,slide02,slide12), produced by the `replicate count=3` in the XML.
-_LEG_BODY_NAMES = ["leg00", "leg10", "leg01", "leg11", "leg02", "leg12"]
-_TOP_CONNECT_NAMES = [
-    "top_connect00",
-    "top_connect10",
-    "top_connect01",
-    "top_connect11",
-    "top_connect02",
-    "top_connect12",
-]
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+    from unilab.managers.observation_manager import ObservationManager
+    from unilab.managers.termination_manager import TerminationManager
 
-_OBS_DIM = 15
+    class _StewartEnv(ManagerBasedRlEnv, Protocol):
+        common_step_counter: int
+        observation_manager: ObservationManager
+
+
 _ACTION_DIM = 2
+_LEG_COUNT = 6
 
 
-@dataclass
-class StewartRewardConfig:
-    """Reward shaping for the ball-balancing task (see `_compute_reward`)."""
+def _real(
+    term: str,
+    name: str,
+    value: Any,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+    strict_minimum: bool = False,
+) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{term} {name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{term} {name} must be finite")
+    if minimum is not None and (result <= minimum if strict_minimum else result < minimum):
+        relation = "greater than" if strict_minimum else "at least"
+        raise ValueError(f"{term} {name} must be {relation} {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{term} {name} must be at most {maximum}")
+    return result
 
-    scales: dict[str, float] = field(
-        default_factory=lambda: {"center": 0.7, "progress": 0.6, "still": 3.0}
-    )
-    fall_penalty: float = -6.0
+
+def _name(term: str, name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{term} {name} must be a non-empty string")
+    return value
 
 
-@registry.envcfg("StewartBalance")
-@dataclass
-class StewartBalanceCfg(EnvCfg):
-    scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
-        default_factory=lambda: SceneCfg(
-            model_file=str(ASSETS_ROOT_PATH / "robots" / "stewart" / "scene.xml")
+def _names(term: str, name: str, value: Any, *, count: int) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
+        raise TypeError(f"{term} {name} must be a sequence of {count} strings")
+    result = tuple(value)
+    if len(result) != count:
+        raise ValueError(f"{term} {name} must contain {count} names, got {len(result)}")
+    if any(not isinstance(item, str) or not item for item in result):
+        raise ValueError(f"{term} {name} must contain non-empty strings")
+    if len(set(result)) != count:
+        raise ValueError(f"{term} {name} must contain unique names: {result}")
+    return result
+
+
+def _pair(term: str, name: str, value: Any) -> tuple[float, float]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
+        raise TypeError(f"{term} {name} must be a numeric (min, max) pair")
+    if len(value) != 2:
+        raise ValueError(f"{term} {name} must contain two values")
+    lower = _real(term, f"{name}[0]", value[0])
+    upper = _real(term, f"{name}[1]", value[1])
+    if lower > upper:
+        raise ValueError(f"{term} {name} lower bound {lower} exceeds upper bound {upper}")
+    return lower, upper
+
+
+def _env_ids(env: ManagerBasedRlEnv, env_ids: np.ndarray | slice | None) -> np.ndarray:
+    if env_ids is None:
+        return np.arange(env.num_envs, dtype=np.int32)
+    if isinstance(env_ids, slice):
+        return np.arange(env.num_envs, dtype=np.int32)[env_ids]
+    return env_ids
+
+
+def _body_id(entity: Entity, name: str, *, term: str) -> int:
+    ids, resolved = entity.find_bodies(name)
+    if len(ids) != 1 or resolved != [name]:
+        raise ValueError(f"{term} body selector {name!r} did not resolve exactly once")
+    return ids[0]
+
+
+def _body_ids(entity: Entity, names: tuple[str, ...], *, term: str) -> np.ndarray:
+    ids, resolved = entity.find_bodies(names, preserve_order=True)
+    if tuple(resolved) != names:
+        raise ValueError(f"{term} body selectors resolved in an unexpected order: {resolved}")
+    result = np.asarray(ids, dtype=np.intp)
+    result.setflags(write=False)
+    return result
+
+
+def _relative_ball_state(
+    entity: Entity,
+    *,
+    ball_body_id: int,
+    top_body_id: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    body_pos = entity.data.body_link_pos_w
+    body_quat = entity.data.body_link_quat_w
+    top_pos = body_pos[:, top_body_id]
+    top_quat = body_quat[:, top_body_id]
+    ball_pos = body_pos[:, ball_body_id]
+    relative = np_quat_apply_inverse(top_quat, ball_pos - top_pos)
+    return relative, top_quat, ball_pos
+
+
+@dataclass(kw_only=True)
+class StewartTiltActionCfg(ActionTermCfg):
+    """Two-axis tilt action converted to six Stewart actuator targets."""
+
+    actuator_names: tuple[str, ...] | list[str]
+    top_body_name: str
+    ball_body_name: str
+    leg_body_names: tuple[str, ...] | list[str]
+    top_connect_body_names: tuple[str, ...] | list[str]
+    raw_action_clip: tuple[float, float] | list[float]
+    target_rotation_limit_deg: float
+    action_smooth: float
+    center_control_radius: float
+    center_control_min_gain: float
+
+    def build(self, env: ManagerBasedRlEnv) -> StewartTiltAction:
+        return StewartTiltAction(self, env)
+
+
+class StewartTiltAction(ActionTerm):
+    """Vectorized tilt IK using only the public entity state/control facade."""
+
+    cfg: StewartTiltActionCfg
+    _entity: Entity
+
+    def __init__(self, cfg: StewartTiltActionCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        term = type(self).__name__
+        if cfg.clip is not None:
+            raise NotImplementedError(
+                f"{term} does not support the actuator-name clip field; use raw_action_clip"
+            )
+        actuator_names = _names(term, "actuator_names", cfg.actuator_names, count=_LEG_COUNT)
+        actuator_ids, resolved = self._entity.find_actuators(actuator_names, preserve_order=True)
+        if tuple(resolved) != actuator_names:
+            raise ValueError(f"{term} actuator selectors resolved out of order: {resolved}")
+        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
+        self._actuator_ids.setflags(write=False)
+
+        top_name = _name(term, "top_body_name", cfg.top_body_name)
+        ball_name = _name(term, "ball_body_name", cfg.ball_body_name)
+        leg_names = _names(term, "leg_body_names", cfg.leg_body_names, count=_LEG_COUNT)
+        connect_names = _names(
+            term,
+            "top_connect_body_names",
+            cfg.top_connect_body_names,
+            count=_LEG_COUNT,
         )
-    )
-    # The XML model is stiff; do not raise sim_dt above ~0.005.
-    sim_dt: float = 0.004
-    ctrl_dt: float = 0.02
-    max_episode_seconds: float = 24.0  # pyright: ignore[reportIncompatibleVariableOverride]
-    render_spacing: float = 4.5
+        self._top_body_id = _body_id(self._entity, top_name, term=term)
+        self._ball_body_id = _body_id(self._entity, ball_name, term=term)
+        self._leg_body_ids = _body_ids(self._entity, leg_names, term=term)
+        self._top_connect_body_ids = _body_ids(self._entity, connect_names, term=term)
 
-    # Body the backend treats as the kinematic base for its base-pose accessors.
-    # The task reads explicit body ids instead, so any real body works; the moving
-    # plate is the natural choice.
-    base_name: str = "top"
-
-    # Geometry (platform centered at the world origin, plate center at z=1).
-    platform_radius: float = 0.8
-    # The episode ends (ball "fallen") once it strays this far from the plate
-    # center. Kept inside the physical rim (platform_radius) so the ball never
-    # reaches the edge-contact regime that destabilizes the stiff closed-loop solver.
-    fall_radius: float = 0.5
-    top_center_z: float = 1.0
-    top_surface_offset: float = 0.1
-    ball_radius: float = 0.10
-    init_ball_radius_ratio: float = 0.18
-
-    # Control.
-    target_rotation_limit_deg: float = 6.0
-    action_smooth: float = 0.60
-    center_control_radius: float = 0.25
-    center_control_min_gain: float = 0.15
-    vel_smooth: float = 0.25
-
-    # Success / stillness window.
-    still_xy: float = 0.12
-    still_vel: float = 0.07
-    still_xy_hysteresis: float = 1.15
-    still_vel_hysteresis: float = 1.20
-    zero_vel_thresh: float = 0.07
-    still_steps_needed: int = 5
-
-    reward_config: StewartRewardConfig = field(default_factory=StewartRewardConfig)
-
-    def validate(self) -> None:
-        super().validate()
-        if not 0.0 <= self.init_ball_radius_ratio <= 1.0:
-            raise ValueError("init_ball_radius_ratio must be in [0, 1]")
-        if not 0.0 <= self.action_smooth <= 1.0:
-            raise ValueError("action_smooth must be in [0, 1]")
-        if not 0.0 <= self.center_control_min_gain <= 1.0:
-            raise ValueError("center_control_min_gain must be in [0, 1]")
-
-
-def _ball_home_z(cfg: StewartBalanceCfg) -> float:
-    return cfg.top_center_z + cfg.top_surface_offset + cfg.ball_radius
-
-
-def _roll_pitch_from_quat(quat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Extract roll/pitch (rad) from a wxyz quaternion, cast to float32."""
-    roll, pitch = np_roll_pitch_from_quat(quat)
-    return roll.astype(np.float32), pitch.astype(np.float32)
-
-
-# The mujoco backend constructs, resets, and steps correctly. Its closed-loop
-# constraint solver is, however, less forgiving than motrix's under load (stiff
-# parallel mechanism + ball contact), so a trained-grade policy is not yet stable
-# there — closed-loop stability tuning for mujoco is a follow-up. The motrix
-# backend is the validated training path.
-@registry.env("StewartBalance", sim_backend="mujoco")
-@registry.env("StewartBalance", sim_backend="motrix")
-@registry.env("StewartBalance", sim_backend="drake")
-class StewartBalanceEnv(NpEnv):
-    _cfg: StewartBalanceCfg
-
-    def __init__(
-        self,
-        cfg: StewartBalanceCfg,
-        num_envs: int = 1,
-        backend_type: str = "motrix",
-        dr_provider: DomainRandomizationProvider | None = None,
-    ) -> None:
-        # add_body_sensors=True injects body-pose tracking sensors the MuJoCo
-        # backend needs for get_body_pos_w/quat_w on arbitrary bodies (the IK + obs
-        # read top/ball/leg poses). The motrix backend reads poses natively and
-        # ignores the flag.
-        backend = create_backend(
-            backend_type,
-            cfg.scene,
-            num_envs,
-            cfg.sim_dt,
-            base_name=cfg.base_name,
-            add_body_sensors=True,
-            **env_backend_kwargs(cfg),
+        self._raw_clip = _pair(term, "raw_action_clip", cfg.raw_action_clip)
+        self._tilt_limit_deg = _real(
+            term,
+            "target_rotation_limit_deg",
+            cfg.target_rotation_limit_deg,
+            minimum=0.0,
+            strict_minimum=True,
         )
-        super().__init__(cfg, backend, num_envs)
+        self._action_smooth = _real(
+            term, "action_smooth", cfg.action_smooth, minimum=0.0, maximum=1.0
+        )
+        self._center_radius = _real(
+            term, "center_control_radius", cfg.center_control_radius, minimum=0.0
+        )
+        self._center_min_gain = _real(
+            term,
+            "center_control_min_gain",
+            cfg.center_control_min_gain,
+            minimum=0.0,
+            maximum=1.0,
+        )
 
-        self._np_dtype = get_global_dtype()
-        self._action_space = gym.spaces.Box(-1.0, 1.0, (_ACTION_DIM,), dtype=np.float32)
+        ranges = np.asarray(self._entity.data.actuator_ctrl_range, dtype=get_global_dtype())
+        self._ctrl_lower = ranges[self._actuator_ids, 0]
+        self._ctrl_upper = ranges[self._actuator_ids, 1]
+        dtype = get_global_dtype()
+        self._raw_action = np.zeros((env.num_envs, _ACTION_DIM), dtype=dtype)
+        self._clipped_action = np.zeros_like(self._raw_action)
+        self._executed_action = np.zeros_like(self._raw_action)
+        self._previous_executed_action = np.zeros_like(self._raw_action)
+        self._effective_action = np.zeros_like(self._raw_action)
+        self._target_tilt_deg = np.zeros_like(self._raw_action)
+        self._target_tilt_rad = np.zeros_like(self._raw_action)
+        self._control = np.zeros((env.num_envs, _LEG_COUNT), dtype=dtype)
 
-        if self._backend.num_actuators != 6:
-            raise ValueError(f"Stewart model needs 6 actuators, got {self._backend.num_actuators}")
-        ctrl_range = np.asarray(self._backend.get_actuator_ctrl_range(), dtype=np.float32)
-        self._ctrl_lo = ctrl_range[:, 0]
-        self._ctrl_hi = ctrl_range[:, 1]
-
-        self._top_body_ids = self._backend.get_body_ids(["top"])
-        self._ball_body_ids = self._backend.get_body_ids(["ball"])
-        self._leg_body_ids = self._backend.get_body_ids(_LEG_BODY_NAMES)
-        self._top_connect_ids = self._backend.get_body_ids(_TOP_CONNECT_NAMES)
-        # The ball free joint is the first jointed body in the scene, so its
-        # position occupies qpos[0:3] (validated against the default qpos in reset).
-        self._ball_pos_qpos_idx = np.array([0, 1, 2], dtype=np.int64)
-
-        # IK calibration (top home center, connect offsets, neutral leg lengths) is
-        # resolved lazily on first use, once reset has placed the home state.
         self._ik_ready = False
-        self._top_pos0 = np.zeros(3, dtype=np.float32)
-        self._connect_offsets = np.zeros((6, 3), dtype=np.float32)
-        self._leg0 = np.zeros(6, dtype=np.float32)
-
-        self._init_domain_randomization(
-            dr_provider if dr_provider is not None else StewartBalanceDRProvider()
-        )
+        self._top_home_pos = np.zeros(3, dtype=dtype)
+        self._connect_offsets = np.zeros((_LEG_COUNT, 3), dtype=dtype)
+        self._neutral_leg_lengths = np.zeros(_LEG_COUNT, dtype=dtype)
 
     @property
-    def action_space(self) -> gym.spaces.Box:
-        return self._action_space
+    def action_dim(self) -> int:
+        return _ACTION_DIM
 
     @property
-    def obs_groups_spec(self) -> dict[str, int]:
-        return {"obs": _OBS_DIM}
+    def raw_action(self) -> np.ndarray:
+        return self._raw_action
+
+    @property
+    def executed_action(self) -> np.ndarray:
+        return self._executed_action
+
+    @property
+    def target_tilt_deg(self) -> np.ndarray:
+        return self._target_tilt_deg
+
+    @property
+    def neutral_leg_lengths(self) -> np.ndarray:
+        self._ensure_ik_calibration()
+        return self._neutral_leg_lengths
 
     def _ensure_ik_calibration(self) -> None:
         if self._ik_ready:
             return
-        top_pos = np.asarray(
-            self._backend.get_body_pos_w(self._top_body_ids)[:, 0, :], dtype=np.float32
-        )
-        connects = np.asarray(self._backend.get_body_pos_w(self._top_connect_ids), dtype=np.float32)
-        legs = np.asarray(self._backend.get_body_pos_w(self._leg_body_ids), dtype=np.float32)
-        # Use env 0 as the reference home configuration (all envs share the model).
-        self._top_pos0 = top_pos[0]
-        self._connect_offsets = (connects[0] - self._top_pos0).astype(np.float32)  # (6,3)
-        self._leg0 = np.linalg.norm(connects[0] - legs[0], axis=-1).astype(np.float32)  # (6,)
+        positions = np.asarray(self._entity.data.body_link_pos_w, dtype=get_global_dtype())
+        top = positions[:, self._top_body_id]
+        connects = positions[:, self._top_connect_body_ids]
+        legs = positions[:, self._leg_body_ids]
+        self._top_home_pos[:] = top[0]
+        self._connect_offsets[:] = connects[0] - self._top_home_pos
+        self._neutral_leg_lengths[:] = np.linalg.norm(connects[0] - legs[0], axis=-1)
         self._ik_ready = True
 
-    def _leg_ctrl_for_tilt(self, target_tilt_rad: np.ndarray) -> np.ndarray:
-        """Inverse kinematics: tilt command -> six prismatic leg targets.
-
-        ``target_tilt_rad`` has shape (N, 2) = (roll, pitch). The plate stays at its
-        home center; only its orientation tracks the commanded tilt.
-        """
+    def leg_control_for_tilt(self, target_tilt_rad: np.ndarray) -> np.ndarray:
+        """Return six actuator controls for ``(roll, pitch)`` radians."""
+        expected = (self.num_envs, _ACTION_DIM)
+        if not isinstance(target_tilt_rad, np.ndarray) or target_tilt_rad.shape != expected:
+            shape = getattr(target_tilt_rad, "shape", None)
+            raise ValueError(f"{type(self).__name__} tilt must have shape {expected}, got {shape}")
+        if not np.isfinite(target_tilt_rad).all():
+            raise ValueError(f"{type(self).__name__} tilt contains NaN or Inf")
         self._ensure_ik_calibration()
-        num = target_tilt_rad.shape[0]
-        zeros = np.zeros((num,), dtype=np.float32)
-        target_quat = np_quat_from_euler_xyz(
-            target_tilt_rad[:, 0], target_tilt_rad[:, 1], zeros
-        ).reshape(num, 4)
-        # Rotate each connect offset by the per-env target quat: (N,1,4) x (1,6,3) -> (N,6,3).
+        zeros = np.zeros(self.num_envs, dtype=target_tilt_rad.dtype)
+        target_quat = np_quat_from_euler_xyz(target_tilt_rad[:, 0], target_tilt_rad[:, 1], zeros)
         rotated = np_quat_apply_batched(target_quat[:, None, :], self._connect_offsets[None, :, :])
-        expected = self._top_pos0[None, None, :] + rotated  # (N,6,3) connect targets
-        bottoms = np.asarray(
-            self._backend.get_body_pos_w(self._leg_body_ids), dtype=np.float32
-        )  # (N,6,3)
-        leg_len = np.linalg.norm(expected - bottoms, axis=-1) - self._leg0[None, :]
-        return np.clip(leg_len, self._ctrl_lo, self._ctrl_hi).astype(np.float32)
-
-    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
-        cfg = self._cfg
-        info = state.info
-        raw = np.clip(np.asarray(actions, dtype=np.float32), -1.0, 1.0).reshape(
-            self._num_envs, _ACTION_DIM
+        expected_connects = self._top_home_pos[None, None, :] + rotated
+        leg_positions = np.asarray(
+            self._entity.data.body_link_pos_w[:, self._leg_body_ids],
+            dtype=get_global_dtype(),
+        )
+        controls = (
+            np.linalg.norm(expected_connects - leg_positions, axis=-1)
+            - self._neutral_leg_lengths[None, :]
+        )
+        return np.asarray(
+            np.clip(controls, self._ctrl_lower, self._ctrl_upper),
+            dtype=get_global_dtype(),
         )
 
-        # Exponential action smoothing.
-        prev = info["prev_action_exec"]
-        alpha = float(cfg.action_smooth)
-        action_exec = (alpha * raw + (1.0 - alpha) * prev).astype(np.float32)
-        info["prev_action_exec"] = action_exec
-        info["action_exec"] = action_exec
+    def process_actions(self, actions: np.ndarray) -> None:
+        expected = self._raw_action.shape
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(
+                f"{type(self).__name__} expected np.ndarray, got {type(actions).__name__}"
+            )
+        if actions.shape != expected:
+            raise ValueError(
+                f"{type(self).__name__} expected action shape {expected}, got {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError(f"{type(self).__name__} received NaN or Inf actions")
+        self._raw_action[:] = actions
+        np.clip(actions, self._raw_clip[0], self._raw_clip[1], out=self._clipped_action)
+        np.multiply(self._clipped_action, self._action_smooth, out=self._executed_action)
+        self._executed_action += (1.0 - self._action_smooth) * self._previous_executed_action
+        self._previous_executed_action[:] = self._executed_action
 
-        # Soften authority while the ball is already near the center.
-        rel_xy = info["last_rel_xy"]
-        if cfg.center_control_radius > 0.0 and cfg.center_control_min_gain < 1.0:
-            ratio = np.clip(rel_xy / max(cfg.center_control_radius, 1e-6), 0.0, 1.0)
-            gain = cfg.center_control_min_gain + (1.0 - cfg.center_control_min_gain) * ratio
+        relative, _, _ = _relative_ball_state(
+            self._entity,
+            ball_body_id=self._ball_body_id,
+            top_body_id=self._top_body_id,
+        )
+        relative_xy = np.linalg.norm(relative[:, :2], axis=-1)
+        if self._center_radius > 0.0 and self._center_min_gain < 1.0:
+            ratio = np.clip(relative_xy / self._center_radius, 0.0, 1.0)
+            gain = self._center_min_gain + (1.0 - self._center_min_gain) * ratio
+            np.multiply(self._executed_action, gain[:, None], out=self._effective_action)
         else:
-            gain = np.ones((self._num_envs,), dtype=np.float32)
-        effective = action_exec * gain[:, None]
+            self._effective_action[:] = self._executed_action
+        np.multiply(self._effective_action, self._tilt_limit_deg, out=self._target_tilt_deg)
+        np.deg2rad(self._target_tilt_deg, out=self._target_tilt_rad)
+        self._control[:] = self.leg_control_for_tilt(self._target_tilt_rad)
 
-        target_tilt_deg = effective * cfg.target_rotation_limit_deg
-        info["target_tilt_cmd"] = target_tilt_deg.astype(np.float32)
-        return self._leg_ctrl_for_tilt(np.deg2rad(target_tilt_deg).astype(np.float32))
+    def apply_actions(self) -> None:
+        self._entity.data.write_ctrl(self._control, actuator_ids=self._actuator_ids)
 
-    def _read_ball_rel(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        top_pos = np.asarray(
-            self._backend.get_body_pos_w(self._top_body_ids)[:, 0, :], dtype=np.float32
-        )
-        top_quat = np.asarray(
-            self._backend.get_body_quat_w(self._top_body_ids)[:, 0, :], dtype=np.float32
-        )
-        ball_pos = np.asarray(
-            self._backend.get_body_pos_w(self._ball_body_ids)[:, 0, :], dtype=np.float32
-        )
-        rel = np_quat_apply_inverse(top_quat, (ball_pos - top_pos)).astype(np.float32)
-        return rel, top_quat, ball_pos
-
-    def update_state(self, state: NpEnvState) -> NpEnvState:
-        cfg = self._cfg
-        info = state.info
-        dt = float(cfg.ctrl_dt)
-
-        rel, top_quat, ball_pos = self._read_ball_rel()
-
-        rel_vel = (rel - info["prev_rel"]) / dt
-        filt_rel_vel = (
-            cfg.vel_smooth * rel_vel + (1.0 - cfg.vel_smooth) * info["filtered_rel_vel"]
-        ).astype(np.float32)
-        info["prev_rel"] = rel
-        info["filtered_rel_vel"] = filt_rel_vel
-
-        quat_delta = np_quat_mul_batched(top_quat, np_quat_conjugate_batched(info["prev_top_quat"]))
-        top_ang_vel = (np_quat_to_axis_angle(quat_delta) / dt).astype(np.float32)
-        filt_ang_vel = (
-            cfg.vel_smooth * top_ang_vel + (1.0 - cfg.vel_smooth) * info["filtered_top_ang_vel"]
-        ).astype(np.float32)
-        info["prev_top_quat"] = top_quat
-        info["filtered_top_ang_vel"] = filt_ang_vel
-        ang_vel_local = np_quat_apply_inverse(top_quat, filt_ang_vel).astype(np.float32)
-
-        roll, pitch = _roll_pitch_from_quat(top_quat)
-        rel_xy = np.linalg.norm(rel[:, :2], axis=-1).astype(np.float32)
-        vel_xy = np.linalg.norm(filt_rel_vel[:, :2], axis=-1).astype(np.float32)
-        info["last_rel_xy"] = rel_xy
-
-        limit = max(cfg.target_rotation_limit_deg, 1e-6)
-        obs = np.concatenate(
-            [
-                rel,
-                filt_rel_vel,
-                np.stack([np.rad2deg(roll) / limit, np.rad2deg(pitch) / limit], axis=-1).astype(
-                    np.float32
-                ),
-                ang_vel_local,
-                info["target_tilt_cmd"] / limit,
-                info["action_exec"],
-            ],
-            axis=-1,
-        ).astype(self._np_dtype)
-
-        reward, terminated = self._compute_reward(cfg, info, rel_xy, vel_xy, ball_pos)
-        return state.replace(obs={"obs": obs}, reward=reward, terminated=terminated)
-
-    def _compute_reward(self, cfg, info, rel_xy, vel_xy, ball_pos):
-        rc = cfg.reward_config
-        scales = rc.scales
-
-        fall_z = cfg.top_center_z - np.sin(np.deg2rad(30.0)) * cfg.platform_radius
-        fallen = (rel_xy > cfg.fall_radius) | (ball_pos[:, 2] < fall_z)
-
-        center_score = np.clip(1.0 - rel_xy / max(cfg.fall_radius, 1e-6), 0.0, 1.0)
-        term_center = scales["center"] * center_score
-
-        # Reward shrinking the stop-radius: progress toward the center between
-        # near-zero-velocity moments (a stable "settled closer than before" event).
-        prev_zero = info["prev_zero_vel_rel_xy"]
-        zero_event = vel_xy <= cfg.zero_vel_thresh
-        improve = np.maximum(prev_zero - rel_xy, 0.0)
-        improve_norm = np.clip(improve / max(cfg.platform_radius, 1e-6), 0.0, 1.0)
-        term_progress = np.where(
-            zero_event & (rel_xy < prev_zero), scales["progress"] * improve_norm, 0.0
-        )
-        next_zero = prev_zero.copy()
-        next_zero[zero_event] = rel_xy[zero_event]
-        info["prev_zero_vel_rel_xy"] = next_zero.astype(np.float32)
-
-        still_steps = self._update_stillness(cfg, info, rel_xy, vel_xy)
-        success = still_steps >= cfg.still_steps_needed
-        term_still = np.where(success, scales["still"], 0.0)
-
-        reward = (term_center + term_progress + term_still).astype(self._np_dtype)
-        reward = np.where(fallen, rc.fall_penalty, reward).astype(self._np_dtype)
-        terminated = (fallen | success).astype(bool)
-        return reward, terminated
-
-    def _update_stillness(self, cfg, info, rel_xy, vel_xy) -> np.ndarray:
-        xy_enter, vel_enter = cfg.still_xy, cfg.still_vel
-        xy_exit = cfg.still_xy * cfg.still_xy_hysteresis
-        vel_exit = cfg.still_vel * cfg.still_vel_hysteresis
-
-        active = info["still_window_active"]
-        steps = info["still_steps"]
-        keep = active & (rel_xy <= xy_exit) & (vel_xy <= vel_exit)
-        enter = (~active) & (rel_xy <= xy_enter) & (vel_xy <= vel_enter)
-        steps = np.where(keep, steps + 1, np.where(enter, 1, 0)).astype(np.int32)
-        active = keep | enter
-        info["still_window_active"] = active
-        info["still_steps"] = steps
-        return steps
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        ids = slice(None) if env_ids is None else env_ids
+        for value in (
+            self._raw_action,
+            self._clipped_action,
+            self._executed_action,
+            self._previous_executed_action,
+            self._effective_action,
+            self._target_tilt_deg,
+            self._target_tilt_rad,
+            self._control,
+        ):
+            value[ids] = 0.0
 
 
-class StewartBalanceDRProvider(DomainRandomizationProvider):
-    """Resets the plate to its level home and drops the ball near the center.
+class StewartObservation(ManagerTermBase):
+    """Legacy 15-D observation with per-environment filtered finite differences."""
 
-    No physical randomization terms are used; the reset variety comes from the
-    randomized ball position, which is the balancing challenge.
-    """
-
-    def validate(self, env, capabilities: DomainRandomizationCapabilities) -> None:  # noqa: D102
-        return None
-
-    def build_reset_plan(self, env: StewartBalanceEnv, env_ids: np.ndarray) -> ResetPlan:
-        cfg: StewartBalanceCfg = env._cfg
-        n = int(env_ids.shape[0])
-        default_qpos = np.asarray(env._backend.get_default_qpos(), dtype=np.float64)
-        # Ball free joint is first in the scene -> position is qpos[0:3].
-        if not np.allclose(default_qpos[0:2], 0.0, atol=1e-3):
-            raise ValueError("Unexpected qpos layout: ball position is not at qpos[0:3]")
-        qpos = np.broadcast_to(default_qpos, (n, default_qpos.shape[0])).copy()
-
-        # Ball: uniform within a disk near the plate center, resting on the surface.
-        radius = (
-            cfg.platform_radius
-            * cfg.init_ball_radius_ratio
-            * np.sqrt(np.random.uniform(0.0, 1.0, size=n))
-        )
-        theta = np.random.uniform(0.0, 2.0 * np.pi, size=n)
-        ball_xyz = np.stack(
-            [radius * np.cos(theta), radius * np.sin(theta), np.full((n,), _ball_home_z(cfg))],
-            axis=-1,
-        )
-        qpos[:, env._ball_pos_qpos_idx] = ball_xyz
-
-        init_qvel = np.asarray(env._backend.get_init_qvel(), dtype=np.float64)
-        qvel = np.broadcast_to(init_qvel, (n, init_qvel.shape[0])).copy()
-
-        zeros3 = np.zeros((n, 3), dtype=np.float32)
-        zeros2 = np.zeros((n, 2), dtype=np.float32)
-        identity_quat = np.tile(np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32), (n, 1))
-        info_updates: dict = {
-            "prev_rel": zeros3.copy(),
-            "filtered_rel_vel": zeros3.copy(),
-            "prev_top_quat": identity_quat,
-            "filtered_top_ang_vel": zeros3.copy(),
-            "target_tilt_cmd": zeros2.copy(),
-            "action_exec": zeros2.copy(),
-            "prev_action_exec": zeros2.copy(),
-            "last_rel_xy": np.zeros((n,), dtype=np.float32),
-            "prev_zero_vel_rel_xy": np.full((n,), cfg.platform_radius, dtype=np.float32),
-            "still_steps": np.zeros((n,), dtype=np.int32),
-            "still_window_active": np.zeros((n,), dtype=bool),
+    _ALLOWED_PARAMS = frozenset(
+        {
+            "entity_name",
+            "action_name",
+            "ball_body_name",
+            "top_body_name",
+            "target_rotation_limit_deg",
+            "vel_smooth",
         }
-        return ResetPlan(env_ids=env_ids, qpos=qpos, qvel=qvel, info_updates=info_updates)
+    )
 
-    def build_reset_observation(
-        self, env: StewartBalanceEnv, env_ids: np.ndarray, info_updates: dict
-    ) -> dict:
-        rel, top_quat, _ = env._read_ball_rel()
-        rel = rel[env_ids]
-        top_quat = top_quat[env_ids]
-        roll, pitch = _roll_pitch_from_quat(top_quat)
-        limit = max(env._cfg.target_rotation_limit_deg, 1e-6)
-        n = int(env_ids.shape[0])
-        info_updates["prev_rel"] = rel.astype(np.float32)
-        info_updates["prev_top_quat"] = top_quat.astype(np.float32)
-        info_updates["last_rel_xy"] = np.linalg.norm(rel[:, :2], axis=-1).astype(np.float32)
-        info_updates["prev_zero_vel_rel_xy"] = info_updates["last_rel_xy"].copy()
-        obs = np.concatenate(
-            [
-                rel,
-                np.zeros((n, 3), dtype=np.float32),
-                np.stack([np.rad2deg(roll) / limit, np.rad2deg(pitch) / limit], axis=-1).astype(
-                    np.float32
-                ),
-                np.zeros((n, 3), dtype=np.float32),
-                np.zeros((n, 2), dtype=np.float32),
-                np.zeros((n, 2), dtype=np.float32),
-            ],
-            axis=-1,
-        ).astype(get_global_dtype())
-        return {"obs": obs}
+    def __init__(self, cfg: ManagerTermBaseCfg, env: _StewartEnv):
+        super().__init__(env)
+        term = type(self).__name__
+        unexpected = set(cfg.params) - self._ALLOWED_PARAMS
+        if unexpected:
+            raise TypeError(f"{term} received unsupported parameters: {sorted(unexpected)}")
+        entity_name = _name(term, "entity_name", cfg.params.get("entity_name"))
+        action_name = _name(term, "action_name", cfg.params.get("action_name"))
+        self._entity = cast("Entity", env.scene[entity_name])
+        self._ball_body_id = _body_id(
+            self._entity,
+            _name(term, "ball_body_name", cfg.params.get("ball_body_name")),
+            term=term,
+        )
+        self._top_body_id = _body_id(
+            self._entity,
+            _name(term, "top_body_name", cfg.params.get("top_body_name")),
+            term=term,
+        )
+        action = env.action_manager.get_term(action_name)
+        if not isinstance(action, StewartTiltAction):
+            raise TypeError(
+                f"{term} action term {action_name!r} must be StewartTiltAction, "
+                f"got {type(action).__name__}"
+            )
+        self._action = action
+        self._tilt_limit_deg = _real(
+            term,
+            "target_rotation_limit_deg",
+            cfg.params.get("target_rotation_limit_deg"),
+            minimum=0.0,
+            strict_minimum=True,
+        )
+        self._vel_smooth = _real(
+            term,
+            "vel_smooth",
+            cfg.params.get("vel_smooth"),
+            minimum=0.0,
+            maximum=1.0,
+        )
+        self._step_dt = _real(term, "step_dt", env.step_dt, minimum=0.0, strict_minimum=True)
+
+        dtype = get_global_dtype()
+        self._relative = np.zeros((env.num_envs, 3), dtype=dtype)
+        self._previous_relative = np.zeros_like(self._relative)
+        self._filtered_relative_velocity = np.zeros_like(self._relative)
+        self._top_quat = np.zeros((env.num_envs, 4), dtype=dtype)
+        self._top_quat[:, 0] = 1.0
+        self._previous_top_quat = self._top_quat.copy()
+        self._filtered_top_angular_velocity = np.zeros_like(self._relative)
+        self._local_top_angular_velocity = np.zeros_like(self._relative)
+        self._ball_pos = np.zeros_like(self._relative)
+        self._relative_xy = np.zeros(env.num_envs, dtype=dtype)
+        self._velocity_xy = np.zeros(env.num_envs, dtype=dtype)
+        self._obs = np.zeros((env.num_envs, 15), dtype=dtype)
+        self._last_counter = self._counter(env)
+        self.reset(None)
+
+    @staticmethod
+    def _counter(env: _StewartEnv) -> int:
+        counter = env.common_step_counter
+        if isinstance(counter, (bool, np.bool_)) or not isinstance(counter, (int, np.integer)):
+            raise TypeError("StewartObservation common_step_counter must be an integer")
+        if counter < 0:
+            raise ValueError("StewartObservation common_step_counter must be non-negative")
+        return int(counter)
+
+    @property
+    def relative_xy(self) -> np.ndarray:
+        return self._relative_xy
+
+    @property
+    def velocity_xy(self) -> np.ndarray:
+        return self._velocity_xy
+
+    @property
+    def ball_pos(self) -> np.ndarray:
+        return self._ball_pos
+
+    def _write_observation_rows(self, ids: np.ndarray, *, reset_actions: bool) -> None:
+        roll, pitch = np_roll_pitch_from_quat(self._top_quat[ids])
+        self._obs[ids, 0:3] = self._relative[ids]
+        self._obs[ids, 3:6] = self._filtered_relative_velocity[ids]
+        self._obs[ids, 6] = np.rad2deg(roll) / self._tilt_limit_deg
+        self._obs[ids, 7] = np.rad2deg(pitch) / self._tilt_limit_deg
+        self._obs[ids, 8:11] = self._local_top_angular_velocity[ids]
+        if reset_actions:
+            self._obs[ids, 11:15] = 0.0
+        else:
+            self._obs[ids, 11:13] = self._action.target_tilt_deg[ids] / self._tilt_limit_deg
+            self._obs[ids, 13:15] = self._action.executed_action[ids]
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        ids = _env_ids(self._env, env_ids)
+        relative, top_quat, ball_pos = _relative_ball_state(
+            self._entity,
+            ball_body_id=self._ball_body_id,
+            top_body_id=self._top_body_id,
+        )
+        self._relative[ids] = relative[ids]
+        self._previous_relative[ids] = relative[ids]
+        self._filtered_relative_velocity[ids] = 0.0
+        self._top_quat[ids] = top_quat[ids]
+        self._previous_top_quat[ids] = top_quat[ids]
+        self._filtered_top_angular_velocity[ids] = 0.0
+        self._local_top_angular_velocity[ids] = 0.0
+        self._ball_pos[ids] = ball_pos[ids]
+        self._relative_xy[ids] = np.linalg.norm(relative[ids, :2], axis=-1)
+        self._velocity_xy[ids] = 0.0
+        self._write_observation_rows(ids, reset_actions=True)
+
+    def _advance(self, env: _StewartEnv) -> None:
+        counter = self._counter(env)
+        if counter == self._last_counter:
+            return
+        if counter != self._last_counter + 1:
+            raise RuntimeError(
+                "StewartObservation missed a control-step update: "
+                f"last={self._last_counter}, current={counter}"
+            )
+        relative, top_quat, ball_pos = _relative_ball_state(
+            self._entity,
+            ball_body_id=self._ball_body_id,
+            top_body_id=self._top_body_id,
+        )
+        relative_velocity = (relative - self._previous_relative) / self._step_dt
+        self._filtered_relative_velocity[:] = (
+            self._vel_smooth * relative_velocity
+            + (1.0 - self._vel_smooth) * self._filtered_relative_velocity
+        )
+        quaternion_delta = np_quat_mul_batched(
+            top_quat, np_quat_conjugate_batched(self._previous_top_quat)
+        )
+        top_angular_velocity = np_quat_to_axis_angle(quaternion_delta) / self._step_dt
+        self._filtered_top_angular_velocity[:] = (
+            self._vel_smooth * top_angular_velocity
+            + (1.0 - self._vel_smooth) * self._filtered_top_angular_velocity
+        )
+        self._local_top_angular_velocity[:] = np_quat_apply_inverse(
+            top_quat, self._filtered_top_angular_velocity
+        )
+        self._relative[:] = relative
+        self._previous_relative[:] = relative
+        self._top_quat[:] = top_quat
+        self._previous_top_quat[:] = top_quat
+        self._ball_pos[:] = ball_pos
+        self._relative_xy[:] = np.linalg.norm(relative[:, :2], axis=-1)
+        self._velocity_xy[:] = np.linalg.norm(self._filtered_relative_velocity[:, :2], axis=-1)
+        all_ids = np.arange(env.num_envs, dtype=np.int32)
+        self._write_observation_rows(all_ids, reset_actions=False)
+        self._last_counter = counter
+
+    def snapshot(self, env: _StewartEnv) -> np.ndarray:
+        self._advance(env)
+        return self._obs
+
+    def __call__(self, env: _StewartEnv, **params: Any) -> np.ndarray:
+        del params
+        return self.snapshot(env)
+
+
+class StewartBalanceState(ManagerTermBase):
+    """Termination-owned progress, stillness, success, and fall state."""
+
+    _ALLOWED_PARAMS = frozenset(
+        {
+            "observation_group",
+            "observation_term",
+            "platform_radius",
+            "fall_radius",
+            "top_center_z",
+            "still_xy",
+            "still_vel",
+            "still_xy_hysteresis",
+            "still_vel_hysteresis",
+            "zero_vel_thresh",
+            "still_steps_needed",
+        }
+    )
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: _StewartEnv):
+        super().__init__(env)
+        term = type(self).__name__
+        unexpected = set(cfg.params) - self._ALLOWED_PARAMS
+        if unexpected:
+            raise TypeError(f"{term} received unsupported parameters: {sorted(unexpected)}")
+        group_name = _name(term, "observation_group", cfg.params.get("observation_group"))
+        observation_name = _name(term, "observation_term", cfg.params.get("observation_term"))
+        observation = env.observation_manager.get_term_cfg(group_name, observation_name).func
+        if not isinstance(observation, StewartObservation):
+            raise TypeError(
+                f"{term} observation {group_name}/{observation_name} must be "
+                f"StewartObservation, got {type(observation).__name__}"
+            )
+        self._observation = observation
+        self._platform_radius = _real(
+            term,
+            "platform_radius",
+            cfg.params.get("platform_radius"),
+            minimum=0.0,
+            strict_minimum=True,
+        )
+        self._fall_radius = _real(
+            term,
+            "fall_radius",
+            cfg.params.get("fall_radius"),
+            minimum=0.0,
+            strict_minimum=True,
+        )
+        self._top_center_z = _real(term, "top_center_z", cfg.params.get("top_center_z"))
+        self._still_xy = _real(term, "still_xy", cfg.params.get("still_xy"), minimum=0.0)
+        self._still_vel = _real(term, "still_vel", cfg.params.get("still_vel"), minimum=0.0)
+        self._still_xy_hysteresis = _real(
+            term,
+            "still_xy_hysteresis",
+            cfg.params.get("still_xy_hysteresis"),
+            minimum=1.0,
+        )
+        self._still_vel_hysteresis = _real(
+            term,
+            "still_vel_hysteresis",
+            cfg.params.get("still_vel_hysteresis"),
+            minimum=1.0,
+        )
+        self._zero_vel_thresh = _real(
+            term,
+            "zero_vel_thresh",
+            cfg.params.get("zero_vel_thresh"),
+            minimum=0.0,
+        )
+        steps = cfg.params.get("still_steps_needed")
+        if isinstance(steps, (bool, np.bool_)) or not isinstance(steps, (int, np.integer)):
+            raise TypeError(f"{term} still_steps_needed must be an integer")
+        if steps <= 0:
+            raise ValueError(f"{term} still_steps_needed must be positive")
+        self._still_steps_needed = int(steps)
+
+        dtype = get_global_dtype()
+        self.fallen = np.zeros(env.num_envs, dtype=np.bool_)
+        self.success = np.zeros(env.num_envs, dtype=np.bool_)
+        self.center_score = np.zeros(env.num_envs, dtype=dtype)
+        self.progress = np.zeros(env.num_envs, dtype=dtype)
+        self.still_steps = np.zeros(env.num_envs, dtype=np.int32)
+        self.still_window_active = np.zeros(env.num_envs, dtype=np.bool_)
+        self._previous_zero_velocity_xy = np.zeros(env.num_envs, dtype=dtype)
+        self._done = np.zeros(env.num_envs, dtype=np.bool_)
+        self._last_counter = int(env.common_step_counter)
+
+    @property
+    def last_counter(self) -> int:
+        return self._last_counter
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        ids = _env_ids(self._env, env_ids)
+        self.fallen[ids] = False
+        self.success[ids] = False
+        self.center_score[ids] = np.clip(
+            1.0 - self._observation.relative_xy[ids] / self._fall_radius,
+            0.0,
+            1.0,
+        )
+        self.progress[ids] = 0.0
+        self.still_steps[ids] = 0
+        self.still_window_active[ids] = False
+        self._previous_zero_velocity_xy[ids] = self._observation.relative_xy[ids]
+        self._done[ids] = False
+
+    def _update(
+        self,
+        relative_xy: np.ndarray,
+        velocity_xy: np.ndarray,
+        ball_pos: np.ndarray,
+    ) -> None:
+        fall_z = self._top_center_z - np.sin(np.deg2rad(30.0)) * self._platform_radius
+        self.fallen[:] = (relative_xy > self._fall_radius) | (ball_pos[:, 2] < fall_z)
+        self.center_score[:] = np.clip(
+            1.0 - relative_xy / self._fall_radius,
+            0.0,
+            1.0,
+        )
+
+        zero_event = velocity_xy <= self._zero_vel_thresh
+        improvement = np.maximum(self._previous_zero_velocity_xy - relative_xy, 0.0)
+        self.progress[:] = np.where(
+            zero_event & (relative_xy < self._previous_zero_velocity_xy),
+            np.clip(improvement / self._platform_radius, 0.0, 1.0),
+            0.0,
+        )
+        self._previous_zero_velocity_xy[zero_event] = relative_xy[zero_event]
+
+        keep = (
+            self.still_window_active
+            & (relative_xy <= self._still_xy * self._still_xy_hysteresis)
+            & (velocity_xy <= self._still_vel * self._still_vel_hysteresis)
+        )
+        enter = (
+            ~self.still_window_active
+            & (relative_xy <= self._still_xy)
+            & (velocity_xy <= self._still_vel)
+        )
+        self.still_steps[:] = np.where(
+            keep,
+            self.still_steps + 1,
+            np.where(enter, 1, 0),
+        )
+        self.still_window_active[:] = keep | enter
+        self.success[:] = self.still_steps >= self._still_steps_needed
+        self._done[:] = self.fallen | self.success
+
+    def __call__(self, env: _StewartEnv, **params: Any) -> np.ndarray:
+        del params
+        counter = int(env.common_step_counter)
+        if counter == self._last_counter:
+            return self._done
+        if counter != self._last_counter + 1:
+            raise RuntimeError(
+                "StewartBalanceState missed a control-step update: "
+                f"last={self._last_counter}, current={counter}"
+            )
+        self._observation.snapshot(env)
+        self._update(
+            self._observation.relative_xy,
+            self._observation.velocity_xy,
+            self._observation.ball_pos,
+        )
+        self._last_counter = counter
+        return self._done
+
+
+def _balance_state(env: _StewartEnv, state_term_name: str) -> StewartBalanceState:
+    name = _name("Stewart reward", "state_term_name", state_term_name)
+    termination_manager = cast("TerminationManager", env.termination_manager)
+    state = termination_manager.get_term_cfg(name).func
+    if not isinstance(state, StewartBalanceState):
+        raise TypeError(
+            f"Stewart reward termination term {name!r} must be StewartBalanceState, "
+            f"got {type(state).__name__}"
+        )
+    if state.last_counter != int(env.common_step_counter):
+        raise RuntimeError(
+            f"Stewart reward state {name!r} was not computed for control step "
+            f"{env.common_step_counter}"
+        )
+    return state
+
+
+def center_reward(env: _StewartEnv, state_term_name: str) -> np.ndarray:
+    state = _balance_state(env, state_term_name)
+    return np.asarray(np.where(state.fallen, 0.0, state.center_score), dtype=get_global_dtype())
+
+
+def progress_reward(env: _StewartEnv, state_term_name: str) -> np.ndarray:
+    state = _balance_state(env, state_term_name)
+    return np.asarray(np.where(state.fallen, 0.0, state.progress), dtype=get_global_dtype())
+
+
+def still_reward(env: _StewartEnv, state_term_name: str) -> np.ndarray:
+    state = _balance_state(env, state_term_name)
+    return np.asarray(state.success & ~state.fallen, dtype=get_global_dtype())
+
+
+def fall_reward(env: _StewartEnv, state_term_name: str) -> np.ndarray:
+    state = _balance_state(env, state_term_name)
+    return np.asarray(state.fallen, dtype=get_global_dtype())
+
+
+class StewartBallReset(ManagerTermBase):
+    """Sample the ball uniformly within a disk via root-state entity writes."""
+
+    _ALLOWED_PARAMS = frozenset(
+        {"entity_name", "platform_radius", "init_ball_radius_ratio", "ball_home_z"}
+    )
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        term = type(self).__name__
+        unexpected = set(cfg.params) - self._ALLOWED_PARAMS
+        if unexpected:
+            raise TypeError(f"{term} received unsupported parameters: {sorted(unexpected)}")
+        entity_name = _name(term, "entity_name", cfg.params.get("entity_name"))
+        self._entity = cast("Entity", env.scene[entity_name])
+        self._platform_radius = _real(
+            term,
+            "platform_radius",
+            cfg.params.get("platform_radius"),
+            minimum=0.0,
+            strict_minimum=True,
+        )
+        self._radius_ratio = _real(
+            term,
+            "init_ball_radius_ratio",
+            cfg.params.get("init_ball_radius_ratio"),
+            minimum=0.0,
+            maximum=1.0,
+        )
+        self._ball_home_z = _real(term, "ball_home_z", cfg.params.get("ball_home_z"))
+        # Resolve the complete floating-root capability on the cold path.
+        default_state = self._entity.data.default_root_state
+        if default_state.shape != (env.num_envs, 13):
+            raise ValueError(
+                f"{term} default root state must have shape ({env.num_envs}, 13), "
+                f"got {default_state.shape}"
+            )
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        **params: Any,
+    ) -> None:
+        del params
+        ids = _env_ids(env, env_ids)
+        root_state = np.array(self._entity.data.default_root_state[ids], copy=True)
+        radius = (
+            self._platform_radius
+            * self._radius_ratio
+            * np.sqrt(env.rng.uniform(0.0, 1.0, size=ids.size))
+        )
+        theta = env.rng.uniform(0.0, 2.0 * np.pi, size=ids.size)
+        root_state[:, 0] = radius * np.cos(theta)
+        root_state[:, 1] = radius * np.sin(theta)
+        root_state[:, 2] = self._ball_home_z
+        self._entity.write_root_link_pose_to_sim(root_state[:, :7], env_ids=ids)
+        self._entity.write_root_link_velocity_to_sim(root_state[:, 7:], env_ids=ids)
+
+
+registry.register_env_config("StewartBalance", ManagerBasedRlEnvCfg)
+registry.register_env("StewartBalance", make_manager_based_rl_env, sim_backend="mujoco")
+registry.register_env("StewartBalance", make_manager_based_rl_env, sim_backend="motrix")
+registry.register_env("StewartBalance", make_manager_based_rl_env, sim_backend="drake")
+
+
+__all__ = [
+    "StewartBalanceState",
+    "StewartBallReset",
+    "StewartObservation",
+    "StewartTiltAction",
+    "StewartTiltActionCfg",
+    "center_reward",
+    "fall_reward",
+    "progress_reward",
+    "still_reward",
+]

--- a/tests/envs/test_stewart.py
+++ b/tests/envs/test_stewart.py
@@ -1,116 +1,382 @@
+"""Hydra-owned production contract for the Stewart Manager-Based task."""
+
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from unilab.base import registry
-from unilab.base.registry import ensure_registries
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, make_manager_based_rl_env
+from unilab.managers import ObservationTermCfg, RewardTermCfg, TerminationTermCfg
+from unilab.tasks.manipulation.stewart.balance import (
+    StewartBalanceState,
+    StewartBallReset,
+    StewartObservation,
+    StewartTiltAction,
+    StewartTiltActionCfg,
+)
+from unilab.training.backend_adapter import BackendAdapter
 
-_CONF_DIR = Path(__file__).resolve().parents[2] / "conf"
-_SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+ROOT_DIR = Path(__file__).parents[2]
+CONF_DIR = ROOT_DIR / "conf"
 
-_OBS_DIM = 15
-_ACTION_DIM = 2
+_BODY_NAMES = (
+    "ball",
+    "top",
+    "leg00",
+    "leg10",
+    "leg01",
+    "leg11",
+    "leg02",
+    "leg12",
+    "top_connect00",
+    "top_connect10",
+    "top_connect01",
+    "top_connect11",
+    "top_connect02",
+    "top_connect12",
+)
+_ACTUATOR_NAMES = ("a0", "a1", "a2", "a3", "a4", "a5")
 
-
-def _make_env(num_envs: int = 2):
-    pytest.importorskip("motrixsim", reason="motrixsim not installed")
-    ensure_registries()
-    return registry.make("StewartBalance", sim_backend="motrix", num_envs=num_envs)
-
-
-def test_stewart_env_uses_backend_contract() -> None:
-    """The task must go through the backend contract, not raw sim internals."""
-    source = (_SRC_DIR / "unilab" / "tasks" / "manipulation" / "stewart" / "balance.py").read_text(
-        encoding="utf-8"
-    )
-    assert "import motrixsim" not in source
-    assert "import mujoco" not in source
-    assert "_backend.model" not in source
-
-
-def test_stewart_registered_backends() -> None:
-    ensure_registries()
-    registered = registry.list_registered_envs()
-    assert "StewartBalance" in registered
-    # motrix is the original validated backend; mujoco and drake are
-    # construct/step-capable comparison backends.
-    assert set(registered["StewartBalance"]["available_backends"]) == {
+_OWNER_CASES = (
+    pytest.param("ppo", ("task=stewart_balance/motrix",), "motrix", id="ppo-motrix"),
+    pytest.param("ppo", ("task=stewart_balance/mujoco",), "mujoco", id="ppo-mujoco"),
+    pytest.param("ppo", ("task=stewart_balance/drake",), "drake", id="ppo-drake"),
+    pytest.param(
+        "offpolicy",
+        ("algo=sac", "task=sac/stewart_balance/drake"),
         "drake",
-        "motrix",
-        "mujoco",
+        id="sac-drake",
+    ),
+)
+
+
+def _compose(config_group: str, overrides: Sequence[str]) -> DictConfig:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / config_group), version_base="1.3"):
+        return compose("config", overrides=list(overrides))
+
+
+def _materialize(
+    config_group: str,
+    overrides: Sequence[str],
+) -> tuple[DictConfig, ManagerBasedRlEnvCfg, dict[str, Any]]:
+    hydra_cfg = _compose(config_group, overrides)
+    env_override = BackendAdapter(hydra_cfg, root_dir=ROOT_DIR).build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config("StewartBalance")
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, env_override)
+    env_cfg.validate()
+    return hydra_cfg, env_cfg, env_override
+
+
+def _make_env(backend: str, *, num_envs: int = 2) -> ManagerBasedRlEnv:
+    hydra_cfg, _, env_override = _materialize(
+        "ppo",
+        (f"task=stewart_balance/{backend}", f"algo.num_envs={num_envs}"),
+    )
+    env = registry.make(
+        str(hydra_cfg.training.task_name),
+        sim_backend=backend,
+        env_cfg_override=env_override,
+        num_envs=num_envs,
+    )
+    assert isinstance(env, ManagerBasedRlEnv)
+    return env
+
+
+def _assert_no_omegaconf(value: Any) -> None:
+    assert not OmegaConf.is_config(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        for item in fields(value):
+            _assert_no_omegaconf(getattr(value, item.name))
+    elif isinstance(value, Mapping):
+        for key, item in value.items():
+            _assert_no_omegaconf(key)
+            _assert_no_omegaconf(item)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            _assert_no_omegaconf(item)
+
+
+@pytest.mark.parametrize("config_group,overrides,backend", _OWNER_CASES)
+def test_stewart_owner_materializes_complete_plain_manager_cfg(
+    config_group: str,
+    overrides: tuple[str, ...],
+    backend: str,
+) -> None:
+    registry.ensure_registries()
+    hydra_cfg, env_cfg, _ = _materialize(config_group, overrides)
+
+    assert hydra_cfg.training.task_name == "StewartBalance"
+    assert hydra_cfg.training.sim_backend == backend
+    assert env_cfg.sim_dt == pytest.approx(0.004)
+    assert env_cfg.ctrl_dt == pytest.approx(0.02)
+    assert env_cfg.max_episode_seconds == pytest.approx(24.0)
+    assert env_cfg.max_episode_steps == 1200
+    assert env_cfg.scale_rewards_by_dt is False
+    assert env_cfg.policy_observation_group == "policy"
+    assert env_cfg.critic_observation_group is None
+
+    assert env_cfg.scene is not None
+    assert env_cfg.scene.model_file.endswith("robots/stewart/scene.xml")
+    assert list(env_cfg.scene.entities) == ["stewart"]
+    entity = env_cfg.scene.entities["stewart"]
+    assert entity.root_body_name == "ball"
+    assert entity.joint_names is None
+    assert tuple(entity.actuator_names or ()) == _ACTUATOR_NAMES
+    assert tuple(entity.body_names or ()) == _BODY_NAMES
+
+    assert list(env_cfg.actions) == ["tilt"]
+    action_cfg = env_cfg.actions["tilt"]
+    assert isinstance(action_cfg, StewartTiltActionCfg)
+    assert action_cfg.entity_name == "stewart"
+    assert tuple(action_cfg.actuator_names) == _ACTUATOR_NAMES
+    assert action_cfg.target_rotation_limit_deg == pytest.approx(6.0)
+    assert action_cfg.action_smooth == pytest.approx(0.60)
+    assert action_cfg.center_control_radius == pytest.approx(0.25)
+    assert action_cfg.center_control_min_gain == pytest.approx(0.15)
+
+    assert list(env_cfg.observations) == ["policy"]
+    policy_group = env_cfg.observations["policy"]
+    assert policy_group is not None
+    assert list(policy_group.terms) == ["balance"]
+    observation_cfg = policy_group.terms["balance"]
+    assert isinstance(observation_cfg, ObservationTermCfg)
+    assert observation_cfg.func is StewartObservation
+    assert observation_cfg.params["vel_smooth"] == pytest.approx(0.25)
+
+    assert list(env_cfg.events) == ["reset_scene_to_default", "reset_ball"]
+    reset_ball = env_cfg.events["reset_ball"]
+    assert reset_ball is not None
+    assert reset_ball.func is StewartBallReset
+    assert reset_ball.params == {
+        "entity_name": "stewart",
+        "platform_radius": 0.8,
+        "init_ball_radius_ratio": 0.18,
+        "ball_home_z": 1.2,
+    }
+    assert list(env_cfg.terminations) == ["balance_state", "time_out"]
+    state_cfg = env_cfg.terminations["balance_state"]
+    assert isinstance(state_cfg, TerminationTermCfg)
+    assert state_cfg.func is StewartBalanceState
+    assert state_cfg.params["still_steps_needed"] == 5
+    time_out = env_cfg.terminations["time_out"]
+    assert time_out is not None
+    assert time_out.time_out is True
+
+    assert list(env_cfg.rewards) == ["center", "progress", "still", "fall"]
+    weights = {
+        name: term.weight
+        for name, term in env_cfg.rewards.items()
+        if isinstance(term, RewardTermCfg)
+    }
+    assert weights == {"center": 0.7, "progress": 0.6, "still": 3.0, "fall": -6.0}
+
+    for manager_name in ("observations", "events", "rewards", "terminations"):
+        for manager_entry in getattr(env_cfg, manager_name).values():
+            if manager_entry is None:
+                continue
+            terms = (
+                manager_entry.terms.values() if manager_name == "observations" else (manager_entry,)
+            )
+            for term in terms:
+                if term is None:
+                    continue
+                module = term.func.__module__
+                assert ".backend." not in module
+                assert not any(name in module for name in (".mujoco", ".motrix", ".drake"))
+
+    _assert_no_omegaconf(env_cfg)
+
+
+def test_stewart_registry_is_manager_only_and_legacy_overrides_fail_closed() -> None:
+    registry.ensure_registries()
+    assert registry.list_registered_envs()["StewartBalance"] == {
+        "config_factory": "ManagerBasedRlEnvCfg",
+        "available_backends": ["mujoco", "motrix", "drake"],
     }
 
-
-def test_stewart_motrix_owner_cfg_composes() -> None:
-    if GlobalHydra().is_initialized():
-        GlobalHydra.instance().clear()
-    with initialize_config_dir(config_dir=str(_CONF_DIR / "ppo"), version_base="1.3"):
-        cfg = compose("config", overrides=["task=stewart_balance/motrix", "algo.num_envs=2"])
-    assert cfg.training.task_name == "StewartBalance"
-    assert cfg.training.sim_backend == "motrix"
-    # Reward block maps onto the env's StewartRewardConfig.
-    reward = OmegaConf.to_container(cfg.reward, resolve=True)
-    assert set(reward) == {"scales", "fall_penalty"}
-    assert set(reward["scales"]) == {"center", "progress", "still"}
-    assert cfg.algo.obs_groups.actor == ["policy"]
+    for legacy_override in (
+        {"reward_config": {}},
+        {"platform_radius": 0.8},
+        {"action_smooth": 0.6},
+    ):
+        with pytest.raises(ValueError, match="has no attribute"):
+            apply_cfg_overrides(ManagerBasedRlEnvCfg(), legacy_override)
 
 
-def test_stewart_mujoco_owner_cfg_composes() -> None:
-    if GlobalHydra().is_initialized():
-        GlobalHydra.instance().clear()
-    with initialize_config_dir(config_dir=str(_CONF_DIR / "ppo"), version_base="1.3"):
-        cfg = compose("config", overrides=["task=stewart_balance/mujoco", "algo.num_envs=2"])
-    # Inherits the motrix owner config, only switching the backend.
-    assert cfg.training.task_name == "StewartBalance"
-    assert cfg.training.sim_backend == "mujoco"
-    assert cfg.algo.obs_groups.actor == ["policy"]
+def test_stewart_terms_do_not_access_physics_implementations() -> None:
+    source = (ROOT_DIR / "src/unilab/tasks/manipulation/stewart/balance.py").read_text(
+        encoding="utf-8"
+    )
+    for forbidden in (
+        "import mujoco",
+        "import motrixsim",
+        "create_backend",
+        "env_backend_kwargs",
+        "._backend",
+        "get_body_pos_w",
+        "get_body_quat_w",
+        "get_default_qpos",
+        "get_init_qvel",
+        "set_state(",
+    ):
+        assert forbidden not in source
 
 
-def test_stewart_env_constructs_and_steps() -> None:
-    pytest.importorskip("motrixsim", reason="motrixsim not installed")
-    env = _make_env(num_envs=2)
-    assert env.obs_groups_spec == {"obs": _OBS_DIM}
-    assert env.action_space.shape == (_ACTION_DIM,)
+@pytest.mark.parametrize("backend", ("motrix", "mujoco"))
+def test_stewart_real_manager_runtime_preserves_io_reset_and_level_ik(backend: str) -> None:
+    try:
+        env = _make_env(backend, num_envs=2)
+    except ImportError as exc:
+        pytest.skip(f"{backend} runtime unavailable: {exc}")
 
-    state = None
-    for _ in range(20):
-        state = env.step(np.zeros((2, _ACTION_DIM), dtype=np.float32))
-    assert state is not None
-    obs = state.obs["obs"]
-    assert obs.shape == (2, _OBS_DIM)
-    assert np.isfinite(obs).all()
-    assert np.isfinite(state.reward).all()
-    assert state.terminated.dtype == bool
+    try:
+        assert env.obs_groups_spec == {"obs": 15}
+        assert env.action_space.shape == (2,)
+        assert env.event_manager.active_terms == {"reset": ["reset_scene_to_default", "reset_ball"]}
+        obs, info = env.reset(seed=7)
+        assert {name: value.shape for name, value in obs.items()} == {"obs": (2, 15)}
+        assert isinstance(info, dict)
+        assert np.isfinite(obs["obs"]).all()
+
+        entity = env.scene["stewart"]
+        ball_id = entity.find_bodies("ball")[0][0]
+        top_id = entity.find_bodies("top")[0][0]
+        ball_pos = entity.data.body_link_pos_w[:, ball_id]
+        assert np.all(np.linalg.norm(ball_pos[:, :2], axis=-1) <= 0.8 * 0.18 + 1e-6)
+        np.testing.assert_allclose(ball_pos[:, 2], 1.2, atol=1e-6)
+
+        action = env.action_manager.get_term("tilt")
+        assert isinstance(action, StewartTiltAction)
+        np.testing.assert_allclose(action.neutral_leg_lengths, 1.1, atol=1e-4)
+        level_control = action.leg_control_for_tilt(np.zeros((2, 2), dtype=np.float32))
+        np.testing.assert_allclose(level_control, 0.0, atol=1e-4)
+
+        state = env.step(np.zeros((2, 2), dtype=np.float32))
+        for _ in range(19):
+            state = env.step(np.zeros((2, 2), dtype=np.float32))
+        assert state.obs["obs"].shape == (2, 15)
+        assert np.isfinite(state.obs["obs"]).all()
+        assert np.isfinite(state.reward).all()
+        assert state.terminated.dtype == np.bool_
+        top_z = entity.data.body_link_pos_w[:, top_id, 2]
+        assert np.all(np.abs(top_z - 1.0) < 0.1)
+    finally:
+        env.close()
 
 
-def test_stewart_ik_holds_level_platform() -> None:
-    """At zero action the IK should hold the plate near its home height (z=1)."""
-    pytest.importorskip("motrixsim", reason="motrixsim not installed")
-    env = _make_env(num_envs=2)
-    env.step(np.zeros((2, _ACTION_DIM), dtype=np.float32))  # triggers reset + calibration
-    # Level-hold control should be ~zero leg displacement and ~1.1 m neutral legs.
-    np.testing.assert_allclose(env._leg0, 1.1, atol=1e-2)
-    ctrl = env._leg_ctrl_for_tilt(np.zeros((2, _ACTION_DIM), dtype=np.float32))
-    assert np.allclose(ctrl, 0.0, atol=1e-2)
-    for _ in range(20):
-        env.step(np.zeros((2, _ACTION_DIM), dtype=np.float32))
-    top_z = env._backend.get_body_pos_w(env._top_body_ids)[:, 0, 2]
-    assert np.all(np.abs(top_z - 1.0) < 0.1)
+def test_stewart_action_smoothing_and_center_authority_match_legacy_equations() -> None:
+    try:
+        env = _make_env("motrix", num_envs=2)
+    except ImportError as exc:
+        pytest.skip(f"motrix runtime unavailable: {exc}")
+
+    try:
+        env.reset(seed=11)
+        action = env.action_manager.get_term("tilt")
+        observation = env.observation_manager.get_term_cfg("policy", "balance").func
+        assert isinstance(action, StewartTiltAction)
+        assert isinstance(observation, StewartObservation)
+
+        action.process_actions(np.full((2, 2), 2.0, dtype=np.float32))
+        np.testing.assert_allclose(action.executed_action, 0.6, atol=1e-6)
+        ratio = np.clip(observation.relative_xy / 0.25, 0.0, 1.0)
+        expected_gain = 0.15 + 0.85 * ratio
+        np.testing.assert_allclose(
+            action.target_tilt_deg,
+            np.broadcast_to(0.6 * expected_gain[:, None] * 6.0, (2, 2)),
+            atol=1e-6,
+        )
+
+        action.process_actions(np.ones((2, 2), dtype=np.float32))
+        np.testing.assert_allclose(action.executed_action, 0.84, atol=1e-6)
+        action.reset(np.array([1], dtype=np.int32))
+        np.testing.assert_allclose(action.executed_action[1], 0.0)
+        np.testing.assert_allclose(action.executed_action[0], 0.84)
+    finally:
+        env.close()
+
+
+def test_stewart_state_machine_and_fall_reward_are_exact() -> None:
+    try:
+        env = _make_env("motrix", num_envs=2)
+    except ImportError as exc:
+        pytest.skip(f"motrix runtime unavailable: {exc}")
+
+    try:
+        env.reset(seed=3)
+        state_term = env.termination_manager.get_term_cfg("balance_state").func
+        assert isinstance(state_term, StewartBalanceState)
+        state_term._previous_zero_velocity_xy[:] = 0.4
+        state_term._update(
+            np.array([0.2, 0.6], dtype=np.float32),
+            np.array([0.0, 0.2], dtype=np.float32),
+            np.array([[0.0, 0.0, 1.2], [0.0, 0.0, 1.2]], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(state_term.fallen, [False, True])
+        np.testing.assert_allclose(state_term.center_score, [0.6, 0.0], atol=1e-6)
+        np.testing.assert_allclose(state_term.progress, [0.25, 0.0], atol=1e-6)
+
+        # Prove fall masking independently of the geometric scores themselves.
+        state_term.center_score[1] = 0.9
+        state_term.progress[1] = 0.5
+        state_term.success[1] = True
+        reward = env.reward_manager.compute(dt=env.step_dt)
+        assert reward[0] == pytest.approx(0.7 * 0.6 + 0.6 * 0.25)
+        # Positive terms are explicitly masked for fallen environments.
+        assert reward[1] == pytest.approx(-6.0)
+
+        state_term.fallen[:] = False
+        state_term.success[:] = False
+        state_term.still_steps[:] = 0
+        state_term.still_window_active[:] = False
+        state_term._previous_zero_velocity_xy[:] = 0.1
+        centered = np.full(2, 0.1, dtype=np.float32)
+        slow = np.full(2, 0.05, dtype=np.float32)
+        ball_pos = np.full((2, 3), (0.0, 0.0, 1.2), dtype=np.float32)
+        for _ in range(5):
+            state_term._update(centered, slow, ball_pos)
+        np.testing.assert_array_equal(state_term.still_steps, [5, 5])
+        np.testing.assert_array_equal(state_term.success, [True, True])
+    finally:
+        env.close()
+
+
+def test_stewart_drake_materializes_or_fails_at_optional_runtime_boundary() -> None:
+    _, env_cfg, _ = _materialize("ppo", ("task=stewart_balance/drake",))
+    try:
+        env = make_manager_based_rl_env(env_cfg, num_envs=1, backend_type="drake")
+    except ImportError as exc:
+        assert "DrakeUni batch runtime is not installed" in str(exc)
+        return
+    try:
+        obs, _ = env.reset(seed=5)
+        assert obs["obs"].shape == (1, 15)
+    finally:
+        env.close()
 
 
 @pytest.mark.slow
 def test_stewart_solver_stable_under_random_actions() -> None:
-    """Regression for the closed-loop solver blow-up (NotPositiveDefinite):
-    the fall-radius margin + softened actuator kp must keep it stable."""
-    pytest.importorskip("motrixsim", reason="motrixsim not installed")
-    env = _make_env(num_envs=8)
-    np.random.seed(0)
-    for _ in range(400):
-        state = env.step(np.random.uniform(-1.0, 1.0, (8, _ACTION_DIM)).astype(np.float32))
-        assert np.isfinite(state.obs["obs"]).all()
+    try:
+        env = _make_env("motrix", num_envs=8)
+    except ImportError as exc:
+        pytest.skip(f"motrix runtime unavailable: {exc}")
+    try:
+        rng = np.random.default_rng(0)
+        for _ in range(400):
+            state = env.step(rng.uniform(-1.0, 1.0, (8, 2)).astype(np.float32))
+            assert np.isfinite(state.obs["obs"]).all()
+    finally:
+        env.close()


### PR DESCRIPTION
Closes #1205
Parent: #1042

## Outcome

- Switch all `StewartBalance` registry backends to `ManagerBasedRlEnvCfg` and `make_manager_based_rl_env`.
- Make PPO and SAC Hydra owners the only production source for scene, action, reset, observation, termination, and reward terms.
- Preserve the 15-D observation, 2-D tilt action, 0.004/0.02 s timing, 24 s episode, six-leg IK, smoothing/center authority, disk reset, and progress/still/fall state machine.
- Keep all task physics access behind the public Entity facade; missing capabilities fail closed.
- Repair MuJoCo's existing injected body-sensor map after `<replicate>` compilation reorders body IDs; no public backend contract was added.
- Remove the legacy Stewart env/config/DR provider and Python reward mirror.

## Validation

Final local head `14c6c7dd`:

- `make test-all`: 2079 passed, 27 skipped, 272 deselected, 1 xfailed; ruff, mypy, pyright, and benchmark import smoke passed.
- Focused Manager/Entity/backend suite: 106 passed.
- Explicit slow Stewart random-action solver regression: 1 passed.
- Real MuJoCo and Motrix reset/step/level-IK smoke passed; Drake owner materializes and fails at the optional-runtime boundary when DrakeUni is absent.

Per the approved #1042 workflow, this child relies on the local gate and does not wait for remote CI.

## Scope report

- Source-derived manager lines: 0.
- Mechanical Torch-to-NumPy conversion lines: 0 (the replaced Stewart task was already NumPy).
- UniLab task/config/adapter/test additions: 1,412 lines.
- Modified existing: 7 files, +1,158/-521 lines.
- New: 2 Hydra base files, +254 lines.
- Deleted: 0 files, 521 lines removed in-place; the legacy classes/provider were deleted from their owner module.
