### PR TITLE
test: add Isaac Lab Manager-Based migration fixture

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable external-task migration fixtures."""

--- a/tests/fixtures/isaac_lab_cartpole/README.md
+++ b/tests/fixtures/isaac_lab_cartpole/README.md
@@ -1,0 +1,22 @@
+# Isaac Lab Cartpole migration fixture
+
+This test-only fixture is derived from Isaac Lab commit
+`b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8`, specifically its manager-based
+Cartpole config and `joint_pos_target_l2` reward. The source is BSD-3-Clause;
+the retained notice is in `task.py`.
+
+The fixture is evidence for #1042, not a production task or a claim that all
+Isaac Lab tasks run unchanged.
+
+| Surface | Status | Migration delta |
+| --- | --- | --- |
+| Manager/term names, `func + params`, dict order | Compatible | Imports change from `isaaclab` to `unilab`; all 12 terms keep their source names and order. |
+| Term math and buffers | Adapted | `torch.Tensor` and Torch ops become `np.ndarray` and NumPy ops. |
+| Config container | Adapted | Nested `@configclass` objects become one Hydra owner YAML, materialized as a plain `ManagerBasedRlEnvCfg`. |
+| Scene | Adapted | USD/`InteractiveSceneCfg` becomes a minimal task-owned MJCF plus `SceneCfg`/`EntityCfg`. |
+| Joint effort action | Adapted, fixture-local | A thin action adapter writes the entity control buffer; it is deliberately not exported as a public built-in. |
+| Reset mutation | Adapted, fixture-local | The same two reset terms write through the scoped entity reset transaction. |
+| PhysX, USD, Isaac renderer | Unsupported | No dependency or fallback is provided. |
+
+The fixture adds no production registry entry, public manager/backend/lifecycle
+contract, training-script branch, runner/IPC path, or external runtime dependency.

--- a/tests/fixtures/isaac_lab_cartpole/__init__.py
+++ b/tests/fixtures/isaac_lab_cartpole/__init__.py
@@ -1,0 +1,3 @@
+"""Isaac Lab Cartpole migration fixture."""
+
+from .task import FIXTURE_ENV_NAME as FIXTURE_ENV_NAME

--- a/tests/fixtures/isaac_lab_cartpole/cartpole.xml
+++ b/tests/fixtures/isaac_lab_cartpole/cartpole.xml
@@ -1,0 +1,16 @@
+<mujoco model="isaac_lab_cartpole_fixture">
+  <option timestep="0.008333333333333333"/>
+  <worldbody>
+    <body name="cart" pos="0 0 1">
+      <joint name="slider_to_cart" type="slide" axis="1 0 0" limited="true" range="-4 4" damping="0.01"/>
+      <geom name="cart" type="box" size="0.2 0.15 0.1" mass="1"/>
+      <body name="pole" pos="0 0 0.1">
+        <joint name="cart_to_pole" type="hinge" axis="0 1 0" damping="0.00001"/>
+        <geom name="pole" type="capsule" fromto="0 0 0 0 0 1" size="0.04" mass="0.1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="slider_to_cart" joint="slider_to_cart" gear="1" ctrllimited="true" ctrlrange="-100 100"/>
+  </actuator>
+</mujoco>

--- a/tests/fixtures/isaac_lab_cartpole/conf/config.yaml
+++ b/tests/fixtures/isaac_lab_cartpole/conf/config.yaml
@@ -1,0 +1,117 @@
+# Derived from Isaac Lab b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8.
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# Modified by UniLab for Hydra and the fixture-local MJCF adapter; BSD-3-Clause.
+# Hydra is the fixture's only task-configuration owner. This declaration mirrors
+# Isaac Lab's CartpoleEnvCfg term names and insertion order.
+training:
+  task_name: IsaacLabCartpoleFixture
+  sim_backend: mujoco
+
+env:
+  scene:
+    model_file: tests/fixtures/isaac_lab_cartpole/cartpole.xml
+    entities:
+      robot:
+        root_body_name: cart
+        joint_names: [slider_to_cart, cart_to_pole]
+        actuator_names: [slider_to_cart]
+  sim_dt: 0.008333333333333333
+  ctrl_dt: 0.016666666666666666
+  max_episode_seconds: 5.0
+  seed: 7
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      enable_corruption: false
+      concatenate_terms: true
+      terms:
+        joint_pos_rel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+        joint_vel_rel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+  actions:
+    joint_effort:
+      _target_: tests.fixtures.isaac_lab_cartpole.task.JointEffortActionCfg
+      entity_name: robot
+      actuator_names: [slider_to_cart]
+      scale: 100.0
+  events:
+    reset_cart_position:
+      _target_: unilab.managers.EventTermCfg
+      func: tests.fixtures.isaac_lab_cartpole.task.reset_joints_by_offset
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: slider_to_cart
+        position_range: [-1.0, 1.0]
+        velocity_range: [-0.5, 0.5]
+    reset_pole_position:
+      _target_: unilab.managers.EventTermCfg
+      func: tests.fixtures.isaac_lab_cartpole.task.reset_joints_by_offset
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: cart_to_pole
+        position_range: [-0.7853981633974483, 0.7853981633974483]
+        velocity_range: [-0.7853981633974483, 0.7853981633974483]
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    cart_out_of_bounds:
+      _target_: unilab.managers.TerminationTermCfg
+      func: tests.fixtures.isaac_lab_cartpole.task.joint_pos_out_of_manual_limit
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: slider_to_cart
+        bounds: [-3.0, 3.0]
+  policy_observation_group: policy
+  critic_observation_group: null
+  scale_rewards_by_dt: true
+
+reward:
+  alive:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.is_alive
+    weight: 1.0
+  terminating:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.is_terminated
+    weight: -2.0
+  pole_pos:
+    _target_: unilab.managers.RewardTermCfg
+    func: tests.fixtures.isaac_lab_cartpole.task.joint_pos_target_l2
+    weight: -1.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: cart_to_pole
+      target: 0.0
+  cart_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: tests.fixtures.isaac_lab_cartpole.task.joint_vel_l1
+    weight: -0.01
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: slider_to_cart
+  pole_vel:
+    _target_: unilab.managers.RewardTermCfg
+    func: tests.fixtures.isaac_lab_cartpole.task.joint_vel_l1
+    weight: -0.005
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: cart_to_pole

--- a/tests/fixtures/isaac_lab_cartpole/task.py
+++ b/tests/fixtures/isaac_lab_cartpole/task.py
@@ -1,0 +1,220 @@
+# Derived from Isaac Lab b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8,
+# source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole.
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# Modified by UniLab for NumPy and the fixture-local MJCF/entity adapter; BSD-3-Clause.
+"""NumPy terms and adapters for the Isaac Lab Cartpole migration fixture."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from numbers import Real
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from unilab.base import registry
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
+from unilab.managers import ActionTerm, ActionTermCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+FIXTURE_ENV_NAME = "IsaacLabCartpoleFixture"
+
+
+def _finite_real(value: Real, *, label: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    return result
+
+
+def _range(value: tuple[float, float] | list[float], *, label: str) -> tuple[float, float]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
+        raise TypeError(f"{label} must be a two-value range")
+    if len(value) != 2:
+        raise ValueError(f"{label} must contain two values")
+    lower = _finite_real(value[0], label=f"{label}[0]")
+    upper = _finite_real(value[1], label=f"{label}[1]")
+    if lower > upper:
+        raise ValueError(f"{label} lower bound {lower} exceeds upper bound {upper}")
+    return lower, upper
+
+
+@dataclass(kw_only=True)
+class JointEffortActionCfg(ActionTermCfg):
+    """Fixture-local adapter for Isaac Lab's ``JointEffortActionCfg``."""
+
+    actuator_names: tuple[str, ...] | list[str]
+    scale: float = 1.0
+
+    def build(self, env: ManagerBasedRlEnv) -> JointEffortAction:
+        return JointEffortAction(self, env)
+
+
+class JointEffortAction(ActionTerm):
+    """Scale policy actions and write entity-local actuator efforts."""
+
+    cfg: JointEffortActionCfg
+
+    def __init__(self, cfg: JointEffortActionCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        if cfg.clip is not None:
+            raise NotImplementedError(
+                "IsaacLabCartpoleFixture JointEffortAction does not support clip"
+            )
+        if isinstance(cfg.actuator_names, (str, bytes)) or not isinstance(
+            cfg.actuator_names, (tuple, list)
+        ):
+            raise TypeError("JointEffortActionCfg actuator_names must be an ordered sequence")
+        actuator_ids, actuator_names = self._entity.find_actuators(
+            cfg.actuator_names,
+            preserve_order=True,
+        )
+        if not actuator_ids:
+            raise ValueError(
+                "JointEffortActionCfg actuator_names resolved no actuators; "
+                f"patterns={list(cfg.actuator_names)}"
+            )
+        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
+        self._actuator_ids.setflags(write=False)
+        self._actuator_names = tuple(actuator_names)
+        self._scale = _finite_real(cfg.scale, label="JointEffortActionCfg scale")
+        self._raw_actions = np.zeros((self.num_envs, len(actuator_ids)), dtype=np.float32)
+        self._processed_actions = np.zeros_like(self._raw_actions)
+
+    @property
+    def action_dim(self) -> int:
+        return self._raw_actions.shape[1]
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._raw_actions
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(
+                "IsaacLabCartpoleFixture JointEffortAction expected np.ndarray, "
+                f"received {type(actions).__name__}"
+            )
+        if actions.shape != self._raw_actions.shape:
+            raise ValueError(
+                "IsaacLabCartpoleFixture JointEffortAction expected shape "
+                f"{self._raw_actions.shape}, received {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError("IsaacLabCartpoleFixture JointEffortAction received NaN or Inf")
+        np.copyto(self._raw_actions, actions)
+        np.multiply(actions, self._scale, out=self._processed_actions)
+
+    def apply_actions(self) -> None:
+        self._entity.data.write_ctrl(
+            self._processed_actions,
+            actuator_ids=self._actuator_ids,
+        )
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        ids = slice(None) if env_ids is None else env_ids
+        self._raw_actions[ids] = 0.0
+        self._processed_actions[ids] = 0.0
+
+
+def reset_joints_by_offset(
+    env: ManagerBasedRlEnv,
+    env_ids: np.ndarray | None,
+    position_range: tuple[float, float] | list[float],
+    velocity_range: tuple[float, float] | list[float],
+    asset_cfg: SceneEntityCfg,
+) -> None:
+    """Port Isaac Lab's joint-offset reset through the entity reset transaction."""
+    if env_ids is None:
+        raise ValueError("reset_joints_by_offset requires concrete environment IDs")
+    position_lower, position_upper = _range(position_range, label="position_range")
+    velocity_lower, velocity_upper = _range(velocity_range, label="velocity_range")
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_ids = asset_cfg.joint_ids
+    default_position = asset.data.default_joint_pos[env_ids][:, joint_ids]
+    default_velocity = asset.data.default_joint_vel[env_ids][:, joint_ids]
+    position = default_position + env.rng.uniform(
+        position_lower,
+        position_upper,
+        default_position.shape,
+    )
+    velocity = default_velocity + env.rng.uniform(
+        velocity_lower,
+        velocity_upper,
+        default_velocity.shape,
+    )
+    asset.write_joint_state_to_sim(
+        position.astype(default_position.dtype, copy=False),
+        velocity.astype(default_velocity.dtype, copy=False),
+        joint_ids=joint_ids,
+        env_ids=env_ids,
+    )
+
+
+def joint_pos_target_l2(
+    env: ManagerBasedRlEnv,
+    target: float,
+    asset_cfg: SceneEntityCfg,
+) -> np.ndarray:
+    """Penalize wrapped joint-position deviation from a target value."""
+    target_value = _finite_real(target, label="joint_pos_target_l2 target")
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    wrapped = np.remainder(joint_pos + math.pi, 2.0 * math.pi) - math.pi
+    return np.sum(np.square(wrapped - target_value), axis=1)
+
+
+def joint_vel_l1(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+) -> np.ndarray:
+    """Penalize the absolute velocity of selected joints."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    return np.sum(np.abs(asset.data.joint_vel[:, asset_cfg.joint_ids]), axis=1)
+
+
+def joint_pos_out_of_manual_limit(
+    env: ManagerBasedRlEnv,
+    bounds: tuple[float, float] | list[float],
+    asset_cfg: SceneEntityCfg,
+) -> np.ndarray:
+    """Terminate when a selected joint leaves the configured manual bounds."""
+    lower, upper = _range(bounds, label="joint_pos_out_of_manual_limit bounds")
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    return np.any((joint_pos < lower) | (joint_pos > upper), axis=1)
+
+
+def register_fixture() -> None:
+    """Register the fixture without adding it to the production task package."""
+    if registry.contains(FIXTURE_ENV_NAME):
+        return
+    registry.register_env_config(FIXTURE_ENV_NAME, ManagerBasedRlEnvCfg)
+    registry.register_env(
+        FIXTURE_ENV_NAME,
+        make_manager_based_rl_env,
+        sim_backend="mujoco",
+    )
+
+
+register_fixture()
+
+
+__all__ = [
+    "FIXTURE_ENV_NAME",
+    "JointEffortAction",
+    "JointEffortActionCfg",
+    "joint_pos_out_of_manual_limit",
+    "joint_pos_target_l2",
+    "joint_vel_l1",
+    "register_fixture",
+    "reset_joints_by_offset",
+]

--- a/tests/managers/test_isaac_lab_migration_fixture.py
+++ b/tests/managers/test_isaac_lab_migration_fixture.py
@@ -1,0 +1,188 @@
+"""End-to-end evidence for the Isaac Lab Manager-Based migration fixture."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import DictConfig, OmegaConf
+
+from tests.fixtures.isaac_lab_cartpole import FIXTURE_ENV_NAME
+from tests.fixtures.isaac_lab_cartpole import task as fixture
+from unilab.base import registry
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnv, ManagerBasedRLEnvCfg, ManagerBasedRlEnvCfg
+from unilab.training import BackendAdapter
+
+ROOT_DIR = Path(__file__).parents[2]
+FIXTURE_DIR = ROOT_DIR / "tests" / "fixtures" / "isaac_lab_cartpole"
+
+
+def _compose_fixture() -> DictConfig:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(FIXTURE_DIR / "conf"), version_base="1.3"):
+        return compose("config")
+
+
+def _materialize_fixture() -> tuple[DictConfig, ManagerBasedRlEnvCfg, dict[str, Any]]:
+    hydra_cfg = _compose_fixture()
+    override = BackendAdapter(hydra_cfg, root_dir=ROOT_DIR).build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config(FIXTURE_ENV_NAME)
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, override)
+    env_cfg.validate()
+    return hydra_cfg, env_cfg, override
+
+
+def _assert_plain(value: Any) -> None:
+    assert not OmegaConf.is_config(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_plain(getattr(value, field.name))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _assert_plain(key)
+            _assert_plain(item)
+    elif isinstance(value, (tuple, list)):
+        for item in value:
+            _assert_plain(item)
+
+
+def test_fixture_hydra_owner_materializes_source_order_as_plain_manager_cfg() -> None:
+    hydra_cfg, env_cfg, _ = _materialize_fixture()
+
+    assert hydra_cfg.training.task_name == FIXTURE_ENV_NAME
+    assert hydra_cfg.training.sim_backend == "mujoco"
+    assert ManagerBasedRLEnvCfg is ManagerBasedRlEnvCfg
+    assert list(env_cfg.observations) == ["policy"]
+    assert list(env_cfg.observations["policy"].terms) == ["joint_pos_rel", "joint_vel_rel"]
+    assert list(env_cfg.actions) == ["joint_effort"]
+    assert list(env_cfg.events) == ["reset_cart_position", "reset_pole_position"]
+    assert list(env_cfg.rewards) == [
+        "alive",
+        "terminating",
+        "pole_pos",
+        "cart_vel",
+        "pole_vel",
+    ]
+    assert list(env_cfg.terminations) == ["time_out", "cart_out_of_bounds"]
+    assert env_cfg.actions["joint_effort"].scale == pytest.approx(100.0)
+    assert env_cfg.sim_dt == pytest.approx(1.0 / 120.0)
+    assert env_cfg.ctrl_dt == pytest.approx(1.0 / 60.0)
+    assert env_cfg.max_episode_seconds == pytest.approx(5.0)
+    assert env_cfg.policy_observation_group == "policy"
+    assert env_cfg.critic_observation_group is None
+    _assert_plain(env_cfg)
+
+
+def test_fixture_real_mujoco_reset_step_and_partial_reset() -> None:
+    _, _, override = _materialize_fixture()
+    env = registry.make(
+        FIXTURE_ENV_NAME,
+        sim_backend="mujoco",
+        env_cfg_override=override,
+        num_envs=8,
+    )
+    assert isinstance(env, ManagerBasedRlEnv)
+    try:
+        state = env.init_state()
+        assert env.obs_groups_spec == {"obs": 4}
+        assert env.action_space.shape == (1,)
+        assert state.obs["obs"].shape == (8, 4)
+        assert np.isfinite(state.obs["obs"]).all()
+
+        before = env.scene["robot"].data.joint_pos.copy()
+        reset_ids = np.asarray([1, 6], dtype=np.int32)
+        reset_obs, _ = env.reset(env_ids=reset_ids)
+        after = env.scene["robot"].data.joint_pos.copy()
+        assert reset_obs["obs"].shape == (2, 4)
+        np.testing.assert_array_equal(after[[0, 2, 3, 4, 5, 7]], before[[0, 2, 3, 4, 5, 7]])
+        assert np.all(np.abs(after[reset_ids, 0]) <= 1.0)
+        assert np.all(np.abs(after[reset_ids, 1]) <= 0.25 * np.pi)
+
+        state = env.step(np.zeros((8, 1), dtype=np.float32))
+        assert state.obs["obs"].shape == (8, 4)
+        assert state.reward.shape == (8,)
+        assert state.terminated.shape == (8,)
+        assert state.truncated.shape == (8,)
+        assert np.isfinite(state.obs["obs"]).all()
+        assert np.isfinite(state.reward).all()
+
+        robot = env.scene["robot"]
+        pole_pos = robot.data.joint_pos[:, 1]
+        expected = 1.0 - np.square(np.remainder(pole_pos + np.pi, 2.0 * np.pi) - np.pi)
+        expected -= 0.01 * np.abs(robot.data.joint_vel[:, 0])
+        expected -= 0.005 * np.abs(robot.data.joint_vel[:, 1])
+        np.testing.assert_allclose(state.reward, expected * env.step_dt, rtol=1e-5, atol=1e-6)
+    finally:
+        env.close()
+
+
+def test_fixture_missing_actuator_fails_during_cold_path_binding() -> None:
+    _, _, override = _materialize_fixture()
+    override["actions"]["joint_effort"]["actuator_names"] = ["missing_actuator"]
+
+    with pytest.raises(
+        ValueError,
+        match="Not all entity selector regular expressions matched.*missing_actuator",
+    ):
+        registry.make(
+            FIXTURE_ENV_NAME,
+            sim_backend="mujoco",
+            env_cfg_override=override,
+            num_envs=2,
+        )
+
+
+def test_fixture_stays_test_only_and_has_no_external_runtime_imports() -> None:
+    source = (FIXTURE_DIR / "task.py").read_text(encoding="utf-8")
+    executable = "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+    for forbidden in (
+        "import torch",
+        "from torch",
+        "import isaaclab",
+        "from isaaclab",
+        "unilab.ipc",
+        "unilab.training",
+    ):
+        assert forbidden not in executable
+    assert Path(fixture.__file__).is_relative_to(ROOT_DIR / "tests" / "fixtures")
+    assert "tests.fixtures" not in tuple(registry._DEFAULT_REGISTRY_PACKAGES)
+    assert set(registry._envs[FIXTURE_ENV_NAME].env_factory_dict) == {"mujoco"}
+
+
+def test_fixture_local_term_math_matches_isaac_source() -> None:
+    class _Data:
+        joint_pos = np.asarray([[0.2, 3.5], [-0.3, -3.4]], dtype=np.float32)
+        joint_vel = np.asarray([[0.4, -0.7], [-0.2, 0.9]], dtype=np.float32)
+
+    class _Entity:
+        data = _Data()
+
+    class _Scene(dict):
+        pass
+
+    env = type("FixtureMathEnv", (), {"scene": _Scene(robot=_Entity())})()
+    pole = fixture.SceneEntityCfg("robot", joint_ids=[1])
+    slider = fixture.SceneEntityCfg("robot", joint_ids=[0])
+
+    expected_wrapped = np.remainder(_Data.joint_pos[:, 1] + np.pi, 2.0 * np.pi) - np.pi
+    np.testing.assert_allclose(
+        fixture.joint_pos_target_l2(env, target=0.0, asset_cfg=pole),
+        np.square(expected_wrapped),
+    )
+    np.testing.assert_allclose(
+        fixture.joint_vel_l1(env, asset_cfg=pole),
+        np.abs(_Data.joint_vel[:, 1]),
+    )
+    np.testing.assert_array_equal(
+        fixture.joint_pos_out_of_manual_limit(env, bounds=(-0.25, 0.25), asset_cfg=slider),
+        np.asarray([False, True]),
+    )


### PR DESCRIPTION
Closes #1215
Parent: #1042

## Summary

- add a test-only Cartpole fixture derived from Isaac Lab commit `b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8`
- preserve the source manager term names, order, and `func + params` structure
- route Hydra owner YAML through `ManagerBasedRlEnvCfg`, registry, and the generic NumPy/MuJoCo runtime
- document Compatible / Adapted / Unsupported boundaries
- keep effort/reset adapters fixture-local; no production task or public contract is added

## Validation

- `uv run pytest tests/managers/test_isaac_lab_migration_fixture.py -q`: 5 passed
- manager/config focused suite: 61 passed
- `make test-all`: 2070 passed, 28 skipped, 272 deselected, 1 xfailed; 75% coverage
- benchmark import smoke: passed (platform-optional MLX entry skipped)

## Scope and provenance

- 7 new test-only files, +567/-0
- source-derived declarations/math: approximately 134 lines
- mechanical Torch-to-NumPy conversion: approximately 37 lines
- UniLab-specific fixture glue: approximately 163 lines
- tests, provenance docs, and MJCF fixture asset: approximately 233 lines
- modified existing files: 0
- deleted files/LOC: 0
- no manager/backend/lifecycle/runner/IPC changes

Remote CI is intentionally skipped by the approved #1042 workflow; the final commit passed the full local gate.