### PR TITLE
docs: align Isaac Lab Manager-Based migration guide

### DIFF
--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/0-index.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/0-index.md
@@ -9,7 +9,7 @@ contract-driven layout.
 :::{grid-item-card} From Isaac Lab
 :link: 1-from_isaac_lab
 :link-type: doc
-Map GPU-resident task structure to UniLab's CPU sim and learner split.
+Keep Manager-Based terms while adapting Hydra config, NumPy execution, and scene access.
 :::
 
 :::{grid-item-card} From Legged Gym

--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/1-from_isaac_lab.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/1-from_isaac_lab.md
@@ -1,93 +1,169 @@
 # Migrating from Isaac Lab
 
-If you have an Isaac Lab task you want to run in UniLab, this page tells
-you what stays the same, what changes, and where the sharp edges are.
+Port an Isaac Lab Manager-Based task to UniLab by keeping its manager and term
+structure, then adapting configuration, numeric execution, and scene access at
+their owner boundaries. Do not rewrite it as a monolithic `NpEnv` subclass.
 
-## What stays the same
+This is source-compatible migration, not a promise that an arbitrary Isaac Lab
+task runs unchanged. The target path is:
 
-- Gymnasium-style env interface (`reset`, `step`, `obs/reward/info`).
-- Hydra-based configuration. Most of your existing YAML can be ported with
-  field-name remapping.
-- The general idea of a "task" that composes scene + reward + DR + obs.
-- PPO as the default algo — UniLab ships RSL-RL's PPO out of the box.
+```text
+Hydra owner YAML
+  -> plain ManagerBasedRlEnvCfg
+  -> Registry + make_manager_based_rl_env
+  -> ManagerBasedRlEnv on the NumPy/SimBackend runtime
+  -> NpEnvState for the existing training and IPC path
+```
 
-## What changes
+## Compatibility boundary
 
 ```{list-table}
 :header-rows: 1
-:widths: 30 35 35
+:widths: 28 24 48
 
-* - Isaac Lab concept
-  - UniLab equivalent
-  - Notes
-* - `DirectRLEnv`
-  - `unilab.base.np_env.NpEnv`
-  - UniLab obs is always a **dict**, not a tensor.
-* - `RigidBody.cfg`
-  - Task-side asset import + scene composition
-  - See {doc}`../../4-developer_guide/1-architecture/4-scene_composition`.
-* - GPU PhysX backend
-  - CPU MuJoCo / Motrix + GPU learner
-  - Architectural inversion — see below.
-* - `RandomizationCfg`
-  - {doc}`../../4-developer_guide/2-contracts/4-dr_contract`
-  - UniLab DR runs in cold-path resampling only.
-* - `RewardManager` chains
-  - Reward composition in env, plus
-    `unilab.training.reward` bookkeeping
-  - Reward terms still keyed for component-wise logging.
-* - `EventCfg` event-driven hooks
-  - Phase + curriculum + DR providers
-  - Hooks are explicit, not implicit.
+* - Isaac Lab surface
+  - UniLab status
+  - Migration rule
+* - Manager categories, term names and dictionary order
+  - Compatible
+  - Keep observation, action, event, reward, termination, command, and
+    curriculum terms in the same order.
+* - Function/class terms and `func + params`
+  - Compatible
+  - Change imports to `unilab.managers`; keep term boundaries and partial
+    `reset(env_ids)` semantics.
+* - `ManagerBasedRLEnv` / `ManagerBasedRLEnvCfg`
+  - Compatible spelling aliases
+  - The canonical UniLab names are `ManagerBasedRlEnv` and
+    `ManagerBasedRlEnvCfg`; the aliases point to the same implementation.
+* - Tensor values and operations
+  - Adapted
+  - Replace `torch.Tensor` with `np.ndarray` and use vectorized NumPy. There is
+    no manager-facing device API.
+* - Nested `@configclass` task configuration
+  - Adapted
+  - Move the complete task declaration to one Hydra owner YAML. `_target_`
+    selects concrete config dataclasses and dotted `func` values select terms.
+* - `InteractiveSceneCfg`, USD, and PhysX views
+  - Adapted or unsupported
+  - Declare a task-owned `SceneCfg` and `EntityCfg`; access state and control
+    only through `SceneEntityCfg` and the public entity facade. Unsupported
+    capabilities raise during cold-path binding.
+* - Omniverse, Isaac renderer, and Torch/PhysX mutation
+  - Unsupported
+  - UniLab does not install or silently emulate these runtimes.
 ```
 
-## The architectural inversion
+The normative boundary is
+{doc}`ADR-0006 </adr/ADR-0006-community-manager-api-on-numpy-runtime>`. Only
+surfaces backed by registration, configuration, and tests should be described
+as compatible.
 
-Isaac Lab places the simulator on GPU and lets you batch thousands of
-envs in PhysX. UniLab places the simulator on CPU (often multithread) and
-batches across worker **processes**, sharing memory with a single GPU
-learner.
+## Migration procedure
 
-Implications:
+### 1. Inventory the source task
 
-- **Per-env step time** in UniLab is comparable or worse than Isaac on a
-  single env. **Throughput** comes from process parallelism + asynchrony
-  (see `unilab.ipc.async_runner`).
-- You can run on **MPS, ROCm, XPU** as the learner device — Isaac is
-  CUDA-only.
-- **No GPU contention** between simulator and learner — your trainer's
-  memory usage is predictable.
+Pin the Isaac Lab revision and list the source manager groups, term names, term
+order, parameters, observation dimensions, action dimensions, reset behavior,
+and episode timing. Classify each dependency before writing code:
 
-## Step-by-step migration
+- reuse an existing `unilab.managers` config or `unilab.envs.mdp` term;
+- adapt a task-specific term from Torch to NumPy;
+- stop if the term requires a capability absent from the public entity or
+  `SimBackend` contract.
 
-1. **Audit observations.** Make sure every observation key is a vector
-   you can express without GPU PhysX queries. If not, add a state
-   estimator or move the query to cold path.
-2. **Port the asset.** UniLab consumes MJCF as its source of truth. If
-   you have USD, convert to MJCF first.
-3. **Port the env.** Subclass `unilab.base.np_env.NpEnv`. Move
-   reward computation into the env's `compute_reward()`.
-4. **Port the YAML.** Map Isaac Lab's `EnvCfg` fields to UniLab task owner
-   YAML following the table in
-   {doc}`5-task_config_translation`.
-5. **Port the reward.** Use the cookbook at
-   {doc}`6-reward_porting`.
-6. **Validate.** Train a small run, compare reward curves against your
-   Isaac baseline.
+Do not probe backend objects with `getattr`/`hasattr`, return zeros, or route the
+task back to a legacy environment.
 
-## What you'll miss (and how to compensate)
+### 2. Port scene and assets on the cold path
 
-- **Isaac Sim renderer.** Use Motrix's headless video export or build a
-  viser scene (`unilab.visualization.viser_scene`).
-- **Per-env tensor obs.** UniLab gives you dict-of-arrays; wrap with your
-  own `obs_to_tensor` if you need a tensor.
-- **Built-in GPU-side DR.** UniLab DR is CPU-side per process. For most
-  tasks this is plenty; for extreme parallelism use more worker
-  processes.
+Replace Isaac Lab's USD/`InteractiveSceneCfg` declaration with a task-owned
+`SceneCfg`. Declare every entity and selector needed by terms. The
+`SceneEntityCfg` selector resolves names and regular expressions once during
+materialization; reset and step reuse cached IDs and NumPy views.
+
+The Cartpole fixture uses a minimal task-owned MJCF asset. More complex assets
+must follow
+{doc}`scene composition <../../4-developer_guide/1-architecture/4-scene_composition>`
+and the selected backend's formal capabilities.
+
+### 3. Port term code, not the manager structure
+
+Keep each function/class term and its parameters. Replace Torch types and
+operators mechanically with NumPy, preserve batch shapes, and return one value
+per environment where the source term does. Stateful terms resolve selectors
+and allocate buffers in their constructor, then update only NumPy buffers on
+the hot path.
+
+Python owns term implementations and reusable config dataclasses. It must not
+hold a second task-specific list of enabled terms or default weights.
+
+### 4. Make Hydra the only task configuration owner
+
+Declare scene, timing, groups, terms, concrete config types, callables,
+parameters, weights, and observation mapping in the owner YAML. For example:
+
+```yaml
+env:
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        joint_pos_rel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  policy_observation_group: policy
+  critic_observation_group: null
+
+reward:
+  alive:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.is_alive
+    weight: 1.0
+```
+
+Hydra composition materializes this declaration into plain typed config on the
+cold path. Unknown fields, unresolved `_target_`/`func` references, and wrong
+config types fail before reset or step. Direct Python config construction is
+reserved for focused lower-level tests.
+
+### 5. Register one generic runtime path
+
+The task module registers `ManagerBasedRlEnvCfg` and
+`make_manager_based_rl_env` for each backend that the repository actually
+supports. Backend owner YAMLs carry backend identity and tuning. Users select
+the composed owner through the normal CLI, for example:
+
+```bash
+uv run train --algo ppo --task <task> --sim mujoco
+```
+
+Do not add a task-specific training-script branch, environment factory, runner,
+or IPC path.
+
+### 6. Validate near each adaptation
+
+Test Hydra composition and typed materialization, term order and math, selector
+failure, observation/action shapes, partial reset, and at least one real
+registered backend transition. Compare behavior with the pinned source task;
+benchmark only after semantic migration is complete.
+
+## Repository evidence
+
+`tests/fixtures/isaac_lab_cartpole/` ports the Manager-Based Cartpole task from
+Isaac Lab commit `b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8`. It preserves all
+12 source term names and their order while adapting Torch to NumPy, nested
+config objects to Hydra YAML, and the scene/action/reset boundaries to a
+fixture-local MJCF implementation. It is test-only evidence, not a production
+task or a blanket Isaac Lab support claim.
 
 ## See also
 
-- {doc}`2-from_legged_gym`
-- {doc}`3-from_rsl_rl`
-- {doc}`5-task_config_translation`
-- {doc}`6-reward_porting`
+- {doc}`Manager-Based API <../../4-developer_guide/1-architecture/6-manager_based_api>`
+- {doc}`Environment contract <../../4-developer_guide/2-contracts/1-env_contract>`
+- {doc}`ADR-0006 </adr/ADR-0006-community-manager-api-on-numpy-runtime>`

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/0-index.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/0-index.md
@@ -8,7 +8,7 @@
 :::{grid-item-card} 从 Isaac Lab 迁移
 :link: 1-from_isaac_lab
 :link-type: doc
-把 GPU 常驻的任务结构映射到 UniLab 的 CPU sim 与 learner 拆分。
+保留 Manager-Based term 结构，适配 Hydra 配置、NumPy 执行和场景访问。
 :::
 
 :::{grid-item-card} 从 Legged Gym 迁移

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/1-from_isaac_lab.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/1-from_isaac_lab.md
@@ -1,83 +1,152 @@
 # 从 Isaac Lab 迁移
 
-如果你有一个想在 UniLab 中运行的 Isaac Lab 任务，本页会告诉你哪些保持不变、
-哪些会改变，以及锋利的边角在哪里。
+把 Isaac Lab Manager-Based task 迁入 UniLab 时，应保留 manager 与 term 结构，只在各自
+owner 边界适配配置、数值执行和场景访问；不要把 task 重写成单体 `NpEnv` 子类。
 
-## 哪些保持不变
+这是基于源码的兼容迁移，不代表任意 Isaac Lab task 都能不修改直接运行。目标路径是：
 
-- Gymnasium 风格的 env 接口（`reset`、`step`、`obs/reward/info`）。
-- 基于 Hydra 的配置。你现有的大部分 YAML 可以通过字段名重映射来移植。
-- "任务"由 scene + reward + DR + obs 组合而成这一总体思路。
-- PPO 作为默认算法 —— UniLab 开箱即带 RSL-RL 的 PPO。
+```text
+Hydra owner YAML
+  -> plain ManagerBasedRlEnvCfg
+  -> Registry + make_manager_based_rl_env
+  -> NumPy/SimBackend runtime 上的 ManagerBasedRlEnv
+  -> 交给现有 training 和 IPC 路径的 NpEnvState
+```
 
-## 哪些会改变
+## 兼容边界
 
 ```{list-table}
 :header-rows: 1
-:widths: 30 35 35
+:widths: 28 24 48
 
-* - Isaac Lab 概念
-  - UniLab 对应物
-  - 备注
-* - `DirectRLEnv`
-  - `unilab.base.np_env.NpEnv`
-  - UniLab 的 obs 始终是 **dict**，而不是 tensor。
-* - `RigidBody.cfg`
-  - 任务侧的 asset 导入 + 场景组合
-  - 参见 {doc}`../../4-developer_guide/1-architecture/4-scene_composition`。
-* - GPU PhysX 后端
-  - CPU MuJoCo / Motrix + GPU learner
-  - 架构倒置 —— 见下文。
-* - `RandomizationCfg`
-  - {doc}`../../4-developer_guide/2-contracts/4-dr_contract`
-  - UniLab 的 DR 只在冷路径重采样中运行。
-* - `RewardManager` 链
-  - env 中的 reward 组合，外加
-    `unilab.training.reward` 记账
-  - reward 项仍然以 key 标识，以便分量级别的日志记录。
-* - `EventCfg` 事件驱动钩子
-  - Phase + curriculum + DR provider
-  - 钩子是显式的，而非隐式的。
+* - Isaac Lab 表面
+  - UniLab 状态
+  - 迁移规则
+* - Manager 类别、term 名称和字典顺序
+  - Compatible
+  - 保持 observation、action、event、reward、termination、command 与
+    curriculum term 的顺序。
+* - Function/class term 与 `func + params`
+  - Compatible
+  - 把 import 改为 `unilab.managers`；保留 term 边界和局部
+    `reset(env_ids)` 语义。
+* - `ManagerBasedRLEnv` / `ManagerBasedRLEnvCfg`
+  - Compatible 拼写 alias
+  - UniLab canonical 名称是 `ManagerBasedRlEnv` 与 `ManagerBasedRlEnvCfg`；alias
+    指向同一份实现。
+* - Tensor 数值与运算
+  - Adapted
+  - 把 `torch.Tensor` 换成 `np.ndarray` 并使用向量化 NumPy；manager-facing
+    API 没有 device 接口。
+* - 嵌套 `@configclass` task 配置
+  - Adapted
+  - 把完整 task 声明迁入唯一 Hydra owner YAML；用 `_target_` 选择具体 config
+    dataclass，用 dotted `func` 选择 term。
+* - `InteractiveSceneCfg`、USD 与 PhysX view
+  - Adapted 或 Unsupported
+  - 声明 task-owned `SceneCfg` 与 `EntityCfg`；状态和控制只通过
+    `SceneEntityCfg` 与公共 entity facade 访问。不支持的能力在冷路径绑定时报错。
+* - Omniverse、Isaac renderer 与 Torch/PhysX mutation
+  - Unsupported
+  - UniLab 不安装这些 runtime，也不提供静默模拟或回退。
 ```
 
-## 架构倒置
+规范边界见 {doc}`ADR-0006 </adr/ADR-0006-community-manager-api-on-numpy-runtime>`。
+只有已经被 registry、配置和测试覆盖的表面才能声明为 Compatible。
 
-Isaac Lab 把模拟器放在 GPU 上，让你在 PhysX 中批处理数千个 env。UniLab 把
-模拟器放在 CPU 上（通常是多线程），并跨 worker **进程**做批处理，与单个 GPU
-learner 共享内存。
+## 迁移步骤
 
-由此带来的影响：
+### 1. 盘点来源 task
 
-- 在单个 env 上，UniLab 的**每个 env 步进时间**与 Isaac 相当甚至更差。
-  **吞吐量**来自进程并行 + 异步（参见 `unilab.ipc.async_runner`）。
-- 你可以用 **MPS、ROCm、XPU** 作为 learner 设备 —— Isaac 仅支持 CUDA。
-- 模拟器与 learner 之间**不存在 GPU 争用** —— 你的 trainer 内存占用是可预测的。
+固定 Isaac Lab revision，并列出来源 manager group、term 名称与顺序、参数、observation
+维度、action 维度、reset 行为和 episode timing。写代码前逐项分类：
 
-## 逐步迁移
+- 复用已有 `unilab.managers` config 或 `unilab.envs.mdp` term；
+- 把 task-specific term 从 Torch 适配为 NumPy；
+- 如果 term 依赖公共 entity 或 `SimBackend` contract 尚未提供的能力，立即停止。
 
-1. **审查观测。** 确保每个观测 key 都是一个无需 GPU PhysX 查询即可表达的向量。
-   如果不是，就添加一个状态估计器，或把该查询移到冷路径。
-2. **移植 asset。** UniLab 以 MJCF 作为唯一真实来源（source of truth）。如果你
-   有 USD，先转换为 MJCF。
-3. **移植 env。** 继承 `unilab.base.np_env.NpEnv`。把 reward 计算移进 env 的
-   `compute_reward()`。
-4. **移植 YAML。** 按照 {doc}`5-task_config_translation` 中的表格，把 Isaac Lab
-   的 `EnvCfg` 字段映射到 UniLab 任务 owner YAML。
-5. **移植 reward。** 使用 {doc}`6-reward_porting` 中的食谱。
-6. **验证。** 训练一个小规模运行，把 reward 曲线与你的 Isaac 基线对比。
+不能用 `getattr`/`hasattr` 探测 backend 对象、返回零，或把 task 路由回 legacy env。
 
-## 你会失去什么（以及如何弥补）
+### 2. 在冷路径迁移 scene 与 asset
 
-- **Isaac Sim 渲染器。** 使用 Motrix 的无头视频导出，或构建一个 viser 场景
-  （`unilab.visualization.viser_scene`）。
-- **每个 env 的 tensor obs。** UniLab 给你的是 dict-of-arrays；如果你需要 tensor，
-  用你自己的 `obs_to_tensor` 包一层。
-- **内置的 GPU 侧 DR。** UniLab 的 DR 是 CPU 侧、按进程进行的。对大多数任务来说
-  这已经足够；对于极端并行，使用更多的 worker 进程。
+用 task-owned `SceneCfg` 代替 Isaac Lab 的 USD/`InteractiveSceneCfg` 声明，显式声明 term
+需要的每个 entity 与 selector。`SceneEntityCfg` 在 materialization 时只解析一次名称和
+正则表达式；reset/step 复用缓存 ID 与 NumPy view。
+
+Cartpole fixture 使用最小 task-owned MJCF。更复杂的 asset 必须遵守
+{doc}`场景组合 <../../4-developer_guide/1-architecture/4-scene_composition>`，并只使用所选
+backend 的正式能力。
+
+### 3. 迁移 term 代码，不改 manager 结构
+
+保留每个 function/class term 及其参数，机械地把 Torch 类型与运算改为 NumPy，保持 batch
+shape，并在来源 term 返回每环境数值时继续返回每环境数值。Stateful term 在构造时解析
+selector、分配 buffer，热路径只更新 NumPy buffer。
+
+Python 只拥有 term 实现和可复用 config dataclass，不能再保存一份 task-specific term
+启停清单或默认 weight。
+
+### 4. 让 Hydra 成为唯一 task 配置 owner
+
+在 owner YAML 中声明 scene、timing、group、term、具体 config 类型、callable、参数、
+weight 和 observation mapping。例如：
+
+```yaml
+env:
+  observations:
+    policy:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        joint_pos_rel:
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  policy_observation_group: policy
+  critic_observation_group: null
+
+reward:
+  alive:
+    _target_: unilab.managers.RewardTermCfg
+    func: unilab.envs.mdp.is_alive
+    weight: 1.0
+```
+
+Hydra compose 在冷路径把这份声明物化为 plain typed config。未知字段、无法解析的
+`_target_`/`func` 和错误 config 类型都会在 reset/step 之前报错。直接用 Python 构造
+config 只用于 focused 底层测试。
+
+### 5. 只注册一条通用 runtime 路径
+
+Task module 为仓库已经实际支持的每个 backend 注册 `ManagerBasedRlEnvCfg` 与
+`make_manager_based_rl_env`。Backend owner YAML 只承载 backend 身份与 tuning。用户通过
+标准 CLI 选择 compose owner，例如：
+
+```bash
+uv run train --algo ppo --task <task> --sim mujoco
+```
+
+不要增加 task-specific 训练脚本分支、env factory、runner 或 IPC 路径。
+
+### 6. 在适配风险附近验证
+
+测试 Hydra compose 与 typed materialization、term 顺序与数学、selector 失败、
+observation/action shape、局部 reset，以及至少一个真实已注册 backend 的 transition。行为
+应与固定来源 task 对比；完成语义迁移后再做性能 benchmark。
+
+## 仓库证据
+
+`tests/fixtures/isaac_lab_cartpole/` 迁移了 Isaac Lab commit
+`b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8` 的 Manager-Based Cartpole task。它保留
+全部 12 个来源 term 的名称和顺序，同时把 Torch 适配为 NumPy、嵌套 config object 适配
+为 Hydra YAML，并用 fixture-local MJCF 实现 scene/action/reset 边界。这只是 test-only
+证据，不是 production task 或 Isaac Lab 全量支持声明。
 
 ## 另请参阅
 
-- {doc}`2-from_legged_gym`
-- {doc}`3-from_rsl_rl`
-- {doc}`5-task_config_translation`
-- {doc}`6-reward_porting`
+- {doc}`Manager-Based API <../../4-developer_guide/1-architecture/6-manager_based_api>`
+- {doc}`Env contract <../../4-developer_guide/2-contracts/1-env_contract>`
+- {doc}`ADR-0006 </adr/ADR-0006-community-manager-api-on-numpy-runtime>`


### PR DESCRIPTION
Closes #1217
Parent: #1042

## Summary

- replace the stale Isaac Lab → monolithic `NpEnv` guidance with the implemented Hydra-owned Manager-Based path
- document the Compatible / Adapted / Unsupported boundary using ADR-0006 and the #1215 Cartpole fixture
- keep the English and Chinese migration pages and section cards aligned
- explicitly prohibit backend-private probing, silent fallback, task-specific runner/IPC paths, and Python task-config mirrors

## Scope

Docs only. No runtime, manager, backend, registry, task, training, runner, IPC, support-level, or performance behavior changes.

## Validation

Final commit `433bd3e0bc197f6cc4735981e50efe8f13919132`:

- `uv run pytest tests/scripts/test_check_docs.py -q`: 20 passed
- prose-only Sphinx build with nitpicky mode: succeeded with no warnings
- `make test-all`: 2070 passed, 28 skipped, 272 deselected, 1 xfailed; 75% coverage
- ruff, mypy, pyright, and benchmark import smoke: passed

Remote child CI is intentionally skipped by the approved #1042 workflow; the final commit carries `[skip ci]`.

## Backend / training impact

None. The guide only describes existing registered/configured/tested behavior.

## Change accounting

- source-derived code: 0
- mechanical Torch→NumPy code: 0
- UniLab-specific documentation: 292 inserted lines
- modified existing: 4 files, +292/-147
- deleted files: 0
