### PR TITLE
perf(mujoco): 单卡默认 pool 线程数收敛到有效 CPU 数，消除 2× 超订 (#1328)

### DIFF
--- a/src/unilab/base/backend/mujoco/backend.py
+++ b/src/unilab/base/backend/mujoco/backend.py
@@ -46,6 +46,19 @@ from ..base import (
 from .playback import run_mujoco_playback
 
 
+def _effective_cpu_count() -> int:
+    """CPUs usable by this process for pool worker sizing.
+
+    ``os.sched_getaffinity`` respects taskset/cgroup affinity masks, unlike
+    ``os.cpu_count`` which reports machine-wide CPUs. Falls back to
+    ``os.cpu_count`` where the syscall is unavailable (e.g. macOS).
+    """
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        return max(1, cpu_count() or 1)
+
+
 def _root_state_dims(model) -> tuple[int, int]:
     if model.njnt > 0 and int(model.jnt_type[0]) == int(mujoco.mjtJoint.mjJNT_FREE):
         return 7, 6
@@ -350,9 +363,12 @@ class MuJoCoBackend(SimBackend):
         self._pending_xfrc_applied = np.zeros((num_envs, 6 * self._model.nbody), dtype=np.float64)
 
         # Thread configuration. An explicit ``cpu_ids`` affinity pins one worker
-        # per CPU, so it also fixes the pool worker count.
+        # per CPU, so it also fixes the pool worker count. Otherwise size the
+        # pool to the CPUs actually usable by this process: oversubscribing
+        # (e.g. 2x) only adds contention once the physics phase saturates
+        # memory bandwidth (#1328).
         self._n_threads = (
-            min(num_envs, cpu_count() * 2) if self._cpu_ids is None else len(self._cpu_ids)
+            min(num_envs, _effective_cpu_count()) if self._cpu_ids is None else len(self._cpu_ids)
         )
 
         self._model_variants: tuple[mujoco.MjModel, ...] = (self._model,)

--- a/tests/base/backend/test_mujoco_chunk_size_wiring.py
+++ b/tests/base/backend/test_mujoco_chunk_size_wiring.py
@@ -130,8 +130,9 @@ def test_benchmark_runs_and_logs_table_on_adaptive(caplog, monkeypatch, tmp_path
 
     # Force nthread < num_envs so there is genuinely something to tune; otherwise the
     # resolve short-circuits (num_envs <= nthread => one chunk => no benchmark). With
-    # cpu_count()==1, nthread = min(_NUM_ENVS, 2) = 2 < _NUM_ENVS, deterministically.
-    monkeypatch.setattr(backend_mod, "cpu_count", lambda: 1)
+    # _effective_cpu_count()==1, nthread = min(_NUM_ENVS, 1) = 1 < _NUM_ENVS,
+    # deterministically.
+    monkeypatch.setattr(backend_mod, "_effective_cpu_count", lambda: 1)
     monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(tmp_path / "chunk_size.json"))
     with caplog.at_level(logging.INFO, logger="unilab.base.backend.mujoco.chunk_tuner"):
         backend = _build_small_backend(adaptive_chunk_size=True, chunk_size=None)

--- a/tests/base/backend/test_mujoco_cpu_affinity_wiring.py
+++ b/tests/base/backend/test_mujoco_cpu_affinity_wiring.py
@@ -145,3 +145,26 @@ def test_default_path_keeps_os_scheduling():
     assert backend._cpu_ids is None
     assert backend._pool.cpu_ids is None
     assert backend._pool.worker_cpu_ids() == ()
+
+
+def test_default_nthread_sized_to_effective_cpus():
+    """Default pool sizing uses the CPUs usable by this process (#1328),
+    not 2x the machine-wide count; explicit ``cpu_ids`` still fixes nthread."""
+    backend = MuJoCoBackend(
+        SceneCfg(model_file=_MODEL_FILE),
+        num_envs=10_000,
+        sim_dt=0.01,
+        base_name="base",
+    )
+    assert backend._cpu_ids is None
+    assert backend._n_threads == len(os.sched_getaffinity(0))
+
+
+def test_default_nthread_capped_by_num_envs():
+    backend = MuJoCoBackend(
+        SceneCfg(model_file=_MODEL_FILE),
+        num_envs=2,
+        sim_dt=0.01,
+        base_name="base",
+    )
+    assert backend._n_threads == 2


### PR DESCRIPTION
Fixes #1328

## 改动

- `src/unilab/base/backend/mujoco/backend.py`：新增 `_effective_cpu_count()`（`len(os.sched_getaffinity(0))`，尊重 taskset/cgroup；macOS 等无此 syscall 的平台回退 `os.cpu_count()`），单卡（`cpu_ids=None`）默认 sizing 从 `min(num_envs, 2*cpu_count())` 改为 `min(num_envs, _effective_cpu_count())`。显式 `cpu_ids` 路径不变（`nthread = len(cpu_ids)`）。
- `tests/base/backend/test_mujoco_cpu_affinity_wiring.py`：新增两条 sizing 规则单测（默认 = 有效 CPU 数；被 `num_envs` 截断）。
- `tests/base/backend/test_mujoco_chunk_size_wiring.py`：原有测试改为 monkeypatch `_effective_cpu_count`（原先 patch `cpu_count`，在 ≥4 核机器上对本 sizing 已失效，会导致 benchmark 分支被短路）。

chunk tuner 的 cache key 含 `nthread`（`chunk_tuner.py`），默认线程数变化后自动重调，无脏 cache。

## Validation

- `make test-all` @ df9def36：**2286 passed, 28 skipped, 1 xfailed**（All checks passed）。
  - 过程中发现并清理了工作区里 `src/unilab/envs/{locomotion,manipulation,motion_tracking}` 三个纯 `__pycache__` 残留目录（非 git 跟踪文件），它们以 namespace package 形式导致 `test_removed_legacy_env_packages_stay_removed` 假失败；与代码改动无关。
  - 另注：在 origin/main 上验证时发现一个 main 预置的测试污染——`scripts/benchmark/env/benchmark_env_step.py` import 时全局且不可撤销地 patch `unilab.base.backend.create_backend`（mujoco_warp 可导入时），致 `tests/base/test_motrix_backend_options.py` 两个用例在全量套件中失败（单跑通过）；base 分支（dev/issue-1042）上不复现。建议单独建 issue 跟进。
- 真实训练前后对比（本机 9950X3D + RTX 4090，32 逻辑核；`uv run train --algo sac --task g1_motion_tracking --sim mujoco algo.num_envs=4096 algo.max_iterations=2000`，tfevents 后半程 median）：

| 指标 | before (nthread=64) | after (nthread=32) | 变化 |
|---|---|---|---|
| `perf/steps_per_sec` | 86,099 / 86,162（两次） | 96,262 | **+11.7%** |
| `perf/iter_ms` | 47.6 | 42.6 | −10.5% |
| `timing/collector_env_step_ms` | 47.7 | 41.9 | −12.2% |
| `timing/learner_train_ms` | 20.3 | 20.4 | 持平 |
| 整机 CPU%（/proc/stat，稳态 median） | 37.8% | 45.2% | +7.4pt |

满足 acceptance：默认 `nthread == min(num_envs, 有效 CPU 数)`；显式 `cpu_ids` 仍为 `len(cpu_ids)`；稳态 steps/s +11.7%（≥5%）。本机为 collector-bound（learner 仅 ~20ms/iter），收益集中在 env_step 物理相，与 issue 的 Linux 机型诊断一致。

## 范围外（issue non-goals，未动）

- drake 后端与 `scripts/benchmark/` 下裸测脚本中的 `2*cpu_count` sizing。
- update_state / reset_done 并行化（#1304 / #1292 路线）、collector↔learner 流水线、多卡 DP 路径、新增配置旋钮。