### PR TITLE
fix(backend): viewer 关闭异常在 step 边界翻译为 RenderClosedError（#1393）

### DIFF
--- a/src/unilab/base/backend/genesis/backend.py
+++ b/src/unilab/base/backend/genesis/backend.py
@@ -540,6 +540,32 @@ class GenesisBackend(SimBackend):
             self._to_device(ctrl), dofs_idx_local=self._actuated_dofs
         )
 
+    def _raise_if_viewer_closed(self, exc: BaseException | None = None) -> None:
+        """Translate a closed genesis viewer into the contract's RenderClosedError.
+
+        Genesis 1.3.3 raises its private exception from ``visualizer.update``,
+        which fires both from our ``render()`` and from ``scene.step()`` itself
+        while a viewer is attached; the contract surface is the same either
+        way. Any other exception while the viewer is still alive is re-raised.
+        The dead viewer is also detached from the visualizer so later physics
+        steps are not poisoned by it (the renderer is gone for good).
+        """
+        if self._viewer is not None and not self._viewer.is_alive():
+            visualizer = self._scene.visualizer
+            if getattr(visualizer, "_viewer", None) is self._viewer:
+                # Only drop the viewer reference; ``viewer_lock`` stays: the
+                # rasterizer uses it as a context manager during destroy.
+                visualizer._viewer = None
+            self._viewer = None
+            raise RenderClosedError("genesis viewer window was closed") from exc
+
+    def _physics_substep(self) -> None:
+        try:
+            self._scene.step()
+        except Exception as exc:
+            self._raise_if_viewer_closed(exc)
+            raise
+
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
         self._require_state("step")
         if isinstance(nsteps, bool) or int(nsteps) <= 0:
@@ -555,7 +581,7 @@ class GenesisBackend(SimBackend):
             # matching MuJoCo ctrl-broadcast semantics (REPORT §3.3 [3b]).
             self._push_control(ctrl_array)
             for _ in range(int(nsteps)):
-                self._scene.step()
+                self._physics_substep()
         else:
             # Adapter-side per-substep hook: the conversion reads the freshly
             # refreshed sensor contract before every physics substep (REPORT
@@ -563,7 +589,7 @@ class GenesisBackend(SimBackend):
             for _ in range(int(nsteps)):
                 converted = self._apply_pre_step_control(ctrl_array)
                 self._push_control(converted)
-                self._scene.step()
+                self._physics_substep()
                 self._refresh_host_cache()
         physics_ms = (time.perf_counter() - t0) * 1000.0
 
@@ -931,13 +957,9 @@ class GenesisBackend(SimBackend):
         except Exception as exc:
             # Genesis 1.3.3 raises its private error when the window is gone;
             # translate it at the interface boundary per the contract.
-            if not self._viewer.is_alive():
-                self._viewer = None
-                raise RenderClosedError("genesis viewer window was closed") from exc
+            self._raise_if_viewer_closed(exc)
             raise
-        if not self._viewer.is_alive():
-            self._viewer = None
-            raise RenderClosedError("genesis viewer window was closed")
+        self._raise_if_viewer_closed()
 
     def capture_video_frame(self) -> np.ndarray:
         """Capture one offscreen RGB frame (self-initializes headless+capture)."""

--- a/tests/base/genesis_fake_runtime.py
+++ b/tests/base/genesis_fake_runtime.py
@@ -337,6 +337,10 @@ class _FakeVisualizer:
         return camera
 
     def update(self, force=True, auto=None):
+        # Real genesis 1.3.3 raises its private exception here when the
+        # attached viewer has been closed by the user.
+        if self._viewer is not None and not self._viewer.is_alive():
+            raise RuntimeError("Viewer closed.")
         self.update_count += 1
 
 
@@ -372,6 +376,9 @@ class _FakeScene:
     def step(self):
         for entity in self.entities:
             entity.step()
+        # Real genesis updates the attached viewer from scene.step() too.
+        if self.visualizer._viewer is not None:
+            self.visualizer.update()
 
 
 def make_fake_genesis() -> types.SimpleNamespace:

--- a/tests/base/test_genesis_backend.py
+++ b/tests/base/test_genesis_backend.py
@@ -592,6 +592,24 @@ def test_interactive_render_self_init_and_close(
     assert backend._viewer is None
 
 
+def test_step_translates_viewer_closed(
+    fake_genesis, tiny_model_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1393: scene.step() updates the attached viewer; a closed viewer must
+    surface as RenderClosedError from backend.step, not a raw private error."""
+    monkeypatch.setenv("DISPLAY", ":0")
+    backend = _backend(tiny_model_file)
+    backend.render()  # attaches the interactive viewer
+    ctrl = np.zeros((backend.num_envs, backend.num_actuators), dtype=np.float32)
+    backend.step(ctrl)  # live viewer: scene.step updates it fine
+    backend._viewer.alive = False
+    with pytest.raises(RenderClosedError, match="viewer window was closed"):
+        backend.step(ctrl)
+    assert backend._viewer is None
+    # Dead viewer is detached: physics keeps working without a renderer.
+    backend.step(ctrl)
+
+
 def test_interactive_viewer_requires_display(
     fake_genesis, tiny_model_file: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -662,7 +680,9 @@ def test_run_playback_interactive_drives_viewer_until_closed(
     )
     assert result is None  # interactive close is a clean exit, not an error
     assert steps == [0, 1, 2]
-    assert backend._scene.visualizer.update_count == 3
+    # Steps 1-2 update the live viewer; at step 3 the viewer is already dead,
+    # so update raises (real genesis semantics) before it could count.
+    assert backend._scene.visualizer.update_count == 2
 
 
 def test_constructor_validation_and_factory_wiring(fake_genesis, tiny_model_file: str) -> None:

--- a/tests/base/test_genesis_runtime.py
+++ b/tests/base/test_genesis_runtime.py
@@ -226,6 +226,19 @@ def test_interactive_viewer_renders_frames() -> None:
     viewer_backend._viewer.stop()
     with pytest.raises(RenderClosedError, match="viewer window was closed"):
         viewer_backend.render()
+    assert viewer_backend._viewer is None
+
+    # #1393: scene.step() updates the attached viewer too; a closed viewer must
+    # surface as RenderClosedError from backend.step, then detach cleanly.
+    # Both backends share the module session (multi-scene, REPORT [9b]); only
+    # the re-init guard test below may destroy it.
+    step_backend = _make_backend()
+    step_backend.init_renderer(headless=False, width=640, height=480)
+    step_backend._viewer.stop()
+    with pytest.raises(RenderClosedError, match="viewer window was closed"):
+        step_backend.step(np.zeros((8, step_backend.num_actuators), dtype=np.float32))
+    assert step_backend._viewer is None
+    step_backend.step(np.zeros((8, step_backend.num_actuators), dtype=np.float32))
     print("[genesis interactive] viewer attached post-build; 3 frames rendered; close detected")
 
 


### PR DESCRIPTION
## 概要

Fixes #1393。真机完整训练（#1391 修复后）5000/5000 iterations 全部完成，但收尾 play 阶段（`play_render_mode=auto` → interactive）以 exit 1 崩溃：`genesis.GenesisException: Viewer closed.` 从 `GenesisBackend.step` 逃逸——Genesis 挂有 viewer 时 `scene.step()` 内部也会更新 viewer（scene.py → visualizer.update → viewer.update），而 #1388 的 `RenderClosedError` 翻译只覆盖了 adapter 自己的 `render()` 路径。

## 修复

- `_raise_if_viewer_closed` 统一翻译（`render()` 与 `step()` 共用）：viewer 死亡时抛契约 `RenderClosedError`，并把死 viewer 从 visualizer 分离（只清 `_viewer` 引用，保留 `viewer_lock`——rasterizer destroy 路径将其用作 context manager）；分离后无 renderer 的物理步进可继续。
- `_physics_substep` 包装 `scene.step()` 的翻译边界，`step()` 两个分支（含/不含 pre_step hook）共用。
- fake runtime 复刻真实行为：`scene.step` 更新挂载的 viewer、viewer 死亡时 `update` 抛错；playback mock 的 update 计数断言同步为忠实语义。
- 测试：mock `test_step_translates_viewer_closed`（含分离后物理续跑）；真机 interactive 测试增补 step 关闭断言（双 backend 共享模块会话，不 close——只有 re-init 守卫测试可销毁会话）。

## Validation

- 真机端到端：短训练 + `play_render_mode=auto` play 阶段 **exit 0**——viewer 中途关闭时 INFO `Render window closed.` 干净退出（修复前同场景 exit 1 崩溃）；
- 真机 slow 电池同进程 **16 passed**（runtime + conformance，含新 step 关闭断言）；mock **26 passed**；
- 最终 head `42dfd387` 本地 `make test-all`：通过（exit=0；ruff clean；pytest 2427 passed / 28 skipped / 1 xfailed）。
