### PR TITLE
feat(tasks): migrate Go2W flat to Manager-Based runtime

### DIFF
--- a/conf/offpolicy/task/go2w_joystick_flat/base.yaml
+++ b/conf/offpolicy/task/go2w_joystick_flat/base.yaml
@@ -1,0 +1,298 @@
+# @package _global_
+# Canonical Go2W flat Manager-Based task declaration. Backend leaves only own
+# backend identity and backend-specific rendering/runtime settings.
+env:
+  scene:
+    model_file: src/unilab/assets/robots/go2w/scene_flat.xml
+    default_keyframe_name: home
+    entities:
+      robot:
+        root_body_name: base_link
+        joint_names:
+          - FR_hip_joint
+          - FR_thigh_joint
+          - FR_calf_joint
+          - FL_hip_joint
+          - FL_thigh_joint
+          - FL_calf_joint
+          - RR_hip_joint
+          - RR_thigh_joint
+          - RR_calf_joint
+          - RL_hip_joint
+          - RL_thigh_joint
+          - RL_calf_joint
+          - FR_wheel_joint
+          - FL_wheel_joint
+          - RR_wheel_joint
+          - RL_wheel_joint
+        actuator_names:
+          - FR_hip
+          - FR_thigh
+          - FR_calf
+          - FL_hip
+          - FL_thigh
+          - FL_calf
+          - RR_hip
+          - RR_thigh
+          - RR_calf
+          - RL_hip
+          - RL_thigh
+          - RL_calf
+          - FR_wheel
+          - FL_wheel
+          - RR_wheel
+          - RL_wheel
+        body_names: [base_link]
+  sim_dt: 0.005
+  ctrl_dt: 0.02
+  max_episode_seconds: 20.0
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        base_ang_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: gyro
+        projected_gravity:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.projected_gravity_from_sensor
+          params:
+            sensor_name: upvector
+        leg_joint_pos:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        leg_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        wheel_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_wheel_joint"
+        actions:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.last_action
+          params:
+            action_name: motor
+        command:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.generated_commands
+          params:
+            command_name: twist
+    critic:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        base_ang_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: gyro
+        projected_gravity:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.projected_gravity_from_sensor
+          params:
+            sensor_name: upvector
+        leg_joint_pos:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        leg_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        wheel_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_wheel_joint"
+        actions:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.last_action
+          params:
+            action_name: motor
+        command:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.generated_commands
+          params:
+            command_name: twist
+        base_lin_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: local_linvel
+        motor_torque:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque
+          params:
+            action_name: motor
+  actions:
+    motor:
+      _target_: unilab.tasks.locomotion.go2w.manager_terms.Go2WMixedActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      leg_action_scale: 0.5
+      wheel_action_scale: 10.0
+      leg_kp: 50.0
+      leg_kd: 1.5
+      wheel_kd: 0.5
+      clip_actions: 1.0
+      simulate_action_latency: false
+  commands:
+    twist:
+      _target_: unilab.tasks.locomotion.go2w.manager_terms.Go2WVelocityCommandCfg
+      entity_name: robot
+      resampling_time_range: [20.0, 20.0]
+      heading_command: false
+      heading_control_stiffness: 0.5
+      rel_standing_envs: 0.0
+      rel_heading_envs: 0.0
+      rel_world_envs: 0.0
+      rel_forward_envs: 0.0
+      init_velocity_prob: 0.0
+      planar_dead_zone: 0.2
+      ranges:
+        lin_vel_x: [0.0, 1.0]
+        lin_vel_y: [0.0, 0.0]
+        ang_vel_z: [-1.0, 1.0]
+  events:
+    reset_scene_to_default:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    reset_root_state_uniform:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_root_state_uniform
+      mode: reset
+      params:
+        pose_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [0.0, 0.0]
+          roll: [0.0, 0.0]
+          pitch: [0.0, 0.0]
+          yaw: [-3.141592653589793, 3.141592653589793]
+        velocity_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [-0.5, 0.5]
+          roll: [-0.5, 0.5]
+          pitch: [-0.5, 0.5]
+          yaw: [-0.5, 0.5]
+    motor_gains:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.tasks.locomotion.go2w.manager_terms.randomize_motor_gains
+      mode: reset
+      params:
+        action_name: motor
+        kp_multiplier_range: [1.0, 1.0]
+        kd_multiplier_range: [1.0, 1.0]
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    bad_orientation:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.bad_orientation
+      params:
+        limit_angle: 1.0471975511965976
+  policy_observation_group: policy
+  critic_observation_group: critic
+
+reward:
+  tracking_lin_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
+    weight: 1.0
+    params:
+      std: 0.5
+      command_name: twist
+  tracking_ang_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
+    weight: 0.75
+    params:
+      std: 0.5
+      command_name: twist
+  lin_vel_z:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
+    weight: -5.0
+  ang_vel_xy:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
+    weight: -0.1
+  base_height:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
+    weight: -100.0
+    params:
+      target_height: 0.4
+  orientation:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.flat_orientation_l2
+    weight: -2.0
+  action_rate:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.clipped_action_rate_l2
+    weight: -0.005
+    params:
+      action_name: motor
+  similar_to_default:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
+    weight: -0.5
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*_(hip|thigh|calf)_joint"
+  torques:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque_l2
+    weight: -0.0002
+    params:
+      action_name: motor
+  wheel_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.joint_vel_l2
+    weight: 0.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*_wheel_joint"
+  alive:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.constant_alive
+    weight: 0.5
+  upward:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
+    weight: 1.0

--- a/conf/offpolicy/task/sac/go2w_joystick_flat/drake.yaml
+++ b/conf/offpolicy/task/sac/go2w_joystick_flat/drake.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/go2w_joystick_flat/base
+  - _self_
+
 training:
   task_name: Go2WJoystickFlat
   sim_backend: drake
@@ -28,36 +32,3 @@ algo:
 env:
   drake_backend_mode: batch
   drake_nthread: 20
-  scene:
-    model_file: src/unilab/assets/robots/go2w/scene_flat.xml
-  commands:
-    vel_limit:
-      - [0.0, 0.0, -1.0]
-      - [1.0, 0.0, 1.0]
-  control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
-    Kp: 50.0
-    Kd: 1.5
-    wheel_Kd: 0.5
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false
-    push_robots: false
-
-reward:
-  scales:
-    tracking_lin_vel: 1.0
-    tracking_ang_vel: 0.75
-    lin_vel_z: -5.0
-    ang_vel_xy: -0.1
-    base_height: -100.0
-    orientation: -2.0
-    action_rate: -0.005
-    similar_to_default: -0.5
-    torques: -0.0002
-    wheel_vel: 0.0
-    alive: 0.5
-    upward: 1.0
-  tracking_sigma: 0.25
-  base_height_target: 0.4

--- a/conf/ppo/task/go2w_joystick_flat/base.yaml
+++ b/conf/ppo/task/go2w_joystick_flat/base.yaml
@@ -1,0 +1,298 @@
+# @package _global_
+# Canonical Go2W flat Manager-Based task declaration. Backend leaves only own
+# backend identity and backend-specific rendering/runtime settings.
+env:
+  scene:
+    model_file: src/unilab/assets/robots/go2w/scene_flat.xml
+    default_keyframe_name: home
+    entities:
+      robot:
+        root_body_name: base_link
+        joint_names:
+          - FR_hip_joint
+          - FR_thigh_joint
+          - FR_calf_joint
+          - FL_hip_joint
+          - FL_thigh_joint
+          - FL_calf_joint
+          - RR_hip_joint
+          - RR_thigh_joint
+          - RR_calf_joint
+          - RL_hip_joint
+          - RL_thigh_joint
+          - RL_calf_joint
+          - FR_wheel_joint
+          - FL_wheel_joint
+          - RR_wheel_joint
+          - RL_wheel_joint
+        actuator_names:
+          - FR_hip
+          - FR_thigh
+          - FR_calf
+          - FL_hip
+          - FL_thigh
+          - FL_calf
+          - RR_hip
+          - RR_thigh
+          - RR_calf
+          - RL_hip
+          - RL_thigh
+          - RL_calf
+          - FR_wheel
+          - FL_wheel
+          - RR_wheel
+          - RL_wheel
+        body_names: [base_link]
+  sim_dt: 0.005
+  ctrl_dt: 0.02
+  max_episode_seconds: 20.0
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        base_ang_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: gyro
+        projected_gravity:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.projected_gravity_from_sensor
+          params:
+            sensor_name: upvector
+        leg_joint_pos:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        leg_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        wheel_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_wheel_joint"
+        actions:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.last_action
+          params:
+            action_name: motor
+        command:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.generated_commands
+          params:
+            command_name: twist
+    critic:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        base_ang_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: gyro
+        projected_gravity:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.projected_gravity_from_sensor
+          params:
+            sensor_name: upvector
+        leg_joint_pos:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        leg_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_(hip|thigh|calf)_joint"
+        wheel_joint_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              joint_names: ".*_wheel_joint"
+        actions:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.last_action
+          params:
+            action_name: motor
+        command:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.generated_commands
+          params:
+            command_name: twist
+        base_lin_vel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.builtin_sensor
+          params:
+            sensor_name: local_linvel
+        motor_torque:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque
+          params:
+            action_name: motor
+  actions:
+    motor:
+      _target_: unilab.tasks.locomotion.go2w.manager_terms.Go2WMixedActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      leg_action_scale: 0.5
+      wheel_action_scale: 10.0
+      leg_kp: 50.0
+      leg_kd: 1.5
+      wheel_kd: 0.5
+      clip_actions: 1.0
+      simulate_action_latency: false
+  commands:
+    twist:
+      _target_: unilab.tasks.locomotion.go2w.manager_terms.Go2WVelocityCommandCfg
+      entity_name: robot
+      resampling_time_range: [20.0, 20.0]
+      heading_command: false
+      heading_control_stiffness: 0.5
+      rel_standing_envs: 0.0
+      rel_heading_envs: 0.0
+      rel_world_envs: 0.0
+      rel_forward_envs: 0.0
+      init_velocity_prob: 0.0
+      planar_dead_zone: 0.2
+      ranges:
+        lin_vel_x: [0.0, 1.0]
+        lin_vel_y: [0.0, 0.0]
+        ang_vel_z: [-1.0, 1.0]
+  events:
+    reset_scene_to_default:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    reset_root_state_uniform:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.envs.mdp.reset_root_state_uniform
+      mode: reset
+      params:
+        pose_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [0.0, 0.0]
+          roll: [0.0, 0.0]
+          pitch: [0.0, 0.0]
+          yaw: [-3.141592653589793, 3.141592653589793]
+        velocity_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [-0.5, 0.5]
+          roll: [-0.5, 0.5]
+          pitch: [-0.5, 0.5]
+          yaw: [-0.5, 0.5]
+    motor_gains:
+      _target_: unilab.managers.EventTermCfg
+      func: unilab.tasks.locomotion.go2w.manager_terms.randomize_motor_gains
+      mode: reset
+      params:
+        action_name: motor
+        kp_multiplier_range: [1.0, 1.0]
+        kd_multiplier_range: [1.0, 1.0]
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    bad_orientation:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.bad_orientation
+      params:
+        limit_angle: 1.0471975511965976
+  policy_observation_group: policy
+  critic_observation_group: critic
+
+reward:
+  tracking_lin_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
+    weight: 1.0
+    params:
+      std: 0.5
+      command_name: twist
+  tracking_ang_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
+    weight: 0.75
+    params:
+      std: 0.5
+      command_name: twist
+  lin_vel_z:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
+    weight: -5.0
+  ang_vel_xy:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
+    weight: -0.1
+  base_height:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
+    weight: -100.0
+    params:
+      target_height: 0.4
+  orientation:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.flat_orientation_l2
+    weight: -2.0
+  action_rate:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.clipped_action_rate_l2
+    weight: -0.005
+    params:
+      action_name: motor
+  similar_to_default:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
+    weight: -0.5
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*_(hip|thigh|calf)_joint"
+  torques:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque_l2
+    weight: -0.0002
+    params:
+      action_name: motor
+  wheel_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.joint_vel_l2
+    weight: 0.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*_wheel_joint"
+  alive:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.constant_alive
+    weight: 0.5
+  upward:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
+    weight: 1.0

--- a/conf/ppo/task/go2w_joystick_flat/drake.yaml
+++ b/conf/ppo/task/go2w_joystick_flat/drake.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/go2w_joystick_flat/base
+  - _self_
+
 training:
   task_name: Go2WJoystickFlat
   sim_backend: drake
@@ -10,6 +14,8 @@ algo:
   obs_groups:
     actor:
       - actor
+    critic:
+      - critic
   policy:
     init_noise_std: 0.5
   algorithm:
@@ -19,36 +25,3 @@ algo:
 env:
   drake_backend_mode: batch
   drake_nthread: 0
-  scene:
-    model_file: src/unilab/assets/robots/go2w/scene_flat.xml
-  commands:
-    vel_limit:
-      - [0.0, 0.0, -1.0]
-      - [1.0, 0.0, 1.0]
-  control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
-    Kp: 50.0
-    Kd: 1.5
-    wheel_Kd: 0.5
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false
-    push_robots: false
-
-reward:
-  scales:
-    tracking_lin_vel: 1.0
-    tracking_ang_vel: 0.75
-    lin_vel_z: -5.0
-    ang_vel_xy: -0.1
-    base_height: -100.0
-    orientation: -2.0
-    action_rate: -0.005
-    similar_to_default: -0.5
-    torques: -0.0002
-    wheel_vel: 0.0
-    alive: 0.5
-    upward: 1.0
-  tracking_sigma: 0.25
-  base_height_target: 0.4

--- a/conf/ppo/task/go2w_joystick_flat/motrix.yaml
+++ b/conf/ppo/task/go2w_joystick_flat/motrix.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/go2w_joystick_flat/base
+  - _self_
+
 training:
   task_name: Go2WJoystickFlat
   sim_backend: motrix
@@ -9,6 +13,8 @@ algo:
   obs_groups:
     actor:
       - actor
+    critic:
+      - critic
   policy:
     init_noise_std: 0.5
   algorithm:
@@ -16,35 +22,6 @@ algo:
     entropy_coef: 1.0e-3
 env:
   render_offset_mode: zero
-  commands:
-    vel_limit:
-      - [0.0, 0.0, -1.0]
-      - [1.0, 0.0, 1.0]
-  control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
-    Kp: 50.0
-    Kd: 1.5
-    wheel_Kd: 0.5
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false
-reward:
-  scales:
-    tracking_lin_vel: 1.0
-    tracking_ang_vel: 0.75
-    lin_vel_z: -5.0
-    ang_vel_xy: -0.1
-    base_height: -100.0
-    orientation: -2.0
-    action_rate: -0.005
-    similar_to_default: -0.5
-    torques: -0.0002
-    wheel_vel: 0.0
-    alive: 0.5
-    upward: 1.0
-  tracking_sigma: 0.25
-  base_height_target: 0.4
 play_profile:
   enabled: true
   env:

--- a/conf/ppo/task/go2w_joystick_flat/mujoco.yaml
+++ b/conf/ppo/task/go2w_joystick_flat/mujoco.yaml
@@ -1,4 +1,8 @@
 # @package _global_
+defaults:
+  - /task/go2w_joystick_flat/base
+  - _self_
+
 training:
   task_name: Go2WJoystickFlat
   sim_backend: mujoco
@@ -9,41 +13,13 @@ algo:
   obs_groups:
     actor:
       - actor
+    critic:
+      - critic
   policy:
     init_noise_std: 0.5
   algorithm:
     learning_rate: 3.0e-4
     entropy_coef: 1.0e-3
-env:
-  commands:
-    vel_limit:
-      - [0.0, 0.0, -1.0]
-      - [1.0, 0.0, 1.0]
-  control_config:
-    action_scale: 0.5
-    wheel_action_scale: 10.0
-    Kp: 50.0
-    Kd: 1.5
-    wheel_Kd: 0.5
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false
-reward:
-  scales:
-    tracking_lin_vel: 1.0
-    tracking_ang_vel: 0.75
-    lin_vel_z: -5.0
-    ang_vel_xy: -0.1
-    base_height: -100.0
-    orientation: -2.0
-    action_rate: -0.005
-    similar_to_default: -0.5
-    torques: -0.0002
-    wheel_vel: 0.0
-    alive: 0.5
-    upward: 1.0
-  tracking_sigma: 0.25
-  base_height_target: 0.4
 play_profile:
   enabled: true
   env:

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -129,7 +129,7 @@ class TaskConfig:
     task_id: str
     env_name: str
     cfg_factory: Callable[[str, list[str]], Any]
-    env_cls_factory: Callable[[], type]
+    env_cls_factory: Callable[[], Callable[..., Any]]
     backends: tuple[str, ...] = ("mujoco", "motrix")
     aliases: tuple[str, ...] = ()
     cfg_finalizer: Callable[[Any, str], None] | None = None
@@ -312,9 +312,11 @@ def _go2_rough_env_cls() -> type:
 
 
 def _go2w_cfg(backend: str, config_overrides: list[str]) -> Any:
-    from unilab.tasks.locomotion.go2w.joystick import Go2WJoystickCfg
+    from unilab.envs import ManagerBasedRlEnvCfg
 
-    return _ppo_owner_yaml_cfg("go2w_joystick_flat", backend, Go2WJoystickCfg, config_overrides)
+    return _ppo_owner_yaml_cfg(
+        "go2w_joystick_flat", backend, ManagerBasedRlEnvCfg, config_overrides
+    )
 
 
 def _go2w_rough_cfg(backend: str, config_overrides: list[str]) -> Any:
@@ -325,10 +327,10 @@ def _go2w_rough_cfg(backend: str, config_overrides: list[str]) -> Any:
     )
 
 
-def _go2w_env_cls() -> type:
-    from unilab.tasks.locomotion.go2w.joystick import Go2WJoystickEnv
+def _go2w_env_cls() -> Callable[..., Any]:
+    from unilab.envs import make_manager_based_rl_env
 
-    return Go2WJoystickEnv
+    return make_manager_based_rl_env
 
 
 def _go2w_rough_env_cls() -> type:
@@ -502,7 +504,7 @@ TASK_CONFIGS: dict[str, TaskConfig] = {
 }
 
 # Default benchmark parameters
-DEFAULT_NUM_ENVS = 2048
+DEFAULT_NUM_ENVS = 4096
 DEFAULT_NUM_STEPS = 20
 DEFAULT_WARMUP_STEPS = 5
 
@@ -708,15 +710,21 @@ def _run_single(extra_args: list[str]) -> dict[str, Any]:
         env_cls = task_config.env_cls_factory()
         env = env_cls(cfg, num_envs=num_envs, backend_type=sim_backend)
 
-        nu = env._backend.num_actuators  # type: ignore[reportAttributeAccessIssue]
+        action_shape = env.action_space.shape
+        if action_shape is None or len(action_shape) != 1:
+            raise ValueError(
+                f"Benchmark task {task_config.env_name!r} requires a flat action space, "
+                f"got {action_shape}"
+            )
+        action_dim = int(action_shape[0])
         env.init_state()
 
         for _ in range(warmup_steps):
-            actions = np.random.uniform(-1, 1, size=(num_envs, nu)).astype(np.float32)
+            actions = np.random.uniform(-1, 1, size=(num_envs, action_dim)).astype(np.float32)
             env.step(actions)
 
         for _ in range(num_steps):
-            actions = np.random.uniform(-1, 1, size=(num_envs, nu)).astype(np.float32)
+            actions = np.random.uniform(-1, 1, size=(num_envs, action_dim)).astype(np.float32)
             state = env.step(actions)
             timing = state.info.get("timing", {})
             for k, v in timing.items():

--- a/src/unilab/tasks/locomotion/go2w/joystick.py
+++ b/src/unilab/tasks/locomotion/go2w/joystick.py
@@ -17,6 +17,7 @@ from unilab.dr.dr_utils import (
     zero_actions,
 )
 from unilab.dtype_config import get_global_dtype
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
 from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import (
     Commands,
@@ -85,7 +86,6 @@ class JoystickSensor:
     gravity = "upvector"
 
 
-@registry.envcfg("Go2WJoystickFlat")
 @dataclass
 class Go2WJoystickCfg(Go2WBaseCfg):
     scene: SceneCfg = field(  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -226,8 +226,6 @@ class Go2WJoystickDomainRandomizationProvider(LocomotionDRProvider):
         return commands
 
 
-@registry.env("Go2WJoystickFlat", sim_backend="mujoco")
-@registry.env("Go2WJoystickFlat", sim_backend="drake")
 class Go2WJoystickEnv(Go2WBaseEnv):
     _cfg: Go2WJoystickCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -644,4 +642,10 @@ class Go2WJoystickEnv(Go2WBaseEnv):
         return np.asarray(mirror, dtype=get_global_dtype())
 
 
-registry.register_env("Go2WJoystickFlat", Go2WJoystickEnv, sim_backend="motrix")
+# Go2WJoystickCfg and Go2WJoystickEnv remain solely as the rough-task bridge.
+# The flat production identity is Hydra-owned and uses the generic Manager-Based
+# factory; the bridge is deleted with the rough-task migration.
+registry.register_env_config("Go2WJoystickFlat", ManagerBasedRlEnvCfg)
+registry.register_env("Go2WJoystickFlat", make_manager_based_rl_env, sim_backend="mujoco")
+registry.register_env("Go2WJoystickFlat", make_manager_based_rl_env, sim_backend="motrix")
+registry.register_env("Go2WJoystickFlat", make_manager_based_rl_env, sim_backend="drake")

--- a/src/unilab/tasks/locomotion/go2w/manager_terms.py
+++ b/src/unilab/tasks/locomotion/go2w/manager_terms.py
@@ -1,0 +1,361 @@
+"""Manager-Based terms owned by the Go2W flat task."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from numbers import Real
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from unilab.dtype_config import get_global_dtype
+from unilab.envs.mdp.commands.velocity_command import (
+    UniformVelocityCommand,
+    UniformVelocityCommandCfg,
+)
+from unilab.managers import ActionTerm, ActionTermCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg
+from unilab.tasks.locomotion.go2w.base import (
+    NUM_GO2W_ACTIONS,
+    NUM_LEG_ACTIONS,
+    NUM_WHEEL_ACTIONS,
+    compute_go2w_motor_ctrl,
+)
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+_HIP_INDICES = np.asarray([0, 3, 6, 9], dtype=np.intp)
+_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+
+
+def _real(
+    value: Any,
+    *,
+    label: str,
+    minimum: float | None = None,
+    strict_minimum: bool = False,
+) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number, got {type(value).__name__}")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    if minimum is not None and (result <= minimum if strict_minimum else result < minimum):
+        relation = "greater than" if strict_minimum else "at least"
+        raise ValueError(f"{label} must be {relation} {minimum}")
+    return result
+
+
+def _range(value: Any, *, label: str) -> tuple[float, float]:
+    if not isinstance(value, (tuple, list)) or len(value) != 2:
+        raise TypeError(f"{label} must be a two-value range")
+    lower = _real(value[0], label=f"{label} lower", minimum=0.0)
+    upper = _real(value[1], label=f"{label} upper", minimum=0.0)
+    if lower > upper:
+        raise ValueError(f"{label} lower {lower} exceeds upper {upper}")
+    return lower, upper
+
+
+@dataclass(kw_only=True)
+class Go2WMixedActionCfg(ActionTermCfg):
+    """Configure the Go2W leg-position and wheel-velocity motor action."""
+
+    actuator_names: tuple[str, ...] | list[str]
+    leg_action_scale: float = 0.25
+    hip_action_scale: float | None = None
+    wheel_action_scale: float = 10.0
+    leg_kp: float = 35.0
+    leg_kd: float = 0.5
+    wheel_kd: float = 0.5
+    clip_actions: float = 1.0
+    simulate_action_latency: bool = False
+
+    def build(self, env: ManagerBasedRlEnv) -> Go2WMixedAction:
+        return Go2WMixedAction(self, env)
+
+
+class Go2WMixedAction(ActionTerm):
+    """Convert one community action term into Go2W motor torques per substep."""
+
+    cfg: Go2WMixedActionCfg
+    _entity: Entity
+
+    def __init__(self, cfg: Go2WMixedActionCfg, env: ManagerBasedRlEnv):
+        self._validate_cfg(cfg)
+        super().__init__(cfg=cfg, env=env)
+        actuator_ids, actuator_names = self._entity.find_actuators(cfg.actuator_names)
+        joint_ids, joint_names = self._entity.find_joints_by_actuator_names(cfg.actuator_names)
+        if len(actuator_ids) != NUM_GO2W_ACTIONS or len(joint_ids) != NUM_GO2W_ACTIONS:
+            raise ValueError(
+                "Go2WMixedAction requires exactly "
+                f"{NUM_GO2W_ACTIONS} actuators and target joints; received "
+                f"actuators={actuator_names}, joints={joint_names}"
+            )
+        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
+        self._joint_ids = np.asarray(joint_ids, dtype=np.intp)
+        self._actuator_ids.setflags(write=False)
+        self._joint_ids.setflags(write=False)
+
+        dtype = get_global_dtype()
+        shape = (self.num_envs, NUM_GO2W_ACTIONS)
+        self._raw_action = np.zeros(shape, dtype=dtype)
+        self._previous_raw_action = np.zeros_like(self._raw_action)
+        self._processed_action = np.zeros_like(self._raw_action)
+        self._motor_torque = np.zeros_like(self._raw_action)
+
+        self._leg_action_scale = np.full(
+            (NUM_LEG_ACTIONS,), float(cfg.leg_action_scale), dtype=dtype
+        )
+        if cfg.hip_action_scale is not None:
+            self._leg_action_scale[_HIP_INDICES] = float(cfg.hip_action_scale)
+        self._base_leg_kp = np.full((NUM_LEG_ACTIONS,), float(cfg.leg_kp), dtype=dtype)
+        self._base_leg_kd = np.full((NUM_LEG_ACTIONS,), float(cfg.leg_kd), dtype=dtype)
+        self._leg_kp = np.broadcast_to(self._base_leg_kp, (self.num_envs, NUM_LEG_ACTIONS)).copy()
+        self._leg_kd = np.broadcast_to(self._base_leg_kd, (self.num_envs, NUM_LEG_ACTIONS)).copy()
+        self._wheel_kd = np.full(
+            (self.num_envs, NUM_WHEEL_ACTIONS), float(cfg.wheel_kd), dtype=dtype
+        )
+
+        ctrl_range = self._entity.data.actuator_ctrl_range[self._actuator_ids]
+        expected_range_shape = (NUM_GO2W_ACTIONS, 2)
+        if ctrl_range.shape != expected_range_shape:
+            raise ValueError(
+                "Go2WMixedAction actuator control range must have shape "
+                f"{expected_range_shape}, got {ctrl_range.shape}"
+            )
+        self._ctrl_lower = np.asarray(ctrl_range[:, 0], dtype=dtype)
+        self._ctrl_upper = np.asarray(ctrl_range[:, 1], dtype=dtype)
+
+    @staticmethod
+    def _validate_cfg(cfg: Go2WMixedActionCfg) -> None:
+        if not isinstance(cfg.simulate_action_latency, bool):
+            raise TypeError("Go2WMixedActionCfg simulate_action_latency must be bool")
+        for name, value in (
+            ("leg_action_scale", cfg.leg_action_scale),
+            ("wheel_action_scale", cfg.wheel_action_scale),
+            ("leg_kp", cfg.leg_kp),
+            ("leg_kd", cfg.leg_kd),
+            ("wheel_kd", cfg.wheel_kd),
+            ("clip_actions", cfg.clip_actions),
+        ):
+            _real(
+                value,
+                label=f"Go2WMixedActionCfg {name}",
+                minimum=0.0,
+                strict_minimum=name == "clip_actions",
+            )
+        if cfg.hip_action_scale is not None:
+            _real(
+                cfg.hip_action_scale,
+                label="Go2WMixedActionCfg hip_action_scale",
+                minimum=0.0,
+            )
+
+    @property
+    def action_dim(self) -> int:
+        return NUM_GO2W_ACTIONS
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        """Clipped policy action, matching the legacy observable action buffer."""
+        return self._raw_action
+
+    @property
+    def previous_raw_action(self) -> np.ndarray:
+        return self._previous_raw_action
+
+    @property
+    def processed_action(self) -> np.ndarray:
+        return self._processed_action
+
+    @property
+    def motor_torque(self) -> np.ndarray:
+        return self._motor_torque
+
+    @property
+    def leg_kp(self) -> np.ndarray:
+        return self._leg_kp
+
+    @property
+    def leg_kd(self) -> np.ndarray:
+        return self._leg_kd
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(f"Go2WMixedAction expected np.ndarray, got {type(actions).__name__}")
+        if actions.shape != self._raw_action.shape:
+            raise ValueError(
+                f"Go2WMixedAction expected action shape {self._raw_action.shape}, "
+                f"got {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError("Go2WMixedAction received NaN or Inf actions")
+
+        self._previous_raw_action[:] = self._raw_action
+        np.clip(
+            actions,
+            -float(self.cfg.clip_actions),
+            float(self.cfg.clip_actions),
+            out=self._raw_action,
+        )
+        executed = (
+            self._previous_raw_action if self.cfg.simulate_action_latency else self._raw_action
+        )
+        np.multiply(
+            executed[:, :NUM_LEG_ACTIONS],
+            self._leg_action_scale,
+            out=self._processed_action[:, :NUM_LEG_ACTIONS],
+        )
+        self._processed_action[:, :NUM_LEG_ACTIONS] += self._entity.data.default_joint_pos[
+            :, self._joint_ids[:NUM_LEG_ACTIONS]
+        ]
+        np.multiply(
+            executed[:, NUM_LEG_ACTIONS:],
+            float(self.cfg.wheel_action_scale),
+            out=self._processed_action[:, NUM_LEG_ACTIONS:],
+        )
+
+    def apply_actions(self) -> None:
+        joint_pos = self._entity.data.joint_pos[:, self._joint_ids]
+        joint_vel = self._entity.data.joint_vel[:, self._joint_ids]
+        compute_go2w_motor_ctrl(
+            self._processed_action,
+            joint_pos,
+            joint_vel,
+            self._leg_kp,
+            self._leg_kd,
+            self._wheel_kd,
+            self._ctrl_lower,
+            self._ctrl_upper,
+            self._motor_torque,
+        )
+        self._entity.data.write_ctrl(self._motor_torque, actuator_ids=self._actuator_ids)
+
+    def set_motor_gain_multipliers(
+        self,
+        env_ids: np.ndarray,
+        kp_multiplier: np.ndarray,
+        kd_multiplier: np.ndarray,
+    ) -> None:
+        expected = (len(env_ids), 1)
+        if kp_multiplier.shape != expected or kd_multiplier.shape != expected:
+            raise ValueError(
+                "Go2WMixedAction motor gain multipliers must have shape "
+                f"{expected}, got kp={kp_multiplier.shape}, kd={kd_multiplier.shape}"
+            )
+        self._leg_kp[env_ids] = self._base_leg_kp * kp_multiplier
+        self._leg_kd[env_ids] = self._base_leg_kd * kd_multiplier
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        if env_ids is None:
+            env_ids = slice(None)
+        self._raw_action[env_ids] = 0.0
+        self._previous_raw_action[env_ids] = 0.0
+        self._processed_action[env_ids] = 0.0
+        self._motor_torque[env_ids] = 0.0
+
+
+@dataclass(kw_only=True)
+class Go2WVelocityCommandCfg(UniformVelocityCommandCfg):
+    """Velocity command with the legacy Go2W planar dead zone."""
+
+    planar_dead_zone: float = 0.2
+
+    def build(self, env: ManagerBasedRlEnv) -> Go2WVelocityCommand:
+        return Go2WVelocityCommand(self, env)
+
+
+class Go2WVelocityCommand(UniformVelocityCommand):
+    cfg: Go2WVelocityCommandCfg  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    def __init__(self, cfg: Go2WVelocityCommandCfg, env: ManagerBasedRlEnv):
+        self._planar_dead_zone = _real(
+            cfg.planar_dead_zone,
+            label="Go2WVelocityCommandCfg planar_dead_zone",
+            minimum=0.0,
+        )
+        super().__init__(cfg, env)
+
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        super()._resample_command(env_ids)
+        planar = self.vel_command_b[env_ids, :2]
+        moving = np.linalg.norm(planar, axis=1) > self._planar_dead_zone
+        self.vel_command_b[env_ids, :2] = planar * moving[:, None]
+
+
+def _action(env: ManagerBasedRlEnv, action_name: str) -> Go2WMixedAction:
+    if not isinstance(action_name, str) or not action_name:
+        raise ValueError("Go2W manager term action_name must be a non-empty string")
+    try:
+        term = env.action_manager.get_term(action_name)
+    except KeyError as exc:
+        raise KeyError(f"Go2W action term '{action_name}' is unavailable") from exc
+    if not isinstance(term, Go2WMixedAction):
+        raise TypeError(
+            f"Go2W action term '{action_name}' must be Go2WMixedAction, got {type(term).__name__}"
+        )
+    return term
+
+
+def randomize_motor_gains(
+    env: ManagerBasedRlEnv,
+    env_ids: np.ndarray | None,
+    action_name: str,
+    kp_multiplier_range: tuple[float, float] | list[float],
+    kd_multiplier_range: tuple[float, float] | list[float],
+) -> None:
+    """Sample owner-level motor gains without mutating backend actuator models."""
+    ids = (
+        np.arange(env.num_envs, dtype=np.int32)
+        if env_ids is None
+        else np.asarray(env_ids, dtype=np.int32)
+    )
+    kp_range = _range(kp_multiplier_range, label="randomize_motor_gains kp_multiplier_range")
+    kd_range = _range(kd_multiplier_range, label="randomize_motor_gains kd_multiplier_range")
+    shape = (len(ids), 1)
+    kp = env.rng.uniform(*kp_range, size=shape).astype(get_global_dtype(), copy=False)
+    kd = env.rng.uniform(*kd_range, size=shape).astype(get_global_dtype(), copy=False)
+    _action(env, action_name).set_motor_gain_multipliers(ids, kp, kd)
+
+
+def motor_torque(env: ManagerBasedRlEnv, action_name: str) -> np.ndarray:
+    return _action(env, action_name).motor_torque
+
+
+def motor_torque_l2(env: ManagerBasedRlEnv, action_name: str) -> np.ndarray:
+    return np.sum(np.square(motor_torque(env, action_name)), axis=1)
+
+
+def clipped_action_rate_l2(env: ManagerBasedRlEnv, action_name: str) -> np.ndarray:
+    action = _action(env, action_name)
+    return np.sum(np.square(action.raw_action - action.previous_raw_action), axis=1)
+
+
+def upward_l2(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return np.square(1.0 - asset.data.projected_gravity_b[:, 2])
+
+
+def constant_alive(env: ManagerBasedRlEnv) -> np.ndarray:
+    return np.ones((env.num_envs,), dtype=get_global_dtype())
+
+
+__all__ = [
+    "Go2WMixedAction",
+    "Go2WMixedActionCfg",
+    "Go2WVelocityCommand",
+    "Go2WVelocityCommandCfg",
+    "clipped_action_rate_l2",
+    "constant_alive",
+    "motor_torque",
+    "motor_torque_l2",
+    "randomize_motor_gains",
+    "upward_l2",
+]

--- a/tests/benchmark/test_env_step_config_contract.py
+++ b/tests/benchmark/test_env_step_config_contract.py
@@ -7,6 +7,18 @@ from hydra.errors import ConfigCompositionException
 from omegaconf import OmegaConf
 from scripts.benchmark.env import benchmark_env_step as bench
 
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
+
+
+def test_go2w_flat_benchmark_uses_production_manager_owner() -> None:
+    cfg = bench.TASK_CONFIGS["go2w"].build_cfg("mujoco")
+
+    assert isinstance(cfg, ManagerBasedRlEnvCfg)
+    assert list(cfg.actions) == ["motor"]
+    assert cfg.critic_observation_group == "critic"
+    assert bench.TASK_CONFIGS["go2w"].env_cls_factory() is make_manager_based_rl_env
+    assert bench.DEFAULT_NUM_ENVS == 4096
+
 
 def test_go2w_rough_cfg_matches_ppo_owner_yaml() -> None:
     cfg = bench.TASK_CONFIGS["go2w_rough"].build_cfg("mujoco")

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -428,19 +428,24 @@ def test_ppo_go2w_mujoco_uses_motor_owner_dr_path():
 
     assert cfg.training.task_name == "Go2WJoystickFlat"
     assert cfg.training.sim_backend == "mujoco"
-    assert cfg.env.commands.vel_limit == [[0.0, 0.0, -1.0], [1.0, 0.0, 1.0]]
-    assert cfg.env.domain_rand.randomize_kp is False
-    assert cfg.env.domain_rand.randomize_kd is False
-    assert cfg.env.control_config.action_scale == pytest.approx(0.5)
-    assert cfg.env.control_config.Kp == pytest.approx(50.0)
-    assert cfg.env.control_config.Kd == pytest.approx(1.5)
-    assert cfg.env.control_config.wheel_action_scale == pytest.approx(10.0)
-    assert cfg.env.control_config.wheel_Kd == pytest.approx(0.5)
-    assert cfg.reward.scales.tracking_ang_vel == pytest.approx(0.75)
-    assert cfg.reward.scales.orientation == pytest.approx(-2.0)
-    assert cfg.reward.scales.upward == pytest.approx(1.0)
-    assert cfg.reward.base_height_target == pytest.approx(0.4)
-    assert cfg.reward.scales.torques < 0.0
+    command = cfg.env.commands.twist
+    assert command.ranges.lin_vel_x == [0.0, 1.0]
+    assert command.ranges.lin_vel_y == [0.0, 0.0]
+    assert command.ranges.ang_vel_z == [-1.0, 1.0]
+    action = cfg.env.actions.motor
+    assert action.leg_action_scale == pytest.approx(0.5)
+    assert action.leg_kp == pytest.approx(50.0)
+    assert action.leg_kd == pytest.approx(1.5)
+    assert action.wheel_action_scale == pytest.approx(10.0)
+    assert action.wheel_kd == pytest.approx(0.5)
+    gains = cfg.env.events.motor_gains.params
+    assert gains.kp_multiplier_range == [1.0, 1.0]
+    assert gains.kd_multiplier_range == [1.0, 1.0]
+    assert cfg.reward.tracking_ang_vel.weight == pytest.approx(0.75)
+    assert cfg.reward.orientation.weight == pytest.approx(-2.0)
+    assert cfg.reward.upward.weight == pytest.approx(1.0)
+    assert cfg.reward.base_height.params.target_height == pytest.approx(0.4)
+    assert cfg.reward.torques.weight < 0.0
 
 
 def test_ppo_go2w_motrix_uses_motor_owner_dr_path():
@@ -449,18 +454,20 @@ def test_ppo_go2w_motrix_uses_motor_owner_dr_path():
     assert cfg.training.task_name == "Go2WJoystickFlat"
     assert cfg.training.sim_backend == "motrix"
     assert cfg.env.render_offset_mode == "zero"
-    assert cfg.env.commands.vel_limit == [[0.0, 0.0, -1.0], [1.0, 0.0, 1.0]]
-    assert cfg.env.domain_rand.randomize_kp is False
-    assert cfg.env.domain_rand.randomize_kd is False
-    assert cfg.env.control_config.action_scale == pytest.approx(0.5)
-    assert cfg.env.control_config.Kp == pytest.approx(50.0)
-    assert cfg.env.control_config.Kd == pytest.approx(1.5)
-    assert cfg.env.control_config.wheel_action_scale == pytest.approx(10.0)
-    assert cfg.env.control_config.wheel_Kd == pytest.approx(0.5)
-    assert cfg.reward.scales.tracking_ang_vel == pytest.approx(0.75)
-    assert cfg.reward.scales.orientation == pytest.approx(-2.0)
-    assert cfg.reward.scales.upward == pytest.approx(1.0)
-    assert cfg.reward.scales.torques < 0.0
+    command = cfg.env.commands.twist
+    assert command.ranges.lin_vel_x == [0.0, 1.0]
+    assert command.ranges.lin_vel_y == [0.0, 0.0]
+    assert command.ranges.ang_vel_z == [-1.0, 1.0]
+    action = cfg.env.actions.motor
+    assert action.leg_action_scale == pytest.approx(0.5)
+    assert action.leg_kp == pytest.approx(50.0)
+    assert action.leg_kd == pytest.approx(1.5)
+    assert action.wheel_action_scale == pytest.approx(10.0)
+    assert action.wheel_kd == pytest.approx(0.5)
+    assert cfg.reward.tracking_ang_vel.weight == pytest.approx(0.75)
+    assert cfg.reward.orientation.weight == pytest.approx(-2.0)
+    assert cfg.reward.upward.weight == pytest.approx(1.0)
+    assert cfg.reward.torques.weight < 0.0
 
 
 def test_ppo_go2w_motrix_uses_motor_owner_scene_path():
@@ -468,11 +475,10 @@ def test_ppo_go2w_motrix_uses_motor_owner_scene_path():
 
     assert cfg.training.task_name == "Go2WJoystickFlat"
     assert cfg.training.sim_backend == "motrix"
-    assert "model_file" not in cfg.env
-    assert cfg.env.domain_rand.randomize_kp is False
-    assert cfg.env.domain_rand.randomize_kd is False
-    assert cfg.env.control_config.wheel_action_scale == pytest.approx(10.0)
-    assert cfg.reward.scales.torques < 0.0
+    assert str(cfg.env.scene.model_file).endswith("src/unilab/assets/robots/go2w/scene_flat.xml")
+    assert cfg.env.scene.default_keyframe_name == "home"
+    assert cfg.env.actions.motor.wheel_action_scale == pytest.approx(10.0)
+    assert cfg.reward.torques.weight < 0.0
 
 
 def test_ppo_go2w_rough_mujoco_uses_terrain_generator():

--- a/tests/envs/locomotion/go2w/test_go2w_manager_based_flat_cfg.py
+++ b/tests/envs/locomotion/go2w/test_go2w_manager_based_flat_cfg.py
@@ -1,0 +1,299 @@
+"""Hydra-owned production contract for the Go2W flat Manager-Based task."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import DictConfig, OmegaConf
+
+from unilab.base import registry
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg, make_manager_based_rl_env
+from unilab.tasks.locomotion.go2w import manager_terms
+from unilab.tasks.locomotion.go2w.manager_terms import (
+    Go2WMixedAction,
+    Go2WMixedActionCfg,
+    Go2WVelocityCommandCfg,
+)
+from unilab.training.backend_adapter import BackendAdapter
+
+ROOT_DIR = Path(__file__).parents[4]
+CONF_DIR = ROOT_DIR / "conf"
+
+_LEG_JOINT_NAMES = tuple(
+    f"{leg}_{joint}_joint" for leg in ("FR", "FL", "RR", "RL") for joint in ("hip", "thigh", "calf")
+)
+_WHEEL_JOINT_NAMES = tuple(f"{leg}_wheel_joint" for leg in ("FR", "FL", "RR", "RL"))
+_JOINT_NAMES = (*_LEG_JOINT_NAMES, *_WHEEL_JOINT_NAMES)
+_ACTUATOR_NAMES = tuple(name.removesuffix("_joint") for name in _JOINT_NAMES)
+_HOME_JOINT_POS = np.asarray([0.0, 0.8, -1.5] * 4 + [0.0] * 4, dtype=np.float32)
+
+
+def _compose(backend: str) -> DictConfig:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        return compose("config", overrides=[f"task=go2w_joystick_flat/{backend}"])
+
+
+def _materialize(
+    backend: str,
+) -> tuple[DictConfig, ManagerBasedRlEnvCfg, dict[str, Any]]:
+    hydra_cfg = _compose(backend)
+    env_override = BackendAdapter(hydra_cfg, root_dir=ROOT_DIR).build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config("Go2WJoystickFlat")
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, env_override)
+    env_cfg.validate()
+    return hydra_cfg, env_cfg, env_override
+
+
+def _assert_no_omegaconf(value: Any) -> None:
+    assert not OmegaConf.is_config(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        for item in fields(value):
+            _assert_no_omegaconf(getattr(value, item.name))
+    elif isinstance(value, Mapping):
+        for key, item in value.items():
+            _assert_no_omegaconf(key)
+            _assert_no_omegaconf(item)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            _assert_no_omegaconf(item)
+
+
+@pytest.mark.parametrize("backend", ["mujoco", "motrix", "drake"])
+def test_go2w_flat_owner_materializes_complete_plain_manager_cfg(backend: str) -> None:
+    registry.ensure_registries()
+    hydra_cfg, env_cfg, _ = _materialize(backend)
+
+    assert hydra_cfg.training.task_name == "Go2WJoystickFlat"
+    assert hydra_cfg.training.sim_backend == backend
+    assert list(hydra_cfg.algo.obs_groups.actor) == ["actor"]
+    assert list(hydra_cfg.algo.obs_groups.critic) == ["critic"]
+    assert env_cfg.sim_dt == pytest.approx(0.005)
+    assert env_cfg.ctrl_dt == pytest.approx(0.02)
+    assert env_cfg.max_episode_seconds == pytest.approx(20.0)
+    assert env_cfg.policy_observation_group == "policy"
+    assert env_cfg.critic_observation_group == "critic"
+
+    assert env_cfg.scene is not None
+    assert env_cfg.scene.model_file.endswith("robots/go2w/scene_flat.xml")
+    assert env_cfg.scene.default_keyframe_name == "home"
+    robot = env_cfg.scene.entities["robot"]
+    assert robot.root_body_name == "base_link"
+    assert tuple(robot.joint_names or ()) == _JOINT_NAMES
+    assert tuple(robot.actuator_names or ()) == _ACTUATOR_NAMES
+    assert robot.body_names == ["base_link"]
+
+    policy_terms = [
+        "base_ang_vel",
+        "projected_gravity",
+        "leg_joint_pos",
+        "leg_joint_vel",
+        "wheel_joint_vel",
+        "actions",
+        "command",
+    ]
+    assert list(env_cfg.observations) == ["policy", "critic"]
+    assert list(env_cfg.observations["policy"].terms) == policy_terms
+    assert list(env_cfg.observations["critic"].terms) == [
+        *policy_terms,
+        "base_lin_vel",
+        "motor_torque",
+    ]
+
+    assert list(env_cfg.actions) == ["motor"]
+    action = env_cfg.actions["motor"]
+    assert isinstance(action, Go2WMixedActionCfg)
+    assert action.leg_action_scale == pytest.approx(0.5)
+    assert action.wheel_action_scale == pytest.approx(10.0)
+    assert action.leg_kp == pytest.approx(50.0)
+    assert action.leg_kd == pytest.approx(1.5)
+    assert action.wheel_kd == pytest.approx(0.5)
+
+    command = env_cfg.commands["twist"]
+    assert isinstance(command, Go2WVelocityCommandCfg)
+    assert command.resampling_time_range == [20.0, 20.0]
+    assert command.planar_dead_zone == pytest.approx(0.2)
+    assert tuple(command.ranges.lin_vel_x) == (0.0, 1.0)
+    assert tuple(command.ranges.lin_vel_y) == (0.0, 0.0)
+    assert tuple(command.ranges.ang_vel_z) == (-1.0, 1.0)
+
+    assert list(env_cfg.events) == [
+        "reset_scene_to_default",
+        "reset_root_state_uniform",
+        "motor_gains",
+    ]
+    gains = env_cfg.events["motor_gains"]
+    assert gains.func is manager_terms.randomize_motor_gains
+    assert gains.params["kp_multiplier_range"] == [1.0, 1.0]
+    assert gains.params["kd_multiplier_range"] == [1.0, 1.0]
+    assert list(env_cfg.terminations) == ["time_out", "bad_orientation"]
+    assert {name: term.weight for name, term in env_cfg.rewards.items()} == {
+        "tracking_lin_vel": 1.0,
+        "tracking_ang_vel": 0.75,
+        "lin_vel_z": -5.0,
+        "ang_vel_xy": -0.1,
+        "base_height": -100.0,
+        "orientation": -2.0,
+        "action_rate": -0.005,
+        "similar_to_default": -0.5,
+        "torques": -0.0002,
+        "wheel_vel": 0.0,
+        "alive": 0.5,
+        "upward": 1.0,
+    }
+
+    for manager_name in ("observations", "events", "rewards", "terminations"):
+        for term in getattr(env_cfg, manager_name).values():
+            if term is None:
+                continue
+            terms = term.terms.values() if manager_name == "observations" else (term,)
+            for nested in terms:
+                if nested is None:
+                    continue
+                module = nested.func.__module__
+                assert ".backend." not in module
+                assert not any(name in module for name in (".mujoco", ".motrix", ".drake"))
+
+    _assert_no_omegaconf(env_cfg)
+
+
+def test_go2w_sac_drake_owner_uses_the_same_manager_contract() -> None:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "offpolicy"), version_base="1.3"):
+        hydra_cfg = compose(
+            "config",
+            overrides=["algo=sac", "task=sac/go2w_joystick_flat/drake"],
+        )
+    env_override = BackendAdapter(hydra_cfg, root_dir=ROOT_DIR).build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config("Go2WJoystickFlat")
+    apply_cfg_overrides(env_cfg, env_override)
+
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    assert hydra_cfg.training.task_name == "Go2WJoystickFlat"
+    assert hydra_cfg.training.sim_backend == "drake"
+    assert list(env_cfg.actions) == ["motor"]
+    assert env_cfg.scene is not None
+    assert env_cfg.scene.default_keyframe_name == "home"
+    env_cfg.validate()
+
+
+def test_go2w_flat_registry_is_manager_only_and_rough_owns_legacy_bridge() -> None:
+    registry.ensure_registries()
+    from unilab.tasks.locomotion.go2w.joystick import Go2WJoystickCfg, Go2WJoystickEnv
+    from unilab.tasks.locomotion.go2w.rough import Go2WJoystickRoughCfg, Go2WJoystickRoughEnv
+
+    assert registry.list_registered_envs()["Go2WJoystickFlat"] == {
+        "config_factory": "ManagerBasedRlEnvCfg",
+        "available_backends": ["mujoco", "motrix", "drake"],
+    }
+    assert Go2WJoystickRoughCfg.__bases__ == (Go2WJoystickCfg,)
+    assert Go2WJoystickRoughEnv.__bases__ == (Go2WJoystickEnv,)
+    for legacy_override in (
+        {"reward_config": {}},
+        {"domain_rand": {"randomize_kp": False}},
+        {"control_config": {"action_scale": 0.5}},
+    ):
+        with pytest.raises(ValueError, match="has no attribute"):
+            apply_cfg_overrides(ManagerBasedRlEnvCfg(), legacy_override)
+
+
+@pytest.mark.parametrize("backend", ["mujoco", "motrix"])
+def test_go2w_flat_registry_executes_real_manager_runtime(backend: str) -> None:
+    registry.ensure_registries()
+    _, _, env_override = _materialize(backend)
+    try:
+        env = registry.make(
+            "Go2WJoystickFlat",
+            sim_backend=backend,
+            env_cfg_override=env_override,
+            num_envs=2,
+        )
+    except ImportError as exc:
+        pytest.skip(f"{backend} runtime unavailable: {exc}")
+
+    try:
+        assert isinstance(env, ManagerBasedRlEnv)
+        assert env.obs_groups_spec == {"obs": 53, "critic": 72}
+        assert env.action_space.shape == (16,)
+        action = env.action_manager.get_term("motor")
+        assert isinstance(action, Go2WMixedAction)
+        np.testing.assert_allclose(action.leg_kp, 50.0)
+        np.testing.assert_allclose(action.leg_kd, 1.5)
+
+        obs, info = env.reset(seed=7)
+        assert {name: value.shape for name, value in obs.items()} == {
+            "obs": (2, 53),
+            "critic": (2, 72),
+        }
+        assert isinstance(info, dict)
+        np.testing.assert_allclose(
+            env.scene["robot"].data.default_joint_pos,
+            np.broadcast_to(_HOME_JOINT_POS, (2, 16)),
+        )
+
+        state = env.step(np.full((2, 16), 2.0, dtype=np.float32))
+        np.testing.assert_allclose(action.raw_action, 1.0)
+        np.testing.assert_allclose(action.previous_raw_action, 0.0)
+        np.testing.assert_allclose(
+            action.processed_action[:, :12],
+            np.broadcast_to(_HOME_JOINT_POS[:12] + 0.5, (2, 12)),
+        )
+        np.testing.assert_allclose(action.processed_action[:, 12:], 10.0)
+        np.testing.assert_allclose(state.obs["critic"][:, -16:], action.motor_torque)
+        for value in (*state.obs.values(), state.reward, action.motor_torque):
+            assert np.isfinite(value).all()
+
+        env.reset(np.asarray([0], dtype=np.int32))
+        np.testing.assert_allclose(action.raw_action[0], 0.0)
+        np.testing.assert_allclose(action.raw_action[1], 1.0)
+        np.testing.assert_allclose(action.motor_torque[0], 0.0)
+    finally:
+        env.close()
+
+
+def test_go2w_flat_dead_zone_and_motor_gain_overrides_are_manager_owned() -> None:
+    _, env_cfg, _ = _materialize("mujoco")
+    command = env_cfg.commands["twist"]
+    command.ranges.lin_vel_x = (0.1, 0.1)
+    command.ranges.lin_vel_y = (0.0, 0.0)
+    command.ranges.ang_vel_z = (0.0, 0.0)
+    gains = env_cfg.events["motor_gains"].params
+    gains["kp_multiplier_range"] = (0.5, 0.5)
+    gains["kd_multiplier_range"] = (2.0, 2.0)
+
+    env = make_manager_based_rl_env(env_cfg, num_envs=2, backend_type="mujoco")
+    try:
+        env.reset(seed=11)
+        np.testing.assert_allclose(env.command_manager.get_command("twist"), 0.0)
+        action = env.action_manager.get_term("motor")
+        assert isinstance(action, Go2WMixedAction)
+        np.testing.assert_allclose(action.leg_kp, 25.0)
+        np.testing.assert_allclose(action.leg_kd, 3.0)
+    finally:
+        env.close()
+
+
+def test_go2w_flat_incomplete_motor_selection_fails_closed() -> None:
+    _, env_cfg, _ = _materialize("mujoco")
+    action = env_cfg.actions["motor"]
+    assert isinstance(action, Go2WMixedActionCfg)
+    action.actuator_names = ["FR_.*"]
+
+    with pytest.raises(ValueError, match="requires exactly 16 actuators and target joints"):
+        make_manager_based_rl_env(env_cfg, num_envs=1, backend_type="mujoco")
+
+
+def test_go2w_manager_terms_do_not_leak_backend_or_physical_layout() -> None:
+    source = inspect.getsource(manager_terms)
+    for forbidden in ("._backend", "getattr(", "hasattr(", "qpos", "qvel", "ASSETS_ROOT_PATH"):
+        assert forbidden not in source

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -2141,7 +2141,6 @@ def test_g1_motion_tracking_clip_end_does_not_override_true_termination():
 # Environments that don't need special config overrides
 _STANDARD_ENVS = [
     "Go1JoystickRough",
-    "Go2WJoystickFlat",
     "Go2WJoystickRough",
     "G1WalkFlat",
     "G1WalkRough",
@@ -2424,36 +2423,5 @@ def test_g1_motion_tracking_deploy_reset_and_step_mujoco():
         state = env.step(np.zeros((2, action_shape[0])))
         assert state.obs["obs"].shape == (2, 154)
         assert state.obs["critic"].shape == (2, 286)
-    finally:
-        env.close()
-
-
-def test_go2w_mujoco_keeps_kp_kd_out_of_backend_position_actuator_path():
-    _require_mujoco_runtime()
-    ensure_registries()
-
-    from unilab.base import registry
-
-    env = cast(
-        Any,
-        registry.make(
-            "Go2WJoystickFlat",
-            num_envs=2,
-            sim_backend="mujoco",
-            env_cfg_override={
-                "reward_config": {
-                    "scales": {"alive": 1.0, "torques": -0.0002},
-                    "tracking_sigma": 0.25,
-                    "base_height_target": 0.3,
-                }
-            },
-        ),
-    )
-    try:
-        env.init_state()
-        assert env._backend._position_actuator_gains is None
-        assert env._backend._pre_step_control_fn.__self__ is env
-        assert env._backend._pre_step_control_fn.__func__ is env._pre_step_motor_control.__func__
-        assert env._last_motor_ctrl.shape == (2, env.action_space.shape[0])
     finally:
         env.close()


### PR DESCRIPTION
Closes #1211

## Outcome

- Switches all Go2WJoystickFlat production registrations to Hydra owner YAML -> ManagerBasedRlEnvCfg -> make_manager_based_rl_env for MuJoCo, Motrix, and Drake.
- Preserves 53-D policy observation, 72-D critic observation, 16-D action, and per-physics-substep leg-position plus wheel-velocity torque control.
- Keeps Go2W-specific mixed action, dead-zone command, gain reset, torque observation, and reward logic task-owned behind the Entity facade.
- Leaves the legacy Go2W config/env only as the explicitly documented Go2WJoystickRough bridge.
- Moves the env-step benchmark to the production MBA factory, derives action dimensions from the public action space, and sets its default to 4096 environments.

## Contract boundaries

- Hydra remains the only production task configuration entry.
- No new SimBackend, lifecycle, runner, or IPC contract.
- No backend-private object, qpos/qvel layout, runtime asset/XML access, or capability probing in the new task terms.
- Missing motor selection/capability fails closed.
- Drake Hydra composition validates; real Drake execution is unavailable locally because drakeuni is not installed and raises ImportError rather than falling back.

## Change accounting

- Source-derived manager lines: 0.
- Mechanical Torch-to-NumPy conversion lines: 0.
- UniLab-specific production/config additions: 957 lines across the task term and the identical PPO/off-policy Hydra bases.
- Adapted/new focused tests: 299 new lines.
- Modified existing files: 96 insertions and 201 deletions across 9 files.
- Total: 13 files, 1352 insertions, 201 deletions.

## Validation

- make test-all on final commit d3ecc491: 2087 passed, 27 skipped, 272 deselected, 1 xfailed; 75% coverage.
- Ruff, mypy, and pyright passed.
- Benchmark module/script import smoke passed (platform-optional mlx entry skipped).
- Focused manager/config/runtime suite: 395 passed.
- Extended scripts/tasks/config/training suite: 634 passed, 4 skipped, 18 deselected.
- Real MuJoCo and Motrix reset/step contract tests passed.

Remote child CI is intentionally skipped with [skip ci] under the approved #1042 workflow; the local gate is authoritative.