### PR TITLE
perf(env): confine DP collector host compute to the per-rank CPU block

### DIFF
--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/3-sac.md
@@ -76,7 +76,9 @@ rank 子目录或任何日志文件。
 `training.log_dir` 保持原样。
 
 collector 的 CPU 亲和按 rank 自动均分（`cpu_count // world_size` 一段），可用
-`training.dp_collector_cpu_ids` 显式指定。
+`training.dp_collector_cpu_ids` 显式指定。该核区经 `EnvCfg.cpu_ids` 生效：除
+MuJoCo worker 线程逐核绑定外，collector 进程本身（含 Numba 并行 kernel 线程池，池
+大小取核区长度）也被限制在同一核区内，避免跨 rank 抢占。
 
 当前限制：
 

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -40,9 +40,12 @@ class EnvCfg:
     post_step_forward_sensor: bool = False
     adaptive_chunk_size: bool = True
     chunk_size: Optional[int] = None
-    # Explicit worker CPU affinity for the MuJoCo BatchEnvPool (Linux only).
-    # ``cpu_ids[i]`` pins pool worker thread ``i`` to one CPU; ``None`` keeps
-    # the default OS scheduling behavior.
+    # Explicit CPU block owned by this env's process (Linux affinity only).
+    # ``cpu_ids[i]`` pins MuJoCo BatchEnvPool worker thread ``i`` to one CPU;
+    # env construction also confines the owning process to the same block and
+    # sizes Numba's parallel pool to ``len(cpu_ids)`` so host-side post-step
+    # compute stays inside the rank's partition. ``None`` keeps the default
+    # OS scheduling behavior.
     cpu_ids: Optional[list[int]] = None
     # ``mjwarp`` owns contact/constraint storage independently from MuJoCo.
     # Keep its capacity knobs explicit in the task owner configuration so a

--- a/src/unilab/base/cpu_runtime.py
+++ b/src/unilab/base/cpu_runtime.py
@@ -1,0 +1,98 @@
+"""Process-local CPU confinement for envs that own an explicit CPU block.
+
+Multi-rank off-policy data-parallel runs partition host CPUs so each rank's
+collector owns one contiguous block (``training.dp_collector_cpu_ids``, routed
+into ``EnvCfg.cpu_ids``). The MuJoCo BatchEnvPool already pins its physics
+workers to that block, but the collector's host-side compute did not follow:
+Numba parallel kernels (``unilab.base.backend.body_state`` and the
+motion-tracking kernels) size their pool from the host CPU count and leave
+placement to the OS, so they drift across rank boundaries and compete with
+sibling ranks' pinned physics workers.
+
+``apply_env_cpu_runtime`` is the generic env-level counterpart, applied once on
+the env-construction cold path — before managers, backend materialization, or
+the first Numba parallel call exist:
+
+- ``os.sched_setaffinity`` pins the calling thread to the block, and every
+  already-running thread (e.g. BLAS pools spawned at ``import numpy``) is
+  pinned individually via ``/proc/self/task``; threads spawned later
+  (including Numba's lazily-launched pool) inherit the mask.
+- ``numba.set_num_threads(len(cpu_ids))`` sizes Numba's pool to the block
+  instead of the host, unless the operator pinned ``NUMBA_NUM_THREADS``
+  (mirroring the motion-kernel runtime policy).
+
+The function is backend-agnostic: ``EnvCfg.cpu_ids`` is the single source of
+truth, so any backend whose env declares a block gets the same confinement.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from collections.abc import Sequence
+
+_PROC_TASK_DIR = "/proc/self/task"
+
+
+def _confine_existing_threads(ids: set[int]) -> None:
+    """Pin already-running threads; later threads inherit the caller's mask.
+
+    Native pools spawned before env construction (OpenBLAS spawns its workers
+    at ``import numpy``) would otherwise keep the host-wide mask and compete
+    with sibling ranks' pinned CPUs. Threads may exit between listing and
+    pinning; those races are ignored.
+    """
+    if not os.path.isdir(_PROC_TASK_DIR):
+        return
+    for entry in os.listdir(_PROC_TASK_DIR):
+        try:
+            os.sched_setaffinity(int(entry), ids)
+        except OSError:
+            continue
+
+
+def apply_env_cpu_runtime(cpu_ids: Sequence[int] | None) -> None:
+    """Confine this process's host-side compute to the env-owned CPU block.
+
+    Cold path only: call from env construction, before the backend pool,
+    managers, or any Numba parallel kernel exist. ``None`` (the single-rank
+    default) is a no-op so the default path stays bit-identical.
+
+    Structural validation (non-empty, unique, non-negative ints) is owned by
+    ``EnvCfg.validate``; this function fails closed on CPU ids that are not
+    available to the process.
+    """
+    if cpu_ids is None:
+        return
+    ids = {int(cpu_id) for cpu_id in cpu_ids}
+
+    if hasattr(os, "sched_setaffinity") and hasattr(os, "sched_getaffinity"):
+        available = set(os.sched_getaffinity(0))
+        missing = sorted(ids - available)
+        if missing:
+            raise ValueError(
+                f"EnvCfg.cpu_ids entries {missing} are not available to this process "
+                f"(sched_getaffinity={sorted(available)})"
+            )
+        os.sched_setaffinity(0, ids)
+        _confine_existing_threads(ids)
+    else:
+        warnings.warn(
+            "EnvCfg.cpu_ids process confinement requires os.sched_setaffinity "
+            "(Linux); only the Numba thread cap is applied",
+            stacklevel=2,
+        )
+
+    if "NUMBA_NUM_THREADS" in os.environ:
+        return
+    from numba import set_num_threads
+
+    try:
+        set_num_threads(len(ids))
+    except ValueError as exc:
+        # len(ids) <= NUMBA_NUM_THREADS holds whenever the pool default came
+        # from this host's CPU count; warn instead of failing env construction.
+        warnings.warn(
+            f"EnvCfg.cpu_ids Numba thread cap to {len(ids)} rejected: {exc}",
+            stacklevel=2,
+        )

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -14,6 +14,7 @@ import numpy as np
 from unilab.base.backend import SimBackend
 from unilab.base.backend.base import BackendPlayRenderPlan
 from unilab.base.base import ABEnv, EnvCfg, EnvPlayCapabilities
+from unilab.base.cpu_runtime import apply_env_cpu_runtime
 from unilab.base.scene import SceneCfg
 from unilab.dr import DomainRandomizationManager, DomainRandomizationProvider
 from unilab.dtype_config import get_global_dtype
@@ -111,6 +112,12 @@ class NpEnv(ABEnv):
     """Backend-agnostic numpy environment base class."""
 
     def __init__(self, cfg: EnvCfg, backend: SimBackend, num_envs: int):
+        # Cold-path process confinement for envs that own an explicit CPU
+        # block (multi-rank DP collectors): keeps host-side NumPy/Numba compute
+        # inside the same CPUs the backend pool workers are pinned to. Runs
+        # before managers/materialization so Numba's lazily-launched pool
+        # inherits the confined mask.
+        apply_env_cpu_runtime(cfg.cpu_ids)
         self._cfg = cfg
         self._backend: SimBackend = backend
         self._num_envs = num_envs

--- a/tests/base/test_cpu_runtime.py
+++ b/tests/base/test_cpu_runtime.py
@@ -1,0 +1,282 @@
+"""Tests for env-owned CPU block process confinement (``apply_env_cpu_runtime``).
+
+Multi-rank off-policy collectors pin their MuJoCo pool workers to a per-rank
+CPU block via ``EnvCfg.cpu_ids``; ``NpEnv.__init__`` additionally confines the
+owning process to the same block and sizes Numba's parallel pool to it, so
+host-side kernels cannot drift onto sibling ranks' CPUs. Unit tests mock the
+OS/Numba seams; one subprocess test validates the real placement contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import gymnasium as gym
+import numba
+import numpy as np
+import pytest
+
+import unilab.base.cpu_runtime as cpu_runtime
+from unilab.base.base import EnvCfg
+from unilab.base.cpu_runtime import apply_env_cpu_runtime
+from unilab.base.np_env import NpEnv, NpEnvState
+
+
+def _record_affinity(monkeypatch: pytest.MonkeyPatch, available: set[int]) -> list[tuple]:
+    calls: list[tuple] = []
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(available))
+    monkeypatch.setattr(os, "sched_setaffinity", lambda pid, ids: calls.append((pid, set(ids))))
+    return calls
+
+
+def _record_numba(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    calls: list[int] = []
+    monkeypatch.setattr(numba, "set_num_threads", lambda n: calls.append(int(n)))
+    return calls
+
+
+def _record_confine(monkeypatch: pytest.MonkeyPatch) -> list[set[int]]:
+    calls: list[set[int]] = []
+    monkeypatch.setattr(
+        cpu_runtime, "_confine_existing_threads", lambda ids: calls.append(set(ids))
+    )
+    return calls
+
+
+def test_none_is_noop(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NUMBA_NUM_THREADS", raising=False)
+    affinity_calls = _record_affinity(monkeypatch, {0, 1, 2, 3})
+    confine_calls = _record_confine(monkeypatch)
+    numba_calls = _record_numba(monkeypatch)
+
+    apply_env_cpu_runtime(None)
+
+    assert affinity_calls == []
+    assert confine_calls == []
+    assert numba_calls == []
+
+
+def test_applies_affinity_and_numba_cap(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NUMBA_NUM_THREADS", raising=False)
+    affinity_calls = _record_affinity(monkeypatch, {0, 1, 2, 3})
+    confine_calls = _record_confine(monkeypatch)
+    numba_calls = _record_numba(monkeypatch)
+
+    apply_env_cpu_runtime([1, 2])
+
+    assert affinity_calls == [(0, {1, 2})]
+    assert confine_calls == [{1, 2}]
+    assert numba_calls == [2]
+
+
+def test_respects_explicit_numba_num_threads(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("NUMBA_NUM_THREADS", "4")
+    affinity_calls = _record_affinity(monkeypatch, {0, 1, 2, 3})
+    confine_calls = _record_confine(monkeypatch)
+    numba_calls = _record_numba(monkeypatch)
+
+    apply_env_cpu_runtime([1, 2])
+
+    assert affinity_calls == [(0, {1, 2})]
+    assert confine_calls == [{1, 2}]
+    assert numba_calls == []
+
+
+def test_unavailable_cpu_ids_fail_closed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NUMBA_NUM_THREADS", raising=False)
+    affinity_calls = _record_affinity(monkeypatch, {0, 1})
+    confine_calls = _record_confine(monkeypatch)
+    numba_calls = _record_numba(monkeypatch)
+
+    with pytest.raises(ValueError, match="not available"):
+        apply_env_cpu_runtime([1, 2])
+
+    assert affinity_calls == []
+    assert confine_calls == []
+    assert numba_calls == []
+
+
+def test_platform_without_affinity_warns_and_caps_numba(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("NUMBA_NUM_THREADS", raising=False)
+    monkeypatch.delattr(os, "sched_setaffinity")
+    monkeypatch.delattr(os, "sched_getaffinity")
+    confine_calls = _record_confine(monkeypatch)
+    numba_calls = _record_numba(monkeypatch)
+
+    with pytest.warns(UserWarning, match="sched_setaffinity"):
+        apply_env_cpu_runtime([0, 1])
+
+    assert confine_calls == []
+    assert numba_calls == [2]
+
+
+def test_confine_existing_threads_pins_tasks_and_skips_failures(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[tuple] = []
+
+    def fake_setaffinity(pid, ids):
+        if pid == 456:
+            raise ProcessLookupError
+        calls.append((pid, set(ids)))
+
+    monkeypatch.setattr(os, "sched_setaffinity", fake_setaffinity)
+    monkeypatch.setattr(os.path, "isdir", lambda path: path == cpu_runtime._PROC_TASK_DIR)
+    monkeypatch.setattr(os, "listdir", lambda path: ["123", "456", "789"])
+
+    cpu_runtime._confine_existing_threads({1, 2})
+
+    assert calls == [(123, {1, 2}), (789, {1, 2})]
+
+
+def test_confine_existing_threads_without_proc_is_noop(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(os, "sched_setaffinity", lambda pid, ids: calls.append((pid, set(ids))))
+    monkeypatch.setattr(os.path, "isdir", lambda path: False)
+
+    cpu_runtime._confine_existing_threads({0})
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# NpEnv wiring
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubCfg(EnvCfg):
+    max_episode_seconds: float | None = 1.0
+
+
+class _StubNpEnv(NpEnv):
+    def __init__(self, cfg: EnvCfg):
+        backend = MagicMock()
+        backend.get_scene_model_file.return_value = None
+        super().__init__(cfg, backend, 1)
+
+    @property
+    def obs_groups_spec(self) -> dict[str, int]:
+        return {"obs": 1}
+
+    @property
+    def action_space(self) -> gym.Space:
+        return gym.spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+
+    def apply_action(self, actions: np.ndarray, state: NpEnvState) -> np.ndarray:
+        return actions
+
+    def update_state(self, state: NpEnvState) -> NpEnvState:
+        return state
+
+
+@pytest.mark.parametrize("cpu_ids", (None, [2, 3]))
+def test_np_env_init_applies_env_cpu_runtime(monkeypatch: pytest.MonkeyPatch, cpu_ids):
+    import unilab.base.np_env as np_env_module
+
+    calls: list[list[int] | None] = []
+    monkeypatch.setattr(
+        np_env_module,
+        "apply_env_cpu_runtime",
+        lambda value: calls.append(None if value is None else list(value)),
+    )
+
+    _StubNpEnv(EnvCfg(cpu_ids=cpu_ids))
+
+    assert calls == [cpu_ids]
+
+
+# ---------------------------------------------------------------------------
+# Real placement contract in a fresh process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (hasattr(os, "sched_setaffinity") and os.path.isdir("/proc/self/task")),
+    reason="requires Linux sched affinity and /proc",
+)
+def test_numba_threads_inherit_confined_block_in_fresh_process():
+    script = r"""
+import json
+import os
+
+# Production collectors import numpy/numba (through the backend modules)
+# before env construction, so mirror that ordering here: the OpenBLAS pool
+# spawned at `import numpy` predates the env hook and must be confined
+# retroactively, while Numba's pool launches after it and inherits the mask.
+import numba  # noqa: F401
+import numpy as np
+
+from unilab.base.cpu_runtime import apply_env_cpu_runtime
+
+block = sorted(os.sched_getaffinity(0))[:2]
+apply_env_cpu_runtime(block)
+
+from numba import get_num_threads, njit, prange
+
+
+@njit(parallel=True)
+def _probe(out):
+    for i in prange(out.shape[0]):
+        out[i] = i * 2.0
+
+
+_probe(np.zeros(256))
+
+
+def _expand(mask):
+    cpus = set()
+    for part in mask.split(","):
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            cpus.update(range(int(lo), int(hi) + 1))
+        elif part:
+            cpus.add(int(part))
+    return sorted(cpus)
+
+
+masks = []
+for tid in os.listdir("/proc/self/task"):
+    with open(f"/proc/self/task/{tid}/status") as fh:
+        for line in fh:
+            if line.startswith("Cpus_allowed_list"):
+                masks.append(_expand(line.split(":", 1)[1].strip()))
+
+print(
+    "RESULT:"
+    + json.dumps(
+        {
+            "block": block,
+            "affinity": sorted(os.sched_getaffinity(0)),
+            "numba_threads": get_num_threads(),
+            "masks": masks,
+        }
+    )
+)
+"""
+    env = dict(os.environ)
+    env.pop("NUMBA_NUM_THREADS", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result_lines = [line for line in proc.stdout.splitlines() if line.startswith("RESULT:")]
+    assert len(result_lines) == 1, proc.stdout
+    payload = json.loads(result_lines[0].removeprefix("RESULT:"))
+    assert payload["affinity"] == payload["block"]
+    assert payload["numba_threads"] == len(payload["block"])
+    # Every thread in the process must stay inside the block: the main thread,
+    # the OpenBLAS pool spawned at import (confined retroactively), and Numba's
+    # pool (inherits the confined mask at its lazy launch).
+    assert payload["masks"]
+    for mask in payload["masks"]:
+        assert set(mask) <= set(payload["block"])


### PR DESCRIPTION
## 问题

多 rank off-policy DP 下，每个 rank 的 collector 通过 `EnvCfg.cpu_ids` 把 MuJoCo BatchEnvPool 的物理 worker 逐核绑定到本 rank 的 CPU 核区（#959/#966），但 collector 进程内的 host 侧计算没有跟随：

- Numba 并行 kernel（`base/backend/body_state.py`、motion-tracking `kernels.py`）的线程池按宿主 CPU 总数建池、位置交给 OS 调度，会漂移到其他 rank 的核区，与相邻 rank 已绑定的物理 worker 互相抢占。
- `import numpy` 时 OpenBLAS 就建好的线程池（早于 env 构造）同样保留全机 mask。

## 方案

通用 env 层修改，不依赖具体后端：`EnvCfg.cpu_ids` 是唯一事实来源，`NpEnv.__init__` 冷路径首先调用新的 `apply_env_cpu_runtime(cfg.cpu_ids)`（`src/unilab/base/cpu_runtime.py`），在 managers 加载、backend materialize、首个 Numba 并行 kernel 之前完成：

1. `os.sched_setaffinity(0, ids)` 绑定调用线程，之后创建的线程（含 Numba 惰性启动的线程池）继承受限 mask；
2. 通过 `/proc/self/task` 逐线程绑定**已存在**的线程（覆盖 import 期创建的 OpenBLAS 池），单线程退出竞态按 OSError 跳过；
3. 未显式设置 `NUMBA_NUM_THREADS` 时 `numba.set_num_threads(len(cpu_ids))`，把 Numba 池规模从宿主核数收敛到核区长度（与 motion kernel runtime 的既有策略一致）；
4. CPU id 不在 `sched_getaffinity` 内时 fail-closed 抛 `ValueError`（先于 backend pool 创建失败）；无 `sched_setaffinity` 的平台告警降级为只限制 Numba 线程数。

`cpu_ids=None`（单 rank 默认）完全 no-op，单卡路径 bit-identical。motrix 后端目前不消费 `cpu_ids`；一旦其接入该字段（#962），env 层 confinement 自动生效，无需本 PR 之外的改动。

## 改动

- `src/unilab/base/cpu_runtime.py`（新增）：`apply_env_cpu_runtime` + `_confine_existing_threads`。
- `src/unilab/base/np_env.py`：`NpEnv.__init__` 冷路径接入。
- `src/unilab/base/base.py`：`EnvCfg.cpu_ids` 注释更新为扩展后的语义。
- `tests/base/test_cpu_runtime.py`（新增）：mock 单测覆盖 no-op/生效/NUMBA_NUM_THREADS 优先/不可用 CPU fail-closed/无 affinity 平台降级/逐线程绑定跳过失败项/NpEnv 接线；另有一个 Linux 子进程实测，断言主线程、import 期 OpenBLAS 池与 Numba 池全部落在核区内且 `get_num_threads()==len(block)`。
- `docs/sphinx/.../zh_CN/2-user_guide/2-algorithms/3-sac.md`：补充核区对 collector 进程与 Numba 池的约束说明（en 页未记载该字段，不做强制镜像）。

## Validation

- `make test-all` 通过（ruff format/check、mypy、pyright、pytest -m "not slow" --cov、benchmark smoke 33/34 + 34/35，唯一 skip 为平台可选 mlx）。
- `tests/base/test_cpu_runtime.py` 10 项全过，含真实子进程 placement 验证。

## 说明

- **Base 分支为 `dev/issue-1304-motion-numba-body-state`**（栈式）：本 PR 修复的 Numba kernel 只存在于该分支链，尚未进 main。
- 按 maintainer 要求**不等待远程 CI**，请人工审核并手动合并。