### PR TITLE
perf: bound mjwarp partial reset forward

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -39,6 +39,8 @@ from .materialization import materialize_mjwarp_scene
 from .playback import run_mjwarp_playback, validate_mjwarp_visual_model
 
 _GRAPH_CAPTURE_MIN_DRIVER = (12, 4)
+_RESET_SCRATCH_CAPACITY = 128
+_RESET_SCRATCH_MIN_BATCH_SIZE = 8 * _RESET_SCRATCH_CAPACITY
 
 
 @contextmanager
@@ -226,6 +228,18 @@ class MjwarpBackend(SimBackend):
         self._ctrl_staging = np.zeros((self._num_envs, self._nu), dtype=np.float32)
         self._reset_mask_host = np.zeros((self._num_envs,), dtype=np.bool_)
         self._reset_mask_device = deps.warp.zeros(self._num_envs, dtype=bool)
+        # A bounded secondary Data avoids running reset-time forward over every
+        # production world when only a small row set terminated.  It is built
+        # only for batches large enough to amortize the extra graph and copies.
+        self._reset_scratch_capacity = (
+            _RESET_SCRATCH_CAPACITY if self._num_envs >= _RESET_SCRATCH_MIN_BATCH_SIZE else 0
+        )
+        self._reset_scratch_data: Any | None = None
+        self._reset_scratch_mask_device: Any | None = None
+        self._reset_scratch_qpos_staging: np.ndarray | None = None
+        self._reset_scratch_qvel_staging: np.ndarray | None = None
+        self._reset_scratch_sensor_storage: Any | None = None
+        self._reset_scratch_sensor_cache: np.ndarray | None = None
         # Tracked-body views are zero-copy slices of _sensor_cache; they must be
         # bound before the first forward barrier refreshes the cache below.
         self._body_id_to_tracked_idx: np.ndarray | None = None
@@ -412,7 +426,44 @@ class MjwarpBackend(SimBackend):
         self._step_graph = None
         self._forward_graph = None
         self._reset_graph = None
+        self._reset_scratch_reset_graph = None
+        self._reset_scratch_forward_graph = None
         self._cuda_graph_disable_reason: str | None = reason
+
+    def _prepare_reset_scratch(self) -> None:
+        """Materialize and warm the bounded reset-forward data on the cold path."""
+        if self._reset_scratch_capacity == 0 or self._reset_scratch_data is not None:
+            return
+
+        capacity = self._reset_scratch_capacity
+        data = self._mujoco_warp.make_data(
+            self._cpu_model,
+            nworld=capacity,
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+        )
+        qpos = np.broadcast_to(
+            np.asarray(self._cpu_model.qpos0, dtype=np.float32),
+            (capacity, self._nq),
+        ).copy()
+        qvel = np.zeros((capacity, self._nv), dtype=np.float32)
+        reset_mask = self._warp.ones(capacity, dtype=bool)
+        sensor_storage, sensor_cache = self._allocate_pinned_host_cache(data.sensordata)
+
+        self._reset_scratch_data = data
+        self._reset_scratch_mask_device = reset_mask
+        self._reset_scratch_qpos_staging = qpos
+        self._reset_scratch_qvel_staging = qvel
+        self._reset_scratch_sensor_storage = sensor_storage
+        self._reset_scratch_sensor_cache = sensor_cache
+
+        # Warm dynamically specialized reset/forward kernels before capture;
+        # compiling or allocating from inside a CUDA capture is unsupported.
+        self._mujoco_warp.reset_data(self._device_model, data, reset=reset_mask)
+        self._upload(data.qpos, qpos)
+        self._upload(data.qvel, qvel)
+        self._mujoco_warp.forward(self._device_model, data)
+        self._synchronize()
 
     def _initialize_cuda_graphs(self, device: Any) -> None:
         """Capture fixed-address device operations or retain the eager fallback.
@@ -434,6 +485,7 @@ class MjwarpBackend(SimBackend):
             return
 
         try:
+            self._prepare_reset_scratch()
             # Assign only after all captures succeed. This keeps step/reset on
             # one execution mode if any MJWarp operation is not capturable.
             with _suspend_gc(), self._warp.ScopedDevice(device):
@@ -447,9 +499,32 @@ class MjwarpBackend(SimBackend):
                         self._device_data,
                         reset=self._reset_mask_device,
                     )
+                reset_scratch_reset_capture = None
+                reset_scratch_forward_capture = None
+                if self._reset_scratch_data is not None:
+                    assert self._reset_scratch_mask_device is not None
+                    with self._warp.ScopedCapture() as reset_scratch_reset_capture:
+                        self._mujoco_warp.reset_data(
+                            self._device_model,
+                            self._reset_scratch_data,
+                            reset=self._reset_scratch_mask_device,
+                        )
+                    with self._warp.ScopedCapture() as reset_scratch_forward_capture:
+                        self._mujoco_warp.forward(
+                            self._device_model,
+                            self._reset_scratch_data,
+                        )
             step_graph = step_capture.graph
             forward_graph = forward_capture.graph
             reset_graph = reset_capture.graph
+            reset_scratch_reset_graph = (
+                None if reset_scratch_reset_capture is None else reset_scratch_reset_capture.graph
+            )
+            reset_scratch_forward_graph = (
+                None
+                if reset_scratch_forward_capture is None
+                else reset_scratch_forward_capture.graph
+            )
         except Exception as exc:
             reason = f"capture failed: {type(exc).__name__}: {exc}"
             self._disable_cuda_graphs(reason)
@@ -463,6 +538,8 @@ class MjwarpBackend(SimBackend):
         self._step_graph = step_graph
         self._forward_graph = forward_graph
         self._reset_graph = reset_graph
+        self._reset_scratch_reset_graph = reset_scratch_reset_graph
+        self._reset_scratch_forward_graph = reset_scratch_forward_graph
         self._cuda_graph_enabled = True
         self._cuda_graph_disable_reason = None
 
@@ -495,6 +572,47 @@ class MjwarpBackend(SimBackend):
             self._warp.capture_launch(self._forward_graph)
             return
         self._mujoco_warp.forward(self._device_model, self._device_data)
+
+    def _can_use_reset_scratch(self, num_rows: int) -> bool:
+        return (
+            self._cuda_graph_enabled
+            and 0 < num_rows <= self._reset_scratch_capacity
+            and self._reset_scratch_data is not None
+            and self._reset_scratch_reset_graph is not None
+            and self._reset_scratch_forward_graph is not None
+        )
+
+    def _execute_reset_scratch_forward(
+        self,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+    ) -> None:
+        """Forward reset rows in bounded scratch storage without touching main rows."""
+        data = self._reset_scratch_data
+        qpos_staging = self._reset_scratch_qpos_staging
+        qvel_staging = self._reset_scratch_qvel_staging
+        assert data is not None
+        assert qpos_staging is not None and qvel_staging is not None
+        assert self._reset_scratch_reset_graph is not None
+        assert self._reset_scratch_forward_graph is not None
+
+        num_rows = len(qpos)
+        np.copyto(qpos_staging[:num_rows], qpos)
+        np.copyto(qvel_staging[:num_rows], qvel)
+        self._warp.capture_launch(self._reset_scratch_reset_graph)
+        self._upload(data.qpos, qpos_staging)
+        self._upload(data.qvel, qvel_staging)
+        self._warp.capture_launch(self._reset_scratch_forward_graph)
+
+    def _refresh_reset_scratch_cache(self, row_ids: np.ndarray) -> None:
+        """Publish scratch sensor rows while retaining complement host-cache rows."""
+        data = self._reset_scratch_data
+        storage = self._reset_scratch_sensor_storage
+        cache = self._reset_scratch_sensor_cache
+        assert data is not None and storage is not None and cache is not None
+        self._download(data.sensordata, storage)
+        self._synchronize()
+        self._sensor_cache[row_ids] = cache[: len(row_ids)]
 
     def _validate_rows(self, env_indices: np.ndarray) -> np.ndarray:
         rows = np.asarray(env_indices, dtype=np.intp)
@@ -771,6 +889,8 @@ class MjwarpBackend(SimBackend):
         row_ids: np.ndarray,
         qpos: np.ndarray,
         qvel: np.ndarray,
+        reset_qpos: np.ndarray,
+        reset_qvel: np.ndarray,
     ) -> dict[str, float]:
         """Commit one explicit reset barrier from host staging.
 
@@ -779,6 +899,7 @@ class MjwarpBackend(SimBackend):
         forward/sync, then cache D2H.
         """
 
+        use_scratch = self._can_use_reset_scratch(len(row_ids))
         t0 = time.perf_counter()
         self._reset_mask_host.fill(False)
         self._reset_mask_host[row_ids] = True
@@ -790,15 +911,21 @@ class MjwarpBackend(SimBackend):
         # one explicit barrier.
         self._upload(self._device_data.qpos, qpos)
         self._upload(self._device_data.qvel, qvel)
+        if use_scratch:
+            self._execute_reset_scratch_forward(reset_qpos, reset_qvel)
         reset_upload_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        self._execute_device_forward()
+        if not use_scratch:
+            self._execute_device_forward()
         self._synchronize()
         reset_forward_ms = (time.perf_counter() - t0) * 1000.0
 
         t0 = time.perf_counter()
-        self._refresh_host_cache()
+        if use_scratch:
+            self._refresh_reset_scratch_cache(row_ids)
+        else:
+            self._refresh_host_cache()
         self._time_cache[row_ids] = 0.0
         host_cache_ms = (time.perf_counter() - t0) * 1000.0
         return {
@@ -852,7 +979,13 @@ class MjwarpBackend(SimBackend):
 
         self._qpos_cache[rows] = qpos_array
         self._qvel_cache[rows] = qvel_array
-        timings = self._execute_host_reset(rows, self._qpos_cache, self._qvel_cache)
+        timings = self._execute_host_reset(
+            rows,
+            self._qpos_cache,
+            self._qvel_cache,
+            qpos_array,
+            qvel_array,
+        )
         return {
             "timing": {
                 "set_state_reset_ms": timings["reset_upload_ms"] + timings["reset_forward_ms"],

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -123,6 +123,74 @@ def test_selected_row_reset_isolated() -> None:
     assert np.isfinite(backend.get_sensor_data("pelvis_local_linvel")).all()
 
 
+def test_large_batch_sparse_reset_matches_full_forward(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bounded reset graph preserves reset sensors and the following step."""
+    num_envs = 1024
+    backend = create_backend(
+        "mjwarp",
+        _scene(),
+        num_envs,
+        0.02 / 3.0,
+        base_name="pelvis",
+        body_state_required=True,
+    )
+    capacity = backend._reset_scratch_capacity
+    assert capacity == 128
+    assert backend._reset_scratch_forward_graph is not None
+
+    rng = np.random.default_rng(7)
+    all_rows = np.arange(num_envs, dtype=np.int32)
+    all_qpos, all_qvel = _stand_state(backend, num_envs)
+    rows = np.sort(rng.choice(num_envs, 32, replace=False)).astype(np.int32)
+    reset_qpos, reset_qvel = _stand_state(backend, len(rows))
+    reset_qpos[:, 0] += rng.uniform(-0.2, 0.2, len(rows)).astype(np.float32)
+    reset_qvel[:] = rng.uniform(-0.2, 0.2, reset_qvel.shape).astype(np.float32)
+    ctrl = np.zeros((num_envs, backend.num_actuators), dtype=np.float32)
+
+    def snapshot() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        return (
+            backend._qpos_cache[rows].copy(),
+            backend._qvel_cache[rows].copy(),
+            backend._sensor_cache[rows].copy(),
+        )
+
+    backend.set_state(all_rows, all_qpos, all_qvel)
+    backend._reset_scratch_capacity = 0
+    backend.set_state(rows, reset_qpos, reset_qvel)
+    full_reset = snapshot()
+    backend.step(ctrl, nsteps=3)
+    full_step = snapshot()
+
+    backend._reset_scratch_capacity = capacity
+    backend.set_state(all_rows, all_qpos, all_qvel)
+    graph_launches: list[Any] = []
+    original_capture_launch = backend._warp.capture_launch
+
+    def capture_launch(graph: Any) -> None:
+        graph_launches.append(graph)
+        original_capture_launch(graph)
+
+    monkeypatch.setattr(backend._warp, "capture_launch", capture_launch)
+    backend.set_state(rows, reset_qpos, reset_qvel)
+    assert graph_launches == [
+        backend._reset_graph,
+        backend._reset_scratch_reset_graph,
+        backend._reset_scratch_forward_graph,
+    ]
+    sparse_reset = snapshot()
+    backend.step(ctrl, nsteps=3)
+    sparse_step = snapshot()
+
+    for actual, expected in zip(sparse_reset[:2], full_reset[:2], strict=True):
+        np.testing.assert_array_equal(actual, expected)
+    np.testing.assert_allclose(sparse_reset[2], full_reset[2], rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(sparse_step[0], full_step[0], rtol=1e-3, atol=2e-5)
+    np.testing.assert_allclose(sparse_step[1], full_step[1], rtol=1e-3, atol=1e-3)
+    np.testing.assert_allclose(sparse_step[2], full_step[2], rtol=1e-3, atol=1e-2)
+
+
 @pytest.mark.parametrize(
     ("config_group", "overrides", "algo_name"),
     [

--- a/tests/base/test_mjwarp_cuda_graph.py
+++ b/tests/base/test_mjwarp_cuda_graph.py
@@ -94,6 +94,8 @@ def _backend(warp: _FakeWarp, mujoco_warp: _FakeMujocoWarp) -> MjwarpBackend:
     backend._device_model = object()
     backend._device_data = object()
     backend._reset_mask_device = object()
+    backend._reset_scratch_capacity = 0
+    backend._reset_scratch_data = None
     return backend
 
 
@@ -151,6 +153,25 @@ def test_cuda_graph_capture_replays_fixed_address_operations() -> None:
         mujoco_warp.forward_calls,
         mujoco_warp.reset_calls,
     ) == capture_calls
+
+
+def test_cuda_graph_capture_includes_materialized_reset_scratch() -> None:
+    warp = _FakeWarp(driver=(12, 4), mempool=True)
+    mujoco_warp = _FakeMujocoWarp()
+    backend = _backend(warp, mujoco_warp)
+    backend._reset_scratch_capacity = 4
+    backend._reset_scratch_data = object()
+    backend._reset_scratch_mask_device = object()
+
+    backend._initialize_cuda_graphs(_FakeDevice())
+
+    assert backend._cuda_graph_enabled is True
+    assert backend._reset_scratch_reset_graph == "graph-3"
+    assert backend._reset_scratch_forward_graph == "graph-4"
+    assert mujoco_warp.reset_calls == 2
+    assert mujoco_warp.forward_calls == 2
+    assert backend._can_use_reset_scratch(4) is True
+    assert backend._can_use_reset_scratch(5) is False
 
 
 def test_ineligible_cuda_graph_warns_and_uses_eager_operations() -> None:

--- a/tests/base/test_mjwarp_host_cache.py
+++ b/tests/base/test_mjwarp_host_cache.py
@@ -69,3 +69,78 @@ def test_refresh_host_cache_batches_all_downloads_before_sync() -> None:
         ("copy", "host-sensor", "device-sensor"),
         ("sync",),
     ]
+
+
+def test_refresh_reset_scratch_cache_only_scatters_selected_rows() -> None:
+    warp = _FakeWarp()
+    backend = _backend(warp)
+    scratch_values = np.arange(12, dtype=np.float32).reshape(4, 3)
+    scratch_storage = _FakeStorage(np.empty_like(scratch_values))
+    backend._reset_scratch_data = SimpleNamespace(sensordata=scratch_values)
+    backend._reset_scratch_sensor_storage = scratch_storage
+    backend._reset_scratch_sensor_cache = scratch_storage.array
+    backend._sensor_cache = np.full((6, 3), -1.0, dtype=np.float32)
+    backend._download = lambda source, destination: np.copyto(  # type: ignore[method-assign]
+        destination.array, source
+    )
+    backend._synchronize = lambda: warp.events.append(("sync",))  # type: ignore[method-assign]
+
+    backend._refresh_reset_scratch_cache(np.asarray([4, 1], dtype=np.int32))
+
+    np.testing.assert_array_equal(backend._sensor_cache[4], scratch_values[0])
+    np.testing.assert_array_equal(backend._sensor_cache[1], scratch_values[1])
+    np.testing.assert_array_equal(
+        backend._sensor_cache[[0, 2, 3, 5]],
+        np.full((4, 3), -1.0, dtype=np.float32),
+    )
+    assert warp.events == [("sync",)]
+
+
+def test_host_reset_routes_small_row_sets_through_scratch() -> None:
+    warp = _FakeWarp()
+    backend = _backend(warp)
+    backend._reset_mask_host = np.zeros(8, dtype=np.bool_)
+    backend._reset_mask_device = "main-mask"
+    backend._device_data = SimpleNamespace(qpos="main-qpos", qvel="main-qvel")
+    backend._time_cache = np.ones(8, dtype=np.float32)
+    events: list[tuple[Any, ...]] = []
+    backend._can_use_reset_scratch = lambda _count: True  # type: ignore[method-assign]
+    backend._upload = lambda target, source: events.append(  # type: ignore[method-assign]
+        ("upload", target, np.asarray(source).copy())
+    )
+    backend._execute_device_reset = lambda: events.append(  # type: ignore[method-assign]
+        ("main-reset",)
+    )
+    backend._execute_reset_scratch_forward = (  # type: ignore[method-assign]
+        lambda qpos, qvel: events.append(("scratch-forward", qpos.copy(), qvel.copy()))
+    )
+    backend._execute_device_forward = lambda: events.append(  # type: ignore[method-assign]
+        ("main-forward",)
+    )
+    backend._synchronize = lambda: events.append(("sync",))  # type: ignore[method-assign]
+    backend._refresh_reset_scratch_cache = (  # type: ignore[method-assign]
+        lambda rows: events.append(("scratch-refresh", rows.copy()))
+    )
+    backend._refresh_host_cache = lambda: events.append(  # type: ignore[method-assign]
+        ("main-refresh",)
+    )
+    rows = np.asarray([6, 2], dtype=np.int32)
+    full_qpos = np.zeros((8, 3), dtype=np.float32)
+    full_qvel = np.zeros((8, 2), dtype=np.float32)
+    reset_qpos = np.ones((2, 3), dtype=np.float32)
+    reset_qvel = np.ones((2, 2), dtype=np.float32)
+
+    backend._execute_host_reset(rows, full_qpos, full_qvel, reset_qpos, reset_qvel)
+
+    assert np.flatnonzero(backend._reset_mask_host).tolist() == [2, 6]
+    assert backend._time_cache[rows].tolist() == [0.0, 0.0]
+    assert [event[0] for event in events] == [
+        "upload",
+        "main-reset",
+        "upload",
+        "upload",
+        "scratch-forward",
+        "sync",
+        "scratch-refresh",
+    ]
+    assert not any(event[0] in {"main-forward", "main-refresh"} for event in events)


### PR DESCRIPTION
## Summary

- 为 2048-world MJWarp 的少量 partial reset 在初始化/capture 冷路径建立固定 128-world scratch `Data`，在 scratch 上执行完整 forward，并只回填 reset rows 的 sensor cache。
- qpos/qvel 与 transient state 仍写入主 device data；下一次 `step()` 保持原有完整 forward/physics 顺序和公开 getter 语义。
- reset 数量超过 scratch 容量或 CUDA graph 不可用时，保留主 data full-forward fallback。

## Scope / backend impact

- 仅修改 MJWarp backend owner 与 focused tests；不新增或修改 `SimBackend`、env/manager lifecycle、配置、runner/learner 或 support 声明。
- MuJoCo、Motrix 与其他 backend 行为不变。
- scratch 容量固定，热路径不解析 asset/model metadata，也不动态 materialize MJWarp data。
- 128-world scratch 对当前 G1 model 额外占用约 32 MiB GPU memory。

## Benchmark

同机交替 A/B，各 3 个 fresh process；before `56dff844`，after code tree `d478f68b`（本 PR rebase 后为 `5d0b1d30`）；SAC G1WalkFlat MJWarp，2048 env，10 warm-up + 100 measured vector steps：

| Metric (median of 3 runs) | Before | After | Delta |
|---|---:|---:|---:|
| Reset Done | 2.692 ms | 2.015 ms | -25.1% |
| Reset call | 2.659 ms | 1.983 ms | -25.4% |
| Env step | 10.436 ms | 9.717 ms | -6.9% |
| Collector throughput | 192,422 env/s | 206,831 env/s | +7.5% |
| Physics | 5.416 ms | 5.436 ms | +0.36% |

reset rows/step 中位数 36.18→36.30（+0.33%），physics 处于噪声范围；收益定位在 reset-time full-forward 避免。完整 benchmark 与验证记录见 [#1288 comment](https://github.com/unilabsim/UniLab/issues/1288#issuecomment-5394294306)。

## Correctness / fallback

- 覆盖真实 CUDA selected-row scratch route、全部 sensor cache 与 reset→3-step differential。
- 大批 reset 回退主 data full forward；graph 不可用时不 materialize scratch，继续使用 eager/full-forward 路径。
- scratch 结果只覆盖 selected rows，非 reset rows 保持隔离。

## Validation

Final commit: `5d0b1d30d7f177462a42ec2b9af78e4ed9756681`

- `make test-all` — passed on the final commit:
  - Ruff, mypy (243 source files), Pyright passed.
  - pytest: 2226 passed, 28 skipped, 278 deselected, 1 xfailed.
  - benchmark smoke: module 33/34 and script 34/35; only platform-optional MLX skipped.
- `uv run --extra mjwarp pytest -q -m slow tests/base/test_mjwarp_backend.py tests/base/test_mjwarp_capabilities.py tests/base/test_mjwarp_differential.py tests/base/test_backend_conformance.py` — 18 passed, 26 deselected.
- `uv run --extra mjwarp pytest -q tests/base/test_mjwarp_host_cache.py tests/base/test_mjwarp_cuda_graph.py tests/base/test_mjwarp_identity.py tests/base/test_mjwarp_playback.py` — 24 passed.

Per #1259 child gate, this PR targets the bound dev branch and uses the completed local full gate; remote CI/Docs is not part of this child merge gate.

Closes #1288
Related to #1259
