### PR TITLE
perf(obs): 跨组同参 term 计算共享（#1351）

### DIFF
--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -366,8 +366,15 @@ class ObservationManager(ManagerBase):
             return self._obs_buffer
 
         obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] = dict()
+        # Cross-group sharing of identical term computations (issue #1351):
+        # within one compute() call, terms with the same func and params yield
+        # the same raw output (the per-term pipeline never mutates func outputs
+        # in place), so later groups reuse the first group's raw result.
+        share_cache: dict[tuple, np.ndarray] = {}
         for group_name in self._group_obs_term_names:
-            obs_buffer[group_name] = self.compute_group(group_name, update_history, env_ids)
+            obs_buffer[group_name] = self.compute_group(
+                group_name, update_history, env_ids, share_cache=share_cache
+            )
         if env_ids is None:
             self._obs_buffer = obs_buffer
         return obs_buffer
@@ -377,6 +384,8 @@ class ObservationManager(ManagerBase):
         group_name: str,
         update_history: bool = False,
         env_ids: np.ndarray | None = None,
+        *,
+        share_cache: dict[tuple, np.ndarray] | None = None,
     ) -> np.ndarray | dict[str, np.ndarray]:
         group_cfg = self.cfg[group_name]
         if group_cfg is None:
@@ -384,6 +393,9 @@ class ObservationManager(ManagerBase):
         group_term_names = self._group_obs_term_names[group_name]
         group_obs: dict[str, np.ndarray] = {}
         obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name], strict=False)
+        if share_cache is None:
+            share_cache = {}
+        share_map = self._group_obs_term_share.get(group_name, {})
         # In the strict default policy a finite result is by far the common
         # case.  For concatenated groups, scan the assembled output once and
         # only inspect individual slices when an error is actually found; this
@@ -403,7 +415,13 @@ class ObservationManager(ManagerBase):
         # full-batch RNG-stream parity requirement.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
         for term_name, term_cfg in obs_terms:
-            obs = term_cfg.func(self._env, **term_cfg.params)
+            share_key = share_map.get(term_name)
+            if share_key is not None and share_key in share_cache:
+                obs = share_cache[share_key]
+            else:
+                obs = term_cfg.func(self._env, **term_cfg.params)
+                if share_key is not None:
+                    share_cache[share_key] = obs
             if not isinstance(obs, np.ndarray):
                 raise TypeError(
                     f"ObservationManager term '{group_name}/{term_name}' returned "
@@ -709,3 +727,25 @@ class ObservationManager(ManagerBase):
                 term_cfg.delay_max_lag > 0 or term_cfg.history_length > 0
                 for term_cfg in self._group_obs_term_cfgs[group_name]
             )
+
+        # Cross-group sharing of identical term computations (issue #1351):
+        # within one compute() call, terms with the same func and params yield
+        # the same raw output, so later groups reuse the first group's result.
+        # Class-based terms (possibly stateful per call) and terms with
+        # unhashable params are never shared.
+        self._group_obs_term_share: dict[str, dict[str, tuple]] = {}
+        for share_group, share_terms in self._group_obs_term_cfgs.items():
+            share_entry: dict[str, tuple] = {}
+            for share_name, share_cfg in zip(
+                self._group_obs_term_names[share_group], share_terms, strict=False
+            ):
+                func = share_cfg.func
+                if hasattr(func, "reset") and callable(func.reset):
+                    continue
+                try:
+                    share_key = (func, tuple(sorted(share_cfg.params.items())))
+                    hash(share_key)
+                except TypeError:
+                    continue
+                share_entry[share_name] = share_key
+            self._group_obs_term_share[share_group] = share_entry

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -366,3 +366,69 @@ def test_observation_explicit_sanitize_and_shape_error(fake_env: FakeEnv) -> Non
             },
             fake_env,
         )
+
+
+def test_identical_terms_share_raw_compute_across_groups() -> None:
+    """Issue #1351: terms with identical func+params compute once per compute().
+
+    The critic group reuses the raw (pre-noise) output of the policy group's
+    identical term; the policy group still applies its own noise on top.
+    """
+    calls = {"n": 0}
+
+    def counting(env: FakeEnv, scale: float = 1.0) -> np.ndarray:
+        calls["n"] += 1
+        return env.obs * scale
+
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "state": ObservationTermCfg(
+                        func=counting,
+                        params={"scale": 2.0},
+                        noise=UniformNoiseCfg(n_min=-0.1, n_max=0.1),
+                    )
+                },
+                enable_corruption=True,
+            ),
+            "critic": ObservationGroupCfg(
+                terms={"state": ObservationTermCfg(func=counting, params={"scale": 2.0})}
+            ),
+        },
+        FakeEnv(seed=3),
+    )
+    env = manager._env
+    calls["n"] = 0
+    out = manager.compute(update_history=True)
+    assert calls["n"] == 1
+    np.testing.assert_array_equal(out["critic"], env.obs * 2.0)
+    noise = out["policy"] - out["critic"]
+    assert np.abs(noise).max() <= 0.1 + 1e-6
+    assert np.abs(noise).max() > 0.0
+
+    # The cache is per compute() call, not across calls.
+    manager.compute(update_history=True)
+    assert calls["n"] == 2
+
+
+def test_class_terms_are_never_shared_across_groups() -> None:
+    """Class-based (possibly stateful) terms must keep per-group calls."""
+
+    class StatefulTerm:
+        def __call__(self, env: FakeEnv) -> np.ndarray:
+            return env.obs.copy()
+
+        def reset(self, env_ids: np.ndarray | None = None) -> None:
+            del env_ids
+
+    shared = StatefulTerm()
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(terms={"state": ObservationTermCfg(func=shared)}),
+            "critic": ObservationGroupCfg(terms={"state": ObservationTermCfg(func=shared)}),
+        },
+        FakeEnv(seed=5),
+    )
+    assert manager._group_obs_term_share["policy"] == {}
+    assert manager._group_obs_term_share["critic"] == {}


### PR DESCRIPTION
## Summary

- observation group 间同参 term 共享：manager 在冷路径为每组构建 share key（仅纯函数 term + 可哈希 params；class term 排除），同一 compute() 调用内后续组复用首组的 raw 输出
- 安全性依据：term func 输出在管线内从不被就地修改（noise/clip/scale 均作用于新数组；temporal buffer 拷贝入缓冲）；新增 2 个契约测试（共享生效 + class term 排除）
- g1_motion_tracking 下 critic 组 8 个与 actor 完全同参的 term 不再重复全批量计算：obs.compute 2.06 → 1.57ms/step @4096

## Linked Work

- Issue: #1351
- Parent roadmap: #1348
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1348-host-phase-throughput`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run:

```bash
uv run pytest tests/managers/ tests/envs/ -q
uv run python /tmp/issue1340/attribute_host_phases.py --num-envs 4096 --warmup 20 --iters 500
make test-all
```

Results:

- focused: 560 passed, 1 skipped（含 2 个新增共享契约测试）
- 归因复测 @4096：us obs.compute 2.06 → 1.57ms；reset obs.compute[rows] 0.61 → 0.43ms；update_state 4.68ms、reset_done 2.85ms
- `make test-all`: 2330 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none
- Platform impact: both
- Training effect expected: no（obs 数值不变；func 调用次数减少——纯函数 term 语义等价）

## Checklist

- [x] Added or updated tests where needed
- [x] Updated docs if behavior or workflow changed（compute 注释）
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（roadmap #1348 收官）
