### PR TITLE
feat: route MuJoCo interactive eval to viewer

### DIFF
--- a/docs/sphinx/source/en/1-getting_started/3-evaluation_and_playback.md
+++ b/docs/sphinx/source/en/1-getting_started/3-evaluation_and_playback.md
@@ -22,6 +22,11 @@ Render modes:
 - `record` — write MP4 to `runs/<run>/playback/`.
 - `none` — skip rendering, just compute metrics.
 
+For `--sim mujoco --render-mode interactive`, `uv run eval` launches the dedicated
+`play_interactive.py` MuJoCo viewer directly. This mode rolls out one environment
+so the viewer camera and controls remain interactive; `training.play_env_num` is
+ignored.
+
 `training.export_onnx=false` currently applies only to the off-policy playback path
 (`src/unilab/scripts/train_sac.py` / `src/unilab/scripts/train_td3.py` / `src/unilab/scripts/train_flashsac.py`
 and CLI runs with `--algo sac|td3|flashsac`). It skips

--- a/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/en/2-user_guide/1-training/1-cli_reference.md
@@ -90,6 +90,9 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1 \
 
 Supported render modes are `auto`, `interactive`, `record`, and `none`.
 
+The MuJoCo interactive mode (`--sim mujoco --render-mode interactive`) routes
+directly to `play_interactive.py` and always rolls out one environment.
+
 ## Demo
 
 ```bash

--- a/docs/sphinx/source/zh_CN/1-getting_started/3-evaluation_and_playback.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/3-evaluation_and_playback.md
@@ -22,6 +22,10 @@ uv run demo dance
 - `record` — 将 MP4 写入 `runs/<run>/playback/`。
 - `none` — 跳过渲染，仅计算指标。
 
+当使用 `--sim mujoco --render-mode interactive` 时，`uv run eval` 会直接启动
+`play_interactive.py` MuJoCo viewer。该模式只 rollout 一个环境以保持相机和交互控制；
+`training.play_env_num` 在此模式下会被忽略。
+
 `training.export_onnx=false` 目前仅适用于 off-policy 回放路径
 （`src/unilab/scripts/train_sac.py` / `src/unilab/scripts/train_td3.py` / `src/unilab/scripts/train_flashsac.py`
 以及使用 `--algo sac|td3|flashsac` 的 CLI 运行）。它会跳过

--- a/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/1-training/1-cli_reference.md
@@ -85,7 +85,9 @@ uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1 \
   --render-mode record
 ```
 
-支持的渲染模式为 `auto`、`interactive`、`record` 和 `none`。
+支持的渲染模式为 `auto`、`interactive`、`record` 和 `none`。其中 MuJoCo 交互模式
+（`--sim mujoco --render-mode interactive`）直接路由到 `play_interactive.py`，并始终只
+rollout 一个环境。
 
 ## 演示
 

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -297,6 +297,10 @@ def build_command(
     generated = [] if use_interactive_play else list(route.generated_overrides)
     if render_mode is not None and _override_value(overrides, "training.play_render_mode") is None:
         generated.append(f"training.play_render_mode={render_mode}")
+    if use_interactive_play and _override_value(overrides, "interactive.action_mode") is None:
+        # The low-level viewer defaults to zero actions for debugging, while
+        # eval must preserve the policy-control behavior of the train scripts.
+        generated.append("interactive.action_mode=policy")
     if mode == "eval":
         generated.append("training.play_only=true")
         if load_run is not None:

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -19,6 +19,7 @@ SUPPORTED_ALGOS = ("ppo", "appo", "sac", "td3", "flashsac")
 SUPPORTED_SIMS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym", "genesis", "isaacsim")
 SUPPORTED_RENDER_MODES = ("auto", "interactive", "record", "none")
 OFFPOLICY_ALGOS = {"sac", "td3", "flashsac"}
+INTERACTIVE_PLAY_ALGOS = {"ppo", "appo", "sac", "td3", "flashsac"}
 RESERVED_OVERRIDE_KEYS = {
     "algo",
     "task",
@@ -127,8 +128,7 @@ def _check_runtime_requirements(algo: str, sim: str) -> None:
         if not diagnostics.batch_available:
             detail = diagnostics.batch_import_error or "unknown import error"
             raise SystemExit(
-                "sim=drake requires a working Drake batch extension; "
-                f"diagnostic reported: {detail}"
+                f"sim=drake requires a working Drake batch extension; diagnostic reported: {detail}"
             )
     if sim == "isaacgym":
         from unisim.backend.isaacgym.dependencies import isaacgym_runtime_available
@@ -239,6 +239,21 @@ def build_route(algo: str, task: str, sim: str, profile: str | None = None) -> R
     )
 
 
+def _uses_mujoco_interactive_play(
+    *,
+    mode: str,
+    algo: str,
+    sim: str,
+    render_mode: str | None,
+    overrides: Sequence[str],
+) -> bool:
+    """Return whether eval should use the dedicated MuJoCo viewer script."""
+    if mode != "eval" or sim != "mujoco" or algo not in INTERACTIVE_PLAY_ALGOS:
+        return False
+    selected_mode = _override_value(overrides, "training.play_render_mode") or render_mode
+    return selected_mode is not None and selected_mode.strip().lower() == "interactive"
+
+
 def build_command(
     *,
     mode: str,
@@ -258,7 +273,18 @@ def build_command(
     _check_runtime_requirements(algo, sim)
 
     route = build_route(algo, task, sim, profile)
-    script = _script_path(route, selected_root)
+    use_interactive_play = _uses_mujoco_interactive_play(
+        mode=mode,
+        algo=algo,
+        sim=sim,
+        render_mode=render_mode,
+        overrides=overrides,
+    )
+    script = (
+        selected_root / "scripts" / "play_interactive.py"
+        if use_interactive_play
+        else _script_path(route, selected_root)
+    )
     if not script.is_file():
         raise SystemExit(f"Entrypoint script not found: {script}")
 
@@ -268,8 +294,8 @@ def build_command(
             f"No owner config exists for algo={algo}, task={task}, sim={sim}: {owner_yaml}"
         )
 
-    generated = list(route.generated_overrides)
-    if render_mode is not None:
+    generated = [] if use_interactive_play else list(route.generated_overrides)
+    if render_mode is not None and _override_value(overrides, "training.play_render_mode") is None:
         generated.append(f"training.play_render_mode={render_mode}")
     if mode == "eval":
         generated.append("training.play_only=true")
@@ -280,6 +306,20 @@ def build_command(
             generated.append(f"algo.load_run={load_run}")
 
     executable = _python_executable_for_route(mode, sim, (*generated, *overrides))
+    if use_interactive_play:
+        owner = f"{sim}_{profile}" if profile is not None else sim
+        return [
+            executable,
+            str(script),
+            "--algo",
+            algo,
+            "--task",
+            task,
+            "--sim",
+            owner,
+            *generated,
+            *overrides,
+        ]
     return [executable, str(script), *generated, *overrides]
 
 

--- a/src/unilab/scripts/play_interactive.py
+++ b/src/unilab/scripts/play_interactive.py
@@ -1102,7 +1102,8 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
             mj_model, env, getattr(args, "camera_focus_body_name", "")
         )
 
-        # Initialize camera to a reasonable default and keep lookat on robot base.
+        # Configure the camera once at startup.  Leave it untouched in the
+        # playback loop so the viewer can be adjusted interactively.
         has_cam = hasattr(viewer, "cam")
         if has_cam:
             if getattr(args, "camera_distance", None) is not None:
@@ -1118,6 +1119,19 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
             if getattr(args, "camera_azimuth", None) is not None:
                 viewer.cam.azimuth = float(args.camera_azimuth)
 
+            # Use the reset pose for the initial target only.  Updating this
+            # in the loop would override the user's manual camera movement.
+            initial_phys = playback_session.physics_state()[0].astype(np.float64)
+            mujoco.mj_setState(mj_model, viz_data, initial_phys, state_spec)
+            mujoco.mj_forward(mj_model, viz_data)
+            if bool(getattr(args, "camera_follow_body", True)):
+                base_pos = viz_data.xpos[focus_body_id]
+                viewer.cam.lookat[0] = float(base_pos[0])
+                viewer.cam.lookat[1] = float(base_pos[1])
+                viewer.cam.lookat[2] = float(
+                    base_pos[2] + float(getattr(args, "camera_height_offset", 0.15))
+                )
+
         with torch.inference_mode():
             while viewer.is_running():
                 t0 = time.perf_counter()
@@ -1132,14 +1146,6 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
                 phys = playback_session.physics_state()[0].astype(np.float64)
                 mujoco.mj_setState(mj_model, viz_data, phys, state_spec)
                 mujoco.mj_forward(mj_model, viz_data)
-
-                if has_cam and bool(getattr(args, "camera_follow_body", True)):
-                    base_pos = viz_data.xpos[focus_body_id]
-                    viewer.cam.lookat[0] = float(base_pos[0])
-                    viewer.cam.lookat[1] = float(base_pos[1])
-                    viewer.cam.lookat[2] = float(
-                        base_pos[2] + float(getattr(args, "camera_height_offset", 0.15))
-                    )
 
                 if overlay.enabled:
                     if args.show_reward_debug:

--- a/src/unilab/scripts/play_interactive.py
+++ b/src/unilab/scripts/play_interactive.py
@@ -127,15 +127,16 @@ def _algo_config_dict(cfg: DictConfig | None) -> dict[str, Any]:
     return algo_config_dict(cfg)
 
 
-SUPPORTED_INTERACTIVE_ALGOS = ("ppo", "appo", "sac", "flashsac", "hora_distill")
+SUPPORTED_INTERACTIVE_ALGOS = ("ppo", "appo", "sac", "td3", "flashsac", "hora_distill")
 _CONFIG_ROOT_BY_ALGO = {
     "ppo": "ppo",
     "appo": "appo",
     "sac": "sac",
+    "td3": "td3",
     "flashsac": "flashsac",
     "hora_distill": "hora_distill",
 }
-_OFFPOLICY_INTERACTIVE_ALGOS = {"sac", "flashsac"}
+_OFFPOLICY_INTERACTIVE_ALGOS = {"sac", "td3", "flashsac"}
 
 
 @dataclass(frozen=True)

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -3151,7 +3151,7 @@ def test_play_interactive_parses_explicit_cli():
     assert parsed.overrides == ["task=sharpa_inhand/mujoco_nodr"]
 
 
-@pytest.mark.parametrize("algo", ["appo", "sac", "hora_distill"])
+@pytest.mark.parametrize("algo", ["appo", "sac", "td3", "hora_distill"])
 def test_play_interactive_parses_feature_algo_flags(algo: str):
     mod = _play_interactive()
 
@@ -3208,6 +3208,7 @@ def test_play_interactive_dynamic_compose_supports_algo_roots():
     ppo_cfg = mod._compose_interactive_config("ppo", ["task=go1_joystick_flat/mujoco"])
     appo_cfg = mod._compose_interactive_config("appo", ["task=sharpa_inhand/mujoco_hora"])
     sac_cfg = mod._compose_interactive_config("sac", ["task=sharpa_inhand/mujoco_hora"])
+    td3_cfg = mod._compose_interactive_config("td3", ["task=g1_walk_flat/mujoco"])
     distill_cfg = mod._compose_interactive_config("hora_distill", ["task=sharpa_inhand/mujoco"])
 
     assert ppo_cfg.algo.algo == "ppo"
@@ -3216,6 +3217,7 @@ def test_play_interactive_dynamic_compose_supports_algo_roots():
     assert sac_cfg.algo.algo == "sac"
     assert sac_cfg.algo.runtime_impl == "hora_sac"
     assert sac_cfg.interactive.policy_obs_mode == "actor"
+    assert td3_cfg.algo.algo == "td3"
     assert distill_cfg.algo.algo_log_name == "hora_distill"
     assert distill_cfg.interactive.action_mode == "policy"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,6 +248,7 @@ def test_eval_mujoco_interactive_routes_to_dedicated_viewer(
         "--sim",
         "mujoco",
         "training.play_render_mode=interactive",
+        "interactive.action_mode=policy",
         "training.play_only=true",
         "algo.load_run=-1",
     ]
@@ -293,11 +294,43 @@ def test_eval_mujoco_interactive_honors_profile_and_render_override(
         "g1_walk_flat",
         "--sim",
         "mujoco_hora",
+        "interactive.action_mode=policy",
         "training.play_only=true",
         "algo.load_run=run_1",
         "training.play_render_mode=interactive",
         "algo.num_envs=4096",
     ]
+
+
+def test_eval_mujoco_interactive_preserves_explicit_action_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "train_rsl_rl.py").write_text("", encoding="utf-8")
+    (scripts_dir / "play_interactive.py").write_text("", encoding="utf-8")
+    owner_dir = tmp_path / "conf" / "ppo" / "task" / "go2_joystick_flat"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "mujoco.yaml").write_text("training:\n  sim_backend: mujoco\n", encoding="utf-8")
+    monkeypatch.setattr(
+        cli,
+        "find_spec",
+        lambda name: ModuleSpec(name, loader=None) if name == "mujoco" else None,
+    )
+
+    command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="go2_joystick_flat",
+        sim="mujoco",
+        overrides=["interactive.action_mode=random"],
+        load_run="-1",
+        render_mode="interactive",
+        root=tmp_path,
+    )
+
+    assert "interactive.action_mode=policy" not in command
+    assert "interactive.action_mode=random" in command
 
 
 def test_macos_motrix_render_mode_none_does_not_require_mxpython(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,95 @@ def test_eval_render_mode_generates_training_override(
     assert "algo.load_run=-1" in command
 
 
+def test_eval_mujoco_interactive_routes_to_dedicated_viewer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "train_rsl_rl.py").write_text("", encoding="utf-8")
+    (scripts_dir / "play_interactive.py").write_text("", encoding="utf-8")
+    owner_dir = tmp_path / "conf" / "ppo" / "task" / "go2_joystick_flat"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "mujoco.yaml").write_text("training:\n  sim_backend: mujoco\n", encoding="utf-8")
+    monkeypatch.setattr(
+        cli,
+        "find_spec",
+        lambda name: ModuleSpec(name, loader=None) if name == "mujoco" else None,
+    )
+
+    command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="go2_joystick_flat",
+        sim="mujoco",
+        overrides=[],
+        load_run="-1",
+        render_mode="interactive",
+        root=tmp_path,
+    )
+
+    assert command == [
+        sys.executable,
+        str(scripts_dir / "play_interactive.py"),
+        "--algo",
+        "ppo",
+        "--task",
+        "go2_joystick_flat",
+        "--sim",
+        "mujoco",
+        "training.play_render_mode=interactive",
+        "training.play_only=true",
+        "algo.load_run=-1",
+    ]
+    assert "task=go2_joystick_flat/mujoco" not in command
+
+
+def test_eval_mujoco_interactive_honors_profile_and_render_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "train_td3.py").write_text("", encoding="utf-8")
+    (scripts_dir / "play_interactive.py").write_text("", encoding="utf-8")
+    owner_dir = tmp_path / "conf" / "td3" / "task" / "g1_walk_flat"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "mujoco_hora.yaml").write_text(
+        "training:\n  sim_backend: mujoco\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        cli,
+        "find_spec",
+        lambda name: ModuleSpec(name, loader=None) if name == "mujoco" else None,
+    )
+
+    command = cli.build_command(
+        mode="eval",
+        algo="td3",
+        task="g1_walk_flat",
+        sim="mujoco",
+        profile="hora",
+        overrides=["training.play_render_mode=interactive", "algo.num_envs=4096"],
+        load_run="run_1",
+        render_mode="record",
+        root=tmp_path,
+    )
+
+    assert command == [
+        sys.executable,
+        str(scripts_dir / "play_interactive.py"),
+        "--algo",
+        "td3",
+        "--task",
+        "g1_walk_flat",
+        "--sim",
+        "mujoco_hora",
+        "training.play_only=true",
+        "algo.load_run=run_1",
+        "training.play_render_mode=interactive",
+        "algo.num_envs=4096",
+    ]
+
+
 def test_macos_motrix_render_mode_none_does_not_require_mxpython(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Preserve manual MuJoCo viewer camera controls after startup initialization.
- Route `eval --sim mujoco --render-mode interactive` directly to `play_interactive.py`.
- Force policy action mode for interactive eval by default, while preserving explicit action-mode overrides.
- Roll out exactly one environment in the interactive viewer path; include TD3 support.

## Validation

- `make test-all`
- 2560 passed, 28 skipped, 1 xfailed
- mypy and pyright completed; pyright reports the existing optional `drake_uni.runtime` import warning.
- Benchmark smoke test passed.
