### PR TITLE
feat(isaacsim): add offline and interactive eval rendering

### DIFF
--- a/conf/ppo/task/g1_walk_flat/isaacsim.yaml
+++ b/conf/ppo/task/g1_walk_flat/isaacsim.yaml
@@ -2,8 +2,8 @@
 # IsaacSim owner for the headless Python 3.11 IsaacLab/PhysX subprocess.
 # The owner keeps all policy-defining fields inherited from the MuJoCo base
 # unchanged so a checkpoint has the same observation/action contract. IsaacSim
-# currently exposes physics only: rendering/playback, interval randomization,
-# and reset-time PD-gain mutation are deliberately disabled at the owner layer.
+# keeps interval randomization and reset-time PD-gain mutation disabled at the
+# owner layer; eval rendering is selected before Kit startup.
 defaults:
   - /task/g1_walk_flat/base
   - _self_
@@ -11,7 +11,7 @@ defaults:
 training:
   task_name: G1WalkFlat
   sim_backend: isaacsim
-  play_render_mode: none
+  play_render_mode: auto
 algo:
   num_envs: 2048
   max_iterations: 2200
@@ -26,6 +26,8 @@ env:
   # IsaacSim 5.1 / IsaacLab v2.3.0 run in a dedicated Python 3.11 worker.
   isaacsim_device_id: 0
   isaacsim_worker_timeout_s: 120.0
+  isaacsim_render_width: 1280
+  isaacsim_render_height: 720
   events:
     pd_gains: null
 play_profile:

--- a/conf/sac/task/g1_walk_flat/isaacsim.yaml
+++ b/conf/sac/task/g1_walk_flat/isaacsim.yaml
@@ -1,8 +1,8 @@
 # @package _global_
 # IsaacSim SAC owner for the headless Python 3.11 IsaacLab/PhysX subprocess.
 # Policy-defining fields remain inherited from the MuJoCo owner contract;
-# unsupported rendering, interval randomization, and reset-time PD mutation
-# are explicit fail-closed choices for this physics-only integration slice.
+# interval randomization and reset-time PD mutation remain explicit fail-closed
+# choices.  Eval injects the render intent before the IsaacSim worker launches.
 defaults:
   - /task/g1_walk_flat/base
   - _self_
@@ -10,7 +10,7 @@ defaults:
 training:
   task_name: G1WalkFlat
   sim_backend: isaacsim
-  play_render_mode: none
+  play_render_mode: auto
 algo:
   num_envs: 2048
   learning_starts: 10
@@ -23,6 +23,8 @@ algo:
 env:
   isaacsim_device_id: 0
   isaacsim_worker_timeout_s: 120.0
+  isaacsim_render_width: 1280
+  isaacsim_render_height: 720
   events:
     pd_gains: null
 play_profile:

--- a/docs/sphinx/source/en/2-user_guide/3-backends/5-isaacsim.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/5-isaacsim.md
@@ -4,8 +4,10 @@ UniLab's `isaacsim` backend runs IsaacSim 5.1.0 and IsaacLab v2.3.0 in a
 dedicated Python 3.11 worker process. The host process keeps the regular
 `SimBackend` NumPy contract; pipe messages carry lifecycle commands and shared
 memory carries batched state. The current support boundary is headless physics
-for the registered G1 flat task owners. The support matrix intentionally marks
-the PPO and SAC owners as `Configured`, not `Tested`.
+plus eval-owned native rendering for the registered G1 flat task owners. The
+support matrix intentionally marks the PPO and SAC owners as `Configured`, not
+`Tested`, because the rendering protocol is covered by deterministic worker
+tests but has not completed playback on the currently available IsaacSim host.
 
 ## Runtime boundary
 
@@ -27,27 +29,61 @@ The expected runtime layout is
 library directories under that venv, and an IsaacLab v2.3.0 source checkout at
 `$UNILAB_ISAACSIM_HOME/IsaacLab`.
 
-The first headless Kit launch may spend minutes warming extension and shader
-caches. On the validated 595.x NVIDIA driver family, the standalone/full-app
-path can crash in `librtx.scenedb.plugin.so`; this backend therefore does not
-claim GUI, camera capture, or native playback support. The worker always starts
-IsaacLab's headless `AppLauncher` path.
+The render intent is part of the worker's cold `INIT` handshake. Training does
+not inject a render mode and starts the inexpensive headless, camera-disabled
+Kit experience. Eval selects one of these modes before Kit starts:
+
+- `auto`: use the interactive Kit viewer when `DISPLAY` or `WAYLAND_DISPLAY`
+  is present; otherwise use headless recording.
+- `interactive`: start non-headless Kit and fail before worker launch when no
+  display variable is present.
+- `record`: start the headless rendering experience with IsaacLab RGB cameras;
+  `training.play_steps` must be finite.
+- `none`: run policy evaluation without a viewer or camera.
+
+The record contract is RGB `(height, width, 3)`, `uint8`, contiguous, and
+non-uniform. Invalid or placeholder frames fail closed instead of producing a
+video. Width and height default to 1280 x 720 in the IsaacSim owner YAML and
+can be overridden through `env.isaacsim_render_width` and
+`env.isaacsim_render_height` before env creation.
 
 The current worker supports MJCF materialization, batched articulation state,
-position-target stepping, and masked root/joint resets. Contact-force sensors,
-reset or interval domain randomization, host pre-step callbacks, GUI rendering,
-camera capture, and native playback are unsupported and fail closed.
+position-target stepping, masked root/joint resets, a native Kit viewer, and
+headless IsaacLab RGB camera capture. Contact-force sensors, reset or interval
+domain randomization, and host pre-step callbacks remain unsupported and fail
+closed.
 
 Use the top-level CLI to select the backend and owner:
 
 ```bash
 uv run train --algo ppo --task g1_walk_flat --sim isaacsim
-uv run eval --algo sac --task g1_walk_flat --sim isaacsim --render-mode none
+uv run eval --algo sac --task g1_walk_flat --sim isaacsim \
+  --load-run <run-id> --render-mode record \
+  training.play_steps=120 training.play_env_num=1 training.export_onnx=false
+uv run eval --algo sac --task g1_walk_flat --sim isaacsim \
+  --load-run <run-id> --render-mode interactive training.play_env_num=1
 ```
 
-These commands require the external runtime and an NVIDIA CUDA device. The
-repository does not claim that either command has completed full training or
-playback validation; those claims require a maintainer validation entry.
+Record mode writes `play_video.mp4` in the selected run directory. These
+commands require the external runtime and an NVIDIA CUDA device. The repository
+does not claim completed full training or stable native playback; those claims
+require a maintainer validation entry.
+
+## Current Runtime Validation
+
+A bounded SAC record eval and a bounded interactive eval using an existing
+checkpoint were attempted on IsaacSim 5.1.0, IsaacLab v2.3.0, Kit 107.3.3,
+Ubuntu 24.04.4, an RTX 4090, and NVIDIA driver 595.84. Both paths crashed during
+`AppLauncher` initialization, before camera or viewer creation, with frames in
+`librtx.scenedb.plugin.so`,
+`libcarb.scenerenderer-rtx.plugin.so`, and `libomni.hydra.rtx.plugin.so` after
+EGL initialization warnings. A minimal camera-enabled `AppLauncher` probe also
+failed with `multi_gpu=False`.
+
+This is a runtime blocker, not successful playback evidence. The backend keeps
+the render protocol and its fail-closed tests, while the support matrix remains
+at `Configured`. No placeholder video is generated when the real renderer does
+not initialize.
 
 ## Inspecting The Contract
 
@@ -76,7 +112,9 @@ runtime; it is not a training or playback validation.
 | Partial reset | `write_root_pose_to_sim`, `write_root_velocity_to_sim`, `write_joint_state_to_sim`, `reset(env_ids)` | Selected row changes; other row deltas are zero | Use masked batched writes; reject duplicate/out-of-range ids |
 | Position control | `set_joint_position_target`, `write_data_to_sim`, `SimulationContext.step` | Target moves the first joint over bounded steps | `step(ctrl)` carries position targets; gains/limits are materialized explicitly |
 | State getter boundary | `Articulation.data.*` tensors | All getters are batched with expected leading dimension | Worker copies tensors to host-owned shared-memory slots; hot getters do not parse assets |
-| Rendering | IsaacLab headless `AppLauncher` | Not claimed by this probe | Keep GUI/native rendering fail-closed until a separate driver-tested slice |
+| Rendering startup | `AppLauncher` cold mode selection | Mock worker verifies none/record/interactive mode, dimensions, and graphics handshake | Mode cannot change after env materialization |
+| Offline RGB | IsaacLab `Camera` + `CameraCfg` | Protocol tests verify video writing and reject bad shape, dtype, or uniform frames; current real host crashes before camera creation | Require finite steps and keep support at `Configured` until real playback succeeds |
+| Interactive viewer | non-headless Kit + `SimulationContext.set_camera_view` | Protocol tests drive a frame and map window close to `RenderClosedError`; current host has no successful bounded GUI evidence | Explicit interactive requires a display; `auto` falls back to record without one |
 | Domain randomization | IsaacLab manager/event APIs | Not exercised | Non-empty unsupported plans must fail closed |
 
 The importer returns a different joint/body ordering (for example, left/right

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/5-isaacsim.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/5-isaacsim.md
@@ -3,8 +3,9 @@
 UniLab 的 `isaacsim` 后端在独立的 Python 3.11 worker 进程中运行 IsaacSim
 5.1.0 和 IsaacLab v2.3.0。主进程保留标准 `SimBackend` NumPy contract；管道
 传输生命周期命令，共享内存传输批量状态。当前支持边界是已注册 G1 flat
-task owner 的 headless physics。支持矩阵将 PPO/SAC owner 标为
-`Configured`，不是 `Tested`。
+task owner 的 headless physics 与 eval 专用原生渲染。支持矩阵仍将 PPO/SAC
+owner 标为 `Configured`，不是 `Tested`：渲染协议有确定性 worker 测试，但在
+当前可用 IsaacSim 主机上还没有完成真实 playback。
 
 ## 运行时边界
 
@@ -23,25 +24,54 @@ Python 3.10--3.13。安装入口是 `scripts/tools/setup_isaacsim_env.sh`，默�
 site-packages 和 library 目录，以及
 `$UNILAB_ISAACSIM_HOME/IsaacLab` 下的 IsaacLab v2.3.0 源码。
 
-首次 headless Kit 启动可能需要数分钟预热扩展和 shader cache。在已验证的
-595.x NVIDIA 驱动上，独立 GUI/full-app 路径可能在
-`librtx.scenedb.plugin.so` 崩溃；因此本后端不声明 GUI、camera capture 或
-native playback，worker 始终使用 IsaacLab headless `AppLauncher` 路径。
+渲染意图属于 worker 的冷路径 `INIT` 握手。训练不注入渲染模式，使用低开销的
+headless、camera-disabled Kit experience。eval 在 Kit 启动前选择以下模式：
+
+- `auto`：存在 `DISPLAY` 或 `WAYLAND_DISPLAY` 时使用 Kit 交互窗口，否则使用
+  headless 离线录制。
+- `interactive`：启动非 headless Kit；没有 display 环境变量时在 worker 启动前
+  显式失败。
+- `record`：启动带 IsaacLab RGB camera 的 headless rendering experience；
+  `training.play_steps` 必须是有限值。
+- `none`：不启动 viewer 或 camera，只执行策略 eval。
+
+离线帧 contract 为 `(height, width, 3)`、`uint8`、连续且非均匀。错误帧或占位帧
+会 fail closed，不会写出伪视频。IsaacSim owner 默认 1280 x 720，可在 env 创建前
+通过 `env.isaacsim_render_width` 和 `env.isaacsim_render_height` 覆盖。
 
 当前 worker 支持 MJCF 材质化、批量 articulation 状态、位置 target 步进和
-masked root/joint reset。contact-force sensor、reset/interval domain
-randomization、host pre-step callback、GUI rendering、camera capture 和
-native playback 均不支持，并会 fail closed。
+masked root/joint reset，以及 Kit 原生 viewer 和 headless IsaacLab RGB camera。
+contact-force sensor、reset/interval domain randomization 和 host pre-step
+callback 仍不支持，并会 fail closed。
 
 使用顶层 CLI 选择 backend 和 owner：
 
 ```bash
 uv run train --algo ppo --task g1_walk_flat --sim isaacsim
-uv run eval --algo sac --task g1_walk_flat --sim isaacsim --render-mode none
+uv run eval --algo sac --task g1_walk_flat --sim isaacsim \
+  --load-run <run-id> --render-mode record \
+  training.play_steps=120 training.play_env_num=1 training.export_onnx=false
+uv run eval --algo sac --task g1_walk_flat --sim isaacsim \
+  --load-run <run-id> --render-mode interactive training.play_env_num=1
 ```
 
-这些命令需要外部运行时和 NVIDIA CUDA 设备。仓库没有声称上述命令已完成
-完整训练或 playback 验证；该声明需要 maintainer validation 记录。
+`record` 会在所选 run 目录写入 `play_video.mp4`。这些命令需要外部运行时和
+NVIDIA CUDA 设备。仓库不声称已完成完整训练或稳定的原生 playback；该声明
+需要 maintainer validation 记录。
+
+## 当前运行时验证
+
+已使用现有 SAC checkpoint 在 IsaacSim 5.1.0、IsaacLab v2.3.0、Kit 107.3.3、
+Ubuntu 24.04.4、RTX 4090 和 NVIDIA driver 595.84 上分别执行有界 record eval
+和 interactive eval。两条路径均在 `AppLauncher` 初始化期间、camera 或 viewer
+创建之前崩溃；栈包含
+`librtx.scenedb.plugin.so`、`libcarb.scenerenderer-rtx.plugin.so` 和
+`libomni.hydra.rtx.plugin.so`，崩溃前有 EGL 初始化警告。最小 camera-enabled
+`AppLauncher` probe 即使设置 `multi_gpu=False` 也失败。
+
+这是真实 runtime blocker，不是 playback 成功证据。backend 保留渲染协议和
+fail-closed 测试，支持矩阵仍为 `Configured`；真实 renderer 未初始化时不会生成
+占位视频。
 
 ## 检查 Contract
 
@@ -69,7 +99,9 @@ uv run --active --no-project \
 | partial reset | `write_root_pose_to_sim`、`write_root_velocity_to_sim`、`write_joint_state_to_sim`、`reset(env_ids)` | 只改变选中行，其他行 delta 为零 | 使用 masked batch write；拒绝重复或越界 id |
 | 位置控制 | `set_joint_position_target`、`write_data_to_sim`、`SimulationContext.step` | 有界步数内首个 joint 移动 | `step(ctrl)` 传位置 target；gain/limit 在 cold path 显式材质化 |
 | 状态 getter 边界 | `Articulation.data.*` tensor | getter 均为 batch，leading dimension 符合预期 | worker 将 tensor 拷贝到 host-owned shm；热路径不解析 asset |
-| 渲染 | IsaacLab headless `AppLauncher` | 本探测不声明 | 独立驱动验证前保持 GUI/native rendering fail-closed |
+| 渲染启动 | `AppLauncher` 冷路径模式选择 | mock worker 验证 none/record/interactive mode、尺寸和 graphics 握手 | env 材质化后不能切换 mode |
+| 离线 RGB | IsaacLab `Camera` + `CameraCfg` | 协议测试验证视频写入，并拒绝错误 shape、dtype 或均匀帧；当前真实主机在 camera 创建前崩溃 | 要求有限步数；真实 playback 成功前支持等级保持 `Configured` |
+| 交互窗口 | 非 headless Kit + `SimulationContext.set_camera_view` | 协议测试驱动一帧并将关闭窗口映射为 `RenderClosedError`；当前主机没有成功的有界 GUI 证据 | 显式 interactive 需要 display；无 display 时 `auto` 回退到 record |
 | Domain randomization | IsaacLab manager/event API | 未探测 | 非空不支持 plan 必须 fail-closed |
 
 Importer 返回的 joint/body 顺序与 MJCF 文档顺序不同（例如左右分支交错）。

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -21,7 +21,8 @@
 - `mujoco`: `--render-mode auto` 会导出 `play_video.mp4`
 - `motrix`: `--render-mode auto` 会打开交互式 renderer 窗口，不录制视频，不受 `play_steps` 限制
 - `mjwarp`: 仅支持显式、有限步数的 `record`，通过 task owner 的 MuJoCo visual model 离线录制；不支持 `auto`、interactive 或 native renderer
-- `--render-mode record`: MuJoCo、mjwarp 和 Motrix 都只录制视频
+- `isaacsim`: `auto` 在有 display 时选择 Kit viewer，否则选择 headless RGB camera；当前真实主机仍有 RTX renderer 初始化 blocker，支持等级保持 `Configured`
+- `--render-mode record`: MuJoCo、mjwarp、Motrix 和 IsaacSim 都只录制视频
 - `--render-mode none`: 不回放
 
 ## Support Matrix
@@ -49,7 +50,7 @@ uv run scripts/generate_support_matrix.py --write
 
 `isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机（external Python 3.8 worker runtime，不在仓库 CI 覆盖）完成训练与 record playback 验证，标记为 `Tested`；其余 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。playback 走 IsaacGym 原生渲染（viewer + camera sensor 离屏录制），有显示器时 `play_render_mode=auto` 打开交互 viewer，无显示器时自动降级为离屏录制。
 
-`isaacsim` 是 IsaacSim 5.1 / IsaacLab v2.3.0 的独立 Python 3.11 子进程后端，当前只接入 `g1_walk_flat` 的 PPO/SAC owner，矩阵标记为 `Configured`。仓库没有把 bounded headless physics smoke 提升为训练或 playback 的 `Tested` 证据；GUI、camera、native playback、contact-force sensor 和 domain randomization 均保持 fail-closed。
+`isaacsim` 是 IsaacSim 5.1 / IsaacLab v2.3.0 的独立 Python 3.11 子进程后端，当前只接入 `g1_walk_flat` 的 PPO/SAC owner，矩阵标记为 `Configured`。仓库没有把 bounded headless physics smoke 和 mock rendering protocol 覆盖提升为训练或 playback 的 `Tested` 证据。eval 已接入 Kit viewer 与 IsaacLab RGB camera；当前真实主机在 RTX renderer 初始化阶段崩溃，因此没有成功 playback 证据，也不会生成占位视频。contact-force sensor 和 domain randomization 仍保持 fail-closed。
 
 未检测到与这些组合绑定的已提交 benchmark manifest，因此当前不会自动提升到 `Benchmarked`。
 仓库中目前也没有单独的 recommendation 元数据，因此当前不会自动提升到 `Recommended`。
@@ -133,5 +134,5 @@ uv run scripts/generate_support_matrix.py --write
 - Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.
 - Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.
 - Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (real hardware via the external Python 3.8 worker runtime; not covered by repo CI).
-- IsaacSim owner scope is intentionally not promoted to `Tested`; `_MAINTAINER_VALIDATED_ISAACSIM_ENTRYPOINT_TASKS` is empty until a maintainer records full training evidence.
+- IsaacSim owner scope is intentionally not promoted to `Tested`; `_MAINTAINER_VALIDATED_ISAACSIM_ENTRYPOINT_TASKS` is empty until a maintainer records full training evidence. Rendering protocol coverage lives in `tests/base/test_isaacsim_backend.py`; it is not a substitute for successful real playback.
 <!-- END GENERATED SUPPORT MATRIX -->

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -34,9 +34,10 @@ _MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS: frozenset[tuple[str, str]] = fr
     }
 )
 
-# IsaacSim is currently a headless-only Python 3.11 worker integration.  No
-# full training validation is promoted here: the checked-in evidence is the
-# owner/registry/compose contract plus bounded backend smoke coverage.
+# IsaacSim is a Python 3.11 worker integration with eval-owned Kit viewer and
+# RGB camera protocol coverage. No full training or successful real playback
+# validation is promoted here: the checked-in evidence remains owner/config,
+# protocol tests, and bounded backend smoke coverage.
 _MAINTAINER_VALIDATED_ISAACSIM_ENTRYPOINT_TASKS: frozenset[tuple[str, str]] = frozenset()
 
 _TASK_ORDER = {
@@ -335,8 +336,10 @@ def render_support_matrix(root: Path | None = None) -> str:
         "",
         "`isaacsim` 是 IsaacSim 5.1 / IsaacLab v2.3.0 的独立 Python 3.11 子进程后端，当前只接入"
         " `g1_walk_flat` 的 PPO/SAC owner，矩阵标记为 `Configured`。仓库没有把 bounded headless"
-        " physics smoke 提升为训练或 playback 的 `Tested` 证据；GUI、camera、native playback、"
-        "contact-force sensor 和 domain randomization 均保持 fail-closed。",
+        " physics smoke 和 mock rendering protocol 覆盖提升为训练或 playback 的 `Tested` 证据。"
+        "eval 已接入 Kit viewer 与 IsaacLab RGB camera；当前真实主机在 RTX renderer 初始化阶段"
+        "崩溃，因此没有成功 playback 证据，也不会生成占位视频。contact-force sensor 和 domain "
+        "randomization 仍保持 fail-closed。",
         "",
         benchmark_note,
         recommendation_note,
@@ -365,7 +368,7 @@ def render_support_matrix(root: Path | None = None) -> str:
             "- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.",
             "- Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.",
             "- Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (real hardware via the external Python 3.8 worker runtime; not covered by repo CI).",
-            "- IsaacSim owner scope is intentionally not promoted to `Tested`; `_MAINTAINER_VALIDATED_ISAACSIM_ENTRYPOINT_TASKS` is empty until a maintainer records full training evidence.",
+            "- IsaacSim owner scope is intentionally not promoted to `Tested`; `_MAINTAINER_VALIDATED_ISAACSIM_ENTRYPOINT_TASKS` is empty until a maintainer records full training evidence. Rendering protocol coverage lives in `tests/base/test_isaacsim_backend.py`; it is not a substitute for successful real playback.",
         ]
     )
     return "\n".join(lines)

--- a/scripts/train_appo.py
+++ b/scripts/train_appo.py
@@ -204,7 +204,7 @@ def play_appo(
             num_envs=n,
             env_cfg_override=BackendAdapter(
                 cfg, root_dir=ROOT_DIR, algo_name="appo"
-            ).build_task_env_cfg_override(),
+            ).build_play_env_cfg_override(),
         ),
         root_dir=ROOT_DIR,
         device=device,

--- a/scripts/train_offpolicy.py
+++ b/scripts/train_offpolicy.py
@@ -57,6 +57,9 @@ from unilab.visualization.interactive_playback import (
 from unilab.visualization.interactive_playback import (
     build_offpolicy_env_cfg_override as _build_offpolicy_env_cfg_override,
 )
+from unilab.visualization.interactive_playback import (
+    build_offpolicy_play_env_cfg_override as _build_offpolicy_play_env_cfg_override,
+)
 
 
 def enable_faulthandler() -> None:
@@ -85,6 +88,10 @@ def build_failure_summary(exc: BaseException, run_summary: Any | None = None) ->
 
 def build_offpolicy_env_cfg_override(algo_name: str, cfg: DictConfig) -> dict[str, Any] | None:
     return _build_offpolicy_env_cfg_override(algo_name, cfg, root_dir=ROOT_DIR)
+
+
+def build_offpolicy_play_env_cfg_override(algo_name: str, cfg: DictConfig) -> dict[str, Any] | None:
+    return _build_offpolicy_play_env_cfg_override(algo_name, cfg, root_dir=ROOT_DIR)
 
 
 def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
@@ -243,7 +250,7 @@ def play_offpolicy(algo_name: str, cfg: DictConfig) -> str | None:
         env_factory=lambda n: create_env(
             cfg,
             num_envs=n,
-            env_cfg_override=build_offpolicy_env_cfg_override(algo_name, cfg),
+            env_cfg_override=build_offpolicy_play_env_cfg_override(algo_name, cfg),
         ),
         root_dir=ROOT_DIR,
         device=device,

--- a/src/unilab/base/backend/__init__.py
+++ b/src/unilab/base/backend/__init__.py
@@ -30,6 +30,9 @@ def env_backend_kwargs(cfg: "EnvCfg") -> dict:
         "isaacgym_worker_timeout_s": cfg.isaacgym_worker_timeout_s,
         "isaacsim_device_id": cfg.isaacsim_device_id,
         "isaacsim_worker_timeout_s": cfg.isaacsim_worker_timeout_s,
+        "isaacsim_render_mode": cfg.isaacsim_render_mode,
+        "isaacsim_render_width": cfg.isaacsim_render_width,
+        "isaacsim_render_height": cfg.isaacsim_render_height,
     }
 
 
@@ -162,6 +165,9 @@ def create_backend(
     isaacgym_worker_timeout_s = kwargs.pop("isaacgym_worker_timeout_s", None)
     isaacsim_device_id = kwargs.pop("isaacsim_device_id", None)
     isaacsim_worker_timeout_s = kwargs.pop("isaacsim_worker_timeout_s", None)
+    isaacsim_render_mode = kwargs.pop("isaacsim_render_mode", None)
+    isaacsim_render_width = kwargs.pop("isaacsim_render_width", 1280)
+    isaacsim_render_height = kwargs.pop("isaacsim_render_height", 720)
     if backend_type == "mujoco":
         MuJoCoBackend = _load_mujoco_backend()
         if body_state_required:
@@ -267,6 +273,10 @@ def create_backend(
         return cast(SimBackend, IsaacGymBackend(scene, num_envs, sim_dt, **kwargs))
     if backend_type == "isaacsim":
         IsaacSimBackend = _load_isaacsim_backend()
+        # Accept the backend-native spellings for direct factory callers while
+        # keeping EnvCfg's explicit ``isaacsim_*`` fields canonical.
+        direct_render_width = kwargs.pop("render_width", None)
+        direct_render_height = kwargs.pop("render_height", None)
         # IsaacLab's implicit actuator path owns the gains in the worker.  A
         # host-side scalar override would silently diverge from the MJCF
         # contract, so reject it at the factory boundary.
@@ -299,6 +309,14 @@ def create_backend(
             kwargs["device_id"] = isaacsim_device_id
         if isaacsim_worker_timeout_s is not None:
             kwargs["worker_timeout_s"] = isaacsim_worker_timeout_s
+        if isaacsim_render_mode is not None:
+            kwargs["render_mode"] = isaacsim_render_mode
+        kwargs["render_width"] = (
+            isaacsim_render_width if direct_render_width is None else direct_render_width
+        )
+        kwargs["render_height"] = (
+            isaacsim_render_height if direct_render_height is None else direct_render_height
+        )
         return cast(SimBackend, IsaacSimBackend(scene, num_envs, sim_dt, **kwargs))
     raise ValueError(f"Unknown backend: {backend_type}")
 

--- a/src/unilab/base/backend/isaacsim/__init__.py
+++ b/src/unilab/base/backend/isaacsim/__init__.py
@@ -15,7 +15,7 @@ def __getattr__(name: str) -> Any:
         from .backend import IsaacSimBackend
 
         return IsaacSimBackend
-    if name in ("IsaacSimModelInfo", "IsaacSimWorkerError"):
+    if name in ("IsaacSimModelInfo", "IsaacSimRenderError", "IsaacSimWorkerError"):
         from . import backend
 
         return getattr(backend, name)
@@ -30,6 +30,7 @@ __all__ = [
     "IsaacSimBackend",
     "IsaacSimDependencyError",
     "IsaacSimModelInfo",
+    "IsaacSimRenderError",
     "IsaacSimWorkerError",
     "isaacsim_runtime_available",
 ]

--- a/src/unilab/base/backend/isaacsim/backend.py
+++ b/src/unilab/base/backend/isaacsim/backend.py
@@ -4,8 +4,8 @@ IsaacSim is deliberately kept out of the UniLab interpreter: the supported
 IsaacSim 5.1 wheels require Python 3.11, while the main project supports a
 different Python range.  The NumPy-facing contract and lifecycle come from the
 backend-neutral ``subprocess_ipc`` owner; this module supplies IsaacSim runtime
-discovery, the worker entrypoint, clone-origin validation, and the headless-only
-capability boundary.
+discovery, the worker entrypoint, clone-origin validation, and the eval-owned
+Kit/viewer/camera capability boundary.
 """
 
 from __future__ import annotations
@@ -17,8 +17,16 @@ from typing import Any
 
 import numpy as np
 
+from unilab.base.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
+    normalize_play_render_mode,
+)
 from unilab.base.backend.isaacgym.backend import IsaacGymWorkerError
-from unilab.base.backend.subprocess_ipc.backend import MjcfSubprocessBackend, SubprocessModelInfo
+from unilab.base.backend.subprocess_ipc.backend import (
+    MjcfSubprocessBackend,
+    SubprocessModelInfo,
+)
 from unilab.base.backend.subprocess_ipc.sensors import (
     KIND_CONTACT_FOUND,
     UnsupportedSensorSpec,
@@ -28,6 +36,16 @@ from .dependencies import build_worker_env, resolve_isaacsim_runtime
 
 _MODULE_DIR = Path(__file__).resolve().parent
 _WORKER_PATH = _MODULE_DIR / "worker.py"
+
+
+def _display_available() -> bool:
+    """Return whether a local Kit window can be opened."""
+
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+class IsaacSimRenderError(RuntimeError):
+    """Raised when the requested IsaacSim render mode cannot be initialized."""
 
 
 class IsaacSimWorkerError(IsaacGymWorkerError):
@@ -51,15 +69,62 @@ class IsaacSimBackend(MjcfSubprocessBackend):
 
     The shared client owns pipe framing, shared-memory slot allocation,
     timeout/crash diagnostics, XML cold-path metadata, and all NumPy state
-    views.  IsaacSim currently promises headless physics only; native GUI,
-    camera capture, and offline rendering are intentionally rejected until a
-    separately validated driver/runtime slice exists.
+    views.  Physics remains the default (``render_mode=None``). Eval/play
+    profiles pass a concrete render intent through the cold ``INIT`` payload
+    so Kit selects the correct experience before simulation materialization.
+    The worker owns all camera/viewport operations; this class validates the
+    NumPy-facing frame contract.
     """
 
     _BACKEND_TYPE = "isaacsim"
     _BACKEND_LABEL = "isaacsim"
     _WORKER_ERROR_CLS = IsaacSimWorkerError
     _MODEL_INFO_CLS = IsaacSimModelInfo
+
+    def __init__(
+        self,
+        scene: Any,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        render_mode: str | None = None,
+        render_width: int = 1280,
+        render_height: int = 720,
+        **kwargs: Any,
+    ) -> None:
+        mode = None if render_mode is None else normalize_play_render_mode(render_mode)
+        for name, value in (("render_width", render_width), ("render_height", render_height)):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        self._requested_render_mode = mode
+        self._resolved_render_mode: str | None = None
+        super().__init__(scene, num_envs, sim_dt, **kwargs)
+        self._render_width = int(render_width)
+        self._render_height = int(render_height)
+
+    def _resolve_render_mode(self) -> str:
+        """Resolve eval intent before Kit is launched."""
+        requested = self._requested_render_mode
+        if requested is None or requested == "none":
+            return "none"
+        if requested == "auto":
+            return "interactive" if _display_available() else "record"
+        if requested == "interactive" and not _display_available():
+            raise IsaacSimRenderError(
+                "IsaacSim interactive rendering was requested but no local display was found; "
+                "set DISPLAY/WAYLAND_DISPLAY or use training.play_render_mode=record for "
+                "headless RGB capture."
+            )
+        return requested
+
+    def _worker_init_payload(self) -> dict[str, Any]:
+        mode = self._resolve_render_mode()
+        self._resolved_render_mode = mode
+        return {
+            "render_mode": mode,
+            "render_width": self._render_width,
+            "render_height": self._render_height,
+        }
 
     def _worker_entrypoint(self) -> Path:
         return _WORKER_PATH
@@ -104,7 +169,57 @@ class IsaacSimBackend(MjcfSubprocessBackend):
         return resolved
 
     def _bind_model_metadata(self, meta: dict[str, Any]) -> None:
-        """Validate the worker's private clone-origin/collision contract."""
+        """Validate the worker's private clone, collision, and render contract."""
+        expected_render_mode = self._resolved_render_mode
+        if expected_render_mode is None:
+            raise self._worker_error(
+                "isaacsim worker metadata arrived before the host resolved its render mode"
+            )
+        required_render_fields = {
+            "graphics_enabled",
+            "render_mode",
+            "render_width",
+            "render_height",
+        }
+        missing_render_fields = sorted(required_render_fields.difference(meta))
+        if missing_render_fields:
+            raise self._worker_error(
+                "isaacsim worker metadata is missing render startup fields: "
+                + ", ".join(missing_render_fields)
+            )
+
+        reported_render_mode = meta["render_mode"]
+        if reported_render_mode != expected_render_mode:
+            raise self._worker_error(
+                "isaacsim worker render_mode does not match the host INIT request: "
+                f"worker={reported_render_mode!r}, host={expected_render_mode!r}"
+            )
+        raw_width = meta["render_width"]
+        raw_height = meta["render_height"]
+        if (
+            isinstance(raw_width, bool)
+            or not isinstance(raw_width, (int, np.integer))
+            or isinstance(raw_height, bool)
+            or not isinstance(raw_height, (int, np.integer))
+            or (int(raw_width), int(raw_height)) != (self._render_width, self._render_height)
+        ):
+            raise self._worker_error(
+                "isaacsim worker render dimensions do not match the host INIT request: "
+                f"worker={raw_width!r}x{raw_height!r}, "
+                f"host={self._render_width}x{self._render_height}"
+            )
+        reported_graphics = meta["graphics_enabled"]
+        expected_graphics = expected_render_mode != "none"
+        if (
+            not isinstance(reported_graphics, (bool, np.bool_))
+            or bool(reported_graphics) != expected_graphics
+        ):
+            raise self._worker_error(
+                "isaacsim worker graphics_enabled does not match its startup render mode: "
+                f"render_mode={expected_render_mode!r}, "
+                f"graphics_enabled={reported_graphics!r}, expected={expected_graphics!r}"
+            )
+
         raw_origins = meta.get("env_origins")
         if raw_origins is None:
             raise self._worker_error(
@@ -133,15 +248,12 @@ class IsaacSimBackend(MjcfSubprocessBackend):
         self._collision_filtering_applied = bool(meta.get("collision_filtering_applied", False))
         super()._bind_model_metadata(meta)
 
-    def get_play_capabilities(self):
-        """IsaacSim's supported slice is headless physics only."""
-        # Import lazily to keep this module cheap and mirror the parent API.
-        from unilab.base.backend.base import BackendPlayCapabilities
-
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        """Return the native Kit viewer and RGB camera capabilities."""
         return BackendPlayCapabilities(
-            supports_native_interactive_renderer=False,
+            supports_native_interactive_renderer=True,
             supports_physics_state_playback=False,
-            supports_native_video_capture=False,
+            supports_native_video_capture=True,
         )
 
     def resolve_play_render_plan(
@@ -150,14 +262,9 @@ class IsaacSimBackend(MjcfSubprocessBackend):
         play_render_mode: str | None,
         play_steps: int | None,
         output_video: str | os.PathLike[str] | None,
-    ):
-        # ``none`` remains a valid explicit plan so callers can disable
-        # playback cleanly. Every rendering mode fails closed at this boundary.
-        from unilab.base.backend.base import BackendPlayRenderPlan, normalize_play_render_mode
-
-        del play_steps, output_video
-        mode = normalize_play_render_mode(play_render_mode)
-        if mode == "none":
+    ) -> BackendPlayRenderPlan:
+        requested_mode = normalize_play_render_mode(play_render_mode)
+        if requested_mode == "none":
             return BackendPlayRenderPlan(
                 mode="none",
                 headless=True,
@@ -165,32 +272,104 @@ class IsaacSimBackend(MjcfSubprocessBackend):
                 num_steps=None,
                 output_video=None,
             )
-        raise NotImplementedError(
-            "isaacsim currently supports headless physics only; native GUI/camera "
-            "playback is not available for this runtime"
+
+        # Kit's experience is immutable after AppLauncher starts. Resolve
+        # ``auto`` from the same cold-start decision and fail before playback
+        # if a direct caller created a no-rendering or differently configured
+        # worker. The eval adapters inject matching intent before env creation.
+        startup_mode = self._resolved_render_mode
+        if startup_mode is None:
+            startup_mode = self._resolve_render_mode()
+        mode = startup_mode if requested_mode == "auto" else requested_mode
+        if startup_mode == "none" or startup_mode != mode:
+            raise IsaacSimRenderError(
+                f"IsaacSim worker started in render_mode={startup_mode!r}, but playback requested "
+                f"{requested_mode!r}; select the matching training.play_render_mode before env creation."
+            )
+        if mode == "interactive":
+            return BackendPlayRenderPlan(
+                mode=mode,
+                headless=False,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
+            raise ValueError(
+                "isaacsim record playback requires a positive finite training.play_steps value."
+            )
+        if output_video is None:
+            raise ValueError("isaacsim record playback requires an output video path.")
+        return BackendPlayRenderPlan(
+            mode="record",
+            headless=True,
+            record_video=True,
+            num_steps=int(play_steps),
+            output_video=output_video,
         )
 
-    def init_renderer(self, *args: Any, **kwargs: Any) -> None:
-        del args, kwargs
-        raise NotImplementedError(
-            "isaacsim currently supports headless physics only; native rendering is unavailable"
+    def init_renderer(
+        self,
+        spacing: float = 1.0,
+        *,
+        offset_mode: str = "grid",
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        mode = self._resolved_render_mode
+        if mode is None:
+            mode = self._resolve_render_mode()
+        requested = "record" if (headless or capture) else "interactive"
+        if mode != requested:
+            raise IsaacSimRenderError(
+                f"IsaacSim worker started in render_mode={mode!r}, but renderer requested "
+                f"{requested!r}; select the matching training.play_render_mode before env creation."
+            )
+        if (
+            isinstance(width, bool)
+            or not isinstance(width, (int, np.integer))
+            or isinstance(height, bool)
+            or not isinstance(height, (int, np.integer))
+            or int(width) <= 0
+            or int(height) <= 0
+        ):
+            raise IsaacSimRenderError(
+                f"IsaacSim render dimensions must be positive integers; got {width!r}x{height!r}."
+            )
+        if int(width) != self._render_width or int(height) != self._render_height:
+            raise IsaacSimRenderError(
+                "IsaacSim render dimensions are fixed at worker startup: "
+                f"configured {self._render_width}x{self._render_height}, requested {width}x{height}."
+            )
+        # ``super`` owns the protocol/lifecycle and is intentionally called
+        # only after the mode/dimension checks above.
+        super().init_renderer(
+            spacing=spacing,
+            offset_mode=offset_mode,
+            headless=headless,
+            capture=capture,
+            width=width,
+            height=height,
+            camera_kwargs=camera_kwargs,
         )
 
-    def render(self) -> None:
-        raise NotImplementedError(
-            "isaacsim currently supports headless physics only; interactive rendering is unavailable"
-        )
-
-    def capture_video_frame(self):
-        raise NotImplementedError(
-            "isaacsim currently supports headless physics only; video capture is unavailable"
-        )
-
-    def run_playback(self, **kwargs: Any) -> str | None:
-        del kwargs
-        raise NotImplementedError(
-            "isaacsim currently supports headless physics only; playback rendering is unavailable"
-        )
+    def capture_video_frame(self) -> np.ndarray:
+        frame = np.asarray(super().capture_video_frame())
+        expected = (self._render_height, self._render_width, 3)
+        if frame.dtype != np.uint8 or frame.shape != expected:
+            raise IsaacSimRenderError(
+                "IsaacSim camera returned an invalid RGB frame: "
+                f"shape={frame.shape}, dtype={frame.dtype}, expected shape={expected}, dtype=uint8"
+            )
+        if frame.size == 0 or int(np.ptp(frame)) == 0:
+            raise IsaacSimRenderError(
+                "IsaacSim camera returned an empty/uniform RGB frame; refusing to write a "
+                "placeholder video. Check camera pose, lighting, and RTX camera support."
+            )
+        return np.ascontiguousarray(frame)
 
 
 # The model metadata shape is backend-neutral; retaining the alias avoids a
@@ -199,5 +378,6 @@ class IsaacSimBackend(MjcfSubprocessBackend):
 __all__ = [
     "IsaacSimBackend",
     "IsaacSimModelInfo",
+    "IsaacSimRenderError",
     "IsaacSimWorkerError",
 ]

--- a/src/unilab/base/backend/isaacsim/worker.py
+++ b/src/unilab/base/backend/isaacsim/worker.py
@@ -5,16 +5,17 @@ after receiving ``INIT`` and communicates with the host through the canonical
 ``subprocess_ipc.protocol`` module loaded by path.  Control messages stay on
 the pipe; all batched numeric state is copied into shared-memory slots.
 
-This worker implements the currently supported IsaacSim slice: headless
-MJCF-backed articulation physics, masked root/joint reset, and implicit
-position-target control.  Rendering and domain-randomization commands fail
-closed at the host contract boundary.
+This worker implements MJCF-backed articulation physics, masked root/joint
+reset, implicit position-target control, and the eval-owned Kit viewer/RGB
+camera commands.  Rendering is selected before Kit starts so a training
+worker can remain on the inexpensive no-rendering experience.
 """
 
 from __future__ import annotations
 
 import argparse
 import importlib.util
+import math
 import os
 import sys
 import time
@@ -116,6 +117,14 @@ class _WorkerContext:
         self.robot: Any = None
         self.simulation_app: Any = None
         self.torch: Any = None
+        self.render_mode = "none"
+        self.render_width = 1280
+        self.render_height = 720
+        self.camera: Any = None
+        self.camera_distance = 2.0
+        self.camera_elevation_deg = 20.0
+        self.camera_azimuth_deg = 90.0
+        self.viewport_camera_initialized = False
         self.native_joint_names: list[str] = []
         self.native_body_names: list[str] = []
         self.contract_joint_names: list[str] = []
@@ -149,10 +158,60 @@ class _WorkerContext:
             )
         self.device = f"cuda:{device_id}"
 
+        raw_render_mode = payload.get("render_mode", "none")
+        if not isinstance(raw_render_mode, str):
+            raise TypeError(
+                "isaacsim worker render_mode must be a string; "
+                f"got {type(raw_render_mode).__name__}"
+            )
+        render_mode = raw_render_mode.strip().lower()
+        if render_mode not in {"none", "record", "interactive"}:
+            raise ValueError(
+                "isaacsim worker render_mode must be one of none, record, interactive; "
+                f"got {render_mode!r}"
+            )
+        self.render_mode = render_mode
+        raw_render_width = payload.get("render_width", 1280)
+        raw_render_height = payload.get("render_height", 720)
+        if (
+            isinstance(raw_render_width, bool)
+            or not isinstance(raw_render_width, int)
+            or isinstance(raw_render_height, bool)
+            or not isinstance(raw_render_height, int)
+            or raw_render_width <= 0
+            or raw_render_height <= 0
+        ):
+            raise ValueError(
+                "isaacsim worker render dimensions must be positive integers; "
+                f"got {raw_render_width!r}x{raw_render_height!r}"
+            )
+        self.render_width = raw_render_width
+        self.render_height = raw_render_height
+        headless = render_mode != "interactive"
+        enable_cameras = render_mode == "record"
+        # AppLauncher treats false/default values as "consult the environment".
+        # Pin both variables explicitly so a user's shell cannot accidentally
+        # turn a training worker into a GUI/camera process.
+        os.environ["HEADLESS"] = "1" if headless else "0"
+        os.environ["ENABLE_CAMERAS"] = "1" if enable_cameras else "0"
+        os.environ["LIVESTREAM"] = "0"
+        os.environ["XR"] = "0"
+
         # Kit must be launched before importing IsaacSim/IsaacLab modules.
         from isaaclab.app import AppLauncher  # type: ignore[import-not-found]
 
-        self.simulation_app = AppLauncher({"headless": True, "device": self.device}).app
+        self.simulation_app = AppLauncher(
+            {
+                "headless": headless,
+                "enable_cameras": enable_cameras,
+                "device": self.device,
+                "multi_gpu": False,
+                "width": self.render_width,
+                "height": self.render_height,
+                "window_width": self.render_width,
+                "window_height": self.render_height,
+            }
+        ).app
 
         import isaaclab.sim as sim_utils  # type: ignore[import-not-found]
         import isaacsim.core.utils.prims as prim_utils  # type: ignore[import-not-found]
@@ -167,6 +226,9 @@ class _WorkerContext:
         from isaacsim.core.utils.extensions import (
             enable_extension,  # type: ignore[import-not-found]
         )
+
+        if render_mode == "record":
+            from isaaclab.sensors.camera import Camera, CameraCfg  # type: ignore[import-not-found]
 
         self.torch = torch
         # The extension is enabled explicitly because IsaacSim 5.1 does not
@@ -242,9 +304,42 @@ class _WorkerContext:
                 )
             },
         )
-        self.robot = Articulation(robot_cfg)
         sim_cfg = sim_utils.SimulationCfg(dt=self.sim_dt, device=self.device)
         self.sim = sim_utils.SimulationContext(sim_cfg)
+        # IsaacLab's SimulationContext owns the singleton simulation stage and
+        # must be materialized before assets/articulations bind to it.  Keep
+        # this ordering explicit so a real Kit worker does not accidentally
+        # construct an Articulation against an uninitialized context.
+        self.robot = Articulation(robot_cfg)
+        if render_mode != "none":
+            # MJCF scenes do not necessarily carry a renderer light.  This is
+            # a real scene light (not a post-process or synthetic frame), and
+            # is created only on the cold rendering path.
+            light_cfg = sim_utils.DomeLightCfg(
+                intensity=2500.0,
+                color=(0.75, 0.75, 0.75),
+            )
+            light_cfg.func("/World/UniLabDomeLight", light_cfg)
+            if render_mode == "record":
+                camera_cfg = CameraCfg(
+                    # Playback emits one video stream, so own one camera in
+                    # env 0 rather than allocating an RTX render product for
+                    # every policy-eval environment. This mirrors the
+                    # IsaacGym capture path and keeps camera cost independent
+                    # of ``training.play_env_num``.
+                    prim_path="/World/envs/env_0/UniLabCamera",
+                    update_period=0.0,
+                    data_types=["rgb"],
+                    width=self.render_width,
+                    height=self.render_height,
+                    spawn=sim_utils.PinholeCameraCfg(
+                        focal_length=24.0,
+                        focus_distance=400.0,
+                        horizontal_aperture=20.955,
+                        clipping_range=(0.1, 1.0e5),
+                    ),
+                )
+                self.camera = Camera(camera_cfg)
         # Apply IsaacLab's PhysX collision-group filtering before the first
         # reset/step.  Without this stage operation, the translated clones
         # can still collide when a reset puts two local roots at the same pose.
@@ -259,6 +354,14 @@ class _WorkerContext:
             self.collision_filtering_applied = True
         self.sim.reset()
         self.robot.update(self.sim_dt)
+        if self.camera is not None:
+            if not self.camera.is_initialized:
+                raise RuntimeError(
+                    "IsaacSim RGB camera did not initialize; ensure the Kit experience "
+                    "was launched with enable_cameras=True"
+                )
+            self.camera.reset()
+            self.camera.update(self.sim_dt, force_recompute=True)
 
         self.native_joint_names = [str(name) for name in self.robot.joint_names]
         self.native_body_names = [str(name) for name in self.robot.body_names]
@@ -289,7 +392,10 @@ class _WorkerContext:
             "effort": self._joint_limits()[2],
             "gravity": [0.0, 0.0, -9.81],
             "use_gpu_pipeline": True,
-            "graphics_enabled": False,
+            "graphics_enabled": render_mode != "none",
+            "render_mode": render_mode,
+            "render_width": self.render_width,
+            "render_height": self.render_height,
             "native_dof_names": list(self.native_joint_names),
             "native_body_names": list(self.native_body_names),
             "usd_path": str(converter.usd_path),
@@ -520,12 +626,176 @@ class _WorkerContext:
             "body_names": list(self.contract_body_names),
             "gravity": [0.0, 0.0, -9.81],
             "use_gpu_pipeline": True,
-            "graphics_enabled": False,
+            "graphics_enabled": self.render_mode != "none",
+            "render_mode": self.render_mode,
+            "render_width": self.render_width,
+            "render_height": self.render_height,
             "env_origins": self.env_origins.tolist(),
             "collision_filtering_applied": self.collision_filtering_applied,
         }
 
+    # ------------------------------------------------------------------
+    # Native rendering (cold setup + eval/play commands)
+    # ------------------------------------------------------------------
+
+    def _require_render_mode(self, expected: str) -> None:
+        if self.render_mode != expected:
+            raise RuntimeError(
+                "isaacsim renderer request is incompatible with the worker startup mode: "
+                f"worker={self.render_mode!r}, requested={expected!r}"
+            )
+
+    def _camera_view(self) -> tuple[Any, Any]:
+        """Return batched eye/target tensors for the spherical tracking view."""
+        if self.robot is None:
+            raise RuntimeError("isaacsim camera requested before articulation initialization")
+        root_pos = self.robot.data.root_pos_w
+        if tuple(root_pos.shape) != (self.num_envs, 3):
+            raise RuntimeError(
+                f"IsaacLab root positions have shape {root_pos.shape}; expected "
+                f"({self.num_envs}, 3) for camera tracking"
+            )
+        elevation = math.radians(self.camera_elevation_deg)
+        azimuth = math.radians(self.camera_azimuth_deg)
+        offset = self.camera_distance * np.asarray(
+            [
+                math.cos(elevation) * math.cos(azimuth),
+                math.cos(elevation) * math.sin(azimuth),
+                math.sin(elevation),
+            ],
+            dtype=np.float32,
+        )
+        offset_tensor = _to_tensor(self.torch, offset, self.device)
+        targets = root_pos.clone()
+        targets[:, 2] += 0.5
+        eyes = targets + offset_tensor[None, :]
+        return eyes, targets
+
+    def _set_capture_camera(self) -> None:
+        if self.camera is None:
+            raise RuntimeError(
+                "isaacsim capture camera is unavailable; worker was not started in record mode"
+            )
+        eyes, targets = self._camera_view()
+        self.camera.set_world_poses_from_view(eyes[0:1], targets[0:1])
+
+    def _set_viewport_camera(self) -> None:
+        if self.sim is None:
+            raise RuntimeError(
+                "isaacsim viewport requested before SimulationContext initialization"
+            )
+        eyes, targets = self._camera_view()
+        # SimulationContext.set_camera_view accepts Python sequences and uses
+        # the first environment for the default viewport.
+        eye = eyes[0].detach().cpu().tolist()
+        target = targets[0].detach().cpu().tolist()
+        self.sim.set_camera_view(eye=eye, target=target)
+        self.viewport_camera_initialized = True
+
+    @staticmethod
+    def _app_is_running(app: Any) -> bool:
+        """Read the documented SimulationApp lifecycle state."""
+        try:
+            return bool(app.is_running()) and not bool(app.is_exiting())
+        except Exception:
+            # A closed Kit app may invalidate the Python proxy before the
+            # status methods can be queried. Treat that as a closed window.
+            return False
+
+    def init_renderer(self, payload: dict[str, Any]) -> dict[str, Any]:
+        headless = bool(payload.get("headless", False))
+        capture = bool(payload.get("capture", False))
+        requested = "record" if (headless or capture) else "interactive"
+        self._require_render_mode(requested)
+        width = int(payload.get("width", self.render_width))
+        height = int(payload.get("height", self.render_height))
+        if width != self.render_width or height != self.render_height:
+            raise ValueError(
+                "isaacsim renderer dimensions differ from INIT: "
+                f"requested={width}x{height}, configured={self.render_width}x{self.render_height}"
+            )
+        camera = payload.get("camera") or {}
+        self.camera_distance = float(camera.get("distance", 2.0))
+        self.camera_elevation_deg = float(camera.get("elevation_deg", 20.0))
+        self.camera_azimuth_deg = float(camera.get("azimuth_deg", 90.0))
+        if (
+            not np.isfinite(
+                [self.camera_distance, self.camera_elevation_deg, self.camera_azimuth_deg]
+            ).all()
+            or self.camera_distance <= 0.0
+        ):
+            raise ValueError(
+                "isaacsim camera distance/elevation/azimuth must be finite and distance > 0"
+            )
+
+        if requested == "record":
+            if not capture:
+                raise RuntimeError("isaacsim record renderer requires capture=true")
+            self._set_capture_camera()
+            # Warm up Hydra/Replicator once on the cold path. Camera buffers
+            # are then ready for the first playback frame.
+            self.sim.render()
+            self.camera.update(self.sim_dt, force_recompute=True)
+            return {"viewer": False, "capture": True}
+
+        if headless or capture:
+            raise RuntimeError(
+                "isaacsim interactive renderer cannot be headless or capture-enabled"
+            )
+        self._set_viewport_camera()
+        self.sim.render()
+        return {"viewer": self._app_is_running(self.simulation_app), "capture": False}
+
+    def render_frame(self) -> dict[str, Any]:
+        self._require_render_mode("interactive")
+        if not self.viewport_camera_initialized:
+            raise RuntimeError("isaacsim viewport is not initialized; call INIT_RENDERER first")
+        if not self._app_is_running(self.simulation_app):
+            return {"closed": True}
+        self._set_viewport_camera()
+        self.sim.render()
+        return {"closed": not self._app_is_running(self.simulation_app)}
+
+    def capture_frame(self) -> dict[str, Any]:
+        self._require_render_mode("record")
+        if self.camera is None:
+            raise RuntimeError(
+                "isaacsim capture camera is not initialized; call INIT_RENDERER first"
+            )
+        self._set_capture_camera()
+        self.sim.render()
+        self.camera.update(self.sim_dt, force_recompute=True)
+        output = self.camera.data.output
+        if not isinstance(output, dict) or "rgb" not in output:
+            raise RuntimeError(
+                f"IsaacSim camera did not return an rgb output; available={list(output) if isinstance(output, dict) else output!r}"
+            )
+        image = output["rgb"]
+        if not isinstance(image, self.torch.Tensor):
+            raise RuntimeError("IsaacSim camera rgb output is not a torch tensor")
+        frame = np.asarray(image[0].detach().cpu().numpy())
+        if frame.ndim != 3 or frame.shape != (self.render_height, self.render_width, 3):
+            raise RuntimeError(
+                "IsaacSim camera rgb output has invalid shape: "
+                f"got {frame.shape}, expected {(self.render_height, self.render_width, 3)}"
+            )
+        if frame.dtype != np.uint8:
+            # IsaacLab's RGB annotator is uint8 by contract. Refuse lossy
+            # coercion when an IsaacSim release changes that surface.
+            raise RuntimeError(
+                f"IsaacSim camera rgb output has dtype {frame.dtype}, expected uint8"
+            )
+        frame = np.ascontiguousarray(frame)
+        if frame.size == 0 or int(np.ptp(frame)) == 0:
+            raise RuntimeError("IsaacSim camera returned an empty or uniform RGB frame")
+        return {
+            "frame": frame,
+            "width": self.render_width,
+            "height": self.render_height,
+        }
+
     def shutdown(self) -> None:
+        self.camera = None
         for handle in self._shm_handles:
             try:
                 handle.close()
@@ -555,9 +825,13 @@ def _dispatch(ctx: _WorkerContext, protocol: Any, cmd: str, payload: Any) -> tup
         return protocol.CMD_READY, None
     if cmd == protocol.CMD_GET_META:
         return protocol.CMD_META, ctx.get_meta()
-    raise NotImplementedError(
-        f"isaacsim worker command {cmd!r} is unsupported; this backend is headless physics only"
-    )
+    if cmd == protocol.CMD_INIT_RENDERER:
+        return protocol.CMD_META, ctx.init_renderer(payload or {})
+    if cmd == protocol.CMD_RENDER_FRAME:
+        return protocol.CMD_META, ctx.render_frame()
+    if cmd == protocol.CMD_CAPTURE_FRAME:
+        return protocol.CMD_META, ctx.capture_frame()
+    raise NotImplementedError(f"isaacsim worker command {cmd!r} is unsupported")
 
 
 def main(argv: list[str]) -> int:

--- a/src/unilab/base/backend/subprocess_ipc/backend.py
+++ b/src/unilab/base/backend/subprocess_ipc/backend.py
@@ -228,6 +228,16 @@ class MjcfSubprocessBackend(SimBackend):
         del runtime
         return {}
 
+    def _worker_init_payload(self) -> dict[str, Any]:
+        """Return backend-owned cold-path INIT options.
+
+        Subprocess workers must receive any runtime mode that changes Kit
+        startup before the first ``INIT`` handshake.  The shared adapter keeps
+        this hook empty so IsaacGym and other workers retain their existing
+        startup contract; IsaacSim overrides it for eval rendering.
+        """
+        return {}
+
     # Same column-stability contract as the other backends: non-applicable
     # sub-steps report 0.0.
     _SET_STATE_TIMING_ZERO_KEYS = (
@@ -328,6 +338,11 @@ class MjcfSubprocessBackend(SimBackend):
         self._render_config: tuple[bool, bool] | None = None
         self._viewer_open = False
         self._capture_ready = False
+        # Native playback dimensions are fixed for one worker lifetime.  The
+        # IsaacSim specialization overwrites these from EnvCfg before INIT;
+        # IsaacGym keeps the historical 1280x720 defaults.
+        self._render_width = 1280
+        self._render_height = 720
 
     # ------------------------------------------------------------------ #
     # Worker lifecycle (cold path)
@@ -360,6 +375,12 @@ class MjcfSubprocessBackend(SimBackend):
             command = list(self._worker_command)
             env = None
         runtime_payload = self._runtime_payload(runtime) if runtime is not None else {}
+        worker_init_payload = self._worker_init_payload()
+        if not isinstance(worker_init_payload, dict):
+            raise TypeError(
+                f"{self._BACKEND_LABEL} _worker_init_payload() must return a dict, "
+                f"got {type(worker_init_payload).__name__}"
+            )
 
         self._stderr_file = tempfile.TemporaryFile(
             mode="w+b", prefix=f"{self._BACKEND_LABEL}_worker_stderr_"
@@ -387,6 +408,7 @@ class MjcfSubprocessBackend(SimBackend):
                     "sim_dt": self._sim_dt,
                     "device_id": self._device_id,
                     **runtime_payload,
+                    **worker_init_payload,
                     "root_body_name": self._base_name
                     or self._get_scene_metadata().freejoint_body_name,
                     # Some importers do not preserve MJCF traversal order.
@@ -1194,7 +1216,11 @@ class MjcfSubprocessBackend(SimBackend):
     def render(self) -> None:
         """Draw one interactive viewer frame through the worker."""
         if not self._viewer_open:
-            self.init_renderer(headless=False)
+            self.init_renderer(
+                headless=False,
+                width=self._render_width,
+                height=self._render_height,
+            )
         reply = self._request(protocol.CMD_RENDER_FRAME, None, expect=protocol.CMD_META)
         if bool(reply.get("closed")):
             self._viewer_open = False
@@ -1203,9 +1229,16 @@ class MjcfSubprocessBackend(SimBackend):
     def capture_video_frame(self) -> np.ndarray:
         """Capture one RGB frame from the worker's camera sensor."""
         if not self._capture_ready:
-            self.init_renderer(headless=True, capture=True)
+            self.init_renderer(
+                headless=True,
+                capture=True,
+                width=self._render_width,
+                height=self._render_height,
+            )
         reply = self._request(protocol.CMD_CAPTURE_FRAME, None, expect=protocol.CMD_META)
-        return np.asarray(reply["frame"], dtype=np.uint8)
+        # Preserve the worker's dtype so backend specializations can validate
+        # the frame contract instead of silently coercing malformed output.
+        return np.asarray(reply["frame"])
 
     def run_playback(
         self,
@@ -1241,6 +1274,8 @@ class MjcfSubprocessBackend(SimBackend):
                 headless=should_run_headless,
                 record_video=should_record_video,
                 camera_kwargs=camera_kwargs,
+                width=self._render_width,
+                height=self._render_height,
             )
         except RenderClosedError:
             if not should_run_headless and not should_record_video:

--- a/src/unilab/base/backend/subprocess_ipc/playback.py
+++ b/src/unilab/base/backend/subprocess_ipc/playback.py
@@ -31,6 +31,8 @@ def run_subprocess_playback(
     headless: bool,
     record_video: bool,
     camera_kwargs: dict[str, Any] | None,
+    width: int = 1280,
+    height: int = 720,
     extra_data_getter: Callable[[], np.ndarray | None] | None = None,
 ) -> str | None:
     del extra_data_getter
@@ -47,8 +49,8 @@ def run_subprocess_playback(
         backend.init_renderer(
             headless=headless,
             capture=True,
-            width=1280,
-            height=720,
+            width=int(width),
+            height=int(height),
             camera_kwargs=dict(camera_kwargs or {}),
         )
 
@@ -70,7 +72,12 @@ def run_subprocess_playback(
         return str(output_video)
 
     del render_spacing, render_offset_mode
-    backend.init_renderer(headless=False)
+    backend.init_renderer(
+        headless=False,
+        width=int(width),
+        height=int(height),
+        camera_kwargs=dict(camera_kwargs or {}),
+    )
     obs = initialize()
     last_render_time = time.perf_counter()
     render_dt = 1.0 / 60.0

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -59,9 +59,14 @@ class EnvCfg:
     isaacgym_worker_timeout_s: Optional[float] = None
     # ``isaacsim`` runs IsaacLab/PhysX in a dedicated Python 3.11 worker.
     # Keep its knobs separate from IsaacGym because the two runtimes have
-    # incompatible interpreters and installation roots.
+    # incompatible interpreters and installation roots.  The render intent is
+    # populated only by play/eval config materialization; training leaves it
+    # unset so the worker stays on the cheap headless experience.
     isaacsim_device_id: Optional[int] = None
     isaacsim_worker_timeout_s: Optional[float] = None
+    isaacsim_render_mode: Optional[str] = None
+    isaacsim_render_width: int = 1280
+    isaacsim_render_height: int = 720
 
     @property
     def max_episode_steps(self) -> Optional[int]:
@@ -129,6 +134,20 @@ class EnvCfg:
                 "isaacsim_worker_timeout_s must be a positive number or None, "
                 f"got {self.isaacsim_worker_timeout_s!r}"
             )
+        if self.isaacsim_render_mode is not None:
+            mode = str(self.isaacsim_render_mode).strip().lower()
+            if mode not in {"auto", "interactive", "record", "none"}:
+                raise ValueError(
+                    "isaacsim_render_mode must be one of auto, interactive, record, none, or None; "
+                    f"got {self.isaacsim_render_mode!r}"
+                )
+            self.isaacsim_render_mode = mode
+        for name, value in (
+            ("isaacsim_render_width", self.isaacsim_render_width),
+            ("isaacsim_render_height", self.isaacsim_render_height),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
         if self.cpu_ids is not None:
             ids = list(self.cpu_ids)
             if not ids:

--- a/src/unilab/base/config_adapter.py
+++ b/src/unilab/base/config_adapter.py
@@ -50,6 +50,18 @@ class BackendAdapter:
     def build_play_env_cfg_override(self) -> dict[str, Any]:
         """Build play-mode overrides from an optional backend-agnostic play profile."""
         env_cfg_override = self.build_task_env_cfg_override()
+        # IsaacSim must know the render intent before its Python 3.11 worker
+        # launches Kit.  Keep this routing in the config adapter (the owner
+        # layer) so training env construction remains headless and the
+        # renderer never leaks into runners/learners.  Other backends do not
+        # consume this field and retain their existing play contracts.
+        if str(OmegaConf.select(self.cfg, "training.sim_backend", default="")) == "isaacsim":
+            play_render_mode = OmegaConf.select(
+                self.cfg, "training.play_render_mode", default="auto"
+            )
+            env_cfg_override["isaacsim_render_mode"] = (
+                "auto" if play_render_mode is None else str(play_render_mode)
+            )
         play_profile = getattr(self.cfg, "play_profile", None)
         if (
             play_profile is None

--- a/src/unilab/visualization/interactive_playback.py
+++ b/src/unilab/visualization/interactive_playback.py
@@ -984,7 +984,7 @@ def build_offpolicy_env_cfg_override(
     *,
     root_dir: str | Path,
 ) -> dict[str, Any] | None:
-    """Build the task env override for off-policy play through the backend adapter."""
+    """Build the task env override for off-policy training."""
     from unilab.base.config_adapter import BackendAdapter
     from unilab.training.common import assert_offpolicy_task_choice_matches_algo
 
@@ -992,6 +992,28 @@ def build_offpolicy_env_cfg_override(
     return cast(
         dict[str, Any] | None,
         BackendAdapter(cfg, root_dir=root_dir, algo_name=algo_name).build_task_env_cfg_override(),
+    )
+
+
+def build_offpolicy_play_env_cfg_override(
+    algo_name: str,
+    cfg: DictConfig,
+    *,
+    root_dir: str | Path,
+) -> dict[str, Any] | None:
+    """Build the off-policy play override, including backend render intent.
+
+    Training and playback deliberately use separate adapters: an IsaacSim
+    renderer must be selected before the worker's Kit ``INIT`` handshake, but
+    learner/collector environments must stay on the no-rendering experience.
+    """
+    from unilab.base.config_adapter import BackendAdapter
+    from unilab.training.common import assert_offpolicy_task_choice_matches_algo
+
+    assert_offpolicy_task_choice_matches_algo(cfg, algo_name=algo_name)
+    return cast(
+        dict[str, Any] | None,
+        BackendAdapter(cfg, root_dir=root_dir, algo_name=algo_name).build_play_env_cfg_override(),
     )
 
 

--- a/tests/base/isaacgym_mock_worker.py
+++ b/tests/base/isaacgym_mock_worker.py
@@ -20,7 +20,11 @@ Failure modes are selected with ``UNILAB_ISAACGYM_MOCK_BEHAVIOR``:
 (``os._exit(3)`` on the first STEP), ``hang_on_step`` (sleep on the first
 STEP), ``no_graphics`` (INIT reports no graphics context and INIT_RENDERER
 fails), ``viewer_fails`` (INIT_RENDERER cannot create the viewer),
-``close_on_render`` (the first RENDER_FRAME reports the window closed).
+``close_on_render`` (the first RENDER_FRAME reports the window closed),
+``render_meta_missing``, ``render_meta_mode_mismatch``,
+``render_meta_size_mismatch``, and ``render_meta_graphics_mismatch`` corrupt
+the IsaacSim render handshake; ``capture_uniform``, ``capture_float``, and
+``capture_wrong_shape`` return malformed camera frames.
 Model dims come from ``UNILAB_ISAACGYM_MOCK_DOF_NAMES`` /
 ``UNILAB_ISAACGYM_MOCK_BODY_NAMES`` (comma-separated).
 """
@@ -56,8 +60,14 @@ class _MockSim:
         dof_names: List[str],
         body_names: List[str],
         graphics_enabled: bool = True,
+        startup_render_mode: str | None = None,
+        startup_width: int = 1280,
+        startup_height: int = 720,
     ):
         self.graphics_enabled = graphics_enabled
+        self.startup_render_mode = startup_render_mode
+        self.startup_width = int(startup_width)
+        self.startup_height = int(startup_height)
         self.num_envs = num_envs
         self.sim_dt = sim_dt
         self.dof_names = dof_names
@@ -148,8 +158,8 @@ class _MockSim:
         self.dof[env_ids, :, 1] = qvel[:, 6 : 6 + self.num_dof]
         self.write_state_slots()
 
-    def meta(self) -> Dict[str, Any]:
-        return {
+    def meta(self, behavior: str = "ok") -> Dict[str, Any]:
+        result = {
             "num_dof": self.num_dof,
             "num_bodies": self.num_bodies,
             "dof_names": list(self.dof_names),
@@ -166,6 +176,25 @@ class _MockSim:
             "env_origins": [[float(i) * 2.0, 0.0, 0.0] for i in range(self.num_envs)],
             "collision_filtering_applied": True,
         }
+        if self.startup_render_mode is not None:
+            result.update(
+                {
+                    "render_mode": self.startup_render_mode,
+                    "render_width": self.startup_width,
+                    "render_height": self.startup_height,
+                }
+            )
+            if behavior == "render_meta_missing":
+                result.pop("render_mode")
+            elif behavior == "render_meta_mode_mismatch":
+                result["render_mode"] = (
+                    "record" if self.startup_render_mode != "record" else "interactive"
+                )
+            elif behavior == "render_meta_size_mismatch":
+                result["render_width"] = self.startup_width + 1
+            elif behavior == "render_meta_graphics_mismatch":
+                result["graphics_enabled"] = not self.graphics_enabled
+        return result
 
     def close(self) -> None:
         for handle in self._shm_handles:
@@ -183,6 +212,16 @@ class _MockSim:
             )
         headless = bool(payload.get("headless", False))
         capture = bool(payload.get("capture", False))
+        if self.startup_render_mode is not None:
+            expected = "record" if (headless or capture) else "interactive"
+            if expected != self.startup_render_mode:
+                raise RuntimeError(
+                    f"mock renderer mode mismatch: startup={self.startup_render_mode}, requested={expected}"
+                )
+            width = int(payload.get("width", self.startup_width))
+            height = int(payload.get("height", self.startup_height))
+            if (width, height) != (self.startup_width, self.startup_height):
+                raise RuntimeError("mock renderer dimensions differ from INIT")
         if not headless:
             if behavior == "viewer_fails":
                 raise RuntimeError(
@@ -204,7 +243,7 @@ class _MockSim:
             return {"closed": True}
         return {"closed": False}
 
-    def capture_frame(self) -> Dict[str, Any]:
+    def capture_frame(self, behavior: str = "ok") -> Dict[str, Any]:
         if not self.capture_ready:
             raise RuntimeError(
                 "isaacgym capture camera is not initialized; call INIT_RENDERER first"
@@ -216,6 +255,12 @@ class _MockSim:
         frame[:, :, 0] = rows
         frame[:, :, 1] = cols
         frame[:, :, 2] = 128
+        if behavior == "capture_uniform":
+            frame.fill(7)
+        elif behavior == "capture_float":
+            frame = frame.astype(np.float32)
+        elif behavior == "capture_wrong_shape":
+            frame = frame[:, :, :2]
         return {"frame": frame, "width": self.capture_width, "height": self.capture_height}
 
 
@@ -249,12 +294,20 @@ def main(argv: List[str]) -> int:
                 body_names=_csv_env(
                     "UNILAB_ISAACGYM_MOCK_BODY_NAMES", ["base", "link0", "link1", "link2"]
                 ),
-                graphics_enabled=behavior != "no_graphics",
+                graphics_enabled=(
+                    behavior != "no_graphics"
+                    and str(payload.get("render_mode", "interactive")) != "none"
+                ),
+                startup_render_mode=(
+                    str(payload["render_mode"]) if "render_mode" in payload else None
+                ),
+                startup_width=int(payload.get("render_width", 1280)),
+                startup_height=int(payload.get("render_height", 720)),
             )
             keyframe_qpos = payload.get("keyframe_qpos")
             if keyframe_qpos is not None:
                 sim.apply_keyframe(keyframe_qpos, payload.get("mjcf_joint_names") or [])
-            return protocol.CMD_META, sim.meta()
+            return protocol.CMD_META, sim.meta(behavior)
         assert sim is not None
         if cmd == protocol.CMD_ATTACH:
             sim.attach(payload["slots"])
@@ -288,13 +341,13 @@ def main(argv: List[str]) -> int:
             sim.write_state_slots()
             return protocol.CMD_READY, None
         if cmd == protocol.CMD_GET_META:
-            return protocol.CMD_META, sim.meta()
+            return protocol.CMD_META, sim.meta(behavior)
         if cmd == protocol.CMD_INIT_RENDERER:
             return protocol.CMD_META, sim.init_renderer(payload, behavior)
         if cmd == protocol.CMD_RENDER_FRAME:
             return protocol.CMD_META, sim.render_frame(behavior)
         if cmd == protocol.CMD_CAPTURE_FRAME:
-            return protocol.CMD_META, sim.capture_frame()
+            return protocol.CMD_META, sim.capture_frame(behavior)
         raise ValueError(f"unknown command {cmd!r}")
 
     while True:

--- a/tests/base/test_isaacsim_backend.py
+++ b/tests/base/test_isaacsim_backend.py
@@ -12,14 +12,20 @@ import sys
 import textwrap
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pytest
 
 from unilab.base.backend import create_backend
+from unilab.base.backend.base import RenderClosedError
 from unilab.base.backend.isaacgym.backend import IsaacGymWorkerError
-from unilab.base.backend.isaacsim.backend import IsaacSimBackend, IsaacSimWorkerError
+from unilab.base.backend.isaacsim.backend import (
+    IsaacSimBackend,
+    IsaacSimRenderError,
+    IsaacSimWorkerError,
+)
 from unilab.base.backend.isaacsim.dependencies import (
     ENV_HOME,
     ENV_PYTHON,
@@ -31,6 +37,7 @@ from unilab.base.backend.isaacsim.worker import (
     _quat_rotate_wxyz,
     _resolve_articulation_root_prim_path,
 )
+from unilab.base.base import EnvCfg
 from unilab.base.scene import SceneCfg
 
 _MOCK_WORKER = str(Path(__file__).resolve().parent / "isaacgym_mock_worker.py")
@@ -132,6 +139,21 @@ def test_factory_routes_isaacsim_without_importing_kit(scene_file: str) -> None:
         backend.close()
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"isaacsim_render_mode": "video"}, "isaacsim_render_mode"),
+        ({"isaacsim_render_width": 0}, "isaacsim_render_width"),
+        ({"isaacsim_render_height": True}, "isaacsim_render_height"),
+    ],
+)
+def test_env_cfg_rejects_invalid_isaacsim_render_settings(
+    kwargs: dict[str, Any], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        EnvCfg(**kwargs).validate()
+
+
 def test_dependencies_resolve_default_layout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -204,38 +226,280 @@ def test_contact_sensor_is_explicitly_unsupported(backend: IsaacSimBackend) -> N
     assert backend.get_sensor_data("base_gyro").shape == (NUM_ENVS, 3)
 
 
-def test_headless_only_play_contract_fails_closed(backend: IsaacSimBackend, tmp_path: Path) -> None:
+def test_play_contract_advertises_native_rendering(
+    backend: IsaacSimBackend,
+    scene_file: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     caps = backend.get_play_capabilities()
-    assert not caps.supports_native_interactive_renderer
-    assert not caps.supports_native_video_capture
+    assert caps.supports_native_interactive_renderer
+    assert caps.supports_native_video_capture
     assert not caps.supports_physics_state_playback
 
     plan = backend.resolve_play_render_plan(
         play_render_mode="none", play_steps=3, output_video=tmp_path / "ignored.mp4"
     )
     assert plan.mode == "none" and plan.headless and not plan.record_video
-    for mode in ("auto", "interactive", "record"):
-        with pytest.raises(NotImplementedError, match="headless physics only"):
-            backend.resolve_play_render_plan(
-                play_render_mode=mode,
-                play_steps=3,
-                output_video=tmp_path / "play.mp4",
+    with pytest.raises(IsaacSimRenderError, match="before env creation"):
+        backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=3, output_video=tmp_path / "play.mp4"
+        )
+
+    monkeypatch.setenv("DISPLAY", ":0")
+    interactive_backend = _make_backend(scene_file, render_mode="auto")
+    try:
+        interactive = interactive_backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=3, output_video=None
+        )
+        assert interactive.mode == "interactive" and not interactive.headless
+    finally:
+        interactive_backend.close()
+
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    record_backend = _make_backend(scene_file, render_mode="auto")
+    try:
+        record = record_backend.resolve_play_render_plan(
+            play_render_mode="auto", play_steps=3, output_video=tmp_path / "play.mp4"
+        )
+        assert record.mode == "record" and record.headless and record.record_video
+        explicit = record_backend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=7, output_video=tmp_path / "explicit.mp4"
+        )
+        assert explicit.mode == "record" and explicit.num_steps == 7
+        with pytest.raises(IsaacSimRenderError, match="playback requested 'interactive'"):
+            record_backend.resolve_play_render_plan(
+                play_render_mode="interactive", play_steps=3, output_video=None
             )
-    with pytest.raises(NotImplementedError, match="native rendering"):
-        backend.init_renderer(headless=True)
-    with pytest.raises(NotImplementedError, match="interactive rendering"):
-        backend.render()
-    with pytest.raises(NotImplementedError, match="video capture"):
-        backend.capture_video_frame()
-    with pytest.raises(NotImplementedError, match="playback rendering"):
-        backend.run_playback(
-            env=object(),
-            initialize=lambda: None,
-            step=lambda value: value,
-            num_steps=1,
+        with pytest.raises(ValueError, match="play_steps"):
+            record_backend.resolve_play_render_plan(
+                play_render_mode="record", play_steps=None, output_video=tmp_path / "play.mp4"
+            )
+        with pytest.raises(ValueError, match="positive finite"):
+            record_backend.resolve_play_render_plan(
+                play_render_mode="record", play_steps=0, output_video=tmp_path / "play.mp4"
+            )
+        with pytest.raises(ValueError, match="output video path"):
+            record_backend.resolve_play_render_plan(
+                play_render_mode="record", play_steps=3, output_video=None
+            )
+    finally:
+        record_backend.close()
+
+
+def test_record_renderer_roundtrip(scene_file: str) -> None:
+    backend = _make_backend(
+        scene_file,
+        render_mode="record",
+        render_width=64,
+        render_height=48,
+    )
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=True, capture=True, width=64, height=48)
+        frame = backend.capture_video_frame()
+        assert frame.shape == (48, 64, 3)
+        assert frame.dtype == np.uint8
+        assert frame.flags.c_contiguous
+        assert int(np.ptp(frame)) > 0
+        with pytest.raises(IsaacSimRenderError, match="worker started"):
+            backend.init_renderer(headless=False, capture=False, width=64, height=48)
+        with pytest.raises(IsaacSimRenderError, match="positive integers"):
+            backend.init_renderer(headless=True, capture=True, width=True, height=48)
+    finally:
+        backend.close()
+
+
+def test_record_playback_writes_video(scene_file: str, tmp_path: Path) -> None:
+    output = tmp_path / "play_video.mp4"
+    backend = _make_backend(
+        scene_file,
+        render_mode="record",
+        render_width=64,
+        render_height=48,
+    )
+    backend.materialize()
+    try:
+        result = backend.run_playback(
+            env=SimpleNamespace(cfg=SimpleNamespace(ctrl_dt=0.02)),
+            initialize=lambda: 0,
+            step=lambda obs: obs + 1,
+            num_steps=3,
+            output_video=output,
             headless=True,
+            record_video=True,
+        )
+        assert result == str(output)
+        assert output.exists() and output.stat().st_size > 0
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize(
+    ("behavior", "message"),
+    [
+        ("capture_uniform", "empty/uniform"),
+        ("capture_float", "dtype=float32"),
+        ("capture_wrong_shape", "invalid RGB frame"),
+    ],
+)
+def test_record_frame_contract_fails_closed(
+    scene_file: str,
+    monkeypatch: pytest.MonkeyPatch,
+    behavior: str,
+    message: str,
+) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", behavior)
+    backend = _make_backend(
+        scene_file,
+        render_mode="record",
+        render_width=64,
+        render_height=48,
+    )
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=True, capture=True, width=64, height=48)
+        with pytest.raises(IsaacSimRenderError, match=message):
+            backend.capture_video_frame()
+    finally:
+        backend.close()
+
+
+def test_interactive_renderer_roundtrip(scene_file: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    backend = _make_backend(scene_file, render_mode="interactive")
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=False, capture=False)
+        backend.render()
+    finally:
+        backend.close()
+
+
+def test_interactive_playback_routes_startup_dimensions_and_camera(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    backend = _make_backend(
+        scene_file,
+        render_mode="interactive",
+        render_width=64,
+        render_height=48,
+    )
+    init_calls: list[dict[str, Any]] = []
+    original_init_renderer = backend.init_renderer
+
+    def record_init_renderer(*args: Any, **kwargs: Any) -> None:
+        init_calls.append(dict(kwargs))
+        original_init_renderer(*args, **kwargs)
+
+    backend.init_renderer = record_init_renderer  # type: ignore[method-assign]
+    backend.materialize()
+    try:
+        result = backend.run_playback(
+            env=SimpleNamespace(cfg=None),
+            initialize=lambda: 0,
+            step=lambda obs: obs + 1,
+            num_steps=1,
+            headless=False,
+            record_video=False,
+            camera_kwargs={
+                "cam_distance": 3.0,
+                "cam_elevation": -15.0,
+                "cam_azimuth": 45.0,
+            },
+        )
+        assert result is None
+        assert init_calls == [
+            {
+                "headless": False,
+                "width": 64,
+                "height": 48,
+                "camera_kwargs": {
+                    "cam_distance": 3.0,
+                    "cam_elevation": -15.0,
+                    "cam_azimuth": 45.0,
+                },
+            }
+        ]
+    finally:
+        backend.close()
+
+
+def test_interactive_window_close_maps_to_interface_error(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "close_on_render")
+    backend = _make_backend(scene_file, render_mode="interactive")
+    backend.materialize()
+    try:
+        backend.init_renderer(headless=False, capture=False)
+        with pytest.raises(RenderClosedError, match="closed"):
+            backend.render()
+    finally:
+        backend.close()
+
+
+def test_interactive_playback_stops_when_window_closes(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", "close_on_render")
+    backend = _make_backend(scene_file, render_mode="interactive")
+    backend.materialize()
+    steps: list[int] = []
+    try:
+        result = backend.run_playback(
+            env=SimpleNamespace(cfg=None),
+            initialize=lambda: 0,
+            step=lambda obs: steps.append(obs) or (obs + 1),
+            num_steps=None,
+            headless=False,
             record_video=False,
         )
+        assert result is None
+        assert steps == [0]
+    finally:
+        backend.close()
+
+
+def test_explicit_interactive_without_display_fails_closed(
+    scene_file: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    backend = _make_backend(scene_file, render_mode="interactive")
+    try:
+        with pytest.raises(IsaacSimRenderError, match="no local display"):
+            backend.materialize()
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize(
+    ("behavior", "message"),
+    [
+        ("render_meta_missing", "missing render startup fields"),
+        ("render_meta_mode_mismatch", "render_mode does not match"),
+        ("render_meta_size_mismatch", "render dimensions do not match"),
+        ("render_meta_graphics_mismatch", "graphics_enabled does not match"),
+    ],
+)
+def test_render_startup_metadata_mismatch_fails_closed(
+    scene_file: str,
+    monkeypatch: pytest.MonkeyPatch,
+    behavior: str,
+    message: str,
+) -> None:
+    monkeypatch.setenv("UNILAB_ISAACGYM_MOCK_BEHAVIOR", behavior)
+    backend = _make_backend(scene_file, render_mode="record", render_width=64, render_height=48)
+    try:
+        with pytest.raises(IsaacSimWorkerError, match=message):
+            backend.materialize()
+    finally:
+        backend.close()
 
 
 def test_isaacsim_worker_error_is_not_isaacgym_error_type(

--- a/tests/envs/locomotion/g1/test_g1_owner_contract.py
+++ b/tests/envs/locomotion/g1/test_g1_owner_contract.py
@@ -511,7 +511,7 @@ def test_g1_owner_materializes_complete_plain_manager_cfg(
     if backend == "isaacsim":
         assert env_cfg.isaacsim_device_id == 0
         assert env_cfg.isaacsim_worker_timeout_s == pytest.approx(120.0)
-        assert hydra_cfg.training.play_render_mode == "none"
+        assert hydra_cfg.training.play_render_mode == "auto"
         assert hydra_cfg.play_profile.enabled is False
 
     pose = env_cfg.rewards["pose"]

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -603,6 +603,22 @@ def test_offpolicy_g1_walk_flat_env_cfg_override_has_rewards_and_events():
     assert env_cfg_override["events"]["pd_gains"] is None
 
 
+def test_offpolicy_isaacsim_training_and_eval_use_separate_render_overrides():
+    cfg = _offpolicy_cfg(
+        [
+            "task=g1_walk_flat/isaacsim",
+            "training.play_render_mode=record",
+        ]
+    )
+    mod = _offpolicy()
+
+    training_override = mod.build_offpolicy_env_cfg_override("sac", cfg)
+    play_override = mod.build_offpolicy_play_env_cfg_override("sac", cfg)
+
+    assert "isaacsim_render_mode" not in training_override
+    assert play_override["isaacsim_render_mode"] == "record"
+
+
 def test_ppo_go1_resolved_algo_matches_old_motrix_behavior():
     """Equivalence: PPO Go1 algo hyperparams match pre-refactor motrix values."""
     cfg = _ppo_cfg(["task=go1_joystick_flat/motrix"])

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -383,6 +383,24 @@ def test_backend_adapter_env_cfg_override_for_motrix_sac_g1_walk_flat():
     assert cfg.algo.max_iterations == 5000
 
 
+def test_backend_adapter_injects_isaacsim_render_intent_only_for_play():
+    cfg = _offpolicy_cfg(
+        [
+            "task=g1_walk_flat/isaacsim",
+            "training.play_render_mode=record",
+        ]
+    )
+    adapter = BackendAdapter(cfg, root_dir=_ROOT_DIR, algo_name="sac")
+
+    training_override = adapter.build_task_env_cfg_override()
+    play_override = adapter.build_play_env_cfg_override()
+
+    assert "isaacsim_render_mode" not in training_override
+    assert play_override["isaacsim_render_mode"] == "record"
+    assert play_override["isaacsim_render_width"] == 1280
+    assert play_override["isaacsim_render_height"] == 720
+
+
 def test_backend_adapter_keeps_motion_manager_scene_during_play():
     cfg = _ppo_cfg(["task=g1_motion_tracking/motrix", "training.play_only=true"])
     assert cfg.training.play_env_num == 16


### PR DESCRIPTION
## Summary

- add IsaacSim worker-owned offline RGB camera capture and interactive Kit viewport rendering
- route render intent before Kit startup through the existing eval/play adapter, while keeping training workers on the no-rendering experience
- validate RGB frame shape/dtype/contiguity/non-uniformity and map closed viewers to `RenderClosedError`
- add SAC/PPO IsaacSim render defaults, mock protocol/lifecycle coverage, and bilingual backend documentation

Fixes #1416

## Validation

- `make test-all` ✅
  - ruff format/check, mypy, pyright
  - `2442 passed, 28 skipped, 293 deselected, 1 xfailed`
  - benchmark smoke test passed (platform-optional `mlx` checks skipped)
- targeted rendering/backend/config tests: `288 passed in 16.74s`
- public CLI probe (existing SAC checkpoint; no training):
  - `uv run eval --algo sac --task g1_walk_flat --sim isaacsim --load-run 2026-09-01_11-58-25_isaacsim --render-mode record training.play_steps=2 training.play_env_num=1 training.export_onnx=false`
  - reached the IsaacSim worker `INIT` path, then the local IsaacSim 5.1 RTX stack terminated natively (`SIGSEGV` in `librtx.scenedb.plugin.so` / `libcarb.scenerenderer-rtx.plugin.so`) before metadata/camera startup
  - no placeholder frame/video was written; real record and bounded interactive playback should be run on the driver-compatible IsaacSim host

## Scope notes

The PR base is `dev/issue-1369-isaacsim-backend`; local gate plus review is the merge gate for this integration branch. This change does not alter checkpoint format, learner/runner lifecycle, or start a new training run.
