### PR TITLE
fix: compact asset download output

### DIFF
--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -17,6 +17,7 @@ import os
 import posixpath
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from unilab.assets import ASSETS_ROOT_PATH
 
@@ -82,6 +83,8 @@ def resolve_motion_files(
 
 def resolve_grasp_cache_files(
     cache_file: str | Sequence[str],
+    *,
+    show_progress: bool = True,
 ) -> str | list[str]:
     """Ensure grasp cache file(s) exist locally, downloading from HF if needed.
 
@@ -95,8 +98,11 @@ def resolve_grasp_cache_files(
         returns a list of strings.
     """
     if isinstance(cache_file, str):
-        return _resolve_single(cache_file, repo_id=_HF_CACHES_REPO_ID)
-    return [_resolve_single(p, repo_id=_HF_CACHES_REPO_ID) for p in cache_file]
+        return _resolve_single(cache_file, repo_id=_HF_CACHES_REPO_ID, show_progress=show_progress)
+    return [
+        _resolve_single(p, repo_id=_HF_CACHES_REPO_ID, show_progress=show_progress)
+        for p in cache_file
+    ]
 
 
 def resolve_checkpoint_file(
@@ -118,7 +124,12 @@ def resolve_checkpoint_file(
     return [_resolve_single(p, repo_id=_HF_CHECKPOINTS_REPO_ID) for p in checkpoint_file]
 
 
-def _resolve_single(path_str: str, *, repo_id: str = _HF_MOTIONS_REPO_ID) -> str:
+def _resolve_single(
+    path_str: str,
+    *,
+    repo_id: str = _HF_MOTIONS_REPO_ID,
+    show_progress: bool = True,
+) -> str:
     """Resolve one asset file path, downloading if absent."""
     path = Path(path_str)
     is_absolute_input = path.is_absolute() or ntpath.isabs(path_str) or posixpath.isabs(path_str)
@@ -144,7 +155,7 @@ def _resolve_single(path_str: str, *, repo_id: str = _HF_MOTIONS_REPO_ID) -> str
                 f"ASSETS_ROOT_PATH ({ASSETS_ROOT_PATH}): {path_str}"
             ) from None
 
-    return _download_from_hf(relative, repo_id=repo_id)
+    return _download_from_hf(relative, repo_id=repo_id, show_progress=show_progress)
 
 
 def _hf_relative_path(path_str: str) -> str:
@@ -152,22 +163,30 @@ def _hf_relative_path(path_str: str) -> str:
     return path_str.replace("\\", "/")
 
 
-def _hf_download(hf_hub_download, relative_path: str, *, repo_id: str) -> str:  # type: ignore[no-untyped-def]
+def _hf_download(
+    hf_hub_download,
+    relative_path: str,
+    *,
+    repo_id: str,
+    show_progress: bool = True,
+) -> str:  # type: ignore[no-untyped-def]
     """Call ``hf_hub_download`` with the standard arguments."""
-    return str(
-        hf_hub_download(
-            repo_id=repo_id,
-            filename=relative_path,
-            repo_type=_HF_REPO_TYPE,
-            local_dir=str(ASSETS_ROOT_PATH),
-        )
-    )
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "filename": relative_path,
+        "repo_type": _HF_REPO_TYPE,
+        "local_dir": str(ASSETS_ROOT_PATH),
+    }
+    if not show_progress:
+        kwargs["tqdm_class"] = _silent_tqdm_class()
+    return str(hf_hub_download(**kwargs))
 
 
 def _download_from_hf(
     relative_path: str,
     *,
     repo_id: str = _HF_MOTIONS_REPO_ID,
+    show_progress: bool = True,
 ) -> str:
     """Download *relative_path* from an HF dataset repo.
 
@@ -188,7 +207,12 @@ def _download_from_hf(
     logger.info("Downloading %s from HF repo %s ...", relative_path, repo_id)
 
     try:
-        local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
+        local_path = _hf_download(
+            hf_hub_download,
+            relative_path,
+            repo_id=repo_id,
+            show_progress=show_progress,
+        )
     except Exception:
         # If a mirror endpoint is configured and it failed, retry with
         # the official endpoint before giving up.
@@ -202,7 +226,12 @@ def _download_from_hf(
             original = os.environ["HF_ENDPOINT"]
             os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
             try:
-                local_path = _hf_download(hf_hub_download, relative_path, repo_id=repo_id)
+                local_path = _hf_download(
+                    hf_hub_download,
+                    relative_path,
+                    repo_id=repo_id,
+                    show_progress=show_progress,
+                )
             finally:
                 os.environ["HF_ENDPOINT"] = original
         else:
@@ -217,19 +246,40 @@ def _download_from_hf(
 # ---------------------------------------------------------------------------
 
 
-def _snapshot_download(snapshot_download_fn, directory: str, *, repo_id: str) -> str:  # type: ignore[no-untyped-def]
+def _silent_tqdm_class() -> type[Any]:
+    """Return a tqdm class that keeps HF snapshot downloads silent."""
+    from tqdm.auto import tqdm
+
+    class _SilentTqdm(tqdm):  # type: ignore[misc]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["disable"] = True
+            super().__init__(*args, **kwargs)
+
+    return _SilentTqdm
+
+
+def _snapshot_download(
+    snapshot_download_fn,
+    directory: str,
+    *,
+    repo_id: str,
+    show_progress: bool = True,
+) -> str:  # type: ignore[no-untyped-def]
     """Call ``snapshot_download`` with the standard arguments."""
-    return str(
-        snapshot_download_fn(
-            repo_id=repo_id,
-            repo_type=_HF_REPO_TYPE,
-            allow_patterns=f"{directory}/**",
-            local_dir=str(ASSETS_ROOT_PATH),
-        )
-    )
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "repo_type": _HF_REPO_TYPE,
+        "allow_patterns": f"{directory}/**",
+        "local_dir": str(ASSETS_ROOT_PATH),
+    }
+    if not show_progress:
+        kwargs["tqdm_class"] = _silent_tqdm_class()
+    return str(snapshot_download_fn(**kwargs))
 
 
-def _resolve_snapshot_dir(directory: str, *, repo_id: str, marker: str) -> Path:
+def _resolve_snapshot_dir(
+    directory: str, *, repo_id: str, marker: str, show_progress: bool = True
+) -> Path:
     """Ensure an HF-hosted directory exists locally, downloading if needed.
 
     If the current ``HF_ENDPOINT`` (e.g. a mirror) fails, automatically
@@ -263,7 +313,9 @@ def _resolve_snapshot_dir(directory: str, *, repo_id: str, marker: str) -> Path:
     logger.info("Downloading %s from HF repo %s ...", hf_directory, repo_id)
 
     try:
-        _snapshot_download(snapshot_download, hf_directory, repo_id=repo_id)
+        _snapshot_download(
+            snapshot_download, hf_directory, repo_id=repo_id, show_progress=show_progress
+        )
     except Exception:
         current_endpoint = os.environ.get("HF_ENDPOINT", "")
         if current_endpoint and current_endpoint != _HF_OFFICIAL_ENDPOINT:
@@ -275,7 +327,9 @@ def _resolve_snapshot_dir(directory: str, *, repo_id: str, marker: str) -> Path:
             original = os.environ["HF_ENDPOINT"]
             os.environ["HF_ENDPOINT"] = _HF_OFFICIAL_ENDPOINT
             try:
-                _snapshot_download(snapshot_download, hf_directory, repo_id=repo_id)
+                _snapshot_download(
+                    snapshot_download, hf_directory, repo_id=repo_id, show_progress=show_progress
+                )
             finally:
                 os.environ["HF_ENDPOINT"] = original
         else:
@@ -299,7 +353,7 @@ def resolve_scene_dir(directory: str, *, marker: str = "teaser.xml") -> Path:
     return _resolve_snapshot_dir(directory, repo_id=_HF_SCENES_REPO_ID, marker=marker)
 
 
-def resolve_robot_asset_dir(directory: str, *, marker: str) -> Path:
+def resolve_robot_asset_dir(directory: str, *, marker: str, show_progress: bool = True) -> Path:
     """Ensure a robot asset directory (e.g. meshes) exists locally.
 
     Robot binary assets (STL meshes) are hosted on Hugging Face rather than
@@ -312,11 +366,17 @@ def resolve_robot_asset_dir(directory: str, *, marker: str) -> Path:
             (e.g. ``"robots/x2/meshes"``).
         marker: A file inside the directory used to check completeness
             (e.g. ``"pelvis.STL"``).
+        show_progress: Whether Hugging Face snapshot downloads may render progress bars.
 
     Returns:
         Absolute ``Path`` to the resolved directory.
     """
-    return _resolve_snapshot_dir(directory, repo_id=_HF_ROBOTS_REPO_ID, marker=marker)
+    return _resolve_snapshot_dir(
+        directory,
+        repo_id=_HF_ROBOTS_REPO_ID,
+        marker=marker,
+        show_progress=show_progress,
+    )
 
 
 def ensure_robot_assets_for_paths(paths: Sequence[str | None]) -> None:

--- a/src/unilab/assets/pull.py
+++ b/src/unilab/assets/pull.py
@@ -18,10 +18,19 @@ from __future__ import annotations
 import argparse
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
 
 from unilab.assets.hub import ROBOT_ASSET_SPECS, resolve_robot_asset_dir
 
 _ALL = "all"
+
+
+@dataclass(frozen=True)
+class _AssetSummary:
+    target: Path
+    count: int
+    label: str
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -32,6 +41,11 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=[*_sorted_robots(), _ALL],
         help="Robot whose binary assets to download, or 'all' (default: x2).",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show per-directory download logs and Hugging Face progress bars.",
+    )
     return parser.parse_args(argv)
 
 
@@ -39,20 +53,47 @@ def _sorted_robots() -> list[str]:
     return sorted(ROBOT_ASSET_SPECS)
 
 
-def _pull_robot(robot: str) -> None:
+def _pull_robot(robot: str, *, show_progress: bool) -> list[_AssetSummary]:
+    summaries: list[_AssetSummary] = []
     for directory, marker, pattern, label in ROBOT_ASSET_SPECS[robot]:
-        target = resolve_robot_asset_dir(directory, marker=marker)
+        target = resolve_robot_asset_dir(directory, marker=marker, show_progress=show_progress)
         count = sum(1 for path in target.rglob(pattern) if path.is_file())
-        print(f"{robot} assets ready at {target} ({count} {label} files)")
+        summaries.append(_AssetSummary(target=target, count=count, label=label))
+    return summaries
+
+
+def _format_single_robot_summary(robot: str, summaries: Sequence[_AssetSummary]) -> str:
+    parts = [f"{summary.count} {summary.label} files at {summary.target}" for summary in summaries]
+    return f"{robot} assets ready: {'; '.join(parts)}"
+
+
+def _format_all_summary(robots: Sequence[str], summaries: Sequence[_AssetSummary]) -> str:
+    total_files = sum(summary.count for summary in summaries)
+    label_counts: dict[str, int] = {}
+    for summary in summaries:
+        label_counts[summary.label] = label_counts.get(summary.label, 0) + summary.count
+    counts = ", ".join(f"{count} {label}" for label, count in sorted(label_counts.items()))
+    return (
+        f"Robot assets ready: {len(robots)} robots, {len(summaries)} directories, "
+        f"{total_files} files ({counts})"
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
     args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING, format="%(message)s"
+    )
 
     robots = _sorted_robots() if args.robot == _ALL else [args.robot]
+    summaries: list[_AssetSummary] = []
     for robot in robots:
-        _pull_robot(robot)
+        summaries.extend(_pull_robot(robot, show_progress=args.verbose))
+
+    if args.robot == _ALL:
+        print(_format_all_summary(robots, summaries))
+    else:
+        print(_format_single_robot_summary(args.robot, summaries))
     return 0
 
 

--- a/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
@@ -92,7 +92,10 @@ def _materialize_grasp_caches(
     missing_files: list[str] = []
     for scale_value in np.asarray(scale_values, dtype=np.float64):
         cache_file = resolve_grasp_cache_file(grasp_cache_path, float(scale_value))
-        resolved = cast(str, resolve_grasp_cache_files(str(cache_file)))
+        resolved = cast(
+            str,
+            resolve_grasp_cache_files(str(cache_file), show_progress=False),
+        )
         cache_file = Path(resolved)
         if not cache_file.exists():
             missing_files.append(str(cache_file))

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -9,7 +9,12 @@ import numpy as np
 import pytest
 
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.assets.hub import resolve_grasp_cache_files, resolve_motion_files, resolve_scene_dir
+from unilab.assets.hub import (
+    resolve_grasp_cache_files,
+    resolve_motion_files,
+    resolve_robot_asset_dir,
+    resolve_scene_dir,
+)
 
 # ---------------------------------------------------------------------------
 # Local-path fast path
@@ -217,6 +222,32 @@ def test_resolve_grasp_cache_relative_path_uses_caches_repo():
     )
 
 
+def test_resolve_grasp_cache_can_disable_download_progress():
+    rel = "caches/__test_nonexistent_quiet__.npy"
+    local = ASSETS_ROOT_PATH / rel
+    assert not local.exists()
+
+    fake_download = MagicMock(return_value=str(local))
+    fake_module = MagicMock()
+    fake_module.hf_hub_download = fake_download
+
+    with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+        result = resolve_grasp_cache_files(rel, show_progress=False)
+
+    assert result == str(local)
+    fake_download.assert_called_once()
+    kwargs = fake_download.call_args.kwargs
+    assert kwargs["repo_id"] == "unilabsim/unilab-caches"
+    assert kwargs["filename"] == rel
+    assert kwargs["repo_type"] == "dataset"
+    assert kwargs["local_dir"] == str(ASSETS_ROOT_PATH)
+    progress = kwargs["tqdm_class"](range(1))
+    try:
+        assert progress.disable is True
+    finally:
+        progress.close()
+
+
 # Scene directory resolver
 # ---------------------------------------------------------------------------
 
@@ -277,6 +308,29 @@ def test_resolve_scene_dir_raises_import_error_when_hf_hub_missing(tmp_path: Pat
         with patch.dict("sys.modules", {"huggingface_hub": None}):
             with pytest.raises(ImportError, match="huggingface_hub"):
                 resolve_scene_dir("scenes/teaser")
+
+
+def test_resolve_robot_asset_dir_can_disable_snapshot_progress(tmp_path: Path):
+    fake_snapshot = MagicMock(return_value=str(tmp_path))
+    fake_module = MagicMock()
+    fake_module.snapshot_download = fake_snapshot
+
+    with patch("unilab.assets.hub.ASSETS_ROOT_PATH", tmp_path):
+        with patch.dict("sys.modules", {"huggingface_hub": fake_module}):
+            resolve_robot_asset_dir("robots/x2/meshes", marker="pelvis.STL", show_progress=False)
+
+    fake_snapshot.assert_called_once()
+    kwargs = fake_snapshot.call_args.kwargs
+    assert kwargs["repo_id"] == "unilabsim/unilab-robots"
+    assert kwargs["repo_type"] == "dataset"
+    assert kwargs["allow_patterns"] == "robots/x2/meshes/**"
+    assert kwargs["local_dir"] == str(tmp_path)
+    tqdm_class = kwargs["tqdm_class"]
+    progress = tqdm_class(range(1))
+    try:
+        assert progress.disable is True
+    finally:
+        progress.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/envs/test_sharpa.py
+++ b/tests/envs/test_sharpa.py
@@ -205,7 +205,8 @@ def test_sharpa_grasp_cache_is_materialized_once_and_reset_samples_memory(
         path_resolve_calls.append((path, scale))
         return original_resolve_grasp_cache_file(path, scale)
 
-    def resolve_hf_once(path: str) -> str:
+    def resolve_hf_once(path: str, *, show_progress: bool) -> str:
+        assert show_progress is False
         hf_resolve_calls.append(path)
         return path
 

--- a/tests/test_pull_assets.py
+++ b/tests/test_pull_assets.py
@@ -25,22 +25,23 @@ def test_pull_assets_t800_resolves_both_asset_directories(
         "robots/t800/assets": _populate(tmp_path / "assets", suffix=".obj", count=26),
         "robots/t800/textures": _populate(tmp_path / "textures", suffix=".png", count=15),
     }
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
 
-    def fake_resolver(directory: str, *, marker: str) -> Path:
-        calls.append((directory, marker))
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append((directory, marker, show_progress))
         return targets[directory]
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "t800"]) == 0
     assert calls == [
-        ("robots/t800/assets", "LINK_BASE.obj"),
-        ("robots/t800/textures", "LINK_BASE.png"),
+        ("robots/t800/assets", "LINK_BASE.obj", False),
+        ("robots/t800/textures", "LINK_BASE.png", False),
     ]
     output = capsys.readouterr().out
     assert "26 OBJ files" in output
     assert "15 PNG files" in output
+    assert len(output.strip().splitlines()) == 1
 
 
 def test_pull_assets_microduck_keeps_single_stl_directory(
@@ -49,17 +50,19 @@ def test_pull_assets_microduck_keeps_single_stl_directory(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     target = _populate(tmp_path / "assets", suffix=".stl", count=47)
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
 
-    def fake_resolver(directory: str, *, marker: str) -> Path:
-        calls.append((directory, marker))
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append((directory, marker, show_progress))
         return target
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "microduck"]) == 0
-    assert calls == [("robots/microduck/assets", "trunk_base.stl")]
-    assert "47 STL files" in capsys.readouterr().out
+    assert calls == [("robots/microduck/assets", "trunk_base.stl", False)]
+    output = capsys.readouterr().out
+    assert "47 STL files" in output
+    assert len(output.strip().splitlines()) == 1
 
 
 def test_pull_assets_x2_keeps_single_mesh_directory(
@@ -67,16 +70,16 @@ def test_pull_assets_x2_keeps_single_mesh_directory(
     tmp_path: Path,
 ):
     target = _populate(tmp_path / "meshes", suffix=".STL", count=2)
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
 
-    def fake_resolver(directory: str, *, marker: str) -> Path:
-        calls.append((directory, marker))
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append((directory, marker, show_progress))
         return target
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "x2"]) == 0
-    assert calls == [("robots/x2/meshes", "pelvis.STL")]
+    assert calls == [("robots/x2/meshes", "pelvis.STL", False)]
 
 
 def test_pull_assets_g1_resolves_assets_and_textures(
@@ -88,22 +91,23 @@ def test_pull_assets_g1_resolves_assets_and_textures(
         "robots/g1/assets": _populate(tmp_path / "assets", suffix=".STL", count=54),
         "robots/g1/textures": _populate(tmp_path / "textures", suffix=".png", count=2),
     }
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
 
-    def fake_resolver(directory: str, *, marker: str) -> Path:
-        calls.append((directory, marker))
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append((directory, marker, show_progress))
         return targets[directory]
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "g1"]) == 0
     assert calls == [
-        ("robots/g1/assets", "head_link.STL"),
-        ("robots/g1/textures", "floor.png"),
+        ("robots/g1/assets", "head_link.STL", False),
+        ("robots/g1/textures", "floor.png", False),
     ]
     output = capsys.readouterr().out
     assert "54 asset files" in output
     assert "2 PNG files" in output
+    assert len(output.strip().splitlines()) == 1
 
 
 def test_pull_assets_all_covers_every_registered_robot(
@@ -113,17 +117,55 @@ def test_pull_assets_all_covers_every_registered_robot(
     from unilab.assets.hub import ROBOT_ASSET_SPECS
 
     target = _populate(tmp_path / "dir", suffix=".stl", count=1)
-    calls: list[str] = []
+    calls: list[tuple[str, bool]] = []
 
-    def fake_resolver(directory: str, *, marker: str) -> Path:
-        calls.append(directory)
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append((directory, show_progress))
         return target
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "all"]) == 0
     assert calls == [
-        directory
+        (directory, False)
         for robot in sorted(ROBOT_ASSET_SPECS)
         for directory, _marker, _pattern, _label in ROBOT_ASSET_SPECS[robot]
     ]
+
+
+def test_pull_assets_all_prints_one_compact_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    from unilab.assets.hub import ROBOT_ASSET_SPECS
+
+    target = _populate(tmp_path / "dir", suffix=".stl", count=1)
+
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        return target
+
+    monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
+
+    assert pull_assets.main(["--robot", "all"]) == 0
+    output = capsys.readouterr().out.strip()
+    assert len(output.splitlines()) == 1
+    assert f"{len(ROBOT_ASSET_SPECS)} robots" in output
+    assert "Robot assets ready:" in output
+
+
+def test_pull_assets_verbose_keeps_hf_progress_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    target = _populate(tmp_path / "meshes", suffix=".STL", count=2)
+    calls: list[bool] = []
+
+    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
+        calls.append(show_progress)
+        return target
+
+    monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
+
+    assert pull_assets.main(["--robot", "x2", "--verbose"]) == 0
+    assert calls == [True]


### PR DESCRIPTION
Summary:\n- Compact unilab-pull-assets output to one summary line by default\n- Add optional verbose mode for detailed HF progress\n- Silence Sharpa grasp cache downloads on the cold path\n\nValidation:\n- uv run --no-sync pytest tests/test_pull_assets.py tests/assets/test_hub.py tests/envs/test_sharpa.py -q\n- uv run --no-sync ruff check src/unilab/assets/hub.py src/unilab/assets/pull.py src/unilab/tasks/manipulation/sharpa_inhand/rotation.py tests/assets/test_hub.py tests/envs/test_sharpa.py tests/test_pull_assets.py\n- uv run --no-sync mypy src/unilab/assets src/unilab/tasks/manipulation/sharpa_inhand/rotation.py\n- uv run --no-sync pyright src/unilab/assets/hub.py src/unilab/assets/pull.py src/unilab/tasks/manipulation/sharpa_inhand/rotation.py\n- make test-all\n