### PR TITLE
feat(config): g1_walk_flat SAC owner 接入 genesis 训练支持（#1386）

### DIFF
--- a/conf/sac/task/g1_walk_flat/genesis.yaml
+++ b/conf/sac/task/g1_walk_flat/genesis.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+# Genesis SAC owner for the in-process backend (genesis-world==1.3.3,
+# torch>=2.8). Keeps DENYLIST parity with the MuJoCo SAC owner (identical algo
+# block) so cross-backend play transfers 1:1. Genesis drops the MJCF global
+# <option> block at import (REPORT #1372 §3.3), so the integrator g1.xml
+# declares (<option integrator="implicitfast" timestep="0.006666666666666667"/>)
+# is re-declared here: the timestep flows through the existing base.yaml
+# sim_dt -> ctrl_dt chain, and the integrator through the EnvCfg genesis
+# fields below. Solver/constraint-cone/iterations stay at Genesis defaults:
+# the MJCF option block does not declare them and MuJoCo's implicit defaults
+# (PGS solver, pyramidal cone) have no Genesis equivalent. Unlike the
+# isaacgym owner (events.pd_gains: null), kp/kd reset randomization stays
+# enabled from base.yaml because the genesis backend declares the measured
+# RESET_TERM_KP/KD DR terms (REPORT §5.7). Playback/rendering is not a
+# declared capability, so play_render_mode=none enters playback safely as a
+# no-op; any other mode fails closed in the backend with an explanatory error.
+defaults:
+  - /task/g1_walk_flat/base
+  - _self_
+
+training:
+  task_name: G1WalkFlat
+  sim_backend: genesis
+  play_render_mode: none
+algo:
+  num_envs: 2048
+  learning_starts: 10
+  max_iterations: 5000
+  save_interval: 1000
+  updates_per_step: 8
+  algo_params:
+    alpha_init: 0.001
+    target_entropy_ratio: 0.0
+env:
+  # Re-declares the MJCF <option integrator="implicitfast"> that Genesis drops
+  # at import; the remaining global options keep the Genesis defaults.
+  genesis_integrator: implicitfast

--- a/docs/sphinx/source/en/2-user_guide/3-backends/5-genesis.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/5-genesis.md
@@ -7,15 +7,19 @@ contract on top of it, so physics shares the training process with the
 learner — no worker subprocess, no IPC.
 
 Current status: `GenesisBackend` is implemented and registered; `g1_walk_flat`
-ships a PPO owner config (`conf/ppo/task/g1_walk_flat/genesis.yaml`), and the
-cross-backend contract audit (`scripts/audit_sim2sim_contracts.py`) covers the
-mujoco/genesis pair (verdict TRANSFERABLE). Support level is **experimental**:
-the evidence is registry + owner YAML + compose/contract coverage, plus a
-real-machine slow-lane env smoke
+ships PPO and SAC owner configs
+(`conf/{ppo,sac}/task/g1_walk_flat/genesis.yaml`), and the cross-backend
+contract audit (`scripts/audit_sim2sim_contracts.py`) covers the
+mujoco/genesis pair in both algo trees (verdict TRANSFERABLE). Support level
+is **experimental**: the evidence is registry + owner YAML + compose/contract
+coverage, plus a real-machine slow-lane env smoke
 (`tests/envs/locomotion/g1/test_g1_owner_contract.py`: compose -> env
-construction -> keyframe reset -> 12 finite steps -> cleanup). No training
-validation has been completed, so the support matrix marks the cell
-`Configured`, and playback/rendering is not a declared capability.
+construction -> keyframe reset -> 12 finite steps -> cleanup, run for both
+the ppo and sac trees), plus a short SAC training-loop smoke (64 envs / 3
+iterations through the learning_starts/updates_per_step path with checkpoint
+saving). No training validation has been completed, so the support matrix
+marks the cells `Configured`, and playback/rendering is not a declared
+capability.
 
 Env-construction lifecycle (fixed in #1383): entity validation during
 `ManagerBasedRlEnv` construction reads state getters before the env's
@@ -73,6 +77,9 @@ real-machine slow-lane smoke; there is no training-convergence evidence yet):
 ```bash
 # PPO
 uv run train --algo ppo --task g1_walk_flat --sim genesis
+
+# SAC
+uv run train --algo sac --task g1_walk_flat --sim genesis
 
 # Small smoke run: 64 environments, 3 iterations only
 uv run train --algo ppo --task g1_walk_flat --sim genesis \

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/5-genesis.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/5-genesis.md
@@ -7,13 +7,16 @@ NumPy contract，物理与 learner 同进程运行——没有 worker 子进程�
 IPC。
 
 当前状态：`GenesisBackend` 已实现并注册到 registry；`g1_walk_flat` 提供
-PPO owner 配置（`conf/ppo/task/g1_walk_flat/genesis.yaml`），跨后端契约
-审计（`scripts/audit_sim2sim_contracts.py`）覆盖 mujoco↔genesis（结论
-TRANSFERABLE）。支持等级为 **experimental**：现有证据是 registry +
-owner YAML + compose/contract 覆盖，以及真机 slow-lane env smoke
+PPO 与 SAC owner 配置（`conf/{ppo,sac}/task/g1_walk_flat/genesis.yaml`），
+跨后端契约审计（`scripts/audit_sim2sim_contracts.py`）在两棵 algo 树上
+覆盖 mujoco↔genesis（结论 TRANSFERABLE）。支持等级为 **experimental**：
+现有证据是 registry + owner YAML + compose/contract 覆盖，以及真机
+slow-lane env smoke
 （`tests/envs/locomotion/g1/test_g1_owner_contract.py`：compose →
-env 构造 → keyframe reset → 12 步有限稳定 → cleanup）。尚未完成任何
-训练验证，因此支持矩阵中该 cell 标记为 `Configured`，且 playback/渲染
+env 构造 → keyframe reset → 12 步有限稳定 → cleanup，覆盖 ppo 与 sac
+两棵树），另有 SAC 短训练回路 smoke（64 envs / 3 iterations，经
+learning_starts/updates_per_step 路径并保存 checkpoint）。尚未完成任何
+训练验证，因此支持矩阵中这些 cell 标记为 `Configured`，且 playback/渲染
 不是已声明能力。
 
 env 构造生命周期（#1383 已修复）：`ManagerBasedRlEnv` 构造期的 entity
@@ -68,6 +71,9 @@ uv sync --extra genesis
 ```bash
 # PPO
 uv run train --algo ppo --task g1_walk_flat --sim genesis
+
+# SAC
+uv run train --algo sac --task g1_walk_flat --sim genesis
 
 # 小规模 smoke：64 个环境、只跑 3 个 iteration
 uv run train --algo ppo --task g1_walk_flat --sim genesis \

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -49,7 +49,7 @@ uv run scripts/generate_support_matrix.py --write
 
 `isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机（external Python 3.8 worker runtime，不在仓库 CI 覆盖）完成训练与 record playback 验证，标记为 `Tested`；其余 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。playback 走 IsaacGym 原生渲染（viewer + camera sensor 离屏录制），有显示器时 `play_render_mode=auto` 打开交互 viewer，无显示器时自动降级为离屏录制。
 
-`genesis` 是进程内后端（genesis-world==1.3.3，要求 torch>=2.8 与 CUDA；一进程只允许一次 `gs.init`），当前只接入 `g1_walk_flat` 的 PPO (torch) owner。该 cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练验证。真机 env smoke 慢车道测试（`tests/envs/locomotion/g1/test_g1_owner_contract.py`：compose → env 构造 → keyframe reset → 12 步有限稳定 → cleanup）在装有 CUDA 与 genesis extra 的机器上通过。adapter 的 `materialize()` 幂等且惰性触发（entity 校验在 env 的 materialize 钩子前读取状态 getter；isaacgym 后端同模式）。Genesis 在 import 时丢弃 MJCF 全局 `<option>`，owner YAML 显式重声明 `genesis_integrator=implicitfast`。未支持边界：geom 名称契约、terrain spawn 与 height scanner、playback/render（`play_render_mode` 仅 `none` 安全进入，其余模式 fail-closed）、contact sensor 为 per-link net-force 阈值近似（非 geom 对 `data="found"`）、`get_geom_friction` 类绝对摩擦 DR fail-closed（geom 摩擦只有 per-env ratio API）。
+`genesis` 是进程内后端（genesis-world==1.3.3，要求 torch>=2.8 与 CUDA；一进程只允许一次 `gs.init`），当前只接入 `g1_walk_flat` 的 PPO (torch) 与 SAC (torch) owner。这些 cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练验证。真机证据：env smoke 慢车道测试（`tests/envs/locomotion/g1/test_g1_owner_contract.py`：compose → env 构造 → keyframe reset → 12 步有限稳定 → cleanup，覆盖 ppo 与 sac 两棵树）在装有 CUDA 与 genesis extra 的机器上通过；SAC owner 另有短训练回路 smoke（64 envs / 3 iterations，含 learning_starts/updates_per_step 路径与 checkpoint 保存）验证，均非完整训练验证。adapter 的 `materialize()` 幂等且惰性触发（entity 校验在 env 的 materialize 钩子前读取状态 getter；isaacgym 后端同模式）。Genesis 在 import 时丢弃 MJCF 全局 `<option>`，owner YAML 显式重声明 `genesis_integrator=implicitfast`。未支持边界：geom 名称契约、terrain spawn 与 height scanner、playback/render（`play_render_mode` 仅 `none` 安全进入，其余模式 fail-closed）、contact sensor 为 per-link net-force 阈值近似（非 geom 对 `data="found"`）、`get_geom_friction` 类绝对摩擦 DR fail-closed（geom 摩擦只有 per-env ratio API）。
 
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
@@ -103,7 +103,7 @@ uv run scripts/generate_support_matrix.py --write
 | APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - | - |
 | APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - | - |
 | APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - | - |
-| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Tested | Registered |
+| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Tested | Configured |
 | SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested | - | - |
 | SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested | - | - |
 | SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered | - | - |

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -336,10 +336,12 @@ def render_support_matrix(root: Path | None = None) -> str:
         "无显示器时自动降级为离屏录制。",
         "",
         "`genesis` 是进程内后端（genesis-world==1.3.3，要求 torch>=2.8 与 CUDA；一进程只允许一次 "
-        "`gs.init`），当前只接入 `g1_walk_flat` 的 PPO (torch) owner。该 cell 最高只到 `Configured`"
-        "（registry + owner YAML + compose/contract 覆盖），不代表任何训练验证。真机 env smoke 慢车道"
-        "测试（`tests/envs/locomotion/g1/test_g1_owner_contract.py`：compose → env 构造 → keyframe "
-        "reset → 12 步有限稳定 → cleanup）在装有 CUDA 与 genesis extra 的机器上通过。adapter 的 "
+        "`gs.init`），当前只接入 `g1_walk_flat` 的 PPO (torch) 与 SAC (torch) owner。这些 cell 最高只到 "
+        "`Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练验证。真机证据："
+        "env smoke 慢车道测试（`tests/envs/locomotion/g1/test_g1_owner_contract.py`：compose → env 构造 "
+        "→ keyframe reset → 12 步有限稳定 → cleanup，覆盖 ppo 与 sac 两棵树）在装有 CUDA 与 genesis "
+        "extra 的机器上通过；SAC owner 另有短训练回路 smoke（64 envs / 3 iterations，含 "
+        "learning_starts/updates_per_step 路径与 checkpoint 保存）验证，均非完整训练验证。adapter 的 "
         "`materialize()` 幂等且惰性触发（entity 校验在 env 的 materialize 钩子前读取状态 getter；"
         "isaacgym 后端同模式）。Genesis 在 import 时丢弃 MJCF 全局 "
         "`<option>`，owner YAML 显式重声明 `genesis_integrator=implicitfast`。未支持边界：geom 名称"

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -245,6 +245,22 @@ _OWNER_CASES = (
     ),
     pytest.param(
         "sac",
+        ("task=g1_walk_flat/genesis",),
+        "G1WalkFlat",
+        "genesis",
+        29,
+        1.0,
+        "scene_flat.xml",
+        _OFFPOLICY_REWARDS,
+        # kp/kd reset randomization stays enabled: the backend declares the
+        # measured RESET_TERM_KP/KD DR terms (REPORT #1372 §5.7), unlike the
+        # isaacgym owner which disables pd_gains.
+        (*_RESET_EVENTS, "pd_gains"),
+        True,
+        id="sac-genesis",
+    ),
+    pytest.param(
+        "sac",
         ("task=g1_walk_rough/mujoco",),
         "G1WalkRough",
         "mujoco",
@@ -327,6 +343,7 @@ _WALK_PROFILE_IDS = {
     "sac-mujoco",
     "sac-motrix",
     "sac-mjwarp",
+    "sac-genesis",
     "sac-rough-mujoco",
     "sac-rough-motrix",
     "sac-23dof-mujoco",
@@ -869,7 +886,10 @@ def _genesis_runtime_available() -> bool:
 # (REPORT #1372 §3.5 [9a]) and tests/base/test_genesis_runtime.py deliberately
 # destroys the session to verify re-init fails closed, so an in-process smoke
 # could observe a poisoned session depending on pytest collection order.
+# The config group (ppo/sac) arrives as argv[1]; each parametrized case gets
+# its own subprocess, hence its own gs session.
 _GENESIS_ENV_SMOKE_SCRIPT = """
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -882,16 +902,19 @@ from unilab.base.config_materialization import apply_cfg_overrides
 from unilab.envs import ManagerBasedRlEnv, ManagerBasedRlEnvCfg
 
 ROOT = Path.cwd()
+CONFIG_GROUP = sys.argv[1]
 
 registry.ensure_registries()
 GlobalHydra.instance().clear()
-with initialize_config_dir(config_dir=str(ROOT / "conf" / "ppo"), version_base="1.3"):
+with initialize_config_dir(config_dir=str(ROOT / "conf" / CONFIG_GROUP), version_base="1.3"):
     hydra_cfg = compose("config", overrides=["task=g1_walk_flat/genesis"])
 assert hydra_cfg.training.task_name == "G1WalkFlat"
 assert hydra_cfg.training.sim_backend == "genesis"
 assert hydra_cfg.training.play_render_mode == "none"
 
-env_override = BackendAdapter(hydra_cfg, root_dir=ROOT).build_task_env_cfg_override()
+env_override = BackendAdapter(
+    hydra_cfg, root_dir=ROOT, algo_name=CONFIG_GROUP
+).build_task_env_cfg_override()
 env_cfg = registry.materialize_env_config("G1WalkFlat")
 assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
 apply_cfg_overrides(env_cfg, env_override)
@@ -942,7 +965,7 @@ try:
         raise AssertionError("genesis playback mode 'record' must fail closed")
 
     print(
-        "[genesis env smoke] reset+12 steps OK; "
+        f"[genesis env smoke:{CONFIG_GROUP}] reset+12 steps OK; "
         f"obs={obs['obs'].shape} critic={obs['critic'].shape} "
         f"reward0={state.reward.mean():.4f}"
     )
@@ -953,20 +976,21 @@ finally:
 
 
 @pytest.mark.slow
-def test_g1_walk_flat_genesis_owner_real_runtime_smoke() -> None:
+@pytest.mark.parametrize("config_group", ("ppo", "sac"))
+def test_g1_walk_flat_genesis_owner_real_runtime_smoke(config_group: str) -> None:
     """Real-runtime smoke for the genesis owner (genesis-world 1.3.3 + CUDA).
 
-    Full chain: Hydra compose of task=g1_walk_flat/genesis -> registry lookup
-    -> ManagerBasedRlEnv construction -> keyframe reset -> 12 steps with
-    finite/shape-stable action/state/sensor reads -> explicit cleanup; the
-    play path enters safely with play_render_mode=none and fails closed on
-    rendering modes.
+    Full chain per algo tree: Hydra compose of task=g1_walk_flat/genesis ->
+    registry lookup -> ManagerBasedRlEnv construction -> keyframe reset -> 12
+    steps with finite/shape-stable action/state/sensor reads -> explicit
+    cleanup; the play path enters safely with play_render_mode=none and fails
+    closed on rendering modes.
     """
     if not _genesis_runtime_available():
         pytest.skip("genesis requires the genesis-world extra and a CUDA device")
 
     result = subprocess.run(
-        [sys.executable, "-c", _GENESIS_ENV_SMOKE_SCRIPT],
+        [sys.executable, "-c", _GENESIS_ENV_SMOKE_SCRIPT, config_group],
         cwd=ROOT_DIR,
         capture_output=True,
         text=True,
@@ -974,4 +998,4 @@ def test_g1_walk_flat_genesis_owner_real_runtime_smoke() -> None:
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
-    assert "[genesis env smoke]" in result.stdout
+    assert f"[genesis env smoke:{config_group}]" in result.stdout

--- a/tests/envs/test_env_configs.py
+++ b/tests/envs/test_env_configs.py
@@ -50,7 +50,9 @@ def _allegro_manager_override(
     ).build_task_env_cfg_override()
 
 
-def _g1_manager_override(task: str = "g1_walk_flat", backend: str = "mujoco") -> dict[str, Any]:
+def _g1_manager_override(
+    task: str = "g1_walk_flat", backend: str = "mujoco", config_group: str = "ppo"
+) -> dict[str, Any]:
     from hydra import compose, initialize_config_dir
 
     from unilab.base.config_adapter import BackendAdapter
@@ -63,9 +65,13 @@ def _g1_manager_override(task: str = "g1_walk_flat", backend: str = "mujoco") ->
         return BackendAdapter(
             cfg, root_dir=repo_root, algo_name="sac"
         ).build_task_env_cfg_override()
-    with initialize_config_dir(config_dir=str(repo_root / "conf" / "ppo"), version_base="1.3"):
+    with initialize_config_dir(
+        config_dir=str(repo_root / "conf" / config_group), version_base="1.3"
+    ):
         cfg = compose("config", overrides=[f"task={task}/{backend}"])
-    return BackendAdapter(cfg, root_dir=repo_root, algo_name="ppo").build_task_env_cfg_override()
+    return BackendAdapter(
+        cfg, root_dir=repo_root, algo_name=config_group
+    ).build_task_env_cfg_override()
 
 
 def _motion_manager_override(
@@ -182,14 +188,15 @@ def test_g1_walk_flat_isaacgym_owner_composes_and_materializes():
     assert env_cfg.events["pd_gains"] is None
 
 
-def test_g1_walk_flat_genesis_owner_composes_and_materializes():
-    """The genesis owner composes and materializes a plain manager env cfg."""
+@pytest.mark.parametrize("config_group", ("ppo", "sac"))
+def test_g1_walk_flat_genesis_owner_composes_and_materializes(config_group):
+    """The genesis owners compose and materialize a plain manager env cfg."""
     from unilab.base import registry
     from unilab.base.config_materialization import apply_cfg_overrides
     from unilab.envs import ManagerBasedRlEnvCfg
 
     ensure_registries()
-    override = _g1_manager_override("g1_walk_flat", backend="genesis")
+    override = _g1_manager_override("g1_walk_flat", backend="genesis", config_group=config_group)
     env_cfg = registry.materialize_env_config("G1WalkFlat")
     assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
     apply_cfg_overrides(env_cfg, override)

--- a/tests/scripts/test_audit_sim2sim_contracts.py
+++ b/tests/scripts/test_audit_sim2sim_contracts.py
@@ -32,7 +32,7 @@ def test_discover_offpolicy_trees_group_by_task() -> None:
     flashsac = audit._discover("flashsac")
     td3 = audit._discover("td3")
 
-    assert {"mujoco", "motrix", "mjwarp", "isaacgym"}.issubset(sac["g1_walk_flat"])
+    assert {"mujoco", "motrix", "mjwarp", "isaacgym", "genesis"}.issubset(sac["g1_walk_flat"])
     assert {"mujoco", "motrix", "mjwarp"}.issubset(flashsac["g1_walk_flat"])
     assert td3["g1_walk_flat"] == ["mujoco"]
 

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -74,12 +74,12 @@ def test_support_matrix_does_not_promote_unvalidated_isaacgym_entries():
 
 
 def test_support_matrix_marks_g1_genesis_owner_configured_only():
-    """Genesis ships owner YAML + contract coverage but no training validation."""
-    ppo_row = _row("PPO (torch)", "g1_walk_flat")
-    assert ppo_row.cells["genesis"].level == EvidenceLevel.CONFIGURED
+    """Genesis ships owner YAMLs + contract coverage but no training validation."""
+    for entrypoint_label in ("PPO (torch)", "SAC (torch)"):
+        row = _row(entrypoint_label, "g1_walk_flat")
+        assert row.cells["genesis"].level == EvidenceLevel.CONFIGURED
     for entrypoint_label in (
         "APPO (torch)",
-        "SAC (torch)",
         "TD3 (torch)",
         "FlashSAC (torch)",
     ):


### PR DESCRIPTION
## 概要

Implements #1386（roadmap #1339 追加项，maintainer 确认）。为 g1_walk_flat 追加 **SAC** 任务的 genesis owner，训练链路真机验证通过。沿用 Child 3（#1384）的 ppo owner 全部约定。

## 交付物（9 文件：1 新 + 8 改；约 125 手写 LOC）

- `conf/sac/task/g1_walk_flat/genesis.yaml`：algo 块与 mujoco SAC owner 逐项一致（num_envs 2048 / learning_starts 10 / max_iterations 5000 / save_interval 1000 / updates_per_step 8 / algo_params）保 DENYLIST parity；`genesis_integrator: implicitfast`；`play_render_mode: none`；kp/kd reset 随机化保持启用（genesis 声明实测 RESET_TERM_KP/KD DR，注释写明与 isaacgym owner `pd_gains: null` 的差异理由）
- 测试：owner contract 追加 sac-genesis 用例（action_scale / offpolicy rewards / pd_gains 事件 / curriculum 断言）；既有真机 smoke 参数化 ppo/sac 两树（子进程隔离，满足一进程一 gs.init）；compose / audit discovery / support matrix 断言同步
- 支持矩阵：genesis 列追加 SAC g1_walk_flat cell（Configured，上限不变）；`5-support_matrix.md` 重新生成
- 文档：5-genesis.md 中英文从「只接入 PPO」更新为 PPO+SAC，加 `uv run train --algo sac --task g1_walk_flat --sim genesis` canonical 命令

## Validation（RTX 4090 / torch 2.8.0+cu128 / genesis-world 1.3.3，均实跑）

- **SAC 短训练回路 smoke**：`uv run train --algo sac --task g1_walk_flat --sim genesis algo.num_envs=64 algo.max_iterations=3 algo.learning_starts=1 algo.save_interval=1` → exit 0；`Iterations: 3/3 | Total env steps: 8,384`；`Actor Loss -0.7412 / Qf Loss 9.107 / Alpha 0.0010 / Policy Entropy -28.688`；checkpoint `model_1/2/3.pt` + `run_config.json` 落盘（override learning_starts/save_interval 是为触发 updates 与保存路径的验证目标）
- **env smoke（slow lane，ppo+sac 参数化）**：2 passed（compose → 构造 → keyframe reset → 12 步有限稳定 → play none/record → cleanup）
- **audit**：sac 树自动发现 genesis owner，`VERDICT (mujoco<->genesis): TRANSFERABLE`
- 非 slow 全量：2418 passed / 28 skipped / 1 xfailed（既有）；ruff/format、docs 检查、Sphinx 构建全绿
- 最终 head `2f0400f3` 本地 `make test-all`（标准 env）：通过（exit=0；ruff clean；pytest 2418 passed / 28 skipped / 1 xfailed）

## 边界确认

- 不验证训练收敛（cell 仍标 Configured 而非 Tested）；td3/flashsac/appo 不在本次范围；无 playback/render 集成；未改 adapter/contract。
