### PR TITLE
chore: drop inferable manager term _target_ from G1 owner configs

### DIFF
--- a/conf/appo/task/g1_walk_flat/base.yaml
+++ b/conf/appo/task/g1_walk_flat/base.yaml
@@ -76,69 +76,52 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: pelvis_local_linvel}
   actions:
@@ -167,11 +150,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -190,7 +171,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -199,16 +179,13 @@ env:
         operation: scale
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     tilt:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.g1.manager_terms.g1_tilt_exceeded
       params:
         max_tilt_deg: 25.0
     base_height:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.root_height_below_minimum
       params:
         minimum_height: 0.55
@@ -217,21 +194,18 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_lin_vel
     weight: 2.0
     params:
       tracking_sigma: 0.25
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_ang_vel
     weight: 0.2
     params:
       tracking_sigma: 0.25
       command_name: twist
   feet_phase:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase
     weight: 1.0
     params:
@@ -241,29 +215,23 @@ reward:
       min_forward_speed: 0.0
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.lin_vel_z
     weight: -1.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.ang_vel_xy
     weight: -0.25
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.base_height
     weight: -500.0
     params:
       target_height: 0.754
   orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.orientation
     weight: -5.0
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.01
   pose:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.weighted_pose
     weight: -0.1
     params:

--- a/conf/offpolicy/task/g1_walk_flat/base.yaml
+++ b/conf/offpolicy/task/g1_walk_flat/base.yaml
@@ -77,73 +77,56 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
           scale: 0.25
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           scale: 0.05
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
           scale: 0.25
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
           scale: 0.05
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: pelvis_local_linvel}
           scale: 2.0
@@ -173,11 +156,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -196,7 +177,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -205,22 +185,18 @@ env:
         operation: scale
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     tilt:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.g1.manager_terms.g1_tilt_exceeded
       params:
         max_tilt_deg: 65.0
     base_height:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.root_height_below_minimum
       params:
         minimum_height: 0.3
   curriculum:
     penalty_scaling:
-      _target_: unilab.managers.CurriculumTermCfg
       func: unilab.tasks.locomotion.g1.manager_terms.G1PenaltyCurriculum
       params:
         initial_scale: 0.5
@@ -234,43 +210,35 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_lin_vel
     weight: 2.0
     params:
       tracking_sigma: 0.25
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_ang_vel
     weight: 1.5
     params:
       tracking_sigma: 0.25
       command_name: twist
   penalty_ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.ang_vel_xy
     weight: -1.0
   penalty_orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.orientation
     weight: -10.0
   penalty_action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -4.0
   pose:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.weighted_pose
     weight: -0.5
     params:
       pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
   penalty_feet_ori:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.penalty_feet_ori
     weight: -20.0
   feet_phase:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase
     weight: 5.0
     params:
@@ -280,6 +248,5 @@ reward:
       min_forward_speed: 0.0
       command_name: twist
   alive:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.alive
     weight: 10.0

--- a/conf/ppo/task/g1_23dof_walk_flat/motrix.yaml
+++ b/conf/ppo/task/g1_23dof_walk_flat/motrix.yaml
@@ -56,25 +56,21 @@ reward:
   tracking_ang_vel:
     weight: 0.25
   forward_progress:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.forward_progress
     weight: 0.0
     params:
       command_name: twist
   under_speed:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.under_speed
     weight: -0.2
     params:
       command_name: twist
   upper_body_pose:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.upper_body_pose
     weight: -0.05
     params:
       pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
   penalty_feet_ori:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.penalty_feet_ori
     weight: 0.0
   feet_phase:
@@ -82,7 +78,6 @@ reward:
     params:
       min_forward_speed: 0.05
   feet_phase_contrast:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase_contrast
     weight: 1.5
     params:
@@ -92,7 +87,6 @@ reward:
       min_forward_speed: 0.05
       command_name: twist
   feet_phase_contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase_contact
     weight: 1.0
     params:
@@ -102,7 +96,6 @@ reward:
       min_forward_speed: 0.05
       command_name: twist
   feet_double_stance:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_double_stance
     weight: -1.0
     params:

--- a/conf/ppo/task/g1_23dof_walk_rough/mujoco.yaml
+++ b/conf/ppo/task/g1_23dof_walk_rough/mujoco.yaml
@@ -20,7 +20,6 @@ env:
     model_file: src/unilab/assets/robots/g1/scene_rough_23dof.xml
   curriculum:
     penalty_scaling:
-      _target_: unilab.managers.CurriculumTermCfg
       func: unilab.tasks.locomotion.g1.manager_terms.G1PenaltyCurriculum
       params:
         initial_scale: 0.5

--- a/conf/ppo/task/g1_walk_flat/base.yaml
+++ b/conf/ppo/task/g1_walk_flat/base.yaml
@@ -76,69 +76,52 @@ env:
   max_episode_seconds: 20.0
   observations:
     policy:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
     critic:
-      _target_: unilab.managers.ObservationGroupCfg
       terms:
         base_ang_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: torso_gyro}
         projected_gravity:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.projected_gravity_from_sensor
           params: {sensor_name: torso_upvector}
         joint_pos:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_pos_rel
         joint_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.joint_vel_rel
         actions:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
         command:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.generated_commands
           params: {command_name: twist}
         gait_phase:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.tasks.locomotion.g1.manager_terms.G1GaitPhase
           params:
             frequency: 1.5
             init_mode: offset_phase
         base_lin_vel:
-          _target_: unilab.managers.ObservationTermCfg
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: pelvis_local_linvel}
   actions:
@@ -167,11 +150,9 @@ env:
         ang_vel_z: [-0.8, 0.8]
   events:
     reset_scene_to_default:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_scene_to_default
       mode: reset
     reset_root_state_uniform:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.reset_root_state_uniform
       mode: reset
       params:
@@ -190,7 +171,6 @@ env:
           pitch: [-0.5, 0.5]
           yaw: [-0.5, 0.5]
     pd_gains:
-      _target_: unilab.managers.EventTermCfg
       func: unilab.envs.mdp.pd_gains
       mode: reset
       params:
@@ -199,16 +179,13 @@ env:
         operation: scale
   terminations:
     time_out:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.time_out
       time_out: true
     tilt:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.tasks.locomotion.g1.manager_terms.g1_tilt_exceeded
       params:
         max_tilt_deg: 25.0
     base_height:
-      _target_: unilab.managers.TerminationTermCfg
       func: unilab.envs.mdp.root_height_below_minimum
       params:
         minimum_height: 0.55
@@ -217,21 +194,18 @@ env:
 
 reward:
   tracking_lin_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_lin_vel
     weight: 2.0
     params:
       tracking_sigma: 0.25
       command_name: twist
   tracking_ang_vel:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.track_ang_vel
     weight: 0.2
     params:
       tracking_sigma: 0.25
       command_name: twist
   feet_phase:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase
     weight: 1.0
     params:
@@ -241,29 +215,23 @@ reward:
       min_forward_speed: 0.0
       command_name: twist
   lin_vel_z:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.lin_vel_z
     weight: -1.0
   ang_vel_xy:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.ang_vel_xy
     weight: -0.25
   base_height:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.base_height
     weight: -500.0
     params:
       target_height: 0.754
   orientation:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.orientation
     weight: -5.0
   action_rate:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.01
   pose:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.weighted_pose
     weight: -0.1
     params:

--- a/conf/ppo/task/g1_walk_flat/motrix.yaml
+++ b/conf/ppo/task/g1_walk_flat/motrix.yaml
@@ -58,25 +58,21 @@ reward:
   tracking_ang_vel:
     weight: 0.25
   forward_progress:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.forward_progress
     weight: 0.0
     params:
       command_name: twist
   under_speed:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.under_speed
     weight: -0.2
     params:
       command_name: twist
   upper_body_pose:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.upper_body_pose
     weight: -0.05
     params:
       pose_weights: [0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 0.01, 1.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
   penalty_feet_ori:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.penalty_feet_ori
     weight: 0.0
   feet_phase:
@@ -84,7 +80,6 @@ reward:
     params:
       min_forward_speed: 0.05
   feet_phase_contrast:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase_contrast
     weight: 1.5
     params:
@@ -94,7 +89,6 @@ reward:
       min_forward_speed: 0.05
       command_name: twist
   feet_phase_contact:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_phase_contact
     weight: 1.0
     params:
@@ -104,7 +98,6 @@ reward:
       min_forward_speed: 0.05
       command_name: twist
   feet_double_stance:
-    _target_: unilab.managers.RewardTermCfg
     func: unilab.tasks.locomotion.g1.manager_terms.feet_double_stance
     weight: -1.0
     params:

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -116,7 +116,24 @@ def _install_mjwarp_patch() -> bool:
 
     _ub_backend.create_backend = _patched_create_backend
     _ub_backend._mjwarp_patched = True
+    _ub_backend._mjwarp_orig_create_backend = _orig_create_backend
     return True
+
+
+def _uninstall_mjwarp_patch() -> None:
+    """Undo the import-time factory patch installed by :func:`_install_mjwarp_patch`.
+
+    Importing this module inside a pytest session would otherwise leak the
+    mjwarp rerouting into unrelated tests that exercise the real factory.
+    """
+    import unilab.base.backend as _ub_backend
+
+    if not getattr(_ub_backend, "_mjwarp_patched", False):
+        return
+    orig = getattr(_ub_backend, "_mjwarp_orig_create_backend", None)
+    if orig is not None:
+        _ub_backend.create_backend = orig
+    _ub_backend._mjwarp_patched = False
 
 
 MJWARP_AVAILABLE = _install_mjwarp_patch()

--- a/tests/benchmark/test_env_step_config_contract.py
+++ b/tests/benchmark/test_env_step_config_contract.py
@@ -7,6 +7,11 @@ from scripts.benchmark.env import benchmark_env_step as bench
 from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
 from unilab.tasks.locomotion.common.rough_manager_terms import QuadrupedRoughTerrainCfg
 
+# Importing benchmark_env_step installs a process-wide create_backend patch for
+# the benchmark script. These tests only build configs, so undo the patch to
+# keep the global factory pristine for the rest of the pytest session.
+bench._uninstall_mjwarp_patch()
+
 
 def test_go2w_flat_benchmark_uses_production_manager_owner() -> None:
     cfg = bench.TASK_CONFIGS["go2w"].build_cfg("mujoco")


### PR DESCRIPTION
Follow-up to #1231 and #1232.

## Summary
- sweep the 6 G1 owner YAMLs that still carried redundant `_target_` lines after #1231 introduced type-annotation inference: drop 112 inferable entries (ObservationTermCfg/ObservationGroupCfg/RewardTermCfg/TerminationTermCfg/EventTermCfg/CurriculumTermCfg) from conf/ppo, conf/appo, conf/offpolicy G1 owners
- remaining `_target_` entries are exactly the meaningful ones: JointPositionActionCfg (actions) and G1VelocityCommandCfg (commands), whose base configs are abstract

## Also included (gate-blocking pre-existing fix)
- fix a test-isolation leak: scripts/benchmark/env/benchmark_env_step.py installs a process-wide create_backend patch at import time; when tests/benchmark/test_env_step_config_contract.py is collected in the same pytest session, the leaked patch overrode monkeypatches in tests/base/test_motrix_backend_options.py (3 failures) whenever mujoco_warp is importable in the venv. Reproducible on 20162bb1 (pre-#1231/#1232), so unrelated to this sweep. The patch now stashes the original factory and exposes _uninstall_mjwarp_patch(); the contract test (which only builds configs) uninstalls right after import.

## Validation
- `make test-all` on final commit 7bd6bc4a: **2048 passed, 28 skipped, 272 deselected, 1 xfailed** (incl. the 3 previously failing motrix backend tests); Ruff, Mypy, Pyright, coverage gate, benchmark import smoke all passed (run exactly once)
- focused: 240 passed across tests/envs/locomotion/g1, test_manager_config_overlay, test_config_system, test_locomotion_params; minimal leak repro combo 41 passed