### PR TITLE
refactor: converge scripts/motion parallel implementations into library layer

### DIFF
--- a/scripts/benchmark/mjwarp/backend.py
+++ b/scripts/benchmark/mjwarp/backend.py
@@ -200,7 +200,7 @@ class MjwarpBackend(SimBackend):
             )
             self._mj_model, self.terrain_origins, self.terrain_surface_sampler = result
         elif scene.fragment_files:
-            from unilab.base.backend.mujoco.xml import materialize_scene_fragments
+            from unilab.base.backend import materialize_scene_fragments
 
             xml_path = materialize_scene_fragments(
                 scene.model_file, fragment_files=scene.fragment_files

--- a/scripts/deploy/sim_prototype.py
+++ b/scripts/deploy/sim_prototype.py
@@ -26,6 +26,14 @@ Differences from training-side eval (deliberate):
   - No noise injected on obs (matches deploy convention).
   - Robot anchor pos in world is locked to the first motion frame's torso pos
     (since real robot has no GPS/SLAM).
+
+Contract anchors (the numpy rewrite above is intentional — keep it standalone):
+  - Training-side obs contract owner: conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml
+    (per-term obs layout + history as assembled by the training ObservationManager).
+  - Alignment test: tests/scripts/test_obs_alignment_g1_wbt.py checks this
+    file's ObsAssembler against training-side and deploy-side (C++) semantics
+    bit-for-bit. If the training obs terms change, that test must keep passing
+    WITHOUT this file importing env classes.
 """
 
 from __future__ import annotations

--- a/scripts/motion/bones_seed_csv_to_npz.py
+++ b/scripts/motion/bones_seed_csv_to_npz.py
@@ -21,21 +21,21 @@ The exported NPZ format contains:
 - ``body_lin_vel_w``
 - ``body_ang_vel_w``
 
+Interpolation and velocity estimation reuse the library implementation in
+``unilab.tasks.motion_tracking.common.motion_loader``; forward kinematics reuse
+``unilab.base.backend.compute_tracking_fk``.
+
 Usage:
     uv run scripts/motion/bones_seed_csv_to_npz.py
     uv run scripts/motion/bones_seed_csv_to_npz.py --dry-run
     uv run scripts/motion/bones_seed_csv_to_npz.py --input path/to/flip_090_001__A304.csv
 """
 
-# pyright: reportAttributeAccessIssue=false
-
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 from pathlib import Path
 
-import mujoco
 import numpy as np
 from scripts.motion.bones_seed_csv import (
     ROOT_COLUMNS,
@@ -44,32 +44,14 @@ from scripts.motion.bones_seed_csv import (
     parse_joint_names,
     resolve_input_files,
 )
-from tqdm import tqdm
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
-from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
+from unilab.base.backend import compute_tracking_fk
+from unilab.tasks.motion_tracking.common.motion_loader import interpolate_motion
+from unilab.utils.rotation import np_quat_ensure_continuity
 
 DEFAULT_INPUT = "src/unilab/assets/motions/g1/flip"
 DEFAULT_OUTPUT_DIR = "src/unilab/assets/motions/g1/flip_npz"
-
-
-def quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
-    """Spherical linear interpolation between two quaternions (wxyz format)."""
-    dot = np.dot(q1, q2)
-    if dot < 0:
-        q2 = -q2
-        dot = -dot
-
-    if dot > 0.9995:
-        result = q1 + t * (q2 - q1)
-        return result / np.linalg.norm(result)
-
-    theta = np.arccos(np.clip(dot, -1, 1))
-    sin_theta = np.sin(theta)
-    w1 = np.sin((1 - t) * theta) / sin_theta
-    w2 = np.sin(t * theta) / sin_theta
-    return w1 * q1 + w2 * q2
 
 
 def default_model_path() -> str:
@@ -102,182 +84,34 @@ def resolve_output_targets(
     return [output_root / f"{csv_file.stem}.npz" for csv_file in csv_files]
 
 
-@dataclass
-class MotionLoader:
-    motion_file: Path
-    input_fps: int
-    output_fps: int
-    position_scale: float
-    euler_order: str
+def load_csv_motion(
+    motion_file: Path,
+    *,
+    position_scale: float,
+    euler_order: str,
+) -> tuple[list[str], np.ndarray, np.ndarray, np.ndarray]:
+    """Load a BONES-SEED CSV into (joint_names, base/dof trajectory arrays)."""
+    header = load_header(motion_file)
+    joint_names = parse_joint_names(header, motion_file)
 
-    def __post_init__(self) -> None:
-        self.input_dt = 1.0 / self.input_fps
-        self.output_dt = 1.0 / self.output_fps
-        self._load_motion()
-        self._interpolate_motion()
-        self._compute_velocities()
+    motion = np.loadtxt(motion_file, delimiter=",", dtype=np.float32, skiprows=1)
+    motion = np.atleast_2d(motion)
+    if motion.shape[1] != len(header):
+        raise ValueError(f"{motion_file} has {motion.shape[1]} columns, expected {len(header)}")
 
-    def _load_motion(self) -> None:
-        header = load_header(self.motion_file)
-        self.joint_names = parse_joint_names(header, self.motion_file)
-
-        motion = np.loadtxt(self.motion_file, delimiter=",", dtype=np.float32, skiprows=1)
-        motion = np.atleast_2d(motion)
-        if motion.shape[1] != len(header):
+    frames = motion[:, 0].astype(np.int32)
+    if frames.shape[0] > 1:
+        frame_diffs = np.diff(frames)
+        if not np.all(frame_diffs == 1):
             raise ValueError(
-                f"{self.motion_file} has {motion.shape[1]} columns, expected {len(header)}"
+                f"{motion_file} has non-contiguous Frame values: {np.unique(frame_diffs)}"
             )
 
-        self.frames = motion[:, 0].astype(np.int32)
-        if self.frames.shape[0] > 1:
-            frame_diffs = np.diff(self.frames)
-            if not np.all(frame_diffs == 1):
-                raise ValueError(
-                    f"{self.motion_file} has non-contiguous Frame values: {np.unique(frame_diffs)}"
-                )
-
-        self.motion_base_poss_input = motion[:, 1:4] * self.position_scale
-        self.motion_base_rots_input = euler_deg_to_quat_wxyz(motion[:, 4:7], self.euler_order)
-        self.motion_base_rots_input = np_quat_ensure_continuity(self.motion_base_rots_input)
-        self.motion_dof_poss_input = np.deg2rad(motion[:, len(ROOT_COLUMNS) :])
-
-        self.input_frames = motion.shape[0]
-        self.duration = (self.input_frames - 1) * self.input_dt
-
-    def _interpolate_motion(self) -> None:
-        times = np.arange(0, self.duration, self.output_dt, dtype=np.float32)
-        self.output_frames = times.shape[0]
-        index_0, index_1, blend = self._compute_frame_blend(times)
-
-        self.motion_base_poss = (
-            self.motion_base_poss_input[index_0] * (1 - blend[:, None])
-            + self.motion_base_poss_input[index_1] * blend[:, None]
-        )
-
-        self.motion_base_rots = np.zeros((self.output_frames, 4), dtype=np.float32)
-        for i in range(self.output_frames):
-            self.motion_base_rots[i] = quat_slerp(
-                self.motion_base_rots_input[index_0[i]],
-                self.motion_base_rots_input[index_1[i]],
-                blend[i],
-            )
-        self.motion_base_rots = np_quat_ensure_continuity(self.motion_base_rots)
-
-        self.motion_dof_poss = (
-            self.motion_dof_poss_input[index_0] * (1 - blend[:, None])
-            + self.motion_dof_poss_input[index_1] * blend[:, None]
-        )
-
-    def _compute_frame_blend(self, times: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        phase = times / self.duration
-        index_0 = np.floor(phase * (self.input_frames - 1)).astype(np.int32)
-        index_1 = np.minimum(index_0 + 1, self.input_frames - 1)
-        blend = phase * (self.input_frames - 1) - index_0
-        return index_0, index_1, blend
-
-    def _compute_velocities(self) -> None:
-        self.motion_base_lin_vels = np.gradient(self.motion_base_poss, self.output_dt, axis=0)
-        self.motion_dof_vels = np.gradient(self.motion_dof_poss, self.output_dt, axis=0)
-        self.motion_base_ang_vels = np_quat_angular_velocity(self.motion_base_rots, self.output_dt)
-
-
-def run_simulation(
-    motion_loader: MotionLoader,
-    model_file: str,
-    output_file: Path,
-) -> None:
-    tmp_model_path, _, _ = inject_mujoco_tracking_sensors(model_file)
-    try:
-        model = mujoco.MjModel.from_xml_path(tmp_model_path)
-    finally:
-        Path(tmp_model_path).unlink(missing_ok=True)
-    data = mujoco.MjData(model)
-
-    joint_indices = []
-    for name in motion_loader.joint_names:
-        jnt_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
-        if jnt_id < 0:
-            raise ValueError(f"Joint '{name}' not found in model")
-        joint_indices.append(jnt_id)
-
-    num_frames = motion_loader.output_frames
-    num_joints = len(joint_indices)
-    num_bodies = model.nbody
-
-    joint_pos = np.zeros((num_frames, num_joints), dtype=np.float32)
-    joint_vel = np.zeros((num_frames, num_joints), dtype=np.float32)
-    body_pos_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-    body_quat_w = np.zeros((num_frames, num_bodies, 4), dtype=np.float32)
-    body_lin_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-    body_ang_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-
-    sensor_adrs = np.full((num_bodies, 4), -1, dtype=np.int32)
-    sensor_dims = np.array([3, 4, 3, 3], dtype=np.int32)
-    sensor_prefixes = (
-        "track_pos_w_",
-        "track_quat_w_",
-        "track_linvel_w_",
-        "track_angvel_w_",
-    )
-    for body_id in range(num_bodies):
-        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
-        if not body_name:
-            continue
-        for k, prefix in enumerate(sensor_prefixes):
-            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, f"{prefix}{body_name}")
-            if sensor_id >= 0:
-                sensor_adrs[body_id, k] = model.sensor_adr[sensor_id]
-
-    for i in tqdm(range(num_frames), desc=output_file.stem, leave=False):
-        data.qpos[0:3] = motion_loader.motion_base_poss[i]
-        data.qpos[3:7] = motion_loader.motion_base_rots[i]
-        data.qvel[0:3] = motion_loader.motion_base_lin_vels[i]
-        data.qvel[3:6] = motion_loader.motion_base_ang_vels[i]
-
-        for j, jnt_id in enumerate(joint_indices):
-            qpos_adr = model.jnt_qposadr[jnt_id]
-            qvel_adr = model.jnt_dofadr[jnt_id]
-            data.qpos[qpos_adr] = motion_loader.motion_dof_poss[i, j]
-            data.qvel[qvel_adr] = motion_loader.motion_dof_vels[i, j]
-
-        mujoco.mj_forward(model, data)
-
-        for j, jnt_id in enumerate(joint_indices):
-            qpos_adr = model.jnt_qposadr[jnt_id]
-            qvel_adr = model.jnt_dofadr[jnt_id]
-            joint_pos[i, j] = data.qpos[qpos_adr]
-            joint_vel[i, j] = data.qvel[qvel_adr]
-
-        for body_id in range(num_bodies):
-            pos_adr, quat_adr, lin_adr, ang_adr = sensor_adrs[body_id]
-
-            if pos_adr >= 0:
-                body_pos_w[i, body_id] = data.sensordata[pos_adr : pos_adr + sensor_dims[0]]
-            else:
-                body_pos_w[i, body_id] = data.xpos[body_id]
-
-            if quat_adr >= 0:
-                body_quat_w[i, body_id] = data.sensordata[quat_adr : quat_adr + sensor_dims[1]]
-            else:
-                body_quat_w[i, body_id] = data.xquat[body_id]
-
-            if lin_adr >= 0:
-                body_lin_vel_w[i, body_id] = data.sensordata[lin_adr : lin_adr + sensor_dims[2]]
-
-            if ang_adr >= 0:
-                body_ang_vel_w[i, body_id] = data.sensordata[ang_adr : ang_adr + sensor_dims[3]]
-
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-    np.savez(
-        output_file,
-        fps=np.array([motion_loader.output_fps], dtype=np.int32),
-        joint_pos=joint_pos,
-        joint_vel=joint_vel,
-        body_pos_w=body_pos_w,
-        body_quat_w=body_quat_w,
-        body_lin_vel_w=body_lin_vel_w,
-        body_ang_vel_w=body_ang_vel_w,
-    )
+    motion_base_poss_input = motion[:, 1:4] * position_scale
+    motion_base_rots_input = euler_deg_to_quat_wxyz(motion[:, 4:7], euler_order)
+    motion_base_rots_input = np_quat_ensure_continuity(motion_base_rots_input)
+    motion_dof_poss_input = np.deg2rad(motion[:, len(ROOT_COLUMNS) :])
+    return joint_names, motion_base_poss_input, motion_base_rots_input, motion_dof_poss_input
 
 
 def print_plan(
@@ -331,16 +165,40 @@ def convert(args: argparse.Namespace) -> None:
         run_dry_run(csv_files, output_files)
         return
 
+    input_fps = int(args.input_fps)
+    output_fps = int(args.output_fps)
     for csv_file, output_file in zip(csv_files, output_files, strict=True):
         print(f"[bones_seed_csv_to_npz] Converting {csv_file} -> {output_file}")
-        motion_loader = MotionLoader(
-            motion_file=csv_file,
-            input_fps=int(args.input_fps),
-            output_fps=int(args.output_fps),
+        joint_names, base_poss_input, base_rots_input, dof_poss_input = load_csv_motion(
+            csv_file,
             position_scale=args.position_scale,
             euler_order=args.euler_order,
         )
-        run_simulation(motion_loader, model_file, output_file)
+        motion = interpolate_motion(
+            base_poss_input,
+            base_rots_input,
+            dof_poss_input,
+            input_fps=input_fps,
+            output_fps=output_fps,
+        )
+        arrays = compute_tracking_fk(
+            model_file,
+            joint_names=joint_names,
+            base_poss=motion.base_poss,
+            base_rots=motion.base_rots,
+            base_lin_vels=motion.base_lin_vels,
+            base_ang_vels=motion.base_ang_vels,
+            dof_poss=motion.dof_poss,
+            dof_vels=motion.dof_vels,
+            progress=True,
+            progress_desc=output_file.stem,
+        )
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(
+            output_file,
+            fps=np.array([output_fps], dtype=np.int32),
+            **arrays,
+        )
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/motion/csv_to_npz.py
+++ b/scripts/motion/csv_to_npz.py
@@ -17,252 +17,44 @@ Output NPZ format:
 - body_quat_w: Body quaternions in world frame (N_frames × N_bodies × 4, wxyz)
 - body_lin_vel_w: Body linear velocities (N_frames × N_bodies × 3)
 - body_ang_vel_w: Body angular velocities (N_frames × N_bodies × 3)
-"""
 
-# pyright: reportAttributeAccessIssue=false
+Interpolation and velocity estimation reuse the library implementation in
+``unilab.tasks.motion_tracking.common.motion_loader``; forward kinematics reuse
+``unilab.base.backend.compute_tracking_fk``.
+"""
 
 import argparse
 from pathlib import Path
 
-import mujoco
 import numpy as np
-from tqdm import tqdm
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
-from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
+from unilab.base.backend import compute_tracking_fk
+from unilab.tasks.motion_tracking.common.motion_loader import interpolate_motion
+from unilab.utils.rotation import np_quat_ensure_continuity
 
 
-def quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
-    """Spherical linear interpolation between two quaternions (wxyz format)."""
-    # Ensure shortest path
-    dot = np.dot(q1, q2)
-    if dot < 0:
-        q2 = -q2
-        dot = -dot
-
-    # If quaternions are very close, use linear interpolation
-    if dot > 0.9995:
-        result = q1 + t * (q2 - q1)
-        return result / np.linalg.norm(result)
-
-    # Compute angle
-    theta = np.arccos(np.clip(dot, -1, 1))
-    sin_theta = np.sin(theta)
-
-    # Compute interpolation weights
-    w1 = np.sin((1 - t) * theta) / sin_theta
-    w2 = np.sin(t * theta) / sin_theta
-
-    return w1 * q1 + w2 * q2
-
-
-class MotionLoader:
-    """Load and interpolate motion from CSV file."""
-
-    def __init__(
-        self,
-        motion_file: str,
-        input_fps: int,
-        output_fps: int,
-        line_range: tuple[int, int] | None = None,
-    ):
-        self.motion_file = motion_file
-        self.input_fps = input_fps
-        self.output_fps = output_fps
-        self.input_dt = 1.0 / self.input_fps
-        self.output_dt = 1.0 / self.output_fps
-        self.line_range = line_range
-        self._load_motion()
-        self._interpolate_motion()
-        self._compute_velocities()
-
-    def _load_motion(self):
-        """Load motion from CSV file."""
-        if self.line_range is None:
-            motion = np.loadtxt(self.motion_file, delimiter=",", dtype=np.float32, skiprows=1)
-        else:
-            motion = np.loadtxt(
-                self.motion_file,
-                delimiter=",",
-                skiprows=max(1, self.line_range[0] - 1),
-                max_rows=self.line_range[1] - self.line_range[0] + 1,
-                dtype=np.float32,
-            )
-
-        self.motion_base_poss_input = motion[:, :3]
-        # Convert quaternion from xyzw to wxyz
-        self.motion_base_rots_input = motion[:, 3:7][:, [3, 0, 1, 2]]
-        self.motion_base_rots_input = np_quat_ensure_continuity(self.motion_base_rots_input)
-        self.motion_dof_poss_input = motion[:, 7:]
-
-        self.input_frames = motion.shape[0]
-        self.duration = (self.input_frames - 1) * self.input_dt
-
-    def _interpolate_motion(self):
-        """Interpolate motion to output FPS."""
-        times = np.arange(0, self.duration, self.output_dt, dtype=np.float32)
-        self.output_frames = times.shape[0]
-        index_0, index_1, blend = self._compute_frame_blend(times)
-
-        # Linear interpolation for positions
-        self.motion_base_poss = (
-            self.motion_base_poss_input[index_0] * (1 - blend[:, None])
-            + self.motion_base_poss_input[index_1] * blend[:, None]
+def load_csv_motion(
+    motion_file: str, line_range: tuple[int, int] | None = None
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Load a Unitree-convention CSV into base/dof trajectory arrays."""
+    if line_range is None:
+        motion = np.loadtxt(motion_file, delimiter=",", dtype=np.float32, skiprows=1)
+    else:
+        motion = np.loadtxt(
+            motion_file,
+            delimiter=",",
+            skiprows=max(1, line_range[0] - 1),
+            max_rows=line_range[1] - line_range[0] + 1,
+            dtype=np.float32,
         )
 
-        # Spherical linear interpolation for quaternions
-        self.motion_base_rots = np.zeros((self.output_frames, 4), dtype=np.float32)
-        for i in range(self.output_frames):
-            self.motion_base_rots[i] = quat_slerp(
-                self.motion_base_rots_input[index_0[i]],
-                self.motion_base_rots_input[index_1[i]],
-                blend[i],
-            )
-        self.motion_base_rots = np_quat_ensure_continuity(self.motion_base_rots)
-
-        # Linear interpolation for joint positions
-        self.motion_dof_poss = (
-            self.motion_dof_poss_input[index_0] * (1 - blend[:, None])
-            + self.motion_dof_poss_input[index_1] * blend[:, None]
-        )
-
-        print(
-            f"Motion interpolated: {self.input_frames} frames @ {self.input_fps} Hz "
-            f"→ {self.output_frames} frames @ {self.output_fps} Hz"
-        )
-
-    def _compute_frame_blend(self, times: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Compute frame indices and blend weights for interpolation."""
-        phase = times / self.duration
-        index_0 = np.floor(phase * (self.input_frames - 1)).astype(np.int32)
-        index_1 = np.minimum(index_0 + 1, self.input_frames - 1)
-        blend = phase * (self.input_frames - 1) - index_0
-        return index_0, index_1, blend
-
-    def _compute_velocities(self):
-        """Compute velocities using numerical differentiation."""
-        # Linear velocities
-        self.motion_base_lin_vels = np.gradient(self.motion_base_poss, self.output_dt, axis=0)
-        self.motion_dof_vels = np.gradient(self.motion_dof_poss, self.output_dt, axis=0)
-
-        # Angular velocities from quaternion derivatives
-        self.motion_base_ang_vels = np_quat_angular_velocity(self.motion_base_rots, self.output_dt)
-
-
-def run_simulation(
-    motion_loader: MotionLoader,
-    model_file: str,
-    joint_names: list[str],
-    output_file: str,
-):
-    """Run MuJoCo simulation to compute forward kinematics for the export."""
-    # Inject track_* sensors so exported body_* fields match training-time semantics.
-    tmp_model_path, _, _ = inject_mujoco_tracking_sensors(model_file)
-    try:
-        model = mujoco.MjModel.from_xml_path(tmp_model_path)
-        print(f"Model loaded from {tmp_model_path}")
-    finally:
-        Path(tmp_model_path).unlink(missing_ok=True)
-    data = mujoco.MjData(model)
-
-    # Get joint indices
-    joint_indices = []
-    for name in joint_names:
-        jnt_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
-        if jnt_id < 0:
-            raise ValueError(f"Joint '{name}' not found in model")
-        joint_indices.append(jnt_id)
-
-    # Prepare output arrays
-    num_frames = motion_loader.output_frames
-    num_joints = len(joint_indices)
-    num_bodies = model.nbody
-
-    joint_pos = np.zeros((num_frames, num_joints), dtype=np.float32)
-    joint_vel = np.zeros((num_frames, num_joints), dtype=np.float32)
-    body_pos_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-    body_quat_w = np.zeros((num_frames, num_bodies, 4), dtype=np.float32)
-    body_lin_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-    body_ang_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
-
-    # Keep NPZ in model body-id layout (nbody), but read from track_* sensors for
-    # named bodies to align with backend.get_body_*_w semantics used in training.
-    sensor_adrs = np.full((num_bodies, 4), -1, dtype=np.int32)
-    sensor_dims = np.array([3, 4, 3, 3], dtype=np.int32)
-    sensor_prefixes = (
-        "track_pos_w_",
-        "track_quat_w_",
-        "track_linvel_w_",
-        "track_angvel_w_",
-    )
-    for body_id in range(num_bodies):
-        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
-        if not body_name:
-            continue
-        for k, prefix in enumerate(sensor_prefixes):
-            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, f"{prefix}{body_name}")
-            if sensor_id >= 0:
-                sensor_adrs[body_id, k] = model.sensor_adr[sensor_id]
-
-    print(f"\nProcessing {num_frames} frames...")
-    for i in tqdm(range(num_frames)):
-        # Set root state
-        data.qpos[0:3] = motion_loader.motion_base_poss[i]
-        data.qpos[3:7] = motion_loader.motion_base_rots[i]
-        data.qvel[0:3] = motion_loader.motion_base_lin_vels[i]
-        data.qvel[3:6] = motion_loader.motion_base_ang_vels[i]
-
-        # Set joint states
-        for j, jnt_id in enumerate(joint_indices):
-            qpos_adr = model.jnt_qposadr[jnt_id]
-            qvel_adr = model.jnt_dofadr[jnt_id]
-            data.qpos[qpos_adr] = motion_loader.motion_dof_poss[i, j]
-            data.qvel[qvel_adr] = motion_loader.motion_dof_vels[i, j]
-
-        # Run forward pass so kinematics and sensors are up-to-date.
-        mujoco.mj_forward(model, data)
-
-        # Extract joint states
-        for j, jnt_id in enumerate(joint_indices):
-            qpos_adr = model.jnt_qposadr[jnt_id]
-            qvel_adr = model.jnt_dofadr[jnt_id]
-            joint_pos[i, j] = data.qpos[qpos_adr]
-            joint_vel[i, j] = data.qvel[qvel_adr]
-
-        # Extract body states
-        for body_id in range(num_bodies):
-            pos_adr, quat_adr, lin_adr, ang_adr = sensor_adrs[body_id]
-
-            if pos_adr >= 0:
-                body_pos_w[i, body_id] = data.sensordata[pos_adr : pos_adr + sensor_dims[0]]
-            else:
-                body_pos_w[i, body_id] = data.xpos[body_id]
-
-            if quat_adr >= 0:
-                body_quat_w[i, body_id] = data.sensordata[quat_adr : quat_adr + sensor_dims[1]]
-            else:
-                body_quat_w[i, body_id] = data.xquat[body_id]
-
-            if lin_adr >= 0:
-                body_lin_vel_w[i, body_id] = data.sensordata[lin_adr : lin_adr + sensor_dims[2]]
-
-            if ang_adr >= 0:
-                body_ang_vel_w[i, body_id] = data.sensordata[ang_adr : ang_adr + sensor_dims[3]]
-
-    # Save to NPZ
-    print(f"\nSaving to {output_file}...")
-    np.savez(
-        output_file,
-        fps=np.array([motion_loader.output_fps], dtype=np.int32),
-        joint_pos=joint_pos,
-        joint_vel=joint_vel,
-        body_pos_w=body_pos_w,
-        body_quat_w=body_quat_w,
-        body_lin_vel_w=body_lin_vel_w,
-        body_ang_vel_w=body_ang_vel_w,
-    )
-    print("Done!")
+    motion_base_poss_input = motion[:, :3]
+    # Convert quaternion from xyzw to wxyz
+    motion_base_rots_input = motion[:, 3:7][:, [3, 0, 1, 2]]
+    motion_base_rots_input = np_quat_ensure_continuity(motion_base_rots_input)
+    motion_dof_poss_input = motion[:, 7:]
+    return motion_base_poss_input, motion_base_rots_input, motion_dof_poss_input
 
 
 def main():
@@ -363,16 +155,47 @@ def main():
         "right_wrist_yaw_joint",
     ]
 
+    input_fps = int(args.input_fps)
+    output_fps = int(args.output_fps)
+
     # Load and interpolate motion
-    motion_loader = MotionLoader(
+    base_poss_input, base_rots_input, dof_poss_input = load_csv_motion(
         args.input_file,
-        int(args.input_fps),
-        int(args.output_fps),
         (args.line_range[0], args.line_range[1]) if args.line_range else None,
     )
+    motion = interpolate_motion(
+        base_poss_input,
+        base_rots_input,
+        dof_poss_input,
+        input_fps=input_fps,
+        output_fps=output_fps,
+    )
+    print(
+        f"Motion interpolated: {base_poss_input.shape[0]} frames @ {input_fps} Hz "
+        f"→ {motion.output_frames} frames @ {output_fps} Hz"
+    )
 
-    # Run simulation
-    run_simulation(motion_loader, args.model_file, joint_names, args.output_file)
+    # Run forward kinematics and save to NPZ
+    print(f"\nProcessing {motion.output_frames} frames...")
+    arrays = compute_tracking_fk(
+        args.model_file,
+        joint_names=joint_names,
+        base_poss=motion.base_poss,
+        base_rots=motion.base_rots,
+        base_lin_vels=motion.base_lin_vels,
+        base_ang_vels=motion.base_ang_vels,
+        dof_poss=motion.dof_poss,
+        dof_vels=motion.dof_vels,
+        progress=True,
+    )
+
+    print(f"\nSaving to {args.output_file}...")
+    np.savez(
+        args.output_file,
+        fps=np.array([output_fps], dtype=np.int32),
+        **arrays,
+    )
+    print("Done!")
 
 
 if __name__ == "__main__":

--- a/scripts/motion/remap_fullbody_npz.py
+++ b/scripts/motion/remap_fullbody_npz.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.mujoco.xml import _get_named_bodies
+from unilab.base.backend import get_named_bodies
 
 # MuJoCo root free-joint sizes
 _ROOT_QPOS_DIM = 7  # 3 pos + 4 quat
@@ -57,7 +57,7 @@ def remap_npz(input_path: str, output_path: str, model_file: str, *, dry_run: bo
     source_body_names: list[str] = data["body_names"].tolist()
 
     # --- target body list from training model --------------------------------
-    _, named_bodies = _get_named_bodies(model_file)
+    _, named_bodies = get_named_bodies(model_file)
     target_body_names = ["world"] + named_bodies  # prepend MuJoCo implicit body 0
 
     remap = _build_body_remap(source_body_names, target_body_names)

--- a/scripts/motion/x2_csv_to_tracking_npz.py
+++ b/scripts/motion/x2_csv_to_tracking_npz.py
@@ -8,6 +8,10 @@ The source CSV is expected to contain one frame per row:
 
 The output layout matches the existing X2 ``*_g1format.npz`` assets consumed by
 the shared humanoid motion-tracking loader.
+
+Velocity estimation reuses the library implementation in
+``unilab.tasks.motion_tracking.common.motion_loader``; forward kinematics reuse
+``unilab.base.backend.compute_tracking_fk``.
 """
 
 from __future__ import annotations
@@ -19,32 +23,18 @@ import mujoco
 import numpy as np
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
-from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
+from unilab.base.backend import compute_tracking_fk
+from unilab.tasks.motion_tracking.common.motion_loader import (
+    compute_motion_velocities,
+    quat_slerp,
+)
+from unilab.utils.rotation import np_quat_ensure_continuity
 
 ROOT_QPOS_DIM = 7
 ROOT_QVEL_DIM = 6
 DEFAULT_INPUT = ASSETS_ROOT_PATH / "motions" / "x2" / "csv" / "shangxiaoche_5-28_15.csv"
 DEFAULT_OUTPUT = ASSETS_ROOT_PATH / "motions" / "x2" / "shangxiaoche_5-28_15_g1format.npz"
 DEFAULT_MODEL = ASSETS_ROOT_PATH / "robots" / "x2" / "x2_simple_collision.xml"
-
-
-def _quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
-    q1 = q1.astype(np.float64, copy=False)
-    q2 = q2.astype(np.float64, copy=False)
-    dot = float(np.dot(q1, q2))
-    if dot < 0.0:
-        q2 = -q2
-        dot = -dot
-    if dot > 0.9995:
-        result = q1 + t * (q2 - q1)
-        return (result / np.linalg.norm(result)).astype(np.float32)
-
-    theta = np.arccos(np.clip(dot, -1.0, 1.0))
-    sin_theta = np.sin(theta)
-    w1 = np.sin((1.0 - t) * theta) / sin_theta
-    w2 = np.sin(t * theta) / sin_theta
-    return (w1 * q1 + w2 * q2).astype(np.float32)
 
 
 def _load_csv_qpos(input_path: Path, model_nq: int) -> np.ndarray:
@@ -92,11 +82,12 @@ def _resample_qpos(qpos: np.ndarray, input_fps: int, output_fps: int) -> np.ndar
     out = np.empty((output_times.shape[0], qpos.shape[1]), dtype=np.float32)
     out[:, :3] = qpos[index_0, :3] * (1.0 - blend[:, None]) + qpos[index_1, :3] * blend[:, None]
     for frame, t in enumerate(blend):
-        out[frame, 3:7] = _quat_slerp(
-            qpos[index_0[frame], 3:7],
-            qpos[index_1[frame], 3:7],
+        # Interpolate in float64, then cast back to float32.
+        out[frame, 3:7] = quat_slerp(
+            qpos[index_0[frame], 3:7].astype(np.float64),
+            qpos[index_1[frame], 3:7].astype(np.float64),
             float(t),
-        )
+        ).astype(np.float32)
     out[:, 7:] = qpos[index_0, 7:] * (1.0 - blend[:, None]) + qpos[index_1, 7:] * blend[:, None]
     out[:, 3:7] = np_quat_ensure_continuity(out[:, 3:7])
     return out
@@ -104,10 +95,13 @@ def _resample_qpos(qpos: np.ndarray, input_fps: int, output_fps: int) -> np.ndar
 
 def _qvel_from_qpos(qpos: np.ndarray, fps: int) -> np.ndarray:
     dt = 1.0 / float(fps)
+    base_lin_vels, base_ang_vels, dof_vels = compute_motion_velocities(
+        qpos[:, :3], qpos[:, 3:7], qpos[:, 7:], dt
+    )
     qvel = np.empty((qpos.shape[0], qpos.shape[1] - 1), dtype=np.float32)
-    qvel[:, :3] = np.gradient(qpos[:, :3], dt, axis=0).astype(np.float32)
-    qvel[:, 3:6] = np_quat_angular_velocity(qpos[:, 3:7], dt).astype(np.float32)
-    qvel[:, 6:] = np.gradient(qpos[:, 7:], dt, axis=0).astype(np.float32)
+    qvel[:, :3] = base_lin_vels.astype(np.float32)
+    qvel[:, 3:6] = base_ang_vels.astype(np.float32)
+    qvel[:, 6:] = dof_vels.astype(np.float32)
     return qvel
 
 
@@ -123,75 +117,6 @@ def _target_joint_names(model: mujoco.MjModel) -> list[str]:
     return names
 
 
-def _sensor_addresses(model: mujoco.MjModel) -> np.ndarray:
-    sensor_adrs = np.full((model.nbody, 4), -1, dtype=np.int32)
-    prefixes = (
-        "track_pos_w_",
-        "track_quat_w_",
-        "track_linvel_w_",
-        "track_angvel_w_",
-    )
-    for body_id in range(model.nbody):
-        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
-        if not body_name:
-            continue
-        for slot, prefix in enumerate(prefixes):
-            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, prefix + body_name)
-            if sensor_id >= 0:
-                sensor_adrs[body_id, slot] = int(model.sensor_adr[sensor_id])
-    return sensor_adrs
-
-
-def _export_body_arrays(
-    model: mujoco.MjModel,
-    qpos: np.ndarray,
-    qvel: np.ndarray,
-    target_joint_names: list[str],
-) -> dict[str, np.ndarray]:
-    data = mujoco.MjData(model)
-    frames = qpos.shape[0]
-    body_pos_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
-    body_quat_w = np.zeros((frames, model.nbody, 4), dtype=np.float32)
-    body_lin_vel_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
-    body_ang_vel_w = np.zeros((frames, model.nbody, 3), dtype=np.float32)
-    sensor_adrs = _sensor_addresses(model)
-
-    joint_ids = [
-        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name) for name in target_joint_names
-    ]
-    if any(joint_id < 0 for joint_id in joint_ids):
-        raise ValueError("Target joint list contains joints not found in model")
-
-    for frame in range(frames):
-        data.qpos[:] = qpos[frame]
-        data.qvel[:] = qvel[frame]
-        mujoco.mj_forward(model, data)
-
-        for body_id in range(model.nbody):
-            pos_adr, quat_adr, lin_adr, ang_adr = sensor_adrs[body_id]
-            if pos_adr >= 0:
-                body_pos_w[frame, body_id] = data.sensordata[pos_adr : pos_adr + 3]
-            else:
-                body_pos_w[frame, body_id] = data.xpos[body_id]
-
-            if quat_adr >= 0:
-                body_quat_w[frame, body_id] = data.sensordata[quat_adr : quat_adr + 4]
-            else:
-                body_quat_w[frame, body_id] = data.xquat[body_id]
-
-            if lin_adr >= 0:
-                body_lin_vel_w[frame, body_id] = data.sensordata[lin_adr : lin_adr + 3]
-            if ang_adr >= 0:
-                body_ang_vel_w[frame, body_id] = data.sensordata[ang_adr : ang_adr + 3]
-
-    return {
-        "body_pos_w": body_pos_w,
-        "body_quat_w": body_quat_w,
-        "body_lin_vel_w": body_lin_vel_w,
-        "body_ang_vel_w": body_ang_vel_w,
-    }
-
-
 def convert_csv(
     input_path: Path,
     output_path: Path,
@@ -200,22 +125,17 @@ def convert_csv(
     output_fps: int,
     dry_run: bool,
 ) -> None:
-    tmp_model_path, _, _ = inject_mujoco_tracking_sensors(str(model_file))
-    try:
-        model = mujoco.MjModel.from_xml_path(tmp_model_path)
-    finally:
-        Path(tmp_model_path).unlink(missing_ok=True)
+    model = mujoco.MjModel.from_xml_path(str(model_file))
 
     target_names = _target_joint_names(model)
     qpos_input = _load_csv_qpos(input_path, model.nq)
     qpos = _resample_qpos(qpos_input, input_fps, output_fps)
     qvel = _qvel_from_qpos(qpos, output_fps)
-    joint_pos = qpos[:, ROOT_QPOS_DIM:].astype(np.float32)
-    joint_vel = qvel[:, ROOT_QVEL_DIM:].astype(np.float32)
 
-    if joint_pos.shape[1] != len(target_names):
+    if qpos.shape[1] - ROOT_QPOS_DIM != len(target_names):
         raise ValueError(
-            f"CSV joint count {joint_pos.shape[1]} does not match model joints {len(target_names)}"
+            f"CSV joint count {qpos.shape[1] - ROOT_QPOS_DIM} does not match model joints "
+            f"{len(target_names)}"
         )
 
     print(f"Source : {input_path}")
@@ -223,7 +143,7 @@ def convert_csv(
     print(f"Output : {output_path}")
     print(f"frames : {qpos_input.shape[0]} -> {qpos.shape[0]}")
     print(f"fps    : {input_fps} -> {output_fps}")
-    print(f"joints : {joint_pos.shape[1]}")
+    print(f"joints : {qpos.shape[1] - ROOT_QPOS_DIM}")
     print(f"bodies : {model.nbody} (MuJoCo body-id layout, including world)")
 
     if dry_run:
@@ -231,13 +151,20 @@ def convert_csv(
         return
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    body_arrays = _export_body_arrays(model, qpos, qvel, target_names)
+    arrays = compute_tracking_fk(
+        str(model_file),
+        joint_names=target_names,
+        base_poss=qpos[:, :3],
+        base_rots=qpos[:, 3:7],
+        base_lin_vels=qvel[:, :3],
+        base_ang_vels=qvel[:, 3:6],
+        dof_poss=qpos[:, ROOT_QPOS_DIM:],
+        dof_vels=qvel[:, ROOT_QVEL_DIM:],
+    )
     np.savez(
         output_path,
         fps=np.array([output_fps], dtype=np.int32),
-        joint_pos=joint_pos,
-        joint_vel=joint_vel,
-        **body_arrays,
+        **arrays,
     )
 
 

--- a/scripts/tools/import_robot.py
+++ b/scripts/tools/import_robot.py
@@ -486,7 +486,7 @@ def _materialize_tuning_scene(
     add_height_joint: bool = True,
     height_range: tuple[float, float] = (-1.0, 1.0),
 ) -> Path:
-    from unilab.base.backend.mujoco.xml import materialize_scene_fragments
+    from unilab.base.backend import materialize_scene_fragments
 
     merged = materialize_scene_fragments(str(robot_xml), fragment_files=[str(scene_xml)])
     tree = ET.parse(merged)

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -33,6 +33,7 @@ _MUJOCO_XML_EXPORTS = frozenset(
     {
         "add_sensor",
         "create_discardvisual_xml",
+        "get_named_bodies",
         "get_named_body_ids",
         "inject_mujoco_tracking_sensors",
         "materialize_mujoco_hfield_attached_scene",
@@ -41,6 +42,7 @@ _MUJOCO_XML_EXPORTS = frozenset(
         "processed_xml",
     }
 )
+_MUJOCO_MOTION_EXPORT_EXPORTS = frozenset({"compute_tracking_fk"})
 _MOTRIX_SCENE_EXPORTS = frozenset(
     {
         "add_motrix_tracking_frame_sensors",
@@ -228,6 +230,10 @@ def __getattr__(name: str):
         from .mujoco import xml
 
         return getattr(xml, name)
+    if name in _MUJOCO_MOTION_EXPORT_EXPORTS:
+        from .mujoco import motion_export
+
+        return getattr(motion_export, name)
     if name in _MOTRIX_SCENE_EXPORTS:
         return _load_motrix_scene_export(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
@@ -244,8 +250,10 @@ __all__ = [
     "DRAKE_AVAILABLE",
     "MJWARP_AVAILABLE",
     "add_sensor",
+    "compute_tracking_fk",
     "create_discardvisual_xml",
     "create_backend",
+    "get_named_bodies",
     "get_named_body_ids",
     "inject_mujoco_tracking_sensors",
     "add_motrix_tracking_frame_sensors",

--- a/src/unilab/base/backend/mujoco/__init__.py
+++ b/src/unilab/base/backend/mujoco/__init__.py
@@ -17,8 +17,15 @@ def __getattr__(name: str):
 
         return getattr(playback, name)
     if name in {
+        "compute_tracking_fk",
+    }:
+        from . import motion_export
+
+        return getattr(motion_export, name)
+    if name in {
         "add_sensor",
         "create_discardvisual_xml",
+        "get_named_bodies",
         "get_named_body_ids",
         "inject_mujoco_tracking_sensors",
         "materialize_mujoco_hfield_attached_scene",
@@ -35,7 +42,9 @@ def __getattr__(name: str):
 __all__ = [
     "MuJoCoBackend",
     "add_sensor",
+    "compute_tracking_fk",
     "create_discardvisual_xml",
+    "get_named_bodies",
     "get_named_body_ids",
     "inject_mujoco_tracking_sensors",
     "materialize_visual_playback_model",

--- a/src/unilab/base/backend/mujoco/motion_export.py
+++ b/src/unilab/base/backend/mujoco/motion_export.py
@@ -1,0 +1,157 @@
+"""MuJoCo-only forward-kinematics export for motion-tracking NPZ conversion.
+
+Cold-path tooling shared by the ``scripts/motion/`` CSV-to-NPZ converters. It
+injects ``track_*`` sensors into a model, replays a (root + named joints)
+trajectory through ``mj_forward``, and reads back joint/body states with the
+same ``track_*``-sensor-first semantics the training backend uses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+from unilab.base.backend.mujoco.xml import inject_mujoco_tracking_sensors
+
+_SENSOR_DIMS = (3, 4, 3, 3)
+_SENSOR_PREFIXES = (
+    "track_pos_w_",
+    "track_quat_w_",
+    "track_linvel_w_",
+    "track_angvel_w_",
+)
+
+
+def compute_tracking_fk(
+    model_file: str,
+    *,
+    joint_names: Sequence[str],
+    base_poss: np.ndarray,
+    base_rots: np.ndarray,
+    base_lin_vels: np.ndarray,
+    base_ang_vels: np.ndarray,
+    dof_poss: np.ndarray,
+    dof_vels: np.ndarray,
+    progress: bool = False,
+    progress_desc: str | None = None,
+) -> dict[str, np.ndarray]:
+    """Replay a root+joint trajectory and return tracking FK arrays.
+
+    Args:
+        model_file: MuJoCo XML scene file. ``track_*`` sensors are injected on
+            a temporary copy; the source file is not modified.
+        joint_names: Actuated joint names in the desired output column order.
+        base_poss: (N, 3) root positions, world frame.
+        base_rots: (N, 4) root quaternions, wxyz.
+        base_lin_vels: (N, 3) root linear velocities, world frame.
+        base_ang_vels: (N, 3) root angular velocities, world frame.
+        dof_poss: (N, len(joint_names)) joint positions.
+        dof_vels: (N, len(joint_names)) joint velocities.
+        progress: Show a tqdm progress bar over frames.
+        progress_desc: Optional tqdm description.
+
+    Returns:
+        Dict with float32 arrays ``joint_pos`` / ``joint_vel``
+        (N, len(joint_names)) and ``body_pos_w`` / ``body_quat_w`` /
+        ``body_lin_vel_w`` / ``body_ang_vel_w`` (N, nbody, ...) in MuJoCo
+        body-id layout, including the implicit world body 0.
+    """
+    import mujoco
+
+    tmp_model_path, _, _ = inject_mujoco_tracking_sensors(model_file)
+    try:
+        model = mujoco.MjModel.from_xml_path(tmp_model_path)
+    finally:
+        Path(tmp_model_path).unlink(missing_ok=True)
+    data = mujoco.MjData(model)
+
+    joint_indices = []
+    for name in joint_names:
+        jnt_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if jnt_id < 0:
+            raise ValueError(f"Joint '{name}' not found in model")
+        joint_indices.append(jnt_id)
+
+    num_frames = base_poss.shape[0]
+    num_joints = len(joint_indices)
+    num_bodies = model.nbody
+
+    joint_pos = np.zeros((num_frames, num_joints), dtype=np.float32)
+    joint_vel = np.zeros((num_frames, num_joints), dtype=np.float32)
+    body_pos_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
+    body_quat_w = np.zeros((num_frames, num_bodies, 4), dtype=np.float32)
+    body_lin_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
+    body_ang_vel_w = np.zeros((num_frames, num_bodies, 3), dtype=np.float32)
+
+    # Keep arrays in model body-id layout (nbody), but read named bodies from
+    # the injected track_* sensors to align with backend.get_body_*_w semantics.
+    sensor_adrs = np.full((num_bodies, 4), -1, dtype=np.int32)
+    for body_id in range(num_bodies):
+        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+        if not body_name:
+            continue
+        for k, prefix in enumerate(_SENSOR_PREFIXES):
+            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, f"{prefix}{body_name}")
+            if sensor_id >= 0:
+                sensor_adrs[body_id, k] = model.sensor_adr[sensor_id]
+
+    frame_iter = range(num_frames)
+    if progress:
+        from tqdm import tqdm
+
+        frame_iter = tqdm(frame_iter, desc=progress_desc, leave=progress_desc is None)
+
+    for i in frame_iter:
+        # Set root state
+        data.qpos[0:3] = base_poss[i]
+        data.qpos[3:7] = base_rots[i]
+        data.qvel[0:3] = base_lin_vels[i]
+        data.qvel[3:6] = base_ang_vels[i]
+
+        # Set joint states
+        for j, jnt_id in enumerate(joint_indices):
+            qpos_adr = model.jnt_qposadr[jnt_id]
+            qvel_adr = model.jnt_dofadr[jnt_id]
+            data.qpos[qpos_adr] = dof_poss[i, j]
+            data.qvel[qvel_adr] = dof_vels[i, j]
+
+        # Run forward pass so kinematics and sensors are up-to-date.
+        mujoco.mj_forward(model, data)
+
+        # Extract joint states
+        for j, jnt_id in enumerate(joint_indices):
+            qpos_adr = model.jnt_qposadr[jnt_id]
+            qvel_adr = model.jnt_dofadr[jnt_id]
+            joint_pos[i, j] = data.qpos[qpos_adr]
+            joint_vel[i, j] = data.qvel[qvel_adr]
+
+        # Extract body states
+        for body_id in range(num_bodies):
+            pos_adr, quat_adr, lin_adr, ang_adr = sensor_adrs[body_id]
+
+            if pos_adr >= 0:
+                body_pos_w[i, body_id] = data.sensordata[pos_adr : pos_adr + _SENSOR_DIMS[0]]
+            else:
+                body_pos_w[i, body_id] = data.xpos[body_id]
+
+            if quat_adr >= 0:
+                body_quat_w[i, body_id] = data.sensordata[quat_adr : quat_adr + _SENSOR_DIMS[1]]
+            else:
+                body_quat_w[i, body_id] = data.xquat[body_id]
+
+            if lin_adr >= 0:
+                body_lin_vel_w[i, body_id] = data.sensordata[lin_adr : lin_adr + _SENSOR_DIMS[2]]
+
+            if ang_adr >= 0:
+                body_ang_vel_w[i, body_id] = data.sensordata[ang_adr : ang_adr + _SENSOR_DIMS[3]]
+
+    return {
+        "joint_pos": joint_pos,
+        "joint_vel": joint_vel,
+        "body_pos_w": body_pos_w,
+        "body_quat_w": body_quat_w,
+        "body_lin_vel_w": body_lin_vel_w,
+        "body_ang_vel_w": body_ang_vel_w,
+    }

--- a/src/unilab/base/backend/mujoco/xml.py
+++ b/src/unilab/base/backend/mujoco/xml.py
@@ -58,7 +58,12 @@ def _iter_named_bodies(root: ET.Element, base_dir: Path) -> Iterator[str]:
         yield from _iter_named_bodies(child, child_base_dir)
 
 
-def _get_named_bodies(model_file: str) -> tuple[list[int], list[str]]:
+def get_named_bodies(model_file: str) -> tuple[list[int], list[str]]:
+    """List MuJoCo-style body ids and names declared in a (possibly included) XML.
+
+    Returns ``(ids, names)`` in document order, with ids starting at 1 (the
+    MuJoCo implicit world body 0 is not listed).
+    """
     model_path = Path(model_file).resolve()
     names = list(_iter_named_bodies(ET.parse(model_path).getroot(), model_path.parent))
     ids = list(range(1, len(names) + 1))
@@ -67,7 +72,7 @@ def _get_named_bodies(model_file: str) -> tuple[list[int], list[str]]:
 
 def get_named_body_ids(model_file: str, names: Sequence[str]) -> list[int]:
     """Resolve MuJoCo-style body ids from XML without importing mujoco."""
-    body_ids, body_names = _get_named_bodies(model_file)
+    body_ids, body_names = get_named_bodies(model_file)
     body_id_by_name = dict(zip(body_names, body_ids, strict=True))
     missing = [name for name in names if name not in body_id_by_name]
     if missing:
@@ -524,7 +529,7 @@ def inject_mujoco_tracking_sensors(
         (tmp_xml_path, tracked_body_ids, valid_bnames)
     """
     mujoco = _mujoco_module()
-    tracked_body_ids, valid_bnames = _get_named_bodies(model_file)
+    tracked_body_ids, valid_bnames = get_named_bodies(model_file)
 
     spec = mujoco.MjSpec.from_file(model_file)
     _add_w_sensors(spec, valid_bnames)

--- a/src/unilab/tasks/motion_tracking/common/motion_loader.py
+++ b/src/unilab/tasks/motion_tracking/common/motion_loader.py
@@ -10,6 +10,7 @@ from typing import Literal
 import numpy as np
 
 from unilab.assets.hub import resolve_motion_files
+from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
 
 
 @dataclass
@@ -22,6 +23,126 @@ class MotionData:
     body_quat_w: np.ndarray  # (N, num_bodies, 4)
     body_lin_vel_w: np.ndarray  # (N, num_bodies, 3)
     body_ang_vel_w: np.ndarray  # (N, num_bodies, 3)
+
+
+def quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
+    """Spherical linear interpolation between two quaternions (wxyz format).
+
+    The computation runs in the input dtype; pass float64 arrays for a
+    float64 interpolation path.
+    """
+    # Ensure shortest path
+    dot = np.dot(q1, q2)
+    if dot < 0:
+        q2 = -q2
+        dot = -dot
+
+    # If quaternions are very close, use linear interpolation
+    if dot > 0.9995:
+        result = q1 + t * (q2 - q1)
+        return result / np.linalg.norm(result)
+
+    # Compute angle
+    theta = np.arccos(np.clip(dot, -1, 1))
+    sin_theta = np.sin(theta)
+
+    # Compute interpolation weights
+    w1 = np.sin((1 - t) * theta) / sin_theta
+    w2 = np.sin(t * theta) / sin_theta
+
+    return w1 * q1 + w2 * q2
+
+
+@dataclass
+class InterpolatedMotion:
+    """Root/joint trajectory resampled to the output frame rate."""
+
+    output_frames: int
+    base_poss: np.ndarray  # (N, 3)
+    base_rots: np.ndarray  # (N, 4), wxyz
+    dof_poss: np.ndarray  # (N, num_joints)
+    base_lin_vels: np.ndarray  # (N, 3)
+    base_ang_vels: np.ndarray  # (N, 3)
+    dof_vels: np.ndarray  # (N, num_joints)
+
+
+def compute_motion_velocities(
+    base_poss: np.ndarray,
+    base_rots: np.ndarray,
+    dof_poss: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Numerically differentiate a trajectory into base/dof velocities."""
+    base_lin_vels = np.gradient(base_poss, dt, axis=0)
+    dof_vels = np.gradient(dof_poss, dt, axis=0)
+    base_ang_vels = np_quat_angular_velocity(base_rots, dt)
+    return base_lin_vels, base_ang_vels, dof_vels
+
+
+def compute_frame_blend(
+    times: np.ndarray, duration: float, input_frames: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute frame indices and blend weights for interpolation."""
+    phase = times / duration
+    index_0 = np.floor(phase * (input_frames - 1)).astype(np.int32)
+    index_1 = np.minimum(index_0 + 1, input_frames - 1)
+    blend = phase * (input_frames - 1) - index_0
+    return index_0, index_1, blend
+
+
+def interpolate_motion(
+    base_poss_input: np.ndarray,
+    base_rots_input: np.ndarray,
+    dof_poss_input: np.ndarray,
+    *,
+    input_fps: int,
+    output_fps: int,
+) -> InterpolatedMotion:
+    """Resample a root+joint trajectory from ``input_fps`` to ``output_fps``.
+
+    Positions and joint angles are linearly interpolated, root quaternions
+    (wxyz) use slerp, and velocities are computed by numerical
+    differentiation at the output rate.
+    """
+    input_dt = 1.0 / input_fps
+    output_dt = 1.0 / output_fps
+    input_frames = base_poss_input.shape[0]
+    duration = (input_frames - 1) * input_dt
+
+    times = np.arange(0, duration, output_dt, dtype=np.float32)
+    output_frames = times.shape[0]
+    index_0, index_1, blend = compute_frame_blend(times, duration, input_frames)
+
+    # Linear interpolation for positions
+    base_poss = (
+        base_poss_input[index_0] * (1 - blend[:, None]) + base_poss_input[index_1] * blend[:, None]
+    )
+
+    # Spherical linear interpolation for quaternions
+    base_rots = np.zeros((output_frames, 4), dtype=np.float32)
+    for i in range(output_frames):
+        base_rots[i] = quat_slerp(
+            base_rots_input[index_0[i]], base_rots_input[index_1[i]], blend[i]
+        )
+    base_rots = np_quat_ensure_continuity(base_rots)
+
+    # Linear interpolation for joint positions
+    dof_poss = (
+        dof_poss_input[index_0] * (1 - blend[:, None]) + dof_poss_input[index_1] * blend[:, None]
+    )
+
+    base_lin_vels, base_ang_vels, dof_vels = compute_motion_velocities(
+        base_poss, base_rots, dof_poss, output_dt
+    )
+    return InterpolatedMotion(
+        output_frames=output_frames,
+        base_poss=base_poss,
+        base_rots=base_rots,
+        dof_poss=dof_poss,
+        base_lin_vels=base_lin_vels,
+        base_ang_vels=base_ang_vels,
+        dof_vels=dof_vels,
+    )
 
 
 class MotionLoader:

--- a/tests/envs/test_motion_interpolation.py
+++ b/tests/envs/test_motion_interpolation.py
@@ -1,0 +1,200 @@
+"""Tests for the shared CSV-motion interpolation helpers in the library layer.
+
+The reference functions below are verbatim copies of the implementations that
+used to live in ``scripts/motion/csv_to_npz.py`` and
+``scripts/motion/x2_csv_to_tracking_npz.py`` (see issue #1244). The library
+helpers must reproduce them exactly so converted NPZ products stay
+bit-identical.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from unilab.tasks.motion_tracking.common.motion_loader import (
+    compute_motion_velocities,
+    interpolate_motion,
+    quat_slerp,
+)
+from unilab.utils.rotation import np_quat_angular_velocity, np_quat_ensure_continuity
+
+
+def _reference_quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
+    """Former scripts/motion/csv_to_npz.py::quat_slerp (float32 path)."""
+    dot = np.dot(q1, q2)
+    if dot < 0:
+        q2 = -q2
+        dot = -dot
+
+    if dot > 0.9995:
+        result = q1 + t * (q2 - q1)
+        return result / np.linalg.norm(result)
+
+    theta = np.arccos(np.clip(dot, -1, 1))
+    sin_theta = np.sin(theta)
+
+    w1 = np.sin((1 - t) * theta) / sin_theta
+    w2 = np.sin(t * theta) / sin_theta
+
+    return w1 * q1 + w2 * q2
+
+
+def _reference_x2_quat_slerp(q1: np.ndarray, q2: np.ndarray, t: float) -> np.ndarray:
+    """Former scripts/motion/x2_csv_to_tracking_npz.py::_quat_slerp (float64 path)."""
+    q1 = q1.astype(np.float64, copy=False)
+    q2 = q2.astype(np.float64, copy=False)
+    dot = float(np.dot(q1, q2))
+    if dot < 0.0:
+        q2 = -q2
+        dot = -dot
+    if dot > 0.9995:
+        result = q1 + t * (q2 - q1)
+        return (result / np.linalg.norm(result)).astype(np.float32)
+
+    theta = np.arccos(np.clip(dot, -1.0, 1.0))
+    sin_theta = np.sin(theta)
+    w1 = np.sin((1.0 - t) * theta) / sin_theta
+    w2 = np.sin(t * theta) / sin_theta
+    return (w1 * q1 + w2 * q2).astype(np.float32)
+
+
+def _reference_interpolate(
+    base_poss_input: np.ndarray,
+    base_rots_input: np.ndarray,
+    dof_poss_input: np.ndarray,
+    input_fps: int,
+    output_fps: int,
+) -> dict[str, np.ndarray]:
+    """Former scripts/motion MotionLoader._interpolate_motion + _compute_velocities."""
+    input_dt = 1.0 / input_fps
+    output_dt = 1.0 / output_fps
+    input_frames = base_poss_input.shape[0]
+    duration = (input_frames - 1) * input_dt
+
+    times = np.arange(0, duration, output_dt, dtype=np.float32)
+    output_frames = times.shape[0]
+
+    phase = times / duration
+    index_0 = np.floor(phase * (input_frames - 1)).astype(np.int32)
+    index_1 = np.minimum(index_0 + 1, input_frames - 1)
+    blend = phase * (input_frames - 1) - index_0
+
+    base_poss = (
+        base_poss_input[index_0] * (1 - blend[:, None]) + base_poss_input[index_1] * blend[:, None]
+    )
+
+    base_rots = np.zeros((output_frames, 4), dtype=np.float32)
+    for i in range(output_frames):
+        base_rots[i] = _reference_quat_slerp(
+            base_rots_input[index_0[i]], base_rots_input[index_1[i]], blend[i]
+        )
+    base_rots = np_quat_ensure_continuity(base_rots)
+
+    dof_poss = (
+        dof_poss_input[index_0] * (1 - blend[:, None]) + dof_poss_input[index_1] * blend[:, None]
+    )
+
+    base_lin_vels = np.gradient(base_poss, output_dt, axis=0)
+    dof_vels = np.gradient(dof_poss, output_dt, axis=0)
+    base_ang_vels = np_quat_angular_velocity(base_rots, output_dt)
+
+    return {
+        "output_frames": output_frames,
+        "base_poss": base_poss,
+        "base_rots": base_rots,
+        "dof_poss": dof_poss,
+        "base_lin_vels": base_lin_vels,
+        "base_ang_vels": base_ang_vels,
+        "dof_vels": dof_vels,
+    }
+
+
+def _random_quats(rng: np.random.Generator, n: int, dtype=np.float32) -> np.ndarray:
+    quats = rng.standard_normal((n, 4)).astype(dtype)
+    return quats / np.linalg.norm(quats, axis=1, keepdims=True)
+
+
+def test_quat_slerp_matches_former_script_float32() -> None:
+    rng = np.random.default_rng(0)
+    quats = _random_quats(rng, 32)
+    for i in range(0, 30, 2):
+        for t in (0.0, 0.13, 0.5, 0.97, 1.0):
+            expected = _reference_quat_slerp(quats[i], quats[i + 1], np.float32(t))
+            actual = quat_slerp(quats[i], quats[i + 1], np.float32(t))
+            assert actual.dtype == expected.dtype
+            np.testing.assert_array_equal(actual, expected)
+
+
+def test_quat_slerp_matches_former_script_near_identical() -> None:
+    rng = np.random.default_rng(1)
+    q1 = _random_quats(rng, 1)[0]
+    q2 = q1 + rng.standard_normal(4).astype(np.float32) * 1e-4
+    q2 = q2 / np.linalg.norm(q2)
+    expected = _reference_quat_slerp(q1, q2, np.float32(0.3))
+    np.testing.assert_array_equal(quat_slerp(q1, q2, np.float32(0.3)), expected)
+
+
+def test_quat_slerp_float64_path_matches_former_x2_script() -> None:
+    rng = np.random.default_rng(2)
+    quats = _random_quats(rng, 8)
+    for i in range(0, 6, 2):
+        for t in (0.0, 0.42, 1.0):
+            expected = _reference_x2_quat_slerp(quats[i], quats[i + 1], t)
+            actual = quat_slerp(
+                quats[i].astype(np.float64), quats[i + 1].astype(np.float64), t
+            ).astype(np.float32)
+            np.testing.assert_array_equal(actual, expected)
+
+
+def test_quat_slerp_takes_shortest_path() -> None:
+    rng = np.random.default_rng(3)
+    q1, q2 = _random_quats(rng, 2)
+    direct = quat_slerp(q1, q2, 0.5)
+    flipped = quat_slerp(q1, -q2, 0.5)
+    np.testing.assert_allclose(direct, flipped, atol=1e-6)
+
+
+def test_interpolate_motion_matches_former_script() -> None:
+    rng = np.random.default_rng(4)
+    input_frames = 61
+    base_poss_input = rng.standard_normal((input_frames, 3)).astype(np.float32)
+    base_rots_input = np_quat_ensure_continuity(_random_quats(rng, input_frames))
+    dof_poss_input = rng.standard_normal((input_frames, 29)).astype(np.float32)
+
+    for input_fps, output_fps in ((30, 50), (120, 50), (50, 50), (120, 30)):
+        expected = _reference_interpolate(
+            base_poss_input, base_rots_input, dof_poss_input, input_fps, output_fps
+        )
+        actual = interpolate_motion(
+            base_poss_input,
+            base_rots_input,
+            dof_poss_input,
+            input_fps=input_fps,
+            output_fps=output_fps,
+        )
+        assert actual.output_frames == expected["output_frames"]
+        for key in (
+            "base_poss",
+            "base_rots",
+            "dof_poss",
+            "base_lin_vels",
+            "base_ang_vels",
+            "dof_vels",
+        ):
+            np.testing.assert_array_equal(getattr(actual, key), expected[key])
+
+
+def test_compute_motion_velocities_matches_former_script() -> None:
+    rng = np.random.default_rng(5)
+    frames = 40
+    base_poss = rng.standard_normal((frames, 3)).astype(np.float32)
+    base_rots = np_quat_ensure_continuity(_random_quats(rng, frames))
+    dof_poss = rng.standard_normal((frames, 7)).astype(np.float32)
+    dt = 1.0 / 50
+
+    base_lin_vels, base_ang_vels, dof_vels = compute_motion_velocities(
+        base_poss, base_rots, dof_poss, dt
+    )
+    np.testing.assert_array_equal(base_lin_vels, np.gradient(base_poss, dt, axis=0))
+    np.testing.assert_array_equal(dof_vels, np.gradient(dof_poss, dt, axis=0))
+    np.testing.assert_array_equal(base_ang_vels, np_quat_angular_velocity(base_rots, dt))

--- a/tests/utils/test_motion_export.py
+++ b/tests/utils/test_motion_export.py
@@ -1,0 +1,120 @@
+"""Tests for the MuJoCo tracking FK export shared by scripts/motion converters."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import compute_tracking_fk, get_named_bodies
+
+
+def _g1_scene() -> str:
+    return str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+
+
+_G1_JOINT_NAMES = [
+    "left_hip_pitch_joint",
+    "left_hip_roll_joint",
+    "left_hip_yaw_joint",
+    "left_knee_joint",
+    "left_ankle_pitch_joint",
+    "left_ankle_roll_joint",
+    "right_hip_pitch_joint",
+    "right_hip_roll_joint",
+    "right_hip_yaw_joint",
+    "right_knee_joint",
+    "right_ankle_pitch_joint",
+    "right_ankle_roll_joint",
+    "waist_yaw_joint",
+    "waist_roll_joint",
+    "waist_pitch_joint",
+    "left_shoulder_pitch_joint",
+    "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "left_wrist_roll_joint",
+    "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+    "right_shoulder_pitch_joint",
+    "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",
+    "right_elbow_joint",
+    "right_wrist_roll_joint",
+    "right_wrist_pitch_joint",
+    "right_wrist_yaw_joint",
+]
+
+
+def test_get_named_bodies_matches_g1_scene() -> None:
+    ids, names = get_named_bodies(_g1_scene())
+    assert ids == list(range(1, len(names) + 1))
+    assert "pelvis" in names
+    assert len(names) == 30
+
+
+def test_compute_tracking_fk_shapes_and_joint_roundtrip() -> None:
+    pytest.importorskip("mujoco")
+    rng = np.random.default_rng(0)
+    num_frames = 4
+    num_joints = len(_G1_JOINT_NAMES)
+
+    base_poss = rng.standard_normal((num_frames, 3)).astype(np.float32) * 0.05
+    base_poss[:, 2] += 0.8
+    base_rots = np.zeros((num_frames, 4), dtype=np.float32)
+    base_rots[:, 0] = 1.0
+    base_lin_vels = np.zeros((num_frames, 3), dtype=np.float32)
+    base_ang_vels = np.zeros((num_frames, 3), dtype=np.float32)
+    dof_poss = rng.standard_normal((num_frames, num_joints)).astype(np.float32) * 0.1
+    dof_vels = rng.standard_normal((num_frames, num_joints)).astype(np.float32) * 0.1
+
+    arrays = compute_tracking_fk(
+        _g1_scene(),
+        joint_names=_G1_JOINT_NAMES,
+        base_poss=base_poss,
+        base_rots=base_rots,
+        base_lin_vels=base_lin_vels,
+        base_ang_vels=base_ang_vels,
+        dof_poss=dof_poss,
+        dof_vels=dof_vels,
+    )
+
+    _, body_names = get_named_bodies(_g1_scene())
+    num_bodies = len(body_names) + 1  # + implicit world body 0
+
+    assert arrays["joint_pos"].shape == (num_frames, num_joints)
+    assert arrays["joint_vel"].shape == (num_frames, num_joints)
+    assert arrays["body_pos_w"].shape == (num_frames, num_bodies, 3)
+    assert arrays["body_quat_w"].shape == (num_frames, num_bodies, 4)
+    assert arrays["body_lin_vel_w"].shape == (num_frames, num_bodies, 3)
+    assert arrays["body_ang_vel_w"].shape == (num_frames, num_bodies, 3)
+    for array in arrays.values():
+        assert array.dtype == np.float32
+
+    # Joint states written into qpos/qvel must read back exactly.
+    np.testing.assert_array_equal(arrays["joint_pos"], dof_poss)
+    np.testing.assert_array_equal(arrays["joint_vel"], dof_vels)
+
+    # World body stays at the origin; pelvis tracks the commanded root state.
+    np.testing.assert_array_equal(arrays["body_pos_w"][:, 0], 0.0)
+    pelvis_id = body_names.index("pelvis") + 1
+    np.testing.assert_allclose(arrays["body_pos_w"][:, pelvis_id], base_poss, atol=1e-5)
+    np.testing.assert_allclose(arrays["body_quat_w"][:, pelvis_id], base_rots, atol=1e-5)
+
+
+def test_compute_tracking_fk_unknown_joint_raises() -> None:
+    pytest.importorskip("mujoco")
+    base = np.zeros((1, 3), dtype=np.float32)
+    quat = np.zeros((1, 4), dtype=np.float32)
+    quat[:, 0] = 1.0
+    with pytest.raises(ValueError, match="not_a_joint"):
+        compute_tracking_fk(
+            _g1_scene(),
+            joint_names=["not_a_joint"],
+            base_poss=base,
+            base_rots=quat,
+            base_lin_vels=base,
+            base_ang_vels=base,
+            dof_poss=np.zeros((1, 1), dtype=np.float32),
+            dof_vels=np.zeros((1, 1), dtype=np.float32),
+        )


### PR DESCRIPTION
Fixes #1244

## What

- **Promote backend XML utilities to public interfaces**: `_get_named_bodies` → public `get_named_bodies` in `unilab.base.backend.mujoco.xml`; scripts (`remap_fullbody_npz.py`, `import_robot.py`, `benchmark/mjwarp/backend.py`) now import via the public `unilab.base.backend` facade instead of private/ deep module paths.
- **New `compute_tracking_fk`** (`src/unilab/base/backend/mujoco/motion_export.py`, re-exported through both backend facades): the `track_*`-sensor injection + `mj_forward` + readback loop that was triplicated across `csv_to_npz.py`, `bones_seed_csv_to_npz.py`, and `x2_csv_to_tracking_npz.py`.
- **Library-layer interpolation** (`tasks/motion_tracking/common/motion_loader.py`): new `quat_slerp` / `compute_frame_blend` / `compute_motion_velocities` / `interpolate_motion`, replacing the per-script `MotionLoader` copies in `csv_to_npz.py` and `bones_seed_csv_to_npz.py`. `x2_csv_to_tracking_npz.py` reuses the shared slerp / velocity / FK pieces while keeping its own qpos resampling arithmetic (its phase computation differs; merging it would change numeric output).
- **`sim_prototype.py` untouched** (deliberate standalone deploy-side numpy obs assembly); header gains contract anchors: owner config `conf/offpolicy/task/sac/g1_wbt_obs/mujoco.yaml` and alignment test `tests/scripts/test_obs_alignment_g1_wbt.py`.
- No `SimBackend` interface change: the promoted capabilities are module-level cold-path utilities, not backend instance methods.

Net: +320/-561 across 14 files (incl. 2 new test files).

## Validation

- `make test-all` passed locally (ruff format/check, mypy, pyright, full pytest, benchmark smoke).
- Bit-identical conversion products: old vs new `csv_to_npz`, `bones_seed_csv_to_npz`, and `x2_csv_to_tracking_npz` run on synthetic CSVs — all NPZ keys (`fps`, `joint_pos/vel`, `body_*_w`) compare exactly equal.
- New tests: `tests/envs/test_motion_interpolation.py` (library interpolation vs verbatim copies of the former script implementations, exact equality) and `tests/utils/test_motion_export.py` (FK shapes, joint round-trip, pelvis pose, unknown-joint error).
- Existing suites: motion loader, bones_seed CSV, XML utils, import_robot, obs alignment, tooling markers — 56 tests passed.