### PR TITLE
perf(motion): 固定五个 update_state 热点改为 Numba-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
+    "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
     "torch==2.7.0 ; sys_platform != 'linux' or platform_machine != 'aarch64'",

--- a/src/unilab/tasks/motion_tracking/common/kernels.py
+++ b/src/unilab/tasks/motion_tracking/common/kernels.py
@@ -1,0 +1,170 @@
+"""Parallel CPU kernels for the fixed motion-tracking hot-term set."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from numba import config, njit, prange, set_num_threads
+
+_DEFAULT_MOTION_KERNEL_THREADS = 8
+_runtime_configured = False
+
+# The OpenMP layer's worker wakeups dominate these short kernels after a long
+# backend physics phase. Workqueue has stable sub-millisecond dispatch here.
+# Respect an application-provided NUMBA_THREADING_LAYER selection.
+if "NUMBA_THREADING_LAYER" not in os.environ:
+    setattr(config, "THREADING_LAYER", "workqueue")
+
+
+def configure_motion_kernel_runtime() -> None:
+    """Initialize the task-local Numba worker mask once on the cold path."""
+    global _runtime_configured
+    if _runtime_configured:
+        return
+    if "NUMBA_NUM_THREADS" not in os.environ:
+        available_threads = int(getattr(config, "NUMBA_DEFAULT_NUM_THREADS", os.cpu_count() or 1))
+        set_num_threads(min(_DEFAULT_MOTION_KERNEL_THREADS, available_threads))
+    _runtime_configured = True
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def termination_anchor_pos_kernel(
+    motion_body_pos_w: np.ndarray,
+    robot_body_pos_w: np.ndarray,
+    anchor_body_idx: int,
+    threshold: float,
+    out: np.ndarray,
+) -> None:
+    """Write the per-environment anchor-height termination mask."""
+    for env_idx in prange(motion_body_pos_w.shape[0]):
+        error = abs(
+            motion_body_pos_w[env_idx, anchor_body_idx, 2]
+            - robot_body_pos_w[env_idx, anchor_body_idx, 2]
+        )
+        out[env_idx] = error > threshold
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def reward_motion_body_pos_kernel(
+    reference: np.ndarray,
+    actual: np.ndarray,
+    body_ids: np.ndarray,
+    std: float,
+    out: np.ndarray,
+) -> None:
+    """Write the relative body-position exponential reward."""
+    num_bodies = body_ids.shape[0]
+    if num_bodies == 0:
+        out[:] = np.nan
+        return
+    denominator = -(num_bodies * std * std)
+    for env_idx in prange(reference.shape[0]):
+        error = reference[env_idx, body_ids[0], 0] * 0
+        for body_offset in range(num_bodies):
+            body_idx = body_ids[body_offset]
+            dx = reference[env_idx, body_idx, 0] - actual[env_idx, body_idx, 0]
+            dy = reference[env_idx, body_idx, 1] - actual[env_idx, body_idx, 1]
+            dz = reference[env_idx, body_idx, 2] - actual[env_idx, body_idx, 2]
+            error += dx * dx + dy * dy + dz * dz
+        out[env_idx] = np.exp(error / denominator)
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def reward_motion_body_ori_kernel(
+    reference: np.ndarray,
+    actual: np.ndarray,
+    body_ids: np.ndarray,
+    std: float,
+    out: np.ndarray,
+) -> None:
+    """Write the relative body-orientation exponential reward."""
+    num_bodies = body_ids.shape[0]
+    if num_bodies == 0:
+        out[:] = np.nan
+        return
+    denominator = -(num_bodies * std * std)
+    for env_idx in prange(reference.shape[0]):
+        error = reference[env_idx, body_ids[0], 0] * 0
+        for body_offset in range(num_bodies):
+            body_idx = body_ids[body_offset]
+            w1 = reference[env_idx, body_idx, 0]
+            x1 = reference[env_idx, body_idx, 1]
+            y1 = reference[env_idx, body_idx, 2]
+            z1 = reference[env_idx, body_idx, 3]
+            w2 = actual[env_idx, body_idx, 0]
+            x2 = actual[env_idx, body_idx, 1]
+            y2 = actual[env_idx, body_idx, 2]
+            z2 = actual[env_idx, body_idx, 3]
+
+            # Relative rotation actual * conjugate(reference), matching
+            # np_quat_error_magnitude_squared_batched without materializing arrays.
+            rel_w = abs(w2 * w1 + x2 * x1 + y2 * y1 + z2 * z1)
+            rel_x = -w2 * x1 + x2 * w1 - y2 * z1 + z2 * y1
+            rel_y = -w2 * y1 + x2 * z1 + y2 * w1 - z2 * x1
+            rel_z = -w2 * z1 - x2 * y1 + y2 * x1 + z2 * w1
+            xyz_norm = np.sqrt(rel_x * rel_x + rel_y * rel_y + rel_z * rel_z)
+            clipped_w = min(max(rel_w, -1.0), 1.0)
+            angle = 2.0 * np.arctan2(xyz_norm, clipped_w)
+            error += angle * angle
+        out[env_idx] = np.exp(error / denominator)
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def reward_motion_body_lin_vel_kernel(
+    reference: np.ndarray,
+    actual: np.ndarray,
+    body_ids: np.ndarray,
+    std: float,
+    out: np.ndarray,
+) -> None:
+    """Write the global body-linear-velocity exponential reward."""
+    num_bodies = body_ids.shape[0]
+    if num_bodies == 0:
+        out[:] = np.nan
+        return
+    denominator = -(num_bodies * std * std)
+    for env_idx in prange(reference.shape[0]):
+        error = reference[env_idx, body_ids[0], 0] * 0
+        for body_offset in range(num_bodies):
+            body_idx = body_ids[body_offset]
+            dx = reference[env_idx, body_idx, 0] - actual[env_idx, body_idx, 0]
+            dy = reference[env_idx, body_idx, 1] - actual[env_idx, body_idx, 1]
+            dz = reference[env_idx, body_idx, 2] - actual[env_idx, body_idx, 2]
+            error += dx * dx + dy * dy + dz * dz
+        out[env_idx] = np.exp(error / denominator)
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def reward_motion_body_ang_vel_kernel(
+    reference: np.ndarray,
+    actual: np.ndarray,
+    body_ids: np.ndarray,
+    std: float,
+    out: np.ndarray,
+) -> None:
+    """Write the global body-angular-velocity exponential reward."""
+    num_bodies = body_ids.shape[0]
+    if num_bodies == 0:
+        out[:] = np.nan
+        return
+    denominator = -(num_bodies * std * std)
+    for env_idx in prange(reference.shape[0]):
+        error = reference[env_idx, body_ids[0], 0] * 0
+        for body_offset in range(num_bodies):
+            body_idx = body_ids[body_offset]
+            dx = reference[env_idx, body_idx, 0] - actual[env_idx, body_idx, 0]
+            dy = reference[env_idx, body_idx, 1] - actual[env_idx, body_idx, 1]
+            dz = reference[env_idx, body_idx, 2] - actual[env_idx, body_idx, 2]
+            error += dx * dx + dy * dy + dz * dz
+        out[env_idx] = np.exp(error / denominator)
+
+
+__all__ = [
+    "configure_motion_kernel_runtime",
+    "reward_motion_body_ang_vel_kernel",
+    "reward_motion_body_lin_vel_kernel",
+    "reward_motion_body_ori_kernel",
+    "reward_motion_body_pos_kernel",
+    "termination_anchor_pos_kernel",
+]

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -23,6 +23,14 @@ from unilab.utils.rotation import (
     np_quat_mul,
 )
 
+from .kernels import (
+    configure_motion_kernel_runtime,
+    reward_motion_body_ang_vel_kernel,
+    reward_motion_body_lin_vel_kernel,
+    reward_motion_body_ori_kernel,
+    reward_motion_body_pos_kernel,
+    termination_anchor_pos_kernel,
+)
 from .motion_loader import MotionData, MotionLoader, MotionSampler
 from .observations import write_body_ori6_in_anchor_frame, write_body_pos_in_anchor_frame
 from .transforms import update_relative_transforms
@@ -807,7 +815,37 @@ class _BodyTerm(ManagerTermBase):
         return _command(self._env, command_name), _positive_std(std, term_name=type(self).__name__)
 
 
-class motion_relative_body_position_error_exp(_BodyTerm):
+class _NumbaBodyTerm(_BodyTerm):
+    """Shared cold-path setup for the four fixed parallel body reward kernels."""
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        configure_motion_kernel_runtime()
+        command = _command(env, self._command_name)
+        if isinstance(self._body_ids, slice):
+            body_ids = np.arange(len(command.cfg.body_names), dtype=np.intp)
+        else:
+            body_ids = self._body_ids
+        body_ids.setflags(write=False)
+        self._kernel_body_ids = body_ids
+        self._kernel_result = np.empty(self.num_envs, dtype=command.body_pos_relative_w.dtype)
+
+    def _kernel_std(self, scale: float) -> float:
+        return cast(float, self._kernel_result.dtype.type(scale))
+
+
+class motion_relative_body_position_error_exp(_NumbaBodyTerm):
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        command = _command(env, self._command_name)
+        reward_motion_body_pos_kernel(
+            command.body_pos_relative_w,
+            command.robot_body_pos_w,
+            self._kernel_body_ids,
+            self._kernel_std(1.0),
+            self._kernel_result,
+        )
+
     def __call__(
         self,
         env: ManagerBasedRlEnv,
@@ -817,14 +855,28 @@ class motion_relative_body_position_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = self._squared_error_3d(
-            command.body_pos_relative_w[:, self._body_ids],
-            command.robot_body_pos_w[:, self._body_ids],
+        reward_motion_body_pos_kernel(
+            command.body_pos_relative_w,
+            command.robot_body_pos_w,
+            self._kernel_body_ids,
+            self._kernel_std(scale),
+            self._kernel_result,
         )
-        return self._exp_neg_scaled(error.mean(axis=-1), scale)
+        return self._kernel_result
 
 
-class motion_relative_body_orientation_error_exp(_BodyTerm):
+class motion_relative_body_orientation_error_exp(_NumbaBodyTerm):
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        command = _command(env, self._command_name)
+        reward_motion_body_ori_kernel(
+            command.body_quat_relative_w,
+            command.robot_body_quat_w,
+            self._kernel_body_ids,
+            self._kernel_std(1.0),
+            self._kernel_result,
+        )
+
     def __call__(
         self,
         env: ManagerBasedRlEnv,
@@ -834,14 +886,28 @@ class motion_relative_body_orientation_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = np_quat_error_magnitude_squared_batched(
-            command.body_quat_relative_w[:, self._body_ids],
-            command.robot_body_quat_w[:, self._body_ids],
+        reward_motion_body_ori_kernel(
+            command.body_quat_relative_w,
+            command.robot_body_quat_w,
+            self._kernel_body_ids,
+            self._kernel_std(scale),
+            self._kernel_result,
         )
-        return self._exp_neg_scaled(error.mean(axis=-1), scale)
+        return self._kernel_result
 
 
-class motion_global_body_linear_velocity_error_exp(_BodyTerm):
+class motion_global_body_linear_velocity_error_exp(_NumbaBodyTerm):
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        command = _command(env, self._command_name)
+        reward_motion_body_lin_vel_kernel(
+            command.body_lin_vel_w,
+            command.robot_body_lin_vel_w,
+            self._kernel_body_ids,
+            self._kernel_std(1.0),
+            self._kernel_result,
+        )
+
     def __call__(
         self,
         env: ManagerBasedRlEnv,
@@ -851,14 +917,28 @@ class motion_global_body_linear_velocity_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = self._squared_error_3d(
-            command.body_lin_vel_w[:, self._body_ids],
-            command.robot_body_lin_vel_w[:, self._body_ids],
+        reward_motion_body_lin_vel_kernel(
+            command.body_lin_vel_w,
+            command.robot_body_lin_vel_w,
+            self._kernel_body_ids,
+            self._kernel_std(scale),
+            self._kernel_result,
         )
-        return self._exp_neg_scaled(error.mean(axis=-1), scale)
+        return self._kernel_result
 
 
-class motion_global_body_angular_velocity_error_exp(_BodyTerm):
+class motion_global_body_angular_velocity_error_exp(_NumbaBodyTerm):
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        command = _command(env, self._command_name)
+        reward_motion_body_ang_vel_kernel(
+            command.body_ang_vel_w,
+            command.robot_body_ang_vel_w,
+            self._kernel_body_ids,
+            self._kernel_std(1.0),
+            self._kernel_result,
+        )
+
     def __call__(
         self,
         env: ManagerBasedRlEnv,
@@ -868,11 +948,14 @@ class motion_global_body_angular_velocity_error_exp(_BodyTerm):
     ) -> np.ndarray:
         del env, body_names
         command, scale = self._validate(command_name, std)
-        error = self._squared_error_3d(
-            command.body_ang_vel_w[:, self._body_ids],
-            command.robot_body_ang_vel_w[:, self._body_ids],
+        reward_motion_body_ang_vel_kernel(
+            command.body_ang_vel_w,
+            command.robot_body_ang_vel_w,
+            self._kernel_body_ids,
+            self._kernel_std(scale),
+            self._kernel_result,
         )
-        return self._exp_neg_scaled(error.mean(axis=-1), scale)
+        return self._kernel_result
 
 
 class motion_relative_body_position_z_error_exp(_BodyTerm):
@@ -948,11 +1031,48 @@ class undesired_body_contacts(_BodyTerm):
         return np.sum(command.robot_body_pos_w[:, self._body_ids, 2] < threshold, axis=-1)
 
 
-def bad_anchor_pos_z_only(
-    env: ManagerBasedRlEnv, command_name: str, threshold: float
-) -> np.ndarray:
-    command = _command(env, command_name)
-    return np.abs(command.anchor_pos_w[:, 2] - command.robot_anchor_pos_w[:, 2]) > threshold
+class bad_anchor_pos_z_only(ManagerTermBase):
+    """Anchor-height termination backed by a parallel, pre-warmed Numba kernel."""
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        configure_motion_kernel_runtime()
+        command_name = cfg.params.get("command_name")
+        if not isinstance(command_name, str) or not command_name:
+            raise ValueError(f"{type(self).__name__} requires a non-empty command_name")
+        self._command_name = command_name
+        self._result = np.empty(self.num_envs, dtype=np.bool_)
+        command = _command(env, command_name)
+        threshold = command.body_pos_w.dtype.type(cfg.params.get("threshold", 0.0))
+        termination_anchor_pos_kernel(
+            command.body_pos_w,
+            command.robot_body_pos_w,
+            command.anchor_body_idx,
+            threshold,
+            self._result,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        command_name: str,
+        threshold: float,
+    ) -> np.ndarray:
+        del env
+        if command_name != self._command_name:
+            raise ValueError(
+                f"{type(self).__name__} was bound to '{self._command_name}', got '{command_name}'"
+            )
+        command = _command(self._env, command_name)
+        threshold_value = command.body_pos_w.dtype.type(threshold)
+        termination_anchor_pos_kernel(
+            command.body_pos_w,
+            command.robot_body_pos_w,
+            command.anchor_body_idx,
+            threshold_value,
+            self._result,
+        )
+        return self._result
 
 
 def bad_anchor_ori(

--- a/tests/tasks/test_motion_term_parity.py
+++ b/tests/tasks/test_motion_term_parity.py
@@ -1,44 +1,76 @@
-"""Issue #1296: bit-parity tests for the temp-array-eliminated motion tracking
-terms. Each optimized term is compared against the naive NumPy expression it
-replaced; results must be exactly equal (same op order, only fewer temps).
-
-``_command`` is monkeypatched to return a stub because the terms type-check
-against the real MotionCommand; the stub provides the same buffer attributes.
-"""
+"""Numerical-contract tests for optimized motion-tracking manager terms."""
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pytest
+from numba import config, get_num_threads, threading_layer
 
-from unilab.managers import RewardTermCfg
+from unilab.managers import RewardTermCfg, TerminationTermCfg
+from unilab.tasks.motion_tracking.common import kernels
 from unilab.tasks.motion_tracking.common import manager_terms as mt
+from unilab.utils.rotation import np_quat_error_magnitude_squared_batched
 
 
 def _make_env(command: Any) -> SimpleNamespace:
     return SimpleNamespace(num_envs=command.num_envs)
 
 
+def _unit_quat(value: np.ndarray) -> np.ndarray:
+    value /= np.linalg.norm(value, axis=-1, keepdims=True)
+    return value
+
+
 @pytest.fixture
 def body_setup(monkeypatch: pytest.MonkeyPatch):
     rng = np.random.default_rng(42)
-    num_envs, num_bodies = 8, 12
+    num_envs, num_bodies = 257, 12
+    anchor_body_idx = 4
+
+    body_pos_relative_w = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    body_pos_w = body_pos_relative_w.copy()
+    robot_body_pos_w = body_pos_relative_w + 0.1 * rng.standard_normal(
+        body_pos_relative_w.shape, dtype=np.float32
+    )
+    body_quat_relative_w = _unit_quat(
+        rng.standard_normal((num_envs, num_bodies, 4), dtype=np.float32)
+    )
+    robot_body_quat_w = _unit_quat(
+        body_quat_relative_w
+        + 0.05 * rng.standard_normal(body_quat_relative_w.shape, dtype=np.float32)
+    )
+    body_lin_vel_w = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    robot_body_lin_vel_w = body_lin_vel_w + 0.2 * rng.standard_normal(
+        body_lin_vel_w.shape, dtype=np.float32
+    )
+    body_ang_vel_w = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    robot_body_ang_vel_w = body_ang_vel_w + 0.5 * rng.standard_normal(
+        body_ang_vel_w.shape, dtype=np.float32
+    )
+
     command = SimpleNamespace(
         num_envs=num_envs,
         cfg=SimpleNamespace(body_names=tuple(f"b{i}" for i in range(num_bodies))),
-        anchor_pos_w=rng.standard_normal((num_envs, 3), dtype=np.float32),
-        robot_anchor_pos_w=rng.standard_normal((num_envs, 3), dtype=np.float32),
+        anchor_body_idx=anchor_body_idx,
+        body_pos_w=body_pos_w,
+        robot_body_pos_w=robot_body_pos_w,
+        anchor_pos_w=body_pos_w[:, anchor_body_idx],
+        robot_anchor_pos_w=robot_body_pos_w[:, anchor_body_idx],
         joint_pos=rng.standard_normal((num_envs, 29), dtype=np.float32),
         robot_joint_pos=rng.standard_normal((num_envs, 29), dtype=np.float32),
-        body_pos_relative_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
-        robot_body_pos_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
-        body_lin_vel_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
-        robot_body_lin_vel_w=rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32),
+        body_pos_relative_w=body_pos_relative_w,
+        body_quat_relative_w=body_quat_relative_w,
+        robot_body_quat_w=robot_body_quat_w,
+        body_lin_vel_w=body_lin_vel_w,
+        robot_body_lin_vel_w=robot_body_lin_vel_w,
+        body_ang_vel_w=body_ang_vel_w,
+        robot_body_ang_vel_w=robot_body_ang_vel_w,
     )
-    # Snapshot inputs so tests can assert the terms never mutate them.
+
     snapshots = {
         key: value.copy() for key, value in vars(command).items() if isinstance(value, np.ndarray)
     }
@@ -46,11 +78,38 @@ def body_setup(monkeypatch: pytest.MonkeyPatch):
     return command, _make_env(command), snapshots
 
 
+def _reward_cfg(*, body_names: tuple[str, ...] | None = None) -> RewardTermCfg:
+    params: dict[str, Any] = {"command_name": "motion"}
+    if body_names is not None:
+        params["body_names"] = body_names
+    return RewardTermCfg(func=None, weight=1.0, params=params)
+
+
+def _expected_body_reward(
+    reference: np.ndarray,
+    actual: np.ndarray,
+    body_ids: slice | list[int],
+    std: float,
+    *,
+    orientation: bool,
+) -> np.ndarray:
+    reference = reference[:, body_ids]
+    actual = actual[:, body_ids]
+    if orientation:
+        error = np_quat_error_magnitude_squared_batched(reference, actual)
+    else:
+        error = np.square(reference - actual).sum(axis=-1)
+    return np.exp(-error.mean(axis=-1) / std**2)
+
+
 def test_anchor_position_error_exp_bit_parity(body_setup) -> None:
     command, env, snapshots = body_setup
     out = mt.motion_global_anchor_position_error_exp(env, "motion", std=0.3)
     expected = np.exp(
-        -np.sum(np.square(snapshots["anchor_pos_w"] - snapshots["robot_anchor_pos_w"]), axis=-1)
+        -np.sum(
+            np.square(snapshots["anchor_pos_w"] - snapshots["robot_anchor_pos_w"]),
+            axis=-1,
+        )
         / 0.3**2
     )
     np.testing.assert_array_equal(out, expected)
@@ -66,50 +125,199 @@ def test_joint_position_error_exp_bit_parity(body_setup) -> None:
     np.testing.assert_array_equal(out, expected)
 
 
-def test_body_term_error_exp_bit_parity_and_scratch_reuse(body_setup) -> None:
+def test_anchor_pos_termination_numba_parity_and_output_reuse(body_setup) -> None:
     command, env, snapshots = body_setup
-    cfg = RewardTermCfg(func=None, weight=1.0, params={"command_name": "motion"})
-    term = mt.motion_relative_body_position_error_exp(cfg, env)
+    cfg = TerminationTermCfg(
+        func=mt.bad_anchor_pos_z_only,
+        params={"command_name": "motion", "threshold": 0.15},
+    )
+    term = mt.bad_anchor_pos_z_only(cfg, env)
 
-    out = term(env, "motion", std=0.3)
-    expected = np.exp(
-        -np.square(snapshots["body_pos_relative_w"] - snapshots["robot_body_pos_w"])
-        .sum(axis=-1)
-        .mean(axis=-1)
-        / 0.3**2
+    out = term(env, "motion", threshold=0.15)
+    expected = (
+        np.abs(
+            snapshots["body_pos_w"][:, command.anchor_body_idx, 2]
+            - snapshots["robot_anchor_pos_w"][:, 2]
+        )
+        > 0.15
     )
     np.testing.assert_array_equal(out, expected)
 
-    # Repeat calls reuse scratch and stay correct after the buffers change.
-    rng = np.random.default_rng(7)
-    command.body_pos_relative_w[:] = rng.standard_normal(
-        command.body_pos_relative_w.shape, dtype=np.float32
-    )
-    out2 = term(env, "motion", std=0.3)
-    expected2 = np.exp(
-        -np.square(command.body_pos_relative_w - snapshots["robot_body_pos_w"])
-        .sum(axis=-1)
-        .mean(axis=-1)
-        / 0.3**2
+    out2 = term(env, "motion", threshold=0.3)
+    assert out2 is out
+    expected2 = (
+        np.abs(
+            snapshots["body_pos_w"][:, command.anchor_body_idx, 2]
+            - snapshots["robot_anchor_pos_w"][:, 2]
+        )
+        > 0.3
     )
     np.testing.assert_array_equal(out2, expected2)
+    np.testing.assert_array_equal(command.body_pos_w, snapshots["body_pos_w"])
 
-    # Body-subset selection changes the scratch shape but stays bit-identical.
-    cfg_sub = RewardTermCfg(
-        func=None,
-        weight=1.0,
-        params={"command_name": "motion", "body_names": ("b0", "b3", "b11")},
+
+@pytest.mark.parametrize(
+    ("term_type", "reference_name", "actual_name", "std", "orientation"),
+    [
+        (
+            mt.motion_relative_body_position_error_exp,
+            "body_pos_relative_w",
+            "robot_body_pos_w",
+            0.3,
+            False,
+        ),
+        (
+            mt.motion_relative_body_orientation_error_exp,
+            "body_quat_relative_w",
+            "robot_body_quat_w",
+            0.4,
+            True,
+        ),
+        (
+            mt.motion_global_body_linear_velocity_error_exp,
+            "body_lin_vel_w",
+            "robot_body_lin_vel_w",
+            1.0,
+            False,
+        ),
+        (
+            mt.motion_global_body_angular_velocity_error_exp,
+            "body_ang_vel_w",
+            "robot_body_ang_vel_w",
+            3.14,
+            False,
+        ),
+    ],
+)
+def test_numba_body_rewards_match_numpy_and_reuse_output(
+    body_setup,
+    term_type,
+    reference_name: str,
+    actual_name: str,
+    std: float,
+    orientation: bool,
+) -> None:
+    command, env, snapshots = body_setup
+    term = term_type(_reward_cfg(), env)
+
+    out = term(env, "motion", std=std)
+    expected = _expected_body_reward(
+        snapshots[reference_name],
+        snapshots[actual_name],
+        slice(None),
+        std,
+        orientation=orientation,
     )
-    term_sub = mt.motion_global_body_linear_velocity_error_exp(cfg_sub, env)
-    out_sub = term_sub(env, "motion", std=1.0, body_names=("b0", "b3", "b11"))
-    ids = [0, 3, 11]
-    expected_sub = np.exp(
-        -np.square(snapshots["body_lin_vel_w"][:, ids] - snapshots["robot_body_lin_vel_w"][:, ids])
-        .sum(axis=-1)
-        .mean(axis=-1)
-        / 1.0**2
+    np.testing.assert_allclose(out, expected, rtol=2e-6, atol=2e-7)
+    assert out.dtype == snapshots[reference_name].dtype
+    first_result = out.copy()
+
+    second_std = std * 1.5
+    out2 = term(env, "motion", std=second_std)
+    assert out2 is out
+    expected2 = _expected_body_reward(
+        snapshots[reference_name],
+        snapshots[actual_name],
+        slice(None),
+        second_std,
+        orientation=orientation,
     )
-    np.testing.assert_array_equal(out_sub, expected_sub)
+    np.testing.assert_allclose(out2, expected2, rtol=2e-6, atol=2e-7)
+    assert np.any(first_result != out2)
+    np.testing.assert_array_equal(getattr(command, reference_name), snapshots[reference_name])
+    np.testing.assert_array_equal(getattr(command, actual_name), snapshots[actual_name])
+
+
+@pytest.mark.parametrize(
+    ("term_type", "reference_name", "actual_name", "std", "orientation"),
+    [
+        (
+            mt.motion_relative_body_position_error_exp,
+            "body_pos_relative_w",
+            "robot_body_pos_w",
+            0.3,
+            False,
+        ),
+        (
+            mt.motion_relative_body_orientation_error_exp,
+            "body_quat_relative_w",
+            "robot_body_quat_w",
+            0.4,
+            True,
+        ),
+        (
+            mt.motion_global_body_linear_velocity_error_exp,
+            "body_lin_vel_w",
+            "robot_body_lin_vel_w",
+            1.0,
+            False,
+        ),
+        (
+            mt.motion_global_body_angular_velocity_error_exp,
+            "body_ang_vel_w",
+            "robot_body_ang_vel_w",
+            3.14,
+            False,
+        ),
+    ],
+)
+def test_numba_body_rewards_preserve_body_subset_contract(
+    body_setup,
+    term_type,
+    reference_name: str,
+    actual_name: str,
+    std: float,
+    orientation: bool,
+) -> None:
+    command, env, snapshots = body_setup
+    body_names = ("b0", "b3", "b11")
+    term = term_type(_reward_cfg(body_names=body_names), env)
+
+    out = term(env, "motion", std=std, body_names=body_names)
+    expected = _expected_body_reward(
+        snapshots[reference_name],
+        snapshots[actual_name],
+        [0, 3, 11],
+        std,
+        orientation=orientation,
+    )
+    np.testing.assert_allclose(out, expected, rtol=2e-6, atol=2e-7)
+    assert command.cfg.body_names == tuple(f"b{i}" for i in range(12))
+
+
+def test_motion_hot_kernels_compile_parallel_on_term_construction(body_setup) -> None:
+    _, env, _ = body_setup
+    mt.bad_anchor_pos_z_only(
+        TerminationTermCfg(
+            func=mt.bad_anchor_pos_z_only,
+            params={"command_name": "motion", "threshold": 0.15},
+        ),
+        env,
+    )
+    for term_type in (
+        mt.motion_relative_body_position_error_exp,
+        mt.motion_relative_body_orientation_error_exp,
+        mt.motion_global_body_linear_velocity_error_exp,
+        mt.motion_global_body_angular_velocity_error_exp,
+    ):
+        term_type(_reward_cfg(), env)
+
+    dispatchers = (
+        kernels.termination_anchor_pos_kernel,
+        kernels.reward_motion_body_pos_kernel,
+        kernels.reward_motion_body_ori_kernel,
+        kernels.reward_motion_body_lin_vel_kernel,
+        kernels.reward_motion_body_ang_vel_kernel,
+    )
+    for dispatcher in dispatchers:
+        assert dispatcher.targetoptions["nopython"] is True
+        assert dispatcher.targetoptions["nogil"] is True
+        assert dispatcher.targetoptions["parallel"] is True
+        assert dispatcher.signatures
+    if "NUMBA_THREADING_LAYER" not in os.environ:
+        assert threading_layer() == "workqueue"
+    if "NUMBA_NUM_THREADS" not in os.environ:
+        assert get_num_threads() == min(8, config.NUMBA_DEFAULT_NUM_THREADS)
 
 
 def test_joint_pos_limits_bit_parity() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1298,6 +1298,30 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/27/72ae94ea5c8f7349ec1c229d4cd058feb799cbd0833ad6d1b47c919b37b7/llvmlite-0.49.0.tar.gz", hash = "sha256:00f16db782f4a13c78c5804aedc434e46794a77e89999a168f9401106270e50a", size = 194467, upload-time = "2026-08-11T16:26:00.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/0d/daceb212c44cad1115b2d05dd55beafe23ff06627344adb4ded0c661bb1a/llvmlite-0.49.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ee81e96c15a6f870918f1eb60c913551c16aa23defb4f5f1acfa660d6a0aaac2", size = 40479229, upload-time = "2026-08-11T16:22:56.104Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2c/eb42378b4f3afc71f9fe172d01f30135dc1d54c7fd95cf76d5445d6f7809/llvmlite-0.49.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:854941c2267fd4fc5b2ce02b8af8ecdffa79fb7784591d3a89370322039ea09f", size = 59890659, upload-time = "2026-08-11T16:23:03.359Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/dc/fe880ac1eb93c09b6c9a0539ad18c98778386978a0e20a13a55788044ad2/llvmlite-0.49.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da7b64474ac15ca595efa2644d5c6836638ccf70709fad3aba3fc56a55966928", size = 58344482, upload-time = "2026-08-11T16:23:12.122Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/5c18be29145cfca1d9e859e55a3c586a8c5a821825017b04c7999cd166c9/llvmlite-0.49.0-cp310-cp310-win_amd64.whl", hash = "sha256:b352c14353330c879e339b8f8d7491d565fe94242697714a24e80bd757202384", size = 41865252, upload-time = "2026-08-11T16:23:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/ab52de2328e97ca96cdf0331a5f774796bddc420a51768f4501193f80cbb/llvmlite-0.49.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4b0e710880b7cc910392bd6b9f1bbf468fed99b182e4420d51598f36114b3dce", size = 40479230, upload-time = "2026-08-11T16:23:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/80/0989432d12b7c86a6f5f380eb92eca7de779af9b34dedbd311b694d7da8d/llvmlite-0.49.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a8c0fc9d624bdc30a3d2db11eb2fb98f80fb209d20b37604eda516cd9b699cf4", size = 59890659, upload-time = "2026-08-11T16:23:37.346Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e9/76859ca36aaa460b6ae0508e01637f0e9bdb9b59faaa4637ade3b94bbcca/llvmlite-0.49.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20496a5c9fdb8179fb9300e7d19f6782555d98aeeb4a322264aa7fd99f980618", size = 58344482, upload-time = "2026-08-11T16:23:44.199Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/49/47cd23e05d52d117b6119871ec299adedc9d8d332a2296964d9b2adc06d9/llvmlite-0.49.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a5b06c1b5fc4ae4c9b169b065f42b719448ef1f873687ef224ef69969b75ec3", size = 41865253, upload-time = "2026-08-11T16:23:50.198Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/3f699ebe3590e15e023a6372dd147526fd8ec398aacf9ceb844e854964a8/llvmlite-0.49.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b541c8fac3450db7574d1f53cf9dff83f285bfed9d69bf81fe71fc2a7d4f97fe", size = 40479231, upload-time = "2026-08-11T16:23:56.773Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3c/e97f69c62a2d972066d9a2612ce1f3de313035ac897a5b9f787cad8b55f7/llvmlite-0.49.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6acba646d88abbc87d5c113a3d62c1fbf8b8fee11c6493f516803e30f21ae870", size = 59890658, upload-time = "2026-08-11T16:24:05.451Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e6/e942ee08605fc0526ff3854260c384d8315a5830e16c4c2a5aebc14dc9bf/llvmlite-0.49.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec8ad805e7515cb8440a690eb3cef4d34acb29eef80b705ec4e1c1ad3c43c68", size = 58344481, upload-time = "2026-08-11T16:24:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/49/2a44871cac6b5a2fd4aabd68cfdaf6de9a5c7edb36dee5d47b77bda4b50f/llvmlite-0.49.0-cp312-cp312-win_amd64.whl", hash = "sha256:3a9c9e3af4e214acfefa4f73ebe7bc3fb35854a62b654edb3953f5ae33c08ba3", size = 41865543, upload-time = "2026-08-11T16:24:20.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/85/0b536a3c59f2636d9dd51dda832b6c1d0ffec37608429dedf128664918f1/llvmlite-0.49.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:039fa4054a06f537fb39248d4472284ca96be311a142ec09e69f95630ab469cc", size = 40479230, upload-time = "2026-08-11T16:24:27.295Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/ca8ba47b057b793099784475499771780ec46839f2782f753a7079d23520/llvmlite-0.49.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddc7aecd4f56397ed6e8f120ec5dcd5a1a8f0e6032ca4af413462792d4dca2e3", size = 59890659, upload-time = "2026-08-11T16:24:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/9526dfdd33a923f33e29a18b8f9801ee7ee4b7397e88d28192c1024c4a75/llvmlite-0.49.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3dee64784201b64c13a8df62c48a4f4218858faaa65889866bb29bdc243c038", size = 58344482, upload-time = "2026-08-11T16:24:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/9f5afcf6476b228d6b170408f377a0c4f91477fc1fc91f8141088b45bf46/llvmlite-0.49.0-cp313-cp313-win_amd64.whl", hash = "sha256:a1b414dc6b164738ec39dd8987cea73829057b7dd92fc6d91b52838385fc1dd2", size = 41865544, upload-time = "2026-08-11T16:24:53.962Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1953,6 +1977,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.67.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2544f4e3a61e501d6c9a5418fd4b905323222693d54a02cab0106a0af865/numba-0.67.0.tar.gz", hash = "sha256:cd75aa535b33fa05d9d930b1ae8af9f97a2881e96d72dfb38ec9b78284d9f851", size = 2836515, upload-time = "2026-08-11T23:04:00.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/2e/6e72b3edbb7c7d6b44b2ca9e1b62e91997415d181541ef47fc6957c59bf2/numba-0.67.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:8c0e88acd4341ddf40779db3c0228b9188aca7fcab5f5f3ce9949a1fc71e9a02", size = 2745135, upload-time = "2026-08-11T23:03:08.321Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/5358f24235ef1a5a80b7e28f3e1baa886c0bcf07dc68557009284e6ba698/numba-0.67.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6c8e9ba3f9602471e8c6f563ffcce8db8046741f0bafb782a052e41dc6b6861", size = 3821881, upload-time = "2026-08-11T23:03:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/18/2f00694248e32c53812baf3d36a7c656dbdd667c6993087b3da068f74b02/numba-0.67.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694c81c6560b2b47e5fc1dc39c29175b907adf862d9af0af801453400a022a61", size = 3528397, upload-time = "2026-08-11T23:03:13.107Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/39/4175b074929938011bd4b564beb4e0fcffd46252e01f60602b57ffb02b06/numba-0.67.0-cp310-cp310-win_amd64.whl", hash = "sha256:ed333e0af4386294e7f03e550e01411856b6935e717d859225e0a7338c6b6795", size = 2815861, upload-time = "2026-08-11T23:03:15.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ed/55ba4e54ee878396de6b18e6533cc4a92fa519e8c82d55cf40f98c0a6831/numba-0.67.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:3fa3d1b27f96f2c0d54513d953d7197886aa1eaa7d2439a0eedc44d993fb181a", size = 2744821, upload-time = "2026-08-11T23:03:17.321Z" },
+    { url = "https://files.pythonhosted.org/packages/be/78/3f3c45dbaec3cf02bbb1825731beca50f591227e95143d6bd7a64897641c/numba-0.67.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c80c847301dc33dc8f84a97a952004023d9a05578ae4512b087176264cc1960", size = 3827182, upload-time = "2026-08-11T23:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/4e70cb86534283d859c3aea2302da523e41539b98dd6c3c4d0a42af95cda/numba-0.67.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7a7b0121466f1e9a8a074b0545fe90e16389623abf979b5d7c299dca1294d7e", size = 3532817, upload-time = "2026-08-11T23:03:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4d/23dab7f4233be0fc34f54a169ed85238467cd24d8adf2498e5c12ea19dc7/numba-0.67.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfba1ac34f0363fb1a250a10e97240780d11e05227892f7286b26fbfd0ad58ce", size = 2815700, upload-time = "2026-08-11T23:03:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/58/915cddba90010348ed0444451132fdde9b000bcbaff1582029b5bf115d11/numba-0.67.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6004d8d5f28d4028687fb2d972d629295b13685943bd2ed5cd8810c3b848e219", size = 2745050, upload-time = "2026-08-11T23:03:25.607Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/38/926757caaac18a66f057d7544a63620bf360a07d281c9f7ecadd2aa83963/numba-0.67.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f63d43db06b4756424d6d2484737c902e0ae944a0eec3e8b0b4de2c695b15caa", size = 3884596, upload-time = "2026-08-11T23:03:27.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6d/58291dc58da39d98b32db7f044729f6d8d4920cd9622fbab3179b54ff4c4/numba-0.67.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76d3335aaeffb9dc88309420890e73497a00be08a7530441bc2b58ffe025bfa5", size = 3585290, upload-time = "2026-08-11T23:03:29.684Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/63/ab21828b4056afed71f9ecb40f4de26c2c19de731cc001961aca74b79464/numba-0.67.0-cp312-cp312-win_amd64.whl", hash = "sha256:50e2b72406c18cda5dd7431b0082cb85ea94e06c64c33607248fc8bef92cfb81", size = 2815645, upload-time = "2026-08-11T23:03:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/bd9fe772f6c84597b76cac229b3f2890f01a2c64fd70e48ceaae10dd65cb/numba-0.67.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:77e1c7173fee57a0d84e006c7e70346689d6cb3e7db503489bae58646b4eff7b", size = 2744872, upload-time = "2026-08-11T23:03:33.649Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/1c/c05609739cc41116d36e30cb2b41fb00f126bb52e1b0bac907051ad8a35d/numba-0.67.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9c4953387c77864b596d8296e2cfbdef82b0eea4166ab4864b05d226c51143e0", size = 3892004, upload-time = "2026-08-11T23:03:35.797Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/77/a5276ad4178250403e0e2251f3e1f8ac18feac779b0474a8bcb08558490d/numba-0.67.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88f6e0f5cb6c545e158b6ef0496c01b6d6958a7ccc6634a1576a94bbbab29ff2", size = 3591878, upload-time = "2026-08-11T23:03:37.845Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/d48f0ba7442516ceb5a1585f0c81d3aa531bc96bfcabcd9f8f925768c426/numba-0.67.0-cp313-cp313-win_amd64.whl", hash = "sha256:b68ad5125fe245339cc8dcc036081fc1ea482c5063387b9612a76ccd83dc91cd", size = 2815504, upload-time = "2026-08-11T23:03:39.736Z" },
 ]
 
 [[package]]
@@ -3928,6 +3981,7 @@ dependencies = [
     { name = "lark" },
     { name = "mediapy" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
+    { name = "numba" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3990,6 +4044,7 @@ requires-dist = [
     { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.4.0" },
     { name = "mujoco-warp", marker = "extra == 'mjwarp'", specifier = "==3.10.0.3" },
     { name = "ninja", marker = "sys_platform == 'linux'" },
+    { name = "numba", specifier = ">=0.67" },
     { name = "numpy" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.20" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11'", specifier = ">=1.20" },


### PR DESCRIPTION
## Summary

- Replace termination/anchor_pos and the four motion_body_* rewards with pre-warmed njit(nogil=True, parallel=True) kernels.
- Keep the four reward formulas Numba-only in the production call graph; NumPy expressions remain only as test oracles.
- Reuse caller-owned result buffers and preserve body subset, dtype, input immutability, and manager class-term contracts.
- Add Numba as a runtime dependency.

## Linked Work

- Resolves #1306
- Parent roadmap: #1304
- Follow-up: #1307

## Validation

- [x] make check
- [x] uv run pytest -m "not slow"
- [x] make test-all
- [x] Three-backend 8192-env benchmark, warmup 10 / measure 100, 3 runs per side, median of run means

Commands actually run:

```bash
make test-all
uv run --no-sync scripts/benchmark/rl/benchmark_offpolicy_collector_active.py --cases sac/g1_motion_tracking/mujoco --num-envs 8192 --warmup-steps 10 --measure-steps 100
uv run --no-sync scripts/benchmark/rl/benchmark_offpolicy_collector_active.py --cases sac/g1_motion_tracking/motrixsim --num-envs 8192 --warmup-steps 10 --measure-steps 100
uv run --no-sync --extra mjwarp scripts/benchmark/rl/benchmark_offpolicy_collector_active.py --cases sac/g1_motion_tracking/mjwarp --num-envs 8192 --warmup-steps 10 --measure-steps 100
```

make test-all result: 2294 passed, 27 skipped, 281 deselected, 1 xfailed; ruff, mypy, pyright, and benchmark smoke passed.

Maintainer override: local make test-all only; remote CI is intentionally not awaited or required for this roadmap.

## Benchmark

Same host: Ryzen 9 9950X3D, RTX 4090. Values are before → after.

| Backend | update_state ms | reset_done ms | env/s |
|---|---:|---:|---:|
| MuJoCo | 29.766 → 25.778 (-13.4%) | 7.031 → 7.077 (+0.6%) | 70,297 → 73,628 (+4.7%) |
| Motrix | 38.648 → 35.782 (-7.4%) | 12.942 → 13.837 (+6.9%) | 65,423 → 66,543 (+1.7%) |
| MJWarp | 28.704 → 25.323 (-11.8%) | 14.916 → 14.971 (+0.4%) | 122,524 → 130,895 (+6.8%) |

reset_done is not modified by this child. MuJoCo/MJWarp are flat; the Motrix delta tracks reset-count/backend run variance and is reported without claiming a reset improvement.

## Impact

- Backend impact: mujoco / motrix / mjwarp
- Platform impact: Linux CPU hot path; Numba thread env overrides are respected
- Training effect expected: same reward/termination semantics with lower update_state CPU cost
- Configuration and runner/lifecycle behavior: unchanged

## Artifacts

- benchmark result: local gitignored JSON/CSV, 18 runs total
- W&B/video/ONNX/checkpoint: not applicable

## Checklist

- [x] Added numerical parity, subset, output reuse, input immutability, and compilation tests
- [x] Linked the driving issue
- [x] Follow-up body-state copy work is isolated in #1307
