### PR TITLE
feat(backend): IsaacGym subprocess 后端实现

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructu
 - SAC / TD3 / FlashSAC: `scripts/train_sac.py` / `scripts/train_td3.py` / `scripts/train_flashsac.py`
 - env contract: `src/unilab/base/np_env.py`
 - backend contract: `src/unilab/base/backend/base.py`
+- isaacgym subprocess 后端（Python 3.8 worker + shm 协议）: `src/unilab/base/backend/isaacgym/`
 - training run helpers: `src/unilab/training/run.py`
 - visualization helpers: `src/unilab/visualization/`
 - shared numeric helpers: `src/unilab/utils/rotation.py`, `src/unilab/utils/geometry.py`

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -26,6 +26,8 @@ def env_backend_kwargs(cfg: "EnvCfg") -> dict:
         "mjwarp_njmax": cfg.mjwarp_njmax,
         "drake_backend_mode": cfg.drake_backend_mode,
         "drake_nthread": cfg.drake_nthread,
+        "isaacgym_device_id": cfg.isaacgym_device_id,
+        "isaacgym_worker_timeout_s": cfg.isaacgym_worker_timeout_s,
     }
 
 
@@ -95,6 +97,12 @@ def _drake_available() -> bool:
     return ensure_drake_batch_available()[0]
 
 
+def _load_isaacgym_backend() -> Any:
+    from .isaacgym.backend import IsaacGymBackend
+
+    return IsaacGymBackend
+
+
 def create_backend(
     backend_type: str,
     scene: SceneCfg,
@@ -107,8 +115,8 @@ def create_backend(
     """Create a simulation backend.
 
     Args:
-        backend_type: ``"mujoco"``, ``"mjwarp"``, ``"motrix"``, or
-            ``"drake"``.
+        backend_type: ``"mujoco"``, ``"mjwarp"``, ``"motrix"``, ``"drake"``,
+            or ``"isaacgym"``.
         scene: SceneCfg for either static or composed scenes.
         num_envs: Number of environments.
         sim_dt: Simulation timestep.
@@ -141,6 +149,8 @@ def create_backend(
     mjwarp_njmax = kwargs.pop("mjwarp_njmax", None)
     drake_backend_mode = kwargs.pop("drake_backend_mode", "batch")
     drake_nthread = kwargs.pop("drake_nthread", None)
+    isaacgym_device_id = kwargs.pop("isaacgym_device_id", None)
+    isaacgym_worker_timeout_s = kwargs.pop("isaacgym_worker_timeout_s", None)
     if backend_type == "mujoco":
         MuJoCoBackend = _load_mujoco_backend()
         if body_state_required:
@@ -210,6 +220,40 @@ def create_backend(
         if drake_nthread is not None:
             kwargs["nthread"] = drake_nthread
         return cast(SimBackend, DrakeBackend(scene, num_envs, sim_dt, **kwargs))
+    if backend_type == "isaacgym":
+        IsaacGymBackend = _load_isaacgym_backend()
+        # Body states are always available from the rigid-body state tensor;
+        # the flag exists for backends that need extra scene materialization.
+        kwargs.pop("add_body_sensors", None)
+        if position_actuator_gains is not None:
+            raise ValueError(
+                "isaacgym runs torque-mode dofs only; position_actuator_gains has no "
+                "IsaacGym equivalent in the subprocess profile."
+            )
+        ignored_non_defaults = {
+            key: value
+            for key, value, default in (
+                ("post_step_forward_sensor", post_step_forward_sensor, None),
+                ("iterations", iterations, None),
+                ("chunk_size", chunk_size, None),
+                ("adaptive_chunk_size", adaptive_chunk_size, False),
+                ("cpu_ids", cpu_ids, None),
+                ("bench_nsteps", bench_nsteps, 1),
+            )
+            if value != default
+        }
+        if ignored_non_defaults:
+            rendered = ", ".join(f"{key}={value!r}" for key, value in ignored_non_defaults.items())
+            warnings.warn(
+                "isaacgym ignores non-default MuJoCo-only backend options: " + rendered,
+                UserWarning,
+                stacklevel=2,
+            )
+        if isaacgym_device_id is not None:
+            kwargs["device_id"] = isaacgym_device_id
+        if isaacgym_worker_timeout_s is not None:
+            kwargs["worker_timeout_s"] = isaacgym_worker_timeout_s
+        return cast(SimBackend, IsaacGymBackend(scene, num_envs, sim_dt, **kwargs))
     raise ValueError(f"Unknown backend: {backend_type}")
 
 
@@ -228,6 +272,8 @@ def __getattr__(name: str):
         return _load_drake_backend()
     if name == "DRAKE_AVAILABLE":
         return _drake_available()
+    if name == "IsaacGymBackend":
+        return _load_isaacgym_backend()
     if name in _MUJOCO_XML_EXPORTS:
         from .mujoco import xml
 
@@ -249,6 +295,7 @@ __all__ = [
     "MjwarpBackend",
     "MotrixBackend",
     "DrakeBackend",
+    "IsaacGymBackend",
     "DRAKE_AVAILABLE",
     "MJWARP_AVAILABLE",
     "add_sensor",

--- a/src/unilab/base/backend/isaacgym/__init__.py
+++ b/src/unilab/base/backend/isaacgym/__init__.py
@@ -1,0 +1,35 @@
+"""IsaacGym subprocess backend package.
+
+Imports are lazy: importing this package must not spawn a worker or probe the
+filesystem for the Python 3.8 runtime.  Use ``create_backend("isaacgym", ...)``
+which defers runtime resolution to ``materialize()``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "IsaacGymBackend":
+        from .backend import IsaacGymBackend
+
+        return IsaacGymBackend
+    if name in ("IsaacGymModelInfo", "IsaacGymWorkerError"):
+        from . import backend
+
+        return getattr(backend, name)
+    if name in ("IsaacGymDependencyError", "isaacgym_runtime_available"):
+        from . import dependencies
+
+        return getattr(dependencies, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "IsaacGymBackend",
+    "IsaacGymDependencyError",
+    "IsaacGymModelInfo",
+    "IsaacGymWorkerError",
+    "isaacgym_runtime_available",
+]

--- a/src/unilab/base/backend/isaacgym/backend.py
+++ b/src/unilab/base/backend/isaacgym/backend.py
@@ -68,7 +68,11 @@ from unilab.dr.types import (
     IntervalRandomizationPlan,
     ResetRandomizationPayload,
 )
-from unilab.utils.rotation import np_quat_apply_inverse_batched, np_quat_mul_batched
+from unilab.utils.rotation import (
+    np_quat_apply_batched,
+    np_quat_apply_inverse_batched,
+    np_quat_mul_batched,
+)
 
 from . import protocol
 from .dependencies import (
@@ -80,6 +84,7 @@ from .sensors import (
     KIND_CONTACT_FOUND,
     KIND_FRAMEPOS,
     KIND_FRAMEQUAT,
+    KIND_FRAMEZAXIS,
     KIND_GYRO,
     KIND_LOCAL_LINVEL,
     SceneMetadata,
@@ -280,7 +285,7 @@ class IsaacGymBackend(SimBackend):
         self._worker_dead_error: IsaacGymWorkerError | None = None
         self._model_info: IsaacGymModelInfo | None = None
         self._scene_metadata: SceneMetadata | None = None
-        self._sensor_map: dict[str, tuple[str, int]] = {}
+        self._sensor_map: dict[str, tuple[SceneSensorSpec, int]] = {}
         self._body_id_by_name: dict[str, int] = {}
         self._dof_id_by_name: dict[str, int] = {}
         self._joint_range: np.ndarray | None = None
@@ -409,10 +414,10 @@ class IsaacGymBackend(SimBackend):
             for name, handle in self._shm_handles.items()
         }
 
-    def _resolve_sensor_map(self) -> dict[str, tuple[str, int]]:
-        """Resolve supported scene sensors to (kind, body_id) on the cold path."""
+    def _resolve_sensor_map(self) -> dict[str, tuple[SceneSensorSpec, int]]:
+        """Resolve supported scene sensors to (spec, body_id) on the cold path."""
         assert self._scene_metadata is not None
-        resolved: dict[str, tuple[str, int]] = {}
+        resolved: dict[str, tuple[SceneSensorSpec, int]] = {}
         for name, spec in self._scene_metadata.sensors.items():
             body_id = self._body_id_by_name.get(spec.body_name)
             if body_id is None:
@@ -424,7 +429,7 @@ class IsaacGymBackend(SimBackend):
                     "asset rigid-body list",
                 )
                 continue
-            resolved[name] = (spec.kind, body_id)
+            resolved[name] = (spec, body_id)
         return resolved
 
     # ------------------------------------------------------------------ #
@@ -891,16 +896,26 @@ class IsaacGymBackend(SimBackend):
                 )
             available = ", ".join(sorted(self._sensor_map))
             raise ValueError(f"Sensor {name!r} not found; available: {available}")
-        kind, body_id = mapped
+        spec, body_id = mapped
         state = self._body_slot()[:, body_id, :]
+        kind = spec.kind
+        local_quat = np.asarray(spec.local_quat, dtype=np.float32)[None, :]
+        local_pos = np.asarray(spec.local_pos, dtype=np.float32)[None, :]
         if kind == KIND_GYRO:
-            return np_quat_apply_inverse_batched(state[:, 3:7], state[:, 10:13]).astype(np.float32)
+            body_frame = np_quat_apply_inverse_batched(state[:, 3:7], state[:, 10:13])
+            return np_quat_apply_inverse_batched(local_quat, body_frame).astype(np.float32)
         if kind == KIND_LOCAL_LINVEL:
-            return np_quat_apply_inverse_batched(state[:, 3:7], state[:, 7:10]).astype(np.float32)
+            body_frame = np_quat_apply_inverse_batched(state[:, 3:7], state[:, 7:10])
+            return np_quat_apply_inverse_batched(local_quat, body_frame).astype(np.float32)
         if kind == KIND_FRAMEQUAT:
-            return state[:, 3:7].copy()
+            return np_quat_mul_batched(state[:, 3:7], local_quat).astype(np.float32)
         if kind == KIND_FRAMEPOS:
-            return state[:, 0:3].copy()
+            offset = np_quat_apply_batched(state[:, 3:7], local_pos)
+            return (state[:, 0:3] + offset).astype(np.float32)
+        if kind == KIND_FRAMEZAXIS:
+            frame_quat = np_quat_mul_batched(state[:, 3:7], local_quat)
+            z_axis = np.array([[0.0, 0.0, 1.0]], dtype=np.float32)
+            return np_quat_apply_batched(frame_quat, z_axis).astype(np.float32)
         if kind == KIND_CONTACT_FOUND:
             force = self._slots["contact_force"][:, body_id, :]
             return (np.linalg.norm(force, axis=-1, keepdims=True) > 0.0).astype(np.float32)

--- a/src/unilab/base/backend/isaacgym/backend.py
+++ b/src/unilab/base/backend/isaacgym/backend.py
@@ -1,0 +1,914 @@
+"""Host-side ``SimBackend`` implementation driving an IsaacGym subprocess.
+
+IsaacGym (Preview 4, EOL) only supports Python 3.6-3.8 and cannot be installed
+into the main UniLab environment, so physics runs in a dedicated worker
+interpreter (see ``dependencies.py``).  This class owns the worker process,
+the shared-memory state slots, and the numpy-facing contract; the worker
+(``worker.py``) owns the actual IsaacGym tensors.
+
+Design invariants:
+
+- The constructor is light: it only validates arguments.  ``materialize()``
+  spawns the worker, runs the INIT/META handshake, creates the shared-memory
+  slots, and attaches them (ATTACH_SLOTS) on the cold path.
+- Bulk state crosses the process boundary through ``multiprocessing.shared_memory``
+  only.  The stdin/stdout pipe carries length-prefixed pickle commands
+  (``protocol.py``).  Hot-path getters read the shm caches written at the last
+  STEP/SET_STATE barrier; they never round-trip the worker.
+- ``step(ctrl)`` semantics match the MuJoCo motor profile: ``ctrl`` is the
+  per-DoF actuation force (torque), applied through IsaacGym's
+  ``set_dof_actuation_force_tensor`` with ``DOF_MODE_EFFORT``.
+- Quaternions on the public surface are ``wxyz`` (IsaacGym tensors are
+  ``xyzw``; the worker converts at the shm boundary).  ``set_state`` qvel root
+  columns carry body-frame angular velocity per the ``SimBackend`` contract;
+  the worker converts to IsaacGym's world-frame angular velocity.
+- Domain randomization, native rendering/playback, and pre-step control
+  callbacks are fail-closed (see ``get_dr_capabilities`` /
+  ``apply_interval_randomization`` / ``set_pre_step_control``).
+
+Sensor contract: IsaacGym has no MuJoCo sensor concept.  The scene MJCF is
+scanned once on the cold path (``sensors.py``) and supported sensors
+(``gyro``, ``velocimeter``, ``framequat``, ``framepos``, ``contact`` with
+``data="found"``) are computed from the shm tensor caches; everything else
+fails closed with an explanatory ``NotImplementedError``.
+
+Known real-runtime gaps to validate on hardware (the development machine has
+no IsaacGym install, so all runtime behavior is covered by a mock worker):
+
+- MJCF importer fidelity (fixed-joint handling, armature, actuator mapping);
+- whether ``set_dof_state_tensor_indexed`` / ``set_actor_root_state_tensor_indexed``
+  semantics match the wrapped-full-buffer pattern used here;
+- body-state staleness right after SET_STATE (IsaacGym has no kinematics-only
+  forward call; rigid-body/contact slots refresh at the next physics step).
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import select
+import subprocess
+import tempfile
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+from pathlib import Path
+from typing import Any, BinaryIO, cast
+
+import numpy as np
+
+from unilab.base.backend.base import (
+    BackendRootStateLayout,
+    SimBackend,
+)
+from unilab.base.scene import SceneCfg
+from unilab.dr.types import (
+    DomainRandomizationCapabilities,
+    IntervalRandomizationPlan,
+    ResetRandomizationPayload,
+)
+from unilab.utils.rotation import np_quat_apply_inverse_batched, np_quat_mul_batched
+
+from . import protocol
+from .dependencies import (
+    IsaacGymRuntime,
+    build_worker_env,
+    resolve_isaacgym_runtime,
+)
+from .sensors import (
+    KIND_CONTACT_FOUND,
+    KIND_FRAMEPOS,
+    KIND_FRAMEQUAT,
+    KIND_GYRO,
+    KIND_LOCAL_LINVEL,
+    SceneMetadata,
+    SceneSensorSpec,
+    UnsupportedSensorSpec,
+    scan_scene_metadata,
+)
+
+_MODULE_DIR = Path(__file__).resolve().parent
+_WORKER_PATH = _MODULE_DIR / "worker.py"
+_PROTOCOL_PATH = _MODULE_DIR / "protocol.py"
+
+_DEFAULT_WORKER_TIMEOUT_S = 120.0
+_SHUTDOWN_TIMEOUT_S = 5.0
+_STDERR_TAIL_BYTES = 4096
+
+_ROOT_QPOS_DIM = 7
+_ROOT_QVEL_DIM = 6
+
+
+class IsaacGymWorkerError(RuntimeError):
+    """Raised when the worker reports an error, dies, or stops responding.
+
+    Carries the worker-side traceback and/or the captured stderr tail so
+    crashes inside the Python 3.8 process remain diagnosable from the host.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        worker_traceback: str | None = None,
+        stderr_tail: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.worker_traceback = worker_traceback
+        self.stderr_tail = stderr_tail
+
+
+@dataclass(frozen=True)
+class IsaacGymModelInfo:
+    """Opaque backend-owned model metadata returned by ``IsaacGymBackend.model``."""
+
+    num_dof: int
+    num_bodies: int
+    dof_names: tuple[str, ...]
+    body_names: tuple[str, ...]
+    gravity: tuple[float, float, float]
+    use_gpu_pipeline: bool
+
+
+def _release_worker(
+    proc: "subprocess.Popen[bytes] | None",
+    shm_handles: list[shared_memory.SharedMemory],
+    stderr_file: Any,
+) -> None:
+    """Best-effort worker shutdown: SHUTDOWN handshake, then terminate, then kill.
+
+    Called from ``close()``/``__del__``/``atexit`` so the worker never survives
+    the host process or leaks shared-memory segments.
+    """
+    if proc is not None and proc.poll() is None:
+        try:
+            if proc.stdin is not None:
+                protocol.send_message(cast(BinaryIO, proc.stdin), protocol.CMD_SHUTDOWN)
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+        except Exception:
+            try:
+                proc.terminate()
+                proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+            except Exception:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+                except Exception:
+                    pass
+    for handle in shm_handles:
+        try:
+            handle.close()
+            handle.unlink()
+        except Exception:
+            pass
+    if stderr_file is not None:
+        try:
+            stderr_file.close()
+        except Exception:
+            pass
+
+
+def _read_exactly_with_deadline(stream: Any, size: int, deadline: float) -> bytes:
+    """Read exactly ``size`` bytes from an unbuffered stream before ``deadline``.
+
+    ``stream`` must be unbuffered (``Popen(..., bufsize=0)``) so ``select`` on
+    the underlying fd cannot be desynchronized by read-ahead buffering.
+    """
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        wait = deadline - time.monotonic()
+        if wait <= 0:
+            raise TimeoutError(f"timed out waiting for {size} bytes from worker")
+        readable, _, _ = select.select([stream], [], [], wait)
+        if not readable:
+            raise TimeoutError(f"timed out waiting for {size} bytes from worker")
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise protocol.WorkerDisconnectedError(
+                f"worker pipe closed while reading {size} bytes (got {size - remaining})"
+            )
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+class IsaacGymBackend(SimBackend):
+    """``SimBackend`` implementation delegating physics to an IsaacGym worker."""
+
+    # Same column-stability contract as the other backends: non-applicable
+    # sub-steps report 0.0.
+    _SET_STATE_TIMING_ZERO_KEYS = (
+        "set_state_mask_ms",
+        "set_state_data_slice_ms",
+        "set_state_data_reset_ms",
+        "set_state_clear_forces_ms",
+        "set_state_geom_overrides_ms",
+        "set_state_reset_rand_ms",
+        "set_state_set_dof_vel_ms",
+        "set_state_set_dof_pos_ms",
+        "set_state_actuator_ctrl_ms",
+        "set_state_forward_kinematic_ms",
+        "set_state_refresh_pose_cache_ms",
+        "set_state_invalidate_velocity_ms",
+        "set_state_qpos_convert_ms",
+        "set_state_pool_reset_ms",
+        "set_state_state_scatter_ms",
+    )
+
+    def __init__(
+        self,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        base_name: str | None = None,
+        device_id: int | None = None,
+        worker_timeout_s: float | None = None,
+        worker_command: list[str] | None = None,
+        headless: bool = True,
+        **unexpected_kwargs: Any,
+    ) -> None:
+        if unexpected_kwargs:
+            names = ", ".join(sorted(unexpected_kwargs))
+            raise TypeError(f"IsaacGymBackend does not accept backend options: {names}")
+        if isinstance(num_envs, bool) or int(num_envs) <= 0:
+            raise ValueError(f"num_envs must be a positive integer, got {num_envs!r}")
+        if float(sim_dt) <= 0.0:
+            raise ValueError(f"sim_dt must be positive, got {sim_dt!r}")
+        if worker_command is not None and (
+            not isinstance(worker_command, list)
+            or not worker_command
+            or not all(isinstance(part, str) for part in worker_command)
+        ):
+            raise TypeError(
+                "worker_command must be a non-empty list of strings or None, "
+                f"got {worker_command!r}"
+            )
+        if scene.fragment_files:
+            raise NotImplementedError(
+                "isaacgym backend does not compose MuJoCo scene fragments; provide a "
+                "self-contained MJCF scene through scene.model_file"
+            )
+        if scene.terrain is not None:
+            raise NotImplementedError(
+                "isaacgym backend does not support generated terrain scenes yet"
+            )
+
+        self._scene = scene
+        self._num_envs = int(num_envs)
+        self._sim_dt = float(sim_dt)
+        self._base_name = base_name
+        self._device_id = 0 if device_id is None else int(device_id)
+        self._worker_timeout_s = (
+            _DEFAULT_WORKER_TIMEOUT_S if worker_timeout_s is None else float(worker_timeout_s)
+        )
+        if self._worker_timeout_s <= 0.0:
+            raise ValueError(f"worker_timeout_s must be positive, got {self._worker_timeout_s!r}")
+        self._worker_command = list(worker_command) if worker_command is not None else None
+        self._headless = bool(headless)
+        self.backend_type = "isaacgym"
+        self._pre_step_control_fn = None
+        self._scene_cleanup_handle = None
+
+        # Everything below is materialized lazily in materialize().
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._shm_handles: dict[str, shared_memory.SharedMemory] = {}
+        self._slots: dict[str, np.ndarray] = {}
+        self._stderr_file: Any = None
+        self._worker_dead_error: IsaacGymWorkerError | None = None
+        self._model_info: IsaacGymModelInfo | None = None
+        self._scene_metadata: SceneMetadata | None = None
+        self._sensor_map: dict[str, tuple[str, int]] = {}
+        self._body_id_by_name: dict[str, int] = {}
+        self._dof_id_by_name: dict[str, int] = {}
+        self._joint_range: np.ndarray | None = None
+        self._ctrl_range: np.ndarray | None = None
+        self._base_body_id = 0
+
+    # ------------------------------------------------------------------ #
+    # Worker lifecycle (cold path)
+    # ------------------------------------------------------------------ #
+
+    def materialize(self) -> None:
+        """Spawn the worker, run the handshake, and bind shared-memory slots."""
+        if self._proc is not None:
+            return
+        runtime: IsaacGymRuntime | None = None
+        if self._worker_command is None:
+            runtime = resolve_isaacgym_runtime()
+            command = [str(runtime.python), str(_WORKER_PATH)]
+            env = build_worker_env(runtime)
+        else:
+            command = list(self._worker_command)
+            env = None
+        isaacgym_python = str(runtime.isaacgym_python) if runtime is not None else ""
+
+        self._stderr_file = tempfile.TemporaryFile(mode="w+b", prefix="isaacgym_worker_stderr_")
+        try:
+            self._proc = subprocess.Popen(
+                [*command, "--protocol", str(_PROTOCOL_PATH)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=self._stderr_file,
+                bufsize=0,
+                env=env,
+            )
+        except OSError as exc:
+            raise IsaacGymWorkerError(f"failed to spawn isaacgym worker {command}: {exc}") from exc
+
+        try:
+            meta = self._request(
+                protocol.CMD_INIT,
+                {
+                    "model_file": str(Path(self._scene.model_file).expanduser()),
+                    "num_envs": self._num_envs,
+                    "sim_dt": self._sim_dt,
+                    "device_id": self._device_id,
+                    "headless": self._headless,
+                    "isaacgym_python": isaacgym_python,
+                },
+                expect=protocol.CMD_META,
+            )
+            self._bind_model_metadata(meta)
+            self._allocate_slots()
+            self._request(
+                protocol.CMD_ATTACH, {"slots": self._slot_specs()}, expect=protocol.CMD_READY
+            )
+            self._scene_metadata = scan_scene_metadata(
+                str(Path(self._scene.model_file).expanduser())
+            )
+            self._sensor_map = self._resolve_sensor_map()
+            if self._base_name is not None:
+                try:
+                    self._base_body_id = self._body_id_by_name[self._base_name]
+                except KeyError as exc:
+                    raise ValueError(
+                        f"Base body {self._base_name!r} not found in isaacgym model"
+                    ) from exc
+        except Exception:
+            self.close()
+            raise
+        # Subprocess liveness cannot rely on __del__ alone during interpreter
+        # teardown; the atexit hook is unregistered by close().
+        atexit.register(self.close)
+
+    def _bind_model_metadata(self, meta: dict[str, Any]) -> None:
+        num_dof = int(meta["num_dof"])
+        num_bodies = int(meta["num_bodies"])
+        dof_names = tuple(str(name) for name in meta["dof_names"])
+        body_names = tuple(str(name) for name in meta["body_names"])
+        if len(dof_names) != num_dof or len(body_names) != num_bodies:
+            raise IsaacGymWorkerError(
+                "isaacgym worker metadata is inconsistent: "
+                f"num_dof={num_dof} vs {len(dof_names)} names, "
+                f"num_bodies={num_bodies} vs {len(body_names)} names"
+            )
+        gravity = tuple(float(value) for value in meta["gravity"])
+        self._model_info = IsaacGymModelInfo(
+            num_dof=num_dof,
+            num_bodies=num_bodies,
+            dof_names=dof_names,
+            body_names=body_names,
+            gravity=(gravity[0], gravity[1], gravity[2]),
+            use_gpu_pipeline=bool(meta.get("use_gpu_pipeline", False)),
+        )
+        self._body_id_by_name = {name: index for index, name in enumerate(body_names)}
+        self._dof_id_by_name = {name: index for index, name in enumerate(dof_names)}
+        lower = np.asarray(meta["dof_lower"], dtype=np.float32)
+        upper = np.asarray(meta["dof_upper"], dtype=np.float32)
+        self._joint_range = (
+            np.stack([lower, upper], axis=1) if num_dof > 0 else np.zeros((0, 2), np.float32)
+        )
+        effort = np.asarray(meta["effort"], dtype=np.float32)
+        self._ctrl_range = (
+            np.stack([-effort, effort], axis=1) if num_dof > 0 else np.zeros((0, 2), np.float32)
+        )
+
+    def _allocate_slots(self) -> None:
+        assert self._model_info is not None
+        shapes = protocol.slot_shapes(
+            self._num_envs, self._model_info.num_dof, self._model_info.num_bodies
+        )
+        for name in protocol.SLOT_NAMES:
+            shape = shapes[name]
+            handle = shared_memory.SharedMemory(create=True, size=protocol.slot_nbytes(name, shape))
+            self._shm_handles[name] = handle
+            self._slots[name] = np.ndarray(
+                shape, dtype=protocol.slot_dtype(name), buffer=handle.buf
+            )
+
+    def _slot_specs(self) -> dict[str, dict[str, Any]]:
+        return {
+            name: {
+                "shm": handle.name,
+                "shape": list(self._slots[name].shape),
+                "dtype": str(self._slots[name].dtype),
+            }
+            for name, handle in self._shm_handles.items()
+        }
+
+    def _resolve_sensor_map(self) -> dict[str, tuple[str, int]]:
+        """Resolve supported scene sensors to (kind, body_id) on the cold path."""
+        assert self._scene_metadata is not None
+        resolved: dict[str, tuple[str, int]] = {}
+        for name, spec in self._scene_metadata.sensors.items():
+            body_id = self._body_id_by_name.get(spec.body_name)
+            if body_id is None:
+                # The MJCF importer may drop or rename bodies; record as
+                # unsupported so access fails closed with context.
+                self._scene_metadata.unsupported_sensors[name] = _unsupported_spec(
+                    spec,
+                    f"sensor body {spec.body_name!r} is not present in the IsaacGym "
+                    "asset rigid-body list",
+                )
+                continue
+            resolved[name] = (spec.kind, body_id)
+        return resolved
+
+    # ------------------------------------------------------------------ #
+    # Request/response plumbing
+    # ------------------------------------------------------------------ #
+
+    def _stderr_tail(self) -> str:
+        if self._stderr_file is None:
+            return ""
+        try:
+            self._stderr_file.flush()
+            self._stderr_file.seek(0, os.SEEK_END)
+            size = self._stderr_file.tell()
+            self._stderr_file.seek(max(0, size - _STDERR_TAIL_BYTES))
+            return str(self._stderr_file.read().decode("utf-8", errors="replace"))
+        except Exception:
+            return ""
+
+    def _request(self, cmd: str, payload: Any, *, expect: str) -> Any:
+        if self._worker_dead_error is not None:
+            raise IsaacGymWorkerError(
+                f"isaacgym worker is unavailable from an earlier failure; refusing {cmd}"
+            ) from self._worker_dead_error
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise IsaacGymWorkerError(
+                "isaacgym backend is not materialized; call materialize() first"
+            )
+        if proc.poll() is not None:
+            error = IsaacGymWorkerError(
+                f"isaacgym worker exited with code {proc.returncode} before {cmd}; "
+                f"stderr tail:\n{self._stderr_tail()}",
+                stderr_tail=self._stderr_tail(),
+            )
+            self._worker_dead_error = error
+            raise error
+        try:
+            protocol.send_message(cast(BinaryIO, proc.stdin), cmd, payload)
+            message = self._recv_with_timeout(proc.stdout, self._worker_timeout_s, cmd)
+        except IsaacGymWorkerError as exc:
+            self._worker_dead_error = exc
+            self._kill_worker()
+            raise
+        if message["cmd"] == protocol.CMD_ERROR:
+            error = IsaacGymWorkerError(
+                protocol.format_worker_error(message["payload"]),
+                worker_traceback=message["payload"].get("traceback"),
+            )
+            raise error
+        if message["cmd"] != expect:
+            raise IsaacGymWorkerError(
+                f"isaacgym worker replied {message['cmd']!r} to {cmd}, expected {expect!r}"
+            )
+        return message.get("payload")
+
+    def _recv_with_timeout(self, stream: Any, timeout_s: float, cmd: str) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_s
+        try:
+            header = _read_exactly_with_deadline(stream, protocol.HEADER_SIZE, deadline)
+            body = _read_exactly_with_deadline(stream, protocol.unpack_header(header), deadline)
+        except TimeoutError as exc:
+            raise IsaacGymWorkerError(
+                f"isaacgym worker did not answer {cmd} within {timeout_s}s; "
+                f"stderr tail:\n{self._stderr_tail()}",
+                stderr_tail=self._stderr_tail(),
+            ) from exc
+        except protocol.WorkerDisconnectedError as exc:
+            raise IsaacGymWorkerError(
+                f"isaacgym worker closed its pipe during {cmd} "
+                f"(exit code {self._proc.poll() if self._proc else '?'}); "
+                f"stderr tail:\n{self._stderr_tail()}",
+                stderr_tail=self._stderr_tail(),
+            ) from exc
+        return protocol.decode_message(body)
+
+    def _kill_worker(self) -> None:
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            try:
+                proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        """Shut down the worker and release shared memory. Idempotent."""
+        proc, self._proc = self._proc, None
+        shm_handles, self._shm_handles = list(self._shm_handles.values()), {}
+        self._slots = {}
+        stderr_file, self._stderr_file = self._stderr_file, None
+        try:
+            atexit.unregister(self.close)
+        except Exception:
+            pass
+        _release_worker(proc, shm_handles, stderr_file)
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+        try:
+            super().__del__()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ #
+    # Materialized-state guards and views
+    # ------------------------------------------------------------------ #
+
+    def _require_materialized(self) -> IsaacGymModelInfo:
+        if self._model_info is None:
+            raise RuntimeError(
+                "IsaacGymBackend metadata is unavailable before materialize(); "
+                "the worker handshake runs on the materialize cold path"
+            )
+        return self._model_info
+
+    def _require_state(self, operation: str) -> None:
+        self._require_materialized()
+        if self._worker_dead_error is not None:
+            raise IsaacGymWorkerError(
+                f"isaacgym worker is unavailable from an earlier failure; refusing {operation}"
+            ) from self._worker_dead_error
+        if not self._slots:
+            raise IsaacGymWorkerError(
+                f"isaacgym backend is closed or not materialized; refusing {operation}"
+            )
+
+    # ------------------------------------------------------------------ #
+    # SimBackend properties and cold metadata
+    # ------------------------------------------------------------------ #
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def model(self) -> IsaacGymModelInfo:
+        """Return backend-owned model metadata; never a live physics object."""
+        return self._require_materialized()
+
+    @property
+    def num_actuators(self) -> int:
+        return self._require_materialized().num_dof
+
+    @property
+    def num_dof_vel(self) -> int:
+        return self._require_materialized().num_dof
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        self._require_materialized()
+        assert self._ctrl_range is not None
+        return self._ctrl_range.copy()
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self._require_materialized().dof_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        """IsaacGym drives one DoF per joint, so actuator order equals DoF order."""
+        return self._require_materialized().dof_names
+
+    def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
+        """Effort-mode dofs carry no PD gains; report zeros explicitly."""
+        info = self._require_materialized()
+        zeros = np.zeros((info.num_dof,), dtype=np.float32)
+        return zeros, zeros.copy()
+
+    def get_scene_model_file(self) -> str | None:
+        return str(self._scene.model_file)
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        metadata = self._scene_metadata
+        if metadata is None:
+            self._require_materialized()
+            metadata = self._scene_metadata
+        assert metadata is not None
+        try:
+            qpos = metadata.keyframes[name]
+        except KeyError as exc:
+            available = ", ".join(sorted(metadata.keyframes))
+            raise ValueError(f"Keyframe {name!r} not found; available: {available}") from exc
+        nq = _ROOT_QPOS_DIM + self._require_materialized().num_dof
+        if qpos.size != nq:
+            raise ValueError(
+                f"Keyframe {name!r} qpos has {qpos.size} entries; expected {nq} "
+                f"(7 root + {nq - 7} dofs) for the isaacgym layout"
+            )
+        return qpos.copy()
+
+    def get_default_qpos(self) -> np.ndarray:
+        info = self._require_materialized()
+        qpos = np.zeros((_ROOT_QPOS_DIM + info.num_dof,), dtype=np.float32)
+        qpos[3] = 1.0
+        return qpos
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        info = self._require_materialized()
+        return np.zeros((info.num_dof,), dtype=np.float32)
+
+    def get_init_qvel(self) -> np.ndarray:
+        info = self._require_materialized()
+        return np.zeros((_ROOT_QVEL_DIM + info.num_dof,), dtype=np.float32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        info = self._require_materialized()
+        if root_body_name != info.body_names[0]:
+            raise NotImplementedError(
+                "backend 'isaacgym' capability 'root-state layout' requires "
+                f"{root_body_name!r} to be the actor root body {info.body_names[0]!r}"
+            )
+        return BackendRootStateLayout(
+            qpos_indices=tuple(range(_ROOT_QPOS_DIM)),
+            qvel_indices=tuple(range(_ROOT_QVEL_DIM)),
+        )
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        self._require_materialized()
+        resolved: list[int] = []
+        for name in names:
+            try:
+                resolved.append(self._body_id_by_name[str(name)])
+            except KeyError as exc:
+                raise ValueError(f"Body {name!r} not found in isaacgym model") from exc
+        return np.asarray(resolved, dtype=np.int32)
+
+    def get_motion_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_body_ids(names)
+
+    def get_joint_range(self) -> np.ndarray | None:
+        self._require_materialized()
+        if self._joint_range is None or self._joint_range.size == 0:
+            return None
+        return self._joint_range.copy()
+
+    def get_gravity(self) -> np.ndarray:
+        info = self._require_materialized()
+        return np.asarray(info.gravity, dtype=np.float32).copy()
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self._resolve_dof_ids(names)
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self._resolve_dof_ids(names)
+
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self._resolve_dof_ids(names) + _ROOT_QPOS_DIM
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self._resolve_dof_ids(names) + _ROOT_QVEL_DIM
+
+    def _resolve_dof_ids(self, names: Sequence[str]) -> np.ndarray:
+        self._require_materialized()
+        resolved: list[int] = []
+        for name in names:
+            try:
+                resolved.append(self._dof_id_by_name[str(name)])
+            except KeyError as exc:
+                raise ValueError(f"Joint {name!r} not found in isaacgym model") from exc
+        return np.asarray(resolved, dtype=np.int32)
+
+    # ------------------------------------------------------------------ #
+    # Simulation control
+    # ------------------------------------------------------------------ #
+
+    def set_pre_step_control(self, fn: Any | None) -> None:
+        if fn is not None:
+            raise NotImplementedError(
+                "isaacgym rejects host pre-step callbacks; a per-substep callback "
+                "cannot cross the worker process boundary inside one physics substep."
+            )
+        self._pre_step_control_fn = None
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
+        self._require_state("step")
+        if isinstance(nsteps, bool) or int(nsteps) <= 0:
+            raise ValueError(f"nsteps must be a positive integer, got {nsteps!r}")
+        info = self._require_materialized()
+        ctrl_array = np.asarray(ctrl, dtype=np.float32)
+        expected = (self._num_envs, info.num_dof)
+        if ctrl_array.shape != expected:
+            raise ValueError(f"ctrl must have shape {expected}, got {ctrl_array.shape}")
+
+        t0 = time.perf_counter()
+        np.copyto(self._slots["ctrl"], ctrl_array)
+        payload = self._request(
+            protocol.CMD_STEP, {"nsteps": int(nsteps)}, expect=protocol.CMD_READY
+        )
+        ipc_ms = (time.perf_counter() - t0) * 1000.0
+        timing = dict(payload.get("timing", {})) if isinstance(payload, dict) else {}
+        timing["worker_ipc_total_ms"] = ipc_ms
+        return {"timing": timing}
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> dict[str, dict[str, float]]:
+        self._require_state("set_state")
+        if randomization is not None and not randomization.is_empty():
+            requested = ", ".join(sorted(randomization.requested_terms()))
+            raise NotImplementedError(
+                f"isaacgym does not support reset domain randomization terms: {requested}."
+            )
+        info = self._require_materialized()
+        rows = np.asarray(env_indices, dtype=np.intp)
+        if rows.ndim != 1:
+            raise ValueError(f"env_indices must be one-dimensional, got shape {rows.shape}")
+        if np.any(rows < 0) or np.any(rows >= self._num_envs):
+            raise ValueError(f"env_indices must be in [0, {self._num_envs}), got {rows}")
+        if np.unique(rows).size != rows.size:
+            raise ValueError("env_indices must not contain duplicate rows")
+        nq = _ROOT_QPOS_DIM + info.num_dof
+        nv = _ROOT_QVEL_DIM + info.num_dof
+        qpos_array = np.asarray(qpos, dtype=np.float32)
+        qvel_array = np.asarray(qvel, dtype=np.float32)
+        if qpos_array.shape != (rows.size, nq):
+            raise ValueError(f"qpos must have shape ({rows.size}, {nq}), got {qpos_array.shape}")
+        if qvel_array.shape != (rows.size, nv):
+            raise ValueError(f"qvel must have shape ({rows.size}, {nv}), got {qvel_array.shape}")
+
+        timing: dict[str, float] = {key: 0.0 for key in self._SET_STATE_TIMING_ZERO_KEYS}
+        timing.update(
+            {
+                "set_state_reset_upload_ms": 0.0,
+                "set_state_reset_forward_ms": 0.0,
+                "set_state_host_cache_refresh_ms": 0.0,
+                "set_state_internal_gap_ms": 0.0,
+            }
+        )
+        if rows.size == 0:
+            return {"timing": timing}
+
+        t0 = time.perf_counter()
+        count = int(rows.size)
+        np.copyto(self._slots["reset_env_ids"][:count], rows.astype(np.int32))
+        np.copyto(self._slots["reset_qpos"][:count], qpos_array)
+        np.copyto(self._slots["reset_qvel"][:count], qvel_array)
+        payload = self._request(protocol.CMD_SET_STATE, {"count": count}, expect=protocol.CMD_READY)
+        ipc_ms = (time.perf_counter() - t0) * 1000.0
+        if isinstance(payload, dict):
+            worker_timing = payload.get("timing", {})
+            timing["set_state_reset_upload_ms"] = float(
+                worker_timing.get("set_state_reset_upload_ms", 0.0)
+            )
+            timing["set_state_host_cache_refresh_ms"] = float(
+                worker_timing.get("set_state_host_cache_refresh_ms", 0.0)
+            )
+        timing["set_state_internal_gap_ms"] = (
+            ipc_ms - timing["set_state_reset_upload_ms"] - timing["set_state_host_cache_refresh_ms"]
+        )
+        return {"timing": timing}
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        """Advertise no DR until per-env model mutation is effect-tested."""
+        return DomainRandomizationCapabilities()
+
+    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
+        if plan.is_empty():
+            return
+        raise NotImplementedError(
+            "isaacgym does not support interval randomization; disable "
+            "push/body-force/body-velocity terms in the owner YAML."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Cached state getters (shm views; no worker round trip)
+    # ------------------------------------------------------------------ #
+
+    def _root_slot(self) -> np.ndarray:
+        self._require_state("state read")
+        return self._slots["root_state"]
+
+    def _body_slot(self) -> np.ndarray:
+        self._require_state("state read")
+        return self._slots["body_state"]
+
+    def get_base_pos(self) -> np.ndarray:
+        return self._root_slot()[:, 0:3]
+
+    def get_base_quat(self) -> np.ndarray:
+        return self._root_slot()[:, 3:7]
+
+    def get_base_lin_vel(self) -> np.ndarray:
+        return self._root_slot()[:, 7:10]
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        return self._root_slot()[:, 10:13]
+
+    def get_dof_pos(self) -> np.ndarray:
+        self._require_state("get_dof_pos")
+        return self._slots["dof_state"][:, :, 0]
+
+    def get_dof_vel(self) -> np.ndarray:
+        self._require_state("get_dof_vel")
+        return self._slots["dof_state"][:, :, 1]
+
+    def _selected_body_state(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = np.asarray(body_ids, dtype=np.intp)
+        info = self._require_materialized()
+        if ids.ndim != 1 or np.any(ids < 0) or np.any(ids >= info.num_bodies):
+            raise ValueError(
+                f"body_ids must be a 1-D array in [0, {info.num_bodies}), got {body_ids!r}"
+            )
+        return self._body_slot()[:, ids, :]
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._selected_body_state(body_ids)[:, :, 0:3]
+
+    def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._selected_body_state(body_ids)[:, :, 3:7]
+
+    def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._selected_body_state(body_ids)[:, :, 7:10]
+
+    def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._selected_body_state(body_ids)[:, :, 10:13]
+
+    def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
+        base_state = self._body_slot()[:, self._base_body_id, :]
+        rel = self.get_body_pos_w(body_ids) - base_state[:, 0:3][:, None, :]
+        return np_quat_apply_inverse_batched(base_state[:, 3:7][:, None, :], rel)
+
+    def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
+        inverse = self._body_slot()[:, self._base_body_id, 3:7].copy()
+        inverse[:, 1:4] = -inverse[:, 1:4]
+        quat_w = self.get_body_quat_w(body_ids)
+        return np_quat_mul_batched(inverse[:, None, :], quat_w)
+
+    def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        # Contract definition (#1254): world velocity rotated into each body's
+        # own frame, identical to the MuJoCo/mjwarp backends.
+        return np_quat_apply_inverse_batched(
+            self.get_body_quat_w(body_ids), self.get_body_lin_vel_w(body_ids)
+        )
+
+    def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        return np_quat_apply_inverse_batched(
+            self.get_body_quat_w(body_ids), self.get_body_ang_vel_w(body_ids)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Sensors
+    # ------------------------------------------------------------------ #
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        """Compute one mapped scene sensor from the shm state caches.
+
+        See ``sensors.py`` for the MJCF-sensor → tensor-quantity mapping table.
+        Names that are not declared in the scene raise ``ValueError``; declared
+        but unmappable sensors fail closed with ``NotImplementedError``.
+        """
+        self._require_state("get_sensor_data")
+        metadata = self._scene_metadata
+        assert metadata is not None
+        mapped = self._sensor_map.get(name)
+        if mapped is None:
+            unsupported = metadata.unsupported_sensors.get(name)
+            if unsupported is not None:
+                raise NotImplementedError(
+                    f"isaacgym cannot serve sensor {name!r}: {unsupported.reason}"
+                )
+            available = ", ".join(sorted(self._sensor_map))
+            raise ValueError(f"Sensor {name!r} not found; available: {available}")
+        kind, body_id = mapped
+        state = self._body_slot()[:, body_id, :]
+        if kind == KIND_GYRO:
+            return np_quat_apply_inverse_batched(state[:, 3:7], state[:, 10:13]).astype(np.float32)
+        if kind == KIND_LOCAL_LINVEL:
+            return np_quat_apply_inverse_batched(state[:, 3:7], state[:, 7:10]).astype(np.float32)
+        if kind == KIND_FRAMEQUAT:
+            return state[:, 3:7].copy()
+        if kind == KIND_FRAMEPOS:
+            return state[:, 0:3].copy()
+        if kind == KIND_CONTACT_FOUND:
+            force = self._slots["contact_force"][:, body_id, :]
+            return (np.linalg.norm(force, axis=-1, keepdims=True) > 0.0).astype(np.float32)
+        raise NotImplementedError(f"isaacgym sensor kind {kind!r} is not implemented")
+
+
+def _unsupported_spec(spec: SceneSensorSpec, reason: str) -> UnsupportedSensorSpec:
+    return UnsupportedSensorSpec(name=spec.name, reason=reason)
+
+
+__all__ = ["IsaacGymBackend", "IsaacGymModelInfo", "IsaacGymWorkerError"]

--- a/src/unilab/base/backend/isaacgym/dependencies.py
+++ b/src/unilab/base/backend/isaacgym/dependencies.py
@@ -1,0 +1,126 @@
+"""Runtime discovery for the out-of-process IsaacGym (Preview 4) worker.
+
+IsaacGym only supports Python 3.6-3.8 and can never be installed into the
+main UniLab environment (Python >= 3.10).  Physics therefore runs in a
+dedicated conda env created by ``scripts/tools/setup_isaacgym_env.sh`` under
+``$UNILAB_ISAACGYM_HOME`` (default ``~/.unilab/isaacgym``):
+
+- ``miniconda3/envs/hsgym/bin/python3.8`` — the worker interpreter,
+- ``miniconda3/envs/hsgym/lib`` — prepended to the worker's
+  ``LD_LIBRARY_PATH`` (conda ``libstdcxx-ng`` fixes the GLIBCXX mismatch),
+- ``isaacgym/python`` — appended to the worker's ``sys.path``.
+
+``UNILAB_ISAACGYM_PYTHON`` overrides the interpreter path explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+ENV_PYTHON = "UNILAB_ISAACGYM_PYTHON"
+ENV_HOME = "UNILAB_ISAACGYM_HOME"
+
+_CONDA_ENV_REL = Path("miniconda3") / "envs" / "hsgym"
+_ISAACGYM_PYTHON_REL = Path("isaacgym") / "python"
+
+_SETUP_HINT = (
+    "Install the dedicated IsaacGym worker environment with "
+    "scripts/tools/setup_isaacgym_env.sh (see the IsaacGym backend page in "
+    "docs/sphinx/source/*/2-user_guide/3-backends/4-isaacgym.md). The script "
+    "requires a manually downloaded IsaacGym Preview 4 tarball."
+)
+
+
+class IsaacGymDependencyError(ImportError):
+    """Raised with an actionable setup hint when the worker runtime is absent."""
+
+
+@dataclass(frozen=True)
+class IsaacGymRuntime:
+    """Resolved on-disk locations for the Python 3.8 IsaacGym worker."""
+
+    python: Path
+    isaacgym_python: Path
+    lib_path: Path
+
+
+def default_isaacgym_home() -> Path:
+    """Return the default IsaacGym install root (``UNILAB_ISAACGYM_HOME`` aware)."""
+    return Path(os.environ.get(ENV_HOME, "~/.unilab/isaacgym")).expanduser()
+
+
+def _candidate_paths(home: Path) -> IsaacGymRuntime:
+    env_root = home / _CONDA_ENV_REL
+    return IsaacGymRuntime(
+        python=env_root / "bin" / "python3.8",
+        isaacgym_python=home / _ISAACGYM_PYTHON_REL,
+        lib_path=env_root / "lib",
+    )
+
+
+def resolve_isaacgym_runtime(python_override: str | None = None) -> IsaacGymRuntime:
+    """Resolve the worker interpreter and IsaacGym package locations.
+
+    Raises:
+        IsaacGymDependencyError: If any required component is missing.
+    """
+    home = default_isaacgym_home()
+    runtime = _candidate_paths(home)
+
+    if python_override:
+        python = Path(python_override).expanduser()
+    elif os.environ.get(ENV_PYTHON):
+        python = Path(os.environ[ENV_PYTHON]).expanduser()
+    else:
+        python = runtime.python
+    if not python.is_file():
+        raise IsaacGymDependencyError(
+            f"isaacgym backend could not find the Python 3.8 worker interpreter at "
+            f"{python}. {_SETUP_HINT}"
+        )
+    if not runtime.isaacgym_python.is_dir():
+        raise IsaacGymDependencyError(
+            f"isaacgym backend could not find the IsaacGym package directory at "
+            f"{runtime.isaacgym_python}. {_SETUP_HINT}"
+        )
+    if not runtime.lib_path.is_dir():
+        raise IsaacGymDependencyError(
+            f"isaacgym backend could not find the worker conda env lib directory at "
+            f"{runtime.lib_path}. {_SETUP_HINT}"
+        )
+    return IsaacGymRuntime(
+        python=python,
+        isaacgym_python=runtime.isaacgym_python,
+        lib_path=runtime.lib_path,
+    )
+
+
+def isaacgym_runtime_available() -> bool:
+    """Return True when the worker runtime resolves without raising."""
+    try:
+        resolve_isaacgym_runtime()
+    except IsaacGymDependencyError:
+        return False
+    return True
+
+
+def build_worker_env(runtime: IsaacGymRuntime) -> dict[str, str]:
+    """Build the worker process environment with the conda lib path prepended."""
+    env = dict(os.environ)
+    existing = env.get("LD_LIBRARY_PATH", "")
+    env["LD_LIBRARY_PATH"] = f"{runtime.lib_path}:{existing}" if existing else str(runtime.lib_path)
+    return env
+
+
+__all__ = [
+    "ENV_HOME",
+    "ENV_PYTHON",
+    "IsaacGymDependencyError",
+    "IsaacGymRuntime",
+    "build_worker_env",
+    "default_isaacgym_home",
+    "isaacgym_runtime_available",
+    "resolve_isaacgym_runtime",
+]

--- a/src/unilab/base/backend/isaacgym/protocol.py
+++ b/src/unilab/base/backend/isaacgym/protocol.py
@@ -1,0 +1,252 @@
+"""Shared IPC protocol between the host ``IsaacGymBackend`` and its worker.
+
+Both ends load this module by file path: the host through the regular package
+import, the Python 3.8 worker through ``importlib`` on an explicit path.  It
+must therefore stay compatible with Python 3.8 and import only the standard
+library and NumPy — never ``unilab`` itself.
+
+Wire protocol: every control message is a dict ``{"cmd": str, "payload": ...}``
+pickled with protocol 4 (the highest version Python 3.8 understands) and
+framed with an 8-byte little-endian length prefix.  Bulk state never travels
+through the pipe; it lives in ``multiprocessing.shared_memory`` slots whose
+layout is declared by :func:`default_slot_specs`.
+
+Conventions shared by both ends (aligned with the ``SimBackend`` contract):
+
+- ``root_state``/``body_state`` quaternions are ``wxyz``; the worker converts
+  from IsaacGym's native ``xyzw`` at the shm boundary.
+- Angular velocities in shm slots are world-frame; the ``set_state`` qvel
+  root columns carry body-frame angular velocity (converted by the worker).
+- ``ctrl`` is per-DoF actuation force (torque), matching the MuJoCo backend's
+  ``step(ctrl)`` semantics for motor actuators.
+"""
+
+from __future__ import annotations
+
+import pickle
+import struct
+import traceback
+from typing import Any, BinaryIO, Dict, Tuple
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Commands and replies
+# ---------------------------------------------------------------------------
+
+CMD_INIT = "INIT"
+CMD_ATTACH = "ATTACH_SLOTS"
+CMD_STEP = "STEP"
+CMD_SET_STATE = "SET_STATE"
+CMD_REFRESH = "REFRESH"
+CMD_GET_META = "GET_META"
+CMD_SHUTDOWN = "SHUTDOWN"
+
+CMD_READY = "READY"
+CMD_META = "META"
+CMD_ERROR = "ERROR"
+
+_PICKLE_PROTOCOL = 4
+_HEADER = struct.Struct("<Q")
+HEADER_SIZE = _HEADER.size
+
+
+def pack_message(cmd: str, payload: Any = None) -> bytes:
+    """Serialize one message body (without the length header)."""
+    return pickle.dumps({"cmd": cmd, "payload": payload}, protocol=_PICKLE_PROTOCOL)
+
+
+def unpack_header(data: bytes) -> int:
+    """Decode an 8-byte length header into the message body size."""
+    (size,) = _HEADER.unpack(data)
+    return int(size)
+
+
+def decode_message(body: bytes) -> Dict[str, Any]:
+    """Decode one pickled message body and validate its envelope."""
+    message = pickle.loads(body)
+    if not isinstance(message, dict) or "cmd" not in message:
+        raise ValueError(f"malformed worker message: {message!r}")
+    return message
+
+
+# ---------------------------------------------------------------------------
+# Message framing
+# ---------------------------------------------------------------------------
+
+
+class WorkerDisconnectedError(EOFError):
+    """Raised when the pipe to the worker closes mid-message or at EOF."""
+
+
+def send_message(stream: BinaryIO, cmd: str, payload: Any = None) -> None:
+    """Write one framed pickle message and flush."""
+    body = pack_message(cmd, payload)
+    stream.write(_HEADER.pack(len(body)))
+    stream.write(body)
+    stream.flush()
+
+
+def _read_exactly(stream: BinaryIO, size: int) -> bytes:
+    chunks = []
+    remaining = size
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise WorkerDisconnectedError(
+                f"pipe closed while reading {size} bytes (got {size - remaining})"
+            )
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def recv_message(stream: BinaryIO) -> Dict[str, Any]:
+    """Read one framed pickle message."""
+    size = unpack_header(_read_exactly(stream, _HEADER.size))
+    return decode_message(_read_exactly(stream, size))
+
+
+# ---------------------------------------------------------------------------
+# Shared-memory slot layout
+# ---------------------------------------------------------------------------
+
+# name -> (dtype, per-env trailing shape or None for reset staging slots)
+_SLOT_DTYPES: Dict[str, str] = {
+    "ctrl": "float32",
+    "root_state": "float32",
+    "dof_state": "float32",
+    "body_state": "float32",
+    "contact_force": "float32",
+    "reset_env_ids": "int32",
+    "reset_qpos": "float32",
+    "reset_qvel": "float32",
+}
+
+SLOT_NAMES = tuple(_SLOT_DTYPES)
+
+
+def slot_shapes(num_envs: int, num_dof: int, num_bodies: int) -> Dict[str, Tuple[int, ...]]:
+    """Return the fixed shm slot shapes for one backend instance.
+
+    ``num_dof`` excludes the floating root; the full qpos/qvel are therefore
+    ``7 + num_dof`` / ``6 + num_dof``.  Reset staging slots are sized at the
+    full batch so any subset of env rows can be staged in one transaction.
+    """
+    if num_envs <= 0 or num_dof < 0 or num_bodies <= 0:
+        raise ValueError(
+            f"slot shapes require num_envs>0, num_dof>=0, num_bodies>0; "
+            f"got {num_envs}, {num_dof}, {num_bodies}"
+        )
+    nq = 7 + num_dof
+    nv = 6 + num_dof
+    return {
+        "ctrl": (num_envs, num_dof),
+        "root_state": (num_envs, 13),
+        "dof_state": (num_envs, num_dof, 2),
+        "body_state": (num_envs, num_bodies, 13),
+        "contact_force": (num_envs, num_bodies, 3),
+        "reset_env_ids": (num_envs,),
+        "reset_qpos": (num_envs, nq),
+        "reset_qvel": (num_envs, nv),
+    }
+
+
+def slot_dtype(name: str) -> np.dtype:
+    try:
+        return np.dtype(_SLOT_DTYPES[name])
+    except KeyError as exc:
+        raise ValueError(f"unknown shm slot {name!r}; known: {sorted(_SLOT_DTYPES)}") from exc
+
+
+def slot_nbytes(name: str, shape: Tuple[int, ...]) -> int:
+    return int(np.prod(shape, dtype=np.int64)) * int(slot_dtype(name).itemsize)
+
+
+# ---------------------------------------------------------------------------
+# Error payloads
+# ---------------------------------------------------------------------------
+
+
+def serialize_exception(exc: BaseException) -> Dict[str, str]:
+    """Pack a worker-side exception into a picklable ERROR payload."""
+    return {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": traceback.format_exc(),
+    }
+
+
+def format_worker_error(payload: Dict[str, str]) -> str:
+    """Render an ERROR payload for the host-side exception message."""
+    return (
+        f"isaacgym worker raised {payload.get('type', 'Error')}: "
+        f"{payload.get('message', '')}\n"
+        f"worker traceback:\n{payload.get('traceback', '<unavailable>')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quaternion helpers (wxyz, shared so both ends agree on conversions)
+# ---------------------------------------------------------------------------
+
+
+def xyzw_to_wxyz(quat: np.ndarray) -> np.ndarray:
+    """Reorder (..., 4) quaternions from xyzw to wxyz."""
+    quat = np.asarray(quat)
+    return quat[..., [3, 0, 1, 2]]
+
+
+def wxyz_to_xyzw(quat: np.ndarray) -> np.ndarray:
+    """Reorder (..., 4) quaternions from wxyz to xyzw."""
+    quat = np.asarray(quat)
+    return quat[..., [1, 2, 3, 0]]
+
+
+def quat_rotate(quat_wxyz: np.ndarray, vec: np.ndarray) -> np.ndarray:
+    """Rotate (..., 3) vectors by (..., 4) wxyz quaternions (batched)."""
+    q = np.asarray(quat_wxyz, dtype=np.float64)
+    v = np.asarray(vec, dtype=np.float64)
+    w = q[..., 0:1]
+    u = q[..., 1:4]
+    uv = np.cross(u, v)
+    uuv = np.cross(u, uv)
+    return v + 2.0 * (w * uv + uuv)
+
+
+def quat_rotate_inverse(quat_wxyz: np.ndarray, vec: np.ndarray) -> np.ndarray:
+    """Rotate (..., 3) vectors by the inverse of (..., 4) wxyz quaternions."""
+    q = np.asarray(quat_wxyz, dtype=np.float64).copy()
+    q[..., 1:4] = -q[..., 1:4]
+    return quat_rotate(q, vec)
+
+
+__all__ = [
+    "CMD_ATTACH",
+    "CMD_ERROR",
+    "CMD_GET_META",
+    "CMD_INIT",
+    "CMD_META",
+    "CMD_READY",
+    "CMD_REFRESH",
+    "CMD_SET_STATE",
+    "CMD_SHUTDOWN",
+    "CMD_STEP",
+    "HEADER_SIZE",
+    "SLOT_NAMES",
+    "WorkerDisconnectedError",
+    "decode_message",
+    "format_worker_error",
+    "pack_message",
+    "quat_rotate",
+    "quat_rotate_inverse",
+    "recv_message",
+    "send_message",
+    "serialize_exception",
+    "slot_dtype",
+    "slot_nbytes",
+    "slot_shapes",
+    "unpack_header",
+    "wxyz_to_xyzw",
+    "xyzw_to_wxyz",
+]

--- a/src/unilab/base/backend/isaacgym/sensors.py
+++ b/src/unilab/base/backend/isaacgym/sensors.py
@@ -14,13 +14,20 @@ Supported sensor kinds and their tensor-API source:
 ==================  ====================  ===================================
 MJCF element        kind                  source
 ==================  ====================  ===================================
-``gyro``            ``gyro``              body ang-vel rotated into body frame
-``velocimeter``     ``local_linvel``      body lin-vel rotated into body frame
-``framequat``       ``framequat``         body quat (wxyz)
-``framepos``        ``framepos``          body world position
+``gyro``            ``gyro``              body ang-vel in the site frame
+``velocimeter``     ``local_linvel``      body lin-vel in the site frame
+``framequat``       ``framequat``         body/site frame quat (wxyz)
+``framepos``        ``framepos``          body/site frame world position
+``framezaxis``      ``framezaxis``        body/site frame z axis in world
 ``contact``         ``contact_found``     1.0 when the body's net contact force
 (data=found)                              norm is positive, else 0.0
 ==================  ====================  ===================================
+
+Sites are rigidly attached to their owning body, so a site frame is exact:
+the cold-path scan records each site's local ``pos``/``quat`` (identity by
+default) and the hot path composes them with the body's shm state.  Sites
+declared with ``euler``/``axisangle``/``xyaxes``/``zaxis`` orientation
+attributes fail closed — only ``quat`` (wxyz) is parsed.
 
 Anything else (force/torque sensors, accelerometers, rangefinders, contact
 sensors requesting ``force``/``dist`` data, ...) is recorded as unsupported
@@ -41,6 +48,7 @@ KIND_GYRO = "gyro"
 KIND_LOCAL_LINVEL = "local_linvel"
 KIND_FRAMEQUAT = "framequat"
 KIND_FRAMEPOS = "framepos"
+KIND_FRAMEZAXIS = "framezaxis"
 KIND_CONTACT_FOUND = "contact_found"
 
 SUPPORTED_KINDS = (
@@ -48,6 +56,7 @@ SUPPORTED_KINDS = (
     KIND_LOCAL_LINVEL,
     KIND_FRAMEQUAT,
     KIND_FRAMEPOS,
+    KIND_FRAMEZAXIS,
     KIND_CONTACT_FOUND,
 )
 
@@ -56,17 +65,41 @@ _KIND_DIMS = {
     KIND_LOCAL_LINVEL: 3,
     KIND_FRAMEQUAT: 4,
     KIND_FRAMEPOS: 3,
+    KIND_FRAMEZAXIS: 3,
     KIND_CONTACT_FOUND: 1,
 }
+
+# Orientation attributes on a <site> that this backend does not parse; their
+# presence fails the referencing sensor closed instead of silently assuming
+# the identity rotation.
+_UNSUPPORTED_SITE_ORIENTATION_ATTRS = ("euler", "axisangle", "xyaxes", "zaxis")
+
+_IDENTITY_QUAT = (1.0, 0.0, 0.0, 0.0)
+_ZERO_POS = (0.0, 0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class SiteFrame:
+    """Rigid local transform of a site inside its owning body (cold-path data)."""
+
+    body_name: str
+    local_pos: tuple[float, float, float]
+    local_quat: tuple[float, float, float, float]  # wxyz
 
 
 @dataclass(frozen=True)
 class SceneSensorSpec:
-    """One MJCF sensor declaration resolved to its host-side quantity."""
+    """One MJCF sensor declaration resolved to its host-side quantity.
+
+    ``local_pos``/``local_quat`` express the sensor frame (a site, or the
+    identity for a body) inside ``body_name``'s frame.
+    """
 
     name: str
     kind: str
     body_name: str
+    local_pos: tuple[float, float, float] = _ZERO_POS
+    local_quat: tuple[float, float, float, float] = _IDENTITY_QUAT
 
     @property
     def dim(self) -> int:
@@ -115,6 +148,15 @@ def _iter_scene_files(model_file: Path) -> list[Path]:
     return ordered
 
 
+def _parse_floats(raw: str | None, count: int, *, what: str) -> tuple[float, ...] | None:
+    if raw is None:
+        return None
+    values = tuple(float(value) for value in raw.split())
+    if len(values) != count:
+        raise ValueError(f"{what} must have {count} floats, got {raw!r}")
+    return values
+
+
 def _scan_one_file(path: Path, metadata: dict) -> None:
     root = ET.parse(path).getroot()
 
@@ -122,7 +164,26 @@ def _scan_one_file(path: Path, metadata: dict) -> None:
         body_name = body.get("name", "")
         for child in body:
             if child.tag == "site" and child.get("name"):
-                metadata["site_body"][child.get("name")] = body_name
+                site_name = child.get("name")
+                assert site_name is not None
+                metadata["site_attrs"][site_name] = dict(child.attrib)
+                local_pos = (
+                    _parse_floats(child.get("pos"), 3, what=f"site {site_name!r} pos") or _ZERO_POS
+                )
+                local_quat = (
+                    _parse_floats(child.get("quat"), 4, what=f"site {site_name!r} quat")
+                    or _IDENTITY_QUAT
+                )
+                metadata["site_frames"][site_name] = SiteFrame(
+                    body_name=body_name,
+                    local_pos=(local_pos[0], local_pos[1], local_pos[2]),
+                    local_quat=(
+                        local_quat[0],
+                        local_quat[1],
+                        local_quat[2],
+                        local_quat[3],
+                    ),
+                )
             elif child.tag == "geom" and child.get("name"):
                 metadata["geom_body"][child.get("name")] = body_name
             elif child.tag == "body":
@@ -150,11 +211,83 @@ def _scan_one_file(path: Path, metadata: dict) -> None:
         )
 
 
+def _resolve_frame_target(
+    sensor_name: str,
+    tag: str,
+    attrib: dict[str, str],
+    site_frames: dict[str, SiteFrame],
+    site_attrs: dict[str, dict[str, str]],
+) -> SiteFrame | UnsupportedSensorSpec:
+    """Resolve a body/site frame target for frame* sensors."""
+
+    def unsupported(reason: str) -> UnsupportedSensorSpec:
+        return UnsupportedSensorSpec(name=sensor_name, reason=reason)
+
+    objtype = attrib.get("objtype", "body")
+    objname = attrib.get("objname")
+    if objtype == "body":
+        if not objname:
+            return unsupported(f"{tag} sensor {sensor_name!r} has no objname")
+        return SiteFrame(body_name=objname, local_pos=_ZERO_POS, local_quat=_IDENTITY_QUAT)
+    if objtype == "site":
+        orientation_error = _site_orientation_error(sensor_name, tag, objname, site_attrs)
+        if orientation_error is not None:
+            return unsupported(orientation_error)
+        frame = site_frames.get(objname or "")
+        if frame is None:
+            return unsupported(f"{tag} sensor {sensor_name!r} references unknown site {objname!r}")
+        return frame
+    return unsupported(
+        f"{tag} sensor {sensor_name!r} uses unsupported objtype {objtype!r} "
+        f"(objname {objname!r}); only body and site frames map to the IsaacGym "
+        "rigid-body state tensor"
+    )
+
+
+def _site_orientation_error(
+    sensor_name: str,
+    tag: str,
+    site_name: str | None,
+    site_attrs: dict[str, dict[str, str]],
+) -> str | None:
+    """Fail closed when the referenced site uses an unparsed orientation attr."""
+    site_attr = site_attrs.get(site_name or "", {})
+    bad = [key for key in _UNSUPPORTED_SITE_ORIENTATION_ATTRS if key in site_attr]
+    if not bad:
+        return None
+    return (
+        f"{tag} sensor {sensor_name!r} references site {site_name!r} whose orientation "
+        f"is declared via {bad}; only the quat attribute is parsed"
+    )
+
+
+def _resolve_site_sensor(
+    sensor_name: str,
+    tag: str,
+    attrib: dict[str, str],
+    site_frames: dict[str, SiteFrame],
+    site_attrs: dict[str, dict[str, str]],
+) -> SiteFrame | UnsupportedSensorSpec:
+    """Resolve a site-attached sensor (gyro/velocimeter) to its site frame."""
+    site = attrib.get("site")
+    orientation_error = _site_orientation_error(sensor_name, tag, site, site_attrs)
+    if orientation_error is not None:
+        return UnsupportedSensorSpec(name=sensor_name, reason=orientation_error)
+    frame = site_frames.get(site or "")
+    if frame is None:
+        return UnsupportedSensorSpec(
+            name=sensor_name,
+            reason=f"{tag} sensor {sensor_name!r} references unknown site {site!r}",
+        )
+    return frame
+
+
 def _resolve_sensor(
     tag: str,
     name: str,
     attrib: dict[str, str],
-    site_body: dict[str, str],
+    site_frames: dict[str, SiteFrame],
+    site_attrs: dict[str, dict[str, str]],
     geom_body: dict[str, str],
 ) -> SceneSensorSpec | UnsupportedSensorSpec:
     """Map one MJCF sensor element onto a tensor-API-computable quantity."""
@@ -162,33 +295,35 @@ def _resolve_sensor(
     def unsupported(reason: str) -> UnsupportedSensorSpec:
         return UnsupportedSensorSpec(name=name, reason=reason)
 
+    def from_frame(kind: str, frame: SiteFrame) -> SceneSensorSpec:
+        return SceneSensorSpec(
+            name=name,
+            kind=kind,
+            body_name=frame.body_name,
+            local_pos=frame.local_pos,
+            local_quat=frame.local_quat,
+        )
+
     if tag == "gyro":
-        site = attrib.get("site")
-        if site is None or site not in site_body:
-            return unsupported(f"gyro sensor {name!r} references unknown site {site!r}")
-        return SceneSensorSpec(name=name, kind=KIND_GYRO, body_name=site_body[site])
+        frame = _resolve_site_sensor(name, tag, attrib, site_frames, site_attrs)
+        if isinstance(frame, UnsupportedSensorSpec):
+            return frame
+        return from_frame(KIND_GYRO, frame)
     if tag == "velocimeter":
-        site = attrib.get("site")
-        if site is None or site not in site_body:
-            return unsupported(f"velocimeter sensor {name!r} references unknown site {site!r}")
-        return SceneSensorSpec(name=name, kind=KIND_LOCAL_LINVEL, body_name=site_body[site])
-    if tag in ("framequat", "framepos"):
-        objtype = attrib.get("objtype", "body")
-        objname = attrib.get("objname")
-        if objtype == "body":
-            body_name = objname
-        elif objtype == "site" and objname in site_body:
-            # Site frames are approximated by their owning body frame; the
-            # IsaacGym tensor API exposes rigid-body poses only.
-            body_name = site_body[objname]
-        else:
-            return unsupported(
-                f"{tag} sensor {name!r} uses unsupported objtype {objtype!r} (objname {objname!r})"
-            )
-        if not body_name:
-            return unsupported(f"{tag} sensor {name!r} has no resolvable target body")
-        kind = KIND_FRAMEQUAT if tag == "framequat" else KIND_FRAMEPOS
-        return SceneSensorSpec(name=name, kind=kind, body_name=body_name)
+        frame = _resolve_site_sensor(name, tag, attrib, site_frames, site_attrs)
+        if isinstance(frame, UnsupportedSensorSpec):
+            return frame
+        return from_frame(KIND_LOCAL_LINVEL, frame)
+    if tag in ("framequat", "framepos", "framezaxis"):
+        frame = _resolve_frame_target(name, tag, attrib, site_frames, site_attrs)
+        if isinstance(frame, UnsupportedSensorSpec):
+            return frame
+        kind = {
+            "framequat": KIND_FRAMEQUAT,
+            "framepos": KIND_FRAMEPOS,
+            "framezaxis": KIND_FRAMEZAXIS,
+        }[tag]
+        return from_frame(kind, frame)
     if tag == "contact":
         data = (attrib.get("data") or "found").split()
         if data != ["found"]:
@@ -212,14 +347,22 @@ def scan_scene_metadata(model_file: str) -> SceneMetadata:
     path = Path(model_file).expanduser()
     if not path.is_file():
         raise ValueError(f"isaacgym scene model file does not exist: {path}")
-    raw: dict = {"site_body": {}, "geom_body": {}, "sensors": [], "keyframes": {}}
+    raw: dict = {
+        "site_frames": {},
+        "site_attrs": {},
+        "geom_body": {},
+        "sensors": [],
+        "keyframes": {},
+    }
     for scene_file in _iter_scene_files(path):
         _scan_one_file(scene_file, raw)
 
     sensors: dict[str, SceneSensorSpec] = {}
     unsupported: dict[str, UnsupportedSensorSpec] = {}
     for source_file, tag, name, attrib in raw["sensors"]:
-        resolved = _resolve_sensor(tag, name, attrib, raw["site_body"], raw["geom_body"])
+        resolved = _resolve_sensor(
+            tag, name, attrib, raw["site_frames"], raw["site_attrs"], raw["geom_body"]
+        )
         if isinstance(resolved, SceneSensorSpec):
             sensors[name] = resolved
         else:
@@ -241,11 +384,13 @@ __all__ = [
     "KIND_CONTACT_FOUND",
     "KIND_FRAMEPOS",
     "KIND_FRAMEQUAT",
+    "KIND_FRAMEZAXIS",
     "KIND_GYRO",
     "KIND_LOCAL_LINVEL",
     "SUPPORTED_KINDS",
     "SceneMetadata",
     "SceneSensorSpec",
+    "SiteFrame",
     "UnsupportedSensorSpec",
     "scan_scene_metadata",
 ]

--- a/src/unilab/base/backend/isaacgym/sensors.py
+++ b/src/unilab/base/backend/isaacgym/sensors.py
@@ -1,0 +1,251 @@
+"""Cold-path MJCF scene metadata scan for the IsaacGym subprocess backend.
+
+IsaacGym has no MuJoCo sensor concept, so the host backend rebuilds the sensor
+contract from the tensor API.  This module parses the scene MJCF once during
+``materialize()`` (the only lifecycle phase allowed to touch asset files) and
+extracts:
+
+- sensor declarations mapped to quantities computable from the shm tensor
+  caches (see the kind table below), and
+- ``<keyframe>`` qpos snapshots (MuJoCo ``wxyz`` convention, returned as-is).
+
+Supported sensor kinds and their tensor-API source:
+
+==================  ====================  ===================================
+MJCF element        kind                  source
+==================  ====================  ===================================
+``gyro``            ``gyro``              body ang-vel rotated into body frame
+``velocimeter``     ``local_linvel``      body lin-vel rotated into body frame
+``framequat``       ``framequat``         body quat (wxyz)
+``framepos``        ``framepos``          body world position
+``contact``         ``contact_found``     1.0 when the body's net contact force
+(data=found)                              norm is positive, else 0.0
+==================  ====================  ===================================
+
+Anything else (force/torque sensors, accelerometers, rangefinders, contact
+sensors requesting ``force``/``dist`` data, ...) is recorded as unsupported
+and fails closed with an explanatory ``NotImplementedError`` on access.
+Sensor ``noise``/``cutoff`` attributes are ignored: the tensor API has no
+equivalent, and UniLab applies observation noise at the env layer.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+KIND_GYRO = "gyro"
+KIND_LOCAL_LINVEL = "local_linvel"
+KIND_FRAMEQUAT = "framequat"
+KIND_FRAMEPOS = "framepos"
+KIND_CONTACT_FOUND = "contact_found"
+
+SUPPORTED_KINDS = (
+    KIND_GYRO,
+    KIND_LOCAL_LINVEL,
+    KIND_FRAMEQUAT,
+    KIND_FRAMEPOS,
+    KIND_CONTACT_FOUND,
+)
+
+_KIND_DIMS = {
+    KIND_GYRO: 3,
+    KIND_LOCAL_LINVEL: 3,
+    KIND_FRAMEQUAT: 4,
+    KIND_FRAMEPOS: 3,
+    KIND_CONTACT_FOUND: 1,
+}
+
+
+@dataclass(frozen=True)
+class SceneSensorSpec:
+    """One MJCF sensor declaration resolved to its host-side quantity."""
+
+    name: str
+    kind: str
+    body_name: str
+
+    @property
+    def dim(self) -> int:
+        return _KIND_DIMS[self.kind]
+
+
+@dataclass(frozen=True)
+class UnsupportedSensorSpec:
+    """A declared MJCF sensor this backend cannot reproduce, with the reason."""
+
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class SceneMetadata:
+    """Cold-path scan result for one MJCF scene."""
+
+    model_file: str
+    sensors: dict[str, SceneSensorSpec] = field(default_factory=dict)
+    unsupported_sensors: dict[str, UnsupportedSensorSpec] = field(default_factory=dict)
+    keyframes: dict[str, np.ndarray] = field(default_factory=dict)
+
+
+def _iter_scene_files(model_file: Path) -> list[Path]:
+    """Return the scene file plus transitively included MJCF files."""
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+
+    def visit(path: Path) -> None:
+        resolved = path.resolve()
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        ordered.append(resolved)
+        try:
+            root = ET.parse(resolved).getroot()
+        except ET.ParseError as exc:
+            raise ValueError(f"failed to parse MJCF scene file {resolved}: {exc}") from exc
+        for include in root.iter("include"):
+            include_file = include.get("file")
+            if include_file:
+                visit(resolved.parent / include_file)
+
+    visit(model_file)
+    return ordered
+
+
+def _scan_one_file(path: Path, metadata: dict) -> None:
+    root = ET.parse(path).getroot()
+
+    def walk_body(body: ET.Element) -> None:
+        body_name = body.get("name", "")
+        for child in body:
+            if child.tag == "site" and child.get("name"):
+                metadata["site_body"][child.get("name")] = body_name
+            elif child.tag == "geom" and child.get("name"):
+                metadata["geom_body"][child.get("name")] = body_name
+            elif child.tag == "body":
+                walk_body(child)
+
+    for worldbody in root.iter("worldbody"):
+        for body in worldbody:
+            if body.tag == "body":
+                walk_body(body)
+
+    for sensor_block in root.iter("sensor"):
+        for element in sensor_block:
+            name = element.get("name")
+            if not name:
+                continue
+            metadata["sensors"].append((path, element.tag, name, dict(element.attrib)))
+
+    for keyframe in root.iter("key"):
+        name = keyframe.get("name")
+        qpos = keyframe.get("qpos")
+        if not name or qpos is None:
+            continue
+        metadata["keyframes"][name] = np.asarray(
+            [float(value) for value in qpos.split()], dtype=np.float32
+        )
+
+
+def _resolve_sensor(
+    tag: str,
+    name: str,
+    attrib: dict[str, str],
+    site_body: dict[str, str],
+    geom_body: dict[str, str],
+) -> SceneSensorSpec | UnsupportedSensorSpec:
+    """Map one MJCF sensor element onto a tensor-API-computable quantity."""
+
+    def unsupported(reason: str) -> UnsupportedSensorSpec:
+        return UnsupportedSensorSpec(name=name, reason=reason)
+
+    if tag == "gyro":
+        site = attrib.get("site")
+        if site is None or site not in site_body:
+            return unsupported(f"gyro sensor {name!r} references unknown site {site!r}")
+        return SceneSensorSpec(name=name, kind=KIND_GYRO, body_name=site_body[site])
+    if tag == "velocimeter":
+        site = attrib.get("site")
+        if site is None or site not in site_body:
+            return unsupported(f"velocimeter sensor {name!r} references unknown site {site!r}")
+        return SceneSensorSpec(name=name, kind=KIND_LOCAL_LINVEL, body_name=site_body[site])
+    if tag in ("framequat", "framepos"):
+        objtype = attrib.get("objtype", "body")
+        objname = attrib.get("objname")
+        if objtype == "body":
+            body_name = objname
+        elif objtype == "site" and objname in site_body:
+            # Site frames are approximated by their owning body frame; the
+            # IsaacGym tensor API exposes rigid-body poses only.
+            body_name = site_body[objname]
+        else:
+            return unsupported(
+                f"{tag} sensor {name!r} uses unsupported objtype {objtype!r} (objname {objname!r})"
+            )
+        if not body_name:
+            return unsupported(f"{tag} sensor {name!r} has no resolvable target body")
+        kind = KIND_FRAMEQUAT if tag == "framequat" else KIND_FRAMEPOS
+        return SceneSensorSpec(name=name, kind=kind, body_name=body_name)
+    if tag == "contact":
+        data = (attrib.get("data") or "found").split()
+        if data != ["found"]:
+            return unsupported(
+                f"contact sensor {name!r} requests data={data}; only data='found' maps "
+                "to the IsaacGym net-contact-force tensor"
+            )
+        geom = attrib.get("geom2") or attrib.get("geom1")
+        if geom is None or geom not in geom_body:
+            return unsupported(f"contact sensor {name!r} references unknown geom {geom!r}")
+        return SceneSensorSpec(name=name, kind=KIND_CONTACT_FOUND, body_name=geom_body[geom])
+    return unsupported(f"sensor {name!r} uses unsupported MJCF sensor type {tag!r}")
+
+
+def scan_scene_metadata(model_file: str) -> SceneMetadata:
+    """Scan one MJCF scene (with includes) for sensors and keyframes.
+
+    Cold path only: this reads and parses asset XML and must never run on
+    step/reset hot paths.
+    """
+    path = Path(model_file).expanduser()
+    if not path.is_file():
+        raise ValueError(f"isaacgym scene model file does not exist: {path}")
+    raw: dict = {"site_body": {}, "geom_body": {}, "sensors": [], "keyframes": {}}
+    for scene_file in _iter_scene_files(path):
+        _scan_one_file(scene_file, raw)
+
+    sensors: dict[str, SceneSensorSpec] = {}
+    unsupported: dict[str, UnsupportedSensorSpec] = {}
+    for source_file, tag, name, attrib in raw["sensors"]:
+        resolved = _resolve_sensor(tag, name, attrib, raw["site_body"], raw["geom_body"])
+        if isinstance(resolved, SceneSensorSpec):
+            sensors[name] = resolved
+        else:
+            if not resolved.reason.endswith(f"(file: {source_file})"):
+                resolved = UnsupportedSensorSpec(
+                    name=resolved.name, reason=f"{resolved.reason} (file: {source_file})"
+                )
+            unsupported[name] = resolved
+
+    return SceneMetadata(
+        model_file=str(path),
+        sensors=sensors,
+        unsupported_sensors=unsupported,
+        keyframes=raw["keyframes"],
+    )
+
+
+__all__ = [
+    "KIND_CONTACT_FOUND",
+    "KIND_FRAMEPOS",
+    "KIND_FRAMEQUAT",
+    "KIND_GYRO",
+    "KIND_LOCAL_LINVEL",
+    "SUPPORTED_KINDS",
+    "SceneMetadata",
+    "SceneSensorSpec",
+    "UnsupportedSensorSpec",
+    "scan_scene_metadata",
+]

--- a/src/unilab/base/backend/isaacgym/worker.py
+++ b/src/unilab/base/backend/isaacgym/worker.py
@@ -1,0 +1,373 @@
+"""Python 3.8 worker process for the out-of-process IsaacGym backend.
+
+PYTHON 3.8 COMPATIBILITY: IsaacGym (Preview 4, EOL) only supports Python
+3.6-3.8, so this file runs on the dedicated ``hsgym`` conda interpreter.  Keep
+it stdlib + numpy + torch + isaacgym only, and never import ``unilab`` — the
+shared protocol module is loaded by file path (``--protocol``) because the
+worker interpreter has no access to the main environment's site-packages.
+
+Message loop: read one framed command from stdin, dispatch, write one framed
+reply to stdout.  Bulk state crosses the process boundary through shared
+memory slots declared by the host (see ``protocol.slot_shapes``); the pipe
+only carries commands, metadata, and error payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+import time
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+
+def _load_protocol(path: str) -> Any:
+    """Load the shared protocol module by file path (no package import)."""
+    spec = importlib.util.spec_from_file_location("unilab_isaacgym_protocol", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load protocol module from {path!r}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _WorkerContext:
+    """Owns the IsaacGym sim, tensor views, and attached shared-memory slots."""
+
+    def __init__(self, protocol: Any) -> None:
+        self.protocol = protocol
+        # IsaacGym/torch modules are imported inside init_sim; they do not
+        # exist on the host interpreter, so these stay ``Any``.
+        self.gymapi: Any = None
+        self.gymtorch: Any = None
+        self.torch: Any = None
+        self.gym: Any = None
+        self.sim: Any = None
+        self.num_envs = 0
+        self.num_dof = 0
+        self.num_bodies = 0
+        self.sim_dt = 0.0
+        self.device = "cpu"
+        self.use_gpu_pipeline = False
+        self.env_handles: List[Any] = []
+        self.actor_handles: List[Any] = []
+        self.slots: Dict[str, np.ndarray] = {}
+        self._shm_handles: List[Any] = []
+        self._root_state: Any = None
+        self._dof_state: Any = None
+        self._body_state: Any = None
+        self._contact_force: Any = None
+
+    # ------------------------------------------------------------------ #
+    # INIT
+    # ------------------------------------------------------------------ #
+
+    def init_sim(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        isaacgym_python = payload["isaacgym_python"]
+        if isaacgym_python not in sys.path:
+            sys.path.insert(0, isaacgym_python)
+        import torch  # noqa: PLC0415
+        from isaacgym import gymapi, gymtorch  # noqa: PLC0415
+
+        self.gymapi = gymapi
+        self.gymtorch = gymtorch
+        self.torch = torch
+
+        gymapi = self.gymapi
+        self.num_envs = int(payload["num_envs"])
+        self.sim_dt = float(payload["sim_dt"])
+        device_id = int(payload.get("device_id", 0))
+        self.use_gpu_pipeline = device_id >= 0
+        self.device = "cuda:%d" % device_id if self.use_gpu_pipeline else "cpu"
+
+        self.gym = gymapi.acquire_gym()
+        sim_params = gymapi.SimParams()
+        sim_params.dt = self.sim_dt
+        sim_params.substeps = 1
+        sim_params.up_axis = gymapi.UpAxis.UP_AXIS_Z
+        sim_params.gravity = gymapi.Vec3(0.0, 0.0, -9.81)
+        sim_params.physx.solver_type = 1
+        sim_params.physx.num_position_iterations = 4
+        sim_params.physx.num_velocity_iterations = 1
+        sim_params.physx.num_threads = 0
+        sim_params.physx.use_gpu = self.use_gpu_pipeline
+        sim_params.use_gpu_pipeline = self.use_gpu_pipeline
+        graphics_device_id = -1 if payload.get("headless", True) else device_id
+        self.sim = self.gym.create_sim(device_id, graphics_device_id, gymapi.SIM_PHYSX, sim_params)
+        if self.sim is None:
+            raise RuntimeError(
+                "isaacgym create_sim failed (device_id=%d, gpu_pipeline=%s)"
+                % (device_id, self.use_gpu_pipeline)
+            )
+
+        plane_params = gymapi.PlaneParams()
+        plane_params.normal = gymapi.Vec3(0.0, 0.0, 1.0)
+        self.gym.add_ground(self.sim, plane_params)
+
+        model_file = os.fspath(payload["model_file"])
+        asset_root, asset_file = os.path.split(model_file)
+        if not asset_file.lower().endswith((".xml", ".mjcf")):
+            raise RuntimeError(
+                "isaacgym backend currently loads MJCF scenes only; got asset file "
+                "%r. Convert the task scene or extend the worker asset loader." % asset_file
+            )
+        asset_options = gymapi.AssetOptions()
+        asset_options.flip_visual_attachments = True
+        asset_options.default_dof_drive_mode = int(gymapi.DOF_MODE_EFFORT)
+        asset = self.gym.load_asset(self.sim, asset_root, asset_file, asset_options)
+        if asset is None:
+            raise RuntimeError(
+                "isaacgym load_asset failed for %r. MJCF import requires the file to be "
+                "self-contained for IsaacGym's importer (some MuJoCo elements are "
+                "unsupported); run the worker command manually for the importer log." % model_file
+            )
+
+        dof_props = self.gym.get_asset_dof_properties(asset)
+        # Torque-controlled dofs: ctrl maps 1:1 to actuation force, matching the
+        # MuJoCo motor semantics of SimBackend.step(ctrl).
+        dof_props["driveMode"][:].fill(gymapi.DOF_MODE_EFFORT)
+        dof_props["stiffness"][:].fill(0.0)
+        dof_props["damping"][:].fill(0.0)
+
+        spacing = 2.0
+        num_per_row = max(1, int(np.ceil(np.sqrt(self.num_envs))))
+        env_lower = gymapi.Vec3(-spacing, -spacing, 0.0)
+        env_upper = gymapi.Vec3(spacing, spacing, 0.0)
+        pose = gymapi.Transform()
+        pose.p = gymapi.Vec3(0.0, 0.0, 0.0)
+        pose.r = gymapi.Quat(0.0, 0.0, 0.0, 1.0)
+        for env_index in range(self.num_envs):
+            env_handle = self.gym.create_env(self.sim, env_lower, env_upper, num_per_row)
+            actor_handle = self.gym.create_actor(env_handle, asset, pose, "robot", env_index, 0)
+            self.gym.set_actor_dof_properties(env_handle, actor_handle, dof_props)
+            self.env_handles.append(env_handle)
+            self.actor_handles.append(actor_handle)
+
+        self.gym.prepare_sim(self.sim)
+        self._acquire_tensors()
+
+        self.num_dof = int(self.gym.get_asset_dof_count(asset))
+        self.num_bodies = int(self.gym.get_asset_rigid_body_count(asset))
+        lower = np.asarray(dof_props["lower"], dtype=np.float64)
+        upper = np.asarray(dof_props["upper"], dtype=np.float64)
+        effort = np.asarray(dof_props["effort"], dtype=np.float64)
+        return {
+            "num_dof": self.num_dof,
+            "num_bodies": self.num_bodies,
+            "dof_names": list(self.gym.get_asset_dof_names(asset)),
+            "body_names": list(self.gym.get_asset_rigid_body_names(asset)),
+            "dof_lower": lower.tolist(),
+            "dof_upper": upper.tolist(),
+            "effort": effort.tolist(),
+            "gravity": [0.0, 0.0, -9.81],
+            "use_gpu_pipeline": self.use_gpu_pipeline,
+        }
+
+    def _acquire_tensors(self) -> None:
+        gym = self.gym
+        gymtorch = self.gymtorch
+        self._root_state = gymtorch.wrap_tensor(gym.acquire_actor_root_state_tensor(self.sim))
+        self._dof_state = gymtorch.wrap_tensor(gym.acquire_dof_state_tensor(self.sim))
+        self._body_state = gymtorch.wrap_tensor(gym.acquire_rigid_body_state_tensor(self.sim))
+        self._contact_force = gymtorch.wrap_tensor(gym.acquire_net_contact_force_tensor(self.sim))
+
+    # ------------------------------------------------------------------ #
+    # Shared-memory slots
+    # ------------------------------------------------------------------ #
+
+    def attach_slots(self, payload: Dict[str, Any]) -> None:
+        """Attach host-created shm slots and detach them from resource tracking.
+
+        Python's shared_memory resource tracker would otherwise unlink the
+        host-owned segments when this worker exits (CPython issue 39959), so
+        every attached name is unregistered here; the host owns unlinking.
+        """
+        from multiprocessing import resource_tracker, shared_memory  # noqa: PLC0415
+
+        for name, spec in payload["slots"].items():
+            handle = shared_memory.SharedMemory(name=spec["shm"], create=False)
+            resource_tracker.unregister(handle._name, "shared_memory")  # type: ignore[attr-defined]
+            array = np.ndarray(
+                tuple(spec["shape"]), dtype=np.dtype(spec["dtype"]), buffer=handle.buf
+            )
+            self.slots[name] = array
+            self._shm_handles.append(handle)
+        self.refresh_state_slots()
+
+    # ------------------------------------------------------------------ #
+    # State exchange
+    # ------------------------------------------------------------------ #
+
+    def _refresh_tensors(self) -> None:
+        self.gym.refresh_actor_root_state_tensor(self.sim)
+        self.gym.refresh_dof_state_tensor(self.sim)
+        self.gym.refresh_rigid_body_state_tensor(self.sim)
+        self.gym.refresh_net_contact_force_tensor(self.sim)
+
+    def refresh_state_slots(self) -> None:
+        """Copy the latest tensor state into every host-visible shm slot."""
+        protocol = self.protocol
+        self._refresh_tensors()
+        root = self._root_state.view(self.num_envs, -1, 13)[:, 0, :].cpu().numpy()
+        root_slot = self.slots["root_state"]
+        root_slot[:, 0:3] = root[:, 0:3]
+        root_slot[:, 3:7] = protocol.xyzw_to_wxyz(root[:, 3:7])
+        root_slot[:, 7:13] = root[:, 7:13]
+        np.copyto(
+            self.slots["dof_state"],
+            self._dof_state.view(self.num_envs, self.num_dof, 2).cpu().numpy(),
+        )
+        bodies = self._body_state.view(self.num_envs, self.num_bodies, 13).cpu().numpy()
+        body_slot = self.slots["body_state"]
+        body_slot[:, :, 0:3] = bodies[:, :, 0:3]
+        body_slot[:, :, 3:7] = protocol.xyzw_to_wxyz(bodies[:, :, 3:7])
+        body_slot[:, :, 7:13] = bodies[:, :, 7:13]
+        np.copyto(
+            self.slots["contact_force"],
+            self._contact_force.view(self.num_envs, self.num_bodies, 3).cpu().numpy(),
+        )
+
+    def step(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        nsteps = int(payload["nsteps"])
+        timings: Dict[str, float] = {}
+        t0 = time.perf_counter()
+        torch_ctrl = self.torch.from_numpy(np.ascontiguousarray(self.slots["ctrl"])).to(self.device)
+        self.gym.set_dof_actuation_force_tensor(
+            self.sim, self.gymtorch.unwrap_tensor(torch_ctrl.reshape(-1).contiguous())
+        )
+        timings["control_upload_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        for _ in range(nsteps):
+            self.gym.simulate(self.sim)
+            self.gym.fetch_results(self.sim, True)
+        timings["physics_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self.refresh_state_slots()
+        timings["state_refresh_ms"] = (time.perf_counter() - t0) * 1000.0
+        return {"timing": timings}
+
+    def set_state(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        protocol = self.protocol
+        torch = self.torch
+        timings: Dict[str, float] = {}
+        t0 = time.perf_counter()
+        count = int(payload["count"])
+        env_ids = np.ascontiguousarray(self.slots["reset_env_ids"][:count])
+        qpos = np.ascontiguousarray(self.slots["reset_qpos"][:count])
+        qvel = np.ascontiguousarray(self.slots["reset_qvel"][:count])
+
+        root = np.zeros((count, 13), dtype=np.float32)
+        root[:, 0:3] = qpos[:, 0:3]
+        root[:, 3:7] = protocol.wxyz_to_xyzw(qpos[:, 3:7])
+        root[:, 7:10] = qvel[:, 0:3]
+        # Contract qvel carries body-frame angular velocity; IsaacGym root
+        # states take world-frame angular velocity.
+        root[:, 10:13] = protocol.quat_rotate(qpos[:, 3:7], qvel[:, 3:6]).astype(np.float32)
+        # Indexed writes mutate the shared wrapped buffers in place and then
+        # commit through the full tensors (the IsaacGym indexed API pattern:
+        # one actor per env, so the global actor index equals the env index).
+        env_id_tensor = torch.from_numpy(env_ids.astype(np.int32)).to(self.device)
+        root_view = self._root_state.view(self.num_envs, -1, 13)
+        root_view[env_id_tensor.long(), 0, :] = torch.from_numpy(root).to(self.device)
+        self.gym.set_actor_root_state_tensor_indexed(
+            self.sim,
+            self.gymtorch.unwrap_tensor(self._root_state),
+            self.gymtorch.unwrap_tensor(env_id_tensor),
+            count,
+        )
+
+        dof = np.zeros((count, self.num_dof, 2), dtype=np.float32)
+        dof[:, :, 0] = qpos[:, 7 : 7 + self.num_dof]
+        dof[:, :, 1] = qvel[:, 6 : 6 + self.num_dof]
+        dof_view = self._dof_state.view(self.num_envs, self.num_dof, 2)
+        dof_view[env_id_tensor.long(), :, :] = torch.from_numpy(dof).to(self.device)
+        self.gym.set_dof_state_tensor_indexed(
+            self.sim,
+            self.gymtorch.unwrap_tensor(self._dof_state),
+            self.gymtorch.unwrap_tensor(env_id_tensor),
+            count,
+        )
+        timings["set_state_reset_upload_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        # IsaacGym has no kinematics-only forward call; root/dof slots reflect
+        # the applied state immediately, while body/contact slots stay as of
+        # the last physics step until the next STEP.
+        t0 = time.perf_counter()
+        self.refresh_state_slots()
+        timings["set_state_host_cache_refresh_ms"] = (time.perf_counter() - t0) * 1000.0
+        return {"timing": timings}
+
+    def get_meta(self) -> Dict[str, Any]:
+        return {
+            "num_dof": self.num_dof,
+            "num_bodies": self.num_bodies,
+            "use_gpu_pipeline": self.use_gpu_pipeline,
+        }
+
+    def shutdown(self) -> None:
+        if self.gym is not None and self.sim is not None:
+            self.gym.destroy_sim(self.sim)
+            self.sim = None
+        for handle in self._shm_handles:
+            try:
+                handle.close()
+            except Exception:
+                pass
+        self._shm_handles = []
+
+
+def _dispatch(ctx: _WorkerContext, protocol: Any, cmd: str, payload: Any) -> Tuple[str, Any]:
+    if cmd == protocol.CMD_INIT:
+        return protocol.CMD_META, ctx.init_sim(payload)
+    if cmd == protocol.CMD_ATTACH:
+        ctx.attach_slots(payload)
+        return protocol.CMD_READY, None
+    if cmd == protocol.CMD_STEP:
+        return protocol.CMD_READY, ctx.step(payload)
+    if cmd == protocol.CMD_SET_STATE:
+        return protocol.CMD_READY, ctx.set_state(payload)
+    if cmd == protocol.CMD_REFRESH:
+        ctx.refresh_state_slots()
+        return protocol.CMD_READY, None
+    if cmd == protocol.CMD_GET_META:
+        return protocol.CMD_META, ctx.get_meta()
+    raise ValueError(f"unknown command {cmd!r}")
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--protocol", required=True, help="path to protocol.py")
+    args = parser.parse_args(argv)
+    protocol = _load_protocol(args.protocol)
+    ctx = _WorkerContext(protocol)
+
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+    while True:
+        try:
+            message = protocol.recv_message(stdin)
+        except (EOFError, protocol.WorkerDisconnectedError):
+            return 0
+        cmd = message["cmd"]
+        payload = message.get("payload")
+        if cmd == protocol.CMD_SHUTDOWN:
+            try:
+                ctx.shutdown()
+            finally:
+                protocol.send_message(stdout, protocol.CMD_READY)
+            return 0
+        try:
+            reply_cmd, reply_payload = _dispatch(ctx, protocol, cmd, payload)
+        except Exception as exc:  # noqa: BLE001 - every worker error crosses the wire
+            protocol.send_message(stdout, protocol.CMD_ERROR, protocol.serialize_exception(exc))
+            continue
+        protocol.send_message(stdout, reply_cmd, reply_payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -52,6 +52,11 @@ class EnvCfg:
     # device profile never relies on an implicit backend-wide allocation size.
     mjwarp_nconmax: Optional[int] = None
     mjwarp_njmax: Optional[int] = None
+    # ``isaacgym`` runs physics in a Python 3.8 worker subprocess (Preview 4 is
+    # EOL and incompatible with the main environment). ``None`` keeps the
+    # backend defaults (device 0, generous handshake/step timeout).
+    isaacgym_device_id: Optional[int] = None
+    isaacgym_worker_timeout_s: Optional[float] = None
 
     @property
     def max_episode_steps(self) -> Optional[int]:
@@ -83,6 +88,24 @@ class EnvCfg:
                 isinstance(value, bool) or not isinstance(value, int) or value <= 0
             ):
                 raise ValueError(f"{name} must be a positive integer or None, got {value!r}")
+        if self.isaacgym_device_id is not None and (
+            isinstance(self.isaacgym_device_id, bool)
+            or not isinstance(self.isaacgym_device_id, int)
+            or self.isaacgym_device_id < 0
+        ):
+            raise ValueError(
+                "isaacgym_device_id must be a non-negative integer or None, "
+                f"got {self.isaacgym_device_id!r}"
+            )
+        if self.isaacgym_worker_timeout_s is not None and (
+            not isinstance(self.isaacgym_worker_timeout_s, (int, float))
+            or isinstance(self.isaacgym_worker_timeout_s, bool)
+            or self.isaacgym_worker_timeout_s <= 0
+        ):
+            raise ValueError(
+                "isaacgym_worker_timeout_s must be a positive number or None, "
+                f"got {self.isaacgym_worker_timeout_s!r}"
+            )
         if self.cpu_ids is not None:
             ids = list(self.cpu_ids)
             if not ids:

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -39,7 +39,7 @@ class EnvFactory(Protocol):
 
 TEnvFactory = TypeVar("TEnvFactory", bound=EnvFactory)
 RewardOverrideField = Literal["reward_config", "rewards"]
-_SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake")
+_SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 _REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"
 _DEFAULT_REGISTRY_PACKAGES = ("unilab.tasks",)

--- a/tests/base/isaacgym_mock_worker.py
+++ b/tests/base/isaacgym_mock_worker.py
@@ -1,0 +1,222 @@
+"""Deterministic mock IsaacGym worker for protocol-level backend tests.
+
+Runs on the host Python (no IsaacGym install required) and speaks the exact
+``unilab.base.backend.isaacgym.protocol`` wire protocol against shared-memory
+slots.  The physics model is a deterministic kinematic fake, documented here
+so tests can assert exact values:
+
+- STEP integrates ``dof_vel += ctrl * dt`` then ``dof_pos += dof_vel * dt``,
+  and applies free fall to the root: ``lin_vel.z += -9.81 * dt`` then
+  ``pos += lin_vel * dt`` (per substep).
+- ``body_state`` row 0 mirrors the root; body ``i > 0`` sits at a static
+  ``[0.1 * i, 0, 0]` offset from the root with the root's orientation.
+- ``contact_force[:, 1, 0]`` is ``sum(|ctrl|)`` so contact "found" flips with
+  nonzero control.
+- SET_STATE applies the reset slots verbatim (root columns pass through
+  without frame conversion — the mock does not model quat frame math).
+
+Failure modes are selected with ``UNILAB_ISAACGYM_MOCK_BEHAVIOR``:
+``ok`` (default), ``fail_init`` (raise during INIT), ``die_on_step``
+(``os._exit(3)`` on the first STEP), ``hang_on_step`` (sleep on the first
+STEP).  Model dims come from ``UNILAB_ISAACGYM_MOCK_DOF_NAMES`` /
+``UNILAB_ISAACGYM_MOCK_BODY_NAMES`` (comma-separated).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+import time
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+_GRAVITY_Z = -9.81
+
+
+def _load_protocol(path: str) -> Any:
+    spec = importlib.util.spec_from_file_location("unilab_isaacgym_mock_protocol", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load protocol module from {path!r}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _MockSim:
+    def __init__(self, num_envs: int, sim_dt: float, dof_names: List[str], body_names: List[str]):
+        self.num_envs = num_envs
+        self.sim_dt = sim_dt
+        self.dof_names = dof_names
+        self.body_names = body_names
+        self.num_dof = len(dof_names)
+        self.num_bodies = len(body_names)
+        self.root = np.zeros((num_envs, 13), dtype=np.float32)
+        self.root[:, 2] = 1.0
+        self.root[:, 3] = 1.0  # identity quat, wxyz
+        self.dof = np.zeros((num_envs, self.num_dof, 2), dtype=np.float32)
+        self.slots: Dict[str, np.ndarray] = {}
+        self._shm_handles: List[Any] = []
+
+    def attach(self, slots: Dict[str, Dict[str, Any]]) -> None:
+        from multiprocessing import resource_tracker, shared_memory
+
+        for name, spec in slots.items():
+            handle = shared_memory.SharedMemory(name=spec["shm"], create=False)
+            resource_tracker.unregister(handle._name, "shared_memory")
+            self.slots[name] = np.ndarray(
+                tuple(spec["shape"]), dtype=np.dtype(spec["dtype"]), buffer=handle.buf
+            )
+            self._shm_handles.append(handle)
+        self.write_state_slots()
+
+    def write_state_slots(self) -> None:
+        np.copyto(self.slots["root_state"], self.root)
+        np.copyto(self.slots["dof_state"], self.dof)
+        body = self.slots["body_state"]
+        for body_index in range(self.num_bodies):
+            body[:, body_index, :] = self.root
+            if body_index > 0:
+                body[:, body_index, 0:3] = self.root[:, 0:3] + np.float32(0.1 * body_index) * (
+                    np.array([1.0, 0.0, 0.0], dtype=np.float32)
+                )
+        contact = self.slots["contact_force"]
+        contact.fill(0.0)
+        if self.num_bodies > 1:
+            # Tests bind contact sensors to the deepest link; report the mock
+            # force there.
+            contact[:, -1, 0] = np.abs(self.slots["ctrl"]).sum(axis=1)
+
+    def step(self, nsteps: int) -> None:
+        ctrl = self.slots["ctrl"]
+        dt = np.float32(self.sim_dt)
+        for _ in range(nsteps):
+            self.dof[:, :, 1] += ctrl * dt
+            self.dof[:, :, 0] += self.dof[:, :, 1] * dt
+            self.root[:, 9] += np.float32(_GRAVITY_Z) * dt  # lin_vel z
+            self.root[:, 0:3] += self.root[:, 7:10] * dt
+        self.write_state_slots()
+
+    def set_state(self, count: int) -> None:
+        env_ids = self.slots["reset_env_ids"][:count].astype(np.int64)
+        qpos = self.slots["reset_qpos"][:count]
+        qvel = self.slots["reset_qvel"][:count]
+        self.root[env_ids, 0:3] = qpos[:, 0:3]
+        self.root[env_ids, 3:7] = qpos[:, 3:7]
+        self.root[env_ids, 7:10] = qvel[:, 0:3]
+        self.root[env_ids, 10:13] = qvel[:, 3:6]
+        self.dof[env_ids, :, 0] = qpos[:, 7 : 7 + self.num_dof]
+        self.dof[env_ids, :, 1] = qvel[:, 6 : 6 + self.num_dof]
+        self.write_state_slots()
+
+    def meta(self) -> Dict[str, Any]:
+        return {
+            "num_dof": self.num_dof,
+            "num_bodies": self.num_bodies,
+            "dof_names": list(self.dof_names),
+            "body_names": list(self.body_names),
+            "dof_lower": [-1.5] * self.num_dof,
+            "dof_upper": [1.5] * self.num_dof,
+            "effort": [100.0] * self.num_dof,
+            "gravity": [0.0, 0.0, _GRAVITY_Z],
+            "use_gpu_pipeline": False,
+        }
+
+    def close(self) -> None:
+        for handle in self._shm_handles:
+            try:
+                handle.close()
+            except Exception:
+                pass
+        self._shm_handles = []
+
+
+def _csv_env(name: str, default: List[str]) -> List[str]:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return list(default)
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--protocol", required=True)
+    args = parser.parse_args(argv)
+    protocol = _load_protocol(args.protocol)
+    behavior = os.environ.get("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "ok")
+
+    sim: _MockSim | None = None
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+
+    def dispatch(cmd: str, payload: Any) -> Tuple[str, Any]:
+        nonlocal sim
+        if cmd == protocol.CMD_INIT:
+            if behavior == "fail_init":
+                raise RuntimeError("mock init failure")
+            sim = _MockSim(
+                num_envs=int(payload["num_envs"]),
+                sim_dt=float(payload["sim_dt"]),
+                dof_names=_csv_env("UNILAB_ISAACGYM_MOCK_DOF_NAMES", ["j0", "j1", "j2"]),
+                body_names=_csv_env("UNILAB_ISAACGYM_MOCK_BODY_NAMES", ["base", "link0", "link1"]),
+            )
+            return protocol.CMD_META, sim.meta()
+        assert sim is not None
+        if cmd == protocol.CMD_ATTACH:
+            sim.attach(payload["slots"])
+            return protocol.CMD_READY, None
+        if cmd == protocol.CMD_STEP:
+            if behavior == "die_on_step":
+                sys.stderr.write("mock dying on step\n")
+                sys.stderr.flush()
+                os._exit(3)
+            if behavior == "hang_on_step":
+                time.sleep(3600.0)
+            t0 = time.perf_counter()
+            sim.step(int(payload["nsteps"]))
+            physics_ms = (time.perf_counter() - t0) * 1000.0
+            return protocol.CMD_READY, {
+                "timing": {
+                    "control_upload_ms": 0.0,
+                    "physics_ms": physics_ms,
+                    "state_refresh_ms": 0.0,
+                }
+            }
+        if cmd == protocol.CMD_SET_STATE:
+            sim.set_state(int(payload["count"]))
+            return protocol.CMD_READY, {
+                "timing": {
+                    "set_state_reset_upload_ms": 0.0,
+                    "set_state_host_cache_refresh_ms": 0.0,
+                }
+            }
+        if cmd == protocol.CMD_REFRESH:
+            sim.write_state_slots()
+            return protocol.CMD_READY, None
+        if cmd == protocol.CMD_GET_META:
+            return protocol.CMD_META, sim.meta()
+        raise ValueError(f"unknown command {cmd!r}")
+
+    while True:
+        try:
+            message = protocol.recv_message(stdin)
+        except (EOFError, protocol.WorkerDisconnectedError):
+            return 0
+        cmd = message["cmd"]
+        if cmd == protocol.CMD_SHUTDOWN:
+            if sim is not None:
+                sim.close()
+            protocol.send_message(stdout, protocol.CMD_READY)
+            return 0
+        try:
+            reply_cmd, reply_payload = dispatch(cmd, message.get("payload"))
+        except Exception as exc:  # noqa: BLE001 - every worker error crosses the wire
+            protocol.send_message(stdout, protocol.CMD_ERROR, protocol.serialize_exception(exc))
+            continue
+        protocol.send_message(stdout, reply_cmd, reply_payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -26,7 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
 _FACTORY_FILE = SRC_ROOT / "unilab" / "base" / "backend" / "__init__.py"
 _BACKEND_CLASS_NAMES = frozenset(
-    {"MuJoCoBackend", "MotrixBackend", "DrakeBackend", "MjwarpBackend"}
+    {"MuJoCoBackend", "MotrixBackend", "DrakeBackend", "MjwarpBackend", "IsaacGymBackend"}
 )
 _TASK_SOURCE_ROOTS = (
     SRC_ROOT / "unilab" / "envs",
@@ -69,6 +69,12 @@ def _drake_batch_available() -> bool:
     return bool(available)
 
 
+def _isaacgym_runtime_available() -> bool:
+    from unilab.base.backend.isaacgym.dependencies import isaacgym_runtime_available
+
+    return isaacgym_runtime_available()
+
+
 def _require_backend(backend_type: str) -> None:
     if backend_type == "mujoco":
         pytest.importorskip("mujoco", reason="mujoco not installed")
@@ -80,6 +86,9 @@ def _require_backend(backend_type: str) -> None:
     elif backend_type == "drake":
         if not _drake_batch_available():
             pytest.skip("drake batch extension not available")
+    elif backend_type == "isaacgym":
+        if not _isaacgym_runtime_available():
+            pytest.skip("isaacgym requires the Python 3.8 worker runtime")
 
 
 _BACKEND_PARAMS = [
@@ -87,6 +96,7 @@ _BACKEND_PARAMS = [
     pytest.param("motrix", id="motrix"),
     pytest.param("drake", id="drake"),
     pytest.param("mjwarp", id="mjwarp", marks=pytest.mark.slow),
+    pytest.param("isaacgym", id="isaacgym", marks=pytest.mark.slow),
 ]
 
 

--- a/tests/base/test_isaacgym_backend.py
+++ b/tests/base/test_isaacgym_backend.py
@@ -1,0 +1,504 @@
+"""Protocol-level tests for the IsaacGym subprocess backend.
+
+The development machine has no IsaacGym install (the Preview 4 tarball
+requires an NVIDIA account), so these tests drive ``IsaacGymBackend`` through
+``isaacgym_mock_worker.py`` — a deterministic kinematic fake that speaks the
+real wire protocol over real shared memory on the host interpreter.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from unilab.base.backend import create_backend
+from unilab.base.backend.isaacgym import protocol
+from unilab.base.backend.isaacgym.backend import IsaacGymBackend, IsaacGymWorkerError
+from unilab.base.backend.isaacgym.dependencies import (
+    ENV_HOME,
+    ENV_PYTHON,
+    IsaacGymDependencyError,
+    build_worker_env,
+    resolve_isaacgym_runtime,
+)
+from unilab.base.scene import SceneCfg
+
+_MOCK_WORKER = str(Path(__file__).resolve().parent / "isaacgym_mock_worker.py")
+
+SIM_DT = 0.005
+NUM_ENVS = 2
+
+_ROBOT_XML = """
+<mujoco>
+  <worldbody>
+    <geom name="floor_geom" type="plane" size="0 0 0.05"/>
+    <body name="base">
+      <freejoint/>
+      <site name="imu_site"/>
+      <geom name="base_geom" size="0.1"/>
+      <body name="link0">
+        <joint name="j0" type="hinge"/>
+        <geom name="g0" size="0.1"/>
+        <body name="link1">
+          <joint name="j1" type="hinge"/>
+          <geom name="foot_geom" size="0.1"/>
+          <body name="link2">
+            <joint name="j2" type="hinge"/>
+            <geom name="g2" size="0.1"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_SCENE_XML = """
+<mujoco>
+  <include file="robot.xml"/>
+  <sensor>
+    <gyro name="base_gyro" site="imu_site"/>
+    <velocimeter name="base_local_linvel" site="imu_site"/>
+    <framequat name="link0_quat" objtype="body" objname="link0"/>
+    <framepos name="link1_pos" objtype="body" objname="link1"/>
+    <contact name="foot_contact" geom1="floor_geom" geom2="foot_geom" data="found" num="1"/>
+    <accelerometer name="base_acc" site="imu_site"/>
+  </sensor>
+  <keyframe>
+    <key name="home" qpos="0 0 0.8 1 0 0 0 0.1 0.2 0.3"/>
+  </keyframe>
+</mujoco>
+"""
+
+
+@pytest.fixture()
+def scene_file(tmp_path: Path) -> str:
+    (tmp_path / "robot.xml").write_text(textwrap.dedent(_ROBOT_XML), encoding="utf-8")
+    scene = tmp_path / "scene.xml"
+    scene.write_text(textwrap.dedent(_SCENE_XML), encoding="utf-8")
+    return str(scene)
+
+
+def _make_backend(scene_file: str, **kwargs: Any) -> IsaacGymBackend:
+    kwargs.setdefault("worker_command", [sys.executable, _MOCK_WORKER])
+    kwargs.setdefault("worker_timeout_s", 30.0)
+    backend = create_backend(
+        "isaacgym",
+        SceneCfg(model_file=scene_file),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="base",
+        **kwargs,
+    )
+    assert isinstance(backend, IsaacGymBackend)
+    return backend
+
+
+@pytest.fixture()
+def backend(scene_file: str) -> Any:
+    instance = _make_backend(scene_file)
+    instance.materialize()
+    yield instance
+    instance.close()
+
+
+# ---------------------------------------------------------------------------
+# Protocol unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_message_roundtrip() -> None:
+    stream = io.BytesIO()
+    protocol.send_message(stream, protocol.CMD_STEP, {"nsteps": 4})
+    stream.seek(0)
+    message = protocol.recv_message(stream)
+    assert message == {"cmd": "STEP", "payload": {"nsteps": 4}}
+
+    stream.seek(0)
+    header = stream.read(protocol.HEADER_SIZE)
+    assert protocol.unpack_header(header) == len(
+        protocol.pack_message(protocol.CMD_STEP, {"nsteps": 4})
+    )
+    assert protocol.decode_message(stream.read())["cmd"] == "STEP"
+
+
+def test_protocol_recv_eof_raises() -> None:
+    with pytest.raises(protocol.WorkerDisconnectedError):
+        protocol.recv_message(io.BytesIO(b""))
+    with pytest.raises(protocol.WorkerDisconnectedError):
+        protocol.recv_message(io.BytesIO(b"\x10\x00"))
+
+
+def test_protocol_slot_layout() -> None:
+    shapes = protocol.slot_shapes(num_envs=4, num_dof=3, num_bodies=2)
+    assert shapes["ctrl"] == (4, 3)
+    assert shapes["root_state"] == (4, 13)
+    assert shapes["dof_state"] == (4, 3, 2)
+    assert shapes["body_state"] == (4, 2, 13)
+    assert shapes["contact_force"] == (4, 2, 3)
+    assert shapes["reset_env_ids"] == (4,)
+    assert shapes["reset_qpos"] == (4, 10)
+    assert shapes["reset_qvel"] == (4, 9)
+    assert protocol.slot_dtype("reset_env_ids") == np.dtype(np.int32)
+    assert protocol.slot_nbytes("ctrl", shapes["ctrl"]) == 4 * 3 * 4
+    with pytest.raises(ValueError, match="unknown shm slot"):
+        protocol.slot_dtype("nope")
+    with pytest.raises(ValueError, match="num_envs>0"):
+        protocol.slot_shapes(0, 3, 2)
+
+
+def test_protocol_error_payload() -> None:
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        payload = protocol.serialize_exception(exc)
+    assert payload["type"] == "RuntimeError"
+    assert payload["message"] == "boom"
+    assert "RuntimeError: boom" in payload["traceback"]
+    rendered = protocol.format_worker_error(payload)
+    assert "RuntimeError" in rendered and "boom" in rendered
+
+
+def test_protocol_quat_helpers() -> None:
+    xyzw = np.array([[0.1, 0.2, 0.3, 0.9]])
+    wxyz = protocol.xyzw_to_wxyz(xyzw)
+    np.testing.assert_allclose(wxyz, [[0.9, 0.1, 0.2, 0.3]])
+    np.testing.assert_allclose(protocol.wxyz_to_xyzw(wxyz), xyzw)
+
+    # 90-degree rotation about z maps +x to +y (and inverse maps +y to +x).
+    half = np.sqrt(0.5)
+    quat = np.array([[half, 0.0, 0.0, half]])
+    np.testing.assert_allclose(
+        protocol.quat_rotate(quat, np.array([[1.0, 0.0, 0.0]])), [[0.0, 1.0, 0.0]], atol=1e-7
+    )
+    np.testing.assert_allclose(
+        protocol.quat_rotate_inverse(quat, np.array([[0.0, 1.0, 0.0]])),
+        [[1.0, 0.0, 0.0]],
+        atol=1e-7,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dependency discovery
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime_tree(home: Path) -> None:
+    python = home / "miniconda3" / "envs" / "hsgym" / "bin" / "python3.8"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    (home / "miniconda3" / "envs" / "hsgym" / "lib").mkdir(parents=True)
+    (home / "isaacgym" / "python").mkdir(parents=True)
+
+
+def test_dependencies_resolve_default_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_HOME, str(tmp_path))
+    monkeypatch.delenv(ENV_PYTHON, raising=False)
+    _make_runtime_tree(tmp_path)
+    runtime = resolve_isaacgym_runtime()
+    assert runtime.python == tmp_path / "miniconda3" / "envs" / "hsgym" / "bin" / "python3.8"
+    assert runtime.isaacgym_python == tmp_path / "isaacgym" / "python"
+    env = build_worker_env(runtime)
+    assert env["LD_LIBRARY_PATH"].split(":")[0] == str(
+        tmp_path / "miniconda3" / "envs" / "hsgym" / "lib"
+    )
+
+
+def test_dependencies_python_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_HOME, str(tmp_path))
+    _make_runtime_tree(tmp_path)
+    custom = tmp_path / "custom_python"
+    custom.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv(ENV_PYTHON, str(custom))
+    assert resolve_isaacgym_runtime().python == custom
+    assert resolve_isaacgym_runtime(python_override=str(custom)).python == custom
+
+
+def test_dependencies_missing_runtime_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_HOME, str(tmp_path / "empty"))
+    monkeypatch.delenv(ENV_PYTHON, raising=False)
+    with pytest.raises(IsaacGymDependencyError, match="setup_isaacgym_env.sh"):
+        resolve_isaacgym_runtime()
+
+
+# ---------------------------------------------------------------------------
+# Mock-worker protocol tests
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_binds_metadata_and_slots(backend: IsaacGymBackend) -> None:
+    assert backend.num_envs == NUM_ENVS
+    assert backend.num_actuators == 3
+    assert backend.num_dof_vel == 3
+    assert backend.get_actuator_names() == ("j0", "j1", "j2")
+    assert backend.get_actuator_joint_names() == ("j0", "j1", "j2")
+    np.testing.assert_allclose(
+        backend.get_actuator_ctrl_range(), np.array([[-100.0, 100.0]] * 3, dtype=np.float32)
+    )
+    np.testing.assert_allclose(
+        backend.get_joint_range(), np.array([[-1.5, 1.5]] * 3, dtype=np.float32)
+    )
+    np.testing.assert_allclose(backend.get_gravity(), [0.0, 0.0, -9.81])
+    np.testing.assert_array_equal(
+        backend.get_body_ids(["base", "link1"]), np.array([0, 2], dtype=np.int32)
+    )
+    with pytest.raises(ValueError, match="not found"):
+        backend.get_body_ids(["missing_body"])
+
+    default_qpos = backend.get_default_qpos()
+    assert default_qpos.shape == (10,)
+    np.testing.assert_allclose(default_qpos, [0, 0, 0, 1, 0, 0, 0, 0, 0, 0], atol=1e-7)
+    np.testing.assert_allclose(backend.get_init_qvel(), np.zeros(9))
+    np.testing.assert_allclose(backend.get_default_dof_pos(), np.zeros(3))
+    np.testing.assert_allclose(
+        backend.get_keyframe_qpos("home"), [0, 0, 0.8, 1, 0, 0, 0, 0.1, 0.2, 0.3]
+    )
+    with pytest.raises(ValueError, match="Keyframe 'missing'"):
+        backend.get_keyframe_qpos("missing")
+
+    layout = backend.get_root_state_layout("base")
+    assert layout.qpos_indices == tuple(range(7))
+    assert layout.qvel_indices == tuple(range(6))
+    with pytest.raises(NotImplementedError, match="root-state layout"):
+        backend.get_root_state_layout("link0")
+
+    np.testing.assert_array_equal(
+        backend.get_joint_state_qpos_indices(["j1"]), np.array([8], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        backend.get_joint_state_qvel_indices(["j1"]), np.array([7], dtype=np.int32)
+    )
+
+    # Initial state written by the mock at ATTACH.
+    np.testing.assert_allclose(backend.get_base_pos(), [[0, 0, 1], [0, 0, 1]], atol=1e-6)
+    np.testing.assert_allclose(np.linalg.norm(backend.get_base_quat(), axis=-1), 1.0)
+    assert backend.model.num_bodies == 3
+
+
+def test_step_integrates_mock_physics(backend: IsaacGymBackend) -> None:
+    ctrl = np.ones((NUM_ENVS, 3), dtype=np.float32)
+    result = backend.step(ctrl, nsteps=2)
+    assert "timing" in result
+    assert "physics_ms" in result["timing"]
+
+    # Mock: dof_vel += ctrl*dt; dof_pos += dof_vel*dt per substep.
+    expected_vel = np.float32(2 * SIM_DT)
+    expected_pos = np.float32(SIM_DT * SIM_DT) + np.float32(2 * SIM_DT * SIM_DT)
+    np.testing.assert_allclose(backend.get_dof_vel(), expected_vel, atol=1e-7)
+    np.testing.assert_allclose(backend.get_dof_pos(), expected_pos, atol=1e-7)
+
+    # Free fall: v_z after 2 substeps, z += v_z*dt each substep.
+    expected_vz = 2 * (-9.81) * SIM_DT
+    expected_z = 1.0 + (-9.81 * SIM_DT * SIM_DT) + (-9.81 * 2 * SIM_DT * SIM_DT)
+    np.testing.assert_allclose(backend.get_base_lin_vel()[:, 2], expected_vz, rtol=1e-6, atol=1e-7)
+    np.testing.assert_allclose(backend.get_base_pos()[:, 2], expected_z, rtol=1e-6, atol=1e-7)
+
+    with pytest.raises(ValueError, match="ctrl must have shape"):
+        backend.step(np.zeros((NUM_ENVS, 2), dtype=np.float32))
+    with pytest.raises(ValueError, match="nsteps"):
+        backend.step(ctrl, nsteps=0)
+
+
+def test_set_state_roundtrip_and_cache_refresh(backend: IsaacGymBackend) -> None:
+    nq = 10
+    nv = 9
+    rows = np.array([0], dtype=np.int32)
+    qpos = np.zeros((1, nq), dtype=np.float32)
+    qpos[0, :3] = [1.0, 2.0, 0.8]
+    qpos[0, 3] = 1.0
+    qpos[0, 7:] = [0.1, 0.2, 0.3]
+    qvel = np.zeros((1, nv), dtype=np.float32)
+    qvel[0, :3] = [0.5, 0.0, 0.0]
+    qvel[0, 6:] = [1.0, 2.0, 3.0]
+
+    result = backend.set_state(rows, qpos, qvel)
+    assert isinstance(result, dict) and "timing" in result
+    assert "set_state_internal_gap_ms" in result["timing"]
+
+    np.testing.assert_allclose(backend.get_base_pos()[0], [1.0, 2.0, 0.8], atol=1e-6)
+    np.testing.assert_allclose(backend.get_base_lin_vel()[0], [0.5, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(backend.get_dof_pos()[0], [0.1, 0.2, 0.3], atol=1e-6)
+    np.testing.assert_allclose(backend.get_dof_vel()[0], [1.0, 2.0, 3.0], atol=1e-6)
+    # Untouched env keeps its previous state.
+    np.testing.assert_allclose(backend.get_base_pos()[1], [0, 0, 1], atol=1e-6)
+
+    with pytest.raises(ValueError, match="qpos must have shape"):
+        backend.set_state(rows, np.zeros((1, nq + 1), dtype=np.float32), qvel)
+    with pytest.raises(ValueError, match="duplicate rows"):
+        backend.set_state(np.array([0, 0], dtype=np.int32), np.zeros((2, nq)), np.zeros((2, nv)))
+
+
+def test_sensor_mapping_from_scene_scan(backend: IsaacGymBackend) -> None:
+    gyro = backend.get_sensor_data("base_gyro")
+    assert gyro.shape == (NUM_ENVS, 3)
+    np.testing.assert_allclose(gyro, 0.0, atol=1e-6)
+    linvel = backend.get_sensor_data("base_local_linvel")
+    assert linvel.shape == (NUM_ENVS, 3)
+
+    quat = backend.get_sensor_data("link0_quat")
+    assert quat.shape == (NUM_ENVS, 4)
+    np.testing.assert_allclose(np.linalg.norm(quat, axis=-1), 1.0, atol=1e-6)
+
+    pos = backend.get_sensor_data("link1_pos")
+    np.testing.assert_allclose(pos, [[0.2, 0.0, 1.0]] * NUM_ENVS, atol=1e-6)
+
+    # contact "found": zero while ctrl is zero, one after a nonzero torque step.
+    np.testing.assert_allclose(backend.get_sensor_data("foot_contact"), 0.0)
+    backend.step(np.ones((NUM_ENVS, 3), dtype=np.float32))
+    np.testing.assert_allclose(backend.get_sensor_data("foot_contact"), 1.0)
+
+    # Declared but unmappable sensor type fails closed with context.
+    with pytest.raises(NotImplementedError, match="accelerometer"):
+        backend.get_sensor_data("base_acc")
+    with pytest.raises(ValueError, match="Sensor 'nope' not found"):
+        backend.get_sensor_data("nope")
+
+    view = backend.bind_sensor_data(("base_gyro", "base_local_linvel"))
+    assert view.dimensions == (3, 3)
+    values = view.read()
+    assert values.shape == (NUM_ENVS, 6)
+    assert np.isfinite(values).all()
+
+
+def test_body_state_views(backend: IsaacGymBackend) -> None:
+    ids = backend.get_body_ids(["base", "link1"])
+    pos_w = backend.get_body_pos_w(ids)
+    assert pos_w.shape == (NUM_ENVS, 2, 3)
+    np.testing.assert_allclose(pos_w[:, 1], [[0.2, 0.0, 1.0]] * NUM_ENVS, atol=1e-6)
+    # Base-frame link1 offset: [0.2, 0, 0] under the identity base orientation.
+    pos_b = backend.get_body_pos_b(ids)
+    np.testing.assert_allclose(pos_b[:, 1], [[0.2, 0.0, 0.0]] * NUM_ENVS, atol=1e-6)
+    quat_b = backend.get_body_quat_b(ids)
+    np.testing.assert_allclose(quat_b[:, :, 0], 1.0, atol=1e-6)
+    with pytest.raises(ValueError, match="body_ids"):
+        backend.get_body_pos_w(np.array([99]))
+
+
+def test_dr_and_pre_step_control_fail_closed(backend: IsaacGymBackend) -> None:
+    capabilities = backend.get_dr_capabilities()
+    assert not capabilities.supported_reset_terms
+    assert not capabilities.supports_interval_push
+    assert not capabilities.supports_interval_body_force
+
+    class _Plan:
+        def is_empty(self) -> bool:
+            return False
+
+    with pytest.raises(NotImplementedError, match="interval randomization"):
+        backend.apply_interval_randomization(_Plan())
+
+    class _Payload:
+        def is_empty(self) -> bool:
+            return False
+
+        def requested_terms(self) -> set[str]:
+            return {"base_mass"}
+
+    with pytest.raises(NotImplementedError, match="reset domain randomization"):
+        backend.set_state(
+            np.array([0], dtype=np.int32),
+            np.zeros((1, 10), dtype=np.float32),
+            np.zeros((1, 9), dtype=np.float32),
+            randomization=_Payload(),
+        )
+
+    with pytest.raises(NotImplementedError, match="pre-step"):
+        backend.set_pre_step_control(lambda backend_, ctrl: ctrl)
+    backend.set_pre_step_control(None)
+
+    with pytest.raises(NotImplementedError, match="render"):
+        backend.init_renderer()
+    with pytest.raises(NotImplementedError, match="playback"):
+        backend.run_playback(env=None, initialize=None, step=None, num_steps=None)
+
+
+def test_close_reaps_worker_and_unlinks_shm(backend: IsaacGymBackend) -> None:
+    proc = backend._proc
+    assert proc is not None and proc.poll() is None
+    shm_names = [handle.name for handle in backend._shm_handles.values()]
+    backend.close()
+    assert proc.poll() is not None
+    from multiprocessing import shared_memory
+
+    for name in shm_names:
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name, create=False)
+    backend.close()  # idempotent
+    with pytest.raises(IsaacGymWorkerError, match="closed or not materialized"):
+        backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
+
+
+def test_worker_init_error_propagates(scene_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "fail_init")
+    backend = _make_backend(scene_file)
+    try:
+        with pytest.raises(IsaacGymWorkerError, match="mock init failure"):
+            backend.materialize()
+    finally:
+        backend.close()
+
+
+def test_worker_death_reports_stderr_tail(scene_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "die_on_step")
+    backend = _make_backend(scene_file)
+    backend.materialize()
+    try:
+        with pytest.raises(IsaacGymWorkerError, match="mock dying on step"):
+            backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
+        # Later calls fail fast with the cached death diagnostic.
+        with pytest.raises(IsaacGymWorkerError, match="earlier failure"):
+            backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
+    finally:
+        backend.close()
+
+
+def test_worker_timeout_kills_worker(scene_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "hang_on_step")
+    backend = _make_backend(scene_file, worker_timeout_s=1.0)
+    backend.materialize()
+    try:
+        with pytest.raises(IsaacGymWorkerError, match="did not answer STEP"):
+            backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
+        assert backend._proc is not None
+        assert backend._proc.poll() is not None
+    finally:
+        backend.close()
+
+
+def test_constructor_rejects_bad_arguments(scene_file: str) -> None:
+    with pytest.raises(ValueError, match="num_envs"):
+        create_backend("isaacgym", SceneCfg(model_file=scene_file), 0, SIM_DT)
+    with pytest.raises(ValueError, match="sim_dt"):
+        create_backend("isaacgym", SceneCfg(model_file=scene_file), 1, -1.0, worker_command=["x"])
+    with pytest.raises(TypeError, match="worker_command"):
+        _make_backend(scene_file, worker_command="not-a-list")
+    with pytest.raises(NotImplementedError, match="fragments"):
+        create_backend(
+            "isaacgym",
+            SceneCfg(model_file=scene_file, fragment_files=["extra.xml"]),
+            1,
+            SIM_DT,
+        )
+    with pytest.raises(TypeError, match="does not accept backend options"):
+        create_backend("isaacgym", SceneCfg(model_file=scene_file), 1, SIM_DT, bogus_option=1)
+
+
+def test_metadata_access_before_materialize_fails(scene_file: str) -> None:
+    backend = _make_backend(scene_file)
+    try:
+        with pytest.raises(RuntimeError, match="materialize"):
+            _ = backend.num_actuators
+        with pytest.raises(RuntimeError, match="materialize"):
+            backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
+    finally:
+        backend.close()

--- a/tests/base/test_isaacgym_backend.py
+++ b/tests/base/test_isaacgym_backend.py
@@ -41,6 +41,8 @@ _ROBOT_XML = """
     <body name="base">
       <freejoint/>
       <site name="imu_site"/>
+      <site name="tilted_site" pos="0.1 0 0" quat="0.7071068 0 0.7071068 0"/>
+      <site name="euler_site" euler="0.1 0 0"/>
       <geom name="base_geom" size="0.1"/>
       <body name="link0">
         <joint name="j0" type="hinge"/>
@@ -67,6 +69,12 @@ _SCENE_XML = """
     <velocimeter name="base_local_linvel" site="imu_site"/>
     <framequat name="link0_quat" objtype="body" objname="link0"/>
     <framepos name="link1_pos" objtype="body" objname="link1"/>
+    <framepos name="tilted_site_pos" objtype="site" objname="tilted_site"/>
+    <framezaxis name="base_upvector" objtype="body" objname="base"/>
+    <framezaxis name="imu_upvector" objtype="site" objname="imu_site"/>
+    <framezaxis name="tilted_upvector" objtype="site" objname="tilted_site"/>
+    <framezaxis name="euler_upvector" objtype="site" objname="euler_site"/>
+    <framezaxis name="geom_upvector" objtype="geom" objname="base_geom"/>
     <contact name="foot_contact" geom1="floor_geom" geom2="foot_geom" data="found" num="1"/>
     <accelerometer name="base_acc" site="imu_site"/>
   </sensor>
@@ -88,12 +96,13 @@ def scene_file(tmp_path: Path) -> str:
 def _make_backend(scene_file: str, **kwargs: Any) -> IsaacGymBackend:
     kwargs.setdefault("worker_command", [sys.executable, _MOCK_WORKER])
     kwargs.setdefault("worker_timeout_s", 30.0)
+    base_name = kwargs.pop("base_name", "base")
     backend = create_backend(
         "isaacgym",
         SceneCfg(model_file=scene_file),
         NUM_ENVS,
         SIM_DT,
-        base_name="base",
+        base_name=base_name,
         **kwargs,
     )
     assert isinstance(backend, IsaacGymBackend)
@@ -370,6 +379,56 @@ def test_sensor_mapping_from_scene_scan(backend: IsaacGymBackend) -> None:
     assert np.isfinite(values).all()
 
 
+def test_framezaxis_sensor_mapping(backend: IsaacGymBackend) -> None:
+    """framezaxis reports the target frame's z axis in world coordinates."""
+    # Identity orientations at materialize: body/site z axes point up; the
+    # tilted site's local quat (90 deg about y) maps its z axis to +x.
+    np.testing.assert_allclose(
+        backend.get_sensor_data("base_upvector"), [[0, 0, 1]] * NUM_ENVS, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        backend.get_sensor_data("imu_upvector"), [[0, 0, 1]] * NUM_ENVS, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        backend.get_sensor_data("tilted_upvector"), [[1, 0, 0]] * NUM_ENVS, atol=1e-5
+    )
+    # framepos on a site includes the site's local pos offset (rigid attach).
+    np.testing.assert_allclose(
+        backend.get_sensor_data("tilted_site_pos"), [[0.1, 0.0, 1.0]] * NUM_ENVS, atol=1e-6
+    )
+
+    # Rotate the root 90 deg about x (wxyz): body z axis maps to -y.
+    half = np.float32(np.sqrt(0.5))
+    qpos = np.zeros((NUM_ENVS, 10), dtype=np.float32)
+    qpos[:, 2] = 1.0
+    qpos[:, 3] = half
+    qpos[:, 4] = half
+    qvel = np.zeros((NUM_ENVS, 9), dtype=np.float32)
+    backend.set_state(np.arange(NUM_ENVS, dtype=np.int32), qpos, qvel)
+
+    np.testing.assert_allclose(
+        backend.get_sensor_data("base_upvector"), [[0, -1, 0]] * NUM_ENVS, atol=1e-5
+    )
+    np.testing.assert_allclose(
+        backend.get_sensor_data("imu_upvector"), [[0, -1, 0]] * NUM_ENVS, atol=1e-5
+    )
+    # tilted site: local z->x, then the body rotation keeps +x at +x.
+    np.testing.assert_allclose(
+        backend.get_sensor_data("tilted_upvector"), [[1, 0, 0]] * NUM_ENVS, atol=1e-5
+    )
+
+    # Sites declared with euler/axisangle/xyaxes/zaxis fail closed.
+    with pytest.raises(NotImplementedError, match="euler"):
+        backend.get_sensor_data("euler_upvector")
+    # Unknown frame target objtype fails closed as well.
+    with pytest.raises(NotImplementedError, match="objtype"):
+        backend.get_sensor_data("geom_upvector")
+    metadata = backend._scene_metadata
+    assert metadata is not None
+    assert "euler_upvector" in metadata.unsupported_sensors
+    assert "geom_upvector" in metadata.unsupported_sensors
+
+
 def test_body_state_views(backend: IsaacGymBackend) -> None:
     ids = backend.get_body_ids(["base", "link1"])
     pos_w = backend.get_body_pos_w(ids)
@@ -491,6 +550,40 @@ def test_constructor_rejects_bad_arguments(scene_file: str) -> None:
         )
     with pytest.raises(TypeError, match="does not accept backend options"):
         create_backend("isaacgym", SceneCfg(model_file=scene_file), 1, SIM_DT, bogus_option=1)
+
+
+def test_g1_scene_framezaxis_sensors_resolve_from_real_xml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The g1_walk_flat scene declares the upvector sensors the policy needs.
+
+    All four are ``objtype="site"`` frames in ``g1.xml``; the mock worker
+    reports the owning bodies so the cold-path scan must resolve them to
+    exact site-frame z axes.
+    """
+    from unilab.assets import ASSETS_ROOT_PATH
+
+    scene = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+    monkeypatch.setenv(
+        "UNILAB_ISAACGYM_MOCK_BODY_NAMES",
+        "pelvis,torso_link,left_ankle_roll_link,right_ankle_roll_link",
+    )
+    backend = _make_backend(scene, base_name="pelvis")
+    backend.materialize()
+    try:
+        for name in (
+            "pelvis_upvector",
+            "torso_upvector",
+            "left_foot_upvector",
+            "right_foot_upvector",
+        ):
+            value = backend.get_sensor_data(name)
+            assert value.shape == (NUM_ENVS, 3)
+            # Mock state starts at the identity orientation, so every z axis
+            # (these sites are identity-rotated within their bodies) points up.
+            np.testing.assert_allclose(value, [[0.0, 0.0, 1.0]] * NUM_ENVS, atol=1e-6)
+    finally:
+        backend.close()
 
 
 def test_metadata_access_before_materialize_fails(scene_file: str) -> None:

--- a/tests/base/test_registry.py
+++ b/tests/base/test_registry.py
@@ -219,7 +219,7 @@ def test_register_env_invalid_backend_raises():
     if not registry_mod.contains(_name):
         registry_mod.register_env_config(_name, _TestCfgA)
     with pytest.raises(ValueError, match="Unsupported simulation backend"):
-        registry_mod.register_env(_name, _TestEnvA, "isaacgym")
+        registry_mod.register_env(_name, _TestEnvA, "not_a_backend")
 
 
 def test_register_env_without_config_raises():


### PR DESCRIPTION
## 关联

- Closes #1336（Child 2 of roadmap #1332）；依赖 #1334 的运行时布局约定
- Base: `dev/issue-1332-isaacgym-backend`（集成分支）

## 改动

新增 `src/unilab/base/backend/isaacgym/`（~2200 行）：

- `backend.py` — `IsaacGymBackend(SimBackend)`，实现全部 22 个 abstract 方法；metadata 在 INIT/冷路径一次性拉取缓存，热路径 getter 直接读共享内存视图，**零 IPC round trip**。
- `worker.py` — Python 3.8 兼容独立 worker（不 import unilab），驱动 PhysX `use_gpu_pipeline`，经 tensor API 采集 root/dof/body/contact 状态；坐标边界转换（IsaacGym xyzw → 仓库 wxyz 契约）。
- `protocol.py` — 双端共享（仅 stdlib+numpy）：length-prefixed pickle 命令（INIT/ATTACH_SLOTS/STEP/SET_STATE/REFRESH/GET_META/SHUTDOWN）+ `multiprocessing.shared_memory` 批量 slot（ctrl/root_state/dof_state/body_state/reset_*）。
- `sensors.py` — 冷路径 MJCF sensor/keyframe 扫描（含 `<include>` 递归）：gyro / velocimeter / framequat / framepos / framezaxis（site 局部姿态精确复合，euler 等声明 fail-closed）/ contact-found；不可映射类型 fail-closed。
- `dependencies.py` — 运行时发现（`UNILAB_ISAACGYM_PYTHON` / `UNILAB_ISAACGYM_HOME`，默认 `~/.unilab/isaacgym`），缺失时报错指向 `scripts/tools/setup_isaacgym_env.sh`。
- 接线：`create_backend()` isaacgym 分支 + `env_backend_kwargs()`（`isaacgym_device_id` / `isaacgym_worker_timeout_s`）、`_SUPPORTED_SIM_BACKENDS`、conformance 参数化（无运行时 skip）、`test_registry.py` 非法后端用例改名。
- 测试：`tests/base/test_isaacgym_backend.py`（22 用例，mock worker 全协议覆盖：step/set_state/状态回读/sensor 数值/崩溃诊断/僵尸回收/shm 释放）。

## 行为影响

不改现有后端行为；`mujoco`/`motrix`/`mjwarp`/`drake` 路径不变（`create_backend` 仅新增分支）。可选能力（DR、render、playback、pre-step control）按契约 fail-closed。

## Validation（最终 head `cb53b892`）

- `make test-all`（worktree 稳定检出 `cb53b892`，exit 0）：check（ruff+mypy+pyright）通过；`pytest -m "not slow"` 全绿；benchmark smoke 35/36 + 36/37（唯一 skip 为 platform-optional `mlx`）。
- `uv run pytest tests/base -q`：438 passed, 17 skipped, 1 xfailed（isaacgym 真机用例正确 skip）。
- `uv run mypy src/unilab`：Success（254 files）；`ruff format`/`ruff check` 干净；worker.py/protocol.py 经 `ast.parse(feature_version=(3,8))` 验证 py3.8 语法。

## 遗留验证（本机无 IsaacGym tarball，需 NVIDIA 账号下载）

真机端到端：MJCF importer 保真度、`set_*_tensor_indexed` 提交模式、SET_STATE 后 body/contact slot 一步滞后（已注 docstring）、`ctrl_range` 以 dof effort 近似。首台目标机器上人工确认，详见 issue #1336 验收标准。

## 范围复核记录

- 实施中发现 g1 的 `*_upvector` sensor 是 site 上的 `framezaxis`，且 g1_walk_flat policy obs 依赖 `torso_upvector`——触发 #1337 的范围复核点。经评估属于 backend owner layer 内的最小补齐（shm 已有 body quat，site 刚性附着可精确复合），在本 PR 内一并交付（第二个 commit），已在 #1337 汇报中记录。
