### PR TITLE
feat: 降低学术场景跨双仓摩擦——new algorithm recipe + 约定式 CLI 路由（issue #1487）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 UniLab 是一个 **高性能、模块化、contract 驱动** 的 RL infrastructure 仓库。
 
-RL 算法与异步 runtime（PPO/APPO/SAC/TD3/HORA 的 runner、learner、collector、IPC、训练日志）由独立包 **uni_rl**（仓库 [unilabsim/unilab-rl](https://github.com/unilabsim/unilab-rl)，distribution 名 `unilab-rl`，拆分期发布在 TestPyPI）承载；UniLab 不构造 uni_rl 消费的 env，而是通过注入式 env contract 对接：`uni_rl.env_contract.EnvFactory = Callable[[int, Mapping | None], EnvProtocol]`（必须可被 pickle 引用，collector 跑在 spawn 子进程），UniLab 侧适配器为 `src/unilab/base/env_factory.py` 的 `registry_env_factory`，mjwarp 设备绑定经 `src/unilab/base/process_device.py` 的 `bind_backend_process_device` 注入。unilab 可以 import uni_rl；uni_rl 永远不 import unilab / unisim。
+RL 算法与异步 runtime（PPO/APPO/SAC/TD3/HORA 的 runner、learner、collector、IPC、训练日志）由独立包 **uni_rl**（仓库 [unilabsim/unilab_rl](https://github.com/unilabsim/unilab_rl)，distribution 名 `unilab-rl`，拆分期发布在 TestPyPI）承载；UniLab 不构造 uni_rl 消费的 env，而是通过注入式 env contract 对接：`uni_rl.env_contract.EnvFactory = Callable[[int, Mapping | None], EnvProtocol]`（必须可被 pickle 引用，collector 跑在 spawn 子进程），UniLab 侧适配器为 `src/unilab/base/env_factory.py` 的 `registry_env_factory`，mjwarp 设备绑定经 `src/unilab/base/process_device.py` 的 `bind_backend_process_device` 注入。unilab 可以 import uni_rl；uni_rl 永远不 import unilab / unisim。
 
 ## Core Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ RL 算法与异步 runtime（PPO/APPO/SAC/TD3/HORA 的 runner、learner、collec
 - uni_rl env factory 适配: `src/unilab/base/env_factory.py`
 - HORA APPO play 编排: `src/unilab/scripts/play_hora_appo.py`；HORA distill 配置组合: `src/unilab/training/hora_distill_config.py`
 - sim2sim 跨后端契约: `src/unilab/utils/sim2sim.py`
+- new algorithm recipe（三档扩展方式 + 约定式 CLI 路由 footprint）: `docs/sphinx/source/zh_CN/4-developer_guide/3-extending/3-new_algorithm.md`
 
 ## GitHub CLI (gh) 速查
 

--- a/docs/sphinx/source/en/4-developer_guide/3-extending/3-new_algorithm.md
+++ b/docs/sphinx/source/en/4-developer_guide/3-extending/3-new_algorithm.md
@@ -4,37 +4,102 @@ Algorithm work must preserve the env, config, and runner contracts. Start with
 {doc}`../2-contracts/1-env_contract`, {doc}`../2-contracts/3-task_owner`, and
 {doc}`../2-contracts/5-runner_lifecycle`.
 
-## Choose The Integration Path
+## Three Extension Tiers
 
-- Synchronous on-policy example: `src/unilab/scripts/train_rsl_rl.py`.
-- Async on-policy example: `src/unilab/scripts/train_appo.py` with `APPORunner`.
-- Off-policy examples: `src/unilab/scripts/train_sac.py`, `src/unilab/scripts/train_td3.py`, and
-  `src/unilab/scripts/train_flashsac.py`, each with its own config tree under
-  `src/unilab/conf/<algo>/`.
+Ordered from shallowest to deepest; prefer the shallowest tier that meets your
+needs.
+
+### 1. Pure Config: Reuse An Existing Algorithm
+
+Change no code — only adjust the Hydra config under `src/unilab/conf/<algo>/`:
+
+- Algorithm hyperparameters are inlined in `src/unilab/conf/<algo>/config.yaml`;
+- Each task×backend combination maps to one owner YAML:
+  `src/unilab/conf/<algo>/task/<task>/<backend>.yaml`;
+- Swapping policy / algorithm implementation classes works through the
+  `class_name` dotted path in the owner YAML (in-repo example:
+  `uni_rl.algos.hora:HoraActorModel`), with no new code path required.
+
+### 2. `runtime_resolver`: Algorithm Code In Your Own Repository
+
+A researcher imports `uni_rl` (distribution name `unilab-rl`) as a library in
+their own repository and implements the runner / learner / play logic there —
+**no fork of unilab_rl needed**. The owner YAML declares a dotted path
+(`module:attr`) via `algo.runtime_resolver`:
+
+```yaml
+algo:
+  runtime_resolver: my_pkg.my_module:resolve_my_runtime
+```
+
+Contract:
+
+- Signature is `(rl_cfg: dict) -> Runtime | None`; returning `None` falls back
+  to the algorithm's default runtime;
+- The returned object must carry `runner_cls`; depending on the algorithm
+  family it may optionally carry `play_fn` (APPO style) or `wrapper_cls`
+  (PPO style);
+- Resolution happens on the uni_rl side (`uni_rl.algos.appo.runtime` /
+  `uni_rl.algos.rsl_rl_runtime`); the dotted path may point at any importable
+  module.
+
+In-repo example: `src/unilab/conf/appo/task/sharpa_inhand/mujoco_hora.yaml`
+points at `unilab.scripts.play_hora_appo:resolve_hora_appo_runtime`; the HORA
+SAC / PPO variants point at `uni_rl.algos.hora.sac:resolve_hora_sac_runtime`
+and `uni_rl.algos.hora.rsl_rl:resolve_hora_ppo_runtime` respectively.
+
+### 3. Fork unilab_rl: Modify `uni_rl/algos/`
+
+Only when you need to change the shared runner / learner / collector
+implementation (for example a new IPC lifecycle) should you fork
+[unilabsim/unilab_rl](https://github.com/unilabsim/unilab_rl) and modify
+`uni_rl/algos/`. Async algorithms should reuse `AsyncRunner`, `ReplayBuffer` /
+`RolloutRingBuffer`, and `SharedWeightSync` instead of creating a new IPC
+lifecycle.
+
+## Footprint Of A CLI-Routable Algorithm
+
+`uv run train --algo <algo>` / `uv run eval --algo <algo>` use
+convention-based routing (`available_algos` and `build_route` in
+`src/unilab/cli.py`): an algo name `<algo>` is routable if and only if both of
+the following exist — **no cli.py change required**:
+
+1. `src/unilab/conf/<algo>/config.yaml` — the Hydra config root with the
+   algorithm hyperparameters inlined;
+2. `src/unilab/scripts/train_<algo>.py` — the entrypoint script, kept as a
+   thin assembly shell: compose Hydra, call `ensure_registries()`, construct
+   the env through the registry path, then hand control to the runner or
+   trainer. Thin-shell precedent: `train_sac.py` / `train_td3.py` /
+   `train_flashsac.py` reuse the shared implementation in `train_offpolicy.py`.
+
+On top of that, each task×backend combination needs an owner YAML at
+`src/unilab/conf/<algo>/task/<task>/<backend>.yaml`. Unknown algos fail
+closed, and the error message lists every available algo (built-in plus
+convention-discovered).
+
+Notes:
+
+- Config trees that have a conf directory but no entrypoint script (such as
+  `hora_distill` and `ppo_him`) are not routable — they are not standalone
+  CLI algos.
+- The special script-name mappings for built-in algorithms are preserved:
+  `ppo` → `train_rsl_rl.py`, `appo` → `train_appo.py`.
+- The dataclasses in `src/unilab/structured_configs.py` are an **optional**
+  conventional mirror; there is no ConfigStore enforcement, so a new algorithm
+  is not required to add one.
 
 ## Implementation Checklist
 
-1. Put reusable learner or runner code under `uni_rl` (unilab-rl repo).
-2. Add Hydra config under the owning config root. A new off-policy variant should
-   add its own config tree: `src/unilab/conf/<algo>/config.yaml` with the algorithm
-   hyperparameters inlined, plus matching
-   `src/unilab/conf/<algo>/task/<task>/<backend>.yaml` owner YAMLs.
-3. If a new top-level training script is required, keep it as assembly:
-   compose Hydra, call `ensure_registries()`, construct the env through the
-   registry path, then hand control to the runner or trainer.
-4. Keep third-party adapter naming at adapter boundaries. Do not change the
+1. Pick the integration path from the three tiers above: prefer pure config
+   over code, and `runtime_resolver` over a fork.
+2. Keep third-party adapter naming at adapter boundaries. Do not change the
    internal `obs` plus optional `critic` env contract to match a library.
-5. For async algorithms, reuse `AsyncRunner`, `ReplayBuffer` or
-   `RolloutRingBuffer`, and `SharedWeightSync` instead of creating a new IPC
-   lifecycle.
-6. For off-policy algorithms, the CLI `--algo <algo>` selection maps to the
-   per-algorithm config tree; owner YAMLs live at
-   `src/unilab/conf/<algo>/task/<task>/<backend>.yaml`.
+3. Keep new entrypoint scripts as assembly; no long-term business rules in
+   `scripts/`.
 
 ## Validation Near Risk
 
-- Algorithm unit tests under `tests/algos/`
-- IPC tests under `tests/ipc/` for async paths
+- CLI routing and convention discovery: `tests/test_cli.py`
 - Script/config tests: `tests/scripts/test_train_script_configs.py`,
   `tests/scripts/test_train_scripts.py`
 
@@ -43,4 +108,5 @@ Algorithm work must preserve the env, config, and runner contracts. Start with
 - Structured config dataclasses: `src/unilab/structured_configs.py`
 - Training helpers: `src/unilab/training/common.py`,
   `src/unilab/training/run.py`
-- Existing algorithm packages: `uni_rl` (unilab-rl repo)
+- Existing algorithm packages: `uni_rl` in
+  [unilabsim/unilab_rl](https://github.com/unilabsim/unilab_rl)

--- a/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/3-new_algorithm.md
+++ b/docs/sphinx/source/zh_CN/4-developer_guide/3-extending/3-new_algorithm.md
@@ -4,34 +4,88 @@
 {doc}`../2-contracts/1-env_contract`、{doc}`../2-contracts/3-task_owner` 与
 {doc}`../2-contracts/5-runner_lifecycle` 开始。
 
-## 选择集成路径
+## 三档扩展方式
 
-- 同步 on-policy 示例：`src/unilab/scripts/train_rsl_rl.py`。
-- 异步 on-policy 示例：使用 `APPORunner` 的 `src/unilab/scripts/train_appo.py`。
-- Off-policy 示例：`src/unilab/scripts/train_sac.py`、`src/unilab/scripts/train_td3.py` 与
-  `src/unilab/scripts/train_flashsac.py`，各自在 `src/unilab/conf/<algo>/` 下拥有独立的配置树。
+按改动深度从低到高有三档；优先选择能满足需求的最浅一档。
+
+### 1. 纯配置：复用现有算法
+
+不改任何代码，只调整 `src/unilab/conf/<algo>/` 下的 Hydra 配置：
+
+- 算法超参数内联在 `src/unilab/conf/<algo>/config.yaml`；
+- 每个 task×backend 组合对应一个 owner YAML：
+  `src/unilab/conf/<algo>/task/<task>/<backend>.yaml`；
+- 替换策略 / 算法实现类可以走 owner YAML 中的 `class_name` dotted path
+  （现网实例：`uni_rl.algos.hora:HoraActorModel`），无需新增代码路径。
+
+### 2. `runtime_resolver`：算法代码放在自己的仓库
+
+研究者在自己的仓库里 import `uni_rl`（distribution 名 `unilab-rl`）作为库，
+实现 runner / learner / play 逻辑，**不需要 fork unilab_rl**。owner YAML
+通过 `algo.runtime_resolver` 声明一个 dotted path（`module:attr`）：
+
+```yaml
+algo:
+  runtime_resolver: my_pkg.my_module:resolve_my_runtime
+```
+
+约定：
+
+- 签名为 `(rl_cfg: dict) -> Runtime | None`；返回 `None` 表示回落到该算法的
+  默认 runtime；
+- 返回对象必须携带 `runner_cls`；按算法族可选携带 `play_fn`（APPO 风格）
+  或 `wrapper_cls`（PPO 风格）；
+- 解析发生在 uni_rl 侧（`uni_rl.algos.appo.runtime` /
+  `uni_rl.algos.rsl_rl_runtime`），dotted path 可以指向任何可 import 的模块。
+
+仓库内实例：`src/unilab/conf/appo/task/sharpa_inhand/mujoco_hora.yaml` 指向
+`unilab.scripts.play_hora_appo:resolve_hora_appo_runtime`；HORA 的 SAC / PPO
+变体分别指向 `uni_rl.algos.hora.sac:resolve_hora_sac_runtime` 与
+`uni_rl.algos.hora.rsl_rl:resolve_hora_ppo_runtime`。
+
+### 3. fork unilab_rl：改 `uni_rl/algos/`
+
+只有当需要改动 runner / learner / collector 的共享实现（例如新的 IPC
+生命周期）时，才 fork [unilabsim/unilab_rl](https://github.com/unilabsim/unilab_rl)
+并修改 `uni_rl/algos/`。异步算法应复用 `AsyncRunner`、`ReplayBuffer` /
+`RolloutRingBuffer` 与 `SharedWeightSync`，而不是新建一套 IPC 生命周期。
+
+## CLI 可路由算法的 footprint
+
+`uv run train --algo <algo>` / `uv run eval --algo <algo>` 采用约定式路由
+（`src/unilab/cli.py` 的 `available_algos` 与 `build_route`）：algo 名
+`<algo>` 可路由，当且仅当以下两个文件同时存在，**不需要修改 cli.py**：
+
+1. `src/unilab/conf/<algo>/config.yaml` —— Hydra config 根，算法超参数内联；
+2. `src/unilab/scripts/train_<algo>.py` —— 入口脚本，保持为组装层薄壳：
+   compose Hydra、调用 `ensure_registries()`、通过 registry 路径构造 env，
+   然后把控制权交给 runner 或 trainer。薄壳先例：`train_sac.py` /
+   `train_td3.py` / `train_flashsac.py` 复用 `train_offpolicy.py` 的共享实现。
+
+除此之外，每个 task×backend 组合需要 owner YAML
+`src/unilab/conf/<algo>/task/<task>/<backend>.yaml`。未知 algo 会
+fail-closed，报错信息列出全部可用 algo（内置 + 约定发现的）。
+
+注意：
+
+- 只有 conf 目录而没有入口脚本的 config 树（如 `hora_distill`、`ppo_him`）
+  不可路由——它们不是独立的 CLI algo。
+- 内置算法的特殊脚本名映射保留不变：`ppo` → `train_rsl_rl.py`、
+  `appo` → `train_appo.py`。
+- `src/unilab/structured_configs.py` 的 dataclass 是**可选**的约定俗成镜像，
+  没有 ConfigStore 强制注册；新增算法不强制要求添加对应 dataclass。
 
 ## 实现清单
 
-1. 把可复用的 learner 或 runner 代码放在 `uni_rl` (unilab-rl repo) 下。
-2. 在归属的 config 根目录下添加 Hydra config。一个新的 off-policy 变体
-   应当建立自己的配置树：算法超参数内联在 `src/unilab/conf/<algo>/config.yaml` 中，
-   并添加对应的 `src/unilab/conf/<algo>/task/<task>/<backend>.yaml` owner YAML。
-3. 如果需要新的顶层训练脚本，请让它保持为组装层：
-   compose Hydra、调用 `ensure_registries()`、通过 registry 路径构造 env，
-   然后把控制权交给 runner 或 trainer。
-4. 把第三方适配器命名保留在适配器边界上。不要为了迎合某个库而改动
+1. 按上面三档选择集成路径，能纯配置就不写代码，能 `runtime_resolver`
+   就不 fork。
+2. 把第三方适配器命名保留在适配器边界上。不要为了迎合某个库而改动
    内部的 `obs` 加可选 `critic` 的 env 契约。
-5. 对于异步算法，复用 `AsyncRunner`、`ReplayBuffer` 或
-   `RolloutRingBuffer` 以及 `SharedWeightSync`，而不是新建一套 IPC
-   生命周期。
-6. 对于 off-policy 算法，CLI 的 `--algo <algo>` 选择映射到按算法划分的
-   配置树；owner YAML 位于 `src/unilab/conf/<algo>/task/<task>/<backend>.yaml`。
+3. 新入口脚本保持为组装层，不承载长期业务规则。
 
 ## 在风险点附近验证
 
-- `tests/algos/` 下的算法单元测试
-- 异步路径的 IPC 测试，位于 `tests/ipc/`
+- CLI 路由与约定式发现：`tests/test_cli.py`
 - 脚本/配置测试：`tests/scripts/test_train_script_configs.py`、
   `tests/scripts/test_train_scripts.py`
 
@@ -40,4 +94,5 @@
 - 结构化 config dataclass：`src/unilab/structured_configs.py`
 - 训练辅助工具：`src/unilab/training/common.py`、
   `src/unilab/training/run.py`
-- 现有算法包：`uni_rl` (unilab-rl repo)
+- 现有算法包：[unilabsim/unilab_rl](https://github.com/unilabsim/unilab_rl)
+  的 `uni_rl`

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -19,6 +19,9 @@ SUPPORTED_ALGOS = ("ppo", "appo", "sac", "td3", "flashsac")
 SUPPORTED_SIMS = ("mujoco", "mjwarp", "motrix", "drake", "isaacgym", "genesis", "isaacsim")
 SUPPORTED_RENDER_MODES = ("auto", "interactive", "record", "none")
 OFFPOLICY_ALGOS = {"sac", "td3", "flashsac"}
+# Built-in algos whose entrypoint script does not follow the train_<algo>.py
+# naming convention.
+SPECIAL_SCRIPT_NAMES = {"ppo": "train_rsl_rl.py", "appo": "train_appo.py"}
 INTERACTIVE_PLAY_ALGOS = {"ppo", "appo", "sac", "td3", "flashsac"}
 # Physics backends whose interactive eval runs through the dedicated MuJoCo
 # viewer script: the selected backend owns the rollout while MuJoCo renders.
@@ -223,17 +226,49 @@ def _mxpython_executable() -> str:
     )
 
 
-def build_route(algo: str, task: str, sim: str, profile: str | None = None) -> Route:
+def available_algos(root: Path | None = None) -> tuple[str, ...]:
+    """Return routable algo names: built-ins plus convention-discovered ones.
+
+    A custom algo ``X`` is routable when both ``conf/X/config.yaml`` and
+    ``scripts/train_X.py`` exist under the package root. Config trees without
+    an entrypoint script (e.g. ``hora_distill``) are not routable.
+    """
+    selected_root = root or package_root()
+    discovered: list[str] = []
+    conf_root = selected_root / "conf"
+    if conf_root.is_dir():
+        for child in sorted(conf_root.iterdir()):
+            if not child.is_dir() or child.name in SUPPORTED_ALGOS:
+                continue
+            if not (child / "config.yaml").is_file():
+                continue
+            if (selected_root / "scripts" / f"train_{child.name}.py").is_file():
+                discovered.append(child.name)
+    return (*SUPPORTED_ALGOS, *discovered)
+
+
+def build_route(
+    algo: str, task: str, sim: str, profile: str | None = None, *, root: Path | None = None
+) -> Route:
     owner = f"{sim}_{profile}" if profile is not None else sim
     task_choice = f"{task}/{owner}"
     if algo in OFFPOLICY_ALGOS:
         script_name = f"train_{algo}.py"
-    elif algo == "ppo":
-        script_name = "train_rsl_rl.py"
-    elif algo == "appo":
-        script_name = "train_appo.py"
+    elif algo in SPECIAL_SCRIPT_NAMES:
+        script_name = SPECIAL_SCRIPT_NAMES[algo]
     else:
-        raise SystemExit(f"Unsupported algo={algo!r}; choose one of: {', '.join(SUPPORTED_ALGOS)}")
+        selected_root = root or package_root()
+        script_name = f"train_{algo}.py"
+        routable = (
+            TASK_NAME_PATTERN.fullmatch(algo) is not None
+            and (selected_root / "conf" / algo / "config.yaml").is_file()
+            and (selected_root / "scripts" / script_name).is_file()
+        )
+        if not routable:
+            raise SystemExit(
+                f"Unsupported algo={algo!r}; choose one of: "
+                f"{', '.join(available_algos(selected_root))}"
+            )
     return Route(
         script_name=script_name,
         config_group=algo,
@@ -297,7 +332,7 @@ def build_command(
     _check_reserved_overrides(overrides)
     _check_runtime_requirements(algo, sim)
 
-    route = build_route(algo, task, sim, profile)
+    route = build_route(algo, task, sim, profile, root=selected_root)
     use_interactive_play = _uses_mujoco_interactive_play(
         mode=mode,
         algo=algo,
@@ -383,7 +418,16 @@ def build_command(
 
 def _train_eval_parser(*, mode: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog=mode)
-    parser.add_argument("--algo", required=True, choices=SUPPORTED_ALGOS)
+    parser.add_argument(
+        "--algo",
+        required=True,
+        metavar="ALGO",
+        help=(
+            "algorithm config tree under conf/; built-ins: "
+            f"{', '.join(SUPPORTED_ALGOS)}. Custom algos are routable when "
+            "conf/<algo>/config.yaml and scripts/train_<algo>.py both exist."
+        ),
+    )
     parser.add_argument("--task", required=True)
     parser.add_argument("--sim", required=True, choices=SUPPORTED_SIMS)
     parser.add_argument("--profile", default=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1150,3 +1150,112 @@ def test_genesis_train_builds_owner_route(tmp_path: Path, monkeypatch: pytest.Mo
         "task=g1_walk_flat/genesis",
         "algo.num_envs=64",
     ]
+
+
+def _make_custom_algo_checkout(
+    root: Path,
+    *,
+    algo: str = "dreamer",
+    task: str = "go2_joystick_flat",
+    with_script: bool = True,
+    with_config: bool = True,
+    with_owner: bool = True,
+) -> None:
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    if with_script:
+        (root / "scripts" / f"train_{algo}.py").write_text("", encoding="utf-8")
+    if with_config:
+        (root / "conf" / algo).mkdir(parents=True, exist_ok=True)
+        (root / "conf" / algo / "config.yaml").write_text("algo: {}\n", encoding="utf-8")
+    if with_owner:
+        owner_dir = root / "conf" / algo / "task" / task
+        owner_dir.mkdir(parents=True, exist_ok=True)
+        (owner_dir / "motrix.yaml").write_text(
+            "training:\n  sim_backend: motrix\n",
+            encoding="utf-8",
+        )
+
+
+def test_convention_routes_custom_algo_with_config_and_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_custom_algo_checkout(tmp_path)
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+    command = cli.build_command(
+        mode="train",
+        algo="dreamer",
+        task="go2_joystick_flat",
+        sim="motrix",
+        overrides=[],
+        root=tmp_path,
+    )
+
+    assert command[1:] == [
+        str(tmp_path / "scripts" / "train_dreamer.py"),
+        "task=go2_joystick_flat/motrix",
+    ]
+    assert "dreamer" in cli.available_algos(tmp_path)
+
+
+def test_convention_requires_entrypoint_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_custom_algo_checkout(tmp_path, with_script=False)
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+    with pytest.raises(SystemExit, match="Unsupported algo='dreamer'"):
+        cli.build_command(
+            mode="train",
+            algo="dreamer",
+            task="go2_joystick_flat",
+            sim="motrix",
+            overrides=[],
+            root=tmp_path,
+        )
+    assert "dreamer" not in cli.available_algos(tmp_path)
+
+
+def test_convention_requires_config_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_custom_algo_checkout(tmp_path, with_config=False)
+    _pretend_motrix_is_installed(monkeypatch)
+    monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+    with pytest.raises(SystemExit, match="Unsupported algo='dreamer'"):
+        cli.build_command(
+            mode="train",
+            algo="dreamer",
+            task="go2_joystick_flat",
+            sim="motrix",
+            overrides=[],
+            root=tmp_path,
+        )
+
+
+def test_unknown_algo_error_lists_builtin_and_discovered_algos(tmp_path: Path) -> None:
+    _make_custom_algo_checkout(tmp_path)
+
+    with pytest.raises(SystemExit, match="choose one of") as excinfo:
+        cli.build_route("dqn", "go2_joystick_flat", "motrix", root=tmp_path)
+
+    message = str(excinfo.value)
+    assert "Unsupported algo='dqn'" in message
+    for builtin in ("ppo", "appo", "sac", "td3", "flashsac"):
+        assert builtin in message
+    assert "dreamer" in message
+
+
+def test_conf_tree_without_entrypoint_is_not_routable() -> None:
+    # hora_distill ships a conf tree (compose-only) but no train_hora_distill.py.
+    with pytest.raises(SystemExit, match="Unsupported algo='hora_distill'"):
+        cli.build_route("hora_distill", "sharpa_inhand", "mujoco")
+    assert "hora_distill" not in cli.available_algos()
+
+
+def test_malformed_algo_name_is_rejected_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="Unsupported algo"):
+        cli.build_route("../etc", "go2_joystick_flat", "motrix", root=tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1218,9 +1218,7 @@ def test_convention_requires_entrypoint_script(
     assert "dreamer" not in cli.available_algos(tmp_path)
 
 
-def test_convention_requires_config_yaml(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_convention_requires_config_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _make_custom_algo_checkout(tmp_path, with_config=False)
     _pretend_motrix_is_installed(monkeypatch)
     monkeypatch.setattr(cli.platform, "system", lambda: "Linux")


### PR DESCRIPTION
对应 issue #1487（uni_rl 拆分后学术场景跨双仓摩擦缓解）在 UniLab 侧的行动项 1/3/5。base 为父 roadmap #1476 集成分支 `dev/issue-1476-uni-rl-split`。配套 unilab_rl 侧 PR：[unilabsim/unilab_rl#7](https://github.com/unilabsim/unilab_rl/pull/7)（行动项 1/2/4/5 的 unilab_rl 部分）。

## 改动

- **行动项1（UniLab 侧）— 文档化 new algorithm recipe**：重写 `docs/sphinx/source/{zh_CN,en}/4-developer_guide/3-extending/3-new_algorithm.md`，明确三档扩展方式——① 纯配置（`conf/<algo>/` YAML）；② `runtime_resolver` / `class_name` 指向外部包（研究者在自己仓库 import uni_rl 作为库，无需 fork unilab_rl；含 resolver 签名约定 `(rl_cfg: dict) -> Runtime | None` 与 hora 现网实例）；③ fork unilab_rl 改 `uni_rl/algos/`。AGENTS.md Pointers 加 recipe 指针（CLAUDE.md 为 symlink 自动同步）。
- **行动项3 — 新算法最小 footprint（评估 + 落地）**：评估结论——此前新增 CLI 可路由算法必须改 `cli.py` 两处硬编码（`SUPPORTED_ALGOS` + `build_route`）。本 PR 落地约定式路由：algo 名 `<algo>` 可路由当且仅当 `src/unilab/conf/<algo>/config.yaml` 与 `src/unilab/scripts/train_<algo>.py` 同时存在，**不再需要改 cli.py**；无入口脚本的 conf 树（`hora_distill`、`ppo_him`）不会被误认为 algo；未知 algo fail-closed 且报错列出全部可用 algo（内置 + 约定发现）。内置五个 algo 的映射与报错语义逐字不变；`structured_configs` dataclass 保持可选约定（无 ConfigStore 强制）。落地后新算法 footprint = 1 个 conf 目录 + 1 个薄壳入口脚本（复用 `train_offpolicy.py` 先例）+ owner YAML。
- **行动项5（UniLab 侧）— 旧 URL 清扫**：仓库改名 `unilabsim/unilab-rl` → `unilabsim/unilab_rl`，全仓仅 `AGENTS.md:7` 一处真 URL，已改（distribution 名 `unilab-rl` 保留）。

## Validation

- `make test-all` 于最终 head 内容全绿：`pytest -m "not slow" --cov=src/unilab` 2240 passed（含 `tests/test_cli.py` 新增 6 条约定路由测试：发现成功 / 缺脚本 / 缺 config.yaml 各 fail-closed / 报错列出可用 algo / `hora_distill` 不可路由 / 路径穿越名拒绝），benchmark smoke 35/36 与 36/37（1 个 platform-optional mlx skip）。注：首轮运行因旧分支残留的 `src/unilab/{algos,ipc,logging}/__pycache__` 触发两个 "migrated layer must not re-grow" 测试失败，清理残留目录后复跑通过，与本 PR 改动无关。
- `uv run ruff check src/unilab/cli.py tests/test_cli.py`：All checks passed
- sphinx 构建（`UNILAB_DOCS_SKIP_AUTODOC=1 sphinx-build -b html -n`）：成功，无新增 warning

## 需要 maintainer 注意的取舍

1. `--algo` 拼写错误现在在 `build_route` 抛 `SystemExit`（信息列出可选值），不再是 argparse 的 invalid choice 错误；无测试依赖旧行为。
2. docs 中约 20 处 "(unilab-rl repo)" 散文提法与 distribution 名同形，未动；如需统一改称 "unilab_rl repo" 可做后续清扫。
3. 通用 `train_custom` 入口（issue 行动项3 括号内的另一选项）未实施：约定式路由以更小的新 surface 达到同等 footprint，且不构成新 execution path；如 maintainer 认为仍需 `train_custom`，可作为后续 issue。
4. UniLab 消费 uni_rl 0.3.0 的 `algo_capabilities`（NpEnv 暴露 action bounds / joint names）依赖 unilab_rl#7 合入并发版，为后续 issue。