### PR TITLE
feat(isaacgym): 原生渲染打通 eval playback（viewer + 离屏录制）

### DIFF
--- a/conf/ppo/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/ppo/task/g1_walk_flat/isaacgym.yaml
@@ -6,8 +6,9 @@
 # and scans keyframes/sensors/actuators from it on the materialize cold path,
 # reproducing the <position kp kv forcerange> actuators with PhysX
 # DOF_MODE_POS. Runtime kp/kd randomization is unsupported, so pd_gains
-# stays disabled; with no native or offline-record playback yet, playback is
-# disabled at the config level instead of failing closed mid-run.
+# stays disabled. Playback uses IsaacGym native rendering: with a display,
+# `play_render_mode=auto` opens the interactive viewer; headless hosts fall
+# back to offscreen camera-sensor recording.
 defaults:
   - /task/g1_walk_flat/base
   - _self_
@@ -15,7 +16,6 @@ defaults:
 training:
   task_name: G1WalkFlat
   sim_backend: isaacgym
-  play_render_mode: none
 algo:
   num_envs: 2048
   max_iterations: 2200

--- a/conf/sac/task/g1_walk_flat/isaacgym.yaml
+++ b/conf/sac/task/g1_walk_flat/isaacgym.yaml
@@ -4,9 +4,10 @@
 # the self-contained MJCF scene from base.yaml directly (no scene fragments or
 # generated terrain) and reproduces the <position kp kv forcerange> actuators
 # with PhysX DOF_MODE_POS (gains parsed from the MJCF, not the importer);
-# runtime kp/kd randomization is unsupported, so pd_gains stays disabled; with
-# no native or offline-record playback yet, playback is disabled at the config
-# level instead of failing closed mid-run.
+# runtime kp/kd randomization is unsupported, so pd_gains stays disabled.
+# Playback uses IsaacGym native rendering: with a display,
+# `play_render_mode=auto` opens the interactive viewer; headless hosts fall
+# back to offscreen camera-sensor recording.
 defaults:
   - /task/g1_walk_flat/base
   - _self_
@@ -14,7 +15,6 @@ defaults:
 training:
   task_name: G1WalkFlat
   sim_backend: isaacgym
-  play_render_mode: none
 algo:
   num_envs: 2048
   learning_starts: 10

--- a/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/4-isaacgym.md
@@ -11,10 +11,11 @@ the external Python 3.8 worker) is implemented and registered; `g1_walk_flat`
 ships isaacgym owner configs
 (`conf/{ppo,sac}/task/g1_walk_flat/isaacgym.yaml`), and the cross-backend
 contract audit (`scripts/audit_sim2sim_contracts.py`) covers the
-mujoco/isaacgym pair. Playback rendering is not supported yet (owner configs
-set `play_render_mode: none`). Real-machine end-to-end validation depends on
-the external environment described below and is not covered by repo CI. The
-repository also ships a physics benchmark script
+mujoco/isaacgym pair. Playback rendering uses IsaacGym's native rendering
+(viewer + camera sensor); both interactive and video-recording modes work
+(see "Training and Evaluation" below). Real-machine end-to-end validation
+depends on the external environment described below and is not covered by
+repo CI. The repository also ships a physics benchmark script
 `scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`, which locates
 the external environment through variables such as
 `UNILAB_BENCHMARK_HOLOSOMA_DEPS`. This page covers preparing the external
@@ -114,6 +115,33 @@ uv run train --algo sac --task g1_walk_flat --sim isaacgym
 uv run train --algo ppo --task g1_walk_flat --sim isaacgym
 ```
 
+Playback rendering is provided natively by IsaacGym: the interactive mode
+opens the gym viewer inside the worker process, and the record mode renders
+offscreen with a camera sensor and writes `play_video.mp4` (the camera tracks
+env 0's root; the view is adjustable via `training.cam_distance` /
+`cam_elevation` / `cam_azimuth`). `play_render_mode=auto` (the default)
+selects the interactive viewer when a display is reachable
+(`DISPLAY`/`WAYLAND_DISPLAY`) and falls back to recording on headless hosts;
+recording requires a finite `training.play_steps` (the default configs
+provide one).
+
+```bash
+# Training enters playback automatically (auto); headless servers record video
+uv run train --algo sac --task g1_walk_flat --sim isaacgym
+
+# Evaluate a trained checkpoint in the interactive viewer
+uv run eval --algo sac --task g1_walk_flat --sim isaacgym \
+    --render-mode interactive --load-run <run_dir_name>
+
+# Record a video on headless hosts (force record)
+uv run eval --algo sac --task g1_walk_flat --sim isaacgym \
+    --render-mode record --load-run <run_dir_name> training.play_steps=800
+```
+
+Note: both the interactive viewer and camera capture require the worker sim
+to run on a GPU (`env.isaacgym_device_id >= 0`); a CPU-pipeline sim has no
+graphics context and render requests fail closed with an explanatory error.
+
 Common overrides (Hydra arguments follow the command directly):
 
 ```bash
@@ -128,11 +156,10 @@ uv run train --algo sac --task g1_walk_flat --sim isaacgym env.isaacgym_device_i
 Cross-backend migration (sim2sim): the isaacgym owner configs are fully
 contract-compatible with the mujoco owner under the audit guard
 (`src/unilab/utils/sim2sim.py`, verdict TRANSFERABLE), so checkpoints of the
-same task transfer across backends. Note that playback rendering is not
-implemented on the isaacgym backend yet — the owner configs set
-`play_render_mode: none`, which makes `uv run eval` skip playback at the
-script level. Cross-backend policy evaluation becomes available once playback
-lands.
+same task transfer across backends. Playback rendering works on isaacgym, so
+cross-backend policy evaluation (playing a mujoco-trained checkpoint on
+isaacgym, or vice versa) runs directly through the `uv run eval` commands
+above.
 
 ## Manual Setup
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/4-isaacgym.md
@@ -8,8 +8,9 @@ IsaacGym（NVIDIA Preview 4）是 NVIDIA 已停止维护（EOL）的 GPU 物理�
 当前状态：`IsaacGymBackend`（subprocess 后端，物理跑在外部 Python 3.8
 worker 中）已实现并注册到 registry；`g1_walk_flat` 提供 isaacgym owner
 配置（`conf/{ppo,sac}/task/g1_walk_flat/isaacgym.yaml`），跨后端契约审计
-（`scripts/audit_sim2sim_contracts.py`）覆盖 mujoco↔isaacgym。回放渲染
-尚未支持（owner 配置已将 `play_render_mode` 置为 `none`）。真机端到端
+（`scripts/audit_sim2sim_contracts.py`）覆盖 mujoco↔isaacgym。回放渲染走
+IsaacGym 原生渲染（viewer + camera sensor），交互与录视频两种模式均可用
+（见下文「训练与评估」）。真机端到端
 验证依赖下文所述的外部环境，不在仓库 CI 中覆盖。仓库内另有物理性能
 benchmark 脚本
 `scripts/benchmark/physics/benchmark_physics_step_isaacgym.py`，它通过
@@ -98,6 +99,30 @@ uv run train --algo sac --task g1_walk_flat --sim isaacgym
 uv run train --algo ppo --task g1_walk_flat --sim isaacgym
 ```
 
+回放渲染由 IsaacGym 原生提供：交互模式在 worker 进程里打开 gym viewer，
+录制模式用 camera sensor 离屏渲染并写出 `play_video.mp4`（相机跟踪
+env 0 的 root，视角可用 `training.cam_distance` / `cam_elevation` /
+`cam_azimuth` 调整）。`play_render_mode=auto`（默认）在有显示器
+（`DISPLAY`/`WAYLAND_DISPLAY`）时进入交互模式，无显示器的机器自动降级为
+录制模式；录制需要有限的 `training.play_steps`（默认配置已给出）。
+
+```bash
+# 训练后自动进入回放（auto）；无显示器的服务器自动录视频
+uv run train --algo sac --task g1_walk_flat --sim isaacgym
+
+# 对已训练的 checkpoint 做评估：交互 viewer
+uv run eval --algo sac --task g1_walk_flat --sim isaacgym \
+    --render-mode interactive --load-run <run_dir_name>
+
+# 无显示器环境录视频（强制 record）
+uv run eval --algo sac --task g1_walk_flat --sim isaacgym \
+    --render-mode record --load-run <run_dir_name> training.play_steps=800
+```
+
+注意：交互 viewer 与 camera 采集都要求 worker 的 sim 跑在 GPU 上
+（`env.isaacgym_device_id >= 0`）；CPU pipeline 的 sim 没有图形上下文，
+渲染请求会 fail-closed 并给出提示。
+
 常用覆盖（Hydra 参数直接跟在命令后面）：
 
 ```bash
@@ -111,9 +136,9 @@ uv run train --algo sac --task g1_walk_flat --sim isaacgym env.isaacgym_device_i
 
 跨后端迁移（sim2sim）：isaacgym owner 配置与 mujoco owner 在契约守卫
 （`src/unilab/utils/sim2sim.py`）审计下全部字段兼容（TRANSFERABLE），
-同一 task 的 checkpoint 可跨后端使用。注意 `uv run eval` 的回放渲染尚未
-在 isaacgym 后端实现（owner 配置 `play_render_mode: none` 会在脚本层跳过
-回放），跨后端策略评估将在回放能力落地后可用。
+同一 task 的 checkpoint 可跨后端使用；回放渲染在 isaacgym 上已可用，
+跨后端策略评估（在 isaacgym 上播放 mujoco 训练的 checkpoint，或反向）
+可直接用上面的 `uv run eval` 命令完成。
 
 ## 手动安装
 

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -47,7 +47,7 @@ uv run scripts/generate_support_matrix.py --write
 
 `mjwarp` 完成训练验证的只有 `g1_walk_flat` host adapter：PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`。SAC `t800_walk_flat` 的 mjwarp owner 只有 owner YAML 与 compose 覆盖，标记为 `Configured`，不代表训练验证。mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
 
-`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`，且开发环境没有 IsaacGym runtime：所有 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。owner YAML 通过 `training.play_render_mode=none` 在配置层停用 playback（backend 尚无 native 或离线 record playback）。
+`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机（external Python 3.8 worker runtime，不在仓库 CI 覆盖）完成训练与 record playback 验证，标记为 `Tested`；其余 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。playback 走 IsaacGym 原生渲染（viewer + camera sensor 离屏录制），有显示器时 `play_render_mode=auto` 打开交互 viewer，无显示器时自动降级为离屏录制。
 
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -316,10 +316,12 @@ def render_support_matrix(root: Path | None = None) -> str:
         "interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry "
         "identity，不代表对应算法、terrain、完整 DR 或 production training 支持。",
         "",
-        "`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`，且开发环境没有 IsaacGym "
-        "runtime：所有 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract "
-        "覆盖），不代表任何训练或 play 验证。owner YAML 通过 `training.play_render_mode=none` 在配置层"
-        "停用 playback（backend 尚无 native 或离线 record playback）。",
+        "`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机"
+        "（external Python 3.8 worker runtime，不在仓库 CI 覆盖）完成训练与 record playback 验证，"
+        "标记为 `Tested`；其余 isaacgym cell 最高只到 `Configured`（registry + owner YAML + "
+        "compose/contract 覆盖），不代表任何训练或 play 验证。playback 走 IsaacGym 原生渲染"
+        "（viewer + camera sensor 离屏录制），有显示器时 `play_render_mode=auto` 打开交互 viewer，"
+        "无显示器时自动降级为离屏录制。",
         "",
         benchmark_note,
         recommendation_note,

--- a/src/unilab/base/backend/isaacgym/backend.py
+++ b/src/unilab/base/backend/isaacgym/backend.py
@@ -39,9 +39,14 @@ Design invariants:
   ``xyzw``; the worker converts at the shm boundary).  ``set_state`` qvel root
   columns carry body-frame angular velocity per the ``SimBackend`` contract;
   the worker converts to IsaacGym's world-frame angular velocity.
-- Domain randomization, native rendering/playback, and pre-step control
-  callbacks are fail-closed (see ``get_dr_capabilities`` /
-  ``apply_interval_randomization`` / ``set_pre_step_control``).
+- Domain randomization and pre-step control callbacks are fail-closed (see
+  ``get_dr_capabilities`` / ``apply_interval_randomization`` /
+  ``set_pre_step_control``).
+- Native rendering (interactive viewer and headless camera capture) is owned
+  by the worker process, which holds the sim handle: ``init_renderer`` /
+  ``render`` / ``capture_video_frame`` forward to it over the pipe (one frame
+  per reply for capture).  Rendering requires a GPU sim (``device_id >= 0``);
+  CPU-pipeline sims fail closed.
 
 Sensor contract: IsaacGym has no MuJoCo sensor concept.  The scene MJCF is
 scanned once on the cold path (``sensors.py``) and supported sensors
@@ -61,6 +66,7 @@ Known real-runtime notes (validated on hardware during the G1 bring-up):
 from __future__ import annotations
 
 import atexit
+import logging
 import os
 import select
 import subprocess
@@ -75,8 +81,12 @@ from typing import Any, BinaryIO, cast
 import numpy as np
 
 from unilab.base.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
     BackendRootStateLayout,
+    RenderClosedError,
     SimBackend,
+    normalize_play_render_mode,
 )
 from unilab.base.scene import SceneCfg
 from unilab.dr.types import (
@@ -96,6 +106,7 @@ from .dependencies import (
     build_worker_env,
     resolve_isaacgym_runtime,
 )
+from .playback import run_isaacgym_playback
 from .sensors import (
     KIND_CONTACT_FOUND,
     KIND_FRAMEPOS,
@@ -108,6 +119,8 @@ from .sensors import (
     UnsupportedSensorSpec,
     scan_scene_metadata,
 )
+
+logger = logging.getLogger(__name__)
 
 _MODULE_DIR = Path(__file__).resolve().parent
 _WORKER_PATH = _MODULE_DIR / "worker.py"
@@ -123,6 +136,35 @@ _ROOT_QVEL_DIM = 6
 # PhysX clamps |force| <= dof effort; MJCF forcerange "0 0" (or absent) means
 # unlimited, mapped to a finite stand-in (float32-safe) for the dof property.
 _UNLIMITED_DOF_EFFORT = 1e20
+
+
+def _display_available() -> bool:
+    """Return whether a display is reachable for the interactive viewer."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _normalize_camera_kwargs(camera_kwargs: dict[str, Any] | None) -> dict[str, float]:
+    """Map repository camera kwargs onto the worker's spherical camera offset.
+
+    Callers pass the repo-wide MuJoCo-style keys (``cam_distance`` /
+    ``cam_elevation`` / ``cam_azimuth``); MuJoCo's negative-elevation
+    convention is converted to the worker's height-above-horizon angle.
+    """
+    kwargs = dict(camera_kwargs or {})
+    distance = float(kwargs.get("cam_distance", kwargs.get("distance", 2.0)))
+    elevation = kwargs.get("cam_elevation")
+    elevation_deg = (
+        float(-float(elevation))
+        if elevation is not None
+        else float(kwargs.get("elevation_deg", 20.0))
+    )
+    azimuth = kwargs.get("cam_azimuth")
+    azimuth_deg = float(azimuth) if azimuth is not None else float(kwargs.get("azimuth_deg", 90.0))
+    return {
+        "distance": distance,
+        "elevation_deg": elevation_deg,
+        "azimuth_deg": azimuth_deg,
+    }
 
 
 class IsaacGymWorkerError(RuntimeError):
@@ -252,7 +294,6 @@ class IsaacGymBackend(SimBackend):
         device_id: int | None = None,
         worker_timeout_s: float | None = None,
         worker_command: list[str] | None = None,
-        headless: bool = True,
         **unexpected_kwargs: Any,
     ) -> None:
         if unexpected_kwargs:
@@ -292,7 +333,6 @@ class IsaacGymBackend(SimBackend):
         if self._worker_timeout_s <= 0.0:
             raise ValueError(f"worker_timeout_s must be positive, got {self._worker_timeout_s!r}")
         self._worker_command = list(worker_command) if worker_command is not None else None
-        self._headless = bool(headless)
         self.backend_type = "isaacgym"
         self._pre_step_control_fn = None
         self._scene_cleanup_handle = None
@@ -312,6 +352,13 @@ class IsaacGymBackend(SimBackend):
         self._dof_id_by_name: dict[str, int] = {}
         self._base_body_id = 0
         self._closed = False
+        # Native rendering state (worker-owned viewer/camera; see the play
+        # contract section below).  ``_render_config`` pins the first
+        # init_renderer(headless, capture) pair like the Motrix backend.
+        self._graphics_enabled = False
+        self._render_config: tuple[bool, bool] | None = None
+        self._viewer_open = False
+        self._capture_ready = False
 
     # ------------------------------------------------------------------ #
     # Worker lifecycle (cold path)
@@ -364,7 +411,6 @@ class IsaacGymBackend(SimBackend):
                     "num_envs": self._num_envs,
                     "sim_dt": self._sim_dt,
                     "device_id": self._device_id,
-                    "headless": self._headless,
                     "isaacgym_python": isaacgym_python,
                     "keyframe_qpos": (
                         None
@@ -377,6 +423,7 @@ class IsaacGymBackend(SimBackend):
                 expect=protocol.CMD_META,
             )
             self._bind_model_metadata(meta)
+            self._graphics_enabled = bool(meta.get("graphics_enabled", False))
             self._validate_initial_keyframe()
             self._allocate_slots()
             self._request(
@@ -1031,6 +1078,163 @@ class IsaacGymBackend(SimBackend):
             "isaacgym does not support interval randomization; disable "
             "push/body-force/body-velocity terms in the owner YAML."
         )
+
+    # ------------------------------------------------------------------ #
+    # Native rendering / playback (worker-owned viewer and camera sensor)
+    # ------------------------------------------------------------------ #
+
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        return BackendPlayCapabilities(
+            supports_native_interactive_renderer=True,
+            supports_native_video_capture=True,
+        )
+
+    def resolve_play_render_plan(
+        self,
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | os.PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        mode = normalize_play_render_mode(play_render_mode)
+        if mode == "auto":
+            # The interactive viewer needs a reachable display; headless hosts
+            # fall back to offscreen camera-sensor recording.
+            mode = "interactive" if _display_available() else "record"
+        if mode == "none":
+            return BackendPlayRenderPlan(
+                mode=mode,
+                headless=True,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        if mode == "interactive":
+            return BackendPlayRenderPlan(
+                mode=mode,
+                headless=False,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        assert mode == "record"
+        if play_steps is None:
+            raise ValueError(
+                "isaacgym record playback requires a finite training.play_steps value."
+            )
+        if output_video is None:
+            raise ValueError("isaacgym record playback requires an output video path.")
+        return BackendPlayRenderPlan(
+            mode=mode,
+            headless=True,
+            record_video=True,
+            num_steps=int(play_steps),
+            output_video=output_video,
+        )
+
+    def init_renderer(
+        self,
+        spacing: float = 1.0,
+        *,
+        offset_mode: str = "grid",
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the worker-side viewer and/or capture camera.
+
+        ``spacing``/``offset_mode`` are accepted for contract parity and
+        ignored: envs are already laid out on the worker sim's grid.
+        """
+        del spacing, offset_mode
+        config = (bool(headless), bool(capture))
+        if self._render_config is not None:
+            if self._render_config != config:
+                raise RuntimeError(
+                    "isaacgym renderer is already initialized with "
+                    f"headless={self._render_config[0]}, capture={self._render_config[1]}; "
+                    f"cannot reinitialize it with headless={config[0]}, capture={config[1]}"
+                )
+            return
+        self._require_materialized()
+        if not self._graphics_enabled:
+            raise NotImplementedError(
+                "isaacgym rendering requires a GPU sim (env.isaacgym_device_id >= 0); "
+                "this backend runs on the CPU pipeline without a graphics context"
+            )
+        reply = self._request(
+            protocol.CMD_INIT_RENDERER,
+            {
+                "headless": config[0],
+                "capture": config[1],
+                "width": int(width),
+                "height": int(height),
+                "camera": _normalize_camera_kwargs(camera_kwargs),
+            },
+            expect=protocol.CMD_META,
+        )
+        self._render_config = config
+        self._viewer_open = bool(reply.get("viewer"))
+        self._capture_ready = bool(reply.get("capture"))
+
+    def render(self) -> None:
+        """Draw one interactive viewer frame through the worker."""
+        if not self._viewer_open:
+            self.init_renderer(headless=False)
+        reply = self._request(protocol.CMD_RENDER_FRAME, None, expect=protocol.CMD_META)
+        if bool(reply.get("closed")):
+            self._viewer_open = False
+            raise RenderClosedError("isaacgym viewer window was closed")
+
+    def capture_video_frame(self) -> np.ndarray:
+        """Capture one RGB frame from the worker's camera sensor."""
+        if not self._capture_ready:
+            self.init_renderer(headless=True, capture=True)
+        reply = self._request(protocol.CMD_CAPTURE_FRAME, None, expect=protocol.CMD_META)
+        return np.asarray(reply["frame"], dtype=np.uint8)
+
+    def run_playback(
+        self,
+        *,
+        env: Any,
+        initialize: Any,
+        step: Any,
+        num_steps: int | None,
+        output_video: str | os.PathLike[str] | None = None,
+        render_spacing: float | None = None,
+        render_offset_mode: str | None = None,
+        headless: bool | None = None,
+        record_video: bool | None = None,
+        frame_state_getter: Any = None,
+        camera_kwargs: dict[str, Any] | None = None,
+        extra_data_getter: Any = None,
+    ) -> str | None:
+        del frame_state_getter, extra_data_getter
+        should_record_video = (
+            bool(record_video) if record_video is not None else output_video is not None
+        )
+        should_run_headless = bool(headless) if headless is not None else should_record_video
+        try:
+            return run_isaacgym_playback(
+                backend=self,
+                env=env,
+                initialize=initialize,
+                step=step,
+                num_steps=num_steps,
+                output_video=output_video,
+                render_spacing=render_spacing,
+                render_offset_mode=render_offset_mode,
+                headless=should_run_headless,
+                record_video=should_record_video,
+                camera_kwargs=camera_kwargs,
+            )
+        except RenderClosedError:
+            if not should_run_headless and not should_record_video:
+                logger.info("Render window closed.")
+                return None
+            raise
 
     # ------------------------------------------------------------------ #
     # Cached state getters (shm views; no worker round trip)

--- a/src/unilab/base/backend/isaacgym/playback.py
+++ b/src/unilab/base/backend/isaacgym/playback.py
@@ -1,0 +1,87 @@
+"""IsaacGym-owned playback execution helpers.
+
+Mirrors ``motrix/playback.py``: the interactive path drives the worker's
+native viewer at ~60 Hz; the record path captures camera-sensor frames
+headlessly and writes them through the shared ``write_playback_video``.
+"""
+
+from __future__ import annotations
+
+import time
+from os import PathLike
+from typing import Any, Callable, TypeVar
+
+import numpy as np
+
+from unilab.base.backend.playback_common import env_cfg_value, write_playback_video
+
+ObsT = TypeVar("ObsT")
+
+
+def run_isaacgym_playback(
+    *,
+    backend: Any,
+    env: Any,
+    initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT],
+    num_steps: int | None,
+    output_video: str | PathLike[str] | None,
+    render_spacing: float | None,
+    render_offset_mode: str | None,
+    headless: bool,
+    record_video: bool,
+    camera_kwargs: dict[str, Any] | None,
+    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+) -> str | None:
+    del extra_data_getter
+    if record_video and not headless:
+        raise ValueError("isaacgym video recording requires headless=true.")
+
+    if headless or record_video:
+        if num_steps is None:
+            raise ValueError("isaacgym captured playback requires a finite num_steps value.")
+        if record_video and output_video is None:
+            raise ValueError("isaacgym video recording requires an output_video path.")
+
+        backend.init_renderer(
+            headless=headless,
+            capture=True,
+            width=1280,
+            height=720,
+            camera_kwargs=dict(camera_kwargs or {}),
+        )
+
+        obs = initialize()
+        frames: list[np.ndarray] | None = [] if record_video else None
+        for _ in range(num_steps):
+            obs = step(obs)
+            frame = np.asarray(backend.capture_video_frame(), dtype=np.uint8)
+            if frames is not None:
+                frames.append(frame.copy())
+
+        if not record_video:
+            return None
+
+        assert output_video is not None
+        assert frames is not None
+        ctrl_dt = float(env_cfg_value(env, "ctrl_dt", 1.0 / 60.0))
+        write_playback_video(str(output_video), frames, fps=int(1.0 / ctrl_dt))
+        return str(output_video)
+
+    del render_spacing, render_offset_mode
+    backend.init_renderer(headless=False)
+    obs = initialize()
+    last_render_time = time.perf_counter()
+    render_dt = 1.0 / 60.0
+    steps_run = 0
+
+    while num_steps is None or steps_run < num_steps:
+        obs = step(obs)
+        current_time = time.perf_counter()
+        elapsed = current_time - last_render_time
+        if elapsed < render_dt:
+            time.sleep(render_dt - elapsed)
+        last_render_time = time.perf_counter()
+        backend.render()
+        steps_run += 1
+    return None

--- a/src/unilab/base/backend/isaacgym/protocol.py
+++ b/src/unilab/base/backend/isaacgym/protocol.py
@@ -40,6 +40,9 @@ CMD_STEP = "STEP"
 CMD_SET_STATE = "SET_STATE"
 CMD_REFRESH = "REFRESH"
 CMD_GET_META = "GET_META"
+CMD_INIT_RENDERER = "INIT_RENDERER"
+CMD_RENDER_FRAME = "RENDER_FRAME"
+CMD_CAPTURE_FRAME = "CAPTURE_FRAME"
 CMD_SHUTDOWN = "SHUTDOWN"
 
 CMD_READY = "READY"
@@ -223,12 +226,15 @@ def quat_rotate_inverse(quat_wxyz: np.ndarray, vec: np.ndarray) -> np.ndarray:
 
 __all__ = [
     "CMD_ATTACH",
+    "CMD_CAPTURE_FRAME",
     "CMD_ERROR",
     "CMD_GET_META",
     "CMD_INIT",
+    "CMD_INIT_RENDERER",
     "CMD_META",
     "CMD_READY",
     "CMD_REFRESH",
+    "CMD_RENDER_FRAME",
     "CMD_SET_STATE",
     "CMD_SHUTDOWN",
     "CMD_STEP",

--- a/src/unilab/base/backend/isaacgym/worker.py
+++ b/src/unilab/base/backend/isaacgym/worker.py
@@ -60,6 +60,19 @@ class _WorkerContext:
         self._dof_state: Any = None
         self._body_state: Any = None
         self._contact_force: Any = None
+        # Native rendering state (viewer and/or camera sensor).  Both live in
+        # this process because the sim handle does.
+        self.graphics_device_id = -1
+        self.viewer: Any = None
+        self.camera_handle: Any = None
+        self.camera_env: Any = None
+        self.camera_width = 0
+        self.camera_height = 0
+        # Defaults match the repository's MuJoCo playback camera convention
+        # (elevation is the height angle above the horizon, in degrees).
+        self.camera_distance = 2.0
+        self.camera_elevation_deg = 20.0
+        self.camera_azimuth_deg = 90.0
 
     # ------------------------------------------------------------------ #
     # INIT
@@ -96,8 +109,15 @@ class _WorkerContext:
         sim_params.physx.num_threads = 0
         sim_params.physx.use_gpu = self.use_gpu_pipeline
         sim_params.use_gpu_pipeline = self.use_gpu_pipeline
-        graphics_device_id = -1 if payload.get("headless", True) else device_id
-        self.sim = self.gym.create_sim(device_id, graphics_device_id, gymapi.SIM_PHYSX, sim_params)
+        # The graphics context is enabled whenever the sim runs on a GPU
+        # device.  It opens no window by itself (only create_viewer does) and
+        # is required for both the interactive viewer and headless camera
+        # capture; the cost for training-only runs is negligible.  CPU-pipeline
+        # sims get no graphics context and fail closed on render requests.
+        self.graphics_device_id = device_id if device_id >= 0 else -1
+        self.sim = self.gym.create_sim(
+            device_id, self.graphics_device_id, gymapi.SIM_PHYSX, sim_params
+        )
         if self.sim is None:
             raise RuntimeError(
                 "isaacgym create_sim failed (device_id=%d, gpu_pipeline=%s)"
@@ -182,6 +202,7 @@ class _WorkerContext:
             "effort": effort.tolist(),
             "gravity": [0.0, 0.0, -9.81],
             "use_gpu_pipeline": self.use_gpu_pipeline,
+            "graphics_enabled": self.graphics_device_id >= 0,
         }
 
     def _apply_actuator_props(self, dof_props: Any, payload: Dict[str, Any]) -> None:
@@ -426,9 +447,134 @@ class _WorkerContext:
             "num_dof": self.num_dof,
             "num_bodies": self.num_bodies,
             "use_gpu_pipeline": self.use_gpu_pipeline,
+            "graphics_enabled": self.graphics_device_id >= 0,
         }
 
+    # ------------------------------------------------------------------ #
+    # Native rendering (viewer + camera sensor)
+    # ------------------------------------------------------------------ #
+
+    def _require_graphics(self) -> None:
+        if self.graphics_device_id < 0:
+            raise RuntimeError(
+                "isaacgym rendering requires a GPU sim (device_id >= 0); this sim was "
+                "created without a graphics context"
+            )
+
+    def init_renderer(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Create the interactive viewer and/or the headless capture camera."""
+        gym = self.gym
+        gymapi = self.gymapi
+        self._require_graphics()
+        headless = bool(payload.get("headless", False))
+        capture = bool(payload.get("capture", False))
+
+        if not headless and self.viewer is None:
+            viewer = gym.create_viewer(self.sim, gymapi.CameraProperties())
+            if viewer is None:
+                raise RuntimeError(
+                    "isaacgym create_viewer failed (no display reachable); use "
+                    "play_render_mode=record for headless video capture"
+                )
+            # Default view: env 0 area, slightly above the grid.
+            gym.viewer_camera_look_at(
+                viewer,
+                None,
+                gymapi.Vec3(2.5, 2.5, 1.8),
+                gymapi.Vec3(0.0, 0.0, 0.5),
+            )
+            self.viewer = viewer
+
+        if capture and self.camera_handle is None:
+            camera = payload.get("camera") or {}
+            self.camera_distance = float(camera.get("distance", 2.0))
+            self.camera_elevation_deg = float(camera.get("elevation_deg", 20.0))
+            self.camera_azimuth_deg = float(camera.get("azimuth_deg", 90.0))
+            self.camera_width = int(payload.get("width", 1280))
+            self.camera_height = int(payload.get("height", 720))
+            cam_props = gymapi.CameraProperties()
+            cam_props.width = self.camera_width
+            cam_props.height = self.camera_height
+            self.camera_env = self.env_handles[0]
+            self.camera_handle = gym.create_camera_sensor(self.camera_env, cam_props)
+            self._position_tracking_camera()
+
+        return {
+            "viewer": self.viewer is not None,
+            "capture": self.camera_handle is not None,
+        }
+
+    def _position_tracking_camera(self) -> None:
+        """Aim the capture camera at env 0's root on a spherical offset."""
+        import math  # noqa: PLC0415
+
+        gymapi = self.gymapi
+        root = self._root_state.view(self.num_envs, -1, 13)[0, 0, :].cpu().numpy()
+        target = np.asarray(root[0:3], dtype=np.float64)
+        elevation = math.radians(self.camera_elevation_deg)
+        azimuth = math.radians(self.camera_azimuth_deg)
+        offset = self.camera_distance * np.array(
+            [
+                math.cos(elevation) * math.cos(azimuth),
+                math.cos(elevation) * math.sin(azimuth),
+                math.sin(elevation),
+            ]
+        )
+        eye = target + offset
+        self.gym.set_camera_location(
+            self.camera_handle,
+            self.camera_env,
+            gymapi.Vec3(float(eye[0]), float(eye[1]), float(eye[2])),
+            gymapi.Vec3(float(target[0]), float(target[1]), float(target[2])),
+        )
+
+    def render_frame(self) -> Dict[str, Any]:
+        """Draw one viewer frame; report whether the user closed the window."""
+        if self.viewer is None:
+            raise RuntimeError("isaacgym viewer is not initialized; call INIT_RENDERER first")
+        gym = self.gym
+        if gym.query_viewer_has_closed(self.viewer):
+            self._destroy_viewer()
+            return {"closed": True}
+        gym.step_graphics(self.sim)
+        gym.draw_viewer(self.viewer, self.sim, True)
+        if gym.query_viewer_has_closed(self.viewer):
+            self._destroy_viewer()
+            return {"closed": True}
+        return {"closed": False}
+
+    def capture_frame(self) -> Dict[str, Any]:
+        """Render the capture camera and return one RGB uint8 frame."""
+        if self.camera_handle is None:
+            raise RuntimeError(
+                "isaacgym capture camera is not initialized; call INIT_RENDERER first"
+            )
+        gym = self.gym
+        self._position_tracking_camera()
+        gym.step_graphics(self.sim)
+        gym.render_all_camera_sensors(self.sim)
+        image = np.asarray(
+            gym.get_camera_image(
+                self.sim, self.camera_env, self.camera_handle, self.gymapi.IMAGE_COLOR
+            )
+        )
+        frame = np.ascontiguousarray(
+            image.reshape(self.camera_height, self.camera_width, 4)[:, :, :3]
+        )
+        return {
+            "frame": frame,
+            "width": self.camera_width,
+            "height": self.camera_height,
+        }
+
+    def _destroy_viewer(self) -> None:
+        if self.viewer is not None:
+            self.gym.destroy_viewer(self.viewer)
+            self.viewer = None
+
     def shutdown(self) -> None:
+        if self.gym is not None:
+            self._destroy_viewer()
         if self.gym is not None and self.sim is not None:
             self.gym.destroy_sim(self.sim)
             self.sim = None
@@ -455,6 +601,12 @@ def _dispatch(ctx: _WorkerContext, protocol: Any, cmd: str, payload: Any) -> Tup
         return protocol.CMD_READY, None
     if cmd == protocol.CMD_GET_META:
         return protocol.CMD_META, ctx.get_meta()
+    if cmd == protocol.CMD_INIT_RENDERER:
+        return protocol.CMD_META, ctx.init_renderer(payload)
+    if cmd == protocol.CMD_RENDER_FRAME:
+        return protocol.CMD_META, ctx.render_frame()
+    if cmd == protocol.CMD_CAPTURE_FRAME:
+        return protocol.CMD_META, ctx.capture_frame()
     raise ValueError(f"unknown command {cmd!r}")
 
 

--- a/tests/base/isaacgym_mock_worker.py
+++ b/tests/base/isaacgym_mock_worker.py
@@ -18,7 +18,10 @@ so tests can assert exact values:
 Failure modes are selected with ``UNILAB_ISAACGYM_MOCK_BEHAVIOR``:
 ``ok`` (default), ``fail_init`` (raise during INIT), ``die_on_step``
 (``os._exit(3)`` on the first STEP), ``hang_on_step`` (sleep on the first
-STEP).  Model dims come from ``UNILAB_ISAACGYM_MOCK_DOF_NAMES`` /
+STEP), ``no_graphics`` (INIT reports no graphics context and INIT_RENDERER
+fails), ``viewer_fails`` (INIT_RENDERER cannot create the viewer),
+``close_on_render`` (the first RENDER_FRAME reports the window closed).
+Model dims come from ``UNILAB_ISAACGYM_MOCK_DOF_NAMES`` /
 ``UNILAB_ISAACGYM_MOCK_BODY_NAMES`` (comma-separated).
 """
 
@@ -46,7 +49,15 @@ def _load_protocol(path: str) -> Any:
 
 
 class _MockSim:
-    def __init__(self, num_envs: int, sim_dt: float, dof_names: List[str], body_names: List[str]):
+    def __init__(
+        self,
+        num_envs: int,
+        sim_dt: float,
+        dof_names: List[str],
+        body_names: List[str],
+        graphics_enabled: bool = True,
+    ):
+        self.graphics_enabled = graphics_enabled
         self.num_envs = num_envs
         self.sim_dt = sim_dt
         self.dof_names = dof_names
@@ -59,6 +70,10 @@ class _MockSim:
         self.dof = np.zeros((num_envs, self.num_dof, 2), dtype=np.float32)
         self.slots: Dict[str, np.ndarray] = {}
         self._shm_handles: List[Any] = []
+        self.viewer_open = False
+        self.capture_ready = False
+        self.capture_width = 0
+        self.capture_height = 0
 
     def attach(self, slots: Dict[str, Dict[str, Any]]) -> None:
         from multiprocessing import resource_tracker, shared_memory
@@ -144,6 +159,7 @@ class _MockSim:
             "effort": [100.0] * self.num_dof,
             "gravity": [0.0, 0.0, _GRAVITY_Z],
             "use_gpu_pipeline": False,
+            "graphics_enabled": self.graphics_enabled,
         }
 
     def close(self) -> None:
@@ -153,6 +169,49 @@ class _MockSim:
             except Exception:
                 pass
         self._shm_handles = []
+
+    def init_renderer(self, payload: Dict[str, Any], behavior: str) -> Dict[str, Any]:
+        if not self.graphics_enabled:
+            raise RuntimeError(
+                "isaacgym rendering requires a GPU sim (device_id >= 0); this sim was "
+                "created without a graphics context"
+            )
+        headless = bool(payload.get("headless", False))
+        capture = bool(payload.get("capture", False))
+        if not headless:
+            if behavior == "viewer_fails":
+                raise RuntimeError(
+                    "isaacgym create_viewer failed (no display reachable); use "
+                    "play_render_mode=record for headless video capture"
+                )
+            self.viewer_open = True
+        if capture:
+            self.capture_ready = True
+            self.capture_width = int(payload.get("width", 1280))
+            self.capture_height = int(payload.get("height", 720))
+        return {"viewer": self.viewer_open, "capture": self.capture_ready}
+
+    def render_frame(self, behavior: str) -> Dict[str, Any]:
+        if not self.viewer_open:
+            raise RuntimeError("isaacgym viewer is not initialized; call INIT_RENDERER first")
+        if behavior == "close_on_render":
+            self.viewer_open = False
+            return {"closed": True}
+        return {"closed": False}
+
+    def capture_frame(self) -> Dict[str, Any]:
+        if not self.capture_ready:
+            raise RuntimeError(
+                "isaacgym capture camera is not initialized; call INIT_RENDERER first"
+            )
+        # Deterministic gradient so tests can verify the frame is not blank.
+        rows = np.arange(self.capture_height, dtype=np.uint8)[:, None]
+        cols = np.arange(self.capture_width, dtype=np.uint8)[None, :]
+        frame = np.zeros((self.capture_height, self.capture_width, 3), dtype=np.uint8)
+        frame[:, :, 0] = rows
+        frame[:, :, 1] = cols
+        frame[:, :, 2] = 128
+        return {"frame": frame, "width": self.capture_width, "height": self.capture_height}
 
 
 def _csv_env(name: str, default: List[str]) -> List[str]:
@@ -185,6 +244,7 @@ def main(argv: List[str]) -> int:
                 body_names=_csv_env(
                     "UNILAB_ISAACGYM_MOCK_BODY_NAMES", ["base", "link0", "link1", "link2"]
                 ),
+                graphics_enabled=behavior != "no_graphics",
             )
             keyframe_qpos = payload.get("keyframe_qpos")
             if keyframe_qpos is not None:
@@ -224,6 +284,12 @@ def main(argv: List[str]) -> int:
             return protocol.CMD_READY, None
         if cmd == protocol.CMD_GET_META:
             return protocol.CMD_META, sim.meta()
+        if cmd == protocol.CMD_INIT_RENDERER:
+            return protocol.CMD_META, sim.init_renderer(payload, behavior)
+        if cmd == protocol.CMD_RENDER_FRAME:
+            return protocol.CMD_META, sim.render_frame(behavior)
+        if cmd == protocol.CMD_CAPTURE_FRAME:
+            return protocol.CMD_META, sim.capture_frame()
         raise ValueError(f"unknown command {cmd!r}")
 
     while True:

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -473,3 +473,36 @@ def test_isaacgym_position_hold_is_stable() -> None:
         )
     finally:
         backend.close()
+
+
+@pytest.mark.slow
+def test_isaacgym_native_camera_capture_renders_scene() -> None:
+    """Real-runtime guard for the native capture path used by record playback.
+
+    The camera sensor tracks env 0's root; after a physics step the frame must
+    be a real render (correct shape, non-uniform pixels — the ground plane and
+    the robot differ in color).
+    """
+    if not _isaacgym_runtime_available():
+        pytest.skip("isaacgym requires the Python 3.8 worker runtime")
+
+    backend = create_backend(
+        "isaacgym",
+        SceneCfg(model_file=_G1_SCENE),
+        NUM_ENVS,
+        SIM_DT,
+        base_name="pelvis",
+    )
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=True, capture=True, width=320, height=240)
+        backend.step(np.zeros((NUM_ENVS, backend.num_actuators), dtype=np.float32))
+        frame = backend.capture_video_frame()
+        assert frame.shape == (240, 320, 3)
+        assert frame.dtype == np.uint8
+        assert np.unique(frame).size > 8, "camera frame looks blank"
+        # A second init with the same config is a no-op and keeps capturing.
+        backend.init_renderer(headless=True, capture=True, width=320, height=240)
+        assert backend.capture_video_frame().shape == (240, 320, 3)
+    finally:
+        backend.close()

--- a/tests/base/test_isaacgym_backend.py
+++ b/tests/base/test_isaacgym_backend.py
@@ -692,10 +692,10 @@ def test_dr_and_pre_step_control_fail_closed(backend: IsaacGymBackend) -> None:
         backend.set_pre_step_control(lambda backend_, ctrl: ctrl)
     backend.set_pre_step_control(None)
 
-    with pytest.raises(NotImplementedError, match="render"):
-        backend.init_renderer()
-    with pytest.raises(NotImplementedError, match="playback"):
-        backend.run_playback(env=None, initialize=None, step=None, num_steps=None)
+    # Physics-state playback export stays unsupported; native rendering has
+    # its own dedicated tests below.
+    with pytest.raises(NotImplementedError, match="physics-state playback"):
+        backend.get_physics_state()
 
 
 def test_close_reaps_worker_and_unlinks_shm(backend: IsaacGymBackend) -> None:
@@ -822,5 +822,203 @@ def test_state_access_before_materialize_lazy_spawns_worker(scene_file: str) -> 
         backend.materialize()
         backend.step(np.zeros((NUM_ENVS, 3), dtype=np.float32))
         assert backend.get_dof_pos().shape == (NUM_ENVS, 3)
+    finally:
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# Native rendering / playback
+# ---------------------------------------------------------------------------
+
+
+def test_play_capabilities_advertise_native_rendering(backend: IsaacGymBackend) -> None:
+    caps = backend.get_play_capabilities()
+    assert caps.supports_native_interactive_renderer
+    assert caps.supports_native_video_capture
+    assert not caps.supports_physics_state_playback
+
+
+def test_normalize_camera_kwargs_maps_mujoco_convention() -> None:
+    from unilab.base.backend.isaacgym.backend import _normalize_camera_kwargs
+
+    out = _normalize_camera_kwargs(
+        {"cam_distance": 3.0, "cam_elevation": -20.0, "cam_azimuth": 90.0}
+    )
+    assert out == {"distance": 3.0, "elevation_deg": 20.0, "azimuth_deg": 90.0}
+    assert _normalize_camera_kwargs(None) == {
+        "distance": 2.0,
+        "elevation_deg": 20.0,
+        "azimuth_deg": 90.0,
+    }
+
+
+def test_resolve_play_render_plan_modes(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backend = _make_backend(scene_file)
+    try:
+        plan = backend.resolve_play_render_plan(
+            play_render_mode="none", play_steps=10, output_video=tmp_path / "x.mp4"
+        )
+        assert plan.mode == "none" and plan.num_steps is None
+
+        plan = backend.resolve_play_render_plan(
+            play_render_mode="interactive", play_steps=None, output_video=None
+        )
+        assert plan.mode == "interactive" and not plan.headless and not plan.record_video
+
+        plan = backend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=5, output_video=tmp_path / "x.mp4"
+        )
+        assert plan.mode == "record" and plan.headless and plan.record_video
+        assert plan.num_steps == 5
+
+        with pytest.raises(ValueError, match="play_steps"):
+            backend.resolve_play_render_plan(
+                play_render_mode="record", play_steps=None, output_video=tmp_path / "x.mp4"
+            )
+        with pytest.raises(ValueError, match="output video path"):
+            backend.resolve_play_render_plan(
+                play_render_mode="record", play_steps=5, output_video=None
+            )
+
+        monkeypatch.setenv("DISPLAY", ":0")
+        plan = backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=5, output_video=None
+        )
+        assert plan.mode == "interactive"
+
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        plan = backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=5, output_video=tmp_path / "x.mp4"
+        )
+        assert plan.mode == "record" and plan.headless
+    finally:
+        backend.close()
+
+
+def test_interactive_renderer_roundtrip(backend: IsaacGymBackend) -> None:
+    backend.init_renderer(headless=False)
+    backend.render()
+    # Re-initializing with the same config is a no-op; a different one fails.
+    backend.init_renderer(headless=False)
+    with pytest.raises(RuntimeError, match="already initialized"):
+        backend.init_renderer(headless=True, capture=True)
+    # Capturing on an interactive-only renderer must not silently succeed.
+    with pytest.raises(RuntimeError, match="already initialized"):
+        backend.capture_video_frame()
+
+
+def test_viewer_close_raises_render_closed(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unilab.base.backend.base import RenderClosedError
+
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "close_on_render")
+    backend = _make_backend(scene_file)
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=False)
+        with pytest.raises(RenderClosedError, match="closed"):
+            backend.render()
+    finally:
+        backend.close()
+
+
+def test_viewer_creation_failure_is_actionable(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "viewer_fails")
+    backend = _make_backend(scene_file)
+    backend.materialize()
+    try:
+        with pytest.raises(IsaacGymWorkerError, match="create_viewer failed"):
+            backend.init_renderer(headless=False)
+    finally:
+        backend.close()
+
+
+def test_renderer_requires_graphics_context(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "no_graphics")
+    backend = _make_backend(scene_file)
+    backend.materialize()
+    try:
+        with pytest.raises(NotImplementedError, match="requires a GPU sim"):
+            backend.init_renderer(headless=True, capture=True)
+    finally:
+        backend.close()
+
+
+def test_capture_video_frame_roundtrip(backend: IsaacGymBackend) -> None:
+    backend.init_renderer(headless=True, capture=True, width=64, height=48)
+    frame = backend.capture_video_frame()
+    assert frame.shape == (48, 64, 3)
+    assert frame.dtype == np.uint8
+    # Mock frame is a deterministic gradient: red follows rows, green columns.
+    assert frame[10, 0, 0] == 10
+    assert frame[0, 20, 1] == 20
+    assert (frame[:, :, 2] == 128).all()
+
+
+def test_capture_without_init_uses_record_config(backend: IsaacGymBackend) -> None:
+    # capture_video_frame lazily initializes the headless capture camera.
+    frame = backend.capture_video_frame()
+    assert frame.shape == (720, 1280, 3)
+
+
+def test_run_playback_record_writes_video(backend: IsaacGymBackend, tmp_path: Path) -> None:
+    from types import SimpleNamespace
+
+    output = tmp_path / "play.mp4"
+    result = backend.run_playback(
+        env=SimpleNamespace(cfg=None),
+        initialize=lambda: 0,
+        step=lambda obs: obs + 1,
+        num_steps=3,
+        output_video=output,
+        headless=True,
+        record_video=True,
+    )
+    assert result == str(output)
+    assert output.exists() and output.stat().st_size > 0
+
+
+def test_run_playback_interactive_finite_steps(backend: IsaacGymBackend) -> None:
+    from types import SimpleNamespace
+
+    steps: list[int] = []
+    result = backend.run_playback(
+        env=SimpleNamespace(cfg=None),
+        initialize=lambda: 0,
+        step=lambda obs: steps.append(obs) or (obs + 1),
+        num_steps=2,
+        headless=False,
+        record_video=False,
+    )
+    assert result is None
+    assert steps == [0, 1]
+
+
+def test_run_playback_interactive_window_close_is_graceful(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from types import SimpleNamespace
+
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "close_on_render")
+    backend = _make_backend(scene_file)
+    backend.materialize()
+    try:
+        result = backend.run_playback(
+            env=SimpleNamespace(cfg=None),
+            initialize=lambda: 0,
+            step=lambda obs: obs + 1,
+            num_steps=None,
+            headless=False,
+            record_video=False,
+        )
+        assert result is None
     finally:
         backend.close()

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -478,8 +478,9 @@ def test_g1_owner_materializes_complete_plain_manager_cfg(
         assert env_cfg.mjwarp_njmax == 256
     if backend == "isaacgym":
         assert env_cfg.isaacgym_device_id == 0
-        # No native or offline-record playback yet: disabled at config level.
-        assert hydra_cfg.training.play_render_mode == "none"
+        # Native rendering (viewer + camera-sensor record) is supported;
+        # playback stays on the base config's auto mode.
+        assert hydra_cfg.training.play_render_mode == "auto"
 
     pose = env_cfg.rewards["pose"]
     expected_weights = _POSE_WEIGHTS_29 if num_dof == 29 else _POSE_WEIGHTS_23


### PR DESCRIPTION
## 概要

Closes #1365。

isaacgym 后端实现 `SimBackend` play 契约，eval/playback 不再跳过：训练结束自动进入回放，`uv run eval` 支持交互 viewer 与离屏视频录制两种模式。

## 改动

- **worker**（`isaacgym/worker.py`、`protocol.py`）：GPU sim 一律创建 graphics context（只有 `create_viewer` 才开窗），新增 `INIT_RENDERER` / `RENDER_FRAME` / `CAPTURE_FRAME` 命令；viewer 关闭经 `query_viewer_has_closed` 检测并在 host 侧抛 `RenderClosedError`；camera sensor 绑定 env 0，按 root 位置做球面跟踪（视角沿用仓库 MuJoCo 相机约定，支持 `training.cam_distance/cam_elevation/cam_azimuth`）。
- **host**（`isaacgym/backend.py`）：`get_play_capabilities`（interactive renderer + native video capture）、`resolve_play_render_plan`（`auto`：有显示器 → interactive，否则 → record）、`init_renderer` / `render` / `capture_video_frame`（IPC 转发，渲染配置首次初始化后锁定，参照 motrix）、`run_playback`。
- **playback 循环**（新增 `isaacgym/playback.py`）：镜像 `motrix/playback.py` 的 interactive（60fps 节流）/ record（采集帧 + `write_playback_video`）双路径。
- **配置**：`conf/{sac,ppo}/task/g1_walk_flat/isaacgym.yaml` 移除 `play_render_mode: none`（回到 base 的 `auto`）。
- **测试**：mock worker 扩展渲染命令与失败注入（`no_graphics` / `viewer_fails` / `close_on_render`）；host 单测覆盖 plan 解析、viewer 生命周期、capture 回读、record 写视频、窗口关闭优雅退出；新增真机 slow 测试 `test_isaacgym_native_camera_capture_renders_scene`；owner 契约测试断言更新为 `auto`。
- **文档**：isaacgym 指南（en/zh）新增 eval/渲染用法（含无显示器降级与 GPU graphics 前提）；支持矩阵说明更新并重新生成。

## 验证

- `make test-all` 于最终 head 通过：2379 passed, 28 skipped, 1 xfailed。
- 真机（GPU + IsaacGym worker runtime）：
  - `uv run eval --algo sac --task g1_walk_flat --sim isaacgym --render-mode record --load-run 2026-08-28_01-21-02_isaacgym training.play_steps=100` → 生成 `play_video.mp4`（1280x720@50fps，画面经目检正常：G1 站立行走、相机跟踪正确）。
  - 交互 viewer 路径真机验证：`init_renderer(headless=False)` + 连续 `render()` 正常开窗绘制。
  - `pytest tests/base -m slow -k isaacgym`：6 passed（含新增 camera capture 测试与既有 hold-pose 回归）。
  - 训练→eval 自动衔接：`uv run train --algo sac --task g1_walk_flat --sim isaacgym algo.num_envs=64 algo.max_iterations=3 training.play_render_mode=record training.play_steps=30` → 训练结束后自动进 play、ONNX 导出、录制出视频。

## 范围外

- `play_interactive.py` 的 MuJoCo keyboard 交互工具链保持不变。
- CPU pipeline（`env.isaacgym_device_id=-1`）无图形上下文，渲染请求 fail-closed 并给出提示。

Base: `dev/issue-1332-isaacgym-backend`（依赖其中未合入的 isaacgym backend）。