### PR TITLE
feat: adopt unilab-rl 0.2.0 algos layout (issue #1485)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructure 仓库。
 
-RL 算法与异步 runtime（PPO/APPO/SAC/TD3/HORA 的 runner、learner、collector、IPC、训练日志）由独立包 **uni_rl**（distribution 名 `unilab-rl`，拆分期发布在 TestPyPI）承载；UniLab 不构造 uni_rl 消费的 env，而是通过注入式 env contract 对接：`uni_rl.env_contract.EnvFactory = Callable[[int, Mapping | None], EnvProtocol]`（必须可被 pickle 引用，collector 跑在 spawn 子进程），UniLab 侧适配器为 `src/unilab/base/env_factory.py` 的 `registry_env_factory`，mjwarp 设备绑定经 `src/unilab/base/process_device.py` 的 `bind_backend_process_device` 注入。unilab 可以 import uni_rl；uni_rl 永远不 import unilab / unisim。
+RL 算法与异步 runtime（PPO/APPO/SAC/TD3/HORA 的 runner、learner、collector、IPC、训练日志）由独立包 **uni_rl**（仓库 [unilabsim/unilab-rl](https://github.com/unilabsim/unilab-rl)，distribution 名 `unilab-rl`，拆分期发布在 TestPyPI）承载；UniLab 不构造 uni_rl 消费的 env，而是通过注入式 env contract 对接：`uni_rl.env_contract.EnvFactory = Callable[[int, Mapping | None], EnvProtocol]`（必须可被 pickle 引用，collector 跑在 spawn 子进程），UniLab 侧适配器为 `src/unilab/base/env_factory.py` 的 `registry_env_factory`，mjwarp 设备绑定经 `src/unilab/base/process_device.py` 的 `bind_backend_process_device` 注入。unilab 可以 import uni_rl；uni_rl 永远不 import unilab / unisim。
 
 ## Core Principles
 

--- a/docs/sphinx/source/api_reference/algos/index.md
+++ b/docs/sphinx/source/api_reference/algos/index.md
@@ -4,13 +4,13 @@ The RL algorithm layer moved out of the `unilab` package into the
 independently released **uni_rl** package (distribution name `unilab-rl`,
 consumed from TestPyPI during the split rollout; issue #1480):
 
-- `uni_rl.rsl_rl` / `uni_rl.rsl_rl_ppo` / `uni_rl.rsl_rl_runtime` — PPO (RSL-RL) integration
-- `uni_rl.appo` — APPO runner, learner, staging, worker
-- `uni_rl.fast_sac` / `uni_rl.fast_td3` / `uni_rl.flash_sac` — off-policy learners and runners
+- `uni_rl.algos.rsl_rl` / `uni_rl.algos.rsl_rl_ppo` / `uni_rl.algos.rsl_rl_runtime` — PPO (RSL-RL) integration
+- `uni_rl.algos.appo` — APPO runner, learner, staging, worker
+- `uni_rl.algos.fast_sac` / `uni_rl.algos.fast_td3` / `uni_rl.algos.flash_sac` — off-policy learners and runners
 - `uni_rl.offpolicy` — generic off-policy runner, worker, thread budget
-- `uni_rl.him_ppo` — HIM-PPO
-- `uni_rl.hora` — HORA models, trainers, and distillation
-- `uni_rl.common` — shared actor factory, networks, normalization, compile helpers
+- `uni_rl.algos.him_ppo` — HIM-PPO
+- `uni_rl.algos.hora` — HORA models, trainers, and distillation
+- `uni_rl.algos.common` — shared actor factory, networks, normalization, compile helpers
 
 UniLab keeps the training *entrypoints* (`src/unilab/scripts/train_*.py`),
 which inject environments into uni_rl runners through

--- a/docs/sphinx/source/en/1-getting_started/4-project_structure.md
+++ b/docs/sphinx/source/en/1-getting_started/4-project_structure.md
@@ -10,8 +10,8 @@ changing behavior.
 | `src/unilab/conf/` | Hydra roots and task owner YAMLs. The top-level CLI exposes backend selection as `--task` plus `--sim`, then composes the matching owner YAML. |
 | `src/unilab/base/` | Registry, env state, scene, and backend contracts. |
 | `src/unilab/envs/` | Task env implementations and task-specific reset, reward, observation, and DR logic. |
-| `uni_rl` (uni_rl repo) | PPO, APPO, off-policy, HIM-PPO, and HORA algorithm code. |
-| `uni_rl.ipc` (uni_rl repo) | Shared-memory and async runner primitives. |
+| `uni_rl` (unilab-rl repo) | PPO, APPO, off-policy, HIM-PPO, and HORA algorithm code. |
+| `uni_rl.ipc` (unilab-rl repo) | Shared-memory and async runner primitives. |
 | `src/unilab/training/` | Shared training helpers for logging, playback, seed handling, and config guards. |
 | `src/unilab/visualization/` | Playback, rendering, NaN inspection, and scene/export utilities. |
 | `tests/` | Contract, config, env, algorithm, script, and integration tests. |

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/1-ppo.md
@@ -2,7 +2,7 @@
 
 PPO is the default synchronous on-policy training path. It uses
 `src/unilab/scripts/train_rsl_rl.py`, composes from `src/unilab/conf/ppo/config.yaml`, and runs the
-RSL-RL adapter code in `uni_rl.rsl_rl_ppo` (uni_rl repo) and
+RSL-RL adapter code in `uni_rl.algos.rsl_rl_ppo` (unilab-rl repo) and
 `src/unilab/training/rsl_rl.py`.
 
 ## Quick Start

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/2-appo.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/2-appo.md
@@ -1,7 +1,7 @@
 # APPO
 
 APPO is UniLab's asynchronous PPO path. It uses `src/unilab/scripts/train_appo.py`,
-`src/unilab/conf/appo/config.yaml`, and the runtime under `uni_rl.appo` (uni_rl repo).
+`src/unilab/conf/appo/config.yaml`, and the runtime under `uni_rl.algos.appo` (unilab-rl repo).
 The config exposes `algo.steps_per_env`, `training.collector_device`, and
 `training.replay_queue_size`; the algorithm config includes V-trace clipping
 fields.

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/5-flash_sac.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/5-flash_sac.md
@@ -3,7 +3,7 @@
 FlashSAC runs through `src/unilab/scripts/train_flashsac.py` in its own config tree.
 Select it with `--algo flashsac`; defaults are inlined in
 `src/unilab/conf/flashsac/config.yaml`, and the implementation lives under
-`uni_rl.flash_sac` (uni_rl repo).
+`uni_rl.algos.flash_sac` (unilab-rl repo).
 
 It shares the off-policy runner design with SAC and TD3, but does not use the
 same default networks: the actor uses a block-based structure and the critic

--- a/docs/sphinx/source/en/2-user_guide/2-algorithms/7-hora.md
+++ b/docs/sphinx/source/en/2-user_guide/2-algorithms/7-hora.md
@@ -13,7 +13,7 @@ uv run train --algo appo --task sharpa_inhand --sim mujoco --profile hora traini
 ```
 
 The HORA PPO owner sets `algo.algo_log_name=hora_ppo` and resolves the runtime
-through `uni_rl.hora.rsl_rl:resolve_hora_ppo_runtime`. The APPO
+through `uni_rl.algos.hora.rsl_rl:resolve_hora_ppo_runtime`. The APPO
 variant sets `algo.algo_log_name=hora_appo`.
 
 ## Student Distillation

--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -14,7 +14,7 @@ mostly mechanical.
 | `_reward_*` methods | env's `compute_reward()` + reward term registry |
 | `command_ranges` | task owner YAML's `commands` block |
 | Terrain curriculum | {doc}`../../2-user_guide/6-terrain/1-procedural` |
-| RSL-RL PPO | `uni_rl.rsl_rl_ppo` |
+| RSL-RL PPO | `uni_rl.algos.rsl_rl_ppo` |
 
 ## What's new
 
@@ -22,7 +22,7 @@ mostly mechanical.
   + Motrix. Pick one (or both) before porting; see
   {doc}`../2-sim_to_sim/1-backend_swap`.
 - **Async collection.** Legged Gym collects on-GPU synchronously; UniLab's
-  APPO (`uni_rl.appo`) decouples collectors from
+  APPO (`uni_rl.algos.appo`) decouples collectors from
   learner. If wall-clock matters, port to APPO once your reward parity is
   established.
 - **Hardware deployment.** Legged Gym → real-world deployment is a

--- a/docs/sphinx/source/en/3-deployment/3-framework_migration/3-from_rsl_rl.md
+++ b/docs/sphinx/source/en/3-deployment/3-framework_migration/3-from_rsl_rl.md
@@ -1,7 +1,7 @@
 # Migrating from RSL-RL
 
 You're already using RSL-RL standalone? Good news: UniLab ships RSL-RL PPO
-as one of its supported algorithms (`uni_rl.rsl_rl_ppo`)
+as one of its supported algorithms (`uni_rl.algos.rsl_rl_ppo`)
 and it's nearly drop-in.
 
 ## What you gain by moving inside UniLab
@@ -13,7 +13,7 @@ and it's nearly drop-in.
    backend / task / algo selection. No more bespoke train scripts per
    robot.
 3. **Async runner.** Wrap RSL-RL PPO inside
-   `uni_rl.appo` for higher throughput on machines
+   `uni_rl.algos.appo` for higher throughput on machines
    with many CPU cores.
 4. **Deployment story.** ONNX export with the right wrapper, safety
    layer documentation, and the

--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/1-overview.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/1-overview.md
@@ -14,7 +14,7 @@ MuJoCo or Motrix      shared memory       torch
 
 PPO is a synchronous single-process path. APPO and off-policy
 algorithms use the async runner, shared buffers, and weight synchronization
-primitives under `uni_rl.ipc` (uni_rl repo) and `uni_rl` (uni_rl repo).
+primitives under `uni_rl.ipc` (unilab-rl repo) and `uni_rl` (unilab-rl repo).
 
 ## Layer Boundaries
 
@@ -23,7 +23,7 @@ primitives under `uni_rl.ipc` (uni_rl repo) and `uni_rl` (uni_rl repo).
 | Backend | `unisim.backend` | `SimBackend`, physics state, optional capabilities |
 | Env | `src/unilab/envs/`, `src/unilab/base/np_env.py` | MDP semantics, observation, reward, reset |
 | Config and registry | `src/unilab/conf/`, `src/unilab/base/registry.py`, `src/unilab/structured_configs.py` | Schema, owner YAMLs, env/backend registration |
-| Algorithms and IPC | `uni_rl` (uni_rl repo), `uni_rl.ipc` (uni_rl repo) | Learners, runners, buffers, weight sync |
+| Algorithms and IPC | `uni_rl` (unilab-rl repo), `uni_rl.ipc` (unilab-rl repo) | Learners, runners, buffers, weight sync |
 | Scripts | `scripts/`, `src/unilab/cli.py` | Thin assembly and CLI routing |
 
 ## Design Rules
@@ -85,7 +85,7 @@ Use `make test` for the fast path and `make test-all` (`make check`,
 - `src/unilab/base/np_env.py`
 - `unisim.backend.base`
 - `src/unilab/base/registry.py`
-- `uni_rl.ipc.async_runner` (uni_rl repo)
+- `uni_rl.ipc.async_runner` (unilab-rl repo)
 - `src/unilab/training/run.py`
 
 ## Related ADRs

--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/2-runtime_model.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/2-runtime_model.md
@@ -28,7 +28,7 @@ CPU physics env loop -> shared IPC buffer -> learner
 - SAC, TD3, and FlashSAC use one off-policy execution path: `ReplayBuffer`
   provides bounded host ingress, the complete ring lives on one CUDA/MPS
   learner device, and `SharedWeightSync` publishes actor weights.
-- `AsyncRunner` in `uni_rl.ipc.async_runner` (uni_rl repo) owns collector process
+- `AsyncRunner` in `uni_rl.ipc.async_runner` (unilab-rl repo) owns collector process
   startup, stop signaling, and shared-resource cleanup.
 
 ## Boundary Rules
@@ -41,8 +41,8 @@ CPU physics env loop -> shared IPC buffer -> learner
 ## Evidence In Repo
 
 - PPO entrypoint: `src/unilab/scripts/train_rsl_rl.py`
-- APPO runner: `uni_rl.appo.runner` (uni_rl repo)
-- Off-policy runner: `uni_rl.offpolicy.double_buffer_runner` (uni_rl repo)
-- IPC primitives: `uni_rl.ipc.async_runner` (uni_rl repo),
-  `uni_rl.ipc.rollout_ring_buffer` (uni_rl repo), `uni_rl.ipc.replay_buffer` (uni_rl repo),
-  `uni_rl.ipc.weight_sync` (uni_rl repo)
+- APPO runner: `uni_rl.algos.appo.runner` (unilab-rl repo)
+- Off-policy runner: `uni_rl.offpolicy.double_buffer_runner` (unilab-rl repo)
+- IPC primitives: `uni_rl.ipc.async_runner` (unilab-rl repo),
+  `uni_rl.ipc.rollout_ring_buffer` (unilab-rl repo), `uni_rl.ipc.replay_buffer` (unilab-rl repo),
+  `uni_rl.ipc.weight_sync` (unilab-rl repo)

--- a/docs/sphinx/source/en/4-developer_guide/1-architecture/3-layer_boundaries.md
+++ b/docs/sphinx/source/en/4-developer_guide/1-architecture/3-layer_boundaries.md
@@ -11,7 +11,7 @@ standard is {doc}`/zh_CN/4-developer_guide/0-index`.
 | L0 Backend | `unisim.backend` | Physics backend abstraction, backend-owned scene materialization, backend capabilities. |
 | L1 Env | `src/unilab/envs/`, `src/unilab/base/np_env.py` | MDP semantics, observations, rewards, reset logic, backend-to-task adaptation. |
 | L2 Config and Registry | `src/unilab/conf/`, `src/unilab/structured_configs.py`, `src/unilab/base/registry.py`, `src/unilab/training/reward.py` | Hydra composition, owner YAML identity, env/reward registration. |
-| L3 Algo and IPC | `uni_rl` (uni_rl repo), `uni_rl.ipc` (uni_rl repo) | Learners, runners, collectors, replay and rollout buffers, weight sync. |
+| L3 Algo and IPC | `uni_rl` (unilab-rl repo), `uni_rl.ipc` (unilab-rl repo) | Learners, runners, collectors, replay and rollout buffers, weight sync. |
 | L4 Scripts | `scripts/` | Entrypoint assembly only. |
 
 ## Rules

--- a/docs/sphinx/source/en/4-developer_guide/2-contracts/5-runner_lifecycle.md
+++ b/docs/sphinx/source/en/4-developer_guide/2-contracts/5-runner_lifecycle.md
@@ -39,6 +39,6 @@ The training scripts follow the same high-level sequence:
 
 - Shared training helpers: `src/unilab/training/common.py`,
   `src/unilab/training/run.py`
-- Async lifecycle: `uni_rl.ipc.async_runner` (uni_rl repo)
+- Async lifecycle: `uni_rl.ipc.async_runner` (unilab-rl repo)
 - Runner tests: `tests/algos/test_appo_runner.py`,
   `tests/algos/test_offpolicy_runner.py`, `tests/ipc/test_async_runner.py`

--- a/docs/sphinx/source/en/4-developer_guide/3-extending/3-new_algorithm.md
+++ b/docs/sphinx/source/en/4-developer_guide/3-extending/3-new_algorithm.md
@@ -14,7 +14,7 @@ Algorithm work must preserve the env, config, and runner contracts. Start with
 
 ## Implementation Checklist
 
-1. Put reusable learner or runner code under `uni_rl` (uni_rl repo).
+1. Put reusable learner or runner code under `uni_rl` (unilab-rl repo).
 2. Add Hydra config under the owning config root. A new off-policy variant should
    add its own config tree: `src/unilab/conf/<algo>/config.yaml` with the algorithm
    hyperparameters inlined, plus matching
@@ -43,4 +43,4 @@ Algorithm work must preserve the env, config, and runner contracts. Start with
 - Structured config dataclasses: `src/unilab/structured_configs.py`
 - Training helpers: `src/unilab/training/common.py`,
   `src/unilab/training/run.py`
-- Existing algorithm packages: `uni_rl` (uni_rl repo)
+- Existing algorithm packages: `uni_rl` (unilab-rl repo)

--- a/docs/sphinx/source/zh_CN/1-getting_started/4-project_structure.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/4-project_structure.md
@@ -8,8 +8,8 @@ UniLab 将运行时 contract、配置、训练脚本和文档分置于不同的 
 | `src/unilab/conf/` | Hydra 根配置和任务 owner YAML。顶层 CLI 将后端选择暴露为 `--task` 加 `--sim`，然后组合出匹配的 owner YAML。 |
 | `src/unilab/base/` | Registry、env state、scene 以及 backend contract。 |
 | `src/unilab/envs/` | 任务 env 实现，以及任务专属的 reset、reward、observation 和 DR 逻辑。 |
-| `uni_rl` (uni_rl repo) | PPO、APPO、off-policy、HIM-PPO 和 HORA 算法代码。 |
-| `uni_rl.ipc` (uni_rl repo) | 共享内存与异步 runner 原语。 |
+| `uni_rl` (unilab-rl repo) | PPO、APPO、off-policy、HIM-PPO 和 HORA 算法代码。 |
+| `uni_rl.ipc` (unilab-rl repo) | 共享内存与异步 runner 原语。 |
 | `src/unilab/training/` | 共享的训练辅助工具，用于日志、回放、种子处理和配置守卫（config guard）。 |
 | `src/unilab/visualization/` | 回放、渲染、NaN 检查以及 scene/export 工具。 |
 | `tests/` | Contract、config、env、algorithm、script 和集成测试。 |

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/1-ppo.md
@@ -1,7 +1,7 @@
 # PPO
 
 PPO 是默认的同步 on-policy 训练路径。它使用 `src/unilab/scripts/train_rsl_rl.py`，从
-`src/unilab/conf/ppo/config.yaml` 组合配置，并运行 `uni_rl.rsl_rl_ppo` (uni_rl repo)
+`src/unilab/conf/ppo/config.yaml` 组合配置，并运行 `uni_rl.algos.rsl_rl_ppo` (unilab-rl repo)
 和 `src/unilab/training/rsl_rl.py` 中的 RSL-RL 适配代码。
 
 ## 快速开始

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/2-appo.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/2-appo.md
@@ -1,7 +1,7 @@
 # APPO
 
 APPO 是 UniLab 的异步 PPO 路径。它使用 `src/unilab/scripts/train_appo.py`、
-`src/unilab/conf/appo/config.yaml` 以及 `uni_rl.appo` (uni_rl repo) 下的运行时。该配置暴露
+`src/unilab/conf/appo/config.yaml` 以及 `uni_rl.algos.appo` (unilab-rl repo) 下的运行时。该配置暴露
 了 `algo.steps_per_env`、`training.collector_device` 和
 `training.replay_queue_size`；算法配置中包含 V-trace 裁剪字段。
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/5-flash_sac.md
@@ -2,7 +2,7 @@
 
 FlashSAC 通过 `src/unilab/scripts/train_flashsac.py` 运行，拥有独立的配置树。使用
 `--algo flashsac` 选择它；默认值内联在 `src/unilab/conf/flashsac/config.yaml` 中，实现位于
-`uni_rl.flash_sac` (uni_rl repo) 下。
+`uni_rl.algos.flash_sac` (unilab-rl repo) 下。
 
 它与 SAC、TD3 共用 off-policy runner 设计，但默认网络并不相同：actor 使用
 block-based 结构，critic 使用 distributional（categorical）Q 变体。

--- a/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/7-hora.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/2-algorithms/7-hora.md
@@ -13,7 +13,7 @@ uv run train --algo appo --task sharpa_inhand --sim mujoco --profile hora traini
 ```
 
 HORA PPO owner 设置 `algo.algo_log_name=hora_ppo`，并通过
-`uni_rl.hora.rsl_rl:resolve_hora_ppo_runtime` 解析运行时。APPO 变体设置
+`uni_rl.algos.hora.rsl_rl:resolve_hora_ppo_runtime` 解析运行时。APPO 变体设置
 `algo.algo_log_name=hora_appo`。
 
 ## Student 蒸馏

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/2-from_legged_gym.md
@@ -13,7 +13,7 @@ Legged Gym 曾是那套 GPU 常驻的 PPO 模板，教会了整个领域如何�
 | `_reward_*` 方法 | env 的 `compute_reward()` + reward 项 registry |
 | `command_ranges` | 任务 owner YAML 的 `commands` 块 |
 | 地形课程 | {doc}`../../2-user_guide/6-terrain/1-procedural` |
-| RSL-RL PPO | `uni_rl.rsl_rl_ppo` |
+| RSL-RL PPO | `uni_rl.algos.rsl_rl_ppo` |
 
 ## 有哪些新东西
 
@@ -21,7 +21,7 @@ Legged Gym 曾是那套 GPU 常驻的 PPO 模板，教会了整个领域如何�
   在移植之前先选一个（或两个都选）；参见
   {doc}`../2-sim_to_sim/1-backend_swap`。
 - **异步采集。** Legged Gym 在 GPU 上同步采集；UniLab 的
-  APPO（`uni_rl.appo`）把 collector 与 learner 解耦。如果你在意
+  APPO（`uni_rl.algos.appo`）把 collector 与 learner 解耦。如果你在意
   wall-clock 时间，在建立起 reward 一致性之后，就移植到 APPO。
 - **硬件部署。** Legged Gym → 真实世界部署，是各实验室各自手工搭建的流程。UniLab
   把 {doc}`../1-sim_to_real/1-overview` 流水线作为一等公民产物提供给你。

--- a/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/3-from_rsl_rl.md
+++ b/docs/sphinx/source/zh_CN/3-deployment/3-framework_migration/3-from_rsl_rl.md
@@ -1,7 +1,7 @@
 # 从 RSL-RL 迁移
 
 你已经在独立使用 RSL-RL 了？好消息：UniLab 把 RSL-RL PPO 作为其受支持算法之一
-（`uni_rl.rsl_rl_ppo`）提供，而且几乎是即插即用的。
+（`uni_rl.algos.rsl_rl_ppo`）提供，而且几乎是即插即用的。
 
 ## 迁移进 UniLab 后你能获得什么
 
@@ -10,7 +10,7 @@
    更不容易出错。
 2. **任务 owner。** 基于 Hydra 的配置组合，外加 registry 驱动的
    backend / task / algo 选择。不再需要为每种机器人编写定制的训练脚本。
-3. **异步 runner。** 把 RSL-RL PPO 包进 `uni_rl.appo`，在拥有许多
+3. **异步 runner。** 把 RSL-RL PPO 包进 `uni_rl.algos.appo`，在拥有许多
    CPU 核心的机器上获得更高吞吐量。
 4. **部署流程。** 配合正确 wrapper 的 ONNX 导出、安全层文档，以及
    {doc}`../1-sim_to_real/1-overview` 流水线。

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/1-overview.md
@@ -14,8 +14,8 @@ MuJoCo or Motrix      shared memory       torch
 
 PPO 是同步路径：默认单进程，也可在单机上按一卡一进程运行 RSL-RL 数据并行；
 每个 rank 独立持有 env/rollout，RSL-RL 在每个 mini-batch 后平均梯度。APPO 与
-off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `uni_rl.ipc` (uni_rl repo) 与
-`uni_rl` (uni_rl repo) 下的权重同步原语。
+off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `uni_rl.ipc` (unilab-rl repo) 与
+`uni_rl` (unilab-rl repo) 下的权重同步原语。
 
 ## 分层边界
 
@@ -24,7 +24,7 @@ off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `uni_rl
 | Backend | `unisim.backend` | `SimBackend`、物理状态、可选能力 |
 | Env | `src/unilab/envs/`、`src/unilab/base/np_env.py` | MDP 语义、观测、奖励、reset |
 | Config 与 registry | `src/unilab/conf/`、`src/unilab/base/registry.py`、`src/unilab/structured_configs.py` | Schema、owner YAML、env/backend 注册 |
-| 算法与 IPC | `uni_rl` (uni_rl repo)、`uni_rl.ipc` (uni_rl repo) | Learner、runner、buffer、权重同步 |
+| 算法与 IPC | `uni_rl` (unilab-rl repo)、`uni_rl.ipc` (unilab-rl repo) | Learner、runner、buffer、权重同步 |
 | Scripts | `scripts/`、`src/unilab/cli.py` | 轻量装配与 CLI 路由 |
 
 ## 设计规则
@@ -79,7 +79,7 @@ off-policy 算法则使用异步 runner、共享缓冲区，以及位于 `uni_rl
 - `src/unilab/base/np_env.py`
 - `unisim.backend.base`
 - `src/unilab/base/registry.py`
-- `uni_rl.ipc.async_runner` (uni_rl repo)
+- `uni_rl.ipc.async_runner` (unilab-rl repo)
 - `src/unilab/training/run.py`
 
 ## 相关 ADR

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/2-runtime_model.md
@@ -35,7 +35,7 @@ CPU physics env loop -> shared IPC buffer -> learner
 - SAC、TD3 与 FlashSAC 只使用一条 off-policy execution path：`ReplayBuffer`
   提供有界 host ingress，完整 ring 驻留在一个 CUDA/MPS learner device，
   `SharedWeightSync` 负责发布 actor 权重。
-- `uni_rl.ipc.async_runner` (uni_rl repo) 中的 `AsyncRunner` 负责 collector 进程启动、
+- `uni_rl.ipc.async_runner` (unilab-rl repo) 中的 `AsyncRunner` 负责 collector 进程启动、
   停止信号以及共享资源清理。
 
 ## 边界规则
@@ -50,8 +50,8 @@ CPU physics env loop -> shared IPC buffer -> learner
 ## 仓库中的证据
 
 - PPO 入口：`src/unilab/scripts/train_rsl_rl.py`
-- APPO runner：`uni_rl.appo.runner` (uni_rl repo)
-- Off-policy runner：`uni_rl.offpolicy.double_buffer_runner` (uni_rl repo)
-- IPC 原语：`uni_rl.ipc.async_runner` (uni_rl repo)、
-  `uni_rl.ipc.rollout_ring_buffer` (uni_rl repo)、`uni_rl.ipc.replay_buffer` (uni_rl repo)、
-  `uni_rl.ipc.weight_sync` (uni_rl repo)
+- APPO runner：`uni_rl.algos.appo.runner` (unilab-rl repo)
+- Off-policy runner：`uni_rl.offpolicy.double_buffer_runner` (unilab-rl repo)
+- IPC 原语：`uni_rl.ipc.async_runner` (unilab-rl repo)、
+  `uni_rl.ipc.rollout_ring_buffer` (unilab-rl repo)、`uni_rl.ipc.replay_buffer` (unilab-rl repo)、
+  `uni_rl.ipc.weight_sync` (unilab-rl repo)

--- a/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/3-layer_boundaries.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/1-architecture/3-layer_boundaries.md
@@ -12,7 +12,7 @@
 | L0 Backend | `unisim.backend` | 物理 backend 抽象、由 backend 拥有的场景 materialization、backend 能力。 |
 | L1 Env | `src/unilab/envs/`、`src/unilab/base/np_env.py` | MDP 语义、观测、奖励、reset 逻辑、backend 到任务的适配。 |
 | L2 Config 与 Registry | `src/unilab/conf/`、`src/unilab/structured_configs.py`、`src/unilab/base/registry.py`、`src/unilab/training/reward.py` | Hydra compose、owner YAML 身份、env/reward 注册。 |
-| L3 算法与 IPC | `uni_rl` (uni_rl repo)、`uni_rl.ipc` (uni_rl repo) | Learner、runner、collector、replay 与 rollout buffer、权重同步。 |
+| L3 算法与 IPC | `uni_rl` (unilab-rl repo)、`uni_rl.ipc` (unilab-rl repo) | Learner、runner、collector、replay 与 rollout buffer、权重同步。 |
 | L4 Scripts | `scripts/` | 仅做入口装配。 |
 
 ## 规则

--- a/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/5-runner_lifecycle.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/2-contracts/5-runner_lifecycle.md
@@ -36,6 +36,6 @@ runner；它们不应另起第二套 collector/learner 协议。
 
 - 共享训练 helper：`src/unilab/training/common.py`、
   `src/unilab/training/run.py`
-- 异步生命周期：`uni_rl.ipc.async_runner` (uni_rl repo)
+- 异步生命周期：`uni_rl.ipc.async_runner` (unilab-rl repo)
 - Runner 测试：`tests/algos/test_appo_runner.py`、
   `tests/algos/test_offpolicy_runner.py`、`tests/ipc/test_async_runner.py`

--- a/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/3-new_algorithm.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/3-new_algorithm.md
@@ -13,7 +13,7 @@
 
 ## 实现清单
 
-1. 把可复用的 learner 或 runner 代码放在 `uni_rl` (uni_rl repo) 下。
+1. 把可复用的 learner 或 runner 代码放在 `uni_rl` (unilab-rl repo) 下。
 2. 在归属的 config 根目录下添加 Hydra config。一个新的 off-policy 变体
    应当建立自己的配置树：算法超参数内联在 `src/unilab/conf/<algo>/config.yaml` 中，
    并添加对应的 `src/unilab/conf/<algo>/task/<task>/<backend>.yaml` owner YAML。
@@ -40,4 +40,4 @@
 - 结构化 config dataclass：`src/unilab/structured_configs.py`
 - 训练辅助工具：`src/unilab/training/common.py`、
   `src/unilab/training/run.py`
-- 现有算法包：`uni_rl` (uni_rl repo)
+- 现有算法包：`uni_rl` (unilab-rl repo)

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -28,7 +28,7 @@ dependencies = [
     "unisim-core>=0.1.14",
     # RL algorithms and async runtimes live in the independently released
     # uni-rl package (distribution name ``unilab-rl``); see pyproject.toml.
-    "unilab-rl==0.1.0",
+    "unilab-rl==0.2.0",
     "torch==2.11.0",
     "triton-rocm==3.6.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "gymnasium",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # package (distribution name ``unilab-rl``), consumed via the injected
     # env contract (uni_rl.env_contract.EnvFactory). Published on TestPyPI
     # during the split rollout (issue #1480).
-    "unilab-rl==0.1.0",
+    "unilab-rl==0.2.0",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",

--- a/scripts/play_viser.py
+++ b/scripts/play_viser.py
@@ -46,7 +46,7 @@ if str(SRC_DIR) not in sys.path:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from uni_rl.rsl_rl import (
+from uni_rl.algos.rsl_rl import (
     RslRlVecEnvWrapper,
     get_policy_obs_dims,
     normalize_ppo_train_cfg,

--- a/scripts/train_him_ppo.py
+++ b/scripts/train_him_ppo.py
@@ -18,8 +18,8 @@ if str(SRC_DIR) not in sys.path:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from uni_rl.him_ppo.runner import HIMOnPolicyRunner
-from uni_rl.rsl_rl import RslRlVecEnvWrapper, get_policy_obs_dims
+from uni_rl.algos.him_ppo.runner import HIMOnPolicyRunner
+from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper, get_policy_obs_dims
 from unisim.backend.mujoco.xml import materialize_scene_visual_override
 
 from unilab.base.config_adapter import (

--- a/scripts/train_hora_distill.py
+++ b/scripts/train_hora_distill.py
@@ -14,14 +14,14 @@ if str(SRC_DIR) not in sys.path:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from uni_rl.hora import HoraDistillationTrainer
-from uni_rl.hora.distill import (
+from uni_rl.algos.hora import HoraDistillationTrainer
+from uni_rl.algos.hora.distill import (
     build_student_actor_and_normalizer,
     cfg_with_checkpoint_runtime,
     load_distilled_checkpoint,
     student_policy,
 )
-from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper as RslRlVecEnvWrapper
+from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper as RslRlVecEnvWrapper
 from unisim.backend.base import log_playback_plan
 from unisim.backend.mujoco.xml import materialize_scene_visual_override
 

--- a/src/unilab/conf/appo/task/sharpa_inhand/mujoco_hora.yaml
+++ b/src/unilab/conf/appo/task/sharpa_inhand/mujoco_hora.yaml
@@ -38,11 +38,11 @@ algo:
       actor: 0
       priv_info: 0
   actor:
-    class_name: uni_rl.hora:HoraActorModel
+    class_name: uni_rl.algos.hora:HoraActorModel
     priv_info_embed_dim: 9
     priv_mlp_hidden_dims: [256, 128, 9]
   critic:
-    class_name: uni_rl.hora:HoraCriticModel
+    class_name: uni_rl.algos.hora:HoraCriticModel
     priv_info_embed_dim: 9
     priv_mlp_hidden_dims: [256, 128, 9]
   algorithm:

--- a/src/unilab/conf/ppo/config.yaml
+++ b/src/unilab/conf/ppo/config.yaml
@@ -28,7 +28,7 @@ algo:
     activation: elu
     class_name: ActorCritic
   algorithm:
-    class_name: uni_rl.rsl_rl_ppo:FinalObservationAwarePPO
+    class_name: uni_rl.algos.rsl_rl_ppo:FinalObservationAwarePPO
     value_loss_coef: 1.0
     use_clipped_value_loss: true
     clip_param: 0.2

--- a/src/unilab/conf/ppo/task/sharpa_inhand/mujoco_hora.yaml
+++ b/src/unilab/conf/ppo/task/sharpa_inhand/mujoco_hora.yaml
@@ -14,12 +14,12 @@ interactive:
 algo:
   algo_log_name: hora_ppo
   runtime_impl: hora_ppo
-  runtime_resolver: uni_rl.hora.rsl_rl:resolve_hora_ppo_runtime
+  runtime_resolver: uni_rl.algos.hora.rsl_rl:resolve_hora_ppo_runtime
   obs_groups:
     actor: [actor]
     critic: [actor]
   actor:
-    class_name: uni_rl.hora:HoraActorModel
+    class_name: uni_rl.algos.hora:HoraActorModel
     hidden_dims: [512, 256, 128]
     activation: elu
     obs_normalization: true
@@ -30,14 +30,14 @@ algo:
       init_std: 1.0
       std_type: scalar
   critic:
-    class_name: uni_rl.hora:HoraCriticModel
+    class_name: uni_rl.algos.hora:HoraCriticModel
     hidden_dims: [512, 256, 128]
     activation: elu
     obs_normalization: true
     priv_info_embed_dim: 9
     priv_mlp_hidden_dims: [256, 128, 9]
   algorithm:
-    class_name: uni_rl.hora:HoraPPO
+    class_name: uni_rl.algos.hora:HoraPPO
 
 env:
   obs:

--- a/src/unilab/conf/sac/task/sharpa_inhand/mujoco_hora.yaml
+++ b/src/unilab/conf/sac/task/sharpa_inhand/mujoco_hora.yaml
@@ -24,7 +24,7 @@ interactive:
 algo:
   algo_log_name: hora_sac
   runtime_impl: hora_sac
-  runtime_resolver: uni_rl.hora.sac:resolve_hora_sac_runtime
+  runtime_resolver: uni_rl.algos.hora.sac:resolve_hora_sac_runtime
   num_envs: 1024
   batch_size: 2048
   replay_buffer_n: 1280

--- a/src/unilab/scripts/play_hora_appo.py
+++ b/src/unilab/scripts/play_hora_appo.py
@@ -1,11 +1,11 @@
 """HORA APPO checkpoint playback, owned by UniLab (issue #1480).
 
-The HORA APPO *training* runner lives in uni_rl (``uni_rl.hora.appo_runner``);
+The HORA APPO *training* runner lives in uni_rl (``uni_rl.algos.hora.appo_runner``);
 the play-mode orchestration is UniLab-side business logic because it drives
 UniLab's registry-backed env construction, sim2sim contract validation, and
 backend playback plan logging. ``resolve_hora_appo_runtime`` is the owner
 config's ``runtime_resolver`` entrypoint consumed by
-``uni_rl.appo.runtime.resolve_appo_runtime``.
+``uni_rl.algos.appo.runtime.resolve_appo_runtime``.
 """
 
 from __future__ import annotations
@@ -18,15 +18,15 @@ from typing import Any, cast
 
 import torch
 from omegaconf import DictConfig
-from uni_rl.hora.appo_runner import HoraAPPORunner
-from uni_rl.hora.models import build_hora_shared_actor_critic
-from uni_rl.hora.observations import build_hora_actor_tensordict, split_hora_obs_with_priv_info
-from uni_rl.hora.rsl_rl_compat import (
+from uni_rl.algos.hora.appo_runner import HoraAPPORunner
+from uni_rl.algos.hora.models import build_hora_shared_actor_critic
+from uni_rl.algos.hora.observations import build_hora_actor_tensordict, split_hora_obs_with_priv_info
+from uni_rl.algos.hora.rsl_rl_compat import (
     convert_config_v3_to_v4,
     is_rsl_rl_v4,
     is_rsl_rl_v5,
 )
-from uni_rl.hora.runtime import is_hora_appo_runtime
+from uni_rl.algos.hora.runtime import is_hora_appo_runtime
 from uni_rl.utils.observations import get_obs_dims
 from unisim.backend.base import log_playback_plan
 

--- a/src/unilab/scripts/play_hora_appo.py
+++ b/src/unilab/scripts/play_hora_appo.py
@@ -20,7 +20,10 @@ import torch
 from omegaconf import DictConfig
 from uni_rl.algos.hora.appo_runner import HoraAPPORunner
 from uni_rl.algos.hora.models import build_hora_shared_actor_critic
-from uni_rl.algos.hora.observations import build_hora_actor_tensordict, split_hora_obs_with_priv_info
+from uni_rl.algos.hora.observations import (
+    build_hora_actor_tensordict,
+    split_hora_obs_with_priv_info,
+)
 from uni_rl.algos.hora.rsl_rl_compat import (
     convert_config_v3_to_v4,
     is_rsl_rl_v4,

--- a/src/unilab/scripts/play_interactive.py
+++ b/src/unilab/scripts/play_interactive.py
@@ -44,7 +44,7 @@ from omegaconf import DictConfig, OmegaConf
 
 _PACKAGE_CONF_ROOT = Path(__file__).resolve().parents[1] / "conf"
 
-from uni_rl.rsl_rl import (
+from uni_rl.algos.rsl_rl import (
     RslRlVecEnvWrapper,
     get_policy_obs_dims,
     normalize_ppo_train_cfg,
@@ -947,7 +947,7 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
         if algo == "ppo":
             wrapper_cls = RslRlVecEnvWrapper
             if cfg is not None:
-                from uni_rl.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
+                from uni_rl.algos.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 
                 wrapper_cls = resolve_rsl_rl_ppo_runtime(
                     _algo_config_dict(cfg),

--- a/src/unilab/scripts/train_appo.py
+++ b/src/unilab/scripts/train_appo.py
@@ -11,8 +11,8 @@ from typing import Any, cast
 import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
-from uni_rl.appo.runtime import resolve_appo_runtime
-from uni_rl.rsl_rl import RslRlVecEnvWrapper
+from uni_rl.algos.appo.runtime import resolve_appo_runtime
+from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 from unisim.backend.base import log_playback_plan
 
 from unilab.base.config_adapter import (

--- a/src/unilab/scripts/train_offpolicy.py
+++ b/src/unilab/scripts/train_offpolicy.py
@@ -176,19 +176,19 @@ def build_runner(algo_name: str, cfg: DictConfig, log_dir: str | None = None):
         "backend_device_binder": bind_backend_process_device,
     }
     if algo_name == "sac":
-        from uni_rl.fast_sac.double_buffer import (
+        from uni_rl.algos.fast_sac.double_buffer import (
             build_sac_double_buffer_runner,
         )
 
         runner = build_sac_double_buffer_runner(cfg, **builder_kwargs)
     elif algo_name == "td3":
-        from uni_rl.fast_td3.double_buffer import (
+        from uni_rl.algos.fast_td3.double_buffer import (
             build_td3_double_buffer_runner,
         )
 
         runner = build_td3_double_buffer_runner(cfg, **builder_kwargs)
     elif algo_name == "flashsac":
-        from uni_rl.flash_sac.double_buffer import (
+        from uni_rl.algos.flash_sac.double_buffer import (
             build_flashsac_double_buffer_runner,
         )
 

--- a/src/unilab/scripts/train_rsl_rl.py
+++ b/src/unilab/scripts/train_rsl_rl.py
@@ -9,15 +9,6 @@ from typing import Any, cast
 import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
-from uni_rl.ipc.dp_launcher import (
-    UNILAB_DP_LOG_DIR,
-    current_torch_distributed_local_rank,
-    current_torch_distributed_rank,
-    current_torch_distributed_world_size,
-    launch_torchrun_workers,
-    resolve_dp_topology,
-    validate_dp_launchable,
-)
 from uni_rl.algos.rsl_rl import (
     RslRlVecEnvWrapper,
     apply_rsl_rl_rank_seed,
@@ -29,6 +20,15 @@ from uni_rl.algos.rsl_rl import (
     rsl_rl_single_process_topology,
 )
 from uni_rl.algos.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
+from uni_rl.ipc.dp_launcher import (
+    UNILAB_DP_LOG_DIR,
+    current_torch_distributed_local_rank,
+    current_torch_distributed_rank,
+    current_torch_distributed_world_size,
+    launch_torchrun_workers,
+    resolve_dp_topology,
+    validate_dp_launchable,
+)
 from unisim.backend.base import RenderClosedError, log_playback_plan
 from unisim.backend.mujoco.xml import materialize_scene_visual_override
 

--- a/src/unilab/scripts/train_rsl_rl.py
+++ b/src/unilab/scripts/train_rsl_rl.py
@@ -18,7 +18,7 @@ from uni_rl.ipc.dp_launcher import (
     resolve_dp_topology,
     validate_dp_launchable,
 )
-from uni_rl.rsl_rl import (
+from uni_rl.algos.rsl_rl import (
     RslRlVecEnvWrapper,
     apply_rsl_rl_rank_seed,
     finish_rsl_rl_distributed,
@@ -28,7 +28,7 @@ from uni_rl.rsl_rl import (
     resolve_rsl_rl_device,
     rsl_rl_single_process_topology,
 )
-from uni_rl.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
+from uni_rl.algos.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 from unisim.backend.base import RenderClosedError, log_playback_plan
 from unisim.backend.mujoco.xml import materialize_scene_visual_override
 

--- a/src/unilab/structured_configs.py
+++ b/src/unilab/structured_configs.py
@@ -237,7 +237,7 @@ class PPOPolicyConfig:
 
 @dataclass
 class PPOAlgorithmConfig:
-    class_name: str = "uni_rl.rsl_rl_ppo:FinalObservationAwarePPO"
+    class_name: str = "uni_rl.algos.rsl_rl_ppo:FinalObservationAwarePPO"
     value_loss_coef: float = 1.0
     use_clipped_value_loss: bool = True
     clip_param: float = 0.2

--- a/src/unilab/visualization/interactive_playback.py
+++ b/src/unilab/visualization/interactive_playback.py
@@ -666,8 +666,8 @@ def _build_appo_actor(
     rl_cfg_dict = deepcopy(rl_cfg)
 
     if is_hora:
-        from uni_rl.hora.models import build_hora_shared_actor_critic
-        from uni_rl.hora.rsl_rl_compat import (
+        from uni_rl.algos.hora.models import build_hora_shared_actor_critic
+        from uni_rl.algos.hora.rsl_rl_compat import (
             convert_config_v3_to_v4,
             is_rsl_rl_v4,
             is_rsl_rl_v5,
@@ -766,13 +766,13 @@ def create_appo_playback_session(
     if env is None:
         raise RuntimeError("Playback env factory did not return an environment.")
 
-    from uni_rl.hora.runtime import is_hora_appo_runtime
+    from uni_rl.algos.hora.runtime import is_hora_appo_runtime
 
     is_hora = is_hora_appo_runtime(rl_cfg)
     selected_wrapper_cls = wrapper_cls
     policy_obs_mode = playback_cfg.policy_obs_mode
     if is_hora:
-        from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper
+        from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper
 
         selected_wrapper_cls = HoraRslRlVecEnvWrapper
         policy_obs_mode = "actor"
@@ -909,7 +909,7 @@ def build_play_actor(
 ) -> tuple[Any, Any | None, str, dict[str, Any]]:
     """Build the policy actor selected by an off-policy owner config."""
     import torch
-    from uni_rl.common.actor_factory import build_actor
+    from uni_rl.algos.common.actor_factory import build_actor
 
     actor_algo_type, actor_kwargs = resolve_play_actor_spec(
         algo_name,
@@ -929,7 +929,7 @@ def build_play_actor(
             **actor_kwargs,
         )
     elif algo_name == "td3":
-        from uni_rl.fast_td3.learner import EmpiricalNormalization, TD3Actor
+        from uni_rl.algos.fast_td3.learner import EmpiricalNormalization, TD3Actor
 
         actor = TD3Actor(
             obs_dim,
@@ -956,7 +956,7 @@ def build_play_actor(
             actor_noise_zeta_max=cfg.algo.algo_params.actor_noise_zeta_max,
         )
         if cfg.algo.obs_normalization:
-            from uni_rl.common.normalization import EmpiricalNormalization
+            from uni_rl.algos.common.normalization import EmpiricalNormalization
 
             normalizer = EmpiricalNormalization(shape=obs_dim, device=device)
     else:
@@ -1040,7 +1040,7 @@ def create_sac_playback_session(
 
     import os
 
-    from uni_rl.common.actor_factory import build_actor
+    from uni_rl.algos.common.actor_factory import build_actor
     from uni_rl.offpolicy.worker import resolve_offpolicy_actor_priv_info
 
     from unilab.utils.checkpoint import resolve_offpolicy_checkpoint_path
@@ -1074,7 +1074,7 @@ def create_sac_playback_session(
     checkpoint_path: str | None = None
     normalizer = None
     if bool(getattr(cfg.algo, "obs_normalization", False)):
-        from uni_rl.common.normalization import EmpiricalNormalization
+        from uni_rl.algos.common.normalization import EmpiricalNormalization
 
         normalizer = EmpiricalNormalization(shape=obs_dim, device=device_name)
     if playback_cfg.action_mode == "policy":
@@ -1135,13 +1135,13 @@ def create_sac_playback_session(
 
 
 def _default_hora_distill_playback_deps(root_dir: str | Path) -> dict[str, Any]:
-    from uni_rl.hora.distill import (
+    from uni_rl.algos.hora.distill import (
         build_student_actor_and_normalizer,
         cfg_with_checkpoint_runtime,
         load_distilled_checkpoint,
         student_policy,
     )
-    from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper
+    from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper
 
     from unilab.base.config_adapter import BackendAdapter, create_env
     from unilab.training import (

--- a/tests/algos/test_appo_runner.py
+++ b/tests/algos/test_appo_runner.py
@@ -15,7 +15,7 @@ from hydra.core.global_hydra import GlobalHydra
 
 pytest.importorskip("mujoco")
 
-from uni_rl.appo.runner import APPORunner
+from uni_rl.algos.appo.runner import APPORunner
 
 from unilab.base.config_adapter import BackendAdapter
 from unilab.base.env_factory import registry_env_factory

--- a/tests/algos/test_hora_contract.py
+++ b/tests/algos/test_hora_contract.py
@@ -15,7 +15,7 @@ from tensordict import TensorDict
 def test_hora_ppo_logs_when_symmetry_is_logging_only(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    from uni_rl.hora.ppo import HoraPPO
+    from uni_rl.algos.hora.ppo import HoraPPO
 
     actor = torch.nn.Linear(2, 2)
     critic = torch.nn.Linear(2, 1)
@@ -27,7 +27,7 @@ def test_hora_ppo_logs_when_symmetry_is_logging_only(
         "data_augmentation_func": lambda *_args: None,
     }
 
-    with caplog.at_level(logging.WARNING, logger="uni_rl.hora.ppo"):
+    with caplog.at_level(logging.WARNING, logger="uni_rl.algos.hora.ppo"):
         HoraPPO(
             cast(Any, actor),
             cast(Any, critic),
@@ -39,7 +39,7 @@ def test_hora_ppo_logs_when_symmetry_is_logging_only(
 
 
 def test_hora_sac_actor_shapes_and_stable_module_names() -> None:
-    from uni_rl.hora.sac_models import HoraSACActor
+    from uni_rl.algos.hora.sac_models import HoraSACActor
 
     actor = HoraSACActor(
         obs_dim=5,
@@ -65,7 +65,7 @@ def test_hora_sac_actor_shapes_and_stable_module_names() -> None:
 
 
 def test_hora_sac_learner_derives_priv_info_from_critic_contract() -> None:
-    from uni_rl.hora.sac_learner import derive_priv_info_from_critic_obs
+    from uni_rl.algos.hora.sac_learner import derive_priv_info_from_critic_obs
 
     actor_obs = torch.zeros((4, 5), dtype=torch.float32)
     priv_info = torch.arange(12, dtype=torch.float32).reshape(4, 3)
@@ -81,7 +81,7 @@ def test_hora_sac_learner_derives_priv_info_from_critic_contract() -> None:
 
 
 def test_hora_sac_learner_updates_with_privileged_tail() -> None:
-    from uni_rl.hora.sac_learner import HoraSACLearner
+    from uni_rl.algos.hora.sac_learner import HoraSACLearner
 
     torch.manual_seed(23)
     learner = HoraSACLearner(
@@ -123,7 +123,7 @@ def test_hora_sac_learner_updates_with_privileged_tail() -> None:
 
 
 def test_hora_sac_disables_cuda_graph_critic_path() -> None:
-    from uni_rl.hora.sac_learner import HoraSACLearner
+    from uni_rl.algos.hora.sac_learner import HoraSACLearner
 
     learner = HoraSACLearner(
         obs_dim=5,
@@ -144,7 +144,7 @@ def test_hora_sac_disables_cuda_graph_critic_path() -> None:
 
 
 def test_hora_sac_distilled_student_forward_does_not_require_priv_info() -> None:
-    from uni_rl.hora.distill import HoraSACDistillActor, HoraSACDistillShared
+    from uni_rl.algos.hora.distill import HoraSACDistillActor, HoraSACDistillShared
 
     shared = HoraSACDistillShared(
         obs_dim=12,
@@ -175,12 +175,12 @@ def test_hora_sac_distilled_student_forward_does_not_require_priv_info() -> None
 
 
 def test_hora_sac_distill_loads_teacher_actor_weights(tmp_path) -> None:
-    from uni_rl.hora.distill import (
+    from uni_rl.algos.hora.distill import (
         HoraSACDistillActor,
         HoraSACDistillShared,
         load_teacher_actor_weights,
     )
-    from uni_rl.hora.sac_models import HoraSACActor
+    from uni_rl.algos.hora.sac_models import HoraSACActor
 
     teacher = HoraSACActor(
         obs_dim=12,
@@ -226,7 +226,7 @@ def test_hora_sac_distill_loads_teacher_actor_weights(tmp_path) -> None:
 
 def test_hora_rsl_wrapper_uses_explicit_np_env_state_contract() -> None:
     """HORA wrapper must not probe required NpEnvState fields dynamically."""
-    from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper
+    from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper
 
     source = textwrap.dedent(inspect.getsource(HoraRslRlVecEnvWrapper.step))
     tree = ast.parse(source)
@@ -245,7 +245,7 @@ def test_hora_rsl_wrapper_uses_explicit_np_env_state_contract() -> None:
 
 
 def test_hora_appo_learner_derives_priv_info_from_critic_contract() -> None:
-    from uni_rl.hora.appo_learner import _derive_priv_info_from_critic
+    from uni_rl.algos.hora.appo_learner import _derive_priv_info_from_critic
 
     actor_obs = torch.zeros((2, 3, 4), dtype=torch.float32)
     priv_info = torch.arange(12, dtype=torch.float32).reshape(2, 3, 2)
@@ -261,8 +261,8 @@ def test_hora_appo_learner_derives_priv_info_from_critic_contract() -> None:
 
 
 def _make_hora_appo_learner(**algorithm_overrides):
-    from uni_rl.hora.appo_learner import HoraAPPOLearner
-    from uni_rl.hora.models import (
+    from uni_rl.algos.hora.appo_learner import HoraAPPOLearner
+    from uni_rl.algos.hora.models import (
         HoraActorModel,
         HoraCriticModel,
         HoraSharedActorCritic,
@@ -326,7 +326,7 @@ def test_hora_appo_minibatch_tensor_path_matches_tensordict_forward() -> None:
 
 
 def test_hora_appo_runner_builds_shared_actor_critic_core() -> None:
-    from uni_rl.hora.appo_runner import HoraAPPORunner
+    from uni_rl.algos.hora.appo_runner import HoraAPPORunner
 
     runner = HoraAPPORunner.__new__(HoraAPPORunner)
     runner.num_envs = 4
@@ -341,13 +341,13 @@ def test_hora_appo_runner_builds_shared_actor_critic_core() -> None:
             "critic": {"actor": 5, "priv_info": 2},
         },
         "actor": {
-            "class_name": "uni_rl.hora:HoraActorModel",
+            "class_name": "uni_rl.algos.hora:HoraActorModel",
             "hidden_dims": [8],
             "priv_info_embed_dim": 2,
             "priv_mlp_hidden_dims": [4, 2],
         },
         "critic": {
-            "class_name": "uni_rl.hora:HoraCriticModel",
+            "class_name": "uni_rl.algos.hora:HoraCriticModel",
             "priv_info_embed_dim": 2,
             "priv_mlp_hidden_dims": [4, 2],
         },
@@ -363,7 +363,7 @@ def test_hora_appo_runner_builds_shared_actor_critic_core() -> None:
 
 
 def test_hora_appo_worker_builds_shared_actor_critic_core() -> None:
-    from uni_rl.hora.appo_worker import hora_appo_collector_fn
+    from uni_rl.algos.hora.appo_worker import hora_appo_collector_fn
 
     source = textwrap.dedent(inspect.getsource(hora_appo_collector_fn))
     tree = ast.parse(source)
@@ -534,7 +534,7 @@ def test_hora_appo_play_dim_mismatch_reraises_explicit_sim2sim_diagnostic(
 
 
 def test_hora_appo_resume_rejects_inconsistent_shared_checkpoint() -> None:
-    from uni_rl.hora.appo_runner import _validate_hora_shared_checkpoint
+    from uni_rl.algos.hora.appo_runner import _validate_hora_shared_checkpoint
 
     learner = _make_hora_appo_learner()
     joint_checkpoint = {

--- a/tests/algos/test_hora_distill_config.py
+++ b/tests/algos/test_hora_distill_config.py
@@ -76,7 +76,7 @@ def test_hora_actor_mapping_strips_distribution_class_name() -> None:
         {
             "algo": {
                 "actor": {
-                    "class_name": "uni_rl.hora:HoraActorModel",
+                    "class_name": "uni_rl.algos.hora:HoraActorModel",
                     "hidden_dims": [64, 32],
                     "activation": "relu",
                     "obs_normalization": False,
@@ -111,7 +111,7 @@ def test_hora_actor_mapping_fails_closed_when_teacher_field_is_missing() -> None
         {
             "algo": {
                 "actor": {
-                    "class_name": "uni_rl.hora:HoraActorModel",
+                    "class_name": "uni_rl.algos.hora:HoraActorModel",
                     "activation": "elu",
                     "obs_normalization": True,
                     "priv_info_embed_dim": 9,

--- a/tests/algos/test_offpolicy_double_buffer_runner.py
+++ b/tests/algos/test_offpolicy_double_buffer_runner.py
@@ -155,7 +155,7 @@ def test_sac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     module = _offpolicy()
     cfg = _offpolicy_cfg([])
 
-    import uni_rl.fast_sac.double_buffer as owner_module
+    import uni_rl.algos.fast_sac.double_buffer as owner_module
 
     monkeypatch.setattr(module, "registry_env_factory", lambda *args, **kwargs: _fake_env_factory)
     monkeypatch.setattr(owner_module, "FastSACLearner", _FakeLearner)
@@ -214,7 +214,7 @@ def test_sac_genesis_owner_raises_inference_request_timeout():
 def test_sac_owner_custom_runtime_can_override_base_learner_kwargs(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    from uni_rl.fast_sac import double_buffer as owner_module
+    from uni_rl.algos.fast_sac import double_buffer as owner_module
     from uni_rl.offpolicy.runtime import OffPolicyRuntime
 
     cfg = _offpolicy_cfg([])
@@ -248,7 +248,7 @@ def test_td3_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPatch):
     module = _offpolicy()
     cfg = _offpolicy_cfg(algo="td3")
 
-    import uni_rl.fast_td3.double_buffer as owner_module
+    import uni_rl.algos.fast_td3.double_buffer as owner_module
 
     monkeypatch.setattr(owner_module, "get_env_dims", lambda *args, **kwargs: (4, 2, 6))
     monkeypatch.setattr(owner_module, "FastTD3Learner", _FakeLearner)
@@ -321,7 +321,7 @@ def test_flashsac_dispatch_constructs_unique_runner(monkeypatch: pytest.MonkeyPa
     module = _offpolicy()
     cfg = _offpolicy_cfg(algo="flashsac")
 
-    import uni_rl.flash_sac.double_buffer as flash_module
+    import uni_rl.algos.flash_sac.double_buffer as flash_module
 
     monkeypatch.setattr(module, "registry_env_factory", lambda *args, **kwargs: _fake_env_factory)
     monkeypatch.setattr(flash_module, "FlashSACLearner", _FakeLearner)
@@ -384,7 +384,7 @@ def _build_sac_runner_with_fakes(
             lambda backend, device: backend_binding_calls.append((str(backend), str(device))),
         )
 
-    import uni_rl.fast_sac.double_buffer as owner_module
+    import uni_rl.algos.fast_sac.double_buffer as owner_module
 
     monkeypatch.setattr(
         module, "registry_env_factory", lambda *args, **kwargs: fake_probe_env_factory

--- a/tests/algos/test_offpolicy_dp_sync.py
+++ b/tests/algos/test_offpolicy_dp_sync.py
@@ -350,7 +350,7 @@ def test_learn_source_orders_sync_around_collector_and_logging():
 
 
 def test_fast_sac_initial_sync_tensors_return_live_references():
-    from uni_rl.fast_sac.learner import FastSACLearner
+    from uni_rl.algos.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
         obs_dim=4,
@@ -389,7 +389,7 @@ def test_fast_sac_initial_sync_tensors_return_live_references():
 
 
 def test_fast_sac_syncs_each_optimizer_gradient_before_step():
-    from uni_rl.fast_sac.learner import FastSACLearner
+    from uni_rl.algos.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
         obs_dim=4,
@@ -446,7 +446,7 @@ def test_fast_sac_syncs_each_optimizer_gradient_before_step():
 
 
 def test_fast_sac_gradient_sync_preserves_cuda_graph_capture():
-    from uni_rl.fast_sac.learner import FastSACLearner
+    from uni_rl.algos.fast_sac.learner import FastSACLearner
 
     learner = FastSACLearner(
         obs_dim=4,
@@ -482,7 +482,7 @@ def _build_sac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overrides: 
     cfg = _offpolicy_cfg(overrides)
     monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
 
-    import uni_rl.fast_sac.double_buffer as owner_module
+    import uni_rl.algos.fast_sac.double_buffer as owner_module
 
     class _Learner:
         def __init__(self, *args, **kwargs):
@@ -552,7 +552,7 @@ def test_build_runner_multi_gpu_rank0_requires_log_dir(monkeypatch: pytest.Monke
 
 
 def test_flash_sac_initial_sync_tensors_return_live_references():
-    from uni_rl.flash_sac.learner import FlashSACLearner
+    from uni_rl.algos.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
         obs_dim=4,
@@ -599,7 +599,7 @@ def test_flash_sac_initial_sync_tensors_return_live_references():
 
 
 def test_flash_sac_syncs_each_optimizer_gradient_before_step():
-    from uni_rl.flash_sac.learner import FlashSACLearner
+    from uni_rl.algos.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
         obs_dim=4,
@@ -646,7 +646,7 @@ def test_flash_sac_syncs_each_optimizer_gradient_before_step():
 
 
 def test_flash_sac_gradient_sync_preserves_cuda_graph_and_cpu_fallback_updates():
-    from uni_rl.flash_sac.learner import FlashSACLearner
+    from uni_rl.algos.flash_sac.learner import FlashSACLearner
 
     learner = FlashSACLearner(
         obs_dim=4,
@@ -702,7 +702,7 @@ def _build_flashsac_runner_with_dp_fakes(monkeypatch: pytest.MonkeyPatch, overri
     cfg = _offpolicy_cfg(overrides, algo="flashsac")
     monkeypatch.setattr(module.os, "cpu_count", lambda: 128)
 
-    import uni_rl.flash_sac.double_buffer as flash_module
+    import uni_rl.algos.flash_sac.double_buffer as flash_module
 
     monkeypatch.setattr(module, "registry_env_factory", lambda *args, **kwargs: _fake_env_factory)
 

--- a/tests/algos/test_rsl_rl_runner.py
+++ b/tests/algos/test_rsl_rl_runner.py
@@ -20,7 +20,7 @@ rsl_rl = pytest.importorskip("rsl_rl")
 import numpy as np
 import torch
 from tensordict import TensorDict
-from uni_rl.rsl_rl import normalize_ppo_train_cfg
+from uni_rl.algos.rsl_rl import normalize_ppo_train_cfg
 
 from unilab.base import registry
 from unilab.base.config_adapter import BackendAdapter

--- a/tests/config/test_locomotion_params.py
+++ b/tests/config/test_locomotion_params.py
@@ -95,7 +95,7 @@ def test_ppo_config_defaults():
     assert cfg.algo == "ppo"
     assert cfg.max_iterations == 101
     assert cfg.algorithm.clip_param == 0.2
-    assert cfg.algorithm.class_name == "uni_rl.rsl_rl_ppo:FinalObservationAwarePPO"
+    assert cfg.algorithm.class_name == "uni_rl.algos.rsl_rl_ppo:FinalObservationAwarePPO"
     assert cfg.algorithm.enable_compile is True
     assert cfg.policy.class_name == "ActorCritic"
 

--- a/tests/envs/locomotion/microduck/test_infra_alignment.py
+++ b/tests/envs/locomotion/microduck/test_infra_alignment.py
@@ -23,7 +23,7 @@ import pytest
 import torch
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
-from uni_rl.rsl_rl import RslRlVecEnvWrapper
+from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 
 from unilab.base import registry
 from unilab.base.config_adapter import BackendAdapter

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -410,7 +410,7 @@ def test_hora_distill_runtime_checkpoint_records_model_only():
 
 
 def test_hora_distill_checkpoint_runtime_only_restores_model_structure():
-    from uni_rl.hora.distill import cfg_with_checkpoint_runtime
+    from uni_rl.algos.hora.distill import cfg_with_checkpoint_runtime
 
     from unilab.training.hora_distill_config import apply_teacher_defaults
 
@@ -476,7 +476,7 @@ def test_hora_distill_checkpoint_runtime_only_overrides_model_side(
     teacher_algo_family: str,
     checkpoint_model: dict[str, Any],
 ):
-    from uni_rl.hora.distill import cfg_with_checkpoint_runtime
+    from uni_rl.algos.hora.distill import cfg_with_checkpoint_runtime
 
     from unilab.training import hora_distill_config as distill_config
 
@@ -1978,8 +1978,8 @@ def test_offpolicy_play_actor_spec_keeps_standard_sac_and_flashsac():
 def test_offpolicy_build_play_actor_preserves_flashsac_model_kwargs(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import uni_rl.common.actor_factory as actor_factory
-    import uni_rl.common.normalization as normalization
+    import uni_rl.algos.common.actor_factory as actor_factory
+    import uni_rl.algos.common.normalization as normalization
 
     from unilab.visualization.interactive_playback import build_play_actor
 
@@ -2035,7 +2035,7 @@ def test_offpolicy_build_play_actor_restores_td3_state_and_normalizer(
     monkeypatch: pytest.MonkeyPatch,
 ):
     import torch
-    import uni_rl.fast_td3.learner as learner_module
+    import uni_rl.algos.fast_td3.learner as learner_module
 
     from unilab.visualization.interactive_playback import build_play_actor, load_play_actor
 
@@ -2205,7 +2205,7 @@ def test_play_offpolicy_can_skip_onnx_export_and_still_record_video(
         ),
     )
 
-    import uni_rl.common.actor_factory as actor_factory
+    import uni_rl.algos.common.actor_factory as actor_factory
 
     monkeypatch.setattr(actor_factory, "build_actor", lambda *args, **kwargs: FakeActor())
 
@@ -2335,7 +2335,7 @@ def test_play_offpolicy_uses_hora_sac_actor_and_priv_info(
         lambda *args, **kwargs: (str(checkpoint), str(run_dir)),
     )
 
-    import uni_rl.common.actor_factory as actor_factory
+    import uni_rl.algos.common.actor_factory as actor_factory
 
     def fake_build_actor(algo_type, obs_dim, action_dim, hidden_dim, use_layer_norm, device, **kw):
         captured["build_actor"] = (algo_type, obs_dim, action_dim, kw)
@@ -2445,7 +2445,7 @@ def _play_interactive():
 
 def test_play_wrapper_imports_shared_implementation():
     """Verify play_interactive.py uses shared RslRlVecEnvWrapper."""
-    from uni_rl.rsl_rl import RslRlVecEnvWrapper as SharedWrapper
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper as SharedWrapper
 
     mod = _play_interactive()
     # The wrapper class in play_interactive should be the shared one
@@ -2456,7 +2456,7 @@ def test_play_wrapper_uses_current_reset_contract():
     """Verify wrapper reset() uses current (obs, info) contract, not old (_, obs, _)."""
     import numpy as np
     from tensordict import TensorDict
-    from uni_rl.rsl_rl import RslRlVecEnvWrapper
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 
     # Create a fake environment that returns (obs, info) tuple
     class FakeEnv:
@@ -2490,7 +2490,7 @@ def test_play_wrapper_uses_current_reset_contract():
 def test_play_wrapper_policy_obs_mode_actor():
     """Verify wrapper supports policy_obs_mode='actor'."""
     import numpy as np
-    from uni_rl.rsl_rl import RslRlVecEnvWrapper
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 
     class FakeEnv:
         def __init__(self):
@@ -2527,7 +2527,7 @@ def test_play_wrapper_policy_obs_mode_actor():
 
 def test_play_wrapper_flat_policy_excludes_critic_only_group():
     import numpy as np
-    from uni_rl.rsl_rl import RslRlVecEnvWrapper
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 
     class FakeEnv:
         def __init__(self):
@@ -2570,7 +2570,7 @@ def test_play_wrapper_flat_policy_excludes_critic_only_group():
 
 def test_play_wrapper_preserves_hora_priv_info_and_proprio_history():
     import numpy as np
-    from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper
+    from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper
 
     class FakeEnv:
         def __init__(self):
@@ -2633,7 +2633,7 @@ def test_play_wrapper_preserves_hora_priv_info_and_proprio_history():
 
 def test_play_wrapper_step_exports_timeout_bootstrap_obs():
     import torch
-    from uni_rl.rsl_rl import RslRlVecEnvWrapper
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper
 
     class FakeEnv:
         def __init__(self):
@@ -2689,7 +2689,7 @@ def test_play_wrapper_step_exports_timeout_bootstrap_obs():
 
 def test_play_wrapper_timeout_bootstrap_preserves_hora_priv_info():
     import torch
-    from uni_rl.hora.rsl_rl import HoraRslRlVecEnvWrapper
+    from uni_rl.algos.hora.rsl_rl import HoraRslRlVecEnvWrapper
 
     class FakeEnv:
         def __init__(self):

--- a/tests/visualization/test_interactive_playback.py
+++ b/tests/visualization/test_interactive_playback.py
@@ -511,7 +511,7 @@ def test_sac_playback_session_runs_sim2sim_preflight(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import uni_rl.common.actor_factory as actor_factory
+    import uni_rl.algos.common.actor_factory as actor_factory
     from omegaconf import OmegaConf
 
     import unilab.utils.checkpoint as checkpoint_utils
@@ -650,8 +650,8 @@ def test_appo_hora_playback_session_uses_hora_wrapper_and_actor_checkpoint(
     tmp_path: Path,
 ) -> None:
     import rsl_rl.utils as rsl_rl_utils
-    import uni_rl.hora.models as hora_models
-    import uni_rl.hora.rsl_rl as hora_rsl
+    import uni_rl.algos.hora.models as hora_models
+    import uni_rl.algos.hora.rsl_rl as hora_rsl
     from omegaconf import OmegaConf
     from tensordict import TensorDict
 
@@ -766,7 +766,7 @@ def test_sac_hora_playback_session_updates_priv_info_after_reset_and_step(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import uni_rl.common.actor_factory as actor_factory
+    import uni_rl.algos.common.actor_factory as actor_factory
     from omegaconf import OmegaConf
 
     import unilab.utils.checkpoint as checkpoint_utils
@@ -898,8 +898,8 @@ def test_hora_distill_playback_session_loads_stage2_checkpoint_and_student_polic
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import uni_rl.hora.distill as distill
-    import uni_rl.hora.rsl_rl as hora_rsl
+    import uni_rl.algos.hora.distill as distill
+    import uni_rl.algos.hora.rsl_rl as hora_rsl
     from omegaconf import OmegaConf
     from tensordict import TensorDict
 
@@ -1298,7 +1298,7 @@ def test_create_sac_playback_session_td3_load_filters_noise_scales(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import uni_rl.common.actor_factory as actor_factory
+    import uni_rl.algos.common.actor_factory as actor_factory
     from omegaconf import OmegaConf
 
     import unilab.utils.checkpoint as checkpoint_utils

--- a/uv.lock
+++ b/uv.lock
@@ -5053,7 +5053,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.1.0", index = "https://test.pypi.org/simple/" },
+    { name = "unilab-rl", specifier = "==0.2.0", index = "https://test.pypi.org/simple/" },
     { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
@@ -5073,7 +5073,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "hydra-core" },
@@ -5090,9 +5090,9 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/b0/dc/649ec43d713316d374a92b263159cb70e2f97ab05b5c89aacbb88e227179/unilab_rl-0.1.0.tar.gz", hash = "sha256:569d533d3d13ceab00a72df9151cead271fa302f9c154bf3acb737efa131a5a1", size = 173801, upload-time = "2026-09-03T22:13:14.763Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/bb/a5/84e9371e794e8bf6ffb50e5309526eb4469a493fba80b0f35e6b74c14fc4/unilab_rl-0.2.0.tar.gz", hash = "sha256:35a7a9d2407b3e9ae1c4f3eb3e7d23f12b9f089f4699cb62433fccb5479600d6", size = 174173, upload-time = "2026-09-04T03:09:04.332Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/97/c0/a04703caec8d54f794c1352497fcb582e7bc3f260ee621f74ed87ad2ccf5/unilab_rl-0.1.0-py3-none-any.whl", hash = "sha256:7a1fc89deab07e1ffb3eb2c921bf5abd4c726a7d6e3c235e4190181393b12a34", size = 218103, upload-time = "2026-09-03T22:13:11.427Z" },
+    { url = "https://test-files.pythonhosted.org/packages/6c/39/f9c6b3e3028c3ce2e74dd64caab5af11340018287d78dc662a659b3088bd/unilab_rl-0.2.0-py3-none-any.whl", hash = "sha256:0cb1ee05b8f0ab813b79aff2d7b951746d8a92c9466c18bf0b4ebd256a76a883", size = 219641, upload-time = "2026-09-04T03:09:03.192Z" },
 ]
 
 [[package]]

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3791,7 +3791,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.1.0", index = "https://test.pypi.org/simple/" },
+    { name = "unilab-rl", specifier = "==0.2.0", index = "https://test.pypi.org/simple/" },
     { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
@@ -3810,7 +3810,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "hydra-core" },
@@ -3826,9 +3826,9 @@ dependencies = [
     { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/b0/dc/649ec43d713316d374a92b263159cb70e2f97ab05b5c89aacbb88e227179/unilab_rl-0.1.0.tar.gz", hash = "sha256:569d533d3d13ceab00a72df9151cead271fa302f9c154bf3acb737efa131a5a1", size = 173801, upload-time = "2026-09-03T22:13:14.763Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/bb/a5/84e9371e794e8bf6ffb50e5309526eb4469a493fba80b0f35e6b74c14fc4/unilab_rl-0.2.0.tar.gz", hash = "sha256:35a7a9d2407b3e9ae1c4f3eb3e7d23f12b9f089f4699cb62433fccb5479600d6", size = 174173, upload-time = "2026-09-04T03:09:04.332Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/97/c0/a04703caec8d54f794c1352497fcb582e7bc3f260ee621f74ed87ad2ccf5/unilab_rl-0.1.0-py3-none-any.whl", hash = "sha256:7a1fc89deab07e1ffb3eb2c921bf5abd4c726a7d6e3c235e4190181393b12a34", size = 218103, upload-time = "2026-09-03T22:13:11.427Z" },
+    { url = "https://test-files.pythonhosted.org/packages/6c/39/f9c6b3e3028c3ce2e74dd64caab5af11340018287d78dc662a659b3088bd/unilab_rl-0.2.0-py3-none-any.whl", hash = "sha256:0cb1ee05b8f0ab813b79aff2d7b951746d8a92c9466c18bf0b4ebd256a76a883", size = 219641, upload-time = "2026-09-04T03:09:03.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements Motphys/UniLab#1485. Base: `dev/issue-1476-uni-rl-split`.

Adopts `unilab-rl==0.2.0` (TestPyPI), which restructured the algorithm packages under `uni_rl.algos.*` (unilabsim/unilab-rl#4, PRs unilabsim/unilab-rl#5 + #6, tag `v0.2.0`).

## Changes

- `pyproject.toml` / `pyproject.rocm.toml`: `unilab-rl==0.1.0` → `==0.2.0`; `uv.lock` / `uv.rocm.lock` regenerated (rocm via the Makefile `sync-rocm` swap procedure, files restored after).
- Import rewrite (word-boundary, one pass): `uni_rl.{appo,common,fast_sac,fast_td3,flash_sac,him_ppo,hora,rsl_rl,rsl_rl_ppo,rsl_rl_runtime}` → `uni_rl.algos.<same>` across `src/` imports, repo-root `scripts/`, `tests/`, `conf/**/*.yaml` (`class_name` / `runtime_resolver` strings), and `structured_configs.py` defaults. `uni_rl.{ipc,logging,offpolicy,utils,env_contract}` references deliberately untouched — runtime infrastructure stays top-level in 0.2.0. Zero leftover matches verified.
- `AGENTS.md` + `docs/sphinx`: repo references renamed `unilabsim/uni_rl` → `unilabsim/unilab-rl`; algo module paths updated to `uni_rl.algos.*`; `(uni_rl repo)` annotations → `(unilab-rl repo)`.
- Second commit is pure ruff format/import-sort fallout from the longer module paths.

## Validation

`make test-all` green at the final head (cdec7711):
- ruff format + ruff check --fix: clean; ruff check tests (F401/F821/F811/F841): clean
- mypy src/unilab: Success, no issues (156 files)
- pyright: 0 errors (1 pre-existing `drake_uni.runtime` import warning in cli.py)
- pytest -m "not slow" --cov: **2234 passed, 20 skipped, 319 deselected, 1 xfailed** (236s)
- benchmark smoke: module-mode 35/36, script-mode 36/37 (platform-optional `mlx` skips)

unilab-rl side: PRs #5/#6 merged; CI green (run 33831953291: ruff×2, mypy, pyright, pytest+cov); release workflow run 33832114252 published `unilab-rl==0.2.0` to TestPyPI; isolated install verified (`uni_rl.__version__ == 0.2.0`, `uni_rl.algos.fast_sac` importable).
