### PR TITLE
feat: expose Wuji reset and training progress adapters

### DIFF
--- a/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
+++ b/docs/sphinx/source/adr/ADR-0006-community-manager-api-on-numpy-runtime.md
@@ -33,6 +33,41 @@ composer、viewer、simulation 或 training runtime 带入 UniLab，也不恢复
 
 ## Decision
 
+### Manipulation reset and training progress extension (2026-09-07)
+
+[UniLab #1539](https://github.com/Motphys/UniLab/issues/1539) extends the existing
+Entity/reset transaction boundary for downstream Wuji training. Entity exposes
+cold bindings and reset writes for `geom_size`, `geom_solref`, `geom_solimp`,
+joint damping and joint frictionloss. Defaults and model-column IDs come from
+declared UniSim capabilities; unsupported fields fail during binding. Writes
+compose with the existing dense reset payload and preserve unselected columns.
+
+A fixed mocap body is bound explicitly with
+`Entity.bind_mocap_pose_write(body_name, term_name=...)`; it does not become the
+scene's primary floating root. `write_mocap_pose_to_sim` stages selected poses.
+The reset transaction validates staged values before any upload and commits
+generalized state first, then mocap poses. A term failure discards all pending
+state. Backend upload failures propagate; this interface does not promise
+rollback after the first backend upload has succeeded. A mocap-only transaction
+does not reset generalized state. Terms read pending poses through
+`Entity.read_mocap_pose`, without accessing backend-native data.
+
+`NpEnv.export_training_state()` returns a versioned cumulative control-step
+counter; `import_training_state()` validates it before replacing the counter.
+The Manager-Based adapter also restores its derived command/simulation counters,
+so the next step continues from the restored progress. This does not serialize
+physics, RNG, episode buffers or task curriculum internals. A downstream training
+state provider explicitly combines this payload with its own validated task
+state. UniRL owns checkpoint storage and the runner; no learner imports UniLab.
+The owner-selected PPO runtime may provide a runner class. Training consumes it,
+while playback loads actor state without restoring training progress.
+
+Validation lives in `tests/base/test_reset_state.py`,
+`tests/base/test_entity_facade.py` and `tests/envs/test_manager_based_rl_env.py`:
+masked fields, immutable cold defaults, mocap commit order and abort, entity-local
+column mapping, and restore followed by an actual control step. The governing
+package boundary remains [ADR-0007](ADR-0007-unisim-extraction-boundary.md).
+
 ### 1. Source-aligned public surface
 
 `src/unilab/managers/` 按 pinned mjlab package 的模块职责和 exports 直接迁移。以下名称

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -25,10 +25,10 @@ dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
     # unisim-core package from the production PyPI index.
-    "unisim-core>=1.1.3",
+    "unisim-core>=1.1.4",
     # RL algorithms and async runtimes live in the independently released
     # uni-rl package (distribution name ``unilab-rl``); see pyproject.toml.
-    "unilab-rl==0.2.0",
+    "unilab-rl==1.1.1",
     "torch==2.11.0",
     "triton-rocm==3.6.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "gymnasium",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dependencies = [
     "numpy",
     # Physics implementations are provided by the independently released
     # unisim-core package from the production PyPI index.
-    "unisim-core>=1.1.3",
+    "unisim-core>=1.1.4",
     # RL algorithms and async runtimes (PPO/APPO/SAC/TD3/HORA runners,
     # collectors, IPC, logging) live in the independently released uni-rl
     # package (distribution name ``unilab-rl``), consumed via the injected
     # env contract (uni_rl.env_contract.EnvFactory). Published on PyPI.
-    "unilab-rl==1.1.0",
+    "unilab-rl==1.1.1",
     "numba>=0.67",
     "prettytable>=3.10",
     # torch is a range (not an exact pin) so that published PyPI metadata lets

--- a/src/unilab/base/config_adapter.py
+++ b/src/unilab/base/config_adapter.py
@@ -115,7 +115,17 @@ class BackendAdapter:
         return env_cfg_override
 
     def _apply_env_profile(self, env_cfg_override: dict[str, Any], env_profile: Any) -> None:
-        env_cfg_override.update(self._to_plain_dict(env_profile))
+        self._merge_mappings(env_cfg_override, self._to_plain_dict(env_profile))
+
+    @classmethod
+    def _merge_mappings(cls, base: dict[str, Any], override: dict[str, Any]) -> None:
+        """Apply a partial play profile without discarding typed term declarations."""
+        for key, value in override.items():
+            current = base.get(key)
+            if isinstance(current, dict) and isinstance(value, dict):
+                cls._merge_mappings(current, value)
+            else:
+                base[key] = value
 
     def _resolve_root_relative_path(self, path_value: str) -> str:
         candidate = Path(path_value)

--- a/src/unilab/base/entity.py
+++ b/src/unilab/base/entity.py
@@ -578,6 +578,7 @@ class Entity:
         self._reset_joint_qvel_ids: np.ndarray | None = None
         self._joint_model_dof_ids: np.ndarray | None = None
         self._motion_body_ids: np.ndarray | None = None
+        self._mocap_body_name: str | None = None
 
         self._joint_names = _normalize_names(name, "joint", cfg.joint_names)
         self._body_names = _normalize_names(name, "body", cfg.body_names)
@@ -1368,6 +1369,259 @@ class Entity:
             self._actuator_ids[local_ids],
             kp,
             kd,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_geom_size_write(
+        self,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local geom_size columns and immutable defaults."""
+        transaction, local_ids, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        _, defaults = transaction.bind_geom_size_write(
+            model_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_geom_size_to_sim(
+        self,
+        values: np.ndarray,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "geom_size",
+    ) -> None:
+        """Stage geom_size values through the reset transaction."""
+        transaction, _, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        transaction.write_geom_size(
+            self._normalize_reset_env_ids(env_ids),
+            model_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_geom_solref_write(
+        self,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local geom_solref columns and immutable defaults."""
+        transaction, local_ids, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        _, defaults = transaction.bind_geom_solref_write(
+            model_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_geom_solref_to_sim(
+        self,
+        values: np.ndarray,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "geom_solref",
+    ) -> None:
+        """Stage geom_solref values through the reset transaction."""
+        transaction, _, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        transaction.write_geom_solref(
+            self._normalize_reset_env_ids(env_ids),
+            model_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_geom_solimp_write(
+        self,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local geom_solimp columns and immutable defaults."""
+        transaction, local_ids, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        _, defaults = transaction.bind_geom_solimp_write(
+            model_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_geom_solimp_to_sim(
+        self,
+        values: np.ndarray,
+        geom_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "geom_solimp",
+    ) -> None:
+        """Stage geom_solimp values through the reset transaction."""
+        transaction, _, model_ids = self._reset_model_field_ids(
+            "geom",
+            geom_ids,
+            term_name=term_name,
+        )
+        transaction.write_geom_solimp(
+            self._normalize_reset_env_ids(env_ids),
+            model_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_joint_damping_write(
+        self,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local joint_damping columns and immutable defaults."""
+        transaction, local_ids, model_ids = self._reset_model_field_ids(
+            "joint",
+            joint_ids,
+            term_name=term_name,
+        )
+        _, defaults = transaction.bind_dof_damping_write(
+            model_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_joint_damping_to_sim(
+        self,
+        values: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "joint_damping",
+    ) -> None:
+        """Stage joint_damping values through the reset transaction."""
+        transaction, _, model_ids = self._reset_model_field_ids(
+            "joint",
+            joint_ids,
+            term_name=term_name,
+        )
+        transaction.write_dof_damping(
+            self._normalize_reset_env_ids(env_ids),
+            model_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def bind_joint_frictionloss_write(
+        self,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind entity-local joint_frictionloss columns and immutable defaults."""
+        transaction, local_ids, model_ids = self._reset_model_field_ids(
+            "joint",
+            joint_ids,
+            term_name=term_name,
+        )
+        _, defaults = transaction.bind_dof_frictionloss_write(
+            model_ids,
+            term_name=f"{term_name}:{self.name}",
+        )
+        return self._readonly_local_binding(local_ids, defaults)
+
+    def write_joint_frictionloss_to_sim(
+        self,
+        values: np.ndarray,
+        joint_ids: np.ndarray | Sequence[int] | slice | None = None,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "joint_frictionloss",
+    ) -> None:
+        """Stage joint_frictionloss values through the reset transaction."""
+        transaction, _, model_ids = self._reset_model_field_ids(
+            "joint",
+            joint_ids,
+            term_name=term_name,
+        )
+        transaction.write_dof_frictionloss(
+            self._normalize_reset_env_ids(env_ids),
+            model_ids,
+            values,
+            term_name=f"{term_name}:{self.name}",
+        )
+
+    def _reset_model_field_ids(
+        self,
+        kind: str,
+        ids: np.ndarray | Sequence[int] | slice | None,
+        *,
+        term_name: str,
+    ) -> tuple[ResetStateTransaction, np.ndarray, np.ndarray]:
+        if self._reset_state is None:
+            raise self._capability_error(term_name, "no env-owned reset transaction")
+        if kind == "geom":
+            if self._geom_ids is None:
+                raise self._capability_error(term_name, "geom names were not declared")
+            local_ids = self._normalize_local_geom_ids(ids, capability=term_name)
+            model_ids = self._geom_ids[local_ids]
+        else:
+            local_ids = self._normalize_local_joint_ids(ids, capability=term_name)
+            model_ids = self._materialize_joint_model_dof_ids()[local_ids]
+        if local_ids.size == 0:
+            raise ValueError(f"Entity '{self.name}' {term_name} selected no {kind}s")
+        return self._reset_state, local_ids, model_ids
+
+    def bind_mocap_pose_write(self, body_name: str, *, term_name: str) -> np.ndarray:
+        """Bind an explicitly named mocap body, independently of the floating root."""
+        if self._reset_state is None:
+            raise self._capability_error(term_name, "no env-owned reset transaction")
+        if body_name not in self.body_names:
+            raise ValueError(f"Entity '{self.name}' does not expose mocap body {body_name!r}")
+        if self._mocap_body_name is not None and self._mocap_body_name != body_name:
+            raise ValueError(
+                f"Entity '{self.name}' already bound mocap body {self._mocap_body_name!r}"
+            )
+        binding = self._reset_state.bind_mocap_pose(body_name)
+        self._mocap_body_name = body_name
+        return binding.default_pose.copy()
+
+    def read_mocap_pose(self) -> np.ndarray:
+        """Read full-batch mocap poses, including pending reset writes."""
+        if self._reset_state is None or self._mocap_body_name is None:
+            raise RuntimeError(f"Entity '{self.name}' must bind its mocap pose before reading")
+        return self._reset_state.read_mocap_pose(self._mocap_body_name)
+
+    def write_mocap_pose_to_sim(
+        self,
+        poses: np.ndarray,
+        env_ids: np.ndarray | slice | None = None,
+        *,
+        term_name: str = "mocap_pose",
+    ) -> None:
+        """Stage poses to commit after the ordinary reset state upload."""
+        if self._reset_state is None or self._mocap_body_name is None:
+            raise RuntimeError(f"Entity '{self.name}' must bind its mocap pose before writing")
+        self._reset_state.write_mocap_pose(
+            self._mocap_body_name,
+            self._normalize_reset_env_ids(env_ids),
+            poses,
             term_name=f"{term_name}:{self.name}",
         )
 

--- a/src/unilab/base/np_env.py
+++ b/src/unilab/base/np_env.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from os import PathLike
 from typing import TYPE_CHECKING, Any, Optional, Tuple, cast
@@ -613,6 +613,25 @@ class NpEnv(ABEnv):
         disable it so a terminated robot stays put until a manual reset.
         """
         self._autoreset = bool(enabled)
+
+    def export_training_state(self) -> dict[str, Any]:
+        """Export cumulative training progress, independently of episode/physics state.
+
+        Task-specific curriculum state belongs to the task's explicit provider;
+        this payload deliberately does not inspect manager or environment internals.
+        """
+        return {"version": 1, "step_counter": self.step_counter}
+
+    def import_training_state(self, state: Mapping[str, Any]) -> None:
+        """Validate and restore cumulative progress before the next control step."""
+        if not isinstance(state, Mapping) or set(state) != {"version", "step_counter"}:
+            raise ValueError("NpEnv training state requires version and step_counter only")
+        if type(state["version"]) is not int or state["version"] != 1:
+            raise ValueError("Unsupported NpEnv training state version")
+        counter = state["step_counter"]
+        if type(counter) is not int or counter < 0:
+            raise ValueError("NpEnv training step_counter must be a non-negative integer")
+        self.step_counter = counter
 
     def close(self) -> None:
         """Close the environment and release backend-owned scene assets."""

--- a/src/unilab/base/reset_state.py
+++ b/src/unilab/base/reset_state.py
@@ -13,13 +13,18 @@ from contextlib import contextmanager
 from typing import cast
 
 import numpy as np
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import BackendMocapPoseBinding, BackendRootStateLayout, SimBackend
 from unisim.dr.types import (
     RESET_TERM_BODY_INERTIA,
     RESET_TERM_BODY_IPOS,
     RESET_TERM_BODY_MASS,
     RESET_TERM_DOF_ARMATURE,
+    RESET_TERM_DOF_DAMPING,
+    RESET_TERM_DOF_FRICTIONLOSS,
     RESET_TERM_GEOM_FRICTION,
+    RESET_TERM_GEOM_SIZE,
+    RESET_TERM_GEOM_SOLIMP,
+    RESET_TERM_GEOM_SOLREF,
     RESET_TERM_GRAVITY,
     RESET_TERM_KD,
     RESET_TERM_KP,
@@ -64,6 +69,9 @@ class ResetStateTransaction:
         self._requesting_terms: set[str] = set()
         self._last_commit_had_writes = False
         self._last_set_state_timing_ms: dict[str, float] = {}
+        self._mocap_bindings: dict[str, BackendMocapPoseBinding] = {}
+        self._mocap_values: dict[str, np.ndarray] = {}
+        self._mocap_masks: dict[str, np.ndarray] = {}
 
     @property
     def active(self) -> bool:
@@ -113,6 +121,201 @@ class ResetStateTransaction:
         self._last_commit_had_writes = False
         self._last_set_state_timing_ms = {}
         self._active = True
+
+    def bind_geom_size_write(
+        self,
+        column_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind immutable geom_size defaults through the declared backend capability."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_GEOM_SIZE,
+            getter=self._backend.get_geom_sizes,
+            expected_tail=(3,),
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            column_ids,
+            width=default.shape[0],
+            capability="geom_size IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def write_geom_size(
+        self,
+        env_ids: np.ndarray,
+        column_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected geom_size values in the active reset."""
+        self._write_selected_randomization(
+            RESET_TERM_GEOM_SIZE,
+            env_ids,
+            column_ids,
+            values,
+            value_tail=(3,),
+            term_name=term_name,
+        )
+
+    def bind_geom_solref_write(
+        self,
+        column_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind immutable geom_solref defaults through the declared backend capability."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_GEOM_SOLREF,
+            getter=self._backend.get_geom_solref,
+            expected_tail=(2,),
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            column_ids,
+            width=default.shape[0],
+            capability="geom_solref IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def write_geom_solref(
+        self,
+        env_ids: np.ndarray,
+        column_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected geom_solref values in the active reset."""
+        self._write_selected_randomization(
+            RESET_TERM_GEOM_SOLREF,
+            env_ids,
+            column_ids,
+            values,
+            value_tail=(2,),
+            term_name=term_name,
+        )
+
+    def bind_geom_solimp_write(
+        self,
+        column_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind immutable geom_solimp defaults through the declared backend capability."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_GEOM_SOLIMP,
+            getter=self._backend.get_geom_solimp,
+            expected_tail=(5,),
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            column_ids,
+            width=default.shape[0],
+            capability="geom_solimp IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def write_geom_solimp(
+        self,
+        env_ids: np.ndarray,
+        column_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected geom_solimp values in the active reset."""
+        self._write_selected_randomization(
+            RESET_TERM_GEOM_SOLIMP,
+            env_ids,
+            column_ids,
+            values,
+            value_tail=(5,),
+            term_name=term_name,
+        )
+
+    def bind_dof_damping_write(
+        self,
+        column_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind immutable dof_damping defaults through the declared backend capability."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_DOF_DAMPING,
+            getter=self._backend.get_dof_damping,
+            expected_tail=None,
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            column_ids,
+            width=default.shape[0],
+            capability="dof_damping IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def write_dof_damping(
+        self,
+        env_ids: np.ndarray,
+        column_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected dof_damping values in the active reset."""
+        self._write_selected_randomization(
+            RESET_TERM_DOF_DAMPING,
+            env_ids,
+            column_ids,
+            values,
+            value_tail=(),
+            term_name=term_name,
+        )
+
+    def bind_dof_frictionloss_write(
+        self,
+        column_ids: np.ndarray,
+        *,
+        term_name: str,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Bind immutable dof_frictionloss defaults through the declared backend capability."""
+        default = self._materialize_randomization_default(
+            RESET_TERM_DOF_FRICTIONLOSS,
+            getter=self._backend.get_dof_frictionloss,
+            expected_tail=None,
+            term_name=term_name,
+        )
+        columns = self._validate_columns(
+            column_ids,
+            width=default.shape[0],
+            capability="dof_frictionloss IDs",
+            term_name=term_name,
+        )
+        return self._readonly_binding(columns, default[columns])
+
+    def write_dof_frictionloss(
+        self,
+        env_ids: np.ndarray,
+        column_ids: np.ndarray,
+        values: np.ndarray,
+        *,
+        term_name: str,
+    ) -> None:
+        """Stage selected dof_frictionloss values in the active reset."""
+        self._write_selected_randomization(
+            RESET_TERM_DOF_FRICTIONLOSS,
+            env_ids,
+            column_ids,
+            values,
+            value_tail=(),
+            term_name=term_name,
+        )
 
     def bind_body_mass_write(
         self,
@@ -670,13 +873,53 @@ class ResetStateTransaction:
         assert self._qpos is not None
         return np.array(self._qpos[ids[:, None], qpos_columns[None, :]], copy=True)
 
+    def bind_mocap_pose(self, body_name: str) -> BackendMocapPoseBinding:
+        """Resolve a mocap body once, without exposing a native backend handle."""
+        if body_name not in self._mocap_bindings:
+            if self._active:
+                raise RuntimeError("Mocap bodies must be bound before reset starts")
+            binding = self._backend.bind_mocap_pose(body_name)
+            if binding.num_envs != self._num_envs or binding.body_name != body_name:
+                raise ValueError("Backend mocap binding does not match the requested body/batch")
+            self._mocap_bindings[body_name] = binding
+            self._mocap_values[body_name] = np.empty((self._num_envs, 7))
+            self._mocap_masks[body_name] = np.zeros(self._num_envs, dtype=np.bool_)
+        return self._mocap_bindings[body_name]
+
+    def read_mocap_pose(self, body_name: str) -> np.ndarray:
+        """Read current poses with this transaction's pending rows overlaid."""
+        poses = self._mocap_bindings[body_name].read()
+        mask = self._mocap_masks[body_name]
+        poses[mask] = self._mocap_values[body_name][mask]
+        return poses
+
+    def write_mocap_pose(
+        self, body_name: str, env_ids: np.ndarray, poses: np.ndarray, *, term_name: str
+    ) -> None:
+        """Stage poses; upload only after the ordinary reset state has committed."""
+        self._require_active()
+        if body_name not in self._mocap_bindings:
+            raise RuntimeError(f"Mocap body {body_name!r} must be bound before writing")
+        ids = self._validate_ids(env_ids, capability="mocap pose")
+        if np.any(~self._active_mask[ids]):
+            raise ValueError(f"{term_name}: mocap mutation outside the active reset")
+        values = self._validate_values(
+            poses, shape=(ids.size, 7), capability="mocap pose", term_name=term_name
+        )
+        self._validate_quaternions(values[:, 3:], term_name=term_name)
+        self._mocap_values[body_name][ids] = values
+        self._mocap_masks[body_name][ids] = True
+        self._requesting_terms.add(term_name)
+
     def commit(self) -> dict | None:
         """Commit all staged rows through one public backend call."""
         self._require_active()
         dirty_ids = np.flatnonzero(self._dirty_mask).astype(np.int32, copy=False)
-        self._last_commit_had_writes = bool(dirty_ids.size)
+        mocap_dirty = any(np.any(mask) for mask in self._mocap_masks.values())
+        self._last_commit_had_writes = bool(dirty_ids.size) or mocap_dirty
         try:
             if dirty_ids.size == 0:
+                self._commit_mocap_poses()
                 return None
             assert self._qpos is not None
             assert self._qvel is not None
@@ -690,6 +933,7 @@ class ResetStateTransaction:
                     randomization=randomization,
                 )
                 self._record_committed_payload(dirty_ids, randomization)
+                self._commit_mocap_poses()
                 timing: dict[str, float] = {
                     "dr_reset_set_state_ms": (time.perf_counter() - set_state_t0) * 1000.0
                 }
@@ -707,6 +951,12 @@ class ResetStateTransaction:
                 ) from exc
         finally:
             self._finish()
+
+    def _commit_mocap_poses(self) -> None:
+        for name, mask in self._mocap_masks.items():
+            ids = np.flatnonzero(mask).astype(np.int32, copy=False)
+            if ids.size:
+                self._mocap_bindings[name].write(ids, self._mocap_values[name][ids])
 
     def abort(self) -> None:
         """Discard staged rows without touching the backend."""
@@ -927,7 +1177,12 @@ class ResetStateTransaction:
             RESET_TERM_BODY_MASS,
             RESET_TERM_BODY_IPOS,
             RESET_TERM_DOF_ARMATURE,
+            RESET_TERM_DOF_DAMPING,
+            RESET_TERM_DOF_FRICTIONLOSS,
             RESET_TERM_GEOM_FRICTION,
+            RESET_TERM_GEOM_SIZE,
+            RESET_TERM_GEOM_SOLREF,
+            RESET_TERM_GEOM_SOLIMP,
             RESET_TERM_GRAVITY,
         ):
             mask = self._randomization_dirty_masks.get(field)
@@ -1012,7 +1267,12 @@ class ResetStateTransaction:
             RESET_TERM_BODY_MASS,
             RESET_TERM_BODY_IPOS,
             RESET_TERM_DOF_ARMATURE,
+            RESET_TERM_DOF_DAMPING,
+            RESET_TERM_DOF_FRICTIONLOSS,
             RESET_TERM_GEOM_FRICTION,
+            RESET_TERM_GEOM_SIZE,
+            RESET_TERM_GEOM_SOLREF,
+            RESET_TERM_GEOM_SOLIMP,
             RESET_TERM_GRAVITY,
         ):
             values = getattr(payload, field)
@@ -1264,6 +1524,8 @@ class ResetStateTransaction:
         self._dirty_mask.fill(False)
         self._gain_dirty_mask.fill(False)
         for mask in self._randomization_dirty_masks.values():
+            mask.fill(False)
+        for mask in self._mocap_masks.values():
             mask.fill(False)
         self._requesting_terms.clear()
 

--- a/src/unilab/envs/manager_based_rl_env.py
+++ b/src/unilab/envs/manager_based_rl_env.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 import secrets
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -700,6 +701,12 @@ class ManagerBasedRlEnv(NpEnv):
         self.rng.bit_generator.state = replacement.bit_generator.state
         self._cfg.seed = seed
         return seed
+
+    def import_training_state(self, state: Mapping[str, Any]) -> None:
+        """Restore the authoritative counter and its manager-derived counters."""
+        super().import_training_state(state)
+        self.common_step_counter = self.step_counter
+        self._sim_step_counter = self.step_counter * self._cfg.sim_substeps
 
     def close(self) -> None:
         self.recorder_manager.close()

--- a/src/unilab/scripts/play_interactive.py
+++ b/src/unilab/scripts/play_interactive.py
@@ -973,13 +973,16 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
         playback_cfg = build_playback_config(args, num_envs=1)
         if algo == "ppo":
             wrapper_cls = RslRlVecEnvWrapper
+            runner_cls = OnPolicyRunner
             if cfg is not None:
                 from uni_rl.algos.rsl_rl_runtime import resolve_rsl_rl_ppo_runtime
 
-                wrapper_cls = resolve_rsl_rl_ppo_runtime(
+                runtime = resolve_rsl_rl_ppo_runtime(
                     _algo_config_dict(cfg),
                     default_wrapper_cls=RslRlVecEnvWrapper,
-                ).wrapper_cls
+                )
+                wrapper_cls = runtime.wrapper_cls
+                runner_cls = runtime.runner_cls or OnPolicyRunner
             session: Any = create_rsl_rl_playback_session(
                 playback_cfg=playback_cfg,
                 env_factory=_create_env,
@@ -990,7 +993,7 @@ def play_interactive(args, cfg: DictConfig | None = None, *, algo: str | None = 
                 checkpoint_input_dim_reader=infer_checkpoint_actor_input_dim,
                 entrypoint_log_root=get_entrypoint_log_root,
                 wrapper_cls=wrapper_cls,
-                runner_cls=OnPolicyRunner,
+                runner_cls=runner_cls,
                 policy_obs_dims_getter=get_policy_obs_dims,
                 train_cfg_normalizer=normalize_ppo_train_cfg,
                 sim2sim_preflight=make_sim2sim_preflight(cfg, algo_name="ppo"),

--- a/src/unilab/scripts/train_rsl_rl.py
+++ b/src/unilab/scripts/train_rsl_rl.py
@@ -328,7 +328,10 @@ def play_rsl_rl(cfg: DictConfig, device: str) -> str | None:
         checkpoint_input_dim_reader=infer_checkpoint_actor_input_dim,
         entrypoint_log_root=get_entrypoint_log_root,
         wrapper_cls=_resolve_ppo_wrapper_cls(rl_cfg),
-        runner_cls=OnPolicyRunner,
+        runner_cls=resolve_rsl_rl_ppo_runtime(
+            rl_cfg, default_wrapper_cls=RslRlVecEnvWrapper
+        ).runner_cls
+        or OnPolicyRunner,
         policy_obs_dims_getter=get_policy_obs_dims,
         train_cfg_normalizer=_normalize_play_train_cfg,
         sim2sim_preflight=make_sim2sim_preflight(cfg, algo_name="ppo"),
@@ -582,9 +585,15 @@ def main(cfg: DictConfig) -> None:
                         train_cfg["wandb_notes"] = wandb_settings["notes"]
                         train_cfg["wandb_mode"] = wandb_settings["mode"]
 
+                    runner_cls = (
+                        resolve_rsl_rl_ppo_runtime(
+                            rl_cfg, default_wrapper_cls=RslRlVecEnvWrapper
+                        ).runner_cls
+                        or OnPolicyRunner
+                    )
                     runner = cast(
                         Any,
-                        OnPolicyRunner(
+                        runner_cls(
                             cast(Any, wrapped_env), train_cfg, log_dir=log_dir, device=device
                         ),
                     )

--- a/src/unilab/training/experiment.py
+++ b/src/unilab/training/experiment.py
@@ -365,18 +365,12 @@ class ExperimentTracker:
 
 
 def patch_rsl_rl_action_std_logging(runner: Any) -> None:
-    """Attach rsl-rl action standard deviation to each logger payload."""
-    import torch
-
+    """Log the current distribution's public standard deviation, including state dependence."""
     original_log = runner.logger.log
 
     def _safe_log(self: Any, *args: Any, **kwargs: Any) -> Any:
         distribution = runner.alg.get_policy().distribution
-        if distribution.std_type == "scalar":
-            action_std = distribution.std_param
-        else:
-            action_std = torch.exp(distribution.log_std_param)
-        kwargs["action_std"] = action_std.detach().clone()
+        kwargs["action_std"] = distribution.std.detach().clone()
         return original_log(*args, **kwargs)
 
     runner.logger.log = _safe_log.__get__(runner.logger, type(runner.logger))

--- a/src/unilab/visualization/interactive_playback.py
+++ b/src/unilab/visualization/interactive_playback.py
@@ -567,6 +567,13 @@ def create_rsl_rl_playback_session(
                 if runner_loader is not None:
                     runner_loader(runner, checkpoint_path)
                 else:
+                    from uni_rl.algos.rsl_rl_training_state import TrainingStateOnPolicyRunner
+
+                    load_options = (
+                        {"restore_training_state": False}
+                        if isinstance(runner, TrainingStateOnPolicyRunner)
+                        else {}
+                    )
                     runner.load(
                         checkpoint_path,
                         load_cfg={
@@ -576,6 +583,7 @@ def create_rsl_rl_playback_session(
                             "iteration": False,
                             "rnd": False,
                         },
+                        **load_options,
                     )
             policy = runner.get_inference_policy(device=device_name)
 

--- a/tests/base/test_entity_facade.py
+++ b/tests/base/test_entity_facade.py
@@ -8,11 +8,12 @@ from typing import Any, cast
 
 import numpy as np
 import pytest
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import BackendMocapPoseBinding, BackendRootStateLayout, SimBackend
+from unisim.dr.types import DomainRandomizationCapabilities
 
 import unilab.base.entity as entity_module
 from unilab.assets import ASSETS_ROOT_PATH
-from unilab.base.entity import EntityCfg, EntityScene
+from unilab.base.entity import Entity, EntityCfg, EntityScene
 from unilab.base.reset_state import ResetStateTransaction
 from unilab.base.scene import SceneCfg
 from unilab.managers import RewardManager, RewardTermCfg, SceneEntityCfg
@@ -179,6 +180,77 @@ class _StrictBackendProfile:
     def get_body_ang_vel_b(self, ids: np.ndarray) -> np.ndarray:
         self._check("body-frame angular velocity state")
         return self.body_ang_vel_b[:, ids]
+
+
+def test_manipulation_entity_maps_local_columns_and_binds_mocap_without_floating_root():
+    class Backend(_StrictBackendProfile):
+        def __init__(self):
+            super().__init__("mjwarp")
+            self.payload = None
+            self.poses = np.tile([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], (3, 1))
+
+        def get_dr_capabilities(self):
+            return DomainRandomizationCapabilities(
+                supported_reset_terms=frozenset(("geom_size", "dof_damping"))
+            )
+
+        def get_geom_sizes(self):
+            self._check("geom size defaults")
+            return np.ones((3, 3))
+
+        def get_dof_damping(self):
+            self._check("damping defaults")
+            return np.ones(9)
+
+        def get_joint_dof_indices(self, names):
+            self._check("model DOF IDs")
+            return np.array([{"hip": 7}[name] for name in names], dtype=np.int32)
+
+        def bind_mocap_pose(self, name):
+            self._check("mocap binding")
+
+            def write(ids, poses):
+                self.poses[ids] = poses
+
+            return BackendMocapPoseBinding(
+                "mjwarp", name, self.num_envs, self.poses[0], lambda: self.poses, write
+            )
+
+        def set_state(self, env_ids, qpos, qvel, randomization=None):
+            self.payload = randomization
+            self.poses[env_ids, 0] = 0.0
+
+    backend = Backend()
+    transaction = ResetStateTransaction(cast(SimBackend, backend))
+    hand = Entity(
+        "hand",
+        EntityCfg(
+            body_names=("foot",),
+            joint_names=("hip",),
+            geom_names=("foot_collision", "base_collision"),
+        ),
+        cast(SimBackend, backend),
+        reset_state=transaction,
+    )
+    geom_ids, _ = hand.bind_geom_size_write([0], term_name="size")
+    joint_ids, _ = hand.bind_joint_damping_write(term_name="damping")
+    default_pose = hand.bind_mocap_pose_write("foot", term_name="wrist")
+    calls = backend.calls.copy()
+    ids = np.array([2], dtype=np.int32)
+    pose = default_pose[None].copy()
+    pose[:, 0] = 0.8
+    for _ in range(2):
+        with transaction.scoped(ids):
+            hand.write_geom_size_to_sim(np.full((1, 1, 3), 0.5), geom_ids, ids)
+            hand.write_joint_damping_to_sim(np.full((1, 1), 0.2), joint_ids, ids)
+            hand.write_mocap_pose_to_sim(pose, ids)
+    np.testing.assert_array_equal(backend.payload.geom_size[0, 2], 0.5)
+    np.testing.assert_array_equal(backend.payload.geom_size[0, :2], 1.0)
+    assert backend.payload.dof_damping[0, 7] == 0.2
+    np.testing.assert_array_equal(hand.read_mocap_pose()[ids], pose)
+    for name in ("geom size defaults", "damping defaults", "model DOF IDs", "mocap binding"):
+        assert backend.calls[name] == calls[name] == 1
+    assert backend.calls["root-state layout"] == 0
 
 
 def _scene(backend_type: str = "mujoco") -> tuple[_StrictBackendProfile, EntityScene]:

--- a/tests/base/test_reset_state.py
+++ b/tests/base/test_reset_state.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import numpy as np
 import pytest
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import BackendMocapPoseBinding, BackendRootStateLayout, SimBackend
 from unisim.dr.types import (
     RESET_TERM_KD,
     RESET_TERM_KP,
@@ -71,6 +71,142 @@ class _Backend:
 
 def _transaction(backend: _Backend) -> ResetStateTransaction:
     return ResetStateTransaction(cast(SimBackend, backend))
+
+
+class _ManipulationBackend(_Backend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[str] = []
+        self.poses = np.tile([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], (self.num_envs, 1))
+        self.default_calls = 0
+
+    def get_dr_capabilities(self):
+        return DomainRandomizationCapabilities(
+            supported_reset_terms=frozenset(
+                (
+                    "geom_size",
+                    "geom_solref",
+                    "geom_solimp",
+                    "dof_damping",
+                    "dof_frictionloss",
+                )
+            )
+        )
+
+    def _defaults(self, width):
+        self.default_calls += 1
+        return np.ones((3, width)) if width else np.ones(2)
+
+    def get_geom_sizes(self):
+        return self._defaults(3)
+
+    def get_geom_solref(self):
+        return self._defaults(2)
+
+    def get_geom_solimp(self):
+        return self._defaults(5)
+
+    def get_dof_damping(self):
+        return self._defaults(0)
+
+    def get_dof_frictionloss(self):
+        return self._defaults(0)
+
+    def set_state(self, env_ids, qpos, qvel, randomization=None):
+        self.events.append("state")
+        self.poses[env_ids, 0] = 0.0
+        return super().set_state(env_ids, qpos, qvel, randomization)
+
+    def bind_mocap_pose(self, body_name):
+        def write(ids, poses):
+            self.events.append("mocap")
+            self.poses[ids] = poses
+
+        return BackendMocapPoseBinding(
+            self.backend_type,
+            body_name,
+            self.num_envs,
+            self.poses[0].copy(),
+            lambda: self.poses,
+            write,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,width",
+    [
+        ("geom_size", 3),
+        ("geom_solref", 2),
+        ("geom_solimp", 5),
+        ("dof_damping", 0),
+        ("dof_frictionloss", 0),
+    ],
+)
+def test_manipulation_fields_preserve_unselected_columns_and_bind_once(field, width):
+    backend = _ManipulationBackend()
+    transaction = _transaction(backend)
+    columns = np.array([1], dtype=np.int32)
+    _, defaults = getattr(transaction, f"bind_{field}_write")(columns, term_name=field)
+    assert not defaults.flags.writeable
+    ids = np.array([2, 0], dtype=np.int32)
+    values = np.full((2, 1, width) if width else (2, 1), 0.25)
+    for _ in range(2):
+        with transaction.scoped(ids):
+            getattr(transaction, f"write_{field}")(ids, columns, values, term_name=field)
+    assert backend.default_calls == 1
+    payload = backend.randomization_calls[-1]
+    np.testing.assert_array_equal(backend.set_state_calls[-1][0], [0, 2])
+    np.testing.assert_array_equal(getattr(payload, field)[:, 1], 0.25)
+    np.testing.assert_array_equal(getattr(payload, field)[:, 0], 1.0)
+
+
+def test_mocap_pose_is_staged_then_committed_after_generalized_state():
+    backend = _ManipulationBackend()
+    transaction = _transaction(backend)
+    transaction.bind_mocap_pose("palm")
+    ids = np.array([2], dtype=np.int32)
+    poses = backend.poses[ids].copy()
+    poses[:, 0] = 0.7
+    with transaction.scoped(ids):
+        transaction.write_mocap_pose("palm", ids, poses, term_name="wrist")
+        transaction.reset_to_default(ids, term_name="scene")
+        np.testing.assert_array_equal(transaction.read_mocap_pose("palm")[ids], poses)
+        assert backend.events == []
+    assert backend.events == ["state", "mocap"]
+    np.testing.assert_array_equal(backend.poses[ids], poses)
+    np.testing.assert_array_equal(backend.poses[[0, 1, 3], 0], 0.0)
+    assert transaction.last_commit_had_writes
+
+
+def test_mocap_only_write_does_not_reset_physics_and_abort_discards_pose():
+    backend = _ManipulationBackend()
+    transaction = _transaction(backend)
+    transaction.bind_mocap_pose("palm")
+    ids = np.array([1], dtype=np.int32)
+    poses = backend.poses[ids].copy()
+    poses[:, 0] = 0.4
+    with pytest.raises(RuntimeError, match="cancel"):
+        with transaction.scoped(ids):
+            transaction.write_mocap_pose("palm", ids, poses, term_name="wrist")
+            raise RuntimeError("cancel")
+    assert backend.events == []
+    with transaction.scoped(ids):
+        transaction.write_mocap_pose("palm", ids, poses, term_name="wrist")
+    assert backend.events == ["mocap"]
+    assert backend.default_qpos_calls == 0
+    np.testing.assert_array_equal(backend.poses[ids], poses)
+
+
+def test_invalid_mocap_write_fails_before_any_backend_mutation():
+    backend = _ManipulationBackend()
+    transaction = _transaction(backend)
+    transaction.bind_mocap_pose("palm")
+    ids = np.array([0], dtype=np.int32)
+    with pytest.raises(ValueError, match="quaternion"):
+        with transaction.scoped(ids):
+            transaction.reset_to_default(ids, term_name="scene")
+            transaction.write_mocap_pose("palm", ids, np.zeros((1, 7)), term_name="bad")
+    assert backend.events == []
 
 
 def test_transaction_is_lazy_and_combines_terms_into_one_commit() -> None:

--- a/tests/envs/test_manager_based_rl_env.py
+++ b/tests/envs/test_manager_based_rl_env.py
@@ -456,6 +456,29 @@ def _make_env(
     return env, backend
 
 
+def test_training_progress_restore_survives_next_step_and_rejects_invalid_state():
+    env, _ = _make_env()
+    env.reset()
+    env.import_training_state({"version": 1, "step_counter": 700})
+    assert env.common_step_counter == 700
+    assert env._sim_step_counter == 700 * env.cfg.sim_substeps
+    env.step(np.zeros((env.num_envs, 1), dtype=np.float32))
+    assert env.step_counter == 701
+    assert env.common_step_counter == 701
+    assert env.export_training_state() == {"version": 1, "step_counter": 701}
+    for invalid in (
+        {"version": 1, "step_counter": -1},
+        {"version": True, "step_counter": 4},
+        {"version": 1, "step_counter": True},
+        {"version": 2, "step_counter": 4},
+        {"version": 1, "step_counter": 4, "extra": 0},
+    ):
+        with pytest.raises(ValueError):
+            env.import_training_state(invalid)
+        assert env.step_counter == env.common_step_counter == 701
+    env.close()
+
+
 def _make_state_env(
     *,
     commands: dict[str, CommandTermCfg | None] | None = None,

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1018,19 +1018,28 @@ def test_build_ppo_env_cfg_override_sharpa_grasp_motrix_owner(
     assert env_cfg_override["domain_rand"]["scale_list"] == [0.8]
 
 
-@pytest.mark.parametrize("std_type", ["scalar", "vector"])
-def test_rsl_action_std_logging_patch_delegates_with_detached_clone(std_type: str):
+@pytest.mark.parametrize("std_type", ["scalar", "log"])
+@pytest.mark.parametrize("state_dependent", [False, True])
+def test_rsl_action_std_logging_patch_delegates_with_detached_clone(
+    std_type: str, state_dependent: bool,
+):
     import torch
+    from rsl_rl.modules.distribution import GaussianDistribution, HeteroscedasticGaussianDistribution
 
     from unilab.training.experiment import patch_rsl_rl_action_std_logging
 
     captured: dict[str, Any] = {}
-    expected = torch.tensor([0.25, 0.5], requires_grad=True)
-    distribution = types.SimpleNamespace(
-        std_type=std_type,
-        std_param=expected,
-        log_std_param=torch.log(expected),
-    )
+    if state_dependent:
+        expected = torch.tensor([[0.25, 0.5], [0.4, 0.9]], requires_grad=True)
+        distribution = HeteroscedasticGaussianDistribution(output_dim=2, std_type=std_type)
+        std_head = expected if std_type == "scalar" else torch.log(expected)
+        distribution.update(torch.stack((torch.zeros_like(expected), std_head), dim=-2))
+        assert not hasattr(distribution, "std_param")
+        assert not hasattr(distribution, "log_std_param")
+    else:
+        expected = torch.full((2, 2), 0.5)
+        distribution = GaussianDistribution(output_dim=2, init_std=0.5, std_type=std_type)
+        distribution.update(torch.zeros_like(expected))
 
     class Logger:
         def log(self, *args, **kwargs):

--- a/tests/scripts/test_train_scripts.py
+++ b/tests/scripts/test_train_scripts.py
@@ -1021,10 +1021,14 @@ def test_build_ppo_env_cfg_override_sharpa_grasp_motrix_owner(
 @pytest.mark.parametrize("std_type", ["scalar", "log"])
 @pytest.mark.parametrize("state_dependent", [False, True])
 def test_rsl_action_std_logging_patch_delegates_with_detached_clone(
-    std_type: str, state_dependent: bool,
+    std_type: str,
+    state_dependent: bool,
 ):
     import torch
-    from rsl_rl.modules.distribution import GaussianDistribution, HeteroscedasticGaussianDistribution
+    from rsl_rl.modules.distribution import (
+        GaussianDistribution,
+        HeteroscedasticGaussianDistribution,
+    )
 
     from unilab.training.experiment import patch_rsl_rl_action_std_logging
 

--- a/tests/training/test_training_helpers.py
+++ b/tests/training/test_training_helpers.py
@@ -425,6 +425,58 @@ def test_backend_adapter_keeps_motion_manager_scene_during_play():
     assert captured == {}
 
 
+def test_backend_adapter_play_profile_merges_partial_observation_term() -> None:
+    """A play profile may change term parameters without removing its callable."""
+    override = {
+        "observations": {
+            "policy": {
+                "enable_corruption": True,
+                "terms": {
+                    "position": {
+                        "func": "example.position",
+                        "params": {"injection_prob": 0.2, "scale": 1.0},
+                        "history_length": 3,
+                    },
+                    "velocity": {
+                        "func": "example.velocity",
+                        "noise": {"std": 0.1},
+                    },
+                },
+            },
+            "critic": {"terms": {"privileged": {"func": "example.privileged"}}},
+        }
+    }
+    profile = OmegaConf.create(
+        {
+            "observations": {
+                "policy": {
+                    "enable_corruption": False,
+                    "terms": {"position": {"params": {"injection_prob": 0.0}}},
+                }
+            }
+        }
+    )
+
+    adapter = BackendAdapter(OmegaConf.create({}), root_dir=_ROOT_DIR)
+    adapter._apply_env_profile(override, profile)
+
+    position = override["observations"]["policy"]["terms"]["position"]
+    assert override["observations"]["policy"]["enable_corruption"] is False
+    assert position["func"] == "example.position"
+    assert position["params"] == {"injection_prob": 0.0, "scale": 1.0}
+    assert position["history_length"] == 3
+    assert override["observations"]["policy"]["terms"]["velocity"] == {
+        "func": "example.velocity",
+        "noise": {"std": 0.1},
+    }
+    assert override["observations"]["critic"]["terms"]["privileged"]["func"] == (
+        "example.privileged"
+    )
+
+    adapter._apply_env_profile(override, OmegaConf.create({"events": {"randomize": None}}))
+    assert override["events"]["randomize"] is None
+
+
 def test_backend_adapter_materializes_visuals_without_dropping_manager_entities():
     cfg = _ppo_cfg(["task=g1_box_tracking/motrix", "training.play_only=true"])
     captured: dict[str, object] = {}

--- a/tests/visualization/test_interactive_playback.py
+++ b/tests/visualization/test_interactive_playback.py
@@ -1213,6 +1213,30 @@ def test_build_play_backend_adapter_injects_root_dir_and_materializer(
     }
 
 
+def test_playback_explicitly_skips_training_progress_for_stateful_runner(tmp_path):
+    from uni_rl.algos.rsl_rl_training_state import TrainingStateOnPolicyRunner
+
+    captured = {}
+
+    class Runner(TrainingStateOnPolicyRunner):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load(self, path, **kwargs):
+            captured.update(kwargs)
+
+        def get_inference_policy(self, **kwargs):
+            return lambda obs: torch.ones((1, 2))
+
+    kwargs = _rsl_rl_session_kwargs(tmp_path)
+    kwargs["runner_cls"] = Runner
+    kwargs["checkpoint_resolver"] = lambda *args: str(tmp_path / "model.pt")
+    create_rsl_rl_playback_session(**kwargs)
+    assert captured["restore_training_state"] is False
+    assert captured["load_cfg"]["actor"] is True
+    assert not any(value for key, value in captured["load_cfg"].items() if key != "actor")
+
+
 def test_create_rsl_rl_playback_session_uses_runner_loader_and_exposes_runner(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5118,8 +5118,8 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'newton'", specifier = ">=3.21.7" },
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==1.1.0" },
-    { name = "unisim-core", specifier = ">=1.1.3" },
+    { name = "unilab-rl", specifier = "==1.1.1" },
+    { name = "unisim-core", specifier = ">=1.1.4" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = "==1.16.0" },
@@ -5139,7 +5139,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hydra-core" },
@@ -5156,20 +5156,20 @@ dependencies = [
     { name = "torch", version = "2.9.0+cu130", source = { registry = "https://download-r2.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/d2/93615e9770553ac4c3f67b27203c28509767f994484c2c1237ac1fdce731/unilab_rl-1.1.0.tar.gz", hash = "sha256:1051ef15e0b809fd9a7197458987421fb11052b34ffa49a90a92f76fb5d38e0d", size = 176655, upload-time = "2026-09-06T07:01:21.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/a9/feca1ac03d07248d4870d405e03ae61e683476637f94673b53f154249e36/unilab_rl-1.1.1.tar.gz", hash = "sha256:e75c0a0a414e11d0bd70b0ba7bb45e4e549978e07a76b61429724197d5fa5848", size = 171127, upload-time = "2026-09-08T10:19:53.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/94/4300a8b866d275226e78d2d4dbb92d82d857cb328e14ab02cf5bd20b1d90/unilab_rl-1.1.0-py3-none-any.whl", hash = "sha256:c35e76b4a138a9196f835c5166c1f32c16df82df74a8fcdf356393be53ee5952", size = 222098, upload-time = "2026-09-06T07:01:20.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/f1c15d42f25455571c29879fca00b9a0197ca69c7aa73a6f4a0980eabbbe/unilab_rl-1.1.1-py3-none-any.whl", hash = "sha256:d156fa47bc886b8b5285ecb6eb0bdd6e0bde302ad3cf9e42b2cb14b91c3270e4", size = 214137, upload-time = "2026-09-08T10:19:52.688Z" },
 ]
 
 [[package]]
 name = "unisim-core"
-version = "1.1.3"
+version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/00/a3cd085e53e296f9866ba480d4839da1ed5609d48de9de47abd12ef6e17a/unisim_core-1.1.3.tar.gz", hash = "sha256:513cce7de986b3dfbe9f6bb50ca1dc675174f72173a22d2c801ad066cdd42a88", size = 215793, upload-time = "2026-09-06T09:59:39.934Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/52/6b276891a561c9cdfacd909cbe4e11437efd97064002e92851eaad2002ea/unisim_core-1.1.4.tar.gz", hash = "sha256:9a98c6189489100191ef93e8d5de4a5be051f2a38687ce51422f90ed4d182a19", size = 219821, upload-time = "2026-09-08T10:18:43.113Z" }
 
 [[package]]
 name = "urllib3"

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3801,8 +3801,8 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'viser'", specifier = ">=3.21.7" },
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
     { name = "typing-extensions" },
-    { name = "unilab-rl", specifier = "==0.2.0" },
-    { name = "unisim-core", specifier = ">=1.1.3" },
+    { name = "unilab-rl", specifier = "==1.1.1" },
+    { name = "unisim-core", specifier = ">=1.1.4" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.26" },
     { name = "wandb" },
     { name = "wheel", marker = "extra == 'mujoco'" },
@@ -3820,7 +3820,7 @@ dev = [
 
 [[package]]
 name = "unilab-rl"
-version = "0.2.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hydra-core" },
@@ -3836,20 +3836,20 @@ dependencies = [
     { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/a5/84e9371e794e8bf6ffb50e5309526eb4469a493fba80b0f35e6b74c14fc4/unilab_rl-0.2.0.tar.gz", hash = "sha256:35a7a9d2407b3e9ae1c4f3eb3e7d23f12b9f089f4699cb62433fccb5479600d6", size = 174173, upload-time = "2026-09-04T09:41:57.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/a9/feca1ac03d07248d4870d405e03ae61e683476637f94673b53f154249e36/unilab_rl-1.1.1.tar.gz", hash = "sha256:e75c0a0a414e11d0bd70b0ba7bb45e4e549978e07a76b61429724197d5fa5848", size = 171127, upload-time = "2026-09-08T10:19:53.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8c/e5f84672f485d441985be4d4fe6f81d72e88ee2456d7573b5f370d0bee8e/unilab_rl-0.2.0-py3-none-any.whl", hash = "sha256:158493e303a210235853e5a2443d898dd05038f74490a0a91594246e9dd7ef78", size = 219641, upload-time = "2026-09-04T09:41:55.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/f1c15d42f25455571c29879fca00b9a0197ca69c7aa73a6f4a0980eabbbe/unilab_rl-1.1.1-py3-none-any.whl", hash = "sha256:d156fa47bc886b8b5285ecb6eb0bdd6e0bde302ad3cf9e42b2cb14b91c3270e4", size = 214137, upload-time = "2026-09-08T10:19:52.688Z" },
 ]
 
 [[package]]
 name = "unisim-core"
-version = "1.1.3"
+version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/00/a3cd085e53e296f9866ba480d4839da1ed5609d48de9de47abd12ef6e17a/unisim_core-1.1.3.tar.gz", hash = "sha256:513cce7de986b3dfbe9f6bb50ca1dc675174f72173a22d2c801ad066cdd42a88", size = 215793, upload-time = "2026-09-06T09:59:39.934Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/52/6b276891a561c9cdfacd909cbe4e11437efd97064002e92851eaad2002ea/unisim_core-1.1.4.tar.gz", hash = "sha256:9a98c6189489100191ef93e8d5de4a5be051f2a38687ce51422f90ed4d182a19", size = 219821, upload-time = "2026-09-08T10:18:43.113Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## Summary

Implements the UniLab owner-layer portion of `unilabsim/wuji_unilab#1` for the mjwarp-only Wuji reorientation task.

- Adds declared Entity and reset-state bindings for selected-world mocap and geometry/contact/DOF randomization.
- Preserves manager progress through reset and resume, exposes the selected PPO runtime runner, and logs state-dependent action scales.
- Updates owner integration points for training and interactive playback, with facade, reset, manager, training, script, and playback coverage.

This PR depends on the accompanying non-main owner PRs:

- `unilabsim/unisim` capability and position-actuator fix: `#42`, `#44`
- `unilabsim/unilab_rl` explicit training-state provider: `#17`
- downstream Wuji integration: `unilabsim/wuji_unilab#1`

The Wuji run only permits `mjwarp`; unsupported capability paths fail explicitly and no fallback backend was added.

## Linked Work

- Issue: Motphys/UniLab#1539
- Parent roadmap: unilabsim/wuji_unilab#1
- Roadmap declared base: `dev/bootstrap`
- Base branch: `main`

## Validation

Focused facade/reset/manager/training/playback tests and `make check` passed during the reviewed integration PR #1540.

Latest candidate composition result:

```bash
uv pip install --no-deps --reinstall ../wuji-unisim ../wuji-unilab-rl
UV_NO_SYNC=1 make test-all
```

Result: 1566 passed, 3 failed, 52 skipped. The failures are outside this PR's changed paths: the standard test rejects the local candidate `unisim-core` install, and two existing Motrix tests lack the optional `motrixsim` runtime. The main-target CI must run against the merged/released owner dependency line before this PR can be considered merge-ready.

## Impact

- Backend impact: mjwarp; declared interfaces also fail closed in other adapters until implemented.
- Platform impact: Linux GPU evidence; no macOS behavior claim.
- Training effect expected: yes, for Wuji reset randomization, curriculum restore, and PPO state handling.

## Limitations

This enables the reviewed Wuji integration path. It does not claim full mjlab feature parity, multi-GPU validation, or hardware deployment.

No release tag was created and no PyPI package was published.
