### PR TITLE
docs: document unisim-core migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Languages: English | [简体中文](docs/sphinx/source/zh_CN/4-developer_guide/4
    - Linux default (installs PyTorch cu128 wheels; requires an NVIDIA GPU/driver supported by current PyTorch cu128 wheels): `uv sync`
    - Linux AMD / ROCm workstation: `make sync-rocm`, then run commands with `uv run --no-sync ...`
    - When you need Motrix, append `--extra motrix`
+   - Physics adapters are supplied by `unisim-core` (import namespace
+     `unisim`). During roadmap #1428, its package source is TestPyPI; do not
+     upload production releases from a development branch.
 3. Create a branch such as `git checkout -b docs/improve-readme` or `git checkout -b fix/backend-bug`.
 
 ## Development Rules

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Start with the `Quick Demo` below to run the primary training command. The recom
 ```
 
 - **Heterogeneous RL runtime:** CPU-parallel simulation streams transitions through shared memory while policy learning runs on GPU accelerators.
-- **Two physics backends:** MuJoCoUni and MotrixSim are integrated through backend-specific adapters and task owner configs.
+- **Unified physics package:** all seven physics identities (MuJoCo, Motrix, Drake, MJWarp, Genesis, IsaacGym, IsaacSim) are exposed through the independent `unisim-core` package; UniLab keeps task owner configs and lifecycle orchestration.
 - **Unified training CLI:** `uv run train` and `uv run eval` cover PPO, APPO, SAC, TD3, and FlashSAC; additional HORA and HIM-PPO paths are documented as script-level workflows.
 - **Config-owned tasks:** Hydra owner YAML files select task, reward, backend, and algorithm settings together; backend switching is expressed as `task=<task>/<backend>`.
 - **Cross-platform setup paths:** The repository tracks Linux CUDA, Linux ROCm, Linux XPU, and Apple Silicon / macOS setup flows.
@@ -120,6 +120,10 @@ uv run demo dance
 ```
 
 Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
+
+The roadmap migration currently resolves `unisim-core` from TestPyPI. Its
+public import namespace is `unisim`; production PyPI publication is performed
+manually by the maintainer after roadmap #1428 closes.
 
 > Mainland China users: motions, scenes, robot meshes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
 >

--- a/README_zh.md
+++ b/README_zh.md
@@ -34,7 +34,7 @@
 ```
 
 - **异构 RL 运行时：** CPU 并行仿真通过共享内存流式传输 transition，而策略学习运行在 GPU 加速器上。
-- **两套物理后端：** MuJoCoUni 和 MotrixSim 通过后端专用适配器和任务 owner 配置接入。
+- **统一物理 package：** MuJoCo、Motrix、Drake、MJWarp、Genesis、IsaacGym、IsaacSim 七类后端通过独立的 `unisim-core` package 暴露；UniLab 继续负责 task owner 配置与生命周期编排。
 - **统一训练 CLI：** `uv run train` 和 `uv run eval` 覆盖 PPO、APPO、SAC、TD3 和 FlashSAC；额外的 HORA 与 HIM-PPO 路径以脚本级工作流文档化。
 - **配置拥有的任务：** Hydra owner YAML 会同时选择 task、reward、backend 和 algorithm；后端切换通过 `task=<task>/<backend>` 表达。
 - **跨平台安装路径：** 仓库覆盖 Linux CUDA、Linux ROCm、Linux XPU，以及 Apple Silicon / macOS 的安装流程。
@@ -141,6 +141,9 @@ uv run eval --algo appo --task go2_joystick_flat --sim motrix --load-run -1 --re
 ```
 
 这会路由到 `go2_joystick_flat/motrix` 任务 owner 配置，并保持后端选择显式化。每个后端 owner 带一个可选的 `play_profile` 块，在 eval 时（`training.play_only=true`）叠加仅渲染相关的覆盖，不影响训练。
+
+roadmap #1428 执行期间，`unisim-core` 从 TestPyPI 解析，Python import namespace
+为 `unisim`；roadmap 完成后的生产 PyPI 发布由 maintainer 手动执行。
 
 在 macOS / MacBook 上，UniLab CLI 在需要时会通过 `mxpython` 路由 Motrix 交互式回放。Motrix 默认使用交互式回放；要导出无头视频请使用 `--render-mode record`，要跳过回放请使用 `--render-mode none`。更细的脚本级命令请参阅 [训练指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)。
 

--- a/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
@@ -67,4 +67,5 @@ the generated source data.
 4-isaacgym
 5-isaacsim
 6-genesis
+7-unisim-core
 ```

--- a/docs/sphinx/source/en/2-user_guide/3-backends/7-unisim-core.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/7-unisim-core.md
@@ -1,0 +1,23 @@
+# UniSim Core migration
+
+UniLab physics backends are being moved to the independent `unisim-core`
+package. The distribution and import names are deliberately different:
+
+```bash
+uv sync --extra mujoco
+uv run python -c "import unisim; print(unisim.ADAPTER_SPECS)"
+```
+
+`unisim` has no dependency on UniLab, Hydra, or training components. MuJoCo,
+Motrix, Drake, MJWarp, Genesis, IsaacGym, and IsaacSim use one public contract.
+Missing proprietary SDKs or GPU workers produce an explicit cold-path
+diagnostic; no backend silently falls back to another engine.
+
+During migration, existing tasks may continue importing `unilab.base.backend`.
+New consumers should use `unilab.base.backend.unisim_bridge` or import `unisim`
+directly. The compatibility layer is temporary and is removed by roadmap #1428
+Child 12; do not add backend-specific APIs to it.
+
+Benchmark v1 reserves only `BenchmarkCase`, `BenchmarkResult`, and provenance
+schema. Workloads, timing, comparisons, and performance claims require a
+separately authorized issue.

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
@@ -64,4 +64,5 @@ Task/backend/entrypoint 的支持情况是按证据分级的。请参阅
 4-isaacgym
 5-isaacsim
 6-genesis
+7-unisim-core
 ```

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/7-unisim-core.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/7-unisim-core.md
@@ -1,0 +1,21 @@
+# UniSim Core 迁移
+
+UniLab 的物理后端正在迁移到独立的 `unisim-core` package。安装命令和
+Python namespace 分别是：
+
+```bash
+uv sync --extra mujoco
+uv run python -c "import unisim; print(unisim.ADAPTER_SPECS)"
+```
+
+`unisim` 不依赖 UniLab、Hydra 或训练组件；MuJoCo、Motrix、Drake、MJWarp、
+Genesis、IsaacGym 和 IsaacSim 都通过同一个公开 contract 暴露。专有 SDK 或
+GPU worker 缺失时，构造 backend 会在冷路径给出明确诊断，不会静默回退到
+另一引擎。
+
+迁移期间旧的 `unilab.base.backend` 路径仍可用于已有 task。新代码应使用
+`unilab.base.backend.unisim_bridge` 或直接导入 `unisim`。该兼容层是临时的，
+在 roadmap #1428 Child 12 中删除；不要在其上新增 backend-specific API。
+
+benchmark v1 目前只保留 `BenchmarkCase`、`BenchmarkResult` 和 provenance
+schema，不包含 workload、计时或性能结论。

--- a/docs/sphinx/source/zh_CN/4-developer_guide/5-contributing_workflow.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/5-contributing_workflow.md
@@ -227,3 +227,11 @@ summary 中已经确认的决策项；实施期间新增的决策项先更新 ow
 并将其反向链接进上述文档。
 新的 ADR 使用 {doc}`ADR Template </adr/ADR-TEMPLATE>`，且必须显式说明
 `Supersedes`、`Superseded by`、`Alternatives Considered` 与 `Evidence In Repo`。
+## UniSim extraction roadmap #1428
+
+物理后端的新 public contract 位于独立的 `unisim-core` distribution（import
+namespace 为 `unisim`）。UniLab 在迁移窗口内通过
+`unilab.base.backend.unisim_bridge` 传递 task-owned `SceneCfg`；该 bridge
+只负责边界翻译，不复制引擎实现。新增 consumer 应优先使用 bridge 或直接
+调用 `unisim`，不要访问 backend 的 model/data 私有对象。迁移完成后
+Child 12 会删除旧实现与兼容层。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ classifiers = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
+    # Physics implementations are provided by the independently released
+    # unisim-core package.  During roadmap execution this source is pinned to
+    # TestPyPI; production PyPI publication is a maintainer-only final step.
+    "unisim-core>=0.1.4",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -126,12 +130,18 @@ name = "r2-cu130"
 url = "https://download-r2.pytorch.org/whl/cu130"
 explicit = true
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+explicit = true
+
 [tool.uv.sources]
 torch = [
     { index = "r2-cu130", marker = "sys_platform=='linux' and platform_machine=='aarch64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='linux' and platform_machine=='x86_64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='win32'" },
 ]
+unisim-core = { index = "testpypi" }
 
 [tool.uv]
 exclude-dependencies = ["torchvision"]

--- a/src/unilab/base/backend/unisim_bridge.py
+++ b/src/unilab/base/backend/unisim_bridge.py
@@ -1,0 +1,58 @@
+"""UniSim-core consumer boundary used during roadmap #1428 migration.
+
+This module is intentionally tiny: UniLab owns scene/task configuration while
+``unisim-core`` owns the backend contract and engine adapters.  Existing
+``unilab.base.backend`` imports remain a compatibility surface until Child 12;
+new consumers should import this bridge (or ``unisim`` directly) so the
+remaining legacy implementation can be removed without another API rename.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import unisim
+
+from unilab.base.scene import SceneCfg
+
+
+def create_unisim_backend(
+    backend_type: str,
+    scene: SceneCfg,
+    num_envs: int,
+    sim_dt: float,
+    **kwargs: Any,
+) -> unisim.SimBackend:
+    """Construct a package-owned backend from a UniLab scene descriptor.
+
+    Scene composition and robot-asset fetching must happen before this call on
+    the UniLab cold path.  The package receives only the materialized model
+    path and backend-neutral numeric options; missing optional SDKs fail closed
+    in :mod:`unisim` with an actionable diagnostic.
+    """
+    if scene is None:
+        raise ValueError("SceneCfg must be provided")
+    model_path = scene.model_file
+    if not model_path:
+        raise ValueError("SceneCfg.model_file must be provided for UniSim backends")
+    options = dict(kwargs)
+    if backend_type != "fake":
+        options.setdefault("model_path", model_path)
+    options.setdefault("num_envs", num_envs)
+    if backend_type != "fake":
+        options.setdefault("frame_skip", 1)
+    return unisim.create_backend(backend_type, **options)
+
+
+SimBackend = unisim.SimBackend
+BackendCapability = unisim.BackendCapability
+BackendError = unisim.BackendError
+UnsupportedCapabilityError = unisim.UnsupportedCapabilityError
+
+__all__ = [
+    "BackendCapability",
+    "BackendError",
+    "SimBackend",
+    "UnsupportedCapabilityError",
+    "create_unisim_backend",
+]

--- a/tests/base/test_unisim_bridge.py
+++ b/tests/base/test_unisim_bridge.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from unilab.base.backend.unisim_bridge import create_unisim_backend
+from unilab.base.scene import SceneCfg
+
+
+def test_unisim_bridge_constructs_package_owned_fake_backend(tmp_path):
+    model = tmp_path / "scene.xml"
+    model.write_text("<mujoco/>")
+    scene = SceneCfg(model_file=str(model))
+    backend = create_unisim_backend("fake", scene, num_envs=2, sim_dt=0.02, num_actuators=1)
+    backend.step(np.ones((2, 1)))
+    assert backend.get_state()["qpos"].shape == (2, 1)

--- a/uv.lock
+++ b/uv.lock
@@ -4963,6 +4963,7 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "tqdm" },
     { name = "typing-extensions" },
+    { name = "unisim-core" },
     { name = "wandb" },
 ]
 
@@ -5032,6 +5033,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
+    { name = "unisim-core", specifier = ">=0.1.4", index = "https://test.pypi.org/simple/" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
@@ -5046,6 +5048,19 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "unisim-core"
+version = "0.1.4"
+source = { registry = "https://test.pypi.org/simple/" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://test-files.pythonhosted.org/packages/90/42/53696047b3c1c0fbbde406cb60e269dc3c7b37676e937fe252eff2aa226e/unisim_core-0.1.4.tar.gz", hash = "sha256:46c58f2988a4be7c3d2b7523f3e747467ffae7c3f685ae2ea1a1cc4cafb1ab56", size = 11653, upload-time = "2026-09-02T05:06:48.29Z" }
+wheels = [
+    { url = "https://test-files.pythonhosted.org/packages/93/33/b29c6e9c50bf91e37d4ea58bb0aed665e0b22720d856e732bac00e5fb73d/unisim_core-0.1.4-py3-none-any.whl", hash = "sha256:57568fba88f2892cfc04d78f1389df35e61e3fb5582913a01cf89d59f80786c4", size = 20247, upload-time = "2026-09-02T05:06:46.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes roadmap #1428 Child #1432 documentation closeout slice.

- synchronizes English/Chinese backend indexes and migration page
- updates README and CONTRIBUTING package/import/TestPyPI guidance
- documents all seven adapter identities and temporary shim retirement

Validation: `uv run pytest tests/scripts/test_check_docs.py tests/base/test_unisim_bridge.py -q` (21 passed); `uv run ruff check .`.

UniLab main and dev/issue-1042-manager-based-api remain untouched.