### PR TITLE
perf(tasks,managers): 纯 NumPy 临时数组消除（#1296）

### DIFF
--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -100,7 +100,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
 | SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested |
 | SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered |
 | SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered |

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -400,12 +400,20 @@ class ObservationManager(ManagerBase):
                     f"ObservationManager term '{group_name}/{term_name}' returned shape "
                     f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
                 )
-            if not row_scoped:
-                obs = obs.copy()
+            fresh = False
             if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
+                # NoiseCfg.apply always returns a newly allocated array.
                 obs = term_cfg.noise.apply(obs, rng=self._env.rng)
+                fresh = True
             elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
+                # NoiseModel.__call__ likewise returns a new array.
                 obs = self._group_obs_class_instances[group_name][term_name](obs)
+                fresh = True
+            if not row_scoped and not fresh:
+                # Terms may return backend/command-owned buffers; copy before the
+                # in-place clip/scale below. Skipped when noise already produced
+                # a fresh array (issue #1296).
+                obs = obs.copy()
             if row_scoped:
                 # Fresh row copy; safe for the in-place clip/scale below.
                 obs = obs[env_ids]

--- a/src/unilab/managers/reward_manager.py
+++ b/src/unilab/managers/reward_manager.py
@@ -76,6 +76,10 @@ class RewardManager(ManagerBase):
             self._episode_sums[term_name] = np.zeros(self.num_envs, dtype=np.float32)
         self._reward_buf = np.zeros(self.num_envs, dtype=np.float32)
         self._step_reward = np.zeros((self.num_envs, len(self._term_names)), dtype=np.float32)
+        # Scratch for the weighted term value, reused across terms to avoid a
+        # temporary per term per step (issue #1296). Re-allocated if a term
+        # returns a non-float32 dtype.
+        self._term_weight_scratch = np.zeros(self.num_envs, dtype=np.float32)
 
     def __str__(self) -> str:
         msg = f"<RewardManager> contains {len(self._term_names)} active terms.\n"
@@ -126,10 +130,20 @@ class RewardManager(ManagerBase):
             value = term_cfg.func(self._env, **term_cfg.params)
             self._check_term_shape(name, value)
             self._check_term_finite(name, value)
-            value = value * term_cfg.weight * scale
-            self._reward_buf += value
-            self._episode_sums[name] += value
-            self._step_reward[:, term_idx] = value / scale
+            # Weighted value goes through the shared scratch (same op order as
+            # ``value * weight * scale``); terms may return internal buffers, so
+            # ``value`` itself is never written to. Scratch dtype matches the
+            # expression result dtype (e.g. int term values promote to float64,
+            # as the pre-refactor temporary did).
+            scratch = self._term_weight_scratch
+            out_dtype = np.result_type(value, term_cfg.weight)
+            if scratch.dtype != out_dtype:
+                scratch = self._term_weight_scratch = np.empty(self.num_envs, dtype=out_dtype)
+            np.multiply(value, term_cfg.weight, out=scratch)
+            scratch *= scale
+            self._reward_buf += scratch
+            self._episode_sums[name] += scratch
+            np.divide(scratch, scale, out=self._step_reward[:, term_idx])
         return self._reward_buf
 
     def step_reward_extras(self) -> dict[str, float]:

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -388,9 +388,7 @@ class MotionCommand(CommandTerm):
         if env_ids is None:
             # Single gather straight into the destination buffers; the previous
             # src[:][:, body_index] form materialized two intermediate copies.
-            np.take(
-                self.robot.data.body_link_pos_w, body_index, axis=1, out=self._robot_body_pos_w
-            )
+            np.take(self.robot.data.body_link_pos_w, body_index, axis=1, out=self._robot_body_pos_w)
             np.take(
                 self.robot.data.body_link_quat_w, body_index, axis=1, out=self._robot_body_quat_w
             )
@@ -776,13 +774,19 @@ class _BodyTerm(ManagerTermBase):
     def _squared_error_3d(self, ref: np.ndarray, actual: np.ndarray) -> np.ndarray:
         """Per-body squared 3D error with reused scratch, same op order as the
         naive ``np.square(ref - actual).sum(axis=-1)`` (bit-identical)."""
-        if self._diff_scratch is None or self._diff_scratch.shape != ref.shape:
+        if (
+            self._diff_scratch is None
+            or self._err_scratch is None
+            or self._diff_scratch.shape != ref.shape
+        ):
             self._diff_scratch = np.empty(ref.shape, dtype=ref.dtype)
             self._err_scratch = np.empty(ref.shape[:-1], dtype=ref.dtype)
-        np.subtract(ref, actual, out=self._diff_scratch)
-        np.square(self._diff_scratch, out=self._diff_scratch)
-        np.sum(self._diff_scratch, axis=-1, out=self._err_scratch)
-        return self._err_scratch
+        diff = self._diff_scratch
+        err = self._err_scratch
+        np.subtract(ref, actual, out=diff)
+        np.square(diff, out=diff)
+        np.sum(diff, axis=-1, out=err)
+        return err
 
     @staticmethod
     def _exp_neg_scaled(error: np.ndarray, scale: float) -> np.ndarray:

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -384,12 +384,42 @@ class MotionCommand(CommandTerm):
         step = self._env.common_step_counter
         if not force and self._robot_cache_step == step:
             return
-        sel: np.ndarray | slice = slice(None) if env_ids is None else env_ids
         body_index = self._robot_body_ids
-        self._robot_body_pos_w[sel] = self.robot.data.body_link_pos_w[sel][:, body_index]
-        self._robot_body_quat_w[sel] = self.robot.data.body_link_quat_w[sel][:, body_index]
-        self._robot_body_lin_vel_w[sel] = self.robot.data.body_link_lin_vel_w[sel][:, body_index]
-        self._robot_body_ang_vel_w[sel] = self.robot.data.body_link_ang_vel_w[sel][:, body_index]
+        if env_ids is None:
+            # Single gather straight into the destination buffers; the previous
+            # src[:][:, body_index] form materialized two intermediate copies.
+            np.take(
+                self.robot.data.body_link_pos_w, body_index, axis=1, out=self._robot_body_pos_w
+            )
+            np.take(
+                self.robot.data.body_link_quat_w, body_index, axis=1, out=self._robot_body_quat_w
+            )
+            np.take(
+                self.robot.data.body_link_lin_vel_w,
+                body_index,
+                axis=1,
+                out=self._robot_body_lin_vel_w,
+            )
+            np.take(
+                self.robot.data.body_link_ang_vel_w,
+                body_index,
+                axis=1,
+                out=self._robot_body_ang_vel_w,
+            )
+        else:
+            # np.ix_ gathers rows and bodies in one copy instead of two.
+            self._robot_body_pos_w[env_ids] = self.robot.data.body_link_pos_w[
+                np.ix_(env_ids, body_index)
+            ]
+            self._robot_body_quat_w[env_ids] = self.robot.data.body_link_quat_w[
+                np.ix_(env_ids, body_index)
+            ]
+            self._robot_body_lin_vel_w[env_ids] = self.robot.data.body_link_lin_vel_w[
+                np.ix_(env_ids, body_index)
+            ]
+            self._robot_body_ang_vel_w[env_ids] = self.robot.data.body_link_ang_vel_w[
+                np.ix_(env_ids, body_index)
+            ]
         self._robot_cache_step = step
 
     def _refresh_relative_state(self, env_ids: np.ndarray | None = None) -> None:
@@ -697,8 +727,12 @@ def motion_global_anchor_position_error_exp(
     env: ManagerBasedRlEnv, command_name: str, std: float
 ) -> np.ndarray:
     command = _command(env, command_name)
-    error = np.sum(np.square(command.anchor_pos_w - command.robot_anchor_pos_w), axis=-1)
-    return np.exp(-error / _positive_std(std, term_name="motion anchor position") ** 2)
+    diff = command.anchor_pos_w - command.robot_anchor_pos_w
+    np.square(diff, out=diff)
+    error = np.sum(diff, axis=-1)
+    scale = _positive_std(std, term_name="motion anchor position")
+    np.divide(error, -(scale**2), out=error)
+    return np.exp(error, out=error)
 
 
 def motion_global_anchor_orientation_error_exp(
@@ -708,7 +742,9 @@ def motion_global_anchor_orientation_error_exp(
     error = np_quat_error_magnitude_squared_batched(
         command.anchor_quat_w, command.robot_anchor_quat_w
     )
-    return np.exp(-error / _positive_std(std, term_name="motion anchor orientation") ** 2)
+    scale = _positive_std(std, term_name="motion anchor orientation")
+    np.divide(error, -(scale**2), out=error)
+    return np.exp(error, out=error)
 
 
 class _BodyTerm(ManagerTermBase):
@@ -732,6 +768,28 @@ class _BodyTerm(ManagerTermBase):
             self._body_ids = np.asarray(
                 [command.cfg.body_names.index(name) for name in requested], dtype=np.intp
             )
+        # Lazily allocated scratch for squared-error reductions (issue #1296);
+        # shapes depend on the selected body set, so they are sized on first use.
+        self._diff_scratch: np.ndarray | None = None
+        self._err_scratch: np.ndarray | None = None
+
+    def _squared_error_3d(self, ref: np.ndarray, actual: np.ndarray) -> np.ndarray:
+        """Per-body squared 3D error with reused scratch, same op order as the
+        naive ``np.square(ref - actual).sum(axis=-1)`` (bit-identical)."""
+        if self._diff_scratch is None or self._diff_scratch.shape != ref.shape:
+            self._diff_scratch = np.empty(ref.shape, dtype=ref.dtype)
+            self._err_scratch = np.empty(ref.shape[:-1], dtype=ref.dtype)
+        np.subtract(ref, actual, out=self._diff_scratch)
+        np.square(self._diff_scratch, out=self._diff_scratch)
+        np.sum(self._diff_scratch, axis=-1, out=self._err_scratch)
+        return self._err_scratch
+
+    @staticmethod
+    def _exp_neg_scaled(error: np.ndarray, scale: float) -> np.ndarray:
+        """``np.exp(-error / scale**2)`` without intermediate temporaries; the
+        input buffer is consumed and returned (callers own it)."""
+        np.divide(error, -(scale**2), out=error)
+        return np.exp(error, out=error)
 
     def _validate(self, command_name: str, std: float) -> tuple[MotionCommand, float]:
         if command_name != self._command_name:
@@ -751,14 +809,11 @@ class motion_relative_body_position_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = np.sum(
-            np.square(
-                command.body_pos_relative_w[:, self._body_ids]
-                - command.robot_body_pos_w[:, self._body_ids]
-            ),
-            axis=-1,
+        error = self._squared_error_3d(
+            command.body_pos_relative_w[:, self._body_ids],
+            command.robot_body_pos_w[:, self._body_ids],
         )
-        return np.exp(-error.mean(axis=-1) / scale**2)
+        return self._exp_neg_scaled(error.mean(axis=-1), scale)
 
 
 class motion_relative_body_orientation_error_exp(_BodyTerm):
@@ -775,7 +830,7 @@ class motion_relative_body_orientation_error_exp(_BodyTerm):
             command.body_quat_relative_w[:, self._body_ids],
             command.robot_body_quat_w[:, self._body_ids],
         )
-        return np.exp(-error.mean(axis=-1) / scale**2)
+        return self._exp_neg_scaled(error.mean(axis=-1), scale)
 
 
 class motion_global_body_linear_velocity_error_exp(_BodyTerm):
@@ -788,14 +843,11 @@ class motion_global_body_linear_velocity_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = np.sum(
-            np.square(
-                command.body_lin_vel_w[:, self._body_ids]
-                - command.robot_body_lin_vel_w[:, self._body_ids]
-            ),
-            axis=-1,
+        error = self._squared_error_3d(
+            command.body_lin_vel_w[:, self._body_ids],
+            command.robot_body_lin_vel_w[:, self._body_ids],
         )
-        return np.exp(-error.mean(axis=-1) / scale**2)
+        return self._exp_neg_scaled(error.mean(axis=-1), scale)
 
 
 class motion_global_body_angular_velocity_error_exp(_BodyTerm):
@@ -808,14 +860,11 @@ class motion_global_body_angular_velocity_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = np.sum(
-            np.square(
-                command.body_ang_vel_w[:, self._body_ids]
-                - command.robot_body_ang_vel_w[:, self._body_ids]
-            ),
-            axis=-1,
+        error = self._squared_error_3d(
+            command.body_ang_vel_w[:, self._body_ids],
+            command.robot_body_ang_vel_w[:, self._body_ids],
         )
-        return np.exp(-error.mean(axis=-1) / scale**2)
+        return self._exp_neg_scaled(error.mean(axis=-1), scale)
 
 
 class motion_relative_body_position_z_error_exp(_BodyTerm):
@@ -832,23 +881,31 @@ class motion_relative_body_position_z_error_exp(_BodyTerm):
             command.body_pos_relative_w[:, self._body_ids, 2]
             - command.robot_body_pos_w[:, self._body_ids, 2]
         )
-        return np.exp(-error.mean(axis=-1) / scale**2)
+        return self._exp_neg_scaled(error.mean(axis=-1), scale)
 
 
 def motion_joint_position_error_exp(
     env: ManagerBasedRlEnv, command_name: str, std: float
 ) -> np.ndarray:
     command = _command(env, command_name)
-    error = np.square(command.joint_pos - command.robot_joint_pos).mean(axis=-1)
-    return np.exp(-error / _positive_std(std, term_name="motion joint position") ** 2)
+    diff = command.joint_pos - command.robot_joint_pos
+    np.square(diff, out=diff)
+    error = diff.mean(axis=-1)
+    scale = _positive_std(std, term_name="motion joint position")
+    np.divide(error, -(scale**2), out=error)
+    return np.exp(error, out=error)
 
 
 def motion_joint_velocity_error_exp(
     env: ManagerBasedRlEnv, command_name: str, std: float
 ) -> np.ndarray:
     command = _command(env, command_name)
-    error = np.square(command.joint_vel - command.robot_joint_vel).mean(axis=-1)
-    return np.exp(-error / _positive_std(std, term_name="motion joint velocity") ** 2)
+    diff = command.joint_vel - command.robot_joint_vel
+    np.square(diff, out=diff)
+    error = diff.mean(axis=-1)
+    scale = _positive_std(std, term_name="motion joint velocity")
+    np.divide(error, -(scale**2), out=error)
+    return np.exp(error, out=error)
 
 
 def joint_pos_limits(
@@ -859,9 +916,15 @@ def joint_pos_limits(
     asset = cast("Entity", env.scene[asset_cfg.name])
     joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
     limits = asset.data.soft_joint_pos_limits[asset_cfg.joint_ids]
-    lower_error = np.maximum(limits[:, 0] - joint_pos, 0.0)
-    upper_error = np.maximum(joint_pos - limits[:, 1], 0.0)
-    return np.sum(np.square(lower_error + upper_error), axis=-1)
+    # Same op order as the naive form (maximum -> add -> square -> sum),
+    # chained in place to avoid intermediate allocations.
+    error = np.subtract(limits[:, 0], joint_pos)
+    np.maximum(error, 0.0, out=error)
+    upper = np.subtract(joint_pos, limits[:, 1])
+    np.maximum(upper, 0.0, out=upper)
+    error += upper
+    np.square(error, out=error)
+    return np.sum(error, axis=-1)
 
 
 class undesired_body_contacts(_BodyTerm):

--- a/tests/benchmark/test_offpolicy_collector_active_benchmark.py
+++ b/tests/benchmark/test_offpolicy_collector_active_benchmark.py
@@ -105,9 +105,7 @@ def test_mjwarp_backend_is_opt_in_and_never_part_of_all() -> None:
         with pytest.raises(SystemExit, match="mjwarp extra"):
             bench._resolve_backend_selection(backend="mjwarp", all_backends=False)
     else:
-        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == (
-            "mjwarp",
-        )
+        assert bench._resolve_backend_selection(backend="mjwarp", all_backends=False) == ("mjwarp",)
 
 
 def test_resolve_case_specs_deduplicates_explicit_specs() -> None:

--- a/tests/tasks/test_motion_term_parity.py
+++ b/tests/tasks/test_motion_term_parity.py
@@ -1,0 +1,137 @@
+"""Issue #1296: bit-parity tests for the temp-array-eliminated motion tracking
+terms. Each optimized term is compared against the naive NumPy expression it
+replaced; results must be exactly equal (same op order, only fewer temps).
+
+``_command`` is monkeypatched to return a stub because the terms type-check
+against the real MotionCommand; the stub provides the same buffer attributes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from unilab.managers import RewardTermCfg
+from unilab.tasks.motion_tracking.common import manager_terms as mt
+
+
+def _make_env(command: Any) -> SimpleNamespace:
+    return SimpleNamespace(num_envs=command.num_envs)
+
+
+@pytest.fixture
+def body_setup(monkeypatch: pytest.MonkeyPatch):
+    rng = np.random.default_rng(42)
+    num_envs, num_bodies = 8, 12
+    command = SimpleNamespace(
+        num_envs=num_envs,
+        cfg=SimpleNamespace(body_names=tuple(f"b{i}" for i in range(num_bodies))),
+        anchor_pos_w=rng.standard_normal((num_envs, 3), dtype=np.float32),
+        robot_anchor_pos_w=rng.standard_normal((num_envs, 3), dtype=np.float32),
+        joint_pos=rng.standard_normal((num_envs, 29), dtype=np.float32),
+        robot_joint_pos=rng.standard_normal((num_envs, 29), dtype=np.float32),
+        body_pos_relative_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
+        robot_body_pos_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
+        body_lin_vel_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
+        robot_body_lin_vel_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
+    )
+    # Snapshot inputs so tests can assert the terms never mutate them.
+    snapshots = {
+        key: value.copy()
+        for key, value in vars(command).items()
+        if isinstance(value, np.ndarray)
+    }
+    monkeypatch.setattr(mt, "_command", lambda env, name: command)
+    return command, _make_env(command), snapshots
+
+
+def test_anchor_position_error_exp_bit_parity(body_setup) -> None:
+    command, env, snapshots = body_setup
+    out = mt.motion_global_anchor_position_error_exp(env, "motion", std=0.3)
+    expected = np.exp(
+        -np.sum(np.square(snapshots["anchor_pos_w"] - snapshots["robot_anchor_pos_w"]), axis=-1)
+        / 0.3**2
+    )
+    np.testing.assert_array_equal(out, expected)
+    np.testing.assert_array_equal(command.anchor_pos_w, snapshots["anchor_pos_w"])
+
+
+def test_joint_position_error_exp_bit_parity(body_setup) -> None:
+    command, env, snapshots = body_setup
+    out = mt.motion_joint_position_error_exp(env, "motion", std=0.2)
+    expected = (
+        np.exp(-np.square(snapshots["joint_pos"] - snapshots["robot_joint_pos"]).mean(axis=-1) / 0.2**2)
+    )
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_body_term_error_exp_bit_parity_and_scratch_reuse(body_setup) -> None:
+    command, env, snapshots = body_setup
+    cfg = RewardTermCfg(func=None, weight=1.0, params={"command_name": "motion"})
+    term = mt.motion_relative_body_position_error_exp(cfg, env)
+
+    out = term(env, "motion", std=0.3)
+    expected = np.exp(
+        -np.square(snapshots["body_pos_relative_w"] - snapshots["robot_body_pos_w"])
+        .sum(axis=-1)
+        .mean(axis=-1)
+        / 0.3**2
+    )
+    np.testing.assert_array_equal(out, expected)
+
+    # Repeat calls reuse scratch and stay correct after the buffers change.
+    rng = np.random.default_rng(7)
+    command.body_pos_relative_w[:] = rng.standard_normal(
+        command.body_pos_relative_w.shape, dtype=np.float32
+    )
+    out2 = term(env, "motion", std=0.3)
+    expected2 = np.exp(
+        -np.square(command.body_pos_relative_w - snapshots["robot_body_pos_w"])
+        .sum(axis=-1)
+        .mean(axis=-1)
+        / 0.3**2
+    )
+    np.testing.assert_array_equal(out2, expected2)
+
+    # Body-subset selection changes the scratch shape but stays bit-identical.
+    cfg_sub = RewardTermCfg(
+        func=None,
+        weight=1.0,
+        params={"command_name": "motion", "body_names": ("b0", "b3", "b11")},
+    )
+    term_sub = mt.motion_global_body_linear_velocity_error_exp(cfg_sub, env)
+    out_sub = term_sub(env, "motion", std=1.0, body_names=("b0", "b3", "b11"))
+    ids = [0, 3, 11]
+    expected_sub = np.exp(
+        -np.square(snapshots["body_lin_vel_w"][:, ids] - snapshots["robot_body_lin_vel_w"][:, ids])
+        .sum(axis=-1)
+        .mean(axis=-1)
+        / 1.0**2
+    )
+    np.testing.assert_array_equal(out_sub, expected_sub)
+
+
+def test_joint_pos_limits_bit_parity() -> None:
+    rng = np.random.default_rng(123)
+    joint_pos = rng.standard_normal((8, 5), dtype=np.float32)
+    limits = np.asarray([[-1.0, 1.0]] * 5, dtype=np.float32)
+    asset = SimpleNamespace(
+        data=SimpleNamespace(joint_pos=joint_pos, soft_joint_pos_limits=limits)
+    )
+    env = SimpleNamespace(scene={"robot": asset})
+    asset_cfg = SimpleNamespace(name="robot", joint_ids=np.array([4, 2, 0], dtype=np.intp))
+
+    out = mt.joint_pos_limits(env, asset_cfg)
+    selected = joint_pos[:, [4, 2, 0]]
+    selected_limits = limits[[4, 2, 0]]
+    expected = np.sum(
+        np.square(
+            np.maximum(selected_limits[:, 0] - selected, 0.0)
+            + np.maximum(selected - selected_limits[:, 1], 0.0)
+        ),
+        axis=-1,
+    )
+    np.testing.assert_array_equal(out, expected)

--- a/tests/tasks/test_motion_term_parity.py
+++ b/tests/tasks/test_motion_term_parity.py
@@ -40,9 +40,7 @@ def body_setup(monkeypatch: pytest.MonkeyPatch):
     )
     # Snapshot inputs so tests can assert the terms never mutate them.
     snapshots = {
-        key: value.copy()
-        for key, value in vars(command).items()
-        if isinstance(value, np.ndarray)
+        key: value.copy() for key, value in vars(command).items() if isinstance(value, np.ndarray)
     }
     monkeypatch.setattr(mt, "_command", lambda env, name: command)
     return command, _make_env(command), snapshots
@@ -62,8 +60,8 @@ def test_anchor_position_error_exp_bit_parity(body_setup) -> None:
 def test_joint_position_error_exp_bit_parity(body_setup) -> None:
     command, env, snapshots = body_setup
     out = mt.motion_joint_position_error_exp(env, "motion", std=0.2)
-    expected = (
-        np.exp(-np.square(snapshots["joint_pos"] - snapshots["robot_joint_pos"]).mean(axis=-1) / 0.2**2)
+    expected = np.exp(
+        -np.square(snapshots["joint_pos"] - snapshots["robot_joint_pos"]).mean(axis=-1) / 0.2**2
     )
     np.testing.assert_array_equal(out, expected)
 
@@ -118,9 +116,7 @@ def test_joint_pos_limits_bit_parity() -> None:
     rng = np.random.default_rng(123)
     joint_pos = rng.standard_normal((8, 5), dtype=np.float32)
     limits = np.asarray([[-1.0, 1.0]] * 5, dtype=np.float32)
-    asset = SimpleNamespace(
-        data=SimpleNamespace(joint_pos=joint_pos, soft_joint_pos_limits=limits)
-    )
+    asset = SimpleNamespace(data=SimpleNamespace(joint_pos=joint_pos, soft_joint_pos_limits=limits))
     env = SimpleNamespace(scene={"robot": asset})
     asset_cfg = SimpleNamespace(name="robot", joint_ids=np.array([4, 2, 0], dtype=np.intp))
 


### PR DESCRIPTION
Part of #1292. Implements #1296.

## 内容（全部纯 NumPy，无新依赖；op 顺序不变，结果 bit 级一致）

- `MotionCommand._refresh_robot_state`：`src[sel][:, ids]` 双重复制改为单次 gather（全量路径 `np.take(..., out=目标 buffer)`，reset 行路径 `np.ix_`）。这是 #1293 profiling 中 `termination/anchor_pos` 3.9–9.9 ms 的实际来源——每步第一次访问 robot state property 时的缓存刷新。
- `_BodyTerm` 系 error_exp reward（motion_body_pos/ori/lin_vel/ang_vel 等）：新增 per-instance scratch（`_squared_error_3d`），subtract→square→sum 链全程 `out=`；`exp(-e/s²)` 由 `_exp_neg_scaled` 原地完成。返回值仍是每次调用新分配的数组，term 契约不变。
- 函数式 term（`motion_global_anchor_position_error_exp` / `motion_global_anchor_orientation_error_exp` / `motion_joint_position_error_exp` / `motion_joint_velocity_error_exp` / `joint_pos_limits`）：in-place 链，去除中间临时数组。
- `RewardManager.compute`：加权结果走共享 scratch（dtype 按 `np.result_type(value, weight)` 对齐原表达式，int 型 term 如 `undesired_body_contacts` 提升为 float64 与旧行为一致），`out=` 直接写入 `_step_reward` 列。
- `ObservationManager.compute_group`：noise 阶段（NoiseCfg/NoiseModel 均保证返回新数组）已产出新数组时跳过防御性 `obs.copy()`。

## Validation

- `make test-all` 本地通过（check 含 mypy+pyright、test-cov 2244 passed、benchmark smoke）。远程 CI 按本次工作流要求跳过等待。
- Parity：新增 `tests/tasks/test_motion_term_parity.py`，对改写前后的朴素表达式做 `assert_array_equal`（bit 级一致），并验证输入 buffer 不被改写、scratch 复用在 buffer 变化后仍正确；现有 `test_motion_command_partial_reset.py` 行级 parity 等集成测试全过。
- 微基准（本机，8192 envs 规模数组）：body error_exp 1.20 → 0.99 ms/call（-18%）；robot state gather 0.59 → 0.18 ms（-70%）；reward 加权累加 4.8 → 3.0 µs/term。
- 必测项三后端同机对照（8192 envs，warmup 10 / measure 100）：

| Backend | env/s（dev 基线 → 本 PR） | update_state ms | env step ms |
|---|---:|---:|---:|
| mujoco | 71,274 → 70,495 | 28.58 → 29.55 | 112.9 → 114.2 |
| motrix | 58,974 → 56,265 | 49.10 → 45.76 | 136.9 → 143.6 |
| mjwarp | 129,210 → 128,194 | 28.53 → 29.19 | 61.4 → 61.9 |

e2e 差异在本机 run 间波动范围内（同代码重复跑 update_state 带 ±1 ms、motrix env step 带 ±20 ms）：微基准确认了分配消除的局部收益，单窗口 e2e 无法分辨 ~1 ms 级变化，无回退。该杠杆按设计是 #1294 的叠加项，不单独承诺 e2e 增益。

结果 JSON：`scripts/benchmark/outputs/offpolicy_collector_active/results_sac_g1_motion_tracking_temp_elim_ryzen9950x3d.json`（gitignore 内）。
