### PR TITLE
feat(microduck): add bilateral mirror loss and keep turn-in-place commands

### DIFF
--- a/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_bam_flat/mujoco.yaml
@@ -22,3 +22,10 @@ algo:
   algorithm:
     learning_rate: 1.0e-3
     entropy_coef: 0.01
+    # Same bilateral mapping as the PD owner. One-sided turning is not an
+    # actuator-model artifact; keep the 61D/14D mirror loss on the BAM path.
+    symmetry_cfg:
+      use_data_augmentation: false
+      use_mirror_loss: true
+      mirror_loss_coeff: 0.5
+      data_augmentation_func: unilab.tasks.locomotion.microduck.symmetry.microduck_velocity_symmetry

--- a/src/unilab/conf/ppo/task/microduck_velocity_flat/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_flat/mujoco.yaml
@@ -9,8 +9,12 @@ training:
   play_steps: 2000
 
 algo:
-  num_envs: 2048
-  max_iterations: 500
+  # algo.num_envs is per rank. Upstream trains 4096 global environments.
+  # On this 4x MI210 host, 2048 per rank (8192 global) with
+  # training.devices=[0,1,2,3] improved omnidirectional coverage versus 1024.
+  num_envs: 4096
+  max_iterations: 6000
+  save_interval: 250
   empirical_normalization: true
   obs_groups:
     actor:
@@ -22,3 +26,10 @@ algo:
   algorithm:
     learning_rate: 1.0e-3
     entropy_coef: 0.01
+    # MuJoCo position-PD runs otherwise converge to seed-dependent one-sided
+    # turning. The mapping follows upstream's 61D/14D bilateral contract.
+    symmetry_cfg:
+      use_data_augmentation: false
+      use_mirror_loss: true
+      mirror_loss_coeff: 0.5
+      data_augmentation_func: unilab.tasks.locomotion.microduck.symmetry.microduck_velocity_symmetry

--- a/src/unilab/conf/ppo/task/microduck_velocity_flat/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/microduck_velocity_flat/mujoco.yaml
@@ -10,8 +10,6 @@ training:
 
 algo:
   # algo.num_envs is per rank. Upstream trains 4096 global environments.
-  # On this 4x MI210 host, 2048 per rank (8192 global) with
-  # training.devices=[0,1,2,3] improved omnidirectional coverage versus 1024.
   num_envs: 4096
   max_iterations: 6000
   save_interval: 250

--- a/src/unilab/tasks/locomotion/common/sensor_reward_terms.py
+++ b/src/unilab/tasks/locomotion/common/sensor_reward_terms.py
@@ -120,10 +120,33 @@ class orientation(_Vec3SensorTerm):
         )
 
 
+class upright(_Vec3SensorTerm):
+    """Gaussian reward for keeping the declared body up-vector vertical."""
+
+    _allowed_params = frozenset({"sensor_name", "std"})
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv):
+        super().__init__(cfg, env)
+        self._std = _real(
+            self.name,
+            "std",
+            cfg.params.get("std", 1.0),
+            minimum=0.0,
+            strict_minimum=True,
+        )
+
+    def __call__(self, env: ManagerBasedRlEnv, **params: Any) -> np.ndarray:
+        del params
+        upvector = self._read_sensor(env)
+        tilt_error = np.square(upvector[:, 0]) + np.square(upvector[:, 1])
+        return np.asarray(np.exp(-tilt_error / self._std**2), dtype=get_global_dtype())
+
+
 __all__ = [
     "ang_vel_xy",
     "lin_vel_z",
     "orientation",
     "track_ang_vel",
     "track_lin_vel",
+    "upright",
 ]

--- a/src/unilab/tasks/locomotion/microduck/manager_terms.py
+++ b/src/unilab/tasks/locomotion/microduck/manager_terms.py
@@ -144,6 +144,11 @@ class MicroduckVelocityCommand(UniformVelocityCommand):
             self._turn_ang_max,
             len(turn_ids),
         )
+        # The base sampler may independently mark one of these rows as
+        # standing. Keep the dedicated turn bucket authoritative and refresh
+        # the world-frame copy, matching upstream VelocityCommandCommandOnly.
+        self.is_standing_env[turn_ids] = False
+        self.vel_command_w[turn_ids] = self.vel_command_b[turn_ids]
 
 
 class GroundPickPhaseCommand(UniformVelocityCommand):

--- a/src/unilab/tasks/locomotion/microduck/symmetry.py
+++ b/src/unilab/tasks/locomotion/microduck/symmetry.py
@@ -1,0 +1,87 @@
+"""Bilateral symmetry mapping for the MicroDuck 61D policy contract."""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+_JOINT_PERM = (9, 10, 11, 12, 13, 5, 6, 7, 8, 0, 1, 2, 3, 4)
+_JOINT_SIGN = (-1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0)
+
+_OBS_PERM = (
+    (0, 1, 2)
+    + (3, 4, 5)
+    + tuple(6 + joint for joint in _JOINT_PERM)
+    + tuple(20 + joint for joint in _JOINT_PERM)
+    + tuple(34 + joint for joint in _JOINT_PERM)
+    + (48, 49, 50)
+    + (51, 52, 53, 54)
+    + (55, 56, 57, 58, 59, 60)
+)
+_OBS_SIGN = (
+    (-1.0, 1.0, -1.0)
+    + (1.0, -1.0, 1.0)
+    + _JOINT_SIGN
+    + _JOINT_SIGN
+    + _JOINT_SIGN
+    + (1.0, -1.0, -1.0)
+    + (1.0, 1.0, -1.0, -1.0)
+    + (1.0, -1.0, 1.0, -1.0, 1.0, -1.0)
+)
+
+_TENSOR_CACHE: dict[
+    torch.device,
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+] = {}
+
+
+def _mapping_tensors(
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    cached = _TENSOR_CACHE.get(device)
+    if cached is None:
+        cached = (
+            torch.tensor(_OBS_PERM, dtype=torch.long, device=device),
+            torch.tensor(_OBS_SIGN, dtype=torch.float32, device=device),
+            torch.tensor(_JOINT_PERM, dtype=torch.long, device=device),
+            torch.tensor(_JOINT_SIGN, dtype=torch.float32, device=device),
+        )
+        _TENSOR_CACHE[device] = cached
+    return cached
+
+
+def microduck_velocity_symmetry(
+    env: object,
+    obs: TensorDict | None,
+    actions: torch.Tensor | None,
+) -> tuple[TensorDict | None, torch.Tensor | None]:
+    """Append sagittal-plane mirrored actor observations and actions."""
+    del env
+    augmented_obs: TensorDict | None = None
+    augmented_actions: torch.Tensor | None = None
+
+    if obs is not None:
+        actor = obs["policy"]
+        critic = obs["critic"]
+        obs_perm, obs_sign, _, _ = _mapping_tensors(actor.device)
+        mirrored_actor = actor[:, obs_perm] * obs_sign
+        augmented_obs = TensorDict(
+            {
+                "policy": torch.cat((actor, mirrored_actor), dim=0),
+                # Mirror loss consumes actor observations only. Keep the critic
+                # batch shape valid without inventing privileged-foot semantics.
+                "critic": torch.cat((critic, critic), dim=0),
+            },
+            batch_size=[actor.shape[0] * 2],
+            device=actor.device,
+        )
+
+    if actions is not None:
+        _, _, action_perm, action_sign = _mapping_tensors(actions.device)
+        mirrored_actions = actions[:, action_perm] * action_sign
+        augmented_actions = torch.cat((actions, mirrored_actions), dim=0)
+
+    return augmented_obs, augmented_actions
+
+
+__all__ = ["microduck_velocity_symmetry"]

--- a/tests/envs/locomotion/microduck/test_bam_action.py
+++ b/tests/envs/locomotion/microduck/test_bam_action.py
@@ -382,7 +382,7 @@ def _materialize(task: str, task_name: str) -> tuple[Any, ManagerBasedRlEnvCfg]:
 
 def test_bam_owner_materializes_and_matches_pd_recipe() -> None:
     cfg, env_cfg = _materialize("microduck_velocity_bam_flat", "MicroduckVelocityBamFlat")
-    _, pd_env_cfg = _materialize("microduck_velocity_flat", "MicroduckVelocityFlat")
+    pd_cfg, pd_env_cfg = _materialize("microduck_velocity_flat", "MicroduckVelocityFlat")
 
     assert cfg.training.task_name == "MicroduckVelocityBamFlat"
     assert cfg.training.sim_backend == "mujoco"
@@ -414,6 +414,13 @@ def test_bam_owner_materializes_and_matches_pd_recipe() -> None:
     # Events: same DR stack as the PD owner (encoder bias, armature, CoM,
     # mass/inertia, foot friction); BAM-specific DR lives inside the term.
     assert list(env_cfg.events) == list(pd_env_cfg.events)
+    assert (
+        cfg.algo.algorithm.symmetry_cfg.data_augmentation_func
+        == pd_cfg.algo.algorithm.symmetry_cfg.data_augmentation_func
+        == "unilab.tasks.locomotion.microduck.symmetry.microduck_velocity_symmetry"
+    )
+    assert cfg.algo.algorithm.symmetry_cfg.use_mirror_loss is True
+    assert pd_cfg.algo.algorithm.symmetry_cfg.use_mirror_loss is True
 
     registered = registry.list_registered_envs()
     assert registered["MicroduckVelocityBamFlat"]["available_backends"] == ["mujoco"]

--- a/tests/envs/locomotion/microduck/test_microduck_rewards.py
+++ b/tests/envs/locomotion/microduck/test_microduck_rewards.py
@@ -8,10 +8,11 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from unilab.envs.mdp import UniformPoseCommandCfg
+from unilab.envs.mdp import UniformPoseCommandCfg, UniformVelocityCommand, UniformVelocityCommandCfg
 from unilab.managers import RewardTermCfg
 from unilab.managers._types import ManagerBasedRlEnv
 from unilab.tasks.locomotion.microduck.manager_terms import (
+    MicroduckVelocityCommandCfg,
     body_pose_tracking,
     flight_phase,
     foot_air_time_biped,
@@ -87,6 +88,52 @@ def test_flight_phase_penalizes_only_double_air() -> None:
     )
     term = _term(flight_phase, env)
     np.testing.assert_array_equal(term(env), [1.0, 0.0])
+
+
+def test_turn_in_place_bucket_overrides_independent_standing_sample(monkeypatch) -> None:
+    env = cast(
+        ManagerBasedRlEnv,
+        SimpleNamespace(
+            num_envs=2,
+            step_dt=0.02,
+            rng=np.random.default_rng(4),
+            scene={
+                "robot": SimpleNamespace(
+                    data=SimpleNamespace(
+                        root_link_lin_vel_b=np.zeros((2, 3), dtype=np.float32),
+                        root_link_ang_vel_b=np.zeros((2, 3), dtype=np.float32),
+                    )
+                )
+            },
+        ),
+    )
+    cfg = MicroduckVelocityCommandCfg(
+        entity_name="robot",
+        resampling_time_range=(1.0, 1.0),
+        rel_standing_envs=1.0,
+        turn_in_place_fraction=1.0,
+        ranges=UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-0.4, 0.4),
+            lin_vel_y=(-0.3, 0.3),
+            ang_vel_z=(-1.0, 1.0),
+        ),
+    )
+    term = cfg.build(env)
+
+    def sample_standing(self, env_ids):
+        self.vel_command_b[env_ids] = (0.2, 0.1, 0.0)
+        self.vel_command_w[env_ids] = self.vel_command_b[env_ids]
+        self.is_standing_env[env_ids] = True
+
+    monkeypatch.setattr(UniformVelocityCommand, "_resample_command", sample_standing)
+    ids = np.asarray([0, 1], dtype=np.int32)
+    term._resample_command(ids)
+    term._update_command()
+
+    np.testing.assert_array_equal(term.is_standing_env, False)
+    np.testing.assert_array_equal(term.command[:, :2], 0.0)
+    assert np.all(np.abs(term.command[:, 2]) >= 0.4)
+    np.testing.assert_array_equal(term.vel_command_w, term.command)
 
 
 def test_contact_terms_read_first_component_from_vector_force_sensors() -> None:

--- a/tests/envs/locomotion/microduck/test_symmetry.py
+++ b/tests/envs/locomotion/microduck/test_symmetry.py
@@ -1,0 +1,40 @@
+"""MicroDuck bilateral policy-contract tests."""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from unilab.tasks.locomotion.microduck.symmetry import microduck_velocity_symmetry
+
+
+def _mirror(actor: torch.Tensor, action: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    obs = TensorDict(
+        {"policy": actor, "critic": torch.zeros((actor.shape[0], 76))},
+        batch_size=[actor.shape[0]],
+    )
+    mirrored_obs, mirrored_action = microduck_velocity_symmetry(None, obs, action)
+    assert mirrored_obs is not None
+    assert mirrored_action is not None
+    return mirrored_obs["policy"][actor.shape[0] :], mirrored_action[action.shape[0] :]
+
+
+def test_microduck_velocity_mirror_is_an_involution() -> None:
+    actor = torch.arange(61, dtype=torch.float32).unsqueeze(0)
+    action = torch.arange(14, dtype=torch.float32).unsqueeze(0)
+
+    mirrored_actor, mirrored_action = _mirror(actor, action)
+    restored_actor, restored_action = _mirror(mirrored_actor, mirrored_action)
+
+    torch.testing.assert_close(restored_actor, actor)
+    torch.testing.assert_close(restored_action, action)
+
+
+def test_microduck_velocity_mirror_flips_lateral_and_yaw_commands() -> None:
+    actor = torch.zeros((1, 61))
+    actor[0, 48:51] = torch.tensor((0.3, 0.2, 0.7))
+    action = torch.zeros((1, 14))
+
+    mirrored_actor, _ = _mirror(actor, action)
+
+    torch.testing.assert_close(mirrored_actor[0, 48:51], torch.tensor((0.3, -0.2, -0.7)))

--- a/tests/envs/locomotion/microduck/test_velocity_contract.py
+++ b/tests/envs/locomotion/microduck/test_velocity_contract.py
@@ -84,6 +84,15 @@ def test_microduck_owner_materializes_complete_manager_contract() -> None:
     assert cfg.algo.obs_groups.actor == ["policy"]
     assert cfg.algo.obs_groups.critic == ["critic"]
     assert cfg.algo.empirical_normalization is True
+    assert cfg.algo.num_envs == 4096
+    assert cfg.algo.max_iterations == 6000
+    assert cfg.algo.save_interval == 250
+    assert cfg.algo.algorithm.symmetry_cfg.use_mirror_loss is True
+    assert cfg.algo.algorithm.symmetry_cfg.mirror_loss_coeff == pytest.approx(0.5)
+    assert (
+        cfg.algo.algorithm.symmetry_cfg.data_augmentation_func
+        == "unilab.tasks.locomotion.microduck.symmetry.microduck_velocity_symmetry"
+    )
 
     assert env_cfg.sim_dt == pytest.approx(0.005)
     assert env_cfg.ctrl_dt == pytest.approx(0.02)

--- a/tests/envs/locomotion/test_sensor_reward_terms.py
+++ b/tests/envs/locomotion/test_sensor_reward_terms.py
@@ -91,10 +91,12 @@ def test_lin_vel_z_ang_vel_xy_and_orientation_read_declared_sensor() -> None:
     lin_vel_z = _term(sensor_reward_terms.lin_vel_z, env, sensor_name="local_linvel")
     ang_vel_xy = _term(sensor_reward_terms.ang_vel_xy, env, sensor_name="gyro")
     orientation = _term(sensor_reward_terms.orientation, env, sensor_name="upvector")
+    upright = _term(sensor_reward_terms.upright, env, sensor_name="upvector", std=0.5)
 
     np.testing.assert_allclose(lin_vel_z(env), [0.09, 0.25], rtol=1e-6)
     np.testing.assert_allclose(ang_vel_xy(env), [0.05, 0.0], rtol=1e-6)
     np.testing.assert_allclose(orientation(env), [0.0, 0.25], rtol=1e-6)
+    np.testing.assert_allclose(upright(env), np.exp(-np.array([0.0, 0.25]) / 0.25), rtol=1e-6)
     assert scene.bound_names == ("upvector",)
 
 
@@ -115,6 +117,8 @@ def test_tracking_terms_validate_params_at_construction() -> None:
         )
     with pytest.raises(TypeError, match="unsupported parameters"):
         _term(sensor_reward_terms.lin_vel_z, env, sensor_name="local_linvel", bogus=1.0)
+    with pytest.raises(ValueError, match="std"):
+        _term(sensor_reward_terms.upright, env, sensor_name="upvector", std=0.0)
 
 
 def test_terms_fail_closed_on_missing_or_misshapen_sensor() -> None:
@@ -145,6 +149,7 @@ def test_hot_paths_use_only_cached_runtime_objects() -> None:
         sensor_reward_terms.lin_vel_z,
         sensor_reward_terms.ang_vel_xy,
         sensor_reward_terms.orientation,
+        sensor_reward_terms.upright,
     ):
         source = inspect.getsource(term_type.__call__)
         for forbidden in (


### PR DESCRIPTION
## Summary

- Add RSL-RL mirror loss (`use_data_augmentation=false`) for the MicroDuck 61D/14D policy contract, on both the PD and BAM owners. Without it, MuJoCo position-PD PPO converges to seed-dependent one-sided turning.
- Keep the 15% turn-in-place command bucket from being zeroed by the base standing sampler.
- Do not change the BAM actuator model or the #1455 reward stack. Multi-GPU env counts stay out of owner YAML.

Builds on #1475 (BAM) and #1455 (reward stack).

## Scope

**In**
- `microduck_velocity_symmetry` plus involution / lateral-and-yaw sign-flip tests
- `symmetry_cfg` on `microduck_velocity_flat/mujoco.yaml` and `microduck_velocity_bam_flat/mujoco.yaml`
- `MicroduckVelocityCommand._resample_command`: `is_standing_env[turn_ids]=False` and refresh `vel_command_w`
- Contract tests: PD owner enables mirror loss; BAM and PD share the same symmetry function

**Out**
- Defaults for `algo.num_envs`, `max_iterations`, and `training.devices` (BAM remains 2048×500 smoke; PD remains 4096×6000)
- BAM voltage servo, XML, and substep torque (#1475)
- Local ROCm `pyproject.toml` / `uv.lock`
- Checkpoints and mp4 (`logs/`)

## Local training notes (not in-tree)

On a 4×MI210 host with a MuJoCo CPU pool, `algo.num_envs` is per rank:

```text
uv run train --algo ppo --task microduck_velocity_bam_flat --sim mujoco \
  algo.num_envs=2048 algo.max_iterations=12000 \
  'training.devices=[0,1,2,3]'
```

Global 8192 improved throughput versus 1024/rank and improved PD omnidirectional coverage on this machine. That is host CPU-thread evidence, not a cross-machine default.

BAM 12k (`2026-09-04_12-41-58`): no NaN; `error_vel_yaw` 2.13 (PD 12k on the same host was ~9.7); fixed-command stand yaw ≈0, turn-left +0.60 / turn-right −0.72 vs ±0.7. Forward/lateral tracking is still weak and is out of this PR.

Tightening `tracking_ang_vel` sigma 0.5→0.25 on a PD resume lowered non-yaw rewards as well; it is not adopted.

## Validation

- `make check` (ruff / mypy / pyright) passed with Node 24 (`PATH` via nvm; system Node 12 cannot run pyright).
- `uv run pytest tests/envs/locomotion/microduck tests/envs/locomotion/test_sensor_reward_terms.py -m "not slow"`: 63 passed.
- `uv run python scripts/benchmark/smoke_test.py`: passed (mlx scripts skipped as platform-optional).
- Full `make test-all` `test-cov`: 2541 passed. Remaining failures/errors on this host were missing HF meshes (go2/a2/allegro recovered after `unilab-pull-assets`; t800 still missing `LINK_HIP_PITCH_R.obj`) and off-policy logger tests asserting untruncated labels under a narrow captured terminal. None of those paths are in this diff.


Made with [Cursor](https://cursor.com)