### PR TITLE
fix(backend): 交互 viewer 相机姿态改用 Z-up 完整矩阵（#1396）

### DIFF
--- a/src/unilab/base/backend/genesis/backend.py
+++ b/src/unilab/base/backend/genesis/backend.py
@@ -913,7 +913,9 @@ class GenesisBackend(SimBackend):
             pos, lookat = playback.camera_pose_from_kwargs(
                 self._camera_kwargs, self._camera_lookat()
             )
-            viewer.set_camera_pose(pos=tuple(pos), lookat=tuple(lookat))
+            # #1396: the viewer's pos/lookat branch reuses its polluted
+            # default _camera_up; pass the full Z-up pose matrix instead.
+            viewer.set_camera_pose(pose=playback.camera_pose_matrix_z_up(pos, lookat))
             if self._camera_tracking_env_idx is not None:
                 viewer.follow_entity(self._entity)
             self._viewer = viewer

--- a/src/unilab/base/backend/genesis/playback.py
+++ b/src/unilab/base/backend/genesis/playback.py
@@ -57,6 +57,29 @@ def camera_pose_from_kwargs(
     return target + offset, target
 
 
+def camera_pose_matrix_z_up(pos: np.ndarray, lookat: np.ndarray) -> np.ndarray:
+    """Build the 4x4 camera-to-world matrix for a Z-up world.
+
+    The interactive viewer's ``set_camera_pose(pos, lookat)`` reuses the
+    viewer's current ``_camera_up``, which genesis initializes from its own
+    default camera pose — a tilted vector, not world Z-up (#1396). Passing the
+    full ``pose=`` matrix bypasses that polluted state entirely.
+    """
+    pos = np.asarray(pos, dtype=np.float64)
+    lookat = np.asarray(lookat, dtype=np.float64)
+    z_axis = pos - lookat
+    z_axis /= np.linalg.norm(z_axis)
+    x_axis = np.cross(np.array([0.0, 0.0, 1.0]), z_axis)
+    x_axis /= np.linalg.norm(x_axis)
+    y_axis = np.cross(z_axis, x_axis)
+    transform = np.eye(4, dtype=np.float64)
+    transform[:3, 0] = x_axis
+    transform[:3, 1] = y_axis
+    transform[:3, 2] = z_axis
+    transform[:3, 3] = pos
+    return transform
+
+
 def run_genesis_playback(
     *,
     backend: Any,

--- a/tests/base/genesis_fake_runtime.py
+++ b/tests/base/genesis_fake_runtime.py
@@ -310,7 +310,7 @@ class _FakeViewer:
         self.built_scene = scene
 
     def set_camera_pose(self, pose=None, pos=None, lookat=None):
-        self.camera_pose = (pos, lookat)
+        self.camera_pose = (pose, pos, lookat)
 
     def follow_entity(self, entity, **kwargs):
         self.followed_entity = entity

--- a/tests/base/test_genesis_backend.py
+++ b/tests/base/test_genesis_backend.py
@@ -586,6 +586,12 @@ def test_interactive_render_self_init_and_close(
     assert backend._scene.visualizer._viewer is viewer
     backend.render()
     assert backend._scene.visualizer.update_count == 2
+    # #1396: the viewer receives the full Z-up pose matrix (the pos/lookat
+    # branch would reuse the viewer's polluted default up vector).
+    pose, pos, lookat = viewer.camera_pose
+    assert pos is None and lookat is None
+    assert pose.shape == (4, 4)
+    assert pose[2, 0] == pytest.approx(0.0, abs=1e-12)  # camera x-axis level
     viewer.alive = False
     with pytest.raises(RenderClosedError, match="viewer window was closed"):
         backend.render()

--- a/tests/base/test_genesis_runtime.py
+++ b/tests/base/test_genesis_runtime.py
@@ -220,6 +220,17 @@ def test_interactive_viewer_renders_frames() -> None:
 
     viewer_backend = _make_backend()
     viewer_backend.init_renderer(headless=False, width=640, height=480)
+    # #1396: the trackball pose must equal the Z-up matrix (the viewer's
+    # pos/lookat branch reuses a tilted default up and rolls the camera).
+    expected_pose = genesis_playback.camera_pose_matrix_z_up(
+        *genesis_playback.camera_pose_from_kwargs(
+            viewer_backend._camera_kwargs, viewer_backend._camera_lookat()
+        )
+    )
+    actual_pose = np.asarray(
+        viewer_backend._viewer._pyrender_viewer._trackball.pose, dtype=np.float64
+    )
+    np.testing.assert_allclose(actual_pose, expected_pose, atol=1e-5)
     for _ in range(3):
         viewer_backend.step(np.zeros((8, viewer_backend.num_actuators), dtype=np.float32))
         viewer_backend.render()


### PR DESCRIPTION
## 概要

Fixes #1396。真机 eval 交互式渲染视角倾斜（地面斜向上，离屏 record 正常）。

根因（genesis-world 1.3.3 `viewer.py:263-288`）：`Viewer.set_camera_pose(pos, lookat)` 复用 `self._camera_up` 作为 up 向量，而 `_camera_up` 在 Viewer 初始化时被改写为 ViewerOptions **默认相机位姿**（pos=(3.5,0.5,2.5)）的相机系 y 轴——倾斜向量 ≈(-0.49,-0.07,0.87)，并非世界 Z-up；`ViewerOptions(camera_up=(0,0,1))` 同样被初始化调用覆盖。实测证据：设置 pos/lookat 后 trackball 位姿与期望 Z-up 矩阵 max abs diff **0.50**（绕视轴滚转约 30°）。离屏 camera 路径显式传 `up=(0,0,1)`，故离线正常。

## 修复

- `playback.camera_pose_matrix_z_up`：adapter 自行用 Z-up 构建 4×4 相机位姿；`init_renderer` 交互分支改传 `pose=`（该分支不读 `_camera_up`），彻底绕开被污染的默认状态。
- mock：断言 viewer 收到完整 pose 矩阵且相机 x 轴水平（`pose[2,0]==0`）；fake 记录 `set_camera_pose` 全参数。
- 真机 slow lane：读回 trackball pose 与期望矩阵 `assert_allclose(atol=1e-5)`——修复前该断言 diff 0.50，现在通过，防回归。

## Validation

- 真机 slow 电池同进程 **16 passed**（含新 trackball 矩阵断言）；mock **26 passed**；
- 最终 head `238b7755` 本地 `make test-all`：通过（exit=0；ruff clean；pytest 2427 passed / 28 skipped / 1 xfailed）。
