### PR TITLE
build: consume released unisim-core from PyPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,8 @@ Languages: English | [简体中文](docs/sphinx/source/zh_CN/4-developer_guide/4
    - Linux default (installs PyTorch cu128 wheels; requires an NVIDIA GPU/driver supported by current PyTorch cu128 wheels): `uv sync`
    - Linux AMD / ROCm workstation: `make sync-rocm`, then run commands with `uv run --no-sync ...`
    - When you need Motrix, append `--extra motrix`
-   - Physics adapters are supplied by `unisim-core` (import namespace
-     `unisim`). During roadmap #1428, its package source is TestPyPI; do not
-     upload production releases from a development branch.
+   - Physics adapters are supplied by the production PyPI package
+     `unisim-core>=0.1.14` (import namespace `unisim`).
 3. Create a branch such as `git checkout -b docs/improve-readme` or `git checkout -b fix/backend-bug`.
 
 ## Development Rules

--- a/README.md
+++ b/README.md
@@ -121,9 +121,8 @@ uv run demo dance
 
 Available demo names: `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`, `inhandgrasp`. See the [Unified CLI](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html) page for the full list and flags.
 
-The roadmap migration currently resolves `unisim-core` from TestPyPI. Its
-public import namespace is `unisim`; production PyPI publication is performed
-manually by the maintainer after roadmap #1428 closes.
+Physics adapters are installed from the production PyPI release
+`unisim-core>=0.1.14`; its public Python import namespace is `unisim`.
 
 > Mainland China users: motions, scenes, robot meshes, and demo checkpoints are pulled from Hugging Face on first run. If `huggingface.co` is unreachable, point the client at the community mirror before running demo commands:
 >

--- a/README_zh.md
+++ b/README_zh.md
@@ -142,8 +142,8 @@ uv run eval --algo appo --task go2_joystick_flat --sim motrix --load-run -1 --re
 
 这会路由到 `go2_joystick_flat/motrix` 任务 owner 配置，并保持后端选择显式化。每个后端 owner 带一个可选的 `play_profile` 块，在 eval 时（`training.play_only=true`）叠加仅渲染相关的覆盖，不影响训练。
 
-roadmap #1428 执行期间，`unisim-core` 从 TestPyPI 解析，Python import namespace
-为 `unisim`；roadmap 完成后的生产 PyPI 发布由 maintainer 手动执行。
+物理适配器从正式 PyPI 安装 `unisim-core>=0.1.14`，其 Python import namespace
+为 `unisim`。
 
 在 macOS / MacBook 上，UniLab CLI 在需要时会通过 `mxpython` 路由 Motrix 交互式回放。Motrix 默认使用交互式回放；要导出无头视频请使用 `--render-mode record`，要跳过回放请使用 `--render-mode none`。更细的脚本级命令请参阅 [训练指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)。
 

--- a/docs/sphinx/source/adr/ADR-0007-unisim-extraction-boundary.md
+++ b/docs/sphinx/source/adr/ADR-0007-unisim-extraction-boundary.md
@@ -39,7 +39,7 @@ Roadmap #1428 将统一物理层拆到 GitHub 仓库 `unilabsim/unisim`。PyPI d
 - backend-neutral state/control/reset/mutation 类型、capability、错误和生命周期；
 - lazy adapter factory/registry、engine-native runtime 与必要的 subprocess IPC；
 - cold-path materialization/selector 和 hot-path buffer/step 规则；
-- conformance helper、benchmark API/result schema 预留、package 文档与 TestPyPI 发布。
+- conformance helper、benchmark API/result schema 预留、package 文档与 PyPI 发布。
 
 UniLab owns：
 
@@ -67,8 +67,8 @@ compatibility shim，不保留长期双实现。
 - UniLab declared base 是 `dev/issue-1042-manager-based-api`，执行期间只读；`main` 同样只读。
 - roadmap 集成分支为 `dev/issue-1428-unisim-extraction`，从 declared base 的只读快照创建。
 - child branch/PR 只合入 roadmap 集成分支；不得向 UniLab `main` 或 declared base 写入。
-- 开发与验证阶段只发布到 TestPyPI，凭据来自 `~/.pypirc` 且不得输出或提交；生产 PyPI
-  发布在 roadmap 完成后由 maintainer 手动执行。
+- `unisim-core` 正式版本发布到 PyPI；UniLab 从正式 PyPI 解析
+  `unisim-core>=0.1.14`，Python import namespace 为 `unisim`。
 
 ## Alternatives Considered
 

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -24,8 +24,8 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
-    # unisim-core package. Production PyPI publication remains maintainer-owned.
-    "unisim-core>=0.1.12",
+    # unisim-core package from the production PyPI index.
+    "unisim-core>=0.1.14",
     "torch==2.11.0",
     "triton-rocm==3.6.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "gymnasium",
@@ -86,11 +86,6 @@ name = "pytorch-rocm72"
 url = "https://download.pytorch.org/whl/rocm7.2"
 explicit = true
 
-[[tool.uv.index]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-explicit = true
-
 [tool.uv.sources]
 torch = [
     { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
@@ -98,7 +93,6 @@ torch = [
 triton-rocm = [
     { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
-unisim-core = { index = "testpypi" }
 
 [tool.uv]
 exclude-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,8 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
-    # unisim-core package.  During roadmap execution this source is pinned to
-    # TestPyPI; production PyPI publication is a maintainer-only final step.
-    "unisim-core>=0.1.12",
+    # unisim-core package from the production PyPI index.
+    "unisim-core>=0.1.14",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -140,18 +139,12 @@ name = "r2-cu130"
 url = "https://download-r2.pytorch.org/whl/cu130"
 explicit = true
 
-[[tool.uv.index]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-explicit = true
-
 [tool.uv.sources]
 torch = [
     { index = "r2-cu130", marker = "sys_platform=='linux' and platform_machine=='aarch64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='linux' and platform_machine=='x86_64'" },
     { index = "pytorch-cu128", marker = "sys_platform=='win32'" },
 ]
-unisim-core = { index = "testpypi" }
 
 [tool.uv]
 exclude-dependencies = ["torchvision"]

--- a/uv.lock
+++ b/uv.lock
@@ -5052,7 +5052,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
-    { name = "unisim-core", specifier = ">=0.1.12", index = "https://test.pypi.org/simple/" },
+    { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
@@ -5071,16 +5071,13 @@ dev = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.12"
-source = { registry = "https://test.pypi.org/simple/" }
+version = "0.1.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/83/98/7e88202e93ce7f4599fa7b67205116e6ec343843410794013dfa55eec358/unisim_core-0.1.12.tar.gz", hash = "sha256:1808b029e5a0ff76e598ffc0c69e72c8ddefda59b0c93da14849b517e88b61b3", size = 187036, upload-time = "2026-09-02T10:57:04.157Z" }
-wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/08/1f/b49b4755e2a758a2eab98f72f30fb799967a5ead10286b75e8ed47947772/unisim_core-0.1.12-py3-none-any.whl", hash = "sha256:76ab24185daa9c038dde1cc8098e069dbabcefc648260e20a6a455b9b538f7f0", size = 216809, upload-time = "2026-09-02T10:57:02.316Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c9/f3a8b96037e41d7af6cf7d676650eff0f5078133937c02617e26f171cfbf/unisim_core-0.1.14.tar.gz", hash = "sha256:6290c2d1b440921ebd8a51bfd7160677df4897a0d26614d005ad1d7df95df23b", size = 187141, upload-time = "2026-09-02T14:59:15.011Z" }
 
 [[package]]
 name = "urllib3"

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3790,7 +3790,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
     { name = "typing-extensions" },
-    { name = "unisim-core", specifier = ">=0.1.12", index = "https://test.pypi.org/simple/" },
+    { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "wheel", marker = "extra == 'mujoco'" },
@@ -3808,16 +3808,13 @@ dev = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.12"
-source = { registry = "https://test.pypi.org/simple/" }
+version = "0.1.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/83/98/7e88202e93ce7f4599fa7b67205116e6ec343843410794013dfa55eec358/unisim_core-0.1.12.tar.gz", hash = "sha256:1808b029e5a0ff76e598ffc0c69e72c8ddefda59b0c93da14849b517e88b61b3", size = 187036, upload-time = "2026-09-02T10:57:04.157Z" }
-wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/08/1f/b49b4755e2a758a2eab98f72f30fb799967a5ead10286b75e8ed47947772/unisim_core-0.1.12-py3-none-any.whl", hash = "sha256:76ab24185daa9c038dde1cc8098e069dbabcefc648260e20a6a455b9b538f7f0", size = 216809, upload-time = "2026-09-02T10:57:02.316Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c9/f3a8b96037e41d7af6cf7d676650eff0f5078133937c02617e26f171cfbf/unisim_core-0.1.14.tar.gz", hash = "sha256:6290c2d1b440921ebd8a51bfd7160677df4897a0d26614d005ad1d7df95df23b", size = 187141, upload-time = "2026-09-02T14:59:15.011Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## Summary
- switch standard and ROCm dependency manifests to released `unisim-core>=0.1.14` from PyPI
- refresh both uv lockfiles to the PyPI source distribution
- update user and architecture documentation to reflect the production package source

## Validation
- `make test-all` passed
- mypy: no issues in 236 source files
- pyright: 0 errors, 1 pre-existing warning for optional `drake_uni.runtime`
- pytest: 2561 passed, 28 skipped, 320 deselected, 1 xfailed
- benchmark smoke: passed (platform-optional `mlx` checks skipped)
