### PR TITLE
docs(motion): 明确 _ingest_motion_rows 子类契约（#1355 follow-up）

### DIFF
--- a/src/unilab/tasks/motion_tracking/common/manager_terms.py
+++ b/src/unilab/tasks/motion_tracking/common/manager_terms.py
@@ -376,6 +376,12 @@ class MotionCommand(CommandTerm):
         those rows are gathered and scattered (partial-reset path). Rows outside
         env_ids keep the values produced by the last per-step refresh, which are
         still valid because untouched envs did not advance or resample frames.
+
+        Subclass contract (issue #1355): on the reset path the row-scoped
+        refresh may be skipped when `_resample_command` already ingested the
+        same rows through `_ingest_motion_rows`. A subclass that overrides this
+        method to refresh additional buffers must override
+        `_ingest_motion_rows` with the same additions (see BoxMotionCommand).
         """
         if env_ids is None:
             self.motion.get_motion_at_frame(self.time_steps, out=self._motion_data)
@@ -509,6 +515,17 @@ class MotionCommand(CommandTerm):
         )
 
     def _resample_command(self, env_ids: np.ndarray) -> None:
+        """Resample motion frames and stage the corresponding state writes.
+
+        The base implementation gathers the resampled frames once, ingests them
+        into the motion-reference buffers via `_ingest_motion_rows`, and exposes
+        the gather as `self._resample_motion` (issue #1355). Subclass contract:
+        call ``super()._resample_command(env_ids)`` first and reuse
+        `self._resample_motion` for additional writes instead of re-gathering;
+        a subclass that does not call super() leaves `_resample_ingested_ids`
+        unset, and the reset-path `_update_command` falls back to a fresh
+        `_refresh_motion(env_ids)` gather.
+        """
         frames = self.sampler.sample_frames(env_ids)
         motion = self.motion.get_motion_at_frame(frames)
         count = len(env_ids)


### PR DESCRIPTION
## Summary

- 在 `MotionCommand._refresh_motion` / `_resample_command` docstring 中明确：reset 路径的行域刷新可能由 `_resample_command` 内的 `_ingest_motion_rows` 承担（#1355 的 gather 去重），重写 `_refresh_motion` 的子类必须同步重写 `_ingest_motion_rows`（参照 `BoxMotionCommand`）；不调用 super() 的子类自动回退到 `_refresh_motion` 重新 gather
- 纯注释变更，无行为变化；回应"不破坏 manager-based API 契约"的审计要求

## Linked Work

- Issue: #1355
- Parent roadmap: #1348
- Base branch: `dev/issue-1042-manager-based-api`

## Validation

- [x] `make test-all` passed on the final local head（2330 passed, 28 skipped, 1 xfailed；benchmark smoke 通过）
- focused: `tests/envs/test_motion_command_partial_reset.py tests/tasks/test_motion_term_parity.py tests/managers/ tests/envs/mdp/ tests/base/test_manager_config_overlay.py` 180 passed

Remote CI route: not scheduled; local make test-all is the test gate（base 非 main）

## Impact

- Backend impact: none; Platform impact: none; Training effect expected: no