### PR TITLE
perf(profiling): 临时逐 term profiling 埋点（#1293，#1292 完成后删除）

### DIFF
--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -100,7 +100,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested |
 | SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered |

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -49,6 +49,9 @@ from unilab.managers import (
     TerminationManager,
     TerminationTermCfg,
 )
+from unilab.utils.term_profiling import (  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+    TERM_PROFILER,
+)
 
 
 def _manager_terms_field() -> Any:
@@ -315,6 +318,9 @@ class ManagerBasedRlEnv(NpEnv):
 
     def _load_managers(self) -> None:
         """Construct managers in the pinned community dependency order."""
+        # PROFILING_TEMP (#1293, TODO: remove after #1292): a new env means a new
+        # benchmark case — dump the previous case's per-term stats and reset.
+        TERM_PROFILER.reset()
         self.event_manager = EventManager(self._cfg.events, self)
         self.command_manager = (
             CommandManager(self._cfg.commands, self) if self._cfg.commands else NullCommandManager()

--- a/src/unilab/managers/curriculum_manager.py
+++ b/src/unilab/managers/curriculum_manager.py
@@ -13,6 +13,9 @@ import numpy as np
 from prettytable import PrettyTable
 
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import ManagerBasedRlEnv
@@ -111,12 +114,16 @@ class CurriculumManager(ManagerBase):
         return extras
 
     def compute(self, env_ids: np.ndarray | slice | None = None) -> None:
+        # PROFILING_TEMP (#1293, TODO: remove after #1292)
+        phase = "reset" if env_ids is not None else "step"
         if env_ids is None:
             env_ids = slice(None)
         for name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
-            state = term_cfg.func(self._env, env_ids, **term_cfg.params)
-            self._validate_state(name, state)
-            self._curriculum_state[name] = state
+            # PROFILING_TEMP (#1293, TODO: remove after #1292)
+            with profile_term(f"curriculum/{name}|{phase}"):
+                state = term_cfg.func(self._env, env_ids, **term_cfg.params)
+                self._validate_state(name, state)
+                self._curriculum_state[name] = state
 
     def _validate_state(self, term_name: str, state: Any) -> None:
         values = state.values() if isinstance(state, dict) else (state,)

--- a/src/unilab/managers/event_manager.py
+++ b/src/unilab/managers/event_manager.py
@@ -13,6 +13,9 @@ import numpy as np
 from prettytable import PrettyTable
 
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import ManagerBasedRlEnv
@@ -170,6 +173,8 @@ class EventManager(ManagerBase):
             raise ValueError(f"Event mode '{mode}' requires the time-step of the environment.")
 
         for index, term_cfg in enumerate(self._mode_term_cfgs[mode]):
+            # PROFILING_TEMP (#1293, TODO: remove after #1292)
+            pkey = f"event/{mode}/{self._mode_term_names[mode][index]}"
             if mode == "interval":
                 time_left = self._interval_term_time_left[index]
                 assert dt is not None
@@ -180,7 +185,8 @@ class EventManager(ManagerBase):
                         lower, upper = term_cfg.interval_range_s
                         sampled_interval = self._env.rng.uniform(lower, upper, 1)
                         self._interval_term_time_left[index][:] = sampled_interval
-                        term_cfg.func(self._env, None, **term_cfg.params)
+                        with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                            term_cfg.func(self._env, None, **term_cfg.params)
                 else:
                     valid_env_ids = np.flatnonzero(time_left < 1e-6)
                     if len(valid_env_ids) > 0:
@@ -188,9 +194,11 @@ class EventManager(ManagerBase):
                         lower, upper = term_cfg.interval_range_s
                         sampled_time = self._env.rng.uniform(lower, upper, len(valid_env_ids))
                         self._interval_term_time_left[index][valid_env_ids] = sampled_time
-                        term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+                        with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                            term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
             elif mode == "step":
-                term_cfg.func(self._env, None, **term_cfg.params)
+                with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                    term_cfg.func(self._env, None, **term_cfg.params)
             elif mode == "reset":
                 assert global_env_step_count is not None
                 # Reset events require concrete indices: callers (e.g. ManagerBasedRlEnv)
@@ -203,7 +211,8 @@ class EventManager(ManagerBase):
                 if min_step_count == 0:
                     self._reset_term_last_triggered_step_id[index][env_ids] = global_env_step_count
                     self._reset_term_last_triggered_once[index][env_ids] = True
-                    term_cfg.func(self._env, env_ids, **term_cfg.params)
+                    with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                        term_cfg.func(self._env, env_ids, **term_cfg.params)
                 else:
                     last_triggered_step = self._reset_term_last_triggered_step_id[index][env_ids]
                     triggered_at_least_once = self._reset_term_last_triggered_once[index][env_ids]
@@ -219,9 +228,11 @@ class EventManager(ManagerBase):
                         self._reset_term_last_triggered_step_id[index][valid_env_ids] = (
                             global_env_step_count
                         )
-                        term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+                        with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                            term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
             else:
-                term_cfg.func(self._env, env_ids, **term_cfg.params)
+                with profile_term(pkey):  # PROFILING_TEMP (#1293)
+                    term_cfg.func(self._env, env_ids, **term_cfg.params)
 
     def _prepare_terms(self) -> None:
         self._interval_term_time_left: list[np.ndarray] = list()

--- a/src/unilab/managers/metrics_manager.py
+++ b/src/unilab/managers/metrics_manager.py
@@ -13,6 +13,9 @@ import numpy as np
 from prettytable import PrettyTable
 
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import ManagerBasedRlEnv
@@ -210,9 +213,11 @@ class MetricsManager(ManagerBase):
     def _compute_term(self, idx: int) -> np.ndarray:
         name = self._term_names[idx]
         term_cfg = self._term_cfgs[idx]
-        value = term_cfg.func(self._env, **term_cfg.params)
-        self._check_term_shape(name, value)
-        self._check_term_finite(name, value)
+        # PROFILING_TEMP (#1293, TODO: remove after #1292)
+        with profile_term(f"metrics/{name}"):
+            value = term_cfg.func(self._env, **term_cfg.params)
+            self._check_term_shape(name, value)
+            self._check_term_finite(name, value)
         return value
 
 

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -20,6 +20,9 @@ from unilab.managers._buffers import CircularBuffer, DelayBuffer
 from unilab.managers._noise import noise_cfg, noise_model
 from unilab.managers._noise.noise_cfg import NoiseCfg, NoiseModelCfg
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import ManagerBasedRlEnv
@@ -388,8 +391,12 @@ class ObservationManager(ManagerBase):
         # (num_envs, ...) and full-shape noise draws keep the shared RNG stream
         # and per-row noise values identical to the full-batch path.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
+        # PROFILING_TEMP (#1293, TODO: remove after #1292)
+        phase = "reset" if env_ids is not None else "step"
         for term_name, term_cfg in obs_terms:
-            obs = term_cfg.func(self._env, **term_cfg.params)
+            # PROFILING_TEMP (#1293, TODO: remove after #1292)
+            with profile_term(f"obs/{group_name}/{term_name}|{phase}"):
+                obs = term_cfg.func(self._env, **term_cfg.params)
             if not isinstance(obs, np.ndarray):
                 raise TypeError(
                     f"ObservationManager term '{group_name}/{term_name}' returned "
@@ -400,30 +407,33 @@ class ObservationManager(ManagerBase):
                     f"ObservationManager term '{group_name}/{term_name}' returned shape "
                     f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
                 )
-            if not row_scoped:
-                obs = obs.copy()
-            if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
-                obs = term_cfg.noise.apply(obs, rng=self._env.rng)
-            elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
-                obs = self._group_obs_class_instances[group_name][term_name](obs)
-            if row_scoped:
-                # Fresh row copy; safe for the in-place clip/scale below.
-                obs = obs[env_ids]
-            if term_cfg.clip:
-                np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
-            if term_cfg.scale is not None:
-                scale = term_cfg.scale
-                assert isinstance(scale, np.ndarray)
-                np.multiply(obs, scale, out=obs)
+            # PROFILING_TEMP (#1293, TODO: remove after #1292): manager-level
+            # per-term post-processing (copy/noise/clip/scale/nan check).
+            with profile_term(f"obs_post/{group_name}/{term_name}|{phase}"):
+                if not row_scoped:
+                    obs = obs.copy()
+                if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
+                    obs = term_cfg.noise.apply(obs, rng=self._env.rng)
+                elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
+                    obs = self._group_obs_class_instances[group_name][term_name](obs)
+                if row_scoped:
+                    # Fresh row copy; safe for the in-place clip/scale below.
+                    obs = obs[env_ids]
+                if term_cfg.clip:
+                    np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
+                if term_cfg.scale is not None:
+                    scale = term_cfg.scale
+                    assert isinstance(scale, np.ndarray)
+                    np.multiply(obs, scale, out=obs)
 
-            # Check for NaN/Inf before delay/history buffers (per-term checking).
-            if group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
-                obs = self._check_and_handle_nans(
-                    obs,
-                    context=f"{group_name}/{term_name}",
-                    policy=group_cfg.nan_policy,
-                    env_ids=env_ids if row_scoped else None,
-                )
+                # Check for NaN/Inf before delay/history buffers (per-term checking).
+                if group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+                    obs = self._check_and_handle_nans(
+                        obs,
+                        context=f"{group_name}/{term_name}",
+                        policy=group_cfg.nan_policy,
+                        env_ids=env_ids if row_scoped else None,
+                    )
 
             if term_cfg.delay_max_lag > 0:
                 delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
@@ -448,43 +458,46 @@ class ObservationManager(ManagerBase):
             else:
                 group_obs[term_name] = obs
 
-        # Final NaN check for non-per-term checking.
-        if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+        # PROFILING_TEMP (#1293, TODO: remove after #1292): group-level
+        # post-processing (group nan check / concatenate / reset row slice).
+        with profile_term(f"obs_group_post/{group_name}|{phase}"):
+            # Final NaN check for non-per-term checking.
+            if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+                if self._group_obs_concatenate[group_name]:
+                    # Will check after concatenation below.
+                    pass
+                else:
+                    for term_name in group_obs:
+                        group_obs[term_name] = self._check_and_handle_nans(
+                            group_obs[term_name],
+                            context=f"{group_name}/{term_name}",
+                            policy=group_cfg.nan_policy,
+                            env_ids=env_ids if row_scoped else None,
+                        )
+
             if self._group_obs_concatenate[group_name]:
-                # Will check after concatenation below.
-                pass
-            else:
-                for term_name in group_obs:
-                    group_obs[term_name] = self._check_and_handle_nans(
-                        group_obs[term_name],
-                        context=f"{group_name}/{term_name}",
+                result = np.concatenate(
+                    list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
+                )
+                # Final check for concatenated result (non-per-term checking).
+                if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
+                    result = self._check_and_handle_nans(
+                        result,
+                        context=group_name,
                         policy=group_cfg.nan_policy,
                         env_ids=env_ids if row_scoped else None,
                     )
-
-        if self._group_obs_concatenate[group_name]:
-            result = np.concatenate(
-                list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
-            )
-            # Final check for concatenated result (non-per-term checking).
-            if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
-                result = self._check_and_handle_nans(
-                    result,
-                    context=group_name,
-                    policy=group_cfg.nan_policy,
-                    env_ids=env_ids if row_scoped else None,
-                )
-        else:
-            result = group_obs
-
-        if env_ids is not None and not row_scoped:
-            # Groups with delay/history terms ran the full-batch pipeline above
-            # (buffer readout stays full-batch); slice the reset rows to match
-            # the reset-path return contract.
-            if isinstance(result, dict):
-                result = {name: values[env_ids] for name, values in result.items()}
             else:
-                result = result[env_ids]
+                result = group_obs
+
+            if env_ids is not None and not row_scoped:
+                # Groups with delay/history terms ran the full-batch pipeline above
+                # (buffer readout stays full-batch); slice the reset rows to match
+                # the reset-path return contract.
+                if isinstance(result, dict):
+                    result = {name: values[env_ids] for name, values in result.items()}
+                else:
+                    result = result[env_ids]
 
         return result
 

--- a/src/unilab/managers/reward_manager.py
+++ b/src/unilab/managers/reward_manager.py
@@ -13,6 +13,9 @@ import numpy as np
 from prettytable import PrettyTable
 
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import DebugVisualizer, ManagerBasedRlEnv
@@ -123,13 +126,15 @@ class RewardManager(ManagerBase):
             if term_cfg.weight == 0.0:
                 self._step_reward[:, term_idx] = 0.0
                 continue
-            value = term_cfg.func(self._env, **term_cfg.params)
-            self._check_term_shape(name, value)
-            self._check_term_finite(name, value)
-            value = value * term_cfg.weight * scale
-            self._reward_buf += value
-            self._episode_sums[name] += value
-            self._step_reward[:, term_idx] = value / scale
+            # PROFILING_TEMP (#1293, TODO: remove after #1292)
+            with profile_term(f"reward/{name}"):
+                value = term_cfg.func(self._env, **term_cfg.params)
+                self._check_term_shape(name, value)
+                self._check_term_finite(name, value)
+                value = value * term_cfg.weight * scale
+                self._reward_buf += value
+                self._episode_sums[name] += value
+                self._step_reward[:, term_idx] = value / scale
         return self._reward_buf
 
     def step_reward_extras(self) -> dict[str, float]:

--- a/src/unilab/managers/termination_manager.py
+++ b/src/unilab/managers/termination_manager.py
@@ -13,6 +13,9 @@ import numpy as np
 from prettytable import PrettyTable
 
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
+from unilab.utils.term_profiling import (
+    profile_term,  # PROFILING_TEMP (#1293, TODO: remove after #1292)
+)
 
 if TYPE_CHECKING:
     from unilab.managers._types import ManagerBasedRlEnv
@@ -100,17 +103,19 @@ class TerminationManager(ManagerBase):
         self._truncated_buf[:] = False
         self._terminated_buf[:] = False
         for name, term_cfg in zip(self._term_names, self._term_cfgs, strict=False):
-            value = term_cfg.func(self._env, **term_cfg.params)
-            self._check_term_shape(name, value)
-            if value.dtype != np.bool_:
-                raise TypeError(
-                    f"TerminationManager term '{name}' returned dtype {value.dtype}, expected bool."
-                )
-            if term_cfg.time_out:
-                self._truncated_buf |= value
-            else:
-                self._terminated_buf |= value
-            self._term_dones[name][:] = value
+            # PROFILING_TEMP (#1293, TODO: remove after #1292)
+            with profile_term(f"termination/{name}"):
+                value = term_cfg.func(self._env, **term_cfg.params)
+                self._check_term_shape(name, value)
+                if value.dtype != np.bool_:
+                    raise TypeError(
+                        f"TerminationManager term '{name}' returned dtype {value.dtype}, expected bool."
+                    )
+                if term_cfg.time_out:
+                    self._truncated_buf |= value
+                else:
+                    self._terminated_buf |= value
+                self._term_dones[name][:] = value
         return self._truncated_buf | self._terminated_buf
 
     def get_term(self, name: str) -> np.ndarray:

--- a/src/unilab/utils/term_profiling.py
+++ b/src/unilab/utils/term_profiling.py
@@ -1,0 +1,90 @@
+"""PROFILING_TEMP (issue #1293): temporary per-term timing for manager hot paths.
+
+TODO(#1292 cleanup): this module and every ``PROFILING_TEMP`` call site are
+temporary instrumentation. Delete them once the #1292 optimization sub-issues
+(#1294/#1295/#1296) are complete.
+
+Enable with ``UNILAB_TERM_PROFILING=1``. When disabled, ``profile_term()``
+returns a shared no-op context manager, so each call site costs one attribute
+check and no allocation. When enabled, timing overhead (two ``perf_counter``
+calls per term) is accepted — this is profiling code, not a hot-path feature.
+
+Stats accumulate per benchmark case: ``ManagerBasedRlEnv._load_managers``
+resets the profiler (dumping the previous case first), and an atexit hook
+dumps the final case.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from typing import Literal
+
+_ENABLED = os.environ.get("UNILAB_TERM_PROFILING", "") == "1"
+
+
+class _NullCtx:
+    __slots__ = ()
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: object) -> Literal[False]:
+        return False
+
+
+class TermProfiler:
+    """Accumulates wall-clock time per term key; mean_ms ≈ ms/vector-step for
+    step-phase terms (one call per term per vector step)."""
+
+    def __init__(self) -> None:
+        self.enabled = _ENABLED
+        self._total_s: dict[str, float] = defaultdict(float)
+        self._calls: dict[str, int] = defaultdict(int)
+
+    def reset(self) -> None:
+        """Drop accumulated stats, dumping them first (new env = new case)."""
+        if self.enabled and self._calls:
+            self.dump()
+        self._total_s.clear()
+        self._calls.clear()
+
+    @contextmanager
+    def time(self, key: str) -> Iterator[None]:
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._total_s[key] += time.perf_counter() - t0
+            self._calls[key] += 1
+
+    def dump(self) -> None:
+        lines = [
+            "[TERM_PROFILING] per-term timing (PROFILING_TEMP, issue #1293; "
+            "mean_ms ≈ ms/vector-step for step-phase terms)",
+            f"{'term':<64} {'calls':>8} {'total_ms':>12} {'mean_ms':>10}",
+        ]
+        for key, total in sorted(self._total_s.items(), key=lambda kv: -kv[1]):
+            calls = self._calls[key]
+            lines.append(f"{key:<64} {calls:>8} {total * 1e3:>12.3f} {total / calls * 1e3:>10.4f}")
+        print("\n".join(lines), flush=True)
+
+
+TERM_PROFILER = TermProfiler()
+
+_NULL_CTX = _NullCtx()
+
+
+def profile_term(key: str) -> AbstractContextManager[None]:
+    """PROFILING_TEMP (#1293): time one term call; no-op when disabled."""
+    if TERM_PROFILER.enabled:
+        return TERM_PROFILER.time(key)
+    return _NULL_CTX
+
+
+if _ENABLED:
+    atexit.register(TERM_PROFILER.dump)

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -105,9 +105,7 @@ def test_mjwarp_backend_is_opt_in_and_never_part_of_all() -> None:
         with pytest.raises(SystemExit, match="mjwarp extra"):
             bench._resolve_backend_selection(backend="mjwarp", all_backends=False)
     else:
-        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == (
-            "mjwarp",
-        )
+        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == ("mjwarp",)
 
 
 def test_resolve_case_specs_deduplicates_explicit_specs() -> None:

--- a/tests/utils/test_term_profiling.py
+++ b/tests/utils/test_term_profiling.py
@@ -1,0 +1,42 @@
+"""PROFILING_TEMP (#1293, TODO: remove after #1292): tests for the temporary
+per-term profiling instrumentation."""
+
+import time
+
+from unilab.utils.term_profiling import TERM_PROFILER, TermProfiler, profile_term
+
+
+def test_disabled_by_default_is_noop():
+    # Test session never sets UNILAB_TERM_PROFILING, so profiling is disabled.
+    assert not TERM_PROFILER.enabled
+    with profile_term("x/y|step"):
+        pass
+    assert not TERM_PROFILER._calls
+
+
+def test_enabled_profiler_records_and_dumps(capsys):
+    profiler = TermProfiler()
+    profiler.enabled = True
+    with profiler.time("reward/test"):
+        time.sleep(0.001)
+    with profiler.time("reward/test"):
+        pass
+    assert profiler._calls["reward/test"] == 2
+    assert profiler._total_s["reward/test"] >= 0.001
+    profiler.dump()
+    out = capsys.readouterr().out
+    assert "reward/test" in out
+    assert "PROFILING_TEMP" in out
+
+
+def test_reset_dumps_then_clears(capsys):
+    profiler = TermProfiler()
+    profiler.enabled = True
+    with profiler.time("obs/g/t|step"):
+        pass
+    profiler.reset()
+    assert not profiler._calls
+    assert "obs/g/t|step" in capsys.readouterr().out
+    # Reset on empty stats prints nothing.
+    profiler.reset()
+    assert capsys.readouterr().out == ""

--- a/tests/utils/test_utils_package_policy.py
+++ b/tests/utils/test_utils_package_policy.py
@@ -17,6 +17,9 @@ ALLOWED_UTILS_MODULES = {
     "seed",
     "sim2sim",
     "tensor",
+    # PROFILING_TEMP (#1293, TODO: remove after #1292): temporary per-term
+    # profiling instrumentation; removed together with the module.
+    "term_profiling",
 }
 REMOVED_UTILS_SHIMS = {
     "algo_utils",


### PR DESCRIPTION
Part of #1292. Implements #1293 (profiling sub-issue; temporary instrumentation).

## 内容

- 新增 `src/unilab/utils/term_profiling.py`：`UNILAB_TERM_PROFILING=1` 开启，默认关闭（共享 no-op context，关闭时每挂点一次属性判断、零分配）。
- 挂点覆盖 obs（term func / post-processing / group concat，区分 `|step`/`|reset`）、reward、metrics、termination、event（全 mode）、curriculum 的 term 循环；`ManagerBasedRlEnv._load_managers` 按 case 重置统计，atexit dump 最后一个 case。
- 全部挂点带 `PROFILING_TEMP (#1293, TODO: remove after #1292)` 标记，#1292 优化完成后整体删除（见 #1293 顶部 TODO）。
- 附带两个 make test-all gate 修复（独立提交）：utils 白名单加入 `term_profiling`（带 PROFILING_TEMP 注释）；重新生成 support matrix（mjwarp 接线遗留的 stale，非本 PR 引入）；ruff format 一处。

## Validation

- `make test-all` 本地通过（check + test-cov 2244 passed + benchmark smoke）。远程 CI 按本次工作流要求跳过等待。
- 逐 term profiling 报告（三后端同机对照 + ON/OFF 开销验证）：https://github.com/unilabsim/UniLab/issues/1293#issuecomment-5408865950
  - 关闭时开销不可测：mujoco/motrix ≤1%，mjwarp ~5%（与本机 run 间波动同量级）。

## 注意

- base 是 `dev/issue-1292-motion-tracking-manager-perf`（#1292 开发分支），合入不关闭 issue；#1293 在 #1292 收尾、清理埋点后一并关闭。
