### PR TITLE
build: pin uni-rl 0.1.0 from TestPyPI (issue #1481)

### DIFF
--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -28,7 +28,7 @@ dependencies = [
     "unisim-core>=0.1.14",
     # RL algorithms and async runtimes live in the independently released
     # uni-rl package (distribution name ``unilab-rl``); see pyproject.toml.
-    "unilab-rl==0.1.0a2",
+    "unilab-rl==0.1.0",
     "torch==2.11.0",
     "triton-rocm==3.6.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "gymnasium",
@@ -89,7 +89,7 @@ name = "pytorch-rocm72"
 url = "https://download.pytorch.org/whl/rocm7.2"
 explicit = true
 
-# TestPyPI hosts the uni-rl (unilab-rl) prereleases; explicit so nothing
+# TestPyPI hosts the uni-rl (unilab-rl) releases; explicit so nothing
 # else resolves from it.
 [[tool.uv.index]]
 name = "testpypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # package (distribution name ``unilab-rl``), consumed via the injected
     # env contract (uni_rl.env_contract.EnvFactory). Published on TestPyPI
     # during the split rollout (issue #1480).
-    "unilab-rl==0.1.0a2",
+    "unilab-rl==0.1.0",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -147,7 +147,7 @@ name = "r2-cu130"
 url = "https://download-r2.pytorch.org/whl/cu130"
 explicit = true
 
-# TestPyPI hosts the uni-rl (unilab-rl) prereleases consumed during the
+# TestPyPI hosts the uni-rl (unilab-rl) releases consumed during the
 # algo-layer split; explicit so nothing else resolves from it.
 [[tool.uv.index]]
 name = "testpypi"

--- a/src/unilab/scripts/train_offpolicy.py
+++ b/src/unilab/scripts/train_offpolicy.py
@@ -173,6 +173,7 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
         "torch_thread_runtime": torch_thread_runtime,
         "collector_cpu_ids": collector_cpu_ids,
         "dp_sync": dp_sync,
+        "backend_device_binder": bind_backend_process_device,
     }
     if algo_name == "sac":
         from uni_rl.fast_sac.double_buffer import (
@@ -195,10 +196,6 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
     else:
         raise ValueError(f"Unsupported algo: {algo_name}")
 
-    # uni_rl 0.1.0a2's builder helpers do not forward backend_device_binder to
-    # DoubleBufferOffPolicyRunner; the runner reads the attribute at collector
-    # spawn time, so set it here until uni_rl grows the builder kwarg.
-    runner.backend_device_binder = bind_backend_process_device
     return runner
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -5053,7 +5053,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.1.0a2", index = "https://test.pypi.org/simple/" },
+    { name = "unilab-rl", specifier = "==0.1.0", index = "https://test.pypi.org/simple/" },
     { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
@@ -5073,7 +5073,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.1.0a2"
+version = "0.1.0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "hydra-core" },
@@ -5090,9 +5090,9 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/78/cd/d493eb07083701a83b6562231d0f7dfb089fd4ccd1d52fde93fe3c105c99/unilab_rl-0.1.0a2.tar.gz", hash = "sha256:c379f6c98866a76698b30c756ff184448c710a29fdeb40d845910137fe0a30e3", size = 173712, upload-time = "2026-09-03T19:14:06.19Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/b0/dc/649ec43d713316d374a92b263159cb70e2f97ab05b5c89aacbb88e227179/unilab_rl-0.1.0.tar.gz", hash = "sha256:569d533d3d13ceab00a72df9151cead271fa302f9c154bf3acb737efa131a5a1", size = 173801, upload-time = "2026-09-03T22:13:14.763Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/36/da/ddac23e8a65ee963456d3ddcc91a2290758c5784d501c2a755df48c45be3/unilab_rl-0.1.0a2-py3-none-any.whl", hash = "sha256:a29971a6aeb0a63ae9ee0fc628314c22fe87452973b1a3c2f5e885b39bd660f2", size = 217988, upload-time = "2026-09-03T19:14:03.235Z" },
+    { url = "https://test-files.pythonhosted.org/packages/97/c0/a04703caec8d54f794c1352497fcb582e7bc3f260ee621f74ed87ad2ccf5/unilab_rl-0.1.0-py3-none-any.whl", hash = "sha256:7a1fc89deab07e1ffb3eb2c921bf5abd4c726a7d6e3c235e4190181393b12a34", size = 218103, upload-time = "2026-09-03T22:13:11.427Z" },
 ]
 
 [[package]]

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3791,7 +3791,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.1.0a2", index = "https://test.pypi.org/simple/" },
+    { name = "unilab-rl", specifier = "==0.1.0", index = "https://test.pypi.org/simple/" },
     { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
@@ -3810,7 +3810,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.1.0a2"
+version = "0.1.0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "hydra-core" },
@@ -3826,9 +3826,9 @@ dependencies = [
     { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/78/cd/d493eb07083701a83b6562231d0f7dfb089fd4ccd1d52fde93fe3c105c99/unilab_rl-0.1.0a2.tar.gz", hash = "sha256:c379f6c98866a76698b30c756ff184448c710a29fdeb40d845910137fe0a30e3", size = 173712, upload-time = "2026-09-03T19:14:06.19Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/b0/dc/649ec43d713316d374a92b263159cb70e2f97ab05b5c89aacbb88e227179/unilab_rl-0.1.0.tar.gz", hash = "sha256:569d533d3d13ceab00a72df9151cead271fa302f9c154bf3acb737efa131a5a1", size = 173801, upload-time = "2026-09-03T22:13:14.763Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/36/da/ddac23e8a65ee963456d3ddcc91a2290758c5784d501c2a755df48c45be3/unilab_rl-0.1.0a2-py3-none-any.whl", hash = "sha256:a29971a6aeb0a63ae9ee0fc628314c22fe87452973b1a3c2f5e885b39bd660f2", size = 217988, upload-time = "2026-09-03T19:14:03.235Z" },
+    { url = "https://test-files.pythonhosted.org/packages/97/c0/a04703caec8d54f794c1352497fcb582e7bc3f260ee621f74ed87ad2ccf5/unilab_rl-0.1.0-py3-none-any.whl", hash = "sha256:7a1fc89deab07e1ffb3eb2c921bf5abd4c726a7d6e3c235e4190181393b12a34", size = 218103, upload-time = "2026-09-03T22:13:11.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the UniLab half of Motphys/UniLab#1481 (roadmap #1476 wrap-up). Base: `dev/issue-1476-uni-rl-split`.

## Changes

- `pyproject.toml` / `pyproject.rocm.toml`: `unilab-rl==0.1.0a2` → `unilab-rl==0.1.0` (first stable release, published to TestPyPI from unilabsim/uni_rl@`v0.1.0`, uni_rl PR unilabsim/uni_rl#3). Both lockfiles regenerated (`uv.lock` via `uv lock`; `uv.rocm.lock` via the Makefile `sync-rocm` swap procedure, files restored after).
- `src/unilab/scripts/train_offpolicy.py`: removed the post-construction `runner.backend_device_binder = bind_backend_process_device` workaround; the binder is now passed as the new kw-only `backend_device_binder` argument, which uni_rl 0.1.0's `build_{sac,td3,flashsac}_double_buffer_runner` forward to `DoubleBufferOffPolicyRunner`.

No other changes — the 0.1.0 package is interface-identical to 0.1.0a2 apart from the builder kwarg and the uni_rl-side test backfill.

## Validation

`make test-all` green at the final head (163571d9):
- ruff format + ruff check --fix: clean; ruff check tests (F401/F821/F811/F841): clean
- mypy src/unilab: Success, no issues (156 files)
- pyright: 0 errors (1 pre-existing `drake_uni.runtime` import warning in cli.py)
- pytest -m "not slow" --cov: **2234 passed, 20 skipped, 319 deselected, 1 xfailed** (234s)
- benchmark smoke: 36/37 passed (1 skipped: platform-optional `mlx`)

uni_rl side: PR unilabsim/uni_rl#3 merged (squash, main @ 615c0a5), `make publish-test` uploaded to TestPyPI, isolated install verified (`uni_rl.__version__ == 0.1.0`), tag `v0.1.0` pushed.
