### PR TITLE
perf: scan observation finiteness once per term

### DIFF
--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -303,11 +303,17 @@ class ObservationManager(ManagerBase):
         if policy == "disabled":
             return tensor
 
-        has_nan = np.isnan(tensor).any()
-        has_inf = np.isinf(tensor).any()
-
-        if not (has_nan or has_inf):
+        # The overwhelmingly common path is finite.  Use one full tensor scan
+        # here instead of separate isnan/isinf scans for every term.  On the
+        # exceptional path the same allocation is reused as the invalid mask
+        # so diagnostics and sanitization retain their existing semantics.
+        finite = np.isfinite(tensor)
+        if finite.all():
             return tensor
+        invalid = np.logical_not(finite, out=finite)
+        invalid_values = tensor[invalid]
+        has_nan = np.isnan(invalid_values).any()
+        has_inf = np.isinf(invalid_values).any()
 
         def _row_env_ids(mask: np.ndarray) -> list[int]:
             rows = np.flatnonzero(np.asarray(mask, dtype=bool))
@@ -317,7 +323,6 @@ class ObservationManager(ManagerBase):
             return result
 
         if policy == "error":
-            invalid = ~np.isfinite(tensor)
             nan_mask = np.asarray(invalid.reshape(tensor.shape[0], -1).any(axis=1))
             nan_env_ids = _row_env_ids(nan_mask)
             invalid_kind = (
@@ -333,7 +338,6 @@ class ObservationManager(ManagerBase):
             )
 
         if policy == "warn":
-            invalid = ~np.isfinite(tensor)
             nan_mask = np.asarray(invalid.reshape(tensor.shape[0], -1).any(axis=1))
             nan_env_ids = _row_env_ids(nan_mask)
             print(

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -180,6 +180,66 @@ def test_observation_default_finite_policy_fails_closed(fake_env: FakeEnv, bad: 
         manager.compute()
 
 
+@pytest.mark.parametrize(
+    ("invalid_values", "invalid_kind"),
+    [
+        ((np.nan, 0.0), "NaN"),
+        ((np.inf, 0.0), "Inf"),
+        ((np.nan, np.inf), "NaN/Inf"),
+    ],
+)
+def test_observation_finite_error_keeps_kind_term_and_env_diagnostics(
+    fake_env: FakeEnv,
+    invalid_values: tuple[float, float],
+    invalid_kind: str,
+) -> None:
+    def invalid(env: FakeEnv) -> np.ndarray:
+        result = env.obs.copy()
+        result[2] = invalid_values
+        return result
+
+    manager = ObservationManager(
+        {"policy": ObservationGroupCfg(terms={"bad": ObservationTermCfg(func=invalid)})},
+        fake_env,
+    )
+    match = rf"{invalid_kind} detected.*'policy/bad'.*environments: \[2\]"
+    with pytest.raises(ValueError, match=match):
+        manager.compute()
+
+
+def test_observation_finite_warn_sanitizes_and_disabled_preserves(
+    fake_env: FakeEnv, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def invalid(env: FakeEnv) -> np.ndarray:
+        result = env.obs.copy()
+        result[1, 0] = np.nan
+        return result
+
+    warn = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={"bad": ObservationTermCfg(func=invalid)}, nan_policy="warn"
+            )
+        },
+        fake_env,
+    )
+    warned = warn.compute()["policy"]
+    assert np.isfinite(warned).all()
+    warning = capsys.readouterr().out
+    assert "policy/bad" in warning
+    assert "envs: [1]" in warning
+
+    disabled = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={"bad": ObservationTermCfg(func=invalid)}, nan_policy="disabled"
+            )
+        },
+        fake_env,
+    )
+    assert np.isnan(disabled.compute()["policy"][1, 0])
+
+
 def test_observation_explicit_sanitize_and_shape_error(fake_env: FakeEnv) -> None:
     sanitize = ObservationManager(
         {


### PR DESCRIPTION
## Summary

- Replace the valid-observation fast path's separate full-array `isnan` and `isinf` scans with one `isfinite` scan per term.
- Reuse the finite mask on the exceptional path while preserving NaN/Inf/mixed diagnostics, term context, and real environment IDs.
- Preserve observation bytes, term/noise call order, RNG state, output ownership, clip/scale, history/delay/reset semantics, and all four invalid-observation policies (`error`, `warn`, `sanitize`, `disabled`).
- Scope is limited to `ObservationManager` and focused tests: 2 files, +70/-6.
- No user-facing, policy-I/O, config, manager lifecycle, backend contract, or training behavior changes are expected.

Two broader candidates were measured and intentionally rejected under #1279's stop condition:

- Skipping unconditional term copies changed allocation/layout timing and produced a repeatable 2–3× Motrix noise/concat drift.
- Prepacking terms into the final output buffer made per-term slices strided, worsening finite checks and Motrix concatenation.

Neither candidate remains in this PR; no cache, pack plan, layout metadata, or copy-semantics change was introduced.

## Linked Work

- Fixes #1279
- Umbrella: #1259 (Wave 3 U2)
- Base: `dev/issue-1042-manager-based-api`
- Final commit: `c78ee7ed48ce739e20dc1ba9181fbe703f97063a`

## Validation

- [x] Final commit passed `make test-all`
- [x] Cross-commit observation/RNG parity checked for 8 steps
- [x] Focused invalid-observation policy and ownership tests updated
- [x] Seven 8192-env collector cases measured as median-of-3 A/B

Commands actually run on the final commit:

```bash
make test-all
```

`make test-all` result:

- Ruff passed.
- mypy passed across 243 source files.
- Pyright passed with 0 errors.
- pytest: 2220 passed, 28 skipped, 275 deselected, 1 xfailed.
- Benchmark smoke: module 33/34 and script 34/35; only optional MLX skipped.

The cross-commit 8-step digest of observation bytes plus every RNG state was identical:

```text
74048a91be7470d19eb9b6ef8d360cb5e2be1c69781b3fc25372aa578f7d8c0b
```

## Benchmark

8192 environments, median of 3 A/B pairs:

| Case | finite check | `mba_obs_compute_ms` | collector |
|---|---:|---:|---:|
| FlashSAC G1 walk / Motrix | -42.9% | +15.3% drift | -1.2%; paired median -0.2% |
| FlashSAC G1 walk / MuJoCo | -45.2% | -1.5% | -0.5% |
| FlashSAC Go2 / MuJoCo | -43.2% | -2.8% | +0.7% |
| SAC motion / Motrix | -43.4% | -7.9% | +4.6% |
| SAC motion / MuJoCo | -46.1% | -4.4% | +0.7% |
| SAC G1 walk / Motrix | -44.2% | +15.6% drift | +0.7%; paired median +1.5% |
| SAC G1 walk / MuJoCo | -46.0% | -3.9% | +0.1% |

The directly owned finite-check metric improves consistently by 42.9%–46.1%. Motrix walk retains known batch-level `mba_obs_compute_ms` allocation/layout drift, while paired collector measurements show no repeatable regression. Raw gitignored outputs are retained locally under `scripts/benchmark/outputs/offpolicy_collector_active/issue1279_{finite,remaining}_{before,after}_pair{1,2,3}.{json,csv}`.

## Impact

- Backend impact: both MuJoCo and Motrix were exercised; the change is backend-neutral manager code.
- Platform impact: Linux.
- Training effect expected: no; byte/RNG parity was preserved.
- Policy/config/sim2sim contract impact: none.
- Remote gate: per #1259's explicit child-PR exception, this PR does not trigger, require, or wait for remote CI/Docs; the final local `make test-all` is the gate.

## Artifacts

- W&B: not applicable.
- Benchmark result: summarized above; raw local files listed above.
- Video / screenshot: not applicable.
- ONNX / checkpoint: not applicable.

## Checklist

- [x] Added or updated tests where needed
- [x] Docs are unchanged because behavior and workflow are unchanged
- [x] Linked the driving issue
- [x] Rejected candidates and residual Motrix timing drift are documented
