### PR TITLE
perf(noise): float32 直出 noise 抽取（#1350）

### DIFF
--- a/src/unilab/managers/_noise/noise_cfg.py
+++ b/src/unilab/managers/_noise/noise_cfg.py
@@ -69,11 +69,14 @@ class UniformNoiseCfg(NoiseCfg):
         n_max = self._as_array(self.n_max, data.dtype)
 
         # Generate uniform noise in [0, 1) and transform the generated array
-        # in place.  The pre-existing expression allocated one array for each
-        # multiply, add, and final data operation; keeping the same float32
-        # cast and ufunc order preserves bit-level results while returning the
-        # transformed noise buffer itself.
-        noise = rng.random(data.shape).astype(data.dtype, copy=False)
+        # in place.  Float32 data draws directly in float32 (Generator.random
+        # dtype fast path), which is ~2x faster than drawing float64 and
+        # casting; bit-level noise values differ from the float64 path, which
+        # the issue #1348 RNG-stream parity removal allows.
+        if data.dtype == np.float32:
+            noise = rng.random(data.shape, dtype=np.float32)
+        else:
+            noise = rng.random(data.shape).astype(data.dtype, copy=False)
         np.multiply(noise, n_max - n_min, out=noise)
         np.add(noise, n_min, out=noise)
 
@@ -105,8 +108,12 @@ class GaussianNoiseCfg(NoiseCfg):
         mean = self._as_array(self.mean, data.dtype)
         std = self._as_array(self.std, data.dtype)
 
-        # Generate standard normal noise and scale.
-        noise = rng.standard_normal(data.shape).astype(data.dtype, copy=False)
+        # Generate standard normal noise and scale.  Float32 data draws
+        # directly in float32 (same fast path as UniformNoiseCfg).
+        if data.dtype == np.float32:
+            noise = rng.standard_normal(data.shape, dtype=np.float32)
+        else:
+            noise = rng.standard_normal(data.shape).astype(data.dtype, copy=False)
         noise = mean + std * noise
 
         if self.operation == "add":

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -103,7 +103,8 @@ def test_uniform_noise_inplace_matches_reference_expression(operation: str) -> N
     cfg = UniformNoiseCfg(n_min=tuple(n_min), n_max=tuple(n_max), operation=operation)
 
     reference_rng = np.random.default_rng(1702)
-    unit = reference_rng.random(data.shape).astype(data.dtype, copy=False)
+    # Float32 data draws directly in float32 (issue #1350 fast path).
+    unit = reference_rng.random(data.shape, dtype=data.dtype)
     noise = unit * (n_max - n_min) + n_min
     if operation == "add":
         expected = data + noise


### PR DESCRIPTION
## Summary

- `UniformNoiseCfg`/`GaussianNoiseCfg` 对 float32 数据直接以 `dtype=np.float32` 抽取（跳过 float64 生成 + astype），单块 (4096,64) 抽取 643µs → 338µs（~2×）
- 原"融合抽取"方案经微基准否定并记录在 #1350 评论：RNG 抽取成本按元素数计，融合无收益
- bit-level noise 值与旧 float64 路径不同——由 #1348 的全局 RNG 流一致移除授权覆盖；分布/范围/就地 op 顺序不变

## Linked Work

- Issue: #1350
- Parent roadmap: #1348
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1348-host-phase-throughput`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/managers/ tests/envs/ -q
uv run python scripts/benchmark/env/benchmark_env_step_phase_cpu.py --num-envs 4096 --warmup 20 --iters 500
make test-all
```

Results:

- focused: 558 passed, 1 skipped（含更新后的 noise 参考表达式测试）
- phase benchmark @4096：update_state 4.73ms（基线 5.50）、reset_done 2.94ms（基线 3.65）、steps/s 100,867（基线 96,665）
- `make test-all`: 2328 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: obs noise 序列与旧实现不同（已授权）；分布与范围不变

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（#1351 收尾 obs 管线）
