### PR TITLE
feat(config): g1_walk_flat 接入 isaacgym 后端与 sim2sim 契约打通

### DIFF
--- a/conf/appo/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/appo/task/g1_walk_flat/isaacgym.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+# IsaacGym APPO owner: inherits the shared 29-DoF flat Manager-Based contract
+# from base.yaml and keeps DENYLIST parity with the MuJoCo owner. The backend
+# consumes the self-contained MJCF scene directly (no scene fragments or
+# generated terrain); effort-mode dofs carry no PD gains, so kp/kd
+# randomization is disabled; playback stays disabled until the backend grows
+# native or offline-record playback.
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: isaacgym
+  play_render_mode: none
+algo:
+  max_iterations: 500
+  save_interval: 100
+env:
+  # GPU device index handed to the worker sim; unset defaults to device 0.
+  isaacgym_device_id: 0
+  events:
+    # Effort-mode dofs carry no PD gains to randomize.
+    pd_gains: null

--- a/conf/flashsac/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/flashsac/task/g1_walk_flat/isaacgym.yaml
@@ -1,0 +1,39 @@
+# @package _global_
+# IsaacGym FlashSAC owner. Mirrors the MuJoCo owner's algo / env / reward
+# identity; isaacgym-specific settings follow conf/sac/task/g1_walk_flat/
+# isaacgym.yaml (self-contained MJCF scene, effort-mode dofs without kp/kd
+# randomization, playback disabled until the backend grows playback support).
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: isaacgym
+  play_render_mode: none
+algo:
+  num_envs: 4096
+  learning_starts: 49
+  max_iterations: 5000
+  save_interval: 1000
+  updates_per_step: 8
+  replay_buffer_n: 256
+  tau: 0.05
+env:
+  # GPU device index handed to the worker sim; unset defaults to device 0.
+  isaacgym_device_id: 0
+  render_spacing: 2.0
+  events:
+    # Effort-mode dofs carry no PD gains to randomize.
+    pd_gains: null
+reward:
+  penalty_action_rate:
+    weight: -5.0
+  penalty_feet_ori:
+    weight: -25.0
+  feet_phase:
+    params:
+      tracking_sigma: 0.005
+  pose:
+    params:
+      pose_weights: [0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 0.01, 2.0, 5.0, 0.01, 5.0, 5.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]

--- a/conf/ppo/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/ppo/task/g1_walk_flat/isaacgym.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+# IsaacGym owner for the subprocess backend (physics runs in a Python 3.8
+# worker). Keeps DENYLIST parity with the MuJoCo owner so cross-backend play
+# transfers 1:1. The backend consumes the self-contained MJCF scene from
+# base.yaml directly (scene fragments and generated terrain are unsupported)
+# and scans keyframes/sensors from it on the materialize cold path. Effort-mode
+# dofs carry no PD gains, so kp/kd randomization is disabled; with no native or
+# offline-record playback yet, playback is disabled at the config level instead
+# of failing closed mid-run.
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: isaacgym
+  play_render_mode: none
+algo:
+  num_envs: 2048
+  max_iterations: 2200
+  empirical_normalization: false
+  obs_groups:
+    actor:
+      - actor
+  policy:
+    actor_hidden_dims: [512, 256, 128]
+    critic_hidden_dims: [512, 256, 128]
+env:
+  # GPU device index handed to the worker sim; unset defaults to device 0.
+  isaacgym_device_id: 0
+  events:
+    # Effort-mode dofs carry no PD gains to randomize.
+    pd_gains: null
+play_profile:
+  enabled: true
+  env:
+    render_spacing: 2.0

--- a/conf/sac/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/sac/task/g1_walk_flat/isaacgym.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+# IsaacGym SAC owner for the subprocess backend (physics runs in a Python 3.8
+# worker). Keeps DENYLIST parity with the MuJoCo owner. The backend consumes
+# the self-contained MJCF scene from base.yaml directly (no scene fragments or
+# generated terrain); effort-mode dofs carry no PD gains, so kp/kd
+# randomization is disabled; with no native or offline-record playback yet,
+# playback is disabled at the config level instead of failing closed mid-run.
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: isaacgym
+  play_render_mode: none
+algo:
+  num_envs: 2048
+  learning_starts: 10
+  max_iterations: 5000
+  save_interval: 1000
+  updates_per_step: 8
+  algo_params:
+    alpha_init: 0.001
+    target_entropy_ratio: 0.0
+env:
+  # GPU device index handed to the worker sim; unset defaults to device 0.
+  isaacgym_device_id: 0
+  render_spacing: 2.0
+  events:
+    # Effort-mode dofs carry no PD gains to randomize.
+    pd_gains: null

--- a/conf/td3/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/td3/task/g1_walk_flat/isaacgym.yaml
@@ -1,0 +1,23 @@
+# @package _global_
+# IsaacGym TD3 owner: inherits the 29-DoF off-policy Manager-Based contract and
+# keeps DENYLIST parity with the MuJoCo owner. The backend consumes the
+# self-contained MJCF scene directly (no scene fragments or generated terrain);
+# effort-mode dofs carry no PD gains, so kp/kd randomization is disabled;
+# playback stays disabled until the backend grows native or offline-record
+# playback.
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: isaacgym
+  play_render_mode: none
+algo:
+  max_iterations: 100000
+env:
+  # GPU device index handed to the worker sim; unset defaults to device 0.
+  isaacgym_device_id: 0
+  events:
+    # Effort-mode dofs carry no PD gains to randomize.
+    pd_gains: null

--- a/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
@@ -6,14 +6,22 @@ Python >= 3.10, so IsaacGym cannot be installed into it; it is used through an
 external, standalone Python 3.8 environment located purely via environment
 variables, with no machine-local paths written into the repository.
 
-Current status: IsaacGym is not yet wired into the registry, task owners, or the
-train/eval pipelines. What already works in this repository is the physics
-benchmark script
+Current status: `IsaacGymBackend` (a subprocess backend whose physics runs in
+the external Python 3.8 worker) is implemented and registered; `g1_walk_flat`
+ships isaacgym owner configs
+(`conf/{ppo,appo,sac,td3,flashsac}/task/g1_walk_flat/isaacgym.yaml`), and the
+cross-backend contract audit (`scripts/audit_sim2sim_contracts.py`) covers the
+mujoco/isaacgym pair. Playback rendering is not supported yet (owner configs
+set `play_render_mode: none`), and the top-level CLI `--sim` flag does not
+list isaacgym yet (same as drake; the backend is selected through the owner
+YAML). Real-machine end-to-end validation (MJCF import fidelity, etc.)
+depends on the external environment described below and is not covered by
+repo CI. The repository also ships a physics benchmark script
 `scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`, which locates
 the external environment through variables such as
-`UNILAB_BENCHMARK_HOLOSOMA_DEPS`. Backend integration is planned under
-[issue #1332](https://github.com/unilabsim/UniLab/issues/1332); this page only
-covers preparing the external environment and validating it with the benchmark.
+`UNILAB_BENCHMARK_HOLOSOMA_DEPS`. This page covers preparing the external
+environment, validating it with the benchmark, and the current integration
+status.
 
 ## Prerequisites
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
@@ -5,12 +5,17 @@ IsaacGym（NVIDIA Preview 4）是 NVIDIA 已停止维护（EOL）的 GPU 物理�
 装进主环境，必须通过外部独立的 Python 3.8 环境使用；仓库内一律通过环境变量
 定位该环境，不写入任何机器本地路径。
 
-当前状态：IsaacGym 尚未接入 registry / task owner / 训练与回放链路。仓库内
-已可用的是物理性能 benchmark 脚本
+当前状态：`IsaacGymBackend`（subprocess 后端，物理跑在外部 Python 3.8
+worker 中）已实现并注册到 registry；`g1_walk_flat` 已提供 isaacgym owner
+配置（`conf/{ppo,appo,sac,td3,flashsac}/task/g1_walk_flat/isaacgym.yaml`），
+跨后端契约审计（`scripts/audit_sim2sim_contracts.py`）覆盖 mujoco↔isaacgym。
+回放渲染尚未支持（owner 配置已将 `play_render_mode` 置为 `none`）；顶层 CLI
+的 `--sim` 暂不含 isaacgym（与 drake 相同，经 owner YAML 选择后端）。真机
+端到端验证（MJCF 导入保真度等）依赖下文所述的外部环境，尚未在仓库 CI 中
+覆盖。仓库内另有物理性能 benchmark 脚本
 `scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`，它通过
-`UNILAB_BENCHMARK_HOLOSOMA_DEPS` 等环境变量定位外部环境。后端接入在
-[issue #1332](https://github.com/unilabsim/UniLab/issues/1332) 中规划；
-本页只覆盖外部环境准备与 benchmark 验证。
+`UNILAB_BENCHMARK_HOLOSOMA_DEPS` 等环境变量定位外部环境。
+本页覆盖外部环境准备、benchmark 验证与当前接入状态。
 
 ## 前置条件
 

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -47,78 +47,80 @@ uv run scripts/generate_support_matrix.py --write
 
 `mjwarp` 完成训练验证的只有 `g1_walk_flat` host adapter：PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`。SAC `t800_walk_flat` 的 mjwarp owner 只有 owner YAML 与 compose 覆盖，标记为 `Configured`，不代表训练验证。mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
 
+`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`，且开发环境没有 IsaacGym runtime：所有 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。owner YAML 通过 `training.play_render_mode=none` 在配置层停用 playback（backend 尚无 native 或离线 record playback）。
+
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
 
 ### Entrypoint x Task Owner
 
-| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix |
-|------------|------------|--------|--------|--------|
-| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
-| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
-| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested |
-| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
-| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested |
-| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - | Tested |
-| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested |
-| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested |
-| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | - | Tested |
-| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - |
-| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
-| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Registered |
-| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
-| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | - | Tested |
-| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | - | Tested |
-| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - | Tested |
-| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - | Tested |
-| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - | Tested |
-| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested |
-| PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested |
-| PPO (torch) | `t800_walk_flat` (t800 walk flat) | Tested | Registered | - |
-| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested |
-| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested |
-| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered |
-| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested |
-| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested |
-| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested |
-| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered |
-| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested |
-| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested |
-| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested |
-| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered |
-| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered |
-| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered |
-| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested |
-| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
-| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Tested |
-| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Registered |
-| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | - | Registered |
-| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | - | Registered |
-| SAC (torch) | `t800_walk_flat` (t800 walk flat) | Tested | Configured | - |
-| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | - | Tested |
-| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | - | Tested |
-| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered |
-| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered |
-| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Registered |
-| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested |
-| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested |
+| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym |
+|------------|------------|--------|--------|--------|----------|
+| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - |
+| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - |
+| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested | - |
+| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Configured |
+| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - |
+| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - | Tested | - |
+| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - |
+| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - |
+| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | - | Tested | - |
+| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - | - |
+| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - |
+| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Registered | - |
+| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - |
+| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | - | Tested | - |
+| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | - | Tested | - |
+| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - | Tested | - |
+| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - | Tested | - |
+| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - | Tested | - |
+| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested | - |
+| PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested | - |
+| PPO (torch) | `t800_walk_flat` (t800 walk flat) | Tested | Registered | - | - |
+| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - |
+| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - |
+| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Configured |
+| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - |
+| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - |
+| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - |
+| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - |
+| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - |
+| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - |
+| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Configured |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested | - |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested | - |
+| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered | - |
+| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered | - |
+| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered | - |
+| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - |
+| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - |
+| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Tested | - |
+| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Registered | - |
+| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | - | Registered | - |
+| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | - | Registered | - |
+| SAC (torch) | `t800_walk_flat` (t800 walk flat) | Tested | Configured | - | - |
+| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | - | Tested | - |
+| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | - | Tested | - |
+| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Configured |
+| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - |
+| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Registered | - |
+| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested | Configured |
+| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - |
 
 ### Source Index
 
@@ -126,4 +128,5 @@ uv run scripts/generate_support_matrix.py --write
 - Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/sac/task/**`, `conf/td3/task/**`, `conf/flashsac/task/**`.
 - Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.
 - Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.
+- Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (currently empty: no IsaacGym runtime on the development fleet).
 <!-- END GENERATED SUPPORT MATRIX -->

--- a/scripts/audit_sim2sim_contracts.py
+++ b/scripts/audit_sim2sim_contracts.py
@@ -29,7 +29,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CONF_ROOT = REPO_ROOT / "conf"
 ABSENT = "<absent>"
 
-PRIMARY_PAIR = ("mujoco", "motrix")
+# Audited backend pairs. mujoco<->motrix is the historical primary contract;
+# mujoco<->isaacgym covers the subprocess backend owners.
+CONTRACT_PAIRS: tuple[tuple[str, str], ...] = (
+    ("mujoco", "motrix"),
+    ("mujoco", "isaacgym"),
+)
 
 
 def _values_equal(a: Any, b: Any) -> bool:
@@ -73,13 +78,13 @@ def _discover(tree: str) -> dict[str, list[str]]:
     return {task: sorted(backends) for task, backends in sorted(out.items())}
 
 
-def _diff_field(path: str, mj: Any, mx: Any) -> dict[str, Any] | None:
-    mj_absent, mx_absent = mj is ABSENT, mx is ABSENT
-    if mj_absent and mx_absent:
+def _diff_field(path: str, left: Any, right: Any) -> dict[str, Any] | None:
+    left_absent, right_absent = left is ABSENT, right is ABSENT
+    if left_absent and right_absent:
         return None
-    if mj_absent != mx_absent:
+    if left_absent != right_absent:
         kind = "asymmetric-presence"
-    elif _values_equal(mj, mx):
+    elif _values_equal(left, right):
         return None
     else:
         kind = "value-diff"
@@ -89,9 +94,29 @@ def _diff_field(path: str, mj: Any, mx: Any) -> dict[str, Any] | None:
     return {
         "field": path,
         "kind": kind,
-        "mujoco": _fmt(mj),
-        "motrix": _fmt(mx),
+        "left": _fmt(left),
+        "right": _fmt(right),
         "guard_enforced": guard_enforced,
+    }
+
+
+def _audit_pair(
+    left_name: str,
+    right_name: str,
+    left: dict[str, Any],
+    right: dict[str, Any],
+) -> dict[str, Any]:
+    deny = [d for p in DENYLIST if (d := _diff_field(p, left.get(p, ABSENT), right.get(p, ABSENT)))]
+    warn = [
+        d for p in WARNING_LIST if (d := _diff_field(p, left.get(p, ABSENT), right.get(p, ABSENT)))
+    ]
+    return {
+        "pair": f"{left_name}<->{right_name}",
+        "left_name": left_name,
+        "right_name": right_name,
+        "verdict": "TRANSFERABLE" if not deny else "BLOCKED",
+        "deny_diffs": deny,
+        "warn_diffs": warn,
     }
 
 
@@ -110,20 +135,17 @@ def audit_tree(tree: str) -> list[dict[str, Any]]:
             except Exception as exc:  # noqa: BLE001 - report, do not abort the sweep
                 errors[backend] = f"{type(exc).__name__}: {exc}"
 
-        mj_name, mx_name = PRIMARY_PAIR
-        if mj_name in values and mx_name in values:
-            mj, mx = values[mj_name], values[mx_name]
-            deny = [
-                d for p in DENYLIST if (d := _diff_field(p, mj.get(p, ABSENT), mx.get(p, ABSENT)))
-            ]
-            warn = [
-                d
-                for p in WARNING_LIST
-                if (d := _diff_field(p, mj.get(p, ABSENT), mx.get(p, ABSENT)))
-            ]
-            verdict = "TRANSFERABLE" if not deny else "BLOCKED"
+        pairs = [
+            _audit_pair(left_name, right_name, values[left_name], values[right_name])
+            for left_name, right_name in CONTRACT_PAIRS
+            if left_name in values and right_name in values
+        ]
+        if not pairs:
+            verdict = "N/A (no audited backend pair)"
+        elif any(pair["verdict"] == "BLOCKED" for pair in pairs):
+            verdict = "BLOCKED"
         else:
-            deny, warn, verdict = [], [], "N/A (no mujoco+motrix pair)"
+            verdict = "TRANSFERABLE"
 
         rows.append(
             {
@@ -131,8 +153,7 @@ def audit_tree(tree: str) -> list[dict[str, Any]]:
                 "task": task,
                 "backends": backends,
                 "verdict": verdict,
-                "deny_diffs": deny,
-                "warn_diffs": warn,
+                "pairs": pairs,
                 "errors": errors,
             }
         )
@@ -144,24 +165,34 @@ def _print_human(rows: list[dict[str, Any]]) -> None:
         print(f"\n### [{row['tree']}] {row['task']}  backends={row['backends']}")
         if row["errors"]:
             print(f"  COMPOSE ERRORS: {row['errors']}")
-        print(f"  VERDICT (mujoco<->motrix): {row['verdict']}")
-        for diff in row["deny_diffs"]:
-            flag = (
-                "" if diff["guard_enforced"] else "  [guard-blind-spot: re-check dataclass default]"
-            )
-            print(
-                f"    DENY  {diff['field']} [{diff['kind']}]: "
-                f"mujoco={diff['mujoco']}  motrix={diff['motrix']}{flag}"
-            )
-        for diff in row["warn_diffs"]:
-            print(
-                f"    warn  {diff['field']} [{diff['kind']}]: "
-                f"mujoco={diff['mujoco']}  motrix={diff['motrix']}"
-            )
+        if not row["pairs"]:
+            print(f"  VERDICT: {row['verdict']}")
+            continue
+        for pair in row["pairs"]:
+            print(f"  VERDICT ({pair['pair']}): {pair['verdict']}")
+            for diff in pair["deny_diffs"]:
+                flag = (
+                    ""
+                    if diff["guard_enforced"]
+                    else "  [guard-blind-spot: re-check dataclass default]"
+                )
+                print(
+                    f"    DENY  {diff['field']} [{diff['kind']}]: "
+                    f"{pair['left_name']}={diff['left']}  {pair['right_name']}={diff['right']}{flag}"
+                )
+            for diff in pair["warn_diffs"]:
+                print(
+                    f"    warn  {diff['field']} [{diff['kind']}]: "
+                    f"{pair['left_name']}={diff['left']}  {pair['right_name']}={diff['right']}"
+                )
 
     transferable = [r for r in rows if r["verdict"] == "TRANSFERABLE"]
     blocked = [r for r in rows if r["verdict"] == "BLOCKED"]
-    blind = [r for r in blocked if any(not d["guard_enforced"] for d in r["deny_diffs"])]
+    blind = [
+        r
+        for r in blocked
+        if any(not d["guard_enforced"] for pair in r["pairs"] for d in pair["deny_diffs"])
+    ]
     print("\n" + "=" * 80)
     print(
         f"TRANSFERABLE: {len(transferable)}   BLOCKED: {len(blocked)}   "
@@ -170,7 +201,12 @@ def _print_human(rows: list[dict[str, Any]]) -> None:
     if blind:
         print("Tasks with an asymmetric-presence DENYLIST field the guard may NOT enforce:")
         for r in blind:
-            fields = [d["field"] for d in r["deny_diffs"] if not d["guard_enforced"]]
+            fields = [
+                d["field"]
+                for pair in r["pairs"]
+                for d in pair["deny_diffs"]
+                if not d["guard_enforced"]
+            ]
             print(f"  - [{r['tree']}] {r['task']}: {fields}")
 
 

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -14,7 +14,7 @@ from unilab.base.registry import ensure_registries
 
 BEGIN_MARKER = "<!-- BEGIN GENERATED SUPPORT MATRIX -->"
 END_MARKER = "<!-- END GENERATED SUPPORT MATRIX -->"
-BACKENDS: tuple[str, ...] = ("mujoco", "mjwarp", "motrix")
+BACKENDS: tuple[str, ...] = ("mujoco", "mjwarp", "motrix", "isaacgym")
 
 # Maintainer-confirmed completed training validations. Keep this mapping narrow:
 # generic config/contract coverage must not promote an unvalidated entrypoint.
@@ -24,6 +24,11 @@ _MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS = frozenset(
         ("sac_torch", "g1_walk_flat"),
     }
 )
+
+# Maintainer-confirmed completed training validations for the isaacgym
+# subprocess backend. The development fleet has no IsaacGym runtime yet, so no
+# entrypoint qualifies; keep this empty until real-hardware validation lands.
+_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS: frozenset[tuple[str, str]] = frozenset()
 
 _TASK_ORDER = {
     "go1_joystick_flat": 0,
@@ -202,6 +207,11 @@ def _is_tested(spec: EntrypointSpec, task_slug: str, backend: str, root: Path) -
             spec.entrypoint_id,
             task_slug,
         ) in _MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS
+    if backend == "isaacgym":
+        return (
+            spec.entrypoint_id,
+            task_slug,
+        ) in _MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS
     return spec.generic_tested
 
 
@@ -302,20 +312,25 @@ def render_support_matrix(root: Path | None = None) -> str:
         "interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry "
         "identity，不代表对应算法、terrain、完整 DR 或 production training 支持。",
         "",
+        "`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`，且开发环境没有 IsaacGym "
+        "runtime：所有 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract "
+        "覆盖），不代表任何训练或 play 验证。owner YAML 通过 `training.play_render_mode=none` 在配置层"
+        "停用 playback（backend 尚无 native 或离线 record playback）。",
+        "",
         benchmark_note,
         recommendation_note,
         "",
         "### Entrypoint x Task Owner",
         "",
-        "| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix |",
-        "|------------|------------|--------|--------|--------|",
+        "| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym |",
+        "|------------|------------|--------|--------|--------|----------|",
     ]
 
     for row in build_support_rows(resolved_root):
         lines.append(
             f"| {row.entrypoint_label} | `{row.task_slug}` ({row.task_label}) | "
             f"{row.cells['mujoco'].level.label} | {row.cells['mjwarp'].level.label} | "
-            f"{row.cells['motrix'].level.label} |"
+            f"{row.cells['motrix'].level.label} | {row.cells['isaacgym'].level.label} |"
         )
 
     lines.extend(
@@ -327,6 +342,7 @@ def render_support_matrix(root: Path | None = None) -> str:
             "- Owner YAML scan: `conf/ppo/task/**`, `conf/appo/task/**`, `conf/sac/task/**`, `conf/td3/task/**`, `conf/flashsac/task/**`.",
             "- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.",
             "- Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.",
+            "- Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (currently empty: no IsaacGym runtime on the development fleet).",
         ]
     )
     return "\n".join(lines)

--- a/src/unilab/tasks/locomotion/g1/__init__.py
+++ b/src/unilab/tasks/locomotion/g1/__init__.py
@@ -9,6 +9,7 @@ registry.register_env_config("G1WalkFlat", ManagerBasedRlEnvCfg)
 registry.register_env("G1WalkFlat", make_g1_walk_env, sim_backend="mujoco")
 registry.register_env("G1WalkFlat", make_g1_walk_env, sim_backend="mjwarp")
 registry.register_env("G1WalkFlat", make_g1_walk_env, sim_backend="motrix")
+registry.register_env("G1WalkFlat", make_g1_walk_env, sim_backend="isaacgym")
 
 registry.register_env_config("G1WalkRough", ManagerBasedRlEnvCfg)
 registry.register_env("G1WalkRough", make_g1_walk_env, sim_backend="mujoco")

--- a/tests/config/test_config_system.py
+++ b/tests/config/test_config_system.py
@@ -17,7 +17,7 @@ from hydra.core.global_hydra import GlobalHydra
 from omegaconf import OmegaConf
 
 CONF_DIR = Path(__file__).parent.parent.parent / "conf"
-_BACKENDS = ("mujoco", "mjwarp", "motrix")
+_BACKENDS = ("mujoco", "mjwarp", "motrix", "isaacgym")
 
 
 def _expected_backend_from_variant(name: str) -> str | None:

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -111,6 +111,19 @@ _OWNER_CASES = (
     ),
     pytest.param(
         "ppo",
+        ("task=g1_walk_flat/isaacgym",),
+        "G1WalkFlat",
+        "isaacgym",
+        29,
+        0.25,
+        "scene_flat.xml",
+        _PPO_REWARDS,
+        _RESET_EVENTS,
+        False,
+        id="ppo-isaacgym",
+    ),
+    pytest.param(
+        "ppo",
         ("task=g1_23dof_walk_flat/mujoco",),
         "G1Walk23DofFlat",
         "mujoco",
@@ -463,6 +476,10 @@ def test_g1_owner_materializes_complete_plain_manager_cfg(
     if backend == "mjwarp":
         assert env_cfg.mjwarp_nconmax == 128
         assert env_cfg.mjwarp_njmax == 256
+    if backend == "isaacgym":
+        assert env_cfg.isaacgym_device_id == 0
+        # No native or offline-record playback yet: disabled at config level.
+        assert hydra_cfg.training.play_render_mode == "none"
 
     pose = env_cfg.rewards["pose"]
     expected_weights = _POSE_WEIGHTS_29 if num_dof == 29 else _POSE_WEIGHTS_23
@@ -480,7 +497,9 @@ def test_g1_owner_materializes_complete_plain_manager_cfg(
                     continue
                 module = nested.func.__module__
                 assert ".backend." not in module
-                assert not any(name in module for name in (".mujoco", ".motrix", ".mjwarp"))
+                assert not any(
+                    name in module for name in (".mujoco", ".motrix", ".mjwarp", ".isaacgym")
+                )
 
     _assert_no_omegaconf(env_cfg)
 
@@ -491,7 +510,7 @@ def test_g1_walk_registries_are_manager_only() -> None:
 
     assert metadata["G1WalkFlat"] == {
         "config_factory": "ManagerBasedRlEnvCfg",
-        "available_backends": ["mujoco", "mjwarp", "motrix"],
+        "available_backends": ["mujoco", "mjwarp", "motrix", "isaacgym"],
     }
     assert metadata["G1WalkRough"] == {
         "config_factory": "ManagerBasedRlEnvCfg",

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -50,7 +50,7 @@ def _allegro_manager_override(
     ).build_task_env_cfg_override()
 
 
-def _g1_manager_override(task: str = "g1_walk_flat") -> dict[str, Any]:
+def _g1_manager_override(task: str = "g1_walk_flat", backend: str = "mujoco") -> dict[str, Any]:
     from hydra import compose, initialize_config_dir
 
     from unilab.base.config_adapter import BackendAdapter
@@ -64,7 +64,7 @@ def _g1_manager_override(task: str = "g1_walk_flat") -> dict[str, Any]:
             cfg, root_dir=repo_root, algo_name="sac"
         ).build_task_env_cfg_override()
     with initialize_config_dir(config_dir=str(repo_root / "conf" / "ppo"), version_base="1.3"):
-        cfg = compose("config", overrides=[f"task={task}/mujoco"])
+        cfg = compose("config", overrides=[f"task={task}/{backend}"])
     return BackendAdapter(cfg, root_dir=repo_root, algo_name="ppo").build_task_env_cfg_override()
 
 
@@ -146,8 +146,39 @@ def test_g1_walk_tasks_register_to_manager_based_env():
     ensure_registries()
     metadata = registry.list_registered_envs()
     assert metadata["G1WalkFlat"]["config_factory"] == "ManagerBasedRlEnvCfg"
-    assert metadata["G1WalkFlat"]["available_backends"] == ["mujoco", "mjwarp", "motrix"]
+    assert metadata["G1WalkFlat"]["available_backends"] == [
+        "mujoco",
+        "mjwarp",
+        "motrix",
+        "isaacgym",
+    ]
     assert metadata["G1WalkRough"]["available_backends"] == ["mujoco", "motrix"]
+
+
+def test_g1_walk_flat_isaacgym_owner_composes_and_materializes():
+    """The isaacgym owner composes and materializes a plain manager env cfg."""
+    from unilab.base import registry
+    from unilab.base.config_materialization import apply_cfg_overrides
+    from unilab.envs import ManagerBasedRlEnvCfg
+
+    ensure_registries()
+    override = _g1_manager_override("g1_walk_flat", backend="isaacgym")
+    env_cfg = registry.materialize_env_config("G1WalkFlat")
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, override)
+    env_cfg.validate()
+
+    assert env_cfg.scene is not None
+    # The subprocess backend consumes the self-contained MJCF scene directly;
+    # scene fragments and generated terrain stay unset.
+    assert env_cfg.scene.model_file.endswith("robots/g1/scene_flat.xml")
+    assert env_cfg.scene.fragment_files == []
+    assert env_cfg.scene.terrain is None
+    assert env_cfg.scene.default_keyframe_name == "stand"
+    assert env_cfg.isaacgym_device_id == 0
+    # Effort-mode dofs carry no PD gains, so the owner disables kp/kd
+    # randomization like the mjwarp/motrix owners.
+    assert env_cfg.events["pd_gains"] is None
 
 
 def test_g1_walk_flat_assets_define_contact_sensors_for_gait_rewards():

--- a/tests/scripts/test_audit_sim2sim_contracts.py
+++ b/tests/scripts/test_audit_sim2sim_contracts.py
@@ -32,9 +32,9 @@ def test_discover_offpolicy_trees_group_by_task() -> None:
     flashsac = audit._discover("flashsac")
     td3 = audit._discover("td3")
 
-    assert {"mujoco", "motrix", "mjwarp"}.issubset(sac["g1_walk_flat"])
-    assert {"mujoco", "motrix", "mjwarp"}.issubset(flashsac["g1_walk_flat"])
-    assert td3["g1_walk_flat"] == ["mujoco"]
+    assert {"mujoco", "motrix", "mjwarp", "isaacgym"}.issubset(sac["g1_walk_flat"])
+    assert {"mujoco", "motrix", "mjwarp", "isaacgym"}.issubset(flashsac["g1_walk_flat"])
+    assert td3["g1_walk_flat"] == ["isaacgym", "mujoco"]
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -38,9 +38,35 @@ def test_support_matrix_marks_validated_g1_mjwarp_entrypoints_as_tested():
     torch_row = _row("PPO (torch)", "g1_walk_flat")
     sac_row = _row("SAC (torch)", "g1_walk_flat")
 
-    assert BACKENDS == ("mujoco", "mjwarp", "motrix")
+    assert BACKENDS == ("mujoco", "mjwarp", "motrix", "isaacgym")
     assert torch_row.cells["mjwarp"].level == EvidenceLevel.TESTED
     assert sac_row.cells["mjwarp"].level == EvidenceLevel.TESTED
+
+
+def test_support_matrix_marks_g1_isaacgym_owners_configured_only():
+    """isaacgym owners carry registry + owner YAML + compose evidence only."""
+    for entrypoint_label in (
+        "PPO (torch)",
+        "APPO (torch)",
+        "SAC (torch)",
+        "TD3 (torch)",
+        "FlashSAC (torch)",
+    ):
+        row = _row(entrypoint_label, "g1_walk_flat")
+        assert row.cells["isaacgym"].level == EvidenceLevel.CONFIGURED
+
+
+def test_support_matrix_does_not_promote_unvalidated_isaacgym_entries():
+    rows = build_support_rows(Path(__file__).resolve().parents[2])
+
+    tested = {
+        (row.entrypoint_label, row.task_slug)
+        for row in rows
+        if row.cells["isaacgym"].level >= EvidenceLevel.TESTED
+    }
+    assert tested == set()
+    go2_row = _row("PPO (torch)", "go2_joystick_flat")
+    assert go2_row.cells["isaacgym"].level == EvidenceLevel.MISSING
 
 
 def test_support_matrix_does_not_promote_unvalidated_mjwarp_entries():

--- a/tests/training/test_sim2sim_resolver.py
+++ b/tests/training/test_sim2sim_resolver.py
@@ -457,3 +457,15 @@ def test_g1_walk_flat_cross_backend_play_is_guarded(tmp_path):
     motrix = _compose_task("g1_walk_flat/motrix")
     with pytest.raises(CrossBackendIncompatibleError):
         resolve_sim2sim_config(tmp_path, motrix)
+
+
+def test_g1_walk_flat_mujoco_to_isaacgym_play_passes_guard(tmp_path):
+    # The isaacgym owner keeps DENYLIST parity with the MuJoCo owner, so a
+    # MuJoCo-trained checkpoint passes the contract guard for isaacgym play.
+    snapshot = extract_contract_snapshot(_compose_task("g1_walk_flat/mujoco"))
+    (tmp_path / "run_config.json").write_text(
+        json.dumps({"contract_snapshot": snapshot}), encoding="utf-8"
+    )
+    isaacgym = _compose_task("g1_walk_flat/isaacgym")
+    assert OmegaConf.select(isaacgym, "training.sim_backend") == "isaacgym"
+    assert resolve_sim2sim_config(tmp_path, isaacgym) is isaacgym


### PR DESCRIPTION
## 关联

- Closes #1337（Child 3 of roadmap #1332）；依赖 #1336（backend 实现，已合入本集成分支）
- Base: `dev/issue-1332-isaacgym-backend`（集成分支）

## 改动

- `src/unilab/tasks/locomotion/g1/__init__.py`：注册 `G1WalkFlat` × `isaacgym`。
- `conf/{ppo,appo,sac,td3,flashsac}/task/g1_walk_flat/isaacgym.yaml`（5 棵 algo 树）：`training.sim_backend: isaacgym`、`env.isaacgym_device_id`、`events.pd_gains: null`（effort-mode dof 无 PD 增益可随机化）、`play_render_mode: none`（backend 尚无 playback，配置层停用而非运行时 fail-closed）。scene 直接复用 base.yaml 的自包含 `scene_flat.xml`（keyframe/sensor 由 backend 在 materialize 冷路径扫描）。
- `scripts/audit_sim2sim_contracts.py`：`PRIMARY_PAIR` → `CONTRACT_PAIRS`，覆盖 `("mujoco","motrix")` 与 `("mujoco","isaacgym")`。
- 支持矩阵：`scripts/tools/support_matrix.py` 增加 IsaacGym 列（Configured 级，无真机验证不提升 Tested），`zh_CN/5-reference/5-support_matrix.md` 生成块由 `--write` 更新。
- 测试：`test_config_system.py` / `test_env_configs.py` / `test_g1_owner_contract.py` / `test_support_matrix.py` / `test_audit_sim2sim_contracts.py` 纳入 isaacgym；`test_sim2sim_resolver.py` 新增 mujoco→isaacgym play 过 guard 的正例。
- 文档：`4-isaacgym.md`（双语）"当前状态"段更新为已接入（playback 缺口与 CLI 现状如实写明）。

## DENYLIST 一致性

5 棵树分别 compose `g1_walk_flat/mujoco` 与 `.../isaacgym`，逐字段比对全部 DENYLIST + WARNING_LIST 路径：零 diff。

## 行为影响

不改现有后端行为；其他 task/backend 配置不变。`uv run python scripts/audit_sim2sim_contracts.py`：mujoco↔isaacgym 5 个 owner 全部 TRANSFERABLE；总结 TRANSFERABLE 32 / BLOCKED 9（与改动前基线持平，BLOCKED 为历史 intentional 差异）。

## Validation（最终 head `9857486d`）

- `make test-all`（worktree 稳定检出，exit 0）：check 通过；pytest 全绿；benchmark smoke 通过（唯一 skip 为 platform-optional `mlx`）。
- `uv run pytest tests/envs/test_env_configs.py tests/base -q`：478 passed, 17 skipped, 1 xfailed。
- `uv run pytest tests/config/test_config_system.py tests/envs/locomotion/g1/test_g1_owner_contract.py tests/scripts/test_support_matrix.py tests/scripts/test_audit_sim2sim_contracts.py -q`：213 passed。
- `uv run pytest tests/scripts/test_check_docs.py -q`：20 passed；`sphinx-build -b html -n` 无新增 warning。

## 遗留验证与已知缺口（已在文档与 issue 中声明）

- 真机端到端（训练/play）需外部 IsaacGym 运行时，本机不可达，首台目标机器人工确认。
- playback 渲染未支持（`play_render_mode: none`）；顶层 CLI `--sim` 暂不含 isaacgym（drake 同例，经 owner YAML 选择）；accelerometer 等 sensor 类型 fail-closed（本 task 未使用）。
