### PR TITLE
fix(runner): collector inference tick 超时配置化（#1391）

### DIFF
--- a/conf/sac/config.yaml
+++ b/conf/sac/config.yaml
@@ -78,6 +78,10 @@ training:
   log_root: null
   log_dir: null
   env_steps_per_sync: 1
+  # Seconds the learner waits for each collector inference tick before
+  # failing. Tick 0 includes collector env construction, whose cost is
+  # backend-owned; slow-start backends raise this in their task owner YAML.
+  inference_request_timeout_sec: 30.0
   trace_enabled: false
   trace_output_dir: null
   trace_thread_time: false

--- a/conf/sac/task/g1_walk_flat/genesis.yaml
+++ b/conf/sac/task/g1_walk_flat/genesis.yaml
@@ -22,6 +22,10 @@ training:
   task_name: G1WalkFlat
   sim_backend: genesis
   play_render_mode: auto
+  # Genesis compiles its kernels on the materialize cold path (~35 s at
+  # num_envs=2048 on an RTX 4090, no cross-process cache), which exceeds the
+  # runner's default 30 s collector tick-0 budget; raise it for this backend.
+  inference_request_timeout_sec: 180.0
 algo:
   num_envs: 2048
   learning_starts: 10

--- a/src/unilab/algos/fast_sac/double_buffer.py
+++ b/src/unilab/algos/fast_sac/double_buffer.py
@@ -123,4 +123,5 @@ def build_sac_double_buffer_runner(
         torch_thread_runtime=torch_thread_runtime,
         collector_cpu_ids=collector_cpu_ids,
         dp_sync=dp_sync,
+        inference_request_timeout_sec=getattr(cfg.training, "inference_request_timeout_sec", None),
     )

--- a/src/unilab/algos/offpolicy/double_buffer_runner.py
+++ b/src/unilab/algos/offpolicy/double_buffer_runner.py
@@ -157,6 +157,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         replay_prefetch_mode: str = "one_tick",
         collector_cpu_ids: list[int] | None = None,
         dp_sync: DpParameterSync | None = None,
+        inference_request_timeout_sec: float | None = None,
         **kwargs,
     ):
         kwargs["device"] = require_offpolicy_replay_device(kwargs.get("device"))
@@ -170,6 +171,23 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                 "DoubleBufferOffPolicyRunner only supports replay_prefetch_mode='one_tick'"
             )
         self.replay_prefetch_mode = replay_prefetch_mode
+        if inference_request_timeout_sec is not None and (
+            isinstance(inference_request_timeout_sec, bool)
+            or not isinstance(inference_request_timeout_sec, (int, float))
+            or inference_request_timeout_sec <= 0
+        ):
+            raise ValueError(
+                "inference_request_timeout_sec must be a positive number or None, "
+                f"got {inference_request_timeout_sec!r}"
+            )
+        # Tick-0 wait covers collector env construction, whose cost is
+        # backend-owned (e.g. genesis kernel compilation at scale); owners of
+        # slow-start backends raise this via their task YAML.
+        self.inference_request_timeout_sec = (
+            float(inference_request_timeout_sec)
+            if inference_request_timeout_sec is not None
+            else self.INFERENCE_REQUEST_TIMEOUT_SEC
+        )
         # Per-rank CPU block owned by this rank's collector (multi-GPU DP);
         # merged into the collector-only env override at collector startup.
         self.collector_cpu_ids = list(collector_cpu_ids) if collector_cpu_ids is not None else None
@@ -528,7 +546,7 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
         ckpt_path: str | None,
         train_start_wall: float,
     ) -> int:
-        deadline = time.monotonic() + self.INFERENCE_REQUEST_TIMEOUT_SEC
+        deadline = time.monotonic() + self.inference_request_timeout_sec
         while True:
             try:
                 tick_id = int(queue.get(timeout=0.1))
@@ -553,7 +571,8 @@ class DoubleBufferOffPolicyRunner(OffPolicyRunner):
                     )
                 if time.monotonic() >= deadline:
                     raise TimeoutError(
-                        f"Timed out waiting for collector inference tick {expected_tick}"
+                        f"Timed out waiting for collector inference tick {expected_tick} "
+                        f"(inference_request_timeout_sec={self.inference_request_timeout_sec})"
                     )
                 continue
             if tick_id != int(expected_tick):

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -208,6 +208,13 @@ def test_sac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
         "nvtx_profile_ranges": cfg.training.nvtx_profile_ranges,
         "critic_obs_dim": 6,
     }
+    assert runner.kwargs["inference_request_timeout_sec"] == 30.0
+
+
+def test_sac_genesis_owner_raises_inference_request_timeout():
+    """Genesis kernel compilation exceeds the 30 s default tick-0 budget."""
+    cfg = _offpolicy_cfg(["task=g1_walk_flat/genesis"])
+    assert cfg.training.inference_request_timeout_sec == 180.0
 
 
 def test_sac_owner_custom_runtime_can_override_base_learner_kwargs(


### PR DESCRIPTION
## 概要

Fixes #1391。真机完整训练 `uv run train --algo sac --task g1_walk_flat --sim genesis`（owner 原始配置）启动即失败：`TimeoutError: Timed out waiting for collector inference tick 0`。根因实测：Genesis 在 materialize 冷路径编译 quadrants 内核，2048 envs 实测 **33.8–36.3s**（两个独立进程均如此，无跨进程缓存生效），确定性超出 runner 硬编码的 30s tick-0 预算。64 envs 短 smoke 因启动较快未触及。

## 修复（runner owner 层最小变更，不改 lifecycle / 同步协议）

- `DoubleBufferOffPolicyRunner`：`inference_request_timeout_sec` 可选构造参数（默认仍 30.0，校验正数），tick 等待与 TimeoutError 消息改用实例值（消息含当前预算便于诊断）；
- fast_sac builder 从 `cfg.training.inference_request_timeout_sec` 透传（`getattr` 兼容缺失）；td3/flashsac 路径不受影响（None 默认）；
- `conf/sac/config.yaml` 记录默认值 30.0 及语义（tick 0 覆盖 collector env 构造，成本归 backend owner）；
- `conf/sac/task/g1_walk_flat/genesis.yaml` 提至 **180.0**（冷编译 ~35s 的充足余量，注释写明依据）；
- 测试：SAC dispatch kwargs 断言新参数流过；sac genesis owner compose 断言 180.0。

先例：`isaacgym_worker_timeout_s` 同样是把后端相关超时显式配置化。

## Validation

- 单测：`tests/algos/test_offpolicy_double_buffer_runner.py` 35 passed；ruff/format 干净；
- 真机完整训练（RTX 4090 / torch 2.8.0+cu128 / genesis-world 1.3.3）：端到端运行中（启动已越过 tick 0 阶段；完整 5000 iterations 结果将以评论补充）
- 最终 head `737711fd` 本地 `make test-all`：通过（exit=0；ruff clean；pytest 2426 passed / 28 skipped / 1 xfailed）
