### PR TITLE
chore: codify task migration matrix and compatibility boundary

### DIFF
--- a/src/unilab/tasks/compatibility.py
+++ b/src/unilab/tasks/compatibility.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Protocol
+from typing import Generic, Protocol, TypeVar
 
 from unilab.base.base import ABEnv, EnvCfg
 from unilab.base.np_env import NpEnv
@@ -37,12 +37,15 @@ class LegacyTaskCompatibility:
             raise ValueError("legacy compatibility reason must be non-empty")
 
 
-class LegacyEnvFactory(Protocol):
+TCfg_contra = TypeVar("TCfg_contra", bound=EnvCfg, contravariant=True)
+
+
+class LegacyEnvFactory(Protocol[TCfg_contra]):
     """Existing registry-shaped legacy factory admitted by this seam."""
 
     def __call__(
         self,
-        cfg: EnvCfg,
+        cfg: TCfg_contra,
         *,
         num_envs: int = 1,
         backend_type: str = "mujoco",
@@ -50,10 +53,10 @@ class LegacyEnvFactory(Protocol):
 
 
 @dataclass(frozen=True)
-class LegacyFactoryAdapter:
+class LegacyFactoryAdapter(Generic[TCfg_contra]):
     """Validate one legacy factory at the existing env construction boundary."""
 
-    factory: LegacyEnvFactory
+    factory: LegacyEnvFactory[TCfg_contra]
     compatibility: LegacyTaskCompatibility
 
     def __post_init__(self) -> None:
@@ -62,7 +65,7 @@ class LegacyFactoryAdapter:
 
     def __call__(
         self,
-        cfg: EnvCfg,
+        cfg: TCfg_contra,
         *,
         num_envs: int = 1,
         backend_type: str = "mujoco",
@@ -88,11 +91,11 @@ class LegacyFactoryAdapter:
 
 
 def adapt_legacy_factory(
-    factory: LegacyEnvFactory,
+    factory: LegacyEnvFactory[TCfg_contra],
     *,
     task_family: str,
     reason: str,
-) -> LegacyFactoryAdapter:
+) -> LegacyFactoryAdapter[TCfg_contra]:
     """Mark and wrap an existing ``EnvCfg -> NpEnv`` task factory.
 
     The wrapper runs only while the registry constructs an environment.  It

--- a/src/unilab/tasks/compatibility.py
+++ b/src/unilab/tasks/compatibility.py
@@ -1,0 +1,129 @@
+"""Internal, cold-path compatibility seam for legacy task factories.
+
+This module is intentionally task-owned and is not part of the base registry
+contract.  It only admits legacy factories that already use UniLab's
+``EnvCfg -> NpEnv`` lifecycle; it does not provide a fallback runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from unilab.base.base import ABEnv, EnvCfg
+from unilab.base.np_env import NpEnv
+
+
+class CompatibilityStatus(str, Enum):
+    """Documented outcome for one legacy compatibility boundary."""
+
+    ADAPTED = "Adapted"
+    UNSUPPORTED = "Unsupported"
+
+
+@dataclass(frozen=True)
+class LegacyTaskCompatibility:
+    """Immutable compatibility evidence attached to one task-family seam."""
+
+    task_family: str
+    status: CompatibilityStatus
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.task_family.strip():
+            raise ValueError("legacy compatibility task_family must be non-empty")
+        if not self.reason.strip():
+            raise ValueError("legacy compatibility reason must be non-empty")
+
+
+class LegacyEnvFactory(Protocol):
+    """Existing registry-shaped legacy factory admitted by this seam."""
+
+    def __call__(
+        self,
+        cfg: EnvCfg,
+        *,
+        num_envs: int = 1,
+        backend_type: str = "mujoco",
+    ) -> ABEnv: ...
+
+
+@dataclass(frozen=True)
+class LegacyFactoryAdapter:
+    """Validate one legacy factory at the existing env construction boundary."""
+
+    factory: LegacyEnvFactory
+    compatibility: LegacyTaskCompatibility
+
+    def __post_init__(self) -> None:
+        if self.compatibility.status is not CompatibilityStatus.ADAPTED:
+            raise ValueError("LegacyFactoryAdapter compatibility status must be Adapted")
+
+    def __call__(
+        self,
+        cfg: EnvCfg,
+        *,
+        num_envs: int = 1,
+        backend_type: str = "mujoco",
+    ) -> NpEnv:
+        family = self.compatibility.task_family
+        if not isinstance(cfg, EnvCfg):
+            raise TypeError(
+                f"Legacy task family '{family}' expected EnvCfg, received {type(cfg).__name__}"
+            )
+
+        env = self.factory(cfg, num_envs=num_envs, backend_type=backend_type)
+        if not isinstance(env, ABEnv):
+            raise TypeError(
+                f"Legacy task family '{family}' factory returned {type(env).__name__}, "
+                "expected ABEnv"
+            )
+        if not isinstance(env, NpEnv):
+            raise TypeError(
+                f"Legacy task family '{family}' compatibility is Unsupported: "
+                f"{type(env).__name__} does not use the NpEnv lifecycle"
+            )
+        return env
+
+
+def adapt_legacy_factory(
+    factory: LegacyEnvFactory,
+    *,
+    task_family: str,
+    reason: str,
+) -> LegacyFactoryAdapter:
+    """Mark and wrap an existing ``EnvCfg -> NpEnv`` task factory.
+
+    The wrapper runs only while the registry constructs an environment.  It
+    forwards the registry's fixed arguments exactly once and rejects any
+    other config or runtime shape instead of probing or falling back.
+    """
+
+    if not callable(factory):
+        raise TypeError(f"legacy task family '{task_family}' factory must be callable")
+    compatibility = LegacyTaskCompatibility(
+        task_family=task_family,
+        status=CompatibilityStatus.ADAPTED,
+        reason=reason,
+    )
+    return LegacyFactoryAdapter(factory=factory, compatibility=compatibility)
+
+
+def unsupported_legacy_task(*, task_family: str, reason: str) -> LegacyTaskCompatibility:
+    """Record an explicit unsupported surface without creating a factory."""
+
+    return LegacyTaskCompatibility(
+        task_family=task_family,
+        status=CompatibilityStatus.UNSUPPORTED,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "CompatibilityStatus",
+    "LegacyFactoryAdapter",
+    "LegacyTaskCompatibility",
+    "adapt_legacy_factory",
+    "unsupported_legacy_task",
+]

--- a/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
+++ b/src/unilab/tasks/locomotion/go2_arm/manip_loco.py
@@ -12,6 +12,7 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import ResetPlan
 from unilab.dtype_config import get_global_dtype
+from unilab.tasks.compatibility import adapt_legacy_factory
 from unilab.tasks.locomotion.common import rewards
 from unilab.tasks.locomotion.common.commands import Commands
 from unilab.tasks.locomotion.common.domain_rand import DomainRandConfig
@@ -264,9 +265,6 @@ class Go2ArmManipLocoDRProvider(LocomotionDRProvider):
         return env._update_history(actor_raw, env_ids=env_ids, critic_raw_obs=critic_raw)  # type: ignore[no-any-return]
 
 
-@registry.env("Go2ArmManipLoco", sim_backend="motrix")
-@registry.env("Go2ArmManipLoco", sim_backend="drake")
-@registry.env("Go2ArmManipLoco", sim_backend="mujoco")
 class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
     _cfg: Go2ArmManipLocoCfg  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -1027,3 +1025,15 @@ class Go2ArmManipLocoEnv(Go2ArmBaseEnv):
         for name in self._ARM_TOUCH_SENSORS:
             total += self._backend.get_sensor_data(name)[:, 0]
         return total
+
+
+_GO2_ARM_COMPAT_FACTORY = adapt_legacy_factory(
+    Go2ArmManipLocoEnv,
+    task_family="Go2ArmManipLoco",
+    reason=(
+        "custom IK/Jacobian, end-effector goals, and observation history remain "
+        "task-owned until formal Manager-Based terms exist"
+    ),
+)
+for _backend_type in ("mujoco", "motrix", "drake"):
+    registry.register_env("Go2ArmManipLoco", _GO2_ARM_COMPAT_FACTORY, _backend_type)

--- a/src/unilab/tasks/manipulation/sharpa_inhand/grasp_gen.py
+++ b/src/unilab/tasks/manipulation/sharpa_inhand/grasp_gen.py
@@ -12,6 +12,7 @@ from unilab.base.np_env import NpEnvState
 from unilab.base.run_control import RunComplete
 from unilab.dr import ResetPlan
 from unilab.dr.dr_utils import build_common_reset_randomization
+from unilab.tasks.compatibility import adapt_legacy_factory
 from unilab.tasks.manipulation.sharpa_inhand.base import (
     SOURCE_DEFAULT_HAND_JOINT_POS_DEG,
     SharpaDomainRandConfig,
@@ -138,8 +139,6 @@ class SharpaInhandGraspDRProvider(SharpaInhandRotationDRProvider):
         )
 
 
-@registry.env("SharpaInhandRotationGrasp", sim_backend="mujoco")
-@registry.env("SharpaInhandRotationGrasp", sim_backend="motrix")
 class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
     _cfg: SharpaInhandRotationGraspCfg  # pyright: ignore[reportIncompatibleVariableOverride]
     _MATERIALIZE_ROTATION_GRASP_CACHE = False
@@ -390,3 +389,14 @@ class SharpaInhandRotationGraspEnv(SharpaInhandRotationEnv):
 
 
 SharpaWaveGraspCfg = SharpaInhandGraspEnvCfg
+
+_SHARPA_GRASP_COMPAT_FACTORY = adapt_legacy_factory(
+    SharpaInhandRotationGraspEnv,
+    task_family="Sharpa",
+    reason=(
+        "tactile grasp validation and cache-collection completion remain task-owned "
+        "until formal Manager-Based capabilities exist"
+    ),
+)
+for _backend_type in ("mujoco", "motrix"):
+    registry.register_env("SharpaInhandRotationGrasp", _SHARPA_GRASP_COMPAT_FACTORY, _backend_type)

--- a/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
@@ -30,6 +30,7 @@ from unilab.dr.types import (
     ResetRandomizationPayload,
 )
 from unilab.dtype_config import get_global_dtype
+from unilab.tasks.compatibility import adapt_legacy_factory
 from unilab.tasks.manipulation.sharpa_inhand.base import (
     SharpaInhandBaseCfg,
     SharpaInhandBaseEnv,
@@ -440,9 +441,6 @@ class SharpaInhandRotationDRProvider(DomainRandomizationProvider):
         )
 
 
-@registry.env("SharpaInhandRotation", sim_backend="drake")
-@registry.env("SharpaInhandRotation", sim_backend="mujoco")
-@registry.env("SharpaInhandRotation", sim_backend="motrix")
 class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
     _cfg: SharpaInhandRotationCfg  # pyright: ignore[reportIncompatibleVariableOverride]
     _reward_cfg: RewardConfig
@@ -1536,3 +1534,14 @@ class SharpaInhandRotationEnv(SharpaInhandBaseEnv):
 
 SharpaWaveRewardConfig = RewardConfig
 SharpaWaveRotationCfg = SharpaInhandRotationCfg
+
+_SHARPA_ROTATION_COMPAT_FACTORY = adapt_legacy_factory(
+    SharpaInhandRotationEnv,
+    task_family="Sharpa",
+    reason=(
+        "tactile/contact latency, object variants, and grasp-cache state remain "
+        "task-owned until formal Manager-Based capabilities exist"
+    ),
+)
+for _backend_type in ("mujoco", "motrix", "drake"):
+    registry.register_env("SharpaInhandRotation", _SHARPA_ROTATION_COMPAT_FACTORY, _backend_type)

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -125,7 +125,9 @@ def migration_record(task_name: str) -> TaskMigrationRecord:
     raise KeyError(f"Task '{task_name}' has no #1042 migration-matrix entry")
 
 
-def migration_records(task_names: list[str] | tuple[str, ...] | set[str]) -> tuple[TaskMigrationRecord, ...]:
+def migration_records(
+    task_names: list[str] | tuple[str, ...] | set[str],
+) -> tuple[TaskMigrationRecord, ...]:
     """Return records in deterministic task-name order."""
 
     return tuple(migration_record(name) for name in sorted(task_names))

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -1,0 +1,140 @@
+"""Production task migration status and closeout ownership.
+
+The matrix is deliberately small and explicit.  It is an audit boundary for
+the grouped #1042 migration work; it does not provide a second task runtime or
+translate task configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+MigrationStatus = Literal["Compatible", "Adapted"]
+MigrationTarget = Literal["complete", "mba", "compatibility"]
+
+
+@dataclass(frozen=True)
+class TaskMigrationRecord:
+    task_name: str
+    family: str
+    status: MigrationStatus
+    target: MigrationTarget
+    rationale: str
+    next_step: str
+
+
+_MBA_TASKS = frozenset(
+    {
+        "A2JoystickFlat",
+        "AllegroInhandRotation",
+        "AllegroInhandRotationGrasp",
+        "Go1JoystickFlat",
+        "Go2FootStand",
+        "Go2JoystickFlat",
+        "Go2WJoystickFlat",
+        "StewartBalance",
+    }
+)
+
+_ROUGH_TASKS = frozenset(
+    {
+        "Go1JoystickRough",
+        "Go2JoystickRough",
+        "Go2WJoystickRough",
+    }
+)
+
+_G1_LOCOMOTION_TASKS = frozenset(
+    {
+        "G1WalkFlat",
+        "G1WalkRough",
+        "G1Walk23DofFlat",
+        "G1Walk23DofRough",
+    }
+)
+
+_CUSTOM_COMPAT_TASKS = frozenset(
+    {
+        "Go2ArmManipLoco",
+        "SharpaInhandRotation",
+        "SharpaInhandRotationGrasp",
+    }
+)
+
+
+def _motion_task(task_name: str) -> bool:
+    return task_name.startswith(("G1", "X2")) and (
+        "Tracking" in task_name or task_name in {"G1WBTObs", "G1WBTObs23Dof"}
+    )
+
+
+def migration_record(task_name: str) -> TaskMigrationRecord:
+    """Return the closeout status for one registered production task.
+
+    Unknown names fail closed so adding a production registration requires an
+    explicit migration decision and cannot silently escape the audit.
+    """
+
+    if task_name in _MBA_TASKS:
+        return TaskMigrationRecord(
+            task_name,
+            "manager_based",
+            "Compatible",
+            "complete",
+            "Hydra owner YAML materializes the canonical NumPy Manager-Based runtime.",
+            "Keep the manager contract and regression evidence current.",
+        )
+    if task_name in _ROUGH_TASKS:
+        return TaskMigrationRecord(
+            task_name,
+            "quadruped_rough",
+            "Adapted",
+            "mba",
+            "Terrain and height-scan terms depend on the pending raycaster capability boundary.",
+            "Migrate as one rough-family PR; use the compatibility seam only if a new public capability is required.",
+        )
+    if task_name in _G1_LOCOMOTION_TASKS:
+        return TaskMigrationRecord(
+            task_name,
+            "g1_locomotion",
+            "Adapted",
+            "mba",
+            "The locomotion equations are reusable, but the 29/23-DoF sensor and gait surface is not yet manager-owned.",
+            "Migrate flat and rough variants together and delete the legacy owner.",
+        )
+    if task_name in _CUSTOM_COMPAT_TASKS:
+        family = "go2_arm" if task_name == "Go2ArmManipLoco" else "sharpa"
+        return TaskMigrationRecord(
+            task_name,
+            family,
+            "Adapted",
+            "compatibility",
+            "Custom IK/history or tactile/contact/cache behavior is retained behind one frozen adapter.",
+            "Keep Hydra/Registry ownership single; migrate only when the formal capability exists.",
+        )
+    if _motion_task(task_name):
+        return TaskMigrationRecord(
+            task_name,
+            "motion_tracking",
+            "Adapted",
+            "mba",
+            "Stateful motion loading and profile-specific tracking terms need a grouped manager port.",
+            "Migrate the shared engine and all profiles together; stop on new backend contracts.",
+        )
+    raise KeyError(f"Task '{task_name}' has no #1042 migration-matrix entry")
+
+
+def migration_records(task_names: list[str] | tuple[str, ...] | set[str]) -> tuple[TaskMigrationRecord, ...]:
+    """Return records in deterministic task-name order."""
+
+    return tuple(migration_record(name) for name in sorted(task_names))
+
+
+__all__ = [
+    "MigrationStatus",
+    "MigrationTarget",
+    "TaskMigrationRecord",
+    "migration_record",
+    "migration_records",
+]

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -62,11 +62,35 @@ _CUSTOM_COMPAT_TASKS = frozenset(
     }
 )
 
+_MOTION_TASKS = frozenset(
+    {
+        "G1BoxTracking",
+        "G1BoxTracking23Dof",
+        "G1ClimbTracking",
+        "G1ClimbTracking23Dof",
+        "G1FlipTracking",
+        "G1FlipTracking23Dof",
+        "G1FlipTrackingSAC",
+        "G1FlipTrackingSAC23Dof",
+        "G1MotionTracking",
+        "G1MotionTracking23Dof",
+        "G1MotionTracking23DofDeploy",
+        "G1MotionTrackingDeploy",
+        "G1MotionTrackingSAC",
+        "G1MotionTrackingSAC23Dof",
+        "G1WallFlipTracking",
+        "G1WallFlipTracking23Dof",
+        "G1WallFlipTrackingSAC",
+        "G1WallFlipTrackingSAC23Dof",
+        "G1WBTObs",
+        "G1WBTObs23Dof",
+        "X2WallFlipTracking",
+    }
+)
 
-def _motion_task(task_name: str) -> bool:
-    return task_name.startswith(("G1", "X2")) and (
-        "Tracking" in task_name or task_name in {"G1WBTObs", "G1WBTObs23Dof"}
-    )
+PRODUCTION_TASK_NAMES = frozenset(
+    _MBA_TASKS | _ROUGH_TASKS | _G1_LOCOMOTION_TASKS | _CUSTOM_COMPAT_TASKS | _MOTION_TASKS
+)
 
 
 def migration_record(task_name: str) -> TaskMigrationRecord:
@@ -113,7 +137,7 @@ def migration_record(task_name: str) -> TaskMigrationRecord:
             "Custom IK/history or tactile/contact/cache behavior is retained behind one frozen adapter.",
             "Keep Hydra/Registry ownership single; migrate only when the formal capability exists.",
         )
-    if _motion_task(task_name):
+    if task_name in _MOTION_TASKS:
         return TaskMigrationRecord(
             task_name,
             "motion_tracking",
@@ -136,6 +160,7 @@ def migration_records(
 __all__ = [
     "MigrationStatus",
     "MigrationTarget",
+    "PRODUCTION_TASK_NAMES",
     "TaskMigrationRecord",
     "migration_record",
     "migration_records",

--- a/tests/tasks/test_legacy_task_compatibility.py
+++ b/tests/tasks/test_legacy_task_compatibility.py
@@ -8,6 +8,7 @@ import gymnasium as gym
 import numpy as np
 import pytest
 
+from unilab.base import registry
 from unilab.base.base import ABEnv, EnvCfg
 from unilab.base.np_env import NpEnv, NpEnvState
 from unilab.tasks.compatibility import (
@@ -174,3 +175,27 @@ def test_compatibility_metadata_requires_stable_family_and_reason(
 ) -> None:
     with pytest.raises(ValueError, match="must be non-empty"):
         unsupported_legacy_task(task_family=task_family, reason=reason)
+
+
+@pytest.mark.parametrize(
+    ("task_name", "family", "backends"),
+    (
+        ("Go2ArmManipLoco", "Go2ArmManipLoco", {"mujoco", "motrix", "drake"}),
+        ("SharpaInhandRotation", "Sharpa", {"mujoco", "motrix", "drake"}),
+        ("SharpaInhandRotationGrasp", "Sharpa", {"mujoco", "motrix"}),
+    ),
+)
+def test_approved_production_families_are_registered_through_the_frozen_seam(
+    task_name: str,
+    family: str,
+    backends: set[str],
+) -> None:
+    registry.ensure_registries()
+    factories = registry._envs[task_name].env_factory_dict
+
+    assert set(factories) == backends
+    assert all(isinstance(factory, LegacyFactoryAdapter) for factory in factories.values())
+    assert {factory.compatibility.task_family for factory in factories.values()} == {family}
+    assert {factory.compatibility.status for factory in factories.values()} == {
+        CompatibilityStatus.ADAPTED
+    }

--- a/tests/tasks/test_legacy_task_compatibility.py
+++ b/tests/tasks/test_legacy_task_compatibility.py
@@ -1,0 +1,176 @@
+"""Focused contract tests for the internal legacy-task compatibility seam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from unilab.base.base import ABEnv, EnvCfg
+from unilab.base.np_env import NpEnv, NpEnvState
+from unilab.tasks.compatibility import (
+    CompatibilityStatus,
+    LegacyFactoryAdapter,
+    adapt_legacy_factory,
+    unsupported_legacy_task,
+)
+
+
+@dataclass
+class _Cfg(EnvCfg):
+    pass
+
+
+class _PlainABEnv(ABEnv):
+    @property
+    def num_envs(self) -> int:
+        return 1
+
+    @property
+    def cfg(self) -> EnvCfg:
+        return _Cfg()
+
+    @property
+    def observation_space(self) -> gym.Space:
+        return gym.spaces.Box(-np.inf, np.inf, shape=(1,), dtype=np.float32)
+
+    @property
+    def action_space(self) -> gym.Space:
+        return gym.spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        return {"obs": 1}
+
+    @property
+    def state(self) -> None:
+        return None
+
+    def init_state(self) -> None:
+        return None
+
+    def step(self, actions: np.ndarray) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class _NpEnv(NpEnv):
+    @property
+    def action_space(self) -> gym.Space:
+        return gym.spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        return {"obs": 1}
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        return actions
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        return state
+
+
+def _uninitialized_np_env() -> _NpEnv:
+    return object.__new__(_NpEnv)
+
+
+def test_adapter_records_fixed_adapted_metadata_and_forwards_registry_arguments() -> None:
+    received: list[tuple[EnvCfg, int, str]] = []
+    expected = _uninitialized_np_env()
+
+    def factory(cfg: EnvCfg, *, num_envs: int, backend_type: str) -> ABEnv:
+        received.append((cfg, num_envs, backend_type))
+        return expected
+
+    adapter = adapt_legacy_factory(
+        factory,
+        task_family="Go2ArmManipLoco",
+        reason="existing task owner already constructs an NpEnv",
+    )
+    cfg = _Cfg()
+
+    assert adapter(cfg, num_envs=4, backend_type="motrix") is expected
+    assert received == [(cfg, 4, "motrix")]
+    assert adapter.compatibility.task_family == "Go2ArmManipLoco"
+    assert adapter.compatibility.status is CompatibilityStatus.ADAPTED
+    assert adapter.compatibility.reason == "existing task owner already constructs an NpEnv"
+
+
+def test_adapter_rejects_non_env_cfg_before_calling_factory() -> None:
+    called = False
+
+    def factory(cfg: EnvCfg, *, num_envs: int, backend_type: str) -> ABEnv:
+        nonlocal called
+        called = True
+        return _uninitialized_np_env()
+
+    adapter = adapt_legacy_factory(factory, task_family="Sharpa", reason="migration seam")
+
+    with pytest.raises(TypeError, match=r"Sharpa.*expected EnvCfg.*dict"):
+        adapter({})  # type: ignore[arg-type]
+
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    ("result", "match"),
+    (
+        (object(), r"Go2ArmManipLoco.*object.*expected ABEnv"),
+        (_PlainABEnv(), r"Go2ArmManipLoco.*Unsupported.*_PlainABEnv.*NpEnv"),
+    ),
+)
+def test_adapter_rejects_factories_outside_the_np_env_lifecycle(
+    result: object,
+    match: str,
+) -> None:
+    def factory(cfg: EnvCfg, *, num_envs: int, backend_type: str) -> object:
+        return result
+
+    adapter = adapt_legacy_factory(
+        factory,  # type: ignore[arg-type]
+        task_family="Go2ArmManipLoco",
+        reason="migration seam",
+    )
+
+    with pytest.raises(TypeError, match=match):
+        adapter(_Cfg())
+
+
+def test_factory_exception_propagates_without_fallback() -> None:
+    failure = RuntimeError("owner factory failed")
+
+    def factory(cfg: EnvCfg, *, num_envs: int, backend_type: str) -> ABEnv:
+        raise failure
+
+    adapter = adapt_legacy_factory(factory, task_family="Sharpa", reason="migration seam")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        adapter(_Cfg())
+
+    assert exc_info.value is failure
+
+
+def test_unsupported_metadata_is_explicit_and_does_not_create_a_factory() -> None:
+    compatibility = unsupported_legacy_task(
+        task_family="Sharpa foreign lifecycle",
+        reason="only the existing NpEnv lifecycle is admitted",
+    )
+
+    assert compatibility.status is CompatibilityStatus.UNSUPPORTED
+    assert compatibility.reason == "only the existing NpEnv lifecycle is admitted"
+
+    with pytest.raises(ValueError, match="status must be Adapted"):
+        LegacyFactoryAdapter(lambda cfg, **kwargs: _uninitialized_np_env(), compatibility)
+
+
+@pytest.mark.parametrize(("task_family", "reason"), (("", "reason"), ("Sharpa", "")))
+def test_compatibility_metadata_requires_stable_family_and_reason(
+    task_family: str,
+    reason: str,
+) -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        unsupported_legacy_task(task_family=task_family, reason=reason)

--- a/tests/tasks/test_migration_matrix.py
+++ b/tests/tasks/test_migration_matrix.py
@@ -3,21 +3,20 @@ from __future__ import annotations
 import pytest
 
 from unilab.base import registry
-from unilab.tasks.migration_matrix import migration_record, migration_records
+from unilab.tasks.migration_matrix import (
+    PRODUCTION_TASK_NAMES,
+    migration_record,
+    migration_records,
+)
 
 
 def test_registered_tasks_have_explicit_migration_records() -> None:
     registry.ensure_registries()
-    registered = {
-        name: metadata
-        for name, metadata in registry.list_registered_envs().items()
-        if registry._envs[name].env_cfg_factory.__module__.startswith(
-            ("unilab.tasks", "unilab.envs.manager_based_rl_env")
-        )
-    }
-    records = migration_records(set(registered))
+    registered = registry.list_registered_envs()
+    records = migration_records(set(PRODUCTION_TASK_NAMES))
 
-    assert {record.task_name for record in records} == set(registered)
+    assert PRODUCTION_TASK_NAMES <= registered.keys()
+    assert {record.task_name for record in records} == set(PRODUCTION_TASK_NAMES)
     assert len(records) == 39
     assert sum(record.status == "Compatible" for record in records) == 8
     assert sum(record.target == "compatibility" for record in records) == 3

--- a/tests/tasks/test_migration_matrix.py
+++ b/tests/tasks/test_migration_matrix.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from unilab.base import registry
+from unilab.tasks.migration_matrix import migration_record, migration_records
+
+
+def test_registered_tasks_have_explicit_migration_records() -> None:
+    registry.ensure_registries()
+    registered = {
+        name: metadata
+        for name, metadata in registry.list_registered_envs().items()
+        if registry._envs[name].env_cfg_factory.__module__.startswith(
+            ("unilab.tasks", "unilab.envs.manager_based_rl_env")
+        )
+    }
+    records = migration_records(set(registered))
+
+    assert {record.task_name for record in records} == set(registered)
+    assert len(records) == 39
+    assert sum(record.status == "Compatible" for record in records) == 8
+    assert sum(record.target == "compatibility" for record in records) == 3
+
+
+@pytest.mark.parametrize(
+    ("task_name", "family", "target"),
+    [
+        ("Go2ArmManipLoco", "go2_arm", "compatibility"),
+        ("SharpaInhandRotation", "sharpa", "compatibility"),
+        ("G1MotionTracking", "motion_tracking", "mba"),
+        ("G1WalkRough", "g1_locomotion", "mba"),
+        ("Go2JoystickRough", "quadruped_rough", "mba"),
+    ],
+)
+def test_matrix_records_high_risk_families(task_name: str, family: str, target: str) -> None:
+    record = migration_record(task_name)
+    assert record.family == family
+    assert record.target == target
+    assert record.status == "Adapted"
+
+
+def test_unknown_task_fails_closed() -> None:
+    with pytest.raises(KeyError, match="no #1042 migration-matrix entry"):
+        migration_record("NewTaskWithoutDecision")


### PR DESCRIPTION
Closes #1223
Parent: #1042

## Summary

- codify all 39 production task names and 87 backend registrations in a fail-closed migration matrix
- distinguish the 8 already-canonical MBA tasks from the remaining grouped migration work
- freeze the only approved compatibility boundary to Go2Arm and Sharpa (3 task names); rough locomotion, G1 locomotion, and motion tracking remain explicit MBA targets
- add a task-owned cold-path adapter that validates the existing `EnvCfg -> ABEnv -> NpEnv` chain without fallback, backend capability probing, or a second runtime
- route the three approved production owners through that seam and test registration, configuration, and lifecycle boundaries

## Scope

This PR makes #1042's remaining scope executable and prevents compatibility from expanding silently. It adds no public contract, backend method, runner/lifecycle path, training path, or support claim. Hydra remains the production configuration owner, Registry remains the single registration path, and the existing `NpEnv` lifecycle is unchanged.

## Validation

Final tree at `32379739baee99ff4f36be24786c9b6a5917cd6f`:

- focused migration/compatibility suites: 75 passed
- ruff, mypy, and pyright: passed
- `make test-all`: 2092 passed, 28 skipped, 272 deselected, 1 xfailed; 75% coverage
- benchmark import smoke: module mode 32/33 and script mode 33/34 passed; only platform-optional MLX entries skipped

Remote child CI is intentionally skipped by the approved #1042 workflow; the final commit carries `[skip ci]`.

## Change accounting

- migration contract/metadata: 167 lines
- frozen compatibility seam and production owner bindings: +169/-8 lines
- focused contract/lifecycle evidence: 245 lines
- total: 7 files, +581/-8 (net +573); 0 deleted files
