### PR TITLE
docs(backends): IsaacGym 运行时环境自动化配置脚本与指南文档

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
@@ -60,4 +60,5 @@ the generated source data.
 1-mujoco
 2-motrix
 3-choosing_a_backend
+4-isaacgym
 ```

--- a/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
@@ -1,0 +1,107 @@
+# IsaacGym Backend
+
+IsaacGym (NVIDIA Preview 4) is an end-of-life GPU physics simulator from NVIDIA
+that only supports Python 3.6-3.8. The UniLab main environment requires
+Python >= 3.10, so IsaacGym cannot be installed into it; it is used through an
+external, standalone Python 3.8 environment located purely via environment
+variables, with no machine-local paths written into the repository.
+
+Current status: IsaacGym is not yet wired into the registry, task owners, or the
+train/eval pipelines. What already works in this repository is the physics
+benchmark script
+`scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`, which locates
+the external environment through variables such as
+`UNILAB_BENCHMARK_HOLOSOMA_DEPS`. Backend integration is planned under
+[issue #1332](https://github.com/unilabsim/UniLab/issues/1332); this page only
+covers preparing the external environment and validating it with the benchmark.
+
+## Prerequisites
+
+- Linux x86_64 with an NVIDIA GPU driver installed.
+- An NVIDIA developer account: `IsaacGym_Preview_4_Package.tar.gz` must be
+  downloaded manually from <https://developer.nvidia.com/isaac-gym-preview-4>
+  after logging in; the script cannot and will not fetch that URL for you.
+- Disk space: roughly 5 GB for miniconda, the conda environment, and the
+  IsaacGym package combined.
+
+## Automated Setup
+
+From the repository root, run:
+
+```bash
+scripts/tools/setup_isaacgym_env.sh
+```
+
+The script installs everything under `$HOME/.unilab/isaacgym` by default;
+override the install root with the `UNILAB_ISAACGYM_HOME` environment variable,
+and point at the package with `--tarball <path>` (default:
+`$UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz`). The script is
+idempotent and skips completed steps when re-run.
+
+The setup flow: a dedicated miniconda, then a Python 3.8 `hsgym` conda
+environment (including `libstdcxx-ng`, which fixes the GLIBCXX issue on Ubuntu
+24.04), then unpacking the tarball, `pip install -e isaacgym/python`, and
+finally an import self-check.
+
+After installation, add the export lines printed by the script to your shell rc
+(e.g. `~/.bashrc`):
+
+```bash
+export UNILAB_BENCHMARK_HOLOSOMA_DEPS="$HOME/.unilab/isaacgym"
+export UNILAB_BENCHMARK_HSGYM_PYTHON="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/miniconda3/envs/hsgym/bin/python3.8"
+export UNILAB_BENCHMARK_HSGYM_LIB="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/miniconda3/envs/hsgym/lib"
+```
+
+## Validation
+
+Validate the environment with the benchmark script. The benchmark loads robot
+models from URDF, so you must provide your own URDF model tree
+(`go1_description/`, `g1_description/`, ...) and point `--models-root` or
+`UNILAB_BENCHMARK_MODELS_ROOT` at its root directory:
+
+```bash
+PYTHONPATH="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/isaacgym/python" \
+LD_LIBRARY_PATH="$UNILAB_BENCHMARK_HSGYM_LIB" \
+uv run --no-project "$UNILAB_BENCHMARK_HSGYM_PYTHON" \
+    scripts/benchmark/physics/benchmark_physics_step_isaacgym.py \
+    --tasks g1_walk_flat --batch-sizes 256 --models-root "$UNILAB_BENCHMARK_MODELS_ROOT"
+```
+
+## Manual Setup
+
+If the automated script fails, the equivalent manual command sequence is:
+
+```bash
+export UNILAB_ISAACGYM_HOME="${UNILAB_ISAACGYM_HOME:-$HOME/.unilab/isaacgym}"
+mkdir -p "$UNILAB_ISAACGYM_HOME"
+
+# 1. Dedicated miniconda
+curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+bash /tmp/miniconda.sh -b -u -p "$UNILAB_ISAACGYM_HOME/miniconda3"
+rm /tmp/miniconda.sh
+
+# 2. Python 3.8 conda environment
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" install -y -n base -c conda-forge mamba
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/mamba" create -y -n hsgym python=3.8 -c conda-forge --override-channels
+
+# 3. Ubuntu 24.04 GLIBCXX fix
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" install -y -n hsgym -c conda-forge libstdcxx-ng
+
+# 4. Unpack and install IsaacGym (tarball downloaded manually, see prerequisites)
+tar -xzf "$UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz" -C "$UNILAB_ISAACGYM_HOME"
+"$UNILAB_ISAACGYM_HOME/miniconda3/envs/hsgym/bin/pip" install -e "$UNILAB_ISAACGYM_HOME/isaacgym/python"
+```
+
+## Troubleshooting
+
+- **Fetching the NVIDIA download URL with wget fails**: the download requires a
+  login and must be done manually; see Prerequisites.
+- **`GLIBCXX_3.4.32 not found` on Ubuntu 24.04**: the prebuilt IsaacGym
+  libraries link against a newer libstdc++ than the system provides. The setup
+  script installs conda-forge `libstdcxx-ng` into the `hsgym` environment to
+  fix this; at runtime, point `LD_LIBRARY_PATH` at that env's `lib/`.
+- **`from isaacgym import gymapi` fails**: make sure `LD_LIBRARY_PATH` points
+  at `$UNILAB_BENCHMARK_HSGYM_LIB` (the `lib/` directory of the hsgym env) and
+  that `PYTHONPATH` includes `isaacgym/python`.

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
@@ -57,4 +57,5 @@ Task/backend/entrypoint 的支持情况是按证据分级的。请参阅
 1-mujoco
 2-motrix
 3-choosing_a_backend
+4-isaacgym
 ```

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
@@ -1,0 +1,98 @@
+# IsaacGym 后端
+
+IsaacGym（NVIDIA Preview 4）是 NVIDIA 已停止维护（EOL）的 GPU 物理仿真器，
+只支持 Python 3.6–3.8。UniLab 主环境要求 Python >= 3.10，因此 IsaacGym 不能
+装进主环境，必须通过外部独立的 Python 3.8 环境使用；仓库内一律通过环境变量
+定位该环境，不写入任何机器本地路径。
+
+当前状态：IsaacGym 尚未接入 registry / task owner / 训练与回放链路。仓库内
+已可用的是物理性能 benchmark 脚本
+`scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`，它通过
+`UNILAB_BENCHMARK_HOLOSOMA_DEPS` 等环境变量定位外部环境。后端接入在
+[issue #1332](https://github.com/unilabsim/UniLab/issues/1332) 中规划；
+本页只覆盖外部环境准备与 benchmark 验证。
+
+## 前置条件
+
+- Linux x86_64，装有 NVIDIA GPU 驱动。
+- NVIDIA developer 账号：`IsaacGym_Preview_4_Package.tar.gz` 必须在
+  <https://developer.nvidia.com/isaac-gym-preview-4> 登录后手动下载，
+  脚本不会也无法自动拉取该 URL。
+- 磁盘空间：miniconda、conda 环境与 IsaacGym 安装包合计约 5 GB。
+
+## 自动化安装
+
+在仓库根目录运行：
+
+```bash
+scripts/tools/setup_isaacgym_env.sh
+```
+
+脚本默认把所有内容安装到 `$HOME/.unilab/isaacgym`，可用环境变量
+`UNILAB_ISAACGYM_HOME` 覆盖安装根目录；用 `--tarball <path>` 指定安装包位置
+（默认读取 `$UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz`）。
+脚本幂等，重跑时跳过已完成的步骤。
+
+安装流程：专用 miniconda → python 3.8 `hsgym` conda 环境（含
+`libstdcxx-ng`，用于修复 Ubuntu 24.04 的 GLIBCXX 问题）→ 解包 tarball →
+`pip install -e isaacgym/python` → import 自检。
+
+安装完成后，把脚本输出的 export 行写入 shell rc（如 `~/.bashrc`）：
+
+```bash
+export UNILAB_BENCHMARK_HOLOSOMA_DEPS="$HOME/.unilab/isaacgym"
+export UNILAB_BENCHMARK_HSGYM_PYTHON="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/miniconda3/envs/hsgym/bin/python3.8"
+export UNILAB_BENCHMARK_HSGYM_LIB="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/miniconda3/envs/hsgym/lib"
+```
+
+## 验证
+
+用 benchmark 脚本验证环境可用。benchmark 从 URDF 加载机器人模型，
+URDF 模型树（`go1_description/`、`g1_description/` 等）需自备，通过
+`--models-root` 或 `UNILAB_BENCHMARK_MODELS_ROOT` 指向其根目录：
+
+```bash
+PYTHONPATH="$UNILAB_BENCHMARK_HOLOSOMA_DEPS/isaacgym/python" \
+LD_LIBRARY_PATH="$UNILAB_BENCHMARK_HSGYM_LIB" \
+uv run --no-project "$UNILAB_BENCHMARK_HSGYM_PYTHON" \
+    scripts/benchmark/physics/benchmark_physics_step_isaacgym.py \
+    --tasks g1_walk_flat --batch-sizes 256 --models-root "$UNILAB_BENCHMARK_MODELS_ROOT"
+```
+
+## 手动安装
+
+自动脚本失效时，可按下面的等价命令序列手动安装：
+
+```bash
+export UNILAB_ISAACGYM_HOME="${UNILAB_ISAACGYM_HOME:-$HOME/.unilab/isaacgym}"
+mkdir -p "$UNILAB_ISAACGYM_HOME"
+
+# 1. 专用 miniconda
+curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+bash /tmp/miniconda.sh -b -u -p "$UNILAB_ISAACGYM_HOME/miniconda3"
+rm /tmp/miniconda.sh
+
+# 2. python 3.8 conda 环境
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" install -y -n base -c conda-forge mamba
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/mamba" create -y -n hsgym python=3.8 -c conda-forge --override-channels
+
+# 3. Ubuntu 24.04 GLIBCXX 修复
+"$UNILAB_ISAACGYM_HOME/miniconda3/bin/conda" install -y -n hsgym -c conda-forge libstdcxx-ng
+
+# 4. 解包并安装 IsaacGym（tarball 需手动下载，见前置条件）
+tar -xzf "$UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz" -C "$UNILAB_ISAACGYM_HOME"
+"$UNILAB_ISAACGYM_HOME/miniconda3/envs/hsgym/bin/pip" install -e "$UNILAB_ISAACGYM_HOME/isaacgym/python"
+```
+
+## 故障排除
+
+- **wget 直接拉 NVIDIA 下载 URL 失败**：该下载需要登录，必须手动下载，
+  见前置条件。
+- **Ubuntu 24.04 报 `GLIBCXX_3.4.32 not found`**：IsaacGym 预编译库链接的
+  libstdc++ 比系统自带的旧；安装脚本已在 `hsgym` 环境中安装 conda-forge 的
+  `libstdcxx-ng` 解决，运行时把 `LD_LIBRARY_PATH` 指向该 env 的 `lib/` 即可。
+- **`from isaacgym import gymapi` import 失败**：确认 `LD_LIBRARY_PATH`
+  指向 `$UNILAB_BENCHMARK_HSGYM_LIB`（即 hsgym env 的 `lib/`），且
+  `PYTHONPATH` 包含 `isaacgym/python`。

--- a/scripts/tools/setup_isaacgym_env.sh
+++ b/scripts/tools/setup_isaacgym_env.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Install an external, self-contained IsaacGym Preview 4 runtime for UniLab.
+#
+# IsaacGym (NVIDIA Preview 4, EOL) only supports Python 3.6-3.8, so it cannot
+# live in the main uv environment (requires-python >= 3.10). Everything is
+# installed under UNILAB_ISAACGYM_HOME (default: $HOME/.unilab/isaacgym) and
+# located at runtime purely through environment variables; this repo never
+# hard-codes machine-local paths.
+#
+# Layout produced by this script (aligned with the benchmark env vars used by
+# scripts/benchmark/physics/benchmark_physics_step_isaacgym.py):
+#   $UNILAB_ISAACGYM_HOME/miniconda3                        dedicated miniconda
+#   $UNILAB_ISAACGYM_HOME/miniconda3/envs/hsgym             Python 3.8 conda env
+#   $UNILAB_ISAACGYM_HOME/isaacgym/python                   unpacked Preview 4
+#   $UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz user-provided tarball
+#
+# The script is idempotent: completed steps are skipped on re-run.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: setup_isaacgym_env.sh [--tarball <path>] [-h|--help]
+
+Install an external Python 3.8 IsaacGym Preview 4 runtime for UniLab
+benchmarks. IsaacGym cannot be installed into the main uv environment.
+
+Options:
+  --tarball <path>   Path to IsaacGym_Preview_4_Package.tar.gz.
+                     Default: $UNILAB_ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz
+                     The tarball must be downloaded manually from the NVIDIA
+                     developer site (login required):
+                     https://developer.nvidia.com/isaac-gym-preview-4
+  -h, --help         Show this help.
+
+Environment:
+  UNILAB_ISAACGYM_HOME   Install root. Default: $HOME/.unilab/isaacgym
+EOF
+}
+
+ISAACGYM_HOME="${UNILAB_ISAACGYM_HOME:-$HOME/.unilab/isaacgym}"
+TARBALL_ARG=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tarball)
+      [ "$#" -ge 2 ] || { echo "error: --tarball requires a path argument" >&2; exit 2; }
+      TARBALL_ARG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+CONDA_ROOT="$ISAACGYM_HOME/miniconda3"
+ENV_NAME="hsgym"
+ENV_ROOT="$CONDA_ROOT/envs/$ENV_NAME"
+HSGYM_PYTHON="$ENV_ROOT/bin/python3.8"
+ISAACGYM_DIR="$ISAACGYM_HOME/isaacgym"
+TARBALL_PATH="${TARBALL_ARG:-$ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz}"
+MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+LIBSTDCXX_SENTINEL="$ENV_ROOT/.unilab_libstdcxx_installed"
+
+log() {
+  echo "[setup_isaacgym_env] $*"
+}
+
+mkdir -p "$ISAACGYM_HOME"
+
+# Step 1: dedicated miniconda (skipped if already installed).
+if [ -x "$CONDA_ROOT/bin/conda" ]; then
+  log "miniconda already present at $CONDA_ROOT, skipping"
+else
+  log "installing miniconda into $CONDA_ROOT"
+  installer="$(mktemp /tmp/unilab_miniconda_XXXXXX.sh)"
+  curl -fsSL "$MINICONDA_URL" -o "$installer"
+  bash "$installer" -b -u -p "$CONDA_ROOT"
+  rm -f "$installer"
+fi
+
+# Step 2: Python 3.8 conda env with the Ubuntu 24.04 GLIBCXX fix.
+if [ -x "$HSGYM_PYTHON" ]; then
+  log "conda env '$ENV_NAME' already present at $ENV_ROOT, skipping create"
+else
+  log "creating conda env '$ENV_NAME' (python=3.8)"
+  "$CONDA_ROOT/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+  "$CONDA_ROOT/bin/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+  "$CONDA_ROOT/bin/conda" install -y -n base -c conda-forge mamba
+  MAMBA_ROOT_PREFIX="$CONDA_ROOT" "$CONDA_ROOT/bin/mamba" create -y -n "$ENV_NAME" \
+    python=3.8 -c conda-forge --override-channels
+fi
+
+# Fix `version GLIBCXX_3.4.32 not found` on Ubuntu 24.04 by shipping a newer
+# libstdc++ inside the env.
+if [ -f "$LIBSTDCXX_SENTINEL" ]; then
+  log "libstdcxx-ng already installed in '$ENV_NAME', skipping"
+else
+  log "installing libstdcxx-ng into '$ENV_NAME'"
+  "$CONDA_ROOT/bin/conda" install -y -n "$ENV_NAME" -c conda-forge libstdcxx-ng
+  touch "$LIBSTDCXX_SENTINEL"
+fi
+
+# Step 3: the IsaacGym tarball cannot be fetched automatically; the NVIDIA
+# developer download requires a login, so the user must provide it.
+if [ ! -f "$TARBALL_PATH" ]; then
+  cat >&2 <<EOF
+[setup_isaacgym_env] 错误：未找到 IsaacGym Preview 4 安装包：$TARBALL_PATH
+
+IsaacGym Preview 4 需要 NVIDIA developer 账号登录后手动下载，无法通过脚本自动获取：
+  1. 打开 https://developer.nvidia.com/isaac-gym-preview-4 并登录
+  2. 下载 IsaacGym_Preview_4_Package.tar.gz
+  3. 将文件放到 $ISAACGYM_HOME/IsaacGym_Preview_4_Package.tar.gz
+     或用 --tarball <path> 指定路径后重跑本脚本
+EOF
+  exit 1
+fi
+
+# Step 4: unpack and pip install -e with the env's own pip.
+if [ -d "$ISAACGYM_DIR/python" ]; then
+  log "isaacgym already unpacked at $ISAACGYM_DIR, skipping extract"
+else
+  log "unpacking $TARBALL_PATH into $ISAACGYM_HOME"
+  tar -xzf "$TARBALL_PATH" -C "$ISAACGYM_HOME"
+fi
+
+if "$ENV_ROOT/bin/pip" show isaacgym >/dev/null 2>&1; then
+  log "isaacgym already installed in '$ENV_NAME', skipping pip install"
+else
+  log "installing isaacgym (pip install -e) into '$ENV_NAME'"
+  "$ENV_ROOT/bin/pip" install -e "$ISAACGYM_DIR/python"
+fi
+
+# Step 5: self-check the import with the env's lib/ on LD_LIBRARY_PATH.
+log "running isaacgym import self-check"
+LD_LIBRARY_PATH="$ENV_ROOT/lib" "$HSGYM_PYTHON" \
+  -c "from isaacgym import gymapi; print('isaacgym import OK')"
+
+# Step 6: print the exports and verification command for the user's shell rc.
+cat <<EOF
+
+[setup_isaacgym_env] 完成。把下面几行写入你的 shell rc（如 ~/.bashrc）：
+
+export UNILAB_BENCHMARK_HOLOSOMA_DEPS="$ISAACGYM_HOME"
+export UNILAB_BENCHMARK_HSGYM_PYTHON="$HSGYM_PYTHON"
+export UNILAB_BENCHMARK_HSGYM_LIB="$ENV_ROOT/lib"
+# URDF 模型树（go1_description/ 等）需自备，指向其根目录：
+export UNILAB_BENCHMARK_MODELS_ROOT="<path-to-your-urdf-models-root>"
+
+然后在仓库根目录用 benchmark 脚本验证：
+
+PYTHONPATH="\$UNILAB_BENCHMARK_HOLOSOMA_DEPS/isaacgym/python" \\
+LD_LIBRARY_PATH="\$UNILAB_BENCHMARK_HSGYM_LIB" \\
+uv run --no-project "\$UNILAB_BENCHMARK_HSGYM_PYTHON" \\
+    scripts/benchmark/physics/benchmark_physics_step_isaacgym.py \\
+    --tasks g1_walk_flat --batch-sizes 256 --models-root "\$UNILAB_BENCHMARK_MODELS_ROOT"
+EOF


### PR DESCRIPTION
## 关联

- Closes #1334（Child 1 of roadmap #1332）
- Base: `dev/issue-1332-isaacgym-backend`（集成分支；roadmap declared base 为 `dev/issue-1042-manager-based-api`）

## 改动

- 新增 `scripts/tools/setup_isaacgym_env.sh`：幂等安装自包含的 IsaacGym 运行时（专用 miniconda + py3.8 `hsgym` env + `libstdcxx-ng` + 用户手动下载的 Preview 4 tarball + import 自检），安装根 `UNILAB_ISAACGYM_HOME`（默认 `~/.unilab/isaacgym`），与既有 benchmark 环境变量 `UNILAB_BENCHMARK_HOLOSOMA_DEPS` / `UNILAB_BENCHMARK_HSGYM_*` 布局对齐。仓库内零绝对路径。
- 新增双语后端文档 `docs/sphinx/source/{en,zh_CN}/2-user_guide/3-backends/4-isaacgym.md` 并登记 toctree：自动安装、benchmark 验证、手动安装附录、故障排除（NVIDIA 登录下载、Ubuntu 24.04 GLIBCXX、LD_LIBRARY_PATH）。
- 文档遵循 Evidence only：只写外部环境准备与现有 benchmark 用法，不声称训练支持（后续 child issue 接入）。

## 行为影响

不改任何运行时行为；`mujoco`/`motrix`/macOS/Linux 均无变化。

## Validation（最终 head `87032ec7`）

- `make test-all`（worktree 稳定检出，`uv sync --extra mujoco --extra motrix` 后）：check（ruff format/check + mypy + pyright）通过；`pytest -m "not slow"` 全绿；benchmark smoke 35/36 + 36/37（唯一 skip 为 platform-optional `mlx`）。
- `bash -n` / `--help` 正常；stub 环境 + 假 tarball 验证幂等全链路。
- 真实 IsaacGym 安装需 NVIDIA developer 账号下载 tarball，本机不可达——已声明为遗留验证项（首台目标机器人工确认）。

注：本地 gate 期间发现 `src/unilab/envs/{locomotion,manipulation,motion_tracking}/` 下残留陈旧空目录（历史 checkout 的 `__pycache__` 残留）导致 `test_removed_legacy_env_packages_stay_removed` 误报失败；`make clean` + 删除空目录后全绿，与 base 分支本身无关。
