### PR TITLE
perf: reduce mjwarp host-cache D2H overhead

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -208,15 +208,20 @@ class MjwarpBackend(SimBackend):
         ).copy()
         self._joint_range = self._bind_joint_range()
 
-        # All legacy getters below return views into these stable host buffers.
-        # They are refreshed only by _refresh_host_cache(), called after a
-        # device step or a reset/forward lifecycle barrier.
-        self._qpos_cache = np.zeros((self._num_envs, self._nq), dtype=np.float32)
-        self._qvel_cache = np.zeros((self._num_envs, self._nv), dtype=np.float32)
+        # All legacy getters below return views into these stable pinned host
+        # buffers. They are refreshed only by _refresh_host_cache(), called
+        # after a device step or a reset/forward lifecycle barrier. Keeping the
+        # Warp storage alive lets D2H copies target the public NumPy cache
+        # directly instead of allocating a temporary array on every refresh.
+        self._qpos_cache_storage, self._qpos_cache = self._allocate_pinned_host_cache(
+            self._device_data.qpos
+        )
+        self._qvel_cache_storage, self._qvel_cache = self._allocate_pinned_host_cache(
+            self._device_data.qvel
+        )
         self._time_cache = np.zeros((self._num_envs,), dtype=np.float32)
-        self._sensor_cache = np.zeros(
-            (self._num_envs, int(self._cpu_model.nsensordata)),
-            dtype=np.float32,
+        self._sensor_cache_storage, self._sensor_cache = self._allocate_pinned_host_cache(
+            self._device_data.sensordata
         )
         self._ctrl_staging = np.zeros((self._num_envs, self._nu), dtype=np.float32)
         self._reset_mask_host = np.zeros((self._num_envs,), dtype=np.bool_)
@@ -375,17 +380,28 @@ class MjwarpBackend(SimBackend):
     # Explicit host-cache barriers                                        #
     # ------------------------------------------------------------------ #
 
+    def _allocate_pinned_host_cache(self, device_array: Any) -> tuple[Any, np.ndarray]:
+        """Allocate stable CPU storage for one fixed-shape device-state cache."""
+        storage = self._warp.empty(
+            device_array.shape,
+            dtype=device_array.dtype,
+            device="cpu",
+            pinned=True,
+        )
+        return storage, storage.numpy()
+
     def _refresh_host_cache(self) -> None:
         """Copy all legacy-visible device state at one explicit lifecycle barrier."""
-        self._download(self._device_data.qpos, self._qpos_cache)
-        self._download(self._device_data.qvel, self._qvel_cache)
-        self._download(self._device_data.sensordata, self._sensor_cache)
+        self._download(self._device_data.qpos, self._qpos_cache_storage)
+        self._download(self._device_data.qvel, self._qvel_cache_storage)
+        self._download(self._device_data.sensordata, self._sensor_cache_storage)
+        self._synchronize()
 
     def _upload(self, device_array: Any, host_array: np.ndarray) -> None:
         device_array.assign(host_array)
 
-    def _download(self, device_array: Any, host_array: np.ndarray) -> None:
-        np.copyto(host_array, device_array.numpy())
+    def _download(self, device_array: Any, host_array: Any) -> None:
+        self._warp.copy(host_array, device_array)
 
     def _synchronize(self) -> None:
         self._warp.synchronize_device()

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -53,6 +53,16 @@ def test_real_cuda_init_reset_step(monkeypatch: pytest.MonkeyPatch) -> None:
     assert backend.backend_type == "mjwarp"
     assert backend.num_actuators == 29
     assert backend.num_dof_vel == 29
+    caches = (
+        (backend._qpos_cache_storage, backend._qpos_cache),
+        (backend._qvel_cache_storage, backend._qvel_cache),
+        (backend._sensor_cache_storage, backend._sensor_cache),
+    )
+    for storage, cache in caches:
+        assert storage.device.is_cpu
+        assert storage.pinned
+        assert cache.ctypes.data == storage.ptr
+    cache_pointers = tuple(cache.ctypes.data for _, cache in caches)
     root_layout = backend.get_root_state_layout("pelvis")
     assert root_layout.qpos_indices == tuple(range(7))
     assert root_layout.qvel_indices == tuple(range(6))
@@ -87,6 +97,7 @@ def test_real_cuda_init_reset_step(monkeypatch: pytest.MonkeyPatch) -> None:
     assert np.isfinite(backend.get_dof_pos()).all()
     assert np.isfinite(backend.get_sensor_data("torso_upvector")).all()
     assert not np.array_equal(backend.get_base_pos(), before)
+    assert tuple(cache.ctypes.data for _, cache in caches) == cache_pointers
 
 
 def test_selected_row_reset_isolated() -> None:

--- a/tests/base/test_mjwarp_host_cache.py
+++ b/tests/base/test_mjwarp_host_cache.py
@@ -1,0 +1,71 @@
+"""Owner-level tests for MJWarp's explicit pinned host-cache barrier."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from unilab.base.backend.mjwarp.backend import MjwarpBackend
+
+
+class _FakeStorage:
+    def __init__(self, array: np.ndarray) -> None:
+        self.array = array
+
+    def numpy(self) -> np.ndarray:
+        return self.array
+
+
+class _FakeWarp:
+    def __init__(self) -> None:
+        self.empty_calls: list[dict[str, Any]] = []
+        self.events: list[tuple[Any, ...]] = []
+
+    def empty(self, shape: tuple[int, ...], **kwargs: Any) -> _FakeStorage:
+        self.empty_calls.append({"shape": shape, **kwargs})
+        return _FakeStorage(np.empty(shape, dtype=np.float32))
+
+    def copy(self, destination: Any, source: Any) -> None:
+        self.events.append(("copy", destination, source))
+
+
+def _backend(warp: _FakeWarp) -> MjwarpBackend:
+    backend = object.__new__(MjwarpBackend)
+    backend._warp = warp
+    return backend
+
+
+def test_allocate_host_cache_uses_pinned_cpu_storage() -> None:
+    warp = _FakeWarp()
+    backend = _backend(warp)
+    device_array = SimpleNamespace(shape=(4, 7), dtype="float32")
+
+    storage, cache = backend._allocate_pinned_host_cache(device_array)
+
+    assert warp.empty_calls == [
+        {"shape": (4, 7), "dtype": "float32", "device": "cpu", "pinned": True}
+    ]
+    assert cache is storage.array
+
+
+def test_refresh_host_cache_batches_all_downloads_before_sync() -> None:
+    warp = _FakeWarp()
+    backend = _backend(warp)
+    backend._device_data = SimpleNamespace(
+        qpos="device-qpos", qvel="device-qvel", sensordata="device-sensor"
+    )
+    backend._qpos_cache_storage = "host-qpos"
+    backend._qvel_cache_storage = "host-qvel"
+    backend._sensor_cache_storage = "host-sensor"
+    backend._synchronize = lambda: warp.events.append(("sync",))  # type: ignore[method-assign]
+
+    backend._refresh_host_cache()
+
+    assert warp.events == [
+        ("copy", "host-qpos", "device-qpos"),
+        ("copy", "host-qvel", "device-qvel"),
+        ("copy", "host-sensor", "device-sensor"),
+        ("sync",),
+    ]


### PR DESCRIPTION
## Summary

- 让 `MjwarpBackend` 在初始化冷路径为 qpos、qvel、sensordata 分配持久 pinned CPU Warp storage，公开 NumPy cache 直接成为这些 storage 的稳定 view。
- 每个 step/reset barrier 通过 `warp.copy` 连续提交三次 D2H，再在 getter 可见前统一同步；移除每次 `.numpy()` 临时分配与后续 `np.copyto`。
- 保持 cache shape/dtype/address、step/reset/forward 顺序、timing keys、selected-row reset、CUDA graph fallback 与 getter 零隐式传输语义。

## Scope / backend impact

- 仅修改 MJWarp backend owner 与 focused tests；不新增或修改 `SimBackend`、env/manager lifecycle、配置、runner/learner 或 support 声明。
- MuJoCo、Motrix 与其他 backend 行为不变。
- 未实施 multi-substep graph fusion：2048-world paired microbenchmark 无收益，按 #1286 stop condition 保留现状。

## Benchmark

同机串行、交替 A/B；before `e6f136d4`，after `56dff844`：

- Hardware/runtime: AMD Ryzen 9 9950X3D2, NVIDIA RTX 4090 48 GB, driver 595.84, Warp 1.14.0, mujoco-warp 3.10.0.3.
- Production backend: G1 flat scene, 2048 worlds, body-state sensors enabled, 3 substeps, 10 warm-up + 100 measured calls, 3 fresh-backend runs per side.

| Metric (median of 3 run medians) | Before | After | Delta |
|---|---:|---:|---:|
| Host-cache D2H | 0.400 ms | 0.170 ms | -57.5% |
| Full backend step | 4.113 ms | 3.877 ms | -5.7% |
| Physics section | 3.686 ms | 3.679 ms | -0.2% |

Production SAC collector (`sac/g1_walk_flat/mjwarp`, 2048 envs, 10 warm-up + 100 measured vector steps, 3 runs per side):

| Metric (median run) | Before | After | Delta |
|---|---:|---:|---:|
| Collector throughput | 188,816 env/s | 196,576 env/s | +4.1% |
| Env step mean | 10.666 ms | 10.234 ms | -4.0% |
| Non-physics env overhead | 5.261 ms | 4.877 ms | -7.3% |

Physics stayed within 1%; the repeatable gain is localized to the changed host-cache barrier.

## Validation

Final commit: `56dff844fd7ed3c7bc53ef2f7af5f839aedfcf74`

- `make test-all` — passed:
  - Ruff, mypy (243 source files), Pyright passed.
  - pytest: 2223 passed, 28 skipped, 277 deselected, 1 xfailed.
  - benchmark smoke: module 33/34 and script 34/35; only platform-optional MLX skipped.
- `uv run --extra mjwarp pytest -q -m slow tests/base/test_mjwarp_backend.py tests/base/test_mjwarp_capabilities.py tests/base/test_mjwarp_differential.py tests/base/test_backend_conformance.py` — 17 passed, 26 deselected.
- `uv run --extra mjwarp pytest -q tests/base/test_mjwarp_host_cache.py tests/base/test_mjwarp_cuda_graph.py tests/base/test_mjwarp_identity.py tests/base/test_mjwarp_playback.py` — 21 passed.

Per #1259 child gate, this PR targets the bound dev branch and uses the completed local full gate; remote CI/Docs is not part of this child merge gate.

Closes #1286
Related to #1259
