### PR TITLE
perf(body-state): fuse selected body cache copies (#1307)

### DIFF
--- a/src/unilab/base/backend/body_state.py
+++ b/src/unilab/base/backend/body_state.py
@@ -1,0 +1,40 @@
+"""Shared host-copy kernel for backend-owned body-state caches."""
+
+from __future__ import annotations
+
+import numpy as np
+from numba import njit, prange
+
+
+@njit(cache=True, nogil=True, parallel=True)
+def copy_selected_body_state(
+    source_pos: np.ndarray,
+    source_quat: np.ndarray,
+    source_lin_vel: np.ndarray,
+    source_ang_vel: np.ndarray,
+    selected_ids: np.ndarray,
+    out_pos: np.ndarray,
+    out_quat: np.ndarray,
+    out_lin_vel: np.ndarray,
+    out_ang_vel: np.ndarray,
+) -> None:
+    """Copy selected cache columns into four caller-owned state buffers."""
+    for env_idx in prange(source_pos.shape[0]):
+        for output_idx in range(selected_ids.shape[0]):
+            source_idx = selected_ids[output_idx]
+            out_pos[env_idx, output_idx, 0] = source_pos[env_idx, source_idx, 0]
+            out_pos[env_idx, output_idx, 1] = source_pos[env_idx, source_idx, 1]
+            out_pos[env_idx, output_idx, 2] = source_pos[env_idx, source_idx, 2]
+            out_quat[env_idx, output_idx, 0] = source_quat[env_idx, source_idx, 0]
+            out_quat[env_idx, output_idx, 1] = source_quat[env_idx, source_idx, 1]
+            out_quat[env_idx, output_idx, 2] = source_quat[env_idx, source_idx, 2]
+            out_quat[env_idx, output_idx, 3] = source_quat[env_idx, source_idx, 3]
+            out_lin_vel[env_idx, output_idx, 0] = source_lin_vel[env_idx, source_idx, 0]
+            out_lin_vel[env_idx, output_idx, 1] = source_lin_vel[env_idx, source_idx, 1]
+            out_lin_vel[env_idx, output_idx, 2] = source_lin_vel[env_idx, source_idx, 2]
+            out_ang_vel[env_idx, output_idx, 0] = source_ang_vel[env_idx, source_idx, 0]
+            out_ang_vel[env_idx, output_idx, 1] = source_ang_vel[env_idx, source_idx, 1]
+            out_ang_vel[env_idx, output_idx, 2] = source_ang_vel[env_idx, source_idx, 2]
+
+
+__all__ = ["copy_selected_body_state"]

--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -34,6 +34,7 @@ from unilab.dr.types import (
 )
 from unilab.utils.rotation import np_quat_apply_inverse_batched
 
+from ..body_state import copy_selected_body_state
 from .dependencies import load_mjwarp_dependencies
 from .materialization import materialize_mjwarp_scene
 from .playback import run_mjwarp_playback, validate_mjwarp_visual_model
@@ -1196,6 +1197,28 @@ class MjwarpBackend(SimBackend):
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         mapped = self._mapped_tracked_ids("world-frame body angular velocities", body_ids)
         return self._tracked_angvel_w_all[:, mapped, :]
+
+    def copy_body_state_w(
+        self,
+        body_ids: np.ndarray,
+        out_pos: np.ndarray,
+        out_quat: np.ndarray,
+        out_lin_vel: np.ndarray,
+        out_ang_vel: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        mapped = self._mapped_tracked_ids("world-frame body state", body_ids)
+        copy_selected_body_state(
+            self._tracked_pos_w_all,
+            self._tracked_quat_w_all,
+            self._tracked_linvel_w_all,
+            self._tracked_angvel_w_all,
+            mapped,
+            out_pos,
+            out_quat,
+            out_lin_vel,
+            out_ang_vel,
+        )
+        return out_pos, out_quat, out_lin_vel, out_ang_vel
 
     def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
         del body_ids

--- a/src/unilab/base/backend/motrix/backend.py
+++ b/src/unilab/base/backend/motrix/backend.py
@@ -53,6 +53,7 @@ from ..motrix_camera import (
     resolve_system_camera_view,
     tracking_camera_lookat,
 )
+from .body_state import copy_selected_motrix_body_state
 from .playback import run_motrix_playback
 
 logger = logging.getLogger(__name__)
@@ -328,7 +329,6 @@ class MotrixBackend(SimBackend):
         self._render_offsets_np: np.ndarray | None = None
         self._render_tracking_camera: MotrixTrackingCamera | None = None
         self.backend_type = "motrix"
-        self._link_velocity_cache: np.ndarray | None = None
 
         # Pre-cache link objects to avoid repeated get_link() lookups.
         self._link_cache: dict[int, "mtx.Link"] = {}
@@ -1135,31 +1135,15 @@ class MotrixBackend(SimBackend):
         out_ang_vel: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         ids = self._as_body_ids(body_ids)
-        poses_w = self._get_link_poses_w(ids)
-        out_pos[..., 0] = poses_w[..., 0]
-        out_pos[..., 1] = poses_w[..., 1]
-        out_pos[..., 2] = poses_w[..., 2]
-        out_quat[..., 0] = poses_w[..., 6]
-        out_quat[..., 1] = poses_w[..., 3]
-        out_quat[..., 2] = poses_w[..., 4]
-        out_quat[..., 3] = poses_w[..., 5]
-
-        link_velocity_cache = self._ensure_link_velocity_cache()
-        if self._link_velocity_cache is None or self._link_velocity_cache.shape != (
-            self._num_envs,
-            len(ids),
-            6,
-        ):
-            self._link_velocity_cache = np.empty(
-                (self._num_envs, len(ids), 6), dtype=self._np_dtype
-            )
-        np.take(link_velocity_cache, ids, axis=1, out=self._link_velocity_cache)
-        out_lin_vel[..., 0] = self._link_velocity_cache[..., 0]
-        out_lin_vel[..., 1] = self._link_velocity_cache[..., 1]
-        out_lin_vel[..., 2] = self._link_velocity_cache[..., 2]
-        out_ang_vel[..., 0] = self._link_velocity_cache[..., 3]
-        out_ang_vel[..., 1] = self._link_velocity_cache[..., 4]
-        out_ang_vel[..., 2] = self._link_velocity_cache[..., 5]
+        copy_selected_motrix_body_state(
+            self._link_poses,
+            self._ensure_link_velocity_cache(),
+            ids,
+            out_pos,
+            out_quat,
+            out_lin_vel,
+            out_ang_vel,
+        )
         return out_pos, out_quat, out_lin_vel, out_ang_vel
 
     def get_body_vel_w(self, body_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/unilab/base/backend/motrix/body_state.py
+++ b/src/unilab/base/backend/motrix/body_state.py
@@ -1,0 +1,40 @@
+"""Temporary Motrix packed-cache body-state copy kernel."""
+
+from __future__ import annotations
+
+import numpy as np
+from numba import njit, prange
+
+
+# TODO(#1305, #1308): Delete this kernel after MotrixSim exposes the native
+# selected-body fused world-state API tracked by the convergence issue.
+@njit(cache=True, nogil=True, parallel=True)
+def copy_selected_motrix_body_state(
+    link_poses: np.ndarray,
+    link_velocities: np.ndarray,
+    body_ids: np.ndarray,
+    out_pos: np.ndarray,
+    out_quat: np.ndarray,
+    out_lin_vel: np.ndarray,
+    out_ang_vel: np.ndarray,
+) -> None:
+    """Copy selected xyzw pose and packed velocity cache columns as wxyz state."""
+    for env_idx in prange(link_poses.shape[0]):
+        for output_idx in range(body_ids.shape[0]):
+            body_idx = body_ids[output_idx]
+            out_pos[env_idx, output_idx, 0] = link_poses[env_idx, body_idx, 0]
+            out_pos[env_idx, output_idx, 1] = link_poses[env_idx, body_idx, 1]
+            out_pos[env_idx, output_idx, 2] = link_poses[env_idx, body_idx, 2]
+            out_quat[env_idx, output_idx, 0] = link_poses[env_idx, body_idx, 6]
+            out_quat[env_idx, output_idx, 1] = link_poses[env_idx, body_idx, 3]
+            out_quat[env_idx, output_idx, 2] = link_poses[env_idx, body_idx, 4]
+            out_quat[env_idx, output_idx, 3] = link_poses[env_idx, body_idx, 5]
+            out_lin_vel[env_idx, output_idx, 0] = link_velocities[env_idx, body_idx, 0]
+            out_lin_vel[env_idx, output_idx, 1] = link_velocities[env_idx, body_idx, 1]
+            out_lin_vel[env_idx, output_idx, 2] = link_velocities[env_idx, body_idx, 2]
+            out_ang_vel[env_idx, output_idx, 0] = link_velocities[env_idx, body_idx, 3]
+            out_ang_vel[env_idx, output_idx, 1] = link_velocities[env_idx, body_idx, 4]
+            out_ang_vel[env_idx, output_idx, 2] = link_velocities[env_idx, body_idx, 5]
+
+
+__all__ = ["copy_selected_motrix_body_state"]

--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -43,6 +43,7 @@ from ..base import (
     SimBackend,
     normalize_play_render_mode,
 )
+from ..body_state import copy_selected_body_state
 from .playback import run_mujoco_playback
 
 
@@ -1448,10 +1449,17 @@ class MuJoCoBackend(SimBackend):
         out_ang_vel: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         mapped = self._get_mapped_indices(body_ids)
-        np.take(self._tracked_pos_w_all, mapped, axis=1, out=out_pos)
-        np.take(self._tracked_quat_w_all, mapped, axis=1, out=out_quat)
-        np.take(self._tracked_linvel_w_all, mapped, axis=1, out=out_lin_vel)
-        np.take(self._tracked_angvel_w_all, mapped, axis=1, out=out_ang_vel)
+        copy_selected_body_state(
+            self._tracked_pos_w_all,
+            self._tracked_quat_w_all,
+            self._tracked_linvel_w_all,
+            self._tracked_angvel_w_all,
+            mapped,
+            out_pos,
+            out_quat,
+            out_lin_vel,
+            out_ang_vel,
+        )
         return out_pos, out_quat, out_lin_vel, out_ang_vel
 
     # ------------------------------------------------------------------ #

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -8,9 +8,10 @@ public :class:`~unilab.base.backend.base.SimBackend` contract.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import partial
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -26,6 +27,10 @@ if TYPE_CHECKING:
 
 
 NamesCfg = tuple[str, ...] | list[str] | None
+BodyStateCopyFn = Callable[
+    [np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+]
 
 
 @dataclass(frozen=True)
@@ -1210,6 +1215,23 @@ class Entity:
                 f"for passive joints on backend '{self._backend_type}': {passive_names}"
             )
         self.data.write_ctrl(target, env_ids, actuator_ids=actuator_ids)
+
+    def bind_body_state_copy(
+        self,
+        body_ids: np.ndarray | Sequence[int] | slice | None = None,
+    ) -> BodyStateCopyFn:
+        """Bind entity-local body columns to the backend copy contract on the cold path."""
+        if self._body_ids is None:
+            raise self._capability_error(
+                "body-state copy",
+                "body_names were not declared in EntityCfg",
+            )
+        local_ids = self._normalize_local_body_ids(body_ids, capability="body-state copy")
+        if local_ids.size == 0:
+            raise ValueError(f"Entity '{self.name}' body-state copy selected no bodies")
+        backend_ids = np.array(self._body_ids[local_ids], copy=True, dtype=np.int32)
+        backend_ids.setflags(write=False)
+        return partial(self._backend.copy_body_state_w, backend_ids)
 
     def write_root_state_to_sim(
         self,

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -137,6 +137,7 @@ class MotionCommand(CommandTerm):
             )
         self._robot_body_ids = np.asarray(body_ids, dtype=np.intp)
         self._robot_body_ids.setflags(write=False)
+        self._copy_robot_body_state = self.robot.bind_body_state_copy(self._robot_body_ids)
         motion_body_ids = self.robot.motion_body_ids[self._robot_body_ids]
         self.motion = self._make_motion_loader(cfg.motion_file, motion_body_ids)
         if self.motion.num_joints != len(self.robot.joint_names):
@@ -393,24 +394,11 @@ class MotionCommand(CommandTerm):
         if not force and self._robot_cache_step == step:
             return
         if env_ids is None:
-            body_index = self._robot_body_ids
-            # Single gather straight into the destination buffers (issue #1296);
-            # the previous src[:][:, body_index] form materialized two copies.
-            np.take(self.robot.data.body_link_pos_w, body_index, axis=1, out=self._robot_body_pos_w)
-            np.take(
-                self.robot.data.body_link_quat_w, body_index, axis=1, out=self._robot_body_quat_w
-            )
-            np.take(
-                self.robot.data.body_link_lin_vel_w,
-                body_index,
-                axis=1,
-                out=self._robot_body_lin_vel_w,
-            )
-            np.take(
-                self.robot.data.body_link_ang_vel_w,
-                body_index,
-                axis=1,
-                out=self._robot_body_ang_vel_w,
+            self._copy_robot_body_state(
+                self._robot_body_pos_w,
+                self._robot_body_quat_w,
+                self._robot_body_lin_vel_w,
+                self._robot_body_ang_vel_w,
             )
         else:
             # Partial-reset path (issue #1295): gather only the reset rows from

--- a/tests/base/test_body_state_copy.py
+++ b/tests/base/test_body_state_copy.py
@@ -1,0 +1,79 @@
+"""Focused parity tests for shared and temporary body-state copy kernels."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from unilab.base.backend.body_state import copy_selected_body_state
+from unilab.base.backend.motrix.body_state import copy_selected_motrix_body_state
+
+
+def _outputs(num_envs: int, num_selected: int) -> tuple[np.ndarray, ...]:
+    shape = (num_envs, num_selected, 3)
+    return (
+        np.empty(shape, dtype=np.float32),
+        np.empty((num_envs, num_selected, 4), dtype=np.float32),
+        np.empty(shape, dtype=np.float32),
+        np.empty(shape, dtype=np.float32),
+    )
+
+
+def test_shared_body_state_copy_kernel_preserves_selection_and_outputs() -> None:
+    rng = np.random.default_rng(7)
+    num_envs, num_bodies = 257, 9
+    pos = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    quat = rng.standard_normal((num_envs, num_bodies, 4), dtype=np.float32)
+    lin_vel = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    ang_vel = rng.standard_normal((num_envs, num_bodies, 3), dtype=np.float32)
+    selected = np.asarray([7, 1, 5], dtype=np.intp)
+    out_pos, out_quat, out_lin_vel, out_ang_vel = _outputs(num_envs, len(selected))
+
+    copy_selected_body_state(
+        pos,
+        quat,
+        lin_vel,
+        ang_vel,
+        selected,
+        out_pos,
+        out_quat,
+        out_lin_vel,
+        out_ang_vel,
+    )
+
+    np.testing.assert_array_equal(out_pos, pos[:, selected])
+    np.testing.assert_array_equal(out_quat, quat[:, selected])
+    np.testing.assert_array_equal(out_lin_vel, lin_vel[:, selected])
+    np.testing.assert_array_equal(out_ang_vel, ang_vel[:, selected])
+    assert copy_selected_body_state.targetoptions["nopython"] is True
+    assert copy_selected_body_state.targetoptions["nogil"] is True
+    assert copy_selected_body_state.targetoptions["parallel"] is True
+    assert copy_selected_body_state.signatures
+
+
+def test_temporary_motrix_copy_kernel_converts_xyzw_and_packed_velocity() -> None:
+    rng = np.random.default_rng(11)
+    num_envs, num_bodies = 257, 9
+    poses = rng.standard_normal((num_envs, num_bodies, 7), dtype=np.float32)
+    velocities = rng.standard_normal((num_envs, num_bodies, 6), dtype=np.float32)
+    selected = np.asarray([8, 2, 4], dtype=np.int32)
+    out_pos, out_quat, out_lin_vel, out_ang_vel = _outputs(num_envs, len(selected))
+
+    copy_selected_motrix_body_state(
+        poses,
+        velocities,
+        selected,
+        out_pos,
+        out_quat,
+        out_lin_vel,
+        out_ang_vel,
+    )
+
+    np.testing.assert_array_equal(out_pos, poses[:, selected, :3])
+    np.testing.assert_array_equal(out_quat[..., 0], poses[:, selected, 6])
+    np.testing.assert_array_equal(out_quat[..., 1:], poses[:, selected, 3:6])
+    np.testing.assert_array_equal(out_lin_vel, velocities[:, selected, :3])
+    np.testing.assert_array_equal(out_ang_vel, velocities[:, selected, 3:])
+    assert copy_selected_motrix_body_state.targetoptions["nopython"] is True
+    assert copy_selected_motrix_body_state.targetoptions["nogil"] is True
+    assert copy_selected_motrix_body_state.targetoptions["parallel"] is True
+    assert copy_selected_motrix_body_state.signatures

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -157,6 +157,21 @@ class _StrictBackendProfile:
         self._check("body angular velocity state")
         return self.body_ang_vel[:, ids]
 
+    def copy_body_state_w(
+        self,
+        ids: np.ndarray,
+        out_pos: np.ndarray,
+        out_quat: np.ndarray,
+        out_lin_vel: np.ndarray,
+        out_ang_vel: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        self._check("body state copy")
+        np.take(self.body_pos, ids, axis=1, out=out_pos)
+        np.take(self.body_quat, ids, axis=1, out=out_quat)
+        np.take(self.body_lin_vel, ids, axis=1, out=out_lin_vel)
+        np.take(self.body_ang_vel, ids, axis=1, out=out_ang_vel)
+        return out_pos, out_quat, out_lin_vel, out_ang_vel
+
     def get_body_lin_vel_b(self, ids: np.ndarray) -> np.ndarray:
         self._check("body-frame linear velocity state")
         return self.body_lin_vel_b[:, ids]
@@ -214,6 +229,50 @@ def test_backend_profiles_materialize_identical_local_entity_contract(backend_ty
         robot.data.actuator_ctrl_range,
         np.arange(10, dtype=np.float32).reshape(5, 2)[[4, 2]],
     )
+
+
+def test_body_state_copy_binding_freezes_local_to_backend_mapping() -> None:
+    backend, scene = _scene()
+    robot = scene["robot"]
+    copy_body_state = robot.bind_body_state_copy(np.asarray([1, 0], dtype=np.int32))
+    before = backend.calls.copy()
+    out_pos = np.empty((backend.num_envs, 2, 3), dtype=np.float32)
+    out_quat = np.empty((backend.num_envs, 2, 4), dtype=np.float32)
+    out_lin_vel = np.empty_like(out_pos)
+    out_ang_vel = np.empty_like(out_pos)
+
+    result = copy_body_state(out_pos, out_quat, out_lin_vel, out_ang_vel)
+
+    assert result == (out_pos, out_quat, out_lin_vel, out_ang_vel)
+    np.testing.assert_array_equal(out_pos, backend.body_pos[:, [4, 7]])
+    np.testing.assert_array_equal(out_quat, backend.body_quat[:, [4, 7]])
+    np.testing.assert_array_equal(out_lin_vel, backend.body_lin_vel[:, [4, 7]])
+    np.testing.assert_array_equal(out_ang_vel, backend.body_ang_vel[:, [4, 7]])
+    assert backend.calls["body state copy"] == before["body state copy"] + 1
+    for capability in (
+        "body position state",
+        "body quaternion state",
+        "body linear velocity state",
+        "body angular velocity state",
+    ):
+        assert backend.calls[capability] == before[capability]
+
+
+@pytest.mark.parametrize(
+    ("body_ids", "error_type", "message"),
+    [
+        (np.asarray([], dtype=np.int32), ValueError, "selected no bodies"),
+        ([2], IndexError, "out of range"),
+        ([0, 0], ValueError, "contain duplicates"),
+        ([True], TypeError, "1-D integer array"),
+    ],
+)
+def test_body_state_copy_binding_rejects_invalid_local_ids(
+    body_ids: Any, error_type: type[Exception], message: str
+) -> None:
+    _, scene = _scene()
+    with pytest.raises(error_type, match=message):
+        scene["robot"].bind_body_state_copy(body_ids)
 
 
 def test_state_read_cache_is_scoped_shared_and_explicitly_invalidated() -> None:

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -304,6 +304,12 @@ def test_body_state_matches_mujoco_backend() -> None:
         mujoco_backend.get_body_ang_vel_w(body_ids),
         atol=atol,
     )
+    expected_state = mjwarp_backend.get_body_state_w(body_ids)
+    outputs = tuple(np.empty_like(value) for value in expected_state)
+    result = mjwarp_backend.copy_body_state_w(body_ids, *outputs)
+    assert result == outputs
+    for actual, expected in zip(outputs, expected_state, strict=True):
+        np.testing.assert_allclose(actual, expected, atol=atol)
     np.testing.assert_allclose(
         mjwarp_backend.get_body_lin_vel_b(body_ids),
         mujoco_backend.get_body_lin_vel_b(body_ids),


### PR DESCRIPTION
## Summary

- 在冷路径通过 `Entity.bind_body_state_copy()` 固化 local → backend body IDs。
- 让 `MotionCommand` 的 full refresh 直接消费正式 `SimBackend.copy_body_state_w()` contract；partial-reset row getters 保持不变。
- MuJoCo 与 MJWarp 共用永久的 fused Numba host-copy kernel。
- Motrix 暂时使用 packed-cache kernel，并以 `TODO(#1305, #1308)` 明确约束删除时点；它不是长期 support contract。

Closes #1307
Part of #1304
Blocked follow-up: #1308 waits for #1305

## Scope

- 10 files
- 298 additions / 49 deletions
- 未改变 reward、body subset、reset、runner/lifecycle 或配置语义。

## Validation

- `make test-all`
  - 2301 passed
  - 27 skipped
  - 281 deselected
  - 1 xfailed
- MJWarp 真实 CUDA parity：1 passed
- 按 maintainer 对 roadmap #1304 的明确授权，仅执行本地 `make test-all`，跳过远程 CI。

## Performance

统一参数：8192 envs，warmup 10 / measure 100，各 3 次取中位数。相对 Child 1：

| Backend | update_state | reset_done | env/s |
|---|---:|---:|---:|
| MuJoCo | 25.778 → 19.732 ms（-23.5%） | 7.077 → 7.001 ms | 73,628 → 76,884（+4.4%） |
| Motrix | 35.782 → 27.773 ms（-22.4%） | 13.837 → 13.166 ms | 66,543 → 72,965（+9.7%） |
| MJWarp | 25.323 → 18.283 ms（-27.8%） | 14.971 → 14.628 ms | 130,895 → 154,075（+17.7%） |

固定输入 probe：

- 旧双 gather：7.210 ms
- 四次 direct copy：0.732 ms
- fused Numba：0.100 ms

相对 roadmap 初始基线，当前 update_state：

- MuJoCo：29.766 → 19.732 ms（-33.7%）
- Motrix：38.648 → 27.773 ms（-28.2%）
- MJWarp：28.704 → 18.283 ms（-36.3%）
