### PR TITLE
fix(assets): compact pull-assets output with per-robot progress and total summary

### DIFF
--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -84,13 +84,14 @@ def resolve_motion_files(
 def resolve_grasp_cache_files(
     cache_file: str | Sequence[str],
     *,
-    show_progress: bool = True,
+    show_progress: bool = False,
 ) -> str | list[str]:
     """Ensure grasp cache file(s) exist locally, downloading from HF if needed.
 
     Args:
         cache_file: Absolute path or ``ASSETS_ROOT_PATH``-relative path
             (single string or sequence of strings).
+        show_progress: Whether Hugging Face downloads may render progress bars.
 
     Returns:
         Resolved absolute path(s) guaranteed to exist on disk.

--- a/src/unilab/assets/pull.py
+++ b/src/unilab/assets/pull.py
@@ -67,18 +67,6 @@ def _format_single_robot_summary(robot: str, summaries: Sequence[_AssetSummary])
     return f"{robot} assets ready: {'; '.join(parts)}"
 
 
-def _format_all_summary(robots: Sequence[str], summaries: Sequence[_AssetSummary]) -> str:
-    total_files = sum(summary.count for summary in summaries)
-    label_counts: dict[str, int] = {}
-    for summary in summaries:
-        label_counts[summary.label] = label_counts.get(summary.label, 0) + summary.count
-    counts = ", ".join(f"{count} {label}" for label, count in sorted(label_counts.items()))
-    return (
-        f"Robot assets ready: {len(robots)} robots, {len(summaries)} directories, "
-        f"{total_files} files ({counts})"
-    )
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     logging.basicConfig(
@@ -86,14 +74,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
 
     robots = _sorted_robots() if args.robot == _ALL else [args.robot]
-    summaries: list[_AssetSummary] = []
     for robot in robots:
-        summaries.extend(_pull_robot(robot, show_progress=args.verbose))
-
-    if args.robot == _ALL:
-        print(_format_all_summary(robots, summaries))
-    else:
-        print(_format_single_robot_summary(args.robot, summaries))
+        summaries = _pull_robot(robot, show_progress=args.verbose)
+        print(_format_single_robot_summary(robot, summaries), flush=True)
     return 0
 
 

--- a/src/unilab/assets/pull.py
+++ b/src/unilab/assets/pull.py
@@ -67,9 +67,7 @@ def _format_total_summary(robots: Sequence[str], summaries: Sequence[_AssetSumma
     label_counts: dict[str, int] = {}
     for summary in summaries:
         label_counts[summary.label] = label_counts.get(summary.label, 0) + summary.count
-    counts = ", ".join(
-        f"{count} {label} files" for label, count in sorted(label_counts.items())
-    )
+    counts = ", ".join(f"{count} {label} files" for label, count in sorted(label_counts.items()))
     return (
         f"Robot assets ready: {len(robots)} robots, {len(summaries)} directories, "
         f"{total_files} files ({counts})"
@@ -78,7 +76,6 @@ def _format_total_summary(robots: Sequence[str], summaries: Sequence[_AssetSumma
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
-    del args.verbose
     logging.basicConfig(level=logging.WARNING, format="%(message)s")
     logging.getLogger("huggingface_hub").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/src/unilab/assets/pull.py
+++ b/src/unilab/assets/pull.py
@@ -44,7 +44,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help="Show per-directory download logs and Hugging Face progress bars.",
+        help="Retained for compatibility; Hugging Face output remains suppressed.",
     )
     return parser.parse_args(argv)
 
@@ -53,30 +53,44 @@ def _sorted_robots() -> list[str]:
     return sorted(ROBOT_ASSET_SPECS)
 
 
-def _pull_robot(robot: str, *, show_progress: bool) -> list[_AssetSummary]:
+def _pull_robot(robot: str) -> list[_AssetSummary]:
     summaries: list[_AssetSummary] = []
     for directory, marker, pattern, label in ROBOT_ASSET_SPECS[robot]:
-        target = resolve_robot_asset_dir(directory, marker=marker, show_progress=show_progress)
+        target = resolve_robot_asset_dir(directory, marker=marker, show_progress=False)
         count = sum(1 for path in target.rglob(pattern) if path.is_file())
         summaries.append(_AssetSummary(target=target, count=count, label=label))
     return summaries
 
 
-def _format_single_robot_summary(robot: str, summaries: Sequence[_AssetSummary]) -> str:
-    parts = [f"{summary.count} {summary.label} files at {summary.target}" for summary in summaries]
-    return f"{robot} assets ready: {'; '.join(parts)}"
+def _format_total_summary(robots: Sequence[str], summaries: Sequence[_AssetSummary]) -> str:
+    total_files = sum(summary.count for summary in summaries)
+    label_counts: dict[str, int] = {}
+    for summary in summaries:
+        label_counts[summary.label] = label_counts.get(summary.label, 0) + summary.count
+    counts = ", ".join(
+        f"{count} {label} files" for label, count in sorted(label_counts.items())
+    )
+    return (
+        f"Robot assets ready: {len(robots)} robots, {len(summaries)} directories, "
+        f"{total_files} files ({counts})"
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
-    logging.basicConfig(
-        level=logging.INFO if args.verbose else logging.WARNING, format="%(message)s"
-    )
+    del args.verbose
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    logging.getLogger("huggingface_hub").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     robots = _sorted_robots() if args.robot == _ALL else [args.robot]
+    summaries: list[_AssetSummary] = []
     for robot in robots:
-        summaries = _pull_robot(robot, show_progress=args.verbose)
-        print(_format_single_robot_summary(robot, summaries), flush=True)
+        print(f"Downloading {robot} assets ...", flush=True)
+        robot_summaries = _pull_robot(robot)
+        summaries.extend(robot_summaries)
+    print(_format_total_summary(robots, summaries), flush=True)
     return 0
 
 

--- a/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
+++ b/src/unilab/tasks/manipulation/sharpa_inhand/rotation.py
@@ -92,10 +92,7 @@ def _materialize_grasp_caches(
     missing_files: list[str] = []
     for scale_value in np.asarray(scale_values, dtype=np.float64):
         cache_file = resolve_grasp_cache_file(grasp_cache_path, float(scale_value))
-        resolved = cast(
-            str,
-            resolve_grasp_cache_files(str(cache_file), show_progress=False),
-        )
+        resolved = cast(str, resolve_grasp_cache_files(str(cache_file)))
         cache_file = Path(resolved)
         if not cache_file.exists():
             missing_files.append(str(cache_file))

--- a/tests/assets/test_hub.py
+++ b/tests/assets/test_hub.py
@@ -192,12 +192,13 @@ def test_resolve_grasp_cache_calls_hf_download_with_caches_repo():
         result = resolve_grasp_cache_files(str(missing))
 
     assert result == str(missing)
-    fake_download.assert_called_once_with(
-        repo_id="unilabsim/unilab-caches",
-        filename=expected_relative,
-        repo_type="dataset",
-        local_dir=str(ASSETS_ROOT_PATH),
-    )
+    fake_download.assert_called_once()
+    kwargs = fake_download.call_args.kwargs
+    assert kwargs["repo_id"] == "unilabsim/unilab-caches"
+    assert kwargs["filename"] == expected_relative
+    assert kwargs["repo_type"] == "dataset"
+    assert kwargs["local_dir"] == str(ASSETS_ROOT_PATH)
+    assert kwargs["tqdm_class"] is not None
 
 
 def test_resolve_grasp_cache_relative_path_uses_caches_repo():
@@ -214,12 +215,13 @@ def test_resolve_grasp_cache_relative_path_uses_caches_repo():
         result = resolve_grasp_cache_files(rel)
 
     assert result == str(local)
-    fake_download.assert_called_once_with(
-        repo_id="unilabsim/unilab-caches",
-        filename=rel,
-        repo_type="dataset",
-        local_dir=str(ASSETS_ROOT_PATH),
-    )
+    fake_download.assert_called_once()
+    kwargs = fake_download.call_args.kwargs
+    assert kwargs["repo_id"] == "unilabsim/unilab-caches"
+    assert kwargs["filename"] == rel
+    assert kwargs["repo_type"] == "dataset"
+    assert kwargs["local_dir"] == str(ASSETS_ROOT_PATH)
+    assert kwargs["tqdm_class"] is not None
 
 
 def test_resolve_grasp_cache_can_disable_download_progress():

--- a/tests/envs/test_sharpa.py
+++ b/tests/envs/test_sharpa.py
@@ -205,8 +205,7 @@ def test_sharpa_grasp_cache_is_materialized_once_and_reset_samples_memory(
         path_resolve_calls.append((path, scale))
         return original_resolve_grasp_cache_file(path, scale)
 
-    def resolve_hf_once(path: str, *, show_progress: bool) -> str:
-        assert show_progress is False
+    def resolve_hf_once(path: str) -> str:
         hf_resolve_calls.append(path)
         return path
 

--- a/tests/test_pull_assets.py
+++ b/tests/test_pull_assets.py
@@ -148,9 +148,7 @@ def test_pull_assets_all_covers_every_registered_robot(
     assert output_lines[:-1] == [
         f"Downloading {robot} assets ..." for robot in sorted(ROBOT_ASSET_SPECS)
     ]
-    assert output_lines[-1].startswith(
-        f"Robot assets ready: {len(ROBOT_ASSET_SPECS)} robots"
-    )
+    assert output_lines[-1].startswith(f"Robot assets ready: {len(ROBOT_ASSET_SPECS)} robots")
 
 
 def test_pull_assets_verbose_keeps_output_compact(

--- a/tests/test_pull_assets.py
+++ b/tests/test_pull_assets.py
@@ -10,7 +10,7 @@ from unilab.assets import pull as pull_assets
 
 
 def _populate(directory: Path, *, suffix: str, count: int) -> Path:
-    directory.mkdir(parents=True)
+    directory.mkdir(parents=True, exist_ok=True)
     for index in range(count):
         (directory / f"asset_{index}{suffix}").write_bytes(b"asset")
     return directory
@@ -113,6 +113,7 @@ def test_pull_assets_g1_resolves_assets_and_textures(
 def test_pull_assets_all_covers_every_registered_robot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ):
     from unilab.assets.hub import ROBOT_ASSET_SPECS
 
@@ -131,27 +132,29 @@ def test_pull_assets_all_covers_every_registered_robot(
         for robot in sorted(ROBOT_ASSET_SPECS)
         for directory, _marker, _pattern, _label in ROBOT_ASSET_SPECS[robot]
     ]
+    output_lines = capsys.readouterr().out.strip().splitlines()
+    assert len(output_lines) == len(ROBOT_ASSET_SPECS)
+    assert all(" assets ready:" in line for line in output_lines)
 
 
-def test_pull_assets_all_prints_one_compact_summary(
+def test_pull_assets_all_prints_one_line_per_robot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ):
     from unilab.assets.hub import ROBOT_ASSET_SPECS
 
-    target = _populate(tmp_path / "dir", suffix=".stl", count=1)
-
     def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
-        return target
+        return _populate(tmp_path / Path(directory).name, suffix=".stl", count=1)
 
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "all"]) == 0
     output = capsys.readouterr().out.strip()
-    assert len(output.splitlines()) == 1
-    assert f"{len(ROBOT_ASSET_SPECS)} robots" in output
-    assert "Robot assets ready:" in output
+    lines = output.splitlines()
+    assert len(lines) == len(ROBOT_ASSET_SPECS)
+    for robot in sorted(ROBOT_ASSET_SPECS):
+        assert any(line.startswith(f"{robot} assets ready:") for line in lines)
 
 
 def test_pull_assets_verbose_keeps_hf_progress_enabled(

--- a/tests/test_pull_assets.py
+++ b/tests/test_pull_assets.py
@@ -41,7 +41,10 @@ def test_pull_assets_t800_resolves_both_asset_directories(
     output = capsys.readouterr().out
     assert "26 OBJ files" in output
     assert "15 PNG files" in output
-    assert len(output.strip().splitlines()) == 1
+    lines = output.strip().splitlines()
+    assert len(lines) == 2
+    assert lines[0] == "Downloading t800 assets ..."
+    assert lines[-1].startswith("Robot assets ready: 1 robots, 2 directories, 41 files")
 
 
 def test_pull_assets_microduck_keeps_single_stl_directory(
@@ -62,12 +65,15 @@ def test_pull_assets_microduck_keeps_single_stl_directory(
     assert calls == [("robots/microduck/assets", "trunk_base.stl", False)]
     output = capsys.readouterr().out
     assert "47 STL files" in output
-    assert len(output.strip().splitlines()) == 1
+    lines = output.strip().splitlines()
+    assert lines[0] == "Downloading microduck assets ..."
+    assert lines[-1].startswith("Robot assets ready: 1 robots, 1 directories, 47 files")
 
 
 def test_pull_assets_x2_keeps_single_mesh_directory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ):
     target = _populate(tmp_path / "meshes", suffix=".STL", count=2)
     calls: list[tuple[str, str, bool]] = []
@@ -80,6 +86,9 @@ def test_pull_assets_x2_keeps_single_mesh_directory(
 
     assert pull_assets.main(["--robot", "x2"]) == 0
     assert calls == [("robots/x2/meshes", "pelvis.STL", False)]
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0] == "Downloading x2 assets ..."
+    assert lines[-1].startswith("Robot assets ready: 1 robots, 1 directories, 2 files")
 
 
 def test_pull_assets_g1_resolves_assets_and_textures(
@@ -107,7 +116,9 @@ def test_pull_assets_g1_resolves_assets_and_textures(
     output = capsys.readouterr().out
     assert "54 asset files" in output
     assert "2 PNG files" in output
-    assert len(output.strip().splitlines()) == 1
+    lines = output.strip().splitlines()
+    assert lines[0] == "Downloading g1 assets ..."
+    assert lines[-1].startswith("Robot assets ready: 1 robots, 2 directories, 56 files")
 
 
 def test_pull_assets_all_covers_every_registered_robot(
@@ -133,33 +144,19 @@ def test_pull_assets_all_covers_every_registered_robot(
         for directory, _marker, _pattern, _label in ROBOT_ASSET_SPECS[robot]
     ]
     output_lines = capsys.readouterr().out.strip().splitlines()
-    assert len(output_lines) == len(ROBOT_ASSET_SPECS)
-    assert all(" assets ready:" in line for line in output_lines)
+    assert len(output_lines) == len(ROBOT_ASSET_SPECS) + 1
+    assert output_lines[:-1] == [
+        f"Downloading {robot} assets ..." for robot in sorted(ROBOT_ASSET_SPECS)
+    ]
+    assert output_lines[-1].startswith(
+        f"Robot assets ready: {len(ROBOT_ASSET_SPECS)} robots"
+    )
 
 
-def test_pull_assets_all_prints_one_line_per_robot(
+def test_pull_assets_verbose_keeps_output_compact(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-):
-    from unilab.assets.hub import ROBOT_ASSET_SPECS
-
-    def fake_resolver(directory: str, *, marker: str, show_progress: bool) -> Path:
-        return _populate(tmp_path / Path(directory).name, suffix=".stl", count=1)
-
-    monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
-
-    assert pull_assets.main(["--robot", "all"]) == 0
-    output = capsys.readouterr().out.strip()
-    lines = output.splitlines()
-    assert len(lines) == len(ROBOT_ASSET_SPECS)
-    for robot in sorted(ROBOT_ASSET_SPECS):
-        assert any(line.startswith(f"{robot} assets ready:") for line in lines)
-
-
-def test_pull_assets_verbose_keeps_hf_progress_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ):
     target = _populate(tmp_path / "meshes", suffix=".STL", count=2)
     calls: list[bool] = []
@@ -171,4 +168,5 @@ def test_pull_assets_verbose_keeps_hf_progress_enabled(
     monkeypatch.setattr(pull_assets, "resolve_robot_asset_dir", fake_resolver)
 
     assert pull_assets.main(["--robot", "x2", "--verbose"]) == 0
-    assert calls == [True]
+    assert calls == [False]
+    assert len(capsys.readouterr().out.strip().splitlines()) == 2


### PR DESCRIPTION
## 问题

`unilab-pull-assets` 及资产下载路径输出过于吵闹：Hugging Face 进度条与 `huggingface_hub` / `httpx` / `httpcore` 日志刷屏，grasp cache 下载默认也渲染进度条。

## 修改

- `src/unilab/assets/pull.py`：每个机器人下载前打印一行 `Downloading <robot> assets ...` 保留进度感知；下载完成后不再逐机器人打印明细，汇总为一行总摘要（`Robot assets ready: N robots, M directories, K files (...)`）。`--verbose` 保留兼容但不再放开 HF 输出（HF 进度条始终关闭，相关 logger 压到 WARNING）。
- `src/unilab/assets/hub.py`：`resolve_grasp_cache_files` 的 `show_progress` 默认值 `True` → `False`。
- `src/unilab/tasks/manipulation/sharpa_inhand/rotation.py`：删除冗余的显式 `show_progress=False`。
- 测试同步更新：`tests/test_pull_assets.py`、`tests/assets/test_hub.py`、`tests/envs/test_sharpa.py`。

## Validation

- 最终 head `b27e59eb` 本地 `make test-all` 通过（exit 0；benchmark smoke 35/36 module-mode、36/37 script-mode，唯一 skip 为 platform-optional `mlx`）。
- 第一轮 gate 发现 pyright 报错（`del args.verbose` 删除 Namespace 属性）与 ruff format 差异，已在 `b27e59eb` 修复后重跑通过。