### PR TITLE
test: add pinned mjlab task migration fixture

### DIFF
--- a/tests/fixtures/cartpole_manager_adapters.py
+++ b/tests/fixtures/cartpole_manager_adapters.py
@@ -1,0 +1,160 @@
+# Derived from Isaac Lab b0542fe2d45bf91c4e1d9ef6952b9c709c80b4e8,
+# source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole.
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# Modified by UniLab as test-only NumPy/entity adapters; BSD-3-Clause.
+"""Test-only action and reset adapters shared by pinned Cartpole fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from numbers import Real
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from unilab.managers import ActionTerm, ActionTermCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+def finite_real(value: Real, *, label: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    return result
+
+
+def numeric_range(value: tuple[float, float] | list[float], *, label: str) -> tuple[float, float]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
+        raise TypeError(f"{label} must be a two-value range")
+    if len(value) != 2:
+        raise ValueError(f"{label} must contain two values")
+    lower = finite_real(value[0], label=f"{label}[0]")
+    upper = finite_real(value[1], label=f"{label}[1]")
+    if lower > upper:
+        raise ValueError(f"{label} lower bound {lower} exceeds upper bound {upper}")
+    return lower, upper
+
+
+@dataclass(kw_only=True)
+class JointEffortActionCfg(ActionTermCfg):
+    """Fixture-only adapter for the community ``JointEffortActionCfg`` surface."""
+
+    actuator_names: tuple[str, ...] | list[str]
+    scale: float = 1.0
+
+    def build(self, env: ManagerBasedRlEnv) -> JointEffortAction:
+        return JointEffortAction(self, env)
+
+
+class JointEffortAction(ActionTerm):
+    """Scale policy actions and write entity-local actuator efforts."""
+
+    cfg: JointEffortActionCfg
+
+    def __init__(self, cfg: JointEffortActionCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        if cfg.clip is not None:
+            raise NotImplementedError("Cartpole fixture JointEffortAction does not support clip")
+        if isinstance(cfg.actuator_names, (str, bytes)) or not isinstance(
+            cfg.actuator_names, (tuple, list)
+        ):
+            raise TypeError("JointEffortActionCfg actuator_names must be an ordered sequence")
+        actuator_ids, actuator_names = self._entity.find_actuators(
+            cfg.actuator_names,
+            preserve_order=True,
+        )
+        if not actuator_ids:
+            raise ValueError(
+                "JointEffortActionCfg actuator_names resolved no actuators; "
+                f"patterns={list(cfg.actuator_names)}"
+            )
+        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
+        self._actuator_ids.setflags(write=False)
+        self._actuator_names = tuple(actuator_names)
+        self._scale = finite_real(cfg.scale, label="JointEffortActionCfg scale")
+        self._raw_actions = np.zeros((self.num_envs, len(actuator_ids)), dtype=np.float32)
+        self._processed_actions = np.zeros_like(self._raw_actions)
+
+    @property
+    def action_dim(self) -> int:
+        return self._raw_actions.shape[1]
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._raw_actions
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(
+                "Cartpole fixture JointEffortAction expected np.ndarray, "
+                f"received {type(actions).__name__}"
+            )
+        if actions.shape != self._raw_actions.shape:
+            raise ValueError(
+                "Cartpole fixture JointEffortAction expected shape "
+                f"{self._raw_actions.shape}, received {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError("Cartpole fixture JointEffortAction received NaN or Inf")
+        np.copyto(self._raw_actions, actions)
+        np.multiply(actions, self._scale, out=self._processed_actions)
+
+    def apply_actions(self) -> None:
+        self._entity.data.write_ctrl(
+            self._processed_actions,
+            actuator_ids=self._actuator_ids,
+        )
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        ids = slice(None) if env_ids is None else env_ids
+        self._raw_actions[ids] = 0.0
+        self._processed_actions[ids] = 0.0
+
+
+def reset_joints_by_offset(
+    env: ManagerBasedRlEnv,
+    env_ids: np.ndarray | None,
+    position_range: tuple[float, float] | list[float],
+    velocity_range: tuple[float, float] | list[float],
+    asset_cfg: SceneEntityCfg,
+) -> None:
+    """Write uniformly offset joint defaults through the reset transaction."""
+    if env_ids is None:
+        raise ValueError("reset_joints_by_offset requires concrete environment IDs")
+    position_lower, position_upper = numeric_range(position_range, label="position_range")
+    velocity_lower, velocity_upper = numeric_range(velocity_range, label="velocity_range")
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_ids = asset_cfg.joint_ids
+    default_position = asset.data.default_joint_pos[env_ids][:, joint_ids]
+    default_velocity = asset.data.default_joint_vel[env_ids][:, joint_ids]
+    position = default_position + env.rng.uniform(
+        position_lower,
+        position_upper,
+        default_position.shape,
+    )
+    velocity = default_velocity + env.rng.uniform(
+        velocity_lower,
+        velocity_upper,
+        default_velocity.shape,
+    )
+    asset.write_joint_state_to_sim(
+        position.astype(default_position.dtype, copy=False),
+        velocity.astype(default_velocity.dtype, copy=False),
+        joint_ids=joint_ids,
+        env_ids=env_ids,
+    )
+
+
+__all__ = [
+    "JointEffortAction",
+    "JointEffortActionCfg",
+    "finite_real",
+    "numeric_range",
+    "reset_joints_by_offset",
+]

--- a/tests/fixtures/isaac_lab_cartpole/task.py
+++ b/tests/fixtures/isaac_lab_cartpole/task.py
@@ -2,20 +2,24 @@
 # source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole.
 # Copyright (c) 2022-2026, The Isaac Lab Project Developers.
 # Modified by UniLab for NumPy and the fixture-local MJCF/entity adapter; BSD-3-Clause.
-"""NumPy terms and adapters for the Isaac Lab Cartpole migration fixture."""
+"""NumPy terms for the Isaac Lab Cartpole migration fixture."""
 
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from numbers import Real
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
+from tests.fixtures.cartpole_manager_adapters import (
+    JointEffortAction,
+    JointEffortActionCfg,
+    finite_real,
+    numeric_range,
+    reset_joints_by_offset,
+)
 from unilab.base import registry
 from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
-from unilab.managers import ActionTerm, ActionTermCfg
 from unilab.managers.scene_entity_config import SceneEntityCfg
 
 if TYPE_CHECKING:
@@ -26,146 +30,13 @@ if TYPE_CHECKING:
 FIXTURE_ENV_NAME = "IsaacLabCartpoleFixture"
 
 
-def _finite_real(value: Real, *, label: str) -> float:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
-        raise TypeError(f"{label} must be a real number")
-    result = float(value)
-    if not np.isfinite(result):
-        raise ValueError(f"{label} must be finite")
-    return result
-
-
-def _range(value: tuple[float, float] | list[float], *, label: str) -> tuple[float, float]:
-    if isinstance(value, (str, bytes)) or not isinstance(value, (tuple, list)):
-        raise TypeError(f"{label} must be a two-value range")
-    if len(value) != 2:
-        raise ValueError(f"{label} must contain two values")
-    lower = _finite_real(value[0], label=f"{label}[0]")
-    upper = _finite_real(value[1], label=f"{label}[1]")
-    if lower > upper:
-        raise ValueError(f"{label} lower bound {lower} exceeds upper bound {upper}")
-    return lower, upper
-
-
-@dataclass(kw_only=True)
-class JointEffortActionCfg(ActionTermCfg):
-    """Fixture-local adapter for Isaac Lab's ``JointEffortActionCfg``."""
-
-    actuator_names: tuple[str, ...] | list[str]
-    scale: float = 1.0
-
-    def build(self, env: ManagerBasedRlEnv) -> JointEffortAction:
-        return JointEffortAction(self, env)
-
-
-class JointEffortAction(ActionTerm):
-    """Scale policy actions and write entity-local actuator efforts."""
-
-    cfg: JointEffortActionCfg
-
-    def __init__(self, cfg: JointEffortActionCfg, env: ManagerBasedRlEnv):
-        super().__init__(cfg, env)
-        if cfg.clip is not None:
-            raise NotImplementedError(
-                "IsaacLabCartpoleFixture JointEffortAction does not support clip"
-            )
-        if isinstance(cfg.actuator_names, (str, bytes)) or not isinstance(
-            cfg.actuator_names, (tuple, list)
-        ):
-            raise TypeError("JointEffortActionCfg actuator_names must be an ordered sequence")
-        actuator_ids, actuator_names = self._entity.find_actuators(
-            cfg.actuator_names,
-            preserve_order=True,
-        )
-        if not actuator_ids:
-            raise ValueError(
-                "JointEffortActionCfg actuator_names resolved no actuators; "
-                f"patterns={list(cfg.actuator_names)}"
-            )
-        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
-        self._actuator_ids.setflags(write=False)
-        self._actuator_names = tuple(actuator_names)
-        self._scale = _finite_real(cfg.scale, label="JointEffortActionCfg scale")
-        self._raw_actions = np.zeros((self.num_envs, len(actuator_ids)), dtype=np.float32)
-        self._processed_actions = np.zeros_like(self._raw_actions)
-
-    @property
-    def action_dim(self) -> int:
-        return self._raw_actions.shape[1]
-
-    @property
-    def raw_action(self) -> np.ndarray:
-        return self._raw_actions
-
-    def process_actions(self, actions: np.ndarray) -> None:
-        if not isinstance(actions, np.ndarray):
-            raise TypeError(
-                "IsaacLabCartpoleFixture JointEffortAction expected np.ndarray, "
-                f"received {type(actions).__name__}"
-            )
-        if actions.shape != self._raw_actions.shape:
-            raise ValueError(
-                "IsaacLabCartpoleFixture JointEffortAction expected shape "
-                f"{self._raw_actions.shape}, received {actions.shape}"
-            )
-        if not np.isfinite(actions).all():
-            raise ValueError("IsaacLabCartpoleFixture JointEffortAction received NaN or Inf")
-        np.copyto(self._raw_actions, actions)
-        np.multiply(actions, self._scale, out=self._processed_actions)
-
-    def apply_actions(self) -> None:
-        self._entity.data.write_ctrl(
-            self._processed_actions,
-            actuator_ids=self._actuator_ids,
-        )
-
-    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
-        ids = slice(None) if env_ids is None else env_ids
-        self._raw_actions[ids] = 0.0
-        self._processed_actions[ids] = 0.0
-
-
-def reset_joints_by_offset(
-    env: ManagerBasedRlEnv,
-    env_ids: np.ndarray | None,
-    position_range: tuple[float, float] | list[float],
-    velocity_range: tuple[float, float] | list[float],
-    asset_cfg: SceneEntityCfg,
-) -> None:
-    """Port Isaac Lab's joint-offset reset through the entity reset transaction."""
-    if env_ids is None:
-        raise ValueError("reset_joints_by_offset requires concrete environment IDs")
-    position_lower, position_upper = _range(position_range, label="position_range")
-    velocity_lower, velocity_upper = _range(velocity_range, label="velocity_range")
-    asset = cast("Entity", env.scene[asset_cfg.name])
-    joint_ids = asset_cfg.joint_ids
-    default_position = asset.data.default_joint_pos[env_ids][:, joint_ids]
-    default_velocity = asset.data.default_joint_vel[env_ids][:, joint_ids]
-    position = default_position + env.rng.uniform(
-        position_lower,
-        position_upper,
-        default_position.shape,
-    )
-    velocity = default_velocity + env.rng.uniform(
-        velocity_lower,
-        velocity_upper,
-        default_velocity.shape,
-    )
-    asset.write_joint_state_to_sim(
-        position.astype(default_position.dtype, copy=False),
-        velocity.astype(default_velocity.dtype, copy=False),
-        joint_ids=joint_ids,
-        env_ids=env_ids,
-    )
-
-
 def joint_pos_target_l2(
     env: ManagerBasedRlEnv,
     target: float,
     asset_cfg: SceneEntityCfg,
 ) -> np.ndarray:
     """Penalize wrapped joint-position deviation from a target value."""
-    target_value = _finite_real(target, label="joint_pos_target_l2 target")
+    target_value = finite_real(target, label="joint_pos_target_l2 target")
     asset = cast("Entity", env.scene[asset_cfg.name])
     joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
     wrapped = np.remainder(joint_pos + math.pi, 2.0 * math.pi) - math.pi
@@ -187,7 +58,7 @@ def joint_pos_out_of_manual_limit(
     asset_cfg: SceneEntityCfg,
 ) -> np.ndarray:
     """Terminate when a selected joint leaves the configured manual bounds."""
-    lower, upper = _range(bounds, label="joint_pos_out_of_manual_limit bounds")
+    lower, upper = numeric_range(bounds, label="joint_pos_out_of_manual_limit bounds")
     asset = cast("Entity", env.scene[asset_cfg.name])
     joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
     return np.any((joint_pos < lower) | (joint_pos > upper), axis=1)

--- a/tests/fixtures/mjlab_cartpole/README.md
+++ b/tests/fixtures/mjlab_cartpole/README.md
@@ -1,0 +1,18 @@
+# mjlab Cartpole migration fixture
+
+This test-only fixture is derived from mjlab v1.6.0 commit
+`0fb8a681136be94ffc636a3dd423cabb97d91f10`, specifically
+`src/mjlab/tasks/cartpole/cartpole_env_cfg.py` and `cartpole.xml`. The source is
+Apache-2.0; provenance is retained in the derived files.
+
+| Surface | Status | Migration delta |
+| --- | --- | --- |
+| Manager dictionaries, term names/order, `func + params` | Compatible | Imports change from `mjlab` to `unilab`; the Balance task keeps all source entries and ordering. |
+| Term math and buffers | Adapted | `torch.Tensor` and Torch ops become `np.ndarray` and NumPy ops. |
+| Config container | Adapted | The Python config factory becomes one Hydra owner YAML, materialized as a plain `ManagerBasedRlEnvCfg`. |
+| Scene/simulation | Adapted | mjlab scene/sim/viewer objects become task-owned MJCF plus `SceneCfg`/`EntityCfg`; the source contact-disable setting is embedded and visual materials are inlined for replicated scenes. |
+| Joint effort and reset mutation | Adapted, fixture-local | Shared test-only adapters write through the entity control/reset contracts; they are not public built-ins. |
+| mjlab runner, viewer, Torch/Warp runtime | Unsupported | No dependency or fallback is provided. |
+
+This fixture is evidence for #1042, not a production registration or a claim
+that arbitrary mjlab tasks run unchanged.

--- a/tests/fixtures/mjlab_cartpole/__init__.py
+++ b/tests/fixtures/mjlab_cartpole/__init__.py
@@ -1,0 +1,3 @@
+"""Pinned mjlab Cartpole migration fixture."""
+
+from tests.fixtures.mjlab_cartpole.task import FIXTURE_ENV_NAME as FIXTURE_ENV_NAME

--- a/tests/fixtures/mjlab_cartpole/cartpole.xml
+++ b/tests/fixtures/mjlab_cartpole/cartpole.xml
@@ -1,0 +1,31 @@
+<!-- Derived from mujocolab/mjlab 0fb8a681, src/mjlab/tasks/cartpole/cartpole.xml.
+     Copyright 2025, The mjlab Developers. Modified by UniLab to embed the
+     source SimulationCfg contact flag and inline replicated visual colors;
+     Apache-2.0. -->
+<mujoco model="mjlab_cartpole_fixture">
+  <option timestep="0.01">
+    <flag contact="disable"/>
+  </option>
+  <default>
+    <default class="pole">
+      <joint type="hinge" axis="0 1 0" damping="2e-6"/>
+      <geom type="capsule" fromto="0 0 0 0 0 1" size="0.045" rgba=".1 .5 .8 1" mass=".1"/>
+    </default>
+  </default>
+  <worldbody>
+    <geom name="floor" pos="0 0 -.05" size="4 4 .2" type="plane"/>
+    <geom name="rail1" type="capsule" pos="0 .07 1" zaxis="1 0 0" size="0.02 2" rgba=".3 .3 .3 1"/>
+    <geom name="rail2" type="capsule" pos="0 -.07 1" zaxis="1 0 0" size="0.02 2" rgba=".3 .3 .3 1"/>
+    <body name="cart" pos="0 0 1">
+      <joint name="slider" type="slide" limited="true" axis="1 0 0" range="-1.8 1.8" solreflimit=".08 1" damping="5e-4"/>
+      <geom name="cart" type="box" size="0.2 0.15 0.1" rgba=".7 .1 .1 1" mass="1"/>
+      <body name="pole_1" childclass="pole">
+        <joint name="hinge_1"/>
+        <geom name="pole_1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="slide" joint="slider" gear="10" ctrllimited="true" ctrlrange="-1 1"/>
+  </actuator>
+</mujoco>

--- a/tests/fixtures/mjlab_cartpole/conf/config.yaml
+++ b/tests/fixtures/mjlab_cartpole/conf/config.yaml
@@ -1,0 +1,109 @@
+# Derived from mujocolab/mjlab 0fb8a681,
+# src/mjlab/tasks/cartpole/cartpole_env_cfg.py; Apache-2.0.
+# Hydra is the fixture's only task-configuration owner.
+training:
+  task_name: MjlabCartpoleBalanceFixture
+  sim_backend: mujoco
+
+env:
+  scene:
+    model_file: tests/fixtures/mjlab_cartpole/cartpole.xml
+    entities:
+      cartpole:
+        root_body_name: cart
+        joint_names: [slider, hinge_1]
+        actuator_names: [slide]
+  sim_dt: 0.01
+  ctrl_dt: 0.05
+  max_episode_seconds: 50.0
+  seed: 13
+  observations:
+    actor:
+      _target_: unilab.managers.ObservationGroupCfg
+      enable_corruption: true
+      terms:
+        cart_pos: &cart_pos
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_pos_rel
+          params:
+            asset_cfg: &cart_cfg
+              _target_: unilab.managers.SceneEntityCfg
+              name: cartpole
+              joint_names: [slider]
+        pole_angle: &pole_angle
+          _target_: unilab.managers.ObservationTermCfg
+          func: tests.fixtures.mjlab_cartpole.task.pole_angle_cos_sin
+          params:
+            asset_cfg: &hinge_cfg
+              _target_: unilab.managers.SceneEntityCfg
+              name: cartpole
+              joint_names: [hinge_1]
+        cart_vel: &cart_vel
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg: *cart_cfg
+        pole_vel: &pole_vel
+          _target_: unilab.managers.ObservationTermCfg
+          func: unilab.envs.mdp.joint_vel_rel
+          params:
+            asset_cfg: *hinge_cfg
+    critic:
+      _target_: unilab.managers.ObservationGroupCfg
+      terms:
+        cart_pos: *cart_pos
+        pole_angle: *pole_angle
+        cart_vel: *cart_vel
+        pole_vel: *pole_vel
+  actions:
+    effort:
+      _target_: tests.fixtures.cartpole_manager_adapters.JointEffortActionCfg
+      entity_name: cartpole
+      actuator_names: [slide]
+      scale: 1.0
+  events:
+    reset_slider:
+      _target_: unilab.managers.EventTermCfg
+      func: tests.fixtures.cartpole_manager_adapters.reset_joints_by_offset
+      mode: reset
+      params:
+        position_range: [-0.1, 0.1]
+        velocity_range: [-0.01, 0.01]
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: cartpole
+          joint_names: [slider]
+    reset_hinge:
+      _target_: unilab.managers.EventTermCfg
+      func: tests.fixtures.cartpole_manager_adapters.reset_joints_by_offset
+      mode: reset
+      params:
+        position_range: [-0.034, 0.034]
+        velocity_range: [-0.01, 0.01]
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: cartpole
+          joint_names: [hinge_1]
+  terminations:
+    time_out:
+      _target_: unilab.managers.TerminationTermCfg
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  policy_observation_group: actor
+  critic_observation_group: critic
+  scale_rewards_by_dt: true
+
+reward:
+  smooth_reward:
+    _target_: unilab.managers.RewardTermCfg
+    func: tests.fixtures.mjlab_cartpole.task.cartpole_smooth_reward
+    weight: 1.0
+    params:
+      cart_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: cartpole
+        joint_names: [slider]
+      hinge_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: cartpole
+        joint_names: [hinge_1]

--- a/tests/fixtures/mjlab_cartpole/task.py
+++ b/tests/fixtures/mjlab_cartpole/task.py
@@ -1,0 +1,83 @@
+# Derived from mujocolab/mjlab v1.6.0 (0fb8a681),
+# src/mjlab/tasks/cartpole/cartpole_env_cfg.py.
+# Copyright 2025, The mjlab Developers.
+# Modified by UniLab for NumPy and fixture-only Hydra/entity adapters; Apache-2.0.
+"""NumPy terms for the pinned mjlab Cartpole Balance fixture."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from unilab.base import registry
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
+from unilab.managers import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+FIXTURE_ENV_NAME = "MjlabCartpoleBalanceFixture"
+_GAUSSIAN_SCALE = math.sqrt(-2.0 * math.log(0.1))
+_QUADRATIC_SCALE = math.sqrt(1.0 - 0.1)
+
+
+def pole_angle_cos_sin(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> np.ndarray:
+    """Return cosine and sine of the selected pole angle."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    angle = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    return np.concatenate((np.cos(angle), np.sin(angle)), axis=-1)
+
+
+def _gaussian_tolerance(x: np.ndarray, margin: float) -> np.ndarray:
+    if margin == 0.0:
+        return (x == 0.0).astype(np.float32)
+    scaled = x / margin * _GAUSSIAN_SCALE
+    return np.exp(-0.5 * np.square(scaled))
+
+
+def _quadratic_tolerance(x: np.ndarray, margin: float) -> np.ndarray:
+    if margin == 0.0:
+        return (x == 0.0).astype(np.float32)
+    scaled = x / margin * _QUADRATIC_SCALE
+    return np.maximum(1.0 - np.square(scaled), 0.0)
+
+
+def cartpole_smooth_reward(
+    env: ManagerBasedRlEnv,
+    cart_cfg: SceneEntityCfg,
+    hinge_cfg: SceneEntityCfg,
+) -> np.ndarray:
+    """Port mjlab's dm_control-style smooth Cartpole reward to NumPy."""
+    asset = cast("Entity", env.scene[cart_cfg.name])
+    hinge_angle = asset.data.joint_pos[:, hinge_cfg.joint_ids].squeeze(-1)
+    upright = (np.cos(hinge_angle) + 1.0) / 2.0
+    cart_pos = asset.data.joint_pos[:, cart_cfg.joint_ids].squeeze(-1)
+    centered = (1.0 + _gaussian_tolerance(cart_pos, margin=2.0)) / 2.0
+    control = env.action_manager.action.squeeze(-1)
+    small_control = (4.0 + _quadratic_tolerance(control, margin=1.0)) / 5.0
+    hinge_vel = asset.data.joint_vel[:, hinge_cfg.joint_ids].squeeze(-1)
+    small_velocity = (1.0 + _gaussian_tolerance(hinge_vel, margin=5.0)) / 2.0
+    return upright * centered * small_control * small_velocity
+
+
+def register_fixture() -> None:
+    """Register this fixture without adding it to production bootstrap."""
+    if registry.contains(FIXTURE_ENV_NAME):
+        return
+    registry.register_env_config(FIXTURE_ENV_NAME, ManagerBasedRlEnvCfg)
+    registry.register_env(FIXTURE_ENV_NAME, make_manager_based_rl_env, sim_backend="mujoco")
+
+
+register_fixture()
+
+
+__all__ = [
+    "FIXTURE_ENV_NAME",
+    "cartpole_smooth_reward",
+    "pole_angle_cos_sin",
+    "register_fixture",
+]

--- a/tests/managers/test_mjlab_migration_fixture.py
+++ b/tests/managers/test_mjlab_migration_fixture.py
@@ -1,0 +1,150 @@
+"""End-to-end evidence for the pinned mjlab task migration fixture."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import DictConfig, OmegaConf
+
+from tests.fixtures.mjlab_cartpole import FIXTURE_ENV_NAME
+from unilab.base import registry
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
+from unilab.training import BackendAdapter
+
+ROOT_DIR = Path(__file__).parents[2]
+FIXTURE_DIR = ROOT_DIR / "tests" / "fixtures" / "mjlab_cartpole"
+
+
+def _materialize() -> tuple[ManagerBasedRlEnvCfg, dict[str, Any]]:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(FIXTURE_DIR / "conf"), version_base="1.3"):
+        hydra_cfg: DictConfig = compose("config")
+    override = BackendAdapter(hydra_cfg, root_dir=ROOT_DIR).build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config(FIXTURE_ENV_NAME)
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, override)
+    env_cfg.validate()
+    return env_cfg, override
+
+
+def _assert_plain(value: Any) -> None:
+    assert not OmegaConf.is_config(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_plain(getattr(value, field.name))
+    elif isinstance(value, dict):
+        for item in value.values():
+            _assert_plain(item)
+    elif isinstance(value, (tuple, list)):
+        for item in value:
+            _assert_plain(item)
+
+
+def test_mjlab_fixture_hydra_materializes_source_structure() -> None:
+    cfg, _ = _materialize()
+
+    assert list(cfg.observations) == ["actor", "critic"]
+    expected_obs = ["cart_pos", "pole_angle", "cart_vel", "pole_vel"]
+    assert list(cfg.observations["actor"].terms) == expected_obs
+    assert list(cfg.observations["critic"].terms) == expected_obs
+    assert cfg.observations["actor"].enable_corruption is True
+    assert cfg.observations["critic"].enable_corruption is False
+    assert list(cfg.actions) == ["effort"]
+    assert list(cfg.events) == ["reset_slider", "reset_hinge"]
+    assert list(cfg.rewards) == ["smooth_reward"]
+    assert list(cfg.terminations) == ["time_out"]
+    assert cfg.policy_observation_group == "actor"
+    assert cfg.critic_observation_group == "critic"
+    assert cfg.sim_dt == pytest.approx(0.01)
+    assert cfg.ctrl_dt == pytest.approx(0.05)
+    assert cfg.max_episode_seconds == pytest.approx(50.0)
+    assert cfg.scale_rewards_by_dt is True
+    _assert_plain(cfg)
+
+
+def test_mjlab_fixture_real_mujoco_reset_step_and_reward() -> None:
+    _, override = _materialize()
+    env = registry.make(
+        FIXTURE_ENV_NAME,
+        sim_backend="mujoco",
+        env_cfg_override=override,
+        num_envs=8,
+    )
+    assert isinstance(env, ManagerBasedRlEnv)
+    try:
+        state = env.init_state()
+        assert env.obs_groups_spec == {"obs": 5, "critic": 5}
+        assert state.obs["obs"].shape == state.obs["critic"].shape == (8, 5)
+        assert env.action_space.shape == (1,)
+
+        before = env.scene["cartpole"].data.joint_pos.copy()
+        ids = np.asarray([1, 6], dtype=np.int32)
+        reset_obs, _ = env.reset(env_ids=ids)
+        after = env.scene["cartpole"].data.joint_pos.copy()
+        np.testing.assert_array_equal(after[[0, 2, 3, 4, 5, 7]], before[[0, 2, 3, 4, 5, 7]])
+        assert reset_obs["obs"].shape == reset_obs["critic"].shape == (2, 5)
+        assert np.all(np.abs(after[ids, 0]) <= 0.1)
+        assert np.all(np.abs(after[ids, 1]) <= 0.034)
+        assert np.all(np.abs(env.scene["cartpole"].data.joint_vel[ids]) <= 0.01)
+
+        actions = np.full((8, 1), 0.25, dtype=np.float32)
+        state = env.step(actions)
+        entity = env.scene["cartpole"]
+        hinge = entity.data.joint_pos[:, 1]
+        cart = entity.data.joint_pos[:, 0]
+        hinge_vel = entity.data.joint_vel[:, 1]
+        gaussian_scale = np.sqrt(-2.0 * np.log(0.1))
+        quadratic_scale = np.sqrt(0.9)
+        expected = (np.cos(hinge) + 1.0) / 2.0
+        expected *= (1.0 + np.exp(-0.5 * np.square(cart / 2.0 * gaussian_scale))) / 2.0
+        expected *= (4.0 + np.maximum(1.0 - np.square(0.25 * quadratic_scale), 0.0)) / 5.0
+        expected *= (1.0 + np.exp(-0.5 * np.square(hinge_vel / 5.0 * gaussian_scale))) / 2.0
+        np.testing.assert_allclose(state.reward, expected * 0.05, rtol=1e-5, atol=1e-6)
+    finally:
+        env.close()
+
+
+def test_mjlab_fixture_missing_actuator_fails_on_cold_path() -> None:
+    _, override = _materialize()
+    override["actions"]["effort"]["actuator_names"] = ["missing_actuator"]
+    with pytest.raises(ValueError, match="regular expressions matched.*missing_actuator"):
+        registry.make(
+            FIXTURE_ENV_NAME,
+            sim_backend="mujoco",
+            env_cfg_override=override,
+            num_envs=2,
+        )
+
+
+def test_mjlab_fixture_is_pinned_test_only_numpy_code() -> None:
+    task_source = (FIXTURE_DIR / "task.py").read_text(encoding="utf-8")
+    helper_source = (ROOT_DIR / "tests/fixtures/cartpole_manager_adapters.py").read_text(
+        encoding="utf-8"
+    )
+    executable = "\n".join(
+        line
+        for line in (task_source + helper_source).splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    for forbidden in (
+        "import torch",
+        "from torch",
+        "import mjlab",
+        "from mjlab",
+        "unilab.algos",
+        "unilab.ipc",
+        "unilab.training",
+    ):
+        assert forbidden not in executable
+    assert "0fb8a681136be94ffc636a3dd423cabb97d91f10" in (FIXTURE_DIR / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert "tests.fixtures" not in tuple(registry._DEFAULT_REGISTRY_PACKAGES)
+    assert set(registry._envs[FIXTURE_ENV_NAME].env_factory_dict) == {"mujoco"}


### PR DESCRIPTION
Closes #1219
Parent: #1042

## Summary

- add a test-only Cartpole Balance migration fixture pinned to mjlab v1.6.0 commit `0fb8a681136be94ffc636a3dd423cabb97d91f10`
- preserve the source actor/critic, action, event, reward, and termination dictionary names/order through a Hydra-only task declaration
- mechanically port the source pole observation and dm_control-style smooth reward from Torch to NumPy
- run the fixture through typed `ManagerBasedRlEnvCfg`, Registry, the generic NumPy runtime, and a real MuJoCo reset/step
- move the existing Isaac Cartpole effort/reset adapter to a neutral test-only helper and re-export it without changing the Isaac dotted config path

## Scope

Test/migration evidence only. No production task or registry bootstrap, public built-in, backend/entity/lifecycle contract, training path, runner, IPC, or support-level change.

## Validation

Final commit `fdaee6c7e84059a4804d385b1c526117a3b464e4`:

- both Cartpole migration fixtures: 9 passed
- manager/config boundary suite: 113 passed
- fixture + repository boundary checks: 18 passed
- `make test-all`: 2074 passed, 28 skipped, 272 deselected, 1 xfailed; 75% coverage
- ruff, mypy, pyright, and benchmark import smoke: passed

Remote child CI is intentionally skipped by the approved #1042 workflow; the final commit carries `[skip ci]`.

## Backend / training impact

None. The fixture registers only when its test package is imported and supports only the tested MuJoCo path. Missing selectors fail during cold-path binding.

## Change accounting

- source-derived: 31-line pinned XML and the source-shaped 83-line term/registration module
- mechanical adaptation: 109-line Hydra translation plus Torch→NumPy operations in the term module
- UniLab-specific test/evidence: 150-line test, 18-line compatibility note, and 3-line fixture export
- shared test adapter relocation: new 160-line neutral helper; existing Isaac module +10/-139 with unchanged YAML path and behavior
- total: 8 files, +564/-139 (net +425); 0 deleted files
