### PR TITLE
release: unilab 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"> UniLab </h1>
 
 <h3 align="center">
-A Heterogeneous Architecture for Robot RL Beyond GPU-Dominant Paradigms.
+Contract-driven infrastructure for robot learning across physics backends and hardware
 </h3>
 
 <p align="center">Languages: English | <a href="README_zh.md">简体中文</a></p>
@@ -24,32 +24,21 @@ A Heterogeneous Architecture for Robot RL Beyond GPU-Dominant Paradigms.
 
 <p align="center"><em>One task-authoring surface for locomotion, manipulation, and motion tracking.</em></p>
 
-UniLab is a complete, configurable product for robot reinforcement learning.
+UniLab is configurable infrastructure for robot reinforcement learning.
 Describe a task with Hydra, assemble it from manager terms, select a physics
 backend, and train or evaluate through one CLI. The same task-facing contract
 connects CPU, GPU, and external-worker simulation to the learner runtime.
 
-Physics adapters are provided by the independent
-[`unisim-core`](https://github.com/unilabsim/unisim) package. RL algorithms and
-their runners are provided by [`unilab-rl`](https://github.com/unilabsim/unilab_rl)
-(Python namespace `uni_rl`). UniLab keeps the user-facing task, environment,
-configuration, and experiment workflow together.
+The same framework has documented paths for Windows, Apple Silicon macOS, Linux
+CUDA, AMD ROCm, and Intel XPU. Backend and task maturity are evidence-graded;
+use the [support matrix](https://unilabsim.github.io/UniLab-doc/en/5-reference/5-support_matrix.html)
+to choose a tested combination.
 
-New to UniLab? Start with [First success](#first-success-run-a-demo). Already
-have a task? Jump to [Train and evaluate](#train-and-evaluate) and change only
-`--sim` to try another backend when a matching task owner is available.
+See policies in action on the [project page](https://unilabsim.github.io/#demos),
+or read [Why UniLab?](https://unilabsim.github.io/UniLab-doc/en/why_unilab.html)
+to understand the project fit, evidence, and comparison with alternatives.
 
 ## Highlights
-
-```text
-┌──────────────────────────────────────┐     Same task contract    ┌──────────────────────────────────────┐
-│                                      │ ────────────────────────▶ │       Run it where you need          │
-│       Define the task once           │                           │   MuJoCo · Motrix · MJWarp · Drake   │
-│       Hydra · Managers · NumPy       │                           │    Genesis · IsaacGym · IsaacSim     │
-│     Terms · rewards · commands       │                           │   CUDA · ROCm · macOS · MPS · XPU    │
-│                                      │                           │         train · eval                 │
-└──────────────────────────────────────┘                           └──────────────────────────────────────┘
-```
 
 UniLab's core idea is simple: define task semantics once as reusable
 configuration, then change the simulator, hardware, or learner without
@@ -59,154 +48,62 @@ rewriting the task's environment lifecycle.
   events, commands, curricula, and metrics are manager terms assembled in Hydra
   owner YAML. Variants built from existing terms need no new environment class
   — often no Python code at all.
-- **Change the backend, keep the workflow.** Current and future simulators share
-  the public `SimBackend` contract. Choose a backend with `--sim`; the same task
-  authoring and train/eval workflow remains in place while the owner YAML keeps
-  backend-specific details explicit.
-- **Scale across the hardware you have.** CPU-parallel or external-worker
-  simulation feeds accelerator learners through the injected env contract and
-  async runtime. Algorithms and runners are supplied by the unified package
-  ecosystem instead of being tied to one simulator.
+- **Change the backend, keep the workflow.** Registered simulators meet the
+  public `SimBackend` contract. Choose a backend with `--sim`; when a matching
+  task owner exists, task authoring and train/eval stay consistent while
+  backend-specific details remain explicit.
+- **Keep solver and learner devices independent.** CPU-parallel, native, or
+  external-worker simulation can feed an accelerator learner without first
+  becoming a CUDA-resident simulator. The learner can run on CUDA, ROCm, MPS,
+  or XPU; the [support matrix](https://unilabsim.github.io/UniLab-doc/en/5-reference/5-support_matrix.html)
+  records the evidence level of each backend/task combination.
+- **Accelerate replay-based off-policy training.** FastSAC/FlashSAC lets
+  simulation data collection overlap with learner updates. The paper reports
+  3–10× end-to-end gains on representative configurations; see [Why UniLab](https://unilabsim.github.io/UniLab-doc/en/why_unilab.html)
+  for scope and measurements.
 
-## Getting started
+## Quick start
 
-The supported source workflow uses [`uv`](https://docs.astral.sh/uv/).
+The supported source workflow uses [`uv`](https://docs.astral.sh/uv/). This is
+the shortest path to a policy demo:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/unilabsim/UniLab.git
 cd UniLab
 
-# Fastest path to the first Motrix demo.
-make setup-motrix
-
-# Full local setup (MuJoCo + Motrix):
-# make setup
-
-# Optional platform/backend paths:
-# make sync-rocm       # AMD GPU
-# make sync-xpu        # Intel GPU
-# make setup-drake     # Drake + native batch extension
-```
-
-The `mujoco` extra installs the prebuilt `mujoco-uni-runtime` wheel (bound to
-`mujoco==3.11.0`), so no compiler is needed by default; a C++ toolchain and
-Python development headers are only required when switching the MuJoCo version
-(`make mujoco MJ=<version>`), which always rebuilds the native extension from
-source. See the
-[installation guide](https://unilabsim.github.io/UniLab-doc/en/1-getting_started/2-installation.html)
-for platform-specific setup, optional backends, and external worker runtimes.
-
-## First success: run a demo
-
-```bash
+make setup
 # Downloads the checkpoint and assets from Hugging Face on first run.
 uv run demo dance
 ```
 
-Available presets are `teaser`, `dance`, `wallflip`, `boxtracking`, `locomani`,
-and `inhandgrasp`. Use `uv run demo --help` for device and refresh options.
-The [quick demo guide](https://unilabsim.github.io/UniLab-doc/en/1-getting_started/1-quick_demo.html)
-explains rendering modes and server/macOS differences.
+For Windows, macOS, CUDA, ROCm, XPU, optional backends, and headless rendering,
+use the [installation guide](https://unilabsim.github.io/UniLab-doc/en/1-getting_started/2-installation.html)
+and [quick demo guide](https://unilabsim.github.io/UniLab-doc/en/1-getting_started/1-quick_demo.html).
 
 ## Train and evaluate
 
 ```bash
-# Train and replay a task with Motrix.
+# Train and replay one task with Motrix.
 uv run train --algo ppo --task go2_joystick_flat --sim motrix
 uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1
 
-# Switch only the simulator for the same task.
+# Use the same task-facing command with another configured backend.
 uv run train --algo ppo --task go2_joystick_flat --sim mujoco
 
-# Or use the same workflow with an off-policy learner.
+# Replay-based off-policy path.
 uv run train --algo sac --task g1_walk_flat --sim mujoco
-uv run train --algo flashsac --task g1_walk_flat --sim mujoco
-
-# Headless video export.
-uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
-  --load-run -1 --render-mode record
 ```
 
-Route-defining choices are always visible:
-
-```text
---algo + --task + --sim  →  Hydra owner YAML  →  registered environment
-```
-
-Use normal Hydra overrides after those flags:
-
-```bash
-uv run train --algo ppo --task go2_joystick_flat --sim motrix \
-  algo.max_iterations=1 algo.num_envs=16 training.no_play=true
-```
-
-Do not override `training.sim_backend` to switch engines. It is the identity
-field supplied by the selected owner YAML. Find resume, W&B, playback, and the
-full command matrix in the
-[training guide](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/0-index.html).
-
-## Manager-based configuration
-
-UniLab wraps a community-familiar manager API with Hydra composition and a
-NumPy runtime. A task owner can select and parameterize terms declaratively:
-
-```yaml
-env:
-  observations:
-    policy:
-      terms:
-        joint_pos:
-          func: unilab.envs.mdp.joint_pos_rel
-        command:
-          func: unilab.envs.mdp.generated_commands
-          params:
-            command_name: twist
-  actions:
-    joint_pos:
-      _target_: unilab.envs.mdp.JointPositionActionCfg
-      entity_name: robot
-      scale: 0.25
-reward:
-  tracking_lin_vel:
-    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
-    weight: 1.0
-```
-
-This makes common task edits a config change: compose or disable a term, tune
-its parameters, and reuse it across robots and backends without writing a new
-environment class. The API follows the pinned mjlab manager semantics where
-the contracts are shared, but it is a UniLab product with NumPy, Hydra, and
-`NpEnvState` semantics. See the
-[Manager-Based API guide](https://unilabsim.github.io/UniLab-doc/en/4-developer_guide/1-architecture/6-manager_based_api.html)
-for the complete contract and known differences.
-
-## Physics backends
-
-Current backends are available through `unisim-core` and the same UniLab route;
-the contract is designed to grow as new adapters land:
-
-`mujoco` · `motrix` · `mjwarp` · `drake` · `genesis` · `isaacgym` · `isaacsim`
-
-Choose one backend setup (combine extras when needed):
-
-```bash
-uv sync --extra mujoco
-# uv sync --extra mujoco --extra motrix
-# uv sync --extra mujoco --extra mjwarp
-# uv sync --extra genesis
-# make setup-drake
-```
-
-IsaacGym and IsaacSim use dedicated external worker environments. Backend
-installation details, rendering behavior, and the evidence-based task support
-matrix live in the
-[backend guide](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/3-backends/0-index.html)
+The flags keep algorithm, task, and simulator choices visible. Resume, W&B,
+Hydra overrides, playback, backend setup, and the full command matrix belong in
+the [training guide](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/0-index.html),
+[backend guide](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/3-backends/0-index.html),
 and [support matrix](https://unilabsim.github.io/UniLab-doc/en/5-reference/5-support_matrix.html).
 
 ## Ecosystem
 
-UniLab is designed to be the shared product surface for robot-specific
+UniLab is designed to be a shared task and training surface for robot-specific
 repositories. Current downstream examples include
 [MicroDuck RL](https://github.com/unilabsim/microduck_rl_unilab) and
 [EngineAI RL](https://github.com/unilabsim/engineai_rl_unilab). They can ship
@@ -215,12 +112,12 @@ contracts.
 
 ## Documentation
 
-- [Documentation index](https://unilabsim.github.io/UniLab-doc/en/0-index.html)
-- [Unified CLI reference](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/1-cli_reference.html)
-- [Task and manager architecture](https://unilabsim.github.io/UniLab-doc/en/4-developer_guide/1-architecture/0-index.html)
+- [Why UniLab?](https://unilabsim.github.io/UniLab-doc/en/why_unilab.html)
+- [Installation and first demo](https://unilabsim.github.io/UniLab-doc/en/1-getting_started/0-index.html)
+- [Training and evaluation](https://unilabsim.github.io/UniLab-doc/en/2-user_guide/1-training/0-index.html)
+- [Backend support matrix](https://unilabsim.github.io/UniLab-doc/en/5-reference/5-support_matrix.html)
 - [Sim-to-sim deployment](https://unilabsim.github.io/UniLab-doc/en/3-deployment/2-sim_to_sim/1-backend_swap.html)
-- [Algorithm extension recipe](https://unilabsim.github.io/UniLab-doc/en/4-developer_guide/3-extending/3-new_algorithm.html)
-- [Architecture decisions](https://unilabsim.github.io/UniLab-doc/adr/ADR-0000-index.html)
+- [Developer guide](https://unilabsim.github.io/UniLab-doc/en/4-developer_guide/0-index.html)
 
 For development and contribution workflows, see the
 [contributing guide](CONTRIBUTING.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,7 @@
 <h1 align="center"> UniLab </h1>
 
 <h3 align="center">
-面向超越 GPU 主导范式的机器人 RL 异构架构
+面向跨物理后端机器人学习的契约驱动基础设施
 </h3>
 
 <p align="center">语言：简体中文 | <a href="README.md">English</a></p>
@@ -24,30 +24,19 @@
 
 <p align="center"><em>用同一套任务编排体验覆盖运动、操作与动作跟踪。</em></p>
 
-UniLab 是一个完整、可配置的机器人强化学习产品。使用 Hydra 描述任务，
+UniLab 是面向机器人强化学习的可配置基础设施。使用 Hydra 描述任务，
 通过 manager term 组装任务，选择物理后端，再用统一 CLI 完成训练与评估。
 同一套面向任务的 contract 可以把 CPU、GPU 和外部 worker 仿真连接到学习器运行时。
 
-物理适配器由独立的
-[`unisim-core`](https://github.com/unilabsim/unisim) package 提供；RL 算法及其
-runner 由 [`unilab-rl`](https://github.com/unilabsim/unilab_rl) 提供（Python
-namespace 为 `uni_rl`）。UniLab 将面向用户的 task、environment、配置和实验流程
-保持在一起。
+同一套框架已提供 Windows、Apple Silicon macOS、Linux CUDA、AMD ROCm 和 Intel XPU 的文档
+路径。不同 backend/task 的成熟度按证据分级；请选择[支持矩阵](https://unilabsim.github.io/UniLab-doc/zh_CN/5-reference/5-support_matrix.html)
+中有测试证据的组合。
 
-如果你刚接触 UniLab，请从[第一次成功](#第一次成功运行-demo)开始；如果你已经有任务，
-直接进入[训练与评估](#训练与评估)；在存在匹配 task owner 时，只需修改 `--sim` 即可尝试另一个后端。
+可以先在[项目主页](https://unilabsim.github.io/#demos)观看策略运行，或阅读
+[为什么选择 UniLab？](https://unilabsim.github.io/UniLab-doc/zh_CN/why_unilab.html)，
+了解适用场景、证据和同类方案比较。
 
 ## 亮点
-
-```text
-┌──────────────────────────────────────┐    同一套任务 contract    ┌───────────────────────────────────┐
-│                                      │ ────────────────────────▶ │          按需运行任务             │
-│            定义一次任务              │                           │ MuJoCo · Motrix · MJWarp · Drake  │
-│       Hydra · Managers · NumPy       │                           │ Genesis · IsaacGym · IsaacSim     │
-│      Terms · rewards · commands      │                           │   CUDA · ROCm · macOS · MPS · XPU │
-│                                      │                           │            训练 · 评估            │
-└──────────────────────────────────────┘                           └───────────────────────────────────┘
-```
 
 UniLab 的核心理念很简单：将任务语义定义为可复用的配置，然后独立更换仿真器、硬件或
 learner，而无需重写任务的 environment 生命周期。
@@ -55,158 +44,71 @@ learner，而无需重写任务的 environment 生命周期。
 - **配置而非编码。** action、observation、reward、termination、event、command、
   curriculum 和 metrics 都是 manager term，在 Hydra owner YAML 中组装。基于已有 term
   的任务变体无需新写 environment class，很多时候完全不需要 Python 代码。
-- **更换后端而不更换工作流。** 当前和未来的仿真器共用公开的 `SimBackend` contract。
-  使用 `--sim` 选择后端；任务编排和训练/评估工作流保持一致，后端差异由 owner YAML
-  明确表达。
-- **适配手头的硬件并持续扩展。** CPU 并行仿真或外部 worker 仿真通过注入式 env contract
-  和异步运行时向 accelerator learner 提供数据。算法和 runner 由统一 package 生态提供，
-  不绑定单一仿真器。
+- **更换后端而不更换工作流。** 已注册仿真器遵循公开的 `SimBackend` contract。
+  使用 `--sim` 选择后端；存在匹配 task owner 时，任务编排和训练/评估工作流保持一致，
+  后端差异仍然显式。
+- **让 solver 与 learner 的设备彼此独立。** CPU 并行、native 或 external-worker 仿真
+  不必先变成 CUDA-resident simulator，也可以向 accelerator learner 提供数据；learner
+  可以运行在 CUDA、ROCm、MPS 或 XPU 上。每个 backend/task 组合的证据等级请查看
+  [支持矩阵](https://unilabsim.github.io/UniLab-doc/zh_CN/5-reference/5-support_matrix.html)。
+- **加速 replay-based off-policy 训练。** FastSAC/FlashSAC 让仿真数据采集与 learner
+  update 重叠。论文在代表性配置上报告了 3–10 倍端到端收益；测量范围和限制见
+  [为什么选择 UniLab](https://unilabsim.github.io/UniLab-doc/zh_CN/why_unilab.html)。
 
-## 开始使用
+## 快速开始
 
-推荐使用 [`uv`](https://docs.astral.sh/uv/) 完成源码工作流。
+推荐使用 [`uv`](https://docs.astral.sh/uv/) 完成源码工作流。以下是运行策略 demo 的
+最短路径：
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/unilabsim/UniLab.git
 cd UniLab
 
-# 运行 Motrix demo 的最快路径。
-make setup-motrix
-
-# 完整本地环境（MuJoCo + Motrix）：
-# make setup
-
-# 可选的平台/后端路径：
-# make sync-rocm       # AMD GPU
-# make sync-xpu        # Intel GPU
-# make setup-drake     # Drake + 原生 batch extension
-```
-
-`mujoco` extra 默认安装 `mujoco-uni-runtime` 的预编译 wheel（绑定
-`mujoco==3.11.0`），无需编译器；只有切换 MuJoCo 版本
-（`make mujoco MJ=<version>`，总是从源码重建原生扩展）时才需要 C++ 工具链和
-Python 开发头文件。平台相关安装、可选后端和外部 worker 运行时请参阅
-[安装指南](https://unilabsim.github.io/UniLab-doc/zh_CN/1-getting_started/2-installation.html)。
-
-## 第一次成功：运行 demo
-
-```bash
+make setup
 # 首次运行会从 Hugging Face 下载 checkpoint 和 asset。
 uv run demo dance
 ```
 
-可用预设为 `teaser`、`dance`、`wallflip`、`boxtracking`、`locomani` 和
-`inhandgrasp`。运行 `uv run demo --help` 查看 device 和 refresh 选项。
-[快速演示指南](https://unilabsim.github.io/UniLab-doc/zh_CN/1-getting_started/1-quick_demo.html)
-介绍渲染模式以及服务器/macOS 差异。
+Windows、macOS、CUDA、ROCm、XPU、可选后端和无头渲染的说明，请查看
+[安装指南](https://unilabsim.github.io/UniLab-doc/zh_CN/1-getting_started/2-installation.html)和
+[快速演示指南](https://unilabsim.github.io/UniLab-doc/zh_CN/1-getting_started/1-quick_demo.html)。
 
 ## 训练与评估
 
 ```bash
-# 使用 Motrix 训练并回放任务。
+# 使用 Motrix 训练并回放一个任务。
 uv run train --algo ppo --task go2_joystick_flat --sim motrix
 uv run eval --algo ppo --task go2_joystick_flat --sim motrix --load-run -1
 
-# 对同一个任务只切换仿真器。
+# 使用另一个已有配置的后端，保持同样的任务入口。
 uv run train --algo ppo --task go2_joystick_flat --sim mujoco
 
-# 或使用 off-policy learner 跑同样的工作流。
+# Replay-based off-policy 路径。
 uv run train --algo sac --task g1_walk_flat --sim mujoco
-uv run train --algo flashsac --task g1_walk_flat --sim mujoco
-
-# 无头视频导出。
-uv run eval --algo ppo --task go2_joystick_flat --sim motrix \
-  --load-run -1 --render-mode record
 ```
 
-路由选择始终清晰可见：
-
-```text
---algo + --task + --sim  →  Hydra owner YAML  →  已注册的 environment
-```
-
-在这些 flag 之后追加普通 Hydra override：
-
-```bash
-uv run train --algo ppo --task go2_joystick_flat --sim motrix \
-  algo.max_iterations=1 algo.num_envs=16 training.no_play=true
-```
-
-不要通过 override `training.sim_backend` 切换引擎；它是所选 owner YAML 提供的
-identity 字段。续训、W&B、回放和完整命令矩阵请参阅
-[训练指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)。
-
-## Manager-based 配置
-
-UniLab 用 Hydra composition 和 NumPy runtime 包装了一套社区熟悉的 manager API。
-任务 owner 可以用声明式配置选择 term 并设置参数：
-
-```yaml
-env:
-  observations:
-    policy:
-      terms:
-        joint_pos:
-          func: unilab.envs.mdp.joint_pos_rel
-        command:
-          func: unilab.envs.mdp.generated_commands
-          params:
-            command_name: twist
-  actions:
-    joint_pos:
-      _target_: unilab.envs.mdp.JointPositionActionCfg
-      entity_name: robot
-      scale: 0.25
-reward:
-  tracking_lin_vel:
-    func: unilab.tasks.locomotion.common.manager_terms.track_lin_vel_xy_exp
-    weight: 1.0
-```
-
-这意味着常见的任务修改只需改配置：组装或禁用一个 term、调整参数，并在不同机器人和
-后端之间复用，无需新写 environment class。该 API 在共享 contract 范围内遵循 pinned
-mjlab manager 语义，但它是结合 NumPy、Hydra 和 `NpEnvState` 语义的 UniLab 产品。
-完整 contract 与已知差异请参阅
-[Manager-Based API 指南](https://unilabsim.github.io/UniLab-doc/zh_CN/4-developer_guide/1-architecture/6-manager_based_api.html).
-
-## 物理后端
-
-当前后端通过 `unisim-core` 和同一套 UniLab 路由提供；随着新 adapter 加入，
-这套 contract 可以持续扩展：
-
-`mujoco` · `motrix` · `mjwarp` · `drake` · `genesis` · `isaacgym` · `isaacsim`
-
-选择一条后端安装路径（需要多个后端时组合 extras）：
-
-```bash
-uv sync --extra mujoco
-# uv sync --extra mujoco --extra motrix
-# uv sync --extra mujoco --extra mjwarp
-# uv sync --extra genesis
-# make setup-drake
-```
-
-IsaacGym 和 IsaacSim 使用专用的外部 worker 环境。后端安装细节、渲染行为以及基于证据
-的 task support matrix 请参阅
-[后端指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/3-backends/0-index.html)
-和[支持矩阵](https://unilabsim.github.io/UniLab-doc/zh_CN/5-reference/5-support_matrix.html)。
+这些 flag 会让 algorithm、task 和 simulator 选择保持可见。续训、W&B、Hydra override、
+回放、后端安装和完整命令矩阵属于
+[训练指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)、
+[后端指南](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/3-backends/0-index.html)和
+[支持矩阵](https://unilabsim.github.io/UniLab-doc/zh_CN/5-reference/5-support_matrix.html)。
 
 ## 生态
 
-UniLab 被设计为机器人专属仓库共享的产品界面。目前的下游示例包括
+UniLab 被设计为机器人专属仓库共享的任务与训练界面。目前的下游示例包括
 [MicroDuck RL](https://github.com/unilabsim/microduck_rl_unilab) 和
 [EngineAI RL](https://github.com/unilabsim/engineai_rl_unilab)。它们可以独立发布机器人
 recipe，同时消费同一套 task、backend 和 RL contract。
 
 ## 文档
 
-- [文档索引](https://unilabsim.github.io/UniLab-doc/zh_CN/0-index.html)
-- [统一 CLI 参考](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/1-cli_reference.html)
-- [Task 与 manager 架构](https://unilabsim.github.io/UniLab-doc/zh_CN/4-developer_guide/1-architecture/0-index.html)
+- [为什么选择 UniLab？](https://unilabsim.github.io/UniLab-doc/zh_CN/why_unilab.html)
+- [安装与第一次 demo](https://unilabsim.github.io/UniLab-doc/zh_CN/1-getting_started/0-index.html)
+- [训练与评估](https://unilabsim.github.io/UniLab-doc/zh_CN/2-user_guide/1-training/0-index.html)
+- [后端支持矩阵](https://unilabsim.github.io/UniLab-doc/zh_CN/5-reference/5-support_matrix.html)
 - [Sim-to-sim 部署](https://unilabsim.github.io/UniLab-doc/zh_CN/3-deployment/2-sim_to_sim/1-backend_swap.html)
-- [算法扩展教程](https://unilabsim.github.io/UniLab-doc/zh_CN/4-developer_guide/3-extending/3-new_algorithm.html)
-- [架构决策](https://unilabsim.github.io/UniLab-doc/adr/ADR-0000-index.html)
+- [开发者指南](https://unilabsim.github.io/UniLab-doc/zh_CN/4-developer_guide/0-index.html)
 
 开发与贡献工作流请参阅[贡献指南](CONTRIBUTING.md)。
 

--- a/docs/sphinx/source/changelog.md
+++ b/docs/sphinx/source/changelog.md
@@ -2,21 +2,76 @@
 orphan: true
 ---
 
-# Changelog
+# Changelog / 变更日志
 
-UniLab versioning follows [SemVer](https://semver.org/). Notable changes are recorded here; for the day-to-day commit log see the [UniLab repository](https://github.com/unilabsim/UniLab).
+UniLab follows [Semantic Versioning](https://semver.org/). This shared page
+records notable releases in English and Chinese; for the day-to-day commit log,
+see the [UniLab repository](https://github.com/unilabsim/UniLab).
 
-## Unreleased
+UniLab 遵循[语义化版本](https://semver.org/)。本共享页面以中英文记录重要版本变更；
+日常提交记录请参阅 [UniLab 仓库](https://github.com/unilabsim/UniLab)。
 
-## 1.0.0 (current package metadata)
+## Unreleased / 未发布
 
-- `pyproject.toml` declares package version `1.0.0`. The Manager-Based API migration (roadmap #1042) is merged: manager core and NumPy term library ported from mjlab 1.6.0, all production tasks on the Manager-Based runtime, and legacy monolithic envs removed.
-- Physics backends live in the separate `unisim-core` package (MuJoCo, Motrix, mjwarp, IsaacGym, IsaacSim, Genesis, Drake); RL algorithms and the async runtime live in the separate `unilab-rl` package (`uni_rl`).
-- Robot meshes/textures are hosted on the HF dataset `unilabsim/unilab-robots` and pulled on demand; documentation source uses the bilingual Sphinx tree described in `docs/sphinx/README.md`: `source/en/`, `source/zh_CN/`, and shared `adr/`, `api_reference/`, `glossary.md`, and `changelog.md`.
-- ADR, glossary, and changelog pages are shared content rather than per-language pages.
+## 1.1.0 (2026-09-06)
+
+- Update the required `unisim-core` release to `>=1.1.3`, including the ROCm
+  profile, so UniLab consumes the current shared physics-backend contract.
+  将必需的 `unisim-core` 版本更新为 `>=1.1.3`，并同步更新 ROCm 配置档，使 UniLab
+  使用当前共享的物理后端 contract。
+- Add the Newton backend owner path and native ViewerGL playback integration,
+  with explicit device routing for spawned collectors.
+  增加 Newton backend owner 路径和原生 ViewerGL 回放集成，并为 spawn collector
+  增加显式设备路由。
+- Align the MuJoCo extras on the 3.11 line and document the version-switch
+  fallback path for the native runtime extension.
+  将 MuJoCo extras 统一到 3.11 版本线，并补充原生 runtime 扩展切换版本时的回退路径
+  文档。
+- Add third-party task-package discovery through the `unilab.tasks` entry-point
+  group and generic interval domain-randomization dispatch.
+  增加通过 `unilab.tasks` entry-point group 发现第三方 task package 的能力，并增加通用
+  interval domain-randomization dispatch。
+- Expand the bilingual documentation around backend support evidence, platform
+  setup, sim-to-sim contracts, and the Why UniLab project rationale.
+  扩展双语文档，覆盖 backend 支持证据、平台安装、sim-to-sim contract 和 Why UniLab
+  项目定位。
+
+## 1.0.0
+
+- `pyproject.toml` declares package version `1.0.0`. The Manager-Based API migration
+  (roadmap #1042) is merged: manager core and NumPy term library ported from mjlab
+  1.6.0, all production tasks on the Manager-Based runtime, and legacy monolithic
+  envs removed.
+  `pyproject.toml` 声明 package 版本 `1.0.0`。Manager-Based API 迁移（roadmap #1042）
+  完成：manager core 和 NumPy term library 从 mjlab 1.6.0 移植，所有 production task
+  运行在 Manager-Based runtime 上，并移除旧的 monolithic env。
+- Physics backends live in the separate `unisim-core` package (MuJoCo, Motrix,
+  mjwarp, IsaacGym, IsaacSim, Genesis, Drake); RL algorithms and the async runtime
+  live in the separate `unilab-rl` package (`uni_rl`).
+  物理后端位于独立的 `unisim-core` package（MuJoCo、Motrix、mjwarp、IsaacGym、IsaacSim、
+  Genesis、Drake）；RL 算法和异步 runtime 位于独立的 `unilab-rl` package（`uni_rl`）。
+- Robot meshes/textures are hosted on the Hugging Face dataset
+  `unilabsim/unilab-robots` and pulled on demand. The bilingual Sphinx source
+  layout is documented in `docs/sphinx/README.md`.
+  机器人 mesh/texture 托管在 Hugging Face 数据集 `unilabsim/unilab-robots`，按需拉取。
+  双语 Sphinx 源码布局见 `docs/sphinx/README.md`。
+- ADR, glossary, and changelog pages are shared content rather than per-language
+  pages.
+  ADR、术语表和 changelog 页面采用共享内容，而不是分别维护语言版本。
 
 ## 0.1.0
 
-- `pyproject.toml` declares package version `0.1.0` and the first-level console entrypoints `train`, `eval`, `demo`, `unilab-complete`, `unilab-viz-nan`, and `unilab-export-scene`.
-- The repository README documents the CPU simulation, shared-memory runtime, and GPU learning architecture, with MuJoCo and Motrix named as physics backends.
-- Accepted ADRs in `docs/sphinx/source/adr/README.md` cover runtime layer boundaries, backend capability boundaries, task owner config compose, registry bootstrap, and observation / IPC contracts.
+- `pyproject.toml` declares package version `0.1.0` and the first-level console
+  entrypoints `train`, `eval`, `demo`, `unilab-complete`, `unilab-viz-nan`, and
+  `unilab-export-scene`.
+  `pyproject.toml` 声明 package 版本 `0.1.0`，并提供首批顶层 console entrypoint：
+  `train`、`eval`、`demo`、`unilab-complete`、`unilab-viz-nan` 和 `unilab-export-scene`。
+- The repository README documents the CPU simulation, shared-memory runtime, and
+  GPU learning architecture, with MuJoCo and Motrix named as physics backends.
+  仓库 README 介绍 CPU 仿真、共享内存 runtime 和 GPU learning 架构，并将 MuJoCo 与
+  Motrix 列为物理后端。
+- Accepted ADRs in `docs/sphinx/source/adr/README.md` cover runtime layer
+  boundaries, backend capability boundaries, task owner config composition,
+  registry bootstrap, and observation / IPC contracts.
+  `docs/sphinx/source/adr/README.md` 中的已接受 ADR 覆盖 runtime 分层边界、backend
+  capability 边界、task owner 配置组合、registry bootstrap 以及 observation/IPC contract。

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -29,12 +29,12 @@ for _p in _candidate_siblings:
 # produces a usable site for the prose pages. CI installs UniLab properly
 # and gets the full API reference.
 _UNILAB_AVAILABLE = False
-_UNILAB_VERSION = "1.0.0"
+_UNILAB_VERSION = "1.1.0"
 try:
     import unilab  # type: ignore
 
     _UNILAB_AVAILABLE = True
-    _UNILAB_VERSION = getattr(unilab, "__version__", "1.0.0")
+    _UNILAB_VERSION = getattr(unilab, "__version__", "1.1.0")
 except Exception as exc:  # pragma: no cover — diagnostic only
     warnings.warn(
         f"UniLab is not importable in this environment ({exc!r}); "
@@ -275,6 +275,7 @@ _LANGUAGE_ROOT_INDEX = {
 # instead of bouncing to the language index. Forward direction only — reverse
 # map is computed below.
 _LANGUAGE_PATH_FORWARD: dict[str, str] = {
+    "en/why_unilab": "zh_CN/why_unilab",
     "en/2-user_guide/3-backends/6-drake": "zh_CN/2-user_guide/3-backends/6-drake",
     "en/1-getting_started/5-faq": "zh_CN/1-getting_started/5-faq",
     "en/4-developer_guide/1-architecture/6-manager_based_api": (

--- a/docs/sphinx/source/en/0-index.md
+++ b/docs/sphinx/source/en/0-index.md
@@ -18,7 +18,7 @@ UniLab turns task semantics into reusable configuration: assemble manager terms,
 select a physics backend, and run the same train/eval workflow on the hardware
 available to you. Use this landing page to install, run a first demo, follow it
 with a smoke job, choose an algorithm or backend, or jump into deployment and
-extension docs.
+extension docs. For project fit and alternatives, read {doc}`why_unilab`.
 
 ```{button-ref} 1-getting_started/1-quick_demo
 :ref-type: doc
@@ -165,6 +165,7 @@ committed benchmark manifest or separate recommendation metadata.
 :hidden:
 :caption: Documentation
 
+why_unilab
 1-getting_started/0-index
 2-user_guide/0-index
 3-deployment/0-index

--- a/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
@@ -23,6 +23,24 @@ YAML; do not switch a run by overriding `training.sim_backend` alone.
   `mxpython` when needed. Direct script calls that open the native Motrix
   renderer should use `uv run mxpython`.
 
+## OS and GPU Support
+
+| Backend | Operating system | GPU |
+| --- | --- | --- |
+| MuJoCo | Linux / macOS / Windows | Not required: CPU physics; offline playback can render on CPU |
+| Motrix | Linux / Windows / Apple Silicon macOS | Not required: CPU physics (Rust runtime) |
+| MJWarp | Linux (validated path) | Required: NVIDIA CUDA with an explicit CUDA process device |
+| Genesis | Linux x86_64 | Required: NVIDIA GPU and driver; only the `gs.gpu` channel is validated |
+| Newton | Linux | Required: NVIDIA GPU and CUDA driver; CPU devices are not a validated channel |
+| IsaacGym | Linux x86_64 | Required: NVIDIA GPU and driver; physics runs in a separate Python 3.8 worker |
+| IsaacSim | Linux x86_64 | Required: NVIDIA CUDA; native rendering depends on the RTX driver stack; separate Python 3.11 worker |
+| Drake | Linux x86_64 / Apple Silicon macOS (arm64) | Not required: CPU batch physics; Intel macOS has no official Drake binary |
+
+Backend device requirements are independent of the learner device: CPU-physics
+backends (MuJoCo / Motrix / Drake) can still train with the learner on CUDA,
+ROCm, MPS, or XPU; see the platform profiles in
+{doc}`../../1-getting_started/2-installation`.
+
 ## Select A Backend
 
 UniLab selects the simulator through the task owner config. For normal usage,

--- a/docs/sphinx/source/en/why_unilab.md
+++ b/docs/sphinx/source/en/why_unilab.md
@@ -1,0 +1,105 @@
+# Why UniLab?
+
+Robot reinforcement learning depends on a simulation loop that is both
+faithful enough for the task and fast enough for iteration. That loop is no
+longer one-size-fits-all: locomotion, contact-rich manipulation, deformables,
+and deployment validation can favor different physics solvers. Teams also have
+different hardware—NVIDIA CUDA is important, but it is not the only workstation
+or learner target.
+
+Most RL stacks make the simulator the center of the stack. A change of
+simulator, solver, or worker model then leaks into task code, training commands,
+and experiment infrastructure. UniLab fills a different gap: it keeps the
+robot task and RL workflow stable while the physics implementation and learning
+hardware can change.
+
+> Define the task once. Use the solver and hardware that fit the job.
+
+## Design philosophy
+
+UniLab is built around five commitments.
+
+1. **A stable task-facing surface.** Observations, actions, rewards,
+   terminations, commands, events, and curricula are reusable task components.
+   A backend change should not require a second copy of the task's lifecycle.
+2. **Solver-neutral execution.** A physics implementation may be GPU-resident,
+   CPU/native, or an external worker. It can participate in the same robot-RL
+   workflow without first being rewritten as a CUDA simulator.
+3. **Hardware-neutral learning.** Simulation and learning are separate runtime
+   concerns. The learner can use CUDA, ROCm, MPS, or XPU while the solver uses
+   the execution model appropriate to it. Windows and Apple Silicon macOS are
+   documented targets alongside Linux.
+4. **Evidence before parity claims.** A backend name is not a support promise.
+   The [support matrix](5-reference/5-support_matrix) records whether a
+   backend/task combination is registered, configured, tested, benchmarked, or
+   recommended.
+
+5. **Replay-based off-policy training gets its own acceleration path.** SAC and
+   related methods reuse experience, allowing simulation data collection and
+   learner updates to overlap instead of meeting at every update. UniLab's
+   FastSAC/FlashSAC results report **3–10× end-to-end training-efficiency gains**
+   on representative evaluated configurations; see the [paper](https://arxiv.org/abs/2605.30313)
+   for the hardware, tasks, and measurement scope. This is a runtime
+   optimization, not a new SAC objective.
+
+## Why this boundary matters now
+
+The [NVIDIA Technical Blog on Newton and industrial robotics](https://developer.nvidia.com/blog/newton-adds-contact-rich-manipulation-and-locomotion-capabilities-for-industrial-robotics/)
+describes a Newton + Isaac Lab workflow in which the task definition, PPO loop,
+observations, and rewards stay the same while the simulation backend changes.
+That is an industry example of the task/physics boundary UniLab makes explicit.
+
+The same article shows why the boundary matters: Newton combines rigid-body and
+deformable solvers and couples MuJoCo Warp with VBD/MPM for contact-rich tasks.
+Solver choice is increasingly driven by task fidelity. GPU-resident paths can
+be extremely fast on the right hardware—the article reports 252× locomotion
+and 475× manipulation speedups for MuJoCo Warp versus MJX on an RTX PRO 6000
+Blackwell system—but that does not make CUDA-porting every useful solver a
+prerequisite for robot training.
+
+UniLab is the RL infrastructure/runtime layer above that physics-engine evolution. It
+can connect MuJoCo, Motrix, Newton, or another registered adapter when the
+repository has the corresponding configuration and validation evidence. It
+does not claim that every solver or task combination is already production
+ready.
+
+## Scope
+
+UniLab provides the task, environment, configuration, adapter, and experiment
+workflow for robot RL. Physics engines are supplied by
+[`unisim-core`](https://github.com/unilabsim/unisim); algorithms and asynchronous
+runner components are supplied by
+[`unilab-rl`](https://github.com/unilabsim/unilab_rl). This separation lets a
+robot-specific repository reuse task recipes without taking ownership of every
+physics engine or learner implementation.
+
+UniLab is not a new universal physics engine, a guarantee of cross-backend
+numerical equivalence, or a promise that every platform supports every task.
+For installation details, backend limitations, and contract-level behavior,
+use the linked user and developer guides.
+
+## Comparison
+
+The right choice depends on what you want to keep stable.
+
+| Framework | Primary optimization | Best fit |
+| --- | --- | --- |
+| **UniLab** | Stable task/RL workflow across heterogeneous solvers and hardware | Teams comparing, migrating, or operating more than one physics/runtime path |
+| [mjlab](https://github.com/mujocolab/mjlab) | Lightweight, inspectable MuJoCo Warp with a manager API | MuJoCo users who want the shortest NVIDIA GPU path; cross-simulator portability is intentionally out of scope |
+| [Isaac Lab](https://github.com/isaac-sim/IsaacLab) | Comprehensive manager-based robotics stack and Isaac ecosystem | Projects that need Isaac Sim, Omniverse, or its integrated tooling |
+| [Newton](https://github.com/newton-physics/newton) | GPU physics platform with multiple rigid/deformable solvers and OpenUSD | Projects that need Newton's solver composition, contact models, or differentiable simulation |
+| [MuJoCo Playground](https://playground.mujoco.org/) | Minimal abstractions and quick experiments | One-off prototypes and environments authored close to the simulator |
+
+UniLab is a good fit when the simulator is an engineering decision that may
+change. mjlab or MuJoCo Playground may be a better fit when MuJoCo itself is the
+fixed simulator choice. Newton or Isaac Lab may be the better starting point when
+their physics and ecosystem are the primary requirement. UniLab can sit above
+those choices when a validated adapter and task owner are available.
+
+## Start with evidence
+
+- [Run the first demo](1-getting_started/1-quick_demo)
+- [Choose a backend](2-user_guide/3-backends/0-index)
+- [Read the support matrix](5-reference/5-support_matrix)
+- [Learn the manager-based API](4-developer_guide/1-architecture/6-manager_based_api)
+- [Follow the sim-to-sim guide](3-deployment/2-sim_to_sim/1-backend_swap)

--- a/docs/sphinx/source/zh_CN/0-index.md
+++ b/docs/sphinx/source/zh_CN/0-index.md
@@ -16,7 +16,8 @@ sd_hide_title: true
 
 UniLab 将任务语义变成可复用配置：组装 manager term、选择物理后端，并在手头的硬件
 上运行同一套训练/评估工作流。可以从这个着陆页开始：安装、运行第一次 demo、再做
-冒烟训练、选择算法/后端，或直接跳到部署与扩展文档。
+冒烟训练、选择算法/后端，或直接跳到部署与扩展文档。关于项目适用场景和替代方案，
+请阅读 {doc}`why_unilab`。
 
 ```{button-ref} 1-getting_started/1-quick_demo
 :ref-type: doc
@@ -157,6 +158,7 @@ recommendation 元数据。
 :hidden:
 :caption: 文档
 
+why_unilab
 1-getting_started/0-index
 2-user_guide/0-index
 3-deployment/0-index

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
@@ -22,6 +22,24 @@ UniLab 通过 registry/config 路径暴露后端名称，包括在对应 owner �
 - 在 macOS 上，软件包 CLI 在需要时会通过 `mxpython` 路由 Motrix 交互式回放。
   直接打开原生 Motrix 渲染器的脚本调用应使用 `uv run mxpython`。
 
+## 操作系统与 GPU
+
+| 后端 | 操作系统 | GPU |
+| --- | --- | --- |
+| MuJoCo | Linux / macOS / Windows | 非必需：CPU 物理，离线回放可纯 CPU 渲染 |
+| Motrix | Linux / Windows / Apple Silicon macOS | 非必需：CPU 物理（Rust runtime） |
+| MJWarp | Linux（已验证路径） | 必需：NVIDIA CUDA，且需显式 CUDA process device |
+| Genesis | Linux x86_64 | 必需：NVIDIA GPU 与驱动；仅 `gs.gpu` 通道经过验证 |
+| Newton | Linux | 必需：NVIDIA GPU 与 CUDA 驱动；CPU 设备不是已验证通道 |
+| IsaacGym | Linux x86_64 | 必需：NVIDIA GPU 与驱动；物理跑在独立 Python 3.8 worker |
+| IsaacSim | Linux x86_64 | 必需：NVIDIA CUDA；原生渲染器依赖 RTX 驱动栈；独立 Python 3.11 worker |
+| Drake | Linux x86_64 / Apple Silicon macOS（arm64） | 非必需：CPU 批量物理；Intel macOS 没有官方 Drake 二进制 |
+
+物理后端的设备需求与 learner 设备相互独立：CPU 物理后端（MuJoCo /
+Motrix / Drake）同样可以把 learner 放到 CUDA、ROCm、MPS 或 XPU 上，平台
+对应的 torch 配置档见
+{doc}`../../1-getting_started/2-installation`。
+
 ## 选择后端
 
 UniLab 通过 task owner config 选择仿真器。常规用法下，使用 `--task` 和 `--sim`

--- a/docs/sphinx/source/zh_CN/why_unilab.md
+++ b/docs/sphinx/source/zh_CN/why_unilab.md
@@ -1,0 +1,84 @@
+# 为什么选择 UniLab？
+
+机器人强化学习依赖一条既足够忠实、又足够高效的仿真闭环。如今这条闭环已经不是
+“一种方案适用所有任务”：运动控制、接触丰富的操作、可变形物体和部署验证，可能
+需要不同的物理 solver。团队的硬件也各不相同——NVIDIA CUDA 很重要，但并不是唯一
+的工作站或 learner 目标。
+
+多数 RL stack 把 simulator 作为 stack 中心。一旦更换 simulator、solver 或 worker 模型，
+变化就会蔓延到任务代码、训练命令和实验基础设施。UniLab 填补的是另一个空白：让
+机器人任务和 RL 工作流保持稳定，同时允许更换物理实现和学习硬件。
+
+> 任务定义一次，使用适合工作的 solver 和硬件。
+
+## 设计承诺
+
+UniLab 围绕五项承诺构建：
+
+1. **稳定的面向任务界面。** observation、action、reward、termination、command、
+   event 和 curriculum 都是可复用的任务组件。更换后端不应要求复制一套任务生命周期。
+2. **solver 无关的执行方式。** 物理实现可以驻留 GPU、运行在 CPU/native，或作为
+   external worker；无需先重写成 CUDA simulator，就能参与同一套机器人 RL 工作流。
+3. **与硬件解耦的学习过程。** 仿真和学习是分开的 runtime 关注点。learner 可以使用
+   CUDA、ROCm、MPS 或 XPU，而 solver 使用适合自己的执行模型。除 Linux 外，Windows
+   和 Apple Silicon macOS 也有文档化路径。
+4. **先有证据，再谈一致性。** backend 名称本身不是支持承诺。[支持矩阵](5-reference/5-support_matrix)
+   记录每个 backend/task 组合属于 registered、configured、tested、benchmarked 还是
+   recommended。
+5. **为 replay-based off-policy 训练提供专门的加速路径。** SAC 及相关方法可以复用
+   历史经验，使仿真数据采集与 learner update 能够重叠，而不必在每次更新时汇合。UniLab
+   的 FastSAC/FlashSAC 在代表性评估配置上报告了 **3–10 倍端到端训练效率提升**；硬件、
+   任务和测量范围请参阅[论文](https://arxiv.org/abs/2605.30313)。这是 runtime 优化，
+   不是新的 SAC objective。
+
+## 为什么现在需要这样的边界
+
+[NVIDIA 关于 Newton 与工业机器人](https://developer.nvidia.com/blog/newton-adds-contact-rich-manipulation-and-locomotion-capabilities-for-industrial-robotics/)
+的技术博客描述了 Newton + Isaac Lab 的流程：替换 simulation backend 时，task 定义、
+PPO loop、observation 和 reward 保持不变。这是行业中对“任务/物理边界”的一个实例，
+也说明这不是 UniLab 的自定义偏好。
+
+同一篇文章还展示了为什么需要这条边界：Newton 组合刚体与可变形 solver，并将 MuJoCo
+Warp 与 VBD/MPM 耦合，用于接触丰富的任务。solver 选择越来越由任务保真度驱动。GPU
+驻留路径在合适硬件上可以非常快——文章报告 MuJoCo Warp 在 RTX PRO 6000 Blackwell
+上相对 MJX 达到 locomotion 252 倍、manipulation 475 倍加速——但这不意味着每个有用
+的 solver 都必须先 CUDA 化，机器人训练才能使用。
+
+UniLab 是位于 physics engine 演进之上的 RL 基础设施/runtime 层。当仓库具备对应配置和
+验证证据时，它可以连接 MuJoCo、Motrix、Newton 或其他注册 adapter。UniLab 不声称
+每个 solver 或 task 组合都已经达到生产就绪。
+
+## 范围
+
+UniLab 提供机器人 RL 所需的 task、environment、配置、adapter 和实验工作流。物理引擎
+由 [`unisim-core`](https://github.com/unilabsim/unisim) 提供；算法和异步 runner 组件由
+[`unilab-rl`](https://github.com/unilabsim/unilab_rl) 提供。这样的分工让机器人专属仓库
+可以复用任务 recipe，而不必同时维护所有物理引擎和 learner 实现。
+
+UniLab 不是新的通用 physics engine，不保证跨后端数值等价，也不承诺每个平台都支持每个
+task。安装细节、后端限制和 contract 行为请使用对应的用户指南与开发者指南。
+
+## 对比
+
+选择哪种方案，取决于你希望什么保持稳定：
+
+| 框架 | 主要优化目标 | 更适合 |
+| --- | --- | --- |
+| **UniLab** | 在异构 solver 和硬件之间保持稳定的 task/RL 工作流 | 需要比较、迁移或长期维护多种物理/runtime 路径的团队 |
+| [mjlab](https://github.com/mujocolab/mjlab) | 轻量、可检查的 MuJoCo Warp 与 manager API | 想要最短 NVIDIA GPU 路径的 MuJoCo 用户；跨 simulator 可移植性是明确的非目标 |
+| [Isaac Lab](https://github.com/isaac-sim/IsaacLab) | 完整的 manager-based 机器人 stack 与 Isaac 生态 | 需要 Isaac Sim、Omniverse 或其集成工具链的项目 |
+| [Newton](https://github.com/newton-physics/newton) | 基于 GPU、支持多刚体/可变形 solver 和 OpenUSD 的物理平台 | 需要 Newton solver 组合、contact model 或可微分仿真的项目 |
+| [MuJoCo Playground](https://playground.mujoco.org/) | 最少抽象和快速实验 | 一次性原型，以及希望贴近 simulator 编写环境的项目 |
+
+当 simulator 是可能变化的工程决策时，UniLab 更合适。如果 MuJoCo 本身就是固定的仿真器
+选择，mjlab 或 MuJoCo Playground 可能更直接。如果首要需求是 Newton 或 Isaac Lab 的
+物理和生态，则应从它们开始；当存在经过验证的 adapter 与 task owner 时，UniLab 可以
+位于这些选择之上。
+
+## 从证据开始
+
+- [运行第一次 demo](1-getting_started/1-quick_demo)
+- [选择物理后端](2-user_guide/3-backends/0-index)
+- [查看支持矩阵](5-reference/5-support_matrix)
+- [学习 manager-based API](4-developer_guide/1-architecture/6-manager_based_api)
+- [阅读 sim-to-sim 指南](3-deployment/2-sim_to_sim/1-backend_swap)

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "unilab"
-version = "1.0.0"
+version = "1.1.0"
 description = "Universal Lab for Robot Learning"
 readme = "README.md"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
     # unisim-core package from the production PyPI index.
-    "unisim-core>=1.1.1",
+    "unisim-core>=1.1.3",
     # RL algorithms and async runtimes live in the independently released
     # uni-rl package (distribution name ``unilab-rl``); see pyproject.toml.
     "unilab-rl==0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ source-exclude = [
 
 [project]
 name = "unilab"
-version = "1.0.0"
+version = "1.1.0"
 description = "Configurable, contract-driven robot learning across physics backends"
 readme = "README.md"
 license = "Apache-2.0"
@@ -43,7 +43,7 @@ dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
     # unisim-core package from the production PyPI index.
-    "unisim-core>=1.1.2",
+    "unisim-core>=1.1.3",
     # RL algorithms and async runtimes (PPO/APPO/SAC/TD3/HORA runners,
     # collectors, IPC, logging) live in the independently released uni-rl
     # package (distribution name ``unilab-rl``), consumed via the injected

--- a/uv.lock
+++ b/uv.lock
@@ -4996,7 +4996,7 @@ wheels = [
 
 [[package]]
 name = "unilab"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5119,7 +5119,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
     { name = "unilab-rl", specifier = "==1.0.0" },
-    { name = "unisim-core", specifier = ">=1.1.2" },
+    { name = "unisim-core", specifier = ">=1.1.3" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = "==1.16.0" },
@@ -5163,13 +5163,13 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "1.1.2"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/2d/f51ec524c1e414415abeff128396831612b16e93dc5d58e63e858430a82a/unisim_core-1.1.2.tar.gz", hash = "sha256:b6021cf79abcd3cc7fcbf5e23be70bf204fd21d9540af047557d724b7e0acab8", size = 214913, upload-time = "2026-09-06T08:11:42.756Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/00/a3cd085e53e296f9866ba480d4839da1ed5609d48de9de47abd12ef6e17a/unisim_core-1.1.3.tar.gz", hash = "sha256:513cce7de986b3dfbe9f6bb50ca1dc675174f72173a22d2c801ad066cdd42a88", size = 215793, upload-time = "2026-09-06T09:59:39.934Z" }
 
 [[package]]
 name = "urllib3"

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3710,7 +3710,7 @@ wheels = [
 
 [[package]]
 name = "unilab"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3802,7 +3802,7 @@ requires-dist = [
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
     { name = "typing-extensions" },
     { name = "unilab-rl", specifier = "==0.2.0" },
-    { name = "unisim-core", specifier = ">=1.1.1" },
+    { name = "unisim-core", specifier = ">=1.1.3" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "wheel", marker = "extra == 'mujoco'" },
@@ -3843,13 +3843,13 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "1.1.1"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/43/e6bf70eccd780c8c3622e136f90f20a7075fbe027d24ab040c1fb247f36b/unisim_core-1.1.1.tar.gz", hash = "sha256:f10de8083a27cebe95dba5ec26be02de209cff05bb919b028ba9fd58d0f12188", size = 214991, upload-time = "2026-09-06T07:25:50.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/00/a3cd085e53e296f9866ba480d4839da1ed5609d48de9de47abd12ef6e17a/unisim_core-1.1.3.tar.gz", hash = "sha256:513cce7de986b3dfbe9f6bb50ca1dc675174f72173a22d2c801ad066cdd42a88", size = 215793, upload-time = "2026-09-06T09:59:39.934Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## 内容

将 unilab 1.1.0 发布内容合回 main（tag `v1.1.0` 已从本分支 head 发布到 PyPI）：

- `pyproject.toml` / `pyproject.rocm.toml` 版本 bump 至 1.1.0，`unisim-core>=1.1.3`，同步 `uv.lock` / `uv.rocm.lock`
- changelog 增加 1.1.0 双语条目
- README / README_zh 精简，文档指向后端指南与支持矩阵
- 新增 why_unilab 双语页（含 `_LANGUAGE_PATH_FORWARD` 映射）
- 后端索引页新增操作系统与 GPU 支持表格（en + zh_CN）

## Validation

- `make test-all` 于最终 head `f2a09b03` 本地通过（含 benchmark entrypoint smoke，仅 mlx 平台可选项跳过）
- `uv build` 通过：`unilab-1.1.0.tar.gz` / `unilab-1.1.0-py3-none-any.whl`
- 远程 CI：ci.yml run [34028487779](https://github.com/Motphys/UniLab/actions/runs/34028487779) 在 head `f2a09b03` 上 `success`（workflow_dispatch，release gate 前置）
- release run [34028748704](https://github.com/Motphys/UniLab/actions/runs/34028748704) 两个 job 均 `success`，PyPI 已上架 `unilab==1.1.0`