### PR TITLE
feat: infer manager term _target_ from type annotation

### DIFF
--- a/conf/appo/task/allegro_inhand/base.yaml
+++ b/conf/appo/task/allegro_inhand/base.yaml
@@ -48,12 +48,10 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       history_length: 3
       flatten_history_dim: true
       terms:
         rotation:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroRotationObservation
           params:
             entity_name: robot
@@ -70,11 +68,9 @@ env:
       raw_action_clip: [-1.0, 1.0]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_hand_ball:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroHandBallReset
       mode: reset
       params:
@@ -86,7 +82,6 @@ env:
         ball_velocity_noise: 0.0
         ball_z_offset: 0.0
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -95,14 +90,12 @@ env:
         operation: abs
   terminations:
     dropped:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroDropTermination
       params:
         observation_group: policy
         observation_term: rotation
         minimum_ball_height: 0.125
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   scale_rewards_by_dt: true
@@ -111,7 +104,6 @@ env:
 
 reward:
   rotate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroRotateReward
     weight: 1.25
     params:
@@ -120,31 +112,26 @@ reward:
       clip_min: -0.5
       clip_max: 0.5
   obj_linvel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.object_linear_velocity_l1
     weight: -0.3
     params:
       state_term_name: dropped
   pose_diff:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.hand_pose_deviation_l2
     weight: -0.3
     params:
       state_term_name: dropped
   torque:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.estimated_torque_l2
     weight: -0.1
     params:
       state_term_name: dropped
   work:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.estimated_work_l2
     weight: -2.0
     params:
       state_term_name: dropped
   drop:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.dropped
     weight: 0.0
     params:

--- a/conf/appo/task/go1_joystick_flat/base.yaml
+++ b/conf/appo/task/go1_joystick_flat/base.yaml
@@ -40,71 +40,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -133,11 +116,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -156,24 +137,22 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     base_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         mass_distribution_params: [-1.5, 1.5]
         operation: add
         recompute_inertia: false
     base_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         com_range:
@@ -181,7 +160,6 @@ env:
           y: [0.0, 0.0]
           z: [0.0, 0.0]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -189,7 +167,6 @@ env:
         kd_range: [0.5, 0.5]
         operation: abs
     push_robot:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [15.0, 15.0]
@@ -204,11 +181,9 @@ env:
           yaw: [0.0, 0.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -217,43 +192,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     # Legacy Go1 sums four matching feet while this community term returns their mean.
     weight: 0.96
@@ -267,7 +234,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/appo/task/go1_joystick_flat/motrix.yaml
+++ b/conf/appo/task/go1_joystick_flat/motrix.yaml
@@ -30,7 +30,6 @@ reward:
   action_rate:
     weight: -0.015
   action_smooth:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_acc_l2
     weight: -0.01
   similar_to_default:

--- a/conf/appo/task/go2_joystick_flat/base.yaml
+++ b/conf/appo/task/go2_joystick_flat/base.yaml
@@ -39,71 +39,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -132,11 +115,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -155,7 +136,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -164,11 +144,9 @@ env:
         operation: abs
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -177,47 +155,38 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.is_alive
     weight: 0.0
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
@@ -230,7 +199,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/offpolicy/task/flashsac/go2_joystick_flat/mujoco.yaml
+++ b/conf/offpolicy/task/flashsac/go2_joystick_flat/mujoco.yaml
@@ -29,12 +29,12 @@ env:
       terms:
         joint_pos:
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: -0.01
             n_max: 0.01
         joint_vel:
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: -0.1
             n_max: 0.1
     critic:
@@ -42,40 +42,37 @@ env:
       terms:
         joint_pos:
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: -0.01
             n_max: 0.01
         joint_vel:
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: -0.1
             n_max: 0.1
   events:
     randomize_rigid_body_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: base
         mass_distribution_params: [-1.5, 1.5]
         operation: add
         recompute_inertia: false
     randomize_rigid_body_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: base
         com_range:
           x: [-0.05, 0.05]
     randomize_physics_scene_gravity:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_physics_scene_gravity
       mode: reset
       params:
@@ -84,7 +81,6 @@ env:
           - [0.0, 0.0, -9.81]
         operation: abs
     push_by_setting_velocity:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [15.0, 15.0]

--- a/conf/offpolicy/task/go1_joystick_flat/base.yaml
+++ b/conf/offpolicy/task/go1_joystick_flat/base.yaml
@@ -40,71 +40,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -133,11 +116,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -156,24 +137,22 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     base_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         mass_distribution_params: [-1.5, 1.5]
         operation: add
         recompute_inertia: false
     base_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         com_range:
@@ -181,7 +160,6 @@ env:
           y: [0.0, 0.0]
           z: [0.0, 0.0]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -189,7 +167,6 @@ env:
         kd_range: [0.5, 0.5]
         operation: abs
     push_robot:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [15.0, 15.0]
@@ -204,11 +181,9 @@ env:
           yaw: [0.0, 0.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -217,43 +192,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     # Legacy Go1 sums four matching feet while this community term returns their mean.
     weight: 0.96
@@ -267,7 +234,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/offpolicy/task/go2_joystick_flat/base.yaml
+++ b/conf/offpolicy/task/go2_joystick_flat/base.yaml
@@ -39,71 +39,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -132,11 +115,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -155,7 +136,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -164,11 +144,9 @@ env:
         operation: abs
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -177,43 +155,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
@@ -226,7 +196,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/offpolicy/task/go2w_joystick_flat/base.yaml
+++ b/conf/offpolicy/task/go2w_joystick_flat/base.yaml
@@ -48,106 +48,88 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         leg_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         wheel_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_wheel_joint"
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params:
             action_name: motor
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         leg_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         wheel_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_wheel_joint"
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params:
             action_name: motor
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
         motor_torque:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque
           params:
             action_name: motor
@@ -182,11 +164,9 @@ env:
         ang_vel_z: [-1.0, 1.0]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -205,7 +185,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     motor_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2w.manager_terms.randomize_motor_gains
       mode: reset
       params:
@@ -214,11 +193,9 @@ env:
         kd_multiplier_range: [1.0, 1.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -227,72 +204,60 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.75
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.4
   orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.flat_orientation_l2
     weight: -2.0
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.clipped_action_rate_l2
     weight: -0.005
     params:
       action_name: motor
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.5
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_(hip|thigh|calf)_joint"
   torques:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque_l2
     weight: -0.0002
     params:
       action_name: motor
   wheel_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.joint_vel_l2
     weight: 0.0
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_wheel_joint"
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.constant_alive
     weight: 0.5
   upward:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
     weight: 1.0

--- a/conf/offpolicy/task/sac/go2_footstand/base.yaml
+++ b/conf/offpolicy/task/sac/go2_footstand/base.yaml
@@ -55,30 +55,25 @@ env:
   adaptive_chunk_size: false
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       enable_corruption: true
       terms:
         frame:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.frame_observation
           params:
             action_name: joint_pos
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: [-0.1, -0.1, -0.1, -0.2, -0.2, -0.2, -0.05, -0.05, -0.05, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             n_max: [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.05, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
           history_length: 15
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         frame:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.frame_observation
           params:
             action_name: joint_pos
           history_length: 15
         privileged:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.privileged_observation
           params:
             action_name: joint_pos
@@ -132,11 +127,9 @@ env:
       simulate_action_latency: false
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -155,17 +148,15 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     reset_joints:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2.footstand.FootstandJointReset
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           joint_names: ".*"
         position_offset_range: [-0.05, 0.05]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -178,7 +169,6 @@ env:
     joint_armature: null
   terminations:
     footstand:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.go2.footstand.FootstandTermination
       params:
         action_name: joint_pos
@@ -187,7 +177,6 @@ env:
         orientation_threshold: 0.2
         energy_threshold: 200.0
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   policy_observation_group: policy
@@ -196,7 +185,6 @@ env:
 
 reward:
   footstand:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2.footstand.FootstandReward
     weight: 1.0
     params:

--- a/conf/offpolicy/task/stewart_balance/base.yaml
+++ b/conf/offpolicy/task/stewart_balance/base.yaml
@@ -29,10 +29,8 @@ env:
   render_spacing: 4.5
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         balance:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.manipulation.stewart.balance.StewartObservation
           params:
             entity_name: stewart
@@ -63,11 +61,9 @@ env:
       center_control_min_gain: 0.15
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_ball:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.manipulation.stewart.balance.StewartBallReset
       mode: reset
       params:
@@ -77,7 +73,6 @@ env:
         ball_home_z: 1.2
   terminations:
     balance_state:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.stewart.balance.StewartBalanceState
       params:
         observation_group: policy
@@ -92,7 +87,6 @@ env:
         zero_vel_thresh: 0.07
         still_steps_needed: 5
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   scale_rewards_by_dt: false
@@ -101,25 +95,21 @@ env:
 
 reward:
   center:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.center_reward
     weight: 0.7
     params:
       state_term_name: balance_state
   progress:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.progress_reward
     weight: 0.6
     params:
       state_term_name: balance_state
   still:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.still_reward
     weight: 3.0
     params:
       state_term_name: balance_state
   fall:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.fall_reward
     weight: -6.0
     params:

--- a/conf/ppo/task/a2_joystick_flat/base.yaml
+++ b/conf/ppo/task/a2_joystick_flat/base.yaml
@@ -41,75 +41,58 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
             command_name: twist
             command_threshold: 0.1
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
             command_name: twist
             command_threshold: 0.1
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -138,11 +121,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -161,24 +142,22 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     base_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: base_link
         mass_distribution_params: [0.0, 8.0]
         operation: add
         recompute_inertia: false
     base_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: base_link
         com_range:
@@ -186,12 +165,11 @@ env:
           y: [-0.08, 0.08]
           z: [-0.08, 0.08]
     foot_friction:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.geom_friction
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           geom_names: floor
         ranges: [0.3, 1.6]
@@ -199,30 +177,27 @@ env:
         axes: [0]
         shared_random: true
     joint_armature:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.joint_armature
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           joint_names: ".*"
         ranges: [0.9, 1.1]
         operation: scale
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           actuator_names: ".*"
         kp_range: [0.9, 1.1]
         kd_range: [0.9, 1.1]
         operation: scale
     push_robot:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [8.0, 8.0]
@@ -237,11 +212,9 @@ env:
           yaw: [0.0, 0.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -250,43 +223,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.4
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.4
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.02
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.25
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.5
     params:
@@ -297,7 +262,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:
@@ -309,23 +273,20 @@ reward:
       kernel: 0.01
       swing_start: 0.6
   stand_still:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.stand_still_l1
     weight: -4.0
     params:
       command_name: twist
       command_threshold: 0.1
   hip_deviation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -1.0
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_hip_joint"
   stand_feet_air:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_air_while_standing
     weight: -1.0
     params:

--- a/conf/ppo/task/allegro_inhand/base.yaml
+++ b/conf/ppo/task/allegro_inhand/base.yaml
@@ -49,12 +49,10 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       history_length: 3
       flatten_history_dim: true
       terms:
         rotation:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroRotationObservation
           params:
             entity_name: robot
@@ -71,11 +69,9 @@ env:
       raw_action_clip: [-1.0, 1.0]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_hand_ball:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroHandBallReset
       mode: reset
       params:
@@ -87,7 +83,6 @@ env:
         ball_velocity_noise: 0.0
         ball_z_offset: 0.0
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -96,14 +91,12 @@ env:
         operation: abs
   terminations:
     dropped:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroDropTermination
       params:
         observation_group: policy
         observation_term: rotation
         minimum_ball_height: 0.125
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   scale_rewards_by_dt: true
@@ -112,7 +105,6 @@ env:
 
 reward:
   rotate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.AllegroRotateReward
     weight: 1.25
     params:
@@ -121,31 +113,26 @@ reward:
       clip_min: -0.5
       clip_max: 0.5
   obj_linvel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.object_linear_velocity_l1
     weight: -0.3
     params:
       state_term_name: dropped
   pose_diff:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.hand_pose_deviation_l2
     weight: -0.3
     params:
       state_term_name: dropped
   torque:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.estimated_torque_l2
     weight: -0.1
     params:
       state_term_name: dropped
   work:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.estimated_work_l2
     weight: -2.0
     params:
       state_term_name: dropped
   drop:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.allegro_inhand.manager_terms.dropped
     weight: 0.0
     params:

--- a/conf/ppo/task/allegro_inhand_grasp/motrix.yaml
+++ b/conf/ppo/task/allegro_inhand_grasp/motrix.yaml
@@ -48,7 +48,6 @@ env:
         ball_z_offset: 0.0
   terminations:
     invalid_grasp:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityTermination
       params:
         entity_name: robot
@@ -62,24 +61,19 @@ env:
         enabled: true
   metrics:
     fingertips_close:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: fingertips_close}
     enough_contacts:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: enough_contacts}
     ball_held:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: ball_held}
     valid:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: valid}
   recorders:
     grasp_cache:
-      _target_: unilab.managers.RecorderTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspRecorder
       params:
         quality_term_name: invalid_grasp

--- a/conf/ppo/task/allegro_inhand_grasp/mujoco.yaml
+++ b/conf/ppo/task/allegro_inhand_grasp/mujoco.yaml
@@ -52,7 +52,6 @@ env:
         ball_z_offset: 0.0
   terminations:
     invalid_grasp:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityTermination
       params:
         entity_name: robot
@@ -66,24 +65,19 @@ env:
         enabled: true
   metrics:
     fingertips_close:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: fingertips_close}
     enough_contacts:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: enough_contacts}
     ball_held:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: ball_held}
     valid:
-      _target_: unilab.managers.MetricsTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspQualityMetric
       params: {quality_term_name: invalid_grasp, condition: valid}
   recorders:
     grasp_cache:
-      _target_: unilab.managers.RecorderTermCfg
       func: unilab.tasks.manipulation.allegro_inhand.grasp_gen.AllegroGraspRecorder
       params:
         quality_term_name: invalid_grasp

--- a/conf/ppo/task/go1_joystick_flat/base.yaml
+++ b/conf/ppo/task/go1_joystick_flat/base.yaml
@@ -40,71 +40,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -133,11 +116,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -156,24 +137,22 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     base_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         mass_distribution_params: [-1.5, 1.5]
         operation: add
         recompute_inertia: false
     base_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: trunk
         com_range:
@@ -181,7 +160,6 @@ env:
           y: [0.0, 0.0]
           z: [0.0, 0.0]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -189,7 +167,6 @@ env:
         kd_range: [0.5, 0.5]
         operation: abs
     push_robot:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [15.0, 15.0]
@@ -204,11 +181,9 @@ env:
           yaw: [0.0, 0.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -217,43 +192,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     # Legacy Go1 sums four matching feet while this community term returns their mean.
     weight: 0.96
@@ -267,7 +234,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/ppo/task/go2_footstand/base.yaml
+++ b/conf/ppo/task/go2_footstand/base.yaml
@@ -55,30 +55,25 @@ env:
   adaptive_chunk_size: false
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       enable_corruption: true
       terms:
         frame:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.frame_observation
           params:
             action_name: joint_pos
           noise:
-            _target_: unilab.managers._noise.UniformNoiseCfg
+            _target_: UniformNoiseCfg
             n_min: [-0.1, -0.1, -0.1, -0.2, -0.2, -0.2, -0.05, -0.05, -0.05, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -0.01, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             n_max: [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.05, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
           history_length: 15
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         frame:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.frame_observation
           params:
             action_name: joint_pos
           history_length: 15
         privileged:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2.footstand.privileged_observation
           params:
             action_name: joint_pos
@@ -132,11 +127,9 @@ env:
       simulate_action_latency: false
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -155,17 +148,15 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     reset_joints:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2.footstand.FootstandJointReset
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           joint_names: ".*"
         position_offset_range: [-0.05, 0.05]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -178,7 +169,6 @@ env:
     joint_armature: null
   terminations:
     footstand:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.go2.footstand.FootstandTermination
       params:
         action_name: joint_pos
@@ -187,7 +177,6 @@ env:
         orientation_threshold: 0.2
         energy_threshold: 200.0
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   policy_observation_group: policy
@@ -196,7 +185,6 @@ env:
 
 reward:
   footstand:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2.footstand.FootstandReward
     weight: 1.0
     params:

--- a/conf/ppo/task/go2_footstand/mujoco.yaml
+++ b/conf/ppo/task/go2_footstand/mujoco.yaml
@@ -10,35 +10,32 @@ training:
 env:
   events:
     floor_friction:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.geom_friction
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           geom_names: floor
         ranges: [0.4, 1.0]
         operation: abs
     link_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2.footstand.FootstandMassRandomization
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: ".*"
         torso_body_name: base
         link_mass_scale_range: [0.9, 1.1]
         torso_added_mass_range: [-1.0, 1.0]
     torso_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: base
         com_range:
@@ -46,12 +43,11 @@ env:
           y: [-0.05, 0.05]
           z: [-0.05, 0.05]
     joint_armature:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.joint_armature
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           joint_names: ".*"
         ranges: [1.0, 1.05]

--- a/conf/ppo/task/go2_joystick_flat/base.yaml
+++ b/conf/ppo/task/go2_joystick_flat/base.yaml
@@ -39,71 +39,54 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.manager_terms.quadruped_gait_phase
           params:
             frequency: 2.0
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
@@ -132,11 +115,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -155,7 +136,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -164,11 +144,9 @@ env:
         operation: abs
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -177,43 +155,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.2
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.3
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.005
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.1
   contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_contact
     weight: 0.24
     params:
@@ -226,7 +196,6 @@ reward:
       contact_threshold: 0.1
       stance_threshold: 0.6
   swing_feet_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.feet_phase_swing_height
     weight: 4.0
     params:

--- a/conf/ppo/task/go2w_joystick_flat/base.yaml
+++ b/conf/ppo/task/go2w_joystick_flat/base.yaml
@@ -48,106 +48,88 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         leg_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         wheel_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_wheel_joint"
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params:
             action_name: motor
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: gyro
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params:
             sensor_name: upvector
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         leg_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         wheel_joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_wheel_joint"
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params:
             action_name: motor
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params:
             command_name: twist
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params:
             sensor_name: local_linvel
         motor_torque:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque
           params:
             action_name: motor
@@ -182,11 +164,9 @@ env:
         ang_vel_z: [-1.0, 1.0]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -205,7 +185,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     motor_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2w.manager_terms.randomize_motor_gains
       mode: reset
       params:
@@ -214,11 +193,9 @@ env:
         kd_multiplier_range: [1.0, 1.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     bad_orientation:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.bad_orientation
       params:
         limit_angle: 1.0471975511965976
@@ -227,72 +204,60 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 1.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 0.75
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -5.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.1
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -100.0
     params:
       target_height: 0.4
   orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.flat_orientation_l2
     weight: -2.0
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.clipped_action_rate_l2
     weight: -0.005
     params:
       action_name: motor
   similar_to_default:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.joint_deviation_l1
     weight: -0.5
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_(hip|thigh|calf)_joint"
   torques:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque_l2
     weight: -0.0002
     params:
       action_name: motor
   wheel_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.joint_vel_l2
     weight: 0.0
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_wheel_joint"
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.constant_alive
     weight: 0.5
   upward:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
     weight: 1.0

--- a/conf/ppo/task/quadruped_joystick_rough/base.yaml
+++ b/conf/ppo/task/quadruped_joystick_rough/base.yaml
@@ -36,16 +36,14 @@ env:
         heading: [-3.141592653589793, 3.141592653589793]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     terrain_root_state:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.common.rough_manager_terms.RoughTerrainReset
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
         pose_range:
           x: [-0.5, 0.5]
@@ -66,24 +64,22 @@ env:
         cycle_top_frac: 0.5
         spawn_height_margin: 0.05
     base_mass:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_mass
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: ".*"
         mass_distribution_params: [-1.0, 3.0]
         operation: add
         recompute_inertia: false
     base_com:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.randomize_rigid_body_com
       mode: reset
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
           body_names: ".*"
         com_range:
@@ -91,7 +87,6 @@ env:
           y: [0.0, 0.0]
           z: [0.0, 0.0]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -99,7 +94,6 @@ env:
         kd_range: [0.25, 1.0]
         operation: abs
     push_robot:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
       interval_range_s: [12.5, 12.5]
@@ -114,53 +108,45 @@ env:
           yaw: [0.0, 0.0]
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     terrain_out_of_bounds:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.common.rough_manager_terms.RoughTerrainOutOfBounds
       time_out: true
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
         distance_buffer: 3.0
   curriculum:
     terrain_levels:
-      _target_: unilab.managers.CurriculumTermCfg
       func: unilab.tasks.locomotion.common.rough_manager_terms.RoughTerrainCurriculum
       params:
         asset_cfg:
-          _target_: unilab.managers.SceneEntityCfg
+          _target_: SceneEntityCfg
           name: robot
   policy_observation_group: policy
   critic_observation_group: critic
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
     weight: 3.0
     params:
       std: 0.5
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.track_ang_vel_z_exp
     weight: 1.5
     params:
       std: 0.5
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.lin_vel_z_l2
     weight: -2.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.ang_vel_xy_l2
     weight: -0.05
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.01

--- a/conf/ppo/task/quadruped_joystick_rough/go2w.yaml
+++ b/conf/ppo/task/quadruped_joystick_rough/go2w.yaml
@@ -6,77 +6,61 @@ defaults:
 env:
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: gyro}
           scale: 0.25
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: upvector}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           scale: 0.05
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: motor}
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: local_linvel}
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: upvector}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         leg_joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
               joint_names: ".*_(hip|thigh|calf)_joint"
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: motor}
         height_scan:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.rough_manager_terms.RoughHeightScan
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
             geom_name: floor
             vertical_offset: 0.5
@@ -97,7 +81,6 @@ env:
   events:
     pd_gains: null
     motor_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.locomotion.go2w.manager_terms.randomize_motor_gains
       mode: reset
       params:
@@ -107,44 +90,38 @@ env:
 
 reward:
   orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.flat_orientation_l2
     weight: -2.0
   motor_torque:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.motor_torque_l2
     weight: -2.5e-5
     params: {action_name: motor}
   stand_still:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.stand_still_l1
     weight: -2.0
     params:
       command_name: twist
       command_threshold: 0.1
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_(hip|thigh|calf)_joint"
   hip_pos:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.rough_manager_terms.joint_deviation_l2
     weight: -2.0
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_hip_joint"
   joint_pos_penalty:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.rough_manager_terms.joint_deviation_l2
     weight: -1.0
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_(hip|thigh|calf)_joint"
   upward:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
     weight: 1.0

--- a/conf/ppo/task/quadruped_joystick_rough/quadruped.yaml
+++ b/conf/ppo/task/quadruped_joystick_rough/quadruped.yaml
@@ -6,67 +6,51 @@ defaults:
 env:
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: gyro}
           scale: 0.25
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: upvector}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           scale: 0.05
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: local_linvel}
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: upvector}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         height_scan:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.common.rough_manager_terms.RoughHeightScan
           params:
             asset_cfg:
-              _target_: unilab.managers.SceneEntityCfg
+              _target_: SceneEntityCfg
               name: robot
             geom_name: floor
             vertical_offset: 0.5
@@ -84,26 +68,22 @@ env:
 
 reward:
   stand_still:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.manager_terms.stand_still_l1
     weight: -2.0
     params:
       command_name: twist
       command_threshold: 0.1
   hip_pos:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.rough_manager_terms.joint_deviation_l2
     weight: -0.5
     params:
       asset_cfg:
-        _target_: unilab.managers.SceneEntityCfg
+        _target_: SceneEntityCfg
         name: robot
         joint_names: ".*_hip_joint"
   joint_pos_penalty:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.common.rough_manager_terms.joint_deviation_l2
     weight: -1.0
   upward:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.go2w.manager_terms.upward_l2
     weight: 1.0

--- a/conf/ppo/task/stewart_balance/base.yaml
+++ b/conf/ppo/task/stewart_balance/base.yaml
@@ -30,10 +30,8 @@ env:
   render_spacing: 4.5
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         balance:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.manipulation.stewart.balance.StewartObservation
           params:
             entity_name: stewart
@@ -64,11 +62,9 @@ env:
       center_control_min_gain: 0.15
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_ball:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.tasks.manipulation.stewart.balance.StewartBallReset
       mode: reset
       params:
@@ -78,7 +74,6 @@ env:
         ball_home_z: 1.2
   terminations:
     balance_state:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.manipulation.stewart.balance.StewartBalanceState
       params:
         observation_group: policy
@@ -93,7 +88,6 @@ env:
         zero_vel_thresh: 0.07
         still_steps_needed: 5
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   # Legacy Stewart rewards were discrete per-control-step values, not rates.
@@ -103,25 +97,21 @@ env:
 
 reward:
   center:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.center_reward
     weight: 0.7
     params:
       state_term_name: balance_state
   progress:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.progress_reward
     weight: 0.6
     params:
       state_term_name: balance_state
   still:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.still_reward
     weight: 3.0
     params:
       state_term_name: balance_state
   fall:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.manipulation.stewart.balance.fall_reward
     weight: -6.0
     params:

--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/1-from_isaac_lab.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/1-from_isaac_lab.md
@@ -107,14 +107,11 @@ parameters, weights, and observation mapping in the owner YAML. For example:
 env:
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         joint_pos_rel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   policy_observation_group: policy
@@ -122,10 +119,18 @@ env:
 
 reward:
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.is_alive
     weight: 1.0
 ```
+
+Manager mappings whose value type is a single concrete config dataclass
+(observations / events / rewards / terminations / curriculum / metrics /
+recorders) may omit `_target_`; materialization infers it from the field type
+annotation. `actions` / `commands` have abstract base configs, so they must
+still declare a concrete `_target_` (for example
+`unilab.envs.mdp.JointPositionActionCfg`). Config classes under
+`unilab.managers.` (such as `SceneEntityCfg`) may be referenced by their bare
+class name.
 
 Hydra composition materializes this declaration into plain typed config on the
 cold path. Unknown fields, unresolved `_target_`/`func` references, and wrong

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/1-from_isaac_lab.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/1-from_isaac_lab.md
@@ -95,14 +95,11 @@ weight 和 observation mapping。例如：
 env:
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         joint_pos_rel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
   policy_observation_group: policy
@@ -110,10 +107,15 @@ env:
 
 reward:
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.is_alive
     weight: 1.0
 ```
+
+值类型唯一且具体的 manager mapping（observations / events / rewards /
+terminations / curriculum / metrics / recorders）可以省略 `_target_`，物化时按字段
+类型注解推断；`actions` / `commands` 的基类是抽象的，必须显式声明具体 `_target_`
+（如 `unilab.envs.mdp.JointPositionActionCfg`）。`unilab.managers.` 下的 config 类
+（如 `SceneEntityCfg`）可以直接写裸类名。
 
 Hydra compose 在冷路径把这份声明物化为 plain typed config。未知字段、无法解析的
 `_target_`/`func` 和错误 config 类型都会在 reset/step 之前报错。直接用 Python 构造

--- a/src/unilab/base/config_materialization.py
+++ b/src/unilab/base/config_materialization.py
@@ -66,12 +66,27 @@ def _dict_value_type(annotation: Any) -> Any:
 def _resolve(reference: Any, *, path: str) -> Any:
     if not isinstance(reference, str) or not reference.strip():
         raise TypeError(f"Config field '{path}' must be a non-empty dotted string")
+    if "." not in reference:
+        try:
+            return get_object(f"unilab.managers.{reference}")
+        except Exception as exc:
+            raise ValueError(
+                f"Config field '{path}' could not resolve short reference {reference!r} "
+                f"(tried 'unilab.managers.{reference}'): {exc}"
+            ) from exc
     try:
         return get_object(reference)
     except Exception as exc:
         raise ValueError(
             f"Config field '{path}' could not resolve dotted reference {reference!r}: {exc}"
         ) from exc
+
+
+def _inferable_target(annotation: Any) -> type[Any] | None:
+    candidates = _dataclass_types(annotation)
+    if len(candidates) == 1 and not inspect.isabstract(candidates[0]):
+        return candidates[0]
+    return None
 
 
 def _resolve_target(
@@ -155,7 +170,7 @@ def _prepare_manager_mapping(value: Any, *, annotation: Any, path: str) -> dict[
                 dict(entry),
                 expected=value_type,
                 path=entry_path,
-                require_target=True,
+                require_target=_inferable_target(value_type) is None,
             )
     return result
 
@@ -185,6 +200,7 @@ def _prepare_dataclass(
         reference = _target_path(target)
     else:
         target = _resolve_target(reference, expected=expected, path=path)
+        reference = _target_path(target)
 
     fields = {field.name: field for field in dataclasses.fields(target) if field.init}
     unknown = [name for name in values if name not in fields]
@@ -219,8 +235,16 @@ def _prepare_dataclass(
     return prepared
 
 
-def _materialize_entry(value: Mapping[str, Any], *, expected: Any, path: str) -> Any:
-    prepared = _prepare_dataclass(value, expected=expected, path=path, require_target=True)
+def _materialize_entry(
+    value: Mapping[str, Any],
+    *,
+    expected: Any,
+    path: str,
+    require_target: bool = True,
+) -> Any:
+    prepared = _prepare_dataclass(
+        value, expected=expected, path=path, require_target=require_target
+    )
     try:
         result = instantiate(prepared, _convert_="all")
     except Exception as exc:
@@ -299,6 +323,11 @@ def _apply_manager_mapping(
         else:
             current = existing.get(term_name, _MISSING)
             if current is _MISSING or current is None:
+                if _inferable_target(value_type) is not None:
+                    existing[term_name] = _materialize_entry(
+                        value, expected=value_type, path=path, require_target=False
+                    )
+                    continue
                 raise ValueError(
                     f"Config field '{path}' is a new Manager-Based entry and must declare "
                     f"'{HYDRA_TARGET_KEY}'"

--- a/src/unilab/managers/__init__.py
+++ b/src/unilab/managers/__init__.py
@@ -3,6 +3,14 @@
 # Modified by UniLab for NumPy and UniLab contracts; licensed under Apache-2.0.
 """Environment managers."""
 
+from unilab.managers._noise.noise_cfg import ConstantNoiseCfg as ConstantNoiseCfg
+from unilab.managers._noise.noise_cfg import GaussianNoiseCfg as GaussianNoiseCfg
+from unilab.managers._noise.noise_cfg import NoiseCfg as NoiseCfg
+from unilab.managers._noise.noise_cfg import NoiseModelCfg as NoiseModelCfg
+from unilab.managers._noise.noise_cfg import (
+    NoiseModelWithAdditiveBiasCfg as NoiseModelWithAdditiveBiasCfg,
+)
+from unilab.managers._noise.noise_cfg import UniformNoiseCfg as UniformNoiseCfg
 from unilab.managers.action_manager import ActionManager as ActionManager
 from unilab.managers.action_manager import ActionTerm as ActionTerm
 from unilab.managers.action_manager import ActionTermCfg as ActionTermCfg

--- a/tests/base/backend/test_mujoco_cpu_affinity_wiring.py
+++ b/tests/base/backend/test_mujoco_cpu_affinity_wiring.py
@@ -34,6 +34,13 @@ from unilab.base.scene import SceneCfg
 
 _MODEL_FILE = str(ASSETS_ROOT_PATH / "robots" / "go2_arm" / "scene_flat.xml")
 _NUM_ENVS = 4
+
+if not hasattr(os, "sched_getaffinity"):
+    pytest.skip(
+        "os.sched_getaffinity unavailable on this platform (e.g. macOS)",
+        allow_module_level=True,
+    )
+
 _AVAILABLE_CPUS = sorted(os.sched_getaffinity(0))
 
 

--- a/tests/base/test_manager_config_overlay.py
+++ b/tests/base/test_manager_config_overlay.py
@@ -280,8 +280,7 @@ def test_hydra_mapping_fully_materializes_empty_manager_config() -> None:
 @pytest.mark.parametrize(
     ("overrides", "match"),
     [
-        ({"rewards": {"missing": {"weight": 1.0}}}, "missing.*_target_"),
-        ({"rewards": {"disabled": {"weight": 1.0}}}, "disabled.*_target_"),
+        ({"actions": {"missing": {"scale": 0.25}}}, "missing.*_target_"),
         ({"rewards": {"tracking": _second_term}}, "tracking.*field mapping"),
         ({"rewards": []}, "rewards.*mapping"),
         ({"rewards": {"tracking": {"func": _second_term}}}, "func.*typed term"),
@@ -290,6 +289,88 @@ def test_hydra_mapping_fully_materializes_empty_manager_config() -> None:
 def test_manager_mapping_overlay_fails_closed(overrides: dict, match: str) -> None:
     with pytest.raises((TypeError, ValueError), match=match):
         apply_cfg_overrides(_manager_cfg(), overrides)
+
+
+def test_manager_mapping_overlay_infers_concrete_term_target() -> None:
+    cfg = _manager_cfg()
+
+    apply_cfg_overrides(
+        cfg,
+        {
+            "rewards": {
+                "missing": {
+                    "func": "unilab.envs.mdp.is_alive",
+                    "weight": 0.5,
+                },
+                "disabled": {
+                    "func": "unilab.envs.mdp.is_alive",
+                    "weight": 0.2,
+                },
+            },
+            "observations": {
+                "critic": {
+                    "terms": {
+                        "joint_vel": {"func": "unilab.envs.mdp.joint_vel_rel"},
+                    }
+                }
+            },
+        },
+    )
+
+    missing = cfg.rewards["missing"]
+    assert isinstance(missing, RewardTermCfg)
+    assert callable(missing.func)
+    assert missing.weight == pytest.approx(0.5)
+    disabled = cfg.rewards["disabled"]
+    assert isinstance(disabled, RewardTermCfg)
+    assert disabled.weight == pytest.approx(0.2)
+    assert list(cfg.rewards) == ["tracking", "alive", "disabled", "missing"]
+    critic = cfg.observations["critic"]
+    assert isinstance(critic, ObservationGroupCfg)
+    joint_vel = critic.terms["joint_vel"]
+    assert isinstance(joint_vel, ObservationTermCfg)
+    assert callable(joint_vel.func)
+
+
+def test_hydra_materialization_resolves_managers_short_name() -> None:
+    cfg = ManagerBasedRlEnvCfg()
+
+    apply_cfg_overrides(
+        cfg,
+        {
+            "events": {
+                "base_mass": {
+                    "func": "unilab.envs.mdp.is_alive",
+                    "mode": "reset",
+                    "params": {
+                        "asset_cfg": {"_target_": "SceneEntityCfg", "name": "robot"},
+                    },
+                }
+            }
+        },
+    )
+
+    base_mass = cfg.events["base_mass"]
+    assert isinstance(base_mass, EventTermCfg)
+    asset_cfg = base_mass.params["asset_cfg"]
+    assert isinstance(asset_cfg, SceneEntityCfg)
+    assert asset_cfg.name == "robot"
+
+
+def test_hydra_materialization_rejects_unknown_short_name() -> None:
+    with pytest.raises(ValueError, match="could not resolve"):
+        apply_cfg_overrides(
+            ManagerBasedRlEnvCfg(),
+            {
+                "rewards": {
+                    "term": {
+                        "_target_": "NoSuchCfg",
+                        "func": "unilab.envs.mdp.is_alive",
+                        "weight": 1.0,
+                    }
+                }
+            },
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -72,7 +72,6 @@ def _assert_reward_populated(cfg, label: str):
     assert active_terms, f"{label} Manager-Based reward terms must be non-empty"
     for term_name, term in active_terms.items():
         assert isinstance(term, dict), f"{label} reward.{term_name} must be a mapping"
-        assert "_target_" in term, f"{label} reward.{term_name} must declare _target_"
         assert "func" in term, f"{label} reward.{term_name} must declare func"
         assert "weight" in term, f"{label} reward.{term_name} must declare weight"
 


### PR DESCRIPTION
Part of #1042.

## Summary

Migrated MBA task YAMLs repeated `_target_: unilab.managers.ObservationTermCfg` (and siblings) on every term entry — 508 occurrences across 23 files — even though the manager mapping value types make the target uniquely determined. This PR teaches the materialization engine to infer it, and sweeps the configs.

- `src/unilab/base/config_materialization.py`: new `_inferable_target()` — when a manager mapping's value type annotation resolves to exactly one concrete (non-abstract) dataclass, new entries may omit `_target_` (observations incl. groups, events, rewards, terminations, curriculum, metrics, recorders). `actions`/`commands` keep explicit `_target_` because `ActionTermCfg`/`CommandTermCfg` are abstract; un-inferable omissions stay fail-closed. Explicit `_target_` is normalized to its canonical path before hydra instantiate.
- Bare class names now resolve against `unilab.managers.` (e.g. `_target_: SceneEntityCfg`); the noise cfg family (`NoiseCfg`, `ConstantNoiseCfg`, `UniformNoiseCfg`, `GaussianNoiseCfg`, `NoiseModelCfg`, `NoiseModelWithAdditiveBiasCfg`) is re-exported from `unilab.managers`, replacing private `unilab.managers._noise.*` references in YAML.
- Swept all 23 migrated MBA task YAMLs (ppo 12 / appo 3 / offpolicy 8): ~460 redundant lines removed. Remaining `_target_` entries are exactly the meaningful ones — concrete action/command types and short names.
- Tests: `test_manager_config_overlay.py` updated to the new semantics (inference succeeds for concrete types, abstract mappings still fail closed, short-name resolution accepted/rejected); `test_config_system.py` drops the obsolete compose-level `_target_` assertion.
- Docs: zh/en IsaacLab migration guide examples updated to the simplified form with the inference rule spelled out.
- Also fixes `tests/base/backend/test_mujoco_cpu_affinity_wiring.py` crashing collection on macOS (`os.sched_getaffinity` missing) — now skips module-level on such platforms. This was pre-existing on the base branch and blocked local `make test-all`.

Note: this PR intentionally spans >15 files; the YAML sweep is purely mechanical deletion of now-redundant lines (net diff −329), reviewed file by file.

## Validation

- `make test-all` passes on the head commit (`e330732b`): mypy + pyright clean, pytest 2018 passed / 45 skipped, script smoke 32/33 + 33/34 (mlx-only skips).
- Materialization equivalence spot-check: HEAD vs swept YAML for `go1_joystick_flat` and `go2_footstand` produce field-identical `ManagerBasedRlEnvCfg` under the new engine; composed tasks are covered by the 30 `test_supported_task_composes` cases and per-task manager-based e2e tests.
- No checkpoint / contract_snapshot format change; sim2sim contract unaffected.
