### PR TITLE
feat: migrate motion tracking core to Manager-Based API

### DIFF
--- a/conf/appo/task/g1_23dof_motion_tracking/motrix.yaml
+++ b/conf/appo/task/g1_23dof_motion_tracking/motrix.yaml
@@ -1,29 +1,8 @@
 # @package _global_
+defaults:
+  - /task/g1_23dof_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23Dof
   sim_backend: motrix
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 5000
-  save_interval: 500
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/appo/task/g1_23dof_motion_tracking/mujoco.yaml
+++ b/conf/appo/task/g1_23dof_motion_tracking/mujoco.yaml
@@ -1,32 +1,67 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23Dof
   sim_backend: mujoco
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 5000
-  save_interval: 500
-  algorithm:
-    adaptive_kl_factor: 2.0
-    adaptive_lr_factor: 1.5
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+
+env:
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
+    entities:
+      robot:
+        joint_names: &g1_23dof_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+        actuator_names: *g1_23dof_joints
+        body_names: &tracked_bodies_23dof
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_roll_rubber_hand
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_roll_rubber_hand
+  commands:
+    motion:
+      params:
+        motion_file: motions/g1/dance1_subject2_part_23dof.npz
+        body_names: *tracked_bodies_23dof
+  terminations:
+    ee_body_pos:
+      params:
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_roll_rubber_hand
+          - right_wrist_roll_rubber_hand

--- a/conf/appo/task/g1_motion_tracking/motrix.yaml
+++ b/conf/appo/task/g1_motion_tracking/motrix.yaml
@@ -1,30 +1,8 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking
   sim_backend: motrix
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 5000
-  save_interval: 500
-env:
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/appo/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/appo/task/g1_motion_tracking/mujoco.yaml
@@ -3,6 +3,7 @@ training:
   task_name: G1MotionTracking
   sim_backend: mujoco
   play_steps: 1000
+
 algo:
   num_envs: 1024
   max_iterations: 5000
@@ -10,24 +11,224 @@ algo:
   algorithm:
     adaptive_kl_factor: 2.0
     adaptive_lr_factor: 1.5
+
 env:
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat.xml
+    default_keyframe_name: stand
+    entities:
+      robot:
+        root_body_name: pelvis
+        joint_names: &g1_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - waist_roll_joint
+          - waist_pitch_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - left_wrist_pitch_joint
+          - left_wrist_yaw_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+          - right_wrist_pitch_joint
+          - right_wrist_yaw_joint
+        actuator_names: *g1_joints
+        body_names: &tracked_bodies
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_yaw_link
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_yaw_link
+        geom_names:
+          - left_foot1_collision
+          - left_foot2_collision
+          - left_foot3_collision
+          - left_foot4_collision
+          - left_foot5_collision
+          - left_foot6_collision
+          - left_foot7_collision
+          - right_foot1_collision
+          - right_foot2_collision
+          - right_foot3_collision
+          - right_foot4_collision
+          - right_foot5_collision
+          - right_foot6_collision
+          - right_foot7_collision
+  sim_dt: 0.006666666666666667
+  ctrl_dt: 0.02
+  max_episode_seconds: 10.0
+  observations:
+    actor:
+      terms:
+        command: &command_obs
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: motion}
+        motion_anchor_pos_b: &anchor_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_pos_b
+          params: {command_name: motion}
+        motion_anchor_ori_b: &anchor_ori_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_ori_b
+          params: {command_name: motion}
+        base_lin_vel: &base_lin_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: pelvis_local_linvel}
+        base_ang_vel: &base_ang_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: torso_gyro}
+        joint_pos: &joint_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_pos_rel
+          params: {command_name: motion}
+        joint_vel: &joint_vel_obs
+          func: unilab.envs.mdp.joint_vel_rel
+        actions: &actions_obs
+          func: unilab.envs.mdp.last_action
+    critic:
+      terms:
+        command: *command_obs
+        motion_anchor_pos_b: *anchor_pos_obs
+        motion_anchor_ori_b: *anchor_ori_obs
+        base_lin_vel: *base_lin_vel_obs
+        base_ang_vel: *base_ang_vel_obs
+        joint_pos: *joint_pos_obs
+        joint_vel: *joint_vel_obs
+        actions: *actions_obs
+        body_pos:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_pos_b
+          params: {command_name: motion}
+        body_ori:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_ori_b
+          params: {command_name: motion}
+  actions:
+    joint_pos:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionJointPositionActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      scale: 0.25
+      use_default_offset: true
+      command_name: motion
+  commands:
+    motion:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionCommandCfg
+      entity_name: robot
+      resampling_time_range: [1.0e9, 1.0e9]
+      params:
+        motion_file: motions/g1/dance1_subject2_part.npz
+        anchor_body_name: torso_link
+        body_names: *tracked_bodies
+        sampling_mode: adaptive
+        sampling_start_ratio: 0.0
+        truncate_on_clip_end: false
+        pose_range:
+          x: [-0.05, 0.05]
+          y: [-0.05, 0.05]
+          z: [-0.01, 0.01]
+          roll: [-0.1, 0.1]
+          pitch: [-0.1, 0.1]
+          yaw: [-0.2, 0.2]
+        velocity_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [-0.2, 0.2]
+          roll: [-0.52, 0.52]
+          pitch: [-0.52, 0.52]
+          yaw: [-0.78, 0.78]
+        joint_position_range: [-0.1, 0.1]
+        joint_default_position_range: [0.0, 0.0]
+  terminations:
+    time_out:
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    anchor_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_pos_z_only
+      params: {command_name: motion, threshold: 0.25}
+    anchor_ori:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_ori
+      params:
+        command_name: motion
+        threshold: 0.8
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+    ee_body_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_motion_body_pos_z_only
+      params:
+        command_name: motion
+        threshold: 0.25
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_yaw_link
+          - right_wrist_yaw_link
+  policy_observation_group: actor
+  critic_observation_group: critic
+
 reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+  motion_global_root_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_position_error_exp
+    weight: 0.5
+    params: {command_name: motion, std: 0.3}
+  motion_global_root_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_orientation_error_exp
+    weight: 0.5
+    params: {command_name: motion, std: 0.4}
+  motion_body_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_position_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.3}
+  motion_body_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_orientation_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.4}
+  motion_body_lin_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_linear_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 1.0}
+  motion_body_ang_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_angular_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 3.14}
+  motion_joint_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_position_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 0.2}
+  motion_joint_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_velocity_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 1.0}
+  action_rate_l2:
+    func: unilab.envs.mdp.action_rate_l2
+    weight: -0.1
+  joint_limit:
+    func: unilab.tasks.motion_tracking.common.manager_terms.joint_pos_limits
+    weight: -10.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*"

--- a/conf/offpolicy/task/sac/g1_23dof_motion_tracking/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_23dof_motion_tracking/motrix.yaml
@@ -1,8 +1,5 @@
 # @package _global_
-# G1 23-DoF Motion Tracking SAC — Motrix variant for sim2sim eval.
-# Inherits the mujoco training config in full and only switches the rendering
-# backend so checkpoints trained on mujoco can be replayed via motrix's native
-# renderer (`eval --sim motrix`). Training on motrix is not the intended path.
+# Motrix is the sim2sim eval owner for MuJoCo-trained WBT checkpoints.
 defaults:
   - /task/sac/g1_23dof_motion_tracking/mujoco
   - _self_
@@ -10,10 +7,3 @@ defaults:
 training:
   task_name: G1MotionTrackingSAC23Dof
   sim_backend: motrix
-env:
-  # motrix backend's kp/kd override path is broken on column slices, and DR
-  # is not desirable during deterministic sim2sim eval anyway. Match the
-  # `g1_walk_flat/motrix.yaml` convention by switching them off.
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false

--- a/conf/offpolicy/task/sac/g1_23dof_motion_tracking/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_23dof_motion_tracking/mujoco.yaml
@@ -1,73 +1,76 @@
 # @package _global_
+defaults:
+  - /task/sac/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTrackingSAC23Dof
   sim_backend: mujoco
-algo:
-  num_envs: 2048
-  max_iterations: 25000
-  save_interval: 1000
-  gamma: 0.99
-  tau: 0.05
-  num_atoms: 501
-  updates_per_step: 4
-  policy_frequency: 2
-  use_symmetry: false
-  algo_params:
-    alpha_init: 0.1
-    target_entropy_ratio: 0.5
-    max_grad_norm: 10.0
+
 env:
-  control_config:
-    action_scale:
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-  anchor_pos_z_threshold: 0.5
-  ee_body_pos_z_threshold: 0.5
-  truncate_on_clip_end: true
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
-reward:
-  scales:
-    motion_global_root_pos: 1.0
-    motion_global_root_ori: 0.5
-    motion_body_pos: 2.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -2.0
-    undesired_contacts: -0.1
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
+    entities:
+      robot:
+        joint_names: &g1_23dof_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+        actuator_names: *g1_23dof_joints
+        body_names: &tracked_bodies_23dof
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_roll_rubber_hand
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_roll_rubber_hand
+  actions:
+    joint_pos:
+      scale:
+        ".*_(hip_pitch|hip_yaw)_joint": 0.5475464629911068
+        ".*_(hip_roll|knee)_joint": 0.35066146637882434
+        ".*_ankle_(pitch|roll)_joint": 0.43857731392336724
+        "waist_yaw_joint": 0.5475464629911068
+        ".*_(shoulder_(pitch|roll|yaw)|elbow)_joint": 0.43857731392336724
+        ".*_wrist_roll_joint": 0.07450087032950714
+  commands:
+    motion:
+      params:
+        motion_file: motions/g1/dance1_subject2_part_23dof.npz
+        body_names: *tracked_bodies_23dof
+  terminations:
+    ee_body_pos:
+      params:
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_roll_rubber_hand
+          - right_wrist_roll_rubber_hand

--- a/conf/offpolicy/task/sac/g1_motion_tracking/motrix.yaml
+++ b/conf/offpolicy/task/sac/g1_motion_tracking/motrix.yaml
@@ -1,8 +1,5 @@
 # @package _global_
-# G1 Whole-Body Tracking (WBT) FastSAC — Motrix variant for sim2sim eval.
-# Inherits the mujoco training config in full and only switches the rendering
-# backend so checkpoints trained on mujoco can be replayed via motrix's native
-# renderer (`eval --sim motrix`). Training on motrix is not the intended path.
+# Motrix is the sim2sim eval owner for MuJoCo-trained WBT checkpoints.
 defaults:
   - /task/sac/g1_motion_tracking/mujoco
   - _self_
@@ -10,10 +7,3 @@ defaults:
 training:
   task_name: G1MotionTrackingSAC
   sim_backend: motrix
-env:
-  # motrix backend's kp/kd override path is broken on column slices, and DR
-  # is not desirable during deterministic sim2sim eval anyway. Match the
-  # `g1_walk_flat/motrix.yaml` convention by switching them off.
-  domain_rand:
-    randomize_kp: false
-    randomize_kd: false

--- a/conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml
+++ b/conf/offpolicy/task/sac/g1_motion_tracking/mujoco.yaml
@@ -4,11 +4,11 @@
 training:
   task_name: G1MotionTrackingSAC
   sim_backend: mujoco
+
 algo:
   num_envs: 2048
   max_iterations: 25000
   save_interval: 1000
-  # --- holosoma WBT-specific overrides (vs sac.yaml defaults) ---
   gamma: 0.99
   tau: 0.05
   num_atoms: 501
@@ -19,28 +19,251 @@ algo:
     alpha_init: 0.1
     target_entropy_ratio: 0.5
     max_grad_norm: 10.0
+
 env:
-  control_config:
-    action_scale: 2.0
-  anchor_pos_z_threshold: 0.5
-  ee_body_pos_z_threshold: 0.5
-  truncate_on_clip_end: true
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
-    seed: null
+  seed: null
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat.xml
+    default_keyframe_name: stand
+    entities:
+      robot:
+        root_body_name: pelvis
+        joint_names: &g1_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - waist_roll_joint
+          - waist_pitch_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - left_wrist_pitch_joint
+          - left_wrist_yaw_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+          - right_wrist_pitch_joint
+          - right_wrist_yaw_joint
+        actuator_names: *g1_joints
+        body_names: &tracked_bodies
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_yaw_link
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_yaw_link
+  sim_dt: 0.006666666666666667
+  ctrl_dt: 0.02
+  max_episode_seconds: 10.0
+  observations:
+    actor:
+      enable_corruption: true
+      terms:
+        command: &command_obs
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: motion}
+        motion_anchor_pos_b: &anchor_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_pos_b
+          params: {command_name: motion}
+        motion_anchor_ori_b: &anchor_ori_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_ori_b
+          params: {command_name: motion}
+        base_lin_vel: &base_lin_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: pelvis_local_linvel}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.1
+            n_max: 0.1
+        base_ang_vel: &base_ang_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: torso_gyro}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.2
+            n_max: 0.2
+        joint_pos: &joint_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_pos_rel
+          params: {command_name: motion}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.01
+            n_max: 0.01
+        joint_vel: &joint_vel_obs
+          func: unilab.envs.mdp.joint_vel_rel
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -1.5
+            n_max: 1.5
+        actions: &actions_obs
+          func: unilab.envs.mdp.last_action
+    critic:
+      terms:
+        command: *command_obs
+        motion_anchor_pos_b: *anchor_pos_obs
+        motion_anchor_ori_b: *anchor_ori_obs
+        base_lin_vel: *base_lin_vel_obs
+        base_ang_vel: *base_ang_vel_obs
+        joint_pos: *joint_pos_obs
+        joint_vel: *joint_vel_obs
+        actions: *actions_obs
+        body_pos:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_pos_b
+          params: {command_name: motion}
+        body_ori:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_ori_b
+          params: {command_name: motion}
+        sac_base_lin_vel:
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: pelvis_local_linvel}
+  actions:
+    joint_pos:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionJointPositionActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      scale: 2.0
+      use_default_offset: true
+      command_name: motion
+  commands:
+    motion:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionCommandCfg
+      entity_name: robot
+      resampling_time_range: [1.0e9, 1.0e9]
+      params:
+        motion_file: motions/g1/dance1_subject2_part.npz
+        anchor_body_name: torso_link
+        body_names: *tracked_bodies
+        sampling_mode: adaptive
+        sampling_start_ratio: 0.0
+        truncate_on_clip_end: true
+        pose_range:
+          x: [-0.05, 0.05]
+          y: [-0.05, 0.05]
+          z: [-0.01, 0.01]
+          roll: [-0.1, 0.1]
+          pitch: [-0.1, 0.1]
+          yaw: [-0.2, 0.2]
+        velocity_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [-0.2, 0.2]
+          roll: [-0.52, 0.52]
+          pitch: [-0.52, 0.52]
+          yaw: [-0.78, 0.78]
+        joint_position_range: [-0.1, 0.1]
+        joint_default_position_range: [0.0, 0.0]
+  terminations:
+    time_out:
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    motion_clip_end:
+      func: unilab.tasks.motion_tracking.common.manager_terms.motion_clip_end
+      time_out: true
+      params: {command_name: motion}
+    anchor_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_pos_z_only
+      params: {command_name: motion, threshold: 0.5}
+    anchor_ori:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_ori
+      params:
+        command_name: motion
+        threshold: 0.8
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+    ee_body_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_motion_body_pos_z_only
+      params:
+        command_name: motion
+        threshold: 0.5
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_yaw_link
+          - right_wrist_yaw_link
+  policy_observation_group: actor
+  critic_observation_group: critic
+
 reward:
-  scales:
-    motion_global_root_pos: 1.0
-    motion_global_root_ori: 0.5
-    motion_body_pos: 2.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -2.0
-    undesired_contacts: -0.1
+  motion_global_root_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_position_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.3}
+  motion_global_root_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_orientation_error_exp
+    weight: 0.5
+    params: {command_name: motion, std: 0.4}
+  motion_body_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_position_error_exp
+    weight: 2.0
+    params: {command_name: motion, std: 0.3}
+  motion_body_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_orientation_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.4}
+  motion_body_lin_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_linear_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 1.0}
+  motion_body_ang_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_angular_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 3.14}
+  motion_joint_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_position_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 0.2}
+  motion_joint_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_velocity_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 1.0}
+  action_rate_l2:
+    func: unilab.envs.mdp.action_rate_l2
+    weight: -0.1
+  joint_limit:
+    func: unilab.tasks.motion_tracking.common.manager_terms.joint_pos_limits
+    weight: -2.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*"
+  undesired_contacts:
+    func: unilab.tasks.motion_tracking.common.manager_terms.undesired_body_contacts
+    weight: -0.1
+    params:
+      command_name: motion
+      threshold: 0.05
+      body_names:
+        - pelvis
+        - left_hip_roll_link
+        - left_knee_link
+        - right_hip_roll_link
+        - right_knee_link
+        - torso_link
+        - left_shoulder_roll_link
+        - left_elbow_link
+        - right_shoulder_roll_link
+        - right_elbow_link

--- a/conf/ppo/task/g1_23dof_motion_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_23dof_motion_tracking/motrix.yaml
@@ -1,52 +1,37 @@
 # @package _global_
+defaults:
+  - /task/g1_23dof_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23Dof
   sim_backend: motrix
   play_env_num: 16
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
+
+reward:
+  motion_global_root_pos:
+    weight: 1.0
+  action_rate_l2:
+    weight: -0.05
+  undesired_contacts:
+    func: unilab.tasks.motion_tracking.common.manager_terms.undesired_body_contacts
+    weight: -0.1
+    params:
+      command_name: motion
+      threshold: 0.05
+      body_names:
+        - pelvis
+        - left_hip_roll_link
+        - left_knee_link
+        - right_hip_roll_link
+        - right_knee_link
+        - torso_link
+        - left_shoulder_roll_link
+        - left_elbow_link
+        - right_shoulder_roll_link
+        - right_elbow_link
+
 play_profile:
   enabled: true
   env:
     render_spacing: 2.5
-  scene:
-    enabled: true
-    source_model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
-    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
-    skybox_rgb1: [0.90, 0.90, 0.91]
-    skybox_rgb2: [0.68, 0.68, 0.70]
-    ground_texrepeat: [0.25, 0.25]
-reward:
-  scales:
-    motion_global_root_pos: 1.0
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.05
-    joint_limit: -10.0
-    undesired_contacts: -0.1
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_23dof_motion_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_23dof_motion_tracking/mujoco.yaml
@@ -1,34 +1,67 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23Dof
   sim_backend: mujoco
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+
+env:
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
+    entities:
+      robot:
+        joint_names: &g1_23dof_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+        actuator_names: *g1_23dof_joints
+        body_names: &tracked_bodies_23dof
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_roll_rubber_hand
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_roll_rubber_hand
+  commands:
+    motion:
+      params:
+        motion_file: motions/g1/dance1_subject2_part_23dof.npz
+        body_names: *tracked_bodies_23dof
+  terminations:
+    ee_body_pos:
+      params:
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_roll_rubber_hand
+          - right_wrist_roll_rubber_hand

--- a/conf/ppo/task/g1_23dof_motion_tracking_deploy/motrix.yaml
+++ b/conf/ppo/task/g1_23dof_motion_tracking_deploy/motrix.yaml
@@ -1,101 +1,42 @@
 # @package _global_
+defaults:
+  - /task/g1_23dof_motion_tracking_deploy/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23DofDeploy
   sim_backend: motrix
   play_env_num: 16
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
+
 env:
-  sim_dt: 0.005
-  sensor:
-    local_linvel: pelvis_local_linvel
-    gyro: pelvis_gyro
-    upvector: pelvis_upvector
-  domain_rand:
-    random_com: true
-    com_offset_x: [-0.025, 0.025]
-    com_offset_y: [-0.05, 0.05]
-    com_offset_z: [-0.05, 0.05]
-    randomize_base_mass: true
-    added_mass_range: [-1.5, 1.5]
-    push_robots: true
-    push_interval: 750
-    max_force: [1.0, 1.0, 0.5]
-    randomize_joint_default_pos: true
-    joint_default_pos_range: [-0.01, 0.01]
-  noise_config:
-    scale_joint_angle: 0.01
-    scale_joint_vel: 0.5
-    scale_gyro: 0.2
-    scale_linvel: 0.5
-    scale_gravity: 0.05
-  control_config:
-    action_scale:
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
+  events:
+    foot_friction: null
+    push_robot: null
+
+reward:
+  motion_global_root_pos:
+    weight: 1.0
+  action_rate_l2:
+    weight: -0.05
+  undesired_contacts:
+    func: unilab.tasks.motion_tracking.common.manager_terms.undesired_body_contacts
+    weight: -0.1
+    params:
+      command_name: motion
+      threshold: 0.05
+      body_names:
+        - pelvis
+        - left_hip_roll_link
+        - left_knee_link
+        - right_hip_roll_link
+        - right_knee_link
+        - torso_link
+        - left_shoulder_roll_link
+        - left_elbow_link
+        - right_shoulder_roll_link
+        - right_elbow_link
+
 play_profile:
   enabled: true
   env:
     render_spacing: 2.5
-  scene:
-    enabled: true
-    source_model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
-    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
-    skybox_rgb1: [0.90, 0.90, 0.91]
-    skybox_rgb2: [0.68, 0.68, 0.70]
-    ground_texrepeat: [0.25, 0.25]
-reward:
-  scales:
-    motion_global_root_pos: 1.0
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.05
-    joint_limit: -10.0
-    undesired_contacts: -0.1
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_23dof_motion_tracking_deploy/mujoco.yaml
+++ b/conf/ppo/task/g1_23dof_motion_tracking_deploy/mujoco.yaml
@@ -1,85 +1,77 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking_deploy/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking23DofDeploy
   sim_backend: mujoco
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
+
+_g1_23dof_deploy_action_scale:
+  ".*_(hip_pitch|hip_yaw)_joint": 0.5475464629911068
+  ".*_(hip_roll|knee)_joint": 0.35066146637882434
+  ".*_ankle_(pitch|roll)_joint": 0.43857731392336724
+  "waist_yaw_joint": 0.5475464629911068
+  ".*_(shoulder_(pitch|roll|yaw)|elbow|wrist_roll)_joint": 0.43857731392336724
+
 env:
-  sim_dt: 0.005
-  sensor:
-    local_linvel: pelvis_local_linvel
-    gyro: pelvis_gyro
-    upvector: pelvis_upvector
-  domain_rand:
-      random_com: true
-      com_offset_x: [-0.025, 0.025]
-      com_offset_y: [-0.05, 0.05]
-      com_offset_z: [-0.05, 0.05]
-      randomize_base_mass: true
-      added_mass_range: [-1.5, 1.5]
-      push_robots: true
-      push_interval: 750
-      max_force: [1.0, 1.0, 0.5]
-      randomize_geom_friction: true
-      friction_range: [0.3, 1.2]
-      randomize_joint_default_pos: true
-      joint_default_pos_range: [-0.01, 0.01]
-  noise_config:
-      scale_joint_angle: 0.01
-      scale_joint_vel: 0.5
-      scale_gyro: 0.2
-      scale_linvel: 0.5
-      scale_gravity: 0.05
-  control_config:
-    action_scale:
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat_23dof.xml
+    entities:
+      robot:
+        joint_names: &g1_23dof_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+        actuator_names: *g1_23dof_joints
+        body_names: &tracked_bodies_23dof
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_roll_rubber_hand
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_roll_rubber_hand
+  actions:
+    joint_pos:
+      scale: ${_g1_23dof_deploy_action_scale}
+  commands:
+    motion:
+      params:
+        motion_file: motions/g1/dance1_subject2_part_23dof.npz
+        body_names: *tracked_bodies_23dof
+  terminations:
+    ee_body_pos:
+      params:
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_roll_rubber_hand
+          - right_wrist_roll_rubber_hand

--- a/conf/ppo/task/g1_motion_tracking/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking/motrix.yaml
@@ -1,53 +1,37 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTracking
   sim_backend: motrix
   play_env_num: 16
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
-env:
+
+reward:
+  motion_global_root_pos:
+    weight: 1.0
+  action_rate_l2:
+    weight: -0.05
+  undesired_contacts:
+    func: unilab.tasks.motion_tracking.common.manager_terms.undesired_body_contacts
+    weight: -0.1
+    params:
+      command_name: motion
+      threshold: 0.05
+      body_names:
+        - pelvis
+        - left_hip_roll_link
+        - left_knee_link
+        - right_hip_roll_link
+        - right_knee_link
+        - torso_link
+        - left_shoulder_roll_link
+        - left_elbow_link
+        - right_shoulder_roll_link
+        - right_elbow_link
+
 play_profile:
   enabled: true
   env:
     render_spacing: 2.5
-  scene:
-    enabled: true
-    source_model_file: src/unilab/assets/robots/g1/scene_flat.xml
-    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
-    skybox_rgb1: [0.90, 0.90, 0.91]
-    skybox_rgb2: [0.68, 0.68, 0.70]
-    ground_texrepeat: [0.25, 0.25]
-reward:
-  scales:
-    motion_global_root_pos: 1.0
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.05
-    joint_limit: -10.0
-    undesired_contacts: -0.1
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking/mujoco.yaml
@@ -3,36 +3,237 @@ training:
   task_name: G1MotionTracking
   sim_backend: mujoco
   play_steps: 1000
+
 algo:
   num_envs: 1024
   max_iterations: 15000
   save_interval: 500
   obs_groups:
-    actor:
-      - actor
+    actor: [actor]
   algorithm:
     entropy_coef: 0.005
+
 env:
+  scene:
+    model_file: src/unilab/assets/robots/g1/scene_flat.xml
+    default_keyframe_name: stand
+    entities:
+      robot:
+        root_body_name: pelvis
+        joint_names: &g1_joints
+          - left_hip_pitch_joint
+          - left_hip_roll_joint
+          - left_hip_yaw_joint
+          - left_knee_joint
+          - left_ankle_pitch_joint
+          - left_ankle_roll_joint
+          - right_hip_pitch_joint
+          - right_hip_roll_joint
+          - right_hip_yaw_joint
+          - right_knee_joint
+          - right_ankle_pitch_joint
+          - right_ankle_roll_joint
+          - waist_yaw_joint
+          - waist_roll_joint
+          - waist_pitch_joint
+          - left_shoulder_pitch_joint
+          - left_shoulder_roll_joint
+          - left_shoulder_yaw_joint
+          - left_elbow_joint
+          - left_wrist_roll_joint
+          - left_wrist_pitch_joint
+          - left_wrist_yaw_joint
+          - right_shoulder_pitch_joint
+          - right_shoulder_roll_joint
+          - right_shoulder_yaw_joint
+          - right_elbow_joint
+          - right_wrist_roll_joint
+          - right_wrist_pitch_joint
+          - right_wrist_yaw_joint
+        actuator_names: *g1_joints
+        body_names: &tracked_bodies
+          - pelvis
+          - left_hip_roll_link
+          - left_knee_link
+          - left_ankle_roll_link
+          - right_hip_roll_link
+          - right_knee_link
+          - right_ankle_roll_link
+          - torso_link
+          - left_shoulder_roll_link
+          - left_elbow_link
+          - left_wrist_yaw_link
+          - right_shoulder_roll_link
+          - right_elbow_link
+          - right_wrist_yaw_link
+        geom_names:
+          - left_foot1_collision
+          - left_foot2_collision
+          - left_foot3_collision
+          - left_foot4_collision
+          - left_foot5_collision
+          - left_foot6_collision
+          - left_foot7_collision
+          - right_foot1_collision
+          - right_foot2_collision
+          - right_foot3_collision
+          - right_foot4_collision
+          - right_foot5_collision
+          - right_foot6_collision
+          - right_foot7_collision
+  sim_dt: 0.006666666666666667
+  ctrl_dt: 0.02
+  max_episode_seconds: 10.0
+  observations:
+    actor:
+      terms:
+        command: &command_obs
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: motion}
+        motion_anchor_pos_b: &anchor_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_pos_b
+          params: {command_name: motion}
+        motion_anchor_ori_b: &anchor_ori_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_anchor_ori_b
+          params: {command_name: motion}
+        base_lin_vel: &base_lin_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: pelvis_local_linvel}
+        base_ang_vel: &base_ang_vel_obs
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: torso_gyro}
+        joint_pos: &joint_pos_obs
+          func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_pos_rel
+          params: {command_name: motion}
+        joint_vel: &joint_vel_obs
+          func: unilab.envs.mdp.joint_vel_rel
+        actions: &actions_obs
+          func: unilab.envs.mdp.last_action
+    critic:
+      terms:
+        command: *command_obs
+        motion_anchor_pos_b: *anchor_pos_obs
+        motion_anchor_ori_b: *anchor_ori_obs
+        base_lin_vel: *base_lin_vel_obs
+        base_ang_vel: *base_ang_vel_obs
+        joint_pos: *joint_pos_obs
+        joint_vel: *joint_vel_obs
+        actions: *actions_obs
+        body_pos:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_pos_b
+          params: {command_name: motion}
+        body_ori:
+          func: unilab.tasks.motion_tracking.common.manager_terms.robot_body_ori_b
+          params: {command_name: motion}
+  actions:
+    joint_pos:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionJointPositionActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      scale: 0.25
+      use_default_offset: true
+      command_name: motion
+  commands:
+    motion:
+      _target_: unilab.tasks.motion_tracking.common.manager_terms.MotionCommandCfg
+      entity_name: robot
+      resampling_time_range: [1.0e9, 1.0e9]
+      params:
+        motion_file: motions/g1/dance1_subject2_part.npz
+        anchor_body_name: torso_link
+        body_names: *tracked_bodies
+        sampling_mode: adaptive
+        sampling_start_ratio: 0.0
+        truncate_on_clip_end: false
+        pose_range:
+          x: [-0.05, 0.05]
+          y: [-0.05, 0.05]
+          z: [-0.01, 0.01]
+          roll: [-0.1, 0.1]
+          pitch: [-0.1, 0.1]
+          yaw: [-0.2, 0.2]
+        velocity_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [-0.2, 0.2]
+          roll: [-0.52, 0.52]
+          pitch: [-0.52, 0.52]
+          yaw: [-0.78, 0.78]
+        joint_position_range: [-0.1, 0.1]
+        joint_default_position_range: [0.0, 0.0]
+  terminations:
+    time_out:
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    anchor_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_pos_z_only
+      params: {command_name: motion, threshold: 0.25}
+    anchor_ori:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_anchor_ori
+      params:
+        command_name: motion
+        threshold: 0.8
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+    ee_body_pos:
+      func: unilab.tasks.motion_tracking.common.manager_terms.bad_motion_body_pos_z_only
+      params:
+        command_name: motion
+        threshold: 0.25
+        body_names:
+          - left_ankle_roll_link
+          - right_ankle_roll_link
+          - left_wrist_yaw_link
+          - right_wrist_yaw_link
+  policy_observation_group: actor
+  critic_observation_group: critic
+
 reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+  motion_global_root_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_position_error_exp
+    weight: 0.5
+    params: {command_name: motion, std: 0.3}
+  motion_global_root_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_anchor_orientation_error_exp
+    weight: 0.5
+    params: {command_name: motion, std: 0.4}
+  motion_body_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_position_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.3}
+  motion_body_ori:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_relative_body_orientation_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 0.4}
+  motion_body_lin_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_linear_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 1.0}
+  motion_body_ang_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_global_body_angular_velocity_error_exp
+    weight: 1.0
+    params: {command_name: motion, std: 3.14}
+  motion_joint_pos:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_position_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 0.2}
+  motion_joint_vel:
+    func: unilab.tasks.motion_tracking.common.manager_terms.motion_joint_velocity_error_exp
+    weight: 0.0
+    params: {command_name: motion, std: 1.0}
+  action_rate_l2:
+    func: unilab.envs.mdp.action_rate_l2
+    weight: -0.1
+  joint_limit:
+    func: unilab.tasks.motion_tracking.common.manager_terms.joint_pos_limits
+    weight: -10.0
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: ".*"
+
 play_profile:
   enabled: true
   env:

--- a/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/motrix.yaml
@@ -1,107 +1,42 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking_deploy/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTrackingDeploy
   sim_backend: motrix
   play_env_num: 16
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
-  noise_config:
-    level: 1.0
-    scale_joint_angle: 0.01
-    scale_joint_vel: 1.5
-    scale_gyro: 0.2
+
+env:
+  events:
+    foot_friction: null
+    push_robot: null
+
+reward:
+  motion_global_root_pos:
+    weight: 1.0
+  action_rate_l2:
+    weight: -0.05
+  undesired_contacts:
+    func: unilab.tasks.motion_tracking.common.manager_terms.undesired_body_contacts
+    weight: -0.1
+    params:
+      command_name: motion
+      threshold: 0.05
+      body_names:
+        - pelvis
+        - left_hip_roll_link
+        - left_knee_link
+        - right_hip_roll_link
+        - right_knee_link
+        - torso_link
+        - left_shoulder_roll_link
+        - left_elbow_link
+        - right_shoulder_roll_link
+        - right_elbow_link
+
 play_profile:
   enabled: true
   env:
     render_spacing: 2.5
-  scene:
-    enabled: true
-    source_model_file: src/unilab/assets/robots/g1/scene_flat.xml
-    ground_texture_file: src/unilab/assets/robots/g1/textures/floor.png
-    skybox_rgb1: [0.90, 0.90, 0.91]
-    skybox_rgb2: [0.68, 0.68, 0.70]
-    ground_texrepeat: [0.25, 0.25]
-env:
-  sim_dt: 0.005
-  sensor:
-    local_linvel: pelvis_local_linvel
-    gyro: pelvis_gyro
-    upvector: pelvis_upvector
-  domain_rand:
-    random_com: true
-    com_offset_x: [-0.025, 0.025]
-    com_offset_y: [-0.05, 0.05]
-    com_offset_z: [-0.05, 0.05]
-    randomize_base_mass: true
-    added_mass_range: [-1.5, 1.5]
-    push_robots: true
-    push_interval: 750
-    max_force: [1.0, 1.0, 0.5]
-    randomize_joint_default_pos: true
-    joint_default_pos_range: [-0.01, 0.01]
-    # randomize_geom_friction omitted: Motrix does not reliably support it
-  noise_config:
-    scale_joint_angle: 0.01
-    scale_joint_vel: 0.5
-    scale_gyro: 0.2
-    scale_linvel: 0.5
-    scale_gravity: 0.05
-  control_config:
-    action_scale:
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-      - 0.07450087032950714
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-      - 0.07450087032950714
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0

--- a/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
+++ b/conf/ppo/task/g1_motion_tracking_deploy/mujoco.yaml
@@ -1,91 +1,84 @@
 # @package _global_
+defaults:
+  - /task/g1_motion_tracking/mujoco
+  - _self_
+
 training:
   task_name: G1MotionTrackingDeploy
   sim_backend: mujoco
-  play_steps: 1000
-algo:
-  num_envs: 1024
-  max_iterations: 15000
-  save_interval: 500
-  obs_groups:
-    actor:
-      - actor
-  algorithm:
-    entropy_coef: 0.005
+
 env:
   sim_dt: 0.005
-  sensor:
-    local_linvel: pelvis_local_linvel
-    gyro: pelvis_gyro
-    upvector: pelvis_upvector
-  domain_rand:
-      random_com: true
-      com_offset_x: [-0.025, 0.025]
-      com_offset_y: [-0.05, 0.05]
-      com_offset_z: [-0.05, 0.05]
-      randomize_base_mass: true
-      added_mass_range: [-1.5, 1.5]
-      push_robots: true
-      push_interval: 750
-      max_force: [1.0, 1.0, 0.5]
-      randomize_geom_friction: true
-      friction_range: [0.3, 1.2]
-      randomize_joint_default_pos: true
-      joint_default_pos_range: [-0.01, 0.01]
-  noise_config:
-      scale_joint_angle: 0.01
-      scale_joint_vel: 0.5
-      scale_gyro: 0.2
-      scale_linvel: 0.5
-      scale_gravity: 0.05
-  control_config:
-    action_scale:
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.5475464629911068
-      - 0.35066146637882434
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.5475464629911068
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-      - 0.07450087032950714
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.43857731392336724
-      - 0.07450087032950714
-      - 0.07450087032950714
-reward:
-  scales:
-    motion_global_root_pos: 0.5
-    motion_global_root_ori: 0.5
-    motion_body_pos: 1.0
-    motion_body_ori: 1.0
-    motion_body_lin_vel: 1.0
-    motion_body_ang_vel: 1.0
-    motion_joint_pos: 0.0
-    motion_joint_vel: 0.0
-    action_rate_l2: -0.1
-    joint_limit: -10.0
-  std_root_pos: 0.3
-  std_root_ori: 0.4
-  std_body_pos: 0.3
-  std_body_ori: 0.4
-  std_body_lin_vel: 1.0
-  std_body_ang_vel: 3.14
-  std_joint_pos: 0.2
-  std_joint_vel: 1.0
+  observations:
+    actor:
+      terms:
+        motion_anchor_pos_b: null
+        base_lin_vel: null
+        base_ang_vel:
+          params: {sensor_name: pelvis_gyro}
+    critic:
+      terms:
+        base_ang_vel:
+          params: {sensor_name: pelvis_gyro}
+  actions:
+    joint_pos:
+      scale:
+        ".*_(hip_pitch|hip_yaw)_joint": 0.5475464629911068
+        ".*_(hip_roll|knee)_joint": 0.35066146637882434
+        ".*_ankle_(pitch|roll)_joint": 0.43857731392336724
+        "waist_yaw_joint": 0.5475464629911068
+        "waist_(roll|pitch)_joint": 0.43857731392336724
+        ".*_(shoulder_(pitch|roll|yaw)|elbow|wrist_roll)_joint": 0.43857731392336724
+        ".*_wrist_(pitch|yaw)_joint": 0.07450087032950714
+  commands:
+    motion:
+      params:
+        joint_default_position_range: [-0.01, 0.01]
+  events:
+    base_mass:
+      func: unilab.envs.mdp.randomize_rigid_body_mass
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          body_names: pelvis
+        mass_distribution_params: [-1.5, 1.5]
+        operation: add
+        recompute_inertia: false
+    base_com:
+      func: unilab.envs.mdp.randomize_rigid_body_com
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          body_names: pelvis
+        com_range:
+          x: [-0.025, 0.025]
+          y: [-0.05, 0.05]
+          z: [-0.05, 0.05]
+    foot_friction:
+      func: unilab.envs.mdp.geom_friction
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          geom_names: ".*"
+        ranges: [0.3, 1.2]
+        operation: abs
+        shared_random: true
+    push_robot:
+      func: unilab.envs.mdp.push_by_setting_velocity
+      mode: interval
+      interval_range_s: [15.0, 15.0]
+      is_global_time: true
+      params:
+        velocity_range:
+          x: [-1.0, 1.0]
+          y: [-1.0, 1.0]
+          z: [-0.5, 0.5]
+          roll: [0.0, 0.0]
+          pitch: [0.0, 0.0]
+          yaw: [0.0, 0.0]

--- a/scripts/benchmark/benchmark_drake_performance.py
+++ b/scripts/benchmark/benchmark_drake_performance.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Profile Drake vs MuJoCo env-step performance on selected UniLab tasks.
-
-This benchmark is intentionally task-level rather than raw-simulator-level. It
-keeps UniLab's reset, observation, sensor-view, and body-query paths in the
-loop so G1 motion tracking can expose the expensive integration points.
-"""
+"""Profile Drake vs MuJoCo env-step performance on selected UniLab tasks."""
 
 from __future__ import annotations
 
@@ -115,18 +110,7 @@ def _task_specs() -> dict[str, TaskSpec]:
 
         return ManagerBasedRlEnvCfg()
 
-    def g1_tracking_cfg() -> Any:
-        from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnvCfg
-
-        return G1MotionTrackingEnvCfg()
-
-    def g1_tracking_env() -> type:
-        from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnv
-
-        return G1MotionTrackingEnv
-
     return {
-        "g1_motion_tracking": TaskSpec(g1_tracking_cfg, g1_tracking_env),
         "go1_joystick_flat": TaskSpec(go1_cfg, manager_env),
         "go2_joystick_flat": TaskSpec(go2_cfg, manager_env),
     }
@@ -336,10 +320,7 @@ def main() -> None:
     parser.add_argument(
         "--tasks",
         default="go1_joystick_flat,go2_joystick_flat",
-        help=(
-            "Comma-separated task ids. Defaults stay within committed Drake task configs; "
-            "pass g1_motion_tracking explicitly when its Drake config is available."
-        ),
+        help="Comma-separated task ids with committed Drake YAML owners.",
     )
     parser.add_argument("--backends", default="drake,mujoco", help="Comma-separated backends.")
     parser.add_argument("--num-envs", default="64,256,1024", help="Comma-separated env counts.")

--- a/scripts/benchmark/env/benchmark_env_step.py
+++ b/scripts/benchmark/env/benchmark_env_step.py
@@ -351,12 +351,12 @@ def _g1_rough_cfg(backend: str, config_overrides: list[str]) -> Any:
 
 
 def _g1_motion_tracking_cfg(backend: str, config_overrides: list[str]) -> Any:
-    from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnvCfg
+    from unilab.envs import ManagerBasedRlEnvCfg
 
     return _ppo_owner_yaml_cfg(
         "g1_motion_tracking",
         backend,
-        G1MotionTrackingEnvCfg,
+        ManagerBasedRlEnvCfg,
         config_overrides,
     )
 
@@ -422,12 +422,6 @@ def _g1_walk_env_cls() -> type:
     return make_g1_walk_env
 
 
-def _g1_motion_tracking_env_cls() -> type:
-    from unilab.tasks.motion_tracking.g1.tracking import G1MotionTrackingEnv
-
-    return G1MotionTrackingEnv
-
-
 def _sharpa_inhand_env_cls() -> type:
     from unilab.tasks.manipulation.sharpa_inhand.rotation import SharpaInhandRotationEnv
 
@@ -489,8 +483,8 @@ TASK_CONFIGS: dict[str, TaskConfig] = {
         task_id="g1_motion_tracking",
         env_name="G1MotionTracking",
         cfg_factory=_g1_motion_tracking_cfg,
-        env_cls_factory=_g1_motion_tracking_env_cls,
-        backends=("mujoco", "motrix", "mjwarp"),
+        env_cls_factory=_manager_env_cls,
+        backends=("mujoco", "motrix"),
     ),
     "sharpa_inhand": TaskConfig(
         task_id="sharpa_inhand",

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -638,7 +638,20 @@ class MotrixBackend(SimBackend):
         return np.asarray(self._model.options.gravity, dtype=np.float64).copy()
 
     def get_joint_range(self) -> np.ndarray | None:
-        return None
+        """Return single-DoF joint limits in backend DOF order.
+
+        Motrix stores the model-wide limits as a ``(2, num_dof)`` table,
+        whereas the UniLab backend contract exposes the MuJoCo-shaped
+        ``(num_dof, 2)`` table.  This is materialized once by ``Entity`` and
+        never queried from a task hot path.
+        """
+        raw_limits = np.asarray(self._model.joint_limits, dtype=self._np_dtype)
+        if raw_limits.ndim != 2 or raw_limits.shape != (2, self.num_dof_vel):
+            raise ValueError(
+                "Motrix joint limits must have shape (2, num_dof); "
+                f"received {raw_limits.shape} for {self.num_dof_vel} DOFs"
+            )
+        return np.array(raw_limits.T, copy=True)
 
     # ------------------------------------------------------------------ #
     # Simulation control                                                 #

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -146,6 +146,7 @@ class EntityData:
         default_root_state_error: str | None,
         default_joint_pos: np.ndarray | None,
         default_joint_vel: np.ndarray | None,
+        soft_joint_pos_limits: np.ndarray | None,
         gravity_vec_w: np.ndarray | None,
         body_ids: np.ndarray | None,
         actuator_ids: np.ndarray | None,
@@ -164,6 +165,7 @@ class EntityData:
         self._default_root_state_error = default_root_state_error
         self._default_joint_pos = default_joint_pos
         self._default_joint_vel = default_joint_vel
+        self._soft_joint_pos_limits = soft_joint_pos_limits
         self._gravity_vec_w = gravity_vec_w
         self._encoder_bias = (
             None
@@ -225,6 +227,11 @@ class EntityData:
         return np_quat_apply_inverse(self.root_link_quat_w, gravity)
 
     @property
+    def gravity_vec_w(self) -> np.ndarray:
+        """Read-only world-frame unit gravity vector for every environment."""
+        return self._require(self._gravity_vec_w, "world-frame gravity")
+
+    @property
     def root_link_pose_w(self) -> np.ndarray:
         return np.concatenate((self.root_link_pos_w, self.root_link_quat_w), axis=-1)
 
@@ -267,6 +274,11 @@ class EntityData:
     def default_joint_vel(self) -> np.ndarray:
         """Read-only zero default velocities from the UniLab reset contract."""
         return self._require(self._default_joint_vel, "default joint velocity")
+
+    @property
+    def soft_joint_pos_limits(self) -> np.ndarray:
+        """Read-only joint position limits in the declared entity joint order."""
+        return self._require(self._soft_joint_pos_limits, "joint position limits")
 
     @property
     def encoder_bias(self) -> np.ndarray:
@@ -427,6 +439,7 @@ class Entity:
         self._reset_joint_qpos_ids: np.ndarray | None = None
         self._reset_joint_qvel_ids: np.ndarray | None = None
         self._joint_model_dof_ids: np.ndarray | None = None
+        self._motion_body_ids: np.ndarray | None = None
 
         self._joint_names = _normalize_names(name, "joint", cfg.joint_names)
         self._body_names = _normalize_names(name, "body", cfg.body_names)
@@ -493,6 +506,7 @@ class Entity:
             default_qpos,
         )
         default_joint_vel = self._materialize_default_joint_vel(backend, joint_vel_ids)
+        soft_joint_pos_limits = self._materialize_soft_joint_pos_limits(backend, joint_pos_ids)
         gravity_vec_w = self._materialize_gravity_vector(backend, root_body_ids)
         actuator_ctrl_range = self._materialize_actuator_ctrl_range(backend, actuator_ids)
         (
@@ -521,6 +535,7 @@ class Entity:
             default_root_state_error=self._reset_root_layout_error,
             default_joint_pos=default_joint_pos,
             default_joint_vel=default_joint_vel,
+            soft_joint_pos_limits=soft_joint_pos_limits,
             gravity_vec_w=gravity_vec_w,
             body_ids=body_ids,
             actuator_ids=actuator_ids,
@@ -529,6 +544,22 @@ class Entity:
             entity_name=self.name,
             backend_type=self._backend_type,
         )
+
+    @property
+    def motion_body_ids(self) -> np.ndarray:
+        """Motion-dataset body columns for the declared entity body order."""
+        if self._body_names is None:
+            raise self._capability_error(
+                "motion body IDs",
+                "body_names were not declared in EntityCfg",
+            )
+        if self._motion_body_ids is None:
+            self._motion_body_ids = self._resolve_ids(
+                "motion body",
+                self._body_names,
+                self._backend.get_motion_body_ids,
+            )
+        return self._motion_body_ids
 
     def _capability_error(self, capability: str, detail: str) -> NotImplementedError:
         return NotImplementedError(
@@ -722,6 +753,35 @@ class Entity:
         ).astype(current.dtype, copy=True)
         materialized.setflags(write=False)
         return materialized
+
+    def _materialize_soft_joint_pos_limits(
+        self,
+        backend: SimBackend,
+        joint_pos_ids: np.ndarray | None,
+    ) -> np.ndarray | None:
+        if joint_pos_ids is None:
+            return None
+        try:
+            raw_ranges = backend.get_joint_range()
+        except (AttributeError, NotImplementedError) as exc:
+            raise self._capability_error("joint position limits", str(exc)) from exc
+        if raw_ranges is None:
+            return None
+        ranges = np.asarray(raw_ranges)
+        if ranges.ndim != 2 or ranges.shape[1] != 2:
+            raise ValueError(
+                f"Entity '{self.name}' capability 'joint position limits' on backend "
+                f"'{self._backend_type}' returned shape {ranges.shape}; expected (num_dof, 2)"
+            )
+        if joint_pos_ids.size and int(np.max(joint_pos_ids)) >= ranges.shape[0]:
+            raise ValueError(
+                f"Entity '{self.name}' capability 'joint position limits' resolved index "
+                f"{int(np.max(joint_pos_ids))}, but backend '{self._backend_type}' returned "
+                f"only {ranges.shape[0]} rows"
+            )
+        selected = np.array(ranges[_as_column_index(joint_pos_ids)], copy=True)
+        selected.setflags(write=False)
+        return selected
 
     def _materialize_root_state(
         self,

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -243,6 +243,8 @@ class ManagerBasedRlEnv(NpEnv):
         self._command_dt = np.zeros(num_envs, dtype=get_global_dtype())
         self._no_truncation = np.zeros(num_envs, dtype=np.bool_)
         self._manual_reset_pending = np.zeros(num_envs, dtype=np.bool_)
+        self._all_env_ids = np.arange(num_envs, dtype=np.int32)
+        self._all_env_ids.setflags(write=False)
         self._has_transition = False
         self._uses_pre_step_control = False
 
@@ -459,7 +461,9 @@ class ManagerBasedRlEnv(NpEnv):
 
         self._command_dt.fill(self.step_dt)
         self._command_dt[self.reset_buf] = 0.0
-        self.command_manager.compute(dt=self._command_dt)
+        with self._reset_state.scoped(self._all_env_ids):
+            self.command_manager.compute(dt=self._command_dt)
+        self.command_manager.post_compute()
         manager_obs = self.observation_manager.compute(update_history=True)
         self.obs_buf = self._map_observations(manager_obs)
         self._has_transition = True
@@ -504,13 +508,14 @@ class ManagerBasedRlEnv(NpEnv):
 
         log: dict[str, Any] = {}
         self.curriculum_manager.compute(env_ids=ids)
-        if "reset" in self.event_manager.available_modes:
-            with self._reset_state.scoped(ids):
+        with self._reset_state.scoped(ids):
+            if "reset" in self.event_manager.available_modes:
                 self.event_manager.apply(
                     mode="reset",
                     env_ids=ids,
                     global_env_step_count=self.step_counter,
                 )
+            log.update(self.command_manager.reset(ids))
 
         for manager in (
             self.observation_manager,
@@ -518,7 +523,6 @@ class ManagerBasedRlEnv(NpEnv):
             self.reward_manager,
             self.metrics_manager,
             self.curriculum_manager,
-            self.command_manager,
             self.event_manager,
             self.termination_manager,
         ):
@@ -531,6 +535,7 @@ class ManagerBasedRlEnv(NpEnv):
             self._state.info["steps"][ids] = 0
 
         self.command_manager.compute(dt=0.0, env_ids=ids)
+        self.command_manager.post_compute()
         manager_obs = self.observation_manager.compute(update_history=True, env_ids=ids)
         mapped_obs = self._map_observations(manager_obs)
         reset_obs = {name: values[ids].copy() for name, values in mapped_obs.items()}

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -196,6 +196,8 @@ class ManagerActionManager(Protocol):
 class ManagerCommandManager(Protocol):
     def get_command(self, name: str) -> np.ndarray | None: ...
 
+    def get_term(self, name: str) -> Any: ...
+
 
 class ManagerTerminationManager(Protocol):
     @property
@@ -235,6 +237,12 @@ class ManagerBasedRlEnv(Protocol):
 
     @property
     def episode_length_buf(self) -> np.ndarray: ...
+
+    @property
+    def reset_buf(self) -> np.ndarray: ...
+
+    @property
+    def common_step_counter(self) -> int: ...
 
     @property
     def max_episode_length(self) -> int: ...

--- a/src/unilab/managers/command_manager.py
+++ b/src/unilab/managers/command_manager.py
@@ -175,6 +175,9 @@ class CommandTerm(ManagerTermBase):
         """
         raise NotImplementedError
 
+    def post_compute(self) -> None:
+        """Refresh state that depends on committed command-side simulation writes."""
+
 
 class CommandManager(ManagerBase):
     """Manages command generation for the environment.
@@ -234,6 +237,10 @@ class CommandManager(ManagerBase):
         for name, term in self._terms.items():
             term.compute(dt, env_ids)
             self._validate_command(name, term.command)
+
+    def post_compute(self) -> None:
+        for term in self._terms.values():
+            term.post_compute()
 
     def get_command(self, name: str) -> np.ndarray:
         return self._validate_command(name, self._terms[name].command)
@@ -301,6 +308,9 @@ class NullCommandManager:
         return {}
 
     def compute(self, dt: float | np.ndarray, env_ids: np.ndarray | None = None) -> None:
+        pass
+
+    def post_compute(self) -> None:
         pass
 
     def get_command(self, name: str) -> None:

--- a/src/unilab/tasks/manipulation/stewart/balance.py
+++ b/src/unilab/tasks/manipulation/stewart/balance.py
@@ -33,7 +33,9 @@ if TYPE_CHECKING:
     from unilab.managers.termination_manager import TerminationManager
 
     class _StewartEnv(ManagerBasedRlEnv, Protocol):
-        common_step_counter: int
+        @property
+        def common_step_counter(self) -> int: ...
+
         observation_manager: ObservationManager
 
 

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -62,6 +62,17 @@ _CUSTOM_COMPAT_TASKS = frozenset(
     }
 )
 
+_MOTION_CORE_TASKS = frozenset(
+    {
+        "G1MotionTracking",
+        "G1MotionTracking23Dof",
+        "G1MotionTracking23DofDeploy",
+        "G1MotionTrackingDeploy",
+        "G1MotionTrackingSAC",
+        "G1MotionTrackingSAC23Dof",
+    }
+)
+
 _MOTION_TASKS = frozenset(
     {
         "G1BoxTracking",
@@ -72,12 +83,6 @@ _MOTION_TASKS = frozenset(
         "G1FlipTracking23Dof",
         "G1FlipTrackingSAC",
         "G1FlipTrackingSAC23Dof",
-        "G1MotionTracking",
-        "G1MotionTracking23Dof",
-        "G1MotionTracking23DofDeploy",
-        "G1MotionTrackingDeploy",
-        "G1MotionTrackingSAC",
-        "G1MotionTrackingSAC23Dof",
         "G1WallFlipTracking",
         "G1WallFlipTracking23Dof",
         "G1WallFlipTrackingSAC",
@@ -89,7 +94,12 @@ _MOTION_TASKS = frozenset(
 )
 
 PRODUCTION_TASK_NAMES = frozenset(
-    _MBA_TASKS | _ROUGH_TASKS | _G1_LOCOMOTION_TASKS | _CUSTOM_COMPAT_TASKS | _MOTION_TASKS
+    _MBA_TASKS
+    | _ROUGH_TASKS
+    | _G1_LOCOMOTION_TASKS
+    | _CUSTOM_COMPAT_TASKS
+    | _MOTION_CORE_TASKS
+    | _MOTION_TASKS
 )
 
 
@@ -136,6 +146,15 @@ def migration_record(task_name: str) -> TaskMigrationRecord:
             "compatibility",
             "Custom IK/history or tactile/contact/cache behavior is retained behind one frozen adapter.",
             "Keep Hydra/Registry ownership single; migrate only when the formal capability exists.",
+        )
+    if task_name in _MOTION_CORE_TASKS:
+        return TaskMigrationRecord(
+            task_name,
+            "motion_tracking",
+            "Compatible",
+            "complete",
+            "Hydra owner YAML materializes task-owned NumPy motion manager terms on the canonical runtime.",
+            "Keep PPO, APPO, and SAC owners aligned with the shared motion manager contract.",
         )
     if task_name in _MOTION_TASKS:
         return TaskMigrationRecord(

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -1,0 +1,776 @@
+"""Manager-native NumPy terms for motion tracking."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import numpy as np
+
+from unilab.envs.mdp.actions import JointPositionAction, JointPositionActionCfg
+from unilab.managers import CommandTerm, CommandTermCfg, ManagerTermBase, ManagerTermBaseCfg
+from unilab.managers.scene_entity_config import SceneEntityCfg
+from unilab.utils.geometry import (
+    np_write_relative_anchor_transform_pos_rot6d,
+)
+from unilab.utils.rotation import (
+    np_quat_apply_inverse,
+    np_quat_error_magnitude_squared_batched,
+    np_quat_from_euler_xyz,
+    np_quat_mul,
+)
+
+from .motion_loader import MotionData, MotionLoader, MotionSampler
+from .observations import write_body_ori6_in_anchor_frame, write_body_pos_in_anchor_frame
+from .transforms import update_relative_transforms
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+SamplingMode = Literal["start", "clip_start", "uniform", "adaptive", "mixed"]
+_RANGE_KEYS = ("x", "y", "z", "roll", "pitch", "yaw")
+_DEFAULT_ASSET_CFG = SceneEntityCfg("robot")
+
+
+def _range_matrix(value: dict[str, tuple[float, float]], *, name: str) -> np.ndarray:
+    unknown = sorted(set(value) - set(_RANGE_KEYS))
+    if unknown:
+        raise ValueError(f"{name} has unknown axes {unknown}")
+    try:
+        ranges = np.asarray([value.get(key, (0.0, 0.0)) for key in _RANGE_KEYS], dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must map axes to numeric (min, max) pairs") from exc
+    if ranges.shape != (6, 2) or not np.isfinite(ranges).all():
+        raise ValueError(f"{name} must contain six finite (min, max) pairs")
+    if np.any(ranges[:, 0] > ranges[:, 1]):
+        raise ValueError(f"{name} contains a minimum greater than its maximum")
+    ranges.setflags(write=False)
+    return ranges
+
+
+def _pair(value: tuple[float, float], *, name: str) -> tuple[float, float]:
+    try:
+        values = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must be a numeric (min, max) pair") from exc
+    if values.shape != (2,) or not np.isfinite(values).all():
+        raise ValueError(f"{name} must be a finite (min, max) pair")
+    lower, upper = float(values[0]), float(values[1])
+    if lower > upper:
+        raise ValueError(f"{name} minimum {lower} exceeds maximum {upper}")
+    return lower, upper
+
+
+@dataclass
+class MotionCommandParamsCfg:
+    """Hydra-owned motion data and sampling parameters."""
+
+    motion_file: str | list[str]
+    anchor_body_name: str
+    body_names: tuple[str, ...] | list[str]
+    sampling_mode: SamplingMode = "adaptive"
+    sampling_start_ratio: float = 0.0
+    truncate_on_clip_end: bool = False
+    pose_range: dict[str, tuple[float, float]] = field(default_factory=dict)
+    velocity_range: dict[str, tuple[float, float]] = field(default_factory=dict)
+    joint_position_range: tuple[float, float] = (-0.1, 0.1)
+    joint_default_position_range: tuple[float, float] = (0.0, 0.0)
+    adaptive_lambda: float = 0.8
+    adaptive_kernel_size: int = 1
+    adaptive_uniform_ratio: float = 0.1
+    adaptive_alpha: float = 0.001
+
+
+@dataclass(kw_only=True)
+class MotionCommandCfg(CommandTermCfg):
+    """Community-shaped motion command with Hydra-owned nested parameters."""
+
+    entity_name: str
+    params: MotionCommandParamsCfg
+
+    def build(self, env: ManagerBasedRlEnv) -> MotionCommand:
+        return MotionCommand(self, env)
+
+    @property
+    def motion_file(self) -> str | list[str]:
+        return self.params.motion_file
+
+    @property
+    def anchor_body_name(self) -> str:
+        return self.params.anchor_body_name
+
+    @property
+    def body_names(self) -> tuple[str, ...]:
+        return tuple(self.params.body_names)
+
+    @property
+    def sampling_mode(self) -> SamplingMode:
+        return self.params.sampling_mode
+
+
+class MotionCommand(CommandTerm):
+    """Motion reference command on UniLab's NumPy/entity runtime."""
+
+    cfg: MotionCommandCfg
+
+    def __init__(self, cfg: MotionCommandCfg, env: ManagerBasedRlEnv):
+        self._validate_cfg(cfg)
+        super().__init__(cfg, env)
+        self.robot = cast("Entity", env.scene[cfg.entity_name])
+        body_ids, body_names = self.robot.find_bodies(cfg.body_names, preserve_order=True)
+        if tuple(body_names) != cfg.body_names:
+            raise ValueError(
+                f"MotionCommand body order {tuple(body_names)} does not match {cfg.body_names}"
+            )
+        self._robot_body_ids = np.asarray(body_ids, dtype=np.intp)
+        self._robot_body_ids.setflags(write=False)
+        motion_body_ids = self.robot.motion_body_ids[self._robot_body_ids]
+        self.motion = MotionLoader(cfg.motion_file, body_indices=motion_body_ids)
+        if self.motion.num_joints != len(self.robot.joint_names):
+            raise ValueError(
+                f"MotionCommand motion joint width {self.motion.num_joints} does not match "
+                f"entity '{self.robot.name}' joint width {len(self.robot.joint_names)}"
+            )
+        if self.motion.num_bodies != len(cfg.body_names):
+            raise ValueError(
+                f"MotionCommand motion body width {self.motion.num_bodies} does not match "
+                f"configured body width {len(cfg.body_names)}"
+            )
+
+        self.anchor_body_idx = cfg.body_names.index(cfg.anchor_body_name)
+        self.sampler = MotionSampler(
+            self.motion,
+            mode=cfg.params.sampling_mode,
+            num_envs=self.num_envs,
+            adaptive_lambda=cfg.params.adaptive_lambda,
+            adaptive_kernel_size=cfg.params.adaptive_kernel_size,
+            adaptive_uniform_ratio=cfg.params.adaptive_uniform_ratio,
+            adaptive_alpha=cfg.params.adaptive_alpha,
+            start_ratio=cfg.params.sampling_start_ratio,
+            rng=env.rng,
+        )
+        self._pose_range = _range_matrix(cfg.params.pose_range, name="MotionCommand pose_range")
+        self._velocity_range = _range_matrix(
+            cfg.params.velocity_range, name="MotionCommand velocity_range"
+        )
+        self._joint_position_range = _pair(
+            cfg.params.joint_position_range,
+            name="MotionCommand joint_position_range",
+        )
+        self._joint_default_position_range = _pair(
+            cfg.params.joint_default_position_range,
+            name="MotionCommand joint_default_position_range",
+        )
+
+        num_bodies = len(cfg.body_names)
+        num_joints = self.motion.num_joints
+        dtype = self.motion.joint_pos.dtype
+        self.time_steps = self.sampler.current_frames
+        self._motion_data = self.motion.make_motion_data_buffer(self.num_envs)
+        self._command = np.empty((self.num_envs, num_joints * 2), dtype=dtype)
+        self._body_pos_w = np.empty((self.num_envs, num_bodies, 3), dtype=dtype)
+        self.body_pos_relative_w = np.empty_like(self._body_pos_w)
+        self.body_quat_relative_w = np.empty((self.num_envs, num_bodies, 4), dtype=dtype)
+        self.motion_anchor_pos_b = np.empty((self.num_envs, 3), dtype=dtype)
+        self.motion_anchor_ori_b = np.empty((self.num_envs, 6), dtype=dtype)
+        self.robot_body_pos_b = np.empty_like(self._body_pos_w)
+        self.robot_body_ori_b = np.empty((self.num_envs, num_bodies, 6), dtype=dtype)
+        self.joint_default_bias = np.zeros((self.num_envs, num_joints), dtype=dtype)
+        self._delta_pos_w = np.empty((self.num_envs, 3), dtype=dtype)
+        self._delta_ori_w = np.empty((self.num_envs, 4), dtype=dtype)
+        self._body_vec_error = np.empty_like(self._body_pos_w)
+        self._env_error = np.empty(self.num_envs, dtype=dtype)
+        self._reward_term = np.empty(self.num_envs, dtype=dtype)
+        self._robot_cache_step = -1
+        self._robot_body_pos_w = np.empty_like(self._body_pos_w)
+        self._robot_body_quat_w = np.empty((self.num_envs, num_bodies, 4), dtype=dtype)
+        self._robot_body_lin_vel_w = np.empty_like(self._body_pos_w)
+        self._robot_body_ang_vel_w = np.empty_like(self._body_pos_w)
+
+        for name in (
+            "error_anchor_pos",
+            "error_anchor_rot",
+            "error_anchor_lin_vel",
+            "error_anchor_ang_vel",
+            "error_body_pos",
+            "error_body_rot",
+            "error_body_lin_vel",
+            "error_body_ang_vel",
+            "error_joint_pos",
+            "error_joint_vel",
+            "sampling_entropy",
+            "sampling_top1_prob",
+            "sampling_top1_bin",
+        ):
+            self.metrics[name] = np.zeros(self.num_envs, dtype=dtype)
+        self._refresh_motion()
+        self._refresh_robot_state(force=True)
+        self._refresh_relative_state()
+
+    @staticmethod
+    def _validate_cfg(cfg: MotionCommandCfg) -> None:
+        if not isinstance(cfg.entity_name, str) or not cfg.entity_name:
+            raise ValueError("MotionCommandCfg entity_name must be non-empty")
+        if not isinstance(cfg.params, MotionCommandParamsCfg):
+            raise TypeError("MotionCommandCfg params must be MotionCommandParamsCfg")
+        if not cfg.motion_file:
+            raise ValueError("MotionCommandCfg motion_file must be configured")
+        if not cfg.anchor_body_name or cfg.anchor_body_name not in cfg.body_names:
+            raise ValueError("MotionCommandCfg anchor_body_name must occur in body_names")
+        if len(set(cfg.body_names)) != len(cfg.body_names):
+            raise ValueError("MotionCommandCfg body_names must be unique")
+        if cfg.sampling_mode not in ("start", "clip_start", "uniform", "adaptive", "mixed"):
+            raise ValueError(
+                f"MotionCommandCfg has unsupported sampling_mode {cfg.sampling_mode!r}"
+            )
+        if not 0.0 <= cfg.params.sampling_start_ratio <= 1.0:
+            raise ValueError("MotionCommandCfg sampling_start_ratio must be within [0, 1]")
+        if not isinstance(cfg.params.truncate_on_clip_end, bool):
+            raise TypeError("MotionCommandCfg truncate_on_clip_end must be bool")
+
+    @property
+    def command(self) -> np.ndarray:
+        return self._command
+
+    @property
+    def joint_pos(self) -> np.ndarray:
+        return self._motion_data.joint_pos
+
+    @property
+    def joint_vel(self) -> np.ndarray:
+        return self._motion_data.joint_vel
+
+    @property
+    def body_pos_w(self) -> np.ndarray:
+        return self._body_pos_w
+
+    @property
+    def body_quat_w(self) -> np.ndarray:
+        return self._motion_data.body_quat_w
+
+    @property
+    def body_lin_vel_w(self) -> np.ndarray:
+        return self._motion_data.body_lin_vel_w
+
+    @property
+    def body_ang_vel_w(self) -> np.ndarray:
+        return self._motion_data.body_ang_vel_w
+
+    @property
+    def anchor_pos_w(self) -> np.ndarray:
+        return self._body_pos_w[:, self.anchor_body_idx]
+
+    @property
+    def anchor_quat_w(self) -> np.ndarray:
+        return self._motion_data.body_quat_w[:, self.anchor_body_idx]
+
+    @property
+    def anchor_lin_vel_w(self) -> np.ndarray:
+        return self._motion_data.body_lin_vel_w[:, self.anchor_body_idx]
+
+    @property
+    def anchor_ang_vel_w(self) -> np.ndarray:
+        return self._motion_data.body_ang_vel_w[:, self.anchor_body_idx]
+
+    @property
+    def robot_joint_pos(self) -> np.ndarray:
+        return self.robot.data.joint_pos
+
+    @property
+    def robot_joint_vel(self) -> np.ndarray:
+        return self.robot.data.joint_vel
+
+    @property
+    def robot_body_pos_w(self) -> np.ndarray:
+        self._refresh_robot_state()
+        return self._robot_body_pos_w
+
+    @property
+    def robot_body_quat_w(self) -> np.ndarray:
+        self._refresh_robot_state()
+        return self._robot_body_quat_w
+
+    @property
+    def robot_body_lin_vel_w(self) -> np.ndarray:
+        self._refresh_robot_state()
+        return self._robot_body_lin_vel_w
+
+    @property
+    def robot_body_ang_vel_w(self) -> np.ndarray:
+        self._refresh_robot_state()
+        return self._robot_body_ang_vel_w
+
+    @property
+    def robot_anchor_pos_w(self) -> np.ndarray:
+        return self.robot_body_pos_w[:, self.anchor_body_idx]
+
+    @property
+    def robot_anchor_quat_w(self) -> np.ndarray:
+        return self.robot_body_quat_w[:, self.anchor_body_idx]
+
+    @property
+    def robot_anchor_lin_vel_w(self) -> np.ndarray:
+        return self.robot_body_lin_vel_w[:, self.anchor_body_idx]
+
+    @property
+    def robot_anchor_ang_vel_w(self) -> np.ndarray:
+        return self.robot_body_ang_vel_w[:, self.anchor_body_idx]
+
+    def reset(self, env_ids: np.ndarray | slice | None) -> dict[str, float]:
+        ids = (
+            np.arange(self.num_envs, dtype=np.int32)
+            if env_ids is None
+            else np.arange(self.num_envs, dtype=np.int32)[env_ids]
+            if isinstance(env_ids, slice)
+            else env_ids
+        )
+        lower, upper = self._joint_default_position_range
+        self.joint_default_bias[ids] = self._env.rng.uniform(
+            lower, upper, size=(len(ids), self.motion.num_joints)
+        )
+        return super().reset(ids)
+
+    def _refresh_motion(self) -> None:
+        self.motion.get_motion_at_frame(self.time_steps, out=self._motion_data)
+        np.add(
+            self._motion_data.body_pos_w,
+            self._env.scene.env_origins[:, None, :],
+            out=self._body_pos_w,
+        )
+        width = self.motion.num_joints
+        self._command[:, :width] = self._motion_data.joint_pos
+        self._command[:, width:] = self._motion_data.joint_vel
+
+    def _refresh_robot_state(self, *, force: bool = False) -> None:
+        step = self._env.common_step_counter
+        if not force and self._robot_cache_step == step:
+            return
+        body_index = self._robot_body_ids
+        self._robot_body_pos_w[:] = self.robot.data.body_link_pos_w[:, body_index]
+        self._robot_body_quat_w[:] = self.robot.data.body_link_quat_w[:, body_index]
+        self._robot_body_lin_vel_w[:] = self.robot.data.body_link_lin_vel_w[:, body_index]
+        self._robot_body_ang_vel_w[:] = self.robot.data.body_link_ang_vel_w[:, body_index]
+        self._robot_cache_step = step
+
+    def _refresh_relative_state(self) -> None:
+        update_relative_transforms(
+            self,
+            self._motion_data,
+            self._robot_body_pos_w,
+            self._robot_body_quat_w,
+        )
+        np_write_relative_anchor_transform_pos_rot6d(
+            self.robot_anchor_pos_w,
+            self.robot_anchor_quat_w,
+            self.anchor_pos_w,
+            self.anchor_quat_w,
+            self.motion_anchor_pos_b,
+            self.motion_anchor_ori_b,
+        )
+        write_body_pos_in_anchor_frame(
+            self.robot_anchor_pos_w,
+            self.robot_anchor_quat_w,
+            self._robot_body_pos_w,
+            self.robot_body_pos_b,
+            body_vec_error=self._body_vec_error,
+        )
+        write_body_ori6_in_anchor_frame(
+            self.robot_anchor_quat_w,
+            self._robot_body_quat_w,
+            self.robot_body_ori_b,
+        )
+
+    def _update_metrics(self) -> None:
+        self.metrics["error_anchor_pos"][:] = np.linalg.norm(
+            self.anchor_pos_w - self.robot_anchor_pos_w, axis=-1
+        )
+        self.metrics["error_anchor_rot"][:] = np.sqrt(
+            np_quat_error_magnitude_squared_batched(self.anchor_quat_w, self.robot_anchor_quat_w)
+        )
+        self.metrics["error_anchor_lin_vel"][:] = np.linalg.norm(
+            self.anchor_lin_vel_w - self.robot_anchor_lin_vel_w, axis=-1
+        )
+        self.metrics["error_anchor_ang_vel"][:] = np.linalg.norm(
+            self.anchor_ang_vel_w - self.robot_anchor_ang_vel_w, axis=-1
+        )
+        self.metrics["error_body_pos"][:] = np.linalg.norm(
+            self.body_pos_relative_w - self.robot_body_pos_w, axis=-1
+        ).mean(axis=-1)
+        self.metrics["error_body_rot"][:] = np.sqrt(
+            np_quat_error_magnitude_squared_batched(
+                self.body_quat_relative_w, self.robot_body_quat_w
+            )
+        ).mean(axis=-1)
+        self.metrics["error_body_lin_vel"][:] = np.linalg.norm(
+            self.body_lin_vel_w - self.robot_body_lin_vel_w, axis=-1
+        ).mean(axis=-1)
+        self.metrics["error_body_ang_vel"][:] = np.linalg.norm(
+            self.body_ang_vel_w - self.robot_body_ang_vel_w, axis=-1
+        ).mean(axis=-1)
+        self.metrics["error_joint_pos"][:] = np.linalg.norm(
+            self.joint_pos - self.robot_joint_pos, axis=-1
+        )
+        self.metrics["error_joint_vel"][:] = np.linalg.norm(
+            self.joint_vel - self.robot_joint_vel, axis=-1
+        )
+        self.metrics["sampling_entropy"].fill(self.sampler.sampling_entropy)
+        self.metrics["sampling_top1_prob"].fill(self.sampler.sampling_top1_prob)
+        self.metrics["sampling_top1_bin"].fill(self.sampler.sampling_top1_bin)
+
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        frames = self.sampler.sample_frames(env_ids)
+        motion = self.motion.get_motion_at_frame(frames)
+        count = len(env_ids)
+        pose = self._env.rng.uniform(
+            self._pose_range[:, 0], self._pose_range[:, 1], size=(count, 6)
+        )
+        velocity = self._env.rng.uniform(
+            self._velocity_range[:, 0], self._velocity_range[:, 1], size=(count, 6)
+        )
+        root_pos = motion.body_pos_w[:, 0].copy()
+        root_pos += self._env.scene.env_origins[env_ids]
+        root_pos += pose[:, :3]
+        root_quat = np_quat_mul(
+            np_quat_from_euler_xyz(pose[:, 3], pose[:, 4], pose[:, 5]),
+            motion.body_quat_w[:, 0],
+        )
+        root_lin_vel = motion.body_lin_vel_w[:, 0] + velocity[:, :3]
+        root_ang_vel = motion.body_ang_vel_w[:, 0] + velocity[:, 3:]
+        joint_pos = motion.joint_pos.copy()
+        joint_pos += self._env.rng.uniform(
+            *self._joint_position_range,
+            size=joint_pos.shape,
+        )
+        limits = self.robot.data.soft_joint_pos_limits
+        np.clip(joint_pos, limits[:, 0], limits[:, 1], out=joint_pos)
+        self.robot.write_joint_state_to_sim(joint_pos, motion.joint_vel, env_ids=env_ids)
+        root_state = np.concatenate((root_pos, root_quat, root_lin_vel, root_ang_vel), axis=-1)
+        self.robot.write_root_state_to_sim(root_state, env_ids=env_ids)
+
+    def _update_command(self, env_ids: np.ndarray | None) -> None:
+        if env_ids is not None:
+            self._refresh_motion()
+            return
+        self.sampler.update_failure_stats(self._env.termination_manager.terminated)
+        active_ids = np.flatnonzero(~self._env.reset_buf).astype(np.int32, copy=False)
+        wrap_ids = self.sampler.step(active_ids)
+        if len(wrap_ids) and not self.cfg.params.truncate_on_clip_end:
+            self._resample_command(wrap_ids)
+        self._refresh_motion()
+
+    def post_compute(self) -> None:
+        self._refresh_robot_state(force=True)
+        self._refresh_relative_state()
+
+
+@dataclass(kw_only=True)
+class MotionJointPositionActionCfg(JointPositionActionCfg):
+    command_name: str = "motion"
+
+    def build(self, env: ManagerBasedRlEnv) -> MotionJointPositionAction:
+        return MotionJointPositionAction(self, env)
+
+
+class MotionJointPositionAction(JointPositionAction):
+    cfg: MotionJointPositionActionCfg  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    def __init__(self, cfg: MotionJointPositionActionCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        self._motion_command = _command(env, cfg.command_name)
+
+    def apply_actions(self) -> None:
+        encoder_bias = self._entity.data.encoder_bias[:, self._target_ids]
+        np.add(
+            self._processed_actions,
+            self._motion_command.joint_default_bias[:, self._target_ids],
+            out=self._target,
+        )
+        self._target -= encoder_bias
+        self._entity.set_joint_position_target(self._target, joint_ids=self._target_ids)
+
+
+def _command(env: ManagerBasedRlEnv, command_name: str) -> MotionCommand:
+    try:
+        command = env.command_manager.get_term(command_name)
+    except KeyError as exc:
+        raise KeyError(f"Motion command term '{command_name}' not found") from exc
+    if not isinstance(command, MotionCommand):
+        raise TypeError(
+            f"Command term '{command_name}' is {type(command).__name__}, expected MotionCommand"
+        )
+    return command
+
+
+def motion_anchor_pos_b(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    return _command(env, command_name).motion_anchor_pos_b
+
+
+def motion_anchor_ori_b(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    return _command(env, command_name).motion_anchor_ori_b
+
+
+def robot_body_pos_b(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    command = _command(env, command_name)
+    return command.robot_body_pos_b.reshape(env.num_envs, -1)
+
+
+def robot_body_ori_b(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    command = _command(env, command_name)
+    return command.robot_body_ori_b.reshape(env.num_envs, -1)
+
+
+def motion_joint_pos_rel(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    command = _command(env, command_name)
+    return (
+        command.robot_joint_pos - command.robot.data.default_joint_pos - command.joint_default_bias
+    )
+
+
+def _positive_std(value: float, *, term_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+        raise TypeError(f"{term_name} std must be a real number")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{term_name} std must be finite and positive")
+    return result
+
+
+def motion_global_anchor_position_error_exp(
+    env: ManagerBasedRlEnv, command_name: str, std: float
+) -> np.ndarray:
+    command = _command(env, command_name)
+    error = np.sum(np.square(command.anchor_pos_w - command.robot_anchor_pos_w), axis=-1)
+    return np.exp(-error / _positive_std(std, term_name="motion anchor position") ** 2)
+
+
+def motion_global_anchor_orientation_error_exp(
+    env: ManagerBasedRlEnv, command_name: str, std: float
+) -> np.ndarray:
+    command = _command(env, command_name)
+    error = np_quat_error_magnitude_squared_batched(
+        command.anchor_quat_w, command.robot_anchor_quat_w
+    )
+    return np.exp(-error / _positive_std(std, term_name="motion anchor orientation") ** 2)
+
+
+class _BodyTerm(ManagerTermBase):
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        command_name = cfg.params.get("command_name")
+        if not isinstance(command_name, str) or not command_name:
+            raise ValueError(f"{type(self).__name__} requires a non-empty command_name")
+        self._command_name = command_name
+        command = _command(env, command_name)
+        body_names = cfg.params.get("body_names")
+        if body_names is None:
+            self._body_ids = slice(None)
+        else:
+            requested = tuple(body_names)
+            missing = [name for name in requested if name not in command.cfg.body_names]
+            if missing:
+                raise ValueError(
+                    f"Body names {missing} are not tracked by command '{command_name}'"
+                )
+            self._body_ids = np.asarray(
+                [command.cfg.body_names.index(name) for name in requested], dtype=np.intp
+            )
+
+    def _validate(self, command_name: str, std: float) -> tuple[MotionCommand, float]:
+        if command_name != self._command_name:
+            raise ValueError(
+                f"{type(self).__name__} was bound to '{self._command_name}', got '{command_name}'"
+            )
+        return _command(self._env, command_name), _positive_std(std, term_name=type(self).__name__)
+
+
+class motion_relative_body_position_error_exp(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        std: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command, scale = self._validate(command_name, std)
+        error = np.sum(
+            np.square(
+                command.body_pos_relative_w[:, self._body_ids]
+                - command.robot_body_pos_w[:, self._body_ids]
+            ),
+            axis=-1,
+        )
+        return np.exp(-error.mean(axis=-1) / scale**2)
+
+
+class motion_relative_body_orientation_error_exp(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        std: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command, scale = self._validate(command_name, std)
+        error = np_quat_error_magnitude_squared_batched(
+            command.body_quat_relative_w[:, self._body_ids],
+            command.robot_body_quat_w[:, self._body_ids],
+        )
+        return np.exp(-error.mean(axis=-1) / scale**2)
+
+
+class motion_global_body_linear_velocity_error_exp(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        std: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command, scale = self._validate(command_name, std)
+        error = np.sum(
+            np.square(
+                command.body_lin_vel_w[:, self._body_ids]
+                - command.robot_body_lin_vel_w[:, self._body_ids]
+            ),
+            axis=-1,
+        )
+        return np.exp(-error.mean(axis=-1) / scale**2)
+
+
+class motion_global_body_angular_velocity_error_exp(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        std: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command, scale = self._validate(command_name, std)
+        error = np.sum(
+            np.square(
+                command.body_ang_vel_w[:, self._body_ids]
+                - command.robot_body_ang_vel_w[:, self._body_ids]
+            ),
+            axis=-1,
+        )
+        return np.exp(-error.mean(axis=-1) / scale**2)
+
+
+def motion_joint_position_error_exp(
+    env: ManagerBasedRlEnv, command_name: str, std: float
+) -> np.ndarray:
+    command = _command(env, command_name)
+    error = np.square(command.joint_pos - command.robot_joint_pos).mean(axis=-1)
+    return np.exp(-error / _positive_std(std, term_name="motion joint position") ** 2)
+
+
+def motion_joint_velocity_error_exp(
+    env: ManagerBasedRlEnv, command_name: str, std: float
+) -> np.ndarray:
+    command = _command(env, command_name)
+    error = np.square(command.joint_vel - command.robot_joint_vel).mean(axis=-1)
+    return np.exp(-error / _positive_std(std, term_name="motion joint velocity") ** 2)
+
+
+def joint_pos_limits(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Penalize selected joint-limit violations through the entity facade."""
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    limits = asset.data.soft_joint_pos_limits[asset_cfg.joint_ids]
+    lower_error = np.maximum(limits[:, 0] - joint_pos, 0.0)
+    upper_error = np.maximum(joint_pos - limits[:, 1], 0.0)
+    return np.sum(np.square(lower_error + upper_error), axis=-1)
+
+
+class undesired_body_contacts(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        threshold: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command = _command(self._env, command_name)
+        return np.sum(command.robot_body_pos_w[:, self._body_ids, 2] < threshold, axis=-1)
+
+
+def bad_anchor_pos_z_only(
+    env: ManagerBasedRlEnv, command_name: str, threshold: float
+) -> np.ndarray:
+    command = _command(env, command_name)
+    return np.abs(command.anchor_pos_w[:, 2] - command.robot_anchor_pos_w[:, 2]) > threshold
+
+
+def bad_anchor_ori(
+    env: ManagerBasedRlEnv,
+    command_name: str,
+    threshold: float,
+    asset_cfg: SceneEntityCfg | None = None,
+) -> np.ndarray:
+    command = _command(env, command_name)
+    asset = command.robot if asset_cfg is None else cast("Entity", env.scene[asset_cfg.name])
+    gravity_vec_w = asset.data.gravity_vec_w
+    motion_z = np_quat_apply_inverse(command.anchor_quat_w, gravity_vec_w)[:, 2]
+    robot_z = np_quat_apply_inverse(command.robot_anchor_quat_w, gravity_vec_w)[:, 2]
+    return np.abs(motion_z - robot_z) > threshold
+
+
+class bad_motion_body_pos_z_only(_BodyTerm):
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        threshold: float,
+        body_names: tuple[str, ...] | None = None,
+    ) -> np.ndarray:
+        del env, body_names
+        command = _command(self._env, command_name)
+        error = np.abs(
+            command.body_pos_relative_w[:, self._body_ids, 2]
+            - command.robot_body_pos_w[:, self._body_ids, 2]
+        )
+        return np.any(error > threshold, axis=-1)
+
+
+def motion_clip_end(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
+    command = _command(env, command_name)
+    return command.time_steps >= command.sampler.current_clip_end_frames
+
+
+__all__ = [
+    "MotionCommand",
+    "MotionCommandCfg",
+    "MotionCommandParamsCfg",
+    "MotionJointPositionAction",
+    "MotionJointPositionActionCfg",
+    "bad_anchor_ori",
+    "bad_anchor_pos_z_only",
+    "bad_motion_body_pos_z_only",
+    "joint_pos_limits",
+    "motion_anchor_ori_b",
+    "motion_anchor_pos_b",
+    "motion_clip_end",
+    "motion_global_anchor_orientation_error_exp",
+    "motion_global_anchor_position_error_exp",
+    "motion_global_body_angular_velocity_error_exp",
+    "motion_global_body_linear_velocity_error_exp",
+    "motion_joint_pos_rel",
+    "motion_joint_position_error_exp",
+    "motion_joint_velocity_error_exp",
+    "motion_relative_body_orientation_error_exp",
+    "motion_relative_body_position_error_exp",
+    "robot_body_ori_b",
+    "robot_body_pos_b",
+    "undesired_body_contacts",
+]

--- a/src/unilab/tasks/motion_tracking/common/motion_loader.py
+++ b/src/unilab/tasks/motion_tracking/common/motion_loader.py
@@ -214,6 +214,7 @@ class MotionSampler:
         adaptive_uniform_ratio: float = 0.1,
         adaptive_alpha: float = 0.001,
         start_ratio: float = 0.0,
+        rng: np.random.Generator | None = None,
     ):
         """Initialize motion sampler.
 
@@ -236,6 +237,7 @@ class MotionSampler:
         self.mode = mode
         self.num_envs = num_envs
         self.start_ratio = start_ratio
+        self.rng = rng
 
         # Current frame indices for each environment
         self.current_frames = np.zeros(num_envs, dtype=np.int32)
@@ -306,16 +308,28 @@ class MotionSampler:
         if self.motion_loader.num_clips == 1:
             frames = np.zeros(len(env_ids), dtype=np.int32)
         else:
-            clip_indices = np.random.randint(
-                0, self.motion_loader.num_clips, len(env_ids), dtype=np.int32
-            )
+            if self.rng is None:
+                clip_indices = np.random.randint(
+                    0, self.motion_loader.num_clips, len(env_ids), dtype=np.int32
+                )
+            else:
+                clip_indices = self.rng.integers(
+                    0, self.motion_loader.num_clips, len(env_ids), dtype=np.int32
+                )
             frames = np.asarray(self.motion_loader.clip_offsets[clip_indices], dtype=np.int32)
         self._set_sampled_frames(env_ids, frames)
         return frames
 
     def _sample_uniform(self, env_ids: np.ndarray) -> np.ndarray:
         """Sample uniformly across motion."""
-        frames = np.random.randint(0, self.motion_loader.num_frames, len(env_ids), dtype=np.int32)
+        if self.rng is None:
+            frames = np.random.randint(
+                0, self.motion_loader.num_frames, len(env_ids), dtype=np.int32
+            )
+        else:
+            frames = self.rng.integers(
+                0, self.motion_loader.num_frames, len(env_ids), dtype=np.int32
+            )
         self._set_sampled_frames(env_ids, frames)
 
         # Update metrics
@@ -334,11 +348,16 @@ class MotionSampler:
         uniform RSI's whole-clip coverage everywhere else.
         """
         n = len(env_ids)
-        use_start = np.random.random(n) < self.start_ratio
+        random_values = np.random.random(n) if self.rng is None else self.rng.random(n)
+        if self.rng is None:
+            uniform_frames = np.random.randint(0, self.motion_loader.num_frames, n)
+        else:
+            uniform_frames = self.rng.integers(0, self.motion_loader.num_frames, n)
+        use_start = random_values < self.start_ratio
         frames = np.where(
             use_start,
             0,
-            np.random.randint(0, self.motion_loader.num_frames, n),
+            uniform_frames,
         ).astype(np.int32)
         self._set_sampled_frames(env_ids, frames)
 
@@ -374,10 +393,18 @@ class MotionSampler:
         sampling_probs = sampling_probs / sampling_probs.sum()
 
         # Sample bins
-        sampled_bins = np.random.choice(self.bin_count, size=len(env_ids), p=sampling_probs)
+        sampled_bins = (
+            np.random.choice(self.bin_count, size=len(env_ids), p=sampling_probs)
+            if self.rng is None
+            else self.rng.choice(self.bin_count, size=len(env_ids), p=sampling_probs)
+        )
 
         # Add random offset within bin
-        bin_offsets = np.random.uniform(0.0, 1.0, len(env_ids))
+        bin_offsets = (
+            np.random.uniform(0.0, 1.0, len(env_ids))
+            if self.rng is None
+            else self.rng.uniform(0.0, 1.0, len(env_ids))
+        )
         frames = (
             (sampled_bins + bin_offsets) / self.bin_count * (self.motion_loader.num_frames - 1)
         ).astype(np.int32)
@@ -437,12 +464,14 @@ class MotionSampler:
         self.current_clip_indices[env_ids] = clip_indices
         self.current_clip_end_frames[env_ids] = self.motion_loader.clip_end_frames[clip_indices]
 
-    def step(self):
-        """Advance all frames by one step."""
-        self.current_frames += 1
+    def step(self, env_ids: np.ndarray | None = None) -> np.ndarray:
+        """Advance selected frames by one step and return their clip-end rows."""
+        ids = np.arange(self.num_envs, dtype=np.int32) if env_ids is None else env_ids
+        self.current_frames[ids] += 1
 
         # Find environments that reached the end of their current clip.
-        np.greater(self.current_frames, self.current_clip_end_frames, out=self._done_mask)
+        self._done_mask.fill(False)
+        self._done_mask[ids] = self.current_frames[ids] > self.current_clip_end_frames[ids]
         return np.flatnonzero(self._done_mask)
 
     def get_current_motion(self, out: MotionData | None = None) -> MotionData:

--- a/src/unilab/tasks/motion_tracking/g1/tracking.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from unilab.assets import ASSETS_ROOT_PATH
 from unilab.base import registry
 from unilab.base.scene import SceneCfg
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
 
 from ..common.config import (
     Domain_Rand,
@@ -41,7 +42,6 @@ G1MotionTrackingDomainRandomizationProvider = MotionTrackingDomainRandomizationP
 _build_motion_reference_state = build_motion_reference_state
 
 
-@registry.envcfg("G1MotionTracking")
 @dataclass
 class G1MotionTrackingEnvCfg(MotionTrackingCfg):
     """Registered configuration for G1 motion tracking."""
@@ -49,7 +49,6 @@ class G1MotionTrackingEnvCfg(MotionTrackingCfg):
     pass
 
 
-@registry.envcfg("G1MotionTrackingDeploy")
 @dataclass
 class G1MotionTrackingDeployEnvCfg(MotionTrackingDeployEnvCfg):
     """Registered deploy configuration for G1 motion tracking."""
@@ -91,44 +90,40 @@ class G1MotionTracking23DofCfg(G1MotionTrackingCfg):
     )
 
 
-@registry.envcfg("G1MotionTracking23Dof")
 @dataclass
 class G1MotionTracking23DofEnvCfg(G1MotionTracking23DofCfg):
     pass
 
 
-@registry.envcfg("G1MotionTracking23DofDeploy")
 @dataclass
 class G1MotionTracking23DofDeployEnvCfg(G1MotionTracking23DofCfg):
     pass
 
 
-@registry.env("G1MotionTracking", sim_backend="drake")
-@registry.env("G1MotionTracking", sim_backend="mujoco")
-@registry.env("G1MotionTracking", sim_backend="motrix")
 class G1MotionTrackingEnv(MotionTrackingEnv):
     """G1 Motion Tracking Environment."""
 
     _cfg: MotionTrackingCfg
 
 
-@registry.env("G1MotionTrackingDeploy", sim_backend="mujoco")
-@registry.env("G1MotionTrackingDeploy", sim_backend="motrix")
 class G1MotionTrackingDeployEnv(MotionTrackingDeployEnv):
     """Deploy-oriented G1 motion tracking env with unitree_rl_lab mimic actor inputs."""
 
     _cfg: MotionTrackingDeployEnvCfg
 
 
-# --- 23-DoF env registrations (same env classes, 23-DoF configs) ---
-registry.register_env("G1MotionTracking23Dof", G1MotionTrackingEnv, sim_backend="mujoco")
-registry.register_env("G1MotionTracking23Dof", G1MotionTrackingEnv, sim_backend="motrix")
-registry.register_env(
-    "G1MotionTracking23DofDeploy", G1MotionTrackingDeployEnv, sim_backend="mujoco"
-)
-registry.register_env(
-    "G1MotionTracking23DofDeploy", G1MotionTrackingDeployEnv, sim_backend="motrix"
-)
+# The legacy classes above remain explicit consumers for profiles that are not
+# part of #1227.  The four core identities have one Hydra-owned manager config
+# and one generic runtime factory instead of inheriting those classes.
+for _task_name in (
+    "G1MotionTracking",
+    "G1MotionTrackingDeploy",
+    "G1MotionTracking23Dof",
+    "G1MotionTracking23DofDeploy",
+):
+    registry.register_env_config(_task_name, ManagerBasedRlEnvCfg)
+    registry.register_env(_task_name, make_manager_based_rl_env, sim_backend="mujoco")
+    registry.register_env(_task_name, make_manager_based_rl_env, sim_backend="motrix")
 
 
 __all__ = [

--- a/src/unilab/tasks/motion_tracking/g1/tracking_sac.py
+++ b/src/unilab/tasks/motion_tracking/g1/tracking_sac.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from unilab.base import registry
 from unilab.dtype_config import get_global_dtype
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
 
 from .tracking import (
     G1MotionTracking23DofCfg,
@@ -23,14 +24,11 @@ from .tracking import (
 )
 
 
-@registry.envcfg("G1MotionTrackingSAC")
 @dataclass
 class G1MotionTrackingSACCfg(G1MotionTrackingCfg):
     """Config for SAC-based motion tracking (identical fields, separate registry entry)."""
 
 
-@registry.env("G1MotionTrackingSAC", sim_backend="mujoco")
-@registry.env("G1MotionTrackingSAC", sim_backend="motrix")
 class G1MotionTrackingSACEnv(G1MotionTrackingEnv):
     """G1 Motion Tracking environment for FastSAC training.
 
@@ -75,13 +73,16 @@ class G1MotionTrackingSACEnv(G1MotionTrackingEnv):
         return obs
 
 
-@registry.envcfg("G1MotionTrackingSAC23Dof")
 @dataclass
 class G1MotionTrackingSAC23DofCfg(G1MotionTracking23DofCfg):
     pass
 
 
-@registry.env("G1MotionTrackingSAC23Dof", sim_backend="mujoco")
-@registry.env("G1MotionTrackingSAC23Dof", sim_backend="motrix")
 class G1MotionTrackingSAC23DofEnv(G1MotionTrackingSACEnv):
     _cfg: G1MotionTrackingSAC23DofCfg  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+for _task_name in ("G1MotionTrackingSAC", "G1MotionTrackingSAC23Dof"):
+    registry.register_env_config(_task_name, ManagerBasedRlEnvCfg)
+    registry.register_env(_task_name, make_manager_based_rl_env, sim_backend="mujoco")
+    registry.register_env(_task_name, make_manager_based_rl_env, sim_backend="motrix")

--- a/src/unilab/training/sim2sim.py
+++ b/src/unilab/training/sim2sim.py
@@ -44,17 +44,32 @@ DENYLIST: list[str] = [
     "algo.policy.critic_hidden_dims",
     "algo.empirical_normalization",
     "algo.obs_normalization",
-    "env.sampling_mode",
+    "env.commands.motion.params.sampling_mode",
 ]
 
 SNAPSHOT_FIELDS: list[str] = DENYLIST + WARNING_LIST
 
 ENV_STRUCTURAL_DENYLIST: list[str] = [path for path in DENYLIST if path.startswith("env.")]
 
+LEGACY_PATH_ALIASES: dict[str, str] = {
+    "env.sampling_mode": "env.commands.motion.params.sampling_mode",
+}
+_CANONICAL_PATH_FALLBACKS: dict[str, str] = {
+    canonical: legacy for legacy, canonical in LEGACY_PATH_ALIASES.items()
+}
+
 
 def _select(cfg: Any, path: str) -> Any:
     """Return the effective value at a dotted path (or ``None`` if absent)."""
     return OmegaConf.select(cfg, path)
+
+
+def _select_contract(cfg: Any, path: str) -> Any:
+    value = _select(cfg, path)
+    if value is not None:
+        return value
+    legacy_path = _CANONICAL_PATH_FALLBACKS.get(path)
+    return None if legacy_path is None else _select(cfg, legacy_path)
 
 
 def _to_plain(value: Any) -> Any:
@@ -68,7 +83,7 @@ def extract_contract_snapshot(full_cfg: DictConfig) -> dict[str, Any]:
     cfg: Any = full_cfg if OmegaConf.is_config(full_cfg) else OmegaConf.create(full_cfg)
     snapshot: dict[str, Any] = {}
     for path in SNAPSHOT_FIELDS:
-        value = _select(cfg, path)
+        value = _select_contract(cfg, path)
         if value is None:
             continue
         snapshot[path] = _to_plain(value)
@@ -162,8 +177,13 @@ def resolve_sim2sim_config(
         return target_cfg
 
     denials: list[str] = []
-    for path, source_value in snapshot.items():
-        target_value = _select(target_cfg, path)
+    canonical_snapshot: dict[str, Any] = {}
+    for raw_path, source_value in snapshot.items():
+        path = LEGACY_PATH_ALIASES.get(raw_path, raw_path)
+        canonical_snapshot[path] = source_value
+
+    for path, source_value in canonical_snapshot.items():
+        target_value = _select_contract(target_cfg, path)
         if target_value is None:
             if path in ENV_STRUCTURAL_DENYLIST:
                 denials.append(_asymmetric_line(path, source_value, source_present=True))
@@ -177,10 +197,11 @@ def resolve_sim2sim_config(
             print(f"[sim2sim] WARNING override {line}")
 
     for path in ENV_STRUCTURAL_DENYLIST:
-        if path in snapshot:
+        if path in canonical_snapshot:
             continue
-        if _select(target_cfg, path) is not None:
-            denials.append(_asymmetric_line(path, _select(target_cfg, path), source_present=False))
+        target_value = _select_contract(target_cfg, path)
+        if target_value is not None:
+            denials.append(_asymmetric_line(path, target_value, source_present=False))
 
     if denials:
         message = (

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -59,6 +59,10 @@ class _StrictBackendProfile:
             dtype=np.float32,
         )
         self.set_state_calls: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
+        self.joint_range = np.asarray(
+            [[-1.0, 1.0], [-2.0, 2.0], [-3.0, 3.0], [-4.0, 4.0], [-5.0, 5.0]],
+            dtype=np.float32,
+        )
 
     def _check(self, capability: str) -> None:
         self.calls[capability] += 1
@@ -133,6 +137,10 @@ class _StrictBackendProfile:
         self._check("joint velocity state")
         return self.dof_vel
 
+    def get_joint_range(self) -> np.ndarray:
+        self._check("joint position limits")
+        return self.joint_range
+
     def get_body_pos_w(self, ids: np.ndarray) -> np.ndarray:
         self._check("body position state")
         return self.body_pos[:, ids]
@@ -186,6 +194,8 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
     np.testing.assert_array_equal(robot.data.joint_pos, backend.dof_pos[:, [4, 2]])
     np.testing.assert_array_equal(robot.data.joint_vel, backend.dof_vel[:, [4, 2]])
     np.testing.assert_array_equal(robot.data.default_joint_vel, 0.0)
+    np.testing.assert_array_equal(robot.data.soft_joint_pos_limits, backend.joint_range[[4, 2]])
+    np.testing.assert_array_equal(robot.data.gravity_vec_w, [[0.0, 0.0, -1.0]] * 3)
     np.testing.assert_array_equal(robot.data.joint_pos_biased, backend.dof_pos[:, [4, 2]])
     np.testing.assert_array_equal(robot.data.body_link_pos_w, backend.body_pos[:, [7, 4]])
     np.testing.assert_array_equal(robot.data.root_link_pos_w, backend.body_pos[:, 4])
@@ -198,6 +208,8 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
         np.tile([1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], (3, 1)),
     )
     assert not robot.data.default_root_state.flags.writeable
+    assert not robot.data.soft_joint_pos_limits.flags.writeable
+    assert not robot.data.gravity_vec_w.flags.writeable
     np.testing.assert_array_equal(
         robot.data.actuator_ctrl_range,
         np.arange(10, dtype=np.float32).reshape(5, 2)[[4, 2]],

--- a/tests/base/test_sim_backend.py
+++ b/tests/base/test_sim_backend.py
@@ -1221,7 +1221,10 @@ class TestMotrixModelProperties:
             bkd.get_body_ids(["nonexistent_body_xyz"])
 
     def test_get_joint_range(self, bkd):
-        assert bkd.get_joint_range() is None
+        jr = bkd.get_joint_range()
+        assert jr is not None
+        assert jr.shape == (bkd.num_dof_vel, 2)
+        assert np.all(jr[:, 0] <= jr[:, 1])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/base/test_sim_backend_smoke.py
+++ b/tests/base/test_sim_backend_smoke.py
@@ -535,7 +535,9 @@ def test_motrix_model_properties_smoke():
     ctrl_range = bkd.get_actuator_ctrl_range()
     _shape(ctrl_range, bkd.num_actuators, 2)
     assert bkd.get_default_qpos().ndim == 1
-    assert bkd.get_joint_range() is None
+    joint_range = bkd.get_joint_range()
+    assert joint_range is not None
+    assert joint_range.shape == (bkd.num_dof_vel, 2)
 
 
 def test_motrix_copy_body_state_matches_split_queries():

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -135,15 +135,15 @@ def test_auto_discovery_supports_motrixsim_alias() -> None:
 
 
 def test_noise_seed_override_composes_for_target_g1_profiles() -> None:
-    # Manager-Based G1 walk owners no longer carry env.noise_config; only the
-    # legacy motion-tracking owner still composes the seed override.
+    # Manager-Based owners seed their NumPy runtime directly rather than
+    # carrying the legacy observation-noise config.
     for spec in (("sac", "g1_motion_tracking", "mujoco"),):
         cfg = bench._compose_offpolicy_cfg(
             *spec,
-            extra_overrides=["env.noise_config.seed=123"],
+            extra_overrides=["env.seed=123"],
         )
 
-        assert cfg.env.noise_config.seed == 123
+        assert cfg.env.seed == 123
 
 
 def test_stats_reports_distribution() -> None:

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,7 @@ G1_BEYONDMIMIC_ACTION_SCALE = [
     0.07450087032950714,
     0.07450087032950714,
 ]
+G1_23DOF_BEYONDMIMIC_ACTION_SCALE = G1_BEYONDMIMIC_ACTION_SCALE[:13] + [0.43857731392336724] * 10
 X2_ACTION_SCALE = [0.25] * 29
 
 
@@ -411,8 +413,42 @@ def test_ppo_g1_motion_tracking_deploy():
     assert cfg.algo.max_iterations == 15000
     assert cfg.algo.algorithm.entropy_coef == pytest.approx(0.005)
     assert cfg.env.sim_dt == pytest.approx(0.005)
-    assert cfg.env.sensor.gyro == "pelvis_gyro"
-    assert list(cfg.env.control_config.action_scale) == pytest.approx(G1_BEYONDMIMIC_ACTION_SCALE)
+    assert cfg.env.observations.actor.terms.base_ang_vel.params.sensor_name == "pelvis_gyro"
+    assert cfg.env.actions.joint_pos.scale[".*_(hip_pitch|hip_yaw)_joint"] == pytest.approx(
+        G1_BEYONDMIMIC_ACTION_SCALE[0]
+    )
+    assert cfg.env.actions.joint_pos.scale[".*_wrist_(pitch|yaw)_joint"] == pytest.approx(
+        G1_BEYONDMIMIC_ACTION_SCALE[20]
+    )
+
+
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        ("g1_motion_tracking_deploy", G1_BEYONDMIMIC_ACTION_SCALE),
+        ("g1_23dof_motion_tracking_deploy", G1_23DOF_BEYONDMIMIC_ACTION_SCALE),
+    ],
+)
+def test_ppo_g1_motion_tracking_deploy_action_scale_expands_in_joint_order(
+    task: str,
+    expected: list[float],
+) -> None:
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):
+        cfg = compose("config", overrides=[f"task={task}/mujoco"])
+
+    scales = cfg.env.actions.joint_pos.scale
+    resolved: list[float] = []
+    for joint_name in cfg.env.scene.entities.robot.joint_names:
+        matches = [
+            float(value) for pattern, value in scales.items() if re.fullmatch(pattern, joint_name)
+        ]
+        assert len(matches) == 1, f"{joint_name} matched {len(matches)} action-scale patterns"
+        resolved.append(matches[0])
+    assert resolved == pytest.approx(expected)
 
 
 def test_ppo_g1_box_tracking():

--- a/tests/envs/mdp/test_events.py
+++ b/tests/envs/mdp/test_events.py
@@ -215,6 +215,9 @@ class _Backend:
     def get_default_dof_pos(self) -> np.ndarray:
         return np.zeros(3)
 
+    def get_joint_range(self) -> np.ndarray:
+        return np.tile([-1.0, 1.0], (3, 1))
+
     def get_joint_dof_indices(self, names) -> np.ndarray:
         table = {"j0": 6, "j1": 7, "j2": 8}
         return np.asarray([table[name] for name in names], dtype=np.int32)

--- a/tests/envs/mdp/test_joint_position_action.py
+++ b/tests/envs/mdp/test_joint_position_action.py
@@ -60,6 +60,9 @@ class _Backend:
     def get_default_dof_pos(self) -> np.ndarray:
         return np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
 
+    def get_joint_range(self) -> np.ndarray:
+        return np.tile(np.asarray([[-1.0, 1.0]], dtype=np.float32), (3, 1))
+
 
 def _action(
     **overrides,

--- a/tests/envs/mdp/test_observations.py
+++ b/tests/envs/mdp/test_observations.py
@@ -73,6 +73,9 @@ class _Backend:
     def get_default_dof_pos(self) -> np.ndarray:
         return np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
 
+    def get_joint_range(self) -> np.ndarray:
+        return np.tile(np.asarray([[-1.0, 1.0]], dtype=np.float32), (3, 1))
+
     def get_body_pos_w(self, ids: np.ndarray) -> np.ndarray:
         return self.body_pos[:, ids]
 

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -70,6 +70,33 @@ def _g1_manager_override(task: str = "g1_walk_flat") -> dict[str, Any]:
     return BackendAdapter(cfg, root_dir=repo_root, algo_name="ppo").build_task_env_cfg_override()
 
 
+def _motion_manager_override(
+    task: str,
+    backend: str,
+    *,
+    config_root: str = "ppo",
+) -> tuple[str, dict[str, Any]]:
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    from unilab.training.backend_adapter import BackendAdapter
+
+    repo_root = Path(__file__).parents[2]
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(
+        config_dir=str(repo_root / "conf" / config_root), version_base="1.3"
+    ):
+        overrides = [f"task={task}/{backend}"]
+        if config_root == "offpolicy":
+            overrides.insert(0, "algo=sac")
+        cfg = compose("config", overrides=overrides)
+    return str(cfg.training.task_name), BackendAdapter(
+        cfg,
+        root_dir=repo_root,
+        algo_name="sac" if config_root == "offpolicy" else config_root,
+    ).build_task_env_cfg_override()
+
+
 # ---------------------------------------------------------------------------
 # Non-slow: config attribute completeness (no env.step(), no MuJoCo sim)
 # ---------------------------------------------------------------------------
@@ -2154,103 +2181,221 @@ def test_allegro_grasp_manager_runtime_uses_zero_increment_action(sim_backend: s
         env.close()
 
 
+_MOTION_CORE_RUNTIME_CASES = (
+    pytest.param("ppo", "g1_motion_tracking", "G1MotionTracking", 160, 286, 29, False),
+    pytest.param(
+        "ppo",
+        "g1_motion_tracking_deploy",
+        "G1MotionTrackingDeploy",
+        154,
+        286,
+        29,
+        False,
+    ),
+    pytest.param("ppo", "g1_23dof_motion_tracking", "G1MotionTracking23Dof", 130, 256, 23, False),
+    pytest.param(
+        "ppo",
+        "g1_23dof_motion_tracking_deploy",
+        "G1MotionTracking23DofDeploy",
+        124,
+        256,
+        23,
+        False,
+    ),
+    pytest.param("appo", "g1_motion_tracking", "G1MotionTracking", 160, 286, 29, False),
+    pytest.param("appo", "g1_23dof_motion_tracking", "G1MotionTracking23Dof", 130, 256, 23, False),
+    pytest.param(
+        "offpolicy",
+        "sac/g1_motion_tracking",
+        "G1MotionTrackingSAC",
+        160,
+        289,
+        29,
+        True,
+    ),
+    pytest.param(
+        "offpolicy",
+        "sac/g1_23dof_motion_tracking",
+        "G1MotionTrackingSAC23Dof",
+        130,
+        259,
+        23,
+        True,
+    ),
+)
+
+
+def test_g1_motion_core_registrations_are_manager_only() -> None:
+    from unilab.base import registry
+
+    ensure_registries()
+    metadata = registry.list_registered_envs()
+    for task_name in (
+        "G1MotionTracking",
+        "G1MotionTrackingDeploy",
+        "G1MotionTracking23Dof",
+        "G1MotionTracking23DofDeploy",
+        "G1MotionTrackingSAC",
+        "G1MotionTrackingSAC23Dof",
+    ):
+        assert metadata[task_name] == {
+            "config_factory": "ManagerBasedRlEnvCfg",
+            "available_backends": ["mujoco", "motrix"],
+        }
+
+
+def test_g1_motion_manager_ppo_wraps_only_active_rows_in_one_state_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ensure_registries()
+    _require_mujoco_runtime()
+    from unilab.base import registry
+
+    _, override = _motion_manager_override("g1_motion_tracking", "mujoco")
+    env = registry.make(
+        "G1MotionTracking",
+        num_envs=2,
+        sim_backend="mujoco",
+        env_cfg_override=override,
+    )
+    try:
+        env.init_state()
+        command = env.command_manager.get_term("motion")
+        command.time_steps[:] = command.sampler.current_clip_end_frames
+        env.reset_buf[:] = [True, False]
+
+        set_state_env_ids: list[np.ndarray] = []
+        original_set_state = env._backend.set_state
+
+        def record_set_state(
+            env_ids: np.ndarray,
+            qpos: np.ndarray,
+            qvel: np.ndarray,
+            *,
+            randomization: Any = None,
+        ) -> Any:
+            set_state_env_ids.append(env_ids.copy())
+            return original_set_state(
+                env_ids,
+                qpos,
+                qvel,
+                randomization=randomization,
+            )
+
+        monkeypatch.setattr(env._backend, "set_state", record_set_state)
+        all_ids = np.arange(env.num_envs, dtype=np.int32)
+        with env._reset_state.scoped(all_ids):
+            env.command_manager.compute(dt=0.0)
+        env.command_manager.post_compute()
+
+        assert len(set_state_env_ids) == 1
+        np.testing.assert_array_equal(set_state_env_ids[0], [1])
+        assert command.time_steps[0] == command.sampler.current_clip_end_frames[0]
+        assert command.time_steps[1] <= command.sampler.current_clip_end_frames[1]
+        expected_motion = command.motion.get_motion_at_frame(command.time_steps)
+        np.testing.assert_array_equal(command.joint_pos, expected_motion.joint_pos)
+        np.testing.assert_array_equal(
+            command._robot_body_pos_w,
+            command.robot.data.body_link_pos_w[:, command._robot_body_ids],
+        )
+        assert command._robot_cache_step == env.common_step_counter
+    finally:
+        env.close()
+
+
+def test_g1_motion_manager_sac_clip_end_is_truncation() -> None:
+    ensure_registries()
+    _require_mujoco_runtime()
+    from unilab.base import registry
+
+    _, override = _motion_manager_override(
+        "sac/g1_motion_tracking",
+        "mujoco",
+        config_root="offpolicy",
+    )
+    override["auto_reset"] = False
+    env = registry.make(
+        "G1MotionTrackingSAC",
+        num_envs=2,
+        sim_backend="mujoco",
+        env_cfg_override=override,
+    )
+    try:
+        env.init_state()
+        command = env.command_manager.get_term("motion")
+        command.time_steps[:] = command.sampler.current_clip_end_frames
+
+        state = env.step(np.zeros((2, 29), dtype=np.float32))
+
+        np.testing.assert_array_equal(state.terminated, [False, False])
+        np.testing.assert_array_equal(state.truncated, [True, True])
+        np.testing.assert_array_equal(command.time_steps, command.sampler.current_clip_end_frames)
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize(
+    ("config_root", "task", "identity", "actor_dim", "critic_dim", "action_dim", "truncate"),
+    _MOTION_CORE_RUNTIME_CASES,
+)
 @pytest.mark.parametrize("sim_backend", ["mujoco", "motrix"])
-def test_g1_motion_tracking_reset_and_step(sim_backend: str):
-    """G1MotionTracking needs a motion_file — skip if not available."""
+def test_g1_motion_core_manager_reset_and_step(
+    config_root: str,
+    task: str,
+    identity: str,
+    actor_dim: int,
+    critic_dim: int,
+    action_dim: int,
+    truncate: bool,
+    sim_backend: str,
+) -> None:
     ensure_registries()
     from unilab.base import registry
+    from unilab.envs import ManagerBasedRlEnv
 
     if sim_backend == "mujoco":
         _require_mujoco_runtime()
     else:
         pytest.importorskip("motrixsim")
 
-    # Look for any motion file in the expected location
-    motion_dir = Path(__file__).parents[2] / "src" / "unilab" / "assets" / "motions" / "g1"
-    if not motion_dir.exists():
-        pytest.skip(f"Motion data directory not found: {motion_dir}")
-
-    npz_files = list(motion_dir.glob("*.npz"))
-    if not npz_files:
-        pytest.skip(f"No .npz motion files in {motion_dir}")
-
-    # Filter out 23-DoF motion files — G1MotionTracking uses 29-DoF config
-    non_23dof = [f for f in npz_files if "_23dof" not in f.name]
-    if not non_23dof:
-        pytest.skip("No non-23-DoF motion files available for 29-DoF config")
-    motion_file = str(non_23dof[0])
-    env = cast(
-        Any,
-        registry.make(
-            "G1MotionTracking",
-            num_envs=2,
-            sim_backend=sim_backend,
-            env_cfg_override={"motion_file": motion_file},
-        ),
+    task_name, override = _motion_manager_override(
+        task,
+        sim_backend,
+        config_root=config_root,
     )
+    assert task_name == identity
+    env = registry.make(
+        identity,
+        num_envs=2,
+        sim_backend=sim_backend,
+        env_cfg_override=override,
+    )
+    assert isinstance(env, ManagerBasedRlEnv)
     try:
-        spec = env.obs_groups_spec
-        assert isinstance(spec, dict)
-        assert "obs" in spec
-        assert "critic" in spec
-        obs_shape = env.observation_space.shape
-        assert obs_shape is not None
-        assert sum(spec.values()) == obs_shape[0]
+        assert env.obs_groups_spec == {"obs": actor_dim, "critic": critic_dim}
+        assert env.action_space.shape == (action_dim,)
+        command = env.command_manager.get_term("motion")
+        assert command.cfg.params.truncate_on_clip_end is truncate
+        if sim_backend == "motrix" and "deploy" in task:
+            assert env._cfg.events["foot_friction"] is None
+            assert env._cfg.events["push_robot"] is None
+        if sim_backend == "motrix" and config_root in {"ppo", "appo"}:
+            root_pos = env._cfg.rewards["motion_global_root_pos"]
+            action_rate = env._cfg.rewards["action_rate_l2"]
+            assert root_pos is not None
+            assert action_rate is not None
+            expected_weights = (1.0, -0.05) if config_root == "ppo" else (0.5, -0.1)
+            assert (root_pos.weight, action_rate.weight) == pytest.approx(expected_weights)
 
         state = env.init_state()
-        assert isinstance(state.obs, dict)
-        for key, dim in spec.items():
-            assert state.obs[key].shape == (2, dim)
+        assert state.obs["obs"].shape == (2, actor_dim)
+        assert state.obs["critic"].shape == (2, critic_dim)
 
-        action_shape = env.action_space.shape
-        assert action_shape is not None
-        actions = np.zeros((2, action_shape[0]))
-        state = env.step(actions)
-        assert isinstance(state.obs, dict)
+        state = env.step(np.zeros((2, action_dim), dtype=np.float32))
         assert state.reward.shape == (2,)
         assert state.terminated.shape == (2,)
         assert state.truncated.shape == (2,)
-    finally:
-        env.close()
-
-
-def test_g1_motion_tracking_deploy_reset_and_step_mujoco():
-    """Deploy env keeps motion-tracking behavior but exposes unitree mimic actor inputs."""
-    ensure_registries()
-    _require_mujoco_runtime()
-    from unilab.base import registry
-
-    motion_dir = Path(__file__).parents[2] / "src" / "unilab" / "assets" / "motions" / "g1"
-    if not motion_dir.exists():
-        pytest.skip(f"Motion data directory not found: {motion_dir}")
-
-    npz_files = list(motion_dir.glob("*.npz"))
-    if not npz_files:
-        pytest.skip(f"No .npz motion files in {motion_dir}")
-
-    # Filter out 23-DoF motion files — G1MotionTrackingDeploy uses 29-DoF config
-    non_23dof = [f for f in npz_files if "_23dof" not in f.name]
-    if not non_23dof:
-        pytest.skip("No non-23-DoF motion files available for 29-DoF deploy config")
-    env = cast(
-        Any,
-        registry.make(
-            "G1MotionTrackingDeploy",
-            num_envs=2,
-            sim_backend="mujoco",
-            env_cfg_override={"motion_file": str(non_23dof[0])},
-        ),
-    )
-    try:
-        assert env.obs_groups_spec == {"obs": 154, "critic": 286}
-        state = env.init_state()
-        assert state.obs["obs"].shape == (2, 154)
-        assert state.obs["critic"].shape == (2, 286)
-
-        action_shape = env.action_space.shape
-        assert action_shape is not None
-        state = env.step(np.zeros((2, action_shape[0])))
-        assert state.obs["obs"].shape == (2, 154)
-        assert state.obs["critic"].shape == (2, 286)
+        assert np.isfinite(state.reward).all()
+        assert all(np.isfinite(values).all() for values in state.obs.values())
     finally:
         env.close()

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -140,6 +140,9 @@ class _ResetBackend(_FakeBackend):
     def get_dof_vel(self) -> np.ndarray:
         return np.zeros((self.num_envs, 1), dtype=np.float32)
 
+    def get_joint_range(self) -> np.ndarray:
+        return np.array([[-1.0, 1.0]], dtype=np.float32)
+
     def set_state(
         self,
         env_ids: np.ndarray,
@@ -232,6 +235,22 @@ class _Command(CommandTerm):
     def _update_command(self, env_ids: np.ndarray | None) -> None:
         ids = None if env_ids is None else env_ids.copy()
         self._env.command_update_ids.append(ids)
+
+
+@dataclass(kw_only=True)
+class _StateWritingCommandCfg(CommandTermCfg):
+    def build(self, env) -> CommandTerm:
+        return _StateWritingCommand(self, env)
+
+
+class _StateWritingCommand(_Command):
+    def _resample_command(self, env_ids: np.ndarray) -> None:
+        self._command[env_ids, 0] = 0.75
+        self._env.scene["robot"].write_joint_state_to_sim(
+            np.full((len(env_ids), 1), 0.75, dtype=np.float32),
+            np.full((len(env_ids), 1), -0.75, dtype=np.float32),
+            env_ids=env_ids,
+        )
 
 
 class _Recorder(RecorderTerm):
@@ -995,6 +1014,32 @@ def test_reset_events_compose_then_commit_default_state_once() -> None:
     assert backend.default_qpos_calls == 1
     assert backend.init_qvel_calls == 1
     assert backend.joint_layout_calls == 2
+
+
+def test_reset_event_and_command_state_writes_share_one_commit() -> None:
+    cfg = _make_cfg(include_optional_managers=False)
+    cfg.events = {
+        "default_first": EventTermCfg(func=mdp.reset_scene_to_default, mode="reset"),
+        "joint_state": EventTermCfg(func=_write_reset_joint_state, mode="reset"),
+    }
+    cfg.commands = {"state_writer": _StateWritingCommandCfg(resampling_time_range=(1.0, 1.0))}
+    cfg.scene.entities["robot"] = EntityCfg(
+        joint_names=("joint",),
+        actuator_names=("motor",),
+    )
+    backend = _ResetBackend(2)
+    env = _TestEnv(cfg, cast(SimBackend, backend), 2)
+
+    env.reset()
+
+    assert len(backend.set_state_calls) == 1
+    ids, qpos, qvel = backend.set_state_calls[0]
+    np.testing.assert_array_equal(ids, [0, 1])
+    np.testing.assert_array_equal(
+        qpos,
+        [[0.0, 0.0, 0.5, 0.75], [0.0, 0.0, 0.5, 0.75]],
+    )
+    np.testing.assert_array_equal(qvel, [[0.0, 0.0, -0.75], [0.0, 0.0, -0.75]])
 
 
 def test_pure_reset_event_does_not_request_backend_state_capability() -> None:

--- a/tests/envs/test_motion_loader.py
+++ b/tests/envs/test_motion_loader.py
@@ -184,6 +184,30 @@ def test_motion_sampler_step_respects_current_clip_end(tmp_path):
     np.testing.assert_array_equal(sampler.current_frames, np.array([2, 4], dtype=np.int32))
 
 
+def test_motion_sampler_uses_env_owned_rng_and_steps_only_selected_rows(tmp_path):
+    motion = tmp_path / "motion.npz"
+    _write_motion_npz(motion, base_value=0.0, num_frames=8)
+    loader = MotionLoader(str(motion))
+    env_ids = np.array([0, 2], dtype=np.int32)
+    sampler = MotionSampler(
+        loader,
+        mode="uniform",
+        num_envs=3,
+        rng=np.random.default_rng(17),
+    )
+    expected_rng = np.random.default_rng(17)
+
+    frames = sampler.sample_frames(env_ids)
+
+    np.testing.assert_array_equal(frames, expected_rng.integers(0, 8, 2, dtype=np.int32))
+    untouched = int(sampler.current_frames[1])
+    sampler.current_clip_end_frames[:] = 7
+    done = sampler.step(np.array([2], dtype=np.int32))
+    assert done.size == 0
+    assert sampler.current_frames[1] == untouched
+    assert sampler.current_frames[2] == frames[1] + 1
+
+
 def test_box_motion_loader_reads_object_state_and_trims_robot_joints(tmp_path):
     from unilab.tasks.motion_tracking.g1.motion_box_loader import BoxMotionLoader
 

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1275,12 +1275,12 @@ def test_g1_motion_tracking_ppo_motrix_prefers_backend_specific_reward(
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix"])
 
-    assert cfg.reward.scales.motion_body_pos == pytest.approx(1.0)
-    cfg.reward.scales.motion_body_pos = 1.25
+    assert cfg.reward.motion_body_pos.weight == pytest.approx(1.0)
+    cfg.reward.motion_body_pos.weight = 1.25
 
     env_cfg_override = mod.build_ppo_env_cfg_override(cfg)
 
-    assert env_cfg_override["reward_config"]["scales"]["motion_body_pos"] == pytest.approx(1.25)
+    assert env_cfg_override["rewards"]["motion_body_pos"]["weight"] == pytest.approx(1.25)
 
 
 def test_build_ppo_play_env_cfg_override_applies_g1_motion_tracking_play_profile(
@@ -1293,15 +1293,16 @@ def test_build_ppo_play_env_cfg_override_applies_g1_motion_tracking_play_profile
     monkeypatch.setattr(
         mod,
         "materialize_scene_visual_override",
-        lambda source_model_file, **kwargs: "/tmp/g1_motion_tracking_play_scene.xml",
+        lambda *_args, **_kwargs: pytest.fail("manager scene must not be replaced"),
     )
 
     env_cfg_override = mod.build_ppo_play_env_cfg_override(cfg)
 
     assert cfg.training.play_env_num == 16
     assert env_cfg_override["render_spacing"] == pytest.approx(2.5)
-    assert env_cfg_override["scene"].model_file == "/tmp/g1_motion_tracking_play_scene.xml"
-    assert env_cfg_override["reward_config"]["scales"]["motion_body_pos"] == pytest.approx(1.0)
+    assert env_cfg_override["scene"]["model_file"].endswith("robots/g1/scene_flat.xml")
+    assert "robot" in env_cfg_override["scene"]["entities"]
+    assert env_cfg_override["rewards"]["motion_body_pos"]["weight"] == pytest.approx(1.0)
 
 
 def test_build_ppo_play_env_cfg_override_respects_cli_play_env_override(
@@ -1328,27 +1329,21 @@ def test_build_ppo_play_env_cfg_override_respects_cli_play_env_override(
     assert env_cfg_override["render_spacing"] == pytest.approx(2.5)
 
 
-def test_build_ppo_play_env_cfg_override_resolves_relative_ground_texture(
+def test_build_ppo_play_env_cfg_override_keeps_task_owned_manager_scene(
     monkeypatch: pytest.MonkeyPatch,
 ):
     mod = _train_rsl_rl(monkeypatch)
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix", "training.play_only=true"])
-    cfg.play_profile.scene.ground_texture_file = "src/unilab/assets/robots/g1/textures/floor.png"
-
-    captured = {}
-
-    def _fake_materialize(source_model_file, **kwargs):
-        captured["source_model_file"] = source_model_file
-        captured.update(kwargs)
-        return "/tmp/g1_motion_tracking_play_scene.xml"
-
-    monkeypatch.setattr(mod, "materialize_scene_visual_override", _fake_materialize)
-
-    mod.build_ppo_play_env_cfg_override(cfg)
-
-    assert captured["ground_texture_file"] == str(
-        mod.ROOT_DIR / "src/unilab/assets/robots/g1/textures/floor.png"
+    monkeypatch.setattr(
+        mod,
+        "materialize_scene_visual_override",
+        lambda *_args, **_kwargs: pytest.fail("manager scene must not be replaced"),
     )
+
+    env_cfg_override = mod.build_ppo_play_env_cfg_override(cfg)
+
+    assert env_cfg_override["scene"]["entities"]["robot"]["root_body_name"] == "pelvis"
+    assert env_cfg_override["scene"]["entities"]["robot"]["joint_names"]
 
 
 def test_go2_arm_manip_loco_motrix_eval_uses_visual_floor(
@@ -1472,28 +1467,28 @@ def test_run_motrix_rsl_play_loop_uses_render_spacing_and_offset_mode(
 
 
 def test_g1_motion_tracking_appo_reward_extraction_prefers_backend_specific_reward():
-    from unilab.training.reward import extract_reward_config
+    from unilab.training import BackendAdapter
 
     cfg = _appo_cfg(["task=g1_motion_tracking/motrix"])
 
-    assert cfg.reward.scales.motion_body_pos == pytest.approx(1.0)
-    cfg.reward.scales.motion_body_pos = 1.5
+    assert cfg.reward.motion_body_pos.weight == pytest.approx(1.0)
+    cfg.reward.motion_body_pos.weight = 1.5
 
-    env_cfg_override = extract_reward_config(cfg)
+    env_cfg_override = BackendAdapter(cfg, root_dir=_SRC_DIR.parent).build_task_env_cfg_override()
 
-    assert env_cfg_override["reward_config"]["scales"]["motion_body_pos"] == pytest.approx(1.5)
+    assert env_cfg_override["rewards"]["motion_body_pos"]["weight"] == pytest.approx(1.5)
 
 
 def test_g1_motion_tracking_ppo_task_exposes_final_reward():
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix"])
 
-    assert cfg.reward.scales.motion_body_pos == pytest.approx(1.0)
+    assert cfg.reward.motion_body_pos.weight == pytest.approx(1.0)
 
 
 def test_g1_motion_tracking_appo_task_exposes_final_reward():
     cfg = _appo_cfg(["task=g1_motion_tracking/motrix"])
 
-    assert cfg.reward.scales.motion_body_pos == pytest.approx(1.0)
+    assert cfg.reward.motion_body_pos.weight == pytest.approx(1.0)
 
 
 def test_sharpa_appo_motrix_owner_uses_backend_specific_overrides():
@@ -1519,7 +1514,7 @@ def test_build_appo_runner_kwargs_forwards_sim_backend():
 
     runner_kwargs = mod.build_appo_runner_kwargs(
         cfg,
-        env_cfg_override={"reward_config": {"scales": {}}},
+        env_cfg_override={"rewards": {}},
         collector_device="cpu",
     )
 
@@ -1530,7 +1525,7 @@ def test_build_appo_runner_kwargs_forwards_sim_backend():
     assert runner_kwargs["steps_per_env"] == cfg.algo.steps_per_env
     assert "num_workers" not in runner_kwargs
     assert "num_collectors" not in runner_kwargs
-    assert runner_kwargs["env_cfg_overrides"]["reward_config"]["scales"] == {}
+    assert runner_kwargs["env_cfg_overrides"]["rewards"] == {}
 
 
 def test_run_motrix_play_loop_runs_without_physics_state():

--- a/tests/tasks/test_migration_matrix.py
+++ b/tests/tasks/test_migration_matrix.py
@@ -18,7 +18,7 @@ def test_registered_tasks_have_explicit_migration_records() -> None:
     assert PRODUCTION_TASK_NAMES <= registered.keys()
     assert {record.task_name for record in records} == set(PRODUCTION_TASK_NAMES)
     assert len(records) == 39
-    assert sum(record.status == "Compatible" for record in records) == 15
+    assert sum(record.status == "Compatible" for record in records) == 21
     assert sum(record.target == "compatibility" for record in records) == 3
 
 
@@ -27,7 +27,7 @@ def test_registered_tasks_have_explicit_migration_records() -> None:
     [
         ("Go2ArmManipLoco", "go2_arm", "compatibility", "Adapted"),
         ("SharpaInhandRotation", "sharpa", "compatibility", "Adapted"),
-        ("G1MotionTracking", "motion_tracking", "mba", "Adapted"),
+        ("G1MotionTracking", "motion_tracking", "complete", "Compatible"),
         ("G1WalkRough", "g1_locomotion", "complete", "Compatible"),
         ("Go2JoystickRough", "quadruped_rough", "complete", "Compatible"),
     ],

--- a/tests/training/test_sim2sim_resolver.py
+++ b/tests/training/test_sim2sim_resolver.py
@@ -115,7 +115,7 @@ def test_extract_snapshot_includes_only_present_contract_fields():
     assert "training.sim_backend" not in snapshot
     # ...and absent fields are omitted (never stored as None).
     assert "algo.obs_normalization" not in snapshot
-    assert "env.sampling_mode" not in snapshot
+    assert "env.commands.motion.params.sampling_mode" not in snapshot
     assert "reward.base_height_target" not in snapshot
 
 
@@ -272,7 +272,7 @@ def test_env_structural_denylist_is_the_env_subset():
         "env.actions",
         "env.policy_observation_group",
         "env.critic_observation_group",
-        "env.sampling_mode",
+        "env.commands.motion.params.sampling_mode",
     ]
     assert set(ENV_STRUCTURAL_DENYLIST) <= set(DENYLIST)
 
@@ -294,13 +294,33 @@ def test_env_field_present_in_target_absent_in_source_raises(tmp_path):
     # the target sets it explicitly. Still unverifiable -> fail closed.
     _write_sidecar(tmp_path, {"algo.empirical_normalization": False})
     target = OmegaConf.create(
-        {"algo": {"empirical_normalization": False}, "env": {"sampling_mode": "adaptive"}}
+        {
+            "algo": {"empirical_normalization": False},
+            "env": {"commands": {"motion": {"params": {"sampling_mode": "adaptive"}}}},
+        }
     )
     with pytest.raises(CrossBackendIncompatibleError) as excinfo:
         resolve_sim2sim_config(tmp_path, target)
     msg = str(excinfo.value)
     assert "sampling_mode" in msg
     assert "source=<absent>" in msg
+
+
+def test_legacy_sampling_mode_snapshot_resolves_against_manager_path(tmp_path) -> None:
+    _write_sidecar(tmp_path, {"env.sampling_mode": "adaptive"})
+    target = OmegaConf.create(
+        {"env": {"commands": {"motion": {"params": {"sampling_mode": "adaptive"}}}}}
+    )
+
+    assert resolve_sim2sim_config(tmp_path, target) is target
+
+
+def test_legacy_config_sampling_mode_is_snapshotted_under_canonical_path() -> None:
+    cfg = OmegaConf.create({"env": {"sampling_mode": "adaptive"}})
+
+    assert extract_contract_snapshot(cfg) == {
+        "env.commands.motion.params.sampling_mode": "adaptive"
+    }
 
 
 def test_env_field_symmetric_absence_does_not_raise(tmp_path):

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -388,7 +388,7 @@ def test_backend_adapter_env_cfg_override_for_motrix_sac_g1_walk_flat():
     assert cfg.algo.max_iterations == 5000
 
 
-def test_backend_adapter_builds_play_scene_override():
+def test_backend_adapter_keeps_motion_manager_scene_during_play():
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix", "training.play_only=true"])
     assert cfg.training.play_env_num == 16
     captured: dict[str, object] = {}
@@ -396,7 +396,7 @@ def test_backend_adapter_builds_play_scene_override():
     def _fake_materializer(source_model_file: str, **kwargs) -> str:
         captured["source_model_file"] = source_model_file
         captured.update(kwargs)
-        return "/tmp/g1_motion_tracking_play_scene.xml"
+        pytest.fail("manager scene must not be replaced during play")
 
     env_cfg_override = BackendAdapter(
         cfg,
@@ -407,10 +407,9 @@ def test_backend_adapter_builds_play_scene_override():
 
     assert cfg.training.play_env_num == 16
     assert env_cfg_override["render_spacing"] == pytest.approx(2.5)
-    assert env_cfg_override["scene"].model_file == "/tmp/g1_motion_tracking_play_scene.xml"
-    assert captured["ground_texture_file"] == str(
-        _ROOT_DIR / "src/unilab/assets/robots/g1/textures/floor.png"
-    )
+    assert env_cfg_override["scene"]["model_file"].endswith("robots/g1/scene_flat.xml")
+    assert "robot" in env_cfg_override["scene"]["entities"]
+    assert captured == {}
 
 
 def test_render_play_mode_uses_env_interactive_contract():


### PR DESCRIPTION
Parent: #1042

Closes #1227

## Summary

- migrate the six G1 motion-tracking core identities to Hydra-owned Registry → `ManagerBasedRlEnv` construction
- add NumPy motion command, action, observation, reward, and termination terms while preserving PPO/APPO/SAC policy contracts
- keep motion assets/selectors on cold paths, expose required data through the public Entity/backend seam, and fail closed on unsupported capabilities
- move the motion benchmark owner to the Manager-Based runtime with the 4096-env default

## Validation

- `make test-all`
  - Ruff, mypy, and Pyright passed
  - 2070 passed, 28 skipped, 272 deselected, 1 xfailed
  - benchmark smoke passed in module and script modes (one platform-optional MLX entry skipped in each mode)
- focused manager/backend/config suite: 474 passed, 4 skipped, 223 deselected

Per #1042 workflow, child remote CI is intentionally not used; merge is gated by the completed local CI above.