### PR TITLE
fix(logging): widen terminal reward name column by 10 chars

### DIFF
--- a/src/unilab/logging/common.py
+++ b/src/unilab/logging/common.py
@@ -394,7 +394,7 @@ class BaseTrainingLogger:
             expand=True,
             pad_edge=False,
         )
-        table.add_column("Rewards", style="white", width=21, no_wrap=True)
+        table.add_column("Rewards", style="white", width=31, no_wrap=True)
         table.add_column("Value", justify="right", ratio=2, no_wrap=True)
 
         recent = list(self._reward_history if reward_history is None else reward_history)


### PR DESCRIPTION
## 背景

终端 logger 的 reward 分量名在 Rich 表格里被截断为 `…`（例如显示为 `motion global root…`），原因是 `_build_reward_table_common` 中 Rewards 列固定 `width=21`。

## 改动

- `src/unilab/logging/common.py`：Rewards 列固定宽度 21 → 31（截断阈值 +10 字符），`motion global root pos` 等较长分量名可完整显示。
- 该 builder 为 offpolicy / onpolicy 终端 logger 共用，两类显示一并生效。

## Validation

- `uv run pytest tests/algos/test_offpolicy_logger.py`：15 passed（含窄终端不换行回归用例）。
- 最终 head `0bfacdac` 本地 `make test-all` 通过（2328 passed, 28 skipped, 1 xfailed；lint/type/benchmark gates 全绿）。
- 远程 CI：按 maintainer 要求跳过等待。