### PR TITLE
fix: make mujoco fallback bypasses the ~=3.11.0 lock bound (roadmap #1515 acceptance #2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,17 @@ sync:
 # This is the explicit sdist fallback path: the prebuilt mujoco-uni-runtime
 # wheels only bind the default mujoco==3.11.0, so any other version requires
 # recompiling the native extension from source against the requested mujoco.
-# The target repins mujoco in uv.lock, clears uv's build cache (it cannot see
-# that the extension depends on the mujoco version), and forces a source
-# rebuild via --no-binary-package. The default `make setup` path installs the
-# prebuilt wheel and needs no compiler.
+# The mujoco extra declares `mujoco~=3.11.0`, which a lock upgrade can never
+# leave, so the override operates on the environment directly (uv pip, no
+# re-lock): install the requested mujoco plus the runtime's build
+# requirements, then force an in-env sdist rebuild of the runtime. The
+# override is environment-local — uv.lock is untouched, and
+# `uv sync --extra mujoco --reinstall-package mujoco-uni-runtime` reverts to
+# the locked default (mujoco 3.11.0 + prebuilt wheel), which is the
+# switch-back path. The reinstall flag is required there: plain `uv sync`
+# restores mujoco but keeps the locally rebuilt extension, which then fails
+# to load against the reverted mujoco. The default `make setup` path installs
+# the prebuilt wheel and needs no compiler.
 .PHONY: check-cxx-toolchain
 check-cxx-toolchain:
 	@command -v c++ >/dev/null 2>&1 || { \
@@ -25,9 +32,11 @@ check-cxx-toolchain:
 mujoco:
 	@test -n "$(MJ)" || (echo "usage: make mujoco MJ=3.10.0" && exit 1)
 	@$(MAKE) --no-print-directory check-cxx-toolchain
-	uv lock --upgrade-package mujoco==$(MJ)
+	uv pip install "mujoco==$(MJ)" pybind11 wheel setuptools
 	uv cache clean mujoco-uni-runtime
-	uv sync --extra mujoco --extra motrix --no-binary-package mujoco-uni-runtime --reinstall-package mujoco-uni-runtime
+	ver=$$(uv pip show mujoco-uni-runtime | sed -n 's/^Version: //p') && \
+	uv pip install --force-reinstall --no-deps --no-build-isolation \
+		--no-binary mujoco-uni-runtime "mujoco-uni-runtime==$$ver"
 
 .PHONY: setup
 setup:

--- a/docs/sphinx/source/en/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/en/1-getting_started/2-installation.md
@@ -219,21 +219,28 @@ takes the source-rebuild path:
 make mujoco MJ=3.10.0
 ```
 
-The target runs, in order:
+The `mujoco` extra declares `mujoco~=3.11.0`, which a re-lock can never leave,
+so the target operates on the environment directly (`uv pip`, without touching
+`uv.lock`). It runs, in order:
 
 1. the `check-cxx-toolchain` preflight: fails fast when no C++ compiler is
    found and prints per-platform install commands;
-2. `uv lock --upgrade-package mujoco==3.10.0`: repins mujoco in `uv.lock`;
+2. `uv pip install "mujoco==3.10.0" pybind11 wheel setuptools`: installs the
+   requested mujoco plus the runtime's build requirements into the current
+   environment;
 3. `uv cache clean mujoco-uni-runtime`: drops the build cache (uv's cache
    cannot see that the extension depends on the mujoco version);
-4. `uv sync --extra mujoco --extra motrix --no-binary-package
-   mujoco-uni-runtime --reinstall-package mujoco-uni-runtime`: recompiles the
-   native extension in place against the new mujoco.
+4. `uv pip install --force-reinstall --no-deps --no-build-isolation
+   --no-binary mujoco-uni-runtime "mujoco-uni-runtime==<installed version>"`:
+   recompiles the native extension from the sdist against the new mujoco.
 
-The source rebuild requires a C++17 toolchain and Python development headers
-(see "Requirements"). To switch back to the default version, run
-`make mujoco MJ=3.11.0`; or `git restore -- uv.lock` followed by
-`uv sync --extra mujoco` to return to the prebuilt-wheel path.
+The override is **environment-local**: `uv.lock` stays unchanged. The
+switch-back path is `uv sync --extra mujoco --reinstall-package
+mujoco-uni-runtime`, which restores the locked default (mujoco 3.11.0 +
+prebuilt wheel); the `--reinstall-package` flag is required because a plain
+`uv sync` restores mujoco but keeps the locally rebuilt extension, which then
+fails to load. The source rebuild requires a C++17 toolchain and Python
+development headers (see "Requirements").
 
 ## Install Error Signatures
 
@@ -244,9 +251,9 @@ Reverse-lookup from error text to cause and fix.
 | `error: building mujoco-uni-runtime from source requires a C++ toolchain, but 'c++' was not found.` | The `check-cxx-toolchain` preflight of `make mujoco MJ=<version>` | Install a C++ toolchain and retry: Debian/Ubuntu `sudo apt-get install build-essential`; macOS `xcode-select --install`; Fedora/RHEL `sudo dnf install gcc-c++ make` |
 | `error: [Errno 2] No such file or directory: 'c++'` (or `c++: No such file or directory`) | Building `mujoco-uni-runtime` from the sdist without a compiler; only occurs on the source-rebuild path — the default wheel path never compiles | Same toolchain install as above; or do not switch versions and use the default wheel path `uv sync --extra mujoco` |
 | `fatal error: Python.h: No such file or directory` | Missing Python development headers during a source rebuild | A uv-managed Python (`uv python install`) bundles the headers; system Pythons need `python3-dev` (Debian/Ubuntu) or `python3-devel` (Fedora/RHEL) |
-| `MuJoCoUni native batch extension was built against mujoco '3.11.0', but loaded mujoco is '...'` | Version watchdog: the extension's recorded build-time mujoco version does not match the loaded mujoco | Install the mujoco version the extension binds (the prebuilt wheel binds `3.11.0`: `uv sync --extra mujoco`); or rebuild from source against the active mujoco: `make mujoco MJ=<version>` |
+| `MuJoCoUni native batch extension was built against mujoco '3.11.0', but loaded mujoco is '...'` | Version watchdog: the extension's recorded build-time mujoco version does not match the loaded mujoco | Install the mujoco version the extension binds (the prebuilt wheel binds `3.11.0`: `uv sync --extra mujoco --reinstall-package mujoco-uni-runtime`); or rebuild from source against the active mujoco: `make mujoco MJ=<version>` |
 | `mujoco_uni 0.5.0 supports official mujoco>=3.5,<3.12; found mujoco '...'` | The installed mujoco is outside the runtime's support window | Install a mujoco version inside `>=3.5,<3.12` (`make mujoco MJ=<version>`) |
-| `MuJoCoUni native batch extension has not been built` | The native extension failed to import (`mujoco_uni.batch_available()` returns `False`) | Run `uv run python -c "import mujoco_uni; print(mujoco_uni.batch_import_error())"` for the underlying cause, then reinstall the runtime |
+| `MuJoCoUni native batch extension has not been built` | The native extension failed to import (`mujoco_uni.batch_available()` returns `False`); a common cause is a plain `uv sync` after a version switch, which restores mujoco but keeps the locally rebuilt extension linked to the old `libmujoco.so` | Run `uv run python -c "import mujoco_uni; print(mujoco_uni.batch_import_error())"` for the underlying cause; after a version switch, restore the prebuilt wheel with `uv sync --extra mujoco --reinstall-package mujoco-uni-runtime` |
 
 ## Platform Profiles
 

--- a/docs/sphinx/source/en/2-user_guide/3-backends/1-mujoco.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/1-mujoco.md
@@ -37,31 +37,36 @@ window is `>=3.5,<3.12`; switching to any version other than the wheel's
 binding always takes the source-rebuild path. The
 `mujoco-uni-runtime` native extension records its build-time `mujoco`
 version and refuses to load against any other version,
-so switching versions means repinning `mujoco` and rebuilding the extension
-from source (a C++17 toolchain and Python development headers are required;
-the target's `check-cxx-toolchain` preflight fails fast with per-platform
-install commands when no compiler is found):
+so switching versions means installing the requested `mujoco` and rebuilding
+the extension from source (a C++17 toolchain and Python development headers
+are required; the target's `check-cxx-toolchain` preflight fails fast with
+per-platform install commands when no compiler is found):
 
 ```bash
 make mujoco MJ=3.10.0
 ```
 
-The target runs `uv lock --upgrade-package mujoco==3.10.0`, clears uv's build
+Because the `~=` bound can never be re-locked to another line, the target
+operates on the environment directly (`uv pip`, without touching `uv.lock`):
+it installs `mujoco==3.10.0` plus the runtime's build requirements
+(`pybind11`, `wheel`, `setuptools`), clears uv's build
 cache for `mujoco-uni-runtime` (the cache cannot see that the extension
-depends on the mujoco version), and re-syncs with a forced in-env rebuild
-(`--no-binary-package mujoco-uni-runtime --reinstall-package
-mujoco-uni-runtime`).
+depends on the mujoco version), and forces an in-env sdist rebuild of the
+runtime.
 Without the Makefile shortcut, the equivalent is:
 
 ```bash
-uv lock --upgrade-package mujoco==3.10.0
+uv pip install "mujoco==3.10.0" pybind11 wheel setuptools
 uv cache clean mujoco-uni-runtime
-uv sync --extra mujoco --extra motrix --no-binary-package mujoco-uni-runtime --reinstall-package mujoco-uni-runtime
+uv pip install --force-reinstall --no-deps --no-build-isolation \
+  --no-binary mujoco-uni-runtime "mujoco-uni-runtime==0.5.0"
 ```
 
 Skipping the cache clean or the forced reinstall lets uv reuse a cached
 extension built against the previous mujoco version, which then fails to
 import with a version-watchdog error (fail-closed, never a silent behavior
-change). To return to the default prebuilt-wheel path, run
-`make mujoco MJ=3.11.0`, or `git restore -- uv.lock` followed by
-`uv sync --extra mujoco`.
+change). The override is environment-local: to return to the default
+prebuilt-wheel path, run `uv sync --extra mujoco --reinstall-package
+mujoco-uni-runtime`. The `--reinstall-package` flag is required — a plain
+`uv sync` restores mujoco but keeps the locally rebuilt extension, which
+then fails to load against the reverted mujoco.

--- a/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
@@ -196,18 +196,23 @@ Drake、IsaacGym 和 IsaacSim 的 setup 脚本会将外部 runtime 安装到仓�
 make mujoco MJ=3.10.0
 ```
 
-该目标依次执行：
+`mujoco` extra 声明的 `mujoco~=3.11.0` 边界意味着 relock 无法选出窗口内的旧版本，
+所以该目标直接操作当前环境（`uv pip`，不改动 `uv.lock`），依次执行：
 
 1. `check-cxx-toolchain` 预检：缺少 C++ 编译器时立即失败，并打印各平台的安装命令；
-2. `uv lock --upgrade-package mujoco==3.10.0`：在 `uv.lock` 中重新钉住 mujoco；
+2. `uv pip install "mujoco==3.10.0" pybind11 wheel setuptools`：把请求的 mujoco
+   和 runtime 的构建依赖装进当前环境；
 3. `uv cache clean mujoco-uni-runtime`：清除构建缓存（uv 的缓存无法感知该扩展
    依赖 mujoco 版本）；
-4. `uv sync --extra mujoco --extra motrix --no-binary-package mujoco-uni-runtime
-   --reinstall-package mujoco-uni-runtime`：针对新 mujoco 就地重新编译原生扩展。
+4. `uv pip install --force-reinstall --no-deps --no-build-isolation
+   --no-binary mujoco-uni-runtime "mujoco-uni-runtime==<当前版本>"`：从 sdist
+   针对新 mujoco 就地重新编译原生扩展。
 
-源码重建需要 C++17 工具链和 Python 开发头文件（见「环境要求」）。切回默认版本：
-`make mujoco MJ=3.11.0`；或者 `git restore -- uv.lock` 后重新运行
-`uv sync --extra mujoco`，回到预编译 wheel 路径。
+这个覆盖是**环境本地**的：`uv.lock` 不变。切回默认版本的路径是
+`uv sync --extra mujoco --reinstall-package mujoco-uni-runtime`，恢复到 lock
+钉住的默认状态（mujoco 3.11.0 + 预编译 wheel）；`--reinstall-package` 不可省略，
+因为裸 `uv sync` 只恢复 mujoco 而保留本地重编的扩展，扩展会因此无法加载。
+源码重建需要 C++17 工具链和 Python 开发头文件（见「环境要求」）。
 
 ## 安装错误特征对照表
 
@@ -218,9 +223,9 @@ make mujoco MJ=3.10.0
 | `error: building mujoco-uni-runtime from source requires a C++ toolchain, but 'c++' was not found.` | `make mujoco MJ=<version>` 的 `check-cxx-toolchain` 预检失败 | 安装 C++ 工具链后重试：Debian/Ubuntu `sudo apt-get install build-essential`；macOS `xcode-select --install`；Fedora/RHEL `sudo dnf install gcc-c++ make` |
 | `error: [Errno 2] No such file or directory: 'c++'`（或 `c++: No such file or directory`） | 从 sdist 编译 `mujoco-uni-runtime` 时缺少编译器；只会出现在源码重建路径，默认 wheel 路径不会编译 | 同上安装工具链；或者不切换版本，直接走默认 wheel 路径 `uv sync --extra mujoco` |
 | `fatal error: Python.h: No such file or directory` | 源码重建时缺少 Python 开发头文件 | uv 托管的 Python（`uv python install`）自带头文件；系统 Python 需安装 `python3-dev`（Debian/Ubuntu）或 `python3-devel`（Fedora/RHEL） |
-| `MuJoCoUni native batch extension was built against mujoco '3.11.0', but loaded mujoco is '...'` | 版本 watchdog：扩展记录的编译期 mujoco 版本与当前加载的 mujoco 不一致 | 安装扩展绑定的 mujoco 版本（预编译 wheel 绑定 `3.11.0`：`uv sync --extra mujoco`）；或针对当前 mujoco 从源码重建：`make mujoco MJ=<version>` |
+| `MuJoCoUni native batch extension was built against mujoco '3.11.0', but loaded mujoco is '...'` | 版本 watchdog：扩展记录的编译期 mujoco 版本与当前加载的 mujoco 不一致 | 安装扩展绑定的 mujoco 版本（预编译 wheel 绑定 `3.11.0`：`uv sync --extra mujoco --reinstall-package mujoco-uni-runtime`）；或针对当前 mujoco 从源码重建：`make mujoco MJ=<version>` |
 | `mujoco_uni 0.5.0 supports official mujoco>=3.5,<3.12; found mujoco '...'` | 环境中的 mujoco 超出 runtime 支持窗口 | 换装窗口 `>=3.5,<3.12` 内的 mujoco 版本（`make mujoco MJ=<version>`） |
-| `MuJoCoUni native batch extension has not been built` | 原生扩展导入失败（`mujoco_uni.batch_available()` 返回 `False`） | 运行 `uv run python -c "import mujoco_uni; print(mujoco_uni.batch_import_error())"` 查看底层原因，然后重新安装 runtime |
+| `MuJoCoUni native batch extension has not been built` | 原生扩展导入失败（`mujoco_uni.batch_available()` 返回 `False`）；常见诱因是版本切换后裸跑 `uv sync`：mujoco 被恢复而本地重编的扩展仍链接旧版 `libmujoco.so` | 运行 `uv run python -c "import mujoco_uni; print(mujoco_uni.batch_import_error())"` 查看底层原因；版本切换后用 `uv sync --extra mujoco --reinstall-package mujoco-uni-runtime` 恢复预编译 wheel |
 
 ## 平台配置档
 

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/1-mujoco.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/1-mujoco.md
@@ -30,7 +30,7 @@ uv 的 prefer-locked 语义保证普通 relock 不会漂移。默认安装路径
 `mujoco-uni-runtime` 的预编译 wheel（绑定 `mujoco==3.11.0`），不需要编译器。
 支持窗口为 `>=3.5,<3.12`；切换到 wheel 绑定以外的任何版本都必须走源码重建
 路径。`mujoco-uni-runtime` 的原生扩展会记录编译时的 `mujoco` 版本，且拒绝在
-其它版本下加载，因此切换版本 = 重钉 `mujoco` + 从源码重编扩展（需要 C++17
+其它版本下加载，因此切换版本 = 安装指定 `mujoco` + 从源码重编扩展（需要 C++17
 工具链和 Python 开发头文件；缺少编译器时，该目标的 `check-cxx-toolchain`
 预检会立即失败并打印各平台的安装命令）：
 
@@ -38,18 +38,22 @@ uv 的 prefer-locked 语义保证普通 relock 不会漂移。默认安装路径
 make mujoco MJ=3.10.0
 ```
 
-该目标依次执行 `uv lock --upgrade-package mujoco==3.10.0`、清除 uv 对
+`~=` 边界无法 relock 到其它版本线，因此该目标直接操作当前环境
+（`uv pip`，不改动 `uv.lock`）：装入 `mujoco==3.10.0` 和 runtime 的构建依赖
+（`pybind11`、`wheel`、`setuptools`）、清除 uv 对
 `mujoco-uni-runtime` 的构建缓存（缓存无法感知扩展对 mujoco 版本的依赖）、
-并强制在本环境内重新编译同步（`--no-binary-package mujoco-uni-runtime
---reinstall-package mujoco-uni-runtime`）。不用 Makefile 时的等价命令：
+并强制从 sdist 在本环境内重新编译 runtime。不用 Makefile 时的等价命令：
 
 ```bash
-uv lock --upgrade-package mujoco==3.10.0
+uv pip install "mujoco==3.10.0" pybind11 wheel setuptools
 uv cache clean mujoco-uni-runtime
-uv sync --extra mujoco --extra motrix --no-binary-package mujoco-uni-runtime --reinstall-package mujoco-uni-runtime
+uv pip install --force-reinstall --no-deps --no-build-isolation \
+  --no-binary mujoco-uni-runtime "mujoco-uni-runtime==0.5.0"
 ```
 
 如果省略清缓存或强制重装，uv 可能复用按旧版本 mujoco 编译的扩展，
 import 时会以版本 watchdog 错误失败（fail-closed，不会静默出错行为）。
-切回默认预编译 wheel 路径：运行 `make mujoco MJ=3.11.0`，或
-`git restore -- uv.lock` 后重新执行 `uv sync --extra mujoco`。
+该覆盖是环境本地的：切回默认预编译 wheel 路径用
+`uv sync --extra mujoco --reinstall-package mujoco-uni-runtime`。
+`--reinstall-package` 不可省略——裸 `uv sync` 只恢复 mujoco 而保留本地重编的
+扩展，扩展会因此无法加载。

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -109,13 +109,14 @@ exclude-dependencies = [
     "nvidia-cuda-runtime-cu12",
     "nvidia-cudnn-cu12",
 ]
-# Only relevant for the sdist fallback build of mujoco-uni-runtime
-# (`make mujoco MJ=<version>` passes --no-binary-package explicitly): the
-# native extension must be compiled against the mujoco version locked in this
-# project environment rather than in an isolated build env, because it
-# records the build-time mujoco version and refuses to load on mismatch. The
-# default install path resolves the prebuilt wheel (bound to mujoco==3.11.0)
-# and never builds anything.
+# Only relevant if mujoco-uni-runtime is ever built from its sdist inside
+# this project: the native extension must be compiled against the mujoco
+# version installed in this environment rather than in an isolated build env,
+# because it records the build-time mujoco version and refuses to load on
+# mismatch. The sdist fallback path (`make mujoco MJ=<version>`) builds via
+# `uv pip install --no-build-isolation` explicitly; this setting covers any
+# other in-project build. The default install path resolves the prebuilt
+# wheel (bound to mujoco==3.11.0) and never builds anything.
 no-build-isolation-package = ["mujoco-uni-runtime"]
 required-environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,13 +185,15 @@ torch = [
 
 [tool.uv]
 exclude-dependencies = ["torchvision"]
-# Only relevant for the sdist fallback build of mujoco-uni-runtime
-# (`make mujoco MJ=<version>` passes --no-binary-package explicitly): the
-# native extension must be compiled against the mujoco version locked in this
-# project environment rather than in an isolated build env, because it
-# records the build-time mujoco version and refuses to load on mismatch. The
-# default install path resolves the prebuilt wheel (bound to mujoco==3.11.0)
-# and never builds anything, so no compiler is needed for `make setup`.
+# Only relevant if mujoco-uni-runtime is ever built from its sdist inside
+# this project: the native extension must be compiled against the mujoco
+# version installed in this environment rather than in an isolated build env,
+# because it records the build-time mujoco version and refuses to load on
+# mismatch. The sdist fallback path (`make mujoco MJ=<version>`) builds via
+# `uv pip install --no-build-isolation` explicitly; this setting covers any
+# other in-project build. The default install path resolves the prebuilt
+# wheel (bound to mujoco==3.11.0) and never builds anything, so no compiler
+# is needed for `make setup`.
 no-build-isolation-package = ["mujoco-uni-runtime"]
 required-environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",


### PR DESCRIPTION
Follow-up to #1517 / #1520。端到端验收发现 `make mujoco MJ=3.10.0` 在 `uv lock --upgrade-package` 步骤失败：extra 的 `mujoco~=3.11.0` bound 使 lock 无法选出 3.10.0（roadmap 验收标准 2 要求该路径可用）。

## What

- `make mujoco` 改为环境级覆盖（不动 uv.lock、不改 prescribed bound）：`uv pip install mujoco==$(MJ)` + 强制 sdist 重建 `mujoco-uni-runtime`（`--no-binary --no-build-isolation --force-reinstall`，版本取自已安装包）；对窗口 `>=3.5,<3.12` 内任意版本可用，无 3.11.x 特判。
- 切换回默认的路径修正为 `uv sync --extra mujoco --reinstall-package mujoco-uni-runtime`（实测 plain `uv sync` 会留下对旧版本编译的扩展 → watchdog 拒绝加载）。
- 双语安装文档与 1-mujoco.md 同步新机制与切回步骤；错误对照表增补真实命中的形态。

## Validation

- 临时克隆端到端：`make mujoco MJ=3.10.0` → sdist 8.4s 重建 → `3.10.0 True`（watchdog 通过）；切回 → wheel 重装 → `3.11.0 True`。
- `make test-all` 最终 head（815aadfc）：ruff/mypy/pyright clean，pytest 1598 passed / 22 skipped，benchmark smoke 35/36 + 36/37，exit 0。