### PR TITLE
test: stop relying on local unisim checkout

### DIFF
--- a/tests/base/test_backend_imports.py
+++ b/tests/base/test_backend_imports.py
@@ -4,6 +4,7 @@ import ast
 import subprocess
 import sys
 import textwrap
+from importlib.metadata import distribution
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -14,6 +15,15 @@ _MATERIALIZER_CONSUMERS = (
     "scripts/train_hora_distill.py",
     "scripts/manip_loco/benchmark_site_jacobian.py",
 )
+
+
+def test_unisim_dependency_is_installed_from_package_index() -> None:
+    direct_url = distribution("unisim-core").read_text("direct_url.json")
+
+    assert direct_url is None, (
+        "UniLab tests must consume the indexed unisim-core release, not a local, editable, "
+        "or VCS checkout"
+    )
 
 
 def test_materializer_consumers_use_unisim_owner_module() -> None:

--- a/tests/base/test_mjwarp_identity.py
+++ b/tests/base/test_mjwarp_identity.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-import ast
 import subprocess
 import sys
 import textwrap
 from importlib.machinery import ModuleSpec
-from pathlib import Path
 
 import numpy as np
 import pytest
 from unisim.backend.mjwarp import dependencies
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
 
 
 def test_mjwarp_import_path_does_not_eagerly_import_warp_or_mujoco() -> None:
@@ -114,34 +108,6 @@ def test_mjwarp_identity_is_independent_from_mujoco(
         str(tmp_path / "scripts" / "train_rsl_rl.py"),
         "task=g1_walk_flat/mjwarp",
     ]
-
-
-def test_mjwarp_getters_do_not_materialize_warp_arrays() -> None:
-    backend_path = (
-        _repo_root() / ".." / "unisim" / "src" / "unisim" / "backend" / "mjwarp" / "backend.py"
-    )
-    tree = ast.parse(backend_path.read_text(encoding="utf-8"))
-    backend = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "MjwarpBackend"
-    )
-    getter_nodes = [
-        node
-        for node in backend.body
-        if isinstance(node, ast.FunctionDef) and node.name.startswith("get_")
-    ]
-    assert getter_nodes
-    offenders: list[str] = []
-    for getter in getter_nodes:
-        for node in ast.walk(getter):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "numpy"
-            ):
-                offenders.append(getter.name)
-    assert offenders == []
 
 
 def test_mjwarp_actuation_metadata_uses_cpu_model_only() -> None:


### PR DESCRIPTION
## Summary

- remove the UniLab test that reads `../unisim/src/.../backend.py`
- keep the MJWarp implementation contract test in the UniSim owner repository
- add a package boundary regression that rejects local/editable/VCS `unisim-core` installs

Paired UniSim PR: unilabsim/unisim#19
Part of roadmap #1428.

## Validation

- `uv run ruff check tests/base/test_backend_imports.py tests/base/test_mjwarp_identity.py`
- `uv run pytest tests/base/test_backend_imports.py tests/base/test_mjwarp_identity.py -q` (11 passed)
- `make test-all`
  - `mypy`: success; `pyright`: 0 errors, 1 existing Drake import warning
  - pytest: 2556 passed, 28 skipped, 320 deselected, 1 xfailed
  - benchmark smoke: module 35/36 and script 36/37 passed; optional `mlx` skipped

The gate was run on commit `41215d55` before the command formatter's unrelated pre-existing `cli.py` line-wrap was restored; the final diff contains no formatter-only changes.
