### PR TITLE
feat(microduck): 训练基建对齐上游（env RNG 播种 / init_at_random_ep_len / 规模与 seed）

### DIFF
--- a/src/unilab/algos/rsl_rl.py
+++ b/src/unilab/algos/rsl_rl.py
@@ -212,9 +212,27 @@ class RslRlVecEnvWrapper:
 
         self.episode_returns = torch.zeros(self.num_envs, device=device)
         self.episode_lengths = torch.zeros(self.num_envs, device=device)
-        self.episode_length_buf = self.episode_lengths
         self.max_episode_length = np.ceil(env.cfg.max_episode_seconds / env.cfg.ctrl_dt)
         self.reset()
+
+    @property
+    def episode_length_buf(self) -> torch.Tensor:
+        """RSL-RL VecEnv contract view of the wrapper's episode bookkeeping."""
+        return self.episode_lengths
+
+    @episode_length_buf.setter
+    def episode_length_buf(self, value: torch.Tensor) -> None:
+        # RSL-RL's init_at_random_ep_len assigns a fresh tensor here at learn()
+        # start. Propagate the staggered counters into the wrapped env so the
+        # env's own timeout accounting (ManagerBasedRlEnv.episode_length_buf,
+        # mirrored from state.info["steps"]) staggers too — otherwise only the
+        # wrapper's local bookkeeping would randomize. Cold path: the runner
+        # calls this at most once per learn().
+        value = torch.as_tensor(value, device=self.device).clone()
+        self.episode_lengths = value
+        set_env_episode_lengths = getattr(self.env, "set_episode_length_buf", None)
+        if callable(set_env_episode_lengths):
+            set_env_episode_lengths(to_numpy(value).astype(np.int64))
 
     def _policy_obs(self, obs: dict[str, Any]) -> torch.Tensor:
         if self.policy_obs_mode == "actor":

--- a/src/unilab/conf/ppo/task/microduck_ground_pick_flat/mjwarp.yaml
+++ b/src/unilab/conf/ppo/task/microduck_ground_pick_flat/mjwarp.yaml
@@ -12,8 +12,13 @@ training:
   play_render_mode: record
 
 algo:
-  num_envs: 2048
-  max_iterations: 500
+  # Upstream scale: 4096 envs, seed 42 (issue #1456).
+  seed: 42
+  num_envs: 4096
+  # 2000 iterations x 24 env steps = 48000 env steps, exactly covering every
+  # curriculum terminal stage (step 48000). Upstream runs 50000 iterations; the
+  # final training budget is decided by child 5.
+  max_iterations: 2000
   empirical_normalization: true
   obs_groups:
     actor:
@@ -22,6 +27,9 @@ algo:
       - critic
 
 env:
+  # Env-level RNG seed (command / obs-noise / delay / DR sampling) matching
+  # upstream seed=42 so runs are reproducible (issue #1456).
+  seed: 42
   mjwarp_nconmax: 128
   mjwarp_njmax: 256
   render_spacing: 2.0

--- a/src/unilab/conf/ppo/task/microduck_sitstand_flat/mjwarp.yaml
+++ b/src/unilab/conf/ppo/task/microduck_sitstand_flat/mjwarp.yaml
@@ -11,8 +11,13 @@ training:
   play_render_mode: record
 
 algo:
-  num_envs: 2048
-  max_iterations: 500
+  # Upstream scale: 4096 envs, seed 42 (issue #1456).
+  seed: 42
+  num_envs: 4096
+  # 2000 iterations x 24 env steps = 48000 env steps, exactly covering every
+  # curriculum terminal stage (step 48000). Upstream runs 50000 iterations; the
+  # final training budget is decided by child 5.
+  max_iterations: 2000
   empirical_normalization: true
   obs_groups:
     actor:
@@ -21,6 +26,9 @@ algo:
       - critic
 
 env:
+  # Env-level RNG seed (command / obs-noise / delay / DR sampling) matching
+  # upstream seed=42 so runs are reproducible (issue #1456).
+  seed: 42
   mjwarp_nconmax: 128
   mjwarp_njmax: 256
   render_spacing: 2.0

--- a/src/unilab/conf/ppo/task/microduck_velocity_flat/mjwarp.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_flat/mjwarp.yaml
@@ -12,8 +12,13 @@ training:
   play_render_mode: record
 
 algo:
-  num_envs: 2048
-  max_iterations: 500
+  # Upstream scale: 4096 envs, seed 42 (issue #1456).
+  seed: 42
+  num_envs: 4096
+  # 2000 iterations x 24 env steps = 48000 env steps, exactly covering every
+  # curriculum terminal stage (step 48000). Upstream runs 50000 iterations; the
+  # final training budget is decided by child 5.
+  max_iterations: 2000
   empirical_normalization: true
   obs_groups:
     actor:
@@ -27,6 +32,9 @@ algo:
     entropy_coef: 0.01
 
 env:
+  # Env-level RNG seed (command / obs-noise / delay / DR sampling) matching
+  # upstream seed=42 so runs are reproducible (issue #1456).
+  seed: 42
   mjwarp_nconmax: 128
   mjwarp_njmax: 256
   render_spacing: 2.0

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -669,6 +669,28 @@ class ManagerBasedRlEnv(NpEnv):
         self.obs_buf = self._state.obs
         return self.obs_buf
 
+    def set_episode_length_buf(self, values: np.ndarray) -> None:
+        """Overwrite per-env episode counters (cold path, runner-init only).
+
+        ``episode_length_buf`` mirrors ``state.info["steps"]``: each step writes
+        ``info["steps"] + 1`` into the buffer and ``reset()`` zeroes both, so a
+        direct assignment must update the two together. RL runners (e.g. RSL-RL
+        ``init_at_random_ep_len``) call this once before learning starts to
+        stagger initial episode lengths across envs.
+        """
+        values = np.asarray(values)
+        if values.shape != (self.num_envs,):
+            raise ValueError(
+                f"ManagerBasedRlEnv.set_episode_length_buf expects shape "
+                f"({self.num_envs},), got {values.shape}"
+            )
+        values = values.astype(np.int64)
+        if np.any(values < 0):
+            raise ValueError("episode length counters must be non-negative")
+        np.copyto(self.episode_length_buf, values)
+        if self._state is not None:
+            np.copyto(self._state.info["steps"], values, casting="unsafe")
+
     def seed(self, seed: int = -1) -> int:
         if seed == -1:
             seed = secrets.randbits(63)

--- a/src/unilab/tasks/locomotion/microduck/alignment_contract.py
+++ b/src/unilab/tasks/locomotion/microduck/alignment_contract.py
@@ -757,16 +757,25 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         "infra",
         _hydra("algo.num_envs"),
         4096,
-        "gap",
-        "当前 2048。",
+        "match",
+        "issue #1456：三任务 mjwarp owner 统一 4096。",
     ),
     AlignmentEntry(
         "infra.seed",
         "infra",
         _hydra("algo.seed"),
         42,
-        "gap",
-        "当前 1。",
+        "match",
+        "issue #1456：三任务 mjwarp owner 统一 42；env 级采样 RNG 由 env.seed=42 固定。",
+    ),
+    AlignmentEntry(
+        "infra.env_seed",
+        "infra",
+        _hydra("env.seed"),
+        42,
+        "match",
+        "issue #1456：env 级 RNG（command / obs noise / delay / DR 采样）经 Hydra "
+        "env.seed 固定为 42，run 间可复现；默认 None 行为不变（opt-in）。",
     ),
     AlignmentEntry(
         "infra.max_iterations",
@@ -774,7 +783,8 @@ ENTRIES: tuple[AlignmentEntry, ...] = (
         _hydra("algo.max_iterations"),
         None,
         "note",
-        "当前 500，上游 50000；训练预算由 child 5 决策，不参与 match/gap 判定。",
+        "当前 2000（2000×24=48000 env step，恰好覆盖全部 curriculum 终档），上游 50000；"
+        "训练预算由 child 5 决策，不参与 match/gap 判定。",
     ),
     AlignmentEntry(
         "infra.mujoco_warp_version",

--- a/tests/envs/locomotion/microduck/test_infra_alignment.py
+++ b/tests/envs/locomotion/microduck/test_infra_alignment.py
@@ -1,0 +1,164 @@
+"""MicroDuck training-infra alignment (issue #1456, child 4/5).
+
+Covers the two runtime-facing pieces of the infra alignment:
+
+- env-level RNG seeding: the three ``microduck_*/mjwarp`` owners set
+  ``env.seed: 42``; the Hydra -> BackendAdapter -> registry -> ManagerBasedRlEnvCfg
+  chain must thread it through so command/noise/DR sampling is reproducible
+  across runs (default ``None`` behavior stays unchanged).
+- ``init_at_random_ep_len``: RSL-RL's OnPolicyRunner assigns a fresh tensor to
+  ``env.episode_length_buf`` at learn() start; the RslRlVecEnvWrapper setter
+  must propagate it into the env's real episode counters so initial episode
+  timeouts actually stagger (matching upstream mjlab, where the setter writes
+  the env's buffer directly).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+from unilab.algos.rsl_rl import RslRlVecEnvWrapper
+from unilab.base import registry
+from unilab.base.config_adapter import BackendAdapter
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnvCfg
+
+ROOT_DIR = Path(__file__).parents[4]
+CONF_DIR = ROOT_DIR / "src" / "unilab" / "conf" / "ppo"
+
+MICRODUCK_TASKS = (
+    "microduck_velocity_flat",
+    "microduck_sitstand_flat",
+    "microduck_ground_pick_flat",
+)
+
+
+def _compose(task_owner: str) -> Any:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR), version_base="1.3"):
+        return compose("config", overrides=[f"task={task_owner}"])
+
+
+def _materialize_env_cfg(task_owner: str) -> ManagerBasedRlEnvCfg:
+    cfg = _compose(task_owner)
+    registry.ensure_registries()
+    env_cfg = registry.materialize_env_config(str(cfg.training.task_name))
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(
+        env_cfg,
+        BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override(),
+    )
+    env_cfg.validate()
+    return env_cfg
+
+
+@pytest.mark.parametrize("task", MICRODUCK_TASKS)
+def test_mjwarp_owner_threads_env_seed_from_hydra(task: str) -> None:
+    """env.seed=42 in the mjwarp owner reaches ManagerBasedRlEnvCfg.seed."""
+    env_cfg = _materialize_env_cfg(f"{task}/mjwarp")
+    assert env_cfg.seed == 42
+
+
+def test_env_seed_defaults_to_none_when_unset() -> None:
+    """Backward compatibility: owners without env.seed keep the None default."""
+    env_cfg = _materialize_env_cfg("microduck_velocity_flat/mujoco")
+    assert env_cfg.seed is None
+
+
+def _make_velocity_env(seed: int, num_envs: int = 8):
+    cfg = _compose("microduck_velocity_flat/mujoco")
+    registry.ensure_registries()
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    override["seed"] = seed
+    return registry.make(
+        str(cfg.training.task_name),
+        num_envs=num_envs,
+        sim_backend="mujoco",
+        env_cfg_override=override,
+    )
+
+
+def _command_trace(env: Any, rounds: int = 3) -> list[np.ndarray]:
+    all_ids = np.arange(env.num_envs, dtype=np.int32)
+    env.reset(all_ids)
+    trace = [env.command_manager.get_command("twist").copy()]
+    for _ in range(rounds):
+        env.reset(all_ids)
+        trace.append(env.command_manager.get_command("twist").copy())
+    return trace
+
+
+def test_env_seed_makes_command_sampling_reproducible() -> None:
+    """Same env seed -> identical command sampling sequences across runs."""
+    env_a = _make_velocity_env(seed=42)
+    env_b = _make_velocity_env(seed=42)
+    try:
+        trace_a = _command_trace(env_a)
+        trace_b = _command_trace(env_b)
+    finally:
+        env_a.close()
+        env_b.close()
+    for step, (cmd_a, cmd_b) in enumerate(zip(trace_a, trace_b, strict=True)):
+        np.testing.assert_array_equal(cmd_a, cmd_b, err_msg=f"reset round {step}")
+
+
+def test_env_seed_difference_changes_command_sampling() -> None:
+    """Different env seeds -> different command sampling sequences."""
+    env_a = _make_velocity_env(seed=42)
+    env_b = _make_velocity_env(seed=43)
+    try:
+        trace_a = _command_trace(env_a)
+        trace_b = _command_trace(env_b)
+    finally:
+        env_a.close()
+        env_b.close()
+    assert any(
+        not np.array_equal(cmd_a, cmd_b) for cmd_a, cmd_b in zip(trace_a, trace_b, strict=True)
+    )
+
+
+def test_random_ep_len_assignment_staggers_env_episode_counters() -> None:
+    """The wrapper's episode_length_buf setter propagates into the env.
+
+    Mirrors ``OnPolicyRunner.learn(init_at_random_ep_len=True)``: assigning a
+    randomized tensor to ``wrapped.episode_length_buf`` must stagger the env's
+    own timeout counters so initial episodes do not all end in lockstep.
+    """
+    num_envs = 16
+    env = _make_velocity_env(seed=42, num_envs=num_envs)
+    try:
+        wrapped = RslRlVecEnvWrapper(env, device="cpu")
+
+        torch.manual_seed(0)
+        wrapped.episode_length_buf = torch.randint_like(
+            wrapped.episode_length_buf, high=int(wrapped.max_episode_length)
+        )
+
+        expected = wrapped.episode_length_buf.cpu().numpy().astype(np.int64)
+        np.testing.assert_array_equal(env.episode_length_buf, expected)
+
+        remaining = env.max_episode_length - env.episode_length_buf
+        assert len(np.unique(remaining)) > 1, (
+            "initial episode stagger must leave non-uniform remaining lengths"
+        )
+
+        # Step until the shortest episode times out: truncation must be
+        # staggered (some envs time out, others keep running).
+        action_dim = env.action_space.shape[0]
+        assert action_dim is not None
+        actions = np.zeros((num_envs, action_dim), dtype=np.float32)
+        state = None
+        for _ in range(int(remaining.min())):
+            state = env.step(actions)
+        assert state is not None
+        assert state.truncated.any()
+        assert not state.truncated.all()
+    finally:
+        env.close()


### PR DESCRIPTION
Closes #1456 ｜ Parent roadmap: #1452 ｜ Base: `dev/issue-1452-microduck-rl-alignment` ｜ 依赖：#1461（已合入；本分支已同步集成分支）

## 交付内容

1. **env 级 RNG 播种**：链路本就存在（YAML `env:` → `BackendAdapter.build_task_env_cfg_override` → `ManagerBasedRlEnvCfg.seed` → `env.rng`，command/noise/delay/DR 全部消费它），缺的只是 YAML 设值。三个 microduck mjwarp owner YAML 设 `env.seed: 42`（上游默认）；默认 None→随机行为不变（mujoco owner 测试仍断言 None）。新增测试：同 seed 两次建 env 的 command 采样序列一致、不同 seed 不同。
2. **`init_at_random_ep_len` 真实生效**：上游核实 mjlab 的 wrapper `episode_length_buf` setter 直接写 env 内计数（`mjlab/rl/vecenv_wrapper.py:54-59`）且 `train.py:174` 确实传 True——上游错峰生效，故 UniLab 修适配层对齐而非关闭：`RslRlVecEnvWrapper.episode_length_buf` 改 property+setter，传播进 env 新增的冷路径 `set_episode_length_buf`（同步写 `episode_length_buf` 与 `state.info["steps"]`，形状/非负校验）；env 无此方法时只更新本地记账（向后兼容）。附带收益：`him_ppo/runner.py:119` 的同类赋值同步生效。
3. **规模对齐**：三任务 mjwarp owner `algo.num_envs` 2048→4096、`algo.seed` 1→42、`max_iterations` 500→2000（2000×24=48000 env step 恰好覆盖全部 curriculum 终档；上游为 50000，最终预算由 #1457 对比实验决策）。
4. **contract 翻绿**：`infra.num_envs`、`infra.seed` 翻 match，新增 `infra.env_seed` 守卫；audit **GAP 0**（velocity；NOTE 剩 max_iterations 预算与 mujoco-warp 版本两个非判定项）。

## 用户可见行为变化

microduck 三任务（ppo tree, mjwarp）默认并行规模与随机种子变化，训练 run 变为可复现（env RNG 播种后）。其他任务/后端行为不变（opt-in）。macOS/Linux 无差异。

## Validation

- `uv run pytest tests/envs/locomotion/microduck/ -m "" -q`：40 passed（含新增 `test_infra_alignment.py` 7 条：seed 复现、错峰传播后剩余长度非全同且 timeout 错峰触发）。
- `tests/envs/ tests/algos/ -k "seed or episode_length or random_ep"`：12 passed；`test_rsl_rl_ppo.py` 12 passed。
- `uv run scripts/audit_microduck_alignment.py`：MATCH 184 / GAP 0 / MISMATCH 0。
- mjwarp smoke（64 envs × 200 steps）：NaN=0。
- 改动文件 ruff / mypy 干净。
- **最终 head（含集成分支同步 merge）本地 `make test-all`：2551 passed, 28 skipped, 1 xfailed；pre-commit 与 benchmark 检查全部通过。**

Base 非 `main`，按 gate 规则使用本地验证 + review。
