### PR TITLE
chore(deps): bump unilab-rl to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     # collectors, IPC, logging) live in the independently released uni-rl
     # package (distribution name ``unilab-rl``), consumed via the injected
     # env contract (uni_rl.env_contract.EnvFactory). Published on PyPI.
-    "unilab-rl==0.2.0",
+    "unilab-rl==1.0.0",
     "numba>=0.67",
     "prettytable>=3.10",
     "torch==2.9.0 ; sys_platform == 'linux' and platform_machine == 'aarch64'",

--- a/uv.lock
+++ b/uv.lock
@@ -5053,7 +5053,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.2.0" },
+    { name = "unilab-rl", specifier = "==1.0.0" },
     { name = "unisim-core", specifier = ">=0.1.14" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
@@ -5073,7 +5073,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.2.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hydra-core" },
@@ -5090,9 +5090,9 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/a5/84e9371e794e8bf6ffb50e5309526eb4469a493fba80b0f35e6b74c14fc4/unilab_rl-0.2.0.tar.gz", hash = "sha256:35a7a9d2407b3e9ae1c4f3eb3e7d23f12b9f089f4699cb62433fccb5479600d6", size = 174173, upload-time = "2026-09-04T09:41:57.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/ba/d924223d8bccd9714bbe28152a51a12f0ea7f6390584d15fee43f4087a5a/unilab_rl-1.0.0.tar.gz", hash = "sha256:b2ab788a99054b2a75183b08c76c9cb5e70af5a6ed749316106a082ded9fbe16", size = 176442, upload-time = "2026-09-04T12:11:26.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8c/e5f84672f485d441985be4d4fe6f81d72e88ee2456d7573b5f370d0bee8e/unilab_rl-0.2.0-py3-none-any.whl", hash = "sha256:158493e303a210235853e5a2443d898dd05038f74490a0a91594246e9dd7ef78", size = 219641, upload-time = "2026-09-04T09:41:55.167Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b9/f6a5e7772ca8f17c458627657eb1c05564b9abeefdce67afea6a9f044e53/unilab_rl-1.0.0-py3-none-any.whl", hash = "sha256:6405df72e66c0e3f2d20bf92020ef343f0047e63235088ec36151a4a8e0963f9", size = 221834, upload-time = "2026-09-04T12:11:25.27Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述

把 `unilab-rl` 依赖从 `==0.2.0` 升到 `==1.0.0`（uni_rl 首个 stable release，2026-09-04 发布于 PyPI）。

0.2.0 → 1.0.0 的变更（见 unilabsim/unilab_rl CHANGELOG）：

- **1.0.0**：文档类变更（README 重写、Citation），公共 contract（`uni_rl.env_contract`、runner/`runtime_resolver` 约定、算法配置键）正式纳入 semver。
- **0.3.0**（随之带入）：`uni_rl.env_contract` 新增可选的 env algo-capabilities 扩展点（`EnvAlgoCapabilitiesProtocol` / `get_algo_capabilities`，全字段 optional、仅冷路径读取，UniLab issue #1487）——纯增量、向后兼容，不提供的 env 回落到全 `None` 默认值。

同时解锁下游 [unilabsim/microduck_rl_unilab](https://github.com/unilabsim/microduck_rl_unilab) 升级到 unilab-rl 1.0.0（其当前被本仓的 `==0.2.0` pin 卡住，uv 解析 unsatisfiable）。

## Validation

- 最终 head `14e79794` 本地 `make test-all` **PASS (exit 0)**：ruff、mypy、pyright、pytest 2139 passed / 20 skipped / 1 xfailed、benchmark smoke 35/36 + 36/37（1 个平台可选 mlx skip）。
- 快速冒烟：`import uni_rl` / `uni_rl.ipc.async_runner` / `uni_rl.env_contract.get_algo_capabilities` 均正常。
- `git status` 工作树干净。
