### PR TITLE
fix: route Newton rank device into env override for spawn collectors

### DIFF
--- a/docs/sphinx/source/en/2-user_guide/3-backends/7-newton.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/7-newton.md
@@ -21,6 +21,21 @@ playback validated on `model_5000.pt`; PPO remains **Configured**
 (evidence limited to the owner configs, compose/contract checks, and
 fail-closed runtime/import boundaries; no training or playback claim yet).
 
+Multi-GPU data parallelism (issue
+[#1512](https://github.com/unilabsim/UniLab/issues/1512)): verified on
+2026-09-06 on 2x NVIDIA RTX 6000D (Blackwell) / torch 2.8.0+cu128 /
+newton 1.5.1 / mujoco-warp 3.11 — PPO torchrun DP=2 and SAC
+DpRankSupervisor DP=2 (`training.devices=[0,1]`) training smokes both
+complete, and `nvidia-smi` sampling confirms each rank's learner and
+collector sim processes land on their own physical GPU with no cross-GPU
+leakage; single-GPU PPO/SAC regressions pass alongside. Newton/Warp follows
+standard CUDA device semantics, so no `CUDA_VISIBLE_DEVICES` pinning (the
+Genesis quirk) is needed; the rank-local device reaches spawn collectors as
+a `newton_device="cuda:N"` env override (uni_rl 1.0.0's collector-side
+process-binding gate only covers mjwarp), and the SAC owner raises the
+collector tick-0 timeout to 180 s to cover Warp kernel compilation on the
+cold path.
+
 ## Installation
 
 The Newton runtime is an **isolated optional extra**, pinning Newton 1.5.1

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/7-newton.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/7-newton.md
@@ -20,6 +20,19 @@ episode length → 983，约 43k steps/s，wall 4m25s），并对
 证据限于 owner 配置、compose/contract 检查和 fail-closed 的
 runtime/import 边界，尚无训练或回放验证结论）。
 
+多 GPU 数据并行（issue
+[#1512](https://github.com/unilabsim/UniLab/issues/1512)）：2026-09-06
+在 2× NVIDIA RTX 6000D（Blackwell）/ torch 2.8.0+cu128 / newton 1.5.1 /
+mujoco-warp 3.11 上完成实测——PPO torchrun DP=2 与 SAC
+DpRankSupervisor DP=2（`training.devices=[0,1]`）训练冒烟均正常完成，
+`nvidia-smi` 采样确认每个 rank 的 learner 与 collector sim 进程物理落位
+在各自 GPU、无对端泄漏；单卡 PPO/SAC 回归同步通过。Newton/Warp 遵循标准
+CUDA 设备语义，无需 Genesis 那样的 `CUDA_VISIBLE_DEVICES` 钉卡；rank
+本地设备通过 env override 以 `newton_device="cuda:N"` 传入 spawn
+collector（uni_rl 1.0.0 的 collector 进程绑定门只覆盖 mjwarp），SAC
+owner 将 collector tick-0 超时提升到 180 s 以覆盖 Warp 内核编译的冷
+路径。
+
 ## 安装
 
 Newton 运行时是**隔离的 optional extra**，钉定 Newton 1.5.1 与

--- a/src/unilab/base/process_device.py
+++ b/src/unilab/base/process_device.py
@@ -25,6 +25,15 @@ BACKEND_ENV_DEVICE_FIELDS: dict[str, str] = {
 }
 
 
+# Newton consumes an explicit ``cuda:N`` device string (``newton_device``)
+# instead of an integer id.  uni_rl's collector-side binder gate only knows
+# mjwarp, so the rank-local device must reach spawn collectors through the
+# env override rather than through process binding.
+BACKEND_ENV_DEVICE_STR_FIELDS: dict[str, str] = {
+    "newton": "newton_device",
+}
+
+
 # Set once ``bind_genesis_process_device`` has pinned CUDA_VISIBLE_DEVICES for
 # this process.  Genesis/Quadrants binds its CUDA runtime to the first visible
 # device regardless of torch's current device (verified on genesis_world
@@ -124,7 +133,7 @@ def resolve_backend_env_device_id(
     """
 
     backend = _normalize_backend(backend_type)
-    field = BACKEND_ENV_DEVICE_FIELDS.get(backend)
+    field = BACKEND_ENV_DEVICE_FIELDS.get(backend) or BACKEND_ENV_DEVICE_STR_FIELDS.get(backend)
     if field is None:
         return None
 
@@ -187,8 +196,9 @@ def apply_backend_env_device_override(
 
     result = dict(env_cfg_override) if env_cfg_override is not None else {}
     backend = _normalize_backend(backend_type)
-    field = BACKEND_ENV_DEVICE_FIELDS.get(backend)
-    if field is None:
+    int_field = BACKEND_ENV_DEVICE_FIELDS.get(backend)
+    str_field = BACKEND_ENV_DEVICE_STR_FIELDS.get(backend)
+    if int_field is None and str_field is None:
         return result
     device_id = resolve_backend_env_device_id(
         backend,
@@ -198,8 +208,12 @@ def apply_backend_env_device_override(
         world_size=world_size,
         learner_device=learner_device,
     )
-    if device_id is not None:
-        result[field] = int(device_id)
+    if device_id is None:
+        return result
+    if str_field is not None:
+        result[str_field] = f"cuda:{int(device_id)}"
+    elif int_field is not None:
+        result[int_field] = int(device_id)
     return result
 
 
@@ -220,7 +234,7 @@ def warn_if_backend_device_collision(
     """
 
     backend = _normalize_backend(backend_type)
-    if backend not in BACKEND_ENV_DEVICE_FIELDS:
+    if backend not in BACKEND_ENV_DEVICE_FIELDS and backend not in BACKEND_ENV_DEVICE_STR_FIELDS:
         return
     if backend == "genesis" and _genesis_device_pinned:
         # A successful pin places every rank on its own physical GPU; the

--- a/src/unilab/conf/sac/task/g1_walk_flat/newton.yaml
+++ b/src/unilab/conf/sac/task/g1_walk_flat/newton.yaml
@@ -16,6 +16,10 @@ training:
   task_name: G1WalkFlat
   sim_backend: newton
   play_render_mode: record
+  # Newton compiles its Warp kernels on the materialize cold path, which
+  # exceeds the runner's default 30 s collector tick-0 budget; raise it for
+  # this backend (same precedent as the Genesis owner).
+  inference_request_timeout_sec: 180.0
 algo:
   num_envs: 2048
   learning_starts: 10

--- a/tests/base/backend/test_process_device.py
+++ b/tests/base/backend/test_process_device.py
@@ -96,7 +96,7 @@ def test_mjwarp_binding_rejects_non_cuda_warp_resolution(
 
 @pytest.mark.parametrize(
     "backend_type",
-    ["isaacgym", "isaacsim", "genesis"],
+    ["isaacgym", "isaacsim", "genesis", "newton"],
 )
 def test_offpolicy_rank_routes_host_visible_backend_device(backend_type: str) -> None:
     assert (
@@ -113,7 +113,7 @@ def test_offpolicy_rank_routes_host_visible_backend_device(backend_type: str) ->
 
 @pytest.mark.parametrize(
     "backend_type",
-    ["isaacgym", "isaacsim", "genesis"],
+    ["isaacgym", "isaacsim", "genesis", "newton"],
 )
 def test_torchrun_rank_routes_local_backend_device(backend_type: str) -> None:
     # torchrun remaps CUDA_VISIBLE_DEVICES to [4, 5], so rank 1 must send
@@ -167,6 +167,46 @@ def test_non_gpu_backend_is_left_untouched() -> None:
         )
         == owner_override
     )
+
+
+def test_newton_override_carries_cuda_device_string() -> None:
+    # uni_rl's collector binder gate only knows mjwarp, so newton's rank-local
+    # device must reach spawn collectors as a ``cuda:N`` override string.
+    owner_override: dict[str, object] = {"newton_device": None, "nested": {"keep": True}}
+    routed = apply_backend_env_device_override(
+        owner_override,
+        "newton",
+        devices=(0, 1),
+        rank=1,
+        world_size=1,
+    )
+
+    assert routed["newton_device"] == "cuda:1"
+    assert owner_override["newton_device"] is None
+    assert routed["nested"] is owner_override["nested"]
+
+
+def test_newton_override_falls_back_to_learner_device() -> None:
+    routed = apply_backend_env_device_override(
+        None,
+        "newton",
+        devices=None,
+        rank=0,
+        world_size=1,
+        learner_device="cuda:0",
+    )
+
+    assert routed["newton_device"] == "cuda:0"
+
+
+def test_newton_nonzero_rank_device_zero_emits_collision_warning() -> None:
+    with pytest.warns(RuntimeWarning, match=r"training\.devices=\[0, 1\]"):
+        warn_if_backend_device_collision(
+            "newton",
+            devices=(0, 1),
+            rank=1,
+            device_id=0,
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #1512. Verifies Newton multi-GPU data-parallel training on a two-GPU host and fixes the two gaps it uncovered.

- **Root cause 1**: uni_rl 1.0.0's collector-side process-binding gate (`uni_rl.utils.device.resolve_backend_process_device`) only knows `mjwarp`, so off-policy spawn collectors never bound a Newton device and `NewtonBackend` failed closed with "requires explicit device placement". Newton/Warp honors explicit device strings (no Quadrants-style `CUDA_VISIBLE_DEVICES` pinning needed), so the rank-local device now reaches spawn collectors through the env override path: new `BACKEND_ENV_DEVICE_STR_FIELDS` in `src/unilab/base/process_device.py` writes `newton_device="cuda:N"`; `resolve_backend_env_device_id` and `warn_if_backend_device_collision` now include `newton`.
- **Root cause 2**: Newton compiles Warp kernels on the materialize cold path, exceeding the runner's default 30 s collector tick-0 budget. The SAC owner now sets `training.inference_request_timeout_sec: 180.0` (same precedent as the Genesis owner).
- Docs: both Newton backend pages record the multi-GPU evidence.

## Validation

- New/updated unit tests in `tests/base/backend/test_process_device.py` (string override injection, learner-device fallback, collision warning, parametrized routing incl. `newton`).
- `make test-all` on final head 05651384: **passed** — `1603 passed, 22 skipped` (env synced with `--extra mujoco --extra motrix` per CI; the one conditional skip is the `unisim.backend.newton` import probe, absent from locked unisim-core 1.1.0 by design).
- Hardware validation on 2x NVIDIA RTX 6000D (Blackwell), torch 2.8.0+cu128, newton 1.5.1, mujoco-warp 3.11 (editable unisim main, since locked unisim-core 1.1.0 predates the Newton adapter):
  - PPO torchrun DP=2 `task=g1_walk_flat/newton training.devices=[0,1]`: exit 0, iteration completed; `nvidia-smi` shows each rank's worker on its own physical GPU.
  - SAC DpRankSupervisor DP=2: exit 0, iter 2/2; each rank's learner and collector sim on its own GPU, no cross-GPU leakage.
  - Single-GPU PPO/SAC regressions: exit 0.
  - `scripts/audit_sim2sim_contracts.py`: `mujoco<->newton` TRANSFERABLE on both ppo and sac (`--trees sac`) trees.

No package release is performed in this PR.

## Note

DP=2 SAC testing required a temporary local shim for `uni_rl/scripts/train_sac.py` (the unilab-rl 1.0.0 wheel omits `uni_rl/scripts/`, so DpRankSupervisor cannot spawn rank subprocesses). The shim was local-only and removed; the packaging gap belongs to the uni_rl repository.
