### PR TITLE
perf(motion): metrics 惰性化 + reset motion gather 去重（#1355）

### DIFF
--- a/src/unilab/managers/command_manager.py
+++ b/src/unilab/managers/command_manager.py
@@ -88,7 +88,9 @@ class CommandTerm(ManagerTermBase):
         With env_ids=None (the per-step path) all envs are updated; with env_ids
         (the reset path) timers and the command update are scoped to those envs.
         Metrics are refreshed each call; terms may scope per-row metric work to
-        env_ids since other rows are unchanged since the per-step update.
+        env_ids since other rows are unchanged since the per-step update, or
+        defer row-wise metric work to ``reset()`` when reset is the only
+        consumer (e.g. MotionCommand, issue #1355).
 
         dt may be a scalar (all envs) or a per-env tensor (auto-reset path,
         where freshly reset envs get zero to keep their timers full). A tensor

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -193,6 +193,15 @@ class MotionCommand(CommandTerm):
         # per-step compute. Written by `_update_command`, consumed by
         # `post_compute` to restrict refresh work to the reset rows.
         self._post_compute_env_ids: np.ndarray | None = None
+        # Reset rows whose motion-reference buffers were already ingested by
+        # `_resample_command` during the in-flight reset; consumed by the
+        # reset-path `_update_command` to skip the redundant `_refresh_motion`
+        # gather (issue #1355).
+        self._resample_ingested_ids: np.ndarray | None = None
+        # Motion rows gathered by the in-flight `_resample_command`, exposed so
+        # subclasses (e.g. BoxMotionCommand) reuse the same gather instead of
+        # re-reading the same frames.
+        self._resample_motion: MotionData | None = None
         self._robot_body_pos_w = np.empty_like(self._body_pos_w)
         self._robot_body_quat_w = np.empty((self.num_envs, num_bodies, 4), dtype=dtype)
         self._robot_body_lin_vel_w = np.empty_like(self._body_pos_w)
@@ -220,7 +229,7 @@ class MotionCommand(CommandTerm):
         # measured manager step contains no Numba worker/JIT initialization.
         configure_motion_kernel_runtime()
         self._refresh_relative_state()
-        self._update_metrics()
+        self._update_metrics(self._all_env_ids)
 
     def _make_motion_loader(
         self,
@@ -347,6 +356,13 @@ class MotionCommand(CommandTerm):
             if isinstance(env_ids, slice)
             else env_ids
         )
+        # Row-wise error metrics are consumed only here (CommandTerm.reset logs
+        # per-episode means from these rows, then zeroes them). The per-step
+        # compute path skips the full-batch metrics kernel (issue #1355), so
+        # refresh exactly the rows being reset from the current post-step
+        # buffers — the same inputs the former per-step refresh used, keeping
+        # the consumed values bit-identical.
+        self._update_error_metrics(ids)
         lower, upper = self._joint_default_position_range
         self.joint_default_bias[ids] = self._env.rng.uniform(
             lower, upper, size=(len(ids), self.motion.num_joints)
@@ -372,7 +388,15 @@ class MotionCommand(CommandTerm):
             self._command[:, :width] = self._motion_data.joint_pos
             self._command[:, width:] = self._motion_data.joint_vel
             return
-        data = self.motion.get_motion_at_frame(self.time_steps[env_ids])
+        self._ingest_motion_rows(env_ids, self.motion.get_motion_at_frame(self.time_steps[env_ids]))
+
+    def _ingest_motion_rows(self, env_ids: np.ndarray, data: MotionData) -> None:
+        """Scatter one gathered motion frame set into the reference buffers.
+
+        Shared by the row-scoped `_refresh_motion` and by `_resample_command`,
+        so the reset path gathers each reset row's motion frame exactly once
+        (issue #1355).
+        """
         for motion_field in dataclasses.fields(data):
             value = getattr(data, motion_field.name)
             target = getattr(self._motion_data, motion_field.name)
@@ -436,10 +460,25 @@ class MotionCommand(CommandTerm):
         )
 
     def _update_metrics(self, env_ids: np.ndarray | None = None) -> None:
-        # All row-wise metrics are written by one Numba kernel.  Passing an
-        # explicit all-row index buffer for normal steps lets the same kernel
-        # serve partial-reset rows without retaining a NumPy runtime formula.
-        rows = self._all_env_ids if env_ids is None else env_ids
+        # The row-wise error metrics are consumed only by `reset()` (episode
+        # log extras), which refreshes exactly the rows it reads. The per-step
+        # call (env_ids=None) therefore skips the Numba kernel over all rows
+        # (issue #1355); the reset path (env_ids set) refreshes the reset rows
+        # so post-reset metrics track the post-reset state.
+        if env_ids is not None:
+            self._update_error_metrics(env_ids)
+        # Sampler statistics are global scalars, so every row tracks them.
+        self.metrics["sampling_entropy"].fill(self.sampler.sampling_entropy)
+        self.metrics["sampling_top1_prob"].fill(self.sampler.sampling_top1_prob)
+        self.metrics["sampling_top1_bin"].fill(self.sampler.sampling_top1_bin)
+
+    def _update_error_metrics(self, rows: np.ndarray) -> None:
+        """Recompute the row-wise error metrics for the given rows.
+
+        All row-wise metrics are written by one Numba kernel.  Passing an
+        explicit all-row index buffer for normal steps lets the same kernel
+        serve partial-reset rows without retaining a NumPy runtime formula.
+        """
         update_motion_metrics_kernel(
             rows,
             self.anchor_body_idx,
@@ -468,10 +507,6 @@ class MotionCommand(CommandTerm):
             self.metrics["error_joint_pos"],
             self.metrics["error_joint_vel"],
         )
-        # Sampler statistics are global scalars, so every row tracks them.
-        self.metrics["sampling_entropy"].fill(self.sampler.sampling_entropy)
-        self.metrics["sampling_top1_prob"].fill(self.sampler.sampling_top1_prob)
-        self.metrics["sampling_top1_bin"].fill(self.sampler.sampling_top1_bin)
 
     def _resample_command(self, env_ids: np.ndarray) -> None:
         frames = self.sampler.sample_frames(env_ids)
@@ -502,12 +537,23 @@ class MotionCommand(CommandTerm):
         self.robot.write_joint_state_to_sim(joint_pos, motion.joint_vel, env_ids=env_ids)
         root_state = np.concatenate((root_pos, root_quat, root_lin_vel, root_ang_vel), axis=-1)
         self.robot.write_root_state_to_sim(root_state, env_ids=env_ids)
+        # Keep the motion-reference buffers in sync with the resampled frames so
+        # the reset-path `_update_command` does not gather the same rows again
+        # (issue #1355). Subclasses reuse `self._resample_motion` for their own
+        # reset writes instead of re-gathering the same frames.
+        self._ingest_motion_rows(env_ids, motion)
+        self._resample_ingested_ids = env_ids
+        self._resample_motion = motion
 
     def _update_command(self, env_ids: np.ndarray | None) -> None:
         self._post_compute_env_ids = env_ids
         if env_ids is not None:
-            self._refresh_motion(env_ids)
+            ingested = self._resample_ingested_ids
+            self._resample_ingested_ids = None
+            if ingested is None or not np.array_equal(ingested, env_ids):
+                self._refresh_motion(env_ids)
             return
+        self._resample_ingested_ids = None
         self.sampler.update_failure_stats(self._env.termination_manager.terminated)
         active_ids = np.flatnonzero(~self._env.reset_buf).astype(np.int32, copy=False)
         wrap_ids = self.sampler.step(active_ids)

--- a/src/unilab/tasks/motion_tracking/g1/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/g1/manager_terms.py
@@ -87,9 +87,23 @@ class BoxMotionCommand(MotionCommand):
         else:
             self._object_pos_w[env_ids] = value[env_ids] + self._env.scene.env_origins[env_ids]
 
+    def _ingest_motion_rows(self, env_ids: np.ndarray, data) -> None:
+        super()._ingest_motion_rows(env_ids, data)
+        value = cast(BoxMotionData, data).object_pos_w
+        if value is None:
+            raise RuntimeError("Box motion object position was not materialized")
+        # `data` rows are already the gathered reset rows (leading dim
+        # len(env_ids)); scatter positionally into the full-batch buffer.
+        self._object_pos_w[env_ids] = value + self._env.scene.env_origins[env_ids]
+
     def _resample_command(self, env_ids: np.ndarray) -> None:
         super()._resample_command(env_ids)
-        motion = cast(BoxMotionData, self.motion.get_motion_at_frame(self.time_steps[env_ids]))
+        # The base resample already gathered exactly these frames; reuse them
+        # instead of gathering the same rows a second time (issue #1355).
+        motion = self._resample_motion
+        if motion is None:
+            raise RuntimeError("BoxMotionCommand requires the base resample gather")
+        motion = cast(BoxMotionData, motion)
         values = (
             motion.object_pos_w,
             motion.object_quat_w,


### PR DESCRIPTION
## Summary

- **metrics 惰性化**：`MotionCommand._update_metrics` 的 13 项行域 error metrics 此前每步全批量跑 Numba 内核（~0.36ms/step @4096），但其唯一消费者是 `CommandTerm.reset` 的 episode log extras（reward/termination term 直接读 command 缓冲区，不消费 metrics）。per-step 路径跳过该内核；`reset()` 在读出前对所 reset 行用同一批 post-step 缓冲区刷新——消费到的数值与旧实现逐位一致
- **reset 链路 motion gather 去重**：reset 路径此前对同一批采样帧 gather 两次（`_resample_command` + `_update_command`→`_refresh_motion`；BoxMotionCommand 为三次）。`_resample_command` 现通过 `_ingest_motion_rows` 直接写入引用缓冲区，reset 路径 `_update_command` 复用（~0.14ms/step @4096）
- 训练行为：reset extras 数值逐位不变；RNG 消费顺序不变；`term.metrics` 非 reset 行在 per-step 间隔内不再保证新鲜（文档已更新）

## Linked Work

- Issue: #1355
- Parent roadmap: #1348
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1348-host-phase-throughput`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/envs/test_motion_command_partial_reset.py tests/tasks/test_motion_term_parity.py tests/managers/ tests/envs/mdp/ -q
uv run python scripts/benchmark/env/benchmark_env_step_phase_cpu.py --num-envs 4096 --warmup 20 --iters 500
uv run python /tmp/issue1340/attribute_host_phases.py --num-envs 4096 --warmup 20 --iters 500   # 归因插桩复测
make test-all
```

Results:

- focused: 158 passed（含 partial-reset 行域 parity 与 box tracking）
- 归因复测 @4096：`command.compute` 1.154 → 0.790ms；`command.compute[rows]` 0.272 → 0.128ms；update_state 5.75 → 5.02ms；reset_done 3.83 → 3.73ms
- `make test-all`: 2328 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none（manager/term 层，backend 无关）
- Platform impact: both
- Training effect expected: no（消费到的数值逐位一致；`term.metrics` 行的新鲜度语义已在 docstring 更新）

## Checklist

- [x] Added or updated tests where needed（现有 parity 测试覆盖）
- [x] Updated docs if behavior or workflow changed（`CommandTerm.compute` docstring 更新 deferred-metrics 语义）
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（roadmap #1348 剩余切片）
