### PR TITLE
style: ruff format test_observation_partial_reset.py（#1358 补齐）

### DIFF
--- a/tests/managers/test_observation_partial_reset.py
+++ b/tests/managers/test_observation_partial_reset.py
@@ -63,13 +63,9 @@ def test_partial_reset_row_scoped_noise() -> None:
     assert rng_after_rows != rng_after_full
     # The un-noised trailing term stays bit-identical to the full-batch compute.
     state_dim = env.obs.shape[1]
-    np.testing.assert_array_equal(
-        rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:]
-    )
+    np.testing.assert_array_equal(rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:])
     # Noised columns differ from the full-batch slice (row-scoped draws).
-    assert not np.array_equal(
-        rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim]
-    )
+    assert not np.array_equal(rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim])
     # The same RNG state reproduces the same reset rows deterministically.
     env.rng.bit_generator.state = rng_state
     rows_again = manager.compute(update_history=True, env_ids=ids)


### PR DESCRIPTION
## Summary
- #1358 合入后 ruff format 对测试文件的 2 行重排补齐，无行为变化
## Linked Work
- Parent roadmap: #1348
- Base branch: dev/issue-1348-host-phase-throughput
## Validation
- 纯格式化；与该 head 上已通过的 make test-all 一致
Remote CI route: not scheduled; local make test-all is the test gate（base 非 main）