### PR TITLE
feat: 通用 IMU 安装错位 obs term（S4/#1400）

### DIFF
--- a/conf/ppo/task/microduck_velocity_flat/base.yaml
+++ b/conf/ppo/task/microduck_velocity_flat/base.yaml
@@ -47,16 +47,16 @@ env:
       enable_corruption: true
       terms:
         base_ang_vel:
-          func: unilab.envs.mdp.builtin_sensor
-          params: {sensor_name: gyro}
+          func: unilab.envs.mdp.base_ang_vel_imu_misaligned
+          params: {max_angle_deg: 6.0}
           noise:
             _target_: unilab.managers._noise.UniformNoiseCfg
             n_min: -0.03
             n_max: 0.03
             operation: add
         projected_gravity:
-          func: unilab.envs.mdp.projected_gravity_from_sensor
-          params: {sensor_name: upvector}
+          func: unilab.envs.mdp.projected_gravity_imu_misaligned
+          params: {max_angle_deg: 6.0}
           noise:
             _target_: unilab.managers._noise.UniformNoiseCfg
             n_min: -0.01

--- a/conf/sac/task/microduck_velocity_flat/base.yaml
+++ b/conf/sac/task/microduck_velocity_flat/base.yaml
@@ -50,16 +50,16 @@ env:
       enable_corruption: true
       terms:
         base_ang_vel:
-          func: unilab.envs.mdp.builtin_sensor
-          params: {sensor_name: gyro}
+          func: unilab.envs.mdp.base_ang_vel_imu_misaligned
+          params: {max_angle_deg: 6.0}
           noise:
             _target_: unilab.managers._noise.UniformNoiseCfg
             n_min: -0.03
             n_max: 0.03
             operation: add
         projected_gravity:
-          func: unilab.envs.mdp.projected_gravity_from_sensor
-          params: {sensor_name: upvector}
+          func: unilab.envs.mdp.projected_gravity_imu_misaligned
+          params: {max_angle_deg: 6.0}
           noise:
             _target_: unilab.managers._noise.UniformNoiseCfg
             n_min: -0.01

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -19,6 +19,9 @@ from unilab.envs.mdp.events import reset_root_state_uniform as reset_root_state_
 from unilab.envs.mdp.events import reset_scene_to_default as reset_scene_to_default
 from unilab.envs.mdp.events import resolve_env_ids as resolve_env_ids
 from unilab.envs.mdp.observations import base_ang_vel as base_ang_vel
+from unilab.envs.mdp.observations import (
+    base_ang_vel_imu_misaligned as base_ang_vel_imu_misaligned,
+)
 from unilab.envs.mdp.observations import base_lin_vel as base_lin_vel
 from unilab.envs.mdp.observations import builtin_sensor as builtin_sensor
 from unilab.envs.mdp.observations import generated_commands as generated_commands
@@ -28,6 +31,9 @@ from unilab.envs.mdp.observations import last_action as last_action
 from unilab.envs.mdp.observations import projected_gravity as projected_gravity
 from unilab.envs.mdp.observations import (
     projected_gravity_from_sensor as projected_gravity_from_sensor,
+)
+from unilab.envs.mdp.observations import (
+    projected_gravity_imu_misaligned as projected_gravity_imu_misaligned,
 )
 from unilab.envs.mdp.rewards import action_acc_l2 as action_acc_l2
 from unilab.envs.mdp.rewards import action_rate_l2 as action_rate_l2
@@ -54,6 +60,7 @@ __all__ = [
     "action_acc_l2",
     "action_rate_l2",
     "base_ang_vel",
+    "base_ang_vel_imu_misaligned",
     "base_lin_vel",
     "builtin_sensor",
     "bad_orientation",
@@ -77,6 +84,7 @@ __all__ = [
     "is_terminated",
     "projected_gravity",
     "projected_gravity_from_sensor",
+    "projected_gravity_imu_misaligned",
     "reset_root_state_uniform",
     "reset_scene_to_default",
     "resolve_env_ids",

--- a/src/unilab/envs/mdp/observations.py
+++ b/src/unilab/envs/mdp/observations.py
@@ -6,12 +6,14 @@
 
 from __future__ import annotations
 
+import weakref
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
 from unilab.managers.manager_base import ManagerTermBase, ManagerTermBaseCfg
 from unilab.managers.scene_entity_config import SceneEntityCfg
+from unilab.utils.rotation import np_quat_apply_batched, np_quat_from_angle_axis
 
 if TYPE_CHECKING:
     from unilab.base.entity import Entity
@@ -115,6 +117,106 @@ def projected_gravity(
     return asset.data.projected_gravity_b
 
 
+# Per-env constant IMU mounting-misalignment quaternions, keyed by env instance
+# and max_angle_rad. Sampled once per (env, angle) at term construction and
+# shared by every misaligned term of that env, so the gyroscope and gravity
+# observations see the SAME mounting error (legacy microduck recipe,
+# microduck_rl/src/mjlab_microduck/tasks/mdp.py:3618-3660). Weak keys keep the
+# cache from outliving the env.
+_IMU_MISALIGNMENT_QUATS: weakref.WeakKeyDictionary[ManagerBasedRlEnv, dict[float, np.ndarray]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _imu_misalignment_quat(env: ManagerBasedRlEnv, max_angle_rad: float) -> np.ndarray:
+    """Per-env constant IMU mounting-misalignment rotation, sampled once.
+
+    Models a fixed small mounting/calibration error of the IMU on each robot:
+    a rotation about an axis uniform on the sphere with magnitude uniform in
+    [0, max_angle_rad]. Sampled from ``env.rng`` on first use and cached for the
+    whole run (a startup-style systematic per-robot bias, not per-step noise and
+    not resampled on episode reset), matching the legacy semantics.
+
+    Returns (num_envs, 4) unit quaternions (w, x, y, z) in float32.
+    """
+    per_env = _IMU_MISALIGNMENT_QUATS.get(env)
+    if per_env is None:
+        per_env = {}
+        _IMU_MISALIGNMENT_QUATS[env] = per_env
+    quat = per_env.get(max_angle_rad)
+    if quat is None:
+        axis = env.rng.standard_normal((env.num_envs, 3))
+        angle = env.rng.uniform(0.0, max_angle_rad, size=env.num_envs)
+        quat = np_quat_from_angle_axis(angle, axis).astype(np.float32)
+        per_env[max_angle_rad] = quat
+    return quat
+
+
+class _ImuMisalignedObservation(ManagerTermBase):
+    """Cold-path binding shared by IMU mounting-misalignment observation terms."""
+
+    _term_name = "imu_misaligned"
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(env)
+        max_angle_deg = cfg.params.get("max_angle_deg", 1.0)
+        if isinstance(max_angle_deg, bool) or not isinstance(max_angle_deg, (int, float)):
+            raise ValueError(
+                f"Observation term '{self._term_name}' capability 'IMU misalignment' "
+                f"requires a real max_angle_deg, got {max_angle_deg!r}"
+            )
+        max_angle_deg = float(max_angle_deg)
+        if not np.isfinite(max_angle_deg) or max_angle_deg < 0.0:
+            raise ValueError(
+                f"Observation term '{self._term_name}' capability 'IMU misalignment' "
+                f"requires a finite non-negative max_angle_deg, got {max_angle_deg}"
+            )
+        self._max_angle_deg = max_angle_deg
+        self._quat = _imu_misalignment_quat(env, float(np.deg2rad(max_angle_deg)))
+
+    def _validate_max_angle(self, max_angle_deg: float) -> None:
+        if float(max_angle_deg) != self._max_angle_deg:
+            raise ValueError(
+                f"Observation term '{self._term_name}' was bound to max_angle_deg "
+                f"{self._max_angle_deg}, received {max_angle_deg}"
+            )
+
+    def _rotate(self, values: np.ndarray) -> np.ndarray:
+        return np_quat_apply_batched(self._quat, values)
+
+
+class base_ang_vel_imu_misaligned(_ImuMisalignedObservation):
+    """Base angular velocity rotated by the per-env constant IMU misalignment."""
+
+    _term_name = "base_ang_vel_imu_misaligned"
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        max_angle_deg: float = 1.0,
+        asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    ) -> np.ndarray:
+        self._validate_max_angle(max_angle_deg)
+        asset = cast("Entity", env.scene[asset_cfg.name])
+        return self._rotate(asset.data.root_link_ang_vel_b)
+
+
+class projected_gravity_imu_misaligned(_ImuMisalignedObservation):
+    """Projected gravity rotated by the SAME per-env IMU misalignment as the gyro."""
+
+    _term_name = "projected_gravity_imu_misaligned"
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        max_angle_deg: float = 1.0,
+        asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+    ) -> np.ndarray:
+        self._validate_max_angle(max_angle_deg)
+        asset = cast("Entity", env.scene[asset_cfg.name])
+        return self._rotate(asset.data.projected_gravity_b)
+
+
 def joint_pos_rel(
     env: ManagerBasedRlEnv,
     biased: bool = False,
@@ -158,6 +260,7 @@ def generated_commands(env: ManagerBasedRlEnv, command_name: str) -> np.ndarray:
 
 __all__ = [
     "base_ang_vel",
+    "base_ang_vel_imu_misaligned",
     "base_lin_vel",
     "builtin_sensor",
     "generated_commands",
@@ -166,4 +269,5 @@ __all__ = [
     "last_action",
     "projected_gravity",
     "projected_gravity_from_sensor",
+    "projected_gravity_imu_misaligned",
 ]

--- a/src/unilab/utils/rotation.py
+++ b/src/unilab/utils/rotation.py
@@ -119,6 +119,23 @@ def np_quat_to_axis_angle(q: np.ndarray) -> np.ndarray:
     return axis_angle
 
 
+def np_quat_from_angle_axis(angle: np.ndarray, axis: np.ndarray) -> np.ndarray:
+    """Convert axis-angle pairs to unit quaternions (N, 4), w-first.
+
+    ``angle`` has shape (N,) and ``axis`` has shape (N, 3); axes are normalized
+    internally. Inverse of :func:`np_quat_to_axis_angle`.
+    """
+    angle = np.atleast_1d(np.asarray(angle))
+    axis = np.atleast_2d(np.asarray(axis))
+    if axis.shape[-1] != 3 or angle.shape[0] != axis.shape[0]:
+        raise ValueError(f"Expected angle (N,) and axis (N, 3), got {angle.shape} and {axis.shape}")
+    axis = axis / np.linalg.norm(axis, axis=-1, keepdims=True)
+    half = 0.5 * angle
+    w = np.cos(half)
+    xyz = axis * np.sin(half)[:, None]
+    return np.concatenate([w[:, None], xyz], axis=1)
+
+
 def np_quat_angular_velocity(q: np.ndarray, dt: float) -> np.ndarray:
     """Estimate angular velocity from a quaternion time sequence using shortest-arc diffs."""
     if q.ndim != 2 or q.shape[1] != 4:

--- a/tests/envs/mdp/test_observations.py
+++ b/tests/envs/mdp/test_observations.py
@@ -135,6 +135,13 @@ class _CommandManager:
         return self.command
 
 
+class _FakeEnv:
+    """Attribute container with identity hash/eq for per-env term caches."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
 def _env() -> tuple[ManagerBasedRlEnv, _Backend]:
     backend = _Backend()
     scene = EntityScene(
@@ -148,7 +155,7 @@ def _env() -> tuple[ManagerBasedRlEnv, _Backend]:
     )
     env = cast(
         ManagerBasedRlEnv,
-        SimpleNamespace(
+        _FakeEnv(
             num_envs=backend.num_envs,
             scene=scene,
             action_manager=_ActionManager(),
@@ -383,6 +390,131 @@ def test_missing_entity_capability_fails_instead_of_returning_zeros() -> None:
     )
     with pytest.raises(NotImplementedError, match="projected gravity.*not materialized"):
         mdp.projected_gravity(env)
+
+
+def _imu_misalignment_manager(
+    env: ManagerBasedRlEnv, max_angle_deg: float = 6.0
+) -> ObservationManager:
+    """Actor sees IMU-misaligned gyro/gravity; critic keeps the true values."""
+    return ObservationManager(
+        {
+            "policy": ObservationGroupCfg(
+                terms={
+                    "base_ang_vel": ObservationTermCfg(
+                        func=mdp.base_ang_vel_imu_misaligned,
+                        params={"max_angle_deg": max_angle_deg},
+                    ),
+                    "projected_gravity": ObservationTermCfg(
+                        func=mdp.projected_gravity_imu_misaligned,
+                        params={"max_angle_deg": max_angle_deg},
+                    ),
+                }
+            ),
+            "critic": ObservationGroupCfg(
+                terms={
+                    "base_ang_vel": ObservationTermCfg(func=mdp.base_ang_vel),
+                    "projected_gravity": ObservationTermCfg(func=mdp.projected_gravity),
+                }
+            ),
+        },
+        env,
+    )
+
+
+def _rotation_angle_rad(raw: np.ndarray, rotated: np.ndarray) -> np.ndarray:
+    cos = np.sum(raw * rotated, axis=-1) / (
+        np.linalg.norm(raw, axis=-1) * np.linalg.norm(rotated, axis=-1)
+    )
+    return np.arccos(np.clip(cos, -1.0, 1.0))
+
+
+def test_imu_misaligned_terms_share_one_per_env_constant_quaternion() -> None:
+    env, backend = _env()
+    manager = _imu_misalignment_manager(env, max_angle_deg=6.0)
+
+    assert manager.group_obs_dim == {"policy": (6,), "critic": (6,)}
+    obs = manager.compute()
+    policy = obs["policy"]
+    critic = obs["critic"]
+    assert isinstance(policy, np.ndarray)
+    assert isinstance(critic, np.ndarray)
+    gyro_raw, gravity_raw = critic[:, :3], critic[:, 3:]
+    gyro_rot, gravity_rot = policy[:, :3], policy[:, 3:]
+
+    # The critic group keeps the true (unrotated) values.
+    np.testing.assert_array_equal(gyro_raw, backend.body_ang_vel_b[:, 0])
+    np.testing.assert_allclose(gravity_raw, [[0.0, 0.0, -1.0], [0.0, -1.0, 0.0]], atol=1e-6)
+
+    # A rotation preserves vector norms...
+    np.testing.assert_allclose(
+        np.linalg.norm(gyro_rot, axis=-1), np.linalg.norm(gyro_raw, axis=-1), atol=1e-6
+    )
+    np.testing.assert_allclose(np.linalg.norm(gravity_rot, axis=-1), 1.0, atol=1e-6)
+    # ...and the gyro/gravity inner product, proving both actor terms were
+    # rotated by the SAME per-env quaternion.
+    np.testing.assert_allclose(
+        np.sum(gyro_rot * gravity_rot, axis=-1),
+        np.sum(gyro_raw * gravity_raw, axis=-1),
+        atol=1e-6,
+    )
+
+    # Magnitude is bounded by max_angle_deg for every env, and the rotation is
+    # actually applied (seeded RNG keeps this deterministic).
+    max_angle_rad = np.deg2rad(6.0)
+    assert (_rotation_angle_rad(gyro_raw, gyro_rot) <= max_angle_rad + 1e-5).all()
+    assert (_rotation_angle_rad(gravity_raw, gravity_rot) <= max_angle_rad + 1e-5).all()
+    assert _rotation_angle_rad(gravity_raw, gravity_rot).max() > 1e-4
+
+
+def test_imu_misalignment_is_constant_across_calls_and_episode_resets() -> None:
+    env, _ = _env()
+    manager = _imu_misalignment_manager(env)
+
+    first = manager.compute_group("policy")
+    second = manager.compute_group("policy")
+    manager.reset(np.arange(env.num_envs))
+    after_reset = manager.compute_group("policy")
+
+    assert isinstance(first, np.ndarray)
+    np.testing.assert_array_equal(first, second)
+    np.testing.assert_array_equal(first, after_reset)
+
+
+def test_imu_misalignment_reproducible_for_same_env_seed() -> None:
+    env_a, _ = _env()
+    env_b, _ = _env()
+
+    obs_a = _imu_misalignment_manager(env_a).compute_group("policy")
+    obs_b = _imu_misalignment_manager(env_b).compute_group("policy")
+
+    np.testing.assert_array_equal(obs_a, obs_b)
+
+
+def test_imu_misalignment_zero_angle_is_identity() -> None:
+    env, backend = _env()
+
+    policy = _imu_misalignment_manager(env, max_angle_deg=0.0).compute_group("policy")
+
+    assert isinstance(policy, np.ndarray)
+    np.testing.assert_array_equal(policy[:, :3], backend.body_ang_vel_b[:, 0])
+    np.testing.assert_allclose(policy[:, 3:], [[0.0, 0.0, -1.0], [0.0, -1.0, 0.0]], atol=1e-6)
+
+
+@pytest.mark.parametrize("max_angle_deg", [-1.0, float("nan"), True, "6"])
+def test_imu_misalignment_rejects_invalid_max_angle(max_angle_deg) -> None:
+    env, _ = _env()
+    with pytest.raises(ValueError, match="max_angle_deg"):
+        _imu_misalignment_manager(env, max_angle_deg=max_angle_deg)
+
+
+def test_imu_misaligned_term_rejects_call_with_mismatched_angle() -> None:
+    env, _ = _env()
+    manager = _imu_misalignment_manager(env, max_angle_deg=6.0)
+    term = manager.get_term_cfg("policy", "base_ang_vel").func
+    assert isinstance(term, mdp.base_ang_vel_imu_misaligned)
+
+    with pytest.raises(ValueError, match="bound to max_angle_deg"):
+        term(env, max_angle_deg=3.0)
 
 
 def test_observation_module_has_no_forbidden_runtime_dependencies() -> None:

--- a/tests/utils/test_math_utils.py
+++ b/tests/utils/test_math_utils.py
@@ -15,6 +15,7 @@ from unilab.utils.rotation import (
     np_quat_error_magnitude,
     np_quat_error_magnitude_batched,
     np_quat_error_magnitude_squared_batched,
+    np_quat_from_angle_axis,
     np_quat_from_euler_xyz,
     np_quat_mul,
     np_quat_mul_batched,
@@ -65,6 +66,26 @@ def test_quat_error_vectorized_batch() -> None:
     err = np_quat_error_magnitude(q_ref, q_target)
 
     np.testing.assert_allclose(err, np.deg2rad([30.0, 45.0]), atol=1e-7)
+
+
+def test_quat_from_angle_axis_round_trips_through_axis_angle() -> None:
+    rng = np.random.default_rng(0)
+    axes = rng.standard_normal((8, 3))
+    angles = rng.uniform(0.0, np.pi, size=8)
+
+    quats = np_quat_from_angle_axis(angles, axes)
+
+    np.testing.assert_allclose(np.linalg.norm(quats, axis=-1), 1.0, atol=1e-12)
+    recovered = np_quat_to_axis_angle(quats)
+    expected = axes / np.linalg.norm(axes, axis=-1, keepdims=True) * angles[:, None]
+    np.testing.assert_allclose(recovered, expected, atol=1e-7)
+
+
+def test_quat_from_angle_axis_normalizes_axis_and_matches_z_reference() -> None:
+    angle = np.deg2rad(170.0)
+    quats = np_quat_from_angle_axis(np.array([angle]), np.array([[0.0, 0.0, 3.0]]))
+
+    np.testing.assert_allclose(quats[0], _quat_from_axis_angle_z(angle), atol=1e-12)
 
 
 def test_quat_to_axis_angle_invariant_to_sign_flip() -> None:


### PR DESCRIPTION
Fixes #1400

Roadmap #1389 切片 S4：沉淀 sim2real 观测真实化的通用 IMU 安装错位 obs term（`base_ang_vel_imu_misaligned` / `projected_gravity_imu_misaligned`，per-env 常量随机轴旋转 ≤6°，gyro/gravity 共用同一四元数，只加给 actor、critic 看真值），对齐 legacy `microduck_rl/tasks/mdp.py:3618-3660` 语义。microduck PPO/SAC owner base.yaml 已声明引用（policy group 换用错位 term，critic 保持真值），61D actor 布局与 obs_groups 未动。

变更：
- `src/unilab/envs/mdp/observations.py`：两个 class-based obs term + 模块级 per-env 四元数共享缓存（WeakKeyDictionary）
- `src/unilab/utils/rotation.py`：新增 `np_quat_from_angle_axis`
- `conf/{ppo,sac}/task/microduck_velocity_flat/base.yaml`：policy group 声明错位 term（max_angle_deg=6.0）
- 测试：`tests/envs/mdp/test_observations.py` +6（错位四元数一致性、actor/critic 分组语义、reset 后恒定）、`tests/utils/test_math_utils.py` +2

## Validation
- 最终 head 本地 `make test-all` 通过：2415 passed, 28 skipped, 1 xfailed；benchmark smoke 36/37（1 skipped platform-optional mlx）
- slow 端到端 `test_microduck_owner_builds_and_steps_real_mujoco_env` 通过（61D actor / 64D critic 断言，新 term 全链路可用）