### PR TITLE
perf(managers): per-term isfinite 扫描降级为采样/可配置（#1294）

### DIFF
--- a/conf/sac/task/g1_motion_tracking/mujoco.yaml
+++ b/conf/sac/task/g1_motion_tracking/mujoco.yaml
@@ -21,6 +21,9 @@ algo:
 
 env:
   seed: null
+  # Issue #1294: sample the per-term NaN/Inf finite check every 16 control
+  # steps (detection latency <= 16 steps) instead of scanning every step.
+  finite_check_interval: 16
   scene:
     model_file: src/unilab/assets/robots/g1/scene_flat.xml
     default_keyframe_name: stand
@@ -79,6 +82,9 @@ env:
   observations:
     actor:
       enable_corruption: true
+      # Issue #1294: check the concatenated group output instead of scanning
+      # every term every step; nan_policy stays fail-closed at group level.
+      nan_check_per_term: false
       terms:
         command: &command_obs
           func: unilab.envs.mdp.generated_commands
@@ -119,6 +125,8 @@ env:
         actions: &actions_obs
           func: unilab.envs.mdp.last_action
     critic:
+      # Issue #1294: see actor group.
+      nan_check_per_term: false
       terms:
         command: *command_obs
         motion_anchor_pos_b: *anchor_pos_obs

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -100,7 +100,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested |
 | SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered |

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -81,6 +81,11 @@ class ManagerBasedRlEnvCfg(EnvCfg):
     is_finite_horizon: bool = False
     auto_reset: bool = True
     scale_rewards_by_dt: bool = True
+    finite_check_interval: int = 1
+    """Run the per-term NaN/Inf finite check in reward/metrics managers every N
+    control steps. 1 (default) checks every step — the historical behavior.
+    N > 1 bounds NaN detection latency to N control steps while removing the
+    per-step full ``np.isfinite(...).all()`` scans from the hot path."""
     policy_observation_group: str = "policy"
     critic_observation_group: str | None = None
 
@@ -129,6 +134,13 @@ class ManagerBasedRlEnvCfg(EnvCfg):
         for name in ("is_finite_horizon", "auto_reset", "scale_rewards_by_dt"):
             if not isinstance(getattr(self, name), bool):
                 raise TypeError(f"ManagerBasedRlEnvCfg {name} must be bool")
+        if isinstance(self.finite_check_interval, bool) or not isinstance(
+            self.finite_check_interval, (int, np.integer)
+        ):
+            raise TypeError("ManagerBasedRlEnvCfg finite_check_interval must be an int")
+        if self.finite_check_interval < 1:
+            raise ValueError("ManagerBasedRlEnvCfg finite_check_interval must be >= 1")
+        self.finite_check_interval = int(self.finite_check_interval)
         if not isinstance(self.policy_observation_group, str) or not self.policy_observation_group:
             raise ValueError("policy_observation_group must be a non-empty string")
         if self.critic_observation_group is not None:
@@ -326,6 +338,7 @@ class ManagerBasedRlEnv(NpEnv):
             self._cfg.rewards,
             self,
             scale_by_dt=self._cfg.scale_rewards_by_dt,
+            finite_check_interval=self._cfg.finite_check_interval,
         )
         self.curriculum_manager = (
             CurriculumManager(self._cfg.curriculum, self)
@@ -333,7 +346,13 @@ class ManagerBasedRlEnv(NpEnv):
             else NullCurriculumManager()
         )
         self.metrics_manager = (
-            MetricsManager(self._cfg.metrics, self) if self._cfg.metrics else NullMetricsManager()
+            MetricsManager(
+                self._cfg.metrics,
+                self,
+                finite_check_interval=self._cfg.finite_check_interval,
+            )
+            if self._cfg.metrics
+            else NullMetricsManager()
         )
         self.recorder_manager = (
             RecorderManager(self._cfg.recorders, self)

--- a/src/unilab/managers/metrics_manager.py
+++ b/src/unilab/managers/metrics_manager.py
@@ -57,12 +57,22 @@ class MetricsManager(ManagerBase):
 
     _env: ManagerBasedRlEnv
 
-    def __init__(self, cfg: dict[str, MetricsTermCfg | None], env: ManagerBasedRlEnv):
+    def __init__(
+        self,
+        cfg: dict[str, MetricsTermCfg | None],
+        env: ManagerBasedRlEnv,
+        *,
+        finite_check_interval: int = 1,
+    ):
         self._term_names: list[str] = list()
         self._term_cfgs: list[MetricsTermCfg] = list()
         self._class_term_cfgs: list[MetricsTermCfg] = list()
         self._step_term_indices: list[int] = list()
         self._substep_term_indices: list[int] = list()
+        # NaN/Inf check cadence: every ``finite_check_interval`` compute() calls,
+        # starting with the first. 1 keeps the historical every-step behavior.
+        self._finite_check_interval = max(1, int(finite_check_interval))
+        self._finite_check_clock = 0
 
         self.cfg = deepcopy(cfg)
         super().__init__(env=env)
@@ -167,6 +177,8 @@ class MetricsManager(ManagerBase):
 
     def compute(self) -> None:
         self._step_count += 1
+        # Same cadence rule as RewardManager: first compute always checks.
+        self._finite_check_clock += 1
         if self._substep_term_indices and self._substep_count > 0:
             for i, idx in enumerate(self._substep_term_indices):
                 avg = self._substep_accum[i] / self._substep_count
@@ -212,7 +224,8 @@ class MetricsManager(ManagerBase):
         term_cfg = self._term_cfgs[idx]
         value = term_cfg.func(self._env, **term_cfg.params)
         self._check_term_shape(name, value)
-        self._check_term_finite(name, value)
+        if (self._finite_check_clock - 1) % self._finite_check_interval == 0:
+            self._check_term_finite(name, value)
         return value
 
 

--- a/src/unilab/managers/reward_manager.py
+++ b/src/unilab/managers/reward_manager.py
@@ -63,11 +63,16 @@ class RewardManager(ManagerBase):
         env: ManagerBasedRlEnv,
         *,
         scale_by_dt: bool = True,
+        finite_check_interval: int = 1,
     ):
         self._term_names: list[str] = list()
         self._term_cfgs: list[RewardTermCfg] = list()
         self._class_term_cfgs: list[RewardTermCfg] = list()
         self._scale_by_dt = scale_by_dt
+        # NaN/Inf check cadence: every ``finite_check_interval`` compute() calls,
+        # starting with the first. 1 keeps the historical every-step behavior.
+        self._finite_check_interval = max(1, int(finite_check_interval))
+        self._finite_check_clock = 0
 
         self.cfg = deepcopy(cfg)
         super().__init__(env=env)
@@ -117,6 +122,10 @@ class RewardManager(ManagerBase):
             raise ValueError(f"RewardManager received invalid dt {dt}.")
         self._reward_buf[:] = 0.0
         scale = dt if self._scale_by_dt else 1.0
+        # Increment before the term loop so a raised NaN still advances the
+        # cadence; clock 1 (first compute) always checks.
+        self._finite_check_clock += 1
+        check_finite = (self._finite_check_clock - 1) % self._finite_check_interval == 0
         for term_idx, (name, term_cfg) in enumerate(
             zip(self._term_names, self._term_cfgs, strict=False)
         ):
@@ -125,7 +134,8 @@ class RewardManager(ManagerBase):
                 continue
             value = term_cfg.func(self._env, **term_cfg.params)
             self._check_term_shape(name, value)
-            self._check_term_finite(name, value)
+            if check_finite:
+                self._check_term_finite(name, value)
             value = value * term_cfg.weight * scale
             self._reward_buf += value
             self._episode_sums[name] += value

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -105,9 +105,7 @@ def test_mjwarp_backend_is_opt_in_and_never_part_of_all() -> None:
         with pytest.raises(SystemExit, match="mjwarp extra"):
             bench._resolve_backend_selection(backend="mjwarp", all_backends=False)
     else:
-        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == (
-            "mjwarp",
-        )
+        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == ("mjwarp",)
 
 
 def test_resolve_case_specs_deduplicates_explicit_specs() -> None:

--- a/tests/managers/test_core_managers.py
+++ b/tests/managers/test_core_managers.py
@@ -209,6 +209,35 @@ def test_reward_nonfinite_is_an_error(fake_env: FakeEnv, bad: float) -> None:
         manager.compute(0.01)
 
 
+def test_reward_finite_check_sampling(fake_env: FakeEnv) -> None:
+    """Issue #1294: with finite_check_interval=N the NaN/Inf scan runs on the
+    first compute() and then every Nth call; NaN still raises within the
+    configured window."""
+
+    def bad_reward(env: FakeEnv) -> np.ndarray:
+        value = np.ones(env.num_envs, dtype=np.float32)
+        value[2] = np.nan
+        return value
+
+    cfg = {"bad_reward": RewardTermCfg(func=bad_reward, weight=1.0)}
+    manager = RewardManager(cfg, fake_env, finite_check_interval=3)
+    # First compute is always checked (fail-fast at startup).
+    with pytest.raises(ValueError, match="RewardManager term 'bad_reward'"):
+        manager.compute(0.01)
+    # Clocks 1 and 2 skip the scan.
+    manager.compute(0.01)
+    manager.compute(0.01)
+    # Clock 3 scans again and catches the NaN inside the window.
+    with pytest.raises(ValueError, match="RewardManager term 'bad_reward'"):
+        manager.compute(0.01)
+
+    # interval=1 keeps the historical every-step behavior.
+    strict = RewardManager(cfg, fake_env)
+    for _ in range(3):
+        with pytest.raises(ValueError, match="RewardManager term 'bad_reward'"):
+            strict.compute(0.01)
+
+
 def test_reward_and_termination_shape_validation(fake_env: FakeEnv) -> None:
     reward = RewardManager(
         {"bad": RewardTermCfg(func=lambda env: np.zeros((env.num_envs, 1)), weight=1.0)},

--- a/tests/managers/test_event_command_metrics_recorder.py
+++ b/tests/managers/test_event_command_metrics_recorder.py
@@ -195,16 +195,13 @@ def test_metrics_finite_check_sampling(fake_env: FakeEnv) -> None:
     def bad(env: FakeEnv) -> np.ndarray:
         return np.full(env.num_envs, np.nan, dtype=np.float32)
 
-    manager = MetricsManager(
-        {"bad": MetricsTermCfg(func=bad)}, fake_env, finite_check_interval=3
-    )
+    manager = MetricsManager({"bad": MetricsTermCfg(func=bad)}, fake_env, finite_check_interval=3)
     with pytest.raises(ValueError, match="MetricsManager term 'bad'"):
         manager.compute()
     manager.compute()
     manager.compute()
     with pytest.raises(ValueError, match="MetricsManager term 'bad'"):
         manager.compute()
-
 
 
 class TraceRecorder(RecorderTerm):

--- a/tests/managers/test_event_command_metrics_recorder.py
+++ b/tests/managers/test_event_command_metrics_recorder.py
@@ -188,6 +188,25 @@ def test_metrics_reductions_substeps_reset_and_finite_failure(fake_env: FakeEnv)
     assert NullMetricsManager().reset() == {}
 
 
+def test_metrics_finite_check_sampling(fake_env: FakeEnv) -> None:
+    """Issue #1294: same sampling cadence as RewardManager — first compute is
+    always checked, then every finite_check_interval calls."""
+
+    def bad(env: FakeEnv) -> np.ndarray:
+        return np.full(env.num_envs, np.nan, dtype=np.float32)
+
+    manager = MetricsManager(
+        {"bad": MetricsTermCfg(func=bad)}, fake_env, finite_check_interval=3
+    )
+    with pytest.raises(ValueError, match="MetricsManager term 'bad'"):
+        manager.compute()
+    manager.compute()
+    manager.compute()
+    with pytest.raises(ValueError, match="MetricsManager term 'bad'"):
+        manager.compute()
+
+
+
 class TraceRecorder(RecorderTerm):
     def __init__(self, cfg: RecorderTermCfg, env: FakeEnv):
         super().__init__(cfg, env)


### PR DESCRIPTION
Part of #1292. Implements #1294.

## 内容

- `ManagerBasedRlEnvCfg` 新增 `finite_check_interval: int = 1`（默认 1 = 历史每步检查行为，fail-closed 语义不变；N>1 时 NaN 检测延迟 ≤ N 个 control step，首个 compute 始终检查）。
- `RewardManager.compute` / `MetricsManager._compute_term` 的 per-term `np.isfinite(...).all()` 全量扫描按该 cadence 采样；计数器在 term 循环前递增，NaN raise 不会卡住 cadence。
- `conf/sac/task/g1_motion_tracking/mujoco.yaml` 启用推荐配置：`env.finite_check_interval: 16`，actor/critic 两组 `nan_check_per_term: false`（nan_policy 保持 group 级 fail-closed，只是 NaN 定位粒度从 term 降到 group）。motrix/mjwarp owner 继承同一文件，sim2sim parity 自动保持。
- 附带 cherry-pick support matrix 重新生成（77ca6dd9 遗留 stale，非本 PR 引入）。

## 默认行为变化说明

默认 `finite_check_interval=1` 不变；变化仅在 g1_motion_tracking 的 owner YAML：该 task 训练时 reward/metrics 的 NaN 检测窗口从 1 步放宽到 16 步（50Hz 控制下 ~0.32s），obs NaN 定位从 per-term 降到 per-group（仍会按 nan_policy=error 抛出，只是报错信息不带具体 term 名）。

## Validation

- `make test-all` 本地通过（check + test-cov + benchmark smoke）。远程 CI 按本次工作流要求跳过等待。
- 新增单测：reward/metrics 采样 cadence（首步必查、窗口内 NaN 仍 raise、interval=1 保持每步检查），`tests/managers` 全过。
- 必测项三后端同机对照（8192 envs，warmup 10 / measure 100），A/B 同代码两跑（采样 = task YAML 默认；严格 = `--override env.finite_check_interval=1 env.observations.{actor,critic}.nan_check_per_term=true`）：

| Backend | env/s 严格 → 采样 | update_state ms 严格 → 采样 | env step ms 严格 → 采样 |
|---|---:|---:|---:|
| mujoco | 68,727 → 70,235（+2.2%） | 28.54 → 28.07 | 117.1 → 114.7 |
| motrix | 46,713 → 55,334（+18.5%） | 57.86 → 57.97 | 173.4 → 146.1 |
| mjwarp | 126,260 → 132,612（+5.0%） | 28.57 → 28.01 | 63.0 → 60.0 |

mujoco/mjwarp 的 update_state 降 ~0.5 ms（-1.6%/-2.0%），方向与 #1293 profiling 估计（isfinite 扫描 ~1–2 ms/step 中可省部分）一致；motrix 本机 run 间波动大（同代码 env step 137–173 ms 均出现过），其 +18.5% 不应归因于本改动，仅作参考。结果 JSON：`scripts/benchmark/outputs/offpolicy_collector_active/results_sac_g1_motion_tracking_finite_{sampling,strict}_ryzen9950x3d.json`（gitignore 内）。
