### PR TITLE
feat(cli): route mjwarp interactive eval through the MuJoCo viewer

### DIFF
--- a/docs/sphinx/source/en/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/en/5-reference/5-support_matrix.md
@@ -24,9 +24,11 @@ in English. Do not infer support beyond the evidence grade shown below.
 - `mujoco`: `--render-mode auto` exports `play_video.mp4`.
 - `motrix`: `--render-mode auto` opens an interactive renderer window; it does
   not record a video and is not bound by `play_steps`.
-- `mjwarp`: only supports explicit, finite-step `record`, rendered offline
-  through the task owner's MuJoCo visual model; `auto`, interactive, and
-  native renderers are not supported.
+- `mjwarp`: supports explicit, finite-step `record` by default, rendered offline
+  through the task owner's MuJoCo visual model; `--render-mode interactive`
+  routes to the MuJoCo interactive viewer (mjwarp runs the physics while
+  MuJoCo renders env[0], forced to a single env); `auto` and native renderers
+  are not supported.
 - `isaacsim`: headless physics only. Interactive GUI, camera capture, native
   playback, and video recording are fail-closed for the current IsaacSim 5.1 /
   IsaacLab v2.3.0 worker profile.
@@ -54,8 +56,10 @@ validation and have backend, contract, and playback automated coverage, so
 they are marked `Tested`. The SAC `t800_walk_flat` mjwarp owner only has an
 owner YAML and compose coverage, so it is marked `Configured`, which does not
 imply training validation. mjwarp playback
-only supports explicit, finite-step `record` and reuses the MuJoCo offline
-renderer; it does not support `auto`, interactive, or native playback. A
+supports explicit, finite-step `record` and reuses the MuJoCo offline
+renderer; `uv run eval --sim mjwarp --render-mode interactive` routes to the
+MuJoCo interactive viewer (mjwarp physics, MuJoCo rendering of env[0], forced
+single env); it does not support `auto` or native playback. A
 `Registered` mark on other entrypoints only denotes env/backend registry
 identity, not support for the corresponding algorithm, terrain, full DR, or
 production training.

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -20,7 +20,7 @@
 
 - `mujoco`: `--render-mode auto` 会导出 `play_video.mp4`
 - `motrix`: `--render-mode auto` 会打开交互式 renderer 窗口，不录制视频，不受 `play_steps` 限制
-- `mjwarp`: 仅支持显式、有限步数的 `record`，通过 task owner 的 MuJoCo visual model 离线录制；不支持 `auto`、interactive 或 native renderer
+- `mjwarp`: 默认仅支持显式、有限步数的 `record`，通过 task owner 的 MuJoCo visual model 离线录制；`--render-mode interactive` 路由到 MuJoCo 交互 viewer（mjwarp 跑物理、MuJoCo 渲染 env[0]，强制单 env）；不支持 `auto` 或 native renderer
 - `isaacsim`: `auto` 在有 display 时选择 Kit viewer，否则选择 headless RGB camera；当前真实主机仍有 RTX renderer 初始化 blocker，支持等级保持 `Configured`
 - `--render-mode record`: MuJoCo、mjwarp、Motrix 和 IsaacSim 都只录制视频
 - `--render-mode none`: 不回放
@@ -46,7 +46,7 @@ uv run scripts/generate_support_matrix.py --write
 
 `Tested` 只描述仓库中已有自动化覆盖或显式 maintainer 训练验证，不代表该组合具备同名 MuJoCo owner 的全部 backend capability；例如 phase-1 Motrix owner 可能只覆盖训练 smoke 和明确启用的 DR 子集。
 
-`mjwarp` 完成训练验证的只有 `g1_walk_flat` host adapter：PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`。SAC `t800_walk_flat` 的 mjwarp owner 只有 owner YAML 与 compose 覆盖，标记为 `Configured`，不代表训练验证。mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
+`mjwarp` 完成训练验证的只有 `g1_walk_flat` host adapter：PPO (torch) 与 SAC (torch) owner 已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`。SAC `t800_walk_flat` 的 mjwarp owner 只有 owner YAML 与 compose 覆盖，标记为 `Configured`，不代表训练验证。mjwarp playback 默认仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer；`uv run eval --sim mjwarp --render-mode interactive` 路由到 MuJoCo 交互 viewer（mjwarp 跑物理、MuJoCo 渲染 env[0]，强制单 env）；不支持 `auto` 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry identity，不代表对应算法、terrain、完整 DR 或 production training 支持。
 
 `isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机（external Python 3.8 worker runtime，不在仓库 CI 覆盖）完成训练与 record playback 验证，标记为 `Tested`；其余 isaacgym cell 最高只到 `Configured`（registry + owner YAML + compose/contract 覆盖），不代表任何训练或 play 验证。playback 走 IsaacGym 原生渲染（viewer + camera sensor 离屏录制），有显示器时 `play_render_mode=auto` 打开交互 viewer，无显示器时自动降级为离屏录制。
 

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -340,8 +340,10 @@ def render_support_matrix(root: Path | None = None) -> str:
         "已完成训练验证，并有 backend、contract 与 playback 自动化覆盖，因此标记为 `Tested`。"
         "SAC `t800_walk_flat` 的 mjwarp owner 只有 owner YAML 与 compose 覆盖，标记为 `Configured`，"
         "不代表训练验证。"
-        "mjwarp playback 仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer，不支持 `auto`、"
-        "interactive 或 native playback。其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry "
+        "mjwarp playback 默认仅支持显式、有限步数的 `record` 并复用 MuJoCo 离线 renderer；"
+        "`uv run eval --sim mjwarp --render-mode interactive` 路由到 MuJoCo 交互 viewer"
+        "（mjwarp 跑物理、MuJoCo 渲染 env[0]，强制单 env）；不支持 `auto` 或 native playback。"
+        "其他 entrypoint 中出现的 `Registered` 只表示 env/backend registry "
         "identity，不代表对应算法、terrain、完整 DR 或 production training 支持。",
         "",
         "`isaacgym` 是 Python 3.8 子进程后端，当前只接入 `g1_walk_flat`。SAC (torch) owner 已在真机"

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -20,6 +20,9 @@ SUPPORTED_SIMS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym", "genesis", 
 SUPPORTED_RENDER_MODES = ("auto", "interactive", "record", "none")
 OFFPOLICY_ALGOS = {"sac", "td3", "flashsac"}
 INTERACTIVE_PLAY_ALGOS = {"ppo", "appo", "sac", "td3", "flashsac"}
+# Physics backends whose interactive eval runs through the dedicated MuJoCo
+# viewer script: the selected backend owns the rollout while MuJoCo renders.
+MUJOCO_VIEWER_PHYSICS_SIMS = frozenset({"mujoco", "mjwarp"})
 RESERVED_OVERRIDE_KEYS = {
     "algo",
     "task",
@@ -248,7 +251,11 @@ def _uses_mujoco_interactive_play(
     overrides: Sequence[str],
 ) -> bool:
     """Return whether eval should use the dedicated MuJoCo viewer script."""
-    if mode != "eval" or sim != "mujoco" or algo not in INTERACTIVE_PLAY_ALGOS:
+    if (
+        mode != "eval"
+        or sim not in MUJOCO_VIEWER_PHYSICS_SIMS
+        or algo not in INTERACTIVE_PLAY_ALGOS
+    ):
         return False
     selected_mode = _override_value(overrides, "training.play_render_mode") or render_mode
     return selected_mode is not None and selected_mode.strip().lower() == "interactive"
@@ -280,6 +287,12 @@ def build_command(
         render_mode=render_mode,
         overrides=overrides,
     )
+    if use_interactive_play and find_spec("mujoco") is None:
+        raise SystemExit(
+            "interactive eval renders through the MuJoCo viewer and requires the MuJoCo "
+            "extra. Install it with `pip install unilab[mujoco]` (or `uv sync --extra "
+            "mujoco` in a source checkout)."
+        )
     script = (
         selected_root / "scripts" / "play_interactive.py"
         if use_interactive_play

--- a/src/unilab/conf/flashsac/task/g1_walk_flat/mjwarp.yaml
+++ b/src/unilab/conf/flashsac/task/g1_walk_flat/mjwarp.yaml
@@ -2,7 +2,8 @@
 # Configured-only FlashSAC mjwarp owner. Mirrors the MuJoCo owner's algo /
 # env / reward identity; mjwarp-specific host-adapter settings follow
 # conf/sac/task/g1_walk_flat/mjwarp.yaml. Offline record reuses
-# MuJoCo rendering; native playback and device-resident runtime are absent.
+# MuJoCo rendering; interactive eval routes through the MuJoCo viewer.
+# Native playback and device-resident runtime are absent.
 defaults:
   - /task/g1_walk_flat/base
   - _self_

--- a/src/unilab/conf/ppo/task/g1_walk_flat/mjwarp.yaml
+++ b/src/unilab/conf/ppo/task/g1_walk_flat/mjwarp.yaml
@@ -1,8 +1,9 @@
 # @package _global_
 # Configured-only mjwarp owner for the unified host contract adapter. Keeps
 # DENYLIST parity with the MuJoCo owner; legacy kp/kd randomization is disabled.
-# Offline record reuses MuJoCo rendering; native playback and device-resident
-# runtime routing are intentionally absent.
+# Offline record reuses MuJoCo rendering; interactive eval routes through the
+# MuJoCo viewer (mjwarp physics, single env). Native playback and
+# device-resident runtime routing are intentionally absent.
 defaults:
   - /task/g1_walk_flat/base
   - _self_

--- a/src/unilab/conf/sac/task/g1_walk_flat/mjwarp.yaml
+++ b/src/unilab/conf/sac/task/g1_walk_flat/mjwarp.yaml
@@ -2,7 +2,8 @@
 # Configured-only SAC mjwarp owner for the unified host contract adapter. Keeps
 # DENYLIST parity with the MuJoCo owner plus the mjwarp capacity knobs; legacy
 # kp/kd randomization is disabled. Offline record reuses MuJoCo rendering;
-# native playback and device-resident runtime are intentionally absent.
+# interactive eval routes through the MuJoCo viewer; native playback and
+# device-resident runtime are intentionally absent.
 defaults:
   - /task/g1_walk_flat/base
   - _self_

--- a/src/unilab/conf/sac/task/microduck_velocity_flat/mjwarp.yaml
+++ b/src/unilab/conf/sac/task/microduck_velocity_flat/mjwarp.yaml
@@ -1,8 +1,9 @@
 # @package _global_
 # SAC mjwarp owner for the unified host contract adapter. Keeps DENYLIST parity
 # with the MuJoCo owner (env/reward/algo identity unchanged) and only adds the
-# mjwarp capacity knobs. Offline record reuses MuJoCo rendering; native playback
-# and device-resident runtime are intentionally absent.
+# mjwarp capacity knobs. Offline record reuses MuJoCo rendering; interactive
+# eval routes through the MuJoCo viewer. Native playback and device-resident
+# runtime are intentionally absent.
 defaults:
   - /task/microduck_velocity_flat/base
   - _self_

--- a/src/unilab/conf/sac/task/t800_walk_flat/mjwarp.yaml
+++ b/src/unilab/conf/sac/task/t800_walk_flat/mjwarp.yaml
@@ -2,8 +2,9 @@
 # Configured-only SAC mjwarp owner for the T800 Manager-Based task. Keeps
 # DENYLIST parity with the MuJoCo owner plus the mjwarp capacity knobs; kp/kd
 # randomization is disabled because the mjwarp backend does not advertise gain
-# DR support. Offline record reuses MuJoCo rendering; native playback and
-# device-resident runtime are intentionally absent.
+# DR support. Offline record reuses MuJoCo rendering; interactive eval routes
+# through the MuJoCo viewer; native playback and device-resident runtime are
+# intentionally absent.
 defaults:
   - /task/t800_walk_flat/base
   - _self_

--- a/src/unilab/scripts/play_interactive.py
+++ b/src/unilab/scripts/play_interactive.py
@@ -1,8 +1,8 @@
 """MuJoCo interactive play script for trained policies.
 
 This MuJoCo-only viewer implementation opens a live MuJoCo window for any task
-owner config. ``--sim`` selects the physics owner; Drake runs the rollout while
-MuJoCo renders the current Drake state.
+owner config. ``--sim`` selects the physics owner; Drake and mjwarp run the
+rollout while MuJoCo renders the current physics state.
 
 Usage:
     # Zero-action playback for a task/backend owner config
@@ -49,6 +49,7 @@ from unilab.algos.rsl_rl import (
     get_policy_obs_dims,
     normalize_ppo_train_cfg,
 )
+from unilab.base.process_device import configure_backend_process_device
 from unilab.training import (
     algo_config_dict,
     ensure_registries,
@@ -905,6 +906,11 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
             "MuJoCo is used only as the renderer."
         )
         return
+
+    # mjwarp requires an active CUDA Warp device; bind it process-wide before
+    # any env is constructed (same pattern as the offpolicy train entrypoint).
+    # No-op for backends without a device binding requirement.
+    configure_backend_process_device(sim_backend, device)
 
     def _create_env(num_envs: int):
         if cfg is None:

--- a/tests/scripts/test_visualization_entrypoints.py
+++ b/tests/scripts/test_visualization_entrypoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -288,3 +289,65 @@ def test_play_interactive_viewer_model_uses_shared_render_playback_resolver(
     assert resolved["env"] is env
     assert resolved["num_envs"] == 1
     assert Path(resolved["tmp_dir"]).name.startswith("unilab-interactive-viewer-")
+
+
+def test_play_interactive_binds_mjwarp_process_device_before_session(monkeypatch):
+    mod = _load_script("play_interactive")
+    bound: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        mod,
+        "configure_backend_process_device",
+        lambda backend_type, device: bound.append((backend_type, device)),
+    )
+    monkeypatch.setattr(mod, "_select_playback_device", lambda cfg: "cuda:0")
+    monkeypatch.setattr(mod, "available_backends_for_task", lambda task: ["mjwarp"])
+
+    def _stop_before_session(**kwargs):
+        raise RuntimeError("stop-before-session")
+
+    monkeypatch.setattr(mod, "create_rsl_rl_playback_session", _stop_before_session)
+
+    args = SimpleNamespace(
+        algo="ppo",
+        task="g1_walk_flat",
+        sim="mjwarp",
+        load_run="-1",
+        checkpoint=None,
+        action_mode="policy",
+        policy_obs_mode="actor",
+    )
+    with pytest.raises(RuntimeError, match="stop-before-session"):
+        mod.play_interactive(args, None)
+
+    assert bound == [("mjwarp", "cuda:0")]
+
+
+def test_play_interactive_device_binding_is_noop_for_mujoco(monkeypatch):
+    mod = _load_script("play_interactive")
+    bound: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        mod,
+        "configure_backend_process_device",
+        lambda backend_type, device: bound.append((backend_type, device)),
+    )
+    monkeypatch.setattr(mod, "_select_playback_device", lambda cfg: "cuda:0")
+    monkeypatch.setattr(mod, "available_backends_for_task", lambda task: ["mujoco"])
+
+    def _stop_before_session(**kwargs):
+        raise RuntimeError("stop-before-session")
+
+    monkeypatch.setattr(mod, "create_rsl_rl_playback_session", _stop_before_session)
+
+    args = SimpleNamespace(
+        algo="ppo",
+        task="g1_walk_flat",
+        sim="mujoco",
+        load_run="-1",
+        checkpoint=None,
+        action_mode="policy",
+        policy_obs_mode="actor",
+    )
+    with pytest.raises(RuntimeError, match="stop-before-session"):
+        mod.play_interactive(args, None)
+
+    assert bound == [("mujoco", "cuda:0")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,6 +333,103 @@ def test_eval_mujoco_interactive_preserves_explicit_action_mode(
     assert "interactive.action_mode=random" in command
 
 
+def _pretend_mjwarp_is_installed(
+    monkeypatch: pytest.MonkeyPatch, *, with_mujoco: bool = True
+) -> None:
+    installed = {"mujoco_warp", "warp"} | ({"mujoco"} if with_mujoco else set())
+    monkeypatch.setattr(
+        cli,
+        "find_spec",
+        lambda name: ModuleSpec(name, loader=None) if name in installed else None,
+    )
+
+
+def _make_mjwarp_checkout(root: Path) -> Path:
+    scripts_dir = root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "train_rsl_rl.py").write_text("", encoding="utf-8")
+    (scripts_dir / "play_interactive.py").write_text("", encoding="utf-8")
+    owner_dir = root / "conf" / "ppo" / "task" / "g1_walk_flat"
+    owner_dir.mkdir(parents=True)
+    (owner_dir / "mjwarp.yaml").write_text("training:\n  sim_backend: mjwarp\n", encoding="utf-8")
+    return scripts_dir
+
+
+def test_eval_mjwarp_interactive_routes_to_dedicated_viewer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scripts_dir = _make_mjwarp_checkout(tmp_path)
+    _pretend_mjwarp_is_installed(monkeypatch)
+
+    command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="g1_walk_flat",
+        sim="mjwarp",
+        overrides=[],
+        load_run="-1",
+        render_mode="interactive",
+        root=tmp_path,
+    )
+
+    assert command == [
+        sys.executable,
+        str(scripts_dir / "play_interactive.py"),
+        "--algo",
+        "ppo",
+        "--task",
+        "g1_walk_flat",
+        "--sim",
+        "mjwarp",
+        "training.play_render_mode=interactive",
+        "interactive.action_mode=policy",
+        "training.play_only=true",
+        "algo.load_run=-1",
+    ]
+    assert "task=g1_walk_flat/mjwarp" not in command
+
+
+def test_eval_mjwarp_record_stays_on_train_script_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scripts_dir = _make_mjwarp_checkout(tmp_path)
+    _pretend_mjwarp_is_installed(monkeypatch)
+
+    command = cli.build_command(
+        mode="eval",
+        algo="ppo",
+        task="g1_walk_flat",
+        sim="mjwarp",
+        overrides=[],
+        load_run="-1",
+        render_mode="record",
+        root=tmp_path,
+    )
+
+    assert command[:2] == [sys.executable, str(scripts_dir / "train_rsl_rl.py")]
+    assert "task=g1_walk_flat/mjwarp" in command
+    assert "training.play_render_mode=record" in command
+
+
+def test_eval_mjwarp_interactive_requires_mujoco_viewer_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_mjwarp_checkout(tmp_path)
+    _pretend_mjwarp_is_installed(monkeypatch, with_mujoco=False)
+
+    with pytest.raises(SystemExit, match="MuJoCo"):
+        cli.build_command(
+            mode="eval",
+            algo="ppo",
+            task="g1_walk_flat",
+            sim="mjwarp",
+            overrides=[],
+            load_run="-1",
+            render_mode="interactive",
+            root=tmp_path,
+        )
+
+
 def test_macos_motrix_render_mode_none_does_not_require_mxpython(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 概述

`uv run eval --sim mjwarp --render-mode interactive` 现在直接路由到 `scripts/play_interactive.py`：mjwarp 负责物理 rollout，MuJoCo `viewer.launch_passive` 渲染 env[0]，交互模式强制单 env（与 Drake 已有的 "物理 backend 跑状态、MuJoCo viewer 渲染" 机制同一条路径）。

## 改动

- `src/unilab/cli.py`：新增 `MUJOCO_VIEWER_PHYSICS_SIMS = {"mujoco", "mjwarp"}`，`_uses_mujoco_interactive_play` 放行 mjwarp；interactive 路由补 `mujoco` 包依赖检查（viewer 需要，mjwarp 分支原本只查 `mujoco_warp`/`warp`）。
- `src/unilab/scripts/play_interactive.py`：建 env 前调用 `configure_backend_process_device(sim_backend, device)`（与 `train_offpolicy.py` 同模式）。mjwarp backend 要求活跃的 CUDA Warp device，此前只有训练路径做绑定；对其他 backend 是 no-op。num_env=1 由既有 `build_playback_config(args, num_envs=1)` 保证，未新增机制。
- 测试：`tests/test_cli.py` 新增 3 个路由用例（mjwarp interactive → play_interactive、record 仍走训练脚本、缺 mujoco 包时 SystemExit）；`tests/scripts/test_visualization_entrypoints.py` 新增 2 个 device 绑定用例。
- 文档/声明：`scripts/tools/support_matrix.py` 的 mjwarp playback 表述更新并重新生成 zh 矩阵生成块；zh/en 两版 Playback Differences 手写条目同步；5 个 mjwarp owner YAML 头注释更新（`play_render_mode: record` 默认值与 `auto` 不支持保持不变）。

## 明确不做

- 不改 mjwarp backend / unisim-core（`get_physics_state` / `get_playback_model` 契约已满足）。
- 不把 drake 接入 CLI interactive 路由（常量集合保留了扩展位）。

## Validation

- `make test-all` 在最终 head 81647122 通过（首次运行因本地缺 HF 机器人 mesh 资产失败，`unilab-pull-assets --robot all` 补齐后全绿；与本次改动无关）。
- 聚焦测试：`tests/test_cli.py`、`tests/scripts/test_visualization_entrypoints.py`、`tests/scripts/test_check_docs.py`、`tests/base/backend/test_process_device.py` 共 81 passed。
- 真实配置路由验证（不启动 viewer）：interactive 正确生成 `play_interactive.py --sim mjwarp ... interactive.action_mode=policy` 命令；record 仍走 `train_rsl_rl.py task=g1_walk_flat/mjwarp`。
- 真机冒烟（viewer 实际打开 + mjwarp CUDA 物理）未在本机执行：本机 venv 未安装 `mjwarp` extra 且无 display。建议在有 GPU 的机器上跑一次 `uv run eval --algo ppo --task g1_walk_flat --sim mjwarp --render-mode interactive --load-run=-1` 确认 `mj_setState(FULLPHYSICS)` 状态尺寸与 sim2sim preflight 行为。