### PR TITLE
feat: MicroDuck velocity 配方对齐 legacy（S7/#1402 验收 example）

### DIFF
--- a/conf/ppo/task/microduck_velocity_flat/base.yaml
+++ b/conf/ppo/task/microduck_velocity_flat/base.yaml
@@ -1,5 +1,11 @@
 # @package _global_
 # Canonical Pollen Robotics MicroDuck Manager-Based velocity task.
+#
+# Recipe aligned with legacy microduck_rl velocity2 (issue #1402): command
+# ranges/resampling, gait rewards, termination limits, observation delays, DR
+# events, and the five step-staged curricula all mirror the legacy values
+# (stage step = legacy iteration x 24 = env control steps, matching UniLab's
+# num_steps_per_env=24).
 env:
   scene:
     model_file: src/unilab/assets/robots/microduck/scene_flat.xml
@@ -38,7 +44,19 @@ env:
           - right_hip_pitch
           - right_knee
           - right_ankle
-        body_names: [trunk_base]
+        # trunk_base: root + trunk CoM DR; ankle_*: foot clearance/swing/slip and
+        # critic foot_height; neck chain + bearing_roll: legacy head CoM DR set.
+        body_names:
+          - trunk_base
+          - ankle_left
+          - ankle_right
+          - neck
+          - neck_pitch
+          - yaw_roll_motion
+          - jaw_soft
+          - bearing_roll
+        # Foot collision geoms for the foot_friction DR event.
+        geom_names: [left_foot_collision, right_foot_collision]
   sim_dt: 0.01
   ctrl_dt: 0.02
   max_episode_seconds: 20.0
@@ -54,6 +72,10 @@ env:
             n_min: -0.03
             n_max: 0.03
             operation: add
+          # Legacy IMU latency envelope: 0-1 ctrl step lag, resampled every 64 steps.
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
         projected_gravity:
           func: unilab.envs.mdp.projected_gravity_imu_misaligned
           params: {max_angle_deg: 6.0}
@@ -62,6 +84,9 @@ env:
             n_min: -0.01
             n_max: 0.01
             operation: add
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
         joint_pos:
           func: unilab.envs.mdp.joint_pos_rel
           params: {biased: true}
@@ -77,6 +102,10 @@ env:
             n_min: -0.25
             n_max: 0.25
             operation: add
+          # Legacy fixed 1-ctrl-step (20 ms) joint-velocity lag (Dynamixel
+          # firmware moving-average velocity estimate).
+          delay_min_lag: 1
+          delay_max_lag: 1
         actions:
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
@@ -116,6 +145,27 @@ env:
         base_lin_vel:
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: local_linvel}
+        # Privileged per-foot terms (legacy critic 76D layout).
+        foot_height:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_height
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              body_names: [ankle_left, ankle_right]
+              preserve_order: true
+        foot_air_time:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_air_time
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact_forces:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact_forces
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
   actions:
     joint_pos:
       _target_: unilab.envs.mdp.JointPositionActionCfg
@@ -127,20 +177,20 @@ env:
     twist:
       _target_: unilab.tasks.locomotion.microduck.manager_terms.MicroduckVelocityCommandCfg
       entity_name: robot
-      resampling_time_range: [20.0, 20.0]
+      resampling_time_range: [3.0, 8.0]
       heading_command: false
       heading_control_stiffness: 0.5
       rel_standing_envs: 0.02
       rel_heading_envs: 0.0
       rel_world_envs: 0.0
-      rel_forward_envs: 0.0
+      rel_forward_envs: 0.2
       init_velocity_prob: 0.0
-      turn_in_place_fraction: 0.0
+      turn_in_place_fraction: 0.15
       turn_in_place_ang_min: 0.4
       ranges:
-        lin_vel_x: [-0.2, 0.2]
-        lin_vel_y: [-0.1, 0.1]
-        ang_vel_z: [-0.5, 0.5]
+        lin_vel_x: [-0.4, 0.4]
+        lin_vel_y: [-0.3, 0.3]
+        ang_vel_z: [-1.0, 1.0]
     head_pose:
       _target_: unilab.tasks.locomotion.microduck.manager_terms.UniformVectorCommandCfg
       resampling_time_range: [2.0, 5.0]
@@ -175,6 +225,20 @@ env:
           x: [-0.003, 0.003]
           y: [-0.003, 0.003]
           z: [-0.003, 0.003]
+    head_com:
+      func: unilab.envs.mdp.randomize_rigid_body_com
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          # Legacy HEAD_BODY_NAMES resolved against this model: the head-roll
+          # body is jaw_soft here (bottom_head_shell in the legacy walk model).
+          body_names: [neck, neck_pitch, yaw_roll_motion, jaw_soft, bearing_roll]
+        com_range:
+          x: [-0.003, 0.003]
+          y: [-0.003, 0.003]
+          z: [-0.003, 0.003]
     encoder_bias:
       func: unilab.envs.mdp.randomize_encoder_bias
       mode: reset
@@ -184,10 +248,32 @@ env:
           _target_: unilab.managers.SceneEntityCfg
           name: robot
           joint_names: ".*"
+    foot_friction:
+      func: unilab.envs.mdp.geom_friction
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          geom_names: [left_foot_collision, right_foot_collision]
+        ranges: [0.7, 1.3]
+        operation: abs
+        axes: [0]
+        shared_random: true
+    randomize_armature:
+      func: unilab.envs.mdp.joint_armature
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: ".*"
+        ranges: [0.9, 1.1]
+        operation: scale
     push_robot:
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
-      interval_range_s: [3.0, 3.0]
+      interval_range_s: [3.0, 6.0]
       is_global_time: true
       params:
         velocity_range:
@@ -203,10 +289,79 @@ env:
       time_out: true
     tilt:
       func: unilab.envs.mdp.bad_orientation
-      params: {limit_angle: 0.7853981633974483}
+      # Legacy fell_over threshold: 70 degrees.
+      params: {limit_angle: 1.2217304763960306}
     base_height:
       func: unilab.envs.mdp.root_height_below_minimum
       params: {minimum_height: 0.08}
+    nan_state:
+      func: unilab.envs.mdp.nan_detection
+  curriculum:
+    # Legacy curriculum A: action_rate_l2 weight -0.1 -> -1.0 by iter 1500.
+    action_rate_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: action_rate
+        stages:
+          - {step: 0, weight: -0.1}
+          - {step: 12000, weight: -0.2}
+          - {step: 18000, weight: -0.4}
+          - {step: 24000, weight: -0.6}
+          - {step: 30000, weight: -0.8}
+          - {step: 36000, weight: -1.0}
+    # Legacy curriculum B: head_pose_bias weight 0 -> +3.0.
+    head_pose_bias_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: head_pose_bias
+        stages:
+          - {step: 0, weight: 0.0}
+          - {step: 14400, weight: 1.0}
+          - {step: 24000, weight: 2.0}
+          - {step: 36000, weight: 3.0}
+    # Legacy curriculum C: standing envs 0.02 -> 0.25.
+    standing_envs:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: twist
+        stages:
+          - {step: 0, rel_standing_envs: 0.02}
+          - {step: 12000, rel_standing_envs: 0.05}
+          - {step: 18000, rel_standing_envs: 0.1}
+          - {step: 24000, rel_standing_envs: 0.15}
+          - {step: 36000, rel_standing_envs: 0.2}
+          - {step: 48000, rel_standing_envs: 0.25}
+    # Legacy curriculum D: head_pose command ranges widen to
+    # ±1.10 / ±1.10 / ±1.40 / ±0.31 rad (neck_pitch, head_pitch, head_yaw, head_roll).
+    head_pose_range:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: head_pose
+        stages:
+          - {step: 0, ranges: [[-0.05, 0.05], [-0.05, 0.05], [-0.07, 0.07], [-0.015, 0.015]]}
+          - {step: 12000, ranges: [[-0.17, 0.17], [-0.17, 0.17], [-0.21, 0.21], [-0.047, 0.047]]}
+          - {step: 24000, ranges: [[-0.39, 0.39], [-0.39, 0.39], [-0.49, 0.49], [-0.11, 0.11]]}
+          - {step: 36000, ranges: [[-0.72, 0.72], [-0.72, 0.72], [-0.91, 0.91], [-0.2, 0.2]]}
+          - {step: 48000, ranges: [[-1.1, 1.1], [-1.1, 1.1], [-1.4, 1.4], [-0.31, 0.31]]}
+    # Legacy curriculum E (trunk): base CoM range ±3mm -> ±15mm.
+    base_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: base_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
+          - {step: 36000, params: {com_range: {x: [-0.015, 0.015], y: [-0.015, 0.015], z: [-0.015, 0.015]}}}
+    # Legacy curriculum E (head): head CoM range ±3mm -> ±10mm.
+    head_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: head_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
   policy_observation_group: policy
   critic_observation_group: critic
 
@@ -216,9 +371,10 @@ reward:
     weight: 3.0
     params: {sensor_name: local_linvel, tracking_sigma: 0.25, command_name: twist}
   tracking_ang_vel:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.track_ang_vel
-    weight: 1.5
-    params: {sensor_name: gyro, tracking_sigma: 0.25, command_name: twist}
+    # Legacy merged form: exp(-((cmd-wz)^2 + wx^2 + wy^2) / 0.5), std=sqrt(0.5).
+    func: unilab.envs.mdp.track_angular_velocity
+    weight: 2.0
+    params: {std: 0.7071067811865476, command_name: twist}
   head_pose_tracking:
     func: unilab.tasks.locomotion.microduck.manager_terms.head_pose_tracking
     weight: 0.5
@@ -252,10 +408,53 @@ reward:
         name: robot
         joint_names: [left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle, right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle]
         preserve_order: true
-  foot_air_time_biped:
-    func: unilab.tasks.locomotion.microduck.manager_terms.foot_air_time_biped
-    weight: 2.0
-    params: {threshold: 0.3, command_threshold: 0.01, command_name: twist}
+  air_time:
+    # Legacy window form: feet with current air time in (0.125, 0.300) s score.
+    func: unilab.tasks.locomotion.common.gait_terms.feet_air_time
+    weight: 3.0
+    params:
+      threshold_min: 0.125
+      threshold_max: 0.3
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+  foot_clearance:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_clearance
+    weight: -2.0
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_swing_height:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_swing_height
+    weight: -0.25
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_slip:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_slip
+    weight: -0.1
+    params:
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
   flight_phase:
     func: unilab.tasks.locomotion.microduck.manager_terms.flight_phase
     weight: -2.0
@@ -275,9 +474,16 @@ reward:
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -50.0
     params: {target_height: 0.12}
+  dof_pos_limits:
+    func: unilab.envs.mdp.joint_pos_limits
+    weight: -1.0
+  angular_momentum:
+    func: unilab.tasks.locomotion.common.gait_terms.angular_momentum_penalty
+    weight: -0.02
+    params: {sensor_name: root_angmom}
   action_rate:
     func: unilab.envs.mdp.action_rate_l2
-    weight: -0.5
+    weight: -0.1
   alive:
     func: unilab.tasks.locomotion.common.manager_terms.alive
     weight: 0.1

--- a/conf/sac/task/microduck_velocity_flat/base.yaml
+++ b/conf/sac/task/microduck_velocity_flat/base.yaml
@@ -1,8 +1,8 @@
 # @package _global_
 # Canonical Pollen Robotics MicroDuck Manager-Based velocity task (off-policy owners).
-# Environment, command, event, termination, and reward semantics are identical to
-# the on-policy owner (conf/ppo/task/microduck_velocity_flat/base.yaml); backend
-# owner leaves inherit this file and only carry backend/algo identity.
+# Environment, command, event, termination, curriculum, and reward semantics are
+# identical to the on-policy owner (conf/ppo/task/microduck_velocity_flat/base.yaml);
+# backend owner leaves inherit this file and only carry backend/algo identity.
 env:
   scene:
     model_file: src/unilab/assets/robots/microduck/scene_flat.xml
@@ -41,7 +41,19 @@ env:
           - right_hip_pitch
           - right_knee
           - right_ankle
-        body_names: [trunk_base]
+        # trunk_base: root + trunk CoM DR; ankle_*: foot clearance/swing/slip and
+        # critic foot_height; neck chain + bearing_roll: legacy head CoM DR set.
+        body_names:
+          - trunk_base
+          - ankle_left
+          - ankle_right
+          - neck
+          - neck_pitch
+          - yaw_roll_motion
+          - jaw_soft
+          - bearing_roll
+        # Foot collision geoms for the foot_friction DR event.
+        geom_names: [left_foot_collision, right_foot_collision]
   sim_dt: 0.01
   ctrl_dt: 0.02
   max_episode_seconds: 20.0
@@ -57,6 +69,10 @@ env:
             n_min: -0.03
             n_max: 0.03
             operation: add
+          # Legacy IMU latency envelope: 0-1 ctrl step lag, resampled every 64 steps.
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
         projected_gravity:
           func: unilab.envs.mdp.projected_gravity_imu_misaligned
           params: {max_angle_deg: 6.0}
@@ -65,6 +81,9 @@ env:
             n_min: -0.01
             n_max: 0.01
             operation: add
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
         joint_pos:
           func: unilab.envs.mdp.joint_pos_rel
           params: {biased: true}
@@ -80,6 +99,10 @@ env:
             n_min: -0.25
             n_max: 0.25
             operation: add
+          # Legacy fixed 1-ctrl-step (20 ms) joint-velocity lag (Dynamixel
+          # firmware moving-average velocity estimate).
+          delay_min_lag: 1
+          delay_max_lag: 1
         actions:
           func: unilab.envs.mdp.last_action
           params: {action_name: joint_pos}
@@ -119,6 +142,27 @@ env:
         base_lin_vel:
           func: unilab.envs.mdp.builtin_sensor
           params: {sensor_name: local_linvel}
+        # Privileged per-foot terms (legacy critic 76D layout).
+        foot_height:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_height
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              body_names: [ankle_left, ankle_right]
+              preserve_order: true
+        foot_air_time:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_air_time
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact_forces:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact_forces
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
   actions:
     joint_pos:
       _target_: unilab.envs.mdp.JointPositionActionCfg
@@ -130,20 +174,20 @@ env:
     twist:
       _target_: unilab.tasks.locomotion.microduck.manager_terms.MicroduckVelocityCommandCfg
       entity_name: robot
-      resampling_time_range: [20.0, 20.0]
+      resampling_time_range: [3.0, 8.0]
       heading_command: false
       heading_control_stiffness: 0.5
       rel_standing_envs: 0.02
       rel_heading_envs: 0.0
       rel_world_envs: 0.0
-      rel_forward_envs: 0.0
+      rel_forward_envs: 0.2
       init_velocity_prob: 0.0
-      turn_in_place_fraction: 0.0
+      turn_in_place_fraction: 0.15
       turn_in_place_ang_min: 0.4
       ranges:
-        lin_vel_x: [-0.2, 0.2]
-        lin_vel_y: [-0.1, 0.1]
-        ang_vel_z: [-0.5, 0.5]
+        lin_vel_x: [-0.4, 0.4]
+        lin_vel_y: [-0.3, 0.3]
+        ang_vel_z: [-1.0, 1.0]
     head_pose:
       _target_: unilab.tasks.locomotion.microduck.manager_terms.UniformVectorCommandCfg
       resampling_time_range: [2.0, 5.0]
@@ -178,6 +222,20 @@ env:
           x: [-0.003, 0.003]
           y: [-0.003, 0.003]
           z: [-0.003, 0.003]
+    head_com:
+      func: unilab.envs.mdp.randomize_rigid_body_com
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          # Legacy HEAD_BODY_NAMES resolved against this model: the head-roll
+          # body is jaw_soft here (bottom_head_shell in the legacy walk model).
+          body_names: [neck, neck_pitch, yaw_roll_motion, jaw_soft, bearing_roll]
+        com_range:
+          x: [-0.003, 0.003]
+          y: [-0.003, 0.003]
+          z: [-0.003, 0.003]
     encoder_bias:
       func: unilab.envs.mdp.randomize_encoder_bias
       mode: reset
@@ -187,10 +245,32 @@ env:
           _target_: unilab.managers.SceneEntityCfg
           name: robot
           joint_names: ".*"
+    foot_friction:
+      func: unilab.envs.mdp.geom_friction
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          geom_names: [left_foot_collision, right_foot_collision]
+        ranges: [0.7, 1.3]
+        operation: abs
+        axes: [0]
+        shared_random: true
+    randomize_armature:
+      func: unilab.envs.mdp.joint_armature
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: ".*"
+        ranges: [0.9, 1.1]
+        operation: scale
     push_robot:
       func: unilab.envs.mdp.push_by_setting_velocity
       mode: interval
-      interval_range_s: [3.0, 3.0]
+      interval_range_s: [3.0, 6.0]
       is_global_time: true
       params:
         velocity_range:
@@ -206,10 +286,79 @@ env:
       time_out: true
     tilt:
       func: unilab.envs.mdp.bad_orientation
-      params: {limit_angle: 0.7853981633974483}
+      # Legacy fell_over threshold: 70 degrees.
+      params: {limit_angle: 1.2217304763960306}
     base_height:
       func: unilab.envs.mdp.root_height_below_minimum
       params: {minimum_height: 0.08}
+    nan_state:
+      func: unilab.envs.mdp.nan_detection
+  curriculum:
+    # Legacy curriculum A: action_rate_l2 weight -0.1 -> -1.0 by iter 1500.
+    action_rate_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: action_rate
+        stages:
+          - {step: 0, weight: -0.1}
+          - {step: 12000, weight: -0.2}
+          - {step: 18000, weight: -0.4}
+          - {step: 24000, weight: -0.6}
+          - {step: 30000, weight: -0.8}
+          - {step: 36000, weight: -1.0}
+    # Legacy curriculum B: head_pose_bias weight 0 -> +3.0.
+    head_pose_bias_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: head_pose_bias
+        stages:
+          - {step: 0, weight: 0.0}
+          - {step: 14400, weight: 1.0}
+          - {step: 24000, weight: 2.0}
+          - {step: 36000, weight: 3.0}
+    # Legacy curriculum C: standing envs 0.02 -> 0.25.
+    standing_envs:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: twist
+        stages:
+          - {step: 0, rel_standing_envs: 0.02}
+          - {step: 12000, rel_standing_envs: 0.05}
+          - {step: 18000, rel_standing_envs: 0.1}
+          - {step: 24000, rel_standing_envs: 0.15}
+          - {step: 36000, rel_standing_envs: 0.2}
+          - {step: 48000, rel_standing_envs: 0.25}
+    # Legacy curriculum D: head_pose command ranges widen to
+    # ±1.10 / ±1.10 / ±1.40 / ±0.31 rad (neck_pitch, head_pitch, head_yaw, head_roll).
+    head_pose_range:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: head_pose
+        stages:
+          - {step: 0, ranges: [[-0.05, 0.05], [-0.05, 0.05], [-0.07, 0.07], [-0.015, 0.015]]}
+          - {step: 12000, ranges: [[-0.17, 0.17], [-0.17, 0.17], [-0.21, 0.21], [-0.047, 0.047]]}
+          - {step: 24000, ranges: [[-0.39, 0.39], [-0.39, 0.39], [-0.49, 0.49], [-0.11, 0.11]]}
+          - {step: 36000, ranges: [[-0.72, 0.72], [-0.72, 0.72], [-0.91, 0.91], [-0.2, 0.2]]}
+          - {step: 48000, ranges: [[-1.1, 1.1], [-1.1, 1.1], [-1.4, 1.4], [-0.31, 0.31]]}
+    # Legacy curriculum E (trunk): base CoM range ±3mm -> ±15mm.
+    base_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: base_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
+          - {step: 36000, params: {com_range: {x: [-0.015, 0.015], y: [-0.015, 0.015], z: [-0.015, 0.015]}}}
+    # Legacy curriculum E (head): head CoM range ±3mm -> ±10mm.
+    head_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: head_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
   policy_observation_group: policy
   critic_observation_group: critic
 
@@ -219,9 +368,10 @@ reward:
     weight: 3.0
     params: {sensor_name: local_linvel, tracking_sigma: 0.25, command_name: twist}
   tracking_ang_vel:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.track_ang_vel
-    weight: 1.5
-    params: {sensor_name: gyro, tracking_sigma: 0.25, command_name: twist}
+    # Legacy merged form: exp(-((cmd-wz)^2 + wx^2 + wy^2) / 0.5), std=sqrt(0.5).
+    func: unilab.envs.mdp.track_angular_velocity
+    weight: 2.0
+    params: {std: 0.7071067811865476, command_name: twist}
   head_pose_tracking:
     func: unilab.tasks.locomotion.microduck.manager_terms.head_pose_tracking
     weight: 0.5
@@ -255,10 +405,53 @@ reward:
         name: robot
         joint_names: [left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle, right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle]
         preserve_order: true
-  foot_air_time_biped:
-    func: unilab.tasks.locomotion.microduck.manager_terms.foot_air_time_biped
-    weight: 2.0
-    params: {threshold: 0.3, command_threshold: 0.01, command_name: twist}
+  air_time:
+    # Legacy window form: feet with current air time in (0.125, 0.300) s score.
+    func: unilab.tasks.locomotion.common.gait_terms.feet_air_time
+    weight: 3.0
+    params:
+      threshold_min: 0.125
+      threshold_max: 0.3
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+  foot_clearance:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_clearance
+    weight: -2.0
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_swing_height:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_swing_height
+    weight: -0.25
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_slip:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_slip
+    weight: -0.1
+    params:
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
   flight_phase:
     func: unilab.tasks.locomotion.microduck.manager_terms.flight_phase
     weight: -2.0
@@ -278,9 +471,16 @@ reward:
     func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
     weight: -50.0
     params: {target_height: 0.12}
+  dof_pos_limits:
+    func: unilab.envs.mdp.joint_pos_limits
+    weight: -1.0
+  angular_momentum:
+    func: unilab.tasks.locomotion.common.gait_terms.angular_momentum_penalty
+    weight: -0.02
+    params: {sensor_name: root_angmom}
   action_rate:
     func: unilab.envs.mdp.action_rate_l2
-    weight: -0.5
+    weight: -0.1
   alive:
     func: unilab.tasks.locomotion.common.manager_terms.alive
     weight: 10.0

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -4,6 +4,8 @@ from unilab.envs.mdp.actions import JointPositionAction as JointPositionAction
 from unilab.envs.mdp.actions import JointPositionActionCfg as JointPositionActionCfg
 from unilab.envs.mdp.commands import UniformVelocityCommand as UniformVelocityCommand
 from unilab.envs.mdp.commands import UniformVelocityCommandCfg as UniformVelocityCommandCfg
+from unilab.envs.mdp.curriculums import command_curriculum as command_curriculum
+from unilab.envs.mdp.curriculums import event_curriculum as event_curriculum
 from unilab.envs.mdp.curriculums import reward_curriculum as reward_curriculum
 from unilab.envs.mdp.curriculums import termination_curriculum as termination_curriculum
 from unilab.envs.mdp.events import apply_body_impulse as apply_body_impulse
@@ -73,7 +75,9 @@ __all__ = [
     "builtin_sensor",
     "bad_orientation",
     "body_angular_velocity_penalty",
+    "command_curriculum",
     "dof_armature",
+    "event_curriculum",
     "flat_orientation_l2",
     "geom_friction",
     "generated_commands",

--- a/src/unilab/envs/mdp/curriculums.py
+++ b/src/unilab/envs/mdp/curriculums.py
@@ -43,6 +43,36 @@ class TerminationCurriculumStage(_TerminationCurriculumStageOptional):
     step: int
 
 
+class _CommandCurriculumStageOptional(TypedDict, total=False):
+    params: dict[str, Any]
+
+
+class CommandCurriculumStage(_CommandCurriculumStageOptional):
+    """Stage for ``command_curriculum``.
+
+    Any key beyond ``step``/``params`` is applied as a top-level field on the
+    live command term config (e.g. ``rel_standing_envs`` or ``ranges``); the
+    set of valid fields is the target term's config schema.
+    """
+
+    step: int
+
+
+class _EventCurriculumStageOptional(TypedDict, total=False):
+    params: dict[str, Any]
+
+
+class EventCurriculumStage(_EventCurriculumStageOptional):
+    """Stage for ``event_curriculum``.
+
+    Any key beyond ``step``/``params`` is applied as a top-level field on the
+    live event term config; the set of valid fields is the target term's
+    config schema.
+    """
+
+    step: int
+
+
 # Shared engine. Stage dicts are passed directly from the public TypedDict
 # schemas. Any key that isn't "step" or "params" is treated as a top-level
 # field on the target term config (e.g. "weight" on RewardTermCfg).
@@ -69,8 +99,11 @@ def _validate_stages(
                 raise AttributeError(
                     f"Field '{key}' does not exist on the resolved term config for '{term_name}'."
                 )
+    # Command term configs carry plain dataclass fields and no params dict.
+    term_params = getattr(term_cfg, "params", None)
     for stage in stages:
-        unknown = stage.get("params", {}).keys() - term_cfg.params.keys()
+        known = term_params.keys() if term_params is not None else ()
+        unknown = stage.get("params", {}).keys() - known
         if unknown:
             raise KeyError(
                 f"Stage at step {stage['step']} sets unknown param(s)"
@@ -105,8 +138,9 @@ def _apply_stages(
         value = getattr(term_cfg, key)
         if isinstance(value, (int, float, bool, np.number)):
             result[key] = value
+    term_params = getattr(term_cfg, "params", {})
     for key in logged_params:
-        value = term_cfg.params[key]
+        value = term_params[key]
         if isinstance(value, (int, float, bool, np.number)):
             result[key] = value
     return result
@@ -188,4 +222,84 @@ class termination_curriculum:
         stages: list[TerminationCurriculumStage],
     ) -> dict[str, Any]:
         del env_ids, termination_name, stages
+        return _apply_stages(self._term_cfg, env.common_step_counter, self._stages)
+
+
+class command_curriculum:
+    """Update a command term's config fields and/or params based on training steps.
+
+    Command terms read their live ``self.cfg`` at resample time, so mutating
+    the resolved term config (e.g. ``rel_standing_envs`` or ``ranges``) takes
+    effect on the next command resample. Stage semantics match
+    ``reward_curriculum``: every stage whose ``step`` has been reached is
+    applied in order, so later stages win.
+
+    Example owner YAML::
+
+      curriculum:
+        standing_envs:
+          func: unilab.envs.mdp.command_curriculum
+          params:
+            command_name: twist
+            stages:
+              - {step: 0, rel_standing_envs: 0.02}
+              - {step: 12000, rel_standing_envs: 0.1}
+    """
+
+    def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRlEnv):
+        command_name: str = cfg.params["command_name"]
+        stages: list[CommandCurriculumStage] = cfg.params["stages"]
+        self._term_cfg = env.command_manager.get_term_cfg(command_name)
+        if self._term_cfg is None:
+            raise ValueError(f"Command term '{command_name}' not found in active terms.")
+        self._stages = stages
+        _validate_stages(self._term_cfg, command_name, self._stages)
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | slice,
+        command_name: str,
+        stages: list[CommandCurriculumStage],
+    ) -> dict[str, Any]:
+        del env_ids, command_name, stages
+        return _apply_stages(self._term_cfg, env.common_step_counter, self._stages)
+
+
+class event_curriculum:
+    """Update an event term's params and/or config fields based on training steps.
+
+    Event terms are invoked with their live ``cfg.params`` on every apply, so
+    staged ``params`` updates (e.g. a widened ``com_range``) take effect on the
+    next event application. Stage semantics match ``reward_curriculum``.
+
+    Example owner YAML::
+
+      curriculum:
+        com_range:
+          func: unilab.envs.mdp.event_curriculum
+          params:
+            event_name: base_com
+            stages:
+              - {step: 0, params: {com_range: {x: [-0.003, 0.003]}}}
+              - {step: 24000, params: {com_range: {x: [-0.01, 0.01]}}}
+    """
+
+    def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRlEnv):
+        event_name: str = cfg.params["event_name"]
+        stages: list[EventCurriculumStage] = cfg.params["stages"]
+        self._term_cfg = env.event_manager.get_term_cfg(event_name)
+        if self._term_cfg is None:
+            raise ValueError(f"Event term '{event_name}' not found in active terms.")
+        self._stages = stages
+        _validate_stages(self._term_cfg, event_name, self._stages)
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | slice,
+        event_name: str,
+        stages: list[EventCurriculumStage],
+    ) -> dict[str, Any]:
+        del env_ids, event_name, stages
         return _apply_stages(self._term_cfg, env.common_step_counter, self._stages)

--- a/src/unilab/envs/mdp/events.py
+++ b/src/unilab/envs/mdp/events.py
@@ -782,7 +782,12 @@ randomize_rigid_body_mass = RandomizeRigidBodyMass
 
 
 class RandomizeRigidBodyCom(ManagerTermBase):
-    """Community-compatible additive rigid-body CoM randomization."""
+    """Community-compatible additive rigid-body CoM randomization.
+
+    The ``com_range`` param is re-resolved from the live term params on every
+    apply (not cached at construction), so step-staged curricula can widen the
+    range by updating the event term config between resets.
+    """
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedRlEnv):
         super().__init__(env)
@@ -800,7 +805,9 @@ class RandomizeRigidBodyCom(ManagerTermBase):
                 f"EventManager term '{term_name}' asset_cfg must be SceneEntityCfg, "
                 f"got {type(asset_cfg).__name__}"
             )
-        self._ranges = _axis_ranges(
+        # Fail-closed validation of the declared range at construction; the
+        # live value is re-resolved per apply so curricula can stage it.
+        _axis_ranges(
             cfg.params["com_range"],
             term_name=term_name,
             name="com_range",
@@ -819,11 +826,17 @@ class RandomizeRigidBodyCom(ManagerTermBase):
         com_range: dict[str, tuple[float, float]],
         asset_cfg: SceneEntityCfg,
     ) -> None:
-        del com_range, asset_cfg
+        del asset_cfg
+        ranges = _axis_ranges(
+            com_range,
+            term_name="randomize_rigid_body_com",
+            name="com_range",
+            keys=_XYZ_KEYS,
+        )
         ids = resolve_env_ids(env, env_ids)
         offsets = env.rng.uniform(
-            self._ranges[:, 0],
-            self._ranges[:, 1],
+            ranges[:, 0],
+            ranges[:, 1],
             size=(ids.size, 3),
         )
         values = self._default_ipos[None, :, :] + offsets[:, None, :]

--- a/src/unilab/managers/_types.py
+++ b/src/unilab/managers/_types.py
@@ -198,6 +198,14 @@ class ManagerCommandManager(Protocol):
 
     def get_term(self, name: str) -> Any: ...
 
+    def get_term_cfg(self, name: str) -> Any: ...
+
+
+class ManagerEventManager(Protocol):
+    """Cold-path event term config surface consumed by curriculum terms."""
+
+    def get_term_cfg(self, term_name: str) -> Any: ...
+
 
 class ManagerTerminationManager(Protocol):
     @property
@@ -239,6 +247,9 @@ class ManagerBasedRlEnv(Protocol):
 
     @property
     def command_manager(self) -> ManagerCommandManager: ...
+
+    @property
+    def event_manager(self) -> ManagerEventManager: ...
 
     @property
     def termination_manager(self) -> ManagerTerminationManager: ...

--- a/src/unilab/tasks/locomotion/common/gait_terms.py
+++ b/src/unilab/tasks/locomotion/common/gait_terms.py
@@ -3,16 +3,19 @@
 # Copyright 2025, The mjlab Developers.
 # Modified by UniLab for NumPy, named-sensor contact groups, and the
 # base-owned entity facade; Apache-2.0.
-"""mjlab-aligned gait-quality reward terms shared by locomotion families.
+"""mjlab-aligned gait-quality terms shared by locomotion families.
 
 These are the window-form ``feet_air_time`` and the clearance / swing-height /
-slip / angular-momentum terms that mjlab ships in its velocity task.  mjlab
-reads feet through a ``ContactSensor`` (primaries with per-slot any-reduce) and
-a ``TerrainHeightSensor``; the UniLab port binds one named contact sensor group
-per foot through the ``SensorTermBase`` cold-path contract (any sensor in the
-group above the threshold means foot contact, mirroring the slot reduce) and
-reads foot heights/velocities from ``body_link_pos_w`` / ``body_link_lin_vel_w``
-through ``asset_cfg.body_ids``, which is exact on flat terrain without raycast.
+slip / angular-momentum reward terms that mjlab ships in its velocity task,
+plus the privileged per-foot observation terms (``foot_height`` /
+``foot_air_time`` / ``foot_contact`` / ``foot_contact_forces``) its velocity
+critic consumes.  mjlab reads feet through a ``ContactSensor`` (primaries with
+per-slot any-reduce) and a ``TerrainHeightSensor``; the UniLab port binds one
+named contact sensor group per foot through the ``SensorTermBase`` cold-path
+contract (any sensor in the group above the threshold means foot contact,
+mirroring the slot reduce) and reads foot heights/velocities from
+``body_link_pos_w`` / ``body_link_lin_vel_w`` through ``asset_cfg.body_ids``,
+which is exact on flat terrain without raycast.
 """
 
 from __future__ import annotations
@@ -372,10 +375,105 @@ class angular_momentum_penalty(SensorTermBase):
         return np.asarray(np.sum(np.square(angmom), axis=1), dtype=get_global_dtype())
 
 
+# Privileged per-foot observations (mjlab velocity critic terms).  These mirror
+# mjlab's ``foot_height`` / ``foot_air_time`` / ``foot_contact`` /
+# ``foot_contact_forces`` observation terms: heights come from world-frame foot
+# body z (exact on flat terrain without a raycast sensor), contact state from
+# the same named contact-sensor groups as the gait rewards.
+
+
+def foot_height(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Per-foot vertical clearance above the terrain, shape ``(num_envs, num_feet)``.
+
+    mjlab reads this from a ``TerrainHeightSensor`` ring around each foot; the
+    UniLab port returns the world-frame foot body z, which is identical on flat
+    terrain.
+    """
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    positions = asset.data.body_link_pos_w[:, asset_cfg.body_ids, :]
+    if not isinstance(positions, np.ndarray) or positions.ndim != 3 or positions.shape[2] != 3:
+        raise ValueError(
+            f"foot_height foot body position must have shape ({env.num_envs}, num_feet, 3), "
+            f"got {getattr(positions, 'shape', None)}"
+        )
+    positions = _state("foot_height", "foot body position", positions, positions.shape)
+    return np.asarray(positions[:, :, 2], dtype=get_global_dtype())
+
+
+class foot_air_time(_FootContactTerm):
+    """Current per-foot air time in seconds, shape ``(num_envs, num_feet)``.
+
+    Mirrors mjlab ``foot_air_time`` (``ContactSensor.data.current_air_time``):
+    the timer accumulates ``env.step_dt`` while the foot has no contact and
+    resets to zero on contact.
+    """
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        self._air_time = np.zeros((env.num_envs, self.num_feet), dtype=get_global_dtype())
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        self._air_time[env_ids if env_ids is not None else slice(None)] = 0.0
+
+    def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
+        del params
+        contact = self._contact(env)
+        step_dt = _real(self.name, "step_dt", env.step_dt, minimum=0.0, strict_minimum=True)
+        self._air_time = np.where(contact, 0.0, self._air_time + step_dt).astype(
+            get_global_dtype(), copy=False
+        )
+        return self._air_time.copy()
+
+
+class foot_contact(_FootContactTerm):
+    """Per-foot contact flag as float, shape ``(num_envs, num_feet)``.
+
+    Mirrors mjlab ``foot_contact`` (``ContactSensor.data.found > 0``).
+    """
+
+    def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
+        del params
+        return np.asarray(self._contact(env), dtype=get_global_dtype())
+
+
+class foot_contact_forces(_FootContactTerm):
+    """Log-compressed per-foot contact forces, shape ``(num_envs, 3 * num_feet)``.
+
+    Mirrors mjlab ``foot_contact_forces``: the per-foot 3-D contact forces are
+    flattened in sensor-group order and compressed as
+    ``sign(f) * log1p(|f|)``.
+    """
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        if any(width != 3 for width in self._view.dimensions):
+            raise ValueError(
+                f"{self.name} contact sensors must each expose 3-D force; "
+                f"received {self._view.dimensions} on backend '{self._view.backend_type}'"
+            )
+
+    def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
+        del params
+        values = _state(
+            self.name,
+            "foot contact forces",
+            self._read(self._view, self.name),
+            (env.num_envs, self._flat_width),
+        )
+        return np.asarray(np.sign(values) * np.log1p(np.abs(values)), dtype=get_global_dtype())
+
+
 __all__ = [
     "angular_momentum_penalty",
     "feet_air_time",
     "feet_clearance",
     "feet_slip",
     "feet_swing_height",
+    "foot_air_time",
+    "foot_contact",
+    "foot_contact_forces",
+    "foot_height",
 ]

--- a/src/unilab/tasks/locomotion/microduck/deploy_contract.py
+++ b/src/unilab/tasks/locomotion/microduck/deploy_contract.py
@@ -7,7 +7,9 @@ MicroDuck runtime, allowing exported policies to keep a stable I/O contract.
 from __future__ import annotations
 
 MICRODUCK_ACTOR_OBS_DIM = 61
-MICRODUCK_CRITIC_OBS_DIM = 64
+# Legacy microduck_rl critic: actor 61 + base_lin_vel 3 + privileged foot
+# terms (foot_height 2, foot_air_time 2, foot_contact 2, foot_contact_forces 6).
+MICRODUCK_CRITIC_OBS_DIM = 76
 MICRODUCK_NUM_ACTION = 14
 
 MICRODUCK_OBS_SEGMENTS: tuple[tuple[str, int], ...] = (

--- a/src/unilab/tasks/locomotion/microduck/manager_terms.py
+++ b/src/unilab/tasks/locomotion/microduck/manager_terms.py
@@ -116,19 +116,28 @@ class UniformVectorCommandCfg(CommandTermCfg):
 
 
 class UniformVectorCommand(CommandTerm):
-    """Task-local vector command with no runtime scene dependency."""
+    """Task-local vector command with no runtime scene dependency.
+
+    ``cfg.ranges`` is re-read on every resample (not cached), so a step-staged
+    command curriculum can widen the sampling ranges by mutating the live term
+    config between resamples.
+    """
 
     cfg: UniformVectorCommandCfg
 
     def __init__(self, cfg: UniformVectorCommandCfg, env: ManagerBasedRlEnv):
-        ranges = np.asarray(cfg.ranges, dtype=np.float64)
-        if ranges.ndim != 2 or ranges.shape[0] == 0 or ranges.shape[1] != 2:
-            raise ValueError("UniformVectorCommandCfg ranges must have shape (N, 2)")
-        if not np.isfinite(ranges).all() or np.any(ranges[:, 0] > ranges[:, 1]):
-            raise ValueError("UniformVectorCommandCfg ranges must be finite ordered pairs")
-        self._ranges = ranges
+        ranges = self._validated_ranges(cfg.ranges)
         super().__init__(cfg, env)
         self._command = np.zeros((self.num_envs, ranges.shape[0]), dtype=get_global_dtype())
+
+    @staticmethod
+    def _validated_ranges(ranges: Any) -> np.ndarray:
+        array = np.asarray(ranges, dtype=np.float64)
+        if array.ndim != 2 or array.shape[0] == 0 or array.shape[1] != 2:
+            raise ValueError("UniformVectorCommandCfg ranges must have shape (N, 2)")
+        if not np.isfinite(array).all() or np.any(array[:, 0] > array[:, 1]):
+            raise ValueError("UniformVectorCommandCfg ranges must be finite ordered pairs")
+        return array
 
     @property
     def command(self) -> np.ndarray:
@@ -138,10 +147,17 @@ class UniformVectorCommand(CommandTerm):
         del env_ids
 
     def _resample_command(self, env_ids: np.ndarray) -> None:
+        ranges = self._validated_ranges(self.cfg.ranges)
+        if ranges.shape[0] != self._command.shape[1]:
+            raise ValueError(
+                "UniformVectorCommandCfg ranges width changed from "
+                f"{self._command.shape[1]} to {ranges.shape[0]}; curricula may only "
+                "widen per-axis bounds, not the command width"
+            )
         self._command[env_ids] = self._env.rng.uniform(
-            self._ranges[:, 0],
-            self._ranges[:, 1],
-            size=(len(env_ids), self._ranges.shape[0]),
+            ranges[:, 0],
+            ranges[:, 1],
+            size=(len(env_ids), ranges.shape[0]),
         )
 
     def _update_command(self, env_ids: np.ndarray | None) -> None:

--- a/tests/envs/locomotion/microduck/test_microduck_rewards.py
+++ b/tests/envs/locomotion/microduck/test_microduck_rewards.py
@@ -11,6 +11,7 @@ import pytest
 from unilab.managers import RewardTermCfg
 from unilab.managers._types import ManagerBasedRlEnv
 from unilab.tasks.locomotion.microduck.manager_terms import (
+    UniformVectorCommandCfg,
     flight_phase,
     foot_air_time_biped,
 )
@@ -112,3 +113,34 @@ def test_contact_terms_fail_closed_when_sensor_is_missing() -> None:
     del scene.values["right_foot_contact"]
     with pytest.raises(KeyError, match="right_foot_contact"):
         _term(flight_phase, env)
+
+
+def test_uniform_vector_command_resamples_from_live_ranges() -> None:
+    """Step-staged command curricula mutate the live term cfg; the next
+    resample must sample from the widened ranges without rebuilding the term."""
+    env = cast(ManagerBasedRlEnv, SimpleNamespace(num_envs=8, rng=np.random.default_rng(0)))
+    cfg = UniformVectorCommandCfg(
+        resampling_time_range=(2.0, 5.0),
+        ranges=[[-0.05, 0.05], [-0.05, 0.05], [-0.07, 0.07], [-0.015, 0.015]],
+    )
+    term = cfg.build(env)
+    env_ids = np.arange(8)
+    term.reset(env_ids)
+    assert float(np.abs(term.command).max()) <= 0.07
+
+    cfg.ranges = [[-1.1, 1.1], [-1.1, 1.1], [-1.4, 1.4], [-0.31, 0.31]]
+    term.reset(env_ids)
+    assert float(np.abs(term.command[:, 2]).max()) > 0.07
+    assert float(np.abs(term.command).max()) <= 1.4
+
+
+def test_uniform_vector_command_rejects_range_width_change() -> None:
+    env = cast(ManagerBasedRlEnv, SimpleNamespace(num_envs=2, rng=np.random.default_rng(0)))
+    cfg = UniformVectorCommandCfg(
+        resampling_time_range=(2.0, 5.0),
+        ranges=[[-0.05, 0.05], [-0.05, 0.05], [-0.07, 0.07], [-0.015, 0.015]],
+    )
+    term = cfg.build(env)
+    cfg.ranges = [[-1.0, 1.0]] * 3
+    with pytest.raises(ValueError, match="width changed"):
+        term.reset(np.arange(2))

--- a/tests/envs/locomotion/microduck/test_mjwarp_dr_smoke.py
+++ b/tests/envs/locomotion/microduck/test_mjwarp_dr_smoke.py
@@ -42,6 +42,13 @@ def test_microduck_mjwarp_owner_enables_base_com_and_push_events() -> None:
     assert events.push_robot is not None
     assert events.push_robot.func == "unilab.envs.mdp.push_by_setting_velocity"
     assert events.push_robot.mode == "interval"
+    # Legacy-recipe DR events added by #1402 must also reach the mjwarp owner.
+    assert events.head_com is not None
+    assert events.head_com.func == "unilab.envs.mdp.randomize_rigid_body_com"
+    assert events.foot_friction is not None
+    assert events.foot_friction.func == "unilab.envs.mdp.geom_friction"
+    assert events.randomize_armature is not None
+    assert events.randomize_armature.func == "unilab.envs.mdp.joint_armature"
 
 
 def test_microduck_mjwarp_full_dr_reset_and_interval_smoke() -> None:
@@ -77,6 +84,19 @@ def test_microduck_mjwarp_full_dr_reset_and_interval_smoke() -> None:
         assert base_id is not None
         world_ipos = body_ipos[:, base_id, :]
         assert np.ptp(world_ipos, axis=0).max() > 1e-5
+
+        # The #1402 foot-friction (abs, [0.7, 1.3]) and armature (scale,
+        # [0.9, 1.1]) reset payloads also reached the per-world device model.
+        geom_friction = np.asarray(env._backend._device_model.geom_friction.numpy())
+        foot_geom_ids = [
+            env._backend.get_geom_id(name)
+            for name in ("left_foot_collision", "right_foot_collision")
+        ]
+        foot_friction = geom_friction[:, foot_geom_ids, 0]
+        assert np.all(foot_friction >= 0.7 - 1e-6)
+        assert np.all(foot_friction <= 1.3 + 1e-6)
+        dof_armature = np.asarray(env._backend._device_model.dof_armature.numpy())
+        assert np.ptp(dof_armature, axis=0).max() > 0.0
 
         # Step past the 3s push interval (150 control steps at ctrl_dt=0.02)
         # so both the reset and interval DR paths execute on device.

--- a/tests/envs/locomotion/microduck/test_velocity_contract.py
+++ b/tests/envs/locomotion/microduck/test_velocity_contract.py
@@ -113,20 +113,43 @@ def test_microduck_owner_materializes_complete_manager_contract() -> None:
         "body_pose_command",
     )
     assert tuple(policy) == expected
-    assert tuple(critic) == (*expected, "base_lin_vel")
+    assert tuple(critic) == (
+        *expected,
+        "base_lin_vel",
+        "foot_height",
+        "foot_air_time",
+        "foot_contact",
+        "foot_contact_forces",
+    )
     assert sum(dim for _, dim in MICRODUCK_OBS_SEGMENTS) == MICRODUCK_ACTOR_OBS_DIM
-    assert MICRODUCK_CRITIC_OBS_DIM == MICRODUCK_ACTOR_OBS_DIM + 3
+    # Critic 76D = actor 61 + base_lin_vel 3 + foot_height 2 + foot_air_time 2
+    # + foot_contact 2 + foot_contact_forces 6 (legacy privileged foot terms).
+    assert MICRODUCK_CRITIC_OBS_DIM == MICRODUCK_ACTOR_OBS_DIM + 15
     assert policy["joint_pos"].params["biased"] is True
     assert policy["base_ang_vel"].noise.n_max == pytest.approx(0.03)
     assert policy["joint_vel"].noise.n_max == pytest.approx(0.25)
     assert all(term.noise is None for term in critic.values())
+    # Legacy observation latency: IMU terms lag 0-1 ctrl steps resampled every
+    # 64 steps; joint_vel carries a fixed 1-step (20 ms) lag.
+    for name in ("base_ang_vel", "projected_gravity"):
+        assert policy[name].delay_min_lag == 0
+        assert policy[name].delay_max_lag == 1
+        assert policy[name].delay_update_period == 64
+    assert policy["joint_vel"].delay_min_lag == 1
+    assert policy["joint_vel"].delay_max_lag == 1
+    assert all(getattr(term, "delay_max_lag", 0) == 0 for term in critic.values()), (
+        "critic observations must stay undelayed"
+    )
 
     twist = env_cfg.commands["twist"]
     assert isinstance(twist, MicroduckVelocityCommandCfg)
-    assert twist.ranges.lin_vel_x == [-0.2, 0.2]
-    assert twist.ranges.lin_vel_y == [-0.1, 0.1]
-    assert twist.ranges.ang_vel_z == [-0.5, 0.5]
+    assert twist.ranges.lin_vel_x == [-0.4, 0.4]
+    assert twist.ranges.lin_vel_y == [-0.3, 0.3]
+    assert twist.ranges.ang_vel_z == [-1.0, 1.0]
+    assert twist.resampling_time_range == [3.0, 8.0]
     assert twist.rel_standing_envs == pytest.approx(0.02)
+    assert twist.rel_forward_envs == pytest.approx(0.2)
+    assert twist.turn_in_place_fraction == pytest.approx(0.15)
     assert isinstance(env_cfg.commands["head_pose"], UniformVectorCommandCfg)
     assert len(env_cfg.commands["head_pose"].ranges) == 4
     assert len(env_cfg.commands["body_pose"].ranges) == 6
@@ -137,28 +160,91 @@ def test_microduck_owner_materializes_complete_manager_contract() -> None:
         "head_pose_tracking",
         "head_pose_bias",
         "leg_pose",
-        "foot_air_time_biped",
+        "air_time",
+        "foot_clearance",
+        "foot_swing_height",
+        "foot_slip",
         "flight_phase",
         "lin_vel_z",
         "ang_vel_xy",
         "orientation",
         "base_height",
+        "dof_pos_limits",
+        "angular_momentum",
         "action_rate",
         "alive",
     )
     assert tuple(env_cfg.rewards) == expected_rewards
     assert env_cfg.rewards["tracking_lin_vel"].weight == pytest.approx(3.0)
-    assert env_cfg.rewards["foot_air_time_biped"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["tracking_ang_vel"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["air_time"].weight == pytest.approx(3.0)
+    assert env_cfg.rewards["air_time"].params["threshold_min"] == pytest.approx(0.125)
+    assert env_cfg.rewards["air_time"].params["threshold_max"] == pytest.approx(0.3)
+    assert env_cfg.rewards["foot_clearance"].weight == pytest.approx(-2.0)
+    assert env_cfg.rewards["foot_swing_height"].weight == pytest.approx(-0.25)
+    assert env_cfg.rewards["foot_slip"].weight == pytest.approx(-0.1)
+    assert env_cfg.rewards["dof_pos_limits"].weight == pytest.approx(-1.0)
+    assert env_cfg.rewards["angular_momentum"].weight == pytest.approx(-0.02)
     assert env_cfg.rewards["flight_phase"].weight == pytest.approx(-2.0)
     assert env_cfg.rewards["head_pose_bias"].weight == pytest.approx(0.0)
+    assert env_cfg.rewards["action_rate"].weight == pytest.approx(-0.1)
     assert tuple(env_cfg.events) == (
         "reset_scene_to_default",
         "base_com",
+        "head_com",
         "encoder_bias",
+        "foot_friction",
+        "randomize_armature",
         "push_robot",
     )
     assert env_cfg.events["push_robot"].mode == "interval"
-    assert env_cfg.events["push_robot"].interval_range_s == [3.0, 3.0]
+    assert env_cfg.events["push_robot"].interval_range_s == [3.0, 6.0]
+    assert env_cfg.events["foot_friction"].params["ranges"] == [0.7, 1.3]
+    assert env_cfg.events["randomize_armature"].params["ranges"] == [0.9, 1.1]
+    assert env_cfg.events["randomize_armature"].params["operation"] == "scale"
+
+    assert tuple(env_cfg.terminations) == ("time_out", "tilt", "base_height", "nan_state")
+    assert env_cfg.terminations["tilt"].params["limit_angle"] == pytest.approx(1.2217304763960306)
+
+    # Legacy step-staged curricula (stage step = legacy iteration x 24).
+    assert tuple(env_cfg.curriculum) == (
+        "action_rate_weight",
+        "head_pose_bias_weight",
+        "standing_envs",
+        "head_pose_range",
+        "base_com_range",
+        "head_com_range",
+    )
+    action_rate_stages = env_cfg.curriculum["action_rate_weight"].params["stages"]
+    assert [stage["step"] for stage in action_rate_stages] == [
+        0,
+        12000,
+        18000,
+        24000,
+        30000,
+        36000,
+    ]
+    assert [stage["weight"] for stage in action_rate_stages] == [
+        -0.1,
+        -0.2,
+        -0.4,
+        -0.6,
+        -0.8,
+        -1.0,
+    ]
+    standing_stages = env_cfg.curriculum["standing_envs"].params["stages"]
+    assert standing_stages[-1] == {"step": 48000, "rel_standing_envs": 0.25}
+    head_range_stages = env_cfg.curriculum["head_pose_range"].params["stages"]
+    assert head_range_stages[-1]["ranges"] == [
+        [-1.1, 1.1],
+        [-1.1, 1.1],
+        [-1.4, 1.4],
+        [-0.31, 0.31],
+    ]
+    base_com_stages = env_cfg.curriculum["base_com_range"].params["stages"]
+    assert base_com_stages[-1]["params"]["com_range"]["x"] == [-0.015, 0.015]
+    head_com_stages = env_cfg.curriculum["head_com_range"].params["stages"]
+    assert head_com_stages[-1]["params"]["com_range"]["x"] == [-0.01, 0.01]
 
 
 def test_microduck_registry_and_factory_are_manager_based(monkeypatch) -> None:

--- a/tests/envs/locomotion/test_gait_terms.py
+++ b/tests/envs/locomotion/test_gait_terms.py
@@ -352,3 +352,77 @@ def test_gait_term_module_has_no_forbidden_runtime_dependencies() -> None:
         for alias in node.names
     ]
     assert not [name for name in imports if name.startswith(forbidden)]
+
+
+# ---------------------------------------------------------------------------
+# Privileged foot observations (mjlab velocity critic terms, issue #1402)
+# ---------------------------------------------------------------------------
+
+
+def test_foot_height_returns_per_foot_body_z() -> None:
+    scene = _Scene()
+    scene.robot.data.body_link_pos_w[:] = [[[0.0, 0.0, 0.031], [0.0, 0.0, 0.052]]]
+    env = _env(scene)
+    np.testing.assert_allclose(
+        gait_terms.foot_height(env),
+        [[0.031, 0.052], [0.031, 0.052]],
+        rtol=1e-6,
+    )
+
+
+def test_foot_air_time_tracks_current_air_time() -> None:
+    scene = _Scene()
+    env = _env(scene)
+    term = _term(gait_terms.foot_air_time, env, sensor_groups=GROUPS)
+    scene.set_foot_contact(0, True)
+    scene.set_foot_contact(1, False)
+    np.testing.assert_allclose(term(env), [[0.0, 0.02], [0.0, 0.02]])
+    np.testing.assert_allclose(term(env), [[0.0, 0.04], [0.0, 0.04]])
+    scene.set_foot_contact(1, True)
+    np.testing.assert_allclose(term(env), [[0.0, 0.0], [0.0, 0.0]])
+
+
+def test_foot_air_time_reset_clears_only_targeted_rows() -> None:
+    scene = _Scene()
+    env = _env(scene)
+    term = _term(gait_terms.foot_air_time, env, sensor_groups=GROUPS)
+    scene.set_foot_contact(0, False)
+    scene.set_foot_contact(1, False)
+    term(env)  # Both feet at 0.02 s air time in both envs.
+    term.reset(np.array([1]))
+    np.testing.assert_allclose(term(env), [[0.04, 0.04], [0.02, 0.02]])
+
+
+def test_foot_contact_reports_float_flags() -> None:
+    scene = _Scene()
+    env = _env(scene)
+    term = _term(gait_terms.foot_contact, env, sensor_groups=GROUPS)
+    scene.set_foot_contact(0, True, env_ids=(0,))
+    scene.set_foot_contact(1, False)
+    np.testing.assert_allclose(term(env), [[1.0, 0.0], [0.0, 0.0]])
+
+
+def test_foot_contact_forces_log_compressed_in_group_order() -> None:
+    scene = _Scene()
+    scene.contacts = {
+        "left_contact_0": np.array([[1.0, 0.0, -1.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+        "left_contact_1": np.zeros((2, 3), dtype=np.float32),
+        "right_contact_0": np.array([[0.0, 2.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+        "right_contact_1": np.zeros((2, 3), dtype=np.float32),
+    }
+    env = _env(scene)
+    term = _term(gait_terms.foot_contact_forces, env, sensor_groups=GROUPS)
+    values = term(env)
+    assert values.shape == (2, 12)
+    expected_left = np.sign([1.0, 0.0, -1.0]) * np.log1p(np.abs([1.0, 0.0, -1.0]))
+    np.testing.assert_allclose(values[0, :3], expected_left, rtol=1e-6)
+    np.testing.assert_allclose(values[0, 3:6], 0.0, atol=1e-8)
+    np.testing.assert_allclose(values[0, 6:9], [0.0, np.log1p(2.0), 0.0], rtol=1e-6)
+    np.testing.assert_allclose(values[1], 0.0, atol=1e-8)
+
+
+def test_foot_contact_forces_rejects_scalar_found_sensors() -> None:
+    scene = _Scene()  # width-1 "found" sensors
+    env = _env(scene)
+    with pytest.raises(ValueError, match="3-D force"):
+        _term(gait_terms.foot_contact_forces, env, sensor_groups=GROUPS)

--- a/tests/envs/mdp/test_curriculums.py
+++ b/tests/envs/mdp/test_curriculums.py
@@ -7,6 +7,8 @@ fail-closed validation error paths, and the CurriculumManager integration
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -286,3 +288,176 @@ def test_weight_not_logged_when_only_params_staged(fake_env: _FakeEnv) -> None:
     extras = manager.reset()
     assert extras["Curriculum/energy_ramp/threshold"] == pytest.approx(500.0)
     assert "Curriculum/energy_ramp/weight" not in extras
+
+
+# Command and event curricula (issue #1402).
+
+
+class _FakeCommandManager:
+    """Minimal stand-in exposing the cold-path get_term_cfg surface."""
+
+    def __init__(self) -> None:
+        self.cfg = SimpleNamespace(
+            rel_standing_envs=0.02,
+            ranges=[[-0.05, 0.05], [-0.07, 0.07]],
+            params={},
+        )
+
+    def get_term_cfg(self, name: str):
+        if name != "twist":
+            raise KeyError(name)
+        return self.cfg
+
+
+class _FakeEventManager:
+    def __init__(self) -> None:
+        self.cfg = SimpleNamespace(
+            params={"com_range": {"x": (-0.003, 0.003), "y": (-0.003, 0.003)}},
+        )
+
+    def get_term_cfg(self, name: str):
+        if name != "base_com":
+            raise KeyError(name)
+        return self.cfg
+
+
+@pytest.fixture
+def fake_env_full(fake_env: _FakeEnv) -> _FakeEnv:
+    fake_env.command_manager = _FakeCommandManager()
+    fake_env.event_manager = _FakeEventManager()
+    return fake_env
+
+
+def _command_curriculum_manager(env: _FakeEnv, stages: list[dict]) -> CurriculumManager:
+    return CurriculumManager(
+        {
+            "standing_ramp": CurriculumTermCfg(
+                func=mdp.command_curriculum,
+                params={"command_name": "twist", "stages": stages},
+            )
+        },
+        env,
+    )
+
+
+def _event_curriculum_manager(env: _FakeEnv, stages: list[dict]) -> CurriculumManager:
+    return CurriculumManager(
+        {
+            "com_ramp": CurriculumTermCfg(
+                func=mdp.event_curriculum,
+                params={"event_name": "base_com", "stages": stages},
+            )
+        },
+        env,
+    )
+
+
+def test_command_curriculum_field_unchanged_before_threshold(fake_env_full: _FakeEnv) -> None:
+    manager = _command_curriculum_manager(fake_env_full, [{"step": 100, "rel_standing_envs": 0.25}])
+    manager.compute()
+    assert fake_env_full.command_manager.get_term_cfg("twist").rel_standing_envs == pytest.approx(
+        0.02
+    )
+
+
+def test_command_curriculum_field_applied_at_threshold(fake_env_full: _FakeEnv) -> None:
+    manager = _command_curriculum_manager(
+        fake_env_full,
+        [
+            {"step": 0, "rel_standing_envs": 0.05},
+            {"step": 100, "rel_standing_envs": 0.25},
+        ],
+    )
+    fake_env_full.common_step_counter = 100
+    manager.compute()
+    assert fake_env_full.command_manager.get_term_cfg("twist").rel_standing_envs == pytest.approx(
+        0.25
+    )
+
+
+def test_command_curriculum_ranges_field_staged(fake_env_full: _FakeEnv) -> None:
+    manager = _command_curriculum_manager(
+        fake_env_full,
+        [{"step": 50, "ranges": [[-1.1, 1.1], [-1.4, 1.4]]}],
+    )
+    fake_env_full.common_step_counter = 60
+    manager.compute()
+    assert fake_env_full.command_manager.get_term_cfg("twist").ranges == [
+        [-1.1, 1.1],
+        [-1.4, 1.4],
+    ]
+
+
+def test_command_curriculum_logs_scalar_fields(fake_env_full: _FakeEnv) -> None:
+    manager = _command_curriculum_manager(
+        fake_env_full,
+        [
+            {"step": 0, "rel_standing_envs": 0.05},
+            {"step": 50, "ranges": [[-1.1, 1.1], [-1.4, 1.4]]},
+        ],
+    )
+    fake_env_full.common_step_counter = 60
+    manager.compute()
+    extras = manager.reset()
+    assert extras["Curriculum/standing_ramp/rel_standing_envs"] == pytest.approx(0.05)
+    # Non-scalar staged fields are applied but not logged.
+    assert "Curriculum/standing_ramp/ranges" not in extras
+
+
+def test_command_curriculum_unknown_field_raises(fake_env_full: _FakeEnv) -> None:
+    with pytest.raises(AttributeError, match="Field 'rel_standing_env' does not exist"):
+        _command_curriculum_manager(fake_env_full, [{"step": 0, "rel_standing_env": 0.1}])
+
+
+def test_command_curriculum_unknown_term_raises(fake_env_full: _FakeEnv) -> None:
+    with pytest.raises(KeyError, match="missing"):
+        CurriculumManager(
+            {
+                "bad": CurriculumTermCfg(
+                    func=mdp.command_curriculum,
+                    params={"command_name": "missing", "stages": [{"step": 0}]},
+                )
+            },
+            fake_env_full,
+        )
+
+
+def test_event_curriculum_params_follow_stages(fake_env_full: _FakeEnv) -> None:
+    manager = _event_curriculum_manager(
+        fake_env_full,
+        [
+            {"step": 0, "params": {"com_range": {"x": (-0.005, 0.005)}}},
+            {"step": 100, "params": {"com_range": {"x": (-0.015, 0.015)}}},
+        ],
+    )
+    manager.compute()
+    assert fake_env_full.event_manager.get_term_cfg("base_com").params["com_range"]["x"] == (
+        -0.005,
+        0.005,
+    )
+    fake_env_full.common_step_counter = 200
+    manager.compute()
+    assert fake_env_full.event_manager.get_term_cfg("base_com").params["com_range"]["x"] == (
+        -0.015,
+        0.015,
+    )
+
+
+def test_event_curriculum_unknown_param_raises(fake_env_full: _FakeEnv) -> None:
+    with pytest.raises(KeyError, match="unknown param"):
+        _event_curriculum_manager(
+            fake_env_full, [{"step": 0, "params": {"com_ranges": {"x": (-1.0, 1.0)}}}]
+        )
+
+
+def test_event_curriculum_unknown_term_raises(fake_env_full: _FakeEnv) -> None:
+    with pytest.raises(KeyError, match="missing"):
+        CurriculumManager(
+            {
+                "bad": CurriculumTermCfg(
+                    func=mdp.event_curriculum,
+                    params={"event_name": "missing", "stages": [{"step": 0}]},
+                )
+            },
+            fake_env_full,
+        )

--- a/tests/envs/mdp/test_events.py
+++ b/tests/envs/mdp/test_events.py
@@ -1247,3 +1247,35 @@ def test_randomize_encoder_bias_rejects_invalid_cfg_at_construction() -> None:
             },
             env,
         )
+
+
+def test_rigid_body_com_event_consumes_live_params_between_applies() -> None:
+    """Staged CoM-range curricula update the live term params; the next reset
+    application must sample from the widened range without rebuilding the term."""
+    env, backend, transaction = _transaction_env(rng_seed=17)
+    asset_cfg = SceneEntityCfg("robot", body_names=("base",))
+    manager = EventManager(
+        {
+            "com": EventTermCfg(
+                func=mdp.randomize_rigid_body_com,
+                mode="reset",
+                params={"asset_cfg": asset_cfg, "com_range": {"x": (0.1, 0.1)}},
+            )
+        },
+        env,
+    )
+    ids = np.array([0, 1], dtype=np.int32)
+
+    with transaction.scoped(ids):
+        manager.apply(mode="reset", env_ids=ids, global_env_step_count=0)
+    first = backend.randomization_calls[-1].body_ipos
+    assert first is not None
+    np.testing.assert_allclose(first, [[[0.1, 0.0, 0.0]]] * 2)
+
+    # A curriculum stage widens the live term params.
+    manager.get_term_cfg("com").params["com_range"] = {"x": (0.5, 0.5), "z": (-0.2, -0.2)}
+    with transaction.scoped(ids):
+        manager.apply(mode="reset", env_ids=ids, global_env_step_count=1)
+    second = backend.randomization_calls[-1].body_ipos
+    assert second is not None
+    np.testing.assert_allclose(second, [[[0.5, 0.0, -0.2]]] * 2)


### PR DESCRIPTION
Fixes #1402

Roadmap #1389 验收切片 S7：以 legacy `microduck_rl` velocity 配方为参照，用 S1–S5 补齐的 MBA 能力以声明式配置复现 MicroDuck velocity 配方。全部能力经 owner yaml + 共享 term 表达，无 microduck 私有框架 hack。

共享层新增（本切片回补的通用能力，非私有绕道）：
- `envs/mdp/curriculums.py`：`command_curriculum` / `event_curriculum`（复用 S1 stage 引擎，作用于 command/event term 的 live cfg）
- `gait_terms.py`：critic 特权观测 `foot_height`/`foot_air_time`/`foot_contact`/`foot_contact_forces`
- `RandomizeRigidBodyCom` 每次 apply 从 live com_range 重解析；microduck `UniformVectorCommand` resample 时读 live ranges（课表生效前提，含宽度变更守卫）

配方落地（PPO/SAC base.yaml 逐字同步）：
- 课表 A–E 全量（action_rate −0.1→−1.0 @36000 步、head_pose_bias 0→3.0、standing 0.02→0.25、head_pose 范围→±1.1/±1.4 rad、trunk/head CoM →±15/±10mm），stage 步数与 legacy 一致（num_steps_per_env=24 两侧相同）
- reward：foot_clearance −2.0 / foot_swing_height −0.25 / foot_slip −0.1 / dof_pos_limits −1.0 / angular_momentum −0.02 / air_time 窗口形态 (0.125,0.300)s w=3.0；angular tracking 换 ωxy 合并形态 w=2.0 std=√0.5
- 指令：twist ±0.4/±0.3/±1.0、resample (3,8)s、turn-in-place 15%、rel_forward_envs 0.2（legacy base 模板易漏项）；终止：tilt 70°、显式 nan_state
- 观测：IMU delay 0–1 步（period 64）、joint_vel 固定 1 步延迟（纯 delay 管线 yaml）；critic 补 foot 特权观测至 76D（actor 61D 布局零改动，契约测试已同步）
- DR：foot friction (0.7,1.3)、armature ×(0.9,1.1)、head CoM 课表、push interval (3,6)s；mjwarp owner 全量消费（S5），slow 测试确认 payload 到达 per-world device model

Known 不对齐项（逐项声明，详见 PR 描述剩余部分与 issue）：pseudo_inertia（S3 follow-up）、BAM 执行器、sim_dt 0.01 vs 0.005、DR reset-vs-startup 语义、foot_height 零点偏移、部分 reward 形态差异（track_linear_velocity / orientation / leg_pose / self_collisions / head_pose_tracking 权重）、SAC runner 不透传 env extras（error_vel_yaw 仅 PPO 可见）、课表触发语义 >=/reset 时 compute 差一步至一 episode。

## Validation
- 最终 head 本地 `make test-all` 通过：2486 passed, 28 skipped, 1 xfailed；benchmark smoke 36/37（1 skipped platform-optional mlx）
- PPO mujoco smoke（64 envs × 3 iter）：无 NaN，Critic Linear(76→512) 确认 76D，全部新 reward/课表/终止项在册，`Metrics/twist/error_vel_yaw` 正常上报
- SAC mjwarp smoke（64 envs × 3 iter）：全量 DR，loss/reward 有限，ONNX export 校验通过
- `audit_sim2sim_contracts.py` 与基线完全一致（31 TRANSFERABLE / 9 BLOCKED 既有项）

同预算对照训练命令（机时评估由 roadmap 层跟进）：`uv run python scripts/train_rsl_rl.py task=microduck_velocity_flat/mujoco algo.num_envs=4096 algo.max_iterations=4000`