### PR TITLE
feat: connect UniLab consumers to unisim-core

### DIFF
--- a/docs/sphinx/source/zh_CN/4-developer_guide/5-contributing_workflow.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/5-contributing_workflow.md
@@ -227,3 +227,11 @@ summary 中已经确认的决策项；实施期间新增的决策项先更新 ow
 并将其反向链接进上述文档。
 新的 ADR 使用 {doc}`ADR Template </adr/ADR-TEMPLATE>`，且必须显式说明
 `Supersedes`、`Superseded by`、`Alternatives Considered` 与 `Evidence In Repo`。
+## UniSim extraction roadmap #1428
+
+物理后端的新 public contract 位于独立的 `unisim-core` distribution（import
+namespace 为 `unisim`）。UniLab 在迁移窗口内通过
+`unilab.base.backend.unisim_bridge` 传递 task-owned `SceneCfg`；该 bridge
+只负责边界翻译，不复制引擎实现。新增 consumer 应优先使用 bridge 或直接
+调用 `unisim`，不要访问 backend 的 model/data 私有对象。迁移完成后
+Child 12 会删除旧实现与兼容层。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ classifiers = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
+    # Physics implementations are provided by the independently released
+    # unisim-core package.  During roadmap execution this source is pinned to
+    # TestPyPI; production PyPI publication is a maintainer-only final step.
+    "unisim-core>=0.1.4",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -126,12 +130,18 @@ name = "r2-cu130"
 url = "https://download-r2.pytorch.org/whl/cu130"
 explicit = true
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+explicit = true
+
 [tool.uv.sources]
 torch = [
     { index = "r2-cu130", marker = "sys_platform=='linux' and platform_machine=='aarch64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='linux' and platform_machine=='x86_64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='win32'" },
 ]
+unisim-core = { index = "testpypi" }
 
 [tool.uv]
 exclude-dependencies = ["torchvision"]

--- a/src/unilab/base/backend/unisim_bridge.py
+++ b/src/unilab/base/backend/unisim_bridge.py
@@ -1,0 +1,58 @@
+"""UniSim-core consumer boundary used during roadmap #1428 migration.
+
+This module is intentionally tiny: UniLab owns scene/task configuration while
+``unisim-core`` owns the backend contract and engine adapters.  Existing
+``unilab.base.backend`` imports remain a compatibility surface until Child 12;
+new consumers should import this bridge (or ``unisim`` directly) so the
+remaining legacy implementation can be removed without another API rename.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import unisim
+
+from unilab.base.scene import SceneCfg
+
+
+def create_unisim_backend(
+    backend_type: str,
+    scene: SceneCfg,
+    num_envs: int,
+    sim_dt: float,
+    **kwargs: Any,
+) -> unisim.SimBackend:
+    """Construct a package-owned backend from a UniLab scene descriptor.
+
+    Scene composition and robot-asset fetching must happen before this call on
+    the UniLab cold path.  The package receives only the materialized model
+    path and backend-neutral numeric options; missing optional SDKs fail closed
+    in :mod:`unisim` with an actionable diagnostic.
+    """
+    if scene is None:
+        raise ValueError("SceneCfg must be provided")
+    model_path = scene.model_file
+    if not model_path:
+        raise ValueError("SceneCfg.model_file must be provided for UniSim backends")
+    options = dict(kwargs)
+    if backend_type != "fake":
+        options.setdefault("model_path", model_path)
+    options.setdefault("num_envs", num_envs)
+    if backend_type != "fake":
+        options.setdefault("frame_skip", 1)
+    return unisim.create_backend(backend_type, **options)
+
+
+SimBackend = unisim.SimBackend
+BackendCapability = unisim.BackendCapability
+BackendError = unisim.BackendError
+UnsupportedCapabilityError = unisim.UnsupportedCapabilityError
+
+__all__ = [
+    "BackendCapability",
+    "BackendError",
+    "SimBackend",
+    "UnsupportedCapabilityError",
+    "create_unisim_backend",
+]

--- a/tests/base/test_unisim_bridge.py
+++ b/tests/base/test_unisim_bridge.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from unilab.base.backend.unisim_bridge import create_unisim_backend
+from unilab.base.scene import SceneCfg
+
+
+def test_unisim_bridge_constructs_package_owned_fake_backend(tmp_path):
+    model = tmp_path / "scene.xml"
+    model.write_text("<mujoco/>")
+    scene = SceneCfg(model_file=str(model))
+    backend = create_unisim_backend("fake", scene, num_envs=2, sim_dt=0.02, num_actuators=1)
+    backend.step(np.ones((2, 1)))
+    assert backend.get_state()["qpos"].shape == (2, 1)

--- a/uv.lock
+++ b/uv.lock
@@ -4963,6 +4963,7 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "tqdm" },
     { name = "typing-extensions" },
+    { name = "unisim-core" },
     { name = "wandb" },
 ]
 
@@ -5032,6 +5033,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
+    { name = "unisim-core", specifier = ">=0.1.4", index = "https://test.pypi.org/simple/" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
@@ -5046,6 +5048,19 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "unisim-core"
+version = "0.1.4"
+source = { registry = "https://test.pypi.org/simple/" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://test-files.pythonhosted.org/packages/90/42/53696047b3c1c0fbbde406cb60e269dc3c7b37676e937fe252eff2aa226e/unisim_core-0.1.4.tar.gz", hash = "sha256:46c58f2988a4be7c3d2b7523f3e747467ffae7c3f685ae2ea1a1cc4cafb1ab56", size = 11653, upload-time = "2026-09-02T05:06:48.29Z" }
+wheels = [
+    { url = "https://test-files.pythonhosted.org/packages/93/33/b29c6e9c50bf91e37d4ea58bb0aed665e0b22720d856e732bac00e5fb73d/unisim_core-0.1.4-py3-none-any.whl", hash = "sha256:57568fba88f2892cfc04d78f1389df35e61e3fb5582913a01cf89d59f80786c4", size = 20247, upload-time = "2026-09-02T05:06:46.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the UniLab consumer boundary for roadmap #1428 / child #1431.

- pins `unisim-core>=0.1.4` to TestPyPI in the roadmap environment
- adds `unilab.base.backend.unisim_bridge` for package-owned backend construction
- documents the temporary compatibility boundary and Child 12 removal
- adds a fake-backend bridge regression test

Validation: `uv run pytest tests/base/test_unisim_bridge.py -q`; `uv run ruff check src/unilab/base/backend/unisim_bridge.py tests/base/test_unisim_bridge.py`.

UniLab main and dev/issue-1042-manager-based-api remain untouched.