### PR TITLE
feat(microduck): velocity reward 栈对齐上游 microduck_rl HEAD

### DIFF
--- a/src/unilab/assets/robots/microduck/locomotion_task.xml
+++ b/src/unilab/assets/robots/microduck/locomotion_task.xml
@@ -2,6 +2,13 @@
   <sensor>
     <contact name="left_foot_contact" geom1="floor" geom2="left_foot_collision" data="force" num="1" reduce="mindist"/>
     <contact name="right_foot_contact" geom1="floor" geom2="right_foot_collision" data="force" num="1" reduce="mindist"/>
+    <!-- Upstream self_collision sensor (trunk_base subtree vs itself).  The
+         self_collision_only geoms are the only robot geoms that can collide
+         with each other (contype/conaffinity bit 2), so one found-sensor per
+         geom pair reproduces the upstream contact count. -->
+    <contact name="self_collision_trunk_left_leg" geom1="trunk_base_self_collision" geom2="left_leg_self_collision" data="found" num="1" reduce="none"/>
+    <contact name="self_collision_trunk_right_leg" geom1="trunk_base_self_collision" geom2="right_leg_self_collision" data="found" num="1" reduce="none"/>
+    <contact name="self_collision_legs" geom1="left_leg_self_collision" geom2="right_leg_self_collision" data="found" num="1" reduce="none"/>
   </sensor>
 
   <keyframe>

--- a/src/unilab/assets/robots/microduck/microduck.xml
+++ b/src/unilab/assets/robots/microduck/microduck.xml
@@ -96,7 +96,7 @@
       <geom type="mesh" class="visual" pos="0.006 0.0175 0.0115" quat="0 0.707107 -0 0.707107" mesh="xl330" material="xl330_material"/>
       <!-- Part power_support -->
       <geom type="mesh" class="visual" pos="0.004 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="power_support" material="power_support_material"/>
-      <geom type="mesh" class="self_collision_only" pos="0.004 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="power_support" material="power_support_material"/>
+      <geom type="mesh" class="self_collision_only" name="trunk_base_self_collision" pos="0.004 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="power_support" material="power_support_material"/>
       <!-- Part np_f970 -->
       <geom type="mesh" class="visual" pos="-0.0359693 0 -0.00385049" quat="0.00617059 0.70708 -0.70708 -0.00617059" mesh="np_f970" material="np_f970_material"/>
       <!-- Part xl330_2 -->
@@ -151,7 +151,7 @@
               <inertial pos="-1.52e-10 0.0318937 -0.00953505" mass="0.0215844" fullinertia="5.25056e-06 2.15507e-06 4.33925e-06 -1e-12 0 7.65005e-07"/>
               <!-- Part leg -->
               <geom type="mesh" class="visual" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
-              <geom type="mesh" class="self_collision_only" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" name="left_leg_self_collision" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
               <!-- Part xl330_6 -->
               <geom type="mesh" class="visual" pos="0 0.042 -0.0115" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
               <!-- Link ankle_left -->
@@ -306,7 +306,7 @@
               <geom type="mesh" class="visual" pos="-0.042 0 -0.0115" quat="0.707107 -0 -0.707107 -0" mesh="xl330" material="xl330_material"/>
               <!-- Part leg_2 -->
               <geom type="mesh" class="visual" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
-              <geom type="mesh" class="self_collision_only" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" name="right_leg_self_collision" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
               <!-- Link ankle_right -->
               <body name="ankle_right" pos="-0.042 0 -0.026" quat="0 -0.707107 -0.707107 0">
                 <!-- Joint from leg_2 to ankle_right -->

--- a/src/unilab/conf/ppo/task/microduck_velocity_flat/base.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_flat/base.yaml
@@ -1,11 +1,14 @@
 # @package _global_
 # Canonical Pollen Robotics MicroDuck Manager-Based velocity task.
 #
-# Recipe aligned with legacy microduck_rl velocity2 (issue #1402): command
-# ranges/resampling, gait rewards, termination limits, observation delays, DR
-# events, and the five step-staged curricula all mirror the legacy values
-# (stage step = legacy iteration x 24 = env control steps, matching UniLab's
-# num_steps_per_env=24).
+# Reward/MDP stack aligned with upstream microduck_rl HEAD (issue #1455, anchor
+# commit 29e887ec, mjlab 1.3.0): the velocity recipe's reward terms, weights
+# and parameters mirror `microduck_velocity_env_cfg.py` at the anchor; terms
+# without an upstream counterpart (orientation, base_height, alive,
+# flight_phase, lin_vel_z) are removed.  Command ranges/resampling, gait
+# reward windows, observation delays, DR events, and the step-staged curricula
+# mirror the same anchor (stage step = upstream iteration x 24 env control
+# steps, matching UniLab's num_steps_per_env=24).
 env:
   scene:
     model_file: src/unilab/assets/robots/microduck/scene_flat.xml
@@ -392,17 +395,30 @@ env:
 
 reward:
   tracking_lin_vel:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.track_lin_vel
-    weight: 3.0
-    params: {sensor_name: local_linvel, tracking_sigma: 0.25, command_name: twist}
+    # Upstream track_linear_velocity: exp(-(‖cmd_xy−v_xy‖² + v_z²)/std²),
+    # std=√0.1, body-frame root velocity (vz penalty folded into the kernel).
+    func: unilab.envs.mdp.track_linear_velocity
+    weight: 2.0
+    params: {std: 0.31622776601683794, command_name: twist}
   tracking_ang_vel:
-    # Legacy merged form: exp(-((cmd-wz)^2 + wx^2 + wy^2) / 0.5), std=sqrt(0.5).
+    # Upstream track_angular_velocity merged form:
+    # exp(-((cmd-wz)^2 + wx^2 + wy^2) / std^2), std=√0.5.
     func: unilab.envs.mdp.track_angular_velocity
     weight: 2.0
     params: {std: 0.7071067811865476, command_name: twist}
+  upright:
+    # Upstream upright: exp(-pg_xy²/std²), std=√0.05, body=trunk_base.
+    func: unilab.envs.mdp.upright
+    weight: 2.0
+    params:
+      std: 0.22360679774997896
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [trunk_base]
   head_pose_tracking:
     func: unilab.tasks.locomotion.microduck.manager_terms.head_pose_tracking
-    weight: 0.5
+    weight: 2.0
     params:
       command_name: head_pose
       std: 0.5
@@ -422,19 +438,55 @@ reward:
         name: robot
         joint_names: [neck_pitch, head_pitch, head_yaw, head_roll]
         preserve_order: true
+  body_pose_tracking:
+    # Upstream keep-alive term: weight 0.0 keeps the body_pose command/obs
+    # channels alive for tasks that raise the weight (standup family).
+    func: unilab.tasks.locomotion.microduck.manager_terms.body_pose_tracking
+    weight: 0.0
+    params:
+      command_name: body_pose
+      nominal_height: 0.095
+      xy_std: 0.05
+      z_std: 0.02
+      angle_std: 0.2617993877991494
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
   leg_pose:
-    func: unilab.tasks.locomotion.microduck.manager_terms.leg_pose
+    # Upstream pose (variable_posture): leg joints only (head/neck are
+    # command-driven), speed-dependent per-joint std — still scored while
+    # walking, with the looser walking std set (running set identical).
+    func: unilab.envs.mdp.variable_posture
     weight: 1.0
     params:
       command_name: twist
-      std_standing: 0.1
+      walking_threshold: 0.01
+      running_threshold: 1.5
+      std_standing:
+        ".*hip_yaw.*": 0.1
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.15
+        ".*knee.*": 0.15
+        ".*ankle.*": 0.1
+      std_walking:
+        ".*hip_yaw.*": 0.3
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.4
+        ".*knee.*": 0.4
+        ".*ankle.*": 0.25
+      std_running:
+        ".*hip_yaw.*": 0.3
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.4
+        ".*knee.*": 0.4
+        ".*ankle.*": 0.25
       asset_cfg:
         _target_: unilab.managers.SceneEntityCfg
         name: robot
         joint_names: [left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle, right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle]
         preserve_order: true
   air_time:
-    # Legacy window form: feet with current air time in (0.125, 0.300) s score.
+    # Upstream window form: feet with current air time in (0.125, 0.300) s score.
     func: unilab.tasks.locomotion.common.gait_terms.feet_air_time
     weight: 3.0
     params:
@@ -480,25 +532,22 @@ reward:
         name: robot
         body_names: [ankle_left, ankle_right]
         preserve_order: true
-  flight_phase:
-    func: unilab.tasks.locomotion.microduck.manager_terms.flight_phase
-    weight: -2.0
-  lin_vel_z:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.lin_vel_z
-    weight: -1.0
-    params: {sensor_name: local_linvel}
-  ang_vel_xy:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.ang_vel_xy
+  body_ang_vel:
+    # Upstream body_ang_vel: trunk_base world-frame ω_xy penalty (yaw free).
+    func: unilab.envs.mdp.body_angular_velocity_penalty
     weight: -0.05
-    params: {sensor_name: gyro}
-  orientation:
-    func: unilab.tasks.locomotion.common.sensor_reward_terms.orientation
-    weight: -3.0
-    params: {sensor_name: upvector}
-  base_height:
-    func: unilab.tasks.locomotion.common.manager_terms.base_height_l2
-    weight: -50.0
-    params: {target_height: 0.12}
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [trunk_base]
+  self_collisions:
+    # Upstream self_collision_cost: count of active self-collision geom pairs
+    # (locomotion_task.xml self_collision_* found sensors).
+    func: unilab.tasks.locomotion.common.gait_terms.self_collision_cost
+    weight: -1.0
+    params:
+      sensor_groups: [[self_collision_trunk_left_leg], [self_collision_trunk_right_leg], [self_collision_legs]]
   dof_pos_limits:
     func: unilab.envs.mdp.joint_pos_limits
     weight: -1.0
@@ -509,6 +558,3 @@ reward:
   action_rate:
     func: unilab.envs.mdp.action_rate_l2
     weight: -0.1
-  alive:
-    func: unilab.tasks.locomotion.common.manager_terms.alive
-    weight: 0.1

--- a/src/unilab/envs/mdp/__init__.py
+++ b/src/unilab/envs/mdp/__init__.py
@@ -68,6 +68,7 @@ from unilab.envs.mdp.rewards import posture as posture
 from unilab.envs.mdp.rewards import root_height as root_height
 from unilab.envs.mdp.rewards import track_angular_velocity as track_angular_velocity
 from unilab.envs.mdp.rewards import track_linear_velocity as track_linear_velocity
+from unilab.envs.mdp.rewards import upright as upright
 from unilab.envs.mdp.rewards import variable_posture as variable_posture
 from unilab.envs.mdp.terminations import bad_orientation as bad_orientation
 from unilab.envs.mdp.terminations import nan_detection as nan_detection
@@ -135,5 +136,6 @@ __all__ = [
     "time_out",
     "track_angular_velocity",
     "track_linear_velocity",
+    "upright",
     "variable_posture",
 ]

--- a/src/unilab/envs/mdp/rewards.py
+++ b/src/unilab/envs/mdp/rewards.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from unilab.managers.manager_base import ManagerTermBase, ManagerTermBaseCfg
 from unilab.managers.scene_entity_config import SceneEntityCfg
+from unilab.utils.rotation import np_quat_apply_inverse
 
 if TYPE_CHECKING:
     from unilab.base.entity import Entity
@@ -138,6 +139,30 @@ def flat_orientation_l2(
     """Penalize non-flat base orientation."""
     asset = cast("Entity", env.scene[asset_cfg.name])
     return np.sum(np.square(asset.data.projected_gravity_b[:, :2]), axis=1)
+
+
+def upright(
+    env: ManagerBasedRlEnv,
+    std: float,
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Gaussian reward for keeping one selected body upright (mjlab ``upright``).
+
+    The reward is ``exp(-||pg_xy||^2 / std^2)`` where ``pg`` is the world
+    gravity vector expressed in the selected body's link frame.  Flat-ground
+    form only: mjlab's optional terrain-normal sensors are not ported.
+    """
+    scale = _positive_std("upright", std)
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    body_quat_w = asset.data.body_link_quat_w[:, asset_cfg.body_ids, :]
+    if body_quat_w.shape != (env.num_envs, 1, 4):
+        raise ValueError(
+            f"upright requires exactly one body; received state shape {body_quat_w.shape}"
+        )
+    gravity = np.asarray(asset.data.gravity_vec_w)
+    projected_gravity_b = np_quat_apply_inverse(body_quat_w[:, 0, :], gravity)
+    xy_squared = np.sum(np.square(projected_gravity_b[:, :2]), axis=1)
+    return np.exp(-xy_squared / scale**2)
 
 
 def track_linear_velocity(
@@ -331,5 +356,6 @@ __all__ = [
     "root_height",
     "track_angular_velocity",
     "track_linear_velocity",
+    "upright",
     "variable_posture",
 ]

--- a/src/unilab/tasks/locomotion/common/gait_terms.py
+++ b/src/unilab/tasks/locomotion/common/gait_terms.py
@@ -346,6 +346,21 @@ def feet_clearance(
     return np.asarray(cost, dtype=get_global_dtype())
 
 
+class self_collision_cost(_FootContactTerm):
+    """Count monitored self-collision geom pairs reporting contact.
+
+    Mirrors mjlab ``self_collision_cost`` in its found-count form: each sensor
+    group binds one contact sensor watching a geom pair, and the cost is the
+    number of pairs with an active contact.  mjlab's ``force_threshold`` only
+    applies when the sensor records force history, which the upstream config
+    does not enable, so it is not ported.
+    """
+
+    def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
+        del params
+        return np.asarray(np.sum(self._contact(env), axis=1), dtype=get_global_dtype())
+
+
 class angular_momentum_penalty(SensorTermBase):
     """Penalize whole-body angular momentum read from a named vec3 sensor."""
 
@@ -476,4 +491,5 @@ __all__ = [
     "foot_contact",
     "foot_contact_forces",
     "foot_height",
+    "self_collision_cost",
 ]

--- a/src/unilab/tasks/locomotion/microduck/alignment_contract.py
+++ b/src/unilab/tasks/locomotion/microduck/alignment_contract.py
@@ -403,17 +403,17 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.tracking_lin_vel.weight"),
         2.0,
-        "gap",
-        "当前 3.0；上游 track_linear_velocity 权重 2.0。",
+        "match",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
         "mdp.reward.track_linear_velocity.std",
         "mdp",
-        _hydra("reward.tracking_lin_vel.params.tracking_sigma"),
+        _hydra("reward.tracking_lin_vel.params.std"),
         math.sqrt(0.1),
-        "gap",
-        "当前 tracking_sigma=0.25 且只跟踪 xy；上游 std=√0.1，指数内含 vz²，body frame。",
+        "match",
+        "unilab.envs.mdp.track_linear_velocity：exp(-(‖cmd_xy−v_xy‖²+v_z²)/std²)，"
+        "body frame，vz² 并入指数（上游不再单列 lin_vel_z term）。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -437,8 +437,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.upright.weight"),
         2.0,
-        "gap",
-        "缺失；上游 upright 2.0（std=√0.05，trunk_base）。",
+        "match",
+        "unilab.envs.mdp.upright：exp(-‖pg_xy‖²/std²)，std=√0.05，body=trunk_base。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -446,9 +446,10 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.leg_pose.params.std_walking"),
         PRESENT,
-        "gap",
-        "上游 pose（variable_posture）站立/行走两套 std 并在行走时继续评分；"
-        "UniLab leg_pose 仅 std_standing，行走时置零。",
+        "match",
+        "上游 pose（variable_posture）：仅腿关节，站立/行走两套 std，行走时按 "
+        "std_walking 继续评分（std_running 与 std_walking 相同）；UniLab 以 "
+        "unilab.envs.mdp.variable_posture 实现，walking_threshold=0.01。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -465,8 +466,10 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.body_ang_vel.weight"),
         -0.05,
-        "gap",
-        "缺失；上游惩罚 trunk_base 全三轴角速度。UniLab ang_vel_xy(-0.05) 只覆盖 xy。",
+        "match",
+        "上游 body_angular_velocity_penalty 只罚 trunk_base 的 world-frame ω_xy"
+        "（yaw 自由，mjlab 注释明确不罚 z 轴）；UniLab 同名 term 同源实现，"
+        "取代旧的 gyro 传感器 ang_vel_xy(-0.05)。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -555,8 +558,10 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.self_collisions.weight"),
         -1.0,
-        "gap",
-        "缺失；上游 self_collision_cost（10 N 接触力阈值）。",
+        "match",
+        "上游 self_collision_cost 在 found-only 传感器下是碰撞 geom 对计数"
+        "（force_threshold=10 N 仅在 force history 启用时生效，上游未启用）；"
+        "UniLab 由 locomotion_task.xml 三个 self_collision_* found 传感器驱动。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -564,8 +569,7 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.head_pose_tracking.weight"),
         2.0,
-        "gap",
-        "当前 0.5；上游 2.0。",
+        "match",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -581,8 +585,9 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.body_pose_tracking.weight"),
         0.0,
-        "gap",
-        "缺失；上游挂起态（weight 0.0，保持 command/obs 通道活性）。",
+        "match",
+        "挂起态（weight 0.0，保持 command/obs 通道活性）；6D 高斯均值："
+        "nominal_height 0.095、xy_std 0.05、z_std 0.02、angle_std 15°。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -599,8 +604,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.orientation.weight"),
         ABSENT,
-        "gap",
-        "上游无此 term（当前 -3.0）；对齐时需移除。",
+        "match",
+        "上游无此 term（旧栈 -3.0 已移除；直立性由 upright 承载）。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -608,8 +613,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.base_height.weight"),
         ABSENT,
-        "gap",
-        "上游无此 term（当前 -50.0）；对齐时需移除。",
+        "match",
+        "上游无此 term（旧栈 -50.0 已移除）。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -617,8 +622,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.alive.weight"),
         ABSENT,
-        "gap",
-        "上游无此 term（当前 +0.1）；对齐时需移除。",
+        "match",
+        "上游无此 term（旧栈 +0.1 已移除）。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -626,8 +631,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.flight_phase.weight"),
         ABSENT,
-        "gap",
-        "上游无此 term（当前 -2.0）；对齐时需移除。",
+        "match",
+        "上游无此 term（旧栈 -2.0 已移除）。",
         tasks=VELOCITY_TASK,
     ),
     AlignmentEntry(
@@ -635,7 +640,7 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "mdp",
         _hydra("reward.lin_vel_z.weight"),
         ABSENT,
-        "gap",
+        "match",
         "上游无独立 lin_vel_z term（vz² 已并入 track_linear_velocity 指数）。",
         tasks=VELOCITY_TASK,
     ),

--- a/src/unilab/tasks/locomotion/microduck/manager_terms.py
+++ b/src/unilab/tasks/locomotion/microduck/manager_terms.py
@@ -24,6 +24,7 @@ from unilab.managers import (
     SceneEntityCfg,
 )
 from unilab.tasks.locomotion.common.manager_terms import SensorTermBase
+from unilab.utils.rotation import np_wrap_to_pi
 
 if TYPE_CHECKING:
     from unilab.base.entity import Entity
@@ -542,6 +543,67 @@ def phase_height_tracking(
     return np.asarray(np.exp(-np.square((actual - target) / std)), dtype=get_global_dtype())
 
 
+def body_pose_tracking(
+    env: ManagerBasedRlEnv,
+    command_name: str = "body_pose",
+    nominal_height: float = 0.095,
+    xy_std: float = 0.05,
+    z_std: float = 0.02,
+    angle_std: float = math.radians(15),
+    asset_cfg: SceneEntityCfg = _DEFAULT_ASSET_CFG,
+) -> np.ndarray:
+    """Mean of six per-axis Gaussians tracking the commanded 6D body pose delta.
+
+    Mirrors upstream ``body_pose_tracking_6d``: the command is
+    ``[x, y, z, roll, pitch, yaw]`` as deltas from the nominal standing pose
+    (xy from the env origin, z from ``nominal_height``, angles from upright).
+    The velocity task keeps this term at weight zero so the body_pose command
+    and observation channels stay alive for tasks that raise the weight.
+    """
+    _finite_real(nominal_height, label="body_pose_tracking nominal_height")
+    for label, value in (("xy_std", xy_std), ("z_std", z_std), ("angle_std", angle_std)):
+        _finite_real(
+            value,
+            label=f"body_pose_tracking {label}",
+            minimum=0.0,
+            strict_minimum=True,
+        )
+    if not isinstance(asset_cfg, SceneEntityCfg):
+        raise TypeError("body_pose_tracking asset_cfg must be SceneEntityCfg")
+    command = _command(env, "body_pose_tracking", command_name)
+    if command.shape[1] != 6:
+        raise ValueError(
+            f"body_pose_tracking command '{command_name}' must have width 6, "
+            f"received shape {command.shape}"
+        )
+    asset = cast("Entity", env.scene[asset_cfg.name])
+    position = _state(
+        "body_pose_tracking",
+        "root position",
+        asset.data.root_link_pos_w - np.asarray(env.scene.env_origins),
+        (env.num_envs, 3),
+    )
+    quat = _state(
+        "body_pose_tracking",
+        "root quaternion",
+        asset.data.root_link_quat_w,
+        (env.num_envs, 4),
+    )
+    qw, qx, qy, qz = quat[:, 0], quat[:, 1], quat[:, 2], quat[:, 3]
+    roll = np.arctan2(2.0 * (qw * qx + qy * qz), 1.0 - 2.0 * (qx * qx + qy * qy))
+    pitch = np.arcsin(np.clip(2.0 * (qw * qy - qz * qx), -1.0, 1.0))
+    yaw = np.arctan2(2.0 * (qw * qz + qx * qy), 1.0 - 2.0 * (qy * qy + qz * qz))
+    errors = (
+        ((position[:, 0] - command[:, 0]) / xy_std) ** 2,
+        ((position[:, 1] - command[:, 1]) / xy_std) ** 2,
+        ((position[:, 2] - nominal_height - command[:, 2]) / z_std) ** 2,
+        ((roll - command[:, 3]) / angle_std) ** 2,
+        ((pitch - command[:, 4]) / angle_std) ** 2,
+        (np_wrap_to_pi(yaw - command[:, 5]) / angle_std) ** 2,
+    )
+    return np.asarray(np.mean(np.exp(-np.stack(errors, axis=1)), axis=1), dtype=get_global_dtype())
+
+
 __all__ = [
     "GroundPickPhaseCommand",
     "GroundPickPhaseCommandCfg",
@@ -549,6 +611,7 @@ __all__ = [
     "MicroduckVelocityCommandCfg",
     "SitStandCommand",
     "SitStandCommandCfg",
+    "body_pose_tracking",
     "flight_phase",
     "foot_air_time_biped",
     "head_pose_bias",

--- a/tests/envs/locomotion/microduck/test_microduck_rewards.py
+++ b/tests/envs/locomotion/microduck/test_microduck_rewards.py
@@ -11,7 +11,11 @@ import pytest
 from unilab.envs.mdp import UniformPoseCommandCfg
 from unilab.managers import RewardTermCfg
 from unilab.managers._types import ManagerBasedRlEnv
-from unilab.tasks.locomotion.microduck.manager_terms import flight_phase, foot_air_time_biped
+from unilab.tasks.locomotion.microduck.manager_terms import (
+    body_pose_tracking,
+    flight_phase,
+    foot_air_time_biped,
+)
 
 
 class _SensorScene:
@@ -141,3 +145,63 @@ def test_uniform_pose_command_rejects_range_width_change() -> None:
     cfg.ranges = [[-1.0, 1.0]] * 3
     with pytest.raises(ValueError, match="width changed"):
         term.reset(np.arange(2))
+
+
+class _PoseScene:
+    def __init__(self, position: np.ndarray, quat: np.ndarray) -> None:
+        self.env_origins = np.zeros((position.shape[0], 3), dtype=np.float32)
+        self._robot = SimpleNamespace(
+            data=SimpleNamespace(root_link_pos_w=position, root_link_quat_w=quat)
+        )
+
+    def __getitem__(self, name: str):
+        if name != "robot":
+            raise KeyError(name)
+        return self._robot
+
+
+def _pose_env(position: np.ndarray, quat: np.ndarray, command: np.ndarray) -> ManagerBasedRlEnv:
+    return cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=position.shape[0],
+            scene=_PoseScene(position, quat),
+            command_manager=SimpleNamespace(get_command=lambda name: command),
+        ),
+    )
+
+
+def test_body_pose_tracking_matches_upstream_6d_gaussian_mean() -> None:
+    identity = np.asarray([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+    # env0 is exactly at the nominal pose with a zero command; env1 is one
+    # xy_std off in x and one z_std off in z: two axes at exp(-1), four at 1.
+    position = np.asarray([[0.0, 0.0, 0.095], [0.05, 0.0, 0.095 + 0.02]], dtype=np.float32)
+    command = np.zeros((2, 6), dtype=np.float32)
+    env = _pose_env(position, identity, command)
+    expected = (4.0 + 2.0 * np.exp(-1.0)) / 6.0
+    np.testing.assert_allclose(body_pose_tracking(env), [1.0, expected], rtol=1e-6)
+
+    # One angle_std of roll error: quat for roll=15deg about x.
+    half = np.deg2rad(15.0) / 2.0
+    rolled = np.asarray(
+        [[1.0, 0.0, 0.0, 0.0], [np.cos(half), np.sin(half), 0.0, 0.0]], dtype=np.float32
+    )
+    position = np.asarray([[0.0, 0.0, 0.095], [0.0, 0.0, 0.095]], dtype=np.float32)
+    env = _pose_env(position, rolled, command)
+    expected = (5.0 + np.exp(-1.0)) / 6.0
+    np.testing.assert_allclose(body_pose_tracking(env), [1.0, expected], rtol=1e-5)
+
+
+def test_body_pose_tracking_uses_env_origins_and_command_targets() -> None:
+    # A root parked at the env origin plus the commanded xyz delta scores 1.
+    position = np.asarray([[2.01, -1.01, 0.105]], dtype=np.float32)
+    quat = np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+    command = np.asarray([[0.01, -0.01, 0.01, 0.0, 0.0, 0.0]], dtype=np.float32)
+    env = _pose_env(position, quat, command)
+    scene = cast(Any, env.scene)
+    scene.env_origins = np.asarray([[2.0, -1.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(body_pose_tracking(env), [1.0], rtol=1e-6)
+
+    bad_env = _pose_env(position, quat, np.zeros((1, 4), dtype=np.float32))
+    with pytest.raises(ValueError, match="width 6"):
+        body_pose_tracking(bad_env)

--- a/tests/envs/locomotion/microduck/test_velocity_contract.py
+++ b/tests/envs/locomotion/microduck/test_velocity_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import math
 from pathlib import Path
 from typing import Any, cast
 
@@ -160,35 +161,46 @@ def test_microduck_owner_materializes_complete_manager_contract() -> None:
     expected_rewards = (
         "tracking_lin_vel",
         "tracking_ang_vel",
+        "upright",
         "head_pose_tracking",
         "head_pose_bias",
+        "body_pose_tracking",
         "leg_pose",
         "air_time",
         "foot_clearance",
         "foot_swing_height",
         "foot_slip",
-        "flight_phase",
-        "lin_vel_z",
-        "ang_vel_xy",
-        "orientation",
-        "base_height",
+        "body_ang_vel",
+        "self_collisions",
         "dof_pos_limits",
         "angular_momentum",
         "action_rate",
-        "alive",
     )
     assert tuple(env_cfg.rewards) == expected_rewards
-    assert env_cfg.rewards["tracking_lin_vel"].weight == pytest.approx(3.0)
+    # Upstream HEAD reward stack (anchor 29e887ec): vz² is folded into the
+    # tracking kernel, so no standalone lin_vel_z / orientation / base_height /
+    # flight_phase / alive terms.
+    assert env_cfg.rewards["tracking_lin_vel"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["tracking_lin_vel"].params["std"] == pytest.approx(math.sqrt(0.1))
     assert env_cfg.rewards["tracking_ang_vel"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["upright"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["upright"].params["std"] == pytest.approx(math.sqrt(0.05))
+    assert env_cfg.rewards["head_pose_tracking"].weight == pytest.approx(2.0)
+    assert env_cfg.rewards["body_pose_tracking"].weight == pytest.approx(0.0)
+    assert env_cfg.rewards["body_pose_tracking"].params["nominal_height"] == pytest.approx(0.095)
+    assert env_cfg.rewards["leg_pose"].weight == pytest.approx(1.0)
+    assert env_cfg.rewards["leg_pose"].params["walking_threshold"] == pytest.approx(0.01)
+    assert env_cfg.rewards["leg_pose"].params["std_walking"][".*knee.*"] == pytest.approx(0.4)
     assert env_cfg.rewards["air_time"].weight == pytest.approx(3.0)
     assert env_cfg.rewards["air_time"].params["threshold_min"] == pytest.approx(0.125)
     assert env_cfg.rewards["air_time"].params["threshold_max"] == pytest.approx(0.3)
     assert env_cfg.rewards["foot_clearance"].weight == pytest.approx(-2.0)
     assert env_cfg.rewards["foot_swing_height"].weight == pytest.approx(-0.25)
     assert env_cfg.rewards["foot_slip"].weight == pytest.approx(-0.1)
+    assert env_cfg.rewards["body_ang_vel"].weight == pytest.approx(-0.05)
+    assert env_cfg.rewards["self_collisions"].weight == pytest.approx(-1.0)
     assert env_cfg.rewards["dof_pos_limits"].weight == pytest.approx(-1.0)
     assert env_cfg.rewards["angular_momentum"].weight == pytest.approx(-0.02)
-    assert env_cfg.rewards["flight_phase"].weight == pytest.approx(-2.0)
     assert env_cfg.rewards["head_pose_bias"].weight == pytest.approx(0.0)
     assert env_cfg.rewards["action_rate"].weight == pytest.approx(-0.1)
     assert tuple(env_cfg.events) == (

--- a/tests/envs/locomotion/test_gait_terms.py
+++ b/tests/envs/locomotion/test_gait_terms.py
@@ -272,6 +272,31 @@ def test_angular_momentum_penalty_matches_mjlab_squared_norm() -> None:
     np.testing.assert_allclose(term(env), [14.0, 0.3125], rtol=1e-6)
 
 
+def test_self_collision_cost_counts_active_pairs() -> None:
+    """mjlab found-count form: one point per geom pair reporting contact."""
+    scene = _Scene()
+    scene.contacts = {
+        "self_trunk_left": np.array([[1.0], [0.0]], dtype=np.float32),
+        "self_trunk_right": np.array([[0.0], [0.0]], dtype=np.float32),
+        "self_legs": np.array([[1.0], [1.0]], dtype=np.float32),
+    }
+    env = _env(scene)
+    term = _term(
+        gait_terms.self_collision_cost,
+        env,
+        sensor_groups=[["self_trunk_left"], ["self_trunk_right"], ["self_legs"]],
+    )
+    np.testing.assert_allclose(term(env), [2.0, 1.0])
+    # Any-reduce within a group: two sensors of the same pair count once.
+    scene.contacts["self_trunk_right"] = np.array([[1.0], [0.0]], dtype=np.float32)
+    term = _term(
+        gait_terms.self_collision_cost,
+        env,
+        sensor_groups=[["self_trunk_left"], ["self_trunk_right", "self_legs"]],
+    )
+    np.testing.assert_allclose(term(env), [2.0, 1.0])
+
+
 # ---------------------------------------------------------------------------
 # Validation and manager integration
 # ---------------------------------------------------------------------------

--- a/tests/envs/mdp/test_rewards.py
+++ b/tests/envs/mdp/test_rewards.py
@@ -58,6 +58,15 @@ class _Entity:
                 ],
                 dtype=np.float32,
             ),
+            body_link_quat_w=np.asarray(
+                [
+                    [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]],
+                    [[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]],
+                    [[np.sqrt(0.5), 0.0, np.sqrt(0.5), 0.0], [1.0, 0.0, 0.0, 0.0]],
+                ],
+                dtype=np.float32,
+            ),
+            gravity_vec_w=np.asarray([0.0, 0.0, -1.0], dtype=np.float32),
         )
 
     def find_joints(self, keys, preserve_order: bool = False):
@@ -149,6 +158,22 @@ def test_body_angular_velocity_requires_one_selected_body() -> None:
     )
     with pytest.raises(ValueError, match="requires exactly one body"):
         mdp.body_angular_velocity_penalty(env)
+
+
+def test_upright_matches_mjlab_projected_gravity_kernel() -> None:
+    env = _env()
+    # Body 0 quats per env: identity (pg_xy = 0), 180° roll (pg_xy = 0),
+    # 90° pitch (pg_b = (1, 0, 0), pg_xy^2 = 1).
+    selector = SceneEntityCfg("robot", body_ids=[0])
+    np.testing.assert_allclose(
+        mdp.upright(env, std=0.5, asset_cfg=selector),
+        [1.0, 1.0, np.exp(-1.0 / 0.25)],
+        rtol=1e-6,
+    )
+    with pytest.raises(ValueError, match="requires exactly one body"):
+        mdp.upright(env, std=0.5)
+    with pytest.raises(ValueError, match="std must be finite and positive"):
+        mdp.upright(env, std=0.0, asset_cfg=selector)
 
 
 def test_joint_pos_limits_matches_mjlab_soft_limit_equation() -> None:


### PR DESCRIPTION
Closes #1455 ｜ Parent roadmap: #1452 ｜ Base: `dev/issue-1452-microduck-rl-alignment` ｜ 依赖：#1460（已合入；本分支已同步集成分支）

## 交付内容

velocity_flat reward 栈逐项对齐上游 HEAD @ 29e887ec（逐条以 direct read 上游代码核实，非转述）：

- `tracking_lin_vel`：换 mjlab 同源 `track_linear_velocity`，std=√0.1、权重 2.0、指数含 vz²、body frame。
- 新增通用 `upright`（`envs/mdp/rewards.py`，2.0，std=√0.05）、`self_collision_cost`（`gait_terms.py`，-1.0，found 计数）、`body_pose_tracking`（microduck manager_terms，0.0 挂起保活，镜像上游 6 轴高斯）。
- `leg_pose` → 复用既有 `variable_posture`（公式与上游逐字一致：站立/行走双 std，行走仍评分）。
- `body_ang_vel` -0.05（**只罚 ω_xy**，world frame——上游 `rewards.py:184` 明确 "Don't penalize z-angular velocity"；替换了语义近但坐标系不同的旧 `ang_vel_xy`）。
- `head_pose_tracking` 0.5 → 2.0。
- 移除上游没有的：orientation(-3.0) / base_height(-50.0) / alive(+0.1) / flight_phase(-2.0) / lin_vel_z(-1.0)（vz 惩罚已并入 track_linear_velocity 指数）。
- 配套：`microduck.xml` 3 个 self-collision geom 命名 + `locomotion_task.xml` 3 个 `data="found"` contact sensor（两后端编译绑定均已验证）；`alignment_contract.py` 13 条 reward gap 翻 match；base.yaml 头注基线改为上游 HEAD 锚点。
- 公式级单元测试：upright、self_collision_cost、body_pose_tracking（含符号约定：cost≥0 配负权重）。

## 上游核实纠正的转述错误

1. body_ang_vel 只罚 ω_xy（child 1 contract 注释已同步修正）。
2. self_collisions 的 10 N 阈值在上游是 dormant 的（sensor 无 force history），实际语义为 found 计数，按此实现。
3. variable_posture 公式为 `exp(-mean(err²/std²))`，与旧 leg_pose 形式不同；running_threshold 保持上游默认 1.5。

## sitstand / ground_pick 核对结论

两任务经 defaults 继承 velocity 栈，本次改动自动传播且方向是改善对齐（上游同款共享 regularizer）。记录的已知差异（"Adapted" 任务，parity 不在范围，供 maintainer 后续决策）：UniLab 保留了上游会删除的行走项（tracking_*、air_time 等；注意 tracking_lin_vel 在 sitstand 会把 sit flag 当 vx 指令跟踪，系继承带来的既有语义问题）；上游 bespoke shaping 栈（posture_pose_legs、mouth_* 等）UniLab 均无；posture_height 单层 vs 上游双层+L1。

## 用户可见行为变化

microduck 三任务（ppo tree）的 reward 集合/权重变化，训练目标改变（对齐上游的预期效果）。sac tree 未动（仍引用旧 `leg_pose`/`flight_phase` 实现，已为其保留；其 alive=10.0 的已知内部不一致留给后续决策）。

## Validation

- `uv run pytest tests/envs/locomotion/microduck/ -m "" -q`：33 passed（含 slow 真后端）；`tests/envs/mdp/`：146 passed。
- `uv run scripts/audit_microduck_alignment.py`：MATCH 175 / GAP 6 / NOTE 6 / MISMATCH 0（velocity 剩余 gap 仅 infra.num_envs / infra.seed，属 child 4）。
- mjwarp smoke（64 envs × 200 steps）：16 个 reward term 全部上报，所有 penalty 项 ≤ 0，NaN=0。
- 改动文件 ruff / mypy 干净。
- **最终 head（含集成分支同步 merge）本地 `make test-all`：2544 passed, 28 skipped, 1 xfailed；pre-commit 与 benchmark 检查全部通过。**

Base 非 `main`，按 gate 规则使用本地验证 + review。
