### PR TITLE
perf(obs): reset 路径 noise 行域抽取——移除全批量 RNG 流一致契约（#1349）

### DIFF
--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -351,8 +351,11 @@ class ObservationManager(ManagerBase):
         are untouched, so a partial reset does not advance their observation
         timelines. The returned arrays then hold only the reset rows, in env_ids
         order, and the observation cache is left invalidated (the next per-step
-        compute refreshes it); noise is still drawn with full-batch shapes so
-        the shared RNG stream matches the full-batch implementation exactly.
+        compute refreshes it). On row-scoped (non-temporal) groups, noise is
+        drawn only for the reset rows: issue #1349 removed the requirement that
+        the reset path consume the shared RNG stream identically to a
+        full-batch compute, so reset-path noise values and RNG consumption no
+        longer match the full-batch path.
         """
         if env_ids is not None and not update_history:
             raise ValueError("env_ids is only meaningful with update_history=True.")
@@ -394,10 +397,10 @@ class ObservationManager(ManagerBase):
         )
         # Reset path (issue #1259 R2): when no term in this group uses delay or
         # history buffers, everything downstream of the term call is row
-        # independent, so only the reset rows are processed. Term calls and
-        # noise stay full-batch: term funcs are contracted to return
-        # (num_envs, ...) and full-shape noise draws keep the shared RNG stream
-        # and per-row noise values identical to the full-batch path.
+        # independent, so only the reset rows are processed. Term calls stay
+        # full-batch (term funcs are contracted to return (num_envs, ...)), but
+        # noise is drawn for the reset rows only — issue #1349 removed the
+        # full-batch RNG-stream parity requirement.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
         for term_name, term_cfg in obs_terms:
             obs = term_cfg.func(self._env, **term_cfg.params)
@@ -412,6 +415,13 @@ class ObservationManager(ManagerBase):
                     f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
                 )
             fresh = False
+            if row_scoped:
+                # Slice before noise: reset-path noise is drawn for the reset
+                # rows only (issue #1349 removed the full-batch RNG-stream
+                # parity requirement). Fancy indexing already returns a fresh
+                # row copy, safe for the in-place clip/scale below.
+                obs = obs[env_ids]
+                fresh = True
             if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
                 # NoiseCfg.apply always returns a newly allocated array.
                 obs = term_cfg.noise.apply(obs, rng=self._env.rng)
@@ -443,9 +453,6 @@ class ObservationManager(ManagerBase):
                 # Only take a defensive copy when this pipeline may mutate the
                 # term or expose it directly to callers.
                 obs = obs.copy()
-            if row_scoped:
-                # Fresh row copy; safe for the in-place clip/scale below.
-                obs = obs[env_ids]
             if term_cfg.clip:
                 np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
             if term_cfg.scale is not None:

--- a/tests/managers/test_observation_partial_reset.py
+++ b/tests/managers/test_observation_partial_reset.py
@@ -4,8 +4,10 @@ On the partial-reset path (compute(update_history=True, env_ids=...)) the
 manager returns only the reset rows and processes them row-scoped whenever the
 group has no delay/history terms. These tests pin that contract:
 
-- reset rows are bit-identical to a full-batch compute sliced to those rows,
-  and the shared RNG stream is consumed identically (noise stays full-batch);
+- un-noised reset rows are bit-identical to a full-batch compute sliced to
+  those rows; noise is drawn for the reset rows only — issue #1349 removed the
+  full-batch RNG-stream parity requirement, so noised reset rows match neither
+  the full-batch noise values nor its RNG consumption;
 - groups with delay/history terms fall back to the full-batch pipeline and
   only slice the final output; untouched rows' buffers are not advanced;
 - NaN diagnostics on the row-scoped path report real env indices.
@@ -41,7 +43,7 @@ def _noisy_cfg() -> dict[str, ObservationGroupCfg]:
     }
 
 
-def test_partial_reset_rows_match_full_compute_bitwise() -> None:
+def test_partial_reset_row_scoped_noise() -> None:
     env = FakeEnv(seed=11)
     manager = ObservationManager(_noisy_cfg(), env)
     manager.compute(update_history=True)  # populate caches like a step would
@@ -56,8 +58,22 @@ def test_partial_reset_rows_match_full_compute_bitwise() -> None:
     rng_after_full = env.rng.bit_generator.state
 
     assert rows["policy"].shape == (len(ids), full["policy"].shape[1])
-    np.testing.assert_array_equal(rows["policy"], full["policy"][ids])
-    assert rng_after_rows == rng_after_full
+    # Issue #1349: reset-path noise is drawn for the reset rows only, so the
+    # shared RNG stream is consumed strictly less than the full-batch draw.
+    assert rng_after_rows != rng_after_full
+    # The un-noised trailing term stays bit-identical to the full-batch compute.
+    state_dim = env.obs.shape[1]
+    np.testing.assert_array_equal(
+        rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:]
+    )
+    # Noised columns differ from the full-batch slice (row-scoped draws).
+    assert not np.array_equal(
+        rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim]
+    )
+    # The same RNG state reproduces the same reset rows deterministically.
+    env.rng.bit_generator.state = rng_state
+    rows_again = manager.compute(update_history=True, env_ids=ids)
+    np.testing.assert_array_equal(rows["policy"], rows_again["policy"])
 
 
 def test_partial_reset_does_not_populate_obs_cache() -> None:


### PR DESCRIPTION
## Summary

- 移除 observation_manager reset 路径的"全批量 RNG 流一致"契约（maintainer 在 #1348 批准全局移除）：row-scoped 组先切 reset 行再抽 noise，noise 从 (num_envs, dim) 降为 (n_reset, dim)
- term func 的 (num_envs, ...) 返回契约不变；reset 行未加 noise 的数值与全批量计算逐位一致；per-step 路径完全不变
- 更新 `compute()`/`compute_group` 注释与 `tests/managers/test_observation_partial_reset.py` 的契约测试（新语义：未加噪列逐位一致、加噪列行域抽取、RNG 消耗严格小于全批量、同种子确定复现）

## Linked Work

- Issue: #1349
- Parent roadmap: #1348
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1348-host-phase-throughput`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/managers/ tests/envs/ tests/base/test_np_env.py tests/config/ -q
uv run python /tmp/issue1340/attribute_host_phases.py --num-envs 4096 --warmup 20 --iters 500
make test-all
```

Results:

- focused: 804 passed, 1 skipped
- 归因复测 @4096：reset 路径 `obs.compute[rows]` 1.315 → 0.611ms；reset_done 3.73 → 3.10ms
- `make test-all`: 2328 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: obs noise 序列与旧实现不同（契约移除已批准）；noise 分布/范围不变

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed（docstring/注释同步新语义）
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（#1350/#1351 继续 obs 管线）
