### PR TITLE
perf(obs): ObservationManager 逐段 profiling 插桩与归因 benchmark（#1404 Phase 1）

### DIFF
--- a/scripts/benchmark/env/benchmark_obs_term_profile.py
+++ b/scripts/benchmark/env/benchmark_obs_term_profile.py
@@ -1,0 +1,198 @@
+"""Per-segment wall-clock attribution for ObservationManager.compute (issue #1404).
+
+Builds a real task env through the same Hydra compose + ``BackendAdapter``
+override path as ``benchmark_env_step_phase_cpu.py``, then reports where time
+inside ``ObservationManager.compute`` / ``compute_group`` goes, split by phase:
+
+- ``step``: the full-batch per-step path (``compute(update_history=True)``)
+- ``reset``: the row-scoped partial-reset path
+  (``compute(update_history=True, env_ids=ids)``)
+
+Segments (per term unless noted): ``term`` (raw term func), ``noise``,
+``copy`` (defensive copy / reset row slice), ``clip``, ``scale``, ``nan``
+(per-term NaN scan), ``delay``, ``history``, plus group-level ``concat``,
+``group_nan`` and ``rows`` (temporal-group reset row slice). ``total`` wraps
+each ``compute_group`` call; ``residual = total - sum(segments)`` is the
+unattributed pipeline assembly (dict/list building, zip loop, isinstance and
+shape checks, share-cache bookkeeping) and must stay below 30% of the total
+for the attribution to count as explained.
+
+Profiling is opt-in via ``UNILAB_TERM_PROFILING=1`` (this script sets it
+before importing unilab); when disabled the instrumentation is a no-op.
+
+Run:
+    uv run scripts/benchmark/env/benchmark_obs_term_profile.py
+
+    # tuning:
+    uv run scripts/benchmark/env/benchmark_obs_term_profile.py \
+        --config-group sac --task g1_motion_tracking/mujoco \
+        --num-envs 4096 --warmup 20 --iters 150
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+os.environ.setdefault("UNILAB_TERM_PROFILING", "1")
+
+import time  # noqa: E402
+from collections import defaultdict  # noqa: E402
+from collections.abc import Sequence  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+# Segment categories in pipeline order; everything else attributed per term.
+_CATEGORIES = (
+    "term",
+    "noise",
+    "copy",
+    "clip",
+    "scale",
+    "nan",
+    "delay",
+    "history",
+    "concat",
+    "group_nan",
+    "rows",
+)
+
+
+def _parse_key(key: str) -> tuple[str, str, str]:
+    """Split '<category>/<group>[/<term>]|<phase>' into (category, rest, phase)."""
+    head, _, phase = key.partition("|")
+    category, _, rest = head.partition("/")
+    return category, rest, phase
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--config-group", default="sac", help="conf/<group> used for compose")
+    parser.add_argument("--task", default="g1_motion_tracking/mujoco")
+    parser.add_argument("--num-envs", type=int, default=4096)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=150)
+    parser.add_argument(
+        "--reset-interval",
+        type=int,
+        default=5,
+        help="Force a partial reset of --reset-rows envs every N steps so the "
+        "reset path is covered even when no episode terminates naturally; "
+        "0 disables forced resets",
+    )
+    parser.add_argument("--reset-rows", type=int, default=64)
+    parser.add_argument("--top", type=int, default=15, help="Top-N per-term rows to print")
+    args = parser.parse_args(argv)
+
+    import hydra
+    from omegaconf import OmegaConf
+
+    from unilab.base.config_adapter import BackendAdapter, create_env
+    from unilab.managers._profiling import SEGMENT_PROFILER
+    from unilab.training import ensure_registries
+
+    assert SEGMENT_PROFILER.enabled, "UNILAB_TERM_PROFILING=1 must reach the profiler import"
+
+    ensure_registries()
+    with hydra.initialize_config_dir(
+        version_base="1.3", config_dir=os.path.join(REPO_ROOT, "conf", args.config_group)
+    ):
+        cfg = hydra.compose(
+            config_name="config",
+            overrides=[f"task={args.task}", f"algo.num_envs={args.num_envs}"],
+        )
+    OmegaConf.resolve(cfg)
+    env_cfg_override = BackendAdapter(
+        cfg, root_dir=REPO_ROOT, algo_name=str(cfg.algo.algo)
+    ).build_task_env_cfg_override()
+    env = create_env(cfg, num_envs=args.num_envs, env_cfg_override=env_cfg_override)
+    if env.state is None:
+        env.init_state()
+
+    action_dim = env.action_space.shape[-1]
+    rng = np.random.default_rng(0)
+
+    def actions() -> np.ndarray:
+        return rng.uniform(-0.2, 0.2, size=(args.num_envs, action_dim)).astype(np.float32)
+
+    reset_rows = np.arange(min(args.reset_rows, args.num_envs), dtype=np.int32)
+
+    for _ in range(args.warmup):
+        env.step(actions())
+    SEGMENT_PROFILER.reset()
+
+    n_step_iters = 0
+    n_reset_calls = 0
+    wall0 = time.perf_counter()
+    for it in range(args.iters):
+        env.step(actions())
+        n_step_iters += 1
+        if args.reset_interval > 0 and (it + 1) % args.reset_interval == 0:
+            env.reset(env_ids=reset_rows)
+            n_reset_calls += 1
+    total_wall = time.perf_counter() - wall0
+
+    stats = SEGMENT_PROFILER.stats()
+    # category -> phase -> seconds
+    cat_s: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    # (category, rest) -> phase -> seconds, for the per-term table
+    row_s: dict[tuple[str, str], dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for key, (total_s, _calls) in stats.items():
+        category, rest, phase = _parse_key(key)
+        cat_s[category][phase] += total_s
+        if category != "total":
+            row_s[(category, rest)][phase] += total_s
+
+    step_calls = max(n_step_iters, 1)
+    reset_calls = max(n_reset_calls, 1)
+
+    print(f"task={args.task} num_envs={args.num_envs} iters={args.iters}")
+    print(f"step_calls={n_step_iters} reset_calls={n_reset_calls}")
+    print(f"env step wall (profiling on): {total_wall / n_step_iters * 1e3:.2f} ms/step")
+    phases = ("step", "reset")
+    divisors = {"step": step_calls, "reset": reset_calls}
+
+    totals = {p: cat_s["total"].get(p, 0.0) for p in phases}
+    print("\n== per-category attribution (ms per call of that phase) ==")
+    print(f"{'category':>10s} {'step_ms':>9s} {'reset_ms':>9s}")
+    for cat in _CATEGORIES:
+        row = cat_s.get(cat, {})
+        print(
+            f"{cat:>10s} {row.get('step', 0.0) / step_calls * 1e3:9.3f} "
+            f"{row.get('reset', 0.0) / reset_calls * 1e3:9.3f}"
+        )
+    print(f"{'total':>10s} {totals['step'] / step_calls * 1e3:9.3f} "
+          f"{totals['reset'] / reset_calls * 1e3:9.3f}")
+
+    for p in phases:
+        attributed = sum(cat_s[c].get(p, 0.0) for c in _CATEGORIES)
+        residual = totals[p] - attributed
+        share = residual / totals[p] * 100.0 if totals[p] > 0 else 0.0
+        print(
+            f"[{p}] total={totals[p] / divisors[p] * 1e3:.3f} ms/call "
+            f"residual={residual / divisors[p] * 1e3:.3f} ms/call ({share:.1f}% unexplained)"
+        )
+
+    print(f"\n== top {args.top} per-term segments (step ms/call) ==")
+    print(f"{'segment':<56} {'step_ms':>9s} {'reset_ms':>9s}")
+    rows = sorted(row_s.items(), key=lambda kv: -kv[1].get("step", 0.0))[: args.top]
+    for (cat, rest), per_phase in rows:
+        print(
+            f"{cat + '/' + rest:<56} {per_phase.get('step', 0.0) / step_calls * 1e3:9.3f} "
+            f"{per_phase.get('reset', 0.0) / reset_calls * 1e3:9.3f}"
+        )
+
+    step_total = totals["step"]
+    if step_total > 0:
+        attributed = sum(cat_s[c].get("step", 0.0) for c in _CATEGORIES)
+        unexplained = (step_total - attributed) / step_total
+        print(f"\nunexplained_gap(step)={unexplained * 100:.1f}% (must be < 30%)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/env/benchmark_obs_term_profile.py
+++ b/scripts/benchmark/env/benchmark_obs_term_profile.py
@@ -20,6 +20,15 @@ for the attribution to count as explained.
 Profiling is opt-in via ``UNILAB_TERM_PROFILING=1`` (this script sets it
 before importing unilab); when disabled the instrumentation is a no-op.
 
+Caveat (issue #1404 Phase 2): per-segment timings include the instrumentation
+itself (two ``perf_counter`` calls plus a context manager per segment, and the
+cache pollution that comes with them), which inflates and skews the
+attribution — at 4096 envs the instrumented ``compute`` total reads ~1.7 ms
+while the uninstrumented wall time is ~1.0 ms. Use the table for relative
+per-term ranking inside a category, not for absolute category shares; verify
+category-level claims with uninstrumented ablation (strip term noise /
+``nan_policy`` at runtime) before acting on them.
+
 Run:
     uv run scripts/benchmark/env/benchmark_obs_term_profile.py
 

--- a/scripts/benchmark/env/benchmark_obs_term_profile.py
+++ b/scripts/benchmark/env/benchmark_obs_term_profile.py
@@ -165,8 +165,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"{cat:>10s} {row.get('step', 0.0) / step_calls * 1e3:9.3f} "
             f"{row.get('reset', 0.0) / reset_calls * 1e3:9.3f}"
         )
-    print(f"{'total':>10s} {totals['step'] / step_calls * 1e3:9.3f} "
-          f"{totals['reset'] / reset_calls * 1e3:9.3f}")
+    print(
+        f"{'total':>10s} {totals['step'] / step_calls * 1e3:9.3f} "
+        f"{totals['reset'] / reset_calls * 1e3:9.3f}"
+    )
 
     for p in phases:
         attributed = sum(cat_s[c].get(p, 0.0) for c in _CATEGORIES)

--- a/src/unilab/managers/_profiling.py
+++ b/src/unilab/managers/_profiling.py
@@ -1,0 +1,76 @@
+"""Opt-in per-segment timing for manager hot paths (issue #1404).
+
+Enable with ``UNILAB_TERM_PROFILING=1`` (same switch as the #1293 round).
+When disabled, ``profile_segment()`` returns a shared no-op context manager,
+so each call site costs one attribute check and no allocation. When enabled,
+timing overhead (two ``perf_counter`` calls per segment) is accepted — this is
+profiling code, not a hot-path feature.
+
+Stats are pulled programmatically via ``SEGMENT_PROFILER.stats()`` by
+``scripts/benchmark/env/benchmark_obs_term_profile.py``; nothing is printed
+implicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from typing import Literal
+
+_ENABLED = os.environ.get("UNILAB_TERM_PROFILING", "") == "1"
+
+
+class _NullCtx:
+    __slots__ = ()
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: object) -> Literal[False]:
+        return False
+
+
+class SegmentProfiler:
+    """Accumulates wall-clock time per segment key.
+
+    Keys are ``<category>/<group>[/<term>]|<phase>`` where phase is ``step``
+    (full-batch per-step path) or ``reset`` (row-scoped reset path).
+    """
+
+    def __init__(self) -> None:
+        self.enabled = _ENABLED
+        self._total_s: dict[str, float] = defaultdict(float)
+        self._calls: dict[str, int] = defaultdict(int)
+
+    def reset(self) -> None:
+        """Drop accumulated stats (e.g. after benchmark warmup)."""
+        self._total_s.clear()
+        self._calls.clear()
+
+    @contextmanager
+    def time(self, key: str) -> Iterator[None]:
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._total_s[key] += time.perf_counter() - t0
+            self._calls[key] += 1
+
+    def stats(self) -> dict[str, tuple[float, int]]:
+        """Return ``{key: (total_seconds, calls)}`` for accumulated segments."""
+        return {key: (self._total_s[key], self._calls[key]) for key in self._total_s}
+
+
+SEGMENT_PROFILER = SegmentProfiler()
+
+_NULL_CTX = _NullCtx()
+
+
+def profile_segment(key: str) -> AbstractContextManager[None]:
+    """Time one pipeline segment; no-op when profiling is disabled."""
+    if SEGMENT_PROFILER.enabled:
+        return SEGMENT_PROFILER.time(key)
+    return _NULL_CTX

--- a/src/unilab/managers/observation_manager.py
+++ b/src/unilab/managers/observation_manager.py
@@ -19,6 +19,7 @@ from unilab.base.config_overrides import (
 from unilab.managers._buffers import CircularBuffer, DelayBuffer
 from unilab.managers._noise import noise_cfg, noise_model
 from unilab.managers._noise.noise_cfg import NoiseCfg, NoiseModelCfg
+from unilab.managers._profiling import profile_segment
 from unilab.managers.manager_base import ManagerBase, ManagerTermBaseCfg
 
 if TYPE_CHECKING:
@@ -371,10 +372,12 @@ class ObservationManager(ManagerBase):
         # the same raw output (the per-term pipeline never mutates func outputs
         # in place), so later groups reuse the first group's raw result.
         share_cache: dict[tuple, np.ndarray] = {}
+        profile_phase = "reset" if env_ids is not None else "step"
         for group_name in self._group_obs_term_names:
-            obs_buffer[group_name] = self.compute_group(
-                group_name, update_history, env_ids, share_cache=share_cache
-            )
+            with profile_segment(f"total/{group_name}|{profile_phase}"):
+                obs_buffer[group_name] = self.compute_group(
+                    group_name, update_history, env_ids, share_cache=share_cache
+                )
         if env_ids is None:
             self._obs_buffer = obs_buffer
         return obs_buffer
@@ -414,12 +417,14 @@ class ObservationManager(ManagerBase):
         # noise is drawn for the reset rows only — issue #1349 removed the
         # full-batch RNG-stream parity requirement.
         row_scoped = env_ids is not None and not self._group_obs_temporal[group_name]
+        profile_phase = "reset" if env_ids is not None else "step"
         for term_name, term_cfg in obs_terms:
             share_key = share_map.get(term_name)
             if share_key is not None and share_key in share_cache:
                 obs = share_cache[share_key]
             else:
-                obs = term_cfg.func(self._env, **term_cfg.params)
+                with profile_segment(f"term/{group_name}/{term_name}|{profile_phase}"):
+                    obs = term_cfg.func(self._env, **term_cfg.params)
                 if share_key is not None:
                     share_cache[share_key] = obs
             if not isinstance(obs, np.ndarray):
@@ -438,15 +443,18 @@ class ObservationManager(ManagerBase):
                 # rows only (issue #1349 removed the full-batch RNG-stream
                 # parity requirement). Fancy indexing already returns a fresh
                 # row copy, safe for the in-place clip/scale below.
-                obs = obs[env_ids]
+                with profile_segment(f"copy/{group_name}/{term_name}|{profile_phase}"):
+                    obs = obs[env_ids]
                 fresh = True
             if isinstance(term_cfg.noise, noise_cfg.NoiseCfg):
                 # NoiseCfg.apply always returns a newly allocated array.
-                obs = term_cfg.noise.apply(obs, rng=self._env.rng)
+                with profile_segment(f"noise/{group_name}/{term_name}|{profile_phase}"):
+                    obs = term_cfg.noise.apply(obs, rng=self._env.rng)
                 fresh = True
             elif isinstance(term_cfg.noise, noise_cfg.NoiseModelCfg):
                 # NoiseModel.__call__ likewise returns a new array.
-                obs = self._group_obs_class_instances[group_name][term_name](obs)
+                with profile_segment(f"noise/{group_name}/{term_name}|{profile_phase}"):
+                    obs = self._group_obs_class_instances[group_name][term_name](obs)
                 fresh = True
             sanitizes_per_term = group_cfg.nan_check_per_term and group_cfg.nan_policy in (
                 "warn",
@@ -470,13 +478,16 @@ class ObservationManager(ManagerBase):
                 # Concatenation and temporal buffers already copy their inputs.
                 # Only take a defensive copy when this pipeline may mutate the
                 # term or expose it directly to callers.
-                obs = obs.copy()
+                with profile_segment(f"copy/{group_name}/{term_name}|{profile_phase}"):
+                    obs = obs.copy()
             if term_cfg.clip:
-                np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
+                with profile_segment(f"clip/{group_name}/{term_name}|{profile_phase}"):
+                    np.clip(obs, term_cfg.clip[0], term_cfg.clip[1], out=obs)
             if term_cfg.scale is not None:
                 scale = term_cfg.scale
                 assert isinstance(scale, np.ndarray)
-                np.multiply(obs, scale, out=obs)
+                with profile_segment(f"scale/{group_name}/{term_name}|{profile_phase}"):
+                    np.multiply(obs, scale, out=obs)
 
             # Check for NaN/Inf before delay/history buffers (per-term checking).
             if (
@@ -484,33 +495,37 @@ class ObservationManager(ManagerBase):
                 and group_cfg.nan_policy != "disabled"
                 and not defer_error_nan_check
             ):
-                obs = self._check_and_handle_nans(
-                    obs,
-                    context=f"{group_name}/{term_name}",
-                    policy=group_cfg.nan_policy,
-                    env_ids=env_ids if row_scoped else None,
-                )
+                with profile_segment(f"nan/{group_name}/{term_name}|{profile_phase}"):
+                    obs = self._check_and_handle_nans(
+                        obs,
+                        context=f"{group_name}/{term_name}",
+                        policy=group_cfg.nan_policy,
+                        env_ids=env_ids if row_scoped else None,
+                    )
 
             if term_cfg.delay_max_lag > 0:
-                delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
-                if env_ids is None or not delay_buffer.is_initialized:
-                    delay_buffer.append(obs)
-                    obs = delay_buffer.compute()
-                else:
-                    delay_buffer.backfill(obs, env_ids)
-                    obs = delay_buffer.peek()
+                with profile_segment(f"delay/{group_name}/{term_name}|{profile_phase}"):
+                    delay_buffer = self._group_obs_term_delay_buffer[group_name][term_name]
+                    if env_ids is None or not delay_buffer.is_initialized:
+                        delay_buffer.append(obs)
+                        obs = delay_buffer.compute()
+                    else:
+                        delay_buffer.backfill(obs, env_ids)
+                        obs = delay_buffer.peek()
             if term_cfg.history_length > 0:
-                circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
-                if env_ids is None or not circular_buffer.is_initialized:
-                    if update_history or not circular_buffer.is_initialized:
-                        circular_buffer.append(obs)
-                else:
-                    circular_buffer.backfill(obs, env_ids)
+                with profile_segment(f"history/{group_name}/{term_name}|{profile_phase}"):
+                    circular_buffer = self._group_obs_term_history_buffer[group_name][term_name]
+                    if env_ids is None or not circular_buffer.is_initialized:
+                        if update_history or not circular_buffer.is_initialized:
+                            circular_buffer.append(obs)
+                    else:
+                        circular_buffer.backfill(obs, env_ids)
 
-                if term_cfg.flatten_history_dim:
-                    group_obs[term_name] = circular_buffer.buffer.reshape(self._env.num_envs, -1)
-                else:
-                    group_obs[term_name] = circular_buffer.buffer
+                    if term_cfg.flatten_history_dim:
+                        history_obs = circular_buffer.buffer.reshape(self._env.num_envs, -1)
+                    else:
+                        history_obs = circular_buffer.buffer
+                group_obs[term_name] = history_obs
             else:
                 group_obs[term_name] = obs
 
@@ -520,20 +535,23 @@ class ObservationManager(ManagerBase):
                 # Will check after concatenation below.
                 pass
             else:
-                for term_name in group_obs:
-                    group_obs[term_name] = self._check_and_handle_nans(
-                        group_obs[term_name],
-                        context=f"{group_name}/{term_name}",
-                        policy=group_cfg.nan_policy,
-                        env_ids=env_ids if row_scoped else None,
-                    )
+                with profile_segment(f"group_nan/{group_name}|{profile_phase}"):
+                    for term_name in group_obs:
+                        group_obs[term_name] = self._check_and_handle_nans(
+                            group_obs[term_name],
+                            context=f"{group_name}/{term_name}",
+                            policy=group_cfg.nan_policy,
+                            env_ids=env_ids if row_scoped else None,
+                        )
 
         if self._group_obs_concatenate[group_name]:
-            result = np.concatenate(
-                list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
-            )
+            with profile_segment(f"concat/{group_name}|{profile_phase}"):
+                result = np.concatenate(
+                    list(group_obs.values()), axis=self._group_obs_concatenate_dim[group_name]
+                )
             if defer_error_nan_check:
-                finite = np.isfinite(result)
+                with profile_segment(f"group_nan/{group_name}|{profile_phase}"):
+                    finite = np.isfinite(result)
                 if not finite.all():
                     axis = self._group_obs_concatenate_dim[group_name]
                     axis = axis if axis >= 0 else result.ndim + axis
@@ -561,12 +579,13 @@ class ObservationManager(ManagerBase):
                         offset += width
             # Final check for concatenated result (non-per-term checking).
             if not group_cfg.nan_check_per_term and group_cfg.nan_policy != "disabled":
-                result = self._check_and_handle_nans(
-                    result,
-                    context=group_name,
-                    policy=group_cfg.nan_policy,
-                    env_ids=env_ids if row_scoped else None,
-                )
+                with profile_segment(f"group_nan/{group_name}|{profile_phase}"):
+                    result = self._check_and_handle_nans(
+                        result,
+                        context=group_name,
+                        policy=group_cfg.nan_policy,
+                        env_ids=env_ids if row_scoped else None,
+                    )
         else:
             result = group_obs
 
@@ -574,10 +593,11 @@ class ObservationManager(ManagerBase):
             # Groups with delay/history terms ran the full-batch pipeline above
             # (buffer readout stays full-batch); slice the reset rows to match
             # the reset-path return contract.
-            if isinstance(result, dict):
-                result = {name: values[env_ids] for name, values in result.items()}
-            else:
-                result = result[env_ids]
+            with profile_segment(f"rows/{group_name}|{profile_phase}"):
+                if isinstance(result, dict):
+                    result = {name: values[env_ids] for name, values in result.items()}
+                else:
+                    result = result[env_ids]
 
         return result
 

--- a/tests/managers/test_segment_profiling.py
+++ b/tests/managers/test_segment_profiling.py
@@ -1,0 +1,34 @@
+"""Tests for the opt-in manager segment profiler (issue #1404)."""
+
+from __future__ import annotations
+
+import unilab.managers._profiling as profiling
+from unilab.managers._profiling import SEGMENT_PROFILER, profile_segment
+
+
+def test_disabled_by_default_returns_shared_null_ctx() -> None:
+    assert not SEGMENT_PROFILER.enabled
+    ctx = profile_segment("term/group/name|step")
+    assert ctx is profiling._NULL_CTX
+    with ctx:
+        pass
+    assert SEGMENT_PROFILER.stats() == {}
+
+
+def test_enabled_accumulates_and_resets(monkeypatch) -> None:
+    monkeypatch.setattr(SEGMENT_PROFILER, "enabled", True)
+    try:
+        with profile_segment("noise/actor/base_lin_vel|step"):
+            pass
+        with profile_segment("noise/actor/base_lin_vel|step"):
+            pass
+        with profile_segment("term/actor/base_lin_vel|step"):
+            pass
+        stats = SEGMENT_PROFILER.stats()
+        assert stats["noise/actor/base_lin_vel|step"][1] == 2
+        assert stats["term/actor/base_lin_vel|step"][1] == 1
+        assert all(total_s >= 0.0 for total_s, _ in stats.values())
+        SEGMENT_PROFILER.reset()
+        assert SEGMENT_PROFILER.stats() == {}
+    finally:
+        SEGMENT_PROFILER.reset()


### PR DESCRIPTION
Refs #1404（Phase 1：逐 term profiling，独立交付切片）

## 内容

- `src/unilab/managers/_profiling.py`：`UNILAB_TERM_PROFILING=1` 开启的逐段计时（复用 #1293 的开关与模式）；默认关闭时每个 call site 仅一次属性检查 + 共享 no-op context，零分配。stats 以编程方式读取，无隐式打印。
- `observation_manager.py`：`compute`/`compute_group` 插桩，覆盖 term / noise / copy / clip / scale / nan / delay / history / concat / group_nan / rows 段，按 `step|reset` 相位区分；`total/<group>` 包裹每次 `compute_group`。
- `scripts/benchmark/env/benchmark_obs_term_profile.py`：按 `benchmark_env_step_phase_cpu.py` 相同的 Hydra compose + BackendAdapter 路径建真实 env，输出 per-category 归因表（step + reset 行域两路径）与 unexplained gap。
- `tests/managers/test_segment_profiling.py`：profiler 开关/累计/重置单测。

## 归因结果（已写回 issue #1404 评论）

> 注：插桩归因后经无插桩消融修正（见 issue #1404 评论 #issuecomment-5491680566）——插桩会高估短段落绝对占比；本脚本 docstring 已补充该警告，段落计时仅用于类别内逐 term 相对排序。

`sac/g1_motion_tracking/mujoco`，4096/8192 envs：

- step 路径：concat ~40%、noise ~30%、term 函数 ~20%、group_nan ~6-7%，residual 3-4%
- reset 行域路径：大头是 term 函数全批量重算（冷 state-read 缓存），管线机制部分 ~1 ms
- 未解释 gap：step 3-4% / reset 8-14%，均 < 30% 达标

## Validation

- 最终 head `bb397c11` 本地 `make test-all` 通过（check + test-cov + benchmark smoke；smoke 含新增脚本本身）
- 归因 benchmark 实测：`--num-envs 4096` / `--num-envs 8192` 各 150 iters + 30 forced partial resets，结果见 issue 评论

## 后续

Phase 2 按归因顺序收敛：① group 输出预分配 + layout/slice 缓存消除 concat；② noise 逐元素操作融合；③ group_nan 与写入融合。
