### PR TITLE
perf: reuse MBA backend state reads within update phase

### DIFF
--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 import time
 from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -138,8 +139,8 @@ class GetterTimingRecorder:
 
     One recorder per :class:`EntityData` instance; the owning env aggregates and
     resets the recorders around its ``update_state`` pass (see
-    ``ManagerBasedRlEnv``). Timing is always on: two ``perf_counter_ns`` calls
-    per getter invocation, negligible against the getter itself.
+    ``ManagerBasedRlEnv``). Timing is always on for actual backend reads: cache
+    hits add no synthetic getter time.
     """
 
     def __init__(self) -> None:
@@ -153,6 +154,48 @@ class GetterTimingRecorder:
     def reset(self) -> None:
         self.method_ms.clear()
         self.total_ms = 0.0
+
+
+_StateReadKey = tuple[str, tuple[int, ...] | None]
+
+
+class _EntityStateReadCache:
+    """Update-phase cache shared by every entity bound to one backend scene."""
+
+    def __init__(self) -> None:
+        self._active = False
+        self._values: dict[_StateReadKey, np.ndarray] = {}
+
+    def get(self, key: _StateReadKey) -> np.ndarray | None:
+        if not self._active:
+            return None
+        return self._values.get(key)
+
+    def put(self, key: _StateReadKey, value: np.ndarray) -> None:
+        if self._active:
+            self._values[key] = value
+
+    def invalidate(self) -> None:
+        self._values.clear()
+
+    @contextmanager
+    def scoped(self) -> Iterator[None]:
+        if self._active:
+            raise RuntimeError("Entity state-read cache phase is already active")
+        self._active = True
+        self._values.clear()
+        try:
+            yield
+        finally:
+            self._values.clear()
+            self._active = False
+
+
+def _state_selector_key(ids: np.ndarray | None) -> tuple[int, ...] | None:
+    """Freeze a cold-path backend selector into a cheap hot-path cache key."""
+    if ids is None:
+        return None
+    return tuple(int(value) for value in ids)
 
 
 class EntityData:
@@ -177,11 +220,13 @@ class EntityData:
         control_buffer: np.ndarray | None,
         entity_name: str,
         backend_type: str,
+        state_read_cache: _EntityStateReadCache,
     ) -> None:
         self._backend = backend
         self._entity_name = entity_name
         self._backend_type = backend_type
         self._root_body_ids = root_body_ids
+        self._root_body_state_key = _state_selector_key(root_body_ids)
         self._joint_pos_index = None if joint_pos_ids is None else _as_column_index(joint_pos_ids)
         self._joint_vel_index = None if joint_vel_ids is None else _as_column_index(joint_vel_ids)
         self._default_root_state = default_root_state
@@ -196,19 +241,33 @@ class EntityData:
             else np.zeros(default_joint_pos.shape, dtype=default_joint_pos.dtype)
         )
         self._body_ids = body_ids
+        self._body_state_key = _state_selector_key(body_ids)
         self._actuator_ids = actuator_ids
         self._actuator_ctrl_range = actuator_ctrl_range
         self._control_buffer = control_buffer
+        self._state_read_cache = state_read_cache
         # Always-on leaf getter timing; aggregated/reset per update_state by the
         # owning env (MBA update_state instrumentation, issue #1256).
         self.getter_timing = GetterTimingRecorder()
 
-    def _timed_getter(self, method: str, fn: Any, *args: Any) -> np.ndarray:
+    def _timed_getter(
+        self,
+        method: str,
+        fn: Any,
+        *args: Any,
+        selector: tuple[int, ...] | None = None,
+    ) -> np.ndarray:
+        key = (method, selector)
+        cached = self._state_read_cache.get(key)
+        if cached is not None:
+            return cached
         t0 = time.perf_counter_ns()
         try:
-            return fn(*args)
+            value = fn(*args)
         finally:
             self.getter_timing.record(method, (time.perf_counter_ns() - t0) / 1e6)
+        self._state_read_cache.put(key, value)
+        return value
 
     def _require(self, value, capability: str):
         if value is None:
@@ -221,32 +280,62 @@ class EntityData:
     @property
     def root_link_pos_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_pos_w", self._backend.get_body_pos_w, ids)[:, 0]
+        return self._timed_getter(
+            "body_pos_w",
+            self._backend.get_body_pos_w,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def root_link_quat_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_quat_w", self._backend.get_body_quat_w, ids)[:, 0]
+        return self._timed_getter(
+            "body_quat_w",
+            self._backend.get_body_quat_w,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def root_link_lin_vel_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_lin_vel_w", self._backend.get_body_lin_vel_w, ids)[:, 0]
+        return self._timed_getter(
+            "body_lin_vel_w",
+            self._backend.get_body_lin_vel_w,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def root_link_ang_vel_w(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_ang_vel_w", self._backend.get_body_ang_vel_w, ids)[:, 0]
+        return self._timed_getter(
+            "body_ang_vel_w",
+            self._backend.get_body_ang_vel_w,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def root_link_lin_vel_b(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_lin_vel_b", self._backend.get_body_lin_vel_b, ids)[:, 0]
+        return self._timed_getter(
+            "body_lin_vel_b",
+            self._backend.get_body_lin_vel_b,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def root_link_ang_vel_b(self) -> np.ndarray:
         ids = self._require(self._root_body_ids, "root body state")
-        return self._timed_getter("body_ang_vel_b", self._backend.get_body_ang_vel_b, ids)[:, 0]
+        return self._timed_getter(
+            "body_ang_vel_b",
+            self._backend.get_body_ang_vel_b,
+            ids,
+            selector=self._root_body_state_key,
+        )[:, 0]
 
     @property
     def heading_w(self) -> np.ndarray:
@@ -321,22 +410,42 @@ class EntityData:
     @property
     def body_link_pos_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._timed_getter("body_pos_w", self._backend.get_body_pos_w, ids)
+        return self._timed_getter(
+            "body_pos_w",
+            self._backend.get_body_pos_w,
+            ids,
+            selector=self._body_state_key,
+        )
 
     @property
     def body_link_quat_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._timed_getter("body_quat_w", self._backend.get_body_quat_w, ids)
+        return self._timed_getter(
+            "body_quat_w",
+            self._backend.get_body_quat_w,
+            ids,
+            selector=self._body_state_key,
+        )
 
     @property
     def body_link_lin_vel_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._timed_getter("body_lin_vel_w", self._backend.get_body_lin_vel_w, ids)
+        return self._timed_getter(
+            "body_lin_vel_w",
+            self._backend.get_body_lin_vel_w,
+            ids,
+            selector=self._body_state_key,
+        )
 
     @property
     def body_link_ang_vel_w(self) -> np.ndarray:
         ids = self._require(self._body_ids, "body state")
-        return self._timed_getter("body_ang_vel_w", self._backend.get_body_ang_vel_w, ids)
+        return self._timed_getter(
+            "body_ang_vel_w",
+            self._backend.get_body_ang_vel_w,
+            ids,
+            selector=self._body_state_key,
+        )
 
     @property
     def body_link_pose_w(self) -> np.ndarray:
@@ -460,6 +569,7 @@ class Entity:
         reset_state: ResetStateTransaction | None = None,
         *,
         default_qpos: np.ndarray | None = None,
+        state_read_cache: _EntityStateReadCache | None = None,
     ) -> None:
         if not name:
             raise ValueError("Entity name must be a non-empty string")
@@ -576,6 +686,9 @@ class Entity:
             control_buffer=control_buffer,
             entity_name=self.name,
             backend_type=self._backend_type,
+            state_read_cache=(
+                state_read_cache if state_read_cache is not None else _EntityStateReadCache()
+            ),
         )
 
     @property
@@ -1793,6 +1906,7 @@ class EntityScene(Mapping[str, Entity]):
         default_qpos: np.ndarray | None = None,
     ) -> None:
         self._backend = backend
+        self._state_read_cache = _EntityStateReadCache()
         materialized: dict[str, Entity] = {}
         for name, cfg in entities.items():
             if not isinstance(name, str) or not name:
@@ -1808,6 +1922,7 @@ class EntityScene(Mapping[str, Entity]):
                 control_buffer,
                 reset_state,
                 default_qpos=default_qpos,
+                state_read_cache=self._state_read_cache,
             )
         self._entities = MappingProxyType(materialized)
         self._reset_state = reset_state
@@ -1842,6 +1957,16 @@ class EntityScene(Mapping[str, Entity]):
     def env_origins(self) -> np.ndarray:
         """Read-only per-environment origins; flat UniLab scenes default to zero."""
         return self._env_origins
+
+    @contextmanager
+    def _scoped_state_reads(self) -> Iterator[None]:
+        """Internal ManagerBasedRlEnv boundary for one stable update phase."""
+        with self._state_read_cache.scoped():
+            yield
+
+    def _invalidate_state_reads(self) -> None:
+        """Discard cached backend state after an in-phase simulation mutation."""
+        self._state_read_cache.invalidate()
 
     def reset_to_default(self, env_ids: np.ndarray, *, term_name: str) -> None:
         """Stage a full-scene default state in the active reset transaction."""

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -56,6 +56,7 @@ class ResetStateTransaction:
         self._requesting_terms: set[str] = set()
         # Backend sub-timings from the most recent commit()'s set_state call.
         self._last_set_state_timing_ms: dict[str, float] = {}
+        self._last_commit_had_writes = False
 
     @property
     def active(self) -> bool:
@@ -66,6 +67,11 @@ class ResetStateTransaction:
     def last_set_state_timing_ms(self) -> dict[str, float]:
         """Backend-reported set_state sub-timings of the most recent commit."""
         return dict(self._last_set_state_timing_ms)
+
+    @property
+    def last_commit_had_writes(self) -> bool:
+        """Whether the most recent scoped commit submitted dirty rows to set_state."""
+        return self._last_commit_had_writes
 
     @contextmanager
     def scoped(self, env_ids: np.ndarray) -> Iterator[ResetStateTransaction]:
@@ -92,6 +98,7 @@ class ResetStateTransaction:
             mask.fill(False)
         self._requesting_terms.clear()
         self._last_set_state_timing_ms = {}
+        self._last_commit_had_writes = False
         self._active = True
 
     def bind_body_mass_write(
@@ -534,6 +541,7 @@ class ResetStateTransaction:
         """Commit all staged rows through one public backend call."""
         self._require_active()
         dirty_ids = np.flatnonzero(self._dirty_mask).astype(np.int32, copy=False)
+        self._last_commit_had_writes = bool(dirty_ids.size)
         try:
             if dirty_ids.size == 0:
                 return None

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -450,6 +450,12 @@ class ManagerBasedRlEnv(NpEnv):
         return sum(entity.data.getter_timing.total_ms for entity in self.scene.values())
 
     def update_state(self, state: NpEnvState) -> NpEnvState:
+        # Physics stepping and reset/set_state lifecycles sit outside this private
+        # scope. In-phase mutations explicitly invalidate it below.
+        with self.scene._scoped_state_reads():
+            return self._update_state_in_read_phase(state)
+
+    def _update_state_in_read_phase(self, state: NpEnvState) -> NpEnvState:
         log: dict[str, Any] = {}
         state.info["log"] = log
         self.extras = state.info
@@ -496,16 +502,26 @@ class ManagerBasedRlEnv(NpEnv):
         self.metrics_manager.compute()
         t_prev, g_prev = _mark("metrics", t_prev, g_prev)
 
+        applied_runtime_event = False
         if "step" in self.event_manager.available_modes:
             self.event_manager.apply(mode="step", dt=self.step_dt)
+            applied_runtime_event = True
         if "interval" in self.event_manager.available_modes:
             self.event_manager.apply(mode="interval", dt=self.step_dt)
+            applied_runtime_event = True
+        if applied_runtime_event:
+            # Event terms may mutate simulation state through their formal
+            # interval/step capabilities; EventManager does not expose whether a
+            # particular interval fired, so this boundary stays fail-closed.
+            self.scene._invalidate_state_reads()
         t_prev, g_prev = _mark("events", t_prev, g_prev)
 
         self._command_dt.fill(self.step_dt)
         self._command_dt[self.reset_buf] = 0.0
         with self._reset_state.scoped(self._all_env_ids):
             self.command_manager.compute(dt=self._command_dt)
+        if self._reset_state.last_commit_had_writes:
+            self.scene._invalidate_state_reads()
         self.command_manager.post_compute()
         t_prev, g_prev = _mark("command", t_prev, g_prev)
 

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -216,6 +216,49 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
     )
 
 
+def test_state_read_cache_is_scoped_shared_and_explicitly_invalidated() -> None:
+    backend, scene = _scene()
+    robot = scene["robot"]
+    before = backend.calls.copy()
+
+    with scene._scoped_state_reads():
+        np.testing.assert_array_equal(robot.data.joint_pos, robot.data.joint_pos)
+        np.testing.assert_array_equal(robot.data.joint_vel, robot.data.joint_vel)
+        np.testing.assert_array_equal(robot.data.heading_w, robot.data.projected_gravity_b[:, 0])
+        np.testing.assert_array_equal(robot.data.root_link_pos_w, robot.data.root_link_pos_w)
+        np.testing.assert_array_equal(robot.data.body_link_pos_w, robot.data.body_link_pos_w)
+
+        assert backend.calls["joint position state"] == before["joint position state"] + 1
+        assert backend.calls["joint velocity state"] == before["joint velocity state"] + 1
+        assert backend.calls["body quaternion state"] == before["body quaternion state"] + 1
+        # Root and full-body selectors remain distinct cache entries.
+        assert backend.calls["body position state"] == before["body position state"] + 2
+
+        scene._invalidate_state_reads()
+        _ = robot.data.joint_pos
+        assert backend.calls["joint position state"] == before["joint position state"] + 2
+
+    # Reads outside the env-owned phase retain the previous per-access behavior.
+    _ = robot.data.joint_pos
+    _ = robot.data.joint_pos
+    assert backend.calls["joint position state"] == before["joint position state"] + 4
+
+
+def test_state_read_cache_scope_closes_after_exception() -> None:
+    backend, scene = _scene()
+    robot = scene["robot"]
+    before = backend.calls["joint position state"]
+
+    with pytest.raises(RuntimeError, match="term failed"):
+        with scene._scoped_state_reads():
+            _ = robot.data.joint_pos
+            raise RuntimeError("term failed")
+
+    with scene._scoped_state_reads():
+        _ = robot.data.joint_pos
+    assert backend.calls["joint position state"] == before + 2
+
+
 def test_scene_entity_cfg_resolves_only_against_cached_names() -> None:
     backend, scene = _scene()
     cold_path_calls = backend.calls.copy()

--- a/tests/base/test_reset_state.py
+++ b/tests/base/test_reset_state.py
@@ -110,6 +110,26 @@ def test_transaction_is_lazy_and_combines_terms_into_one_commit() -> None:
     assert len(backend.set_state_calls) == 2
 
 
+def test_transaction_reports_only_committed_dirty_rows_as_writes() -> None:
+    backend = _Backend()
+    transaction = _transaction(backend)
+
+    assert not transaction.last_commit_had_writes
+    with transaction.scoped(np.array([0], dtype=np.int32)):
+        pass
+    assert not transaction.last_commit_had_writes
+
+    with transaction.scoped(np.array([0], dtype=np.int32)):
+        transaction.reset_to_default(np.array([0], dtype=np.int32), term_name="dirty")
+    assert transaction.last_commit_had_writes
+
+    with pytest.raises(RuntimeError, match="abort"):
+        with transaction.scoped(np.array([1], dtype=np.int32)):
+            transaction.reset_to_default(np.array([1], dtype=np.int32), term_name="aborted")
+            raise RuntimeError("abort")
+    assert not transaction.last_commit_had_writes
+
+
 def test_exception_aborts_without_backend_mutation_and_next_reset_is_clean() -> None:
     backend = _Backend()
     transaction = _transaction(backend)

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -155,6 +155,31 @@ class _ResetBackend(_FakeBackend):
         self.set_state_calls.append((env_ids.copy(), qpos.copy(), qvel.copy()))
 
 
+class _StateBackend(_ResetBackend):
+    def __init__(self, num_envs: int) -> None:
+        super().__init__(num_envs)
+        self.dof_pos = np.zeros((num_envs, 1), dtype=np.float32)
+        self.dof_pos_calls = 0
+
+    def get_dof_pos(self) -> np.ndarray:
+        self.dof_pos_calls += 1
+        return self.dof_pos.copy()
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        super().step(ctrl, nsteps)
+        self.dof_pos += 1.0
+
+    def set_state(
+        self,
+        env_ids: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization=None,
+    ) -> None:
+        super().set_state(env_ids, qpos, qvel, randomization=randomization)
+        self.dof_pos[env_ids, 0] = qpos[:, 3]
+
+
 class _KeyframeBackend(_ResetBackend):
     def __init__(
         self,
@@ -293,6 +318,23 @@ def _reward(env: _TestEnv) -> np.ndarray:
     return env.action_manager.action[:, 0].copy()
 
 
+def _joint_state_obs(env: _TestEnv) -> np.ndarray:
+    return env.scene["robot"].data.joint_pos
+
+
+def _joint_state_reward(env: _TestEnv) -> np.ndarray:
+    return env.scene["robot"].data.joint_pos[:, 0]
+
+
+def _joint_state_termination(env: _TestEnv) -> np.ndarray:
+    return env.scene["robot"].data.joint_pos[:, 0] > 100.0
+
+
+def _mutate_joint_state_step_event(env: _TestEnv, env_ids: np.ndarray | None) -> None:
+    assert env_ids is None
+    cast(_StateBackend, env._backend).dof_pos += 10.0
+
+
 def _failure(env: _TestEnv) -> np.ndarray:
     return env.action_manager.action[:, 0] > 0.8
 
@@ -399,6 +441,41 @@ def _make_env(
         num_envs,
     )
     return env, backend
+
+
+def _make_state_env(
+    *,
+    commands: dict[str, CommandTermCfg | None] | None = None,
+    events: dict[str, EventTermCfg | None] | None = None,
+    terminations: dict[str, TerminationTermCfg | None] | None = None,
+) -> tuple[_TestEnv, _StateBackend]:
+    cfg = _make_cfg(
+        sim_substeps=1,
+        observations={
+            "actor": ObservationGroupCfg(
+                terms={"joint": ObservationTermCfg(func=_joint_state_obs)}
+            ),
+            "value": ObservationGroupCfg(
+                terms={"joint": ObservationTermCfg(func=_joint_state_obs)}
+            ),
+        },
+        include_optional_managers=False,
+    )
+    cfg.scene.entities["robot"] = EntityCfg(
+        joint_names=("joint",),
+        actuator_names=("motor",),
+    )
+    cfg.scale_rewards_by_dt = False
+    cfg.rewards = {"joint": RewardTermCfg(func=_joint_state_reward, weight=1.0)}
+    cfg.terminations = (
+        {"joint": TerminationTermCfg(func=_joint_state_termination)}
+        if terminations is None
+        else terminations
+    )
+    cfg.commands = {} if commands is None else commands
+    cfg.events = {} if events is None else events
+    backend = _StateBackend(2)
+    return _TestEnv(cfg, cast(SimBackend, backend), 2), backend
 
 
 def test_public_names_are_spelling_only_aliases() -> None:
@@ -1133,6 +1210,81 @@ def test_update_state_reports_mba_block_term_and_getter_timing_keys() -> None:
     ] == pytest.approx(timing["mba_update_total_ms"])
     # update_state detail is refreshed every step, including steps with no reset.
     assert timing["mba_update_total_ms"] <= timing["update_state_ms"] + 1e-6
+
+
+def test_update_state_reuses_backend_state_once_and_refreshes_after_physics() -> None:
+    env, backend = _make_state_env()
+    env.init_state()
+
+    before = backend.dof_pos_calls
+    state = env.step(np.zeros((2, 1), dtype=np.float32))
+    assert backend.dof_pos_calls == before + 1
+    np.testing.assert_array_equal(state.reward, [1.0, 1.0])
+    np.testing.assert_array_equal(state.obs["obs"], [[1.0], [1.0]])
+    np.testing.assert_array_equal(state.obs["critic"], [[1.0], [1.0]])
+
+    before = backend.dof_pos_calls
+    state = env.step(np.zeros((2, 1), dtype=np.float32))
+    assert backend.dof_pos_calls == before + 1
+    np.testing.assert_array_equal(state.reward, [2.0, 2.0])
+    np.testing.assert_array_equal(state.obs["obs"], [[2.0], [2.0]])
+
+
+def test_update_state_invalidates_cache_after_command_set_state() -> None:
+    env, backend = _make_state_env(
+        commands={
+            "writer": _StateWritingCommandCfg(resampling_time_range=(0.01, 0.01)),
+        }
+    )
+    env.init_state()
+
+    before = backend.dof_pos_calls
+    state = env.step(np.zeros((2, 1), dtype=np.float32))
+
+    # Physics advances the pre-command state to 1.75. The command then commits
+    # 0.75 through set_state, so post-command observations must not reuse the
+    # termination/reward snapshot.
+    assert backend.dof_pos_calls == before + 2
+    np.testing.assert_array_equal(state.reward, [1.75, 1.75])
+    np.testing.assert_array_equal(state.obs["obs"], [[0.75], [0.75]])
+    np.testing.assert_array_equal(state.obs["critic"], [[0.75], [0.75]])
+
+
+def test_update_state_invalidates_cache_after_runtime_event() -> None:
+    env, backend = _make_state_env(
+        events={
+            "mutate": EventTermCfg(func=_mutate_joint_state_step_event, mode="step"),
+        }
+    )
+    env.init_state()
+
+    before = backend.dof_pos_calls
+    state = env.step(np.zeros((2, 1), dtype=np.float32))
+
+    assert backend.dof_pos_calls == before + 2
+    np.testing.assert_array_equal(state.reward, [1.0, 1.0])
+    np.testing.assert_array_equal(state.obs["obs"], [[11.0], [11.0]])
+    np.testing.assert_array_equal(state.obs["critic"], [[11.0], [11.0]])
+
+
+def test_partial_reset_observation_reads_post_set_state_rows() -> None:
+    env, backend = _make_state_env(
+        events={
+            "joint_state": EventTermCfg(func=_write_reset_joint_state, mode="reset"),
+        },
+        terminations={"failure": TerminationTermCfg(func=_failure)},
+    )
+    env.init_state()
+
+    state = env.step(np.array([[1.0], [0.0]], dtype=np.float32))
+
+    np.testing.assert_array_equal(state.reward, [1.25, 1.25])
+    np.testing.assert_array_equal(state.terminated, [True, False])
+    np.testing.assert_array_equal(state.obs["obs"], [[0.25], [1.25]])
+    np.testing.assert_array_equal(state.obs["critic"], [[0.25], [1.25]])
+    assert state.final_observation is not None
+    np.testing.assert_array_equal(state.final_observation["obs"][0], [1.25])
+    np.testing.assert_array_equal(backend.dof_pos[:, 0], [0.25, 1.25])
 
 
 def test_partial_reset_preserves_other_env_counter_and_terminal_obs() -> None:


### PR DESCRIPTION
## Summary

- add one scene-shared, private EntityData state-read cache scoped to a single `ManagerBasedRlEnv.update_state()` pass
- reuse identical backend getter + cold-path body-selector reads across termination, reward, metrics, command, and observation consumers
- invalidate fail-closed after runtime events and after ResetStateTransaction commits with actual writes; physics steps, reset, and partial reset remain outside the cache scope
- preserve getter instrumentation by recording only real backend reads, with no synthetic time for cache hits
- add owner tests for reuse, cross-phase refresh, event/set_state invalidation, partial-reset/final-observation semantics, and exception cleanup

No public manager lifecycle, `SimBackend` contract, observation/reward term, runner, config, or backend-specific execution path changes.

## Validation

- Final commit: `476003e7333d95e145b7248e17daf2ac4781cda5`
- `make test-all`: passed
  - ruff format/check: passed
  - mypy: 243 source files, no issues
  - pyright: 0 errors
  - pytest: 2207 passed, 28 skipped, 275 deselected, 1 xfailed
  - benchmark smoke: passed (33/34 module-mode and 34/35 script-mode; only platform-optional MLX entries skipped)
- focused owner suite: 109 passed
- neighboring MotionCommand/R2/G1 suite: 75 passed

Per the explicit #1259 child gate, this PR does not trigger or wait for remote CI/Docs.

## Benchmark

Hardware: AMD Ryzen 9 9950X3D2 16-Core Processor, NVIDIA GeForce RTX 4090. Baseline is clean dev SHA `7780ebf8`; after measurements used the identical implementation tree later committed unchanged as `476003e7`. Each full-suite value below is the delta between before/after medians across three runs (8192 envs, 10 warmup + 100 measured steps).

| Case | Getter time | `update_state` | Collector throughput |
|---|---:|---:|---:|
| FlashSAC Go2 joystick / MuJoCo | -26.4% | -4.9% | +1.4% |
| FlashSAC G1 walk / MuJoCo | +1.4% | -0.1% | +0.1% |
| FlashSAC G1 walk / Motrix | -32.1% | +0.1% | -1.4% |
| SAC G1 walk / MuJoCo | +2.5% | -0.1% | +0.1% |
| SAC G1 walk / Motrix | -27.4% | +29.2% | -8.1% |
| SAC G1 motion / MuJoCo | -49.6% | -6.0% | +1.0% |
| SAC G1 motion / Motrix | -64.3% | -23.0% | +23.5% |

Motrix has known batch-level drift, so the two apparently regressed walk cases were rerun as isolated paired A/B batches. Median paired deltas across three additional pairs were:

| Case | Getter time | `update_state` | Collector throughput |
|---|---:|---:|---:|
| FlashSAC G1 walk / Motrix | -31.9% | -7.6% | -1.0% |
| SAC G1 walk / Motrix | -28.1% | -2.0% | -0.45% |

The isolated pairs confirm the getter reduction and show collector movement within the established Motrix run-to-run noise rather than a repeatable regression. Raw gitignored evidence is under `scripts/benchmark/outputs/offpolicy_collector_active/issue1272_{before,after}_{run1,run2,run3,walk_run4,walk_run5,walk_run6}.{json,csv}`.

## Backend behavior impact

- MuJoCo getters that already expose cheap views remain effectively flat in the walk cases; repeated body-state reads in Go2/motion still decrease. Physics, state layout, and adapter behavior are unchanged.
- Motrix avoids repeated full-batch state copies, producing the larger getter reductions. Cache policy is backend-agnostic and does not add Motrix-specific branching.
- Both backends reread after physics, runtime events, actual command-side `set_state`, reset, and partial reset; observation/reward/termination ordering and final-observation semantics remain unchanged.

Fixes #1272
Parent: #1259 Wave 2 U1
