### PR TITLE
test: 跟随 mjbatch API 消融精简 fake/sentinel 收尾 (roadmap #1552 后续)

### DIFF
--- a/docs/sphinx/source/changelog.md
+++ b/docs/sphinx/source/changelog.md
@@ -21,15 +21,22 @@ UniLab 遵循[语义化版本](https://semver.org/)。本共享页面以中英�
   [integration fork](https://github.com/unilabsim/mjbatch); the fork's final
   distribution identity (PyPI package vs git pin, and prebuilt wheels) is the
   roadmap's open maintainer item. The `sim=mujoco` CLI runtime check now gates
-  on the `mjbatch` module. Numerical equivalence before and after the swap is
-  **not** guaranteed; the accepted drift is characterized by the #1554 drift
-  baseline.
+  on the `mjbatch` module. A post-swap ablation slimmed the pinned fork's
+  API ([#1557](https://github.com/unilabsim/UniLab/issues/1557)): the
+  per-substep callback is `fn(k, state, ctrl)` (no `callback_sensordata`
+  argument), `steps_done` / `stop_on_warning` are gone, and the hfield
+  scanner is height-only with its own validation. Numerical equivalence
+  before and after the swap is **not** guaranteed; the accepted drift is
+  characterized by the #1554 drift baseline.
   全仓库将 `mujoco-uni-runtime` 依赖（`mujoco_uni` 导入）替换为 `mjbatch`
   原生 batch 引擎（roadmap #1552、#1553）。`mujoco` extra 现安装
   `mujoco~=3.11.0` 加钉住的 [集成 fork](https://github.com/unilabsim/mjbatch)
   `mjbatch`；fork 的最终分发身份（PyPI package 还是 git 钉版、是否提供预编译
   wheel）是 roadmap 上的待定维护事项。`sim=mujoco` 的 CLI 运行时检查改为检查
-  `mjbatch` 模块。替换前后数值不保证一致；接受的漂移由 #1554 漂移基线表征。
+  `mjbatch` 模块。替换后的消融精简了钉住 fork 的 API（#1557）：per-substep
+  回调为 `fn(k, state, ctrl)`（不再有 `callback_sensordata` 参数），
+  `steps_done` / `stop_on_warning` 已移除，hfield 扫描器只输出高度并自带
+  校验。替换前后数值不保证一致；接受的漂移由 #1554 漂移基线表征。
 
 - Deprecate and remove the MuJoCo chunk/forward knobs: `EnvCfg` fields
   `post_step_forward_sensor`, `adaptive_chunk_size`, and `chunk_size`, the

--- a/docs/sphinx/source/en/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/en/1-getting_started/2-installation.md
@@ -113,7 +113,7 @@ pip install motrixsim-core==0.8.2
 
 # MuJoCo, when needed (resolves the pinned mjbatch integration fork, built
 # against mujoco==3.11.0):
-pip install "mujoco~=3.11.0" "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@473bba9"
+pip install "mujoco~=3.11.0" "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@cf4a83d"
 ```
 
 The editable install points at the checkout; the regular install copies the

--- a/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
+++ b/docs/sphinx/source/zh_CN/1-getting_started/2-installation.md
@@ -104,7 +104,7 @@ pip install -e .
 pip install motrixsim-core==0.8.2
 
 # 需要 MuJoCo 时（解析钉住的 mjbatch 集成 fork，针对 mujoco==3.11.0 构建）：
-pip install "mujoco~=3.11.0" "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@473bba9"
+pip install "mujoco~=3.11.0" "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@cf4a83d"
 ```
 
 editable install 会指向源码 checkout；常规安装会把 package 和任务配置

--- a/pyproject.rocm.toml
+++ b/pyproject.rocm.toml
@@ -79,7 +79,7 @@ mujoco = [
     # item); its build backend pins mujoco==3.11.0 at build time, so isolated
     # builds are correct and no compiler preflight is needed.
     "mujoco~=3.11.0",
-    "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@e6c19ba",
+    "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@cf4a83d",
 ]
 motrix = ["motrixsim-core==0.8.2"]
 viser = ["viser>=1.0.26", "trimesh>=3.21.7"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ mujoco = [
     # identity (PyPI name vs git pin) is decided on the roadmap (#1552 open
     # maintainer item). Its build backend pins mujoco==3.11.0 at build time,
     # so isolated builds are correct and no compiler preflight is needed.
-    "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@e6c19ba",
+    "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@cf4a83d",
 ]
 mjwarp = [
     # Keep the Warp backend on the same MuJoCo minor line as the host backend.

--- a/scripts/tools/drift_baseline/training_smoke_1554.md
+++ b/scripts/tools/drift_baseline/training_smoke_1554.md
@@ -6,7 +6,8 @@ branches: mjbatch fork + unisim adapter), exercising both action paths:
 - `Go2JoystickFlat` — plain position-action path.
 - `Go2WJoystickFlat` — wheeled-leg task; its mixed action runs through
   `SimBackend.set_pre_step_control`, i.e. mjbatch's native per-substep
-  callback (`callback_sensordata=False`).
+  callback (slimmed to `fn(k, state, ctrl)` by the post-swap ablation; this
+  smoke ran against the pre-ablation build with `callback_sensordata=False`).
 
 Both runs: `algo.num_envs=32 algo.max_iterations=100 algo.seed=42`, zero
 NaN/Inf, playback video rendered after training.

--- a/tests/base/test_backend_pre_step_control.py
+++ b/tests/base/test_backend_pre_step_control.py
@@ -46,11 +46,10 @@ class _FakeMjBatch:
 
     Emulates the documented mjbatch semantics the adapter relies on: the
     callback runs on the calling thread before every substep as
-    ``callback(k, state, sensordata, ctrl)`` with ``sensordata=None`` at k=0
-    (and at every k when ``callback_sensordata=False``), one dispatch per
-    ``step()`` call, and an end-of-call copy-out that leaves the bound
-    qpos/qvel views at the final state and sensordata one substep behind
-    (matching ``mj_step``). Each substep adds 1.0 to every state row.
+    ``callback(k, state, ctrl)``, one dispatch per ``step()`` call, and an
+    end-of-call copy-out that leaves the bound qpos/qvel views at the final
+    state and sensordata one substep behind (matching ``mj_step``). Each
+    substep adds 1.0 to every state row.
     """
 
     def __init__(self, nq: int = 1, nv: int = 1, nu: int = 2, nbody: int = 1) -> None:
@@ -82,23 +81,18 @@ class _FakeMjBatch:
         history=None,
         *,
         callback=None,
-        callback_sensordata: bool = True,
-        steps_done=None,
-        stop_on_warning: bool = False,
     ) -> None:
         self.step_calls.append(
             {
                 "nstep": nstep,
                 "callback": callback,
-                "callback_sensordata": callback_sensordata,
             }
         )
         state = self._state
         ctrl_buf = self._bufs["ctrl"]
         for k in range(nstep):
-            sensor_arg = state[:, :1] if (k > 0 and callback_sensordata) else None
             if callback is not None:
-                callback(k, state, sensor_arg, ctrl_buf)
+                callback(k, state, ctrl_buf)
                 self.callback_controls.append(ctrl_buf.copy())
             state += 1.0
         # End-of-call copy-out of the bound input/derived fields.
@@ -185,12 +179,12 @@ def test_mujoco_step_with_pre_step_control_uses_single_dispatch_callback() -> No
     call = pool.step_calls[0]
     assert call["nstep"] == 3
     assert call["callback"] is not None
-    assert call["callback_sensordata"] is False
     # k=0 refreshes nothing (the bound views already hold the pre-call state);
     # k>0 receives the state after substep k-1.
     np.testing.assert_allclose(seen_qpos, [[[0.0]], [[1.0]], [[2.0]]])
-    # With callback_sensordata=False the hook never sees a sensor refresh; the
-    # bound sensordata view only catches up via the end-of-call copy-out.
+    # The slim callback protocol carries no sensordata argument, so the hook
+    # never sees a sensor refresh; the bound sensordata view only catches up
+    # via the end-of-call copy-out.
     np.testing.assert_allclose(seen_sensors, [[[0.0]], [[0.0]], [[0.0]]])
     assert len(pool.callback_controls) == 3
     np.testing.assert_allclose(pool.callback_controls[0], ctrl + 1)

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 [[package]]
 name = "mjbatch"
 version = "0.1.0"
-source = { git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19ba#e6c19bae4d0aec4fc69ec551ff0329296d1db931" }
+source = { git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d#cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f" }
 dependencies = [
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5195,7 +5195,7 @@ requires-dist = [
     { name = "imgui-bundle", marker = "extra == 'newton'", specifier = ">=1.92.0" },
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
-    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19ba" },
+    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
     { name = "mujoco", marker = "extra == 'drake'", specifier = ">=3.5" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = "~=3.11.0" },

--- a/uv.rocm.lock
+++ b/uv.rocm.lock
@@ -1687,7 +1687,7 @@ wheels = [
 [[package]]
 name = "mjbatch"
 version = "0.1.0"
-source = { git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19ba#e6c19bae4d0aec4fc69ec551ff0329296d1db931" }
+source = { git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d#cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f" }
 dependencies = [
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3755,7 +3755,7 @@ requires-dist = [
     { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "lark", specifier = ">=1.3.1" },
     { name = "mediapy" },
-    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19ba" },
+    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = "~=3.11.0" },
     { name = "ninja", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Closes #1557

## Summary

UniLab-side follow-up of the mjbatch pre-release API ablation (mjbatch dev @ cf4a83d, unisim dev @ 0a9d5e3):

- **Fake pool slim** (`tests/base/test_backend_pre_step_control.py`): `_FakeMjBatch.step` drops the `callback_sensordata` / `steps_done` / `stop_on_warning` kwargs; the callback protocol is now `fn(k, state, ctrl)`. Recording dict and assertions updated (the `callback_sensordata is False` assertion is gone; the sensor comment now cites the slim protocol). Single-dispatch semantics, k=0 no-refresh behavior, and the sensordata-one-substep-behind end-of-call copy-out are unchanged.
- **Repin**: `mjbatch` pin `e6c19ba` → `cf4a83d` (cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f) in `pyproject.toml` + `pyproject.rocm.toml`; both `uv.lock` and `uv.rocm.lock` regenerated and verified to carry the new sha.
- **Stale-reference sweep**: changelog swap entry now records the final slim API shape (`fn(k, state, ctrl)` callback, no `steps_done`/`stop_on_warning`, height-only hfield scanner); installation docs (en + zh_CN) example pin updated `473bba9` → `cf4a83d`; `training_smoke_1554.md` notes the callback was slimmed to `fn(k, state, ctrl)` (the smoke itself predates the ablation). Remaining hits for the removed names are either accurate removal notes (changelog knobs entry, capture-script comment, `#1554` docstring) or historical BEFORE artifacts (`before/*.metadata.json`) — left intact.

## Gates

- `make check`: green (ruff format/check, mypy 138 files, pyright 0 errors, test lint). Note: the local `.venv` had drifted to ruff 0.16.5 / mypy 2.3.1 vs the locked 0.15.9 / 1.20.0, which produced spurious markdown reformats + 2 pre-existing mypy errors; aligned the venv to the locked tool versions before running the gate.
- `pytest -m "not slow"`: **1587 passed, 26 skipped, 837 deselected** — identical to the baseline.
- Benchmark smoke: module-mode 32/33 passed, script-mode 33/34 passed (1 skip each: platform-optional `mlx`).

## Drift re-verification

Re-captured AFTER (`capture_mujoco_drift_baseline.py --output scripts/tools/drift_baseline/after`) against mjbatch cf4a83d + unisim 0a9d5e3: **both `Go2JoystickFlat.npz` and `Go2WJoystickFlat.npz` are bit-identical** to the committed AFTER artifacts (every array `np.array_equal`; `array_sha256` unchanged). The slim is copy-layer only, as expected. Regenerated `drift_report.md` shows no numeric change, so the committed report and artifacts are left untouched (the only metadata deltas were capture timestamp, capture-time HEAD, and venv numpy 2.4.4→2.5.2 — no numeric effect).