### PR TITLE
fix(locomotion): gate foot contact on the contact-frame normal column (issue #1468)

### DIFF
--- a/src/unilab/conf/ppo/task/go2_joystick_flat/drake.yaml
+++ b/src/unilab/conf/ppo/task/go2_joystick_flat/drake.yaml
@@ -31,3 +31,10 @@ env:
   events:
     reset_root_state_uniform: null
     pd_gains: null
+
+reward:
+  # drake_uni reports per-body net contact force in the world frame, not the
+  # MuJoCo contact frame (normal first) the gait terms gate on; keep the
+  # contact reward off until the drake adapter reports contact-frame force
+  # (issue #1471).
+  contact: null

--- a/src/unilab/conf/sac/task/go2_joystick_flat/drake.yaml
+++ b/src/unilab/conf/sac/task/go2_joystick_flat/drake.yaml
@@ -34,3 +34,10 @@ env:
   drake_nthread: 20
   events:
     pd_gains: null
+
+reward:
+  # drake_uni reports per-body net contact force in the world frame, not the
+  # MuJoCo contact frame (normal first) the gait terms gate on; keep the
+  # contact reward off until the drake adapter reports contact-frame force
+  # (issue #1471).
+  contact: null

--- a/src/unilab/tasks/locomotion/common/gait_terms.py
+++ b/src/unilab/tasks/locomotion/common/gait_terms.py
@@ -119,7 +119,10 @@ class _FootContactTerm(SensorTermBase):
                 f"received {self._view.dimensions} on backend '{self._view.backend_type}'"
             )
         starts = np.cumsum((0, *self._view.dimensions[:-1]), dtype=np.int64)
-        columns = starts + [0 if width == 1 else 2 for width in self._view.dimensions]
+        # MuJoCo ``<contact data="force">`` sensors report the force in the
+        # contact frame whose first axis is the contact normal, so the gating
+        # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        columns = starts
         self._flat_width = int(sum(self._view.dimensions))
         # Per-foot column groups in the flattened sensor layout.
         self._columns: list[np.ndarray] = []

--- a/src/unilab/tasks/locomotion/common/gait_terms.py
+++ b/src/unilab/tasks/locomotion/common/gait_terms.py
@@ -122,6 +122,8 @@ class _FootContactTerm(SensorTermBase):
         # MuJoCo ``<contact data="force">`` sensors report the force in the
         # contact frame whose first axis is the contact normal, so the gating
         # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        # ``reduce="netforce"`` variants report world-frame force instead and
+        # are outside this contract.
         columns = starts
         self._flat_width = int(sum(self._view.dimensions))
         # Per-foot column groups in the flattened sensor layout.

--- a/src/unilab/tasks/locomotion/common/manager_terms.py
+++ b/src/unilab/tasks/locomotion/common/manager_terms.py
@@ -395,6 +395,8 @@ class feet_phase_contact(_FootSensorTerm):
         # MuJoCo ``<contact data="force">`` sensors report the force in the
         # contact frame whose first axis is the contact normal, so the gating
         # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        # ``reduce="netforce"`` variants report world-frame force instead and
+        # are outside this contract.
         self._columns = starts
 
     def __call__(self, env: _GaitEnv, **params: Any) -> np.ndarray:
@@ -498,6 +500,8 @@ class feet_air_while_standing(ManagerTermBase):
         # MuJoCo ``<contact data="force">`` sensors report the force in the
         # contact frame whose first axis is the contact normal, so the gating
         # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        # ``reduce="netforce"`` variants report world-frame force instead and
+        # are outside this contract.
         self._columns = starts
 
     def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:

--- a/src/unilab/tasks/locomotion/common/manager_terms.py
+++ b/src/unilab/tasks/locomotion/common/manager_terms.py
@@ -392,7 +392,10 @@ class feet_phase_contact(_FootSensorTerm):
                 f"received {self._view.dimensions} on backend '{self._view.backend_type}'"
             )
         starts = np.cumsum((0, *self._view.dimensions[:-1]), dtype=np.int64)
-        self._columns = starts + [0 if width == 1 else 2 for width in self._view.dimensions]
+        # MuJoCo ``<contact data="force">`` sensors report the force in the
+        # contact frame whose first axis is the contact normal, so the gating
+        # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        self._columns = starts
 
     def __call__(self, env: _GaitEnv, **params: Any) -> np.ndarray:
         del params
@@ -492,7 +495,10 @@ class feet_air_while_standing(ManagerTermBase):
                 f"received {self._view.dimensions} on backend '{self._view.backend_type}'"
             )
         starts = np.cumsum((0, *self._view.dimensions[:-1]), dtype=np.int64)
-        self._columns = starts + [0 if width == 1 else 2 for width in self._view.dimensions]
+        # MuJoCo ``<contact data="force">`` sensors report the force in the
+        # contact frame whose first axis is the contact normal, so the gating
+        # component is column 0 for both 1-D ``found`` and 3-D ``force``.
+        self._columns = starts
 
     def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
         del params

--- a/tests/envs/locomotion/go2/test_manager_based_cfg.py
+++ b/tests/envs/locomotion/go2/test_manager_based_cfg.py
@@ -234,9 +234,16 @@ def test_go2_flat_owner_materializes_complete_plain_manager_cfg(
             "contact": 0.24,
             "swing_feet_z": 4.0,
         }
+        if backend == "drake":
+            # The drake owner disables contact: drake_uni reports world-frame
+            # per-body net contact force, not contact-frame force (#1471).
+            del expected_weights["contact"]
         if alive_declared:
             expected_weights["alive"] = 0.0
-        assert {name: term.weight for name, term in env_cfg.rewards.items()} == expected_weights
+        actual_weights = {
+            name: term.weight for name, term in env_cfg.rewards.items() if term is not None
+        }
+        assert actual_weights == expected_weights
 
     if fixed_command:
         ranges = env_cfg.commands["twist"].ranges

--- a/tests/envs/locomotion/test_gait_terms.py
+++ b/tests/envs/locomotion/test_gait_terms.py
@@ -427,6 +427,24 @@ def test_foot_contact_reports_float_flags() -> None:
     np.testing.assert_allclose(term(env), [[1.0, 0.0], [0.0, 0.0]])
 
 
+def test_force_contact_gating_uses_contact_frame_normal_column() -> None:
+    """Width-3 ``data="force"`` contact sensors gate on column 0.
+
+    MuJoCo reports contact force in the contact frame whose first axis is the
+    contact normal; tangential columns 1-2 must not trigger contact.
+    """
+    scene = _Scene()
+    scene.contacts = {
+        "left_contact_0": np.array([[0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=np.float32),
+        "left_contact_1": np.zeros((2, 3), dtype=np.float32),
+        "right_contact_0": np.array([[0.0, 0.0, 3.0], [0.0, 0.0, 3.0]], dtype=np.float32),
+        "right_contact_1": np.zeros((2, 3), dtype=np.float32),
+    }
+    env = _env(scene)
+    term = _term(gait_terms.foot_contact, env, sensor_groups=GROUPS)
+    np.testing.assert_allclose(term(env), [[1.0, 0.0], [1.0, 0.0]])
+
+
 def test_foot_contact_forces_log_compressed_in_group_order() -> None:
     scene = _Scene()
     scene.contacts = {

--- a/tests/envs/locomotion/test_manager_gait_terms.py
+++ b/tests/envs/locomotion/test_manager_gait_terms.py
@@ -31,9 +31,12 @@ class _Scene:
         self.calls: Counter[str] = Counter()
         self.values = {
             "fl_contact": np.array([[0.2], [0.0]], dtype=np.float32),
-            "fr_contact": np.array([[0, 0, 0], [0, 0, 0.2]], dtype=np.float32),
+            # Width-3 contact ``force`` sensors follow the MuJoCo contact-frame
+            # convention: column 0 is the normal force, columns 1-2 are
+            # tangential and must not gate contact.
+            "fr_contact": np.array([[0, 0.9, 0.9], [0.2, 0, 0]], dtype=np.float32),
             "rl_contact": np.array([[0.0], [0.2]], dtype=np.float32),
-            "rr_contact": np.array([[0, 0, 0.2], [0, 0, 0]], dtype=np.float32),
+            "rr_contact": np.array([[0.2, 0, 0], [0, 0.9, 0.9]], dtype=np.float32),
             "fl_pos": np.array([[0, 0, 0.1], [0, 0, 0]], dtype=np.float32),
             "fr_pos": np.array([[0, 0, 0.2], [0, 0, 0.1]], dtype=np.float32),
             "rl_pos": np.array([[0, 0, 0.1], [0, 0, 0.2]], dtype=np.float32),

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -711,7 +711,9 @@ def test_ppo_go2_drake_batch_config_matches_go2_training_defaults():
     assert cfg.env.drake_nthread == 0
     assert cfg.env.scene.model_file == "src/unilab/assets/robots/go2/scene_flat.xml"
     assert cfg.env.events.pd_gains is None
-    assert cfg.reward.contact.weight == pytest.approx(0.24)
+    # Contact reward disabled on drake: drake_uni reports world-frame net
+    # contact force, not contact-frame force (issue #1471).
+    assert cfg.reward.contact is None
 
 
 def test_build_ppo_env_cfg_override_go1_motrix(


### PR DESCRIPTION
Fixes #1468

## 问题

`gait_terms._FootContactTerm`、`manager_terms.feet_phase_contact`、`manager_terms.feet_air_while_standing` 三处对 3-D force 接触传感器取第 2 列（切向分量）做接触门控。MuJoCo `<contact data="force">` 传感器在接触坐标系下第 0 列才是法向力。仓库内所有 width-3 接触传感器（microduck / go1 / go2 / a2 的 `locomotion_task.xml`）都是 contact-frame 力传感器，旧约定对全部现存用户都是错的。

实测（issue 证据，64 envs / mjwarp / seed 42）：站立时法向接触率 98.3%，旧门控只报 3.5%（一致率 5.2%），污染 `feet_air_time`（weight 3.0）/ `feet_swing_height` / `feet_slip` 奖励及 `foot_contact` / `foot_air_time` / `foot_contact_forces` obs 通道，是 #1452 对齐后 microduck 与上游剩余 return 差距的独立贡献项。

## 修复

- 三处门控统一取第 0 列（1-D `found` 与 3-D `force` 同为首列），并在注释中写明 MuJoCo contact-frame 约定。
- `test_manager_gait_terms.py` fixture 把接触信号移到第 0 列并加入大幅切向干扰值（回退到旧列约定即失败）；`test_gait_terms.py` 新增 width-3 法向列回归测试。

## Validation

- `make test-all` 于最终 head c49c8806 通过（全量 pytest + benchmark module-mode 35/36、script-mode 36/37，仅 platform-optional mlx 跳过）。
- 实证复测（修复后，同 probe 协议）：term 门控与法向力真值一致率 站立 1.000 / 行走样动作 0.998（修复前 0.052 / 0.741）。
- microduck 专用接触项（`microduck/manager_terms.py`，本就用第 0 列）不受影响；g1 的 `found` 标量传感器不受影响。