### PR TITLE
feat(microduck): port BAM xl330-m6 voltage actuator model (issue #1474)

### DIFF
--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -92,6 +92,7 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested | - | - | - |
 | PPO (torch) | `microduck_ground_pick_flat` (microduck ground pick flat) | - | Configured | - | - | - | - |
 | PPO (torch) | `microduck_sitstand_flat` (microduck sitstand flat) | - | Configured | - | - | - | - |
+| PPO (torch) | `microduck_velocity_bam_flat` (microduck velocity bam flat) | Tested | - | - | - | - | - |
 | PPO (torch) | `microduck_velocity_flat` (microduck velocity flat) | Tested | Configured | - | - | - | - |
 | PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested | - | - | - |
 | PPO (torch) | `t800_walk_flat` (t800 walk flat) | Tested | Registered | - | - | - | - |

--- a/src/unilab/assets/robots/microduck/microduck_bam.xml
+++ b/src/unilab/assets/robots/microduck/microduck_bam.xml
@@ -1,0 +1,436 @@
+<?xml version="1.0" ?>
+<!-- Generated using onshape-to-robot -->
+<!-- Onshape https://cad.onshape.com/documents/804927696f06d877f3f1803e/w/5b75db19292e71970de02dee/e/ef6e972847fec8d82570b35e -->
+<mujoco model="microduck_bam">
+  <!-- BAM actuator variant of microduck.xml (issue #1474): the fourteen
+       chosen_actuator servos are <motor> torque actuators driven per physics
+       substep by BamVoltageAction (tasks/locomotion/microduck/bam_action.py),
+       porting the upstream bam xl330-m6 voltage-servo model. Structure,
+       inertials, sensors and all other default classes are identical to
+       microduck.xml. -->
+  <compiler angle="radian" meshdir="assets" autolimits="true"/>
+  <default>
+    <default class="microduck">
+      <joint frictionloss="0.1" armature="0.005"/>
+      <position kp="50" dampratio="1"/>
+      <default class="visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2"/>
+      </default>
+      <default class="collision">
+        <geom group="3"/>
+      </default>
+    </default>
+  </default>
+  <!-- Additional joints_properties.xml -->
+  <default>
+    <default class="perfect_actuator">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.15" frictionloss="0.1" armature="0.001"/>
+      <position kp="10.0" kv="0.1" forcerange="-20.0 20.0"/>
+    </default>
+    <default class="chosen_actuator_old">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.048" frictionloss="0.006" armature="0.002"/>
+      <position kp="0.52" kv="0.0" forcerange="-0.91 0.91" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator_new">
+      <!-- removing contaminated data -->
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.041" frictionloss="0.032" armature="0.002"/>
+      <position kp="0.386" kv="0.0" forcerange="-0.67 0.67" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator_antoine">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.044" frictionloss="0.013" armature="0.0017"/>
+      <position kp="0.43" kv="0.0" forcerange="-0.75 0.75" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator">
+      <!-- BAM xl330-m6 (issue #1474): torque-path actuator. Dry/viscous joint
+           friction is computed inside BamVoltageAction's torque budget, so the
+           solver-side damping/frictionloss stay zero. Armature is the
+           BAM-fitted reflected rotor inertia (upstream dof_armature). -->
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.0" frictionloss="0.0" armature="0.0018077432831600838"/>
+      <!-- Motor mode: BamVoltageAction writes joint torque directly (gear=1).
+           forcerange = max(vin_range) * kt / R = 8.2 * 0.3660135 / 2.8113924;
+           the solver performs the final torque truncation. -->
+      <motor gear="1" forcerange="-1.0676 1.0676" ctrlrange="-1.0676 1.0676"/>
+    </default>
+    <default class="passive_wheel">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.0" frictionloss="0.0" armature="0.0001"/>
+    </default>
+    <default class="passive_joint">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.0" frictionloss="0.0" armature="0.0001"/>
+    </default>
+  </default>
+  <!-- IMU sensors consumed by UniLab locomotion envs. -->
+  <sensor>
+    <gyro site="imu" name="gyro"/>
+    <velocimeter site="imu" name="local_linvel"/>
+    <framezaxis objtype="site" objname="imu" name="upvector"/>
+    <accelerometer name="imu_accel" site="imu"/>
+    <subtreeangmom name="root_angmom" body="trunk_base"/>
+  </sensor>
+  <!-- Additional additional.xml -->
+  <default>
+    <default class="self_collision_only">
+      <geom group="3" contype="2" conaffinity="2"/>
+    </default>
+    <equality solref="0.002 1" solimp="0.99 0.999 0.0005 0.5 2"/>
+  </default>
+  <!-- <contact> -->
+  <!-- Jaw collision mesh overlaps the bottom head shell by ~2cm because the closed -->
+  <!-- loop linkage positions it inside the head. Without these excludes the -->
+  <!-- self-collision sensor reports a constant 2 contacts, giving a -->
+  <!-- permanent ~-2.0 reward penalty in the standup env. -->
+  <!-- <exclude body1="jaw" body2="bottom_head_shell"/> -->
+  <!-- </contact> -->
+  <worldbody>
+    <!-- Link trunk_base -->
+    <body name="trunk_base" pos="0 0 0.12" quat="1 0 0 0" childclass="microduck">
+      <freejoint name="trunk_base_freejoint"/>
+      <inertial pos="-0.0226332 -2.70828e-05 0.00280064" mass="0.199224" fullinertia="0.000123975 0.000145931 0.000115351 7.1651e-08 -2.06915e-05 1.32429e-07"/>
+      <!-- Part seeed_bearing__configuration__22x16x4 -->
+      <geom type="mesh" class="visual" pos="0.006 0.0175 -0.005" quat="1 -0 -0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+      <!-- Part right_shell -->
+      <geom type="mesh" class="visual" pos="0.004 -0.0005 -0.0175" quat="0.707107 -0 -0 0.707107" mesh="right_shell" material="right_shell_material"/>
+      <!-- Part banana_pcb_locker -->
+      <geom type="mesh" class="visual" pos="0.0042 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="banana_pcb_locker" material="banana_pcb_locker_material"/>
+      <!-- Part trunk_base -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175" quat="0.707107 -0 -0 0.707107" mesh="trunk_base" material="trunk_base_material"/>
+      <!-- Part xl330 -->
+      <geom type="mesh" class="visual" pos="0.006 0.0175 0.0115" quat="0 0.707107 -0 0.707107" mesh="xl330" material="xl330_material"/>
+      <!-- Part power_support -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="power_support" material="power_support_material"/>
+      <geom type="mesh" class="self_collision_only" name="trunk_base_self_collision" pos="0.004 -0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="power_support" material="power_support_material"/>
+      <!-- Part np_f970 -->
+      <geom type="mesh" class="visual" pos="-0.0359693 0 -0.00385049" quat="0.00617059 0.70708 -0.70708 -0.00617059" mesh="np_f970" material="np_f970_material"/>
+      <!-- Part xl330_2 -->
+      <geom type="mesh" class="visual" pos="0.006 -0.0175 0.0115" quat="0 0.707107 -0 0.707107" mesh="xl330" material="xl330_material"/>
+      <!-- Part left_shell -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175785" quat="0.707107 0 -0 0.707107" mesh="left_shell" material="left_shell_material"/>
+      <!-- Part seeed_bearing__configuration__22x16x4_2 -->
+      <geom type="mesh" class="visual" pos="0.006 -0.0175 -0.005" quat="1 -0 -0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+      <!-- Frame imu -->
+      <site group="3" name="imu" pos="-0.021 6.64098e-05 -0.0146984" quat="1 -0 -0 0"/>
+      <!-- Link yaw2roll -->
+      <body name="yaw2roll" pos="0.006 0.0175 -0.005" quat="0 -0.707107 -0.707107 -0">
+        <!-- Joint from trunk_base to yaw2roll -->
+        <joint axis="0 0 1" name="left_hip_yaw" type="hinge" range="-0.4363323129985824 0.5235987755982988" class="chosen_actuator"/>
+        <inertial pos="-8.8e-11 0.00099414 0.0168917" mass="0.0230406" fullinertia="4.1964e-06 3.41752e-06 2.3265e-06 -0 -0 -5.0881e-08"/>
+        <!-- Part yaw2roll -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 1 0 0" mesh="yaw2roll" material="yaw2roll_material"/>
+        <!-- Part xl330_3 -->
+        <geom type="mesh" class="visual" pos="-0 0 0.0125" quat="0 -0.707107 0.707107 -0" mesh="xl330" material="xl330_material"/>
+        <!-- Part seeed_bearing__configuration__22x16x4_3 -->
+        <geom type="mesh" class="visual" pos="-0 0.0165 0.0125" quat="0.5 0.5 0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+        <!-- Part bearing_roll -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 -1 -0 -0" mesh="bearing_roll" material="bearing_roll_material"/>
+        <!-- Link hip_l -->
+        <body name="hip_l" pos="0 0.0165 0.0125" quat="0.707107 -0.707107 -0 -0">
+          <!-- Joint from yaw2roll to hip_l -->
+          <joint axis="0 0 1" name="left_hip_roll" type="hinge" range="-0.3839724354387525 0.3839724354387525" class="chosen_actuator"/>
+          <inertial pos="0.014815 1.6179e-08 -0.00829992" mass="0.00618934" fullinertia="8.60626e-07 1.15753e-06 6.51588e-07 1e-12 3.89882e-07 -1e-12"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_4 -->
+          <geom type="mesh" class="visual" pos="0.021 0 -0.0185" quat="0.5 0.5 0.5 0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Part hip_l -->
+          <geom type="mesh" class="visual" pos="-0.0175 0 -0.0185" quat="0.707107 -0.707107 0 -0" mesh="hip_l" material="hip_l_material"/>
+          <!-- Link upper_leg_left -->
+          <body name="upper_leg_left" pos="0.025 0 -0.0185" quat="0.5 -0.5 0.5 -0.5">
+            <!-- Joint from hip_l to upper_leg_left -->
+            <joint axis="0 0 1" name="left_hip_pitch" type="hinge" range="-1.570796326795005 1.5707963267947882" class="chosen_actuator"/>
+            <inertial pos="0.006766 0.0228838 0.0134531" mass="0.0482067" fullinertia="1.68753e-05 1.03691e-05 1.98269e-05 -4.41852e-06 2.27982e-07 3.89298e-07"/>
+            <!-- Part upper_leg_left -->
+            <geom type="mesh" class="visual" pos="-0 -0 -0.0425" quat="0.5 -0.5 -0.5 -0.5" mesh="upper_leg_left" material="upper_leg_left_material"/>
+            <!-- Part xl330_4 -->
+            <geom type="mesh" class="visual" pos="0.022 0.0357771 0.0125" quat="0 -0.707107 -0 -0.707107" mesh="xl330" material="xl330_material"/>
+            <!-- Part upper_leg_rigidity_plate -->
+            <geom type="mesh" class="visual" pos="0 -0 -0.0425" quat="0.5 -0.5 -0.5 -0.5" mesh="upper_leg_rigidity_plate" material="upper_leg_rigidity_plate_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_5 -->
+            <geom type="mesh" class="visual" pos="0.022 0.0357771 -0.004" quat="0 0 0 1" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part xl330_5 -->
+            <geom type="mesh" class="visual" pos="-0 -0 0.0125" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Link leg -->
+            <body name="leg" pos="0.022 0.0357771 -0.004" quat="0 0.707107 0.707107 0">
+              <!-- Joint from upper_leg_left to leg -->
+              <joint axis="0 0 1" name="left_knee" type="hinge" range="-1.570796326795012 1.570796326794781" class="chosen_actuator"/>
+              <inertial pos="-1.52e-10 0.0318937 -0.00953505" mass="0.0215844" fullinertia="5.25056e-06 2.15507e-06 4.33925e-06 -1e-12 0 7.65005e-07"/>
+              <!-- Part leg -->
+              <geom type="mesh" class="visual" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" name="left_leg_self_collision" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
+              <!-- Part xl330_6 -->
+              <geom type="mesh" class="visual" pos="0 0.042 -0.0115" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+              <!-- Link ankle_left -->
+              <body name="ankle_left" pos="0 0.042 -0.026" quat="0 1 -0 0">
+                <!-- Joint from leg to ankle_left -->
+                <joint axis="0 0 1" name="left_ankle" type="hinge" range="-1.5707963267949019 1.5707963267948912" class="chosen_actuator"/>
+                <inertial pos="-0.00615738 -0.0137483 -0.0156586" mass="0.0300246" fullinertia="5.91525e-06 1.11534e-05 7.74015e-06 -2.0535e-07 8.2152e-08 5.6714e-08"/>
+                <!-- Part sole_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="sole_left" material="sole_left_material"/>
+                <geom type="mesh" name="left_foot_collision" class="collision" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="sole_left" material="sole_left_material"/>
+                <!-- Part foot_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="foot_left" material="foot_left_material"/>
+                <!-- Part seeed_bearing__configuration_default -->
+                <geom type="mesh" class="visual" pos="0 0 -0.0322" quat="0 0 -0 1" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+                <!-- Part ankle_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="ankle_left" material="ankle_left_material"/>
+                <!-- Frame left_foot -->
+                <site group="3" name="left_foot" pos="-0 -0.0238146 -0.0140852" quat="0 0 0.707107 0.707107"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- Link neck -->
+      <body name="neck" pos="0.026 0.0145 0.0324215" quat="0 0 0.707107 -0.707107">
+        <!-- Joint from trunk_base to neck -->
+        <joint axis="0 0 1" name="neck_pitch" type="hinge" range="-1.5707963267948966 1.0471975511965976" class="chosen_actuator"/>
+        <inertial pos="0 -0.025 0.0141665" mass="0.0368414" fullinertia="1.72925e-05 3.12694e-06 1.63707e-05 0 0 0"/>
+        <!-- Part neck -->
+        <geom type="mesh" class="visual" pos="0.022 0.05 0.028" quat="0.5 0.5 0.5 -0.5" mesh="neck" material="neck_material"/>
+        <!-- Part xl330_7 -->
+        <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+        <!-- Part xl330_8 -->
+        <geom type="mesh" class="visual" pos="0 -0.05 0.0145" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+        <!-- Part neck_2 -->
+        <geom type="mesh" class="visual" pos="0.022 0.05 0.003" quat="0.5 0.5 0.5 -0.5" mesh="neck" material="neck_material"/>
+        <!-- Link neck_pitch -->
+        <body name="neck_pitch" pos="0 -0.05 -0" quat="0 1 0 0">
+          <!-- Joint from neck to neck_pitch -->
+          <joint axis="0 0 1" name="head_pitch" type="hinge" range="-1.5707963267948974 1.5707963267948957" class="chosen_actuator"/>
+          <inertial pos="-6.533e-09 0.0116641 -0.0145" mass="0.00572" fullinertia="1.09186e-06 9.66855e-07 5.12111e-07 0 0 0"/>
+          <!-- Part neck_pitch -->
+          <geom type="mesh" class="visual" pos="-0 0.0287931 -0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="neck_pitch" material="neck_pitch_material"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_6 -->
+          <geom type="mesh" class="visual" pos="-0 0.0207931 -0.0145" quat="0.707107 0.707107 0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Link yaw_roll_motion -->
+          <body name="yaw_roll_motion" pos="-0 0.0186931 -0.0145" quat="0 0 -0.707107 -0.707107">
+            <!-- Joint from neck_pitch to yaw_roll_motion -->
+            <joint axis="0 0 1" name="head_yaw" type="hinge" range="-2.967059728390373 2.967059728390348" class="chosen_actuator"/>
+            <inertial pos="-0.000166657 -0.00500964 0.0178065" mass="0.0486" fullinertia="6.97903e-06 8.10293e-06 9.57884e-06 3.21657e-07 -3.4797e-08 3.4295e-07"/>
+            <!-- Part yaw_roll_motion -->
+            <geom type="mesh" class="visual" pos="0 0 0.01" quat="0.707107 0 -0 0.707107" mesh="yaw_roll_motion" material="yaw_roll_motion_material"/>
+            <!-- Part xl330_9 -->
+            <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_7 -->
+            <geom type="mesh" class="visual" pos="-0.016 0 0.0145" quat="0.707107 -0 -0.707107 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_8 -->
+            <geom type="mesh" class="visual" pos="0.018 0 0.0145" quat="0.707107 -0 -0.707107 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Link jaw_soft -->
+            <body name="jaw_soft" pos="-0.0179 0 0.0145" quat="0.707107 -0 -0.707107 -0">
+              <!-- Joint from yaw_roll_motion to jaw_soft -->
+              <joint axis="0 0 1" name="head_roll" type="hinge" range="-0.43633231299859127 0.4363323129985735" class="chosen_actuator"/>
+              <inertial pos="0.00460523 0.00120047 -0.0324761" mass="0.188766" fullinertia="0.000320812 0.0002541 0.000149882 -6.32292e-07 6.57154e-06 4.18476e-06"/>
+              <!-- Part lens -->
+              <geom type="mesh" class="visual" pos="0.0155 -9.13778e-05 -0.05548" quat="0.5 -0.5 0.5 -0.5" mesh="lens" material="lens_material"/>
+              <!-- Part face_part -->
+              <geom type="mesh" class="visual" pos="-0.0045 -9.13778e-05 -0.0178" quat="0.5 0.5 0.5 0.5" mesh="face_part" material="face_part_material"/>
+              <!-- Part xl330_10 -->
+              <geom type="mesh" class="visual" pos="0.003 0.0255 -0.018" quat="0.707107 0 -0 -0.707107" mesh="xl330" material="xl330_material"/>
+              <!-- Part jaw_soft -->
+              <geom type="mesh" class="visual" pos="-0.0046 0 -0.0179996" quat="0.5 0.5 0.5 0.5" mesh="jaw_soft" material="jaw_soft_material"/>
+              <!-- Part motor_support -->
+              <geom type="mesh" class="visual" pos="-0.0045 0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="motor_support" material="motor_support_material"/>
+              <!-- Part top_head_shell -->
+              <geom type="mesh" class="visual" pos="-0.0045 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="top_head_shell" material="top_head_shell_material"/>
+              <!-- Part xl330_11 -->
+              <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+              <!-- Part seeed_bearing__configuration_default_2 -->
+              <geom type="mesh" class="visual" pos="0.0032 -0.04 -0.018" quat="0.5 -0.5 0.5 0.5" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+              <!-- Part elec_rpi_robot_hat_pcb -->
+              <geom type="mesh" class="visual" pos="0.02694 0.0289936 -0.0519" quat="0.707107 0 0 -0.707107" mesh="elec_rpi_robot_hat_pcb" material="elec_rpi_robot_hat_pcb_material"/>
+              <!-- Part soft_mouth_top -->
+              <geom type="mesh" class="visual" pos="-0.00420071 1.7776e-08 -0.0180814" quat="0.5 0.5 0.5 0.5" mesh="soft_mouth_top" material="soft_mouth_top_material"/>
+              <!-- Part noenoeil -->
+              <geom type="mesh" class="visual" pos="-0.0045 -9.13778e-05 -0.0178" quat="0.5 0.5 0.5 0.5" mesh="noenoeil" material="noenoeil_material"/>
+              <!-- Part jaw -->
+              <geom type="mesh" class="visual" pos="-0.0045 0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="jaw" material="jaw_material"/>
+              <!-- Part bottom_head_shell -->
+              <geom type="mesh" class="visual" pos="-0.0043 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="bottom_head_shell" material="bottom_head_shell_material"/>
+              <!-- Part m12_lens_holder -->
+              <geom type="mesh" class="visual" pos="0.0155 -9.13778e-05 -0.05558" quat="0.5 -0.5 0.5 -0.5" mesh="m12_lens_holder" material="m12_lens_holder_material"/>
+              <!-- Part pcb__raspberry_pi_zero_2_w -->
+              <geom type="mesh" class="visual" pos="0.015435 -1.13778e-05 -0.06001" quat="0.5 -0.5 -0.5 0.5" mesh="pcb__raspberry_pi_zero_2_w" material="pcb__raspberry_pi_zero_2_w_material"/>
+              <!-- Part speaker -->
+              <geom type="mesh" class="visual" pos="0.01 -0.016786 0.0260226" quat="0.5 0.5 0.5 0.5" mesh="speaker" material="speaker_material"/>
+              <!-- Frame head_camera -->
+              <site group="3" name="head_camera" pos="0.0155 -9.13778e-05 -0.0733" quat="0.707107 0 0.707107 -0"/>
+              <camera name="head_camera" pos="0.0155 -9.13778e-05 -0.0733" quat="0 0 -1 0"/>
+              <!-- Frame tof -->
+              <site group="3" name="tof" pos="0.0135 0.0224086 -0.0733" quat="0.707107 0 0.707107 -0"/>
+              <!-- Frame head_imu -->
+              <site group="3" name="head_imu" pos="0.0152323 0.000111069 -0.05106" quat="1 0 0 -0"/>
+              <!-- Frame mouth_tip -->
+              <site group="3" name="mouth_tip" pos="-0.00809334 -0 -0.0777383" quat="0.704015 0 0.710185 -0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- Link bearing_roll -->
+      <body name="bearing_roll" pos="0.006 -0.0175 -0.005" quat="0 0.707107 0.707107 0">
+        <!-- Joint from trunk_base to bearing_roll -->
+        <joint axis="0 0 1" name="right_hip_yaw" type="hinge" range="-0.5235987755982988 0.4363323129985824" class="chosen_actuator"/>
+        <inertial pos="-8.8e-11 0.00099414 0.0168917" mass="0.0230406" fullinertia="4.1964e-06 3.41752e-06 2.3265e-06 -0 -0 -5.0881e-08"/>
+        <!-- Part yaw2roll_2 -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 1 0 0" mesh="yaw2roll" material="yaw2roll_material"/>
+        <!-- Part xl330_12 -->
+        <geom type="mesh" class="visual" pos="-0 0 0.0125" quat="0 -0.707107 0.707107 -0" mesh="xl330" material="xl330_material"/>
+        <!-- Part bearing_roll_2 -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 -1 -0 -0" mesh="bearing_roll" material="bearing_roll_material"/>
+        <!-- Part seeed_bearing__configuration__22x16x4_9 -->
+        <geom type="mesh" class="visual" pos="-0 0.0165 0.0125" quat="0.5 0.5 0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+        <!-- Link hip_l_2 -->
+        <body name="hip_l_2" pos="-0 0.0165 0.0125" quat="0 -0 0.707107 0.707107">
+          <!-- Joint from bearing_roll to hip_l_2 -->
+          <joint axis="0 0 1" name="right_hip_roll" type="hinge" range="-0.3839724354387525 0.3839724354387525" class="chosen_actuator"/>
+          <inertial pos="0.014815 1.6212e-08 -0.00829992" mass="0.00618934" fullinertia="8.60626e-07 1.15753e-06 6.51588e-07 1e-12 3.89882e-07 -1e-12"/>
+          <!-- Part hip_l_2 -->
+          <geom type="mesh" class="visual" pos="-0.0175 0 -0.0185" quat="0.707107 -0.707107 -0 -0" mesh="hip_l" material="hip_l_material"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_10 -->
+          <geom type="mesh" class="visual" pos="0.025 0 -0.0185" quat="0.5 0.5 -0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Link upper_leg_right -->
+          <body name="upper_leg_right" pos="0.025 0 -0.0185" quat="0.5 -0.5 0.5 -0.5">
+            <!-- Joint from hip_l_2 to upper_leg_right -->
+            <joint axis="0 0 1" name="right_hip_pitch" type="hinge" range="-1.5707963267949268 1.5707963267948664" class="chosen_actuator"/>
+            <inertial pos="-0.006766 0.0228838 0.0134531" mass="0.0482067" fullinertia="1.68753e-05 1.03691e-05 1.98269e-05 4.41852e-06 -2.27982e-07 3.89298e-07"/>
+            <!-- Part xl330_13 -->
+            <geom type="mesh" class="visual" pos="-0.022 0.0357771 0.0125" quat="0.707107 -0 -0.707107 -0" mesh="xl330" material="xl330_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_11 -->
+            <geom type="mesh" class="visual" pos="-0.022 0.0357771 0" quat="0 1 -0 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part upper_leg_rigidity_plate_2 -->
+            <geom type="mesh" class="visual" pos="0 0 0.0435" quat="0.5 -0.5 0.5 0.5" mesh="upper_leg_rigidity_plate" material="upper_leg_rigidity_plate_material"/>
+            <!-- Part upper_leg_right -->
+            <geom type="mesh" class="visual" pos="-0 0 -0.0425" quat="0.5 -0.5 0.5 0.5" mesh="upper_leg_right" material="upper_leg_right_material"/>
+            <!-- Part xl330_14 -->
+            <geom type="mesh" class="visual" pos="0 0 0.0125" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Link leg_2 -->
+            <body name="leg_2" pos="-0.022 0.0357771 -0.004" quat="0 1 -0 -0">
+              <!-- Joint from upper_leg_right to leg_2 -->
+              <joint axis="0 0 1" name="right_knee" type="hinge" range="-1.570796326794932 1.570796326794861" class="chosen_actuator"/>
+              <inertial pos="-0.0318937 -1.52e-10 -0.00953505" mass="0.0215844" fullinertia="2.15507e-06 5.25056e-06 4.33925e-06 1e-12 -7.65005e-07 0"/>
+              <!-- Part xl330_15 -->
+              <geom type="mesh" class="visual" pos="-0.042 0 -0.0115" quat="0.707107 -0 -0.707107 -0" mesh="xl330" material="xl330_material"/>
+              <!-- Part leg_2 -->
+              <geom type="mesh" class="visual" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" name="right_leg_self_collision" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
+              <!-- Link ankle_right -->
+              <body name="ankle_right" pos="-0.042 0 -0.026" quat="0 -0.707107 -0.707107 0">
+                <!-- Joint from leg_2 to ankle_right -->
+                <joint axis="0 0 1" name="right_ankle" type="hinge" range="-1.5707963267949054 1.5707963267948877" class="chosen_actuator"/>
+                <inertial pos="0.00615539 -0.0137482 -0.0156566" mass="0.0300251" fullinertia="5.91534e-06 1.11534e-05 7.74016e-06 2.04877e-07 -8.247e-08 5.7017e-08"/>
+                <!-- Part ankle_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="ankle_right" material="ankle_right_material"/>
+                <!-- Part sole_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="sole_right" material="sole_right_material"/>
+                <geom type="mesh" name="right_foot_collision" class="collision" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="sole_right" material="sole_right_material"/>
+                <!-- Part seeed_bearing__configuration_default_3 -->
+                <geom type="mesh" class="visual" pos="-0 0 -0.0292" quat="0 1 -0 -0" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+                <!-- Part foot_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="foot_right" material="foot_right_material"/>
+                <!-- Frame right_foot -->
+                <site group="3" name="right_foot" pos="0 -0.0238146 -0.0140852" quat="0.707107 -0.707107 0 0"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <asset>
+    <mesh file="xl330.stl"/>
+    <mesh file="trunk_base.stl"/>
+    <mesh file="sole_right.stl"/>
+    <mesh file="power_support.stl"/>
+    <mesh file="bottom_head_shell.stl"/>
+    <mesh file="foot_right.stl"/>
+    <mesh file="foot_left.stl"/>
+    <mesh file="top_head_shell.stl"/>
+    <mesh file="yaw2roll.stl"/>
+    <mesh file="upper_leg_left.stl"/>
+    <mesh file="upper_leg_rigidity_plate.stl"/>
+    <mesh file="seeed_bearing__configuration_default.stl"/>
+    <mesh file="elec_rpi_robot_hat_pcb.stl"/>
+    <mesh file="yaw_roll_motion.stl"/>
+    <mesh file="np_f970.stl"/>
+    <mesh file="ankle_left.stl"/>
+    <mesh file="neck.stl"/>
+    <mesh file="lens.stl"/>
+    <mesh file="sole_left.stl"/>
+    <mesh file="m12_lens_holder.stl"/>
+    <mesh file="leg.stl"/>
+    <mesh file="speaker.stl"/>
+    <mesh file="neck_pitch.stl"/>
+    <mesh file="pcb__raspberry_pi_zero_2_w.stl"/>
+    <mesh file="left_shell.stl"/>
+    <mesh file="soft_mouth_top.stl"/>
+    <mesh file="hip_l.stl"/>
+    <mesh file="bearing_roll.stl"/>
+    <mesh file="motor_support.stl"/>
+    <mesh file="upper_leg_right.stl"/>
+    <mesh file="face_part.stl"/>
+    <mesh file="noenoeil.stl"/>
+    <mesh file="jaw.stl"/>
+    <mesh file="jaw_soft.stl"/>
+    <mesh file="right_shell.stl"/>
+    <mesh file="seeed_bearing__configuration__22x16x4.stl"/>
+    <mesh file="banana_pcb_locker.stl"/>
+    <mesh file="ankle_right.stl"/>
+    <material name="seeed_bearing__configuration__22x16x4_material" rgba="0.713725 0.760784 0.8 1"/>
+    <material name="right_shell_material" rgba="0.8 0.8 0.8 1"/>
+    <material name="banana_pcb_locker_material" rgba="0.647059 0.647059 0.647059 1"/>
+    <material name="trunk_base_material" rgba="0.34902 0.376471 0.4 1"/>
+    <material name="xl330_material" rgba="0.286275 0.286275 0.286275 1"/>
+    <material name="power_support_material" rgba="0.901961 0.901961 0.901961 1"/>
+    <material name="np_f970_material" rgba="0.901961 0.901961 0.901961 1"/>
+    <material name="left_shell_material" rgba="0.8 0.8 0.8 1"/>
+    <material name="yaw2roll_material" rgba="0.647059 0.647059 0.647059 1"/>
+    <material name="bearing_roll_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="hip_l_material" rgba="0.901961 0.901961 0.901961 1"/>
+    <material name="upper_leg_left_material" rgba="0.866667 0.866667 0.866667 1"/>
+    <material name="upper_leg_rigidity_plate_material" rgba="0.537255 0.854902 0.827451 1"/>
+    <material name="leg_material" rgba="0.811765 0.858824 0.898039 1"/>
+    <material name="sole_left_material" rgba="0.537255 0.854902 0.827451 1"/>
+    <material name="foot_left_material" rgba="0.980392 0.713725 0.00392157 1"/>
+    <material name="seeed_bearing__configuration_default_material" rgba="0.713725 0.760784 0.8 1"/>
+    <material name="ankle_left_material" rgba="0.980392 0.713725 0.00392157 1"/>
+    <material name="neck_material" rgba="0.8 0.8 0.8 1"/>
+    <material name="neck_pitch_material" rgba="0.34902 0.376471 0.4 1"/>
+    <material name="yaw_roll_motion_material" rgba="0.768627 0.886275 0.952941 1"/>
+    <material name="lens_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="face_part_material" rgba="0.34902 0.376471 0.4 1"/>
+    <material name="jaw_soft_material" rgba="0.85098 0.756863 0.866667 1"/>
+    <material name="motor_support_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="top_head_shell_material" rgba="0.901961 0.901961 0.901961 1"/>
+    <material name="elec_rpi_robot_hat_pcb_material" rgba="0.313725 0.486275 0.411765 1"/>
+    <material name="soft_mouth_top_material" rgba="0.85098 0.756863 0.866667 1"/>
+    <material name="noenoeil_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="jaw_material" rgba="0.980392 0.713725 0.00392157 1"/>
+    <material name="bottom_head_shell_material" rgba="0.980392 0.713725 0.00392157 1"/>
+    <material name="m12_lens_holder_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="pcb__raspberry_pi_zero_2_w_material" rgba="0.498039 0.498039 0.498039 1"/>
+    <material name="speaker_material" rgba="0.294118 0.290196 0.290196 1"/>
+    <material name="upper_leg_right_material" rgba="0.866667 0.866667 0.866667 1"/>
+    <material name="ankle_right_material" rgba="0.980392 0.713725 0.00392157 1"/>
+    <material name="sole_right_material" rgba="0.537255 0.854902 0.827451 1"/>
+    <material name="foot_right_material" rgba="0.980392 0.713725 0.00392157 1"/>
+  </asset>
+  <actuator>
+    <motor class="chosen_actuator" name="left_hip_yaw" joint="left_hip_yaw"/>
+    <motor class="chosen_actuator" name="left_hip_roll" joint="left_hip_roll"/>
+    <motor class="chosen_actuator" name="left_hip_pitch" joint="left_hip_pitch"/>
+    <motor class="chosen_actuator" name="left_knee" joint="left_knee"/>
+    <motor class="chosen_actuator" name="left_ankle" joint="left_ankle"/>
+    <motor class="chosen_actuator" name="neck_pitch" joint="neck_pitch"/>
+    <motor class="chosen_actuator" name="head_pitch" joint="head_pitch"/>
+    <motor class="chosen_actuator" name="head_yaw" joint="head_yaw"/>
+    <motor class="chosen_actuator" name="head_roll" joint="head_roll"/>
+    <motor class="chosen_actuator" name="right_hip_yaw" joint="right_hip_yaw"/>
+    <motor class="chosen_actuator" name="right_hip_roll" joint="right_hip_roll"/>
+    <motor class="chosen_actuator" name="right_hip_pitch" joint="right_hip_pitch"/>
+    <motor class="chosen_actuator" name="right_knee" joint="right_knee"/>
+    <motor class="chosen_actuator" name="right_ankle" joint="right_ankle"/>
+  </actuator>
+  <equality/>
+</mujoco>

--- a/src/unilab/assets/robots/microduck/scene_flat_bam.xml
+++ b/src/unilab/assets/robots/microduck/scene_flat_bam.xml
@@ -1,0 +1,30 @@
+<mujoco model="microduck bam flat scene">
+  <include file="microduck_bam.xml"/>
+
+  <!-- Solver contract from the upstream microduck_rl recipe (mjlab SimCfg):
+       implicitfast integrator, Newton solver, 10/20 iteration budgets.
+       `timestep` stays undeclared: each backend overrides it from `sim_dt`. -->
+  <option integrator="implicitfast" solver="Newton" cone="pyramidal" iterations="10"
+    ls_iterations="20" tolerance="1e-8" ls_tolerance="0.01" gravity="0 0 -9.81" impratio="1.0"/>
+
+  <statistic center="0 0 0.12" extent="0.5"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="160" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 3.5" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+  </worldbody>
+
+</mujoco>

--- a/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/base.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/base.yaml
@@ -1,0 +1,570 @@
+# @package _global_
+# BAM actuator variant of the MicroDuck Manager-Based velocity task (issue
+# #1474): the XML position-PD servos are replaced by the upstream bam
+# xl330-m6 voltage-servo model (BamVoltageAction, per-substep torque path).
+# Observations, rewards, commands, events, terminations and curricula are
+# item-for-item identical to task/microduck_velocity_flat/base.yaml (issue
+# #1455, anchor commit 29e887ec) so the pair is a controlled actuator
+# experiment. mjwarp has no owner: the substep state-feedback contract is
+# unavailable there (host_numpy profile raises NotImplementedError).
+env:
+  scene:
+    model_file: src/unilab/assets/robots/microduck/scene_flat_bam.xml
+    fragment_files: [src/unilab/assets/robots/microduck/locomotion_task.xml]
+    default_keyframe_name: home
+    entities:
+      robot:
+        root_body_name: trunk_base
+        joint_names:
+          - left_hip_yaw
+          - left_hip_roll
+          - left_hip_pitch
+          - left_knee
+          - left_ankle
+          - neck_pitch
+          - head_pitch
+          - head_yaw
+          - head_roll
+          - right_hip_yaw
+          - right_hip_roll
+          - right_hip_pitch
+          - right_knee
+          - right_ankle
+        actuator_names:
+          - left_hip_yaw
+          - left_hip_roll
+          - left_hip_pitch
+          - left_knee
+          - left_ankle
+          - neck_pitch
+          - head_pitch
+          - head_yaw
+          - head_roll
+          - right_hip_yaw
+          - right_hip_roll
+          - right_hip_pitch
+          - right_knee
+          - right_ankle
+        # trunk_base: root + trunk CoM DR; ankle_*: foot clearance/swing/slip and
+        # critic foot_height; neck chain + bearing_roll: legacy head CoM DR set.
+        body_names:
+          - trunk_base
+          - ankle_left
+          - ankle_right
+          - neck
+          - neck_pitch
+          - yaw_roll_motion
+          - jaw_soft
+          - bearing_roll
+        # Foot collision geoms for the foot_friction DR event.
+        geom_names: [left_foot_collision, right_foot_collision]
+  # Upstream recipe: 200 Hz physics under 50 Hz control (substeps = ctrl_dt / sim_dt = 4).
+  sim_dt: 0.005
+  ctrl_dt: 0.02
+  max_episode_seconds: 20.0
+  observations:
+    policy:
+      enable_corruption: true
+      terms:
+        base_ang_vel:
+          func: unilab.envs.mdp.base_ang_vel_imu_misaligned
+          params: {max_angle_deg: 6.0}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.03
+            n_max: 0.03
+            operation: add
+          # Legacy IMU latency envelope: 0-1 ctrl step lag, resampled every 64 steps.
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
+        projected_gravity:
+          func: unilab.envs.mdp.projected_gravity_imu_misaligned
+          params: {max_angle_deg: 6.0}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.01
+            n_max: 0.01
+            operation: add
+          delay_min_lag: 0
+          delay_max_lag: 1
+          delay_update_period: 64
+        joint_pos:
+          func: unilab.envs.mdp.joint_pos_rel
+          params: {biased: true}
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.001
+            n_max: 0.001
+            operation: add
+        joint_vel:
+          func: unilab.envs.mdp.joint_vel_rel
+          noise:
+            _target_: unilab.managers._noise.UniformNoiseCfg
+            n_min: -0.25
+            n_max: 0.25
+            operation: add
+          # Legacy fixed 1-ctrl-step (20 ms) joint-velocity lag (Dynamixel
+          # firmware moving-average velocity estimate).
+          delay_min_lag: 1
+          delay_max_lag: 1
+        actions:
+          func: unilab.envs.mdp.last_action
+          params: {action_name: joint_pos}
+        twist_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: twist}
+        head_pose_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: head_pose}
+        body_pose_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: body_pose}
+    critic:
+      terms:
+        base_ang_vel:
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: gyro}
+        projected_gravity:
+          func: unilab.envs.mdp.projected_gravity_from_sensor
+          params: {sensor_name: upvector}
+        joint_pos:
+          func: unilab.envs.mdp.joint_pos_rel
+        joint_vel:
+          func: unilab.envs.mdp.joint_vel_rel
+        actions:
+          func: unilab.envs.mdp.last_action
+          params: {action_name: joint_pos}
+        twist_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: twist}
+        head_pose_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: head_pose}
+        body_pose_command:
+          func: unilab.envs.mdp.generated_commands
+          params: {command_name: body_pose}
+        base_lin_vel:
+          func: unilab.envs.mdp.builtin_sensor
+          params: {sensor_name: local_linvel}
+        # Privileged per-foot terms (legacy critic 76D layout).
+        foot_height:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_height
+          params:
+            asset_cfg:
+              _target_: unilab.managers.SceneEntityCfg
+              name: robot
+              body_names: [ankle_left, ankle_right]
+              preserve_order: true
+        foot_air_time:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_air_time
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+        foot_contact_forces:
+          func: unilab.tasks.locomotion.common.gait_terms.foot_contact_forces
+          params:
+            sensor_groups: [[left_foot_contact], [right_foot_contact]]
+  actions:
+    joint_pos:
+      # Upstream bam xl330-m6 (microduck_rl microduck_constants.py): kp_fw=200,
+      # vin ~ U(6.5, 8.2) sampled once at startup, load-dependent sag
+      # vin_drop_gain ~ U(0.0, 0.2) V/Nm floored at 6.0 V, command delay lag ~
+      # U{3..6} physics substeps resampled every substep, friction budget
+      # scaled per episode by U(0.9, 1.1). The fitted electrical/friction
+      # constants stay at the dataclass defaults (= bam params xl330/m6.json).
+      _target_: unilab.tasks.locomotion.microduck.bam_action.BamVoltageActionCfg
+      entity_name: robot
+      actuator_names: [".*"]
+      scale: 1.0
+      kp_fw: 200.0
+      vin_range: [6.5, 8.2]
+      vin_drop_gain_range: [0.0, 0.2]
+      vin_min: 6.0
+      delay_min_lag: 3
+      delay_max_lag: 6
+      friction_scale_range: [0.9, 1.1]
+  commands:
+    twist:
+      _target_: unilab.tasks.locomotion.microduck.manager_terms.MicroduckVelocityCommandCfg
+      entity_name: robot
+      resampling_time_range: [3.0, 8.0]
+      heading_command: false
+      heading_control_stiffness: 0.5
+      rel_standing_envs: 0.02
+      rel_heading_envs: 0.0
+      rel_world_envs: 0.0
+      rel_forward_envs: 0.2
+      init_velocity_prob: 0.0
+      turn_in_place_fraction: 0.15
+      turn_in_place_ang_min: 0.4
+      ranges:
+        lin_vel_x: [-0.4, 0.4]
+        lin_vel_y: [-0.3, 0.3]
+        ang_vel_z: [-1.0, 1.0]
+    head_pose:
+      _target_: unilab.envs.mdp.UniformPoseCommandCfg
+      resampling_time_range: [2.0, 5.0]
+      ranges:
+        - [-0.05, 0.05]
+        - [-0.05, 0.05]
+        - [-0.07, 0.07]
+        - [-0.015, 0.015]
+    body_pose:
+      _target_: unilab.envs.mdp.UniformPoseCommandCfg
+      resampling_time_range: [2.0, 5.0]
+      ranges:
+        - [-0.005, 0.005]
+        - [-0.005, 0.005]
+        - [-0.005, 0.005]
+        - [-0.05, 0.05]
+        - [-0.05, 0.05]
+        - [-0.05, 0.05]
+  events:
+    reset_scene_to_default:
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    # Upstream reset_base: uniform root offsets around the `home` keyframe —
+    # xy ±0.5 m, yaw ±π, z +[0, 0.01] on the keyframe z=0.12 (absolute
+    # z ∈ [0.12, 0.13]); velocities stay zero and joints return to HOME
+    # exactly (reset_scene_to_default above stages the keyframe state first).
+    reset_base:
+      func: unilab.envs.mdp.reset_root_state_uniform
+      mode: reset
+      params:
+        pose_range:
+          x: [-0.5, 0.5]
+          y: [-0.5, 0.5]
+          z: [0.0, 0.01]
+          yaw: [-3.141592653589793, 3.141592653589793]
+        velocity_range: {}
+    base_com:
+      func: unilab.envs.mdp.randomize_rigid_body_com
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          body_names: trunk_base
+        com_range:
+          x: [-0.003, 0.003]
+          y: [-0.003, 0.003]
+          z: [-0.003, 0.003]
+    head_com:
+      func: unilab.envs.mdp.randomize_rigid_body_com
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          # Legacy HEAD_BODY_NAMES resolved against this model: the head-roll
+          # body is jaw_soft here (bottom_head_shell in the legacy walk model).
+          body_names: [neck, neck_pitch, yaw_roll_motion, jaw_soft, bearing_roll]
+        com_range:
+          x: [-0.003, 0.003]
+          y: [-0.003, 0.003]
+          z: [-0.003, 0.003]
+    encoder_bias:
+      func: unilab.envs.mdp.randomize_encoder_bias
+      mode: reset
+      params:
+        bias_range: [-0.015, 0.015]
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: ".*"
+    foot_friction:
+      func: unilab.envs.mdp.geom_friction
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          geom_names: [left_foot_collision, right_foot_collision]
+        ranges: [0.7, 1.3]
+        operation: abs
+        axes: [0]
+        shared_random: true
+    randomize_armature:
+      func: unilab.envs.mdp.joint_armature
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          joint_names: ".*"
+        ranges: [0.9, 1.1]
+        operation: scale
+    # Upstream startup mass/inertia DR (mjlab dr.pseudo_inertia, alpha-only):
+    # trunk_base mass and inertia share one log-uniform factor s ∈ [0.95, 1.05]
+    # sampled once per env and held fixed for the whole run; CoM unchanged.
+    randomize_mass_inertia:
+      func: unilab.envs.mdp.randomize_body_mass_inertia
+      mode: reset
+      params:
+        asset_cfg:
+          _target_: unilab.managers.SceneEntityCfg
+          name: robot
+          body_names: trunk_base
+        scale_range: [0.95, 1.05]
+    push_robot:
+      func: unilab.envs.mdp.push_by_setting_velocity
+      mode: interval
+      interval_range_s: [3.0, 6.0]
+      # Upstream samples the push interval independently per env.
+      is_global_time: false
+      params:
+        velocity_range:
+          x: [-0.3, 0.3]
+          y: [-0.3, 0.3]
+          z: [0.0, 0.0]
+          roll: [0.0, 0.0]
+          pitch: [0.0, 0.0]
+          yaw: [0.0, 0.0]
+  terminations:
+    time_out:
+      func: unilab.envs.mdp.time_out
+      time_out: true
+    tilt:
+      func: unilab.envs.mdp.bad_orientation
+      # Legacy fell_over threshold: 70 degrees.
+      params: {limit_angle: 1.2217304763960306}
+    nan_state:
+      func: unilab.envs.mdp.nan_detection
+  curriculum:
+    # Legacy curriculum A: action_rate_l2 weight -0.1 -> -1.0 by iter 1500.
+    action_rate_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: action_rate
+        stages:
+          - {step: 0, weight: -0.1}
+          - {step: 12000, weight: -0.2}
+          - {step: 18000, weight: -0.4}
+          - {step: 24000, weight: -0.6}
+          - {step: 30000, weight: -0.8}
+          - {step: 36000, weight: -1.0}
+    # Legacy curriculum B: head_pose_bias weight 0 -> +3.0.
+    head_pose_bias_weight:
+      func: unilab.envs.mdp.reward_curriculum
+      params:
+        reward_name: head_pose_bias
+        stages:
+          - {step: 0, weight: 0.0}
+          - {step: 14400, weight: 1.0}
+          - {step: 24000, weight: 2.0}
+          - {step: 36000, weight: 3.0}
+    # Legacy curriculum C: standing envs 0.02 -> 0.25.
+    standing_envs:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: twist
+        stages:
+          - {step: 0, rel_standing_envs: 0.02}
+          - {step: 12000, rel_standing_envs: 0.05}
+          - {step: 18000, rel_standing_envs: 0.1}
+          - {step: 24000, rel_standing_envs: 0.15}
+          - {step: 36000, rel_standing_envs: 0.2}
+          - {step: 48000, rel_standing_envs: 0.25}
+    # Legacy curriculum D: head_pose command ranges widen to
+    # ±1.10 / ±1.10 / ±1.40 / ±0.31 rad (neck_pitch, head_pitch, head_yaw, head_roll).
+    head_pose_range:
+      func: unilab.envs.mdp.command_curriculum
+      params:
+        command_name: head_pose
+        stages:
+          - {step: 0, ranges: [[-0.05, 0.05], [-0.05, 0.05], [-0.07, 0.07], [-0.015, 0.015]]}
+          - {step: 12000, ranges: [[-0.17, 0.17], [-0.17, 0.17], [-0.21, 0.21], [-0.047, 0.047]]}
+          - {step: 24000, ranges: [[-0.39, 0.39], [-0.39, 0.39], [-0.49, 0.49], [-0.11, 0.11]]}
+          - {step: 36000, ranges: [[-0.72, 0.72], [-0.72, 0.72], [-0.91, 0.91], [-0.2, 0.2]]}
+          - {step: 48000, ranges: [[-1.1, 1.1], [-1.1, 1.1], [-1.4, 1.4], [-0.31, 0.31]]}
+    # Legacy curriculum E (trunk): base CoM range ±3mm -> ±15mm.
+    base_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: base_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
+          - {step: 36000, params: {com_range: {x: [-0.015, 0.015], y: [-0.015, 0.015], z: [-0.015, 0.015]}}}
+    # Legacy curriculum E (head): head CoM range ±3mm -> ±10mm.
+    head_com_range:
+      func: unilab.envs.mdp.event_curriculum
+      params:
+        event_name: head_com
+        stages:
+          - {step: 0, params: {com_range: {x: [-0.003, 0.003], y: [-0.003, 0.003], z: [-0.003, 0.003]}}}
+          - {step: 12000, params: {com_range: {x: [-0.005, 0.005], y: [-0.005, 0.005], z: [-0.005, 0.005]}}}
+          - {step: 24000, params: {com_range: {x: [-0.01, 0.01], y: [-0.01, 0.01], z: [-0.01, 0.01]}}}
+  policy_observation_group: policy
+  critic_observation_group: critic
+
+reward:
+  tracking_lin_vel:
+    # Upstream track_linear_velocity: exp(-(‖cmd_xy−v_xy‖² + v_z²)/std²),
+    # std=√0.1, body-frame root velocity (vz penalty folded into the kernel).
+    func: unilab.envs.mdp.track_linear_velocity
+    weight: 2.0
+    params: {std: 0.31622776601683794, command_name: twist}
+  tracking_ang_vel:
+    # Upstream track_angular_velocity merged form:
+    # exp(-((cmd-wz)^2 + wx^2 + wy^2) / std^2), std=√0.5.
+    func: unilab.envs.mdp.track_angular_velocity
+    weight: 2.0
+    params: {std: 0.7071067811865476, command_name: twist}
+  upright:
+    # Upstream upright: exp(-pg_xy²/std²), std=√0.05, body=trunk_base.
+    func: unilab.envs.mdp.upright
+    weight: 2.0
+    params:
+      std: 0.22360679774997896
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [trunk_base]
+  head_pose_tracking:
+    func: unilab.tasks.locomotion.microduck.manager_terms.head_pose_tracking
+    weight: 2.0
+    params:
+      command_name: head_pose
+      std: 0.5
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: [neck_pitch, head_pitch, head_yaw, head_roll]
+        preserve_order: true
+  head_pose_bias:
+    func: unilab.tasks.locomotion.microduck.manager_terms.head_pose_bias
+    weight: 0.0
+    params:
+      command_name: head_pose
+      tau_s: 1.0
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: [neck_pitch, head_pitch, head_yaw, head_roll]
+        preserve_order: true
+  body_pose_tracking:
+    # Upstream keep-alive term: weight 0.0 keeps the body_pose command/obs
+    # channels alive for tasks that raise the weight (standup family).
+    func: unilab.tasks.locomotion.microduck.manager_terms.body_pose_tracking
+    weight: 0.0
+    params:
+      command_name: body_pose
+      nominal_height: 0.095
+      xy_std: 0.05
+      z_std: 0.02
+      angle_std: 0.2617993877991494
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+  leg_pose:
+    # Upstream pose (variable_posture): leg joints only (head/neck are
+    # command-driven), speed-dependent per-joint std — still scored while
+    # walking, with the looser walking std set (running set identical).
+    func: unilab.envs.mdp.variable_posture
+    weight: 1.0
+    params:
+      command_name: twist
+      walking_threshold: 0.01
+      running_threshold: 1.5
+      std_standing:
+        ".*hip_yaw.*": 0.1
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.15
+        ".*knee.*": 0.15
+        ".*ankle.*": 0.1
+      std_walking:
+        ".*hip_yaw.*": 0.3
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.4
+        ".*knee.*": 0.4
+        ".*ankle.*": 0.25
+      std_running:
+        ".*hip_yaw.*": 0.3
+        ".*hip_roll.*": 0.05
+        ".*hip_pitch.*": 0.4
+        ".*knee.*": 0.4
+        ".*ankle.*": 0.25
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        joint_names: [left_hip_yaw, left_hip_roll, left_hip_pitch, left_knee, left_ankle, right_hip_yaw, right_hip_roll, right_hip_pitch, right_knee, right_ankle]
+        preserve_order: true
+  air_time:
+    # Upstream window form: feet with current air time in (0.125, 0.300) s score.
+    func: unilab.tasks.locomotion.common.gait_terms.feet_air_time
+    weight: 3.0
+    params:
+      threshold_min: 0.125
+      threshold_max: 0.3
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+  foot_clearance:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_clearance
+    weight: -2.0
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_swing_height:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_swing_height
+    weight: -0.25
+    params:
+      target_height: 0.02
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  foot_slip:
+    func: unilab.tasks.locomotion.common.gait_terms.feet_slip
+    weight: -0.1
+    params:
+      command_threshold: 0.01
+      command_name: twist
+      sensor_groups: [[left_foot_contact], [right_foot_contact]]
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [ankle_left, ankle_right]
+        preserve_order: true
+  body_ang_vel:
+    # Upstream body_ang_vel: trunk_base world-frame ω_xy penalty (yaw free).
+    func: unilab.envs.mdp.body_angular_velocity_penalty
+    weight: -0.05
+    params:
+      asset_cfg:
+        _target_: unilab.managers.SceneEntityCfg
+        name: robot
+        body_names: [trunk_base]
+  self_collisions:
+    # Upstream self_collision_cost: count of active self-collision geom pairs
+    # (locomotion_task.xml self_collision_* found sensors).
+    func: unilab.tasks.locomotion.common.gait_terms.self_collision_cost
+    weight: -1.0
+    params:
+      sensor_groups: [[self_collision_trunk_left_leg], [self_collision_trunk_right_leg], [self_collision_legs]]
+  dof_pos_limits:
+    func: unilab.envs.mdp.joint_pos_limits
+    weight: -1.0
+  angular_momentum:
+    func: unilab.tasks.locomotion.common.gait_terms.angular_momentum_penalty
+    weight: -0.02
+    params: {sensor_name: root_angmom}
+  action_rate:
+    func: unilab.envs.mdp.action_rate_l2
+    weight: -0.1

--- a/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/mujoco.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - /task/microduck_velocity_bam_flat/base
+  - _self_
+
+training:
+  task_name: MicroduckVelocityBamFlat
+  sim_backend: mujoco
+  play_steps: 2000
+
+algo:
+  num_envs: 2048
+  max_iterations: 500
+  empirical_normalization: true
+  obs_groups:
+    actor:
+      - policy
+    critic:
+      - critic
+  policy:
+    init_noise_std: 1.0
+  algorithm:
+    learning_rate: 1.0e-3
+    entropy_coef: 0.01

--- a/src/unilab/tasks/locomotion/microduck/__init__.py
+++ b/src/unilab/tasks/locomotion/microduck/__init__.py
@@ -27,6 +27,16 @@ registry.register_env(
     sim_backend="mjwarp",
 )
 
+# BAM voltage-actuator variant (issue #1474): mujoco only, because the substep
+# state-feedback contract (SimBackend.set_pre_step_control) is unavailable on
+# the mjwarp host_numpy profile.
+registry.register_env_config("MicroduckVelocityBamFlat", ManagerBasedRlEnvCfg)
+registry.register_env(
+    "MicroduckVelocityBamFlat",
+    make_microduck_velocity_env,
+    sim_backend="mujoco",
+)
+
 # The minimal command/term owners deliberately share the same generic
 # ManagerBasedRlEnv factory.  Their behavior is selected entirely by the
 # Hydra owner (command, metrics, recorder, and reward terms); the runtime does

--- a/src/unilab/tasks/locomotion/microduck/bam_action.py
+++ b/src/unilab/tasks/locomotion/microduck/bam_action.py
@@ -1,0 +1,441 @@
+"""BAM voltage-controlled actuator action term owned by the MicroDuck task.
+
+NumPy port of the upstream ``bam`` xl330-m6 voltage servo (microduck_rl,
+``bam.mjlab.BamActuator`` + ``bam.actuator.VoltageControlledActuator``) onto the
+Manager-Based runtime.  The term recomputes motor torque on every physics
+substep (``requires_substep_state_feedback=True``) through the
+``SimBackend.set_pre_step_control`` contract, mirroring the firmware's 200 Hz
+position loop under the 50 Hz policy.
+
+Per-substep pipeline (all shapes ``(num_envs, num_joints)``):
+
+1. Command delay: the encoder-biased position target is pushed into a LIFO
+   ring buffer (capacity ``delay_max_lag + 1``); each substep resamples a
+   per-env lag uniformly in ``[delay_min_lag, delay_max_lag]`` and serves the
+   frame ``lag`` substeps old (clamped to available history).  Reset clears a
+   row's history; the next append backfills every slot with the first value.
+2. Per-env supply voltage: ``vin_eff = max(vin - vin_drop_gain * Σ|τ_motor_prev|,
+   vin_min)`` where ``vin`` / ``vin_drop_gain`` are sampled once at startup and
+   held across resets.
+3. Firmware P law: ``duty = (q_target - q) * kp_fw * error_gain``, clipped to
+   the firmware current-limit duty window
+   ``[kt·dq/vin_eff ± R·max_current/vin_eff]`` and then to the physical PWM
+   range; ``volts = vin_eff * duty``.
+4. DC motor torque with back-EMF: ``τ_motor = (kt·volts - kt²·dq) / R``.  The
+   XML ``<motor>`` actuators carry ``forcerange = max(vin_range)·kt/R`` so the
+   solver performs the final truncation; the term does not clip its output.
+5. BAM m6 friction budget (Coulomb + Stribeck + directional load terms +
+   quadratic term), scaled per env by ``friction_scale`` (resampled at every
+   episode reset; non-accumulating by assignment).
+
+Approximation boundaries versus upstream (recorded for issue #1474):
+
+- Upstream writes the friction budget into ``dof_frictionloss``/``dof_damping``
+  and lets MuJoCo's constraint solver apply static-friction clipping.  The
+  UniLab ``SimBackend`` contract has no per-substep write channel for those
+  fields, so the budget is folded into the output torque instead: the stiction
+  clip is replicated in the torque domain (zero output when the joint is
+  quasi-static and the motor torque cannot break friction), and the viscous
+  term is subtracted as ``friction_viscous * dq``.
+- Upstream estimates the gearbox external torque from ``qfrc_bias`` /
+  ``qfrc_constraint`` / ``qfrc_friction``; none of those are exposed by the
+  ``SimBackend`` contract.  Here ``τ_ext`` is a finite-difference estimate
+  ``I_eff·(dq_t - dq_{t-1})/sim_dt - τ_applied_prev`` with ``I_eff`` equal to
+  the nominal ``dof_armature`` (link inertia deliberately not faked).  Because
+  the applied-torque path already contains the modeled friction, the estimate
+  excludes it, matching the upstream exclusion of ``qfrc_friction``.  The
+  steady-state behavior is unaffected; only fast transients underestimate the
+  inertial reaction.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from numbers import Integral, Real
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import numpy as np
+
+from unilab.dtype_config import get_global_dtype
+from unilab.managers import ActionTerm, ActionTermCfg
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers._types import ManagerBasedRlEnv
+
+# XL330 firmware scaling (bam/dynamixel/actuator.py): the position error is
+# converted to a PWM duty cycle by kp * error_gain, where error_gain maps
+# radians to encoder counts and then to the KP divisor / PWM limit domain.
+_XL330_ERROR_GAIN = (4096.0 / (2.0 * math.pi)) / (256.0 * 885.0)
+
+# Quasi-static velocity threshold for the torque-domain stiction clip.
+_DQ_EPS = 1.0e-3
+
+
+def _real(
+    value: Any,
+    *,
+    label: str,
+    minimum: float | None = None,
+    strict_minimum: bool = False,
+) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{label} must be a real number, got {type(value).__name__}")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{label} must be finite")
+    if minimum is not None and (result <= minimum if strict_minimum else result < minimum):
+        relation = "greater than" if strict_minimum else "at least"
+        raise ValueError(f"{label} must be {relation} {minimum}")
+    return result
+
+
+def _int(value: Any, *, label: str, minimum: int = 0) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{label} must be an integer, got {type(value).__name__}")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{label} must be at least {minimum}")
+    return result
+
+
+def _range(value: Any, *, label: str) -> tuple[float, float]:
+    if not isinstance(value, (tuple, list)) or len(value) != 2:
+        raise TypeError(f"{label} must be a two-value range")
+    lower = _real(value[0], label=f"{label} lower", minimum=0.0)
+    upper = _real(value[1], label=f"{label} upper", minimum=0.0)
+    if lower > upper:
+        raise ValueError(f"{label} lower {lower} exceeds upper {upper}")
+    return lower, upper
+
+
+@dataclass(kw_only=True)
+class BamVoltageActionCfg(ActionTermCfg):
+    """Configure the BAM xl330-m6 voltage servo action term.
+
+    The electrical/friction defaults are the fitted upstream parameters
+    (``bam/params/xl330/m6.json``); the task-facing knobs (firmware gain,
+    voltage/delay/friction DR ranges) are declared explicitly in the owner
+    YAML.
+    """
+
+    actuator_names: tuple[str, ...] | list[str]
+    scale: float = 1.0
+    # Firmware P gain (Dynamixel KP register domain; microduck keeps 200).
+    kp_fw: float = 200.0
+    error_gain: float = _XL330_ERROR_GAIN
+    # Fitted electrical parameters (bam xl330 m6).
+    kt: float = 0.36601349688984386
+    resistance: float = 2.8113923539223227
+    armature: float = 0.0018077432831600838
+    max_current: float = 1.75
+    max_pwm: float = 1.0
+    # Per-env battery model (startup-sampled, held across resets).
+    vin_range: tuple[float, float] | list[float] = (6.5, 8.2)
+    vin_drop_gain_range: tuple[float, float] | list[float] = (0.0, 0.2)
+    vin_min: float = 6.0
+    # Command delay in physics substeps; lag resampled every substep.
+    delay_min_lag: int = 3
+    delay_max_lag: int = 6
+    # Per-episode multiplier on the velocity-independent friction budget.
+    friction_scale_range: tuple[float, float] | list[float] = (0.9, 1.1)
+    # Fitted BAM m6 friction parameters (bam xl330 m6).
+    friction_base: float = 0.004771183165566
+    friction_stribeck: float = 0.004676345799486616
+    load_friction_motor: float = 0.2667860954283698
+    load_friction_external: float = 8.515871897059342e-06
+    load_friction_motor_stribeck: float = 1.0722918395099123e-05
+    load_friction_external_stribeck: float = 0.08077928978935671
+    load_friction_motor_quad: float = 0.009972471242139415
+    load_friction_external_quad: float = 0.004902565732332559
+    dtheta_stribeck: float = 2.890372094130307
+    stribeck_alpha: float = 8.683259907618984
+    friction_viscous: float = 0.005359668274599504
+
+    def build(self, env: ManagerBasedRlEnv) -> BamVoltageAction:
+        return BamVoltageAction(self, env)
+
+
+class BamVoltageAction(ActionTerm):
+    """Convert policy actions into BAM voltage-servo motor torques per substep."""
+
+    requires_substep_state_feedback: ClassVar[bool] = True
+    cfg: BamVoltageActionCfg
+    _entity: Entity
+
+    def __init__(self, cfg: BamVoltageActionCfg, env: ManagerBasedRlEnv):
+        self._validate_cfg(cfg)
+        super().__init__(cfg=cfg, env=env)
+        actuator_ids, actuator_names = self._entity.find_actuators(cfg.actuator_names)
+        joint_ids, joint_names = self._entity.find_joints_by_actuator_names(cfg.actuator_names)
+        if not actuator_ids or len(actuator_ids) != len(joint_ids):
+            raise ValueError(
+                "BamVoltageAction requires a non-empty 1:1 actuator/joint selection; "
+                f"received actuators={actuator_names}, joints={joint_names}"
+            )
+        self._actuator_ids = np.asarray(actuator_ids, dtype=np.intp)
+        self._joint_ids = np.asarray(joint_ids, dtype=np.intp)
+        self._actuator_ids.setflags(write=False)
+        self._joint_ids.setflags(write=False)
+        num_joints = len(self._joint_ids)
+
+        dtype = get_global_dtype()
+        shape = (self.num_envs, num_joints)
+        self._raw_action = np.zeros(shape, dtype=dtype)
+        self._processed_action = np.zeros(shape, dtype=dtype)
+        self._motor_torque = np.zeros(shape, dtype=dtype)
+        self._prev_motor_torque = np.zeros(shape, dtype=dtype)
+        self._prev_applied_torque = np.zeros(shape, dtype=dtype)
+        self._prev_joint_vel = np.zeros(shape, dtype=dtype)
+
+        # LIFO command-delay ring buffer with per-env history depth; frames are
+        # appended every physics substep (the 50 Hz policy target repeats for
+        # all substeps of one control step).
+        capacity = self._delay_max_lag + 1
+        self._delay_buffer = np.zeros((capacity, self.num_envs, num_joints), dtype=dtype)
+        self._delay_pointer = -1
+        self._delay_pushes = np.zeros((self.num_envs,), dtype=np.int64)
+
+        # Startup-sampled battery model: constant per env across resets
+        # (mirrors the upstream BamActuator.initialize semantics).
+        self._vin = np.asarray(
+            self._env.rng.uniform(*self._vin_range, size=(self.num_envs, 1)), dtype=dtype
+        )
+        self._vin_drop_gain = np.asarray(
+            self._env.rng.uniform(*self._vin_drop_gain_range, size=(self.num_envs, 1)),
+            dtype=dtype,
+        )
+        self._friction_scale = np.ones((self.num_envs, 1), dtype=dtype)
+
+        ctrl_range = self._entity.data.actuator_ctrl_range[self._actuator_ids]
+        expected_range_shape = (num_joints, 2)
+        if ctrl_range.shape != expected_range_shape:
+            raise ValueError(
+                "BamVoltageAction actuator control range must have shape "
+                f"{expected_range_shape}, got {ctrl_range.shape}"
+            )
+
+    def _validate_cfg(self, cfg: BamVoltageActionCfg) -> None:
+        label = "BamVoltageActionCfg"
+        self._scale = _real(cfg.scale, label=f"{label} scale")
+        self._kp_fw = _real(cfg.kp_fw, label=f"{label} kp_fw", minimum=0.0)
+        self._error_gain = _real(cfg.error_gain, label=f"{label} error_gain", minimum=0.0)
+        self._kt = _real(cfg.kt, label=f"{label} kt", minimum=0.0, strict_minimum=True)
+        self._resistance = _real(
+            cfg.resistance, label=f"{label} resistance", minimum=0.0, strict_minimum=True
+        )
+        self._armature = _real(cfg.armature, label=f"{label} armature", minimum=0.0)
+        self._max_current = _real(
+            cfg.max_current, label=f"{label} max_current", minimum=0.0, strict_minimum=True
+        )
+        self._max_pwm = _real(
+            cfg.max_pwm, label=f"{label} max_pwm", minimum=0.0, strict_minimum=True
+        )
+        self._vin_range = _range(cfg.vin_range, label=f"{label} vin_range")
+        self._vin_drop_gain_range = _range(
+            cfg.vin_drop_gain_range, label=f"{label} vin_drop_gain_range"
+        )
+        self._vin_min = _real(
+            cfg.vin_min, label=f"{label} vin_min", minimum=0.0, strict_minimum=True
+        )
+        self._delay_min_lag = _int(cfg.delay_min_lag, label=f"{label} delay_min_lag")
+        self._delay_max_lag = _int(cfg.delay_max_lag, label=f"{label} delay_max_lag")
+        if self._delay_min_lag > self._delay_max_lag:
+            raise ValueError(
+                f"{label} delay_min_lag {self._delay_min_lag} exceeds "
+                f"delay_max_lag {self._delay_max_lag}"
+            )
+        self._friction_scale_range = _range(
+            cfg.friction_scale_range, label=f"{label} friction_scale_range"
+        )
+        for name, value in (
+            ("friction_base", cfg.friction_base),
+            ("friction_stribeck", cfg.friction_stribeck),
+            ("load_friction_motor", cfg.load_friction_motor),
+            ("load_friction_external", cfg.load_friction_external),
+            ("load_friction_motor_stribeck", cfg.load_friction_motor_stribeck),
+            ("load_friction_external_stribeck", cfg.load_friction_external_stribeck),
+            ("load_friction_motor_quad", cfg.load_friction_motor_quad),
+            ("load_friction_external_quad", cfg.load_friction_external_quad),
+            ("dtheta_stribeck", cfg.dtheta_stribeck),
+            ("stribeck_alpha", cfg.stribeck_alpha),
+            ("friction_viscous", cfg.friction_viscous),
+        ):
+            _real(value, label=f"{label} {name}", minimum=0.0)
+
+    @property
+    def action_dim(self) -> int:
+        return len(self._joint_ids)
+
+    @property
+    def raw_action(self) -> np.ndarray:
+        return self._raw_action
+
+    @property
+    def processed_action(self) -> np.ndarray:
+        return self._processed_action
+
+    @property
+    def motor_torque(self) -> np.ndarray:
+        return self._motor_torque
+
+    @property
+    def friction_scale(self) -> np.ndarray:
+        return self._friction_scale
+
+    def process_actions(self, actions: np.ndarray) -> None:
+        if not isinstance(actions, np.ndarray):
+            raise TypeError(f"BamVoltageAction expected np.ndarray, got {type(actions).__name__}")
+        if actions.shape != self._raw_action.shape:
+            raise ValueError(
+                f"BamVoltageAction expected action shape {self._raw_action.shape}, "
+                f"got {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise ValueError("BamVoltageAction received NaN or Inf actions")
+        self._raw_action[:] = actions
+        # q_des = action * scale + default_joint_pos, mirroring the PD recipe's
+        # JointPositionAction (scale=1.0, use_default_offset=True).
+        np.multiply(self._raw_action, self._scale, out=self._processed_action)
+        self._processed_action += self._entity.data.default_joint_pos[:, self._joint_ids]
+
+    def _delay_append(self, q_target: np.ndarray) -> None:
+        capacity = self._delay_buffer.shape[0]
+        self._delay_pointer = (self._delay_pointer + 1) % capacity
+        self._delay_buffer[self._delay_pointer] = q_target
+        # First append after a reset backfills the whole history with the
+        # first frame (upstream CircularBuffer semantics).
+        first = self._delay_pushes == 0
+        if np.any(first):
+            self._delay_buffer[:, first] = q_target[first]
+        self._delay_pushes += 1
+
+    def _delay_read(self) -> np.ndarray:
+        capacity = self._delay_buffer.shape[0]
+        lag = self._env.rng.integers(
+            self._delay_min_lag, self._delay_max_lag + 1, size=self.num_envs
+        )
+        valid = np.minimum(lag, np.maximum(self._delay_pushes, 1) - 1)
+        index = (self._delay_pointer - valid) % capacity
+        return self._delay_buffer[index, np.arange(self.num_envs)]
+
+    def _friction_budget(
+        self,
+        motor_torque: np.ndarray,
+        external_torque: np.ndarray,
+        stribeck_coeff: np.ndarray,
+    ) -> np.ndarray:
+        """BAM m6 velocity-independent friction budget, shape ``(N, J)``."""
+        cfg = self.cfg
+        abs_ext = np.abs(external_torque)
+        abs_mot = np.abs(motor_torque)
+        gearbox = np.abs(
+            external_torque * cfg.load_friction_external - motor_torque * cfg.load_friction_motor
+        )
+        gearbox_stribeck = np.abs(
+            external_torque * cfg.load_friction_external_stribeck
+            - motor_torque * cfg.load_friction_motor_stribeck
+        )
+        # Directional quadratic term: equal loads are classed as backdrive.
+        drive_mask = (abs_mot > abs_ext).astype(get_global_dtype())
+        quad = (
+            drive_mask * cfg.load_friction_external_quad * abs_ext**2
+            + (1.0 - drive_mask) * cfg.load_friction_motor_quad * abs_mot**2
+        )
+        frictionloss = (
+            cfg.friction_base
+            + stribeck_coeff * cfg.friction_stribeck
+            + gearbox
+            + stribeck_coeff * gearbox_stribeck
+            + stribeck_coeff * quad
+        )
+        return frictionloss * self._friction_scale
+
+    def apply_actions(self) -> None:
+        joint_pos = self._entity.data.joint_pos[:, self._joint_ids]
+        joint_vel = self._entity.data.joint_vel[:, self._joint_ids]
+        if not np.isfinite(joint_pos).all() or not np.isfinite(joint_vel).all():
+            raise ValueError(
+                f"BamVoltageAction on entity '{self.cfg.entity_name}' received non-finite "
+                "joint state from the backend"
+            )
+        dtype = get_global_dtype()
+        q = np.asarray(joint_pos, dtype=dtype)
+        dq = np.asarray(joint_vel, dtype=dtype)
+
+        # Encoder bias is subtracted before the delay buffer, matching the PD
+        # recipe's JointPositionAction ordering (target = processed - bias).
+        q_target = self._processed_action - self._entity.data.encoder_bias[:, self._joint_ids]
+        self._delay_append(q_target)
+        q_target_delayed = self._delay_read()
+
+        # Per-env battery voltage with load-dependent sag (previous substep's
+        # motor torque), floored at vin_min.
+        load = np.abs(self._prev_motor_torque).sum(axis=1, keepdims=True)
+        vin_eff = np.maximum(self._vin - self._vin_drop_gain * load, self._vin_min)
+
+        # Firmware P law with the current-limit duty window, then the physical
+        # PWM limit (upstream VoltageControlledActuator.compute_control).
+        duty = (q_target_delayed - q) * (self._kp_fw * self._error_gain)
+        center = self._kt * dq / vin_eff
+        span = self._resistance * self._max_current / vin_eff
+        duty = np.clip(duty, center - span, center + span)
+        duty = np.clip(duty, -self._max_pwm, self._max_pwm)
+        volts = vin_eff * duty
+
+        # DC motor torque with back-EMF (upstream compute_torque).
+        motor_torque = (self._kt * volts - self._kt**2 * dq) / self._resistance
+
+        # External gearbox torque via finite difference (see module docstring
+        # for the approximation boundary): I_eff is the nominal dof_armature.
+        accel_fd = (dq - self._prev_joint_vel) / self._env.physics_dt
+        external_torque = self._armature * accel_fd - self._prev_applied_torque
+
+        stribeck_coeff = np.exp(
+            -((np.abs(dq) / self.cfg.dtheta_stribeck) ** self.cfg.stribeck_alpha)
+        )
+        frictionloss = self._friction_budget(
+            self._prev_motor_torque, external_torque, stribeck_coeff
+        )
+
+        # Torque-domain replica of the solver's static-friction clip: a
+        # quasi-static joint whose motor torque cannot break the friction
+        # budget holds position (zero output); otherwise dry friction opposes
+        # motion. The viscous term is subtracted unconditionally.
+        static = (np.abs(dq) < _DQ_EPS) & (np.abs(motor_torque) < frictionloss)
+        applied = np.where(static, 0.0, motor_torque - frictionloss * np.sign(dq))
+        applied = applied - self.cfg.friction_viscous * dq
+
+        self._entity.data.write_ctrl(applied, actuator_ids=self._actuator_ids)
+
+        self._motor_torque[:] = motor_torque
+        self._prev_motor_torque[:] = motor_torque
+        self._prev_applied_torque[:] = applied
+        self._prev_joint_vel[:] = dq
+
+    def reset(self, env_ids: np.ndarray | slice | None = None) -> None:
+        if env_ids is None:
+            env_ids = slice(None)
+        self._raw_action[env_ids] = 0.0
+        self._processed_action[env_ids] = 0.0
+        self._motor_torque[env_ids] = 0.0
+        self._prev_motor_torque[env_ids] = 0.0
+        self._prev_applied_torque[env_ids] = 0.0
+        self._prev_joint_vel[env_ids] = 0.0
+        # Clear the delay history; the next append backfills all slots.
+        rows = np.arange(self.num_envs)[env_ids] if isinstance(env_ids, slice) else env_ids
+        self._delay_buffer[:, rows] = 0.0
+        self._delay_pushes[rows] = 0
+        # Per-episode friction DR: assignment (not accumulation), so the scale
+        # is exactly one fresh sample per reset. vin / vin_drop_gain are
+        # startup semantics and intentionally untouched.
+        ids = np.asarray(rows, dtype=np.intp).ravel()
+        if ids.size:
+            self._friction_scale[ids] = np.asarray(
+                self._env.rng.uniform(*self._friction_scale_range, size=(ids.size, 1)),
+                dtype=get_global_dtype(),
+            )
+
+
+__all__ = ["BamVoltageAction", "BamVoltageActionCfg"]

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -56,6 +56,7 @@ _G1_LOCOMOTION_TASKS = frozenset(
 
 _EXTERNAL_ASSET_LOCOMOTION_TASKS = frozenset(
     {
+        "MicroduckVelocityBamFlat",
         "MicroduckVelocityFlat",
         "T800WalkFlat",
     }
@@ -177,6 +178,13 @@ def migration_record(task_name: str) -> TaskMigrationRecord:
             if task_name == "MicroduckVelocityFlat"
             else "Hydra owner YAML materializes the locomotion task on the canonical NumPy Manager-Based runtime."
         )
+        if task_name == "MicroduckVelocityBamFlat":
+            scope = (
+                "Hydra owner YAML materializes the BAM voltage-actuator variant of the "
+                "MicroDuck velocity task on the canonical NumPy Manager-Based runtime "
+                "(mujoco owner only; the substep state-feedback contract is unavailable "
+                "on mjwarp)."
+            )
         return TaskMigrationRecord(
             task_name,
             family,

--- a/tests/envs/locomotion/microduck/test_bam_action.py
+++ b/tests/envs/locomotion/microduck/test_bam_action.py
@@ -1,0 +1,451 @@
+"""Focused tests for the MicroDuck BAM voltage-actuator action term."""
+
+from __future__ import annotations
+
+import inspect
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+from unilab.base import registry
+from unilab.base.config_adapter import BackendAdapter
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.envs import ManagerBasedRlEnvCfg
+from unilab.managers._types import ManagerBasedRlEnv
+from unilab.tasks.locomotion.microduck import bam_action
+from unilab.tasks.locomotion.microduck.bam_action import (
+    BamVoltageAction,
+    BamVoltageActionCfg,
+)
+
+ROOT_DIR = Path(__file__).parents[4]
+CONF_DIR = ROOT_DIR / "src" / "unilab" / "conf" / "ppo"
+
+KT = 0.36601349688984386
+RESISTANCE = 2.8113923539223227
+ERROR_GAIN = (4096.0 / (2.0 * math.pi)) / (256.0 * 885.0)
+KP_FW = 200.0
+MAX_CURRENT = 1.75
+VIN = 7.5
+
+_JOINT_NAMES = ("left_knee", "right_knee")
+
+
+class _FakeEntityData:
+    def __init__(self, num_envs: int, num_joints: int) -> None:
+        self.joint_pos = np.zeros((num_envs, num_joints), dtype=np.float32)
+        self.joint_vel = np.zeros((num_envs, num_joints), dtype=np.float32)
+        self.default_joint_pos = np.zeros((num_envs, num_joints), dtype=np.float32)
+        self.encoder_bias = np.zeros((num_envs, num_joints), dtype=np.float32)
+        self.actuator_ctrl_range = np.tile([-1.0676, 1.0676], (num_joints, 1)).astype(np.float32)
+        self.written: np.ndarray | None = None
+        self.written_actuator_ids: np.ndarray | None = None
+
+    def write_ctrl(self, values, env_ids=None, *, actuator_ids=None) -> None:
+        self.written = np.asarray(values, dtype=np.float64).copy()
+        self.written_actuator_ids = None if actuator_ids is None else np.asarray(actuator_ids)
+
+
+class _FakeEntity:
+    def __init__(self, num_envs: int, joint_names: tuple[str, ...]) -> None:
+        self.joint_names = list(joint_names)
+        self.actuator_names = list(joint_names)
+        self.data = _FakeEntityData(num_envs, len(joint_names))
+
+    def find_actuators(self, keys, preserve_order: bool = False):
+        return list(range(len(self.actuator_names))), list(self.actuator_names)
+
+    def find_joints_by_actuator_names(self, keys):
+        return list(range(len(self.joint_names))), list(self.joint_names)
+
+
+def _make_env(num_envs: int = 2, seed: int = 0) -> tuple[ManagerBasedRlEnv, _FakeEntity]:
+    entity = _FakeEntity(num_envs, _JOINT_NAMES)
+    env = cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=num_envs,
+            physics_dt=0.005,
+            rng=np.random.default_rng(seed),
+            scene={"robot": entity},
+        ),
+    )
+    return env, entity
+
+
+def _frictionless_cfg(**overrides: Any) -> BamVoltageActionCfg:
+    params: dict[str, Any] = dict(
+        entity_name="robot",
+        actuator_names=[".*"],
+        scale=1.0,
+        kp_fw=KP_FW,
+        vin_range=(VIN, VIN),
+        vin_drop_gain_range=(0.0, 0.0),
+        delay_min_lag=0,
+        delay_max_lag=0,
+        friction_scale_range=(1.0, 1.0),
+        friction_base=0.0,
+        friction_stribeck=0.0,
+        load_friction_motor=0.0,
+        load_friction_external=0.0,
+        load_friction_motor_stribeck=0.0,
+        load_friction_external_stribeck=0.0,
+        load_friction_motor_quad=0.0,
+        load_friction_external_quad=0.0,
+        friction_viscous=0.0,
+    )
+    params.update(overrides)
+    return BamVoltageActionCfg(**params)
+
+
+def _make_term(
+    cfg: BamVoltageActionCfg | None = None, num_envs: int = 2, seed: int = 0
+) -> tuple[BamVoltageAction, _FakeEntity]:
+    env, entity = _make_env(num_envs=num_envs, seed=seed)
+    term = BamVoltageAction(cfg or _frictionless_cfg(), env)
+    return term, entity
+
+
+def _expected_torque(delta_q: float, dq: float, vin: float = VIN) -> float:
+    duty = delta_q * KP_FW * ERROR_GAIN
+    center = KT * dq / vin
+    span = RESISTANCE * MAX_CURRENT / vin
+    duty = min(max(duty, center - span), center + span)
+    duty = min(max(duty, -1.0), 1.0)
+    volts = vin * duty
+    return (KT * volts - KT**2 * dq) / RESISTANCE
+
+
+def test_bam_voltage_action_declares_substep_state_feedback() -> None:
+    assert BamVoltageAction.requires_substep_state_feedback is True
+
+
+def test_voltage_law_matches_firmware_p_controller() -> None:
+    term, entity = _make_term()
+    entity.data.joint_vel[:] = 0.5
+    term.process_actions(np.full((2, 2), 0.1, dtype=np.float32))
+    term.apply_actions()
+    expected = _expected_torque(0.1, 0.5)
+    np.testing.assert_allclose(entity.data.written, expected, rtol=1e-5)
+    np.testing.assert_allclose(term.motor_torque, expected, rtol=1e-5)
+
+
+def test_current_limit_window_clamps_duty() -> None:
+    term, entity = _make_term()
+    # dq < 0 shifts the duty window down so the P-term output saturates the
+    # upper window edge instead of the PWM limit.
+    entity.data.joint_vel[:] = -3.0
+    term.process_actions(np.full((2, 2), 1.0, dtype=np.float32))
+    term.apply_actions()
+    duty = 1.0 * KP_FW * ERROR_GAIN
+    upper = KT * -3.0 / VIN + RESISTANCE * MAX_CURRENT / VIN
+    assert duty > upper  # window clamp actually engaged
+    np.testing.assert_allclose(entity.data.written, _expected_torque(1.0, -3.0), rtol=1e-5)
+
+
+def test_pwm_limit_clamps_duty_to_unit_range() -> None:
+    term, entity = _make_term()
+    # Large dq pushes the current-limit window past the PWM bound (window
+    # upper edge = kt*dq/vin + R*Imax/vin = 0.488 + 0.656 = 1.144 > 1), so the
+    # physical PWM clamp is the binding constraint.
+    entity.data.joint_vel[:] = 10.0
+    term.process_actions(np.full((2, 2), 5.0, dtype=np.float32))
+    term.apply_actions()
+    assert 5.0 * KP_FW * ERROR_GAIN > 1.0  # duty demand exceeds the PWM limit
+    expected = (KT * VIN - KT**2 * 10.0) / RESISTANCE
+    np.testing.assert_allclose(entity.data.written, expected, rtol=1e-5)
+
+
+def test_back_emf_produces_braking_torque_at_zero_error() -> None:
+    term, entity = _make_term()
+    entity.data.joint_vel[:] = 2.0
+    term.process_actions(np.zeros((2, 2), dtype=np.float32))
+    term.apply_actions()
+    np.testing.assert_allclose(entity.data.written, -(KT**2) * 2.0 / RESISTANCE, rtol=1e-5)
+
+
+def test_encoder_bias_shifts_target_before_delay_buffer() -> None:
+    term, entity = _make_term()
+    entity.data.default_joint_pos[:] = 0.3
+    entity.data.encoder_bias[:] = 0.02
+    term.process_actions(np.zeros((2, 2), dtype=np.float32))
+    term.apply_actions()
+    # target = 0 + 0.3 - 0.02 -> delta_q = 0.28, dq = 0.
+    np.testing.assert_allclose(entity.data.written, _expected_torque(0.28, 0.0), rtol=1e-5)
+
+
+def test_delay_buffer_serves_lifo_frame_with_fixed_lag() -> None:
+    env, entity = _make_env(num_envs=1)
+    cfg = _frictionless_cfg(delay_min_lag=3, delay_max_lag=3)
+    term = BamVoltageAction(cfg, env)
+    values = [0.1 * k for k in range(1, 8)]
+    served = []
+    for value in values:
+        term.process_actions(np.full((1, 2), value, dtype=np.float32))
+        term.apply_actions()
+        served.append(term._delay_read().copy())
+    # Append+read per substep: with lag=3 the read at append t serves the
+    # frame from t-3 (clamped to the oldest available while history fills).
+    np.testing.assert_allclose(served[0], values[0])
+    np.testing.assert_allclose(served[1], values[0])
+    np.testing.assert_allclose(served[2], values[0])
+    np.testing.assert_allclose(served[3], values[0])
+    np.testing.assert_allclose(served[4], values[1])
+    np.testing.assert_allclose(served[5], values[2])
+    np.testing.assert_allclose(served[6], values[3])
+
+
+def test_delay_buffer_reset_backfills_history_with_first_frame() -> None:
+    env, entity = _make_env(num_envs=2)
+    cfg = _frictionless_cfg(delay_min_lag=3, delay_max_lag=6)
+    term = BamVoltageAction(cfg, env)
+    term.process_actions(np.full((2, 2), 0.5, dtype=np.float32))
+    for _ in range(8):
+        term.apply_actions()
+    term.reset(np.asarray([0], dtype=np.int32))
+    assert term._delay_pushes[0] == 0
+    assert term._delay_pushes[1] == 8
+    term.process_actions(np.array([[0.9, 0.9], [0.5, 0.5]], dtype=np.float32))
+    term.apply_actions()
+    served = term._delay_read()
+    # Reset row: lag clamps to the single available frame (the fresh target).
+    np.testing.assert_allclose(served[0], 0.9, rtol=1e-6)
+    # Untouched row keeps serving its own (stale) history.
+    np.testing.assert_allclose(served[1], 0.5, rtol=1e-6)
+
+
+def test_delay_lag_stays_within_sampled_range() -> None:
+    env, _ = _make_env(num_envs=4)
+    cfg = _frictionless_cfg(delay_min_lag=3, delay_max_lag=6)
+    term = BamVoltageAction(cfg, env)
+    # Fill the buffer with 32 distinct constant frames; each read must return
+    # one of the frames 3..6 appends back.
+    for k in range(32):
+        term.process_actions(np.full((4, 2), float(k), dtype=np.float32))
+        term.apply_actions()
+    read = term._delay_read()
+    allowed = {float(k) for k in range(32 - 7, 32 - 2)}
+    assert set(np.unique(read)) <= allowed
+
+
+def test_friction_budget_matches_m6_formula() -> None:
+    term, _ = _make_term(
+        cfg=_frictionless_cfg(
+            friction_base=0.004771183165566,
+            friction_stribeck=0.004676345799486616,
+            load_friction_motor=0.2667860954283698,
+            load_friction_external=8.515871897059342e-06,
+            load_friction_motor_stribeck=1.0722918395099123e-05,
+            load_friction_external_stribeck=0.08077928978935671,
+            load_friction_motor_quad=0.009972471242139415,
+            load_friction_external_quad=0.004902565732332559,
+        )
+    )
+    term._friction_scale[:] = 1.0
+    motor = np.array([[0.5, 0.5]])
+    external = np.array([[0.1, 0.6]])
+    stribeck = np.ones((1, 2))
+    budget = term._friction_budget(motor, external, stribeck)
+
+    def expected(tau_mot: float, tau_ext: float) -> float:
+        gearbox = abs(tau_ext * 8.515871897059342e-06 - tau_mot * 0.2667860954283698)
+        gearbox_stribeck = abs(tau_ext * 0.08077928978935671 - tau_mot * 1.0722918395099123e-05)
+        drive = 1.0 if abs(tau_mot) > abs(tau_ext) else 0.0
+        quad = (
+            drive * 0.004902565732332559 * abs(tau_ext) ** 2
+            + (1.0 - drive) * 0.009972471242139415 * abs(tau_mot) ** 2
+        )
+        return 0.004771183165566 + 0.004676345799486616 + gearbox + gearbox_stribeck + quad
+
+    np.testing.assert_allclose(budget[0, 0], expected(0.5, 0.1), rtol=1e-6)
+    np.testing.assert_allclose(budget[0, 1], expected(0.5, 0.6), rtol=1e-6)
+
+
+def test_friction_scale_multiplies_budget_and_is_per_env() -> None:
+    term, _ = _make_term(cfg=_frictionless_cfg(friction_base=0.01))
+    term._friction_scale[0] = 1.1
+    term._friction_scale[1] = 0.9
+    zeros = np.zeros((2, 2))
+    budget = term._friction_budget(zeros, zeros, np.ones((2, 2)))
+    np.testing.assert_allclose(budget[:, 0], [0.011, 0.009], rtol=1e-6)
+
+
+def test_stiction_clip_holds_quasi_static_joint() -> None:
+    cfg = _frictionless_cfg(
+        friction_base=0.004771183165566,
+        friction_stribeck=0.004676345799486616,
+        load_friction_motor=0.2667860954283698,
+        load_friction_external=8.515871897059342e-06,
+        load_friction_motor_stribeck=1.0722918395099123e-05,
+        load_friction_external_stribeck=0.08077928978935671,
+        load_friction_motor_quad=0.009972471242139415,
+        load_friction_external_quad=0.004902565732332559,
+        friction_viscous=0.005359668274599504,
+    )
+    term, entity = _make_term(cfg=cfg)
+    entity.data.joint_vel[:] = 5.0e-4  # below the quasi-static threshold
+    # Row 0: tiny error -> torque below the friction budget -> held at zero.
+    # Row 1: large error -> torque breaks friction -> dry + viscous friction apply.
+    term.process_actions(np.array([[0.001, 0.001], [0.5, 0.5]], dtype=np.float32))
+    term.apply_actions()
+    # Row 0 holds via stiction; only the unconditional viscous term remains.
+    np.testing.assert_allclose(entity.data.written[0], -0.005359668274599504 * 5.0e-4, rtol=1e-5)
+    motor_row1 = _expected_torque(0.5, 5.0e-4)
+    # First substep: prev motor/applied torques are zero, so tau_ext ~= 0 and
+    # all load-dependent budget terms vanish; only base + Stribeck remain.
+    stribeck = math.exp(-((5.0e-4 / 2.890372094130307) ** 8.683259907618984))
+    budget_row1 = 0.004771183165566 + stribeck * 0.004676345799486616
+    expected_row1 = motor_row1 - budget_row1 * 1.0 - 0.005359668274599504 * 5.0e-4
+    np.testing.assert_allclose(entity.data.written[1], expected_row1, rtol=1e-4)
+
+
+def test_reset_clears_episode_state_and_resamples_friction_scale() -> None:
+    env, entity = _make_env(num_envs=2)
+    cfg = _frictionless_cfg(
+        friction_base=0.01, delay_min_lag=3, delay_max_lag=6, friction_scale_range=(0.9, 1.1)
+    )
+    term = BamVoltageAction(cfg, env)
+    vin_before = term._vin.copy()
+    term.process_actions(np.full((2, 2), 0.4, dtype=np.float32))
+    for _ in range(4):
+        term.apply_actions()
+    assert np.any(term._prev_motor_torque != 0.0)
+    scale_before = term._friction_scale.copy()
+
+    term.reset(np.asarray([0], dtype=np.int32))
+    assert term._delay_pushes[0] == 0
+    np.testing.assert_allclose(term._prev_motor_torque[0], 0.0)
+    np.testing.assert_allclose(term._prev_applied_torque[0], 0.0)
+    np.testing.assert_allclose(term._prev_joint_vel[0], 0.0)
+    np.testing.assert_allclose(term._motor_torque[0], 0.0)
+    assert 0.9 <= term._friction_scale[0, 0] <= 1.1
+    np.testing.assert_allclose(term._vin, vin_before)  # startup semantics: held
+    # Row 1 untouched.
+    np.testing.assert_allclose(term._friction_scale[1], scale_before[1])
+    assert term._delay_pushes[1] == 4
+
+    # After reset the delayed target is the fresh target, not stale history.
+    term.process_actions(np.array([[0.7, 0.7], [0.4, 0.4]], dtype=np.float32))
+    term.apply_actions()
+    np.testing.assert_allclose(term._delay_read()[0], 0.7, rtol=1e-6)
+
+
+def test_process_actions_rejects_bad_input() -> None:
+    term, _ = _make_term()
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        term.process_actions(np.full((2, 2), np.nan, dtype=np.float32))
+    with pytest.raises(ValueError, match="expected action shape"):
+        term.process_actions(np.zeros((2, 3), dtype=np.float32))
+    with pytest.raises(TypeError, match="np.ndarray"):
+        term.process_actions([[0.0, 0.0]])
+
+
+def test_cfg_validation_fails_closed() -> None:
+    base: dict[str, Any] = dict(entity_name="robot", actuator_names=[".*"])
+    env, _ = _make_env()
+    with pytest.raises(ValueError, match="kp_fw"):
+        BamVoltageAction(BamVoltageActionCfg(**base, kp_fw=-1.0), env)
+    with pytest.raises(ValueError, match="delay_min_lag"):
+        BamVoltageAction(BamVoltageActionCfg(**base, delay_min_lag=7, delay_max_lag=3), env)
+    with pytest.raises(ValueError, match="vin_range"):
+        BamVoltageAction(BamVoltageActionCfg(**base, vin_range=(8.2, 6.5)), env)
+    with pytest.raises(TypeError, match="scale"):
+        BamVoltageAction(BamVoltageActionCfg(**base, scale="1.0"), env)
+    with pytest.raises(ValueError, match="kt"):
+        BamVoltageAction(BamVoltageActionCfg(**base, kt=0.0), env)
+
+
+def test_bam_action_source_does_not_probe_backend_privates() -> None:
+    source = inspect.getsource(bam_action)
+    for forbidden in ("._backend", "getattr(", "hasattr(", "qpos", "qvel", "ASSETS_ROOT_PATH"):
+        assert forbidden not in source
+
+
+def _materialize(task: str, task_name: str) -> tuple[Any, ManagerBasedRlEnvCfg]:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(CONF_DIR), version_base="1.3"):
+        cfg = compose("config", overrides=[f"task={task}/mujoco"])
+    registry.ensure_registries()
+    override = BackendAdapter(cfg, root_dir=ROOT_DIR, algo_name="ppo").build_task_env_cfg_override()
+    env_cfg = registry.materialize_env_config(task_name)
+    assert isinstance(env_cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(env_cfg, override)
+    env_cfg.validate()
+    return cfg, env_cfg
+
+
+def test_bam_owner_materializes_and_matches_pd_recipe() -> None:
+    cfg, env_cfg = _materialize("microduck_velocity_bam_flat", "MicroduckVelocityBamFlat")
+    _, pd_env_cfg = _materialize("microduck_velocity_flat", "MicroduckVelocityFlat")
+
+    assert cfg.training.task_name == "MicroduckVelocityBamFlat"
+    assert cfg.training.sim_backend == "mujoco"
+    assert env_cfg.scene is not None
+    assert env_cfg.scene.model_file.endswith("robots/microduck/scene_flat_bam.xml")
+    assert env_cfg.sim_dt == pytest.approx(0.005)
+    assert env_cfg.ctrl_dt == pytest.approx(0.02)
+
+    assert list(env_cfg.actions) == ["joint_pos"]
+    action = env_cfg.actions["joint_pos"]
+    assert isinstance(action, BamVoltageActionCfg)
+    assert action.kp_fw == pytest.approx(200.0)
+    assert tuple(action.vin_range) == (6.5, 8.2)
+    assert tuple(action.vin_drop_gain_range) == (0.0, 0.2)
+    assert action.vin_min == pytest.approx(6.0)
+    assert action.delay_min_lag == 3
+    assert action.delay_max_lag == 6
+    assert tuple(action.friction_scale_range) == (0.9, 1.1)
+
+    # Controlled actuator experiment: reward / observation / command /
+    # termination / curriculum stacks are identical to the PD owner.
+    assert {name: term.weight for name, term in env_cfg.rewards.items()} == {
+        name: term.weight for name, term in pd_env_cfg.rewards.items()
+    }
+    assert list(env_cfg.observations) == list(pd_env_cfg.observations)
+    assert list(env_cfg.commands) == list(pd_env_cfg.commands)
+    assert list(env_cfg.terminations) == list(pd_env_cfg.terminations)
+    assert list(env_cfg.curriculum) == list(pd_env_cfg.curriculum)
+    # Events: same DR stack as the PD owner (encoder bias, armature, CoM,
+    # mass/inertia, foot friction); BAM-specific DR lives inside the term.
+    assert list(env_cfg.events) == list(pd_env_cfg.events)
+
+    registered = registry.list_registered_envs()
+    assert registered["MicroduckVelocityBamFlat"]["available_backends"] == ["mujoco"]
+
+
+@pytest.mark.slow
+def test_bam_owner_builds_and_steps_real_mujoco_env() -> None:
+    pytest.importorskip("mujoco")
+    cfg, _ = _materialize("microduck_velocity_bam_flat", "MicroduckVelocityBamFlat")
+    env = cast(
+        Any,
+        registry.make(
+            "MicroduckVelocityBamFlat",
+            sim_backend="mujoco",
+            num_envs=2,
+            env_cfg_override=BackendAdapter(
+                cfg,
+                root_dir=ROOT_DIR,
+                algo_name="ppo",
+            ).build_task_env_cfg_override(),
+        ),
+    )
+    try:
+        obs, info = env.reset(seed=7)
+        assert isinstance(info, dict)
+        action = env.action_manager.get_term("joint_pos")
+        assert isinstance(action, BamVoltageAction)
+        assert env._uses_pre_step_control is True
+        state = env.step(np.zeros((2, 14), dtype=np.float32))
+        assert np.isfinite(state.obs["obs"]).all()
+        assert np.isfinite(state.reward).all()
+        assert np.isfinite(action.motor_torque).all()
+        assert np.isfinite(env._control).all()
+    finally:
+        env.close()


### PR DESCRIPTION
Fixes #1474

## 背景

#1452 对齐对比的根因分析（#1464 评论区）确认：microduck 与上游 microduck_rl 的剩余训练差距主因是执行器模型不同（原因 1）——UniLab 用 XML position PD（kp=50/kv=0.5），上游用 BAM xl330-m6 电压舵机。本 PR 把 BAM 模型移植到 UniLab 侧，使执行器动力学不再是对齐差距的来源。

## 实现

`BamVoltageAction`（`src/unilab/tasks/locomotion/microduck/bam_action.py`）：task-owned action term，`requires_substep_state_feedback=True`，经 SimBackend 已声明的 `set_pre_step_control` 契约在每个物理 substep 重算力矩（go2w 先例），**零 SimBackend / unisim-core 契约变更**。逐 substep 管线与上游 `bam.mjlab.BamActuator` 逐项对应：

- LIFO 指令延迟环形缓冲（lag ~ U{3..6} substep = 15–30 ms，每 substep 重采，reset 回填）
- 每 env 电池模型：vin ~ U(6.5, 8.2) V、vin_drop_gain ~ U(0, 0.2) V/Nm（startup 采样、跨 reset 保持），vin_eff 下限 6.0 V
- 固件 P 律（kp_fw=200，XL330 error_gain）+ 1.75 A 电流限窗 + PWM 限幅
- back-EMF 力矩 τ=(kt·V−kt²·dq)/R，forcerange ±1.0676 Nm 由 XML `<motor>` 截断
- m6 摩擦预算全项 × friction_scale ~ U(0.9,1.1)（每 reset 赋值式重采）
- encoder_bias 在延迟缓冲之前扣除，与 PD 配方的 JointPositionAction 同序

新 task `MicroduckVelocityBamFlat`（仅 mujoco owner；mjwarp host_numpy profile 显式拒绝 pre-step control，fail-closed）复用 PD 配方的 reward/obs/curriculum/commands/terminations 逐项不变（owner 契约测试断言相等），执行器模型是唯一变量。

## 与上游的近似边界（模块 docstring 同步记录）

1. 上游把摩擦预算写入 `dof_frictionloss`/`dof_damping` 由求解器做静摩擦 clip；UniLab SimBackend 契约无逐 substep 写这两个字段的通道，故预算折算进输出力矩，stiction clip 在力矩域复刻。
2. 上游用 qfrc_bias/qfrc_constraint/qfrc_friction 估计外部力矩；契约拿不到 qfrc_*，改用有限差分 `I_eff·a_fd − τ_applied_prev`（I_eff=名义 dof_armature）。稳态无差，快速暂态略低估惯性反作用。

## 探针对拍（64 envs，seed 42，UniLab BAM/mujoco vs 上游 BAM/mjwarp 既有探针参照值）

| 指标 | UniLab BAM | 上游参照 | 偏差 |
| --- | --- | --- | --- |
| 零 action 姿态保持：倾倒 env 数 | 64/64（356 次） | 64/64（383 次） | 一致 |
| 平均首次倾倒时刻 | 64.1 步（~1.28 s） | 64 步（~1.3 s） | <1% |
| pg_xy 尾段均值 | 0.270 | 0.276 | -2% |
| 膝关节 +0.2 rad 阶跃 t90 | 403 ms | ~370 ms | +9%（含 20 ms 步长量化） |
| 阶跃稳态误差 | -0.076 rad（38% 下垂） | -0.068 rad（34%） | 同方向同量级 |
| 零 action 稳态关节误差（总体/膝/踝） | 0.036 / 0.118 / 0.056 rad | 0.049 / 0.148 / 0.084 rad | 系统性偏硬 ~25%（力矩域摩擦近似所致） |

含延迟、电压 sag、限幅的动态指标（A/B）几乎复刻；静态误差（C）偏硬约 25%，来源于上述力矩域摩擦近似——已在代码与本文档记录。

## Validation

- `make test-all` 于最终 head 83715664 通过（2583 passed；benchmark module/script-mode 仅 platform-optional mlx 跳过）。
- 新增 18 个单测（电压律/电流限窗/PWM 限幅/back-EMF 数值用例、延迟缓冲语义、摩擦预算、stiction clip、reset 语义、fail-closed 校验、owner materialize 与 PD owner recipe 逐项相等断言、真实 mujoco 冒烟）。
- ruff / mypy / pyright 零告警；support matrix 已重新生成。

## 训练对比

BAM task 修复验证训练（mujoco CPU，4096 envs × 2000 iter，seed 42）进行中，结果以本 PR 评论跟进（上游 seed42 run 复用 #1452 既有数据）。