### PR TITLE
feat: instrument MBA update_state with block, term, and getter timing (#1256)

### DIFF
--- a/scripts/benchmark/rl/benchmark_offpolicy_collector_active.py
+++ b/scripts/benchmark/rl/benchmark_offpolicy_collector_active.py
@@ -133,12 +133,42 @@ NP_ENV_STEP_TIMING_KEYS = (
     "set_state_pool_reset_ms",
     "set_state_state_scatter_ms",
     "set_state_internal_gap_ms",
+    # Manager-Based (MBA) update_state blocks, reported every step by
+    # ManagerBasedRlEnv.update_state() (see UPDATE_STATE_DETAIL_TIMING_KEYS in
+    # src/unilab/base/np_env.py). Task-dependent per-term and per-method keys
+    # (mba_obs_term_*, mba_reward_term_*, mba_getter_<method>_ms) are discovered
+    # dynamically at sample time (JSON/console only; not part of the fixed CSV
+    # header).
+    "mba_update_total_ms",
+    "mba_termination_ms",
+    "mba_reward_ms",
+    "mba_metrics_ms",
+    "mba_events_ms",
+    "mba_command_ms",
+    "mba_obs_compute_ms",
+    "mba_obs_map_ms",
+    "mba_termination_getter_ms",
+    "mba_reward_getter_ms",
+    "mba_metrics_getter_ms",
+    "mba_events_getter_ms",
+    "mba_command_getter_ms",
+    "mba_obs_compute_getter_ms",
+    "mba_obs_map_getter_ms",
+    "mba_update_internal_gap_ms",
+    "mba_getters_total_ms",
+    "mba_obs_noise_ms",
+    "mba_obs_clip_scale_ms",
+    "mba_obs_nan_check_ms",
+    "mba_obs_delay_ms",
+    "mba_obs_history_ms",
+    "mba_obs_concat_ms",
 )
 NP_ENV_STEP_COUNT_KEYS = ("reset_done_count",)
 NP_ENV_STEP_SAMPLE_KEYS = (*NP_ENV_STEP_TIMING_KEYS, *NP_ENV_STEP_COUNT_KEYS)
-# Task-dependent per-term event reset timings emitted by ManagerBasedRlEnv;
-# discovered dynamically from info["timing"] since term names vary per task.
-MBA_RESET_EVENT_TERM_PREFIX = "mba_reset_event_term_"
+# Task-dependent MBA timings emitted by ManagerBasedRlEnv (per-term reset event
+# timings, per-term obs/reward timings, per-method getter timings); discovered
+# dynamically from info["timing"] since term/method names vary per task.
+MBA_DYNAMIC_KEY_PREFIX = "mba_"
 NP_RANDOM_PROFILE_FUNCTIONS = (
     "uniform",
     "randint",
@@ -201,6 +231,29 @@ NP_ENV_STEP_TIMING_CSV_FIELDS = (
     ("set_state_pool_reset_ms", "set_state_pool_reset_ms"),
     ("set_state_state_scatter_ms", "set_state_state_scatter_ms"),
     ("set_state_internal_gap_ms", "set_state_internal_gap_ms"),
+    ("mba_update_total_ms", "mba_update_total_ms"),
+    ("mba_termination_ms", "mba_termination_ms"),
+    ("mba_reward_ms", "mba_reward_ms"),
+    ("mba_metrics_ms", "mba_metrics_ms"),
+    ("mba_events_ms", "mba_events_ms"),
+    ("mba_command_ms", "mba_command_ms"),
+    ("mba_obs_compute_ms", "mba_obs_compute_ms"),
+    ("mba_obs_map_ms", "mba_obs_map_ms"),
+    ("mba_termination_getter_ms", "mba_termination_getter_ms"),
+    ("mba_reward_getter_ms", "mba_reward_getter_ms"),
+    ("mba_metrics_getter_ms", "mba_metrics_getter_ms"),
+    ("mba_events_getter_ms", "mba_events_getter_ms"),
+    ("mba_command_getter_ms", "mba_command_getter_ms"),
+    ("mba_obs_compute_getter_ms", "mba_obs_compute_getter_ms"),
+    ("mba_obs_map_getter_ms", "mba_obs_map_getter_ms"),
+    ("mba_update_internal_gap_ms", "mba_update_internal_gap_ms"),
+    ("mba_getters_total_ms", "mba_getters_total_ms"),
+    ("mba_obs_noise_ms", "mba_obs_noise_ms"),
+    ("mba_obs_clip_scale_ms", "mba_obs_clip_scale_ms"),
+    ("mba_obs_nan_check_ms", "mba_obs_nan_check_ms"),
+    ("mba_obs_delay_ms", "mba_obs_delay_ms"),
+    ("mba_obs_history_ms", "mba_obs_history_ms"),
+    ("mba_obs_concat_ms", "mba_obs_concat_ms"),
 )
 
 
@@ -632,13 +685,11 @@ def _run_active_window_case(
                 )
             else:
                 env_step_timing_values["env_step_internal_gap_ms"] = None
-            # Task-dependent MBA per-term event timings (zero-filled by NpEnv on
-            # steps without reset, once the key set has been discovered).
+            # Task-dependent MBA dynamic keys (reset event terms, obs/reward
+            # terms, per-method getter timings); zero-filled by NpEnv on steps
+            # where they don't apply, once the key set has been discovered.
             for key, value in _timing.items():
-                if (
-                    key.startswith(MBA_RESET_EVENT_TERM_PREFIX)
-                    and key not in env_step_timing_values
-                ):
+                if key.startswith(MBA_DYNAMIC_KEY_PREFIX) and key not in env_step_timing_values:
                     env_step_timing_values[key] = value
 
             phase_start_ns = time.perf_counter_ns()
@@ -1579,6 +1630,20 @@ def _print_result(result: CollectorResult) -> None:
             "mba_reset_command_compute_ms",
             "mba_reset_obs_build_ms",
             "mba_reset_internal_gap_ms",
+            "mba_update_total_ms",
+            "mba_termination_ms",
+            "mba_reward_ms",
+            "mba_metrics_ms",
+            "mba_events_ms",
+            "mba_command_ms",
+            "mba_obs_compute_ms",
+            "mba_obs_map_ms",
+            "mba_update_internal_gap_ms",
+            "mba_getters_total_ms",
+            "mba_obs_noise_ms",
+            "mba_obs_clip_scale_ms",
+            "mba_obs_nan_check_ms",
+            "mba_obs_concat_ms",
         ):
             stat = result.env_step_timing_ms_per_vector_step.get(key)
             if stat is None:
@@ -1588,9 +1653,10 @@ def _print_result(result: CollectorResult) -> None:
                 f"pct_env={_env_step_child_env_pct(result, stat.mean_ms):5.1f}% "
                 f"pct_active={_env_step_child_pct(result, stat.mean_ms):5.1f}%"
             )
-        # Task-dependent MBA per-term event timings (reset-mode terms).
+        # Task-dependent MBA dynamic keys (reset event terms, obs/reward terms,
+        # per-method getter timings) not already printed above.
         for key in sorted(result.env_step_timing_ms_per_vector_step):
-            if not key.startswith(MBA_RESET_EVENT_TERM_PREFIX):
+            if not key.startswith(MBA_DYNAMIC_KEY_PREFIX) or key in NP_ENV_STEP_SAMPLE_KEYS:
                 continue
             stat = result.env_step_timing_ms_per_vector_step[key]
             print(

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -8,10 +8,11 @@ public :class:`~unilab.base.backend.base.SimBackend` contract.
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import numpy as np
 
@@ -132,6 +133,28 @@ def _resolve_matching_names(
     return [item[1] for item in matches], [item[2] for item in matches]
 
 
+class GetterTimingRecorder:
+    """Per-step wall-time accumulator for leaf backend state getters.
+
+    One recorder per :class:`EntityData` instance; the owning env aggregates and
+    resets the recorders around its ``update_state`` pass (see
+    ``ManagerBasedRlEnv``). Timing is always on: two ``perf_counter_ns`` calls
+    per getter invocation, negligible against the getter itself.
+    """
+
+    def __init__(self) -> None:
+        self.method_ms: dict[str, float] = {}
+        self.total_ms: float = 0.0
+
+    def record(self, method: str, elapsed_ms: float) -> None:
+        self.method_ms[method] = self.method_ms.get(method, 0.0) + elapsed_ms
+        self.total_ms += elapsed_ms
+
+    def reset(self) -> None:
+        self.method_ms.clear()
+        self.total_ms = 0.0
+
+
 class EntityData:
     """Hot-path NumPy state surface backed by cached backend IDs."""
 
@@ -176,6 +199,16 @@ class EntityData:
         self._actuator_ids = actuator_ids
         self._actuator_ctrl_range = actuator_ctrl_range
         self._control_buffer = control_buffer
+        # Always-on leaf getter timing; aggregated/reset per update_state by the
+        # owning env (MBA update_state instrumentation, issue #1256).
+        self.getter_timing = GetterTimingRecorder()
+
+    def _timed_getter(self, method: str, fn: Any, *args: Any) -> np.ndarray:
+        t0 = time.perf_counter_ns()
+        try:
+            return fn(*args)
+        finally:
+            self.getter_timing.record(method, (time.perf_counter_ns() - t0) / 1e6)
 
     def _require(self, value, capability: str):
         if value is None:
@@ -188,32 +221,32 @@ class EntityData:
     @property
     def root_link_pos_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_pos_w(ids)[:, 0]
+        return self._timed_getter("body_pos_w", self._backend.get_body_pos_w, ids)[:, 0]
 
     @property
     def root_link_quat_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_quat_w(ids)[:, 0]
+        return self._timed_getter("body_quat_w", self._backend.get_body_quat_w, ids)[:, 0]
 
     @property
     def root_link_lin_vel_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_lin_vel_w(ids)[:, 0]
+        return self._timed_getter("body_lin_vel_w", self._backend.get_body_lin_vel_w, ids)[:, 0]
 
     @property
     def root_link_ang_vel_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_ang_vel_w(ids)[:, 0]
+        return self._timed_getter("body_ang_vel_w", self._backend.get_body_ang_vel_w, ids)[:, 0]
 
     @property
     def root_link_lin_vel_b(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_lin_vel_b(ids)[:, 0]
+        return self._timed_getter("body_lin_vel_b", self._backend.get_body_lin_vel_b, ids)[:, 0]
 
     @property
     def root_link_ang_vel_b(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._backend.get_body_ang_vel_b(ids)[:, 0]
+        return self._timed_getter("body_ang_vel_b", self._backend.get_body_ang_vel_b, ids)[:, 0]
 
     @property
     def heading_w(self) -> np.ndarray:
@@ -253,12 +286,12 @@ class EntityData:
     @property
     def joint_pos(self) -> np.ndarray:
         index = self._require(self._joint_pos_index, "joint position")
-        return self._backend.get_dof_pos()[:, index]
+        return self._timed_getter("dof_pos", self._backend.get_dof_pos)[:, index]
 
     @property
     def joint_vel(self) -> np.ndarray:
         index = self._require(self._joint_vel_index, "joint velocity")
-        return self._backend.get_dof_vel()[:, index]
+        return self._timed_getter("dof_vel", self._backend.get_dof_vel)[:, index]
 
     @property
     def joint_pos_biased(self) -> np.ndarray:
@@ -288,22 +321,22 @@ class EntityData:
     @property
     def body_link_pos_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._backend.get_body_pos_w(ids)
+        return self._timed_getter("body_pos_w", self._backend.get_body_pos_w, ids)
 
     @property
     def body_link_quat_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._backend.get_body_quat_w(ids)
+        return self._timed_getter("body_quat_w", self._backend.get_body_quat_w, ids)
 
     @property
     def body_link_lin_vel_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._backend.get_body_lin_vel_w(ids)
+        return self._timed_getter("body_lin_vel_w", self._backend.get_body_lin_vel_w, ids)
 
     @property
     def body_link_ang_vel_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._backend.get_body_ang_vel_w(ids)
+        return self._timed_getter("body_ang_vel_w", self._backend.get_body_ang_vel_w, ids)
 
     @property
     def body_link_pose_w(self) -> np.ndarray:

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -102,6 +102,37 @@ BACKEND_SET_STATE_DETAIL_TIMING_KEYS = (
 )
 
 
+# Fixed MBA update_state detail keys reported by ManagerBasedRlEnv.update_state()
+# (issue #1256). All envs emit the same fixed key set for column stability;
+# direct envs report 0.0. Task-dependent keys (mba_obs_term_*, mba_reward_term_*,
+# mba_getter_<method>_ms) are zero-filled via the env's dynamic extra-key set.
+UPDATE_STATE_DETAIL_TIMING_KEYS = (
+    "mba_update_total_ms",
+    "mba_termination_ms",
+    "mba_reward_ms",
+    "mba_metrics_ms",
+    "mba_events_ms",
+    "mba_command_ms",
+    "mba_obs_compute_ms",
+    "mba_obs_map_ms",
+    "mba_termination_getter_ms",
+    "mba_reward_getter_ms",
+    "mba_metrics_getter_ms",
+    "mba_events_getter_ms",
+    "mba_command_getter_ms",
+    "mba_obs_compute_getter_ms",
+    "mba_obs_map_getter_ms",
+    "mba_update_internal_gap_ms",
+    "mba_getters_total_ms",
+    "mba_obs_noise_ms",
+    "mba_obs_clip_scale_ms",
+    "mba_obs_nan_check_ms",
+    "mba_obs_delay_ms",
+    "mba_obs_history_ms",
+    "mba_obs_concat_ms",
+)
+
+
 @dataclass
 class NpEnvState:
     obs: dict[str, np.ndarray]
@@ -131,6 +162,9 @@ class NpEnv(ABEnv):
         # Task-dependent reset detail keys (e.g. MBA per-event-term timings)
         # merged into info["timing"]; zero-filled alongside the fixed keys.
         self._reset_detail_extra_keys: set[str] = set()
+        # Task-dependent update_state detail keys (MBA obs/reward term and
+        # per-method getter timings); zero-filled every step.
+        self._update_detail_extra_keys: set[str] = set()
         self._nan_guard: NanGuard | None = None
         self._autoreset = True
         self._autoreset_reset_active = False
@@ -247,6 +281,18 @@ class NpEnv(ABEnv):
         timing["step_core_ms"] = step_core_time * 1000.0
         timing["update_state_ms"] = update_state_time * 1000.0
         timing["reset_done_ms"] = reset_done_time * 1000.0
+        # update_state detail runs every step, so fixed keys are simply
+        # overwritten; dynamic keys discovered so far are zero-filled first.
+        for key in UPDATE_STATE_DETAIL_TIMING_KEYS:
+            timing[key] = 0.0
+        for key in self._update_detail_extra_keys:
+            timing[key] = 0.0
+        manager_update_timing = self._collect_manager_update_timing_ms()
+        if manager_update_timing:
+            self._update_detail_extra_keys.update(
+                key for key in manager_update_timing if key not in UPDATE_STATE_DETAIL_TIMING_KEYS
+            )
+            timing.update(manager_update_timing)
         if backend_result is not None:
             backend_timing = backend_result.get("timing")
             if backend_timing:
@@ -355,6 +401,14 @@ class NpEnv(ABEnv):
 
         Direct envs report nothing (the DR manager merge covers them);
         ManagerBasedRlEnv overrides this hook with MBA reset sub-step timings.
+        """
+        return {}
+
+    def _collect_manager_update_timing_ms(self) -> dict[str, float]:
+        """Detail timing from the most recent manager-driven update_state.
+
+        Direct envs report nothing; ManagerBasedRlEnv overrides this hook with
+        MBA update_state block/term/getter timings.
         """
         return {}
 

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -257,6 +257,9 @@ class ManagerBasedRlEnv(NpEnv):
         # Sub-step wall time (ms) of the most recent partial reset; consumed by
         # NpEnv._reset_done_envs via _collect_manager_reset_timing_ms().
         self._last_reset_timing_ms: dict[str, float] = {}
+        # Block/term/getter wall time (ms) of the most recent update_state;
+        # consumed by NpEnv.step via _collect_manager_update_timing_ms().
+        self._last_update_timing_ms: dict[str, float] = {}
 
         self._load_managers()
         self._mapped_obs_dims = self._validate_observation_mapping()
@@ -437,15 +440,38 @@ class ManagerBasedRlEnv(NpEnv):
             self.action_manager.apply_action()
         return self._control
 
+    def _mba_getter_total_ms(self) -> float:
+        """Accumulated leaf backend getter time (ms) across all scene entities.
+
+        EntityData records every leaf getter call into a per-entity
+        GetterTimingRecorder; update_state resets the recorders at block start
+        and reads deltas around blocks/terms for attribution (issue #1256).
+        """
+        return sum(entity.data.getter_timing.total_ms for entity in self.scene.values())
+
     def update_state(self, state: NpEnvState) -> NpEnvState:
         log: dict[str, Any] = {}
         state.info["log"] = log
         self.extras = state.info
 
+        # Reset leaf getter accumulators so this pass measures only update_state.
+        for entity in self.scene.values():
+            entity.data.getter_timing.reset()
+        update_t0 = time.perf_counter()
+        update_timing: dict[str, float] = {}
+
         np.add(state.info["steps"], 1, out=self.episode_length_buf)
         self.common_step_counter = self.step_counter + 1
         self._sim_step_counter = self.common_step_counter * self._cfg.sim_substeps
 
+        def _mark(name: str, t0: float, getter0: float) -> tuple[float, float]:
+            now = time.perf_counter()
+            getter_now = self._mba_getter_total_ms()
+            update_timing[f"mba_{name}_ms"] = (now - t0) * 1000.0
+            update_timing[f"mba_{name}_getter_ms"] = getter_now - getter0
+            return now, getter_now
+
+        t_prev, g_prev = time.perf_counter(), self._mba_getter_total_ms()
         self.termination_manager.compute()
         if self._cfg.is_finite_horizon:
             np.logical_or(
@@ -458,26 +484,61 @@ class ManagerBasedRlEnv(NpEnv):
             np.copyto(self.reset_terminated, self.termination_manager.terminated)
             np.copyto(self.reset_time_outs, self.termination_manager.time_outs)
         np.logical_or(self.reset_terminated, self.reset_time_outs, out=self.reset_buf)
+        t_prev, g_prev = _mark("termination", t_prev, g_prev)
 
         self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
         log.update(self.reward_manager.step_reward_extras())
+        t_prev, g_prev = _mark("reward", t_prev, g_prev)
+        update_timing.update(self.reward_manager.last_compute_timing_ms)
+
         if self._cfg.sim_substeps == 1:
             self.metrics_manager.compute_substep()
         self.metrics_manager.compute()
+        t_prev, g_prev = _mark("metrics", t_prev, g_prev)
 
         if "step" in self.event_manager.available_modes:
             self.event_manager.apply(mode="step", dt=self.step_dt)
         if "interval" in self.event_manager.available_modes:
             self.event_manager.apply(mode="interval", dt=self.step_dt)
+        t_prev, g_prev = _mark("events", t_prev, g_prev)
 
         self._command_dt.fill(self.step_dt)
         self._command_dt[self.reset_buf] = 0.0
         with self._reset_state.scoped(self._all_env_ids):
             self.command_manager.compute(dt=self._command_dt)
         self.command_manager.post_compute()
+        t_prev, g_prev = _mark("command", t_prev, g_prev)
+
         manager_obs = self.observation_manager.compute(update_history=True)
+        t_prev, g_prev = _mark("obs_compute", t_prev, g_prev)
+        update_timing.update(self.observation_manager.last_compute_timing_ms)
+
         self.obs_buf = self._map_observations(manager_obs)
+        t_prev, g_prev = _mark("obs_map", t_prev, g_prev)
         self._has_transition = True
+
+        update_total_ms = (time.perf_counter() - update_t0) * 1000.0
+        block_names = (
+            "termination",
+            "reward",
+            "metrics",
+            "events",
+            "command",
+            "obs_compute",
+            "obs_map",
+        )
+        update_timing["mba_update_total_ms"] = update_total_ms
+        update_timing["mba_update_internal_gap_ms"] = update_total_ms - sum(
+            update_timing[f"mba_{name}_ms"] for name in block_names
+        )
+        getter_method_ms: dict[str, float] = {}
+        for entity in self.scene.values():
+            for method, elapsed_ms in entity.data.getter_timing.method_ms.items():
+                getter_method_ms[method] = getter_method_ms.get(method, 0.0) + elapsed_ms
+        update_timing["mba_getters_total_ms"] = g_prev
+        for method, elapsed_ms in getter_method_ms.items():
+            update_timing[f"mba_getter_{method}_ms"] = elapsed_ms
+        self._last_update_timing_ms = update_timing
 
         return state.replace(
             obs=self.obs_buf,
@@ -486,6 +547,9 @@ class ManagerBasedRlEnv(NpEnv):
             truncated=self.reset_time_outs,
             info=state.info,
         )
+
+    def _collect_manager_update_timing_ms(self) -> dict[str, float]:
+        return dict(self._last_update_timing_ms)
 
     def _compute_truncated(self, state: NpEnvState) -> np.ndarray:
         del state

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -250,6 +250,10 @@ class ManagerBasedRlEnv(Protocol):
     @property
     def max_episode_length_s(self) -> float: ...
 
+    def _mba_getter_total_ms(self) -> float:
+        """Accumulated leaf backend getter time (ms); 0.0 when uninstrumented."""
+        ...
+
     # Concrete task terms may still type their own richer env subclass.  The
     # standalone manager core deliberately depends only on the properties above.
 

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, Sequence
@@ -157,6 +158,11 @@ class ObservationManager(ManagerBase):
                 self._group_obs_dim[group_name] = group_term_dims
 
         self._obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] | None = None
+        # Per-compute() timing breakdown consumed by the env's update_state
+        # instrumentation (issue #1256): per-term totals/getter shares and
+        # cross-term pipeline phases (noise/clip_scale/nan_check/delay/history/
+        # concat), keyed with the mba_obs_* prefix.
+        self._last_compute_timing_ms: dict[str, float] = {}
 
     def __str__(self) -> str:
         msg = f"<ObservationManager> contains {len(self._group_obs_term_names)} groups.\n"
@@ -234,6 +240,11 @@ class ObservationManager(ManagerBase):
     @property
     def group_obs_concatenate(self) -> dict[str, bool]:
         return self._group_obs_concatenate
+
+    @property
+    def last_compute_timing_ms(self) -> dict[str, float]:
+        """Per-term and per-phase wall times (ms) of the latest compute() call."""
+        return dict(self._last_compute_timing_ms)
 
     # Methods.
 
@@ -340,6 +351,7 @@ class ObservationManager(ManagerBase):
             return self._obs_buffer
 
         obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] = dict()
+        self._last_compute_timing_ms = {}
         for group_name in self._group_obs_term_names:
             obs_buffer[group_name] = self.compute_group(group_name, update_history, env_ids)
         self._obs_buffer = obs_buffer
@@ -356,8 +368,22 @@ class ObservationManager(ManagerBase):
             raise KeyError(f"Observation group '{group_name}' is disabled.")
         group_term_names = self._group_obs_term_names[group_name]
         group_obs: dict[str, np.ndarray] = {}
+        # Per-compute() instrumentation (issue #1256): per-term wall time with
+        # leaf-getter share, plus cross-term pipeline phase aggregation. Timing
+        # keys are merged into self._last_compute_timing_ms with mba_obs_* names.
+        phase_ms = {
+            "noise": 0.0,
+            "clip_scale": 0.0,
+            "nan_check": 0.0,
+            "delay": 0.0,
+            "history": 0.0,
+            "concat": 0.0,
+        }
+        term_timing: dict[str, float] = {}
         obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name], strict=False)
         for term_name, term_cfg in obs_terms:
+            term_t0 = time.perf_counter()
+            term_getter0 = self._env._mba_getter_total_ms()
             obs = term_cfg.func(self._env, **term_cfg.params)
             if not isinstance(obs, np.ndarray):
                 raise TypeError(
@@ -370,23 +396,30 @@ class ObservationManager(ManagerBase):
                     f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
                 )
             obs = obs.copy()
+            t0 = time.perf_counter()
             if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
                 obs = term_cfg.noise.apply(obs, rng=self._env.rng)
             elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
                 obs = self._group_obs_class_instances[group_name][term_name](obs)
+            phase_ms["noise"] += time.perf_counter() - t0
+            t0 = time.perf_counter()
             if term_cfg.clip:
                 np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
             if term_cfg.scale is not None:
                 scale = term_cfg.scale
                 assert isinstance(scale, np.ndarray)
                 np.multiply(obs, scale, out=obs)
+            phase_ms["clip_scale"] += time.perf_counter() - t0
 
             # Check for NaN/Inf before delay/history buffers (per-term checking).
+            t0 = time.perf_counter()
             if group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
                 obs = self._check_and_handle_nans(
                     obs, context=f"{group_name}/{term_name}", policy=group_cfg.nan_policy
                 )
+            phase_ms["nan_check"] += time.perf_counter() - t0
 
+            t0 = time.perf_counter()
             if term_cfg.delay_max_lag > 0:
                 delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
                 if env_ids is None or not delay_buffer.is_initialized:
@@ -395,6 +428,8 @@ class ObservationManager(ManagerBase):
                 else:
                     delay_buffer.backfill(obs, env_ids)
                     obs = delay_buffer.peek()
+            phase_ms["delay"] += time.perf_counter() - t0
+            t0 = time.perf_counter()
             if term_cfg.history_length > 0:
                 circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
                 if env_ids is None or not circular_buffer.is_initialized:
@@ -409,8 +444,16 @@ class ObservationManager(ManagerBase):
                     group_obs[term_name] = circular_buffer.buffer
             else:
                 group_obs[term_name] = obs
+            phase_ms["history"] += time.perf_counter() - t0
+
+            term_prefix = f"mba_obs_term_{group_name}_{term_name}"
+            term_timing[f"{term_prefix}_ms"] = (time.perf_counter() - term_t0) * 1000.0
+            term_timing[f"{term_prefix}_getter_ms"] = (
+                self._env._mba_getter_total_ms() - term_getter0
+            )
 
         # Final NaN check for non-per-term checking.
+        t0 = time.perf_counter()
         if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
             if self._group_obs_concatenate[group_name]:
                 # Will check after concatenation below.
@@ -422,18 +465,31 @@ class ObservationManager(ManagerBase):
                         context=f"{group_name}/{term_name}",
                         policy=group_cfg.nan_policy,
                     )
+        phase_ms["nan_check"] += time.perf_counter() - t0
 
+        t0 = time.perf_counter()
         if self._group_obs_concatenate[group_name]:
             result = np.concatenate(
                 list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
             )
+            phase_ms["concat"] += time.perf_counter() - t0
             # Final check for concatenated result (non-per-term checking).
+            t0 = time.perf_counter()
             if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
                 result = self._check_and_handle_nans(
                     result, context=group_name, policy=group_cfg.nan_policy
                 )
-            return result
-        return group_obs
+            phase_ms["nan_check"] += time.perf_counter() - t0
+        else:
+            phase_ms["concat"] += time.perf_counter() - t0
+            result = group_obs
+
+        timing = self._last_compute_timing_ms
+        for phase_name, elapsed_s in phase_ms.items():
+            key = f"mba_obs_{phase_name}_ms"
+            timing[key] = timing.get(key, 0.0) + elapsed_s * 1000.0
+        timing.update(term_timing)
+        return result
 
     def _prepare_terms(self) -> None:
         self._group_obs_term_names: dict[str, list[str]] = dict()

--- a/src/unilab/managers/reward_manager.py
+++ b/src/unilab/managers/reward_manager.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import time
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -72,6 +73,9 @@ class RewardManager(ManagerBase):
         self.cfg = deepcopy(cfg)
         super().__init__(env=env)
         self._episode_sums = dict()
+        # Per-compute() term timing consumed by the env's update_state
+        # instrumentation (issue #1256), keyed mba_reward_term_<name>_[getter_]ms.
+        self._last_compute_timing_ms: dict[str, float] = {}
         for term_name in self._term_names:
             self._episode_sums[term_name] = np.zeros(self.num_envs, dtype=np.float32)
         self._reward_buf = np.zeros(self.num_envs, dtype=np.float32)
@@ -98,6 +102,11 @@ class RewardManager(ManagerBase):
     def active_terms(self) -> list[str]:
         return self._term_names
 
+    @property
+    def last_compute_timing_ms(self) -> dict[str, float]:
+        """Per-term wall time and leaf-getter share (ms) of the latest compute()."""
+        return dict(self._last_compute_timing_ms)
+
     # Methods.
 
     def reset(self, env_ids: np.ndarray | slice | None = None) -> dict[str, float]:
@@ -117,19 +126,26 @@ class RewardManager(ManagerBase):
             raise ValueError(f"RewardManager received invalid dt {dt}.")
         self._reward_buf[:] = 0.0
         scale = dt if self._scale_by_dt else 1.0
+        term_timing: dict[str, float] = {}
         for term_idx, (name, term_cfg) in enumerate(
             zip(self._term_names, self._term_cfgs, strict=False)
         ):
             if term_cfg.weight == 0.0:
                 self._step_reward[:, term_idx] = 0.0
                 continue
+            term_t0 = time.perf_counter()
+            term_getter0 = self._env._mba_getter_total_ms()
             value = term_cfg.func(self._env, **term_cfg.params)
+            term_getter_ms = self._env._mba_getter_total_ms() - term_getter0
             self._check_term_shape(name, value)
             self._check_term_finite(name, value)
             value = value * term_cfg.weight * scale
             self._reward_buf += value
             self._episode_sums[name] += value
             self._step_reward[:, term_idx] = value / scale
+            term_timing[f"mba_reward_term_{name}_ms"] = (time.perf_counter() - term_t0) * 1000.0
+            term_timing[f"mba_reward_term_{name}_getter_ms"] = term_getter_ms
+        self._last_compute_timing_ms = term_timing
         return self._reward_buf
 
     def step_reward_extras(self) -> dict[str, float]:

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -313,6 +313,67 @@ def test_write_csv_includes_mba_reset_sub_step_columns(tmp_path) -> None:
         assert key in header, f"CSV header missing {key!r}"
 
 
+def test_write_csv_includes_mba_update_state_columns(tmp_path) -> None:
+    """CSV headers must expose the fixed MBA update_state block/phase keys."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    out_csv = tmp_path / "collector.csv"
+
+    bench._write_csv(out_csv, [result])
+
+    header = out_csv.read_text(encoding="utf-8").splitlines()[0]
+    for key in (
+        "mba_update_total_ms",
+        "mba_termination_ms",
+        "mba_reward_ms",
+        "mba_metrics_ms",
+        "mba_events_ms",
+        "mba_command_ms",
+        "mba_obs_compute_ms",
+        "mba_obs_map_ms",
+        "mba_termination_getter_ms",
+        "mba_reward_getter_ms",
+        "mba_metrics_getter_ms",
+        "mba_events_getter_ms",
+        "mba_command_getter_ms",
+        "mba_obs_compute_getter_ms",
+        "mba_obs_map_getter_ms",
+        "mba_update_internal_gap_ms",
+        "mba_getters_total_ms",
+        "mba_obs_noise_ms",
+        "mba_obs_clip_scale_ms",
+        "mba_obs_nan_check_ms",
+        "mba_obs_delay_ms",
+        "mba_obs_history_ms",
+        "mba_obs_concat_ms",
+    ):
+        assert key in header, f"CSV header missing {key!r}"
+
+
+def test_print_result_includes_mba_update_and_dynamic_term_timings(capsys) -> None:
+    """Console breakdown shows MBA update blocks and dynamic per-term keys."""
+    result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)
+    result.env_step_timing_ms_per_vector_step["mba_update_total_ms"] = bench.TimingStats(
+        [5.0], 5.0, 5.0, 0.0, 5.0, 5.0
+    )
+    result.env_step_timing_ms_per_vector_step["mba_obs_term_actor_joint_pos_ms"] = (
+        bench.TimingStats([2.0], 2.0, 2.0, 0.0, 2.0, 2.0)
+    )
+    result.env_step_timing_ms_per_vector_step["mba_reward_term_pose_getter_ms"] = bench.TimingStats(
+        [1.0], 1.0, 1.0, 0.0, 1.0, 1.0
+    )
+    result.env_step_timing_ms_per_vector_step["mba_getter_dof_pos_ms"] = bench.TimingStats(
+        [0.5], 0.5, 0.5, 0.0, 0.5, 0.5
+    )
+
+    bench._print_result(result)
+
+    out = capsys.readouterr().out
+    assert "np_env_mba_update_total_ms" in out
+    assert "np_env_mba_obs_term_actor_joint_pos_ms" in out
+    assert "np_env_mba_reward_term_pose_getter_ms" in out
+    assert "np_env_mba_getter_dof_pos_ms" in out
+
+
 def test_print_result_includes_mba_reset_and_per_term_event_timings(capsys) -> None:
     """Console breakdown shows MBA reset sub-steps and dynamic per-term keys."""
     result = _make_result(num_envs=2, throughput=2000.0, include_env_step_breakdown=True)

--- a/tests/envs/locomotion/test_manager_gait_terms.py
+++ b/tests/envs/locomotion/test_manager_gait_terms.py
@@ -100,6 +100,7 @@ def _env(counter: int = 0, scene: _Scene | None = None) -> ManagerBasedRlEnv:
             step_dt=0.02,
             scene=scene or _Scene(),
             command_manager=_Commands(),
+            _mba_getter_total_ms=lambda: 0.0,
         ),
     )
 
@@ -136,6 +137,7 @@ def _parity_env() -> ManagerBasedRlEnv:
             scene=_ParityScene(),
             command_manager=_Commands(),
             max_episode_length_s=20.0,
+            _mba_getter_total_ms=lambda: 0.0,
         ),
     )
 

--- a/tests/envs/mdp/test_observations.py
+++ b/tests/envs/mdp/test_observations.py
@@ -154,6 +154,7 @@ def _env() -> tuple[ManagerBasedRlEnv, _Backend]:
             action_manager=_ActionManager(),
             command_manager=_CommandManager(),
             rng=np.random.default_rng(4),
+            _mba_getter_total_ms=lambda: 0.0,
         ),
     )
     return env, backend

--- a/tests/envs/mdp/test_rewards.py
+++ b/tests/envs/mdp/test_rewards.py
@@ -88,6 +88,7 @@ def _env() -> ManagerBasedRlEnv:
                 terminated=np.asarray([False, True, False], dtype=np.bool_)
             ),
             max_episode_length_s=2.0,
+            _mba_getter_total_ms=lambda: 0.0,
         ),
     )
 

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -1087,6 +1087,54 @@ def test_partial_reset_reports_mba_reset_timing_keys() -> None:
     assert timing["mba_reset_event_term_reset_ms"] == 0.0
 
 
+def test_update_state_reports_mba_block_term_and_getter_timing_keys() -> None:
+    env, _ = _make_env()
+    env.init_state()
+
+    state = env.step(np.array([[0.0], [0.0]], dtype=np.float32))
+    timing = state.info["timing"]
+    block_names = (
+        "termination",
+        "reward",
+        "metrics",
+        "events",
+        "command",
+        "obs_compute",
+        "obs_map",
+    )
+    fixed_keys = (
+        "mba_update_total_ms",
+        "mba_update_internal_gap_ms",
+        "mba_getters_total_ms",
+        "mba_obs_noise_ms",
+        "mba_obs_clip_scale_ms",
+        "mba_obs_nan_check_ms",
+        "mba_obs_delay_ms",
+        "mba_obs_history_ms",
+        "mba_obs_concat_ms",
+        *(f"mba_{name}_ms" for name in block_names),
+        *(f"mba_{name}_getter_ms" for name in block_names),
+    )
+    # Task-dependent per-term keys discovered dynamically.
+    term_keys = (
+        "mba_reward_term_track_ms",
+        "mba_reward_term_track_getter_ms",
+        "mba_obs_term_actor_policy_ms",
+        "mba_obs_term_actor_policy_getter_ms",
+        "mba_obs_term_value_critic_ms",
+        "mba_obs_term_value_critic_getter_ms",
+    )
+    for key in (*fixed_keys, *term_keys):
+        assert key in timing, f"timing missing {key!r}"
+        assert timing[key] >= 0.0
+    # Block decomposition closes against the update_state wall time.
+    assert sum(timing[f"mba_{name}_ms"] for name in block_names) + timing[
+        "mba_update_internal_gap_ms"
+    ] == pytest.approx(timing["mba_update_total_ms"])
+    # update_state detail is refreshed every step, including steps with no reset.
+    assert timing["mba_update_total_ms"] <= timing["update_state_ms"] + 1e-6
+
+
 def test_partial_reset_preserves_other_env_counter_and_terminal_obs() -> None:
     env, _ = _make_env()
     env.init_state()

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -52,6 +52,10 @@ class FakeEnv:
         self.obs_buf: dict[str, np.ndarray] = {}
         self.reset_buf = np.zeros(num_envs, dtype=np.bool_)
 
+    def _mba_getter_total_ms(self) -> float:
+        """Stand-in for ManagerBasedRlEnv's leaf getter timing probe."""
+        return 0.0
+
 
 @pytest.fixture
 def fake_env() -> FakeEnv:


### PR DESCRIPTION
Refs #1256. Part of roadmap #1259 Wave 1 (Evidence line).

## 只做什么

把 #1256 此前"本地未提交"的 update_state term 级插桩按原设计重建并固化，计时键与现有计时键同级保留：

- `EntityData`：叶子 backend getter（`get_dof_pos/vel`、`get_body_*`）逐次计时，按方法聚合（`mba_getter_<method>_ms`、`mba_getters_total_ms`），每实体一个 `GetterTimingRecorder`，由 env 在 update_state 起始处清零。
- `ObservationManager`：逐 term 总耗时 + term 内 getter 归属（`mba_obs_term_<group>_<name>_[getter_]ms`），跨 term 相位聚合（`mba_obs_noise/clip_scale/nan_check/delay/history/concat_ms`）。
- `RewardManager`：逐 term 总耗时 + getter 归属（`mba_reward_term_<name>_[getter_]ms`）。
- `ManagerBasedRlEnv.update_state`：块级分解（`mba_termination/reward/metrics/events/command/obs_compute/obs_map_ms`），每块附 `_getter_ms` 归属；`mba_update_total_ms` + `mba_update_internal_gap_ms` 闭合。
- `NpEnv.step`：固定键每步覆写、动态 extra 键（term/getter 名随 task 变化）零填充后并入 `info["timing"]`，复用 reset detail 的 hook 机制（`_collect_manager_update_timing_ms`）。
- benchmark 脚本：固定键进 CSV 表头；全部动态 `mba_*` 键（obs/reward term、getter 方法）在采样时动态发现，进 JSON/console。

## 不做什么

- 不做任何性能优化（纯测量插桩，优化另开 issue）。
- 不改 obs term 语义、维度或 `obs_groups_spec`；不改 reward 权重与注入方式。
- 不改 manager lifecycle 或公共 contract。

## 闭合性

- 块和 + `mba_update_internal_gap_ms` == `mba_update_total_ms`；块 getter 和 == `mba_getters_total_ms`，由 `tests/envs/test_manager_based_rl_env.py` 新测试锁定。
- 插桩开销：对照 #1260 同机 dev baseline（未插桩），7 case 吞吐差异在 run 间噪声内（±3%，除 sac/g1_motion_tracking/motrix 已记录的批次级漂移外）。

## Validation

- `make test-all` 已通过（ruff format/check、mypy 243 files、pyright、pytest 2191 passed、benchmark smoke 33/34）。
- 插桩 A/B 复测（7 case × 3 runs，本机 Ryzen 9 9950X3D / RTX 4090）：term 级分解结果与本 issue 前次定位结论一致，原始数据与表格见 #1256 评论。