### PR TITLE
fix(backend): GenesisBackend materialize 幂等/lazy 化与体帧运动学（#1382）

### DIFF
--- a/src/unilab/base/backend/genesis/backend.py
+++ b/src/unilab/base/backend/genesis/backend.py
@@ -41,6 +41,7 @@ from unilab.dr.types import (
 from unilab.utils.rotation import (
     np_quat_apply_batched,
     np_quat_apply_inverse_batched,
+    np_quat_conjugate_batched,
     np_quat_mul_batched,
 )
 
@@ -172,11 +173,19 @@ class GenesisBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def materialize(self) -> None:
-        """Build the batched scene, cross-check the import, and bind caches."""
-        if self._closed:
-            raise RuntimeError("genesis backend is closed")
+        """Build the batched scene, cross-check the import, and bind caches.
+
+        Idempotent, and called lazily by the first state access: env
+        constructors that validate state shapes before the explicit
+        lifecycle point (ManagerBasedRlEnv builds its EntityScene before
+        calling ``materialize()``, #1382) work like they do on the MuJoCo
+        backend — the same pattern as the isaacgym backend's lazy
+        materialize.  A closed backend cannot be materialized again.
+        """
         if self._materialized:
-            raise RuntimeError("genesis backend is already materialized")
+            return
+        if self._closed:
+            raise RuntimeError("genesis backend is closed and cannot be materialized again")
         self._scene.build(n_envs=self._num_envs)
         self._materialized = True
         self._bind_materialized_metadata()
@@ -298,13 +307,11 @@ class GenesisBackend(SimBackend):
     # Host-cache barriers                                                 #
     # ------------------------------------------------------------------ #
 
-    def _require_running(self, operation: str) -> None:
+    def _require_state(self, operation: str) -> None:
         if self._closed:
             raise RuntimeError(f"genesis backend is closed; cannot run {operation}")
-        if not self._materialized:
-            raise RuntimeError(
-                f"genesis backend is not materialized; call materialize() before {operation}"
-            )
+        # Lazy, idempotent materialize: the first state read builds the scene.
+        self.materialize()
 
     def _refresh_host_cache(self) -> None:
         """Refresh every legacy-visible cache at one explicit lifecycle barrier."""
@@ -463,7 +470,7 @@ class GenesisBackend(SimBackend):
         matrix semantics are preserved, but the integer values must NOT be
         compared against MuJoCo tables (REPORT #1372 §5.10).
         """
-        self._require_running("get_geom_contact_masks")
+        self._require_state("get_geom_contact_masks")
         return (
             np.asarray([geom.contype for geom in self._entity.geoms], dtype=np.int32),
             np.asarray([geom.conaffinity for geom in self._entity.geoms], dtype=np.int32),
@@ -520,7 +527,7 @@ class GenesisBackend(SimBackend):
         )
 
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
-        self._require_running("step")
+        self._require_state("step")
         if isinstance(nsteps, bool) or int(nsteps) <= 0:
             raise ValueError(f"nsteps must be a positive integer, got {nsteps!r}")
         ctrl_array = np.asarray(ctrl, dtype=np.float32)
@@ -585,7 +592,7 @@ class GenesisBackend(SimBackend):
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
     ) -> dict[str, dict[str, float]]:
-        self._require_running("set_state")
+        self._require_state("set_state")
         rows = self._validate_rows(env_indices)
         qpos_array = np.asarray(qpos, dtype=np.float32)
         qvel_array = np.asarray(qvel, dtype=np.float32)
@@ -714,7 +721,7 @@ class GenesisBackend(SimBackend):
             )
 
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        self._require_running("apply_interval_randomization")
+        self._require_state("apply_interval_randomization")
         if plan.is_empty():
             return
         if plan.push_perturbation_limit is not None:
@@ -734,7 +741,7 @@ class GenesisBackend(SimBackend):
 
     def apply_body_force(self, body_ids: np.ndarray, force: np.ndarray) -> None:
         """Apply a world-frame force per body through the solver-level API."""
-        self._require_running("apply_body_force")
+        self._require_state("apply_body_force")
         ids = np.asarray(body_ids, dtype=np.int32).reshape(-1)
         force_array = np.asarray(force, dtype=np.float32)
         expected = (self._num_envs, ids.size, 3)
@@ -787,7 +794,7 @@ class GenesisBackend(SimBackend):
     # ------------------------------------------------------------------ #
 
     def _require_free_root(self, operation: str) -> None:
-        self._require_running(operation)
+        self._require_state(operation)
         if self._root_qpos_dim != 7 or self._root_qvel_dim != 6:
             raise NotImplementedError(
                 f"{operation} requires a free root joint; genesis host profile is "
@@ -817,58 +824,65 @@ class GenesisBackend(SimBackend):
         return np_quat_apply_batched(self.get_base_quat(), self._qvel_cache[1][:, 3:6])
 
     def get_dof_pos(self) -> np.ndarray:
-        self._require_running("get_dof_pos")
+        self._require_state("get_dof_pos")
         return self._qpos_cache[1][:, self._root_qpos_dim :]
 
     def get_dof_vel(self) -> np.ndarray:
-        self._require_running("get_dof_vel")
+        self._require_state("get_dof_vel")
         return self._qvel_cache[1][:, self._root_qvel_dim :]
 
     def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
-        self._require_running("get_body_pos_w")
+        self._require_state("get_body_pos_w")
         return self._links_pos_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
 
     def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
-        self._require_running("get_body_quat_w")
+        self._require_state("get_body_quat_w")
         return self._links_quat_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
 
     def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        self._require_running("get_body_lin_vel_w")
+        self._require_state("get_body_lin_vel_w")
         return self._links_vel_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
 
     def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
-        self._require_running("get_body_ang_vel_w")
+        self._require_state("get_body_ang_vel_w")
         return self._links_ang_cache[1][:, np.asarray(body_ids, dtype=np.intp), :]
 
     def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
-        del body_ids
-        self._unsupported_base_frame_kinematics("base-frame body positions")
+        # Position relative to the baselink frame: R_base^-1 (pos_w - base_pos_w).
+        self._require_free_root("get_body_pos_b")
+        base_quat = self._links_quat_cache[1][:, self._base_link_idx, :]
+        relative = (
+            self.get_body_pos_w(body_ids)
+            - self._links_pos_cache[1][:, self._base_link_idx, :][:, None, :]
+        )
+        return np_quat_apply_inverse_batched(base_quat[:, None, :], relative)
 
     def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
-        del body_ids
-        self._unsupported_base_frame_kinematics("base-frame body orientations")
-
-    def _unsupported_base_frame_kinematics(self, operation: str) -> None:
-        # Same boundary as the mjwarp host profile: no task consumes
-        # base-frame body pose, and the tracked subsets live in sensors.
-        raise NotImplementedError(f"genesis host profile does not expose {operation}")
+        # Orientation relative to the baselink frame: quat_base^-1 * quat_w.
+        self._require_free_root("get_body_quat_b")
+        base_quat = self._links_quat_cache[1][:, self._base_link_idx, :]
+        return np_quat_mul_batched(
+            np_quat_conjugate_batched(base_quat[:, None, :]), self.get_body_quat_w(body_ids)
+        )
 
     def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
         # Analytical per the SimBackend contract (#1254): world-frame velocity
         # rotated into each body's own frame.
+        self._require_state("get_body_lin_vel_b")
         ids = np.asarray(body_ids, dtype=np.intp)
         return np_quat_apply_inverse_batched(
             self._links_quat_cache[1][:, ids, :], self._links_vel_cache[1][:, ids, :]
         )
 
     def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_ang_vel_b")
         ids = np.asarray(body_ids, dtype=np.intp)
         return np_quat_apply_inverse_batched(
             self._links_quat_cache[1][:, ids, :], self._links_ang_cache[1][:, ids, :]
         )
 
     def get_sensor_data(self, name: str) -> np.ndarray:
-        self._require_running(f"get_sensor_data({name!r})")
+        self._require_state(f"get_sensor_data({name!r})")
         try:
             address, dimension = self._sensor_slots[name]
         except KeyError as exc:

--- a/tests/base/genesis_fake_runtime.py
+++ b/tests/base/genesis_fake_runtime.py
@@ -274,6 +274,7 @@ class _FakeScene:
         self.entities: list[_FakeEntity] = []
         self.sensors: list[_FakeIMU] = []
         self.sim = types.SimpleNamespace(rigid_solver=_FakeRigidSolver())
+        self.build_count = 0
 
     def add_entity(self, morph):
         entity = _FakeEntity(morph)
@@ -286,6 +287,7 @@ class _FakeScene:
         return sensor
 
     def build(self, n_envs=0, **kwargs):
+        self.build_count += 1
         for entity in self.entities:
             entity._build(n_envs)
         for sensor in self.sensors:

--- a/tests/base/test_genesis_backend.py
+++ b/tests/base/test_genesis_backend.py
@@ -150,14 +150,15 @@ def test_session_lifecycle_and_reinit_guard(fake_genesis, tiny_model_file: str) 
     first = _backend(tiny_model_file)
     second = _backend(tiny_model_file)
     assert fake_genesis.init_count == 1  # backends share the process-wide session
-    with pytest.raises(RuntimeError, match="already materialized"):
-        first.materialize()
+    first.materialize()  # idempotent: explicit call after the initial build is a no-op
+    assert first._scene.build_count == 1
     first.close()
     assert fake_genesis.destroy_count == 1
     with pytest.raises(RuntimeError, match="exactly one gs.init per process"):
         _backend(tiny_model_file)
     with pytest.raises(RuntimeError, match="genesis backend is closed"):
         first.step(np.zeros((4, 2), dtype=np.float32))
+    first.materialize()  # no-op when already materialized, even after close
     second.close()
     assert fake_genesis.destroy_count == 1  # idempotent: session already destroyed
 
@@ -328,9 +329,32 @@ def test_base_velocity_frame_conventions(fake_genesis, tiny_model_file: str) -> 
     np.testing.assert_allclose(
         backend.get_body_ang_vel_w(pelvis_id)[0, 0], [0.0, -1.0, 0.0], atol=1e-6
     )
+    # Body-frame velocities are the world-frame values rotated by R^-1:
+    # R_x90^-1 @ [1,2,3] = [1,3,-2]; the angular pair round-trips the qvel
+    # body-frame columns (REPORT §3.2 [2d] semantics).
+    np.testing.assert_allclose(
+        backend.get_body_lin_vel_b(pelvis_id)[0, 0], [1.0, 3.0, -2.0], atol=1e-6
+    )
+    np.testing.assert_allclose(
+        backend.get_body_ang_vel_b(pelvis_id)[0, 0], [0.0, 0.0, 1.0], atol=1e-6
+    )
     # Gyro reports body/sensor-frame components: identity site frame recovers
     # the qvel body-frame columns.
     np.testing.assert_allclose(backend.get_sensor_data("base_gyro")[0], [0.0, 0.0, 1.0], atol=1e-6)
+
+
+def test_body_pose_base_frame(fake_genesis, tiny_model_file: str) -> None:
+    backend = _backend(tiny_model_file, num_envs=1)
+    qpos, qvel = _stand_state(backend, 1)
+    backend.set_state(np.array([0], dtype=np.int32), qpos, qvel)
+    ids = backend.get_body_ids(["pelvis", "shank"])
+    # Root sits at its own frame origin; the fake shank rides at a fixed
+    # [0,0,-0.6] offset in the pelvis frame, and both frames align.
+    np.testing.assert_allclose(backend.get_body_pos_b(ids)[0, 0], [0.0, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(backend.get_body_pos_b(ids)[0, 1], [0.0, 0.0, -0.6], atol=1e-6)
+    np.testing.assert_allclose(
+        backend.get_body_quat_b(ids)[0], [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], atol=1e-6
+    )
 
 
 def test_sensor_equivalents_from_link_state(fake_genesis, tiny_model_file: str) -> None:
@@ -535,8 +559,14 @@ def test_constructor_validation_and_factory_wiring(fake_genesis, tiny_model_file
     assert rigid_kwargs["batch_dofs_info"] is True
     assert backend._scene.sim_options.dt == pytest.approx(0.005)
 
-    with pytest.raises(RuntimeError, match="not materialized"):
-        backend.get_dof_pos()
+    assert backend._scene.build_count == 0
+    # First state access lazily builds the scene (isaacgym-style idempotent
+    # materialize), so Entity validators that read state before the env's
+    # explicit materialize hook work (#1382).
+    np.testing.assert_allclose(backend.get_dof_pos()[0], [0.0, 0.0])
+    assert backend._scene.build_count == 1
+    backend.materialize()
+    assert backend._scene.build_count == 1
     # Cold-path metadata stays available before materialize (manager env
     # constructors read it ahead of the materialize hook).
     assert backend.get_default_dof_pos().shape == (2,)

--- a/tests/base/test_genesis_runtime.py
+++ b/tests/base/test_genesis_runtime.py
@@ -143,8 +143,56 @@ def test_g1_smoke_reset_step_and_cleanup(backend) -> None:
     )
 
 
+def test_body_frame_kinematics_matches_mujoco_backend(backend) -> None:
+    """#1382: body-frame velocity/pose math matches MuJoCo on identical state."""
+    num_envs = 2
+    mujoco_backend = create_backend(
+        "mujoco",
+        SceneCfg(model_file=_G1_SCENE),
+        num_envs,
+        _SIM_DT,
+        base_name="pelvis",
+        add_body_sensors=True,
+    )
+    mujoco_backend.materialize()
+
+    rng = np.random.default_rng(0)
+    qpos = np.tile(backend.get_keyframe_qpos("stand"), (num_envs, 1)).astype(np.float32)
+    qvel = rng.uniform(-0.5, 0.5, size=(num_envs, backend.get_init_qvel().size)).astype(np.float32)
+    rows = np.arange(num_envs, dtype=np.int32)
+    backend.set_state(rows, qpos, qvel)
+    mujoco_backend.set_state(rows, qpos, qvel)
+
+    body_names = ["pelvis", "left_hip_pitch_link", "left_knee_link"]
+    gs_ids = backend.get_body_ids(body_names)
+    mj_ids = mujoco_backend.get_body_ids(body_names)
+    # Same document order across backends (materialize-time cross-check).
+    np.testing.assert_array_equal(gs_ids, mj_ids)
+
+    atol = 2e-3
+    for getter in (
+        "get_body_lin_vel_b",
+        "get_body_ang_vel_b",
+        "get_body_pos_b",
+        "get_body_quat_b",
+    ):
+        actual = getattr(backend, getter)(gs_ids)[:num_envs]
+        expected = getattr(mujoco_backend, getter)(mj_ids)
+        np.testing.assert_allclose(actual, expected, atol=atol, err_msg=getter)
+
+
 def test_reinit_after_destroy_fails_closed(backend) -> None:
-    """Real-runtime lifecycle guard: one gs.init per process (keep last)."""
+    """Real-runtime lifecycle guard: one gs.init per process.
+
+    The reset hook restores the Python-side session flag afterwards so
+    later real-runtime tests in the same pytest process can re-init (the
+    guard's RSS caveat is acceptable in tests; production still inits once).
+    """
+    from unilab.base.backend.genesis.materialization import _reset_session_state_for_tests
+
     backend.close()
-    with pytest.raises(RuntimeError, match="exactly one gs.init per process"):
-        _make_backend()
+    try:
+        with pytest.raises(RuntimeError, match="exactly one gs.init per process"):
+            _make_backend()
+    finally:
+        _reset_session_state_for_tests()


### PR DESCRIPTION
## 概要

Fixes #1382（#1378 跟进，解锁 #1380）。Child 3 真实 runtime smoke 暴露 GenesisBackend 与 Entity 消费者契约的两处缺口，本 PR 在 adapter 内修复，不改 SimBackend 公共接口。

## 缺口与修复

1. **materialize 生命周期**：`ManagerBasedRlEnv.__init__` 先构造 EntityScene（读 `get_dof_pos` / `get_body_*_w` 做 shape/finite 校验，`entity.py:765/791`）后 `_materialize_backend()`；GenesisBackend 此前 pre-materialize fail-closed 且 `materialize()` 一次性。
   修复：isaacgym 模式（`isaacgym/backend.py:367` 注释即为此问题而写）——`materialize()` 幂等 + 首次状态访问 lazy 触发（`_require_running` → `_require_state`，13 处）。不选 mjwarp 构造期 eager：`scene.build` 是重操作（kernel 编译），lazy 让只读冷路径元数据的工具链（sim2sim 解析、keyframe 读取）不支付 build 成本。「一进程一 gs.init」守卫不变（session 构造期 init，仅 scene.build 延后）。
2. **体帧运动学**：g1 声明 `root_body_name`，`_validate_body_state`（entity.py:821-824）据此读 `get_body_lin_vel_b/get_body_ang_vel_b`——#1378 按「无消费者」假设未挂守卫/未实现，假设被证伪。
   修复：实现 `get_body_pos_b/get_body_quat_b` 并给 lin/ang_vel_b 补 lazy 守卫；体帧量从既有 host cache 派生（世界系量按 body 四元数逆旋转，REPORT §3.2），热路径零新增 D2H；genesis 后端体帧运动学表面与 mujoco/motrix/isaacgym 对齐。
3. **测试隔离**：re-init 守卫测试销毁进程级 gs 会话，干扰同 pytest 进程的后续 genesis lane；改为经既有 `_reset_session_state_for_tests` 在 finally 恢复（测试内可再 init，REPORT §3.5 [9a] 的 RSS 代价对测试可接受；生产仍一进程一 init）。

## Validation

- 体帧数学正确性（真实 runtime）：新增 `test_body_frame_kinematics_matches_mujoco_backend`——g1 keyframe stand + 随机 qvel 同状态写入两后端，pelvis/hip/knee 三 body × 四 getter 与 mujoco 后端 atol=2e-3 一致；mock 层另有旋转解析断言（90°-x 下 `R⁻¹@[1,2,3]=[1,3,-2]` 等）。
- 无 runtime 环境（`uv sync --extra mujoco --extra motrix`）：`tests/base/test_genesis_backend.py` 18 mock 测试 passed，conformance 非 slow 全绿。
- 真实 runtime（`uv sync --extra genesis`，RTX 4090 / torch 2.8.0+cu128 / genesis-world 1.3.3）：`test_genesis_runtime.py` + conformance genesis lane 同进程 **13 passed**（含既有 acceptance smoke：base_z=0.7387 / max_dof_drift=0.1499 / foot_force_max=171.3N）。
- Entity 构造路径等价验证：compose g1_walk_flat owner → `ManagerBasedRlEnv(backend_type="genesis")` 构造 → keyframe reset → 12 步有限稳定 → play `none` 可入 / `record` fail-closed → cleanup（输出 `obs=(2,98) critic=(2,101) reward_mean=0.0114`）。
- 最终 head `ff6f95ea` 本地 `make test-all`（标准 env）：通过（exit=0；ruff clean；pytest 2397 passed / 28 skipped / 1 xfailed）
