### PR TITLE
feat: instrument MBA reset path with fine-grained sub-step timing (#1255)

### DIFF
--- a/scripts/benchmark/rl/benchmark_offpolicy_collector_active.py
+++ b/scripts/benchmark/rl/benchmark_offpolicy_collector_active.py
@@ -101,6 +101,19 @@ NP_ENV_STEP_TIMING_KEYS = (
     "dr_reset_obs_get_body_pose_ms",
     "dr_reset_observation_compute_obs_ms",
     "dr_reset_observation_internal_gap_ms",
+    # Manager-Based (MBA) reset sub-steps (see RESET_DONE_DETAIL_TIMING_KEYS in
+    # src/unilab/base/np_env.py). Task-dependent per-term event timings with the
+    # mba_reset_event_term_<name>_ms prefix are discovered dynamically at sample
+    # time (JSON/console only; not part of the fixed CSV header).
+    "mba_reset_total_ms",
+    "mba_reset_curriculum_ms",
+    "mba_reset_event_apply_ms",
+    "mba_reset_command_reset_ms",
+    "mba_reset_set_state_ms",
+    "mba_reset_manager_reset_ms",
+    "mba_reset_command_compute_ms",
+    "mba_reset_obs_build_ms",
+    "mba_reset_internal_gap_ms",
     # Backend set_state internals (see BACKEND_SET_STATE_DETAIL_TIMING_KEYS in
     # src/unilab/base/np_env.py). All backends emit the same key set for column
     # stability; sub-keys that don't apply report 0.0.
@@ -123,6 +136,9 @@ NP_ENV_STEP_TIMING_KEYS = (
 )
 NP_ENV_STEP_COUNT_KEYS = ("reset_done_count",)
 NP_ENV_STEP_SAMPLE_KEYS = (*NP_ENV_STEP_TIMING_KEYS, *NP_ENV_STEP_COUNT_KEYS)
+# Task-dependent per-term event reset timings emitted by ManagerBasedRlEnv;
+# discovered dynamically from info["timing"] since term names vary per task.
+MBA_RESET_EVENT_TERM_PREFIX = "mba_reset_event_term_"
 NP_RANDOM_PROFILE_FUNCTIONS = (
     "uniform",
     "randint",
@@ -160,6 +176,15 @@ NP_ENV_STEP_TIMING_CSV_FIELDS = (
     ("dr_reset_obs_get_body_pose_ms", "dr_reset_obs_get_body_pose_ms"),
     ("dr_reset_observation_compute_obs_ms", "dr_reset_observation_compute_obs_ms"),
     ("dr_reset_observation_internal_gap_ms", "dr_reset_observation_internal_gap_ms"),
+    ("mba_reset_total_ms", "mba_reset_total_ms"),
+    ("mba_reset_curriculum_ms", "mba_reset_curriculum_ms"),
+    ("mba_reset_event_apply_ms", "mba_reset_event_apply_ms"),
+    ("mba_reset_command_reset_ms", "mba_reset_command_reset_ms"),
+    ("mba_reset_set_state_ms", "mba_reset_set_state_ms"),
+    ("mba_reset_manager_reset_ms", "mba_reset_manager_reset_ms"),
+    ("mba_reset_command_compute_ms", "mba_reset_command_compute_ms"),
+    ("mba_reset_obs_build_ms", "mba_reset_obs_build_ms"),
+    ("mba_reset_internal_gap_ms", "mba_reset_internal_gap_ms"),
     ("set_state_mask_ms", "set_state_mask_ms"),
     ("set_state_data_slice_ms", "set_state_data_slice_ms"),
     ("set_state_data_reset_ms", "set_state_data_reset_ms"),
@@ -607,6 +632,14 @@ def _run_active_window_case(
                 )
             else:
                 env_step_timing_values["env_step_internal_gap_ms"] = None
+            # Task-dependent MBA per-term event timings (zero-filled by NpEnv on
+            # steps without reset, once the key set has been discovered).
+            for key, value in _timing.items():
+                if (
+                    key.startswith(MBA_RESET_EVENT_TERM_PREFIX)
+                    and key not in env_step_timing_values
+                ):
+                    env_step_timing_values[key] = value
 
             phase_start_ns = time.perf_counter_ns()
             next_obs_np, next_critic_np = split_obs_dict(state.obs)
@@ -688,7 +721,7 @@ def _run_active_window_case(
                     aux_samples["env_step_overhead_ms"].append(env_step_ms - physics_ms)
                 for key, value in env_step_timing_values.items():
                     if value is not None:
-                        env_step_timing_samples[key].append(value)
+                        env_step_timing_samples.setdefault(key, []).append(value)
     finally:
         if random_profiler is not None:
             random_profiler.uninstall()
@@ -1139,14 +1172,17 @@ def _format_np_env_value(result: CollectorResult, key: str, *, digits: int = 1) 
 def _format_set_state_sub_ms(result: CollectorResult, key: str) -> str:
     """Format a backend set_state sub-timing as ``ms (%of set_state)``.
 
-    The percentage is relative to ``dr_reset_set_state_ms`` (the outer
-    wall-clock measurement in DomainRandomizationManager), not to env_step_ms,
-    so a reader can see which sub-step dominates set_state.
+    The percentage is relative to the outer set_state wall-clock measurement —
+    ``dr_reset_set_state_ms`` on the direct path, ``mba_reset_set_state_ms`` on
+    the MBA path — not to env_step_ms, so a reader can see which sub-step
+    dominates set_state.
     """
     stat = result.env_step_timing_ms_per_vector_step.get(key)
     if stat is None:
         return "n/a"
     outer = result.env_step_timing_ms_per_vector_step.get("dr_reset_set_state_ms")
+    if outer is None or outer.mean_ms <= 0.0:
+        outer = result.env_step_timing_ms_per_vector_step.get("mba_reset_set_state_ms")
     if outer is None or outer.mean_ms <= 0.0:
         return f"{stat.mean_ms:.3f} (n/a)"
     pct = 100.0 * stat.mean_ms / outer.mean_ms
@@ -1534,10 +1570,29 @@ def _print_result(result: CollectorResult) -> None:
             "dr_reset_observation_getters_ms",
             "dr_reset_obs_get_body_pose_ms",
             "dr_reset_observation_compute_obs_ms",
+            "mba_reset_total_ms",
+            "mba_reset_curriculum_ms",
+            "mba_reset_event_apply_ms",
+            "mba_reset_command_reset_ms",
+            "mba_reset_set_state_ms",
+            "mba_reset_manager_reset_ms",
+            "mba_reset_command_compute_ms",
+            "mba_reset_obs_build_ms",
+            "mba_reset_internal_gap_ms",
         ):
             stat = result.env_step_timing_ms_per_vector_step.get(key)
             if stat is None:
                 continue
+            print(
+                f"  {('np_env_' + key):<18} mean={stat.mean_ms:8.3f} ms  "
+                f"pct_env={_env_step_child_env_pct(result, stat.mean_ms):5.1f}% "
+                f"pct_active={_env_step_child_pct(result, stat.mean_ms):5.1f}%"
+            )
+        # Task-dependent MBA per-term event timings (reset-mode terms).
+        for key in sorted(result.env_step_timing_ms_per_vector_step):
+            if not key.startswith(MBA_RESET_EVENT_TERM_PREFIX):
+                continue
+            stat = result.env_step_timing_ms_per_vector_step[key]
             print(
                 f"  {('np_env_' + key):<18} mean={stat.mean_ms:8.3f} ms  "
                 f"pct_env={_env_step_child_env_pct(result, stat.mean_ms):5.1f}% "

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -45,6 +45,20 @@ RESET_DONE_DETAIL_TIMING_KEYS = (
     "dr_reset_obs_get_body_pose_ms",
     "dr_reset_observation_compute_obs_ms",
     "dr_reset_observation_internal_gap_ms",
+    # Manager-Based (MBA) reset sub-steps, reported by ManagerBasedRlEnv.reset().
+    # mba_reset_set_state_ms is the ResetStateTransaction commit wall time; its
+    # backend internals are merged into the set_state_* keys below. Per-term
+    # event timings (mba_reset_event_term_<name>_ms) are task-dependent and are
+    # zero-filled via the env's dynamic extra-key set instead of this tuple.
+    "mba_reset_total_ms",
+    "mba_reset_curriculum_ms",
+    "mba_reset_event_apply_ms",
+    "mba_reset_command_reset_ms",
+    "mba_reset_set_state_ms",
+    "mba_reset_manager_reset_ms",
+    "mba_reset_command_compute_ms",
+    "mba_reset_obs_build_ms",
+    "mba_reset_internal_gap_ms",
     # Backend-internal set_state sub-timings. All backends report the same key
     # set for column stability; sub-keys that don't apply report 0.0.
     "set_state_mask_ms",
@@ -114,6 +128,9 @@ class NpEnv(ABEnv):
         self.step_counter = 0
         self._dr_manager: DomainRandomizationManager | None = None
         self._init_randomization_applied = False
+        # Task-dependent reset detail keys (e.g. MBA per-event-term timings)
+        # merged into info["timing"]; zero-filled alongside the fixed keys.
+        self._reset_detail_extra_keys: set[str] = set()
         self._nan_guard: NanGuard | None = None
         self._autoreset = True
         self._autoreset_reset_active = False
@@ -289,6 +306,12 @@ class NpEnv(ABEnv):
         detail_timing["reset_done_reset_call_ms"] = (time.perf_counter() - t0) * 1000.0
         if self._dr_manager is not None:
             detail_timing.update(self._dr_manager.last_reset_timing_ms)
+        manager_timing = self._collect_manager_reset_timing_ms()
+        if manager_timing:
+            self._reset_detail_extra_keys.update(
+                key for key in manager_timing if key not in RESET_DONE_DETAIL_TIMING_KEYS
+            )
+            detail_timing.update(manager_timing)
 
         t0 = time.perf_counter()
         for key in self._state.obs:
@@ -324,6 +347,16 @@ class NpEnv(ABEnv):
     def _clear_reset_done_detail_timing(self, timing: dict[str, Any]) -> None:
         for key in RESET_DONE_DETAIL_TIMING_KEYS:
             timing[key] = 0.0
+        for key in self._reset_detail_extra_keys:
+            timing[key] = 0.0
+
+    def _collect_manager_reset_timing_ms(self) -> dict[str, float]:
+        """Detail timing from the most recent manager-driven reset.
+
+        Direct envs report nothing (the DR manager merge covers them);
+        ManagerBasedRlEnv overrides this hook with MBA reset sub-step timings.
+        """
+        return {}
 
     def _resolve_nan_guard_model_file(self) -> str:
         scene = getattr(self._cfg, "scene", None)

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -54,11 +54,18 @@ class ResetStateTransaction:
         self._randomization_values: dict[str, np.ndarray] = {}
         self._randomization_dirty_masks: dict[str, np.ndarray] = {}
         self._requesting_terms: set[str] = set()
+        # Backend sub-timings from the most recent commit()'s set_state call.
+        self._last_set_state_timing_ms: dict[str, float] = {}
 
     @property
     def active(self) -> bool:
         """Whether a reset lifecycle currently owns the transaction."""
         return self._active
+
+    @property
+    def last_set_state_timing_ms(self) -> dict[str, float]:
+        """Backend-reported set_state sub-timings of the most recent commit."""
+        return dict(self._last_set_state_timing_ms)
 
     @contextmanager
     def scoped(self, env_ids: np.ndarray) -> Iterator[ResetStateTransaction]:
@@ -84,6 +91,7 @@ class ResetStateTransaction:
         for mask in self._randomization_dirty_masks.values():
             mask.fill(False)
         self._requesting_terms.clear()
+        self._last_set_state_timing_ms = {}
         self._active = True
 
     def bind_body_mass_write(
@@ -533,12 +541,20 @@ class ResetStateTransaction:
             assert self._qvel is not None
             randomization = self._build_randomization_payload(dirty_ids)
             try:
-                return self._backend.set_state(
+                result = self._backend.set_state(
                     dirty_ids,
                     self._qpos[dirty_ids],
                     self._qvel[dirty_ids],
                     randomization=randomization,
                 )
+                backend_timing = result.get("timing") if isinstance(result, dict) else None
+                if isinstance(backend_timing, dict):
+                    self._last_set_state_timing_ms = {
+                        str(key): float(value)
+                        for key, value in backend_timing.items()
+                        if isinstance(value, (int, float))
+                    }
+                return result
             except (AttributeError, NotImplementedError) as exc:
                 terms = ", ".join(sorted(self._requesting_terms))
                 raise NotImplementedError(

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 import secrets
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -253,6 +254,9 @@ class ManagerBasedRlEnv(NpEnv):
         self._all_env_ids.setflags(write=False)
         self._has_transition = False
         self._uses_pre_step_control = False
+        # Sub-step wall time (ms) of the most recent partial reset; consumed by
+        # NpEnv._reset_done_envs via _collect_manager_reset_timing_ms().
+        self._last_reset_timing_ms: dict[str, float] = {}
 
         self._load_managers()
         self._mapped_obs_dims = self._validate_observation_mapping()
@@ -513,17 +517,31 @@ class ManagerBasedRlEnv(NpEnv):
         if self._has_transition and len(done_ids) > 0:
             self.recorder_manager.record_pre_reset(done_ids)
 
+        reset_t0 = time.perf_counter()
         log: dict[str, Any] = {}
+        t0 = time.perf_counter()
         self.curriculum_manager.compute(env_ids=ids)
+        curriculum_ms = (time.perf_counter() - t0) * 1000.0
+        scoped_t0 = time.perf_counter()
         with self._reset_state.scoped(ids):
+            t0 = time.perf_counter()
             if "reset" in self.event_manager.available_modes:
                 self.event_manager.apply(
                     mode="reset",
                     env_ids=ids,
                     global_env_step_count=self.step_counter,
                 )
+            event_apply_ms = (time.perf_counter() - t0) * 1000.0
+            t0 = time.perf_counter()
             log.update(self.command_manager.reset(ids))
+            command_reset_ms = (time.perf_counter() - t0) * 1000.0
+        # The transaction commits (backend set_state) on scoped-exit, so the
+        # remainder of the scoped block is the set_state wall time.
+        set_state_ms = (
+            (time.perf_counter() - scoped_t0) * 1000.0 - event_apply_ms - command_reset_ms
+        )
 
+        t0 = time.perf_counter()
         for manager in (
             self.observation_manager,
             self.action_manager,
@@ -534,6 +552,7 @@ class ManagerBasedRlEnv(NpEnv):
             self.termination_manager,
         ):
             log.update(manager.reset(ids))
+        manager_reset_ms = (time.perf_counter() - t0) * 1000.0
 
         self.episode_length_buf[ids] = 0
         self._control[ids] = 0.0
@@ -541,11 +560,15 @@ class ManagerBasedRlEnv(NpEnv):
         if self._state is not None:
             self._state.info["steps"][ids] = 0
 
+        t0 = time.perf_counter()
         self.command_manager.compute(dt=0.0, env_ids=ids)
         self.command_manager.post_compute()
+        command_compute_ms = (time.perf_counter() - t0) * 1000.0
+        t0 = time.perf_counter()
         manager_obs = self.observation_manager.compute(update_history=True, env_ids=ids)
         mapped_obs = self._map_observations(manager_obs)
         reset_obs = {name: values[ids].copy() for name, values in mapped_obs.items()}
+        obs_build_ms = (time.perf_counter() - t0) * 1000.0
 
         if self._state is not None:
             for name, values in reset_obs.items():
@@ -560,7 +583,36 @@ class ManagerBasedRlEnv(NpEnv):
         self.obs_buf = self._state.obs if self._state is not None else mapped_obs
         self.extras = self._state.info if self._state is not None else {"log": log}
         self.recorder_manager.record_post_reset(ids)
+
+        total_ms = (time.perf_counter() - reset_t0) * 1000.0
+        measured_ms = (
+            curriculum_ms
+            + event_apply_ms
+            + command_reset_ms
+            + set_state_ms
+            + manager_reset_ms
+            + command_compute_ms
+            + obs_build_ms
+        )
+        reset_timing: dict[str, float] = {
+            "mba_reset_total_ms": total_ms,
+            "mba_reset_curriculum_ms": curriculum_ms,
+            "mba_reset_event_apply_ms": event_apply_ms,
+            "mba_reset_command_reset_ms": command_reset_ms,
+            "mba_reset_set_state_ms": set_state_ms,
+            "mba_reset_manager_reset_ms": manager_reset_ms,
+            "mba_reset_command_compute_ms": command_compute_ms,
+            "mba_reset_obs_build_ms": obs_build_ms,
+            "mba_reset_internal_gap_ms": total_ms - measured_ms,
+        }
+        for term_name, term_ms in self.event_manager.last_reset_term_timing_ms.items():
+            reset_timing[f"mba_reset_event_term_{term_name}_ms"] = term_ms
+        reset_timing.update(self._reset_state.last_set_state_timing_ms)
+        self._last_reset_timing_ms = reset_timing
         return reset_obs, {"log": log}
+
+    def _collect_manager_reset_timing_ms(self) -> dict[str, float]:
+        return dict(self._last_reset_timing_ms)
 
     def _normalize_reset_ids(
         self,

--- a/src/unilab/managers/event_manager.py
+++ b/src/unilab/managers/event_manager.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import time
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -79,6 +80,9 @@ class EventManager(ManagerBase):
         self._mode_term_names: dict[EventMode, list[str]] = dict()
         self._mode_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
         self._mode_class_term_cfgs: dict[EventMode, list[EventTermCfg]] = dict()
+        # Per-term wall time (ms) of the latest mode="reset" apply(); all reset
+        # term names are pre-registered at 0.0 in _prepare_terms.
+        self._reset_term_timing_ms: dict[str, float] = dict()
 
         super().__init__(env=env)
 
@@ -112,6 +116,15 @@ class EventManager(ManagerBase):
     @property
     def available_modes(self) -> list[EventMode]:
         return list(self._mode_term_names.keys())
+
+    @property
+    def last_reset_term_timing_ms(self) -> dict[str, float]:
+        """Per-term wall time (ms) of the latest ``mode="reset"`` apply.
+
+        All reset-mode term names are always present; terms gated out by
+        ``min_step_count_between_reset`` report 0.0 for that apply.
+        """
+        return dict(self._reset_term_timing_ms)
 
     # Methods.
 
@@ -169,6 +182,10 @@ class EventManager(ManagerBase):
         if mode == "step" and dt is None:
             raise ValueError(f"Event mode '{mode}' requires the time-step of the environment.")
 
+        if mode == "reset":
+            for term_name in self._reset_term_timing_ms:
+                self._reset_term_timing_ms[term_name] = 0.0
+
         for index, term_cfg in enumerate(self._mode_term_cfgs[mode]):
             if mode == "interval":
                 time_left = self._interval_term_time_left[index]
@@ -203,7 +220,12 @@ class EventManager(ManagerBase):
                 if min_step_count == 0:
                     self._reset_term_last_triggered_step_id[index][env_ids] = global_env_step_count
                     self._reset_term_last_triggered_once[index][env_ids] = True
+                    term_t0 = time.perf_counter()
                     term_cfg.func(self._env, env_ids, **term_cfg.params)
+                    term_name = self._mode_term_names[mode][index]
+                    self._reset_term_timing_ms[term_name] += (
+                        time.perf_counter() - term_t0
+                    ) * 1000.0
                 else:
                     last_triggered_step = self._reset_term_last_triggered_step_id[index][env_ids]
                     triggered_at_least_once = self._reset_term_last_triggered_once[index][env_ids]
@@ -219,7 +241,12 @@ class EventManager(ManagerBase):
                         self._reset_term_last_triggered_step_id[index][valid_env_ids] = (
                             global_env_step_count
                         )
+                        term_t0 = time.perf_counter()
                         term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+                        term_name = self._mode_term_names[mode][index]
+                        self._reset_term_timing_ms[term_name] += (
+                            time.perf_counter() - term_t0
+                        ) * 1000.0
             else:
                 term_cfg.func(self._env, env_ids, **term_cfg.params)
 
@@ -267,6 +294,7 @@ class EventManager(ManagerBase):
                 self._reset_term_last_triggered_step_id.append(step_count)
                 no_trigger = np.zeros(self.num_envs, dtype=np.bool_)
                 self._reset_term_last_triggered_once.append(no_trigger)
+                self._reset_term_timing_ms[term_name] = 0.0
 
             func = term_cfg.func
             if hasattr(func, "model_fields"):

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -291,6 +291,45 @@ def test_write_csv_includes_backend_set_state_sub_timing_columns(tmp_path) -> No
         assert key in header, f"CSV header missing {key!r}"
 
 
+def test_write_csv_includes_mba_reset_sub_step_columns(tmp_path) -> None:
+    """CSV headers must expose the fixed MBA reset sub-step keys."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    out_csv = tmp_path / "collector.csv"
+
+    bench._write_csv(out_csv, [result])
+
+    header = out_csv.read_text(encoding="utf-8").splitlines()[0]
+    for key in (
+        "mba_reset_total_ms",
+        "mba_reset_curriculum_ms",
+        "mba_reset_event_apply_ms",
+        "mba_reset_command_reset_ms",
+        "mba_reset_set_state_ms",
+        "mba_reset_manager_reset_ms",
+        "mba_reset_command_compute_ms",
+        "mba_reset_obs_build_ms",
+        "mba_reset_internal_gap_ms",
+    ):
+        assert key in header, f"CSV header missing {key!r}"
+
+
+def test_print_result_includes_mba_reset_and_per_term_event_timings(capsys) -> None:
+    """Console breakdown shows MBA reset sub-steps and dynamic per-term keys."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    result.env_step_timing_ms_per_vector_step["mba_reset_total_ms"] = bench.TimingStats(
+        [5.0], 5.0, 5.0, 0.0, 5.0, 5.0
+    )
+    result.env_step_timing_ms_per_vector_step["mba_reset_event_term_reset_root_ms"] = (
+        bench.TimingStats([2.0], 2.0, 2.0, 0.0, 2.0, 2.0)
+    )
+
+    bench._print_result(result)
+
+    out = capsys.readouterr().out
+    assert "np_env_mba_reset_total_ms" in out
+    assert "np_env_mba_reset_event_term_reset_root_ms" in out
+
+
 def test_format_set_state_detail_table_reports_sub_key_percentages() -> None:
     """The detail table shows each sub-key next to its share of
     ``dr_reset_set_state_ms`` (percentages must appear)."""

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -1056,6 +1056,37 @@ def test_pure_reset_event_does_not_request_backend_state_capability() -> None:
     assert not hasattr(backend, "get_default_qpos")
 
 
+def test_partial_reset_reports_mba_reset_timing_keys() -> None:
+    # No time_out term: only the explicit failure action triggers a reset.
+    cfg = _make_cfg()
+    cfg.terminations = {"failure": TerminationTermCfg(func=_failure)}
+    env, _ = _make_env(cfg)
+    env.init_state()
+
+    state = env.step(np.array([[1.0], [0.0]], dtype=np.float32))  # env 0 autoresets
+    timing = state.info["timing"]
+    sub_step_keys = (
+        "mba_reset_curriculum_ms",
+        "mba_reset_event_apply_ms",
+        "mba_reset_command_reset_ms",
+        "mba_reset_set_state_ms",
+        "mba_reset_manager_reset_ms",
+        "mba_reset_command_compute_ms",
+        "mba_reset_obs_build_ms",
+        "mba_reset_internal_gap_ms",
+    )
+    for key in ("mba_reset_total_ms", *sub_step_keys, "mba_reset_event_term_reset_ms"):
+        assert key in timing
+        assert timing[key] >= 0.0
+    assert sum(timing[key] for key in sub_step_keys) == pytest.approx(timing["mba_reset_total_ms"])
+
+    # Steps without a reset zero-fill both fixed and per-term MBA keys.
+    state = env.step(np.array([[0.0], [0.0]], dtype=np.float32))
+    timing = state.info["timing"]
+    assert timing["mba_reset_total_ms"] == 0.0
+    assert timing["mba_reset_event_term_reset_ms"] == 0.0
+
+
 def test_partial_reset_preserves_other_env_counter_and_terminal_obs() -> None:
     env, _ = _make_env()
     env.init_state()

--- a/tests/managers/test_event_command_metrics_recorder.py
+++ b/tests/managers/test_event_command_metrics_recorder.py
@@ -78,6 +78,30 @@ def test_event_validation_and_model_mutation_failure(fake_env: FakeEnv) -> None:
     empty.apply("interval")
 
 
+def test_event_reset_term_timing_is_tracked_per_term(fake_env: FakeEnv) -> None:
+    cfg = {
+        "always": EventTermCfg(func=_record, params={"label": "always"}, mode="reset"),
+        "gated": EventTermCfg(
+            func=_record,
+            params={"label": "gated"},
+            mode="reset",
+            min_step_count_between_reset=100,
+        ),
+    }
+    manager = EventManager(cfg, fake_env)
+
+    # First reset: the gated term fires once via the never-triggered exemption.
+    manager.apply("reset", env_ids=np.array([1, 3]), global_env_step_count=1)
+    # Second reset: the gated term is throttled out and must report 0.0.
+    manager.apply("reset", env_ids=np.array([1, 3]), global_env_step_count=2)
+
+    timing = manager.last_reset_term_timing_ms
+    assert set(timing) == {"always", "gated"}
+    assert timing["always"] >= 0.0
+    assert timing["gated"] == 0.0
+    assert [label for label, _ in fake_env.calls] == ["always", "gated", "always"]
+
+
 def test_event_interval_rng_is_reproducible() -> None:
     cfg = {
         "interval": EventTermCfg(


### PR DESCRIPTION
## 目的

定位 #1253 baseline 中 MBA 分支 reset_done 慢 5–6 倍的问题：MBA 的 reset 走 manager event 路径后，现有 `dr_reset_*` 计时键全部归零，看不到 reset 内部分解。本 PR 只补插桩与 benchmark 接线，不做优化、不改 manager 公共 contract / lifecycle / term 语义，不动 direct 路径的 `dr_reset_*` 插桩语义。

## 改动

- `EventManager.apply(mode="reset")`：逐 term 计时，新增 `last_reset_term_timing_ms`（reset term 名单预注册，键集稳定；被 `min_step_count_between_reset` 挡下的 term 报 0）。
- `ManagerBasedRlEnv.reset()`：按子步骤计时（curriculum / event apply / command reset / set_state commit / manager reset 循环 / post-reset command compute / observation 重建），汇总为固定键 `mba_reset_{total,curriculum,event_apply,command_reset,set_state,manager_reset,command_compute,obs_build,internal_gap}_ms`。
- `ResetStateTransaction.commit()`：留存 backend `set_state` 返回的子计时（此前被 `scoped()` 丢弃），MBA 路径复用现有 `set_state_*` 键。
- `NpEnv`：固定键注册进 `RESET_DONE_DETAIL_TIMING_KEYS`；经 `_collect_manager_reset_timing_ms()` 钩子合并（direct env 默认空）；per-term 动态键（`mba_reset_event_term_<name>_ms`）随固定键一起 zero-fill。
- `benchmark_offpolicy_collector_active.py`：固定 `mba_reset_*` 键进采样 / CSV / console；per-term 动态键采样进 JSON / console；set_state 明细表百分比在未走 DR 路径时回退到 `mba_reset_set_state_ms`。
- 新增 3 个测试：event per-term 计时、MBA reset 键合并与 zero-fill、benchmark CSV / console 输出。

## 定位结论（已同步到 #1255 评论）

同机同参重测 #1253 的 7 个 case，reset_done 总量与 baseline 一致（插桩开销可忽略），分解到子步骤级：

- **g1_motion_tracking（53.1 / 62.5ms）**：post-reset `command_manager.compute(dt=0)` + `post_compute` 占 **66–67%**（`MotionCommand._update_metrics` / `_refresh_motion` / `_refresh_relative_state` 全 batch 重复计算），observation 重建占 **20–25%**（`ObservationManager.compute_group` 全 batch 计算只为百余个 reset env 回填）；event term 合计 ~0%。
- **g1_walk_flat（4 case，9.5–14.8ms）**：observation 重建 42–64%（motrix 第一大），set_state 20–43%（mujoco 第一大，其中 backend 内部 `set_state_pool_reset` 占 91%），event term 最大单项 ~0.5ms。

#1253 怀疑的逐 term Python 循环 / 逐 env 重采样 / set_state 均被数据排除；优化另开 issue。

## Validation

- `make test-all` 本地已全部通过（含新增测试；仅 platform-optional 的 mlx benchmark 脚本按既有规则 skipped）。
- 7 个 benchmark case（#1253 复现命令）全部测成，无静默跳过。

Fixes #1255
