### PR TITLE
feat(superdex): integrate FR3 and Go2 research task owners

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -277,6 +277,7 @@ _LANGUAGE_ROOT_INDEX = {
 _LANGUAGE_PATH_FORWARD: dict[str, str] = {
     "en/why_unilab": "zh_CN/why_unilab",
     "en/2-user_guide/3-backends/6-drake": "zh_CN/2-user_guide/3-backends/6-drake",
+    "en/2-user_guide/3-backends/8-superdex": "zh_CN/2-user_guide/3-backends/8-superdex",
     "en/1-getting_started/5-faq": "zh_CN/1-getting_started/5-faq",
     "en/4-developer_guide/1-architecture/6-manager_based_api": (
         "zh_CN/4-developer_guide/1-architecture/6-manager_based_api"

--- a/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/0-index.md
@@ -1,7 +1,7 @@
 # Simulation Backends
 
 UniLab exposes backend names through registry/config paths, including `mujoco`,
-`motrix`, `mjwarp`, `drake`, `isaacgym`, `genesis`, `isaacsim`, and `newton`
+`motrix`, `mjwarp`, `drake`, `isaacgym`, `genesis`, `isaacsim`, `newton`, and `superdex`
 where an owner is registered.
 User commands select them with `--sim`, which routes to the matching task owner
 YAML; do not switch a run by overriding `training.sim_backend` alone.
@@ -146,4 +146,5 @@ separately authorized issue.
 5-genesis
 6-drake
 7-newton
+8-superdex
 ```

--- a/docs/sphinx/source/en/2-user_guide/3-backends/8-superdex.md
+++ b/docs/sphinx/source/en/2-user_guide/3-backends/8-superdex.md
@@ -1,0 +1,115 @@
+# SuperDex Backend
+
+SuperDex is an optional CPU physics adapter owned by `unisim.backend.superdex`.
+The initial UniLab owner is the fixed-base `FR3JointTarget` task:
+`src/unilab/conf/ppo/task/fr3_joint_target/superdex.yaml`. It uses seven torque
+actions, 21 observation values, joint-state resets and the standard NumPy
+manager runtime. Its support level is **Configured**; bounded rollout or short
+training checks do not establish full-training performance or platform support.
+The implementation is tracked in [#1534](https://github.com/Motphys/UniLab/issues/1534)
+under [roadmap #1533](https://github.com/Motphys/UniLab/issues/1533).
+
+## Local Development Setup
+
+This development profile uses locally linked UniSim and UniLab checkouts; it
+does not require a new published version. SuperDex Physics/Robotics 1.0.0 requires
+Python 3.12. CPU physics does not require CUDA. Native rendering and video are
+not part of the FR3 owner; training defaults to `no_play=true`.
+
+In the UniLab checkout, use an existing Python 3.12 virtual environment or create
+one, then install the local packages:
+
+```bash
+uv venv --python 3.12
+export UNILAB_LOCAL_UNISIM=/absolute/path/to/unisim
+uv pip install -e "${UNILAB_LOCAL_UNISIM}[superdex,mujoco]" -e . --group pyproject.toml:dev
+export UV_NO_SYNC=1
+export SUPERDEX_ASSETS_PATH=/absolute/path/to/project_superdex/assets
+```
+
+`UNILAB_LOCAL_UNISIM` enables the repository's local dependency validation:
+tests require an editable installation and check that its metadata and imported
+module point to exactly that checkout. Without this variable, the normal
+indexed-release requirement remains in force. `UV_NO_SYNC=1` preserves the local
+links when running existing Make targets; `uv sync` would re-resolve the locked
+release profile.
+
+Native FR3 assets remain in the upstream SuperDex checkout. The asset hub
+registers `bots/arms/fr3_v2/fr3_v2.superdex_bot`, checking its collision SDF,
+render files, `LICENSE` and `NOTICE` before constructing physics. No native
+robot binaries are bundled or downloaded by UniLab. Set
+`env.superdex_assets_root=/absolute/path/to/project_superdex/assets` to override
+`SUPERDEX_ASSETS_PATH` for a specific owner invocation.
+
+## Run the FR3 Task
+
+```bash
+uv run --no-sync train --algo ppo --task fr3_joint_target --sim superdex \
+  algo.max_iterations=2 algo.num_steps_per_env=16 \
+  algo.algorithm.num_learning_epochs=1
+```
+
+The target joint positions, rewards, reset ranges and action scales live in the
+task's `base.yaml`. The torque bounds `[20,20,20,20,5,5,5]` Nm are an explicit
+research profile, not rated hardware limits. `superdex_effort_limits` declares
+the same bounds at the native backend boundary. `superdex_num_threads=0` uses
+serial physics; thread count is process-wide, so simultaneous backend instances
+must agree. Existing spawned collectors own process parallelism.
+
+The fixed root still has a named entity and readable body state. Reset terms
+write joint state; they do not request a floating-root layout. The task does
+not require contact sensors, cameras, site Jacobians or runtime material DR.
+Selecting playback mode `none` skips playback entirely; it is not evidence that
+a checkpoint has executed a rollout.
+
+`superdex_allow_contact_approximation` defaults to `false`. It is reserved for
+explicitly audited MJCF conversion profiles: enabling it accepts a warning about
+contact/material approximation, including missing torsional/rolling friction
+equivalence. It does not establish arbitrary MJCF task compatibility.
+Contact queries report the last completed solver step. Reset clears this state;
+it does not provide a fresh geometric overlap test until a positive physics step
+has completed. Kinematic body/joint getters are refreshed immediately at reset.
+
+## Validation and Ownership
+
+The `go2_joystick_flat/superdex` PPO owner is a research sim2sim profile. It
+inherits the MuJoCo owner, preserving 49 actor observations, 52 critic
+observations, 12 position-target actions, normalization, network dimensions and
+control timing. It disables runtime PD gain randomization and explicitly opts
+into contact approximation. The adapter's cold-path MJCF conversion is restricted;
+this owner does not imply arbitrary scene support or equivalent walking behavior.
+
+Create a small source checkpoint with the MuJoCo owner, then pass its path to the
+optional checkpoint test:
+
+```bash
+uv run --no-sync train --algo ppo --task go2_joystick_flat --sim mujoco \
+  algo.num_envs=2 algo.max_iterations=2 algo.num_steps_per_env=16 \
+  algo.algorithm.num_mini_batches=1 algo.algorithm.num_learning_epochs=1 \
+  training.device=cpu training.no_play=true
+export UNILAB_SUPERDEX_GO2_CHECKPOINT=/absolute/path/to/source/run/model_1.pt
+uv run --no-sync pytest tests/envs/test_go2_superdex.py -q
+```
+
+This validates the source `run_config.json` before environment construction,
+checks rejection of changed policy action semantics, loads the actual policy
+through the production playback session and executes 64 SuperDex control steps
+without a renderer. It checks finite values and interface compatibility; a
+two-iteration checkpoint is not expected to walk reliably.
+
+```bash
+uv run --no-sync pytest tests/assets/test_superdex_assets.py \
+  tests/envs/test_fr3_superdex.py tests/test_cli_runtime_requirements.py -q
+```
+
+The optional native tests require the SDK and `SUPERDEX_ASSETS_PATH`; they cover
+finite rollout data, selected reset isolation, immediate observation refresh
+and a spawned `EnvFactory`. Missing runtime/assets produce an explicit skip;
+such a run is not native validation. The base asset/config tests need no native
+asset checkout.
+
+Engine conversion and physics live in UniSim; asset registration, Hydra and task
+terms remain in UniLab. See
+{doc}`/adr/ADR-0007-unisim-extraction-boundary`,
+{doc}`/adr/ADR-0006-community-manager-api-on-numpy-runtime` and
+{doc}`/adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot`.

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/0-index.md
@@ -2,7 +2,7 @@
 
 UniLab 通过 registry/config 路径暴露后端名称，包括在对应 owner 注册后可用的
 `mujoco`、`motrix`、`mjwarp`、`drake`、`isaacgym`、`genesis`、`isaacsim` 和
-`newton`。用户命令通过
+`newton`、`superdex`。用户命令通过
 `--sim` 选择后端，该选项会路由到对应的 task owner YAML；不要仅靠 override
 `training.sim_backend` 来切换一次运行。
 
@@ -137,4 +137,5 @@ benchmark v1 目前只保留 `BenchmarkCase`、`BenchmarkResult` 和 provenance 
 5-genesis
 6-drake
 7-newton
+8-superdex
 ```

--- a/docs/sphinx/source/zh_CN/2-user_guide/3-backends/8-superdex.md
+++ b/docs/sphinx/source/zh_CN/2-user_guide/3-backends/8-superdex.md
@@ -1,0 +1,95 @@
+# SuperDex 后端
+
+SuperDex 是由 `unisim.backend.superdex` 拥有的可选 CPU 物理后端。UniLab 首个
+owner 为固定基 `FR3JointTarget`，配置位于
+`src/unilab/conf/ppo/task/fr3_joint_target/superdex.yaml`。任务使用 7 维力矩动作、
+21 维观测、关节状态 reset 和标准 NumPy manager。当前支持等级为 **Configured**；
+短 rollout 或少量训练迭代不能证明完整训练效果、性能或跨平台支持。
+实施见 [#1534](https://github.com/Motphys/UniLab/issues/1534)，所属
+roadmap 为 [#1533](https://github.com/Motphys/UniLab/issues/1533)。
+
+## 本地开发安装
+
+该开发配置使用本地链接的 UniSim 与 UniLab，不要求发布新版本。SuperDex
+Physics/Robotics 1.0.0 要求 Python 3.12；CPU 物理不需要 CUDA。FR3 owner 暂不包含
+原生渲染和视频，默认 `no_play=true`。
+
+在 UniLab checkout 中使用已有的 Python 3.12 环境，或创建环境后安装本地包：
+
+```bash
+uv venv --python 3.12
+export UNILAB_LOCAL_UNISIM=/absolute/path/to/unisim
+uv pip install -e "${UNILAB_LOCAL_UNISIM}[superdex,mujoco]" -e . --group pyproject.toml:dev
+export UV_NO_SYNC=1
+export SUPERDEX_ASSETS_PATH=/absolute/path/to/project_superdex/assets
+```
+
+`UNILAB_LOCAL_UNISIM` 启用严格的本地依赖验证：测试同时检查 editable 安装元数据
+和实际 import 路径确实指向指定 checkout。不设置时保留正常的索引发布包检查。
+`UV_NO_SYNC=1` 让现有 Make 目标保留本地链接；`uv sync` 会重新解析锁定的发布依赖。
+
+FR3 原生资产保留在上游 checkout。asset hub 注册
+`bots/arms/fr3_v2/fr3_v2.superdex_bot`，在物理构造前验证 collision SDF、render、
+`LICENSE` 和 `NOTICE`。UniLab 不打包或下载这些二进制。单次运行可通过
+`env.superdex_assets_root=/absolute/path/to/project_superdex/assets` 覆盖环境变量。
+
+## 运行 FR3 任务
+
+```bash
+uv run --no-sync train --algo ppo --task fr3_joint_target --sim superdex \
+  algo.max_iterations=2 algo.num_steps_per_env=16 \
+  algo.algorithm.num_learning_epochs=1
+```
+
+目标关节角、reward、reset 范围和动作缩放由任务 `base.yaml` 声明。力矩上限
+`[20,20,20,20,5,5,5]` Nm 是显式研究配置，不是硬件额定值；
+`superdex_effort_limits` 在 native backend 边界声明同样的上限。
+`superdex_num_threads=0` 使用串行物理；线程数是进程级设置，同进程多个 backend
+实例必须一致。进程并行仍由现有 spawn collector 拥有。
+
+固定根具有名称和可读的 body state，但 reset 只写 joint state，不要求 free-root
+layout。该任务不需要接触 sensor、相机、site Jacobian 或材料 DR。
+`play_render_mode=none` 会完全跳过回放，不能作为 checkpoint rollout 已执行的证据。
+
+`superdex_allow_contact_approximation` 默认 `false`，只供经过审核的 MJCF 转换配置
+显式启用。启用后会警告 contact/material 近似，包括 torsional/rolling friction
+不等价；这不代表任意 MJCF 任务已兼容。
+接触查询返回最近一次完成求解的结果。reset 清除该结果，需要一次正时间步才会
+产生新接触，不能把 reset 后的 contact 当成即时几何重叠测试。运动学 body/joint
+getter 则在 reset 后立即刷新。
+
+## 验证与归属
+
+`go2_joystick_flat/superdex` PPO owner 是研究性质的 sim2sim 配置。它继承 MuJoCo
+owner，保留 49 维 actor 观测、52 维 critic 观测、12 维位置目标动作、归一化、网络
+维度和控制时序；关闭 runtime PD gain DR，并显式接受接触近似。adapter 的冷路径
+MJCF 转换有明确限制，该 owner 不代表任意场景或行走效果等价。
+
+先用 MuJoCo owner 创建一个小型来源 checkpoint，再把路径传给可选 checkpoint 测试：
+
+```bash
+uv run --no-sync train --algo ppo --task go2_joystick_flat --sim mujoco \
+  algo.num_envs=2 algo.max_iterations=2 algo.num_steps_per_env=16 \
+  algo.algorithm.num_mini_batches=1 algo.algorithm.num_learning_epochs=1 \
+  training.device=cpu training.no_play=true
+export UNILAB_SUPERDEX_GO2_CHECKPOINT=/absolute/path/to/source/run/model_1.pt
+uv run --no-sync pytest tests/envs/test_go2_superdex.py -q
+```
+
+测试在构造 env 前验证来源 `run_config.json`，检查修改动作语义时确实拒绝，随后
+通过 production playback session 加载真实策略，无渲染执行 64 个 SuperDex 控制步。
+它验证有限数值和接口兼容性；只训练两轮的 checkpoint 不以可靠行走为验收标准。
+
+```bash
+uv run --no-sync pytest tests/assets/test_superdex_assets.py \
+  tests/envs/test_fr3_superdex.py tests/test_cli_runtime_requirements.py -q
+```
+
+原生测试要求 SDK 和 `SUPERDEX_ASSETS_PATH`，覆盖有限数值 rollout、局部 reset
+隔离、即时观测刷新及 spawn `EnvFactory`。缺失 SDK/资产会明确 skip，不能将 skip
+记为原生验证通过。基础资产和配置测试不依赖原生资产 checkout。
+
+引擎转换与物理由 UniSim 拥有；资产注册、Hydra 与任务 term 由 UniLab 拥有。
+相关约束见 {doc}`/adr/ADR-0007-unisim-extraction-boundary`、
+{doc}`/adr/ADR-0006-community-manager-api-on-numpy-runtime` 和
+{doc}`/adr/ADR-0002-backend-capability-boundary-for-play-and-snapshot`。

--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -59,77 +59,79 @@ uv run scripts/generate_support_matrix.py --write
 
 ### Entrypoint x Task Owner
 
-| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym | Genesis | IsaacSim | Newton |
-|------------|------------|--------|--------|--------|----------|---------|----------|--------|
-| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Configured | Configured | Configured | Configured |
-| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - | - | - | - | - |
-| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Registered | - | - | - | - |
-| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested | - | - | - | - |
-| PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Registered | Registered | Registered | Registered |
-| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - | - | - | - |
-| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - | - | - | - |
-| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - | - | - | - |
-| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Tested | Tested | Configured | Tested |
-| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested | - | - | - | - |
-| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested | - | - | - | - |
-| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered | - | - | - | - |
-| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered | - | - | - | - |
-| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered | - | - | - | - |
-| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - |
-| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - |
-| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Tested | - | - | - | - |
-| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Registered | - | - | - | - |
-| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | - | Registered | - | - | - | - |
-| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | - | Registered | - | - | - | - |
-| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | - | Tested | - | - | - | - |
-| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | - | Tested | - | - | - | - |
-| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Registered | Registered | Registered | Registered |
-| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - | - | - | - |
-| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Registered | - | - | - | - |
-| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested | Registered | Registered | Registered | Registered |
-| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - |
+| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym | Genesis | IsaacSim | Newton | SuperDex |
+|------------|------------|--------|--------|--------|----------|---------|----------|--------|----------|
+| PPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - | - | - | - | Configured |
+| PPO (torch) | `go2_joystick_rough` (Go2 joystick rough) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Configured | Configured | Configured | Configured | - |
+| PPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `x2_wall_flip_tracking` (X2 wall flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `sharpa_inhand_grasp` (Sharpa in-hand grasp) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - | - | - | - | - | - |
+| PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `fr3_joint_target` (fr3 joint target) | - | - | - | - | - | - | - | Configured |
+| PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_motion_tracking_deploy` (g1 23dof motion tracking deploy) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Registered | - | - | - | - | - |
+| PPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_box_tracking` (g1 box tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `g1_motion_tracking_deploy` (g1 motion tracking deploy) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go1_joystick_rough` (go1 joystick rough) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go2_arm_manip_loco` (go2 arm manip loco) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go2_footstand` (go2 footstand) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go2w_joystick_flat` (go2w joystick flat) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `go2w_joystick_rough` (go2w joystick rough) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `stewart_balance` (stewart balance) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `go1_joystick_flat` (Go1 joystick) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Tested | - | - | - | - | Registered |
+| APPO (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Registered | Registered | Registered | Registered | - |
+| APPO (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `sharpa_inhand` (Sharpa in-hand) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - | - | - | - | - |
+| APPO (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Tested | - | - | - | - | - |
+| APPO (torch) | `g1_climb_tracking` (g1 climb tracking) | Tested | - | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Tested | Tested | Tested | Tested | Configured | Tested | - |
+| SAC (torch) | `g1_walk_rough` (G1 walk rough) | Tested | - | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_motion_tracking` (G1 motion tracking) | Tested | Configured | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_flip_tracking` (G1 flip tracking) | Tested | - | Registered | - | - | - | - | - |
+| SAC (torch) | `g1_wall_flip_tracking` (G1 wall flip tracking) | Tested | - | Registered | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_flip_tracking` (g1 23dof flip tracking) | Tested | - | Registered | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_motion_tracking` (g1 23dof motion tracking) | Tested | - | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_walk_rough` (g1 23dof walk rough) | Tested | - | Tested | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_wall_flip_tracking` (g1 23dof wall flip tracking) | Tested | - | Registered | - | - | - | - | - |
+| SAC (torch) | `g1_23dof_wbt_obs` (g1 23dof wbt obs) | Tested | - | Registered | - | - | - | - | - |
+| SAC (torch) | `g1_wbt_obs` (g1 wbt obs) | Tested | - | Registered | - | - | - | - | - |
+| TD3 (torch) | `go1_joystick_flat` (Go1 joystick) | Registered | - | Tested | - | - | - | - | - |
+| TD3 (torch) | `go2_joystick_flat` (Go2 joystick) | Registered | - | Tested | - | - | - | - | Registered |
+| TD3 (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Registered | Registered | Registered | Registered | Registered | Registered | - |
+| TD3 (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Registered | - | - | - | - | - |
+| FlashSAC (torch) | `go2_joystick_flat` (Go2 joystick) | Tested | - | Registered | - | - | - | - | Registered |
+| FlashSAC (torch) | `g1_walk_flat` (G1 walk flat) | Tested | Configured | Tested | Registered | Registered | Registered | Registered | - |
+| FlashSAC (torch) | `g1_23dof_walk_flat` (g1 23dof walk flat) | Tested | - | Tested | - | - | - | - | - |
 
 ### Source Index
 
 - Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.base.registry.ensure_registries()`.
 - Owner YAML scan: `src/unilab/conf/ppo/task/**`, `src/unilab/conf/appo/task/**`, `src/unilab/conf/sac/task/**`, `src/unilab/conf/td3/task/**`, `src/unilab/conf/flashsac/task/**`.
 - Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.
+- SuperDex remains `Configured`: FR3 has optional CPU rollout/spawn coverage in `tests/envs/test_fr3_superdex.py`; the Go2 research profile has policy-contract/rollout/checkpoint coverage in `tests/envs/test_go2_superdex.py`. Neither profile claims full-training performance or cross-platform support.
 - Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.
 - Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (real hardware via the external Python 3.8 worker runtime; not covered by repo CI).
 - Validated genesis entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_GENESIS_ENTRYPOINT_TASKS` (real hardware, genesis-world extra + CUDA; not covered by repo CI); near-risk coverage lives in `tests/base/test_genesis_backend.py` (fake runtime), `tests/base/test_genesis_runtime.py` (real-runtime slow lane), and the genesis env smoke in `tests/envs/locomotion/g1/test_g1_owner_contract.py`.

--- a/scripts/audit_sim2sim_contracts.py
+++ b/scripts/audit_sim2sim_contracts.py
@@ -41,6 +41,7 @@ CONTRACT_PAIRS: tuple[tuple[str, str], ...] = (
     ("mujoco", "genesis"),
     ("mujoco", "isaacsim"),
     ("mujoco", "newton"),
+    ("mujoco", "superdex"),
 )
 
 

--- a/scripts/tools/support_matrix.py
+++ b/scripts/tools/support_matrix.py
@@ -22,6 +22,7 @@ BACKENDS: tuple[str, ...] = (
     "genesis",
     "isaacsim",
     "newton",
+    "superdex",
 )
 
 # Maintainer-confirmed completed training validations. Keep this mapping narrow:
@@ -249,6 +250,9 @@ def _configured_entries(root: Path, spec: EntrypointSpec) -> dict[str, dict[str,
 
 
 def _is_tested(spec: EntrypointSpec, task_slug: str, backend: str, root: Path) -> bool:
+    if backend == "superdex":
+        # Bounded native smoke/short training does not establish full training support.
+        return False
     if backend == "mjwarp":
         return (
             spec.entrypoint_id,
@@ -411,8 +415,8 @@ def render_support_matrix(root: Path | None = None) -> str:
         "",
         "### Entrypoint x Task Owner",
         "",
-        "| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym | Genesis | IsaacSim | Newton |",
-        "|------------|------------|--------|--------|--------|----------|---------|----------|--------|",
+        "| Entrypoint | Task owner | MuJoCo | mjwarp | Motrix | IsaacGym | Genesis | IsaacSim | Newton | SuperDex |",
+        "|------------|------------|--------|--------|--------|----------|---------|----------|--------|----------|",
     ]
 
     for row in build_support_rows(resolved_root):
@@ -421,7 +425,7 @@ def render_support_matrix(root: Path | None = None) -> str:
             f"{row.cells['mujoco'].level.label} | {row.cells['mjwarp'].level.label} | "
             f"{row.cells['motrix'].level.label} | {row.cells['isaacgym'].level.label} | "
             f"{row.cells['genesis'].level.label} | {row.cells['isaacsim'].level.label} |"
-            f" {row.cells['newton'].level.label} |"
+            f" {row.cells['newton'].level.label} | {row.cells['superdex'].level.label} |"
         )
 
     lines.extend(
@@ -432,6 +436,7 @@ def render_support_matrix(root: Path | None = None) -> str:
             "- Registry bootstrap: `src/unilab/envs/**` decorators via `unilab.base.registry.ensure_registries()`.",
             "- Owner YAML scan: `src/unilab/conf/ppo/task/**`, `src/unilab/conf/appo/task/**`, `src/unilab/conf/sac/task/**`, `src/unilab/conf/td3/task/**`, `src/unilab/conf/flashsac/task/**`.",
             "- Generic compose coverage: `tests/config/test_config_system.py::test_supported_task_composes`.",
+            "- SuperDex remains `Configured`: FR3 has optional CPU rollout/spawn coverage in `tests/envs/test_fr3_superdex.py`; the Go2 research profile has policy-contract/rollout/checkpoint coverage in `tests/envs/test_go2_superdex.py`. Neither profile claims full-training performance or cross-platform support.",
             "- Validated mjwarp entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_MJWARP_ENTRYPOINT_TASKS`; near-risk coverage lives in `tests/base/test_mjwarp_backend.py`, `tests/base/test_backend_conformance.py`, `tests/base/test_mjwarp_differential.py`, and `tests/base/test_mjwarp_playback.py`.",
             "- Validated isaacgym entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_ISAACGYM_ENTRYPOINT_TASKS` (real hardware via the external Python 3.8 worker runtime; not covered by repo CI).",
             "- Validated genesis entrypoints are explicitly recorded in `_MAINTAINER_VALIDATED_GENESIS_ENTRYPOINT_TASKS` (real hardware, genesis-world extra + CUDA; not covered by repo CI); near-risk coverage lives in `tests/base/test_genesis_backend.py` (fake runtime), `tests/base/test_genesis_runtime.py` (real-runtime slow lane), and the genesis env smoke in `tests/envs/locomotion/g1/test_g1_owner_contract.py`.",

--- a/src/unilab/assets/hub.py
+++ b/src/unilab/assets/hub.py
@@ -57,6 +57,54 @@ ROBOT_ASSET_SPECS: dict[str, tuple[tuple[str, str, str, str], ...]] = {
     "x2": (("robots/x2/meshes", "pelvis.STL", "*.STL", "STL"),),
 }
 
+# Upstream native robots stay in the user's audited SuperDex asset checkout.
+# This registry deliberately has no download fallback or SDK import. Relative
+# model names in task owners are resolved only beneath the configured root.
+SUPERDEX_ROBOT_ASSET_SPECS: dict[str, tuple[str, ...]] = {
+    "bots/arms/fr3_v2/fr3_v2.superdex_bot": (
+        "LICENSE",
+        "NOTICE",
+        *(f"collision/fr3_link{i}_collision.mochi.h5" for i in range(8)),
+        *(f"render/fr3_link{i}_render.glb" for i in range(8)),
+    ),
+}
+
+
+def resolve_superdex_robot_asset(model_file: str, *, assets_root: str | None = None) -> str:
+    """Resolve a registered native robot in a local SuperDex asset checkout.
+
+    ``assets_root`` or ``SUPERDEX_ASSETS_PATH`` points to the upstream ``assets``
+    directory, not the repository root. Required collision, visual and license
+    files are checked before physics construction. No files are downloaded or
+    copied into UniLab's package.
+    """
+    root_value = assets_root if assets_root is not None else os.environ.get("SUPERDEX_ASSETS_PATH")
+    if not root_value or not root_value.strip():
+        raise FileNotFoundError(
+            "SuperDex native assets require env.superdex_assets_root or SUPERDEX_ASSETS_PATH "
+            "pointing to the project_superdex/assets directory"
+        )
+    root = Path(root_value).expanduser().resolve()
+    supplied = Path(model_file).expanduser()
+    resolved = (supplied if supplied.is_absolute() else root / supplied).resolve()
+    try:
+        relative = resolved.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"SuperDex robot asset must be inside configured root {root}") from exc
+    if relative not in SUPERDEX_ROBOT_ASSET_SPECS:
+        raise ValueError(f"SuperDex robot asset is not registered: {relative}")
+    required = (
+        resolved,
+        *(resolved.parent / item for item in SUPERDEX_ROBOT_ASSET_SPECS[relative]),
+    )
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "SuperDex registered robot asset is incomplete; restore the upstream checkout "
+            f"including collision/render files and license notices: {', '.join(missing)}"
+        )
+    return str(resolved)
+
 
 def resolve_motion_files(
     motion_file: str | Sequence[str],

--- a/src/unilab/base/backend_factory.py
+++ b/src/unilab/base/backend_factory.py
@@ -8,12 +8,13 @@ factory. Physics implementations and their public contract live in the
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import unisim
 from unisim.backend.base import SimBackend
 
-from unilab.assets.hub import ensure_robot_assets_for_paths
+from unilab.assets.hub import ensure_robot_assets_for_paths, resolve_superdex_robot_asset
 from unilab.base.process_device import bind_genesis_process_device
 
 if TYPE_CHECKING:
@@ -44,6 +45,10 @@ def env_backend_kwargs(cfg: "EnvCfg") -> dict[str, Any]:
     """Translate ``EnvCfg`` backend knobs into UniSim adapter options."""
     result: dict[str, Any] = {
         "post_step_forward_sensor": cfg.post_step_forward_sensor,
+        "superdex_num_threads": cfg.superdex_num_threads,
+        "superdex_assets_root": cfg.superdex_assets_root,
+        "superdex_effort_limits": cfg.superdex_effort_limits,
+        "superdex_allow_contact_approximation": cfg.superdex_allow_contact_approximation,
         "motrix_max_iterations": cfg.motrix_max_iterations,
         "chunk_size": cfg.chunk_size,
         "adaptive_chunk_size": cfg.adaptive_chunk_size,
@@ -90,6 +95,18 @@ def create_backend(
     """Prepare UniLab-owned assets and construct a UniSim backend."""
     if scene is None:
         raise ValueError("SceneCfg must be provided")
+    superdex_assets_root = kwargs.pop("superdex_assets_root", None)
+    if backend_type == "superdex" and scene.model_file.endswith(".superdex_bot"):
+        scene = replace(
+            scene,
+            model_file=resolve_superdex_robot_asset(
+                scene.model_file, assets_root=superdex_assets_root
+            ),
+        )
+    if backend_type != "superdex":
+        kwargs.pop("superdex_num_threads", None)
+        kwargs.pop("superdex_effort_limits", None)
+        kwargs.pop("superdex_allow_contact_approximation", None)
     ensure_robot_assets_for_paths(
         [scene.model_file, scene.visual_model_file, *scene.fragment_files]
     )
@@ -108,7 +125,10 @@ def create_backend(
     # not accept MuJoCo's synthetic body-sensor injection.  Keep this
     # capability translation at the owner/backend boundary so env code remains
     # backend-agnostic.
-    kwargs["body_state_required"] = body_state_required and backend_type != "newton"
+    kwargs["body_state_required"] = body_state_required and backend_type not in {
+        "newton",
+        "superdex",
+    }
     if backend_type == "genesis" and kwargs.get("genesis_device_id") is not None:
         # Bind before any unisim-core Genesis constructor can call gs.init.
         # New unisim-core releases repeat this idempotently; old releases do

--- a/src/unilab/base/base.py
+++ b/src/unilab/base/base.py
@@ -35,6 +35,12 @@ class EnvCfg:
     render_offset_mode: str = "grid"
     drake_backend_mode: str = "batch"
     drake_nthread: int = 0
+    # SuperDex native robots are resolved through the local asset hub registry.
+    # Thread count is process-wide: 0 is serial, positive values are explicit.
+    superdex_num_threads: int = 0
+    superdex_assets_root: Optional[str] = None
+    superdex_effort_limits: Optional[list[float]] = None
+    superdex_allow_contact_approximation: bool = False
     motrix_max_iterations: Optional[int] = None
     post_step_forward_sensor: bool = False
     adaptive_chunk_size: bool = True
@@ -107,6 +113,29 @@ class EnvCfg:
         """
         if self.sim_dt > self.ctrl_dt:
             raise ValueError("sim_dt must be less than or equal to ctrl_dt")
+        if (
+            isinstance(self.superdex_num_threads, bool)
+            or not isinstance(self.superdex_num_threads, int)
+            or self.superdex_num_threads < 0
+        ):
+            raise ValueError("superdex_num_threads must be an integer >= 0")
+        if self.superdex_assets_root is not None and (
+            not isinstance(self.superdex_assets_root, str) or not self.superdex_assets_root.strip()
+        ):
+            raise ValueError("superdex_assets_root must be a non-empty string or None")
+        if self.superdex_effort_limits is not None:
+            if not isinstance(self.superdex_effort_limits, list) or not self.superdex_effort_limits:
+                raise ValueError("superdex_effort_limits must be a non-empty list or None")
+            if any(
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not np.isfinite(value)
+                or value <= 0
+                for value in self.superdex_effort_limits
+            ):
+                raise ValueError("superdex_effort_limits must contain finite positive numbers")
+        if not isinstance(self.superdex_allow_contact_approximation, bool):
+            raise ValueError("superdex_allow_contact_approximation must be bool")
         for name, value in (
             ("mjwarp_nconmax", self.mjwarp_nconmax),
             ("mjwarp_njmax", self.mjwarp_njmax),

--- a/src/unilab/base/registry.py
+++ b/src/unilab/base/registry.py
@@ -49,6 +49,7 @@ _SUPPORTED_SIM_BACKENDS = (
     "genesis",
     "isaacsim",
     "newton",
+    "superdex",
 )
 _DEFAULT_SIM_BACKEND_ORDER: tuple[str, ...] = ("mujoco", "motrix")
 _REGISTRY_MODULES_ATTR = "__unilab_registry_modules__"

--- a/src/unilab/cli.py
+++ b/src/unilab/cli.py
@@ -25,6 +25,7 @@ SUPPORTED_SIMS = (
     "genesis",
     "isaacsim",
     "newton",
+    "superdex",
 )
 SUPPORTED_RENDER_MODES = ("auto", "interactive", "record", "none")
 OFFPOLICY_ALGOS = {"sac", "td3", "flashsac"}
@@ -127,6 +128,21 @@ def _check_runtime_requirements(algo: str, sim: str) -> None:
                 "sim=newton requires the Newton extra "
                 f"(missing: {joined}). Install it with `uv sync --extra newton` "
                 "in a source checkout (or `pip install unilab[newton]`)."
+            )
+    if sim == "superdex":
+        try:
+            from unisim.backend.superdex.dependencies import superdex_dependencies_available
+        except ImportError as exc:
+            raise SystemExit(
+                "sim=superdex requires the locally linked UniSim SuperDex development checkout; "
+                "the installed unisim-core does not provide that adapter."
+            ) from exc
+
+        if not superdex_dependencies_available():
+            raise SystemExit(
+                "sim=superdex requires Python 3.12 and the SuperDex Physics/Robotics runtime. "
+                "Install the locally linked UniSim superdex extra in a Python 3.12 environment; "
+                "see the SuperDex backend page for local development setup."
             )
     if sim == "motrix" and find_spec("motrixsim") is None:
         raise SystemExit(

--- a/src/unilab/conf/ppo/task/fr3_joint_target/base.yaml
+++ b/src/unilab/conf/ppo/task/fr3_joint_target/base.yaml
@@ -1,0 +1,71 @@
+# @package _global_
+# Fixed-base native FR3 task. Targets and research torque limits are task-owned;
+# they are not a claim about the hardware's rated actuator limits.
+env:
+  scene:
+    model_file: bots/arms/fr3_v2/fr3_v2.superdex_bot
+    entities:
+      robot:
+        root_body_name: fr3_link0
+        joint_names: &joints [fr3_joint1, fr3_joint2, fr3_joint3, fr3_joint4, fr3_joint5, fr3_joint6, fr3_joint7]
+        actuator_names: *joints
+        body_names: [fr3_link0, fr3_link7]
+  sim_dt: 0.002
+  ctrl_dt: 0.01
+  max_episode_seconds: 5.0
+  seed: 1
+  observations:
+    policy:
+      terms:
+        target_error:
+          func: unilab.tasks.manipulation.fr3.joint_target.JointTargetObservation
+          params:
+            entity_name: robot
+            target: &target [0.1, -0.7, 0.0, -2.2, 0.0, 1.5, 1.57]
+        joint_vel:
+          func: unilab.envs.mdp.joint_vel_rel
+        actions:
+          func: unilab.envs.mdp.last_action
+  actions:
+    effort:
+      _target_: unilab.envs.mdp.JointEffortActionCfg
+      entity_name: robot
+      actuator_names: *joints
+      scale:
+        fr3_joint[1-4]: 20.0
+        fr3_joint[5-7]: 5.0
+      clip:
+        fr3_joint[1-4]: [-20.0, 20.0]
+        fr3_joint[5-7]: [-5.0, 5.0]
+  events:
+    reset_scene_to_default:
+      func: unilab.envs.mdp.reset_scene_to_default
+      mode: reset
+    reset_joints:
+      func: unilab.tasks.manipulation.fr3.joint_target.ResetJointOffsets
+      mode: reset
+      params:
+        entity_name: robot
+        position_range: [-0.05, 0.05]
+        velocity_range: [-0.01, 0.01]
+  terminations:
+    time_out:
+      func: unilab.envs.mdp.time_out
+      time_out: true
+  policy_observation_group: policy
+  critic_observation_group: null
+
+reward:
+  joint_target:
+    func: unilab.tasks.manipulation.fr3.joint_target.JointTargetReward
+    weight: 2.0
+    params:
+      entity_name: robot
+      target: *target
+      std: 0.5
+  joint_velocity:
+    func: unilab.envs.mdp.joint_vel_l2
+    weight: -0.01
+  action_rate:
+    func: unilab.envs.mdp.action_rate_l2
+    weight: -0.001

--- a/src/unilab/conf/ppo/task/fr3_joint_target/superdex.yaml
+++ b/src/unilab/conf/ppo/task/fr3_joint_target/superdex.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+defaults:
+  - /task/fr3_joint_target/base
+  - _self_
+
+training:
+  task_name: FR3JointTarget
+  sim_backend: superdex
+  device: cpu
+  no_play: true
+  play_render_mode: none
+
+algo:
+  num_envs: 2
+  num_steps_per_env: 32
+  max_iterations: 100
+  empirical_normalization: false
+  obs_groups:
+    actor: [actor]
+    critic: [actor]
+  policy:
+    actor_hidden_dims: [64, 64]
+    critic_hidden_dims: [64, 64]
+    init_noise_std: 0.25
+  algorithm:
+    num_mini_batches: 1
+
+env:
+  adaptive_chunk_size: false
+  superdex_num_threads: 0
+  superdex_assets_root: null
+  superdex_effort_limits: [20.0, 20.0, 20.0, 20.0, 5.0, 5.0, 5.0]
+
+play_profile:
+  enabled: false

--- a/src/unilab/conf/ppo/task/go2_joystick_flat/superdex.yaml
+++ b/src/unilab/conf/ppo/task/go2_joystick_flat/superdex.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# Research sim2sim profile: inherit the exact MuJoCo policy/observation owner.
+# SuperDex contact compliance and slide-only friction are not MuJoCo physics
+# equivalents. This profile permits that conversion explicitly, not silently.
+defaults:
+  - /task/go2_joystick_flat/mujoco
+  - _self_
+
+training:
+  task_name: Go2JoystickFlat
+  sim_backend: superdex
+  device: cpu
+  no_play: true
+  play_render_mode: none
+
+algo:
+  num_envs: 2
+  algorithm:
+    num_mini_batches: 1
+
+env:
+  adaptive_chunk_size: false
+  superdex_num_threads: 0
+  superdex_allow_contact_approximation: true
+  events:
+    pd_gains: null
+
+play_profile:
+  enabled: false

--- a/src/unilab/tasks/__init__.py
+++ b/src/unilab/tasks/__init__.py
@@ -15,6 +15,7 @@ __unilab_registry_modules__ = (
     "unilab.tasks.manipulation.allegro_inhand",
     "unilab.tasks.manipulation.sharpa_inhand",
     "unilab.tasks.manipulation.stewart",
+    "unilab.tasks.manipulation.fr3",
     "unilab.tasks.motion_tracking.g1",
     "unilab.tasks.motion_tracking.x2",
 )

--- a/src/unilab/tasks/locomotion/go2/__init__.py
+++ b/src/unilab/tasks/locomotion/go2/__init__.py
@@ -9,6 +9,7 @@ registry.register_env_config("Go2JoystickFlat", ManagerBasedRlEnvCfg)
 registry.register_env("Go2JoystickFlat", make_manager_based_rl_env, sim_backend="mujoco")
 registry.register_env("Go2JoystickFlat", make_manager_based_rl_env, sim_backend="motrix")
 registry.register_env("Go2JoystickFlat", make_manager_based_rl_env, sim_backend="drake")
+registry.register_env("Go2JoystickFlat", make_manager_based_rl_env, sim_backend="superdex")
 
 registry.register_env_config("Go2JoystickRough", ManagerBasedRlEnvCfg)
 registry.register_env("Go2JoystickRough", make_manager_based_rl_env, sim_backend="mujoco")

--- a/src/unilab/tasks/manipulation/fr3/__init__.py
+++ b/src/unilab/tasks/manipulation/fr3/__init__.py
@@ -1,0 +1,7 @@
+"""Hydra-owned fixed-base FR3 joint-target task registration."""
+
+from unilab.base import registry
+from unilab.envs import ManagerBasedRlEnvCfg, make_manager_based_rl_env
+
+registry.register_env_config("FR3JointTarget", ManagerBasedRlEnvCfg)
+registry.register_env("FR3JointTarget", make_manager_based_rl_env, sim_backend="superdex")

--- a/src/unilab/tasks/manipulation/fr3/joint_target.py
+++ b/src/unilab/tasks/manipulation/fr3/joint_target.py
@@ -1,0 +1,80 @@
+"""Joint-target terms using the public NumPy entity/reset contracts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from unilab.base.entity import Entity
+    from unilab.managers import ManagerTermBaseCfg
+    from unilab.managers._types import ManagerBasedRlEnv
+
+
+class JointTargetObservation:
+    """Bind one ordered joint target on the manager construction path."""
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv) -> None:
+        self._entity = cast("Entity", env.scene[cfg.params["entity_name"]])
+        self._target = np.asarray(cfg.params["target"], dtype=np.float32)
+        expected = (self._entity.num_joints,)
+        if self._target.shape != expected or not np.isfinite(self._target).all():
+            raise ValueError(f"FR3 joint target must be finite with shape {expected}")
+        self._target.setflags(write=False)
+
+    def __call__(self, env: ManagerBasedRlEnv, entity_name: str, target: list[float]) -> np.ndarray:
+        return self._entity.data.joint_pos - self._target
+
+
+class JointTargetReward(JointTargetObservation):
+    """Reward current joint accuracy with a configured squared-error scale."""
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv) -> None:
+        super().__init__(cfg, env)
+        std = cfg.params["std"]
+        if (
+            isinstance(std, bool)
+            or not isinstance(std, (int, float))
+            or not np.isfinite(std)
+            or std <= 0
+        ):
+            raise ValueError("FR3 joint target reward std must be finite and positive")
+        self._variance = float(std) ** 2
+
+    def __call__(
+        self, env: ManagerBasedRlEnv, entity_name: str, target: list[float], std: float = 0.5
+    ) -> np.ndarray:
+        error = self._entity.data.joint_pos - self._target
+        return np.exp(-np.sum(np.square(error), axis=-1) / self._variance)
+
+
+class ResetJointOffsets:
+    """Stage selected joint resets without requiring a floating root."""
+
+    def __init__(self, cfg: ManagerTermBaseCfg, env: ManagerBasedRlEnv) -> None:
+        self._entity = cast("Entity", env.scene[cfg.params["entity_name"]])
+        self._ranges = []
+        for name in ("position_range", "velocity_range"):
+            values = np.asarray(cfg.params[name], dtype=np.float64)
+            if values.shape != (2,) or not np.isfinite(values).all() or values[0] > values[1]:
+                raise ValueError(f"FR3 reset {name} must be a finite ordered pair")
+            self._ranges.append((float(values[0]), float(values[1])))
+
+    def __call__(
+        self,
+        env: ManagerBasedRlEnv,
+        env_ids: np.ndarray | None,
+        entity_name: str,
+        position_range: list[float],
+        velocity_range: list[float],
+    ) -> None:
+        if env_ids is None:
+            raise ValueError("FR3 reset requires explicit environment IDs")
+        positions = self._entity.data.default_joint_pos[env_ids]
+        velocities = self._entity.data.default_joint_vel[env_ids]
+        self._entity.write_joint_state_to_sim(
+            positions + env.rng.uniform(*self._ranges[0], size=positions.shape),
+            velocities + env.rng.uniform(*self._ranges[1], size=velocities.shape),
+            env_ids=env_ids,
+        )

--- a/src/unilab/tasks/migration_matrix.py
+++ b/src/unilab/tasks/migration_matrix.py
@@ -29,6 +29,8 @@ _MBA_TASKS = frozenset(
         "A2JoystickFlat",
         "AllegroInhandRotation",
         "AllegroInhandRotationGrasp",
+        # #1534 starts directly on the canonical manager runtime; no legacy seam.
+        "FR3JointTarget",
         "Go1JoystickFlat",
         "Go2FootStand",
         "Go2JoystickFlat",

--- a/tests/assets/test_superdex_assets.py
+++ b/tests/assets/test_superdex_assets.py
@@ -1,0 +1,49 @@
+"""Native SuperDex assets resolve only through the audited local registry."""
+
+from pathlib import Path
+
+import pytest
+
+from unilab.assets.hub import SUPERDEX_ROBOT_ASSET_SPECS, resolve_superdex_robot_asset
+
+MODEL = "bots/arms/fr3_v2/fr3_v2.superdex_bot"
+
+
+@pytest.fixture
+def asset_root(tmp_path: Path) -> Path:
+    model = tmp_path / MODEL
+    for path in (model, *(model.parent / item for item in SUPERDEX_ROBOT_ASSET_SPECS[MODEL])):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture", encoding="utf-8")
+    return tmp_path
+
+
+def test_local_superdex_asset_root_precedence_and_absolute_paths(
+    asset_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SUPERDEX_ASSETS_PATH", "/missing/other/root")
+    expected = str(asset_root / MODEL)
+    assert resolve_superdex_robot_asset(MODEL, assets_root=str(asset_root)) == expected
+    assert resolve_superdex_robot_asset(expected, assets_root=str(asset_root)) == expected
+    monkeypatch.setenv("SUPERDEX_ASSETS_PATH", str(asset_root))
+    assert resolve_superdex_robot_asset(MODEL) == expected
+
+
+def test_superdex_assets_require_explicit_local_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SUPERDEX_ASSETS_PATH", raising=False)
+    with pytest.raises(FileNotFoundError, match="SUPERDEX_ASSETS_PATH"):
+        resolve_superdex_robot_asset(MODEL)
+
+
+def test_superdex_assets_reject_unregistered_and_escaping_paths(asset_root: Path) -> None:
+    with pytest.raises(ValueError, match="not registered"):
+        resolve_superdex_robot_asset("unknown.superdex_bot", assets_root=str(asset_root))
+    with pytest.raises(ValueError, match="inside configured root"):
+        resolve_superdex_robot_asset("../outside.superdex_bot", assets_root=str(asset_root))
+
+
+def test_superdex_assets_fail_before_sdk_on_incomplete_collision(asset_root: Path) -> None:
+    missing = asset_root / Path(MODEL).parent / "collision/fr3_link4_collision.mochi.h5"
+    missing.unlink()
+    with pytest.raises(FileNotFoundError, match="fr3_link4_collision"):
+        resolve_superdex_robot_asset(MODEL, assets_root=str(asset_root))

--- a/tests/base/test_backend_imports.py
+++ b/tests/base/test_backend_imports.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import ast
+import json
+import os
 import subprocess
 import sys
 import textwrap
 from importlib.metadata import distribution
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MATERIALIZER_CONSUMERS = (
@@ -19,6 +22,25 @@ _MATERIALIZER_CONSUMERS = (
 
 def test_unisim_dependency_is_installed_from_package_index() -> None:
     direct_url = distribution("unisim-core").read_text("direct_url.json")
+
+    local_checkout = os.environ.get("UNILAB_LOCAL_UNISIM")
+    if local_checkout:
+        import unisim
+
+        expected = Path(local_checkout)
+        assert expected.is_absolute(), "UNILAB_LOCAL_UNISIM must be an absolute checkout path"
+        expected = expected.resolve(strict=True)
+        assert direct_url is not None, (
+            "Local UniSim profile requires editable installation metadata"
+        )
+        metadata = json.loads(direct_url)
+        assert metadata.get("dir_info", {}).get("editable") is True
+        installed_url = urlparse(metadata["url"])
+        assert installed_url.scheme == "file" and installed_url.netloc in {"", "localhost"}
+        assert Path(unquote(installed_url.path)).resolve() == expected
+        assert unisim.__file__ is not None
+        assert Path(unisim.__file__).resolve().is_relative_to(expected / "src" / "unisim")
+        return
 
     assert direct_url is None, (
         "UniLab tests must consume the indexed unisim-core release, not a local, editable, "

--- a/tests/base/test_superdex_backend_options.py
+++ b/tests/base/test_superdex_backend_options.py
@@ -1,0 +1,66 @@
+"""UniLab resolves assets and passes only public SuperDex adapter options."""
+
+from typing import Any
+
+import pytest
+
+from unilab.base import backend_factory
+from unilab.base.base import EnvCfg
+from unilab.base.scene import SceneCfg
+
+
+def test_superdex_native_factory_resolves_assets_without_mutating_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def resolve(model_file: str, *, assets_root: str | None) -> str:
+        calls["asset"] = (model_file, assets_root)
+        return "/registered/assets/fr3.superdex_bot"
+
+    def create(name: str, scene: SceneCfg, n: int, dt: float, **kwargs: Any) -> object:
+        calls["backend"] = (name, scene, n, dt, kwargs)
+        return object()
+
+    monkeypatch.setattr(backend_factory, "resolve_superdex_robot_asset", resolve)
+    monkeypatch.setattr(backend_factory, "ensure_robot_assets_for_paths", lambda *_: None)
+    monkeypatch.setattr(backend_factory.unisim, "create_backend", create)
+    cfg = EnvCfg(superdex_assets_root="/registered/assets", superdex_effort_limits=[20.0])
+    scene = SceneCfg(model_file="bots/arms/fr3_v2/fr3_v2.superdex_bot")
+    backend_factory.create_backend(
+        "superdex",
+        scene,
+        2,
+        0.002,
+        body_state_required=True,
+        **backend_factory.env_backend_kwargs(cfg),
+    )
+    name, resolved_scene, n, dt, kwargs = calls["backend"]
+    assert (name, n, dt) == ("superdex", 2, 0.002)
+    assert resolved_scene.model_file == "/registered/assets/fr3.superdex_bot"
+    assert scene.model_file == "bots/arms/fr3_v2/fr3_v2.superdex_bot"
+    assert calls["asset"] == (scene.model_file, "/registered/assets")
+    assert kwargs["superdex_effort_limits"] == [20.0]
+    assert kwargs["superdex_num_threads"] == 0
+    assert kwargs["superdex_allow_contact_approximation"] is False
+    assert kwargs["body_state_required"] is False
+    assert "superdex_assets_root" not in kwargs
+
+
+def test_superdex_options_do_not_leak_to_other_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, Any] = {}
+
+    def create(*args: Any, **kwargs: Any) -> object:
+        calls.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(backend_factory, "ensure_robot_assets_for_paths", lambda *_: None)
+    monkeypatch.setattr(backend_factory.unisim, "create_backend", create)
+    backend_factory.create_backend(
+        "mujoco",
+        SceneCfg(model_file="scene.xml"),
+        1,
+        0.01,
+        **backend_factory.env_backend_kwargs(EnvCfg()),
+    )
+    assert not any(name.startswith("superdex_") for name in calls)

--- a/tests/envs/locomotion/go2/test_manager_based_cfg.py
+++ b/tests/envs/locomotion/go2/test_manager_based_cfg.py
@@ -276,7 +276,7 @@ def test_go2_flat_registry_has_no_legacy_config_fallback() -> None:
     assert bare_cfg.rewards == {}
     assert registry.list_registered_envs()["Go2JoystickFlat"] == {
         "config_factory": "ManagerBasedRlEnvCfg",
-        "available_backends": ["mujoco", "motrix", "drake"],
+        "available_backends": ["mujoco", "motrix", "drake", "superdex"],
     }
     for legacy_override in (
         {"reward_config": {}},

--- a/tests/envs/test_fr3_superdex.py
+++ b/tests/envs/test_fr3_superdex.py
@@ -1,0 +1,125 @@
+"""FR3 owner composition and optional native CPU rollout integration."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+
+from unilab import cli
+from unilab.base import registry
+from unilab.base.base import EnvCfg
+from unilab.base.config_adapter import BackendAdapter
+from unilab.base.config_materialization import apply_cfg_overrides
+from unilab.base.env_factory import registry_env_factory
+from unilab.envs import ManagerBasedRlEnvCfg
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _owner() -> tuple[Any, dict[str, Any]]:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(ROOT / "src/unilab/conf/ppo"), version_base="1.3"):
+        owner = compose("config", overrides=["task=fr3_joint_target/superdex"])
+    return owner, BackendAdapter(owner, root_dir=ROOT).build_task_env_cfg_override()
+
+
+def test_fr3_owner_has_torque_control_without_free_root_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner, overrides = _owner()
+    cfg = registry.materialize_env_config("FR3JointTarget")
+    assert isinstance(cfg, ManagerBasedRlEnvCfg)
+    apply_cfg_overrides(cfg, overrides)
+    cfg.validate()
+    assert cfg.scene is not None
+    assert cfg.scene.entities["robot"].root_body_name == "fr3_link0"
+    assert list(cfg.events) == ["reset_scene_to_default", "reset_joints"]
+    assert list(cfg.observations["policy"].terms) == ["target_error", "joint_vel", "actions"]
+    assert cfg.superdex_effort_limits == [20.0] * 4 + [5.0] * 3
+    assert owner.training.no_play and owner.training.device == "cpu"
+    assert "superdex" in cli.SUPPORTED_SIMS
+    monkeypatch.setattr(cli, "_check_runtime_requirements", lambda *_: None)
+    command = cli.build_command(
+        mode="train", algo="ppo", task="fr3_joint_target", sim="superdex", overrides=[]
+    )
+    assert "task=fr3_joint_target/superdex" in command
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"superdex_num_threads": True},
+        {"superdex_num_threads": -1},
+        {"superdex_num_threads": -2},
+        {"superdex_assets_root": ""},
+        {"superdex_effort_limits": [0.0]},
+        {"superdex_effort_limits": [float("nan")]},
+    ],
+)
+def test_superdex_owner_options_reject_invalid_values(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="superdex"):
+        EnvCfg(**kwargs).validate()
+
+
+def _require_runtime() -> None:
+    if not os.environ.get("SUPERDEX_ASSETS_PATH"):
+        pytest.skip("native FR3 integration requires SUPERDEX_ASSETS_PATH")
+    pytest.importorskip("superdex.physics")
+    pytest.importorskip("superdex.robotics")
+
+
+def test_fr3_native_rollout_and_selected_reset() -> None:
+    _require_runtime()
+    _, overrides = _owner()
+    env = registry.make(
+        "FR3JointTarget", sim_backend="superdex", num_envs=2, env_cfg_override=overrides
+    )
+    try:
+        state = env.init_state()
+        assert env.obs_groups_spec == {"obs": 21}
+        assert env.action_space.shape == (7,)
+        for _ in range(32):
+            state = env.step(np.full((2, 7), 0.05, dtype=np.float32))
+            assert np.isfinite(state.obs["obs"]).all()
+            assert np.isfinite(state.reward).all()
+        before = env.scene["robot"].data.joint_pos.copy()
+        counters = state.info["steps"].copy()
+        obs, _ = env.reset(env_ids=np.array([0], dtype=np.int32))
+        assert obs["obs"].shape == (1, 21)
+        np.testing.assert_array_equal(env.scene["robot"].data.joint_pos[1], before[1])
+        assert state.info["steps"][1] == counters[1]
+        np.testing.assert_allclose(
+            obs["obs"][0, :7],
+            env.scene["robot"].data.joint_pos[0] - np.array([0.1, -0.7, 0, -2.2, 0, 1.5, 1.57]),
+            atol=1e-6,
+        )
+    finally:
+        env.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        env.step(np.zeros((2, 7), dtype=np.float32))
+
+
+def _spawn_rollout(overrides: dict[str, Any]) -> tuple[int, ...]:
+    factory = registry_env_factory("FR3JointTarget", "superdex")
+    env = factory(num_envs=1, env_cfg_override=overrides)
+    try:
+        obs, _ = env.reset(env_ids=np.array([0], dtype=np.int32))
+        env.step(np.zeros((1, 7), dtype=np.float32))
+        return obs["obs"].shape
+    finally:
+        env.close()
+
+
+def test_fr3_factory_survives_spawn() -> None:
+    _require_runtime()
+    _, overrides = _owner()
+    with mp.get_context("spawn").Pool(1) as pool:
+        result = pool.apply_async(_spawn_rollout, (overrides,))
+        assert result.get(timeout=90) == (1, 21)

--- a/tests/envs/test_go2_superdex.py
+++ b/tests/envs/test_go2_superdex.py
@@ -1,0 +1,132 @@
+"""Go2's research SuperDex owner preserves policy I/O and reset semantics."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
+
+from unilab.base import registry
+from unilab.base.config_adapter import BackendAdapter
+from unilab.utils.sim2sim import DENYLIST, CrossBackendIncompatibleError, resolve_sim2sim_config
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _owner(backend: str) -> tuple[Any, dict[str, Any]]:
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(ROOT / "src/unilab/conf/ppo"), version_base="1.3"):
+        owner = compose("config", overrides=[f"task=go2_joystick_flat/{backend}"])
+    return owner, BackendAdapter(owner, root_dir=ROOT).build_task_env_cfg_override()
+
+
+def test_go2_superdex_preserves_mujoco_policy_contract() -> None:
+    source, _ = _owner("mujoco")
+    target, _ = _owner("superdex")
+    for field in DENYLIST:
+        assert OmegaConf.select(source, field) == OmegaConf.select(target, field), field
+    assert target.env.events.pd_gains is None
+    assert target.env.events.reset_root_state_uniform is not None
+    assert target.env.superdex_allow_contact_approximation is True
+    assert target.env.sim_dt == source.env.sim_dt
+    assert target.env.ctrl_dt == source.env.ctrl_dt
+
+
+def test_go2_superdex_native_rollout_and_free_root_reset() -> None:
+    pytest.importorskip("superdex.physics")
+    if not (ROOT / "src/unilab/assets/robots/go2/assets/base_0.obj").is_file():
+        pytest.skip("native Go2 rollout requires the registered Go2 robot assets")
+    _, override = _owner("superdex")
+    env = registry.make(
+        "Go2JoystickFlat", sim_backend="superdex", num_envs=2, env_cfg_override=override
+    )
+    try:
+        state = env.init_state()
+        assert env.action_space.shape == (12,)
+        assert env.obs_groups_spec == {"obs": 49, "critic": 52}
+        for _ in range(32):
+            state = env.step(np.zeros((2, 12), dtype=np.float32))
+            assert np.isfinite(state.reward).all()
+            assert all(np.isfinite(value).all() for value in state.obs.values())
+        before = env.scene["robot"].data.root_link_pos_w.copy()
+        obs, _ = env.reset(env_ids=np.array([0], dtype=np.int32))
+        assert obs["obs"].shape == (1, 49)
+        np.testing.assert_array_equal(env.scene["robot"].data.root_link_pos_w[1], before[1])
+        np.testing.assert_allclose(
+            np.linalg.norm(env.scene["robot"].data.root_link_quat_w, axis=-1), 1.0, atol=1e-5
+        )
+    finally:
+        env.close()
+
+
+def test_go2_superdex_executes_mujoco_checkpoint(tmp_path: Path) -> None:
+    checkpoint_value = os.environ.get("UNILAB_SUPERDEX_GO2_CHECKPOINT")
+    if not checkpoint_value:
+        pytest.skip("set UNILAB_SUPERDEX_GO2_CHECKPOINT to a MuJoCo Go2 PPO checkpoint")
+    pytest.importorskip("superdex.physics")
+    import torch
+    from rsl_rl.runners import OnPolicyRunner
+    from uni_rl.algos.rsl_rl import RslRlVecEnvWrapper, get_policy_obs_dims, normalize_ppo_train_cfg
+
+    from unilab.training.run import algo_config_dict
+    from unilab.visualization.interactive_playback import (
+        RslRlPlaybackConfig,
+        create_rsl_rl_playback_session,
+        infer_checkpoint_actor_input_dim,
+        make_sim2sim_preflight,
+    )
+
+    checkpoint = Path(checkpoint_value).resolve(strict=True)
+    owner, overrides = _owner("superdex")
+    # Validate source policy-I/O before any environment is constructed.
+    resolve_sim2sim_config(str(checkpoint.parent), owner, algo_name="ppo", strict=True)
+    incompatible = OmegaConf.create(OmegaConf.to_container(owner, resolve=True))
+    incompatible.env.actions.joint_pos.scale = 0.5
+    with pytest.raises(CrossBackendIncompatibleError, match="env.actions"):
+        resolve_sim2sim_config(str(checkpoint.parent), incompatible, algo_name="ppo", strict=True)
+
+    env = registry.make(
+        "Go2JoystickFlat", sim_backend="superdex", num_envs=2, env_cfg_override=overrides
+    )
+    try:
+        session, _, loaded = create_rsl_rl_playback_session(
+            playback_cfg=RslRlPlaybackConfig(
+                task="Go2JoystickFlat",
+                load_run=str(checkpoint),
+                checkpoint=None,
+                action_mode="policy",
+                policy_obs_mode="flat",
+                algo_log_name="rsl_rl_ppo",
+                log_root=str(tmp_path),
+                num_envs=2,
+            ),
+            env_factory=lambda n: env,
+            algo_config=algo_config_dict(owner),
+            root_dir=ROOT,
+            device="cpu",
+            checkpoint_resolver=lambda *_: str(checkpoint),
+            checkpoint_input_dim_reader=infer_checkpoint_actor_input_dim,
+            entrypoint_log_root=lambda *args, **kwargs: tmp_path,
+            wrapper_cls=RslRlVecEnvWrapper,
+            runner_cls=OnPolicyRunner,
+            policy_obs_dims_getter=get_policy_obs_dims,
+            train_cfg_normalizer=normalize_ppo_train_cfg,
+            sim2sim_preflight=make_sim2sim_preflight(owner, algo_name="ppo"),
+            guard_algo_name="ppo",
+        )
+        assert loaded == str(checkpoint) and session.policy is not None
+        session.reset()
+        with torch.inference_mode():
+            for _ in range(64):
+                obs = session.step_once()
+                assert all(torch.isfinite(value).all() for value in obs.values())
+                assert np.isfinite(env.state.reward).all()
+        assert session.step_count == 64
+    finally:
+        env.close()

--- a/tests/scripts/test_audit_sim2sim_contracts.py
+++ b/tests/scripts/test_audit_sim2sim_contracts.py
@@ -44,6 +44,18 @@ def test_discover_offpolicy_trees_group_by_task() -> None:
     assert td3["g1_walk_flat"] == ["mujoco"]
 
 
+def test_go2_superdex_pair_is_audited_and_transferable(monkeypatch: pytest.MonkeyPatch) -> None:
+    audit = _load_audit_module()
+    monkeypatch.setattr(
+        audit, "_discover", lambda tree: {"go2_joystick_flat": ["mujoco", "superdex"]}
+    )
+    rows = audit.audit_tree("ppo")
+    assert rows[0]["errors"] == {}
+    assert rows[0]["pairs"][0]["pair"] == "mujoco<->superdex"
+    assert rows[0]["pairs"][0]["verdict"] == "TRANSFERABLE"
+    assert rows[0]["pairs"][0]["warn_diffs"] == []
+
+
 @pytest.mark.parametrize(
     ("tree", "task_variant", "expected_algo"),
     [

--- a/tests/scripts/test_support_matrix.py
+++ b/tests/scripts/test_support_matrix.py
@@ -5,6 +5,14 @@ from pathlib import Path
 import pytest
 from scripts.tools.support_matrix import BACKENDS, EvidenceLevel, build_support_rows
 
+
+def test_superdex_fr3_is_configured_without_full_training_claim() -> None:
+    row = _row("PPO (torch)", "fr3_joint_target")
+    assert row.cells["superdex"].level == EvidenceLevel.CONFIGURED
+    go2_row = _row("PPO (torch)", "go2_joystick_flat")
+    assert go2_row.cells["superdex"].level == EvidenceLevel.CONFIGURED
+
+
 # CPU-bound on the single-core CI runner; kept in the slow lane (make test-slow).
 pytestmark = pytest.mark.slow
 
@@ -37,6 +45,7 @@ def test_support_matrix_marks_validated_g1_mjwarp_entrypoints_as_tested():
         "genesis",
         "isaacsim",
         "newton",
+        "superdex",
     )
     assert torch_row.cells["mjwarp"].level == EvidenceLevel.TESTED
     assert sac_row.cells["mjwarp"].level == EvidenceLevel.TESTED

--- a/tests/tasks/test_migration_matrix.py
+++ b/tests/tasks/test_migration_matrix.py
@@ -22,6 +22,7 @@ def test_registered_tasks_have_explicit_migration_records() -> None:
 @pytest.mark.parametrize(
     ("task_name", "family", "target", "status"),
     [
+        ("FR3JointTarget", "manager_based", "complete", "Compatible"),
         ("Go2ArmManipLoco", "go2_arm", "compatibility", "Adapted"),
         ("SharpaInhandRotation", "sharpa", "compatibility", "Adapted"),
         ("G1MotionTracking", "motion_tracking", "complete", "Compatible"),

--- a/tests/tasks/test_package_boundary.py
+++ b/tests/tasks/test_package_boundary.py
@@ -22,6 +22,7 @@ _TASK_REGISTRY_MODULES = (
     "unilab.tasks.manipulation.allegro_inhand",
     "unilab.tasks.manipulation.sharpa_inhand",
     "unilab.tasks.manipulation.stewart",
+    "unilab.tasks.manipulation.fr3",
     "unilab.tasks.motion_tracking.g1",
     "unilab.tasks.motion_tracking.x2",
 )

--- a/tests/test_cli_runtime_requirements.py
+++ b/tests/test_cli_runtime_requirements.py
@@ -51,7 +51,9 @@ def test_superdex_missing_runtime_reports_python_and_sdk(monkeypatch: pytest.Mon
         cli._check_runtime_requirements("ppo", "superdex")
 
 
-def test_superdex_old_unisim_reports_local_link_requirement(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_superdex_old_unisim_reports_local_link_requirement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import sys
 
     monkeypatch.setitem(sys.modules, "unisim.backend.superdex.dependencies", None)

--- a/tests/test_cli_runtime_requirements.py
+++ b/tests/test_cli_runtime_requirements.py
@@ -41,3 +41,19 @@ def test_check_runtime_requirements_requires_isolated_newton_extra(
 
 def test_newton_is_a_supported_sim() -> None:
     assert "newton" in cli.SUPPORTED_SIMS
+
+
+def test_superdex_missing_runtime_reports_python_and_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    from unisim.backend.superdex import dependencies
+
+    monkeypatch.setattr(dependencies, "superdex_dependencies_available", lambda: False)
+    with pytest.raises(SystemExit, match="Python 3.12.*Physics/Robotics"):
+        cli._check_runtime_requirements("ppo", "superdex")
+
+
+def test_superdex_old_unisim_reports_local_link_requirement(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "unisim.backend.superdex.dependencies", None)
+    with pytest.raises(SystemExit, match="locally linked UniSim SuperDex"):
+        cli._check_runtime_requirements("ppo", "superdex")


### PR DESCRIPTION
## Result

Connects the locally linked UniSim SuperDex adapter to UniLab's CLI, registry, asset owner and Hydra task owners. Adds fixed-base `FR3JointTarget` (21 observations / 7 torque actions) and an experimental Go2 flat profile retaining MuJoCo's 49 actor / 52 critic observations and 12 action policy contract. Includes external asset validation, strict local editable provenance checks, generated support data, bilingual docs and real rollout/spawn/checkpoint tests.

Fixes #1534; supports validation child #1535; parent roadmap #1533. Governing ADR-0007/0006/0003/0004/0002 apply. PR base is **`dev/issue-1533-superdex`**. Neither main branch is written; version remains **1.1.0**, UniSim is linked locally without bumping the dependency requirement, and no package is published.

## Validation

Final code tree committed at `3bfe037a3c5016f3d898a3d61a99d32ca034f6b9` (the gate's sole formatting adjustment is committed), linked to UniSim's SuperDex child:

```sh
UV_NO_SYNC=1 \
UNILAB_LOCAL_UNISIM=/home/user/ws/unilabsim2/superdex-worktrees/unisim \
SUPERDEX_ASSETS_PATH=/home/user/ws/simulator/project_superdex/assets \
UNILAB_SUPERDEX_GO2_CHECKPOINT=/tmp/unilab-superdex-go2-source/Go2JoystickFlat/2026-09-07_18-31-29_mujoco/model_1.pt \
make test-all
```

**1627 passed, 20 skipped, 899 deselected, 1 xfailed**; coverage 70%. Ruff/mypy passed; Pyright had zero errors and the existing optional `drake_uni` warning. Benchmark smoke passed all applicable modules/scripts, skipping optional MLX. Gate log: `/tmp/unilab-superdex-final-child-gate.log`.

- FR3 native N=2 rollout, selected reset, spawned EnvFactory and explicit public cleanup passed.
- FR3 PPO completed 2 iterations / 64 samples and exited 0. A native shutdown crash uncovered during integration was fixed in the UniSim cleanup hook and revalidated.
- Go2's source MuJoCo PPO completed 2 iterations / 64 samples; the actual checkpoint ran 64 SuperDex control steps through the production playback session, with finite outputs. Changed action semantics were rejected by Sim2Sim before constructing an environment.
- Both new task owners are Configured, not full-training or cross-platform support claims.

Remote default CI installs released UniSim and cannot substitute for this explicitly authorized local-link gate. This PR targets a non-main roadmap base; no CI workflow/support expansion is introduced.

## Limits

SuperDex 1.0.0 currently needs Python 3.12. FR3 assets remain in the external registered SuperDex checkout; Go2 uses the existing robot asset hub. No meshes/textures/SDFs enter git. Go2 explicitly accepts approximate sliding contact; finite checkpoint execution does not mean stable walking or MuJoCo-equivalent dynamics. Playback `none` skips rendering/playback and is not the policy-rollout evidence above.
