### PR TITLE
feat(backend): GenesisBackend contract adapter 实现（#1378）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ dependencies = [
     "packaging",
     "mediapy",
     "tensorboard",
-    "setuptools<70",
+    # Unpinned: quadrants (genesis-world 1.3.3 pin) requires setuptools>=77,
+    # and nothing in this repo imports setuptools/pkg_resources at runtime.
+    "setuptools",
     "rich",
     "tqdm",
     "typing-extensions",
@@ -72,6 +74,12 @@ mjwarp = [
     "warp-lang>=1.14.0",
 ]
 motrix = ["motrixsim-core==0.8.2"]
+genesis = [
+    # Genesis imports as ``genesis`` and owns the GPU physics implementation;
+    # it is a separate optional extra pinned exactly to the probed release
+    # (scripts/tools/genesis_feasibility/REPORT.md, #1372).
+    "genesis-world==1.3.3",
+]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]
 
 [dependency-groups]

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -24,6 +24,10 @@ def env_backend_kwargs(cfg: "EnvCfg") -> dict:
         "bench_nsteps": cfg.sim_substeps,
         "mjwarp_nconmax": cfg.mjwarp_nconmax,
         "mjwarp_njmax": cfg.mjwarp_njmax,
+        "genesis_integrator": cfg.genesis_integrator,
+        "genesis_constraint_solver": cfg.genesis_constraint_solver,
+        "genesis_friction_cone": cfg.genesis_friction_cone,
+        "genesis_solver_iterations": cfg.genesis_solver_iterations,
         "drake_backend_mode": cfg.drake_backend_mode,
         "drake_nthread": cfg.drake_nthread,
         "isaacgym_device_id": cfg.isaacgym_device_id,
@@ -79,6 +83,19 @@ def _mjwarp_available() -> bool:
     return mjwarp_dependencies_available()
 
 
+def _load_genesis_backend() -> Any:
+    """Load the independent optional Genesis backend on demand."""
+    from .genesis.backend import GenesisBackend
+
+    return GenesisBackend
+
+
+def _genesis_available() -> bool:
+    from .genesis.dependencies import genesis_dependencies_available
+
+    return genesis_dependencies_available()
+
+
 def _load_motrix_scene_export(name: str) -> Any:
     from .motrix import scene
 
@@ -116,7 +133,7 @@ def create_backend(
 
     Args:
         backend_type: ``"mujoco"``, ``"mjwarp"``, ``"motrix"``, ``"drake"``,
-            or ``"isaacgym"``.
+            ``"isaacgym"``, or ``"genesis"``.
         scene: SceneCfg for either static or composed scenes.
         num_envs: Number of environments.
         sim_dt: Simulation timestep.
@@ -151,6 +168,10 @@ def create_backend(
     drake_nthread = kwargs.pop("drake_nthread", None)
     isaacgym_device_id = kwargs.pop("isaacgym_device_id", None)
     isaacgym_worker_timeout_s = kwargs.pop("isaacgym_worker_timeout_s", None)
+    genesis_integrator = kwargs.pop("genesis_integrator", None)
+    genesis_constraint_solver = kwargs.pop("genesis_constraint_solver", None)
+    genesis_friction_cone = kwargs.pop("genesis_friction_cone", None)
+    genesis_solver_iterations = kwargs.pop("genesis_solver_iterations", None)
     if backend_type == "mujoco":
         MuJoCoBackend = _load_mujoco_backend()
         if body_state_required:
@@ -199,6 +220,40 @@ def create_backend(
         kwargs["nconmax"] = mjwarp_nconmax
         kwargs["njmax"] = mjwarp_njmax
         return cast(SimBackend, MjwarpBackend(scene, num_envs, sim_dt, **kwargs))
+    if backend_type == "genesis":
+        GenesisBackend = _load_genesis_backend()
+        # Body states are served natively from link-addressed getters; the
+        # flag exists for backends that need extra scene materialization.
+        kwargs.pop("add_body_sensors", None)
+        if position_actuator_gains is not None:
+            raise ValueError(
+                "genesis imports the MJCF position-actuator gains directly; "
+                "position_actuator_gains has no Genesis equivalent."
+            )
+        ignored_non_defaults = {
+            key: value
+            for key, value, default in (
+                ("post_step_forward_sensor", post_step_forward_sensor, None),
+                ("iterations", iterations, None),
+                ("chunk_size", chunk_size, None),
+                ("adaptive_chunk_size", adaptive_chunk_size, False),
+                ("cpu_ids", cpu_ids, None),
+                ("bench_nsteps", bench_nsteps, 1),
+            )
+            if value != default
+        }
+        if ignored_non_defaults:
+            rendered = ", ".join(f"{key}={value!r}" for key, value in ignored_non_defaults.items())
+            warnings.warn(
+                "genesis ignores non-default MuJoCo-only backend options: " + rendered,
+                UserWarning,
+                stacklevel=2,
+            )
+        kwargs["integrator"] = genesis_integrator
+        kwargs["constraint_solver"] = genesis_constraint_solver
+        kwargs["friction_cone"] = genesis_friction_cone
+        kwargs["solver_iterations"] = genesis_solver_iterations
+        return cast(SimBackend, GenesisBackend(scene, num_envs, sim_dt, **kwargs))
     if backend_type == "motrix":
         MotrixBackend, motrix_available = _load_motrix_backend()
         if not motrix_available:
@@ -268,6 +323,10 @@ def __getattr__(name: str):
         return _load_mjwarp_backend()
     if name == "MJWARP_AVAILABLE":
         return _mjwarp_available()
+    if name == "GenesisBackend":
+        return _load_genesis_backend()
+    if name == "GENESIS_AVAILABLE":
+        return _genesis_available()
     if name == "DrakeBackend":
         return _load_drake_backend()
     if name == "DRAKE_AVAILABLE":
@@ -293,11 +352,13 @@ __all__ = [
     "RenderClosedError",
     "MuJoCoBackend",
     "MjwarpBackend",
+    "GenesisBackend",
     "MotrixBackend",
     "DrakeBackend",
     "IsaacGymBackend",
     "DRAKE_AVAILABLE",
     "MJWARP_AVAILABLE",
+    "GENESIS_AVAILABLE",
     "add_sensor",
     "compute_tracking_fk",
     "create_discardvisual_xml",

--- a/src/unilab/base/backend/genesis/__init__.py
+++ b/src/unilab/base/backend/genesis/__init__.py
@@ -1,0 +1,27 @@
+"""Independent optional backend built on the Genesis runtime (``genesis-world``).
+
+This package deliberately owns its own runtime implementation.  It reuses
+shared *cold-path* scene materialization helpers (fragment merge) and the
+``mujoco`` package for one-time MJCF metadata scans, but it never subclasses
+or reads the runtime-private state of :mod:`unilab.base.backend.mujoco`.
+"""
+
+from __future__ import annotations
+
+
+def __getattr__(name: str):
+    if name == "GenesisBackend":
+        from .backend import GenesisBackend
+
+        return GenesisBackend
+    if name == "GENESIS_AVAILABLE":
+        from .dependencies import genesis_dependencies_available
+
+        return genesis_dependencies_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "GENESIS_AVAILABLE",
+    "GenesisBackend",
+]

--- a/src/unilab/base/backend/genesis/backend.py
+++ b/src/unilab/base/backend/genesis/backend.py
@@ -1,0 +1,900 @@
+"""Host-compatibility implementation of the independent ``genesis`` backend.
+
+The adapter serves the ``SimBackend`` NumPy contract on top of Genesis 1.3.3,
+following the measured mappings of ``scripts/tools/genesis_feasibility/
+REPORT.md`` (#1372): link-addressed root state (never entity-level getters,
+REPORT §5.5), ``control_dofs_position`` inside an adapter-owned nsteps loop
+honoring ``set_pre_step_control`` (§5.4), host caches refreshed once per
+step/reset barrier (§5.9), MJCF-named sensor equivalents from link state plus
+one IMUSensor per accelerometer site with clean (noise-free) data (§3.4/§5.3),
+genesis-native recoded geom contact masks that must not be compared against
+MuJoCo tables (§5.10), and a DR capability set restricted to the per-env
+round-trip-measured items (§3.5 [8] / §5.7).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from os import PathLike
+from typing import Any
+
+import numpy as np
+
+from unilab.base.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
+    BackendRootStateLayout,
+    SimBackend,
+    normalize_play_render_mode,
+)
+from unilab.base.scene import SceneCfg
+from unilab.dr.types import (
+    RESET_TERM_BASE_MASS,
+    RESET_TERM_BODY_MASS,
+    RESET_TERM_KD,
+    RESET_TERM_KP,
+    DomainRandomizationCapabilities,
+    IntervalRandomizationPlan,
+    ResetRandomizationPayload,
+)
+from unilab.utils.rotation import (
+    np_quat_apply_batched,
+    np_quat_apply_inverse_batched,
+    np_quat_mul_batched,
+)
+
+from . import dependencies, materialization
+
+_WORLD_Z_AXIS = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+
+
+def _make_device_cache(torch: Any, shape: tuple[int, ...]) -> tuple[Any, np.ndarray]:
+    """One fixed-shape host cache: (pinned storage, zero-copy NumPy view)."""
+    pinned = torch.empty(shape, dtype=torch.float32, pin_memory=torch.cuda.is_available())
+    return pinned, pinned.numpy()
+
+
+class GenesisBackend(SimBackend):
+    """Independent Genesis backend exposed through the host NumPy profile.
+
+    Construction performs dependency loading, the MJCF cold-path scan, the
+    process-wide ``gs.init`` (once), and scene/entity/sensor creation;
+    ``materialize()`` builds the batched solver state and binds all runtime
+    caches.  Terrain, geom-name contracts, site Jacobians, playback, and
+    rendering fail closed.  Call ``close()`` to end the process-wide Genesis
+    session; re-initialization afterwards fails closed by design.
+    """
+
+    def __init__(
+        self,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        base_name: str | None = None,
+        push_body_name: str | None = None,
+        integrator: str | None = None,
+        constraint_solver: str | None = None,
+        friction_cone: str | None = None,
+        solver_iterations: int | None = None,
+        **unexpected_kwargs: Any,
+    ) -> None:
+        if unexpected_kwargs:
+            names = ", ".join(sorted(unexpected_kwargs))
+            raise TypeError(f"GenesisBackend does not accept backend options: {names}")
+        if isinstance(num_envs, bool) or int(num_envs) <= 0:
+            raise ValueError(f"num_envs must be a positive integer, got {num_envs!r}")
+        if float(sim_dt) <= 0.0:
+            raise ValueError(f"sim_dt must be positive, got {sim_dt!r}")
+        if solver_iterations is not None and (
+            isinstance(solver_iterations, bool)
+            or not isinstance(solver_iterations, int)
+            or solver_iterations <= 0
+        ):
+            raise ValueError(
+                f"genesis solver_iterations must be a positive integer or None, "
+                f"got {solver_iterations!r}"
+            )
+        if push_body_name is not None:
+            raise NotImplementedError(
+                "genesis backend does not support interval push or external wrench "
+                "randomization; remove domain_rand.push_body_name and disable push_robots."
+            )
+
+        deps = dependencies.load_genesis_dependencies()
+        self._deps = deps
+        self._torch = deps.torch
+        self._gs = deps.genesis
+        self._metadata = materialization.scan_genesis_model_metadata(deps.mujoco, scene)
+        self._scene_cleanup_handle = self._metadata.cleanup_handle
+        self._scene_model_file = str(scene.model_file)
+
+        # One gs.init per process; re-init after destroy fails closed here.
+        materialization.init_genesis_session(deps)
+        self._device = (
+            self._torch.device("cuda", self._torch.cuda.current_device())
+            if (self._torch.cuda.is_available())
+            else self._torch.device("cpu")
+        )
+
+        self._scene = materialization.build_genesis_scene(
+            deps,
+            sim_dt=float(sim_dt),
+            gravity=self._metadata.gravity,
+            integrator=integrator,
+            constraint_solver=constraint_solver,
+            friction_cone=friction_cone,
+            solver_iterations=solver_iterations,
+        )
+        self._entity = self._scene.add_entity(
+            self._gs.morphs.MJCF(file=self._metadata.source_model_file)
+        )
+        # One IMUSensor per accelerometer site (REPORT §3.4 equivalent); the
+        # link index resolves pre-build from the cold-path entity structure.
+        self._imu_sensors: dict[str, Any] = {}
+        for plan in self._metadata.sensor_plans:
+            if plan.kind != "accelerometer" or plan.name in self._imu_sensors:
+                continue
+            assert plan.site_pos is not None  # guaranteed by the cold-path scan
+            link = self._entity.get_link(plan.body_name)
+            self._imu_sensors[plan.name] = self._scene.add_sensor(
+                self._gs.sensors.IMU(
+                    entity_idx=self._entity.idx,
+                    link_idx_local=int(link.idx_local),
+                    pos_offset=tuple(plan.site_pos),
+                )
+            )
+
+        self._pre_step_control_fn = None
+        self.backend_type = "genesis"
+        self._num_envs = int(num_envs)
+        self._sim_dt = float(sim_dt)
+        self._base_name = base_name
+        # Root dims and name->index maps come from the cold-path MJCF scan
+        # (mjwarp-style), so cold metadata like get_default_dof_pos and the
+        # joint index getters are correct before materialize(); the
+        # materialize-time binding validates the live import against them.
+        self._root_qpos_dim = self._metadata.root_qpos_dim
+        self._root_qvel_dim = self._metadata.root_qvel_dim
+        self._body_ids = {name: idx for idx, name in enumerate(self._metadata.body_names)}
+        self._joint_dof_ids = dict(
+            zip(self._metadata.joint_names, self._metadata.joint_dof_adrs, strict=True)
+        )
+        self._joint_qpos_ids = dict(
+            zip(self._metadata.joint_names, self._metadata.joint_qpos_adrs, strict=True)
+        )
+        self._materialized = False
+        self._closed = False
+
+    # ------------------------------------------------------------------ #
+    # Materialization-time binding                                        #
+    # ------------------------------------------------------------------ #
+
+    def materialize(self) -> None:
+        """Build the batched scene, cross-check the import, and bind caches."""
+        if self._closed:
+            raise RuntimeError("genesis backend is closed")
+        if self._materialized:
+            raise RuntimeError("genesis backend is already materialized")
+        self._scene.build(n_envs=self._num_envs)
+        self._materialized = True
+        self._bind_materialized_metadata()
+
+    def _bind_materialized_metadata(self) -> None:
+        metadata = self._metadata
+        entity = self._entity
+        if int(entity.n_dofs) != metadata.nv or int(entity.n_qs) != metadata.nq:
+            raise RuntimeError(
+                f"genesis MJCF import mismatch: n_dofs/n_qs {entity.n_dofs}/{entity.n_qs} "
+                f"!= MJCF nv/nq {metadata.nv}/{metadata.nq}"
+            )
+        if int(entity.n_links) != metadata.nbody:
+            raise RuntimeError(
+                f"genesis MJCF import mismatch: n_links {entity.n_links} != MJCF nbody "
+                f"{metadata.nbody}"
+            )
+        link_names = tuple(str(link.name) for link in entity.links)
+        if link_names != metadata.body_names:
+            raise RuntimeError(
+                f"genesis MJCF import mismatch: link names/order {link_names} != MJCF body "
+                f"names {metadata.body_names}"
+            )
+        one_dof_joints = [joint for joint in entity.joints if int(joint.n_dofs) == 1]
+        joint_names = tuple(str(joint.name) for joint in one_dof_joints)
+        if joint_names != metadata.joint_names:
+            raise RuntimeError(
+                f"genesis MJCF import mismatch: joint names/order {joint_names} != MJCF "
+                f"single-DoF joints {metadata.joint_names}"
+            )
+        entity_dof_ids = {
+            name: int(joint.dofs_idx_local[0])
+            for name, joint in zip(metadata.joint_names, one_dof_joints, strict=True)
+        }
+        entity_qpos_ids = {
+            name: int(joint.qs_idx_local[0])
+            for name, joint in zip(metadata.joint_names, one_dof_joints, strict=True)
+        }
+        if entity_dof_ids != self._joint_dof_ids or entity_qpos_ids != self._joint_qpos_ids:
+            raise RuntimeError(
+                "genesis MJCF import mismatch: joint dof/qpos indices do not match the "
+                "scanned MJCF layout"
+            )
+        # Actuator order: MJCF actuator-target joints map 1:1 onto actuated
+        # dofs (REPORT §3.1 [1b]); gains are cross-checked against the import.
+        self._actuated_dofs = [
+            self._joint_dof_ids[joint_name] for joint_name in metadata.actuator_joint_names
+        ]
+        imported_kp = entity.get_dofs_kp().cpu().numpy()[0, self._actuated_dofs]
+        imported_kv = entity.get_dofs_kv().cpu().numpy()[0, self._actuated_dofs]
+        if not np.allclose(imported_kp, metadata.actuator_kp, atol=1e-4) or not np.allclose(
+            imported_kv, metadata.actuator_kv, atol=1e-4
+        ):
+            raise RuntimeError(
+                "genesis MJCF import mismatch: imported dof kp/kv do not match the MJCF "
+                "position-actuator gains (REPORT §3.1 [3a] expects PD-reducible gains)."
+            )
+
+        self._base_link_idx: int | None = None
+        if self._base_name is not None:
+            try:
+                self._base_link_idx = self._body_ids[self._base_name]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Base body {self._base_name!r} not found in genesis model"
+                ) from exc
+            root_layout = self.get_root_state_layout(self._base_name)
+            if (
+                len(root_layout.qpos_indices) != self._root_qpos_dim
+                or len(root_layout.qvel_indices) != self._root_qvel_dim
+            ):
+                raise RuntimeError(
+                    f"genesis MJCF import mismatch: base link {self._base_name!r} root "
+                    "layout does not match the scanned free-root block"
+                )
+        self._link_start = int(entity.link_start)
+
+        self._sensor_slots, sensor_constants, total_dim = self._bind_sensor_slots()
+        self._sensor_constants = sensor_constants
+
+        torch = self._torch
+        n = self._num_envs
+        self._qpos_cache = _make_device_cache(torch, (n, metadata.nq))
+        self._qvel_cache = _make_device_cache(torch, (n, metadata.nv))
+        self._links_pos_cache = _make_device_cache(torch, (n, metadata.nbody, 3))
+        self._links_quat_cache = _make_device_cache(torch, (n, metadata.nbody, 4))
+        self._links_vel_cache = _make_device_cache(torch, (n, metadata.nbody, 3))
+        self._links_ang_cache = _make_device_cache(torch, (n, metadata.nbody, 3))
+        self._contact_force_cache = _make_device_cache(torch, (n, metadata.nbody, 3))
+        self._sensor_cache = np.zeros((n, total_dim), dtype=np.float32)
+        self._imu_caches = {name: _make_device_cache(torch, (n, 3)) for name in self._imu_sensors}
+        self._time_cache = np.zeros((n,), dtype=np.float32)
+        self._refresh_host_cache()
+
+    def _bind_sensor_slots(self) -> tuple[dict[str, tuple[int, int]], dict[str, tuple], int]:
+        slots: dict[str, tuple[int, int]] = {}
+        constants: dict[str, tuple] = {}
+        address = 0
+        for plan in self._metadata.sensor_plans:
+            if plan.body_name not in self._body_ids:
+                raise RuntimeError(
+                    f"genesis sensor {plan.name!r} references missing body {plan.body_name!r}"
+                )
+            link_idx = self._body_ids[plan.body_name]
+            slots[plan.name] = (address, plan.dim)
+            if plan.kind == "contact":
+                constants[plan.name] = (link_idx,)
+            else:
+                assert plan.site_pos is not None and plan.site_quat is not None
+                constants[plan.name] = (
+                    link_idx,
+                    np.asarray(plan.site_pos, dtype=np.float64),
+                    np.asarray(plan.site_quat, dtype=np.float64),
+                )
+            address += plan.dim
+        return slots, constants, address
+
+    # ------------------------------------------------------------------ #
+    # Host-cache barriers                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _require_running(self, operation: str) -> None:
+        if self._closed:
+            raise RuntimeError(f"genesis backend is closed; cannot run {operation}")
+        if not self._materialized:
+            raise RuntimeError(
+                f"genesis backend is not materialized; call materialize() before {operation}"
+            )
+
+    def _refresh_host_cache(self) -> None:
+        """Refresh every legacy-visible cache at one explicit lifecycle barrier."""
+        entity = self._entity
+        self._qpos_cache[0].copy_(entity.get_qpos())
+        self._qvel_cache[0].copy_(entity.get_dofs_velocity())
+        self._links_pos_cache[0].copy_(entity.get_links_pos())
+        self._links_quat_cache[0].copy_(entity.get_links_quat())
+        self._links_vel_cache[0].copy_(entity.get_links_vel())
+        self._links_ang_cache[0].copy_(entity.get_links_ang())
+        self._contact_force_cache[0].copy_(entity.get_links_net_contact_force())
+        for name, sensor in self._imu_sensors.items():
+            self._imu_caches[name][0].copy_(sensor.read().lin_acc)
+        self._refresh_sensor_cache()
+
+    def _refresh_sensor_cache(self) -> None:
+        """Compute MJCF-named sensors from link caches (REPORT §3.4 mappings)."""
+        for plan in self._metadata.sensor_plans:
+            address, dim = self._sensor_slots[plan.name]
+            out = self._sensor_cache[:, address : address + dim]
+            if plan.kind == "contact":
+                (link_idx,) = self._sensor_constants[plan.name]
+                force = self._contact_force_cache[1][:, link_idx, :]
+                magnitude = np.linalg.norm(force, axis=-1, keepdims=True)
+                threshold = materialization.CONTACT_FOUND_FORCE_THRESHOLD_N
+                out[...] = (magnitude > threshold).astype(np.float32)
+                continue
+            if plan.kind == "accelerometer":
+                out[...] = self._imu_caches[plan.name][1]
+                continue
+            link_idx, site_pos, site_quat = self._sensor_constants[plan.name]
+            link_quat = self._links_quat_cache[1][:, link_idx, :]
+            batch3 = link_quat.shape[:-1] + (3,)
+            site_quat_w = np_quat_mul_batched(
+                link_quat, np.broadcast_to(site_quat, link_quat.shape)
+            )
+            if plan.kind == "gyro":
+                out[...] = np_quat_apply_inverse_batched(
+                    site_quat_w, self._links_ang_cache[1][:, link_idx, :]
+                )
+            elif plan.kind == "framequat":
+                out[...] = site_quat_w
+            elif plan.kind == "framezaxis":
+                out[...] = np_quat_apply_batched(
+                    site_quat_w, np.broadcast_to(_WORLD_Z_AXIS, batch3)
+                )
+            else:
+                offset_w = np_quat_apply_batched(link_quat, np.broadcast_to(site_pos, batch3))
+                if plan.kind == "velocimeter":
+                    lin_vel_w = self._links_vel_cache[1][:, link_idx, :] + np.cross(
+                        self._links_ang_cache[1][:, link_idx, :], offset_w
+                    )
+                    out[...] = np_quat_apply_inverse_batched(site_quat_w, lin_vel_w)
+                elif plan.kind == "framepos":
+                    out[...] = self._links_pos_cache[1][:, link_idx, :] + offset_w
+
+    def _to_device(self, array: np.ndarray) -> Any:
+        host = np.ascontiguousarray(array, dtype=np.float32)
+        return self._torch.from_numpy(host).to(self._device)
+
+    def _validate_rows(self, env_indices: np.ndarray) -> np.ndarray:
+        rows = np.asarray(env_indices, dtype=np.intp)
+        if rows.ndim != 1:
+            raise ValueError(f"env_indices must be one-dimensional, got shape {rows.shape}")
+        if np.any(rows < 0) or np.any(rows >= self._num_envs):
+            raise ValueError(f"env_indices must be in [0, {self._num_envs}), got {rows}")
+        if np.unique(rows).size != rows.size:
+            raise ValueError("env_indices must not contain duplicate rows")
+        return rows
+
+    # ------------------------------------------------------------------ #
+    # SimBackend properties and cold metadata                             #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def model(self) -> Any:
+        """Return the backend-owned Genesis rigid entity."""
+        return self._entity
+
+    @property
+    def num_actuators(self) -> int:
+        return len(self._metadata.actuator_names)
+
+    @property
+    def num_dof_vel(self) -> int:
+        return self._metadata.nv - self._root_qvel_dim
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        """MJCF ``ctrlrange`` metadata; Genesis does not enforce it in-engine."""
+        return self._metadata.actuator_ctrl_range.copy()
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_joint_names
+
+    def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._metadata.actuator_kp.copy(), self._metadata.actuator_kv.copy()
+
+    def get_scene_model_file(self) -> str | None:
+        return self._scene_model_file
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        keyframes = dict(self._metadata.keyframe_qpos)
+        try:
+            return keyframes[name].copy()
+        except KeyError as exc:
+            available = ", ".join(sorted(keyframes))
+            raise ValueError(f"Keyframe {name!r} not found; available: {available}") from exc
+
+    def get_default_qpos(self) -> np.ndarray:
+        return self._metadata.default_qpos.copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return self._metadata.default_qpos[self._root_qpos_dim :].copy()
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros((self._metadata.nv,), dtype=np.float32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        if root_body_name not in self._body_ids:
+            raise ValueError(f"Body {root_body_name!r} not found in genesis model")
+        link = self._entity.get_link(root_body_name)
+        free_joints = [
+            joint for joint in link.joints if int(joint.n_dofs) == 6 and int(joint.n_qs) == 7
+        ]
+        if len(free_joints) != 1:
+            raise NotImplementedError(
+                "backend 'genesis' capability 'root-state layout' requires body "
+                f"{root_body_name!r} to own exactly one free joint"
+            )
+        joint = free_joints[0]
+        return BackendRootStateLayout(
+            qpos_indices=tuple(int(v) for v in joint.qs_idx_local),
+            qvel_indices=tuple(int(v) for v in joint.dofs_idx_local),
+        )
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        resolved: list[int] = []
+        for name in names:
+            try:
+                resolved.append(self._body_ids[str(name)])
+            except KeyError as exc:
+                raise ValueError(f"Body {name!r} not found in genesis model") from exc
+        return np.asarray(resolved, dtype=np.int32)
+
+    def get_geom_contact_masks(self) -> tuple[np.ndarray, np.ndarray]:
+        """Genesis-native recoded contype/conaffinity of collision geoms.
+
+        Genesis re-synthesizes contype/conaffinity at import: the collision
+        matrix semantics are preserved, but the integer values must NOT be
+        compared against MuJoCo tables (REPORT #1372 §5.10).
+        """
+        self._require_running("get_geom_contact_masks")
+        return (
+            np.asarray([geom.contype for geom in self._entity.geoms], dtype=np.int32),
+            np.asarray([geom.conaffinity for geom in self._entity.geoms], dtype=np.int32),
+        )
+
+    def get_gravity(self) -> np.ndarray:
+        return self._metadata.gravity.copy()
+
+    def get_body_mass(self) -> np.ndarray:
+        return self._metadata.body_mass.copy()
+
+    def get_body_ipos(self) -> np.ndarray:
+        return self._metadata.body_ipos.copy()
+
+    def get_dof_armature(self) -> np.ndarray:
+        return self._metadata.dof_armature.copy()
+
+    def get_joint_range(self) -> np.ndarray | None:
+        joint_range = self._metadata.joint_range
+        return None if joint_range is None else joint_range.copy()
+
+    def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
+        return np.asarray(self._resolve_joint_ids(names, self._joint_dof_ids), dtype=np.int32)
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        qpos_ids = np.asarray(self._resolve_joint_ids(names, self._joint_qpos_ids))
+        return (qpos_ids - self._root_qpos_dim).astype(np.int32)
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_indices(names) - self._root_qvel_dim
+
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names) + self._root_qpos_dim
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_vel_indices(names) + self._root_qvel_dim
+
+    def _resolve_joint_ids(self, names: Sequence[str], table: dict[str, int]) -> list[int]:
+        resolved: list[int] = []
+        for name in names:
+            try:
+                resolved.append(table[str(name)])
+            except KeyError as exc:
+                raise ValueError(f"Joint {name!r} not found in genesis model") from exc
+        return resolved
+
+    # ------------------------------------------------------------------ #
+    # Simulation control                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _push_control(self, ctrl: np.ndarray) -> None:
+        self._entity.control_dofs_position(
+            self._to_device(ctrl), dofs_idx_local=self._actuated_dofs
+        )
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
+        self._require_running("step")
+        if isinstance(nsteps, bool) or int(nsteps) <= 0:
+            raise ValueError(f"nsteps must be a positive integer, got {nsteps!r}")
+        ctrl_array = np.asarray(ctrl, dtype=np.float32)
+        expected = (self._num_envs, self.num_actuators)
+        if ctrl_array.shape != expected:
+            raise ValueError(f"ctrl must have shape {expected}, got {ctrl_array.shape}")
+
+        t0 = time.perf_counter()
+        if self._pre_step_control_fn is None:
+            # control_dofs_position holds the target across scene.step() calls,
+            # matching MuJoCo ctrl-broadcast semantics (REPORT §3.3 [3b]).
+            self._push_control(ctrl_array)
+            for _ in range(int(nsteps)):
+                self._scene.step()
+        else:
+            # Adapter-side per-substep hook: the conversion reads the freshly
+            # refreshed sensor contract before every physics substep (REPORT
+            # §5.4); no new SimBackend surface is introduced.
+            for _ in range(int(nsteps)):
+                converted = self._apply_pre_step_control(ctrl_array)
+                self._push_control(converted)
+                self._scene.step()
+                self._refresh_host_cache()
+        physics_ms = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self._refresh_host_cache()
+        self._time_cache += np.float32(int(nsteps) * self._sim_dt)
+        host_cache_ms = (time.perf_counter() - t0) * 1000.0
+        return {"timing": {"physics_ms": physics_ms, "host_cache_refresh_ms": host_cache_ms}}
+
+    # All backends report the same set_state key set for column stability;
+    # sub-keys that don't apply to the genesis host profile report 0.0.
+    _SET_STATE_TIMING_ZERO_KEYS = (
+        "set_state_mask_ms",
+        "set_state_data_slice_ms",
+        "set_state_data_reset_ms",
+        "set_state_clear_forces_ms",
+        "set_state_geom_overrides_ms",
+        "set_state_reset_rand_ms",
+        "set_state_set_dof_vel_ms",
+        "set_state_set_dof_pos_ms",
+        "set_state_actuator_ctrl_ms",
+        "set_state_forward_kinematic_ms",
+        "set_state_refresh_pose_cache_ms",
+        "set_state_invalidate_velocity_ms",
+        "set_state_qpos_convert_ms",
+        "set_state_pool_reset_ms",
+        "set_state_state_scatter_ms",
+    )
+    _SET_STATE_TIMING_OWN_KEYS = (
+        "set_state_reset_upload_ms",
+        "set_state_reset_forward_ms",
+        "set_state_host_cache_refresh_ms",
+        "set_state_internal_gap_ms",
+    )
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> dict[str, dict[str, float]]:
+        self._require_running("set_state")
+        rows = self._validate_rows(env_indices)
+        qpos_array = np.asarray(qpos, dtype=np.float32)
+        qvel_array = np.asarray(qvel, dtype=np.float32)
+        expected_qpos = (rows.size, self._metadata.nq)
+        expected_qvel = (rows.size, self._metadata.nv)
+        if qpos_array.shape != expected_qpos:
+            raise ValueError(f"qpos must have shape {expected_qpos}, got {qpos_array.shape}")
+        if qvel_array.shape != expected_qvel:
+            raise ValueError(f"qvel must have shape {expected_qvel}, got {qvel_array.shape}")
+        timing: dict[str, float] = {
+            key: 0.0 for key in self._SET_STATE_TIMING_ZERO_KEYS + self._SET_STATE_TIMING_OWN_KEYS
+        }
+        if rows.size == 0:
+            return {"timing": timing}
+
+        outer_t0 = time.perf_counter()
+        envs_idx = rows.tolist()
+        t0 = time.perf_counter()
+        # set_qpos runs forward kinematics for the touched envs, so positions
+        # are immediately readable afterwards (REPORT §5.6).
+        self._entity.set_qpos(self._to_device(qpos_array), envs_idx=envs_idx, zero_velocity=False)
+        self._entity.set_dofs_velocity(self._to_device(qvel_array), envs_idx=envs_idx)
+        timing["set_state_reset_upload_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        if randomization is not None and not randomization.is_empty():
+            self._apply_reset_randomization(randomization, rows)
+        self._refresh_host_cache()
+        self._time_cache[rows] = 0.0
+        timing["set_state_host_cache_refresh_ms"] = (time.perf_counter() - t0) * 1000.0
+
+        measured_ms = (
+            timing["set_state_reset_upload_ms"]
+            + timing["set_state_reset_forward_ms"]
+            + timing["set_state_host_cache_refresh_ms"]
+        )
+        total_ms = (time.perf_counter() - outer_t0) * 1000.0
+        timing["set_state_internal_gap_ms"] = total_ms - measured_ms
+        return {"timing": timing}
+
+    # ------------------------------------------------------------------ #
+    # Domain randomization (REPORT §3.5 [8] measured items only)          #
+    # ------------------------------------------------------------------ #
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        """Declare only the per-env round-trip-measured DR items (REPORT §5.7).
+
+        Measured: link inertial mass and dof kp/kv (require the materialize-
+        time batch build flags), plus the solver-level external force API
+        (call-verified; physical effect is a REPORT §8 follow-up).  Measured-
+        but-unmappable items stay undeclared: frictionloss/damping/armature
+        have no SimBackend reset term, and geom friction only has a per-env
+        *ratio* API, so absolute geom_friction randomization is unsupported.
+        """
+        return DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset(
+                {RESET_TERM_BODY_MASS, RESET_TERM_BASE_MASS, RESET_TERM_KP, RESET_TERM_KD}
+            ),
+            supports_interval_body_force=True,
+        )
+
+    _UNSUPPORTED_RESET_TERMS = (
+        "gravity",
+        "body_iquat",
+        "body_inertia",
+        "body_ipos",
+        "base_com_offset",
+        "dof_armature",
+        "geom_friction",
+    )
+
+    def _apply_reset_randomization(
+        self, randomization: ResetRandomizationPayload, rows: np.ndarray
+    ) -> None:
+        unsupported = [
+            term
+            for term in self._UNSUPPORTED_RESET_TERMS
+            if getattr(randomization, term) is not None
+        ]
+        if unsupported:
+            raise NotImplementedError(
+                "genesis backend does not support reset domain randomization terms: "
+                f"{', '.join(sorted(unsupported))} (REPORT #1372 §5.7 declares only the "
+                "measured items)."
+            )
+        envs_idx = rows.tolist()
+        body_mass = randomization.body_mass
+        if randomization.base_mass_delta is not None:
+            if self._base_link_idx is None:
+                raise ValueError(
+                    "genesis base_mass_delta randomization requires base_name to identify "
+                    "the base link"
+                )
+            delta = np.asarray(randomization.base_mass_delta, dtype=np.float32).reshape(-1)
+            if delta.shape != (rows.size,):
+                raise ValueError(
+                    f"base_mass_delta must have shape ({rows.size},), got {delta.shape}"
+                )
+            if body_mass is None:
+                body_mass = np.broadcast_to(
+                    self._metadata.body_mass, (rows.size, self._metadata.nbody)
+                ).copy()
+            else:
+                body_mass = np.asarray(body_mass, dtype=np.float32).copy()
+            body_mass[:, self._base_link_idx] += delta
+        if body_mass is not None:
+            mass = np.asarray(body_mass, dtype=np.float32)
+            expected = (rows.size, self._metadata.nbody)
+            if mass.shape != expected:
+                raise ValueError(f"body_mass must have shape {expected}, got {mass.shape}")
+            self._entity.set_links_inertial_mass(self._to_device(mass), envs_idx=envs_idx)
+        for value, name, setter in (
+            (randomization.kp, "kp", self._entity.set_dofs_kp),
+            (randomization.kd, "kd", self._entity.set_dofs_kv),
+        ):
+            if value is None:
+                continue
+            gains = np.asarray(value, dtype=np.float32)
+            expected = (rows.size, self.num_actuators)
+            if gains.shape != expected:
+                raise ValueError(f"{name} must have shape {expected}, got {gains.shape}")
+            setter(
+                self._to_device(gains),
+                dofs_idx_local=self._actuated_dofs,
+                envs_idx=envs_idx,
+            )
+
+    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
+        self._require_running("apply_interval_randomization")
+        if plan.is_empty():
+            return
+        if plan.push_perturbation_limit is not None:
+            raise NotImplementedError(
+                "genesis backend does not support interval push perturbation; disable "
+                "push_robots in the owner YAML."
+            )
+        if plan.body_linear_velocity_delta is not None:
+            raise NotImplementedError(
+                "genesis backend does not support interval body-velocity deltas; disable "
+                "the term in the owner YAML."
+            )
+        if plan.body_force is not None:
+            if plan.body_ids is None:
+                raise ValueError("Interval body-force perturbation requires body_ids")
+            self.apply_body_force(plan.body_ids, plan.body_force)
+
+    def apply_body_force(self, body_ids: np.ndarray, force: np.ndarray) -> None:
+        """Apply a world-frame force per body through the solver-level API."""
+        self._require_running("apply_body_force")
+        ids = np.asarray(body_ids, dtype=np.int32).reshape(-1)
+        force_array = np.asarray(force, dtype=np.float32)
+        expected = (self._num_envs, ids.size, 3)
+        if force_array.shape != expected:
+            raise ValueError(f"body force must have shape {expected}, got {force_array.shape}")
+        if np.any(ids < 0) or np.any(ids >= self._metadata.nbody):
+            raise ValueError(f"body_ids must be in [0, {self._metadata.nbody}), got {ids}")
+        solver = self._scene.sim.rigid_solver
+        force_device = self._to_device(force_array)
+        for offset, body_id in enumerate(ids):
+            # Solver-level API uses global link indices (REPORT §3.5 [8]);
+            # single-entity scenes keep global == link_start + local.
+            solver.apply_links_external_force(
+                force_device[:, offset, :],
+                links_idx=[self._link_start + int(body_id)],
+            )
+
+    # ------------------------------------------------------------------ #
+    # Play/render: declared honestly, fail closed                          #
+    # ------------------------------------------------------------------ #
+
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        return BackendPlayCapabilities()
+
+    def resolve_play_render_plan(
+        self,
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        mode = normalize_play_render_mode(play_render_mode)
+        if mode == "none":
+            return BackendPlayRenderPlan(
+                mode="none",
+                headless=True,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        raise NotImplementedError(
+            f"genesis backend does not support playback mode {mode!r}; Genesis native "
+            "rendering/playback is not a declared capability of this adapter (offscreen "
+            "camera rendering is a measured-but-unintegrated follow-up, REPORT #1372 "
+            "§3.5 [12]). Select training.play_render_mode=none."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Legacy getters: cache views only, never direct device transfers     #
+    # ------------------------------------------------------------------ #
+
+    def _require_free_root(self, operation: str) -> None:
+        self._require_running(operation)
+        if self._root_qpos_dim != 7 or self._root_qvel_dim != 6:
+            raise NotImplementedError(
+                f"{operation} requires a free root joint; genesis host profile is "
+                "currently validated only for floating-base layouts."
+            )
+
+    def get_base_pos(self) -> np.ndarray:
+        self._require_free_root("get_base_pos")
+        return self._links_pos_cache[1][:, self._base_link_idx, :]
+
+    def get_base_quat(self) -> np.ndarray:
+        self._require_free_root("get_base_quat")
+        return self._links_quat_cache[1][:, self._base_link_idx, :]
+
+    def get_base_lin_vel(self) -> np.ndarray:
+        self._require_free_root("get_base_lin_vel")
+        # qvel[0:3] is the root linear velocity in world coordinates and stays
+        # valid immediately after set_state (REPORT §5.6).
+        return self._qvel_cache[1][:, 0:3]
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        self._require_free_root("get_base_ang_vel")
+        # qvel[3:6] is body-frame angular velocity; the contract wants world
+        # frame.  Deriving it from qvel keeps the value fresh after reset
+        # (genesis link velocity getters only refresh across a step barrier,
+        # REPORT §5.6); it equals get_links_ang(root) after a step.
+        return np_quat_apply_batched(self.get_base_quat(), self._qvel_cache[1][:, 3:6])
+
+    def get_dof_pos(self) -> np.ndarray:
+        self._require_running("get_dof_pos")
+        return self._qpos_cache[1][:, self._root_qpos_dim :]
+
+    def get_dof_vel(self) -> np.ndarray:
+        self._require_running("get_dof_vel")
+        return self._qvel_cache[1][:, self._root_qvel_dim :]
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_running("get_body_pos_w")
+        return self._links_pos_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
+
+    def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_running("get_body_quat_w")
+        return self._links_quat_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
+
+    def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_running("get_body_lin_vel_w")
+        return self._links_vel_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
+
+    def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_running("get_body_ang_vel_w")
+        return self._links_ang_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
+
+    def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
+        del body_ids
+        self._unsupported_base_frame_kinematics("base-frame body positions")
+
+    def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
+        del body_ids
+        self._unsupported_base_frame_kinematics("base-frame body orientations")
+
+    def _unsupported_base_frame_kinematics(self, operation: str) -> None:
+        # Same boundary as the mjwarp host profile: no task consumes
+        # base-frame body pose, and the tracked subsets live in sensors.
+        raise NotImplementedError(f"genesis host profile does not expose {operation}")
+
+    def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        # Analytical per the SimBackend contract (#1254): world-frame velocity
+        # rotated into each body's own frame.
+        ids = np.asarray(body_ids, dtype=np.intp)
+        return np_quat_apply_inverse_batched(
+            self._links_quat_cache[1][:, ids, :], self._links_vel_cache[1][:, ids, :]
+        )
+
+    def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = np.asarray(body_ids, dtype=np.intp)
+        return np_quat_apply_inverse_batched(
+            self._links_quat_cache[1][:, ids, :], self._links_ang_cache[1][:, ids, :]
+        )
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self._require_running(f"get_sensor_data({name!r})")
+        try:
+            address, dimension = self._sensor_slots[name]
+        except KeyError as exc:
+            available = ", ".join(sorted(self._sensor_slots))
+            raise ValueError(f"Sensor {name!r} not found; available: {available}") from exc
+        return self._sensor_cache[:, address : address + dimension]
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]) -> Callable[[], np.ndarray]:
+        """Capture numeric host-cache slots for a zero-metadata hot-path view."""
+        slots = tuple(self._sensor_slots[name] for name in names)
+
+        def read() -> np.ndarray:
+            values = [
+                self._sensor_cache[:, address : address + dimension] for address, dimension in slots
+            ]
+            return np.concatenate(values, axis=1)
+
+        return read
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle                                                           #
+    # ------------------------------------------------------------------ #
+
+    def close(self) -> None:
+        """End the process-wide Genesis session; re-init afterwards fails closed."""
+        if self._closed:
+            return
+        self._closed = True
+        materialization.destroy_genesis_session(self._deps)

--- a/src/unilab/base/backend/genesis/dependencies.py
+++ b/src/unilab/base/backend/genesis/dependencies.py
@@ -1,0 +1,68 @@
+"""Lazy dependency boundary for the independent ``genesis`` backend.
+
+The Genesis runtime (PyPI distribution ``genesis-world``, import name
+``genesis``) is a heavy optional dependency (torch, quadrants) that must never
+be imported at package import time.  It is pinned exactly to the release probed
+in ``scripts/tools/genesis_feasibility/REPORT.md`` (#1372) because the adapter
+relies on measured API behavior of that version.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from importlib.util import find_spec
+from typing import Any
+
+
+class GenesisDependencyError(ImportError):
+    """Raised with an actionable install command when the optional extra is absent."""
+
+
+@dataclass(frozen=True)
+class GenesisDependencies:
+    """Modules required by the production ``genesis`` implementation."""
+
+    genesis: Any
+    torch: Any
+    mujoco: Any
+
+
+_REQUIRED_MODULES = ("genesis", "torch", "mujoco")
+_REQUIRED_GENESIS_VERSION = "1.3.3"
+_INSTALL_HINT = "Install it with `uv sync --extra genesis`."
+
+
+def genesis_dependencies_available() -> bool:
+    """Return availability without importing CUDA/torch runtime modules."""
+    return all(find_spec(module_name) is not None for module_name in _REQUIRED_MODULES)
+
+
+def load_genesis_dependencies() -> GenesisDependencies:
+    """Import optional runtime modules only when a backend instance is built."""
+    try:
+        installed_version = metadata.version("genesis-world")
+    except metadata.PackageNotFoundError as exc:
+        raise GenesisDependencyError(
+            f"genesis backend requires optional dependency 'genesis-world'. {_INSTALL_HINT}"
+        ) from exc
+    if installed_version != _REQUIRED_GENESIS_VERSION:
+        raise GenesisDependencyError(
+            "genesis backend requires exact genesis-world version "
+            f"{_REQUIRED_GENESIS_VERSION}, found {installed_version}. {_INSTALL_HINT}"
+        )
+    try:
+        genesis = importlib.import_module("genesis")
+        torch = importlib.import_module("torch")
+        mujoco = importlib.import_module("mujoco")
+    except ModuleNotFoundError as exc:
+        missing = exc.name or "a genesis dependency"
+        raise GenesisDependencyError(
+            f"genesis backend requires optional dependency {missing!r}. {_INSTALL_HINT}"
+        ) from exc
+    except ImportError as exc:
+        raise GenesisDependencyError(
+            f"genesis backend could not import its optional runtime: {exc}. {_INSTALL_HINT}"
+        ) from exc
+    return GenesisDependencies(genesis=genesis, torch=torch, mujoco=mujoco)

--- a/src/unilab/base/backend/genesis/materialization.py
+++ b/src/unilab/base/backend/genesis/materialization.py
@@ -1,0 +1,458 @@
+"""Cold-path scene materialization for the independent ``genesis`` backend.
+
+Genesis 1.3.3 drops three MJCF features UniLab relies on (measured in
+``scripts/tools/genesis_feasibility/REPORT.md`` #1372 §3): ``<keyframe>``,
+the global ``<option>`` block, and the whole ``<sensor>`` block.  This module
+compensates on the cold path exactly as the report prescribes: keyframe and
+sensor metadata are scanned once with the ``mujoco`` package (the isaacgym
+parent-process metadata-scan pattern) and cached — hot paths never parse XML;
+global options arrive as explicit owner fields; and ``gs.init`` host-side
+effects (torch default device/dtype and RNG) are contained by
+:func:`preserve_torch_globals` plus the one-session-per-process guard.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+import numpy as np
+
+from unilab.base.scene import SceneCfg
+
+# Supported spellings for the explicit owner-YAML global options.  Genesis
+# defaults apply when the owner leaves them unset (REPORT #1372 §5.2).
+_INTEGRATOR_ENUMS = {
+    "euler": "Euler",
+    "implicitfast": "implicitfast",
+    "approximate_implicitfast": "approximate_implicitfast",
+}
+_CONSTRAINT_SOLVER_ENUMS = {
+    "newton": "Newton",
+    "cg": "CG",
+}
+_FRICTION_CONE_ENUMS = {
+    "pyramidal": "pyramidal",
+    "elliptic": "elliptic",
+}
+
+# Contact ``data="found"`` equivalent: per-link net contact force magnitude
+# threshold in newtons (REPORT #1372 §3.4: standing G1 foot reads ~138 N).
+CONTACT_FOUND_FORCE_THRESHOLD_N = 1.0
+
+
+class _TemporarySceneCleanup:
+    """Own the temporary XMLs created while materializing one scene."""
+
+    def __init__(self, *paths: str) -> None:
+        self._paths = paths
+        self._cleaned = False
+
+    def cleanup(self) -> None:
+        if self._cleaned:
+            return
+        self._cleaned = True
+        for path in self._paths:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+@dataclass(frozen=True)
+class GenesisSensorPlan:
+    """One MJCF sensor mapped onto a Genesis-readable equivalent.
+
+    ``body_name`` is the owning link for site sensors and the robot-side geom
+    body for contact sensors.  ``site_pos``/``site_quat`` (wxyz) are the local
+    site frame in the body frame; both are ``None`` for contact sensors.
+    """
+
+    name: str
+    kind: str
+    dim: int
+    body_name: str
+    site_pos: tuple[float, ...] | None
+    site_quat: tuple[float, ...] | None
+
+
+@dataclass(frozen=True)
+class GenesisModelMetadata:
+    """MJCF metadata scanned once on the cold path (never on hot paths)."""
+
+    source_model_file: str
+    cleanup_handle: Any | None
+    nq: int
+    nv: int
+    nbody: int
+    root_qpos_dim: int
+    root_qvel_dim: int
+    joint_names: tuple[str, ...]
+    joint_qpos_adrs: tuple[int, ...]
+    joint_dof_adrs: tuple[int, ...]
+    body_names: tuple[str, ...]
+    actuator_names: tuple[str, ...]
+    actuator_joint_names: tuple[str, ...]
+    actuator_ctrl_range: np.ndarray
+    actuator_kp: np.ndarray
+    actuator_kv: np.ndarray
+    keyframe_qpos: tuple[tuple[str, np.ndarray], ...]
+    default_qpos: np.ndarray
+    joint_range: np.ndarray | None
+    dof_armature: np.ndarray
+    gravity: np.ndarray
+    body_mass: np.ndarray
+    body_ipos: np.ndarray
+    sensor_plans: tuple[GenesisSensorPlan, ...]
+
+
+@contextmanager
+def preserve_torch_globals(torch: Any) -> Iterator[None]:
+    """Snapshot torch global defaults and restore them after ``gs.init``.
+
+    ``gs.init`` mutates the host process: it forces
+    ``torch.set_default_device("cuda:0")`` on the GPU lane, and passing
+    ``seed=`` would reseed the global RNG (REPORT #1372 §3.5 [10]).  The
+    adapter never passes a seed and restores default device/dtype plus the
+    torch RNG state so the training process observes no pollution
+    (REPORT #1372 §5.8).
+    """
+    default_device = torch.get_default_device()
+    default_dtype = torch.get_default_dtype()
+    cpu_rng_state = torch.get_rng_state()
+    cuda_rng_state = torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
+    try:
+        yield
+    finally:
+        torch.set_default_device(default_device)
+        torch.set_default_dtype(default_dtype)
+        torch.set_rng_state(cpu_rng_state)
+        if cuda_rng_state is not None:
+            torch.cuda.set_rng_state_all(cuda_rng_state)
+
+
+_SESSION_ACTIVE = False
+_SESSION_DESTROYED = False
+
+
+def init_genesis_session(deps: Any, *, logging_level: str = "warning") -> None:
+    """Initialize the process-wide Genesis session exactly once.
+
+    Repeated ``init -> destroy`` cycles are functional but leak 200-450 MB of
+    host RSS per cycle (REPORT #1372 §3.5 [9a]), so a long-lived training
+    process gets exactly one session.  Multiple GenesisBackend instances share
+    the live session (multi-scene coexistence is measured OK, REPORT [9b]);
+    after :func:`destroy_genesis_session` any further construction fails
+    closed with a clear error.
+    """
+    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    if _SESSION_DESTROYED:
+        raise RuntimeError(
+            "genesis backend supports exactly one gs.init per process and the session "
+            "was already destroyed; start a fresh process instead of re-initializing "
+            "(init/destroy cycles leak host RSS, REPORT #1372 §3.5 [9a])."
+        )
+    if _SESSION_ACTIVE:
+        return
+    gs = deps.genesis
+    cuda_available = bool(deps.torch.cuda.is_available())
+    backend_kind = gs.gpu if cuda_available else gs.cpu
+    try:
+        with preserve_torch_globals(deps.torch):
+            gs.init(backend=backend_kind, logging_level=logging_level)
+    except Exception as exc:
+        raise RuntimeError(
+            "genesis backend failed to initialize the Genesis runtime "
+            f"(backend={'gpu' if cuda_available else 'cpu'}; only the gs.gpu lane is "
+            f"validated by REPORT #1372): {type(exc).__name__}: {exc}"
+        ) from exc
+    _SESSION_ACTIVE = True
+
+
+def destroy_genesis_session(deps: Any) -> None:
+    """Tear down the process-wide session; re-initialization stays forbidden."""
+    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    if not _SESSION_ACTIVE:
+        return
+    deps.genesis.destroy()
+    _SESSION_ACTIVE = False
+    _SESSION_DESTROYED = True
+
+
+def _reset_session_state_for_tests() -> None:
+    """Reset the lifecycle guard; test-only seam for the fake runtime lane."""
+    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    _SESSION_ACTIVE = False
+    _SESSION_DESTROYED = False
+
+
+def _map_global_option(name: str, value: str, table: dict[str, str], enum_ns: Any) -> Any:
+    try:
+        attr = table[value]
+    except KeyError as exc:
+        supported = ", ".join(sorted(table))
+        raise ValueError(
+            f"{name} must be one of: {supported}; got {value!r}. Genesis drops the MJCF "
+            "global <option> block, so the owner YAML must declare a supported value."
+        ) from exc
+    return getattr(enum_ns, attr)
+
+
+def build_genesis_scene(
+    deps: Any,
+    *,
+    sim_dt: float,
+    gravity: np.ndarray,
+    integrator: str | None,
+    constraint_solver: str | None,
+    friction_cone: str | None,
+    solver_iterations: int | None,
+) -> Any:
+    """Construct the unbuilt Genesis scene with explicit global options."""
+    gs = deps.genesis
+    rigid_kwargs: dict[str, Any] = {
+        # Per-env DR setters (mass/frictionloss/kp/kv) are materialize-time
+        # decisions and require batched link/dof info (REPORT #1372 §5.7).
+        "batch_links_info": True,
+        "batch_dofs_info": True,
+    }
+    if integrator is not None:
+        rigid_kwargs["integrator"] = _map_global_option(
+            "genesis_integrator", integrator, _INTEGRATOR_ENUMS, gs.integrator
+        )
+    if constraint_solver is not None:
+        rigid_kwargs["constraint_solver"] = _map_global_option(
+            "genesis_constraint_solver",
+            constraint_solver,
+            _CONSTRAINT_SOLVER_ENUMS,
+            gs.constraint_solver,
+        )
+    if friction_cone is not None:
+        rigid_kwargs["friction_cone"] = _map_global_option(
+            "genesis_friction_cone", friction_cone, _FRICTION_CONE_ENUMS, gs.friction_cone
+        )
+    if solver_iterations is not None:
+        rigid_kwargs["iterations"] = int(solver_iterations)
+    gravity_tuple = tuple(float(component) for component in np.asarray(gravity, dtype=np.float64))
+    return gs.Scene(
+        sim_options=gs.options.SimOptions(dt=float(sim_dt), gravity=gravity_tuple),
+        rigid_options=gs.options.RigidOptions(**rigid_kwargs),
+        show_viewer=False,
+    )
+
+
+def _scan_sensor_plans(mujoco: Any, model: Any) -> tuple[GenesisSensorPlan, ...]:
+    """Map the MJCF sensor table onto Genesis equivalents (REPORT §5.3).
+
+    Genesis 1.3.3 does not import ``<sensor>`` at all.  Supported mappings:
+    gyro/accelerometer/velocimeter -> IMU-class site sensors computed from
+    link state; framepos/framequat/framezaxis -> link state plus site-frame
+    math; contact ``data="found"`` -> per-link net contact force threshold.
+    Anything else fails closed here, at the nearest cold path.
+    """
+    sensor_obj = mujoco.mjtObj.mjOBJ_SENSOR
+    plans: list[GenesisSensorPlan] = []
+    for sensor_id in range(int(model.nsensor)):
+        name = mujoco.mj_id2name(model, sensor_obj, sensor_id)
+        if not name:
+            raise NotImplementedError(
+                f"genesis backend requires named MJCF sensors; sensor id {sensor_id} is unnamed"
+            )
+        sensor_type = mujoco.mjtSensor(int(model.sensor_type[sensor_id]))
+        dim = int(model.sensor_dim[sensor_id])
+        if sensor_type == mujoco.mjtSensor.mjSENS_CONTACT:
+            plans.append(_scan_contact_sensor(mujoco, model, sensor_id, str(name), dim))
+            continue
+        site_kinds = {
+            mujoco.mjtSensor.mjSENS_GYRO: "gyro",
+            mujoco.mjtSensor.mjSENS_ACCELEROMETER: "accelerometer",
+            mujoco.mjtSensor.mjSENS_VELOCIMETER: "velocimeter",
+            mujoco.mjtSensor.mjSENS_FRAMEPOS: "framepos",
+            mujoco.mjtSensor.mjSENS_FRAMEQUAT: "framequat",
+            mujoco.mjtSensor.mjSENS_FRAMEZAXIS: "framezaxis",
+        }
+        kind = site_kinds.get(sensor_type)
+        if kind is None:
+            raise NotImplementedError(
+                f"genesis backend cannot map MJCF sensor {name!r} of type "
+                f"{sensor_type.name}; supported types: contact(found), gyro, accelerometer, "
+                "velocimeter, framepos, framequat, framezaxis (REPORT #1372 §3.4)."
+            )
+        if int(model.sensor_objtype[sensor_id]) != int(mujoco.mjtObj.mjOBJ_SITE):
+            raise NotImplementedError(
+                f"genesis backend maps {kind} sensors from MJCF sites only; sensor {name!r} "
+                f"uses objtype {int(model.sensor_objtype[sensor_id])}."
+            )
+        site_id = int(model.sensor_objid[sensor_id])
+        body_id = int(model.site_bodyid[site_id])
+        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+        site_pos = tuple(float(v) for v in np.asarray(model.site_pos[site_id], dtype=np.float64))
+        site_quat = tuple(float(v) for v in np.asarray(model.site_quat[site_id], dtype=np.float64))
+        if kind == "accelerometer" and not np.allclose(site_quat, (1.0, 0.0, 0.0, 0.0)):
+            raise NotImplementedError(
+                f"genesis backend maps accelerometer {name!r} onto an IMUSensor, whose "
+                "euler_offset path is not a validated support lane; rotated accelerometer "
+                "sites are rejected (gyro/velocimeter/frame sensors support rotation)."
+            )
+        plans.append(
+            GenesisSensorPlan(
+                name=str(name),
+                kind=kind,
+                dim=dim,
+                body_name=str(body_name),
+                site_pos=site_pos,
+                site_quat=site_quat,
+            )
+        )
+    return tuple(plans)
+
+
+def _scan_contact_sensor(
+    mujoco: Any, model: Any, sensor_id: int, name: str, dim: int
+) -> GenesisSensorPlan:
+    if dim != 1:
+        raise NotImplementedError(
+            f'genesis backend maps contact sensors with data="found" only (dim 1); '
+            f"sensor {name!r} has dim {dim}."
+        )
+    if int(model.sensor_objtype[sensor_id]) != int(mujoco.mjtObj.mjOBJ_GEOM) or int(
+        model.sensor_reftype[sensor_id]
+    ) != int(mujoco.mjtObj.mjOBJ_GEOM):
+        raise NotImplementedError(
+            f"genesis backend maps contact sensors over geom pairs only; sensor {name!r} "
+            "uses a non-geom object type."
+        )
+    geom1_id = int(model.sensor_objid[sensor_id])
+    geom2_id = int(model.sensor_refid[sensor_id])
+    body1_id = int(model.geom_bodyid[geom1_id])
+    body2_id = int(model.geom_bodyid[geom2_id])
+    if (body1_id > 0) == (body2_id > 0):
+        raise NotImplementedError(
+            f"genesis backend maps contact sensor {name!r} onto the robot-side link's net "
+            "contact force; exactly one geom must belong to the world body "
+            f"(got body ids {body1_id}/{body2_id})."
+        )
+    body_id = body1_id if body1_id > 0 else body2_id
+    body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+    return GenesisSensorPlan(
+        name=name,
+        kind="contact",
+        dim=dim,
+        body_name=str(body_name),
+        site_pos=None,
+        site_quat=None,
+    )
+
+
+def scan_genesis_model_metadata(mujoco: Any, scene: SceneCfg) -> GenesisModelMetadata:
+    """Resolve the scene and scan MJCF metadata with the ``mujoco`` package."""
+    if scene is None or not scene.model_file:
+        raise ValueError("GenesisBackend requires SceneCfg.model_file")
+    if scene.terrain is not None:
+        raise NotImplementedError(
+            "genesis backend does not support generated terrain or height-field scanners; "
+            "select a flat owner YAML or a backend with terrain support."
+        )
+    temp_paths: list[str] = []
+    if not scene.fragment_files:
+        source_model_file = str(scene.model_file)
+    else:
+        # Cold-path-only helper, shared with the MuJoCo/mjwarp backends.
+        from unilab.base.backend.mujoco.xml import materialize_scene_fragments
+
+        source_model_file = materialize_scene_fragments(
+            str(scene.model_file),
+            fragment_files=scene.fragment_files,
+        )
+        temp_paths.append(source_model_file)
+
+    model = mujoco.MjModel.from_xml_path(source_model_file)
+    free_joint = int(mujoco.mjtJoint.mjJNT_FREE)
+    single_dof_types = {int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE)}
+    root_qpos_dim, root_qvel_dim = (
+        (7, 6) if int(model.njnt) > 0 and int(model.jnt_type[0]) == free_joint else (0, 0)
+    )
+
+    joint_names: list[str] = []
+    joint_qpos_adrs: list[int] = []
+    joint_dof_adrs: list[int] = []
+    for joint_id in range(int(model.njnt)):
+        if int(model.jnt_type[joint_id]) not in single_dof_types:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        if not name:
+            raise NotImplementedError(
+                f"genesis backend requires named single-DoF joints; joint id {joint_id} is unnamed"
+            )
+        joint_names.append(str(name))
+        joint_qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        joint_dof_adrs.append(int(model.jnt_dofadr[joint_id]))
+
+    actuator_names: list[str] = []
+    actuator_joint_names: list[str] = []
+    supported_transmissions = {
+        int(mujoco.mjtTrn.mjTRN_JOINT),
+        int(mujoco.mjtTrn.mjTRN_JOINTINPARENT),
+    }
+    for actuator_id in range(int(model.nu)):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator_id)
+        transmission = int(model.actuator_trntype[actuator_id])
+        joint_id = int(model.actuator_trnid[actuator_id, 0])
+        if not name or transmission not in supported_transmissions or joint_id < 0:
+            raise NotImplementedError(
+                "genesis backend requires position actuators with a joint transmission; "
+                f"actuator id {actuator_id} (name {name!r}, transmission {transmission}) "
+                "is unsupported."
+            )
+        if int(model.jnt_type[joint_id]) not in single_dof_types:
+            raise NotImplementedError(
+                f"genesis backend requires actuators on single-DoF joints; actuator {name!r} "
+                f"targets joint id {joint_id}."
+            )
+        joint_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        actuator_names.append(str(name))
+        actuator_joint_names.append(str(joint_name))
+
+    keyframes: list[tuple[str, np.ndarray]] = []
+    for key_id in range(int(model.nkey)):
+        key_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, key_id)
+        if key_name is not None:
+            keyframes.append(
+                (str(key_name), np.asarray(model.key_qpos[key_id], dtype=np.float32).copy())
+            )
+
+    non_free_mask = np.asarray(model.jnt_type, dtype=np.int32) != free_joint
+    joint_range = np.asarray(model.jnt_range, dtype=np.float32)[non_free_mask]
+    body_names = tuple(
+        str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id) or "")
+        for body_id in range(int(model.nbody))
+    )
+
+    return GenesisModelMetadata(
+        source_model_file=source_model_file,
+        cleanup_handle=_TemporarySceneCleanup(*temp_paths) if temp_paths else None,
+        nq=int(model.nq),
+        nv=int(model.nv),
+        nbody=int(model.nbody),
+        root_qpos_dim=root_qpos_dim,
+        root_qvel_dim=root_qvel_dim,
+        joint_names=tuple(joint_names),
+        joint_qpos_adrs=tuple(joint_qpos_adrs),
+        joint_dof_adrs=tuple(joint_dof_adrs),
+        body_names=body_names,
+        actuator_names=tuple(actuator_names),
+        actuator_joint_names=tuple(actuator_joint_names),
+        actuator_ctrl_range=np.asarray(model.actuator_ctrlrange, dtype=np.float32).copy(),
+        actuator_kp=np.asarray(model.actuator_gainprm[:, 0], dtype=np.float32).copy(),
+        actuator_kv=np.asarray(-model.actuator_biasprm[:, 2], dtype=np.float32).copy(),
+        keyframe_qpos=tuple(keyframes),
+        default_qpos=np.asarray(model.qpos0, dtype=np.float32).copy(),
+        joint_range=None if joint_range.size == 0 else joint_range.copy(),
+        dof_armature=np.asarray(model.dof_armature, dtype=np.float32).copy(),
+        gravity=np.asarray(model.opt.gravity, dtype=np.float32).copy(),
+        body_mass=np.asarray(model.body_mass, dtype=np.float32).copy(),
+        body_ipos=np.asarray(model.body_ipos, dtype=np.float32).copy(),
+        sensor_plans=_scan_sensor_plans(mujoco, model),
+    )

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -57,6 +57,14 @@ class EnvCfg:
     # backend defaults (device 0, generous handshake/step timeout).
     isaacgym_device_id: Optional[int] = None
     isaacgym_worker_timeout_s: Optional[float] = None
+    # ``genesis`` drops the MJCF global <option> block at import (REPORT #1372
+    # §3.3), so integrator / constraint solver / friction cone / solver
+    # iterations must be explicit owner fields. ``None`` keeps the Genesis
+    # defaults; the backend validates the spellings fail-closed.
+    genesis_integrator: Optional[str] = None
+    genesis_constraint_solver: Optional[str] = None
+    genesis_friction_cone: Optional[str] = None
+    genesis_solver_iterations: Optional[int] = None
 
     @property
     def max_episode_steps(self) -> Optional[int]:
@@ -105,6 +113,22 @@ class EnvCfg:
             raise ValueError(
                 "isaacgym_worker_timeout_s must be a positive number or None, "
                 f"got {self.isaacgym_worker_timeout_s!r}"
+            )
+        for name, value in (
+            ("genesis_integrator", self.genesis_integrator),
+            ("genesis_constraint_solver", self.genesis_constraint_solver),
+            ("genesis_friction_cone", self.genesis_friction_cone),
+        ):
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(f"{name} must be a non-empty string or None, got {value!r}")
+        if self.genesis_solver_iterations is not None and (
+            isinstance(self.genesis_solver_iterations, bool)
+            or not isinstance(self.genesis_solver_iterations, int)
+            or self.genesis_solver_iterations <= 0
+        ):
+            raise ValueError(
+                "genesis_solver_iterations must be a positive integer or None, "
+                f"got {self.genesis_solver_iterations!r}"
             )
         if self.cpu_ids is not None:
             ids = list(self.cpu_ids)

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -39,7 +39,7 @@ class EnvFactory(Protocol):
 
 TEnvFactory = TypeVar("TEnvFactory", bound=EnvFactory)
 RewardOverrideField = Literal["reward_config", "rewards"]
-_SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym")
+_SUPPORTED_SIM_BACKENDS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym", "genesis")
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 _REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"
 _DEFAULT_REGISTRY_PACKAGES = ("unilab.tasks",)

--- a/tests/base/genesis_fake_runtime.py
+++ b/tests/base/genesis_fake_runtime.py
@@ -1,0 +1,331 @@
+"""Fake Genesis runtime for host-free tests of the ``genesis`` backend.
+
+The fake mirrors the exact API surface the adapter consumes (verified against
+genesis-world 1.3.3 on a real RTX 4090) and implements just enough physics to
+exercise contract semantics: PD position control held across substeps,
+env-subset state writes, and link-addressed state reads.  It deliberately
+uses real torch tensors at the boundary so the adapter's host-cache path
+(pinned ``copy_`` D2H) runs unmodified.
+
+Model spec (must stay in sync with ``TINY_MODEL_XML`` in the test file):
+bodies world(0)/pelvis(1, free)/thigh(2, joint_a)/shank(3, joint_b); nq=9,
+nv=8, nu=2.  links_pos: world at origin, pelvis at qpos root xyz, children at
+fixed pelvis-frame offsets; links_quat: children inherit the pelvis quat
+(joint rotation is intentionally not modeled — tests never rely on it).
+"""
+
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import torch
+
+from unilab.utils.rotation import np_quat_apply_batched
+
+# Mirrors TINY_MODEL_XML.  INIT_QPOS equals mj.qpos0 of that document
+# (pelvis body pos z=0.8) so materialize-time state matches the MJCF scan.
+INIT_QPOS = np.array([0.0, 0.0, 0.8, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+NQ = 9
+NV = 8
+N_LINKS = 4
+BODY_NAMES = ("world", "pelvis", "thigh", "shank")
+LINK_MASS = (0.0, 5.0, 2.0, 1.0)
+# Fixed child-link offsets in the pelvis frame (fake kinematics simplification).
+LINK_OFFSET = ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, -0.3), (0.0, 0.0, -0.6))
+ACTUATED_DOFS = (6, 7)
+INIT_KP = (10.0, 20.0)
+INIT_KV = (2.0, 3.0)
+GEOM_TABLE = (
+    # (name, link_idx, friction, contype, conaffinity)
+    ("floor", 0, 1.0, 1, 1),
+    ("pelvis_geom", 1, 0.9, 1, 1),
+    ("thigh_geom", 2, 0.8, 1, 1),
+    ("foot_geom", 3, 0.6, 1, 1),
+)
+SIM_DT = 0.005
+PD_INERTIA = 0.1
+
+
+class _FakeJoint:
+    def __init__(self, name, dofs_idx_local, qs_idx_local, link):
+        self.name = name
+        self.dofs_idx_local = list(dofs_idx_local)
+        self.qs_idx_local = list(qs_idx_local)
+        self.n_dofs = len(self.dofs_idx_local)
+        self.n_qs = len(self.qs_idx_local)
+        self.link = link
+
+
+class _FakeLink:
+    def __init__(self, name, idx):
+        self.name = name
+        self.idx = idx
+        self.idx_local = idx
+        self.joints: list[_FakeJoint] = []
+
+
+class _FakeGeom:
+    def __init__(self, idx, link, friction, contype, conaffinity):
+        self.idx = idx
+        self.link = link
+        self.friction = friction
+        self.contype = contype
+        self.conaffinity = conaffinity
+
+
+class _FakeIMU:
+    def __init__(self, entity_idx, link_idx_local, pos_offset):
+        self.entity_idx = entity_idx
+        self.link_idx_local = link_idx_local
+        self.pos_offset = pos_offset
+        self.lin_acc: torch.Tensor | None = None
+        self.ang_vel: torch.Tensor | None = None
+
+    def read(self):
+        return types.SimpleNamespace(lin_acc=self.lin_acc, ang_vel=self.ang_vel)
+
+
+class _FakeEntity:
+    def __init__(self, morph):
+        self.morph = morph
+        self.idx = 0
+        self.link_start = 0
+        self.n_dofs = NV
+        self.n_qs = NQ
+        self.n_links = N_LINKS
+        self.links = [_FakeLink(name, idx) for idx, name in enumerate(BODY_NAMES)]
+        root = _FakeJoint("floating_base_joint", range(6), range(7), self.links[1])
+        joint_a = _FakeJoint("joint_a", (6,), (7,), self.links[2])
+        joint_b = _FakeJoint("joint_b", (7,), (8,), self.links[3])
+        self.links[1].joints.append(root)
+        self.links[2].joints.append(joint_a)
+        self.links[3].joints.append(joint_b)
+        self.joints = [root, joint_a, joint_b]
+        self.geoms = [
+            _FakeGeom(idx, self.links[link_idx], friction, contype, conaffinity)
+            for idx, (_, link_idx, friction, contype, conaffinity) in enumerate(GEOM_TABLE)
+        ]
+        self.built_envs = 0
+        self.control_calls: list[np.ndarray] = []
+        self.step_count = 0
+
+    def get_link(self, name):
+        for link in self.links:
+            if link.name == name:
+                return link
+        raise KeyError(f"Link not found for name: {name}")
+
+    def _build(self, n_envs: int) -> None:
+        self.built_envs = n_envs
+        self.qpos = torch.from_numpy(np.broadcast_to(INIT_QPOS, (n_envs, NQ)).copy())
+        self.qvel = torch.zeros(n_envs, NV)
+        self.ctrl_target = torch.zeros(n_envs, len(ACTUATED_DOFS))
+        kp = torch.zeros(n_envs, NV)
+        kv = torch.zeros(n_envs, NV)
+        for dof, gain, kd in zip(ACTUATED_DOFS, INIT_KP, INIT_KV, strict=True):
+            kp[:, dof] = gain
+            kv[:, dof] = kd
+        self.dof_kp = kp
+        self.dof_kv = kv
+        self.link_mass = torch.from_numpy(
+            np.broadcast_to(np.asarray(LINK_MASS, dtype=np.float32), (n_envs, N_LINKS)).copy()
+        )
+        self.net_contact_force = torch.zeros(n_envs, N_LINKS, 3)
+
+    # -- getters (torch tensors, like genesis) -------------------------- #
+    def get_qpos(self, qs_idx_local=None, envs_idx=None):
+        return self.qpos
+
+    def get_dofs_velocity(self, dofs_idx_local=None, envs_idx=None):
+        return self.qvel
+
+    def get_dofs_kp(self, dofs_idx_local=None, envs_idx=None):
+        return self.dof_kp
+
+    def get_dofs_kv(self, dofs_idx_local=None, envs_idx=None):
+        return self.dof_kv
+
+    def _link_pose(self):
+        quat = self.qpos[:, 3:7].cpu().numpy()
+        pos = np.zeros((self.built_envs, N_LINKS, 3), dtype=np.float32)
+        quat_out = np.zeros((self.built_envs, N_LINKS, 4), dtype=np.float32)
+        quat_out[:, :, 0] = 1.0
+        for link_idx in range(1, N_LINKS):
+            offset = np.broadcast_to(
+                np.asarray(LINK_OFFSET[link_idx], dtype=np.float32), (self.built_envs, 3)
+            )
+            pos[:, link_idx, :] = self.qpos[:, 0:3].cpu().numpy() + np_quat_apply_batched(
+                quat, offset
+            )
+            quat_out[:, link_idx, :] = quat
+        return pos, quat_out
+
+    def get_links_pos(self, links_idx_local=None, envs_idx=None, **kwargs):
+        pos, _ = self._link_pose()
+        return torch.from_numpy(pos)
+
+    def get_links_quat(self, links_idx_local=None, envs_idx=None, **kwargs):
+        _, quat = self._link_pose()
+        return torch.from_numpy(quat)
+
+    def get_links_vel(self, links_idx_local=None, envs_idx=None, **kwargs):
+        vel = np.zeros((self.built_envs, N_LINKS, 3), dtype=np.float32)
+        vel[:, 1:, :] = self.qvel[:, 0:3].cpu().numpy()[:, None, :]
+        return torch.from_numpy(vel)
+
+    def get_links_ang(self, links_idx_local=None, envs_idx=None):
+        quat = self.qpos[:, 3:7].cpu().numpy()
+        ang = np.zeros((self.built_envs, N_LINKS, 3), dtype=np.float32)
+        ang[:, 1:, :] = np_quat_apply_batched(quat, self.qvel[:, 3:6].cpu().numpy())[:, None, :]
+        return torch.from_numpy(ang)
+
+    def get_links_net_contact_force(self, envs_idx=None):
+        return self.net_contact_force
+
+    # -- setters --------------------------------------------------------- #
+    @staticmethod
+    def _rows(envs_idx):
+        return None if envs_idx is None else list(envs_idx)
+
+    def set_qpos(
+        self, qpos, qs_idx_local=None, envs_idx=None, *, zero_velocity=True, skip_forward=False
+    ):
+        rows = self._rows(envs_idx)
+        value = torch.as_tensor(qpos, dtype=torch.float32).cpu()
+        if rows is None:
+            self.qpos = value.clone()
+        else:
+            self.qpos[rows] = value
+        if zero_velocity:
+            if rows is None:
+                self.qvel.zero_()
+            else:
+                self.qvel[rows] = 0.0
+
+    def set_dofs_velocity(
+        self, velocity=None, dofs_idx_local=None, envs_idx=None, *, skip_forward=False
+    ):
+        rows = self._rows(envs_idx)
+        value = torch.as_tensor(velocity, dtype=torch.float32).cpu()
+        if rows is None:
+            self.qvel = value.clone()
+        else:
+            self.qvel[rows] = value
+
+    def control_dofs_position(self, position, dofs_idx_local=None, envs_idx=None):
+        value = torch.as_tensor(position, dtype=torch.float32).cpu()
+        self.control_calls.append(value.numpy().copy())
+        self.ctrl_target = value.clone()
+
+    def _set_dof_rows(self, table, value, dofs_idx_local, envs_idx):
+        rows = self._rows(envs_idx)
+        dofs = list(dofs_idx_local) if dofs_idx_local is not None else list(range(NV))
+        tensor = torch.as_tensor(value, dtype=torch.float32).cpu()
+        if rows is None:
+            table[:, dofs] = tensor
+        else:
+            table[np.ix_(rows, dofs)] = tensor
+
+    def set_dofs_kp(self, kp, dofs_idx_local=None, envs_idx=None):
+        self._set_dof_rows(self.dof_kp, kp, dofs_idx_local, envs_idx)
+
+    def set_dofs_kv(self, kv, dofs_idx_local=None, envs_idx=None):
+        self._set_dof_rows(self.dof_kv, kv, dofs_idx_local, envs_idx)
+
+    def set_links_inertial_mass(self, inertial_mass, links_idx_local=None, envs_idx=None):
+        rows = self._rows(envs_idx)
+        links = list(links_idx_local) if links_idx_local is not None else list(range(N_LINKS))
+        tensor = torch.as_tensor(inertial_mass, dtype=torch.float32).cpu()
+        if rows is None:
+            self.link_mass[:, links] = tensor
+        else:
+            self.link_mass[np.ix_(rows, links)] = tensor
+
+    # -- physics --------------------------------------------------------- #
+    def step(self):
+        q = self.qpos.numpy()
+        dq = self.qvel.numpy()
+        tau = self.dof_kp.numpy()[:, ACTUATED_DOFS] * (self.ctrl_target.numpy() - q[:, 7:9])
+        tau -= self.dof_kv.numpy()[:, ACTUATED_DOFS] * dq[:, 6:8]
+        dq[:, 6:8] += tau * SIM_DT / PD_INERTIA
+        dq[:, 2] -= 9.81 * SIM_DT
+        q[:, 7:9] += dq[:, 6:8] * SIM_DT
+        q[:, 0:3] += dq[:, 0:3] * SIM_DT
+        self.qpos = torch.from_numpy(q.astype(np.float32))
+        self.qvel = torch.from_numpy(dq.astype(np.float32))
+        self.step_count += 1
+
+
+class _FakeRigidSolver:
+    def __init__(self):
+        self.external_forces: list[tuple[np.ndarray, list[int]]] = []
+
+    def apply_links_external_force(self, force, links_idx=None, envs_idx=None, **kwargs):
+        value = torch.as_tensor(force, dtype=torch.float32).cpu().numpy().copy()
+        self.external_forces.append((value, list(links_idx)))
+
+
+class _FakeScene:
+    def __init__(self, sim_options=None, rigid_options=None, show_viewer=None, **kwargs):
+        self.sim_options = sim_options
+        self.rigid_options = rigid_options
+        self.show_viewer = show_viewer
+        self.entities: list[_FakeEntity] = []
+        self.sensors: list[_FakeIMU] = []
+        self.sim = types.SimpleNamespace(rigid_solver=_FakeRigidSolver())
+
+    def add_entity(self, morph):
+        entity = _FakeEntity(morph)
+        entity.idx = len(self.entities)
+        self.entities.append(entity)
+        return entity
+
+    def add_sensor(self, sensor):
+        self.sensors.append(sensor)
+        return sensor
+
+    def build(self, n_envs=0, **kwargs):
+        for entity in self.entities:
+            entity._build(n_envs)
+        for sensor in self.sensors:
+            sensor.lin_acc = torch.zeros(n_envs, 3)
+            sensor.ang_vel = torch.zeros(n_envs, 3)
+
+    def step(self):
+        for entity in self.entities:
+            entity.step()
+
+
+def make_fake_genesis() -> types.SimpleNamespace:
+    """Create a fresh fake ``genesis`` module with lifecycle counters."""
+    fake = types.SimpleNamespace()
+    fake.gpu = "fake-gpu"
+    fake.cpu = "fake-cpu"
+    fake.init_count = 0
+    fake.destroy_count = 0
+
+    def init(backend=None, logging_level=None, **kwargs):
+        fake.init_count += 1
+
+    def destroy():
+        fake.destroy_count += 1
+
+    options = types.SimpleNamespace(
+        SimOptions=lambda **kw: types.SimpleNamespace(**kw),
+        RigidOptions=lambda **kw: types.SimpleNamespace(kwargs=kw),
+    )
+    fake.init = init
+    fake.destroy = destroy
+    fake.options = options
+    fake.morphs = types.SimpleNamespace(MJCF=lambda **kw: types.SimpleNamespace(**kw))
+    fake.sensors = types.SimpleNamespace(IMU=_FakeIMU)
+    fake.Scene = _FakeScene
+    fake.integrator = types.SimpleNamespace(
+        Euler="Euler",
+        implicitfast="implicitfast",
+        approximate_implicitfast="approximate_implicitfast",
+    )
+    fake.constraint_solver = types.SimpleNamespace(Newton="Newton", CG="CG")
+    fake.friction_cone = types.SimpleNamespace(pyramidal="pyramidal", elliptic="elliptic")
+    return fake

--- a/tests/base/test_backend_conformance.py
+++ b/tests/base/test_backend_conformance.py
@@ -26,7 +26,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
 _FACTORY_FILE = SRC_ROOT / "unilab" / "base" / "backend" / "__init__.py"
 _BACKEND_CLASS_NAMES = frozenset(
-    {"MuJoCoBackend", "MotrixBackend", "DrakeBackend", "MjwarpBackend", "IsaacGymBackend"}
+    {
+        "MuJoCoBackend",
+        "MotrixBackend",
+        "DrakeBackend",
+        "MjwarpBackend",
+        "IsaacGymBackend",
+        "GenesisBackend",
+    }
 )
 _TASK_SOURCE_ROOTS = (
     SRC_ROOT / "unilab" / "envs",
@@ -75,6 +82,19 @@ def _isaacgym_runtime_available() -> bool:
     return isaacgym_runtime_available()
 
 
+def _genesis_runtime_available() -> bool:
+    from unilab.base.backend.genesis.dependencies import genesis_dependencies_available
+
+    if not genesis_dependencies_available():
+        return False
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
 def _require_backend(backend_type: str) -> None:
     if backend_type == "mujoco":
         pytest.importorskip("mujoco", reason="mujoco not installed")
@@ -89,6 +109,9 @@ def _require_backend(backend_type: str) -> None:
     elif backend_type == "isaacgym":
         if not _isaacgym_runtime_available():
             pytest.skip("isaacgym requires the Python 3.8 worker runtime")
+    elif backend_type == "genesis":
+        if not _genesis_runtime_available():
+            pytest.skip("genesis requires the genesis-world extra and a CUDA device")
 
 
 _BACKEND_PARAMS = [
@@ -97,6 +120,7 @@ _BACKEND_PARAMS = [
     pytest.param("drake", id="drake"),
     pytest.param("mjwarp", id="mjwarp", marks=pytest.mark.slow),
     pytest.param("isaacgym", id="isaacgym", marks=pytest.mark.slow),
+    pytest.param("genesis", id="genesis", marks=pytest.mark.slow),
 ]
 
 

--- a/tests/base/test_genesis_backend.py
+++ b/tests/base/test_genesis_backend.py
@@ -1,0 +1,564 @@
+"""Host-free tests for the ``genesis`` backend using a fake Genesis runtime.
+
+These tests run on machines WITHOUT the genesis-world extra (and without
+CUDA): the fake runtime in ``genesis_fake_runtime.py`` mirrors the 1.3.3 API
+surface the adapter consumes, while the adapter's real cold-path MJCF scan
+(the ``mujoco`` package) runs against a tiny inline scene document.  Real
+runtime coverage lives in the slow lanes (``test_genesis_runtime.py`` and the
+genesis parameterization of ``test_backend_conformance.py``).
+"""
+
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import pytest
+import torch
+
+import unilab.base.backend.genesis.dependencies as genesis_dependencies
+import unilab.base.backend.genesis.materialization as genesis_materialization
+from unilab.base.backend import create_backend, env_backend_kwargs
+from unilab.base.backend.genesis.dependencies import (
+    GenesisDependencies,
+    GenesisDependencyError,
+    genesis_dependencies_available,
+    load_genesis_dependencies,
+)
+from unilab.base.backend.genesis.materialization import preserve_torch_globals
+from unilab.base.base import EnvCfg
+from unilab.base.scene import SceneCfg
+from unilab.dr.types import (
+    GeomSizeOverride,
+    InitRandomizationPlan,
+    IntervalRandomizationPlan,
+    ModelVariantSpec,
+    ResetRandomizationPayload,
+)
+
+from .genesis_fake_runtime import ACTUATED_DOFS, N_LINKS, NQ, NV, make_fake_genesis
+
+# Must stay in sync with the model spec in genesis_fake_runtime.py.
+TINY_MODEL_XML = """
+<mujoco model="tiny">
+  <compiler angle="radian"/>
+  <option integrator="implicitfast" timestep="0.005"/>
+  <worldbody>
+    <geom name="floor" type="plane" size="0 0 0.05" friction="1.0"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <site name="imu_site" pos="0.05 0 -0.08"/>
+      <geom name="pelvis_geom" type="capsule" size="0.05 0.1" mass="5.0" friction="0.9"/>
+      <body name="thigh" pos="0 0 -0.3">
+        <joint name="joint_a" type="hinge" axis="0 1 0" range="-0.5 0.5"/>
+        <geom name="thigh_geom" type="capsule" size="0.04 0.1" mass="2.0" friction="0.8"/>
+        <body name="shank" pos="0 0 -0.3">
+          <joint name="joint_b" type="hinge" axis="0 1 0" range="-0.6 0.6"/>
+          <geom name="foot_geom" type="sphere" size="0.05" mass="1.0" friction="0.6"/>
+          <site name="foot_site" pos="0.02 0 -0.03"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="act_a" joint="joint_a" kp="10" kv="2" ctrlrange="-1 1"/>
+    <position name="act_b" joint="joint_b" kp="20" kv="3" ctrlrange="-2 2"/>
+  </actuator>
+  <sensor>
+    <velocimeter site="imu_site" name="base_linvel"/>
+    <gyro site="imu_site" name="base_gyro"/>
+    <accelerometer site="imu_site" name="base_acc"/>
+    <framezaxis objtype="site" objname="imu_site" name="base_up"/>
+    <framepos objtype="site" objname="foot_site" name="foot_pos"/>
+    <framequat objtype="site" objname="foot_site" name="foot_quat"/>
+    <contact name="foot_contact" geom1="floor" geom2="foot_geom" data="found" num="1" reduce="mindist"/>
+  </sensor>
+  <keyframe>
+    <key name="stand" qpos="0 0 0.8 1 0 0 0 0.1 -0.2"/>
+  </keyframe>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def tiny_model_file(tmp_path: Path) -> str:
+    path = tmp_path / "tiny.xml"
+    path.write_text(TINY_MODEL_XML, encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture
+def fake_genesis(monkeypatch: pytest.MonkeyPatch):
+    fake = make_fake_genesis()
+    deps = GenesisDependencies(genesis=fake, torch=torch, mujoco=mujoco)
+    monkeypatch.setattr(genesis_dependencies, "load_genesis_dependencies", lambda: deps)
+    genesis_materialization._reset_session_state_for_tests()
+    yield fake
+    genesis_materialization._reset_session_state_for_tests()
+
+
+def _backend(model_file: str, num_envs: int = 4, **kwargs):
+    backend = create_backend(
+        "genesis",
+        SceneCfg(model_file=model_file),
+        num_envs,
+        0.005,
+        base_name="pelvis",
+        **kwargs,
+    )
+    backend.materialize()
+    return backend
+
+
+def _stand_state(backend, rows: int) -> tuple[np.ndarray, np.ndarray]:
+    qpos = np.tile(backend.get_keyframe_qpos("stand"), (rows, 1)).astype(np.float32)
+    qvel = np.zeros((rows, backend.get_init_qvel().size), dtype=np.float32)
+    return qpos, qvel
+
+
+def test_dependency_boundary_errors_are_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(_name: str) -> str:
+        raise importlib_metadata.PackageNotFoundError("genesis-world")
+
+    monkeypatch.setattr(importlib_metadata, "version", _raise)
+    with pytest.raises(GenesisDependencyError, match="uv sync --extra genesis"):
+        load_genesis_dependencies()
+    monkeypatch.setattr(importlib_metadata, "version", lambda _name: "0.0.0")
+    with pytest.raises(GenesisDependencyError, match="exact genesis-world version"):
+        load_genesis_dependencies()
+    monkeypatch.setattr(genesis_dependencies, "find_spec", lambda name: None)
+    assert genesis_dependencies_available() is False
+
+
+def test_preserve_torch_globals_restores_device_dtype_and_rng() -> None:
+    torch.set_default_device("cpu")
+    torch.set_default_dtype(torch.float32)
+    torch.manual_seed(1234)
+    rng_before = torch.get_rng_state().clone()
+    with preserve_torch_globals(torch):
+        # Simulate the measured gs.init pollution (REPORT §3.5 [10]).
+        torch.set_default_dtype(torch.float64)
+        torch.rand(8)
+    assert torch.get_default_dtype() is torch.float32
+    assert str(torch.get_default_device()) == "cpu"
+    assert torch.equal(torch.get_rng_state(), rng_before)
+
+
+def test_session_lifecycle_and_reinit_guard(fake_genesis, tiny_model_file: str) -> None:
+    first = _backend(tiny_model_file)
+    second = _backend(tiny_model_file)
+    assert fake_genesis.init_count == 1  # backends share the process-wide session
+    with pytest.raises(RuntimeError, match="already materialized"):
+        first.materialize()
+    first.close()
+    assert fake_genesis.destroy_count == 1
+    with pytest.raises(RuntimeError, match="exactly one gs.init per process"):
+        _backend(tiny_model_file)
+    with pytest.raises(RuntimeError, match="genesis backend is closed"):
+        first.step(np.zeros((4, 2), dtype=np.float32))
+    second.close()
+    assert fake_genesis.destroy_count == 1  # idempotent: session already destroyed
+
+
+def test_cold_metadata_matches_mjcf_scan(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    assert backend.backend_type == "genesis"
+    assert backend.num_envs == 4
+    assert backend.num_actuators == 2
+    assert backend.num_dof_vel == 2
+    assert backend.get_actuator_names() == ("act_a", "act_b")
+    assert backend.get_actuator_joint_names() == ("joint_a", "joint_b")
+    np.testing.assert_array_equal(
+        backend.get_actuator_ctrl_range(), np.array([[-1.0, 1.0], [-2.0, 2.0]], np.float32)
+    )
+    kp, kd = backend.get_actuator_gains()
+    np.testing.assert_allclose(kp, [10.0, 20.0])
+    np.testing.assert_allclose(kd, [2.0, 3.0])
+    np.testing.assert_allclose(backend.get_joint_range(), [[-0.5, 0.5], [-0.6, 0.6]])
+    np.testing.assert_allclose(backend.get_gravity(), [0.0, 0.0, -9.81])
+    np.testing.assert_allclose(backend.get_dof_armature(), np.zeros(NV), atol=1e-6)
+    np.testing.assert_allclose(backend.get_body_mass()[1:], [5.0, 2.0, 1.0], atol=1e-4)
+
+    layout = backend.get_root_state_layout("pelvis")
+    assert layout.qpos_indices == tuple(range(7))
+    assert layout.qvel_indices == tuple(range(6))
+    with pytest.raises(NotImplementedError, match="exactly one free joint"):
+        backend.get_root_state_layout("thigh")
+    with pytest.raises(ValueError, match="not found"):
+        backend.get_root_state_layout("missing")
+
+    np.testing.assert_allclose(backend.get_keyframe_qpos("stand")[7:], [0.1, -0.2])
+    with pytest.raises(ValueError, match="Keyframe 'home' not found"):
+        backend.get_keyframe_qpos("home")
+    np.testing.assert_allclose(backend.get_default_qpos()[:3], [0.0, 0.0, 0.8])
+    np.testing.assert_allclose(backend.get_default_dof_pos(), [0.0, 0.0], atol=1e-6)
+    assert backend.get_init_qvel().shape == (NV,)
+    np.testing.assert_allclose(backend.get_dof_pos()[0], backend.get_default_dof_pos())
+    np.testing.assert_array_equal(backend.get_body_ids(["pelvis", "shank"]), [1, 3])
+    np.testing.assert_array_equal(backend.get_joint_dof_indices(["joint_b"]), [7])
+    np.testing.assert_array_equal(backend.get_joint_dof_pos_indices(["joint_b"]), [1])
+    np.testing.assert_array_equal(backend.get_joint_state_qpos_indices(["joint_a"]), [7])
+
+    contype, conaffinity = backend.get_geom_contact_masks()
+    assert contype.dtype == np.int32 and conaffinity.dtype == np.int32
+    assert contype.shape == (4,) and backend.get_scene_model_file() == tiny_model_file
+
+
+def test_import_cross_check_fails_closed(fake_genesis, tiny_model_file: str) -> None:
+    backend = create_backend(
+        "genesis", SceneCfg(model_file=tiny_model_file), 2, 0.005, base_name="pelvis"
+    )
+    joints = backend._entity.joints
+    backend._entity.joints = [joints[0], joints[2], joints[1]]
+    with pytest.raises(RuntimeError, match="import mismatch: joint names"):
+        backend.materialize()
+
+
+def test_unmappable_sensor_type_fails_closed_at_scan(fake_genesis) -> None:
+    model = mujoco.MjModel.from_xml_string(
+        "<mujoco><worldbody><body name='b' pos='0 0 1'><freejoint/><geom size='0.1' mass='1'/>"
+        "</body></worldbody><sensor><subtreelinvel name='sv' body='b'/></sensor></mujoco>"
+    )
+    with pytest.raises(NotImplementedError, match="cannot map MJCF sensor 'sv'"):
+        genesis_materialization._scan_sensor_plans(mujoco, model)
+
+
+def test_control_target_held_across_substeps(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    entity = backend._entity
+    qpos, qvel = _stand_state(backend, 4)
+    backend.set_state(np.arange(4, dtype=np.int32), qpos, qvel)
+
+    ctrl = np.tile(np.array([[0.3, -0.3]], dtype=np.float32), (4, 1))
+    result = backend.step(ctrl, nsteps=3)
+    assert set(result["timing"]) == {"physics_ms", "host_cache_refresh_ms"}
+    assert len(entity.control_calls) == 1  # target pushed once, held across substeps
+    assert entity.step_count == 3
+    dof_pos = backend.get_dof_pos()
+    assert dof_pos.shape == (4, 2) and dof_pos.dtype == np.float32
+    assert np.isfinite(dof_pos).all()
+    assert np.all(dof_pos[:, 0] > 0.1)  # PD pulled joint_a toward 0.3
+    assert np.all(dof_pos[:, 1] < -0.2)
+    np.testing.assert_allclose(entity.control_calls[0], ctrl, atol=1e-6)
+
+    with pytest.raises(ValueError, match="ctrl must have shape"):
+        backend.step(np.zeros((4, 3), dtype=np.float32))
+    with pytest.raises(ValueError, match="nsteps must be a positive integer"):
+        backend.step(ctrl, nsteps=0)
+
+
+def test_pre_step_control_runs_per_substep(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    entity = backend._entity
+    calls: list[np.ndarray] = []
+
+    def convert(owner, ctrl: np.ndarray) -> np.ndarray:
+        assert owner is backend
+        calls.append(ctrl.copy())
+        return np.zeros_like(ctrl)
+
+    backend.set_pre_step_control(convert)
+    ctrl = np.full((4, 2), 0.25, dtype=np.float32)
+    backend.step(ctrl, nsteps=4)
+    assert len(calls) == 4  # conversion runs before every physics substep
+    assert len(entity.control_calls) == 4
+    np.testing.assert_allclose(entity.control_calls[-1], np.zeros((4, 2)), atol=1e-6)
+
+    backend.set_pre_step_control(lambda _owner, c: np.zeros((4, 3), dtype=c.dtype))
+    with pytest.raises(ValueError, match="pre-step control must return shape"):
+        backend.step(ctrl)
+    backend.set_pre_step_control(None)
+    backend.step(ctrl)
+    assert len(entity.control_calls) == 5
+
+
+def test_set_state_subset_reset_isolated(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    qpos, qvel = _stand_state(backend, 4)
+    qpos[:, 0] = np.array([-0.3, -0.1, 0.1, 0.3], dtype=np.float32)
+    qvel[:, 0] = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+    backend.set_state(np.arange(4, dtype=np.int32), qpos, qvel)
+    previous_pos = backend.get_base_pos().copy()
+    previous_vel = backend.get_base_lin_vel().copy()
+
+    rows = np.array([3, 1], dtype=np.int32)
+    reset_qpos, reset_qvel = _stand_state(backend, 2)
+    result = backend.set_state(rows, reset_qpos, reset_qvel)
+    timing = result["timing"]
+    assert timing["set_state_reset_upload_ms"] >= 0.0
+    assert timing["set_state_host_cache_refresh_ms"] >= 0.0
+    assert "set_state_internal_gap_ms" in timing
+
+    np.testing.assert_allclose(backend.get_base_pos()[rows, 2], 0.8, atol=1e-5)
+    np.testing.assert_allclose(backend.get_dof_pos()[rows], [[0.1, -0.2], [0.1, -0.2]], atol=1e-6)
+    complement = np.array([0, 2], dtype=np.int32)
+    np.testing.assert_allclose(backend.get_base_pos()[complement], previous_pos[complement])
+    np.testing.assert_allclose(backend.get_base_lin_vel()[complement], previous_vel[complement])
+    assert np.isfinite(backend.get_dof_vel()).all()
+
+    with pytest.raises(ValueError, match="duplicate rows"):
+        backend.set_state(np.array([1, 1], dtype=np.int32), reset_qpos, reset_qvel)
+    with pytest.raises(ValueError, match="must be in \\[0, 4\\)"):
+        backend.set_state(np.array([9], dtype=np.int32), reset_qpos[:1], reset_qvel[:1])
+    with pytest.raises(ValueError, match="qpos must have shape"):
+        backend.set_state(rows, reset_qpos[:, :5], reset_qvel)
+    empty = backend.set_state(
+        np.array([], dtype=np.int32),
+        np.zeros((0, NQ), dtype=np.float32),
+        np.zeros((0, NV), dtype=np.float32),
+    )
+    assert all(value == 0.0 for value in empty["timing"].values())
+
+
+def test_base_velocity_frame_conventions(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file, num_envs=1)
+    qpos, qvel = _stand_state(backend, 1)
+    half = np.sqrt(0.5)
+    qpos[0, 3:7] = [half, half, 0.0, 0.0]  # 90 deg about x (wxyz)
+    qvel[0, 0:3] = [1.0, 2.0, 3.0]
+    qvel[0, 3:6] = [0.0, 0.0, 1.0]  # body-frame angular velocity
+    backend.set_state(np.array([0], dtype=np.int32), qpos, qvel)
+
+    np.testing.assert_allclose(backend.get_base_lin_vel()[0], [1.0, 2.0, 3.0], atol=1e-6)
+    # World-frame angular velocity: R_x90 @ [0,0,1] = [0,-1,0].
+    np.testing.assert_allclose(backend.get_base_ang_vel()[0], [0.0, -1.0, 0.0], atol=1e-6)
+    pelvis_id = backend.get_body_ids(["pelvis"])
+    np.testing.assert_allclose(
+        backend.get_body_ang_vel_w(pelvis_id)[0, 0], [0.0, -1.0, 0.0], atol=1e-6
+    )
+    # Gyro reports body/sensor-frame components: identity site frame recovers
+    # the qvel body-frame columns.
+    np.testing.assert_allclose(backend.get_sensor_data("base_gyro")[0], [0.0, 0.0, 1.0], atol=1e-6)
+
+
+def test_sensor_equivalents_from_link_state(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file, num_envs=1)
+    qpos, qvel = _stand_state(backend, 1)
+    qvel[0, 0:3] = [1.0, 2.0, 3.0]
+    qvel[0, 3:6] = [0.1, 0.2, 0.3]
+    backend.set_state(np.array([0], dtype=np.int32), qpos, qvel)
+
+    site_pos = np.array([0.05, 0.0, -0.08])
+    expected_linvel = qvel[0, 0:3] + np.cross(qvel[0, 3:6], site_pos)
+    np.testing.assert_allclose(
+        backend.get_sensor_data("base_linvel")[0], expected_linvel, atol=1e-6
+    )
+    np.testing.assert_allclose(backend.get_sensor_data("base_gyro")[0], [0.1, 0.2, 0.3], atol=1e-6)
+    np.testing.assert_allclose(backend.get_sensor_data("base_up")[0], [0.0, 0.0, 1.0], atol=1e-6)
+    np.testing.assert_allclose(
+        backend.get_sensor_data("foot_pos")[0], [0.02, 0.0, 0.8 - 0.63], atol=1e-6
+    )
+    np.testing.assert_allclose(
+        backend.get_sensor_data("foot_quat")[0], [1.0, 0.0, 0.0, 0.0], atol=1e-6
+    )
+
+    # Accelerometer reads through the registered IMUSensor equivalent.
+    imu = backend._imu_sensors["base_acc"]
+    imu.lin_acc = torch.full((1, 3), 7.5)
+    backend.step(np.zeros((1, 2), dtype=np.float32))
+    np.testing.assert_allclose(backend.get_sensor_data("base_acc")[0], [7.5, 7.5, 7.5])
+
+    # contact(found): per-link net force threshold, both directions.
+    assert backend.get_sensor_data("foot_contact")[0, 0] == 0.0
+    entity = backend._entity
+    entity.net_contact_force = torch.zeros(1, N_LINKS, 3)
+    entity.net_contact_force[0, 3, 2] = 50.0
+    backend.step(np.zeros((1, 2), dtype=np.float32))
+    assert backend.get_sensor_data("foot_contact")[0, 0] == 1.0
+    entity.net_contact_force[0, 3, 2] = 0.5
+    backend.step(np.zeros((1, 2), dtype=np.float32))
+    assert backend.get_sensor_data("foot_contact")[0, 0] == 0.0
+
+
+def test_bind_sensor_data_view(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file, num_envs=2)
+    names = ("base_gyro", "base_linvel")
+    view = backend.bind_sensor_data(names)
+    assert view.names == names and view.dimensions == (3, 3)
+    values = view.read()
+    assert values.shape == (2, 6) and np.isfinite(values).all()
+    np.testing.assert_allclose(values, backend.get_sensor_data_batch(names))
+    with pytest.raises(ValueError, match="missing_sensor"):
+        backend.bind_sensor_data(("missing_sensor",))
+    with pytest.raises(ValueError, match="Sensor 'does_not_exist' not found"):
+        backend.get_sensor_data("does_not_exist")
+
+
+def test_dr_capabilities_and_reset_randomization(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    caps = backend.get_dr_capabilities()
+    assert caps.supported_reset_terms == {"body_mass", "base_mass_delta", "kp", "kd"}
+    assert caps.supports_interval_body_force is True
+    assert caps.supports_interval_push is False
+    assert caps.supports_interval_body_velocity_delta is False
+
+    entity = backend._entity
+    rows = np.array([1, 3], dtype=np.int32)
+    qpos, qvel = _stand_state(backend, 2)
+    body_mass = np.tile(np.array([[0.0, 6.0, 2.5, 1.5]], dtype=np.float32), (2, 1))
+    payload = ResetRandomizationPayload(
+        body_mass=body_mass,
+        kp=np.full((2, 2), 55.0),
+        kd=np.full((2, 2), 6.5),
+    )
+    backend.set_state(rows, qpos, qvel, randomization=payload)
+    np.testing.assert_allclose(entity.link_mass[1].numpy(), [0.0, 6.0, 2.5, 1.5])
+    np.testing.assert_allclose(entity.link_mass[0, 1].numpy(), 5.0)  # untouched row
+    np.testing.assert_allclose(entity.dof_kp.numpy()[rows][:, ACTUATED_DOFS], 55.0)
+    np.testing.assert_allclose(entity.dof_kv.numpy()[rows][:, ACTUATED_DOFS], 6.5)
+
+    delta_payload = ResetRandomizationPayload(base_mass_delta=np.array([0.25, -0.5]))
+    backend.set_state(rows, qpos, qvel, randomization=delta_payload)
+    # Delta composes onto the scanned nominal base mass (5.0), matching the
+    # MuJoCo backend's base-table semantics.
+    np.testing.assert_allclose(entity.link_mass.numpy()[rows, 1], [5.25, 4.5])
+
+    with pytest.raises(NotImplementedError, match="gravity"):
+        backend.set_state(
+            rows, qpos, qvel, randomization=ResetRandomizationPayload(gravity=np.zeros((2, 3)))
+        )
+    with pytest.raises(ValueError, match="kp must have shape"):
+        backend.set_state(
+            rows, qpos, qvel, randomization=ResetRandomizationPayload(kp=np.zeros((2, 5)))
+        )
+
+
+def test_interval_randomization_and_body_force(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    solver = backend._scene.sim.rigid_solver
+    force = np.ones((4, 2, 3), dtype=np.float32)
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(body_ids=np.array([1, 3], dtype=np.int32), body_force=force)
+    )
+    assert len(solver.external_forces) == 2
+    np.testing.assert_allclose(solver.external_forces[0][0], np.ones((4, 3)))
+    assert solver.external_forces[0][1] == [1]
+    assert solver.external_forces[1][1] == [3]
+
+    with pytest.raises(NotImplementedError, match="interval push"):
+        backend.apply_interval_randomization(IntervalRandomizationPlan(push_perturbation_limit=5.0))
+    with pytest.raises(NotImplementedError, match="body-velocity"):
+        backend.apply_interval_randomization(
+            IntervalRandomizationPlan(
+                body_ids=np.array([1], dtype=np.int32),
+                body_linear_velocity_delta=np.zeros((4, 1, 3), dtype=np.float32),
+            )
+        )
+    with pytest.raises(ValueError, match="requires body_ids"):
+        backend.apply_interval_randomization(
+            IntervalRandomizationPlan(body_force=np.zeros((4, 1, 3), dtype=np.float32))
+        )
+    with pytest.raises(NotImplementedError, match="init-lifecycle randomization"):
+        backend.apply_init_randomization(
+            InitRandomizationPlan(
+                model_assignments=np.zeros(4, dtype=np.int32),
+                model_variants=(
+                    ModelVariantSpec(geom_size_overrides=(GeomSizeOverride("foot_geom", (0.1,)),)),
+                ),
+            )
+        )
+
+
+def test_unsupported_contract_surface_fails_closed(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file)
+    for call, match in (
+        (lambda: backend.get_geom_id("floor"), "geom ids"),
+        (lambda: backend.get_geom_size("floor"), "geom sizes"),
+        (lambda: backend.get_geom_names(), "geom names"),
+        (lambda: backend.get_site_ids(["imu_site"]), "get_site_ids"),
+        (lambda: backend.get_site_jacobian_w(0, np.array([6])), "get_site_jacobian_w"),
+        (
+            lambda: backend.create_hfield_scanner(
+                hfield_geom_id=0, offsets=np.zeros((1, 2)), frame_body_id=1
+            ),
+            "height-field",
+        ),
+        (lambda: backend.init_renderer(), "native rendering"),
+        (lambda: backend.render(), "native interactive rendering"),
+        (lambda: backend.capture_video_frame(), "native video capture"),
+        (lambda: backend.get_physics_state(), "physics-state playback"),
+        (
+            lambda: backend.run_playback(env=None, initialize=None, step=None, num_steps=None),
+            "playback execution",
+        ),
+    ):
+        with pytest.raises(NotImplementedError, match=match):
+            call()
+
+    caps = backend.get_play_capabilities()
+    assert caps.supports_native_interactive_renderer is False
+    assert caps.supports_physics_state_playback is False
+    assert caps.supports_native_video_capture is False
+    plan = backend.resolve_play_render_plan(
+        play_render_mode="none", play_steps=None, output_video=None
+    )
+    assert plan.mode == "none"
+    with pytest.raises(NotImplementedError, match="playback mode 'record'"):
+        backend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=10, output_video="out.mp4"
+        )
+
+
+def test_constructor_validation_and_factory_wiring(fake_genesis, tiny_model_file: str) -> None:
+    scene = SceneCfg(model_file=tiny_model_file)
+    with pytest.raises(NotImplementedError, match="push_body_name"):
+        create_backend("genesis", scene, 1, 0.005, push_body_name="pelvis")
+    with pytest.raises(TypeError, match="does not accept backend options"):
+        create_backend("genesis", scene, 1, 0.005, bogus_option=1)
+    with pytest.raises(ValueError, match="solver_iterations"):
+        create_backend("genesis", scene, 1, 0.005, genesis_solver_iterations=0)
+    with pytest.raises(ValueError, match="genesis_integrator must be one of"):
+        create_backend("genesis", scene, 1, 0.005, genesis_integrator="bogus")
+    with pytest.raises(ValueError, match="position_actuator_gains"):
+        create_backend("genesis", scene, 1, 0.005, position_actuator_gains={"kp": 1.0})
+    with pytest.raises(ValueError, match="num_envs must be a positive integer"):
+        create_backend("genesis", scene, 0, 0.005)
+
+    backend = create_backend(
+        "genesis",
+        scene,
+        1,
+        0.005,
+        genesis_integrator="implicitfast",
+        genesis_constraint_solver="newton",
+        genesis_friction_cone="elliptic",
+        genesis_solver_iterations=25,
+    )
+    rigid_kwargs = backend._scene.rigid_options.kwargs
+    assert rigid_kwargs["integrator"] == "implicitfast"
+    assert rigid_kwargs["constraint_solver"] == "Newton"
+    assert rigid_kwargs["friction_cone"] == "elliptic"
+    assert rigid_kwargs["iterations"] == 25
+    assert rigid_kwargs["batch_links_info"] is True
+    assert rigid_kwargs["batch_dofs_info"] is True
+    assert backend._scene.sim_options.dt == pytest.approx(0.005)
+
+    with pytest.raises(RuntimeError, match="not materialized"):
+        backend.get_dof_pos()
+    # Cold-path metadata stays available before materialize (manager env
+    # constructors read it ahead of the materialize hook).
+    assert backend.get_default_dof_pos().shape == (2,)
+    assert backend.get_keyframe_qpos("stand").shape == (NQ,)
+
+
+def test_env_cfg_genesis_fields_validate_and_reach_factory() -> None:
+    cfg = EnvCfg(
+        genesis_integrator="implicitfast",
+        genesis_constraint_solver="cg",
+        genesis_friction_cone="pyramidal",
+        genesis_solver_iterations=30,
+    )
+    cfg.validate()
+    kwargs = env_backend_kwargs(cfg)
+    assert (
+        kwargs["genesis_integrator"],
+        kwargs["genesis_constraint_solver"],
+        kwargs["genesis_friction_cone"],
+        kwargs["genesis_solver_iterations"],
+    ) == ("implicitfast", "cg", "pyramidal", 30)
+    with pytest.raises(ValueError, match="genesis_integrator must be a non-empty string"):
+        EnvCfg(genesis_integrator="").validate()
+    with pytest.raises(ValueError, match="genesis_solver_iterations must be a positive integer"):
+        EnvCfg(genesis_solver_iterations=-1).validate()

--- a/tests/base/test_genesis_runtime.py
+++ b/tests/base/test_genesis_runtime.py
@@ -1,0 +1,150 @@
+"""Real-runtime slow lane for the ``genesis`` backend (genesis-world 1.3.3).
+
+These tests require the ``genesis`` extra and a CUDA device; the normal lane
+deselects them.  They cover the #1378 acceptance smoke (g1 scene_flat.xml,
+n_envs=8, keyframe reset, 10 control steps, explicit cleanup) and re-verify
+on torch 2.8 the sensor combination that crashed under torch 2.7 in the
+feasibility probe (REPORT #1372 §3.4/§8: IMUSensor + link net contact force
+reads in one scene).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from unilab.assets import ASSETS_ROOT_PATH
+from unilab.base.backend import create_backend
+from unilab.base.scene import SceneCfg
+
+pytestmark = pytest.mark.slow
+
+_G1_SCENE = str(ASSETS_ROOT_PATH / "robots" / "g1" / "scene_flat.xml")
+_NUM_ENVS = 8
+_SIM_DT = 1.0 / 150.0
+
+
+def _genesis_runtime_available() -> bool:
+    from unilab.base.backend.genesis.dependencies import genesis_dependencies_available
+
+    if not genesis_dependencies_available():
+        return False
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _make_backend():
+    backend = create_backend(
+        "genesis",
+        SceneCfg(model_file=_G1_SCENE),
+        _NUM_ENVS,
+        _SIM_DT,
+        base_name="pelvis",
+        genesis_integrator="implicitfast",
+    )
+    backend.materialize()
+    return backend
+
+
+@pytest.fixture(scope="module")
+def backend():
+    if not _genesis_runtime_available():
+        pytest.skip("genesis requires the genesis-world extra and a CUDA device")
+    instance = _make_backend()
+    yield instance
+    instance.close()
+
+
+def _stand_state(instance, rows: int) -> tuple[np.ndarray, np.ndarray]:
+    qpos = np.tile(instance.get_keyframe_qpos("stand"), (rows, 1)).astype(np.float32)
+    qvel = np.zeros((rows, instance.get_init_qvel().size), dtype=np.float32)
+    return qpos, qvel
+
+
+def test_g1_smoke_reset_step_and_cleanup(backend) -> None:
+    """Acceptance smoke for #1378: reset, 10 control steps, finite reads."""
+    assert backend.num_envs == _NUM_ENVS
+    assert backend.num_actuators == 29
+    assert backend.num_dof_vel == 29
+
+    qpos, qvel = _stand_state(backend, _NUM_ENVS)
+    rows = np.arange(_NUM_ENVS, dtype=np.int32)
+    backend.set_state(rows, qpos, qvel)
+    np.testing.assert_allclose(backend.get_dof_pos(), qpos[:, -backend.num_actuators :], atol=1e-5)
+
+    # DR round-trip on the measured per-env setters (batch_*_info build flags).
+    from unilab.dr.types import ResetRandomizationPayload
+
+    kp, kd = backend.get_actuator_gains()
+    payload = ResetRandomizationPayload(kp=(kp * 1.05)[None].repeat(2, axis=0))
+    backend.set_state(rows[:2], qpos[:2], qvel[:2], randomization=payload)
+    np.testing.assert_allclose(
+        backend._entity.get_dofs_kp().cpu().numpy()[:2, 6:],
+        np.tile(kp * 1.05, (2, 1)),
+        rtol=1e-4,
+    )
+    backend.set_state(
+        rows[:2],
+        qpos[:2],
+        qvel[:2],
+        randomization=ResetRandomizationPayload(kp=kp[None].repeat(2, axis=0)),
+    )
+
+    ctrl = np.broadcast_to(
+        qpos[0, -backend.num_actuators :], (_NUM_ENVS, backend.num_actuators)
+    ).copy()
+    keyframe_dof = qpos[0, -backend.num_actuators :]
+    for _ in range(10):
+        result = backend.step(ctrl, nsteps=3)
+    assert set(result["timing"]) == {"physics_ms", "host_cache_refresh_ms"}
+
+    base_pos = backend.get_base_pos()
+    base_quat = backend.get_base_quat()
+    dof_pos = backend.get_dof_pos()
+    assert base_pos.shape == (_NUM_ENVS, 3)
+    assert np.isfinite(base_pos).all()
+    assert np.isfinite(dof_pos).all()
+    np.testing.assert_allclose(np.linalg.norm(base_quat, axis=-1), 1.0, atol=1e-4)
+    # Position hold at the stand keyframe stays upright over 0.2 s.
+    np.testing.assert_allclose(base_pos[:, 2], qpos[0, 2], atol=0.08)
+    drift = np.abs(dof_pos - keyframe_dof).max()
+    assert drift < 0.3, f"dof drift under position hold: {drift}"
+
+    # Sensor reads, including the IMUSensor + net-contact-force combination
+    # that crashed under torch 2.7 in the #1372 probe (torch 2.8 re-check).
+    sensor_names = (
+        "pelvis_gyro",
+        "pelvis_local_linvel",
+        "pelvis_acceleration",
+        "torso_gyro",
+        "left_foot_pos",
+        "left_foot_quat",
+        "left_foot_contact_0",
+    )
+    batch = backend.get_sensor_data_batch(sensor_names)
+    assert batch.shape == (_NUM_ENVS, 3 + 3 + 3 + 3 + 3 + 4 + 1)
+    assert np.isfinite(batch).all()
+    foot_force = np.linalg.norm(
+        backend._entity.get_links_net_contact_force().cpu().numpy()[:, 1:], axis=-1
+    )
+    assert (foot_force > 1.0).any(), "standing G1 should register foot contact force"
+    assert (backend.get_sensor_data("left_foot_contact_0") > 0.5).all()
+    view = backend.bind_sensor_data(("pelvis_gyro", "pelvis_local_linvel"))
+    assert view.read().shape == (_NUM_ENVS, 6)
+
+    print(
+        "[genesis smoke] n_envs=8 reset+10 steps OK; "
+        f"base_z={base_pos[:, 2].mean():.4f} (target {qpos[0, 2]:.3f}), "
+        f"max_dof_drift={drift:.4f}, foot_force_max={foot_force.max():.1f}N"
+    )
+
+
+def test_reinit_after_destroy_fails_closed(backend) -> None:
+    """Real-runtime lifecycle guard: one gs.init per process (keep last)."""
+    backend.close()
+    with pytest.raises(RuntimeError, match="exactly one gs.init per process"):
+        _make_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -102,12 +102,146 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "17.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/e3/477fa20578c284abeda08d91b63ee9abaebc93445d8feeb989d3d444bae1/av-17.1.0.tar.gz", hash = "sha256:7f1e71ff621b66253333926f948e00faae11d855b2442133c65128bca64cdeb3", size = 4288546, upload-time = "2026-06-07T05:52:55.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/92/c9d0cea4f6f8f93f5b15a39f99d2d593f922484f22a2d98a8d482283e15b/av-17.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:19c84fd72af5ef81a20f18fbc6f9aedff9e1455e53a7062c1d4c95926d73da4e", size = 22622703, upload-time = "2026-06-07T05:51:40.405Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/57/74399770aa103ee4b5ff6da1781440c91a41901d89abb2433fe88773246e/av-17.1.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:19264c9bb4bee404accc7ce9ec461f2044b7f577a70234d29aafde31ed17de46", size = 18273538, upload-time = "2026-06-07T05:51:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/27c85b12e9ffa8f3f6854358b3eabcd91f3c29c7dac36843fa1376e833f4/av-17.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:22dff0ae582d10ef08c75c2150a4fd27cfc26653b54930c7c27b9f7b3aa20723", size = 34519101, upload-time = "2026-06-07T05:51:45.305Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/542d4bfd9f4aec5f3265985b9dbc6b259d45c2e668f9714e5f4e05b71e64/av-17.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:90c49bc9608377d01e82e747377505419a229464873341db18202d5dddecce5a", size = 36647600, upload-time = "2026-06-07T05:51:48.57Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1e/63bd5c59580f38109fa4c452b29b715a20c9a5eb3a078b3c447484593c40/av-17.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cc5a5247622cb77e24c342364eb68f88c1442ddfaab60c1f1f483359d3cc7879", size = 25786289, upload-time = "2026-06-07T05:51:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/70/30/78155cef0c9f8bc13f044130192c58bf962f2c9066982ff3593afe8d27f1/av-17.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ff457ed419348e5b8e8c811d341389b052c5e4d5839da3794d019b125b9fe830", size = 35599848, upload-time = "2026-06-07T05:51:54.207Z" },
+    { url = "https://files.pythonhosted.org/packages/76/cb/ae1d7a735a5ad9dc502dba864c51d605cbe932a769218352fd570254c38e/av-17.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1370b11a697eb3f2555906f8ab3519b0cfe48425d7830a3996ad42e6bffafda5", size = 26776479, upload-time = "2026-06-07T05:51:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/40/128429b9eb0c4a2beb122ed8d04b189515df68967987c2654a2e262a5c43/av-17.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3dcd41e53f53f9a3260751d9c3c11d34e93d70d61e506c81f13dbc1e3606e07b", size = 37763744, upload-time = "2026-06-07T05:51:59.222Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6a/5980e7bbeeadfd7a9db8e38e9f1140a3e0c392fccc31bd7b1e4a75cf5a96/av-17.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:3453b06075c7bb973fdb6de52563f7692ff05cbc64c0bb45f4fd6e8709131f2f", size = 28126516, upload-time = "2026-06-07T05:52:01.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/87/8036b5c781bc3639ea04ef42d4e26da253bd4bd4311d8705b6a1c8824047/av-17.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ad7b4aa011093324b7118245f50ac6db244cfe9900d4072508a5245a2b0d3f41", size = 22460847, upload-time = "2026-06-07T05:52:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/dfdf6fc7b17814b50d0aa9e7a7e37b87be91be3890f44b0d525433cd1fd1/av-17.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:43ebbe977f19a7f2d2bd1a4e119675a0b15e05852cf7309846b6ab922ba7ffe9", size = 18159115, upload-time = "2026-06-07T05:52:06.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/13/64f6c466471cea225b8b2f4cdc51a571f8a286984b55a08d169b932fda5d/av-17.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a20658ec7d96a70e14b1196eff00b7cdd8831ac3b99868e16b8ba8b24090847", size = 33224427, upload-time = "2026-06-07T05:52:09.165Z" },
+    { url = "https://files.pythonhosted.org/packages/77/43/96b35170bf2e64e00a41748c6400ff73232dc0fc62ded283679fb07c7fe0/av-17.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f9a65d1f48b818323fb411e80358f89d77dec340b01d27c6b2dfbb9cbf4b779f", size = 35370183, upload-time = "2026-06-07T05:52:11.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b3/8e8b4b6498731bfbd88e8399a756543f8088f1bd33d08eab678b5aebe728/av-17.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:58f7593726437cda5bd19793027e027768450b5c4a594777bf487798a33db702", size = 24459265, upload-time = "2026-06-07T05:52:14.66Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ac/ceb84b7553db21f1143d817245c560d9267168e1e58b1a8eeae2b62c4d04/av-17.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bbab058bd965309f39962e53caac8126987c68c0be094fc4f9427e5615b0218f", size = 34283709, upload-time = "2026-06-07T05:52:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f9/4115fd84148c9a1cf365096694be6ac882fd3cd3cdb7a2f35e71fecf1631/av-17.1.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9514cfda85180554c430695282faf4be3ffdf95775d8519733821244eecb58e0", size = 25397573, upload-time = "2026-06-07T05:52:20.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ac/92e52d5ed0e0b84d9d93e52b4338c2713d8a44082b8696e6516fdae7c4e4/av-17.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e1c90f85cd7431ede95b11e8e711571a896ebea433f298849c2c0f1594c8d86e", size = 36451495, upload-time = "2026-06-07T05:52:22.581Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/53a7cd34adb6a971d7e6d99663e74db286966c9db8afdca17472fdf0f98e/av-17.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:5df5c1172ef1cf65a1529d612f7da7798ce2cf82c1ff7212466b538a6cc7214c", size = 28036393, upload-time = "2026-06-07T05:52:25.657Z" },
+    { url = "https://files.pythonhosted.org/packages/66/47/cd9ae0edf2206351c1251bb94b5ec58728e42c5f6ee16c03c412f3a1bb3e/av-17.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:ee98534242a74da847af78624779ac5a3177dc7c69f956a4da9e6f0fdb37d7f6", size = 21174601, upload-time = "2026-06-07T05:52:28.077Z" },
+]
+
+[[package]]
+name = "av"
+version = "18.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d2/2cde336b375f55c76ca670f0be3978cc048e31e24f3b4d7ce8473150a388/cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be", size = 183779, upload-time = "2026-08-03T21:19:15.602Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1a/4b2f7c92293ba05cbd4a9a1b28faaf0326272d9488e6354657571c48a7aa/cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b", size = 184178, upload-time = "2026-08-03T21:19:16.67Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0b/ba385d8ccedf926c3cd06e8e2f327027da5afe5f0eb30f1f7bc43ac55125/cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004", size = 211037, upload-time = "2026-08-03T21:19:17.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b9/0f2e58b2cefa33255bff36935d42b13180fe559bba82596540eb404bde7d/cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9", size = 218652, upload-time = "2026-08-03T21:19:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/37/15/180e0dab27b9312c7479003d14c9e547634b7dcb934e2cc4650e1b131a7a/cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98", size = 205422, upload-time = "2026-08-03T21:19:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/03026f0c850cbbaa9030750490225b4a7f4d524ea4df72c3cc740a90f4ef/cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9", size = 205444, upload-time = "2026-08-03T21:19:21.246Z" },
+    { url = "https://files.pythonhosted.org/packages/75/77/60bebf6f818bec84210ac5b6979ce4eeadce6fbbaabc9c7ab23e506d1ce5/cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6", size = 218742, upload-time = "2026-08-03T21:19:22.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/679bf47e73fd77b352171727f07de559a003f14de5d02b904a6ec1fa73ca/cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf", size = 221054, upload-time = "2026-08-03T21:19:23.694Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/eefc0e06913b70aa153bf74c946094a18f58fd4aff11b7f372bfdfdca050/cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659", size = 213489, upload-time = "2026-08-03T21:19:24.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/13/4e56852824a03cdf68523a35686f1c28eacd4bd30a7b0a78e682e6e6e1d3/cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9", size = 220241, upload-time = "2026-08-03T21:19:26.214Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7f/040f9e163e4acac3ee3d85b02d00b2576e7ca980d8785f0a3a5f1a9bf7f5/cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41", size = 174578, upload-time = "2026-08-03T21:19:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0b/644a2ec1a4eaba49c2939410bb1eb1d25b09d6d0582f5d2f95c537043725/cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1", size = 185082, upload-time = "2026-08-03T21:19:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
 ]
 
 [[package]]
@@ -202,6 +336,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "coacd"
+version = "1.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/94/622a380a5c4cac78c1f19379b1d3fa193903f848311c200924309797abf8/coacd-1.0.14-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4cd9e1f327af766f6364e79e384ebfe152780a3d8dbbd09ce0756ec14f9e1256", size = 3426003, upload-time = "2026-08-28T21:53:32.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3e/e930a366ec69a966f1a55307b52d036d266314e2f6c58e72e212fdc09182/coacd-1.0.14-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1242941fc9d49ebcb0368c68f31c86e278b9a6f1a255d11da2f1668797e2626e", size = 2584591, upload-time = "2026-08-28T21:53:33.537Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/ec7edfc77c48fe97434ae813eca7614103289105bb546952ed9a0a266ce8/coacd-1.0.14-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c135b717af096523bbebf1fd8d326e8950c024237fe9806ad46dedd8b4c31f0", size = 2651838, upload-time = "2026-08-28T21:53:34.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/28/edbc4d6766fb3504bf15dabe7340e5686c72b9e3be030b3c8c40469e7af6/coacd-1.0.14-cp39-abi3-win_amd64.whl", hash = "sha256:6b548f44d9a4694cde594dc8cc8fefa678fb7c88153583be4e8b2c707de8fbbd", size = 1487726, upload-time = "2026-08-28T21:53:36.6Z" },
 ]
 
 [[package]]
@@ -490,12 +639,77 @@ wheels = [
 ]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "dracopy"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/1c/5cb492dfa367ba85ac124e7f5d3e685ce32e4ff6d1358cf3266b46fd26b3/dracopy-2.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e3704682b9f013b820d598b451a1b5917bc09f4fb439597f351ef9576a595148", size = 2753432, upload-time = "2025-11-11T16:10:16.464Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3a/812cee5204bee8b9a8063de0c5ddc0cb86d17dede230cdfb2ac59551631b/dracopy-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c171d213f8c810747e4be1b191f537fb2319dadaf1c1874feee29b185274a6c2", size = 2583081, upload-time = "2025-11-11T16:47:18.159Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d0/62d18a620691a274018bf1ca23e4f887bccac34c315934a6b0fe8b1eea66/dracopy-2.0.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50816fe2c5bb253584a4f1556ccd6cfb9885db30a6bdbfed2e09f22dcaf5a28b", size = 4922707, upload-time = "2026-02-23T23:04:56.503Z" },
+    { url = "https://files.pythonhosted.org/packages/73/fd/26c6a1ecf4e0fcc7b30e0f1ba183151cfbf1bbf643beed18a3e738ddf393/dracopy-2.0.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf63039f1abb5bc1e4d1b380985b277994b0e00afe9169276ebce7b4802c7456", size = 5074752, upload-time = "2025-11-11T16:13:06.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c9/85aa8e3b302b6c4c88cece4a75e002a4e5a99211bb3a9999797bd928074f/dracopy-2.0.0-cp310-cp310-win32.whl", hash = "sha256:9fb438db1ea9f4ce1af19c4a8643b3f7c43b12498ed7929ed41b6aba308ae1ec", size = 4282964, upload-time = "2025-11-11T16:13:08.946Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/b28ff30aff5dabba9cfa489db83cf45451d3736ad26ada26fc726f0fb59a/dracopy-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:4a0136a40e3fc3a0ca3cdc25b5f6277f9536b4f4bb10cd45aaa0baa4baae655a", size = 5059040, upload-time = "2025-11-11T16:13:07.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/98/79ab63a4e4b4114e7dde47e52c12718952c0d5e06c6e2e63020902378f95/dracopy-2.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c41311512caee19e6c4ea1eded3895cfa557984a878aa3e4a96b8cf44e769325", size = 2752855, upload-time = "2025-11-11T16:13:10.436Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/29/cf35fcc673f8fd2cb094cf8f1368894818eaa80ead18b9fc1e526c8bee43/dracopy-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e16575abfe1ba2d21c55641b425e6238ee87637256fe573021b4ba8fa450028f", size = 2582155, upload-time = "2025-11-11T16:47:20.261Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/d24295229fd2ba12d3b08cc332d175d929fedca625a517a4f6e598429705/dracopy-2.0.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:418964da7c21f6c3583a3c3113da8afe25efeb77dd80de441ab4efe4f7960d62", size = 4962806, upload-time = "2026-02-23T23:04:58.839Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b7/e67c59d8a2e4f9362c5c07353818c85125821c0f32ab97f2536a7a1f5e98/dracopy-2.0.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fa9a32159669f4291c5e37775b26beb36fac2164afce64d883d6a8f96a32e88e", size = 5116896, upload-time = "2025-11-11T16:14:17.424Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f7/d9c60758b80e31614b162f65b3968001fa953b252af33ba2a3d8c79cb09a/dracopy-2.0.0-cp311-cp311-win32.whl", hash = "sha256:33ddaf26e26485aa0f951df3283d8a4dd94e5c9dc5da727c5db4a44f596b9a38", size = 4282085, upload-time = "2025-11-11T16:14:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3f/baac5aa88aab4117f9f74b892366bb336c9d682588cda11e71b7abc0a930/dracopy-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:106c968fd20fd0d46eab5d3c624db55f5b1dade504c9ae31879459e350d7cf44", size = 5059285, upload-time = "2025-11-11T16:14:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/be/7fccb6eadf9a18118fc125929b078e083e35e97aa3c10b8df677c5d93862/dracopy-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:00ed24e138bcfbf2605d495c3a4e6c17b71cbd0b63b78e945d9d3c89d4fb9d69", size = 2749370, upload-time = "2025-11-11T16:14:24.499Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/59/6c2c83cb8a0f56f61ca297241abb51f4157a0eebebfc24f213e707996857/dracopy-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:218626fc0ec0326ca65dbc47035926a15175d9044d71bcde475e25433eea0056", size = 2579812, upload-time = "2025-11-11T16:47:22.093Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f9/f8d0e9283e17854e2e265a5249b2cc1ba16d89547dd5414f08ae8ecf0ccd/dracopy-2.0.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7787814cf6e7a70814c78228a84f22accbfc5662053260a5756d7eabb87ad23", size = 4938162, upload-time = "2026-02-23T23:05:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/28dff0bc2f992df437aaeeaeffba8f2f1ec031f054cedfc0390ea4300370/dracopy-2.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d6ea2821545b5fa1cfb1ca2911ea6425a2606932cf4fac2f9b1f2d4ccb6e52d", size = 5096811, upload-time = "2025-11-11T16:14:26.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/69af07d283aa3a7d3bbbf4236631742fdbb0a647f605f477161e4203e11c/dracopy-2.0.0-cp312-cp312-win32.whl", hash = "sha256:956c3077342d3b62d28cec10a85e4fa1836caf4641a219f4a536205f8f6e9ad1", size = 4280701, upload-time = "2025-11-11T16:14:29.676Z" },
+    { url = "https://files.pythonhosted.org/packages/35/16/3c9cf0ef315de04ff2a8754685c14e58c04394077d10cf3f3a01ff9afe9e/dracopy-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f1991d0f0575d5096847ef2320d76b2c4a2cf1f88c741cb35dea75d3d682ff4", size = 5058707, upload-time = "2025-11-11T16:14:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b7/41d0831a0055b1be47768dd3e07f3486e4b159ac58763b0dbe70605e68e0/dracopy-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05b5d4054402877f50221bc917e2943214a956d8d746e01b21f57ecc2d0adf21", size = 2748796, upload-time = "2025-11-11T16:14:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dc/321bdc51d6c34d5934873a8625ce1325ac8f7e3e73823540ff2384cf5583/dracopy-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a3e617385b4de48a564ef1ef9cd8dad6fe89f4a1c1897923893dcda51cd992dc", size = 2579323, upload-time = "2025-11-11T16:47:23.465Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ad/fd8a123a65ca53d42446f03edbaf928d96530767082a7393c37cda48668a/dracopy-2.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:802c3904d0454d17284e6bda08c24bf09f47ff7e01bade80c93f67d972a4f410", size = 4934109, upload-time = "2026-02-23T23:05:03.13Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/94/59bdf4654dd9a62520696a91f281464315c3d7331859b8b8f6ccdcd25df9/dracopy-2.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa08c837b1011409a1e5807f42abe339a845b5c93160099ca3dd5f321e9d1e02", size = 5095890, upload-time = "2025-11-11T16:14:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e7/ee246cc789b4bade55d76b71370d4b549e01981452885d3c19fbe4db7516/dracopy-2.0.0-cp313-cp313-win32.whl", hash = "sha256:0ed1b4442c9143956311f2dc70b873eb19577bdddaf44fb7004dcec7739f425a", size = 4280436, upload-time = "2025-11-11T16:14:39.108Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8f/be11f3e6548392bd304f4c929d85be39bde0e058b34936bf22deb2418e58/dracopy-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:c837bf652077f34634af74f5f24015c8c15f1e20b010a12b7804234b7c3c06e0", size = 5058881, upload-time = "2025-11-11T16:14:36.034Z" },
 ]
 
 [[package]]
@@ -613,6 +827,38 @@ wheels = [
 ]
 
 [[package]]
+name = "fast-simplification"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0a/b943887803aefecd01d30cd150bd2a6f03d90b96886e3befdcc5d4276c98/fast_simplification-0.2.0.tar.gz", hash = "sha256:ed02ea6f4968ec98f963f2d3665dbafd0297ec12aea9e4d0a87c4b3c14d608a8", size = 31865, upload-time = "2026-08-12T19:53:50.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9c/81a020d8141980e95b5fb9f24c855dd7aa56fa28769ed13ddf79e47dc278/fast_simplification-0.2.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b3aa6a9d250e9e2b290bccf71e2a95d4fd055e731dfecb901147b0f8f54e1d34", size = 159962, upload-time = "2026-08-12T19:53:17.905Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fa/e6e8ad661d02aee85b6b39c6399e293a08ed20da2cdaad952951d68645d0/fast_simplification-0.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:de6d478662a31304c8687a8b5dfaab5ef3e8860ea770a19b4536b1f94b6d2fe2", size = 153670, upload-time = "2026-08-12T19:53:19.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e7/281150be7cc6e694689fbc13d333249137d5ba49f2a317424a5a2c0dd150/fast_simplification-0.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:706eba06ce2142f9a66b9306f1fd50da90f39eddfe422aa751986ed3662a7afb", size = 282508, upload-time = "2026-08-12T19:53:20.328Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/cd/997dec130d62022c38005dc3908dc06d154661e9416ab16067769392c2d4/fast_simplification-0.2.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:327421879656f3a4cd34b8869a3b2c86cf4dcc6fd100b9d5dee8f57aaeaf80d7", size = 296178, upload-time = "2026-08-12T19:53:21.698Z" },
+    { url = "https://files.pythonhosted.org/packages/39/63/7ad86aee1d918d332c50ae12d33237c1c48b282b8cab847d028e0e79b4cb/fast_simplification-0.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:480deb066c31dc2986fbf11602d4a50d5ca646163f82760194218323ed5d93fc", size = 347844, upload-time = "2026-08-12T19:53:23.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/91/0fe6718df70d6a10a1ba77bd6d0e38292abbec2ac17519ad742fde49796f/fast_simplification-0.2.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:f3631f88f2982c7280c460205fd2ca02ca0514f154f417db6bf36cecb495b4f6", size = 159353, upload-time = "2026-08-12T19:53:24.688Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a1/3108726b166524226ce1fc1d563523c527eef680ac8219ecf68e71808b49/fast_simplification-0.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:67538ec025048553684da3e969ecee24adbfb293834f7109ba668ded0a8ea4fd", size = 153070, upload-time = "2026-08-12T19:53:25.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/24/3b82c7cac016d3c04cb37dc4691454c599ff0e57f5f217b2f87db58b3efd/fast_simplification-0.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad24e10b48348deb6ee8405a79eba72cf41e271acb4921c58ee8cf9730699f15", size = 281729, upload-time = "2026-08-12T19:53:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/51/2f6afc0d0e06f7d12b3a1f4a0f55a101b13725a491b80ab4cf439fee70b0/fast_simplification-0.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2382994836bc760f280f61f9c23ec696052fd8feb59a3c539602e05155e287", size = 295326, upload-time = "2026-08-12T19:53:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d4/a5604279d507b3cb9f06868f2bb49b8d7d8fc9de197c624bc165222a8589/fast_simplification-0.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:c83791c8af1db1156753a3cb723e4eeffc2bf9fc46751894c90338d6fc7f779c", size = 347395, upload-time = "2026-08-12T19:53:29.826Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7c/52ca18d3c8b2b22ec1b70582ba48d4596c5a1fc79a8a22cccdb19bf40249/fast_simplification-0.2.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:5315899a8ee1d6fdf959997e55711a866ed0996ef1be09e905d7917272ba7fc3", size = 155243, upload-time = "2026-08-12T19:53:31.079Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ca/a79667eafa57a93385073549b4ce89c175e44481543709b32c4be504731a/fast_simplification-0.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e394a1cca801a3aa00d54a79206e32f22afe44099fbf9f7b52f2937c19464bf1", size = 148463, upload-time = "2026-08-12T19:53:32.963Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d8/858d63ac701ed90aba0b99941de961f8ee15be254c33dd43382895d28a08/fast_simplification-0.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:15c844cb7d3b6ab0408ff0dc5f31d1264254d0d335a3149e55e9b377ff3615bd", size = 274348, upload-time = "2026-08-12T19:53:34.504Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3e/27802de2a242b6e97716c6f42a708310e1309bba823ea685891d553b6846/fast_simplification-0.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd0d9657902a47c04c9a837257de9cc8020b002e894c5ce26e7b424857af4f76", size = 286806, upload-time = "2026-08-12T19:53:35.763Z" },
+    { url = "https://files.pythonhosted.org/packages/24/94/7f74a1e687e3560163200d071036816712d2d6ab8a083b5f22af84f23012/fast_simplification-0.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:ce22a6f015707eb1d6d431c4896a18eb15c5f3cbaf32533d90371ea1b06875ad", size = 343492, upload-time = "2026-08-12T19:53:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0c/cd5ed17d346b1e37851f38bbef616833fbda2a3578989b924797857402d0/fast_simplification-0.2.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:e88df81992d2594c3122e533d436529e4bb45aafba5b329cd7feb9cb1d853ed8", size = 155247, upload-time = "2026-08-12T19:53:38.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7e/ea960913c749d125c057cb0a2b8a95d02a926364cf9bd54c8f0abadd7d6c/fast_simplification-0.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e82719f90e6649595f593a9d1ab859917e2b14dc203682cf290f91291431f5b9", size = 148471, upload-time = "2026-08-12T19:53:39.312Z" },
+    { url = "https://files.pythonhosted.org/packages/97/39/f40fbae56651f5c73e56e5b8fbed388b06ad789618e9b9cf760053da588f/fast_simplification-0.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f011e846bf875891e3e1028bf34d89c088c74479faa91548e6ff17f0d555fe0", size = 274351, upload-time = "2026-08-12T19:53:40.429Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/af20735fdc8c86d1cf36e419fbe5542c6883827c3e53ea347046abb042ed/fast_simplification-0.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8784fd759a69336f6886429905b3b12de3e40635fed0b6fded66abe2c7d20c4", size = 286813, upload-time = "2026-08-12T19:53:41.597Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/bb/93f22f95086c6a74072420aa6220912f124699a78c682e54e35cf0b7a66b/fast_simplification-0.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:fe735bd246d54cb7818695b0df68ce9abb1f7fabe8edd651559bda86466d8b3f", size = 343483, upload-time = "2026-08-12T19:53:43.051Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -671,12 +917,102 @@ wheels = [
 ]
 
 [[package]]
+name = "freetype-py"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/9c/61ba17f846b922c2d6d101cc886b0e8fb597c109cedfcb39b8c5d2304b54/freetype-py-2.5.1.zip", hash = "sha256:cfe2686a174d0dd3d71a9d8ee9bf6a2c23f5872385cf8ce9f24af83d076e2fbd", size = 851738, upload-time = "2024-08-29T18:32:26.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a8/258dd138ebe60c79cd8cfaa6d021599208a33f0175a5e29b01f60c9ab2c7/freetype_py-2.5.1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:d01ded2557694f06aa0413f3400c0c0b2b5ebcaabeef7aaf3d756be44f51e90b", size = 1747885, upload-time = "2024-08-29T18:32:17.604Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/93/280ad06dc944e40789b0a641492321a2792db82edda485369cbc59d14366/freetype_py-2.5.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d2f6b3d68496797da23204b3b9c4e77e67559c80390fc0dc8b3f454ae1cd819", size = 1051055, upload-time = "2024-08-29T18:32:19.153Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/853cad240ec63e21a37a512ee19c896b655ce1772d803a3dd80fccfe63fe/freetype_py-2.5.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:289b443547e03a4f85302e3ac91376838e0d11636050166662a4f75e3087ed0b", size = 1043856, upload-time = "2024-08-29T18:32:20.565Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6f/fcc1789e42b8c6617c3112196d68e87bfe7d957d80812d3c24d639782dcb/freetype_py-2.5.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:cd3bfdbb7e1a84818cfbc8025fca3096f4f2afcd5d4641184bf0a3a2e6f97bbf", size = 1108180, upload-time = "2024-08-29T18:32:21.871Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/1b/161d3a6244b8a820aef188e4397a750d4a8196316809576d015f26594296/freetype_py-2.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3c1aefc4f0d5b7425f014daccc5fdc7c6f914fb7d6a695cc684f1c09cd8c1660", size = 1106792, upload-time = "2024-08-29T18:32:23.134Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6e/bd7fbfacca077bc6f34f1a1109800a2c41ab50f4704d3a0507ba41009915/freetype_py-2.5.1-py3-none-win_amd64.whl", hash = "sha256:0b7f8e0342779f65ca13ef8bc103938366fecade23e6bb37cb671c2b8ad7f124", size = 814608, upload-time = "2024-08-29T18:32:24.648Z" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/bd/920b1c5ff1df427a5fc3fd4c2f13b0b0e720c3d57fafd80557094c1fefe0/frozendict-2.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bd37c087a538944652363cfd77fb7abe8100cc1f48afea0b88b38bf0f469c3d2", size = 59848, upload-time = "2025-11-11T22:37:10.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/e3e186925b1d84f816d458be4e2ea785bbeba15fd2e9e85c5ae7e7a90421/frozendict-2.4.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2b96f224a5431889f04b2bc99c0e9abe285679464273ead83d7d7f2a15907d35", size = 38164, upload-time = "2025-11-11T22:37:12.622Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/af931d88c51ee2fcbf8c817557dcb975133a188f1b44bfa82caa940beeab/frozendict-2.4.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5c1781f28c4bbb177644b3cb6d5cf7da59be374b02d91cdde68d1d5ef32e046b", size = 38341, upload-time = "2025-11-11T22:37:13.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/c1fd4f736758cf93939cc3b7c8399fe1db0c121881431d41fcdbae344343/frozendict-2.4.7-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8a06f6c3d3b8d487226fdde93f621e04a54faecc5bf5d9b16497b8f9ead0ac3e", size = 112882, upload-time = "2025-11-11T22:37:15.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/304294f7cd099582a98d63e7a9cec34a9905d07f7628b42fc3f9c9a9bc94/frozendict-2.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b809d1c861436a75b2b015dbfd94f6154fa4e7cb0a70e389df1d5f6246b21d1e", size = 120482, upload-time = "2025-11-11T22:37:16.182Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/61/689212ea4124fcbd097c0ac02c2c6a4e345ccc132d9104d054ff6b43ab64/frozendict-2.4.7-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:75eefdf257a84ea73d553eb80d0abbff0af4c9df62529e4600fd3f96ff17eeb3", size = 113527, upload-time = "2025-11-11T22:37:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9b/38a762f4e76903efd4340454cac2820f583929457822111ef6a00ff1a3f4/frozendict-2.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a4d2b27d8156922c9739dd2ff4f3934716e17cfd1cf6fb61aa17af7d378555e9", size = 130068, upload-time = "2025-11-11T22:37:18.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/41/9751e9ec1a2e810e8f961aea4f8958953157478daff6b868277ab7c5ef8c/frozendict-2.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ebd953c41408acfb8041ff9e6c3519c09988fb7e007df7ab6b56e229029d788", size = 126184, upload-time = "2025-11-11T22:37:19.789Z" },
+    { url = "https://files.pythonhosted.org/packages/71/be/b179b5f200cb0f52debeccc63b786cabcc408c4542f47c4245f978ad36e3/frozendict-2.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c64d34b802912ee6d107936e970b90750385a1fdfd38d310098b2918ba4cbf2", size = 120168, upload-time = "2025-11-11T22:37:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c2/1536bc363dbce414e6b632f496aa8219c0db459a99eeafa02eba380e4cfa/frozendict-2.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:294a7d7d51dd979021a8691b46aedf9bd4a594ce3ed33a4bdf0a712d6929d712", size = 114997, upload-time = "2025-11-11T22:37:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/29/63/3e9efb490c00a0bf3c7bbf72fc73c90c4a6ebe30595e0fc44f59182b2ae7/frozendict-2.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f65d1b90e9ddc791ea82ef91a9ae0ab27ef6c0cfa88fadfa0e5ca5a22f8fa22f", size = 117292, upload-time = "2025-11-11T22:37:22.978Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/66/d25b1e94f9b0e64025d5cadc77b9b857737ebffd8963ee91de7c5a06415a/frozendict-2.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:82d5272d08451bcef6fb6235a0a04cf1816b6b6815cec76be5ace1de17e0c1a4", size = 110656, upload-time = "2025-11-11T22:38:37.652Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5d/0e7e3294e18bf41d38dbc9ee82539be607c8d26e763ae12d9e41f03f2dae/frozendict-2.4.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5943c3f683d3f32036f6ca975e920e383d85add1857eee547742de9c1f283716", size = 113225, upload-time = "2025-11-11T22:38:38.631Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fb/b72c9b261ac7a7803528aa63bba776face8ad8d39cc4ca4825ddaa7777a9/frozendict-2.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:88c6bea948da03087035bb9ca9625305d70e084aa33f11e17048cb7dda4ca293", size = 126713, upload-time = "2025-11-11T22:38:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d9/e13af40bd9ef27b5c9ba10b0e31b03acac9468236b878dab030c75102a47/frozendict-2.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ffd1a9f9babec9119712e76a39397d8aa0d72ef8c4ccad917c6175d7e7f81b74", size = 114166, upload-time = "2025-11-11T22:38:41.073Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2b/435583b11f5332cd3eb479d0a67a87bc9247c8b094169b07bd8f0777fc48/frozendict-2.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0ff6f57854cc8aa8b30947ec005f9246d96e795a78b21441614e85d39b708822", size = 121542, upload-time = "2025-11-11T22:38:42.199Z" },
+    { url = "https://files.pythonhosted.org/packages/38/25/097f3c0dc916d7c76f782cb65544e683ff3940a0ed997fc32efdb0989c45/frozendict-2.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d774df483c12d6cba896eb9a1337bbc5ad3f564eb18cfaaee3e95fb4402f2a86", size = 118610, upload-time = "2025-11-11T22:38:43.339Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d1/6964158524484d7f3410386ff27cbc8f33ef06f8d9ee0e188348efb9a139/frozendict-2.4.7-cp310-cp310-win32.whl", hash = "sha256:a10d38fa300f6bef230fae1fdb4bc98706b78c8a3a2f3140fde748469ef3cfe8", size = 34547, upload-time = "2025-11-11T22:38:44.327Z" },
+    { url = "https://files.pythonhosted.org/packages/94/27/c22d614332c61ace4406542787edafaf7df533c6f02d1de8979d35492587/frozendict-2.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:dd518f300e5eb6a8827bee380f2e1a31c01dc0af069b13abdecd4e5769bd8a97", size = 37693, upload-time = "2025-11-11T22:38:45.571Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d8/9d6604357b1816586612e0e89bab6d8a9c029e95e199862dc99ce8ae2ed5/frozendict-2.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:3842cfc2d69df5b9978f2e881b7678a282dbdd6846b11b5159f910bc633cbe4f", size = 35563, upload-time = "2025-11-11T22:38:46.642Z" },
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "genesis-world"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "coacd" },
+    { name = "dracopy" },
+    { name = "fast-simplification" },
+    { name = "freetype-py" },
+    { name = "frozendict" },
+    { name = "gs-madrona", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "libigl" },
+    { name = "moviepy" },
+    { name = "mujoco" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opencv-python" },
+    { name = "openexr" },
+    { name = "pillow" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pycollada" },
+    { name = "pydantic" },
+    { name = "pygel3d", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pygel3d", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyglet" },
+    { name = "pygltflib" },
+    { name = "pymeshlab" },
+    { name = "pyopengl" },
+    { name = "pysplashsurf" },
+    { name = "quadrants" },
+    { name = "rtree" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tetgen" },
+    { name = "trimesh" },
+    { name = "vtk" },
+    { name = "xacro" },
+    { name = "z3-solver" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/63/e4c6e7af1083fda1adecacfff22ebf5533283e6c2730f426210aab05c1a3/genesis_world-1.3.3-py3-none-any.whl", hash = "sha256:74fcece3f080d2de86a25da9c26c979c192ed4a115d556133e8103169f74b3bf", size = 83453245, upload-time = "2026-08-13T13:54:46.247Z" },
 ]
 
 [[package]]
@@ -784,6 +1120,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
     { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
     { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+]
+
+[[package]]
+name = "gs-madrona"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9d/f832d93ee28ff2a492ad1543c7109521d7c8133faefd86ccf645dc300c8c/gs_madrona-0.0.10-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c6c9c6687f56f7ddea4b280d35ff0a9c20abba9e980b9eea7829553cea2d8f7", size = 37601622, upload-time = "2026-07-23T15:58:17.69Z" },
+    { url = "https://files.pythonhosted.org/packages/11/41/e274436f95c5b62132c9bfead0f6c9499990c30bebe7c101d3760f757a14/gs_madrona-0.0.10-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c8ca61166ff4cfe4af460d1ae169f0f3fba71a7d5f425054d58080bc7c3f886", size = 37601343, upload-time = "2026-07-23T15:58:21.973Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b8daad98c6f859aefd38f0ac85fb778b8ecacf84d976b4de64198c953f7f/gs_madrona-0.0.10-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a183a99d980ab3fff676c9d71ba61c2255b96ed301f579c40b7504e6c1c973b", size = 37599063, upload-time = "2026-07-23T15:58:26.103Z" },
 ]
 
 [[package]]
@@ -1239,6 +1589,47 @@ wheels = [
 ]
 
 [[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "libigl"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/26/27a679e6ed3926333a8128b7535da189567885a2852ab1a28e794d3305a0/libigl-2.6.1.tar.gz", hash = "sha256:2d2694ac28b4b6f0f9d00ee6135d3db914bd1233f393c316293289da462eb996", size = 41212074, upload-time = "2025-05-15T20:10:33.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/af/1c68fcfd4a66cbfb29a307327a219203066522010353f924ae3036f108b2/libigl-2.6.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:9b3c4920b065c984ba0b803924d43e4009ecdd756ec9f2f0d43ad8113a2f85aa", size = 12300699, upload-time = "2025-05-15T19:53:19.365Z" },
+    { url = "https://files.pythonhosted.org/packages/27/08/c66609a05876368cfd741cb2a1cb786a79eb2f1ad1b93654edf6092421a2/libigl-2.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d6484317fce9da8451301b24cbb71149e2f93affe2da8515f7391eb198ad9146", size = 11303153, upload-time = "2025-05-15T19:53:46.096Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8f/07d58b038208e19a0d633176ccf05ec7651937644b3c52c2acddce17401f/libigl-2.6.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30d273ae723f3bd74dde961d2ee89b3f52591c0b711ba0911224873daf356bd9", size = 12963496, upload-time = "2025-05-15T19:54:13.741Z" },
+    { url = "https://files.pythonhosted.org/packages/47/27/1af74100201fa299d24a22b137924b9052742eb3bf65df3b894aef2f04ad/libigl-2.6.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:411a79dcab26764e6ab84c33d4d3b24e1e94ed5018dde8f1beb2fb7313003ea4", size = 13387860, upload-time = "2025-05-15T19:54:57.257Z" },
+    { url = "https://files.pythonhosted.org/packages/33/11/1e9b263fd0fa687adb6bb95809955d000c7c322035c17c23cfe6d3899695/libigl-2.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d20ae9c0f3b324787534fc01af72dcb4bb9285da2fcf937c0caf951e742dab7", size = 13519652, upload-time = "2025-05-15T19:56:08.449Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bc/70a1e2d51af72feae4f0933fe90dafbbd9ed9d99cec599de63201d329f03/libigl-2.6.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:fec058d19838e8d2824f5aabe649c05cc123a8480f3ca4643d991632ee1295f7", size = 12300039, upload-time = "2025-05-15T19:53:26.414Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/37b1a945013741b8cafe1b5ece19dd81b1fb910fb9b3d02d69b5b3b367da/libigl-2.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:65bbb69b333491a4200789f4a04e4b562a8455bc5ed96b759de154cf7b226633", size = 11302991, upload-time = "2025-05-15T19:53:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/cf/9d4ab83b1ce21388e562fa40e7a983e0c08d9951536f57c6a9458e94a22a/libigl-2.6.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3020b6bba54d75d5dae7fd4429223fe1969097a5ac5d05440c6130fdadebbc3", size = 12963022, upload-time = "2025-05-15T19:54:20.518Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/41/4efcb97254fd57e572ba7f419108968663a872ca6f1c584b7f012da0d3bd/libigl-2.6.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25697bfbea20957d9b7ae9abff95a560297b33bf92ba255b8a8f1b8990c0fcbb", size = 13387414, upload-time = "2025-05-15T19:55:04.551Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/47a3b80f0d56ffe7436fd13c2aec5f34d9d320756049c9f57e053f8268f0/libigl-2.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:1e3dc3cdbbce5c700a7f804173af42a62ca55e3690d5054edb7b4102a6e22ceb", size = 13519086, upload-time = "2025-05-15T19:56:17.125Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/bc16b51a17ee4ff9e3112a7235b16ed29205fb0b7c08574d68360b64e17a/libigl-2.6.1-cp312-abi3-macosx_10_15_x86_64.whl", hash = "sha256:d6f6df46a8534996cc4b641047e94a5c4107b957612e2b29f0fceb43e3a69c7a", size = 12286509, upload-time = "2025-05-15T19:53:32.714Z" },
+    { url = "https://files.pythonhosted.org/packages/29/6f/dd012c6a8bbe81db49c356f09b221aa684b32c4bb17257a99a43391c58d4/libigl-2.6.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:90e60d769d885d0e64c66ff9cd293c112a0de8ede28840ed1c5bc522680f51ef", size = 11294536, upload-time = "2025-05-15T19:53:58.842Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/592e3e62590a852e9819f3bba86ed7f353495cc4440233dd1ddfad2dd66f/libigl-2.6.1-cp312-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:279db1c84cd957ff29ab1defd794383f68bdb5f49f893a06bf90c68f30a271a7", size = 12943370, upload-time = "2025-05-15T19:54:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/5c/bc7aec8d3a93ce700dd6644c771a22fe6aff00379f7c97073f65a29270e8/libigl-2.6.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fd48f867663df7fd052444c10eb1fa1c303acc86e4016067972b4aab0ae4588", size = 13369663, upload-time = "2025-05-15T19:55:11.72Z" },
+    { url = "https://files.pythonhosted.org/packages/97/8b/77405e7076e218351a14c1561f2a324b499df8dd3711a517e5d082ed1c77/libigl-2.6.1-cp312-abi3-win_amd64.whl", hash = "sha256:9d0516ab8d90b2889e7274b91eb518ec66ec5d7c0bbbbd0be7da0345b682214e", size = 13512802, upload-time = "2025-05-15T19:56:25.704Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1571,6 +1962,18 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "3.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1732,6 +2135,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/b6/3f0f9b85ea90d70f1ac0c82640c6ed59d83d11409723d909ba1c5a95934f/motrixsim_core-0.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0504de2c260380d40ed9393d699034a2cdaf7aff9cf6fe97d55f05b080f4bd0e", size = 54718509, upload-time = "2026-06-08T14:31:33.642Z" },
     { url = "https://files.pythonhosted.org/packages/61/12/d8476ee4da47b5c54ac1625b7645830b9116dbc436a2650a8e727a5aa0d7/motrixsim_core-0.8.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf76189cbf1db814a66694a32653d8f7423ee072122f8f8f57da23243f2f695b", size = 52207612, upload-time = "2026-06-08T14:31:43.047Z" },
     { url = "https://files.pythonhosted.org/packages/c7/3e/f62c0c46cf89da0f174e39fb058ff9e71fa3dcd9ffb42b6d4c3923660700/motrixsim_core-0.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:e91340f961c71d989b34d6717b06a17c3f6a0b8930bc5d47e12a7e485cbd6903", size = 40402629, upload-time = "2026-06-08T14:30:26.842Z" },
+]
+
+[[package]]
+name = "moviepy"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "proglog" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/61/15f9476e270f64c78a834e7459ca045d669f869cec24eed26807b8cd479d/moviepy-2.2.1.tar.gz", hash = "sha256:c80cb56815ece94e5e3e2d361aa40070eeb30a09d23a24c4e684d03e16deacb1", size = 58431438, upload-time = "2025-05-21T19:31:52.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl", hash = "sha256:6b56803fec2ac54b557404126ac1160e65448e03798fa282bd23e8fab3795060", size = 129871, upload-time = "2025-05-21T19:31:50.11Z" },
 ]
 
 [[package]]
@@ -2591,6 +3013,70 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8a/b04776ec45d2dea08a1b176f1829201db3515d4ed16c35f8fcc9fa7beb16/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2b4272e736836f66c2d176e43ab8101f3a00d45654916399f52e150c58981ac", size = 50614064, upload-time = "2026-07-02T06:53:22.604Z" },
+    { url = "https://files.pythonhosted.org/packages/95/54/eb47866b94f2b5b42dde17644b78055ef1ee05aae59962c7290e55270803/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8b6d0a212253dd26ad338c812f1f23ca118fdf05a9c8c6b9444f161aa8c5881", size = 71064711, upload-time = "2026-07-02T06:54:13.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/da/962579f1e703cbf8c5422fd1f576467dcb3b5b0b0b81c1471c979764353a/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:08d5d91d967b58d6db86073b2ad3eaef88ca4ebdfd45c9059bf59f5ded0c7ad2", size = 49798576, upload-time = "2026-07-02T06:54:33.781Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4c/c73f828fdbcd37eaf21d08fa852544a3ca7c2dbb3ea76873d64f2ea413d1/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8de2dec111122a02e8beb28e16c31904992dfd6186560b142a92c71403c1039", size = 73783032, upload-time = "2026-07-02T06:55:03.415Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4b/edaf83b996ca5a1a3d8ccad485706b9c6d4742b13b9c4586bf1c1e7d9423/opencv_python-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:4b4b1a34c79bf8d3738e3cfe9a9e67b51a79663f6b692cbdad8c31f570da4157", size = 35564734, upload-time = "2026-07-02T05:49:57.704Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f0/9fa6e85cb10c8eb36a0222d27e50fe381b86ce49a55446bf39f491727564/opencv_python-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:f90ba04b8f73bc5c3814037699739f0156f597338a98f05956c684e7c3ca10d2", size = 44000345, upload-time = "2026-07-02T05:49:54.971Z" },
+]
+
+[[package]]
+name = "openexr"
+version = "3.4.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a3/8b57f9bef539c195363cf966bbdc02951d3ce5d0a9f612d262f7fe66caad/openexr-3.4.15.tar.gz", hash = "sha256:6c9a28a4f4089379c9c4fd301edaa4dba0ed315862c029f453690a8191370a47", size = 25673422, upload-time = "2026-08-21T23:13:29.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/ee/e33db0f2bf5f427f82803c1fc7c85285a274d63d45b1f1bd4bb01baf5caa/openexr-3.4.15-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:b6cf850f0109c109ddfb8bf1ca36cd28bb4c6ba3dd52c45d3e6790985d607c67", size = 2125996, upload-time = "2026-08-21T23:12:14.428Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/b3bca8d83b6dda0002fe2ff725884dd54183d33c5063478216beda3f3292/openexr-3.4.15-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:c147df2b8c126259c06a087c3108c65f21e3d7021129f92adf4c085868a0a6f6", size = 1129360, upload-time = "2026-08-21T23:12:15.952Z" },
+    { url = "https://files.pythonhosted.org/packages/97/56/94284be7577ffa56ef3b950bea128229d298953cfb914d31d338831c23bd/openexr-3.4.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07eb5575cdf7e371be79df09a90f2b48ba53a06786708b59f3d6e0c1160b30e2", size = 1021440, upload-time = "2026-08-21T23:12:17.325Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4c/607b14ebaf94073fb5256debef6020e1884a16e53d953e8ef2dc6ab09585/openexr-3.4.15-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ba76bbdd2489679a8c7edcdba70f61811516d3843c154efbcdc6d8a185b891fb", size = 1142424, upload-time = "2026-08-21T23:12:19.255Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6d/b7959d6b92a99ad7a9a070ff8710cf1f836b3ccb5d2a96507cab95717bbc/openexr-3.4.15-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:166b3d63b7e4927f6b8f167d0b2141cdeb0825533ebea6a75afe87890b882acf", size = 1292296, upload-time = "2026-08-21T23:12:20.779Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/54/00ed53ce0ae82f61e0cdfd7965e99ec72d5d8379d2587f06825b44cbd26b/openexr-3.4.15-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c10b7bb81c2d6ed38de408db55a755a8bc247d6b6335054a2889417aea791f0d", size = 2142739, upload-time = "2026-08-21T23:12:22.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/26/9aa69ce567fd20c7f116f3bd906e7270844cc85cfac0c138cc55a20b3c19/openexr-3.4.15-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a4735118f2358379172e7f8de022e07808914608ccb2b6baeb7aada62554234e", size = 2327438, upload-time = "2026-08-21T23:12:23.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/59/89db798e8a0c6ab919b0b8bc3dfd7d6677fd8445ee0f4b700666ea164e89/openexr-3.4.15-cp310-cp310-win_amd64.whl", hash = "sha256:9687d761173f03904c58edce9a5617ec558ee2b5219d9af34173479e4771a0bb", size = 737415, upload-time = "2026-08-21T23:12:25.446Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/05b00102a010841be760619aabc3f17d6c17a4d71244637b73f3c96d8265/openexr-3.4.15-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:d8b4531badaf4181194356314bd1a75563c5c7150a01ab52f860c6118bff7702", size = 2129937, upload-time = "2026-08-21T23:12:26.876Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/41/49dccb2f44b8ae3410f385d001aca1dfd3aba04b57593eedb92ce49a2af9/openexr-3.4.15-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9d7d20e181404e7a690b1419ec7627a185b33b005f81b0dded1c813556a91eaa", size = 1130717, upload-time = "2026-08-21T23:12:28.735Z" },
+    { url = "https://files.pythonhosted.org/packages/10/34/e3ddbeda424d92661eea58b8a32ddffd47e6f8399f7e2c838439a674f992/openexr-3.4.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75c410d63c798ecd39e655b337f22d8cad6c672a55306ad90d1cb3a6eee5770a", size = 1022443, upload-time = "2026-08-21T23:12:30.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a4/b3b5a22bfbfad5070e3d4b9792d00d8e7d9217cc24205178661f1f3d413c/openexr-3.4.15-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:46620934e930e00d2dc0d021a3de8dafbea77c3ddaa5d843b79ce2eed07586f2", size = 1143622, upload-time = "2026-08-21T23:12:31.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/b380252d53b6df38b6add8a398bb13c0197878a4e464afaec5a98c9e8561/openexr-3.4.15-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:aede05497f27725abfddf337ef31a1cf6f35c24870510015dda01be7090a429e", size = 1295074, upload-time = "2026-08-21T23:12:33.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6f/353641e12771fc90035d1ce26ec48634247a800ab6a681408f48839db768/openexr-3.4.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dd34fee73b3b25a62115480e26b169d162ed4bd7528a270b9c4d85ea09db6d80", size = 2144003, upload-time = "2026-08-21T23:12:34.908Z" },
+    { url = "https://files.pythonhosted.org/packages/99/76/64446df133dcbfb1220ceabbf7f5dc4d111f5d595ea39ef0b440d8000942/openexr-3.4.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2f29f3677c03d94ff8232941a6003cbb1dce369a6f8beddb31e80215da5c047a", size = 2328320, upload-time = "2026-08-21T23:12:36.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/49/77d06f72c30bda01c4f21eb4f4fc29488176a8b761dbdfcda9d633862c21/openexr-3.4.15-cp311-cp311-win_amd64.whl", hash = "sha256:4e81df1279186913c6726e9ab4895023176130eb62f44ec60d16af18a64919e5", size = 739192, upload-time = "2026-08-21T23:12:37.974Z" },
+    { url = "https://files.pythonhosted.org/packages/84/19/989052e5e870126ebc71470d82927c7cd22ac70f33018b2b63ecf8876177/openexr-3.4.15-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:7520164c6906535c37bd938c9744d4d341c1e6af794d0d15d9517e4318702cda", size = 2132484, upload-time = "2026-08-21T23:12:39.574Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/376a26457856e83a3e35b251187f8c672d5dda61baba24cb76f4089f904b/openexr-3.4.15-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:78570daa1bd3d230f423b9463eb89f1d772f043c6299a48b79d007def7356c92", size = 1133771, upload-time = "2026-08-21T23:12:41.114Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c4/7236691cd3cd86f60bbd257b455e53b85fc1c9e0dfeafb0f9b46ad6e81b8/openexr-3.4.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eb305b2d3a074a259bcf397f56799ed0947ffcafc0ea8f7666a01fbed4a01daa", size = 1022671, upload-time = "2026-08-21T23:12:42.533Z" },
+    { url = "https://files.pythonhosted.org/packages/90/24/df4a8bd023d84eff96bb46194b453f24f455ac5c3f9a40832f67c2d59a33/openexr-3.4.15-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:344b89740b45fe6390c4cb980036831ea33f4d85333bdfb1cfd7b67656c68afb", size = 1144630, upload-time = "2026-08-21T23:12:43.951Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/7d9aacd9884d7f5a2906c34b4c7d4480bff436049e3a234001829a49f5f9/openexr-3.4.15-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5f81c38ec733259da31e257d964de5cfb4b4ef0b9aa1e7037b71fae709abe710", size = 1299460, upload-time = "2026-08-21T23:12:45.35Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/3dab158cc185d27fc68adb73ae71d081f8ff3630a9d193b56af16be0fb32/openexr-3.4.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0cd4a4dbcd76e8a09021d2d01d9add7fba71a637d2eb6fdbbb2f321f2e87e71c", size = 2146211, upload-time = "2026-08-21T23:12:46.847Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/23/5e07709cd60a207e3f38fccfd62aaca64b92492276a462ad7e261536ba04/openexr-3.4.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b88f81bd7e3ae6f8d00316d5ad1bf59a9069ed8f49a25ca08ff0cd388007d7e4", size = 2331665, upload-time = "2026-08-21T23:12:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/1f0d0acc9fbd344d274253dc26876583f74cd619438e914c210faa1c5091/openexr-3.4.15-cp312-cp312-win_amd64.whl", hash = "sha256:7aa145813acfe10a83d6e89340349379828190b321608e69f2aee426e10c890b", size = 740197, upload-time = "2026-08-21T23:12:49.967Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8a/89c957c9502e54140e03973f45949a70ae051b33ddc08cbe8722500fd2ce/openexr-3.4.15-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:1e9155653be0708298cf3685949f27c9680ce7098e95d9d8c65667415dbc2def", size = 2132460, upload-time = "2026-08-21T23:12:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0f/5fb250def71f574a4e7f08182f9166c77ba9385760aae565565008acb495/openexr-3.4.15-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:a8ec48bac5f88dcb5f34739dfc41bc4cc81aa5f83042cb6bbd7072af5b27042e", size = 1133721, upload-time = "2026-08-21T23:12:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/40/32f0412f57f488a6c2b62283128e790fb09ec48f6add11a7eb1794256814/openexr-3.4.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac03f3cb7e274ad792b2f66df100f5605e9d586e6b3db0a2722e7c53a15acc42", size = 1022695, upload-time = "2026-08-21T23:12:54.645Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/f66f823c694485ba0c2e79e08fd3c6ef30dc10698d59b5fb430ffad6a943/openexr-3.4.15-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d5d62c37d0f6c1986d3a5b370b57c37acbc44f3b40806f1043465be0e2270e22", size = 1144474, upload-time = "2026-08-21T23:12:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a4/decca134d677c4b4eaacf164f75ca85a33798dc157ece52a5b58be39a7b8/openexr-3.4.15-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cf30abe5281418b1f038c853dcf8b3106ece69178033ea4846bb95845fd41b9c", size = 1299217, upload-time = "2026-08-21T23:12:57.429Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/aa24f8803c0418659e963a8599cfc87371ab45a8359922da53f21ce23e27/openexr-3.4.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:34ac1c0d7cf288a9f96252170d981b8b79470b1e5a0172b1adece28b2e99e856", size = 2146265, upload-time = "2026-08-21T23:12:58.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/6830eb7bce2a756baef1be794de1344bd5495a18170676b8b7eaad028759/openexr-3.4.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d5490f35abffb66709b9b5921a7bbc65e122bcb07524451db1de2ccf9598b2bb", size = 2331220, upload-time = "2026-08-21T23:13:00.715Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/b336624f2049bbd2ebd8b2bbb51626103da98625a117660b07d788571080/openexr-3.4.15-cp313-cp313-win_amd64.whl", hash = "sha256:8486797567c3e41ea1ec78b64f6833fcb3e04404abe7e9adee4ef3f8e7582842", size = 740189, upload-time = "2026-08-21T23:13:02.348Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2697,75 +3183,82 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
-    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
-    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
-    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
-    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
-    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554, upload-time = "2025-07-01T09:13:39.342Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548, upload-time = "2025-07-01T09:13:41.835Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742, upload-time = "2025-07-03T13:09:47.439Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087, upload-time = "2025-07-03T13:09:51.796Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350, upload-time = "2025-07-01T09:13:43.865Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840, upload-time = "2025-07-01T09:13:46.161Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005, upload-time = "2025-07-01T09:13:47.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372, upload-time = "2025-07-01T09:13:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090, upload-time = "2025-07-01T09:13:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988, upload-time = "2025-07-01T09:13:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899, upload-time = "2025-07-01T09:13:57.497Z" },
+    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531, upload-time = "2025-07-01T09:13:59.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560, upload-time = "2025-07-01T09:14:01.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978, upload-time = "2025-07-03T13:09:55.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168, upload-time = "2025-07-03T13:10:00.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053, upload-time = "2025-07-01T09:14:04.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273, upload-time = "2025-07-01T09:14:06.235Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043, upload-time = "2025-07-01T09:14:07.978Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516, upload-time = "2025-07-01T09:14:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768, upload-time = "2025-07-01T09:14:11.921Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055, upload-time = "2025-07-01T09:14:13.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079, upload-time = "2025-07-01T09:14:15.268Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
+    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
+    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556, upload-time = "2025-07-01T09:16:09.961Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625, upload-time = "2025-07-01T09:16:11.913Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207, upload-time = "2025-07-03T13:11:10.201Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939, upload-time = "2025-07-03T13:11:15.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166, upload-time = "2025-07-01T09:16:13.74Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482, upload-time = "2025-07-01T09:16:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596, upload-time = "2025-07-01T09:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566, upload-time = "2025-07-01T09:16:19.801Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618, upload-time = "2025-07-01T09:16:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248, upload-time = "2025-07-03T13:11:20.738Z" },
+    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963, upload-time = "2025-07-03T13:11:26.283Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
 ]
 
 [[package]]
@@ -2775,6 +3268,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "5.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4f/428f6d959818d7425a94c190a6b26fbc58035cbef40bf249be0b62a9aedd/plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae", size = 9479398, upload-time = "2024-09-12T15:36:31.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ae/580600f441f6fc05218bd6c9d5794f4aef072a7d9093b291f1c50a9db8bc/plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089", size = 19054220, upload-time = "2024-09-12T15:36:24.08Z" },
 ]
 
 [[package]]
@@ -2796,6 +3302,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl", hash = "sha256:b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a", size = 37357, upload-time = "2026-06-22T16:07:48.595Z" },
+]
+
+[[package]]
+name = "proglog"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/af/c108866c452eda1132f3d6b3cb6be2ae8430c97e9309f38ca9dbd430af37/proglog-0.1.12.tar.gz", hash = "sha256:361ee074721c277b89b75c061336cb8c5f287c92b043efa562ccf7866cda931c", size = 8794, upload-time = "2025-05-09T14:36:18.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl", hash = "sha256:ccaafce51e80a81c65dc907a460c07ccb8ec1f78dc660cfd8f9ec3a22f01b84c", size = 6337, upload-time = "2025-05-09T14:36:16.798Z" },
 ]
 
 [[package]]
@@ -2826,6 +3344,28 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2841,6 +3381,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -2864,6 +3413,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/8d/52a5364a17eb96129962cae8d3ee7658775e085ad0ba38388684ad5944e9/pycollada-0.9.3.tar.gz", hash = "sha256:c34d6dcf0fe2eba5896f71c96d37a1c0fe1a61f08440fa0cfcec3dc2895d3302", size = 110826, upload-time = "2026-01-24T15:45:23.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl", hash = "sha256:636e6496f60987586db82455ea7bbd9ade775e8181c6590c83b698b6cd53a9f5", size = 129206, upload-time = "2026-01-24T15:45:22.182Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -2972,12 +3530,120 @@ wheels = [
 ]
 
 [[package]]
+name = "pygel3d"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "plotly" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/fb/eee3d9698b38c7005a500205f2559bf1f2983ecc232cb7ad2f7cc518ed4e/PyGEL3D-0.6.1-py3-none-any.whl", hash = "sha256:6403447c1a2d3c592871ad7ec7c30854e299149cd1532b46c78c5f43009d06f2", size = 4095361, upload-time = "2025-02-24T12:16:07.392Z" },
+]
+
+[[package]]
+name = "pygel3d"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "plotly" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/4f/8e58c1f7cef75c2a4572c8db9b7cf29df8a1a4a23bd90c738935e183003a/pygel3d-0.8.0.tar.gz", hash = "sha256:cdd5407c71259226a618ced64b21fa415ef9eea35d07866dd8454cb4089311c0", size = 859598, upload-time = "2026-08-27T14:59:52.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ba/e4e8dc5f9e754545c1d829a4c248e8f67de0104f8e3b61c2d4c60c5e08cd/pygel3d-0.8.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:b7bbe05e9df2ff9dfc0d333656c5947344592f2866668f2a84e1d76883273479", size = 2204667, upload-time = "2026-08-27T14:59:46.093Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e3/c65ff7ed1b5b0333afb124dc2ca35787a138de7689b919e04247015f51cc/pygel3d-0.8.0-py3-none-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7590220ceb6e1ceb0b53d15ff5e169fe93e8bed62aa910a72bb93a3fb97d6bbf", size = 1555457, upload-time = "2026-08-27T14:59:47.843Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8b/1a6cccf719b893007f277d1b2b0ae4fa3fbf295243eead8e3b83199a4f42/pygel3d-0.8.0-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d3be7b910f39a80bc35ae617b264931a09b531a3ada2e2a3b15bf006b42de0e", size = 1628059, upload-time = "2026-08-27T14:59:49.56Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/51/68173c847160eaf6373b51c24fd413d3abd0e4bfb3b7efdf84db903713ca/pygel3d-0.8.0-py3-none-win_amd64.whl", hash = "sha256:9b729367314f92040d4307017f6aadcb1610e29be523d0859153927daf75536b", size = 676744, upload-time = "2026-08-27T14:59:51.167Z" },
+]
+
+[[package]]
+name = "pyglet"
+version = "2.1.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/af/72a0c4fc95339ec590f441a591143e04acb27b2c94845735809c1630ade6/pyglet-2.1.16.tar.gz", hash = "sha256:ca90ee05532ced8330b8a8087ac2a7b69589b7fa7fb67f85aabe24aaf4ae42c0", size = 6598246, upload-time = "2026-08-01T01:32:35.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/93/b81e304f8954876fed84c5afffe83d2c1c0ceed064d5003b87fbfe9f9076/pyglet-2.1.16-py3-none-any.whl", hash = "sha256:27f9cabf97a64b15d335cf70d9e8979bbab5f84a9900a058206bcd3a2de341ae", size = 1037857, upload-time = "2026-08-01T01:32:30.566Z" },
+]
+
+[[package]]
+name = "pygltflib"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataclasses-json" },
+    { name = "deprecated" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/dd/9464582d08b31223243980bde241566a83991fee60e6870984067a7f09e5/pygltflib-1.16.0.tar.gz", hash = "sha256:ba27c5940f5ef44caec0de1c3c9ee9e1de9bd59920a46e0e5382aa20e86d4fb9", size = 41419, upload-time = "2023-08-08T04:25:01.485Z" }
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymeshlab"
+version = "2025.7.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/7e/d44a74e360163ffc37f380c1be421c1594bd67e4ef9a4805691fdb662449/pymeshlab-2025.7.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5692a0a50cca49178ad9a3ceb02f60f200c7572b72f89964c7dbf915ef9e65a", size = 64994803, upload-time = "2026-01-30T08:40:19.586Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b6/34e2e7791298210472af8c70d284b30fe88b5350024ba274d06f1ef363d3/pymeshlab-2025.7.post1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:7a5ce54e8724259b6dd25bdaa35640a94327e6a5451c440ab80e36817a053cc1", size = 54503555, upload-time = "2026-01-30T08:40:23.404Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d3/80ad31b6ce43d2e134a72038b932b59758fe5b4ed7c856d309ae4752061a/pymeshlab-2025.7.post1-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:f366cccb6ad74673a62cbfa77b38021eb67217c2e02bd0616b4d33214a8a6674", size = 64736555, upload-time = "2026-01-30T08:40:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/b0df05e63303dea51fc5026d00d5c4788c7ddbd7136175b1296b494c9161/pymeshlab-2025.7.post1-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:a2559887a1b8d38390d05f69e7519f95bed3a24c75afba1023e2a98e82f546da", size = 105871876, upload-time = "2026-01-30T08:40:30.021Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b5/eb7c2a986084175d2eb7351ea34de08fe9ca78bc9a0164fc7555a8f6bae8/pymeshlab-2025.7.post1-cp310-cp310-win_amd64.whl", hash = "sha256:c3761b15e9bcdff14c78b9dc291164b9752bef9f1e1b3fc5f83f1cdbefcd3c85", size = 55210061, upload-time = "2026-01-30T08:40:33.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c4/0651d56e6af7680e76460f80ce2812e29b1bc5aefba3988423ea43095074/pymeshlab-2025.7.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4d2e9b9ef05b4205bb61b83326287a140ef87220bb0485c1caf42c446f41d37", size = 64996096, upload-time = "2026-01-30T08:40:36.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d1/d6a0a4fc5f4858f3ddbdaf72a28709aa05fc46efb052f1b14d5ab54c6a61/pymeshlab-2025.7.post1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:56628cf8603195f057884ffafd006391a6baca9ef90aa7f7032c50a276c77bfb", size = 54504910, upload-time = "2026-01-30T08:40:39.149Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7b/caba5fba3e0cc57230b5600b4a4965e797d39aa59b3ef87e405f4fb9b5bc/pymeshlab-2025.7.post1-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:244324df41dc168a0adb0818b0585a91d31d10d73b4415d59b15eaaba0eec900", size = 65089098, upload-time = "2026-01-30T08:40:41.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/20/5b18072334280015899fce0a514a8455619421dfb122d37c1fd7166507db/pymeshlab-2025.7.post1-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:c3c1b01f101334b14469ace3b004382cd313b80a128f551a1da77e3053f09c30", size = 106242890, upload-time = "2026-01-30T08:40:46.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/56/c4383522d9603cca76ad0c1c886014bf6ac4e79df96018e13025c669b068/pymeshlab-2025.7.post1-cp311-cp311-win_amd64.whl", hash = "sha256:3c1b87f3d6e6c8b129311b44f5c75a22df23c969b9d4300843286220a0d2a49c", size = 55210937, upload-time = "2026-01-30T08:40:51.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c1/a8db8ba66b5c51e700ba0eccea2c81f68a3223b775b0afe7b30a3da9a2ec/pymeshlab-2025.7.post1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:693101c1ade7aadbad114878626307bf434fe607de873449fbe6b6b95a30cd01", size = 64995577, upload-time = "2026-01-30T08:40:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/0d/6692ef6d96fa27763899665562c11ee6411eba55b2bddcda6799213dadac/pymeshlab-2025.7.post1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:265503a06968420c8eb6934e3db78ff0767518000d8afd46ef3c976a506cfcf7", size = 54506925, upload-time = "2026-01-30T08:40:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/6082aa85f8c918901221d1a7e1e810cb5b56eecbed59a5e688feea92c148/pymeshlab-2025.7.post1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:d39fbaac1274adbbdf75cd999710d2ba48bd4d9087f34815afbdedb99dd3ded6", size = 65341068, upload-time = "2026-01-30T08:41:02.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4c/b0b1b5ad425acd80abcff4632f0241ca490c52ef9c48013d71f573680a2a/pymeshlab-2025.7.post1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:bc453d89b114671affc747991a939b257d2320b71885b31213190c64081f5c35", size = 106530409, upload-time = "2026-01-30T08:41:05.155Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/66b91d2d77fbb2bf729dfe58692957bad3cea706ecb3fe51fca4b07c0c95/pymeshlab-2025.7.post1-cp312-cp312-win_amd64.whl", hash = "sha256:fc04cb2206e8d0194b2c8f61ea6ef54505bbe3d217e7f1960ee9608464f9bfad", size = 55211790, upload-time = "2026-01-30T08:41:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/ef68bf08d23f44118ab846b93dd30eaf87ad85cc44b4f3e5ac8764e9bc9f/pymeshlab-2025.7.post1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:841b1fa15fc76ab73e594f4bbfcbe339782b36be67d9387ff5aa5f4ca422e180", size = 64995970, upload-time = "2026-01-30T08:41:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/27/52/a11aa52eb3b250f78a891b9e4ffcdf4af4da13a462d079cc6cf3d17d34ac/pymeshlab-2025.7.post1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:06c7171f70ff86753535d1c0d952ead34854923061af37197e9cc22dea515e9d", size = 54507011, upload-time = "2026-01-30T08:41:14.507Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4e/31b08dddba8c77676c9cf7ed90810b7dfcbd99cba845bb9b20b7bbaa4d7c/pymeshlab-2025.7.post1-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:2432dffe99e58e1b5e77dbfeb7690502b6d0ebccb1ed75356fca4676ec56c9a2", size = 65242911, upload-time = "2026-01-30T08:41:17.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/af/3f7597d43813e8918bc2798aeed9b3be123a62e8a5be7de032cce03db8ed/pymeshlab-2025.7.post1-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:99bb0f83ad20c61bdc63beb8d7f0c9ed3af6912a4770da170ce8d4bd02a7ecb0", size = 106407568, upload-time = "2026-01-30T08:41:25.759Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/69/1732c3222ce63758c32746841099ac82059907cc3ff6bd77499da78abcbc/pymeshlab-2025.7.post1-cp313-cp313-win_amd64.whl", hash = "sha256:25eb2578dd6c4d1b2e0253fb3b4f8f7895e8bb4f3f1236832db0ab58e6a44998", size = 55211755, upload-time = "2026-01-30T08:41:29.593Z" },
 ]
 
 [[package]]
@@ -3018,6 +3684,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pysplashsurf"
+version = "0.14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/c0/59a4a1a6a99c691f4fc6e254a73b4fa64986fb1ce66d2329fb4263f7c238/pysplashsurf-0.14.1.0.tar.gz", hash = "sha256:8304e3c923a8b5c6b59e9d9091fb868012053d48ae9bddf907354bd70ce063ac", size = 484484, upload-time = "2026-03-21T20:19:02.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/aa/7ce5cad68114741af6fe24ca9eac8ccf2bdb03cac7e5ad4a3c42a26aee4a/pysplashsurf-0.14.1.0-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:02b4611637ed24995fb5431b11a023def834d30decd890f28199da8d0ffce7a9", size = 2615685, upload-time = "2026-03-21T20:18:47.045Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ce/3df4bb87f4d86e3ef00308e7e8703c0204703e141ba0b80cbca2dacca228/pysplashsurf-0.14.1.0-cp310-abi3-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:b90a2bcb36ced23f9ef726affabd75dc374264f5ec0dc44e0dcac683a856d2a1", size = 2902497, upload-time = "2026-03-21T20:18:48.348Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/82/b919bf251d78d1697d46e5a5baa11a4e47b19733b8286520b8edf121880f/pysplashsurf-0.14.1.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e6b98725ded001b20a58e189218ecd5e9b842ecd12b70d1a5468425301afa743", size = 2667841, upload-time = "2026-03-21T20:18:49.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/9afca118186d324d68a30db82ad3a97338a9f2802ffd333c0a0c25a36c76/pysplashsurf-0.14.1.0-cp310-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:758af61529e868be1dd8bfd57cfc8549cfda1a31caec76a0107a879511d04572", size = 2722866, upload-time = "2026-03-21T20:18:51.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f1/3ef801ccbc42d2f6b862511587bfce8b8e974379f711bcdb2fe125288c01/pysplashsurf-0.14.1.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0bf294ed8eecdf499bb7821a5fb1d7cb5c79a7801e73aebadba13e50d073508", size = 2898981, upload-time = "2026-03-21T20:18:52.509Z" },
+    { url = "https://files.pythonhosted.org/packages/02/82/1df59fe9980b34f30dae65296d4af04e5cf17cb4ecb5eb93d25cd516b1f0/pysplashsurf-0.14.1.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79b150436365258ef5c6eb88ba8bb995b481b559e55a681706d1c17077a25b13", size = 2768804, upload-time = "2026-03-21T20:18:53.636Z" },
+    { url = "https://files.pythonhosted.org/packages/40/75/dcaa1d59b01ea9966b3c18d9782bae2ffc3a37cd2b4e2236673ff3830339/pysplashsurf-0.14.1.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ecbe468c93d7fbc3af4a410801a2468b822f8a5406d0ce7289614003d331d64", size = 2818475, upload-time = "2026-03-21T20:18:54.684Z" },
+    { url = "https://files.pythonhosted.org/packages/17/26/e4b5356840220b535fc6585028d1cb805758c26084b114153508fa382c36/pysplashsurf-0.14.1.0-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0efaa134417426b2a5739794c06920e2181f8fb331752068726a7f6c73e0826f", size = 2986990, upload-time = "2026-03-21T20:18:56.048Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/1870e6faadb0eae58c2ac4c03e47ecff954717d5da68de8d43e41b037c66/pysplashsurf-0.14.1.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27a96c2e8350b14715a9c13987ece9747cbfca30736f9d95e27edf61c5978510", size = 2970359, upload-time = "2026-03-21T20:18:57.414Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/50fa4018144c9a14d94075f71c677d5b6c8e7dcc5ce27ab114dbfb2130ab/pysplashsurf-0.14.1.0-cp310-abi3-win32.whl", hash = "sha256:5adcd387f77f80bef2e3fe05e176ba83e950e7ec524f5c3ad4a9d0764de4c80c", size = 2460405, upload-time = "2026-03-21T20:18:58.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0b/dc9b881ae0c970601ad71c04b4e9ac311388c572aca51c596b33ea916c6c/pysplashsurf-0.14.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:d0cb601a46c2df54d7e8a4b31ac840e67bbc123d52dfe3e2bc2506314139f910", size = 2837768, upload-time = "2026-03-21T20:18:59.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/cf/8a6da08522f6f7f0c8d1ddd8282b450f0e83b25ac129ef54873373092bf2/pysplashsurf-0.14.1.0-cp310-abi3-win_arm64.whl", hash = "sha256:060f5f1e91b226ec50fe8271df0e8db2f4351b3db8349b798aa41d74d8873905", size = 2617115, upload-time = "2026-03-21T20:19:00.992Z" },
 ]
 
 [[package]]
@@ -3062,6 +3752,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]
@@ -3117,6 +3816,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
     { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "quadrants"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "colorama" },
+    { name = "dill" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/13/aafc1a02b354086636b8cb2439bf3084acee4a4635e05e1794c0a39dd111/quadrants-1.3.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:28cdc1290eecbb16e956c90fe8de1ecf27a3233eab9875490ad189cebd65add7", size = 26681758, upload-time = "2026-08-12T14:25:38.603Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/98/0dcfc021a83388c56ef35e8e440e62816650895d8713fa0fa1b6fbbdf1e1/quadrants-1.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_34_aarch64.whl", hash = "sha256:5faf4f067c1404febc05fd12bf32b4aa5d7c4a3d2dfa79de3af7bc62446962c4", size = 38293619, upload-time = "2026-08-11T21:08:03.468Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/62/16ef6186468e807db3eb47ed4fd169e603bfa08b374ebb4e3c72b3d4ebc6/quadrants-1.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ab881eeb9173b62787bf54d2949ae07ef745cde43228ad8b2c0037a0b4575e4", size = 40980560, upload-time = "2026-08-11T21:08:01.337Z" },
+    { url = "https://files.pythonhosted.org/packages/10/20/879067189d24e513befdb556b1cca26b9f68d61b2b43a5a6de71ef8da7f8/quadrants-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:247be967a9aedd1979b6499e3161e9486cbdf5bff49f1d5b0aae61081da0d83e", size = 30985427, upload-time = "2026-08-11T19:52:13.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/a537c1360b8185c1c6e62837f25347736ed450f20457691aca7836578934/quadrants-1.3.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:46bed8c9ddfd2a787f68e77e09961752155684f49615315b3aa1f75f97ed2369", size = 26682035, upload-time = "2026-08-12T14:25:46.714Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f6/b59101a6c35dbb420da2d5c5fb76db813c11330772c6055b68307d47e939/quadrants-1.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_34_aarch64.whl", hash = "sha256:b25b16e13e7ab77c2c3ea8e4863dcd8e41efdbc91788a56c11c04f03dbb6c585", size = 38294125, upload-time = "2026-08-11T21:08:01.45Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3a/cb96b77751e7ed8d0dc74e5a83229f29d2bda2bb6799b8e9f06091b61c20/quadrants-1.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:908bb35442b27de346fa17aa7d6458fc782a668dcfb4c6192dec08a7808509bb", size = 40979986, upload-time = "2026-08-11T21:07:56.668Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/27/1ae772c0328ee191040ac99e6c2d27c396f9b85a7cc06dd0aa9c5a965876/quadrants-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bed8fcf39738fe68890d60233287f2cb338f1ca20141c3072c87f8ab14b290a3", size = 30987172, upload-time = "2026-08-11T19:52:08.714Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3c/8bf3d846b0e385b6fcdfb0ef9760a6f99b73e9fc9d5f7052a644add6b7d3/quadrants-1.3.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:83c9f4fa87b1d70ff279e8e1a1e8cf65344880802b792655a7ef49535dd780c2", size = 26681677, upload-time = "2026-08-12T14:25:46.491Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e0/15cdcea47a587db6ccc03e04eb16cf2983ad7bef6557bce4a4de85019284/quadrants-1.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_34_aarch64.whl", hash = "sha256:edfbd97648e3a0d23b4bb592b51352ddcc4cfb186c11535002c171316321fe29", size = 38293972, upload-time = "2026-08-11T21:07:58.482Z" },
+    { url = "https://files.pythonhosted.org/packages/56/48/68405594c33062faa77d349d5f320300c7bca3a7e6b6f332c8f7e22bde9e/quadrants-1.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79b09a7af4df51f4733dec6b755491ef2b8418cbda3ec042130c555f89e8003a", size = 40973824, upload-time = "2026-08-11T21:08:01.92Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d6/d1b72956a40016260d2197fef80ec27a5611bb1d57f3fcf0bde22f3180e4/quadrants-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:c1e5ede6dff01afab65c22b33ce0a651753743dddd1fb99041af0c7059e67e68", size = 30988310, upload-time = "2026-08-11T19:52:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/62/56/822c0b2d8f61b44d272941ad2e137a54cdf3f5ea107bb494f0e5ca511043/quadrants-1.3.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:f078eaa672d7b7793e3d045287b2caa1bc2ed56dbe9dc4577ebf3ce6f721fe8b", size = 26681512, upload-time = "2026-08-12T14:25:43.407Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5f/fd875f16b75e3f021e9fd6f89cbd5a862e2b2b32de275044ffee3fb40544/quadrants-1.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_34_aarch64.whl", hash = "sha256:e84d152b6bcb7ace8604918f157023f1890703d591ba3dda235d52ea71667688", size = 38293514, upload-time = "2026-08-11T21:07:59.306Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dc/ab888de75da5604d8a604822a32be2761d5716195d04e467347681215f53/quadrants-1.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2593e5a1078c511dd33e22225da8ea024023564feac331f17820d71ce577194", size = 40974418, upload-time = "2026-08-11T21:07:57.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2f/f6ab0908b931e347789634b2f65bc5f1fd07137bc847376fb2abe982bacd/quadrants-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:70c2985fa986b908b1e12564f9ed40b3cd45bae8986d0e5bd41d033d7cf48daf", size = 30988240, upload-time = "2026-08-11T19:52:12.915Z" },
 ]
 
 [[package]]
@@ -3316,6 +4048,124 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/cb/016c63f16065c2d333c8ed0337e18a5cdf9bc32d402e4f26b0db362eb0e2/scikit_image-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d3278f586793176599df6a4cf48cb6beadae35c31e58dc01a98023af3dc31c78", size = 13988922, upload-time = "2025-02-18T18:04:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ca/ff4731289cbed63c94a0c9a5b672976603118de78ed21910d9060c82e859/scikit_image-0.25.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:5c311069899ce757d7dbf1d03e32acb38bb06153236ae77fcd820fd62044c063", size = 13192698, upload-time = "2025-02-18T18:04:15.362Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6d/a2aadb1be6d8e149199bb9b540ccde9e9622826e1ab42fe01de4c35ab918/scikit_image-0.25.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be455aa7039a6afa54e84f9e38293733a2622b8c2fb3362b822d459cc5605e99", size = 14153634, upload-time = "2025-02-18T18:04:18.496Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/916e7d9ee4721031b2f625db54b11d8379bd51707afaa3e5a29aecf10bc4/scikit_image-0.25.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4c464b90e978d137330be433df4e76d92ad3c5f46a22f159520ce0fdbea8a09", size = 14767545, upload-time = "2025-02-18T18:04:22.556Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/c53a009e3997dda9d285402f19226fbd17b5b3cb215da391c4ed084a1424/scikit_image-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:60516257c5a2d2f74387c502aa2f15a0ef3498fbeaa749f730ab18f0a40fd054", size = 12812908, upload-time = "2025-02-18T18:04:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/97/3051c68b782ee3f1fb7f8f5bb7d535cf8cb92e8aae18fa9c1cdf7e15150d/scikit_image-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f4bac9196fb80d37567316581c6060763b0f4893d3aca34a9ede3825bc035b17", size = 14003057, upload-time = "2025-02-18T18:04:30.395Z" },
+    { url = "https://files.pythonhosted.org/packages/19/23/257fc696c562639826065514d551b7b9b969520bd902c3a8e2fcff5b9e17/scikit_image-0.25.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d989d64ff92e0c6c0f2018c7495a5b20e2451839299a018e0e5108b2680f71e0", size = 13180335, upload-time = "2025-02-18T18:04:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/14/0c4a02cb27ca8b1e836886b9ec7c9149de03053650e9e2ed0625f248dd92/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2cfc96b27afe9a05bc92f8c6235321d3a66499995675b27415e0d0c76625173", size = 14144783, upload-time = "2025-02-18T18:04:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/9fb556463a34d9842491d72a421942c8baff4281025859c84fcdb5e7e602/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24cc986e1f4187a12aa319f777b36008764e856e5013666a4a83f8df083c2641", size = 14785376, upload-time = "2025-02-18T18:04:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/b57c500ee85885df5f2188f8bb70398481393a69de44a00d6f1d055f103c/scikit_image-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:b4f6b61fc2db6340696afe3db6b26e0356911529f5f6aee8c322aa5157490c9b", size = 12791698, upload-time = "2025-02-18T18:04:42.868Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8c/5df82881284459f6eec796a5ac2a0a304bb3384eec2e73f35cfdfcfbf20c/scikit_image-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8db8dd03663112783221bf01ccfc9512d1cc50ac9b5b0fe8f4023967564719fb", size = 13986000, upload-time = "2025-02-18T18:04:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e6/93bebe1abcdce9513ffec01d8af02528b4c41fb3c1e46336d70b9ed4ef0d/scikit_image-0.25.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:483bd8cc10c3d8a7a37fae36dfa5b21e239bd4ee121d91cad1f81bba10cfb0ed", size = 13235893, upload-time = "2025-02-18T18:04:51.049Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/eda616e33f67129e5979a9eb33c710013caa3aa8a921991e6cc0b22cea33/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d1e80107bcf2bf1291acfc0bf0425dceb8890abe9f38d8e94e23497cbf7ee0d", size = 14178389, upload-time = "2025-02-18T18:04:54.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b5/b75527c0f9532dd8a93e8e7cd8e62e547b9f207d4c11e24f0006e8646b36/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a17e17eb8562660cc0d31bb55643a4da996a81944b82c54805c91b3fe66f4824", size = 15003435, upload-time = "2025-02-18T18:04:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/49beb08ebccda3c21e871b607c1cb2f258c3fa0d2f609fed0a5ba741b92d/scikit_image-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:bdd2b8c1de0849964dbc54037f36b4e9420157e67e45a8709a80d727f52c7da2", size = 12899474, upload-time = "2025-02-18T18:05:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/7c/9814dd1c637f7a0e44342985a76f95a55dd04be60154247679fd96c7169f/scikit_image-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7efa888130f6c548ec0439b1a7ed7295bc10105458a421e9bf739b457730b6da", size = 13921841, upload-time = "2025-02-18T18:05:03.963Z" },
+    { url = "https://files.pythonhosted.org/packages/84/06/66a2e7661d6f526740c309e9717d3bd07b473661d5cdddef4dd978edab25/scikit_image-0.25.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dd8011efe69c3641920614d550f5505f83658fe33581e49bed86feab43a180fc", size = 13196862, upload-time = "2025-02-18T18:05:06.986Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/63/3368902ed79305f74c2ca8c297dfeb4307269cbe6402412668e322837143/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28182a9d3e2ce3c2e251383bdda68f8d88d9fff1a3ebe1eb61206595c9773341", size = 14117785, upload-time = "2025-02-18T18:05:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/c3da56a145f52cd61a68b8465d6a29d9503bc45bc993bb45e84371c97d94/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8abd3c805ce6944b941cfed0406d88faeb19bab3ed3d4b50187af55cf24d147", size = 14977119, upload-time = "2025-02-18T18:05:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/97/5fcf332e1753831abb99a2525180d3fb0d70918d461ebda9873f66dcc12f/scikit_image-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:64785a8acefee460ec49a354706db0b09d1f325674107d7fa3eadb663fb56d6f", size = 12885116, upload-time = "2025-02-18T18:05:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/75e9f17e3670b5ed93c32456fda823333c6279b144cd93e2c03aa06aa472/scikit_image-0.25.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:330d061bd107d12f8d68f1d611ae27b3b813b8cdb0300a71d07b1379178dd4cd", size = 13862801, upload-time = "2025-02-18T18:05:20.783Z" },
+]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/16/8a407688b607f86f81f8c649bf0d68a2a6d67375f18c2d660aba20f5b648/scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0", size = 12355510, upload-time = "2025-12-20T17:10:31.628Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/7efc088ececb6f6868fd4475e16cfafc11f242ce9ab5fc3557d78b5da0d4/scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd", size = 12056334, upload-time = "2025-12-20T17:10:34.559Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/bc7fb91fb5ff65ef42346c8b7ee8b09b04eabf89235ab7dbfdfd96cbd1ea/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953", size = 13297768, upload-time = "2025-12-20T17:10:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/e71c1a7d90e70da67b88ccc609bd6ae54798d5847369b15d3a8052232f9d/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af", size = 13711217, upload-time = "2025-12-20T17:10:40.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/59/9637ee12c23726266b91296791465218973ce1ad3e4c56fc81e4d8e7d6e1/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d", size = 14337782, upload-time = "2025-12-20T17:10:43.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5c/a3e1e0860f9294663f540c117e4bf83d55e5b47c281d475cc06227e88411/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d", size = 14805997, upload-time = "2025-12-20T17:10:45.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c6/2eeacf173da041a9e388975f54e5c49df750757fcfc3ee293cdbbae1ea0a/scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7", size = 11878486, upload-time = "2025-12-20T17:10:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a4/a852c4949b9058d585e762a66bf7e9a2cd3be4795cd940413dfbfbb0ce79/scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581", size = 11346518, upload-time = "2025-12-20T17:10:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3465,11 +4315,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "69.5.1"
+version = "84.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987", size = 2291314, upload-time = "2024-04-13T21:06:28.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32", size = 894566, upload-time = "2024-04-13T21:06:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]
@@ -3587,6 +4437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tensorboard"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3654,6 +4513,99 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/85/4e54d398a53520f624d291f8a498d389fbbdf740d3a6b018d67c50feef55/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b3d465f72ddc8fac2b1f031f873f38d073dcca897d1c8751fa4e95142d848f", size = 462403, upload-time = "2026-01-26T11:36:19.506Z" },
     { url = "https://files.pythonhosted.org/packages/8a/ec/bfc5384cea17fecca6980ee9e6fe5b75e55bab09bfe1975795107d8491ff/tensordict-0.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a0df47c227c81ce6a3d7a7960a0ca2a9ab832a3460e9a4a88a3c5b929903e4", size = 465141, upload-time = "2026-01-26T11:36:20.658Z" },
     { url = "https://files.pythonhosted.org/packages/a7/d8/b84caf450e1cce55f9b3cd64c3f9d56b3d0cd9265ea728500605fd71a971/tensordict-0.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e963e114e8c03d9b2a93b41899af6598a27db1c5fa17c78aeb0cc16ab9e143c5", size = 520028, upload-time = "2026-01-26T11:36:21.904Z" },
+]
+
+[[package]]
+name = "tetgen"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/15/a52fd7c1049ba8e39f7ee7ada132221ac535c6c18e6c07c27be1ef4fdf6b/tetgen-0.8.2.tar.gz", hash = "sha256:06ca8d8b9e21cdbb75334e20ee77e788e88f4b2cdb85c51b008592cb3f9af964", size = 824449, upload-time = "2026-01-27T20:48:55.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/79/4988cc9fa04a5ff26df1e775aec7f9d15b76cb56f5eae5b1d0ded71669aa/tetgen-0.8.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:0588c8d8bffb7c8a5c21a3ab19ea80254e7eea972f2eae12a2b7157849b8f78f", size = 398256, upload-time = "2026-01-27T20:48:33.297Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/21/d2e7d92c39e1f175a87733b52cb149832dcd9e8970b6c31aa4ccf237e865/tetgen-0.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:076b5d70bf4fb2e7fe1de4c49920e6bb31adf0ed80cd6b3062dda84939a2959e", size = 361869, upload-time = "2026-01-27T20:48:34.979Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/55/c2adce61f6c1a77cbe527e8ef1712e79061083ca23f52329ff70eb4455ff/tetgen-0.8.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:274b57547ceaa2367d013ff82277cd41623dc643d9eb208e02a662aa0dcadd68", size = 408264, upload-time = "2026-01-27T20:48:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1e/91f6052a7cd859d4ed8a171309980822d08f1472d0d5af8fdbe0d7de9458/tetgen-0.8.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff949a316329cce22b23f8ddcde570d2e97a648577b954f516d4a332b66c678", size = 412831, upload-time = "2026-01-27T20:48:37.977Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9b/6106ed5c5629db90f50ae1b98d13655ad16f28818c29865dd945c493b43a/tetgen-0.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:fb261a257d94c7126f6491b1172be6e085e67e00f0905ea0daae6e923b2d9825", size = 306270, upload-time = "2026-01-27T20:48:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bc/e4b40f58c2d4febe53734453daa5744384285416b8ff9c30bc90a8421577/tetgen-0.8.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:80dcb5c507780f05226e5447301000ed2007a439b883332d33118f91f8f0a5b2", size = 398000, upload-time = "2026-01-27T20:48:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8f/72ebd16fef04bfac8f180c743ea90c1f7815485c20836dfb1112332644bf/tetgen-0.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3811a4fac3a67606fad270e364de1b3c0952a6ac2b91d318c5622a84b909117e", size = 361789, upload-time = "2026-01-27T20:48:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/78/6dc18a0ae50b263f3db0fa0bb3a40112832c126f1a0924832d5ff5f43da0/tetgen-0.8.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9e1e4651ebb19e840b367147b6efa82b0d1966eb955afc0853a3558b07a8654", size = 408126, upload-time = "2026-01-27T20:48:44.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2b/0d109f288e0a0c9324357f45b390d6872a05c57ce907eb0efee959057a02/tetgen-0.8.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7a9d086944d0922753d51c487268803afe00efc5e99ac294297baa12e3e4ce6", size = 412588, upload-time = "2026-01-27T20:48:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/80/fe8cb19a2770fbaf99c60205a8957a4ddf14e7a3df84fe075b031a9db399/tetgen-0.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8df1537b5506eb39e282794d267eaec807d1bde597fc5e7eab7c848cc0b7129f", size = 306039, upload-time = "2026-01-27T20:48:46.707Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ca/b21f72e1040b57bdf5221695a864e3a1b753f6c419d95bd2c9ee3279b39a/tetgen-0.8.2-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:7b09907f838f597daf8360032e5e891b5cb03b9ead3000f7f8eeaca9d04baf4f", size = 396447, upload-time = "2026-01-27T20:48:47.996Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3d/b2e59078ff5c6344ecd8d41d4b1d9e4f79f0bfb913ebb73409d5752625f3/tetgen-0.8.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:6042ca364d8f14c62f34fe1c41614e252de4f8a4b8563912e38eb6c0f2a1e3ca", size = 359580, upload-time = "2026-01-27T20:48:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d6/3a9f7a968179533806cf67e30ea57feed78a27d612aaeb2e761699337cee/tetgen-0.8.2-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4f12868b5ddc49b6b435de1027a7a6c329f8bd13d053ff1719878de9ec7492e", size = 404710, upload-time = "2026-01-27T20:48:50.902Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cd/7dbbd4ae5bf94648d6f44e14666d6d41513fbe5931cd33c661f178a5363e/tetgen-0.8.2-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b4d8fd5a17eda89a2d04e82c360bb8e333e13802de2863faca4f0facdadf8a9", size = 408157, upload-time = "2026-01-27T20:48:52.677Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f74139e743c69873d334c81def0f0564f1b4a076a27338e553ecb1d2cb63/tetgen-0.8.2-cp312-abi3-win_amd64.whl", hash = "sha256:77fbc95949273b8bd281067a8f016f2bf42132c53919cad1b7f7d624996f22a3", size = 304171, upload-time = "2026-01-27T20:48:53.94Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2025.5.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/06/bd0a6097da704a7a7c34a94cfd771c3ea3c2f405dd214e790d22c93f6be1/tifffile-2025.5.10-py3-none-any.whl", hash = "sha256:e37147123c0542d67bc37ba5cdd67e12ea6fbe6e86c52bee037a9eb6a064e5ad", size = 226533, upload-time = "2025-05-10T19:22:27.279Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.8.23"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 's390x' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/07/90078f49e60718d414d5440dc498301f11ff049458e65cf8d27c62a5c9d1/tifffile-2026.8.23.tar.gz", hash = "sha256:bd3c816f166f85c93329a54a0c9a1eccc9968a6a78f91d63b65d7b17675915f2", size = 446179, upload-time = "2026-08-23T18:45:05.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/38/05347ae8b1b268c068b3ca38822558038f38c6494604837d7ca3cbcceb9c/tifffile-2026.8.23-py3-none-any.whl", hash = "sha256:a03045afce67d97cb4ef56a1cd47eae6ab8115c7e84cfedeb5cadbfbb6d14fbe", size = 273795, upload-time = "2026-08-23T18:45:04.466Z" },
 ]
 
 [[package]]
@@ -3955,6 +4907,19 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
 name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4002,6 +4967,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+genesis = [
+    { name = "genesis-world" },
+]
 mjwarp = [
     { name = "mujoco-warp" },
     { name = "warp-lang" },
@@ -4032,6 +5000,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "etils" },
+    { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
     { name = "gymnasium" },
     { name = "huggingface-hub", specifier = ">=0.25" },
     { name = "hydra-core", specifier = ">=1.3" },
@@ -4053,7 +5022,7 @@ requires-dist = [
     { name = "pybind11", marker = "extra == 'mujoco'", specifier = ">=2.12" },
     { name = "rich" },
     { name = "rsl-rl-lib", specifier = ">=5.0.0" },
-    { name = "setuptools", specifier = "<70" },
+    { name = "setuptools" },
     { name = "tensorboard" },
     { name = "tensordict" },
     { name = "torch", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')", specifier = "==2.8.0" },
@@ -4068,7 +5037,7 @@ requires-dist = [
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
     { name = "wheel", marker = "extra == 'mujoco'" },
 ]
-provides-extras = ["mujoco", "mjwarp", "motrix", "viser"]
+provides-extras = ["mujoco", "mjwarp", "motrix", "genesis", "viser"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4149,6 +5118,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/12/ce/82a0e50fae21f5e02fcc5d9aff2ab59dccb9c319b6c4cf528f2228049b05/viser-1.0.26.tar.gz", hash = "sha256:dc08c6f505e70324b0603bdddf9714c00ac828c259ee49abd8ad094bfc90c91c", size = 4828261, upload-time = "2026-03-30T11:43:19.513Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/f7/762a2d5fab509d0c632b271e21e634462397cc02cca649771c3e9d2e0bcc/viser-1.0.26-py3-none-any.whl", hash = "sha256:03b177b4ef584f58f7b74fdf44cccb165b8a220ffd90728ef5c1e3d1b1fcf258", size = 4922888, upload-time = "2026-03-30T11:43:21.355Z" },
+]
+
+[[package]]
+name = "vtk"
+version = "9.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/51/fa0acc077a712e3ce1a683868c78fbba29d00a3a590808575160ac627bcc/vtk-9.7.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:43d327f6691e74a97b2a2e44bfd9fed7ea4e5c04f88f7398810a5c199c111f2a", size = 110868260, upload-time = "2026-08-15T21:36:12.314Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/3d19704c84d41ffe46127b61c314e0b3737a520471ea1e1719f77820a7a6/vtk-9.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca0db727b20111009cf26c15194bcd3cddd90dc47cc0278707a9f57debac03d9", size = 102946141, upload-time = "2026-08-15T21:36:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3b/e1c4a1c92f93c422c580461574b3a703c558de8d697a6884e985541bc3ae/vtk-9.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b56c17a68af845e7bfa1d56c3b764f6ee1bd6ff67f65af8bab5ff7541ad749d7", size = 139625215, upload-time = "2026-08-15T21:36:22.432Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/58/109f7d1a8f069e101f3db389a6f78bb13edc5d48262c248fa286ce689a5f/vtk-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:baa2e146611ff93f493104152802773cdfada177856dd29694b34224aad50324", size = 129381180, upload-time = "2026-08-15T21:36:27.31Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8f/561609e42e479fe215b1e9ffa02ded1a0c31e5a3edbdb2b539429f727e51/vtk-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:ab3bc1f8463b0d37a121630a1a44afc01982e622919e0a6e5df6ed14bb6bea54", size = 80419456, upload-time = "2026-08-15T21:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/42/5521187d480ce634e17aee5e6cac7e052eb4b6d4ce6833d825002d597669/vtk-9.7.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:ef393a988d177086a3cdbe86c5529dacea7d3a1620244596bb94435478eb2545", size = 110868355, upload-time = "2026-08-15T21:36:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6a/a6fba1d43690f2bcd24ad27e8a061e68aaaf12e4867921d2c055333425b5/vtk-9.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dea2ecda02180e446f61341ce6fcf6596691470ab08bc5989443437473b9b1c6", size = 102945919, upload-time = "2026-08-15T21:36:40.192Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b5/d2124ab63019e6db4d397b054a8ec540c37f3436fff50bae5e3bd34ed3ff/vtk-9.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64c06b819cb97706ed7be717a9757a97aece3c427c06c9a1d47ad296231ca2b", size = 139624932, upload-time = "2026-08-15T21:36:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/a8ec8b526907a3f83dc9f18be654a1c72a3ef494936da2532d4130712935/vtk-9.7.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:43344d4129bbd9c713e48bdd18a0f52744d36ee66cbdd6add415a530a96d246e", size = 129381463, upload-time = "2026-08-15T21:36:49.877Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/61876263b16543d84d5df2da7aec12492a83d40f89942824068d41a53297/vtk-9.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:38ac723bcf99aa331bbd4e74daced2440e0afb8ceae73e0b5b1b76d4ad8d594f", size = 80420210, upload-time = "2026-08-15T21:36:54.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/1302dcc11cd58ec272bb256a5b923ec503aea016d948a1746ec3799bf937/vtk-9.7.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:cb03235710fb9c1c987a9364b10fe9b91e0dd8b2f0692b415a6257cf6fbf6da2", size = 111042472, upload-time = "2026-08-15T21:37:00.814Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/24/54f867b55584e209bdfba364fdb8bc56fb88a2574bde32f687e8c3c37ef0/vtk-9.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43730881347129c564f55ed1481187c57c18ec92a618a26aa83a9b62de5e419f", size = 102999804, upload-time = "2026-08-15T21:37:04.88Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7d/8d4213c57e06bd181e0d540ef75ea5fb50b528c0085a56f905804513ae0d/vtk-9.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ade6991deefb29803837f3a8525e720d3718094cedc7c3c4ed3eeb9e20586d77", size = 139661657, upload-time = "2026-08-15T21:37:09.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/6d/b87ccf7e1891850e004c2e1231daf8aacde911e3ee83005c13571b5c19bd/vtk-9.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d7bbfbb997b2d22f1569c15e5c5d216fc7e184924652a33204f0e2b277200fa6", size = 129433898, upload-time = "2026-08-15T21:37:15.644Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/e80b5210283f9451805ab3973ab232449a6acefa4e7f4d0c3195d134e426/vtk-9.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:bb2fc0cd53afcf03bf5436f89c4be6bbaadde7f0f7b444a3e3bde8d7cfaaeb95", size = 80435493, upload-time = "2026-08-15T21:37:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/52/cc/2d6750ac498013bc651bb0bbe720f63fabd9504bb22d7a282b9052caeabb/vtk-9.7.0-cp313-cp313-macosx_10_10_x86_64.whl", hash = "sha256:f3a13fc62fef2db91b8ca5f36dc4b4e5cc4ae981584df343f1be05cf4b496a37", size = 111056432, upload-time = "2026-08-15T21:37:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c9/b2cc1998a09bc80812c55418cf75ec4aeb91f8b81a1368675d45d79c9dd4/vtk-9.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:af67723b39616b3a1f2fc9e685dcdde0b73965db0635fa1405a7b46fef19bb12", size = 103003337, upload-time = "2026-08-15T21:37:33.996Z" },
+    { url = "https://files.pythonhosted.org/packages/86/46/06fe7fa56b2fa6e19e9c2838f03dffb85a647b6ccee9685f652fba709756/vtk-9.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b44be314570f74453bfc8398a86279322528b9a1bd8a76c956ddd7beef9beec", size = 139662075, upload-time = "2026-08-15T21:37:40.73Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/296ebece46f39e684575b8ced65416e7712a9e6fb66929cc34e9ac749b32/vtk-9.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fc6ed2d88571e94e785e6ca0716bf552ba5853d9b6795f48a3a5a0791859446c", size = 129434592, upload-time = "2026-08-15T21:37:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a1/32630dd1879be54182649655bc007b6589717a918338712a579b2ad0d13b/vtk-9.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:cd8496c654d5d852e1d75a3b3ca9d56987e7ff230041f5c6e1bfaca65366c655", size = 80434823, upload-time = "2026-08-15T21:37:56.256Z" },
 ]
 
 [[package]]
@@ -4279,6 +5278,71 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/51/8698f7646b9e6f4deca78995c59df25760c047eacfa595262205497b0b07/wrapt-2.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:643e45aa88698c8aae938c50e61940985d4ab9e53ea666d3e8e4eb86a4820d0f", size = 95416, upload-time = "2026-08-30T04:39:07.662Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3c/a4620a03518eb133131aa54ae6973ba273a6f7244f2f771002be5f2db938/wrapt-2.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4597d19904b4aa97331d8bb651ac626d9397727e717942cf11bd7699ff97aa45", size = 95897, upload-time = "2026-08-30T04:39:09.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/ce8d8da15f825d55523ef1af03763de15d62c559c826516726fcafa072b6/wrapt-2.4.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:635cc171ddfd72edff10e295a02daa65edaa1c0ba619ad11eeed15cd2258c5df", size = 209578, upload-time = "2026-08-30T04:39:11.028Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/d5bf17b460fcf280f22ddfdfb8b674f5c213e46cad048d4bb2cfd43ce58d/wrapt-2.4.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:932a8892265df7b71257c30e5752635bc1f06a8c4e264024ff031bdf9bb10918", size = 212288, upload-time = "2026-08-30T04:39:12.601Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ec/bda24f3b18046274dde04feb56fd80ae1bf85f89110ddc86ad45d0dd2f06/wrapt-2.4.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5b8fff692f74782de89ba9d7b526a7cc398569b6a988ddc848159cc033c86237", size = 201612, upload-time = "2026-08-30T04:39:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/98/e8d30eaef0f531831c91e6ec6cf9c2c95ada3f8111463a393bf395445c78/wrapt-2.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a27d9653e0f88aa06598954337a545fc3f75bc811df897157a8614846d18d9c", size = 210648, upload-time = "2026-08-30T04:39:15.948Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9d/eb138df0a2d85953885a6b14768d3416e55f94728bb45b1fc7fa3dcde246/wrapt-2.4.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:9c884240e7415d3a384e70a15ceea0e884cc9289bcc254afd6412d4e7cf99c47", size = 199700, upload-time = "2026-08-30T04:39:17.697Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/38c3d26493869740aec6f4f5eebd51df0781ee703d554310e4e4d12ea2ce/wrapt-2.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37ba372e9ae71ec43e165b5db05f52e71f7c07dafb9d6a254ef7128112dce751", size = 199774, upload-time = "2026-08-30T04:39:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/820553cbd7a94abf1fb3d324f19c09e7bcd73d8f36fca6164f6997c9130c/wrapt-2.4.0-cp310-cp310-win32.whl", hash = "sha256:07daab5babb7edaf89413f5c8bd638474540fb2643b5dfb685bdc0680c96803a", size = 91196, upload-time = "2026-08-30T04:39:20.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/67/fab3ec749a0bb831ab0993d3eff2ca90032b858ab9e0c0b1932f663e7e43/wrapt-2.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ef9797bf7c6f9ad9d294538c4f9a64ef3dbbadb63590a9a067393fd49ba28b0f", size = 96080, upload-time = "2026-08-30T04:39:22.274Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/05/4295a347b2f8772cead2b45f0d4049902242fcb46a5f4488c0e8b0951681/wrapt-2.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:11ccb5f3de2047ef91408464abdc04682e40e7d7bc9614885d2abcaa7e2ef149", size = 92994, upload-time = "2026-08-30T04:39:23.63Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f0/f2f25fe8d516e63354ce4b027d4dc8d824bbf1f5f173f0bb83ce1bcbf706/wrapt-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a67ec80d15ac199d4a9a04a33f3039a1c219c9bf1c07b1b0422497613f167fb9", size = 95620, upload-time = "2026-08-30T04:39:25.116Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/8e1d699fd15591e58f375e1eb5ce444aa955645edc53d09d86cf41d8aa2e/wrapt-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fc1b2cebd6d8db9b4ac0adc817c08b4901922e85604ae2a69aecb5217b2c09d8", size = 95795, upload-time = "2026-08-30T04:39:26.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/81/63c2fde1f11d008596ef86631afb37a8cb250eec62382003b7d12efd0071/wrapt-2.4.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e52c6a5be3284719e53b629ccfa565c146e604e861de35e861c94f7622806eb5", size = 217752, upload-time = "2026-08-30T04:39:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e9/373bc7c86eb41f6ab2e5608afac0bda11130b870c4dff4f4d1f25ffafe8a/wrapt-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9905bceb7b2833559518574ad6259d2ec9ffd111a0aa330ca685db74478e1ae3", size = 219872, upload-time = "2026-08-30T04:39:30.085Z" },
+    { url = "https://files.pythonhosted.org/packages/49/95/a599d1095b6a271ef91ebb6852f7b4cfc7462d0aff7f4cc1fc3e6437193d/wrapt-2.4.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:abc347e92f9202c8ac1d5c1626a800fd5e56e13433f0651b26dddda5b421ac79", size = 205822, upload-time = "2026-08-30T04:39:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/71/59/14ea2e24c2546da9a08cf9da8fcb2a8ada40ddca0c9a4f26f6a559e49efb/wrapt-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52f01626f1d2bc54585954cd8b4931f81003b0ac8dad61c741f43014bc9a0f0b", size = 217806, upload-time = "2026-08-30T04:39:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e8/ff294f964325a6451ff413aa918f5d55a197303b813d0ee0a16ecf3c9bd1/wrapt-2.4.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:811a36628d8b76724b980d508d576e5c5ecae1073b6ec4b4eb21646921906fe6", size = 203892, upload-time = "2026-08-30T04:39:35.103Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/45/34c1b0172f0c36305c26c2ffddc8f0bae7a43d78d6b32b00b1b043f77fec/wrapt-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b33df90f3d1e5b1c8811830b11a3e718b4f3a2823b748fa9be1688cb82b193f1", size = 207087, upload-time = "2026-08-30T04:39:36.55Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a2/db3b55e29d04b685c761b1d6aca9f84a9c4f7e1c93543f23ba8a180a2a3f/wrapt-2.4.0-cp311-cp311-win32.whl", hash = "sha256:be535bdfbedda84cb8ebc6a80955dfd03d46840c13470486bd038f089e38b172", size = 91301, upload-time = "2026-08-30T04:39:38.114Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/55/c9fd1bf55e144082da6d62313d38f1449707bca16b76af4abbd5492f91e6/wrapt-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1117c63a39ba4d1b884e658089e512412d5174217ea1b4fe570977e42a5b129", size = 96308, upload-time = "2026-08-30T04:39:39.432Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/68d6c10590e74c496046f9fcbbb6ef80a2eca823f924305bf79acb65cccd/wrapt-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:637fd6a18bb668a0c27b4767dcbc2fa93119c90da735bd2669fdde2d7b59fab3", size = 92839, upload-time = "2026-08-30T04:39:40.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
+    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/f9de4e11582ff96ad2199eeeceaa17faa27bbdc599243f520070c4f3de07/wrapt-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5c5c4c728cd22a36e4b8bb5df4a7d3bccaa865d27725b36eeb3b6f18fb2e1bc2", size = 96041, upload-time = "2026-08-30T04:39:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ab/1dbf50802bea3b46192fd0dc39bb0eb2e77a064c813b2bbd88d2888ad49f/wrapt-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7de5b8d94417e55c02be50cc226e0ae1209bbc73813bf691dff3979c94438115", size = 96269, upload-time = "2026-08-30T04:40:01.182Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb", size = 225787, upload-time = "2026-08-30T04:40:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f7/d100f6c348b7669f19119cf890dcd4764623e2233af065586d110e0cd99e/wrapt-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e084558fbd112d2e1e34b0f5c71e45a3405bdad51a17150368a959bcf6697964", size = 226649, upload-time = "2026-08-30T04:40:04.647Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/3af8df515d5d7e92306957536f3468c6bdfecbe3659f99dbf09a468c2c4c/wrapt-2.4.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e78c947e18fadfd690c9420c30a96d221feeb93fc8f1cc00509b370ac16c3114", size = 206760, upload-time = "2026-08-30T04:40:06.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/40d355552bd3eb6c5186e26051c19b573d24d7896de42caa7937d6b5ca9f/wrapt-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08d8378c4514ac8dcc0ace76044cf87a873e6a52b5e6109834c8fb9037f4441b", size = 223467, upload-time = "2026-08-30T04:40:07.829Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ab/d198eebdb39f0d7e182e771e590a36673489cd58cebdad8aa273dcf28e04/wrapt-2.4.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:93180c2199784dd6a1075b33f9ed636bd0966821edbece6b3d5379b1c4f0bb7d", size = 205358, upload-time = "2026-08-30T04:40:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0e/974a60672ad507d39a3d8a1c6351ef37fe65b07240d000ceba5d2b83e9e9/wrapt-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d5e5eb76fb87e62752af751d2dcd9d1cd986b12037d2e1363d109ba716029e8", size = 214654, upload-time = "2026-08-30T04:40:10.923Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5a/8b2db70206db0a4246758e0472ce344cb9636217113ef70640fc8d2ce874/wrapt-2.4.0-cp313-cp313-win32.whl", hash = "sha256:49bb5a572469e0e18163a8ec2aa972135a0929899ecbe627665f274506e1b5b4", size = 91171, upload-time = "2026-08-30T04:40:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1e/e782b511c680dbe7369c92e7d981484aacca0cda584da1f28a84cd9a8e1a/wrapt-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:b1737f46b1e4a81eb93500a7f2854319e1c7a86e8863fb050b7b4daadd5a4178", size = 96178, upload-time = "2026-08-30T04:40:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/095ba31123fa5dd482d6183c05200b061314aabbd5442c010aba4b03ff1c/wrapt-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:f1e9e088094f4895f84ab043e7d59401df137d663efbf1e80c82144882960830", size = 92949, upload-time = "2026-08-30T04:40:15.935Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
+]
+
+[[package]]
+name = "xacro"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/b2/12fc318d3563481fe01482dd8e925d38e83b62d64291ed16ab0b6d836a91/xacro-2.1.1.tar.gz", hash = "sha256:3e7adf33cdd90d9fbe8ca0d07d9118acf770a2ad8bf575977019a5c8a60d4d1b", size = 104752, upload-time = "2025-08-28T18:21:20.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl", hash = "sha256:c3b330ebd984a3bce6d6482e0047eae5c5333fedd49b30b9b6df863a086b35f7", size = 27087, upload-time = "2025-08-28T18:21:19.165Z" },
+]
+
+[[package]]
 name = "xxhash"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4380,6 +5444,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/19/20c50861f30aff7720f9a601f386d73760c2df9961de1f98d0dbf3b85e69/yourdfpy-0.0.60.tar.gz", hash = "sha256:2af2d8bdeea1b85b642590a3b4236fdb35746d7b3e38ce460a169c18d9c4f868", size = 538238, upload-time = "2026-01-23T07:32:47.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/60/4ea0d6df0b497d51bf2ef87eaab0eb26f8bc3b3313c012da5df3383cced9/yourdfpy-0.0.60-py3-none-any.whl", hash = "sha256:8a187a8b18c98db87c76e9a950581b3c875b761e00df83942526c17ea693166c", size = 22194, upload-time = "2026-01-23T07:32:46.481Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.15.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz", hash = "sha256:928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946", size = 5018600, upload-time = "2025-10-29T18:12:03.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/33/a3d5d2eaeb0f7b3174d57d405437eabb2075d4d50bd9ea0957696c435c7b/z3_solver-4.15.4.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:407e825cc9211f95ef46bdc8d151bf630e7ab2d62a21d24cd74c09cc5b73f3aa", size = 37052538, upload-time = "2025-10-29T18:11:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/fd7ffac1551cd9f8d44fe41358f738be670fc4c24dfd514fab503f2cf3e7/z3_solver-4.15.4.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:00bd10c5a6a5f6112d3a9a810d0799227e52f76caa860dafa5e00966bb47eb13", size = 39807925, upload-time = "2025-10-29T18:11:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e", size = 29268352, upload-time = "2025-10-29T18:11:53.032Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/0b49f7e4e53817cfb09a0f6585012b782dfe0b666e8abefcb4fac0570606/z3_solver-4.15.4.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:62c7e9cbdd711932301f29919ad9158de9b2f58b4d281dd259bbcd0a2f408ba1", size = 27226534, upload-time = "2025-10-29T18:11:55.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/91/33de49538444d4aafbe47415c450c2f9abab1733e1226f276b496672f46c/z3_solver-4.15.4.0-py3-none-win32.whl", hash = "sha256:be3bc916545c96ffbf89e00d07104ff14f78336e55db069177a1bfbcc01b269d", size = 13191672, upload-time = "2025-10-29T18:11:58.424Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl", hash = "sha256:00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431", size = 16259597, upload-time = "2025-10-29T18:12:01.14Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

Implements #1378（roadmap #1339 Child 2 / 3）。在不改变 `SimBackend` 公共接口的前提下交付 **GenesisBackend**，`create_backend("genesis", ...)` 经现有 factory/registry 可用；无 Genesis runtime 的机器可运行全部 mock 契约测试并获得可操作安装诊断。设计依据为 Child 1 实测报告 `scripts/tools/genesis_feasibility/REPORT.md` §5 的 10 条映射决策。

## 交付物（13 新文件 + 5 处编辑；新增 2,498 手写 LOC，预算内）

- `src/unilab/base/backend/genesis/`
  - `dependencies.py`：lazy optional import、`genesis-world==1.3.3` 精确钉扎、`GenesisDependencyError`（``uv sync --extra genesis`` 提示）
  - `materialization.py`：mujoco 冷路径扫描（keyframe `mj.key_qpos`、sensor 计划、actuator、全局 option）；`preserve_torch_globals` 快照/恢复（配单测）；一进程一 `gs.init` 会话守卫；全局 option fail-closed 映射
  - `backend.py`：link 寻址 root state（entity 级 getter 禁用，REPORT §5.5）；`control_dofs_position` 跨 step 保持 + adapter nsteps 循环实现 `set_pre_step_control`（§5.4）；step/reset 屏障单次 D2H host cache（§5.9）；传感器等价物（§3.4）；DR 只声明实测项（§5.7）；geom 名称/体帧运动学/terrain/playback 等 fail-closed
- factory/registry：`create_backend` genesis 分支、`GENESIS_AVAILABLE`、`_SUPPORTED_SIM_BACKENDS` 增加 genesis
- `EnvCfg`：4 个 Optional genesis 字段（`genesis_integrator` / `genesis_constraint_solver` / `genesis_friction_cone` / `genesis_solver_iterations`，带校验）——补偿 Genesis 丢弃 MJCF 全局 `<option>`（REPORT §3.3）
- pyproject：`genesis = ["genesis-world==1.3.3"]` optional extra（不进基础安装）
- 测试：`tests/base/genesis_fake_runtime.py`（镜像 1.3.3 API 的 fake 模块）+ 17 项 mock 测试 + conformance genesis 参数化（无 runtime 清晰 skip）+ 真实 runtime slow lane（g1 acceptance smoke + re-init 守卫）

## 偏差说明（相对 REPORT/brief，均已在代码中记录）

1. `setuptools<70` pin 解除：quadrants==1.3.0（genesis-world 精确 pin）要求 setuptools>=77；仓库无运行时 setuptools/pkg_resources 引用，已用全量测试 + `mujoco-uni-runtime` 强制重编译验证。
2. `get_geom_friction` fail-closed（REPORT 列为实测 OK）：唯一仓库内消费者期望 mujoco `(n,3)` 表，genesis 只存标量 slide friction；DR geom_friction 项在 genesis 上本就不支持（ratio-only API），提供形状不符的表不诚实。
3. gyro 走 link-state 数学而非 IMUSensor（避免 §5.6 reset 后 staleness）；IMUSensor 仅用于 accelerometer site。
4. batch flags 在 1.3.3 是 `RigidOptions` 字段（非 `scene.build` kwargs）。
5. play capabilities 全部声明 False；`play_render_mode=none` 可解析；离屏 camera（REPORT [12]）留作后续。

## Validation

- 无 runtime 环境（`uv sync --extra mujoco --extra motrix`，确认 genesis 不存在）：`pytest tests/base/test_genesis_backend.py test_registry.py test_backend_conformance.py -m "not slow"` → **67 passed, 4 skipped**（genesis lane 清晰 skip）。
- 真实 runtime 环境（`uv sync --extra genesis`，RTX 4090 / torch 2.8.0+cu128 / genesis-world 1.3.3）：conformance genesis lane **4 passed**；runtime smoke **2 passed**（g1 `scene_flat.xml` n_envs=8 keyframe reset + 10 步控制，base_z 稳定；torch 2.8 下 IMU+contact force 组合工作正常，#1372 的 torch 2.7 崩溃例消失）；re-init 守卫 fail-closed。
- 最终 head `bd7acd82` 本地 `make test-all`（标准 env）：通过（exit=0；ruff clean；pytest 2396 passed / 28 skipped / 1 xfailed；module-mode 35/36、script-mode 36/37）
- 未新增公共 SimBackend 方法/异常/IPC；其他 backend 数值路径未改。

## 后续（Child 3+）

g1_walk_flat owner YAML（消费 4 个 genesis 字段 + `implicitfast`）、env 注册与 compose 验证、`enable_mujoco_compatibility` 数值对齐 benchmark、playback/camera 集成、`apply_links_external_force` 物理效果验证（REPORT §8）。
