### PR TITLE
benchmark(microduck): 受控对比验收——UniLab vs 上游 microduck_rl 统计一致性报告

### DIFF
--- a/scripts/microduck_alignment_compare.py
+++ b/scripts/microduck_alignment_compare.py
@@ -1,0 +1,357 @@
+"""Compare MicroDuck PPO training metrics between UniLab and upstream microduck_rl runs.
+
+Parses rsl_rl tensorboard event files from one or more run directories per side,
+aggregates across seeds (final-window statistics and convergence speed), and
+emits a markdown comparison report plus an optional JSON dump of all curves.
+
+    uv run scripts/microduck_alignment_compare.py \
+        --unilab logs/rsl_rl_ppo/MicroduckVelocityFlat/<dir1> logs/.../<dir2> \
+        --upstream /path/to/microduck_rl/logs/rsl_rl/velocity/<dirA> \
+        [--output report.md] [--json out.json]
+
+Run metadata is read from ``run_config.json`` (UniLab) or ``params/agent.yaml``
+(upstream); both are optional and fall back to the directory name. Read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import re
+import statistics
+import sys
+from pathlib import Path
+
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+# rsl_rl scalar tags shared by both sides.
+OVERVIEW_TAGS = ("Train/mean_reward", "Train/mean_episode_length")
+REWARD_PREFIX = "Episode_Reward/"
+TERMINATION_PREFIX = "Episode_Termination/"
+
+# Reward/termination term names differ between the two codebases for a handful
+# of entries. Keys are UniLab term names, values the upstream equivalents;
+# terms absent here are assumed to share the same name on both sides.
+REWARD_TERM_ALIASES = {
+    "tracking_lin_vel": "track_linear_velocity",
+    "tracking_ang_vel": "track_angular_velocity",
+    "leg_pose": "pose",
+    "action_rate": "action_rate_l2",
+}
+TERMINATION_ALIASES = {
+    "tilt": "fell_over",
+}
+
+# Fraction of trailing iterations used for final-window statistics.
+FINAL_WINDOW_FRAC = 0.2
+# Convergence threshold: first iteration where mean_reward reaches this share
+# of its own final-window mean.
+CONVERGENCE_FRAC = 0.8
+
+
+@dataclasses.dataclass
+class RunData:
+    """Scalar curves and metadata for a single training run."""
+
+    run_dir: str
+    seed: int | None
+    max_iterations: int | None
+    curves: dict[str, list[tuple[int, float]]]  # tag -> [(iteration, value)]
+
+
+def _parse_agent_scalar(text: str, key: str) -> int | None:
+    """Extract a top-level integer field from rsl_rl's agent.yaml.
+
+    The file carries ``!!python/tuple`` tags that SafeLoader cannot parse, and
+    only two flat fields are needed, so a regex keeps this dependency-free.
+    """
+    match = re.search(rf"^{re.escape(key)}:\s*(\d+)\s*$", text, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def _load_curves(run_dir: Path) -> dict[str, list[tuple[int, float]]]:
+    """Load the scalar tags of interest from every tfevents file in a run dir."""
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"run directory not found: {run_dir}")
+    accumulator = EventAccumulator(str(run_dir), size_guidance={"scalars": 0})
+    accumulator.Reload()
+    curves: dict[str, list[tuple[int, float]]] = {}
+    for tag in accumulator.Tags()["scalars"]:
+        if tag in OVERVIEW_TAGS or tag.startswith((REWARD_PREFIX, TERMINATION_PREFIX)):
+            curves[tag] = [(e.step, e.value) for e in accumulator.Scalars(tag)]
+    return curves
+
+
+def _unilab_meta(run_dir: Path) -> tuple[int | None, int | None]:
+    config_path = run_dir / "run_config.json"
+    if not config_path.is_file():
+        return None, None
+    payload = json.loads(config_path.read_text())
+    algo = payload.get("config", {}).get("algo", {})
+    seed = payload.get("run", {}).get("effective_seed", algo.get("seed"))
+    max_iterations = algo.get("max_iterations")
+    return seed, max_iterations
+
+
+def _upstream_meta(run_dir: Path) -> tuple[int | None, int | None]:
+    agent_path = run_dir / "params" / "agent.yaml"
+    if not agent_path.is_file():
+        return None, None
+    text = agent_path.read_text()
+    return _parse_agent_scalar(text, "seed"), _parse_agent_scalar(text, "max_iterations")
+
+
+def load_runs(run_dirs: list[str], side: str) -> list[RunData]:
+    """Load runs; directories without rsl_rl scalars (e.g. aborted runs) are skipped."""
+    meta_fn = _unilab_meta if side == "unilab" else _upstream_meta
+    runs = []
+    for raw in run_dirs:
+        run_dir = Path(raw)
+        curves = _load_curves(run_dir)
+        if not curves:
+            print(f"warning: no rsl_rl scalar tags under {run_dir}, skipped", file=sys.stderr)
+            continue
+        seed, max_iterations = meta_fn(run_dir)
+        runs.append(
+            RunData(
+                run_dir=str(run_dir),
+                seed=seed,
+                max_iterations=max_iterations,
+                curves=curves,
+            )
+        )
+    if not runs:
+        raise ValueError(f"no usable {side} run directories (all empty or missing)")
+    return runs
+
+
+def _final_window(values: list[float]) -> list[float]:
+    n_tail = max(1, math.ceil(len(values) * FINAL_WINDOW_FRAC))
+    return values[-n_tail:]
+
+
+def _final_mean(points: list[tuple[int, float]]) -> float | None:
+    if not points:
+        return None
+    return statistics.mean(_final_window([v for _, v in points]))
+
+
+def _convergence_iteration(points: list[tuple[int, float]]) -> int | None:
+    """First iteration where mean_reward reaches CONVERGENCE_FRAC of its final mean."""
+    if not points:
+        return None
+    final = _final_mean(points)
+    if final is None or final <= 0:
+        return None
+    threshold = CONVERGENCE_FRAC * final
+    for step, value in points:
+        if value >= threshold:
+            return step
+    return None
+
+
+def _aggregate(per_run: list[float | None]) -> tuple[float | None, float | None]:
+    values = [v for v in per_run if v is not None]
+    if not values:
+        return None, None
+    std = statistics.stdev(values) if len(values) > 1 else None
+    return statistics.mean(values), std
+
+
+def summarize_side(runs: list[RunData]) -> dict[str, dict[str, float | None]]:
+    """Per-tag cross-seed statistics: final-window mean/std of per-run means."""
+    tags = sorted({tag for run in runs for tag in run.curves})
+    summary: dict[str, dict[str, float | None]] = {}
+    for tag in tags:
+        per_run = [_final_mean(run.curves.get(tag, [])) for run in runs]
+        mean, std = _aggregate(per_run)
+        summary[tag] = {"mean": mean, "std": std, "n_runs": len(runs)}
+    convergence = [_convergence_iteration(run.curves.get("Train/mean_reward", [])) for run in runs]
+    conv_mean, conv_std = _aggregate([float(it) if it is not None else None for it in convergence])
+    summary["Train/mean_reward@convergence_iter"] = {
+        "mean": conv_mean,
+        "std": conv_std,
+        "n_runs": len(runs),
+    }
+    return summary
+
+
+def _fmt_stat(entry: dict[str, float | None]) -> str:
+    mean, std = entry["mean"], entry["std"]
+    if mean is None:
+        return "n/a"
+    if std is None:
+        return f"{mean:.3f} (n=1)"
+    return f"{mean:.3f} ± {std:.3f}"
+
+
+def _fmt_rel_diff(unilab: dict[str, float | None], upstream: dict[str, float | None]) -> str:
+    u_mean, up_mean = unilab["mean"], upstream["mean"]
+    if u_mean is None or up_mean is None or math.isclose(up_mean, 0.0):
+        return "n/a"
+    return f"{(u_mean - up_mean) / abs(up_mean) * 100:+.1f}%"
+
+
+def _canonical_terms(
+    unilab_tags: list[str], upstream_tags: list[str], prefix: str, aliases: dict[str, str]
+) -> tuple[list[str], list[str], list[str]]:
+    """Pair terms across sides via aliases; return (paired, unilab-only, upstream-only)."""
+    unilab_terms = {t.removeprefix(prefix) for t in unilab_tags}
+    upstream_terms = {t.removeprefix(prefix) for t in upstream_tags}
+    upstream_reverse = {up: uni for uni, up in aliases.items()}
+    paired, unilab_only = [], []
+    for term in sorted(unilab_terms):
+        upstream_name = aliases.get(term, term)
+        if upstream_name in upstream_terms:
+            paired.append(term)
+        else:
+            unilab_only.append(term)
+    upstream_only = sorted(
+        t for t in upstream_terms if upstream_reverse.get(t, t) not in unilab_terms
+    )
+    return paired, unilab_only, upstream_only
+
+
+def _render_run_table(side: str, runs: list[RunData]) -> list[str]:
+    lines = ["| run | seed | max_iterations |", "| --- | --- | --- |"]
+    for run in runs:
+        lines.append(
+            f"| `{run.run_dir}` | {run.seed if run.seed is not None else '?'} "
+            f"| {run.max_iterations if run.max_iterations is not None else '?'} |"
+        )
+    if len(runs) < 2:
+        lines.append("")
+        lines.append(f"> ⚠ {side} 侧只有 {len(runs)} 个 run，std 不可用，统计仅供参考。")
+    return lines
+
+
+def build_report(unilab_runs: list[RunData], upstream_runs: list[RunData]) -> str:
+    unilab_summary = summarize_side(unilab_runs)
+    upstream_summary = summarize_side(upstream_runs)
+    lines = ["# MicroDuck PPO 对比报告", ""]
+    lines.append(
+        f"终段窗口 = 每 run 末尾 {FINAL_WINDOW_FRAC:.0%} iterations；"
+        f"收敛速度 = mean_reward 首次达到自身终段均值 {CONVERGENCE_FRAC:.0%} 的 iteration。"
+    )
+    lines.append("")
+    lines.append("## Runs")
+    lines.append("")
+    lines.append("**UniLab**")
+    lines.extend(_render_run_table("unilab", unilab_runs))
+    lines.append("")
+    lines.append("**Upstream (microduck_rl)**")
+    lines.extend(_render_run_table("upstream", upstream_runs))
+    lines.append("")
+
+    lines.append("## 总览指标")
+    lines.append("")
+    lines.append("| 指标 | UniLab | 上游 | 相对差 |")
+    lines.append("| --- | --- | --- | --- |")
+    overview_rows = [
+        ("Train/mean_reward", "mean_reward 终段均值"),
+        ("Train/mean_episode_length", "episode length 终段均值"),
+        ("Train/mean_reward@convergence_iter", "收敛 iteration (80% final reward)"),
+    ]
+    for tag, label in overview_rows:
+        u = unilab_summary.get(tag, {"mean": None, "std": None})
+        up = upstream_summary.get(tag, {"mean": None, "std": None})
+        lines.append(f"| {label} | {_fmt_stat(u)} | {_fmt_stat(up)} | {_fmt_rel_diff(u, up)} |")
+    lines.append("")
+
+    def _term_section(title: str, prefix: str, aliases: dict[str, str]) -> None:
+        lines.append(f"## {title}")
+        lines.append("")
+        paired, unilab_only, upstream_only = _canonical_terms(
+            [t for t in unilab_summary if t.startswith(prefix)],
+            [t for t in upstream_summary if t.startswith(prefix)],
+            prefix,
+            aliases,
+        )
+        lines.append("| term (UniLab / 上游) | UniLab 终段 | 上游终段 | 相对差 |")
+        lines.append("| --- | --- | --- | --- |")
+        for term in paired:
+            u = unilab_summary[prefix + term]
+            up = upstream_summary[prefix + aliases.get(term, term)]
+            alias_note = f" / {aliases[term]}" if term in aliases else ""
+            lines.append(
+                f"| {term}{alias_note} | {_fmt_stat(u)} | {_fmt_stat(up)} | {_fmt_rel_diff(u, up)} |"
+            )
+        if unilab_only:
+            lines.append("")
+            lines.append(f"UniLab 独有 term: {', '.join(f'`{t}`' for t in unilab_only)}")
+        if upstream_only:
+            lines.append(f"上游独有 term: {', '.join(f'`{t}`' for t in upstream_only)}")
+        lines.append("")
+
+    _term_section("Reward term 终段对比", REWARD_PREFIX, REWARD_TERM_ALIASES)
+    _term_section("Termination 构成对比", TERMINATION_PREFIX, TERMINATION_ALIASES)
+
+    # Termination composition shares (UniLab side naming for paired terms).
+    lines.append("## Termination 终段占比")
+    lines.append("")
+    lines.append("| term | UniLab 占比 | 上游占比 |")
+    lines.append("| --- | --- | --- |")
+
+    def _shares(summary: dict[str, dict[str, float | None]]) -> dict[str, float]:
+        means = {
+            t.removeprefix(TERMINATION_PREFIX): e["mean"] or 0.0
+            for t, e in summary.items()
+            if t.startswith(TERMINATION_PREFIX)
+        }
+        total = sum(means.values())
+        return {k: v / total for k, v in means.items()} if total > 0 else {}
+
+    u_shares, up_shares = _shares(unilab_summary), _shares(upstream_summary)
+    paired_terms, u_only, up_only = _canonical_terms(
+        [t for t in unilab_summary if t.startswith(TERMINATION_PREFIX)],
+        [t for t in upstream_summary if t.startswith(TERMINATION_PREFIX)],
+        TERMINATION_PREFIX,
+        TERMINATION_ALIASES,
+    )
+    for term in paired_terms + u_only:
+        up_name = TERMINATION_ALIASES.get(term, term)
+        lines.append(
+            f"| {term} | {u_shares.get(term, 0.0):.1%} | {up_shares.get(up_name, 0.0):.1%} |"
+        )
+    for term in up_only:
+        lines.append(f"| {term} (上游独有) | — | {up_shares.get(term, 0.0):.1%} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--unilab", nargs="+", required=True, help="UniLab run directories.")
+    parser.add_argument("--upstream", nargs="+", required=True, help="Upstream run directories.")
+    parser.add_argument("--output", help="Write the markdown report to this path.")
+    parser.add_argument("--json", dest="json_path", help="Dump full curve summaries as JSON.")
+    args = parser.parse_args()
+
+    unilab_runs = load_runs(args.unilab, "unilab")
+    upstream_runs = load_runs(args.upstream, "upstream")
+
+    report = build_report(unilab_runs, upstream_runs)
+    print(report)
+    if args.output:
+        Path(args.output).write_text(report + "\n")
+
+    if args.json_path:
+        payload = {
+            "unilab": {
+                "runs": [dataclasses.asdict(run) for run in unilab_runs],
+                "summary": summarize_side(unilab_runs),
+            },
+            "upstream": {
+                "runs": [dataclasses.asdict(run) for run in upstream_runs],
+                "summary": summarize_side(upstream_runs),
+            },
+        }
+        Path(args.json_path).write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/microduck_alignment_report.md
+++ b/scripts/microduck_alignment_report.md
@@ -1,0 +1,87 @@
+# MicroDuck PPO 对比报告（roadmap #1452 / issue #1457）
+
+生成：`uv run scripts/microduck_alignment_compare.py`（数据见下表 Runs）；UniLab 侧为 child 2/3/4 合入后的对齐配方（audit GAP 0），上游为 microduck_rl @ 29e887ec 默认 BAM 配置。按 maintainer 决策，上游 seed43 未执行，上游统计为 n=1。
+
+终段窗口 = 每 run 末尾 20% iterations；收敛速度 = mean_reward 首次达到自身终段均值 80% 的 iteration。
+
+## Runs
+
+**UniLab**
+| run | seed | max_iterations |
+| --- | --- | --- |
+| `logs/rsl_rl_ppo/MicroduckVelocityFlat/2026-09-03_18-54-37_mjwarp` | 42 | 2000 |
+| `logs/rsl_rl_ppo/MicroduckVelocityFlat/2026-09-03_19-20-43_mjwarp` | 43 | 2000 |
+
+**Upstream (microduck_rl)**
+| run | seed | max_iterations |
+| --- | --- | --- |
+| `/home/user/ws/simulator/microduck_rl/logs/rsl_rl/velocity/2026-09-03_19-48-28_seed42` | 42 | 2000 |
+
+> ⚠ upstream 侧只有 1 个 run，std 不可用，统计仅供参考。
+
+## 总览指标
+
+| 指标 | UniLab | 上游 | 相对差 |
+| --- | --- | --- | --- |
+| mean_reward 终段均值 | 83.751 ± 5.422 | 113.833 (n=1) | -26.4% |
+| episode length 终段均值 | 976.211 ± 13.477 | 944.644 (n=1) | +3.3% |
+| 收敛 iteration (80% final reward) | 784.500 ± 132.229 | 128.000 (n=1) | +512.9% |
+
+## Reward term 终段对比
+
+| term (UniLab / 上游) | UniLab 终段 | 上游终段 | 相对差 |
+| --- | --- | --- | --- |
+| action_rate / action_rate_l2 | -0.801 ± 0.127 | -1.039 (n=1) | +22.9% |
+| air_time | 1.391 ± 0.129 | 1.024 (n=1) | +35.8% |
+| angular_momentum | -0.000 ± 0.000 | -0.000 (n=1) | -463.0% |
+| body_ang_vel | -0.349 ± 0.073 | -0.031 (n=1) | -1030.8% |
+| body_pose_tracking | 0.000 ± 0.000 | 0.000 (n=1) | n/a |
+| dof_pos_limits | -0.025 ± 0.017 | -0.001 (n=1) | -2494.5% |
+| foot_clearance | -0.022 ± 0.001 | -0.004 (n=1) | -401.2% |
+| foot_slip | -0.001 ± 0.000 | -0.000 (n=1) | -490.6% |
+| foot_swing_height | -0.077 ± 0.007 | -0.003 (n=1) | -2203.4% |
+| head_pose_bias | -0.219 ± 0.000 | -0.224 (n=1) | +2.3% |
+| head_pose_tracking | 1.702 ± 0.047 | 1.705 (n=1) | -0.1% |
+| leg_pose / pose | 0.062 ± 0.087 | 0.608 (n=1) | -89.7% |
+| self_collisions | -0.007 ± 0.007 | -0.001 (n=1) | -581.4% |
+| tracking_ang_vel / track_angular_velocity | 0.023 ± 0.006 | 0.679 (n=1) | -96.6% |
+| tracking_lin_vel / track_linear_velocity | 0.903 ± 0.171 | 1.267 (n=1) | -28.7% |
+| upright | 1.605 ± 0.079 | 1.713 (n=1) | -6.4% |
+
+## Termination 构成对比
+
+| term (UniLab / 上游) | UniLab 终段 | 上游终段 | 相对差 |
+| --- | --- | --- | --- |
+| nan_state | 0.000 ± 0.000 | 0.000 (n=1) | n/a |
+| tilt / fell_over | 0.214 ± 0.125 | 0.501 (n=1) | -57.4% |
+| time_out | 4.038 ± 0.066 | 3.914 (n=1) | +3.1% |
+上游独有 term: `out_of_terrain_bounds`
+
+## Termination 终段占比
+
+| term | UniLab 占比 | 上游占比 |
+| --- | --- | --- |
+| nan_state | 0.0% | 0.0% |
+| tilt | 5.0% | 11.3% |
+| time_out | 95.0% | 88.7% |
+| out_of_terrain_bounds (上游独有) | — | 0.0% |
+
+
+## 结论与归因
+
+**统计口径是否一致：部分一致。** 两侧在相同预算（2000 iter × 24 × 4096 envs）下都收敛到稳定行走（episode length 终段均 >940/1000，time_out 占比 88.7% vs 95.0%，head_pose_tracking、head_pose_bias、upright 等头部/姿态项几乎相同），说明对齐后的 UniLab 配方在任务结构、reward 构成与学习动态上与上游同族。但整体 return 仍有 -26.4% 差距，且上游收敛快得多（128 vs 785 iteration 达 80%）。
+
+**剩余差距的定量归因**（按观察到的模式与 roadmap 决策 A 的已知剩余项对照）：
+
+1. **执行器模型（PD vs BAM，决策 A 保留项）——与最大差异项的模式一致**：UniLab 侧的平滑性/约束类惩罚显著更大——body_ang_vel -0.349 vs -0.031（约 11 倍）、foot_swing_height -0.077 vs -0.003、foot_clearance -0.022 vs -0.004、dof_pos_limits -0.025 vs -0.001、self_collisions -0.007 vs -0.001；tracking_ang_vel 0.023 vs 0.679（几乎没学会跟踪 yaw 指令）、pose 0.062 vs 0.608。XML PD（kp=50/kv=0.5，100→200Hz 已对齐）与 BAM 电压伺服（电流限幅、每 substep 摩擦预算、15–30ms 命令延迟）的力矩响应特性不同，PD 侧策略以更大的姿态扰动和更糙的步态换取主要追踪项，符合"驱动动力学差异主导剩余差距"的预期。注意本报告未做消融（上游未改动、UniLab 无 BAM 实现），归因基于模式一致性而非受控实验。
+2. **环境项**：mujoco-warp 3.10.0.3 vs 上游 3.8.1（contact solver 实现有版本演进），影响量级未知，预计小于执行器项。
+3. **统计功效**：上游 n=1（seed43 按 maintainer 决策跳过），上述 ± 仅来自 UniLab 双 seed；上游数值的 seed 间方差未知，结论按趋势解读。
+4. **已排除项**：audit（`scripts/audit_microduck_alignment.py`）确认 PPO 超参、obs/commands/curriculum、物理积分、reset/DR、reward 栈、seed/规模全部逐项 match（184 项 MATCH / 0 GAP），差异不再来自配置漂移。
+
+**后续建议**：若需进一步收敛剩余差距，启动 roadmap #1452 决策项①的路线 C（复刻 BAM 执行器，独立 roadmap 规模）；或将本报告作为路线 A 的验收终点归档。
+
+## 数据与复现
+
+- 生成命令见 `logs/alignment_1457/run_all.sh`（训练驱动，未入库）；完整曲线摘要 `logs/alignment_1457/report.json`（未入库，可由 compare 脚本重新生成）。
+- UniLab runs：`logs/rsl_rl_ppo/MicroduckVelocityFlat/2026-09-03_18-54-37_mjwarp`（seed 42）、`2026-09-03_19-20-43_mjwarp`（seed 43）。
+- 上游 run：microduck_rl `logs/rsl_rl/velocity/2026-09-03_19-48-28_seed42`。

--- a/tests/scripts/test_microduck_alignment_compare.py
+++ b/tests/scripts/test_microduck_alignment_compare.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from torch.utils.tensorboard import SummaryWriter
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "microduck_alignment_compare.py"
+
+
+def _load_compare_module():
+    spec = importlib.util.spec_from_file_location("microduck_alignment_compare", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module  # dataclasses resolves cls.__module__ via sys.modules
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_unilab_run(run_dir: Path, rewards: list[float], seed: int) -> None:
+    run_dir.mkdir(parents=True)
+    writer = SummaryWriter(str(run_dir))
+    for step, reward in enumerate(rewards):
+        writer.add_scalar("Train/mean_reward", reward, step)
+        writer.add_scalar("Train/mean_episode_length", 100.0 + step, step)
+        writer.add_scalar("Episode_Reward/tracking_lin_vel", reward / 10.0, step)
+        writer.add_scalar("Episode_Reward/action_rate", -0.1, step)
+        writer.add_scalar("Episode_Termination/tilt", 1.0, step)
+        writer.add_scalar("Episode_Termination/time_out", 3.0, step)
+        writer.add_scalar("Loss/value", 0.5, step)  # out of scope, must be ignored
+    writer.close()
+    (run_dir / "run_config.json").write_text(
+        json.dumps({"run": {"effective_seed": seed}, "config": {"algo": {"max_iterations": 2000}}})
+    )
+
+
+def _write_upstream_run(run_dir: Path, rewards: list[float], seed: int) -> None:
+    run_dir.mkdir(parents=True)
+    writer = SummaryWriter(str(run_dir))
+    for step, reward in enumerate(rewards):
+        writer.add_scalar("Train/mean_reward", reward, step)
+        writer.add_scalar("Train/mean_episode_length", 50.0 + step, step)
+        writer.add_scalar("Episode_Reward/track_linear_velocity", reward / 20.0, step)
+        writer.add_scalar("Episode_Reward/action_rate_l2", -0.2, step)
+        writer.add_scalar("Episode_Reward/head_pose_bias", 0.01, step)  # unpaired on unilab side
+        writer.add_scalar("Episode_Termination/fell_over", 3.0, step)
+        writer.add_scalar("Episode_Termination/time_out", 1.0, step)
+    writer.close()
+    params = run_dir / "params"
+    params.mkdir()
+    (params / "agent.yaml").write_text(
+        f"seed: {seed}\nnum_steps_per_env: 24\nmax_iterations: 2000\n"
+        "obs_groups: !!python/tuple\n  - actor\n"
+    )
+
+
+def test_load_runs_scoped_tags_and_meta(tmp_path: Path) -> None:
+    compare = _load_compare_module()
+    run_dir = tmp_path / "unilab_run"
+    _write_unilab_run(run_dir, [1.0] * 10, seed=42)
+
+    runs = compare.load_runs([str(run_dir)], "unilab")
+
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.seed == 42
+    assert run.max_iterations == 2000
+    assert "Loss/value" not in run.curves
+    assert run.curves["Train/mean_reward"] == [(i, 1.0) for i in range(10)]
+
+
+def test_load_runs_skips_empty_dirs(tmp_path: Path) -> None:
+    compare = _load_compare_module()
+    empty = tmp_path / "aborted_run"
+    empty.mkdir()
+    good = tmp_path / "good_run"
+    _write_upstream_run(good, [1.0] * 10, seed=7)
+
+    runs = compare.load_runs([str(empty), str(good)], "upstream")
+
+    assert [r.seed for r in runs] == [7]
+
+
+def test_summarize_side_final_window_and_convergence(tmp_path: Path) -> None:
+    compare = _load_compare_module()
+    # Linear ramp 0..9: final 20% window covers the last 2 points (8, 9) -> 8.5;
+    # 80% of 8.5 = 6.8 first reached at iteration 7.
+    _write_unilab_run(tmp_path / "run_a", [float(i) for i in range(10)], seed=42)
+    _write_unilab_run(tmp_path / "run_b", [2.0 * i for i in range(10)], seed=43)
+    runs = compare.load_runs([str(tmp_path / "run_a"), str(tmp_path / "run_b")], "unilab")
+
+    summary = compare.summarize_side(runs)
+
+    # run_a final window mean(8, 9) = 8.5; run_b mean(16, 18) = 17 -> cross-run 12.75.
+    assert summary["Train/mean_reward"]["mean"] == 12.75
+    assert summary["Train/mean_reward"]["std"] is not None
+    assert summary["Train/mean_reward@convergence_iter"]["mean"] == 7.0
+    ep = summary["Train/mean_episode_length"]
+    assert ep["mean"] == 108.5  # per-run tail mean(108, 109) for both runs
+
+
+def test_build_report_pairs_aliased_terms(tmp_path: Path) -> None:
+    compare = _load_compare_module()
+    _write_unilab_run(tmp_path / "uni_a", [1.0] * 10, seed=42)
+    _write_upstream_run(tmp_path / "up_a", [2.0] * 10, seed=42)
+    unilab_runs = compare.load_runs([str(tmp_path / "uni_a")], "unilab")
+    upstream_runs = compare.load_runs([str(tmp_path / "up_a")], "upstream")
+
+    report = compare.build_report(unilab_runs, upstream_runs)
+
+    assert "tracking_lin_vel / track_linear_velocity" in report
+    assert "action_rate / action_rate_l2" in report
+    assert "tilt / fell_over" in report
+    assert "上游独有 term: `head_pose_bias`" in report
+    assert "只有 1 个 run" in report
+    # aliased termination values: unilab tilt=1 vs upstream fell_over=3 -> -66.7%
+    assert "-66.7%" in report


### PR DESCRIPTION
Closes #1457 ｜ Parent roadmap: #1452 ｜ Base: `dev/issue-1452-microduck-rl-alignment` ｜ 依赖：#1458/#1460/#1461/#1462（全部已合入）

## 交付内容

1. **`scripts/microduck_alignment_compare.py`**：解析两边 rsl_rl tensorboard tfevents，产出跨 seed 汇总（终段 20% 均值±std、收敛 iteration、episode length、逐 reward term、termination 构成）的 markdown + json；内置两边 term 命名别名表；空 run 跳过；单侧 <2 run 标注统计功效。含测试 `tests/scripts/test_microduck_alignment_compare.py`（伪造 tfevents 覆盖解析/汇总/别名/空目录）。
2. **`scripts/microduck_alignment_report.md`**：受控对比实验报告（真实训练数据）。

## 实验设置

- UniLab（对齐后配方，audit GAP 0）：`microduck_velocity_flat` mjwarp，4096 envs，2000 iter，seed 42/43 双 run（`logs/rsl_rl_ppo/MicroduckVelocityFlat/2026-09-03_18-54-37_mjwarp`、`2026-09-03_19-20-43_mjwarp`）。
- 上游 microduck_rl @ 29e887ec（默认 BAM 配置）：4096 envs，2000 iter，seed 42 单 run（**seed43 按 maintainer 决策跳过**，报告已标注 n=1 的统计局限）。

## 结论（详见报告）

**统计口径部分一致**：两侧同预算下都收敛到稳定行走（episode length 终段 976 vs 945，time_out 占比 95.0% vs 88.7%，头部/姿态项几乎相同）；但整体 return -26.4%（83.8 vs 113.8），收敛慢得多（785 vs 128 iter 达 80%）。剩余差距的模式——平滑性/约束惩罚大一个数量级（body_ang_vel 11×、foot_swing_height 25×）、tracking_ang_vel 几乎没学会（0.023 vs 0.679）——与决策 A 保留的 PD-vs-BAM 执行器动力学差异一致；次因 mujoco-warp 3.10.0.3 vs 3.8.1。配置漂移已被 audit 排除（184 MATCH / 0 GAP）。进一步收敛需启动路线 C（复刻 BAM，独立 roadmap）。

## Validation

- 训练 run：UniLab seed42/43 均收敛（mean reward ~91/84，episode length ~1000/963），上游 seed42 收敛（111/917）；日志在 `logs/alignment_1457/`。
- `uv run pytest tests/scripts/test_microduck_alignment_compare.py`：4 passed；脚本对半截 run 增量解析不炸。
- 改动文件 ruff / mypy 干净。
- **最终 head `8cd43ac0` 本地 `make test-all`：2555 passed, 28 skipped, 1 xfailed；pre-commit 与 benchmark 检查全部通过。**

不改训练行为（纯脚本 + 报告文档）。Base 非 `main`，按 gate 规则使用本地验证 + review。
