### PR TITLE
perf(reset-state): env_ids 重复检查 np.unique → bincount（#1352）

### DIFF
--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -940,7 +940,12 @@ class ResetStateTransaction:
                 f"ManagerBased reset-state {capability} env_ids out of range for "
                 f"{self._num_envs} environments: {ids.tolist()}"
             )
-        if np.unique(ids).size != ids.size:
+        # Duplicate check via bincount instead of np.unique: identical semantics
+        # (ids are already range-checked above) but avoids the sort — ~30x faster
+        # at num_envs=4096 and ~4x at typical partial-reset widths. This runs on
+        # every reset-state write (~6x per env step), so the sort cost was
+        # measurable in the collector host phase (issue #1352).
+        if ids.size > 1 and np.bincount(ids, minlength=self._num_envs).max() > 1:
             raise ValueError(
                 f"ManagerBased reset-state {capability} env_ids contain duplicates: {ids.tolist()}"
             )


### PR DESCRIPTION
## Summary

- `ResetStateTransaction._validate_ids` 的重复检查从 `np.unique`（排序）改为 `np.bincount`（计数），语义完全等价（此前已完成范围检查，ids 合法非负）
- 动机：reset-state 事务每次写都校验 env_ids（每 env step ~6 次，含 update_state 命令事务的一次 4096 全批量 begin）。`np.unique` 在 4096 ids 上 ~145µs、138 行 ~8µs；`bincount` 分别 ~5µs / ~1.8µs（本机微基准）。每步省 ~0.15-0.3ms host 墙钟
- 用户可见/训练行为：无变化（纯性能，错误路径与报错信息不变）

## Linked Work

- Issue: #1352
- Parent roadmap: #1348
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1348-host-phase-throughput`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/base/test_reset_state.py tests/envs/mdp/test_events.py tests/base/test_entity_facade.py -q   # 85 passed
uv run python scripts/benchmark/env/benchmark_env_step_phase_cpu.py --num-envs 4096 --warmup 20 --iters 500
make test-all
```

Results:

- focused: 85 passed
- phase benchmark @4096: update_state 5.50 → 5.35ms/step（4096-id 事务校验收益落点）；reset_done 3.65 → 3.65ms（噪声内）；steps/s 96,665 → 97,644
- `make test-all`: 2328 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none（reset_state 事务层，backend 无关）
- Platform impact: both
- Training effect expected: no

## Checklist

- [x] Added or updated tests where needed（现有 test_reset_state.py 覆盖重复 ids 报错路径）
- [x] Updated docs if behavior or workflow changed（无行为变化）
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（roadmap #1348 其余切片继续）
