### PR TITLE
perf: skip substep callbacks for invariant actions

### DIFF
--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -388,13 +388,17 @@ class ManagerBasedRlEnv(NpEnv):
             )
 
     def _configure_action_control(self) -> None:
-        if self._cfg.sim_substeps <= 1 or not self.action_manager.active_terms:
+        if (
+            self._cfg.sim_substeps <= 1
+            or not self.action_manager.active_terms
+            or not self.action_manager.requires_substep_state_feedback
+        ):
             return
         try:
             self._backend.set_pre_step_control(self._apply_manager_control)
         except NotImplementedError as exc:
             raise NotImplementedError(
-                "ActionManager capability 'apply actions on every physics substep' is "
+                "ActionManager capability 'state-feedback actions on every physics substep' is "
                 f"unavailable on backend '{self._backend.backend_type}': {exc}"
             ) from exc
         self._uses_pre_step_control = True

--- a/src/unilab/managers/action_manager.py
+++ b/src/unilab/managers/action_manager.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, ClassVar, Sequence
 
 import numpy as np
 from prettytable import PrettyTable
@@ -45,6 +45,14 @@ class ActionTerm(ManagerTermBase):
 
     The action term is responsible for processing the raw actions sent to the environment
     and applying them to the entity managed by the term.
+    """
+
+    requires_substep_state_feedback: ClassVar[bool] = False
+    """Whether ``apply_actions`` needs state produced by the previous physics substep.
+
+    ``False`` declares that the generated control is invariant across all physics
+    substeps in one control step, so the env may apply it once before a batched
+    backend step. State-feedback terms must override this declaration with ``True``.
     """
 
     def __init__(self, cfg: ActionTermCfg, env: ManagerBasedRlEnv):
@@ -133,6 +141,11 @@ class ActionManager(ManagerBase):
     def active_terms(self) -> list[str]:
         return self._term_names
 
+    @property
+    def requires_substep_state_feedback(self) -> bool:
+        """Return whether any active action term needs per-substep state feedback."""
+        return any(term.requires_substep_state_feedback for term in self._terms.values())
+
     # Methods.
 
     def get_term(self, name: str) -> ActionTerm:
@@ -185,8 +198,9 @@ class ActionManager(ManagerBase):
     def apply_action(self) -> None:
         """Write processed actions to entity actuator targets.
 
-        Called on every decimation substep (physics step), not just once per policy
-        step. Each term writes its most recently processed targets to the simulation.
+        Called once per control step when all terms produce substep-invariant control.
+        If any term requires state feedback, the env calls this before every physics
+        substep so all terms retain their configured manager order.
         """
         for name, term in self._terms.items():
             try:
@@ -220,6 +234,13 @@ class ActionManager(ManagerBase):
             if not isinstance(term.action_dim, int) or term.action_dim < 0:
                 raise ValueError(
                     f"ActionManager term '{term_name}' has invalid action_dim {term.action_dim}."
+                )
+            feedback = term.requires_substep_state_feedback
+            if not isinstance(feedback, bool):
+                raise TypeError(
+                    "ActionManager term "
+                    f"'{term_name}' requires_substep_state_feedback must be bool, "
+                    f"got {type(feedback).__name__}."
                 )
             self._term_names.append(term_name)
             self._terms[term_name] = term

--- a/src/unilab/tasks/locomotion/go2w/manager_terms.py
+++ b/src/unilab/tasks/locomotion/go2w/manager_terms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from numbers import Real
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 
@@ -81,6 +81,7 @@ class Go2WMixedActionCfg(ActionTermCfg):
 class Go2WMixedAction(ActionTerm):
     """Convert one community action term into Go2W motor torques per substep."""
 
+    requires_substep_state_feedback: ClassVar[bool] = True
     cfg: Go2WMixedActionCfg
     _entity: Entity
 

--- a/tests/envs/locomotion/go2w/test_go2w_manager_based_flat_cfg.py
+++ b/tests/envs/locomotion/go2w/test_go2w_manager_based_flat_cfg.py
@@ -37,6 +37,10 @@ _ACTUATOR_NAMES = tuple(name.removesuffix("_joint") for name in _JOINT_NAMES)
 _HOME_JOINT_POS = np.asarray([0.0, 0.8, -1.5] * 4 + [0.0] * 4, dtype=np.float32)
 
 
+def test_go2w_mixed_action_declares_substep_state_feedback() -> None:
+    assert Go2WMixedAction.requires_substep_state_feedback is True
+
+
 def _compose(backend: str) -> DictConfig:
     GlobalHydra.instance().clear()
     with initialize_config_dir(config_dir=str(CONF_DIR / "ppo"), version_base="1.3"):

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -55,6 +55,7 @@ class _FakeBackend:
         self.reject_materialize = reject_materialize
         self.pre_step_control = None
         self.applied_controls: list[np.ndarray] = []
+        self.step_nsteps: list[int] = []
         self.cleanup_calls = 0
         self.materialize_calls = 0
         self.lifecycle: list[str] = []
@@ -84,6 +85,7 @@ class _FakeBackend:
 
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
         assert self.materialize_calls == 1
+        self.step_nsteps.append(nsteps)
         native = ctrl
         for _ in range(nsteps):
             if self.pre_step_control is not None:
@@ -236,6 +238,16 @@ class _DriveAction(ActionTerm):
         self._entity.data.write_ctrl(self._processed)
 
 
+class _FeedbackDriveAction(_DriveAction):
+    requires_substep_state_feedback = True
+
+
+@dataclass(kw_only=True)
+class _FeedbackDriveCfg(_DriveCfg):
+    def build(self, env) -> ActionTerm:
+        return _FeedbackDriveAction(self, env)
+
+
 @dataclass(kw_only=True)
 class _CommandCfg(CommandTermCfg):
     def build(self, env) -> CommandTerm:
@@ -386,6 +398,7 @@ def _make_cfg(
     auto_reset: bool = True,
     metrics: dict[str, MetricsTermCfg | None] | None = None,
     observations: dict[str, ObservationGroupCfg | None] | None = None,
+    actions: dict[str, ActionTermCfg | None] | None = None,
     include_optional_managers: bool = True,
 ) -> ManagerBasedRlEnvCfg:
     if observations is None:
@@ -403,7 +416,7 @@ def _make_cfg(
         max_episode_seconds=1.0,
         seed=7,
         observations=observations,
-        actions={"drive": _DriveCfg(entity_name="robot")},
+        actions={"drive": _DriveCfg(entity_name="robot")} if actions is None else actions,
         rewards={"track": RewardTermCfg(func=_reward, weight=1.0)},
         terminations={
             "failure": TerminationTermCfg(func=_failure),
@@ -1030,8 +1043,10 @@ def test_np_env_owns_substeps_autoreset_and_final_observation() -> None:
     assert env._dr_manager is None
 
     state = env.step(np.array([[0.25], [0.5]], dtype=np.float32))
+    assert backend.pre_step_control is None
+    assert backend.step_nsteps == [2]
     assert len(backend.applied_controls) == 2
-    assert env.action_sim_steps == [1, 2]
+    assert env.action_sim_steps == [2]
     np.testing.assert_allclose(backend.applied_controls[0][:, 0], [0.25, 0.5])
     np.testing.assert_allclose(backend.applied_controls[1][:, 0], [0.25, 0.5])
     np.testing.assert_allclose(state.reward, [0.005, 0.01])
@@ -1350,9 +1365,101 @@ def test_per_substep_metrics_fail_without_post_substep_backend_hook() -> None:
         _make_env(cfg)
 
 
-def test_multisubstep_action_fails_when_backend_rejects_callback() -> None:
-    with pytest.raises(NotImplementedError, match="ActionManager.*every physics substep.*fake"):
-        _make_env(reject_pre_step=True)
+def test_multisubstep_state_independent_action_skips_callback() -> None:
+    env, backend = _make_env(reject_pre_step=True)
+    try:
+        assert backend.pre_step_control is None
+        assert not env.action_manager.requires_substep_state_feedback
+    finally:
+        env.close()
+
+
+def test_multisubstep_state_feedback_action_uses_callback() -> None:
+    cfg = _make_cfg(
+        actions={"drive": _FeedbackDriveCfg(entity_name="robot")},
+    )
+    env, backend = _make_env(cfg)
+    try:
+        env.init_state()
+        env.step(np.array([[0.25], [0.5]], dtype=np.float32))
+
+        assert env.action_manager.requires_substep_state_feedback
+        assert backend.pre_step_control is not None
+        assert backend.step_nsteps == [2]
+        assert env.action_sim_steps == [1, 2]
+        assert len(backend.applied_controls) == 2
+    finally:
+        env.close()
+
+
+def test_multisubstep_state_feedback_action_fails_when_backend_rejects_callback() -> None:
+    cfg = _make_cfg(
+        actions={"drive": _FeedbackDriveCfg(entity_name="robot")},
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="ActionManager.*state-feedback actions.*every physics substep.*fake",
+    ):
+        _make_env(cfg, reject_pre_step=True)
+
+
+def test_single_substep_feedback_action_does_not_require_callback() -> None:
+    cfg = _make_cfg(
+        sim_substeps=1,
+        actions={"drive": _FeedbackDriveCfg(entity_name="robot")},
+    )
+    env, backend = _make_env(cfg, reject_pre_step=True)
+    try:
+        env.init_state()
+        env.step(np.array([[0.25], [0.5]], dtype=np.float32))
+
+        assert backend.pre_step_control is None
+        assert backend.step_nsteps == [1]
+        assert env.action_sim_steps == [1]
+    finally:
+        env.close()
+
+
+def test_empty_action_manager_does_not_require_callback() -> None:
+    observations = {
+        "actor": ObservationGroupCfg(
+            terms={"episode_step": ObservationTermCfg(func=_episode_step_observation)}
+        ),
+        "value": ObservationGroupCfg(
+            terms={"episode_step": ObservationTermCfg(func=_episode_step_observation)}
+        ),
+    }
+    env, backend = _make_env(
+        _make_cfg(actions={}, observations=observations),
+        reject_pre_step=True,
+    )
+    try:
+        assert env.action_manager.active_terms == []
+        assert not env.action_manager.requires_substep_state_feedback
+        assert backend.pre_step_control is None
+    finally:
+        env.close()
+
+
+def test_state_feedback_action_error_propagates_from_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _make_cfg(
+        actions={"drive": _FeedbackDriveCfg(entity_name="robot")},
+    )
+    env, _ = _make_env(cfg)
+    env.init_state()
+    term = env.action_manager.get_term("drive")
+
+    def fail() -> None:
+        raise ValueError("feedback failed")
+
+    monkeypatch.setattr(term, "apply_actions", fail)
+    try:
+        with pytest.raises(ValueError, match="ActionManager term 'drive'.*feedback failed"):
+            env.step(np.zeros((2, 1), dtype=np.float32))
+    finally:
+        env.close()
 
 
 @pytest.mark.parametrize(
@@ -1387,7 +1494,11 @@ def test_observation_mapping_fails_closed(mutate, error, match: str) -> None:
 
 
 def test_close_unhooks_callback_and_closes_owned_resources() -> None:
-    env, backend = _make_env()
+    cfg = _make_cfg(
+        actions={"drive": _FeedbackDriveCfg(entity_name="robot")},
+    )
+    env, backend = _make_env(cfg)
+    assert backend.pre_step_control is not None
     env.close()
     assert backend.pre_step_control is None
     assert backend.cleanup_calls == 1

--- a/tests/managers/test_core_managers.py
+++ b/tests/managers/test_core_managers.py
@@ -59,6 +59,16 @@ class DummyActionCfg(ActionTermCfg):
         return DummyAction(self, env)
 
 
+class FeedbackDummyAction(DummyAction):
+    requires_substep_state_feedback = True
+
+
+@dataclass(kw_only=True)
+class FeedbackDummyActionCfg(DummyActionCfg):
+    def build(self, env: FakeEnv) -> FeedbackDummyAction:
+        return FeedbackDummyAction(self, env)
+
+
 def test_action_split_history_apply_and_partial_reset(fake_env: FakeEnv) -> None:
     manager = ActionManager(
         {
@@ -69,6 +79,7 @@ def test_action_split_history_apply_and_partial_reset(fake_env: FakeEnv) -> None
         fake_env,
     )
     assert manager.active_terms == ["legs", "arm"]
+    assert not manager.requires_substep_state_feedback
     first = np.arange(12, dtype=np.float32).reshape(4, 3)
     second = first + 20
     manager.process_action(first)
@@ -81,6 +92,28 @@ def test_action_split_history_apply_and_partial_reset(fake_env: FakeEnv) -> None
     manager.reset(np.array([1, 3]))
     np.testing.assert_array_equal(manager.action[[1, 3]], 0.0)
     np.testing.assert_array_equal(manager.action[[0, 2]], second[[0, 2]])
+
+
+def test_action_manager_aggregates_substep_state_feedback(fake_env: FakeEnv) -> None:
+    manager = ActionManager(
+        {
+            "invariant": DummyActionCfg(entity_name="robot", dim=1),
+            "feedback": FeedbackDummyActionCfg(entity_name="robot", dim=1),
+        },
+        fake_env,
+    )
+
+    assert manager.requires_substep_state_feedback
+
+
+def test_action_feedback_declaration_must_be_bool(
+    fake_env: FakeEnv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(DummyAction, "requires_substep_state_feedback", "yes")
+
+    with pytest.raises(TypeError, match="requires_substep_state_feedback must be bool"):
+        ActionManager({"invalid": DummyActionCfg(entity_name="robot", dim=1)}, fake_env)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add a validated `ActionTerm.requires_substep_state_feedback` declaration, defaulting to `False`, and aggregate it in `ActionManager`.
- Register the existing pre-step callback only when an active term needs fresh state between physics substeps.
- Keep `Go2WMixedAction` on the callback path; invariant actions are applied once and use the existing backend `step(ctrl, nsteps=N)` path.
- Cover invariant, mixed-feedback, single-substep, empty-manager, rejection, exception, counter, and close-cleanup behavior.

## Linked Work

- Closes #1276
- Parent: #1259
- Evidence: #1262
- Depends on completed #1267

## Validation

- [x] `make check`
- [x] `uv run pytest tests/managers/test_core_managers.py tests/envs/test_manager_based_rl_env.py tests/envs/locomotion/go2w/test_go2w_manager_based_flat_cfg.py -q` (86 passed)
- [x] `uv run pytest tests/base/test_backend_pre_step_control.py tests/base/test_mjwarp_capabilities.py -q` (13 passed, 1 deselected)
- [x] `make test-all` (2216 passed, 28 skipped, 275 deselected, 1 xfailed)

Final commit: `27e092bcadb47f0c9379375f21c8dc691b75be95`

## Benchmark

Fixed command on the same host for both SHAs:

```bash
uv run scripts/benchmark/rl/benchmark_offpolicy_collector_active.py --cases flashsac/g1_walk_flat/mujoco --num-envs 8192 --warmup-steps 10 --measure-steps 100 --replay-capacity-steps 64
```

| Metric | Before `70836033` | After `27e092bc` | Delta |
| --- | ---: | ---: | ---: |
| Collector throughput | 68,579 env/s | 88,683 env/s | +29.3% |
| Env step | 118.420 ms | 91.330 ms | -22.9% |
| Backend physics | 99.309 ms | 73.716 ms | -25.8% |
| Update state | 8.458 ms | 8.400 ms | stable |
| Reset done | 5.172 ms | 5.228 ms | stable |

The timing shift stays in the expected action/dispatch boundary. Raw local JSON was written to `/tmp/issue1276-{before,after}.json` and is not committed.

## Impact

- Backend impact: MuJoCo invariant-action MBA tasks move from callback dispatch to the existing broadcast trajectory path. Motrix and Drake reuse their existing direct `nsteps` paths. No backend adapter or `SimBackend` method changes.
- `Go2WMixedAction` remains state-feedback driven and keeps per-substep joint-state reads on MuJoCo, Motrix, and Drake.
- mjwarp registration/config/support evidence is unchanged. Its configured-only G1 owner may avoid the callback gate, but this PR does not promote support; local runtime smoke could not proceed because the optional `mujoco-warp` dependency is not installed.
- Platform impact: Linux validation and benchmark.
- Training effect: collector throughput only. Policy I/O, action values, rewards, reset/RNG, control decimation, and sim2sim fields are unchanged.

## Checklist

- [x] Added tests at the action-manager and env callback-selection boundaries
- [x] Linked the driving issue
- [x] Recorded MuJoCo and non-MuJoCo behavior impact
- [x] No task/backend allowlist, new execution path, or support claim added
