### PR TITLE
style: #1401 合并内容的 ruff format 规范形

### DIFF
--- a/src/unilab/base/backend/mjwarp/backend.py
+++ b/src/unilab/base/backend/mjwarp/backend.py
@@ -1368,9 +1368,7 @@ class MjwarpBackend(SimBackend):
     ) -> None:
         """Accumulate world-frame forces on the staged ``xfrc_applied`` rows."""
         if torque is not None:
-            raise NotImplementedError(
-                "mjwarp backend does not support interval body torque yet"
-            )
+            raise NotImplementedError("mjwarp backend does not support interval body torque yet")
         body_ids_np = np.asarray(body_ids, dtype=np.intp).reshape(-1)
         if np.any(body_ids_np < 0) or np.any(body_ids_np >= self._nbody):
             raise ValueError(f"body_ids must be in [0, {self._nbody}), got {body_ids_np}")


### PR DESCRIPTION
PR #1410 合入时工作树中的 `make check` 把 `mjwarp/backend.py` 新增的 NotImplementedError 折叠为单行（gate 实际测试的即此内容），本 PR 仅提交该格式化差异，无功能变化。

## Validation
- 内容已在 #1410 最终 gate（`make test-all` 2468 passed）中以此格式化形态实测