### PR TITLE
perf(collector): host 相吞吐优化——update_state/reset_done 串行热点收敛（roadmap #1348）

### DIFF
--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -940,7 +940,12 @@ class ResetStateTransaction:
                 f"ManagerBased reset-state {capability} env_ids out of range for "
                 f"{self._num_envs} environments: {ids.tolist()}"
             )
-        if np.unique(ids).size != ids.size:
+        # Duplicate check via bincount instead of np.unique: identical semantics
+        # (ids are already range-checked above) but avoids the sort — ~30x faster
+        # at num_envs=4096 and ~4x at typical partial-reset widths. This runs on
+        # every reset-state write (~6x per env step), so the sort cost was
+        # measurable in the collector host phase (issue #1352).
+        if ids.size > 1 and np.bincount(ids, minlength=self._num_envs).max() > 1:
             raise ValueError(
                 f"ManagerBased reset-state {capability} env_ids contain duplicates: {ids.tolist()}"
             )

--- a/src/unilab/managers/_noise/noise_cfg.py
+++ b/src/unilab/managers/_noise/noise_cfg.py
@@ -69,11 +69,14 @@ class UniformNoiseCfg(NoiseCfg):
         n_max = self._as_array(self.n_max, data.dtype)
 
         # Generate uniform noise in [0, 1) and transform the generated array
-        # in place.  The pre-existing expression allocated one array for each
-        # multiply, add, and final data operation; keeping the same float32
-        # cast and ufunc order preserves bit-level results while returning the
-        # transformed noise buffer itself.
-        noise = rng.random(data.shape).astype(data.dtype, copy=False)
+        # in place.  Float32 data draws directly in float32 (Generator.random
+        # dtype fast path), which is ~2x faster than drawing float64 and
+        # casting; bit-level noise values differ from the float64 path, which
+        # the issue #1348 RNG-stream parity removal allows.
+        if data.dtype == np.float32:
+            noise = rng.random(data.shape, dtype=np.float32)
+        else:
+            noise = rng.random(data.shape).astype(data.dtype, copy=False)
         np.multiply(noise, n_max - n_min, out=noise)
         np.add(noise, n_min, out=noise)
 
@@ -105,8 +108,12 @@ class GaussianNoiseCfg(NoiseCfg):
         mean = self._as_array(self.mean, data.dtype)
         std = self._as_array(self.std, data.dtype)
 
-        # Generate standard normal noise and scale.
-        noise = rng.standard_normal(data.shape).astype(data.dtype, copy=False)
+        # Generate standard normal noise and scale.  Float32 data draws
+        # directly in float32 (same fast path as UniformNoiseCfg).
+        if data.dtype == np.float32:
+            noise = rng.standard_normal(data.shape, dtype=np.float32)
+        else:
+            noise = rng.standard_normal(data.shape).astype(data.dtype, copy=False)
         noise = mean + std * noise
 
         if self.operation == "add":

--- a/src/unilab/managers/command_manager.py
+++ b/src/unilab/managers/command_manager.py
@@ -88,7 +88,9 @@ class CommandTerm(ManagerTermBase):
         With env_ids=None (the per-step path) all envs are updated; with env_ids
         (the reset path) timers and the command update are scoped to those envs.
         Metrics are refreshed each call; terms may scope per-row metric work to
-        env_ids since other rows are unchanged since the per-step update.
+        env_ids since other rows are unchanged since the per-step update, or
+        defer row-wise metric work to ``reset()`` when reset is the only
+        consumer (e.g. MotionCommand, issue #1355).
 
         dt may be a scalar (all envs) or a per-env tensor (auto-reset path,
         where freshly reset envs get zero to keep their timers full). A tensor

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -366,8 +366,15 @@ class ObservationManager(ManagerBase):
             return self._obs_buffer
 
         obs_buffer: dict[str, np.ndarray | dict[str, np.ndarray]] = dict()
+        # Cross-group sharing of identical term computations (issue #1351):
+        # within one compute() call, terms with the same func and params yield
+        # the same raw output (the per-term pipeline never mutates func outputs
+        # in place), so later groups reuse the first group's raw result.
+        share_cache: dict[tuple, np.ndarray] = {}
         for group_name in self._group_obs_term_names:
-            obs_buffer[group_name] = self.compute_group(group_name, update_history, env_ids)
+            obs_buffer[group_name] = self.compute_group(
+                group_name, update_history, env_ids, share_cache=share_cache
+            )
         if env_ids is None:
             self._obs_buffer = obs_buffer
         return obs_buffer
@@ -377,6 +384,8 @@ class ObservationManager(ManagerBase):
         group_name: str,
         update_history: bool = False,
         env_ids: np.ndarray | None = None,
+        *,
+        share_cache: dict[tuple, np.ndarray] | None = None,
     ) -> np.ndarray | dict[str, np.ndarray]:
         group_cfg = self.cfg[group_name]
         if group_cfg is None:
@@ -384,6 +393,9 @@ class ObservationManager(ManagerBase):
         group_term_names = self._group_obs_term_names[group_name]
         group_obs: dict[str, np.ndarray] = {}
         obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name], strict=False)
+        if share_cache is None:
+            share_cache = {}
+        share_map = self._group_obs_term_share.get(group_name, {})
         # In the strict default policy a finite result is by far the common
         # case.  For concatenated groups, scan the assembled output once and
         # only inspect individual slices when an error is actually found; this
@@ -403,7 +415,13 @@ class ObservationManager(ManagerBase):
         # full-batch RNG-stream parity requirement.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
         for term_name, term_cfg in obs_terms:
-            obs = term_cfg.func(self._env, **term_cfg.params)
+            share_key = share_map.get(term_name)
+            if share_key is not None and share_key in share_cache:
+                obs = share_cache[share_key]
+            else:
+                obs = term_cfg.func(self._env, **term_cfg.params)
+                if share_key is not None:
+                    share_cache[share_key] = obs
             if not isinstance(obs, np.ndarray):
                 raise TypeError(
                     f"ObservationManager term '{group_name}/{term_name}' returned "
@@ -709,3 +727,25 @@ class ObservationManager(ManagerBase):
                 term_cfg.delay_max_lag > 0 or term_cfg.history_length > 0
                 for term_cfg in self._group_obs_term_cfgs[group_name]
             )
+
+        # Cross-group sharing of identical term computations (issue #1351):
+        # within one compute() call, terms with the same func and params yield
+        # the same raw output, so later groups reuse the first group's result.
+        # Class-based terms (possibly stateful per call) and terms with
+        # unhashable params are never shared.
+        self._group_obs_term_share: dict[str, dict[str, tuple]] = {}
+        for share_group, share_terms in self._group_obs_term_cfgs.items():
+            share_entry: dict[str, tuple] = {}
+            for share_name, share_cfg in zip(
+                self._group_obs_term_names[share_group], share_terms, strict=False
+            ):
+                func = share_cfg.func
+                if hasattr(func, "reset") and callable(func.reset):
+                    continue
+                try:
+                    share_key = (func, tuple(sorted(share_cfg.params.items())))
+                    hash(share_key)
+                except TypeError:
+                    continue
+                share_entry[share_name] = share_key
+            self._group_obs_term_share[share_group] = share_entry

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -351,8 +351,11 @@ class ObservationManager(ManagerBase):
         are untouched, so a partial reset does not advance their observation
         timelines. The returned arrays then hold only the reset rows, in env_ids
         order, and the observation cache is left invalidated (the next per-step
-        compute refreshes it); noise is still drawn with full-batch shapes so
-        the shared RNG stream matches the full-batch implementation exactly.
+        compute refreshes it). On row-scoped (non-temporal) groups, noise is
+        drawn only for the reset rows: issue #1349 removed the requirement that
+        the reset path consume the shared RNG stream identically to a
+        full-batch compute, so reset-path noise values and RNG consumption no
+        longer match the full-batch path.
         """
         if env_ids is not None and not update_history:
             raise ValueError("env_ids is only meaningful with update_history=True.")
@@ -394,10 +397,10 @@ class ObservationManager(ManagerBase):
         )
         # Reset path (issue #1259 R2): when no term in this group uses delay or
         # history buffers, everything downstream of the term call is row
-        # independent, so only the reset rows are processed. Term calls and
-        # noise stay full-batch: term funcs are contracted to return
-        # (num_envs, ...) and full-shape noise draws keep the shared RNG stream
-        # and per-row noise values identical to the full-batch path.
+        # independent, so only the reset rows are processed. Term calls stay
+        # full-batch (term funcs are contracted to return (num_envs, ...)), but
+        # noise is drawn for the reset rows only — issue #1349 removed the
+        # full-batch RNG-stream parity requirement.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
         for term_name, term_cfg in obs_terms:
             obs = term_cfg.func(self._env, **term_cfg.params)
@@ -412,6 +415,13 @@ class ObservationManager(ManagerBase):
                     f"{obs.shape}, expected (num_envs, ...) with num_envs={self.num_envs}."
                 )
             fresh = False
+            if row_scoped:
+                # Slice before noise: reset-path noise is drawn for the reset
+                # rows only (issue #1349 removed the full-batch RNG-stream
+                # parity requirement). Fancy indexing already returns a fresh
+                # row copy, safe for the in-place clip/scale below.
+                obs = obs[env_ids]
+                fresh = True
             if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
                 # NoiseCfg.apply always returns a newly allocated array.
                 obs = term_cfg.noise.apply(obs, rng=self._env.rng)
@@ -443,9 +453,6 @@ class ObservationManager(ManagerBase):
                 # Only take a defensive copy when this pipeline may mutate the
                 # term or expose it directly to callers.
                 obs = obs.copy()
-            if row_scoped:
-                # Fresh row copy; safe for the in-place clip/scale below.
-                obs = obs[env_ids]
             if term_cfg.clip:
                 np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
             if term_cfg.scale is not None:

--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -193,6 +193,15 @@ class MotionCommand(CommandTerm):
         # per-step compute. Written by `_update_command`, consumed by
         # `post_compute` to restrict refresh work to the reset rows.
         self._post_compute_env_ids: np.ndarray | None = None
+        # Reset rows whose motion-reference buffers were already ingested by
+        # `_resample_command` during the in-flight reset; consumed by the
+        # reset-path `_update_command` to skip the redundant `_refresh_motion`
+        # gather (issue #1355).
+        self._resample_ingested_ids: np.ndarray | None = None
+        # Motion rows gathered by the in-flight `_resample_command`, exposed so
+        # subclasses (e.g. BoxMotionCommand) reuse the same gather instead of
+        # re-reading the same frames.
+        self._resample_motion: MotionData | None = None
         self._robot_body_pos_w = np.empty_like(self._body_pos_w)
         self._robot_body_quat_w = np.empty((self.num_envs, num_bodies, 4), dtype=dtype)
         self._robot_body_lin_vel_w = np.empty_like(self._body_pos_w)
@@ -220,7 +229,7 @@ class MotionCommand(CommandTerm):
         # measured manager step contains no Numba worker/JIT initialization.
         configure_motion_kernel_runtime()
         self._refresh_relative_state()
-        self._update_metrics()
+        self._update_metrics(self._all_env_ids)
 
     def _make_motion_loader(
         self,
@@ -347,6 +356,13 @@ class MotionCommand(CommandTerm):
             if isinstance(env_ids, slice)
             else env_ids
         )
+        # Row-wise error metrics are consumed only here (CommandTerm.reset logs
+        # per-episode means from these rows, then zeroes them). The per-step
+        # compute path skips the full-batch metrics kernel (issue #1355), so
+        # refresh exactly the rows being reset from the current post-step
+        # buffers — the same inputs the former per-step refresh used, keeping
+        # the consumed values bit-identical.
+        self._update_error_metrics(ids)
         lower, upper = self._joint_default_position_range
         self.joint_default_bias[ids] = self._env.rng.uniform(
             lower, upper, size=(len(ids), self.motion.num_joints)
@@ -372,7 +388,15 @@ class MotionCommand(CommandTerm):
             self._command[:, :width] = self._motion_data.joint_pos
             self._command[:, width:] = self._motion_data.joint_vel
             return
-        data = self.motion.get_motion_at_frame(self.time_steps[env_ids])
+        self._ingest_motion_rows(env_ids, self.motion.get_motion_at_frame(self.time_steps[env_ids]))
+
+    def _ingest_motion_rows(self, env_ids: np.ndarray, data: MotionData) -> None:
+        """Scatter one gathered motion frame set into the reference buffers.
+
+        Shared by the row-scoped `_refresh_motion` and by `_resample_command`,
+        so the reset path gathers each reset row's motion frame exactly once
+        (issue #1355).
+        """
         for motion_field in dataclasses.fields(data):
             value = getattr(data, motion_field.name)
             target = getattr(self._motion_data, motion_field.name)
@@ -436,10 +460,25 @@ class MotionCommand(CommandTerm):
         )
 
     def _update_metrics(self, env_ids: np.ndarray | None = None) -> None:
-        # All row-wise metrics are written by one Numba kernel.  Passing an
-        # explicit all-row index buffer for normal steps lets the same kernel
-        # serve partial-reset rows without retaining a NumPy runtime formula.
-        rows = self._all_env_ids if env_ids is None else env_ids
+        # The row-wise error metrics are consumed only by `reset()` (episode
+        # log extras), which refreshes exactly the rows it reads. The per-step
+        # call (env_ids=None) therefore skips the Numba kernel over all rows
+        # (issue #1355); the reset path (env_ids set) refreshes the reset rows
+        # so post-reset metrics track the post-reset state.
+        if env_ids is not None:
+            self._update_error_metrics(env_ids)
+        # Sampler statistics are global scalars, so every row tracks them.
+        self.metrics["sampling_entropy"].fill(self.sampler.sampling_entropy)
+        self.metrics["sampling_top1_prob"].fill(self.sampler.sampling_top1_prob)
+        self.metrics["sampling_top1_bin"].fill(self.sampler.sampling_top1_bin)
+
+    def _update_error_metrics(self, rows: np.ndarray) -> None:
+        """Recompute the row-wise error metrics for the given rows.
+
+        All row-wise metrics are written by one Numba kernel.  Passing an
+        explicit all-row index buffer for normal steps lets the same kernel
+        serve partial-reset rows without retaining a NumPy runtime formula.
+        """
         update_motion_metrics_kernel(
             rows,
             self.anchor_body_idx,
@@ -468,10 +507,6 @@ class MotionCommand(CommandTerm):
             self.metrics["error_joint_pos"],
             self.metrics["error_joint_vel"],
         )
-        # Sampler statistics are global scalars, so every row tracks them.
-        self.metrics["sampling_entropy"].fill(self.sampler.sampling_entropy)
-        self.metrics["sampling_top1_prob"].fill(self.sampler.sampling_top1_prob)
-        self.metrics["sampling_top1_bin"].fill(self.sampler.sampling_top1_bin)
 
     def _resample_command(self, env_ids: np.ndarray) -> None:
         frames = self.sampler.sample_frames(env_ids)
@@ -502,12 +537,23 @@ class MotionCommand(CommandTerm):
         self.robot.write_joint_state_to_sim(joint_pos, motion.joint_vel, env_ids=env_ids)
         root_state = np.concatenate((root_pos, root_quat, root_lin_vel, root_ang_vel), axis=-1)
         self.robot.write_root_state_to_sim(root_state, env_ids=env_ids)
+        # Keep the motion-reference buffers in sync with the resampled frames so
+        # the reset-path `_update_command` does not gather the same rows again
+        # (issue #1355). Subclasses reuse `self._resample_motion` for their own
+        # reset writes instead of re-gathering the same frames.
+        self._ingest_motion_rows(env_ids, motion)
+        self._resample_ingested_ids = env_ids
+        self._resample_motion = motion
 
     def _update_command(self, env_ids: np.ndarray | None) -> None:
         self._post_compute_env_ids = env_ids
         if env_ids is not None:
-            self._refresh_motion(env_ids)
+            ingested = self._resample_ingested_ids
+            self._resample_ingested_ids = None
+            if ingested is None or not np.array_equal(ingested, env_ids):
+                self._refresh_motion(env_ids)
             return
+        self._resample_ingested_ids = None
         self.sampler.update_failure_stats(self._env.termination_manager.terminated)
         active_ids = np.flatnonzero(~self._env.reset_buf).astype(np.int32, copy=False)
         wrap_ids = self.sampler.step(active_ids)

--- a/src/unilab/tasks/motion_tracking/g1/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/g1/manager_terms.py
@@ -87,9 +87,23 @@ class BoxMotionCommand(MotionCommand):
         else:
             self._object_pos_w[env_ids] = value[env_ids] + self._env.scene.env_origins[env_ids]
 
+    def _ingest_motion_rows(self, env_ids: np.ndarray, data) -> None:
+        super()._ingest_motion_rows(env_ids, data)
+        value = cast(BoxMotionData, data).object_pos_w
+        if value is None:
+            raise RuntimeError("Box motion object position was not materialized")
+        # `data` rows are already the gathered reset rows (leading dim
+        # len(env_ids)); scatter positionally into the full-batch buffer.
+        self._object_pos_w[env_ids] = value + self._env.scene.env_origins[env_ids]
+
     def _resample_command(self, env_ids: np.ndarray) -> None:
         super()._resample_command(env_ids)
-        motion = cast(BoxMotionData, self.motion.get_motion_at_frame(self.time_steps[env_ids]))
+        # The base resample already gathered exactly these frames; reuse them
+        # instead of gathering the same rows a second time (issue #1355).
+        motion = self._resample_motion
+        if motion is None:
+            raise RuntimeError("BoxMotionCommand requires the base resample gather")
+        motion = cast(BoxMotionData, motion)
         values = (
             motion.object_pos_w,
             motion.object_quat_w,

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -366,3 +366,69 @@ def test_observation_explicit_sanitize_and_shape_error(fake_env: FakeEnv) -> Non
             },
             fake_env,
         )
+
+
+def test_identical_terms_share_raw_compute_across_groups() -> None:
+    """Issue #1351: terms with identical func+params compute once per compute().
+
+    The critic group reuses the raw (pre-noise) output of the policy group's
+    identical term; the policy group still applies its own noise on top.
+    """
+    calls = {"n": 0}
+
+    def counting(env: FakeEnv, scale: float = 1.0) -> np.ndarray:
+        calls["n"] += 1
+        return env.obs * scale
+
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "state": ObservationTermCfg(
+                        func=counting,
+                        params={"scale": 2.0},
+                        noise=UniformNoiseCfg(n_min=-0.1, n_max=0.1),
+                    )
+                },
+                enable_corruption=True,
+            ),
+            "critic": ObservationGroupCfg(
+                terms={"state": ObservationTermCfg(func=counting, params={"scale": 2.0})}
+            ),
+        },
+        FakeEnv(seed=3),
+    )
+    env = manager._env
+    calls["n"] = 0
+    out = manager.compute(update_history=True)
+    assert calls["n"] == 1
+    np.testing.assert_array_equal(out["critic"], env.obs * 2.0)
+    noise = out["policy"] - out["critic"]
+    assert np.abs(noise).max() <= 0.1 + 1e-6
+    assert np.abs(noise).max() > 0.0
+
+    # The cache is per compute() call, not across calls.
+    manager.compute(update_history=True)
+    assert calls["n"] == 2
+
+
+def test_class_terms_are_never_shared_across_groups() -> None:
+    """Class-based (possibly stateful) terms must keep per-group calls."""
+
+    class StatefulTerm:
+        def __call__(self, env: FakeEnv) -> np.ndarray:
+            return env.obs.copy()
+
+        def reset(self, env_ids: np.ndarray | None = None) -> None:
+            del env_ids
+
+    shared = StatefulTerm()
+    manager = ObservationManager(
+        {
+            "policy": ObservationGroupCfg(terms={"state": ObservationTermCfg(func=shared)}),
+            "critic": ObservationGroupCfg(terms={"state": ObservationTermCfg(func=shared)}),
+        },
+        FakeEnv(seed=5),
+    )
+    assert manager._group_obs_term_share["policy"] == {}
+    assert manager._group_obs_term_share["critic"] == {}

--- a/tests/managers/test_observation_buffers_noise.py
+++ b/tests/managers/test_observation_buffers_noise.py
@@ -103,7 +103,8 @@ def test_uniform_noise_inplace_matches_reference_expression(operation: str) -> N
     cfg = UniformNoiseCfg(n_min=tuple(n_min), n_max=tuple(n_max), operation=operation)
 
     reference_rng = np.random.default_rng(1702)
-    unit = reference_rng.random(data.shape).astype(data.dtype, copy=False)
+    # Float32 data draws directly in float32 (issue #1350 fast path).
+    unit = reference_rng.random(data.shape, dtype=data.dtype)
     noise = unit * (n_max - n_min) + n_min
     if operation == "add":
         expected = data + noise

--- a/tests/managers/test_observation_partial_reset.py
+++ b/tests/managers/test_observation_partial_reset.py
@@ -63,13 +63,9 @@ def test_partial_reset_row_scoped_noise() -> None:
     assert rng_after_rows != rng_after_full
     # The un-noised trailing term stays bit-identical to the full-batch compute.
     state_dim = env.obs.shape[1]
-    np.testing.assert_array_equal(
-        rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:]
-    )
+    np.testing.assert_array_equal(rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:])
     # Noised columns differ from the full-batch slice (row-scoped draws).
-    assert not np.array_equal(
-        rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim]
-    )
+    assert not np.array_equal(rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim])
     # The same RNG state reproduces the same reset rows deterministically.
     env.rng.bit_generator.state = rng_state
     rows_again = manager.compute(update_history=True, env_ids=ids)

--- a/tests/managers/test_observation_partial_reset.py
+++ b/tests/managers/test_observation_partial_reset.py
@@ -4,8 +4,10 @@ On the partial-reset path (compute(update_history=True, env_ids=...)) the
 manager returns only the reset rows and processes them row-scoped whenever the
 group has no delay/history terms. These tests pin that contract:
 
-- reset rows are bit-identical to a full-batch compute sliced to those rows,
-  and the shared RNG stream is consumed identically (noise stays full-batch);
+- un-noised reset rows are bit-identical to a full-batch compute sliced to
+  those rows; noise is drawn for the reset rows only — issue #1349 removed the
+  full-batch RNG-stream parity requirement, so noised reset rows match neither
+  the full-batch noise values nor its RNG consumption;
 - groups with delay/history terms fall back to the full-batch pipeline and
   only slice the final output; untouched rows' buffers are not advanced;
 - NaN diagnostics on the row-scoped path report real env indices.
@@ -41,7 +43,7 @@ def _noisy_cfg() -> dict[str, ObservationGroupCfg]:
     }
 
 
-def test_partial_reset_rows_match_full_compute_bitwise() -> None:
+def test_partial_reset_row_scoped_noise() -> None:
     env = FakeEnv(seed=11)
     manager = ObservationManager(_noisy_cfg(), env)
     manager.compute(update_history=True)  # populate caches like a step would
@@ -56,8 +58,22 @@ def test_partial_reset_rows_match_full_compute_bitwise() -> None:
     rng_after_full = env.rng.bit_generator.state
 
     assert rows["policy"].shape == (len(ids), full["policy"].shape[1])
-    np.testing.assert_array_equal(rows["policy"], full["policy"][ids])
-    assert rng_after_rows == rng_after_full
+    # Issue #1349: reset-path noise is drawn for the reset rows only, so the
+    # shared RNG stream is consumed strictly less than the full-batch draw.
+    assert rng_after_rows != rng_after_full
+    # The un-noised trailing term stays bit-identical to the full-batch compute.
+    state_dim = env.obs.shape[1]
+    np.testing.assert_array_equal(
+        rows["policy"][:, state_dim:], full["policy"][ids][:, state_dim:]
+    )
+    # Noised columns differ from the full-batch slice (row-scoped draws).
+    assert not np.array_equal(
+        rows["policy"][:, :state_dim], full["policy"][ids][:, :state_dim]
+    )
+    # The same RNG state reproduces the same reset rows deterministically.
+    env.rng.bit_generator.state = rng_state
+    rows_again = manager.compute(update_history=True, env_ids=ids)
+    np.testing.assert_array_equal(rows["policy"], rows_again["policy"])
 
 
 def test_partial_reset_does_not_populate_obs_cache() -> None:


### PR DESCRIPTION
## Summary

Roadmap #1348 集成分支：收敛 `sac + g1_motion_tracking + mujoco` collector 的两个串行 host 相（update_state / reset_done）。5 个 child PR 已逐一合入并过本地 gate；2 个切片按预设 stop condition 以测量证据关闭（#1353 pool fast-path、#1354 reward 循环批量化）。

- `reset_state` 事务 env_ids 重复检查 `np.unique` → `bincount`（#1356）
- `MotionCommand` 行域 error metrics 惰性化到 reset()（消费值逐位不变）+ reset 路径 motion 重复 gather 去重（#1357）
- observation_manager reset 路径 noise 行域抽取，移除全批量 RNG 流一致契约（maintainer 在 #1348 批准；#1358）
- obs noise float32 直出（#1360）
- observation group 间同参 term 计算共享（#1361）

训练行为：reset extras / reward / termination / obs 数值逐位一致；obs noise 的 RNG 序列按批准放开（分布与范围不变）；`term.metrics` 非 reset 行的新鲜度语义已在 docstring 标注。

## Linked Work

- Parent roadmap: #1348
- 驱动 issue: #1340（归因表与前后对比已写回其评论区）
- Roadmap declared base: `dev/issue-1042-manager-based-api`
- Milestone: none
- Base branch: `dev/issue-1042-manager-based-api`

## Validation

- [x] `make test-all` passed on the final local head before this PR was created or updated
- [x] Additional task-specific validation listed below

Commands actually run（每个 child PR 均独立跑过，此处为集成分支最终 head `e109b1f7`）:

```bash
make test-all
uv run python scripts/benchmark/env/benchmark_env_step_phase_cpu.py --config-group sac --task g1_motion_tracking/mujoco --num-envs {2048,4096,8192} --warmup 20 --iters 1500
uv run python scripts/benchmark/rl/benchmark_offpolicy_collector_active.py --cases sac/g1_motion_tracking/mujoco --num-envs 4096
```

Results（同机 9950X3D 前后对比，1500 步均值）:

| num_envs | update_state | reset_done | steps/s |
|---|---|---|---|
| 2048 | 3.19 → 2.65ms（-17%） | 2.30 → 1.87ms（-19%） | 93,260 → 97,467（+4.5%） |
| 4096 | 5.53 → 4.41ms（-20%） | 3.65 → 2.72ms（-25%） | 96,665 → 102,798（+6.3%） |
| 8192 | 10.47 → 8.56ms（-18%） | 6.51 → 4.57ms（-30%） | 93,935 → 97,851（+4.2%） |

- Active-window @4096：Collector/s 94,409–94,688 → 98,074（+3.8%）
- `make test-all`: 2330 passed, 28 skipped, 1 xfailed；benchmark smoke 通过

Remote CI route:

- not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none（mujoco backend 无改动；motrix/mjwarp 行为不变）
- Platform impact: both
- Training effect expected: 吞吐 +4~6%；除已批准的 noise RNG 序列外数值契约不变

## Checklist

- [x] Added or updated tests where needed（每个 child PR 含契约/parity 测试）
- [x] Updated docs if behavior or workflow changed（docstring 同步新语义）
- [x] Linked the driving issue
- [x] Noted any follow-up work explicitly（#1353/#1354 的否定证据可供后续参考；8192 档 step glue 偶发 4.8ms 未归因，见 #1340 评论）
