### PR TITLE
release: unilab 1.2.0

### DIFF
--- a/docs/sphinx/source/changelog.md
+++ b/docs/sphinx/source/changelog.md
@@ -13,6 +13,8 @@ UniLab 遵循[语义化版本](https://semver.org/)。本共享页面以中英�
 
 ## Unreleased / 未发布
 
+## 1.2.0 (2026-09-10)
+
 - Update the required `unisim-core` release to `>=1.2.0` and the pinned
   `unilab-rl` release to `==1.2.0`, including the ROCm profile.
   将必需的 `unisim-core` 版本更新为 `>=1.2.0`，并将钉定的 `unilab-rl` 版本更新为
@@ -62,6 +64,15 @@ UniLab 遵循[语义化版本](https://semver.org/)。本共享页面以中英�
   Per maintainer instruction, this migration does not change repository versions
   or publish a release; consumers use the coordinated migration commits.
   按维护者要求，本次不修改仓库版本号、不发布新版本，消费方固定配套迁移提交。
+
+- The FR3 SuperDex owner defaults play to the native interactive viewer
+  (`play_render_mode=interactive`, `play_env_num=1`). Record (video) playback
+  stays unavailable for the `.superdex_bot` asset, which carries no MJCF
+  visual model; use `training.play_render_mode=none` for headless runs.
+  FR3 SuperDex owner 的 play 默认改为 native interactive viewer
+  （`play_render_mode=interactive`，`play_env_num=1`）。`.superdex_bot` 资产没有
+  MJCF visual model，record（视频）回放仍不可用；无显示环境使用
+  `training.play_render_mode=none`。
 
 ## 1.1.0 (2026-09-06)
 

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "unilab"
-version = "1.1.0"
+version = "1.2.0"
 description = "Universal Lab for Robot Learning"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ source-exclude = [
 
 [project]
 name = "unilab"
-version = "1.1.1"
+version = "1.2.0"
 description = "Configurable, contract-driven robot learning across physics backends"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -5126,7 +5126,7 @@ wheels = [
 
 [[package]]
 name = "unilab"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -3710,7 +3710,7 @@ wheels = [
 
 [[package]]
 name = "unilab"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Release UniLab 1.2.0:

- `pyproject.toml` / `pyproject.rocm.toml` version → `1.2.0`; `uv.lock` / `uv.rocm.lock` root metadata refreshed.
- `changelog.md`: Unreleased entries collected under `1.2.0 (2026-09-10)`, plus a bilingual entry for the FR3 SuperDex play default (native interactive viewer; record playback unavailable without an MJCF visual model).

Release contents (from #1550): `superdex` optional extra on published wheels, FR3 native assets hosted on Hugging Face with first-use auto-download, `unisim-core>=1.2.0` / `unilab-rl==1.2.0`, bilingual Go2 SuperDex task guide, README ecosystem list.

## Validation

- `make test-all` — pass (exit 0; module/script import sweeps 34/35 and 35/36 with platform-optional mlx skips)
- `make check` — pass
- `uv build` + `twine check` — PASSED (wheel and sdist); FR3 bot binaries verified excluded from the wheel

## Release steps after merge

1. Ensure `ci.yml` has a successful run for the merge commit (dispatch it if needed).
2. Push annotated tag `v1.2.0` on that commit — the release workflow verifies tag/version match, rebuilds, smoke-tests and publishes to PyPI via trusted publishing.