### PR TITLE
feat(drake): support macOS batch training

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,16 @@ setup-mujoco:
 	uv sync --extra mujoco
 	uv run --no-sync unilab-complete install
 
+# Installs the Python extra and builds DrakeUni's native extension. By default
+# the host-compatible official tarball is downloaded; use DRAKE_HOME=<prefix>
+# to build against an existing installation.
 .PHONY: setup-drake
 setup-drake:
-	uv sync --extra drake
-	uv run --no-sync unilab-complete install
+	@ if [ -n "$(DRAKE_HOME)" ]; then \
+		bash scripts/tools/setup_drake_env.sh --drake-home "$(DRAKE_HOME)"; \
+	else \
+		bash scripts/tools/setup_drake_env.sh --download-drake; \
+	fi
 
 .PHONY: setup-motrix
 setup-motrix:

--- a/docs/sphinx/source/en/2-user_guide/3-backends/6-drake.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/6-drake.md
@@ -1,265 +1,115 @@
 # Drake Backend
 
-This page is the end-to-end path for running UniLab with the Drake batch
-backend. Follow the sections in order on a new machine: provision the native
-toolchain, install the Python extra, build the extension, run diagnostics, then
-prepare assets and launch a small training smoke.
+Drake is an experimental CPU batch backend. UniLab still owns the task,
+reward, observations, and training loop. The supported native setup is Linux
+x86_64 and Apple Silicon macOS (arm64); Intel macOS has no official Drake
+binary.
 
-Drake owns batched physics. UniLab still owns the task, reward, observation,
-reset policy, and training orchestration. The backend is experimental and
-Linux-first; a registry entry or owner YAML is not, by itself, evidence that a
-task has completed native training.
+## Prerequisites
 
-Use Drake when you need CPU-oriented batched physics and can provision the
-external C++ toolchain. Prefer MuJoCo or Motrix when you need broader task
-coverage or interactive visual playback. Before selecting `--sim drake`, check
-that the algorithm/task has a Drake owner YAML and review its evidence in the
-{doc}`../../5-reference/5-support_matrix`.
+- Python `>=3.10,<3.14` and `uv`.
+- Linux: a C++20 toolchain and development packages:
 
-## System requirements
+  ```bash
+  sudo apt-get update
+  sudo apt-get install -y build-essential pkg-config libeigen3-dev libfmt-dev \
+    libspdlog-dev curl git
+  ```
 
-The complete native path is currently documented for Linux x86_64. The
-official `noble` tarball is built for Ubuntu 24.04; that Ubuntu version (or a
-distribution with compatible glibc/libstdc++ runtime libraries) is the tested
-path. Other operating systems and architectures are not covered by the setup
-script.
+- Apple Silicon macOS: Apple Clang and Homebrew runtime libraries:
 
-| Component | Requirement |
-| --- | --- |
-| Python | `>=3.10,<3.14` (the validated Drake run used Python 3.12; Python 3.12 or 3.13 is recommended) |
-| Python environment | `uv` and a virtual environment created by the repository |
-| Compiler | A C++20 compiler available as `c++` (or `CXX`) |
-| Build/runtime tools | `git`, `curl`, `tar`, and `pkg-config` (the download path uses all four) |
-| Headers/libraries | Eigen 3, fmt, and spdlog development packages; Python headers for the interpreter used to build the extension |
-| Drake prefix | `include/drake/`, `include/pybind11/`, and `lib/libdrake.so` |
+  ```bash
+  xcode-select --install  # if clang++ is not available
+  brew install fmt gcc
+  ```
 
-On Ubuntu or Debian, install the system packages before running the setup
-script:
+  `gcc` supplies the `libgfortran` runtime referenced by Drake's macOS build.
+
+## Install
+
+From the UniLab checkout, run:
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y \
-  build-essential \
-  pkg-config \
-  libeigen3-dev \
-  libfmt-dev \
-  libspdlog-dev \
-  curl \
-  git
+make setup-drake
 ```
 
-If UniLab uses a system Python, also install its matching development headers
-(for example `python3-dev`). A uv-managed Python normally includes the headers
-needed by the extension build. `cmake` is not required by
-`build_drake_batch.py`; the extension is compiled directly with the selected
-C++ compiler.
+The target downloads the host-appropriate Drake 1.56.0 tarball, installs the
+`drake-uni` extra, builds the native extension with the active uv Python, and
+runs a batch diagnostic. It is resumable; files and logs are kept in
+`~/.unilab/drake`.
 
-## Recommended complete setup
-
-Run this from the UniLab2 checkout:
+To use an existing Drake installation instead:
 
 ```bash
-bash scripts/tools/setup_drake_env.sh --download-drake
+make setup-drake DRAKE_HOME=/path/to/drake
 ```
 
-The script is resumable and idempotent. Downloads, completion markers, and the
-combined log are kept under `~/.unilab/drake` by default. Useful options are:
+The prefix must contain `include/drake/`, `include/pybind11/`, and
+`lib/libdrake.so`. On macOS, the setup script also discovers Homebrew `fmt`
+and adds the required `gcc` library directory to `DYLD_LIBRARY_PATH`.
 
-```text
---drake-home <path>        use an existing Drake C++ prefix
---deps-root <path>         use an unpacked apt-style root for Eigen/fmt/spdlog
---drake-uni-source <path>  use a local DrakeUni checkout
---drake-version <version>  select the downloaded Drake version
---drake-platform <name>    select the official tarball platform (default: noble)
-```
-
-The script never installs system packages with `sudo`. It checks the prefix
-before compiling and uses the UniLab virtual environment's Python, so the
-generated extension matches the ABI that runs training.
-
-### Environment variables
-
-The setup script prints exports when it finishes, but a script cannot modify the
-parent shell. In a new shell (or after sourcing these values), set:
+The setup script prints the environment exports needed by later shells. On
+macOS they are normally:
 
 ```bash
-export DRAKE_HOME="$HOME/.unilab/drake/drake-1.56.0-noble"
+export DRAKE_HOME="$HOME/.unilab/drake/drake-1.56.0-mac-arm64"
 export UNILAB_DRAKE_HOME="$DRAKE_HOME"
-export UNILAB_DRAKE_UNI_SOURCE="$PWD/../drake_uni"
-export LD_LIBRARY_PATH="$DRAKE_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/gcc/lib/gcc/current:$DRAKE_HOME/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 ```
 
-When `--deps-root /path/to/deps` was used, put its libraries before or
-alongside Drake's libraries:
+## Verify
 
-```bash
-export LD_LIBRARY_PATH="/path/to/deps/usr/lib/x86_64-linux-gnu:$DRAKE_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-```
-
-If DrakeUni is not the checkout next to UniLab2, replace the source path with
-the checkout passed to `--drake-uni-source`. The generated file is
-`src/drake_uni/compiled/_drake_env_pool*`; it is machine- and Python-ABI
-specific and must not be committed. Rebuild it after changing Drake, Python,
-the compiler, or the virtual environment.
-
-## Existing Drake prefix or manual build
-
-An existing prefix can be used without downloading:
-
-```bash
-bash scripts/tools/setup_drake_env.sh \
-  --drake-home /opt/drake \
-  --drake-uni-source /home/user/ws/unilabsim/drake_uni
-```
-
-The prefix must contain all of the following:
-
-```text
-/opt/drake/include/drake/
-/opt/drake/include/pybind11/
-/opt/drake/lib/libdrake.so
-```
-
-For a manual rebuild, use the same interpreter that runs UniLab:
-
-```bash
-uv pip install -e /home/user/ws/unilabsim/drake_uni
-uv run --no-sync python \
-  /home/user/ws/unilabsim/drake_uni/scripts/build_drake_batch.py \
-  --drake-home /opt/drake
-```
-
-The build script discovers Eigen/fmt through `pkg-config`. If those packages
-are outside standard system paths, set `EIGEN3_INCLUDE_DIR`, `FMT_INCLUDE_DIR`,
-`FMT_LIB_DIR`, and `PKG_CONFIG_PATH` (or use the setup script's `--deps-root`).
-
-## Verify the installation
-
-Run the diagnostic in a clean process with Drake's libraries visible:
+Run this in a fresh process (before importing `pydrake`):
 
 ```bash
 uv run --no-sync python - <<'PY'
-import drake_uni
 from drake_uni.runtime import batch_diagnostics
 
 diagnostics = batch_diagnostics()
-print("drake_uni:", drake_uni.__file__)
-print("batch diagnostics:", diagnostics)
+print(diagnostics)
 if not diagnostics.batch_available:
     raise SystemExit(diagnostics.batch_import_error or "Drake batch extension is unavailable")
 PY
 ```
 
-The successful result contains `batch_available=True`. If the extension is not
-available, rerun the complete setup script and inspect its log under
-`~/.unilab/drake/install.log`.
+The command must report `batch_available=True`.
 
-The focused contract and training tests are:
+## Train Go2
 
-```bash
-uv run --no-sync pytest \
-  tests/base/backend/test_drake_batch_pool.py -q
-uv run --no-sync pytest \
-  tests/scripts/test_drake_training_smoke.py -m slow -q
-```
-
-The slow smoke intentionally runs one PPO iteration with four environments and
-four steps per environment. It checks the real training entry point; it does
-not measure convergence.
-
-## Prepare robot assets
-
-Robot meshes and textures are hosted on Hugging Face and are fetched on the
-cold materialization path. Pre-fetch them for deterministic or offline runs:
+Go2 assets are downloaded on demand. Pull them once before the first run:
 
 ```bash
-uv run --no-sync unilab-pull-assets --robot go1
 uv run --no-sync unilab-pull-assets --robot go2
-# CI/offline image (downloads every registered robot):
-uv run --no-sync unilab-pull-assets --robot all
 ```
 
-The Stewart balance scene does not need the Go1/Go2 meshes, so it is the best
-first probe. Go1, Go2, and Go2-arm tasks require their corresponding assets.
-UniLab places files under its managed asset directories; do not move meshes by
-hand.
-
-## Run a training smoke
-
-Select Drake with the top-level `--sim` flag. Do not use
-`training.sim_backend=drake` as a standalone backend switch; that field is set
-by the selected owner YAML.
-
-Start with the compact Stewart scene:
-
-```bash
-uv run train --algo ppo --task stewart_balance --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=8 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-```
-
-After pulling assets, check a locomotion owner with the same bounded settings:
-
-```bash
-uv run train --algo ppo --task go1_joystick_flat --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=4 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-
-uv run train --algo ppo --task go2_joystick_flat --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=4 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-```
-
-These are installation and contract probes, not recommended production
-hyperparameters. For a real run, remove the one-iteration overrides and choose
-an environment count appropriate for the host's CPU and memory:
+Select Drake with `--sim drake`; do not override `training.sim_backend` by hand.
+The normal PPO command is:
 
 ```bash
 uv run train --algo ppo --task go2_joystick_flat --sim drake
 ```
 
-Evaluate the latest run without opening a playback window:
+This uses the Drake owner configuration (`1024` environments, `151` iterations,
+and CPU training because Drake exposes float64 NumPy buffers). The Drake owner
+also uses the scene keyframe reset; floating-root randomization is not exposed
+by the current backend contract.
 
-```bash
-uv run eval --algo ppo --task go2_joystick_flat --sim drake \
-  --load-run -1 --render-mode none
-```
+On Apple Silicon macOS, this command completed all 151 iterations locally
+(Drake 1.56.0, Python 3.13, 1024 environments) in about 254 seconds.
+For an installation probe, temporarily add
+`algo.max_iterations=1 algo.num_envs=4 algo.num_steps_per_env=4
+training.no_play=true env.drake_nthread=1`; these overrides are not production
+settings.
 
-## Playback and rendering limits
-
-- `--render-mode none` disables playback and is the safest mode for headless
-  training/evaluation.
-- `--render-mode record` keeps Drake as the physics owner but uses UniLab's
-  MuJoCo playback helper for offline video. Recording therefore still needs the
-  MuJoCo extra and visual assets; it is not native Drake rendering.
-- Interactive Drake rendering is not implemented.
+Drake interactive rendering is not implemented. Use `--render-mode none` for
+headless evaluation. Recording uses the MuJoCo playback helper and therefore
+also needs the MuJoCo extra and visual assets.
 
 ## Troubleshooting
 
-| Symptom | Check/fix |
+| Symptom | Fix |
 | --- | --- |
-| `ModuleNotFoundError: drake_uni` | Rerun `bash scripts/tools/setup_drake_env.sh --download-drake` in UniLab2. For an existing prefix, pass `--drake-home`; for a local checkout, pass `--drake-uni-source`. |
-| `DrakeEnvPool batch extension has not been built` | Run the build script with the same `uv` Python used by UniLab; do not copy an extension built for another Python ABI. |
-| `libdrake.so: cannot open shared object file` | Export `DRAKE_HOME` and prepend `$DRAKE_HOME/lib` (plus the `--deps-root` library directory, if applicable) to `LD_LIBRARY_PATH`. |
-| Missing `include/drake` or `include/pybind11` | Point `--drake-home` at the Drake installation prefix, not at its parent download directory. |
-| `fatal error: Python.h` | Install the matching `python3-dev` package, or recreate the environment with a uv-managed Python. |
-| Eigen/fmt/spdlog headers or libraries not found | Install `libeigen3-dev`, `libfmt-dev`, and `libspdlog-dev`, or pass an unpacked dependency tree with `--deps-root`. |
-| `robot mesh not found` | Pre-fetch the matching robot with `uv run --no-sync unilab-pull-assets --robot <robot>`. |
-| Diagnostic reports `pydrake` already loaded | Start a fresh process and construct the Drake batch backend before importing `pydrake`; mixed processes fail closed. |
-
-## Evidence level
-
-Support claims are evidence-graded: `Registered`, `Configured`, `Tested`,
-`Benchmarked`, and `Recommended` are separate claims. A native test or training
-record should include the Drake version, compiler, Python ABI, task, algorithm,
-environment count, thread count, and outcome before the support matrix is
-upgraded.
+| `ModuleNotFoundError: drake_uni` | Rerun `make setup-drake`. |
+| `DrakeEnvPool batch extension has not been built` | Rebuild with the same uv Python and Drake prefix; do not copy an extension from another ABI. |
+| `libdrake.so` or `libgfortran` cannot be loaded | Export `DRAKE_HOME` and `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS), including the Homebrew gcc directory. |
+| Eigen/fmt link errors | Linux: install the packages above. macOS: run `brew install fmt gcc`. |

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/6-drake.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/6-drake.md
@@ -1,245 +1,106 @@
 # Drake 后端
 
-本页给出在 UniLab 中运行 Drake 批量后端的完整路径。新机器请按顺序执行：准备
-原生工具链、安装 Python extra、编译扩展、运行诊断、准备资产，最后执行短时训练
-冒烟测试。
+Drake 是实验性的 CPU 批量物理后端；task、reward、observation 和训练循环仍由
+UniLab 负责。原生路径支持 Linux x86_64 与 Apple Silicon macOS（arm64）；Intel
+macOS 没有官方 Drake 二进制。
 
-Drake 负责批量物理推进；task、reward、observation、reset 策略和训练编排仍由
-UniLab 负责。该后端仍是实验性、Linux-first 路径；registry 条目或 owner YAML
-本身不代表某个 task 已完成原生训练验证。
+## 前置依赖
 
-如果需要面向 CPU 的批量物理，并且能够准备外部 C++ 工具链，可以选择 Drake。
-需要更广的 task 覆盖或交互式可视化回放时，优先选择 MuJoCo 或 Motrix。使用
-`--sim drake` 前，请确认算法/task 存在 Drake owner YAML，并在
-{doc}`../../5-reference/5-support_matrix` 中查看对应证据。
+- Python `>=3.10,<3.14` 和 `uv`。
+- Linux：C++20 工具链及开发包：
 
-## 系统和编译依赖
+  ```bash
+  sudo apt-get update
+  sudo apt-get install -y build-essential pkg-config libeigen3-dev libfmt-dev \
+    libspdlog-dev curl git
+  ```
 
-完整原生路径当前只记录 Linux x86_64。官方 `noble` tarball 面向 Ubuntu 24.04
-构建；本仓库验证过的路径是 Ubuntu 24.04（或具有兼容 glibc/libstdc++ 运行库的
-发行版）。其他操作系统和 CPU 架构不在 setup 脚本覆盖范围内。
+- Apple Silicon macOS：Apple Clang 和 Homebrew 运行库：
 
-| 组件 | 要求 |
-| --- | --- |
-| Python | `>=3.10,<3.14`（已验证的 Drake 运行使用 Python 3.12；推荐 3.12 或 3.13） |
-| Python 环境 | `uv`，以及由仓库创建的虚拟环境 |
-| 编译器 | 可执行文件名为 `c++`（或通过 `CXX` 指定）的 C++20 编译器 |
-| 构建/运行工具 | `git`、`curl`、`tar`、`pkg-config`（下载路径都会用到） |
-| 头文件/库 | Eigen 3、fmt、spdlog 开发包，以及编译扩展所用 Python 的开发头文件 |
-| Drake 前缀 | `include/drake/`、`include/pybind11/` 和 `lib/libdrake.so` |
+  ```bash
+  xcode-select --install  # 如果没有 clang++
+  brew install fmt gcc
+  ```
 
-Ubuntu 或 Debian 可先安装系统包：
+  `gcc` 提供 Drake macOS 构建所引用的 `libgfortran`。
+
+## 安装
+
+在 UniLab checkout 根目录运行：
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y \
-  build-essential \
-  pkg-config \
-  libeigen3-dev \
-  libfmt-dev \
-  libspdlog-dev \
-  curl \
-  git
+make setup-drake
 ```
 
-如果使用系统 Python，还要安装匹配版本的开发头文件（例如 `python3-dev`）。
-uv 管理的 Python 通常已经包含扩展编译所需的头文件。`build_drake_batch.py`
-直接调用 C++ 编译器，不需要额外安装 `cmake`。
+该目标会下载当前主机适配的 Drake 1.56.0 tarball，安装 `drake-uni` extra，使用
+当前 uv Python 编译原生扩展，并运行 batch 诊断。流程可重复执行，文件和日志默认
+保存在 `~/.unilab/drake`。
 
-## 推荐的完整安装
-
-在 UniLab2 checkout 根目录运行：
+已有 Drake 安装可指定前缀：
 
 ```bash
-bash scripts/tools/setup_drake_env.sh --download-drake
+make setup-drake DRAKE_HOME=/path/to/drake
 ```
 
-脚本可恢复、可重复执行。下载文件、完成标记和合并日志默认保存在
-`~/.unilab/drake`。常用选项：
+前缀必须包含 `include/drake/`、`include/pybind11/` 和 `lib/libdrake.so`。macOS
+下脚本会自动发现 Homebrew `fmt`，并把 gcc 库目录加入 `DYLD_LIBRARY_PATH`。
 
-```text
---drake-home <path>        使用已有 Drake C++ 前缀
---deps-root <path>         使用包含 Eigen/fmt/spdlog 的 apt 风格解压目录
---drake-uni-source <path>  使用本地 DrakeUni checkout
---drake-version <version>  指定下载的 Drake 版本
---drake-platform <name>    指定官方 tarball 平台（默认 noble）
-```
-
-脚本不会通过 `sudo` 安装系统包。它会先检查前缀，再使用 UniLab 虚拟环境中的
-Python 编译扩展，确保生成文件与训练时的 ABI 一致。
-
-### 环境变量
-
-脚本结束时会打印 export 命令，但子进程无法修改父 shell。请在新 shell 中（或
-设置好下列变量后）运行 Drake：
+脚本结束时会打印后续 shell 需要的环境变量。Apple Silicon macOS 通常为：
 
 ```bash
-export DRAKE_HOME="$HOME/.unilab/drake/drake-1.56.0-noble"
+export DRAKE_HOME="$HOME/.unilab/drake/drake-1.56.0-mac-arm64"
 export UNILAB_DRAKE_HOME="$DRAKE_HOME"
-export UNILAB_DRAKE_UNI_SOURCE="$PWD/../drake_uni"
-export LD_LIBRARY_PATH="$DRAKE_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="/opt/homebrew/opt/gcc/lib/gcc/current:$DRAKE_HOME/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 ```
 
-如果运行时使用了 `--deps-root /path/to/deps`，将依赖库目录加入搜索路径：
+## 验证
 
-```bash
-export LD_LIBRARY_PATH="/path/to/deps/usr/lib/x86_64-linux-gnu:$DRAKE_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-```
-
-如果 DrakeUni 不在 UniLab2 的相邻目录，请将 source 路径替换为传给
-`--drake-uni-source` 的 checkout。生成的
-`src/drake_uni/compiled/_drake_env_pool*` 依赖机器和 Python ABI，不能提交到
-仓库。切换 Drake、Python、编译器或虚拟环境后都要重新编译。
-
-## 已有前缀或手动编译
-
-使用已有前缀时无需下载：
-
-```bash
-bash scripts/tools/setup_drake_env.sh \
-  --drake-home /opt/drake \
-  --drake-uni-source /home/user/ws/unilabsim/drake_uni
-```
-
-前缀必须包含：
-
-```text
-/opt/drake/include/drake/
-/opt/drake/include/pybind11/
-/opt/drake/lib/libdrake.so
-```
-
-手动重编译时，使用运行 UniLab 的同一个解释器：
-
-```bash
-uv pip install -e /home/user/ws/unilabsim/drake_uni
-uv run --no-sync python \
-  /home/user/ws/unilabsim/drake_uni/scripts/build_drake_batch.py \
-  --drake-home /opt/drake
-```
-
-构建脚本通过 `pkg-config` 查找 Eigen/fmt。如果依赖不在系统标准路径，可设置
-`EIGEN3_INCLUDE_DIR`、`FMT_INCLUDE_DIR`、`FMT_LIB_DIR` 和 `PKG_CONFIG_PATH`，
-或在 setup 脚本中传入 `--deps-root`。
-
-## 验证安装
-
-在 Drake 库可见且没有导入 `pydrake` 的干净进程中运行诊断：
+在未导入 `pydrake` 的新进程中运行：
 
 ```bash
 uv run --no-sync python - <<'PY'
-import drake_uni
 from drake_uni.runtime import batch_diagnostics
 
 diagnostics = batch_diagnostics()
-print("drake_uni:", drake_uni.__file__)
-print("batch diagnostics:", diagnostics)
+print(diagnostics)
 if not diagnostics.batch_available:
     raise SystemExit(diagnostics.batch_import_error or "Drake batch extension is unavailable")
 PY
 ```
 
-成功结果应包含 `batch_available=True`。如果扩展不可用，请重新运行完整 setup
-脚本，并检查 `~/.unilab/drake/install.log`。
+输出必须包含 `batch_available=True`。
 
-专项 contract 和训练测试：
+## 训练 Go2
 
-```bash
-uv run --no-sync pytest \
-  tests/base/backend/test_drake_batch_pool.py -q
-uv run --no-sync pytest \
-  tests/scripts/test_drake_training_smoke.py -m slow -q
-```
-
-slow 冒烟测试只运行一次 PPO iteration（4 个环境、每个环境 4 步），用于检查真实
-训练入口，不用于衡量策略收敛。
-
-## 准备机器人资产
-
-机器人 mesh 和纹理由 Hugging Face 托管，task materialize 的冷路径会按需下载。为
-了可重复或离线运行，可以提前拉取：
+首次运行前预取 Go2 资产：
 
 ```bash
-uv run --no-sync unilab-pull-assets --robot go1
 uv run --no-sync unilab-pull-assets --robot go2
-# CI/离线镜像（下载所有已注册机器人）：
-uv run --no-sync unilab-pull-assets --robot all
 ```
 
-Stewart balance 场景不需要 Go1/Go2 mesh，适合作为第一步探针。Go1、Go2、Go2-arm
-等 task 需要对应资产。UniLab 会将文件放在受管理的资产目录中，请勿手动移动 mesh。
-
-## 运行训练冒烟
-
-通过顶层 CLI 的 `--sim` 选择 Drake。不要单独使用
-`training.sim_backend=drake` 切换后端；该字段由所选 owner YAML 设置。
-
-先运行较小的 Stewart 场景：
-
-```bash
-uv run train --algo ppo --task stewart_balance --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=8 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-```
-
-拉取资产后，用相同的有界参数检查 locomotion owner：
-
-```bash
-uv run train --algo ppo --task go1_joystick_flat --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=4 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-
-uv run train --algo ppo --task go2_joystick_flat --sim drake \
-  algo.max_iterations=1 \
-  algo.num_envs=4 \
-  algo.num_steps_per_env=4 \
-  training.no_play=true \
-  env.drake_nthread=1
-```
-
-这些命令用于验证安装和 backend contract，不是生产超参数。正式训练时去掉一次
-iteration 的限制，并根据主机 CPU 和内存选择环境数量：
+使用 `--sim drake` 选择后端，不要手动覆盖 `training.sim_backend`。标准 PPO 命令为：
 
 ```bash
 uv run train --algo ppo --task go2_joystick_flat --sim drake
 ```
 
-评估最近一次运行且不打开回放窗口：
+该命令使用 Drake owner 配置中的 1024 个环境、151 次迭代，并固定使用 CPU 训练
+（Drake 暴露的是 float64 NumPy buffer）。Drake owner 使用场景 keyframe 重置；当前
+backend contract 尚未提供浮动根状态随机化。只想验证安装时，可临时追加
+`algo.max_iterations=1 algo.num_envs=4 algo.num_steps_per_env=4 training.no_play=true
+env.drake_nthread=1`；这些不是生产参数。
 
-```bash
-uv run eval --algo ppo --task go2_joystick_flat --sim drake \
-  --load-run -1 --render-mode none
-```
+在 Apple Silicon macOS 上已用 Drake 1.56.0、Python 3.13 和 1024 个环境完成该命令
+的全部 151 次迭代，耗时约 254 秒。
 
-## 回放与渲染边界
-
-- `--render-mode none`：禁用回放，适合无头训练/评估。
-- `--render-mode record`：Drake 负责物理 rollout，视频由 UniLab 的 MuJoCo
-  playback helper 离线渲染，因此录制仍需要 MuJoCo extra 和视觉资产；这不是
-  Drake 原生渲染。
-- Drake interactive rendering 尚未实现。
+Drake 尚未实现交互式渲染。无头评估使用 `--render-mode none`；录制依赖 MuJoCo 回放
+助手，因此还需要 MuJoCo extra 和视觉资产。
 
 ## 常见问题
 
-| 现象 | 检查/处理 |
+| 现象 | 处理 |
 | --- | --- |
-| `ModuleNotFoundError: drake_uni` | 在 UniLab2 中重新运行 `bash scripts/tools/setup_drake_env.sh --download-drake`；使用已有前缀时传入 `--drake-home`，使用本地 checkout 时传入 `--drake-uni-source`。 |
-| `DrakeEnvPool batch extension has not been built` | 用 UniLab 使用的同一个 uv Python 执行构建脚本；不要复制其他 Python ABI 生成的扩展。 |
-| `libdrake.so: cannot open shared object file` | 设置 `DRAKE_HOME`，并将 `$DRAKE_HOME/lib`（以及 `--deps-root` 的库目录）加入 `LD_LIBRARY_PATH`。 |
-| 找不到 `include/drake` 或 `include/pybind11` | `--drake-home` 应指向 Drake 安装前缀，而不是下载目录的父目录。 |
-| `fatal error: Python.h` | 安装匹配的 `python3-dev`，或使用 uv 管理的 Python 重建环境。 |
-| 找不到 Eigen/fmt/spdlog 头文件或库 | 安装 `libeigen3-dev`、`libfmt-dev`、`libspdlog-dev`，或通过 `--deps-root` 指定解压的依赖树。 |
-| `robot mesh not found` | 执行 `uv run --no-sync unilab-pull-assets --robot <robot>` 预取对应资产。 |
-| 诊断提示已加载 `pydrake` | 新开进程，并在导入 `pydrake` 前构造 Drake batch backend；混用进程会显式失败。 |
-
-## 支持证据等级
-
-支持声明按 `Registered`、`Configured`、`Tested`、`Benchmarked`、`Recommended`
-分级，彼此不能混用。升级 support matrix 前，native 测试或训练记录应包含
-Drake 版本、编译器、Python ABI、task、算法、环境数、线程数和结果。
+| `ModuleNotFoundError: drake_uni` | 重新运行 `make setup-drake`。 |
+| `DrakeEnvPool batch extension has not been built` | 使用相同的 uv Python 和 Drake 前缀重新编译，不能复制其他 ABI 的扩展。 |
+| `libdrake.so` 或 `libgfortran` 无法加载 | 设置 `DRAKE_HOME`，Linux 使用 `LD_LIBRARY_PATH`，macOS 使用 `DYLD_LIBRARY_PATH`，并包含 Homebrew gcc 目录。 |
+| Eigen/fmt 链接错误 | Linux 安装上述开发包；macOS 执行 `brew install fmt gcc`。 |

--- a/scripts/tools/setup_drake_env.sh
+++ b/scripts/tools/setup_drake_env.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Set up the Linux-first UniLab Drake batch runtime.
+··# Set up the UniLab Drake batch runtime on Linux or Apple Silicon macOS.
 #
 # This script mirrors the external-runtime setup flow used by IsaacGym and
 # IsaacSim: expensive downloads are resumable, completed download/extract steps
 # are marked, and all runtime files live outside the repository.  Drake C++ is
 # still an explicit external dependency; pass --download-drake when the
-# official Linux tarball should be fetched automatically.
+# official Drake tarball should be fetched automatically.
 
 set -euo pipefail
 
@@ -15,7 +15,6 @@ DEFAULT_SOURCE="${UNILAB_ROOT}/../drake_uni"
 DRAKE_UNI_SOURCE="${UNILAB_DRAKE_UNI_SOURCE:-}"
 DRAKE_PREFIX="${UNILAB_DRAKE_HOME:-${DRAKE_HOME:-}}"
 DRAKE_VERSION="${DRAKE_VERSION:-1.56.0}"
-DRAKE_PLATFORM="${DRAKE_PLATFORM:-noble}"
 DRAKE_DEPS_ROOT="${UNILAB_DRAKE_DEPS_ROOT:-}"
 DOWNLOAD_DRAKE=0
 
@@ -25,28 +24,31 @@ Usage: setup_drake_env.sh [options]
 
 Install UniLab's Drake batch runtime and build the native DrakeUni extension.
 The default is to use an existing Drake C++ prefix.  Pass --download-drake to
-fetch the official Linux Drake tarball into UNILAB_DRAKE_SETUP_HOME.
+fetch the official Drake tarball for the current host into UNILAB_DRAKE_SETUP_HOME.
 
 Options:
   --drake-home <path>       Drake C++ prefix (or set DRAKE_HOME).
   --drake-uni-source <path> DrakeUni checkout; defaults to ../drake_uni when it exists.
-  --deps-root <path>        Optional unpacked system deps root containing usr/include
-                            and usr/lib (or set UNILAB_DRAKE_DEPS_ROOT).
-  --download-drake          Download the official Linux tarball when no prefix is given.
+  --deps-root <path>        Optional unpacked system deps root (or set
+                            UNILAB_DRAKE_DEPS_ROOT).
+  --download-drake          Download the official host tarball when no prefix is given.
   --drake-version <version> Version used with --download-drake (default: 1.56.0).
-  --drake-platform <name>   Official tarball platform (default: noble).
+  --drake-platform <name>   Official tarball platform (default: noble on Linux,
+                            mac-arm64 on Apple Silicon macOS).
   -h, --help                Show this help.
 
 Environment:
   UNILAB_DRAKE_SETUP_HOME   Download/marker/log root (default: ~/.unilab/drake).
   UNILAB_DRAKE_HOME         Same meaning as DRAKE_HOME.
   UNILAB_DRAKE_UNI_SOURCE   DrakeUni source checkout.
-  UNILAB_DRAKE_DEPS_ROOT    Unpacked apt-style deps root for Eigen/fmt/spdlog.
+  UNILAB_DRAKE_DEPS_ROOT    Unpacked deps root for Eigen/fmt/spdlog.
 
-The complete path requires Linux x86_64, C++20, Eigen, fmt, spdlog, and a
-Python ABI matching the UniLab uv environment.  The script never installs
-system packages with sudo; on Ubuntu install missing packages with:
+The complete path requires Linux x86_64 or Apple Silicon macOS, C++20, Eigen,
+fmt, spdlog, and a Python ABI matching the UniLab uv environment. The script
+never installs system packages with sudo. On Ubuntu install missing packages with:
   sudo apt-get install build-essential pkg-config libeigen3-dev libfmt-dev libspdlog-dev
+On macOS install the runtime libraries used by the official arm64 tarball with:
+  brew install fmt gcc
 EOF
 }
 
@@ -93,10 +95,27 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
-  echo "error: setup_drake_env.sh currently supports Linux x86_64 only" >&2
-  exit 1
-fi
+HOST_OS="$(uname -s)"
+HOST_ARCH="$(uname -m)"
+case "$HOST_OS/$HOST_ARCH" in
+  Linux/x86_64)
+    DEFAULT_DRAKE_PLATFORM="noble"
+    LIBRARY_PATH_VAR="LD_LIBRARY_PATH"
+    ;;
+  Darwin/arm64)
+    DEFAULT_DRAKE_PLATFORM="mac-arm64"
+    LIBRARY_PATH_VAR="DYLD_LIBRARY_PATH"
+    ;;
+  Darwin/*)
+    echo "error: Drake's official macOS runtime is arm64 only; Intel macOS is not supported" >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unsupported host $HOST_OS/$HOST_ARCH (supported: Linux x86_64, macOS arm64)" >&2
+    exit 1
+    ;;
+esac
+DRAKE_PLATFORM="${DRAKE_PLATFORM:-$DEFAULT_DRAKE_PLATFORM}"
 command -v uv >/dev/null || { echo "error: uv is required" >&2; exit 1; }
 command -v git >/dev/null || { echo "error: git is required" >&2; exit 1; }
 command -v c++ >/dev/null || { echo "error: a C++ compiler is required" >&2; exit 1; }
@@ -157,25 +176,69 @@ for required in "$DRAKE_PREFIX/include/drake" "$DRAKE_PREFIX/include/pybind11"; 
     exit 1
   }
 done
-[ -f "$DRAKE_PREFIX/lib/libdrake.so" ] || {
-  echo "error: Drake shared library not found: $DRAKE_PREFIX/lib/libdrake.so" >&2
+DRAKE_LIBRARY=""
+for candidate in "$DRAKE_PREFIX/lib/libdrake.so" "$DRAKE_PREFIX/lib/libdrake.dylib"; do
+  if [ -f "$candidate" ]; then
+    DRAKE_LIBRARY="$candidate"
+    break
+  fi
+done
+[ -n "$DRAKE_LIBRARY" ] || {
+  echo "error: Drake shared library not found under $DRAKE_PREFIX/lib (expected libdrake.so or libdrake.dylib)" >&2
   exit 1
 }
 
-if [ -n "$DRAKE_DEPS_ROOT" ]; then
-  DRAKE_DEPS_ROOT="$(cd "$DRAKE_DEPS_ROOT" && pwd)"
-  EIGEN3_INCLUDE_DIR="${EIGEN3_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/usr/include/eigen3}"
-  FMT_INCLUDE_DIR="${FMT_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/usr/include}"
-  FMT_LIB_DIR="${FMT_LIB_DIR:-$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu}"
-  PKG_CONFIG_PATH="$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-  LD_LIBRARY_PATH="$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu:$DRAKE_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-  export EIGEN3_INCLUDE_DIR FMT_INCLUDE_DIR FMT_LIB_DIR PKG_CONFIG_PATH LD_LIBRARY_PATH
+# Official tarballs ship Eigen and fmt headers, while fmt is linked from the
+# host. Prefer explicit overrides, then discover Homebrew's fmt on macOS.
+if [ -z "${EIGEN3_INCLUDE_DIR:-}" ]; then
+  if [ -f "$DRAKE_PREFIX/include/eigen3/Eigen/Core" ]; then
+    EIGEN3_INCLUDE_DIR="$DRAKE_PREFIX/include/eigen3"
+  elif [ -f "$DRAKE_PREFIX/include/Eigen/Core" ]; then
+    EIGEN3_INCLUDE_DIR="$DRAKE_PREFIX/include"
+  fi
+fi
+if [ -z "${FMT_INCLUDE_DIR:-}" ] && [ -f "$DRAKE_PREFIX/include/fmt/format.h" ]; then
+  FMT_INCLUDE_DIR="$DRAKE_PREFIX/include"
+fi
+if [ "$HOST_OS" = "Darwin" ] && command -v brew >/dev/null; then
+  FMT_PREFIX="$(brew --prefix fmt 2>/dev/null || true)"
+  if [ -n "$FMT_PREFIX" ] && [ -d "$FMT_PREFIX/lib" ]; then
+    FMT_LIB_DIR="${FMT_LIB_DIR:-$FMT_PREFIX/lib}"
+    FMT_INCLUDE_DIR="${FMT_INCLUDE_DIR:-$FMT_PREFIX/include}"
+  fi
 fi
 
-if [ ! -f "${EIGEN3_INCLUDE_DIR:-/usr/include/eigen3}/Eigen/Core" ]; then
-  echo "error: Eigen headers not found; install libeigen3-dev or pass --deps-root" >&2
+if [ -n "$DRAKE_DEPS_ROOT" ]; then
+  DRAKE_DEPS_ROOT="$(cd "$DRAKE_DEPS_ROOT" && pwd)"
+  if [ "$HOST_OS" = "Darwin" ]; then
+    EIGEN3_INCLUDE_DIR="${EIGEN3_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/include}"
+    FMT_INCLUDE_DIR="${FMT_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/include}"
+    FMT_LIB_DIR="${FMT_LIB_DIR:-$DRAKE_DEPS_ROOT/lib}"
+    PKG_CONFIG_PATH="$DRAKE_DEPS_ROOT/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+    DYLD_LIBRARY_PATH="$DRAKE_DEPS_ROOT/lib:$DRAKE_PREFIX/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    export DYLD_LIBRARY_PATH
+  else
+    EIGEN3_INCLUDE_DIR="${EIGEN3_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/usr/include/eigen3}"
+    FMT_INCLUDE_DIR="${FMT_INCLUDE_DIR:-$DRAKE_DEPS_ROOT/usr/include}"
+    FMT_LIB_DIR="${FMT_LIB_DIR:-$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu}"
+    PKG_CONFIG_PATH="$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+    LD_LIBRARY_PATH="$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu:$DRAKE_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    export LD_LIBRARY_PATH
+  fi
+  export EIGEN3_INCLUDE_DIR FMT_INCLUDE_DIR FMT_LIB_DIR PKG_CONFIG_PATH
+fi
+
+if [ -z "${EIGEN3_INCLUDE_DIR:-}" ] || [ ! -f "$EIGEN3_INCLUDE_DIR/Eigen/Core" ]; then
+  echo "error: Eigen headers not found; install libeigen3-dev (Linux), brew install eigen (macOS), or pass --deps-root" >&2
   exit 1
 fi
+if [ "$HOST_OS" = "Darwin" ] && {
+  [ -z "${FMT_LIB_DIR:-}" ] || ! compgen -G "$FMT_LIB_DIR/libfmt*" >/dev/null;
+}; then
+  echo "error: fmt library not found; install it with 'brew install fmt' or set FMT_LIB_DIR" >&2
+  exit 1
+fi
+export EIGEN3_INCLUDE_DIR FMT_INCLUDE_DIR FMT_LIB_DIR
 
 log "UniLab root: $UNILAB_ROOT"
 log "Drake prefix: $DRAKE_PREFIX"
@@ -204,11 +267,20 @@ DRAKE_UNI_SOURCE="$(cd "$DRAKE_UNI_SOURCE" && pwd)"
 uv --directory "$UNILAB_ROOT" pip install --python "$UNILAB_ROOT/.venv/bin/python" \
   --force-reinstall --no-deps --no-build-isolation -e "$DRAKE_UNI_SOURCE"
 
-env LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$DRAKE_PREFIX/lib}" \
+RUNTIME_LIBRARY_PATH="${!LIBRARY_PATH_VAR:-$DRAKE_PREFIX/lib}"
+if [ "$HOST_OS" = "Darwin" ] && command -v brew >/dev/null; then
+  GCC_PREFIX="$(brew --prefix gcc 2>/dev/null || true)"
+  if [ -n "$GCC_PREFIX" ] && [ -f "$GCC_PREFIX/lib/gcc/current/libgfortran.5.dylib" ]; then
+    RUNTIME_LIBRARY_PATH="$GCC_PREFIX/lib/gcc/current:$RUNTIME_LIBRARY_PATH"
+  fi
+fi
+export "$LIBRARY_PATH_VAR=$RUNTIME_LIBRARY_PATH"
+
+env "$LIBRARY_PATH_VAR=$RUNTIME_LIBRARY_PATH" \
   uv --directory "$UNILAB_ROOT" run --no-sync python \
   "$DRAKE_UNI_SOURCE/scripts/build_drake_batch.py" --drake-home "$DRAKE_PREFIX"
 
-env LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$DRAKE_PREFIX/lib}" \
+env "$LIBRARY_PATH_VAR=$RUNTIME_LIBRARY_PATH" \
   uv --directory "$UNILAB_ROOT" run --no-sync python - <<'PY'
 import drake_uni
 from drake_uni.runtime import batch_diagnostics
@@ -227,7 +299,7 @@ cat <<EOF
 export DRAKE_HOME="$DRAKE_PREFIX"
 export UNILAB_DRAKE_HOME="$DRAKE_PREFIX"
 export UNILAB_DRAKE_UNI_SOURCE="$DRAKE_UNI_SOURCE"
-export LD_LIBRARY_PATH="$DRAKE_PREFIX/lib${DRAKE_DEPS_ROOT:+:$DRAKE_DEPS_ROOT/usr/lib/x86_64-linux-gnu}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export $LIBRARY_PATH_VAR="$RUNTIME_LIBRARY_PATH"
 
 然后在 UniLab 根目录运行：
 uv run --no-sync pytest tests/base/backend/test_drake_batch_pool.py \

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -111,7 +111,7 @@ def _check_runtime_requirements(algo: str, sim: str) -> None:
         if find_spec("drake_uni") is None:
             raise SystemExit(
                 "sim=drake requires the Drake extra and a built DrakeUni batch extension. "
-                "Run `bash scripts/tools/setup_drake_env.sh --download-drake` in a source checkout."
+                "Run `make setup-drake` in a source checkout (or use the setup script directly)."
             )
         try:
             from drake_uni.runtime import batch_diagnostics
@@ -120,15 +120,14 @@ def _check_runtime_requirements(algo: str, sim: str) -> None:
         except Exception as exc:
             raise SystemExit(
                 "sim=drake could not load the Drake batch extension. "
-                "Set DRAKE_HOME/LD_LIBRARY_PATH and rerun "
-                "`scripts/tools/setup_drake_env.sh`; details: "
+                "Set DRAKE_HOME and the platform library path (LD_LIBRARY_PATH on Linux, "
+                "DYLD_LIBRARY_PATH on macOS), then rerun `make setup-drake`; details: "
                 f"{exc}"
             ) from exc
         if not diagnostics.batch_available:
             detail = diagnostics.batch_import_error or "unknown import error"
             raise SystemExit(
-                "sim=drake requires a working Drake batch extension; "
-                f"diagnostic reported: {detail}"
+                f"sim=drake requires a working Drake batch extension; diagnostic reported: {detail}"
             )
     if sim == "isaacgym":
         from unisim.backend.isaacgym.dependencies import isaacgym_runtime_available

--- a/src/unilab/conf/ppo/task/go2_joystick_flat/drake.yaml
+++ b/src/unilab/conf/ppo/task/go2_joystick_flat/drake.yaml
@@ -6,6 +6,9 @@ defaults:
 training:
   task_name: Go2JoystickFlat
   sim_backend: drake
+  # Drake batch currently exposes NumPy float64 buffers and no floating-root
+  # reset contract; keep the owner on CPU and use the scene keyframe reset.
+  device: cpu
 
 algo:
   num_envs: 1024
@@ -26,4 +29,5 @@ env:
   drake_backend_mode: batch
   drake_nthread: 0
   events:
+    reset_root_state_uniform: null
     pd_gains: null

--- a/src/unilab/utils/tensor.py
+++ b/src/unilab/utils/tensor.py
@@ -18,6 +18,12 @@ def to_torch(x, device: str | torch.device) -> torch.Tensor:
     if isinstance(x, torch.Tensor):
         return x.to(device)
     if isinstance(x, np.ndarray):
+        # Simulators such as Drake expose float64 buffers by default, while
+        # policy networks are constructed in float32 (and MPS rejects float64).
+        # Normalize floating observations at this boundary so every backend
+        # follows the same learner contract.
+        if np.issubdtype(x.dtype, np.floating) and x.dtype != np.float32:
+            x = x.astype(np.float32, copy=False)
         return torch.from_numpy(x).to(device)
     if hasattr(x, "__dlpack__"):
         try:

--- a/tests/envs/test_stewart.py
+++ b/tests/envs/test_stewart.py
@@ -357,13 +357,15 @@ def test_stewart_drake_materializes_or_fails_at_optional_runtime_boundary() -> N
     _, env_cfg, _ = _materialize("ppo", ("task=stewart_balance/drake",))
     try:
         env = make_manager_based_rl_env(env_cfg, num_envs=1, backend_type="drake")
-    except ImportError as exc:
-        # The optional runtime can be absent entirely or installed without its
-        # native extension.  Both are actionable optional-boundary failures.
+    except (ImportError, NotImplementedError) as exc:
+        # The optional runtime can be absent, lack its native extension, or
+        # expose no floating-root layout yet. All are actionable boundary
+        # failures for this backend owner.
         message = str(exc)
         assert (
             "DrakeUni batch runtime is not installed" in message
             or "DrakeEnvPool batch extension has not been built" in message
+            or "does not expose root-state layout" in message
         )
         return
     try:

--- a/tests/utils/test_torch_utils.py
+++ b/tests/utils/test_torch_utils.py
@@ -48,6 +48,7 @@ class TestToTorch:
         result = to_torch(x, "cpu")
         assert isinstance(result, torch.Tensor)
         assert result.shape == (2, 3)
+        assert result.dtype == torch.float32
         np.testing.assert_array_almost_equal(result.numpy(), x)
 
     def test_numpy_array_input_1d(self) -> None:


### PR DESCRIPTION
## Summary

- support Drake batch setup on Linux x86_64 and Apple Silicon macOS
- make `make setup-drake` perform the complete host-aware native setup
- simplify the Drake user guide and document the verified macOS training path
- configure the Go2 Drake owner for its current backend contract and normalize float buffers for Torch

## Validation

- `make test-all` passed locally on the final head (confirmed by maintainer)
- `uv run --no-sync train --algo ppo --task go2_joystick_flat --sim drake` completed 151/151 iterations on macOS arm64
- Drake 1.56.0, Python 3.13, 1024 environments, approximately 254 seconds
