### PR TITLE
perf(mjwarp): reduce g1 motion tracking reset latency

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -40,8 +40,33 @@ from .materialization import materialize_mjwarp_scene
 from .playback import run_mjwarp_playback, validate_mjwarp_visual_model
 
 _GRAPH_CAPTURE_MIN_DRIVER = (12, 4)
-_RESET_SCRATCH_CAPACITY = 128
-_RESET_SCRATCH_MIN_BATCH_SIZE = 8 * _RESET_SCRATCH_CAPACITY
+# Reset scratch storage is deliberately bounded.  The original 128-world
+# allocation covers the smaller G1 owners, while the 8192-world motion
+# tracking owner routinely resets about 250 rows per vector step.  Scale the
+# cold-path allocation with the world count and cap it at 512 so that this
+# workload stays on the sparse route without making an unbounded per-task
+# allocation.  Keeping the minimum at 128 preserves the #1288 route for the
+# 1024/2048-world owners.
+_RESET_SCRATCH_CAPACITY = 512
+_RESET_SCRATCH_MIN_CAPACITY = 128
+_RESET_SCRATCH_MIN_BATCH_SIZE = 8 * _RESET_SCRATCH_MIN_CAPACITY
+_RESET_SCRATCH_WORLD_FRACTION = 16
+
+
+def _reset_scratch_capacity_for_batch(num_envs: int) -> int:
+    """Choose a bounded, power-of-two scratch capacity on the cold path.
+
+    A fixed shape is required by the captured reset graphs.  The capacity is
+    rounded down to a power of two so graph/data shapes stay predictable, and
+    is never allowed below the proven 128-world route or above the 512-world
+    memory bound.  Small batches retain the eager/full-forward fallback rather
+    than paying for a second ``mujoco_warp.Data`` instance.
+    """
+    if num_envs < _RESET_SCRATCH_MIN_BATCH_SIZE:
+        return 0
+    target = max(_RESET_SCRATCH_MIN_CAPACITY, num_envs // _RESET_SCRATCH_WORLD_FRACTION)
+    power_of_two = 1 << (target.bit_length() - 1)
+    return min(_RESET_SCRATCH_CAPACITY, power_of_two)
 
 
 @contextmanager
@@ -232,9 +257,7 @@ class MjwarpBackend(SimBackend):
         # A bounded secondary Data avoids running reset-time forward over every
         # production world when only a small row set terminated.  It is built
         # only for batches large enough to amortize the extra graph and copies.
-        self._reset_scratch_capacity = (
-            _RESET_SCRATCH_CAPACITY if self._num_envs >= _RESET_SCRATCH_MIN_BATCH_SIZE else 0
-        )
+        self._reset_scratch_capacity = _reset_scratch_capacity_for_batch(self._num_envs)
         self._reset_scratch_data: Any | None = None
         self._reset_scratch_mask_device: Any | None = None
         self._reset_scratch_qpos_staging: np.ndarray | None = None
@@ -1190,6 +1213,16 @@ class MjwarpBackend(SimBackend):
         mapped = self._mapped_tracked_ids("world-frame body orientations", body_ids)
         return self._tracked_quat_w_all[:, mapped, :]
 
+    def get_body_pose_w_rows(
+        self, env_ids: np.ndarray, body_ids: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Gather world-frame body pose for selected environments only."""
+        rows = np.asarray(env_ids, dtype=np.intp)
+        mapped = self._mapped_tracked_ids("world-frame body poses", body_ids)
+        return self._tracked_pos_w_all[rows[:, None], mapped], self._tracked_quat_w_all[
+            rows[:, None], mapped
+        ]
+
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         mapped = self._mapped_tracked_ids("world-frame body linear velocities", body_ids)
         return self._tracked_linvel_w_all[:, mapped, :]
@@ -1197,6 +1230,18 @@ class MjwarpBackend(SimBackend):
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
         mapped = self._mapped_tracked_ids("world-frame body angular velocities", body_ids)
         return self._tracked_angvel_w_all[:, mapped, :]
+
+    def get_body_lin_vel_w_rows(self, env_ids: np.ndarray, body_ids: np.ndarray) -> np.ndarray:
+        """Gather world-frame body linear velocity for selected rows."""
+        rows = np.asarray(env_ids, dtype=np.intp)
+        mapped = self._mapped_tracked_ids("world-frame body linear velocities", body_ids)
+        return self._tracked_linvel_w_all[rows[:, None], mapped]
+
+    def get_body_ang_vel_w_rows(self, env_ids: np.ndarray, body_ids: np.ndarray) -> np.ndarray:
+        """Gather world-frame body angular velocity for selected rows."""
+        rows = np.asarray(env_ids, dtype=np.intp)
+        mapped = self._mapped_tracked_ids("world-frame body angular velocities", body_ids)
+        return self._tracked_angvel_w_all[rows[:, None], mapped]
 
     def copy_body_state_w(
         self,

--- a/tests/base/test_mjwarp_backend.py
+++ b/tests/base/test_mjwarp_backend.py
@@ -305,6 +305,20 @@ def test_body_state_matches_mujoco_backend() -> None:
         atol=atol,
     )
     expected_state = mjwarp_backend.get_body_state_w(body_ids)
+    row_ids = np.asarray([1, 0], dtype=np.int32)
+    mjwarp_pose_rows = mjwarp_backend.get_body_pose_w_rows(row_ids, body_ids)
+    for actual, expected in zip(mjwarp_pose_rows, expected_state[:2], strict=True):
+        np.testing.assert_allclose(actual, expected[row_ids], atol=atol)
+    np.testing.assert_allclose(
+        mjwarp_backend.get_body_lin_vel_w_rows(row_ids, body_ids),
+        expected_state[2][row_ids],
+        atol=atol,
+    )
+    np.testing.assert_allclose(
+        mjwarp_backend.get_body_ang_vel_w_rows(row_ids, body_ids),
+        expected_state[3][row_ids],
+        atol=atol,
+    )
     outputs = tuple(np.empty_like(value) for value in expected_state)
     result = mjwarp_backend.copy_body_state_w(body_ids, *outputs)
     assert result == outputs

--- a/tests/base/test_mjwarp_cuda_graph.py
+++ b/tests/base/test_mjwarp_cuda_graph.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import pytest
 
-from unilab.base.backend.mjwarp.backend import MjwarpBackend, _cuda_graph_eligibility
+from unilab.base.backend.mjwarp.backend import (
+    MjwarpBackend,
+    _cuda_graph_eligibility,
+    _reset_scratch_capacity_for_batch,
+)
 
 
 class _FakeDevice:
@@ -172,6 +176,23 @@ def test_cuda_graph_capture_includes_materialized_reset_scratch() -> None:
     assert mujoco_warp.forward_calls == 2
     assert backend._can_use_reset_scratch(4) is True
     assert backend._can_use_reset_scratch(5) is False
+
+
+@pytest.mark.parametrize(
+    ("num_envs", "expected_capacity"),
+    [
+        (512, 0),
+        (1024, 128),
+        (2048, 128),
+        (4096, 256),
+        (8192, 512),
+        (16384, 512),
+    ],
+)
+def test_reset_scratch_capacity_scales_with_batch_and_stays_bounded(
+    num_envs: int, expected_capacity: int
+) -> None:
+    assert _reset_scratch_capacity_for_batch(num_envs) == expected_capacity
 
 
 def test_ineligible_cuda_graph_warns_and_uses_eager_operations() -> None:

--- a/tests/base/test_mjwarp_host_cache.py
+++ b/tests/base/test_mjwarp_host_cache.py
@@ -144,3 +144,38 @@ def test_host_reset_routes_small_row_sets_through_scratch() -> None:
         "scratch-refresh",
     ]
     assert not any(event[0] in {"main-forward", "main-refresh"} for event in events)
+
+
+def test_row_body_getters_gather_selected_rows_without_full_batch_reads() -> None:
+    """MJWarp's partial-reset getters must not materialize the full env batch."""
+    backend = object.__new__(MjwarpBackend)
+    backend._body_id_to_tracked_idx = np.asarray([2, 0, 1], dtype=np.intp)
+    backend._tracked_pos_w_all = np.arange(4 * 3 * 3, dtype=np.float32).reshape(4, 3, 3)
+    backend._tracked_quat_w_all = np.arange(4 * 3 * 4, dtype=np.float32).reshape(4, 3, 4)
+    backend._tracked_linvel_w_all = np.arange(4 * 3 * 3, dtype=np.float32).reshape(4, 3, 3) + 1000
+    backend._tracked_angvel_w_all = np.arange(4 * 3 * 3, dtype=np.float32).reshape(4, 3, 3) + 2000
+
+    def fail_full_getter(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("row getter must not call a full-batch getter")
+
+    backend.get_body_pos_w = fail_full_getter  # type: ignore[method-assign]
+    backend.get_body_quat_w = fail_full_getter  # type: ignore[method-assign]
+    backend.get_body_lin_vel_w = fail_full_getter  # type: ignore[method-assign]
+    backend.get_body_ang_vel_w = fail_full_getter  # type: ignore[method-assign]
+
+    rows = np.asarray([3, 1, 3], dtype=np.int32)
+    body_ids = np.asarray([1, 2], dtype=np.int32)
+    mapped = np.asarray([0, 1], dtype=np.intp)
+    expected_index = (rows[:, None], mapped)
+
+    pose_pos, pose_quat = backend.get_body_pose_w_rows(rows, body_ids)
+    np.testing.assert_array_equal(pose_pos, backend._tracked_pos_w_all[expected_index])
+    np.testing.assert_array_equal(pose_quat, backend._tracked_quat_w_all[expected_index])
+    np.testing.assert_array_equal(
+        backend.get_body_lin_vel_w_rows(rows, body_ids),
+        backend._tracked_linvel_w_all[expected_index],
+    )
+    np.testing.assert_array_equal(
+        backend.get_body_ang_vel_w_rows(rows, body_ids),
+        backend._tracked_angvel_w_all[expected_index],
+    )


### PR DESCRIPTION
## Summary

- Scale the MJWarp reset scratch allocation on the cold path (128/256/512 worlds by batch size, capped at 512) so the 8192-env motion-tracking workload stays on the bounded sparse-forward route for its usual ~250 reset rows.
- Add MJWarp selected-row world body pose/velocity getters, matching the existing `SimBackend` row contract and avoiding full-batch cache materialization during `MotionCommand` partial reset.
- Preserve the existing full-forward path for oversized resets and all eager/graph-disabled fallback behavior; MuJoCo, task config, runner, learner, and lifecycle code are unchanged.

## Linked Work

- Issue: Closes #1325
- Declared integration base: `dev/issue-1304-motion-numba-body-state`
- Implementation branch: `perf/issue-1325-mjwarp-reset`
- Base commit: `4fa6631a3c9c465db86cd671275319168ce36fe0`

## Scope and governance

- Owner layer: `src/unilab/base/backend/mjwarp/` and focused backend tests only.
- No new public contract, task/config change, runner/lifecycle path, or other backend change.
- The PR is intentionally not configured for auto-merge; maintainer review and manual merge are required.
- This PR targets the declared dev integration branch, not `main`; per the governance update in PR #1313, the local `make test-all` result is the child-PR gate.

## Validation

- [x] Focused host-cache/CUDA-graph/smoke tests
- [x] Real CUDA MJWarp slow tests and short differential tests
- [x] `make test-all`
- [x] `git diff --check`

Commands actually run:

```bash
uv run pytest -q tests/base/test_mjwarp_host_cache.py tests/base/test_mjwarp_cuda_graph.py tests/base/test_sim_backend_smoke.py
uv run --extra mjwarp pytest -q -m slow tests/base/test_mjwarp_backend.py tests/base/test_mjwarp_cuda_graph.py tests/base/test_mjwarp_host_cache.py tests/base/test_mjwarp_differential.py tests/base/test_mjwarp_capabilities.py tests/base/test_backend_conformance.py
make test-all
git diff --check
```

Results:

- Focused tests: 40 passed.
- MJWarp CUDA/differential set: 19 passed, 45 deselected.
- `make test-all`: 2316 passed, 28 skipped, 281 deselected, 1 xfailed; benchmark smoke 33/34 module-mode and 34/35 script-mode (the one skip in each is platform-optional MLX).
- Static checks inside `make test-all`: ruff, mypy (247 source files), and pyright all passed.

## Performance evidence

Same-host SAC `g1_motion_tracking`, 8192 envs, 10 warmup + 100 measured vector steps, using `benchmark_offpolicy_collector_active.py`:

| Metric | Baseline (issue investigation) | This branch |
|---|---:|---:|
| collector active throughput | 184,852 env/s | 229,587 env/s |
| env step | 42.553 ms | 33.995 ms |
| `reset_done` | 14.501 ms | 5.859 ms |
| `reset_done_reset_call` | 14.348 ms | 5.708 ms |
| reset rows / vector step | 251.59 | 251.4 |
| MJWarp `set_state` | 5.995 ms | 1.572 ms |
| MJWarp reset forward sub-item | 5.206 ms | 1.276 ms |

The final run selected a 512-world scratch data for the 8192 batch; the measured reset-row population remained below that bound. MuJoCo source behavior is unchanged; in the paired final run its `reset_done` was 6.643 ms and throughput 85,497 env/s (within run-to-run variation of the investigation baseline).

## Impact

- Backend impact: MJWarp only; MuJoCo/Motrix code paths are unchanged.
- Platform impact: Linux/CUDA MJWarp path; CPU-only and graph-disabled paths retain their existing fallback.
- Training effect expected: no change to observations, reset semantics, action/reward dimensions, RNG, or sim2sim configuration; only reset latency should improve for bounded sparse resets.

## Checklist

- [x] Added/updated focused tests for capacity routing, selected-row parity, and no full-batch getter fallback.
- [x] No documentation or configuration change required.
- [x] Linked the driving issue.
- [x] Noted oversized/graph-disabled fallback and manual-merge follow-up.
