### PR TITLE
feat: add optional cricket batting and bowling PPO task configs

### DIFF
--- a/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
+++ b/docs/sphinx/source/zh_CN/5-reference/5-support_matrix.md
@@ -72,6 +72,8 @@ uv run scripts/generate_support_matrix.py --write
 | PPO (torch) | `allegro_inhand` (Allegro in-hand) | Tested | - | Tested | - | - | - | - | - |
 | PPO (torch) | `a2_joystick_flat` (a2 joystick flat) | Tested | - | - | - | - | - | - | - |
 | PPO (torch) | `allegro_inhand_grasp` (allegro inhand grasp) | Tested | - | Tested | - | - | - | - | - |
+| PPO (torch) | `cricket_bowling` (cricket bowling) | - | - | - | - | - | - | - | - |
+| PPO (torch) | `cricket_motor` (cricket motor) | - | - | - | - | - | - | - | - |
 | PPO (torch) | `fr3_joint_target` (fr3 joint target) | - | - | - | - | - | - | - | Configured |
 | PPO (torch) | `g1_23dof_box_tracking` (g1 23dof box tracking) | Tested | - | Tested | - | - | - | - | - |
 | PPO (torch) | `g1_23dof_climb_tracking` (g1 23dof climb tracking) | Tested | - | Tested | - | - | - | - | - |

--- a/src/unilab/conf/ppo/task/cricket_bowling/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/cricket_bowling/mujoco.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+training:
+  task_name: CricketDeliveryStride
+  sim_backend: mujoco
+  device: cpu
+  no_play: true
+  play_render_mode: none
+  nan_guard:
+    enabled: false
+
+algo:
+  seed: 1
+  num_envs: 2
+  num_steps_per_env: 32
+  max_iterations: 32
+  obs_groups:
+    actor: [policy]
+    critic: [policy]
+
+reward:
+  source: cricket_gym_internal
+
+env:
+  base_seed: ${algo.seed}
+  handedness: right

--- a/src/unilab/conf/ppo/task/cricket_motor/mujoco.yaml
+++ b/src/unilab/conf/ppo/task/cricket_motor/mujoco.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+training:
+  task_name: CricketMotorSwing
+  sim_backend: mujoco
+  device: cpu
+  no_play: true
+  play_render_mode: none
+  nan_guard:
+    enabled: false
+
+algo:
+  seed: 1
+  num_envs: 2
+  num_steps_per_env: 32
+  max_iterations: 128
+  obs_groups:
+    actor: [policy]
+    critic: [policy]
+
+reward:
+  source: cricket_gym_internal
+
+env:
+  base_seed: ${algo.seed}
+  handedness: right


### PR DESCRIPTION
## Summary

- Add optional MuJoCo PPO owner configurations for `cricket_motor` (`CricketMotorSwing`) and `cricket_bowling` (`CricketDeliveryStride`), plus two regenerated support-matrix rows: **3 files, 52 insertions, no upstream Python changes**.
- The separately installed [Gym-Cricket package](https://github.com/kishanpb/gym-cricket) supplies environments through UniLab's existing `unilab.tasks` entry point. No default dependency, registry lifecycle, RL implementation, backend capability, or CI workflow changes.
- Both configs select CPU, two environments, existing `policy` observation groups, disabled playback, and the adapter's internal reward source. The backend NaN guard is disabled because simulator state belongs to the external Gymnasium adapter; task tests still check finite observations, rewards, and PPO weights.

| Task | Observation / action sizes | Scope |
| --- | --- | --- |
| `CricketMotorSwing` | 123 / 7 | Arm/wrist residuals around a scripted reference swing; native bat-ball contact |
| `CricketDeliveryStride` | 2 / 3 | Release parameters around a scripted run-up/delivery; native flight and stump contact |

Both tasks support physical right/left variants via `env.handedness`. The generated matrix intentionally shows `-` without the optional package installed; this PR does not claim built-in backend support. [External setup and reproduction](https://github.com/kishanpb/gym-cricket/tree/v0.1.0/integrations/unilab) are documented in the package; UniLab's existing CLI workflow is unchanged.

## Linked Work

- Closes #1559.
- Parent roadmap / declared roadmap base: not applicable; one implementation issue.
- Milestone: unassigned, for maintainer triage.
- Base branch: `main`, selected before implementation; tested base `db1a6e5b3dbe4dd096b16a517837f2d46dba8164` (1.2.0).
- Final local head: `4975ea852ffa20e691a97986bd43048c8fc5a02c`.
- Governing contracts: [ADR-0003](https://github.com/Motphys/UniLab/blob/main/docs/sphinx/source/adr/ADR-0003-task-owner-and-config-compose-contract.md) and [ADR-0004](https://github.com/Motphys/UniLab/blob/main/docs/sphinx/source/adr/ADR-0004-registry-bootstrap-contract.md). No new structural decision or support commitment is proposed.

## Validation

- [x] `make test-all` passed on the final local head before this PR was created.
- [x] Additional task-specific validation listed below.

On macOS CPU, `make test-all` passed lint/type checks, **1,589 tests** (27 skipped, 1 expected failure; 848 slow tests deselected), and benchmark entrypoint smoke checks (34/35 module-mode, 35/36 script-mode; one optional MLX skip in each). Focused support-matrix tests passed **13/13** on the same tree. External adapter tests passed **8/8**. The clean Python 3.11 package suite passed **75 tests**, with two optional UniLab modules skipped; both retained-policy videos regenerated successfully in that environment.

Commands run during setup and validation from the UniLab checkout (the local public-package checkout is named `gym_cricket_public`):

```bash
uv sync --extra mujoco
uv pip install motrixsim-core==0.8.2
uv run --no-sync unilab-pull-assets --robot go2
uv run --no-sync unilab-pull-assets --robot allegro_hand
uv run --no-sync unilab-pull-assets --robot a2
# Upstream-only environment: no cricket plugin installed for this gate.
UV_NO_SYNC=1 OMP_NUM_THREADS=1 make test-all
uv run --no-sync pytest tests/scripts/test_support_matrix.py -m slow -q

uv pip install ../gym_cricket_public/dist/cricket_gym-0.1.0-py3-none-any.whl
OMP_NUM_THREADS=1 uv run --no-sync pytest ../gym_cricket_public/tests/test_motor_unilab.py ../gym_cricket_public/tests/test_bowling_unilab.py --junitxml=../unilab_submission_adapter_tests.xml -q

# Also verified installation directly from the now-public immutable source.
uv pip install 'cricket-gym @ git+https://github.com/kishanpb/gym-cricket@c6e932f306470bdab95b43b86e06d4686a9b384a'
```

After the public-source install, the following CLI invocation was run for each task (`cricket_motor`, `cricket_bowling`) and hand (`right`, `left`), with a separate temporary log directory per run:

```bash
uv run --no-sync train --algo ppo --task "$task" --sim mujoco \
  env.handedness="$hand" algo.max_iterations=1 algo.num_steps_per_env=8 \
  training.log_root="$temporary_log_directory"
```

All four actual CLI runs exited successfully. These are bounded runtime checks, **not convergence or benchmark results**. Temporary smoke checkpoints/logs were removed. The adapter tests additionally verify changed finite bowling PPO weights over two iterations per hand.

Installation states are intentionally separate: UniLab's built-in registry-closure tests expect only built-in tasks and fail if an external plugin auto-registers extra tasks. Initial missing-asset/optional-dependency failures were resolved with the official asset helper and Motrix package, without modifying upstream tests or source. Demo replay pins MuJoCo 3.8.0; the UniLab 1.2.0 adapter/CLI checks used its MuJoCo 3.11.0 environment. No cross-version identical-trajectory claim is made.

Remote CI route: base `main`; current-head [CI](https://github.com/Motphys/UniLab/actions/runs/34721784803) and [Docs](https://github.com/Motphys/UniLab/actions/runs/34721784802) workflows are **awaiting maintainer approval** (`action_required`) for head `4975ea852ffa20e691a97986bd43048c8fc5a02c`, as checked on 2026-09-12. They have not passed or failed the code checks yet. Maintainer review and applicable current-head CI remain required before merge.

## Impact

- Backend impact: optional **MuJoCo** task configs only; no Motrix cricket support.
- Platform impact: **macOS CPU verified**; Linux and GPU execution not verified.
- Training effect expected: **yes for the new opt-in tasks only**; existing tasks, algorithms and defaults are unchanged.

## Artifacts

- W&B / ONNX: not used; none claimed.
- Package and distributions: [Gym-Cricket v0.1.0](https://github.com/kishanpb/gym-cricket/releases/tag/v0.1.0).
- Complete evaluation rows, source/checkpoint hashes, and six checkpoints: [pretrained examples](https://github.com/kishanpb/gym-cricket/tree/v0.1.0/examples/pretrained).
- Video: [batting, both hands](https://github.com/kishanpb/gym-cricket/blob/v0.1.0/release/gym_cricket_batting_human_motion.mp4) and [bowling, both hands](https://github.com/kishanpb/gym-cricket/blob/v0.1.0/release/gym_cricket_bowling_runup.mp4).
- [Release validation](https://github.com/kishanpb/gym-cricket/blob/v0.1.0/docs/validation.md) and [full reproduction instructions](https://github.com/kishanpb/gym-cricket/blob/v0.1.0/docs/reproduction.md).

The videos/results use **SKRL JAX PPO/A2C**, not UniLab-trained checkpoints. They include highlights, misses, and full-pool scorecards. Batting is reference-assisted; bowling is a target drill without a batter, and the left-arm evaluation reflects the same trained checkpoint rather than training independently. These are one-seed exploratory evaluations, not an algorithm ranking, learned whole-body locomotion, biomechanical certification, or full-match cricket. Delivery-foot checks do not cover every no-ball rule. No native UniLab A2C result is claimed.

## Checklist

- [x] Task-specific tests included in the external package and run against this head.
- [x] Generated support matrix updated; external installation/reproduction documented.
- [x] Driving issue linked.
- [x] Follow-up scope explicit: maintainers decide whether to accept these optional examples; Linux/GPU validation, broader biomechanics, and full-match tasks remain outside this PR.
